### PR TITLE
Add Devotion Search Support

### DIFF
--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -63,6 +63,7 @@ DB_COLUMNS = [
     FieldInfo("edhrec_rank", FieldType.NUMERIC, [], ParserClass.NUMERIC),
     FieldInfo("mana_cost_jsonb", FieldType.JSONB_OBJECT, ["mana"], ParserClass.MANA),
     FieldInfo("mana_cost_text", FieldType.TEXT, ["mana", "m"], ParserClass.MANA),
+    FieldInfo("devotion", FieldType.JSONB_OBJECT, ["devotion"], ParserClass.MANA),
     FieldInfo("price_usd", FieldType.NUMERIC, ["usd"], ParserClass.NUMERIC),
     FieldInfo("price_eur", FieldType.NUMERIC, ["eur"], ParserClass.NUMERIC),
     FieldInfo("price_tix", FieldType.NUMERIC, ["tix"], ParserClass.NUMERIC),

--- a/api/parsing/scryfall_nodes.py
+++ b/api/parsing/scryfall_nodes.py
@@ -312,7 +312,7 @@ def calculate_devotion(mana_cost_str: str) -> dict:
     For example, {R/G} contributes 1 to both R devotion and G devotion.
     """
     devotion = {"W": [], "U": [], "B": [], "R": [], "G": [], "C": []}
-    for ichar in mana_cost_str.upper():
+    for ichar in mana_cost_str.upper().strip():
         current_devotion = devotion.get(ichar)
         if current_devotion is not None:
             current_devotion.append(len(current_devotion) + 1)
@@ -659,6 +659,12 @@ class ScryfallBinaryOperatorNode(BinaryOperatorNode):
             context[pname] = rhs
             # Color identity has inverted semantics for the : operator only
             is_color_identity = attr == "card_color_identity"
+        elif attr == "devotion":
+            # Devotion uses mana cost syntax, so we need to convert it to color comparison
+            # Extract color codes from mana cost syntax like {G}, {R}{G}, etc.
+            query_devotion = calculate_devotion(self.rhs.value.strip())
+            pname = param_name(query_devotion)
+            context[pname] = query_devotion
         elif attr == "card_keywords":
             rhs = get_keywords_comparison_object(self.rhs.value.strip())
             pname = param_name(rhs)

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -108,6 +108,22 @@ def test_full_sql_translation(input_query: str, expected_sql: str, expected_para
             r"(card.card_colors <@ %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s AND card.card_colors <> %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
             {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
         ),
+        # devotion tests
+        (
+            "devotion:{G}",
+            r"(card.devotion @> %(p_dict_eydHJzogWzFdfQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}},
+        ),
+        (
+            "devotion>={G}",
+            r"(card.devotion @> %(p_dict_eydHJzogWzFdfQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}},
+        ),
+        (
+            "devotion>={G}{R}",
+            r"(card.devotion @> %(p_dict_eydSJzogWzFdLCAnRyc6IFsxXX0)s)",
+            {"p_dict_eydSJzogWzFdLCAnRyc6IFsxXX0": {"G": [1], "R": [1]}},
+        ),
     ],
 )
 def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, expected_parameters: dict) -> None:


### PR DESCRIPTION
This PR adds support for devotion searches in the Scryfall query parser. Devotion is a Magic: The Gathering mechanic that counts mana symbols of specific colors in a card's mana cost.

* Adds devotion as a new searchable field with JSONB object storage
* Implements parsing and SQL generation for devotion queries with various comparison operators
* Adds comprehensive test coverage for devotion search functionality
