### PR TITLE
Add Loyalty Search

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -701,6 +701,7 @@ class APIResource:
 
         card["creature_power"] = maybe_int(card.get("power"))
         card["creature_toughness"] = maybe_int(card.get("toughness"))
+        card["planeswalker_loyalty"] = maybe_int(card.get("loyalty"))
 
         # objects of keys to true
         card["card_colors"] = dict.fromkeys(card["colors"], True)
@@ -747,6 +748,7 @@ class APIResource:
         card["mana_cost_text"] = card.get("mana_cost")
         card["creature_power_text"] = card.get("power")
         card["creature_toughness_text"] = card.get("toughness")
+        card["planeswalker_loyalty_text"] = card.get("loyalty")
         card["card_artist"] = card.get("artist")
 
         # Handle CMC and edhrec_rank conversion using helper function

--- a/api/db/2025-09-29-great-reset.sql
+++ b/api/db/2025-09-29-great-reset.sql
@@ -182,6 +182,7 @@ CREATE TABLE magic.cards (
     collector_number_int integer,
     creature_power integer,
     creature_toughness integer,
+    planeswalker_loyalty integer,
     edhrec_rank integer,
 
     -- real columns
@@ -210,6 +211,7 @@ CREATE TABLE magic.cards (
     card_keywords jsonb NOT NULL,
     creature_power_text text,
     creature_toughness_text text,
+    planeswalker_loyalty_text text,
     card_oracle_tags jsonb DEFAULT '{}'::jsonb NOT NULL,
     card_set_code text,
     card_artist text,

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -59,6 +59,7 @@ DB_COLUMNS = [
     FieldInfo("cmc", FieldType.NUMERIC, ["cmc"], ParserClass.NUMERIC),
     FieldInfo("creature_power", FieldType.NUMERIC, ["power", "pow"], ParserClass.NUMERIC),
     FieldInfo("creature_toughness", FieldType.NUMERIC, ["toughness", "tou"], ParserClass.NUMERIC),
+    FieldInfo("planeswalker_loyalty", FieldType.NUMERIC, ["loyalty", "loy"], ParserClass.NUMERIC),
     FieldInfo("edhrec_rank", FieldType.NUMERIC, [], ParserClass.NUMERIC),
     FieldInfo("mana_cost_jsonb", FieldType.JSONB_OBJECT, ["mana"], ParserClass.MANA),
     FieldInfo("mana_cost_text", FieldType.TEXT, ["mana", "m"], ParserClass.MANA),

--- a/api/parsing/tests/test_parsing.py
+++ b/api/parsing/tests/test_parsing.py
@@ -73,6 +73,11 @@ from api.parsing.scryfall_nodes import calculate_cmc, mana_cost_str_to_dict
         ("usd=2.5", BinaryOperatorNode(AttributeNode("usd"), "=", NumericValueNode(2.5))),
         ("eur!=10", BinaryOperatorNode(AttributeNode("eur"), "!=", NumericValueNode(10))),
         ("tix>=0.5", BinaryOperatorNode(AttributeNode("tix"), ">=", NumericValueNode(0.5))),
+        # Test cases for loyalty attributes
+        ("loyalty=3", BinaryOperatorNode(AttributeNode("loyalty"), "=", NumericValueNode(3))),
+        ("loyalty>5", BinaryOperatorNode(AttributeNode("loyalty"), ">", NumericValueNode(5))),
+        ("loyalty<=7", BinaryOperatorNode(AttributeNode("loyalty"), "<=", NumericValueNode(7))),
+        ("loy:4", BinaryOperatorNode(AttributeNode("loy"), ":", NumericValueNode(4))),
     ],
 )
 def test_parse_to_nodes(test_input: str, expected_ast: QueryNode) -> None:

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -34,6 +34,11 @@ from api.parsing.scryfall_nodes import get_legality_comparison_object
         ),
         ("cmc:3", "(card.cmc = %(p_int_Mw)s)", {"p_int_Mw": 3}),  # Numeric field uses exact equality
         ("power:5", "(card.creature_power = %(p_int_NQ)s)", {"p_int_NQ": 5}),  # Numeric field uses exact equality
+        # loyalty tests
+        ("loyalty=3", "(card.planeswalker_loyalty = %(p_int_Mw)s)", {"p_int_Mw": 3}),
+        ("loyalty>5", "(card.planeswalker_loyalty > %(p_int_NQ)s)", {"p_int_NQ": 5}),
+        ("loyalty<=7", "(card.planeswalker_loyalty <= %(p_int_Nw)s)", {"p_int_Nw": 7}),
+        ("loy:4", "(card.planeswalker_loyalty = %(p_int_NA)s)", {"p_int_NA": 4}),
         # color
         ("color:g", "(card.card_colors @> %(p_dict_eydHJzogVHJ1ZX0)s)", {"p_dict_eydHJzogVHJ1ZX0": {"G": True}}),  # >=
         ("color=g", "(card.card_colors = %(p_dict_eydHJzogVHJ1ZX0)s)", {"p_dict_eydHJzogVHJ1ZX0": {"G": True}}),  # =


### PR DESCRIPTION
## Pull Request Overview

This PR adds loyalty search functionality for planeswalker cards in the Scryfall OS application. It introduces the ability to search for planeswalker cards by their loyalty values using both "loyalty" and "loy" aliases.

- Adds database schema support for planeswalker loyalty values with both integer and text columns
- Implements query parsing and SQL generation for loyalty searches with various operators (=, >, <=)
- Adds comprehensive test coverage for the new loyalty search functionality
