### PR TITLE
Only Include Non-Default Values in URL

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -1819,17 +1819,46 @@
 
         updateURL(query, order, direction, unique, prefer) {
           const url = new URL(window.location);
+
+          // Define default values
+          const defaults = {
+            orderby: 'edhrec',
+            direction: 'asc',
+            unique: 'card',
+            prefer: 'default'
+          };
+
           if (query.trim()) {
+            // Always include the query parameter
             url.searchParams.set('q', query);
-            url.searchParams.set('orderby', order);
-            url.searchParams.set('direction', direction);
-            url.searchParams.set('unique', unique);
-            if (unique !== UNIQUE_PRINTING) {
+
+            // Only include parameters that differ from defaults
+            if (order !== defaults.orderby) {
+              url.searchParams.set('orderby', order);
+            } else {
+              url.searchParams.delete('orderby');
+            }
+
+            if (direction !== defaults.direction) {
+              url.searchParams.set('direction', direction);
+            } else {
+              url.searchParams.delete('direction');
+            }
+
+            if (unique !== defaults.unique) {
+              url.searchParams.set('unique', unique);
+            } else {
+              url.searchParams.delete('unique');
+            }
+
+            // Handle prefer parameter - only include if unique is not 'printing' and prefer is not default
+            if (unique !== UNIQUE_PRINTING && prefer !== defaults.prefer) {
               url.searchParams.set('prefer', prefer);
             } else {
               url.searchParams.delete('prefer');
             }
           } else {
+            // Clear all parameters when no query
             url.searchParams.delete('q');
             url.searchParams.delete('orderby');
             url.searchParams.delete('direction');


### PR DESCRIPTION
This PR refactors the URL parameter management in the search interface to only include non-default values in the URL, making URLs cleaner and more user-friendly. The changes implement a default-aware parameter system that removes unnecessary URL clutter while maintaining full functionality.

Key Changes:
* Introduced a centralized defaults object for search parameters (orderby, direction, unique, prefer)
* Modified URL update logic to only include parameters that differ from their defaults
* Added explicit parameter deletion for default values to keep URLs clean
