### PR TITLE
Store Devotion Pips

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -30,7 +30,7 @@ from cachetools import LRUCache, TTLCache, cached
 from psycopg import Connection, Cursor
 
 from .parsing import generate_sql_query, parse_scryfall_query
-from .parsing.scryfall_nodes import extract_frame_data_from_raw_card, mana_cost_str_to_dict
+from .parsing.scryfall_nodes import calculate_devotion, extract_frame_data_from_raw_card, mana_cost_str_to_dict
 from .tagger_client import TaggerClient
 from .utils import db_utils, error_monitoring, multiprocessing_utils
 
@@ -137,6 +137,7 @@ def _convert_string_to_type(str_value: str | None, param_type: Any) -> Any:  # n
         return x.lower() in ("true", "1", "yes", "on")
 
     converter_map = {
+        "PreferOrder": PreferOrder,
         "UniqueOn": UniqueOn,
         "bool": convert_to_bool,
         "float": float,
@@ -742,6 +743,7 @@ class APIResource:
 
         mana_cost_text = card.get("mana_cost", "")
         card["mana_cost_jsonb"] = mana_cost_str_to_dict(mana_cost_text)
+        card["devotion"] = calculate_devotion(mana_cost_text)
 
         # Map field names to match database column names for jsonb_populate_record
         card["card_name"] = card.get("name")

--- a/api/db/2025-09-29-great-reset.sql
+++ b/api/db/2025-09-29-great-reset.sql
@@ -204,6 +204,7 @@ CREATE TABLE magic.cards (
     raw_card_blob jsonb NOT NULL,
     mana_cost_text text,
     mana_cost_jsonb jsonb,
+    devotion jsonb,
     card_types jsonb NOT NULL,
     card_subtypes jsonb DEFAULT '[]'::jsonb NOT NULL,
     card_colors jsonb NOT NULL,
@@ -231,6 +232,7 @@ CREATE TABLE magic.cards (
     CONSTRAINT card_color_identity_valid_colors CHECK ((card_color_identity <@ '{"B": true, "C": true, "G": true, "R": true, "U": true, "W": true}'::jsonb)),
     CONSTRAINT card_colors_must_be_object CHECK ((jsonb_typeof(card_colors) = 'object'::text)),
     CONSTRAINT card_colors_valid_colors CHECK ((card_colors <@ '{"B": true, "C": true, "G": true, "R": true, "U": true, "W": true}'::jsonb)),
+    CONSTRAINT devotion_must_be_object CHECK ((jsonb_typeof(devotion) = 'object'::text)),
     CONSTRAINT card_frame_data_must_be_object CHECK ((jsonb_typeof(card_frame_data) = 'object'::text)),
     CONSTRAINT card_is_tags_must_be_object CHECK ((jsonb_typeof(card_is_tags) = 'object'::text)),
     CONSTRAINT card_keywords_must_be_object CHECK ((jsonb_typeof(card_keywords) = 'object'::text)),
@@ -268,6 +270,7 @@ CREATE INDEX IF NOT EXISTS idx_cards_price_eur ON magic.cards USING btree (price
 CREATE INDEX IF NOT EXISTS idx_cards_price_tix ON magic.cards USING btree (price_tix) WHERE (price_tix IS NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_cards_price_usd ON magic.cards USING btree (price_usd) WHERE (price_usd IS NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_cards_produced_mana ON magic.cards USING gin (produced_mana);
+CREATE INDEX IF NOT EXISTS idx_cards_devotion ON magic.cards USING gin (devotion);
 CREATE INDEX IF NOT EXISTS idx_cards_set_code ON magic.cards USING hash (card_set_code) WHERE (card_set_code IS NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_cards_watermark ON magic.cards USING hash (card_watermark) WHERE (card_watermark IS NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_cards_name ON magic.cards USING btree (card_name);

--- a/api/parsing/scryfall_nodes.py
+++ b/api/parsing/scryfall_nodes.py
@@ -305,6 +305,25 @@ def calculate_cmc(mana_cost_str: str) -> int:
     return cmc
 
 
+def calculate_devotion(mana_cost_str: str) -> dict:
+    """Calculate devotion from a mana cost string, handling split mana costs properly.
+
+    For split mana costs like {R/G}, each color contributes 1 to its respective devotion.
+    For example, {R/G} contributes 1 to both R devotion and G devotion.
+    """
+    devotion = {"W": [], "U": [], "B": [], "R": [], "G": [], "C": []}
+    for ichar in mana_cost_str.upper():
+        current_devotion = devotion.get(ichar)
+        if current_devotion is not None:
+            current_devotion.append(len(current_devotion) + 1)
+    # Remove colors with 0 devotion for cleaner storage
+    return {
+        color: color_devotion
+        for color, color_devotion in devotion.items()
+        if color_devotion
+    }
+
+
 class ScryfallBinaryOperatorNode(BinaryOperatorNode):
     """Scryfall-specific binary operator node with custom SQL generation."""
 


### PR DESCRIPTION
## Pull Request Overview

This PR adds support for storing devotion pips from mana costs in the database. Devotion is a Magic: The Gathering mechanic that counts colored mana symbols in permanents' mana costs.

- Adds a new `calculate_devotion` function to parse and calculate devotion values from mana cost strings
- Updates the database schema to include a devotion column with appropriate constraints and indexing
- Integrates devotion calculation into the card preprocessing pipeline