### PR TITLE
Support double-faced/adventure card preprocessing and imports

### DIFF
--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import json
+import pathlib
 import uuid
 from typing import Any
 
 from api.card_processing import preprocess_card
 from api.parsing.card_query_nodes import extract_frame_data_from_raw_card
+
+# Project root directory for accessing sample data
+_PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
+_SAMPLE_DATA_DIR = _PROJECT_ROOT / "docs" / "sample_data"
 
 
 def create_test_card(  # noqa: PLR0913
@@ -103,52 +109,59 @@ def create_test_card(  # noqa: PLR0913
 class TestCardProcessing:
     """Test card processing functions."""
 
-    def test_preprocess_card_filters_non_paper_cards(self: TestCardProcessing) -> None:
+    def test_preprocess_card_filters_non_paper_cards(self) -> None:
         """Test preprocess_card filters out non-paper cards."""
         invalid_card = create_test_card(
             games=["mtgo"],  # Not paper
         )
 
         result = preprocess_card(invalid_card)
-        assert result is None
+        assert result == []
 
-    def test_preprocess_card_filters_card_faces(self: TestCardProcessing) -> None:
-        """Test preprocess_card filters out cards with card_faces."""
-        invalid_card = create_test_card(
-            card_faces=[{"name": "Front"}, {"name": "Back"}],  # Has card_faces
+    def test_preprocess_card_processes_double_faced_cards(self) -> None:
+        """Test preprocess_card processes cards with card_faces (DFCs) correctly."""
+        dfc_card = create_test_card(
+            card_faces=[{"name": "Front", "type_line": "Creature — Human"}, {"name": "Back", "type_line": "Creature — Werewolf"}],
         )
 
-        result = preprocess_card(invalid_card)
-        assert result is None
+        result = preprocess_card(dfc_card)
+        # DFCs should return 2 cards (one per face)
+        assert len(result) == 2
+        assert result[0]["face_idx"] == 1
+        assert result[0]["face_name"] == "Front"
+        assert result[0]["card_name"] == "Test Card"
+        assert result[1]["face_idx"] == 2
+        assert result[1]["face_name"] == "Back"
+        assert result[1]["card_name"] == "Test Card"
 
-    def test_preprocess_card_filters_funny_sets(self: TestCardProcessing) -> None:
+    def test_preprocess_card_filters_funny_sets(self) -> None:
         """Test preprocess_card filters out funny set types."""
         invalid_card = create_test_card(
             set_type="funny",  # Funny set type
         )
 
         result = preprocess_card(invalid_card)
-        assert result is None
+        assert result == []
 
-    def test_preprocess_card_filters_card_type(self: TestCardProcessing) -> None:
+    def test_preprocess_card_filters_card_type(self) -> None:
         """Test preprocess_card filters out cards with Card type."""
         invalid_card = create_test_card(
             type_line="Card",
         )
 
         result = preprocess_card(invalid_card)
-        assert result is None
+        assert result == []
 
-    def test_preprocess_card_filters_token_type(self: TestCardProcessing) -> None:
+    def test_preprocess_card_filters_token_type(self) -> None:
         """Test preprocess_card filters out cards with Token type."""
         invalid_card = create_test_card(
             type_line="Token Creature — Goblin",
         )
 
         result = preprocess_card(invalid_card)
-        assert result is None
+        assert result == []
 
-    def test_preprocess_card_processes_valid_card(self: TestCardProcessing) -> None:
+    def test_preprocess_card_processes_valid_card(self) -> None:
         """Test preprocess_card processes valid cards correctly."""
         valid_card = create_test_card(
             card_id="00000000-0000-0000-0000-000000000006",
@@ -164,7 +177,8 @@ class TestCardProcessing:
 
         result = preprocess_card(valid_card)
 
-        assert result is not None
+        assert len(result) == 1
+        result = result[0]
         assert result["card_types"] == ["Instant"]
         # card_subtypes is now always present, set to empty array when no subtypes
         assert result["card_subtypes"] == []
@@ -176,7 +190,7 @@ class TestCardProcessing:
         assert result["price_tix"] == 0.01
         assert result["card_set_code"] == "m15"
 
-    def test_preprocess_card_processes_frame_data(self: TestCardProcessing) -> None:
+    def test_preprocess_card_processes_frame_data(self) -> None:
         """Test preprocess_card processes frame data correctly."""
         card_with_frame = create_test_card(
             frame="2015",
@@ -185,11 +199,12 @@ class TestCardProcessing:
 
         result = preprocess_card(card_with_frame)
 
-        assert result is not None
+        assert len(result) == 1
+        result = result[0]
         expected_frame_data = {"2015": True, "Showcase": True, "Legendary": True}
         assert result["card_frame_data"] == expected_frame_data
 
-    def test_preprocess_card_handles_missing_frame_data(self: TestCardProcessing) -> None:
+    def test_preprocess_card_handles_missing_frame_data(self) -> None:
         """Test preprocess_card handles missing frame data correctly."""
         card_without_frame = create_test_card(
             name="Regular Card",
@@ -201,10 +216,11 @@ class TestCardProcessing:
 
         result = preprocess_card(card_without_frame)
 
-        assert result is not None
+        assert len(result) == 1
+        result = result[0]
         assert result["card_frame_data"] == {}  # Should be empty object when no frame data present
 
-    def test_extract_frame_data_from_raw_card_with_frame_and_effects(self: TestCardProcessing) -> None:
+    def test_extract_frame_data_from_raw_card_with_frame_and_effects(self) -> None:
         """Test extract_frame_data_from_raw_card with frame and frame_effects."""
         raw_card = {
             "frame": "2015",
@@ -215,7 +231,7 @@ class TestCardProcessing:
         expected = {"2015": True, "Showcase": True, "Legendary": True}
         assert result == expected
 
-    def test_extract_frame_data_from_raw_card_with_only_frame(self: TestCardProcessing) -> None:
+    def test_extract_frame_data_from_raw_card_with_only_frame(self) -> None:
         """Test extract_frame_data_from_raw_card with only frame version."""
         raw_card = {"frame": "1997"}
 
@@ -223,7 +239,7 @@ class TestCardProcessing:
         expected = {"1997": True}
         assert result == expected
 
-    def test_extract_frame_data_from_raw_card_with_only_effects(self: TestCardProcessing) -> None:
+    def test_extract_frame_data_from_raw_card_with_only_effects(self) -> None:
         """Test extract_frame_data_from_raw_card with only frame effects."""
         raw_card = {"frame_effects": ["borderless", "etched"]}
 
@@ -231,7 +247,7 @@ class TestCardProcessing:
         expected = {"Borderless": True, "Etched": True}
         assert result == expected
 
-    def test_extract_frame_data_from_raw_card_empty(self: TestCardProcessing) -> None:
+    def test_extract_frame_data_from_raw_card_empty(self) -> None:
         """Test extract_frame_data_from_raw_card with empty raw card."""
         raw_card = {}
 
@@ -239,7 +255,7 @@ class TestCardProcessing:
         expected = {}
         assert result == expected
 
-    def test_preprocess_card_handles_missing_fields(self: TestCardProcessing) -> None:
+    def test_preprocess_card_handles_missing_fields(self) -> None:
         """Test preprocess_card handles missing optional fields."""
         minimal_card = create_test_card(
             colors=[],
@@ -250,7 +266,8 @@ class TestCardProcessing:
 
         result = preprocess_card(minimal_card)
 
-        assert result is not None
+        assert len(result) == 1
+        result = result[0]
         assert result["card_colors"] == {}
         assert result["card_color_identity"] == {}
         assert result["card_keywords"] == {}
@@ -260,7 +277,7 @@ class TestCardProcessing:
         assert result["price_eur"] is None
         assert result["price_tix"] is None
 
-    def test_preprocess_card_handles_non_numeric_power_toughness(self: TestCardProcessing) -> None:
+    def test_preprocess_card_handles_non_numeric_power_toughness(self) -> None:
         """Test preprocess_card handles non-numeric power/toughness values."""
         card = create_test_card(
             keywords=[],
@@ -271,6 +288,54 @@ class TestCardProcessing:
 
         result = preprocess_card(card)
 
-        assert result is not None
+        assert len(result) == 1
+        result = result[0]
         assert result["creature_power"] is None
         assert result["creature_toughness"] is None
+
+    def test_preprocess_hound_tamer_dfc(self) -> None:
+        """Test preprocess_card processes Hound Tamer DFC sample data correctly."""
+        sample_file = _SAMPLE_DATA_DIR / "hound_tamer.json"
+        with sample_file.open() as f:
+            hound_tamer = json.load(f)
+
+        result = preprocess_card(hound_tamer)
+
+        # Should return 2 faces
+        assert len(result) == 2
+
+        # Check front face
+        front = result[0]
+        assert front["face_idx"] == 1
+        assert front["face_name"] == "Hound Tamer"
+        assert front["card_name"] == "Hound Tamer // Untamed Pup"
+        assert front["creature_power"] == 3
+        assert front["creature_toughness"] == 3
+        assert "Creature" in front["card_types"]
+        assert front["cmc"] == 3
+
+        # Check back face
+        back = result[1]
+        assert back["face_idx"] == 2
+        assert back["face_name"] == "Untamed Pup"
+        assert back["card_name"] == "Hound Tamer // Untamed Pup"
+        assert back["creature_power"] == 4
+        assert back["creature_toughness"] == 4
+        assert "Creature" in back["card_types"]
+        # CMC is inherited from the card (3), even though back face has no mana cost
+        assert back["cmc"] == 3
+
+    def test_preprocess_obyras_attendants(self) -> None:
+        """Test preprocess_card processes Obyra's Attendants DFC sample data correctly."""
+        sample_file = _SAMPLE_DATA_DIR / "obyras_attendants.json"
+        with sample_file.open() as f:
+            obyras_attendants = json.load(f)
+
+        result = preprocess_card(obyras_attendants)
+
+        # Should return 2 faces
+        front, back = result
+        assert front["creature_power"] == 3
+        assert back.get("creature_power") is None
+        assert front["card_types"] == ["Creature"]
+        assert back["card_types"] == ["Instant"]

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -162,7 +162,7 @@ class TestImportCardByName(unittest.TestCase):
         mock_search.return_value = [{"name": "TestCard", "legalities": {"standard": "not_legal"}}]
 
         # Mock preprocessing to return None (filtered out)
-        mock_preprocess.return_value = None
+        mock_preprocess.return_value = []
 
         result = self.api_resource.import_card_by_name(card_name="TestCard")
         assert result == {

--- a/docs/sample_data/obyras_attendants.json
+++ b/docs/sample_data/obyras_attendants.json
@@ -1,0 +1,169 @@
+{
+  "object": "card",
+  "id": "0001e77a-7fff-49d2-a55c-42f6fdf6db08",
+  "oracle_id": "396b088d-f9af-4ee1-843f-dbe1633f9cc8",
+  "multiverse_ids": [
+    629564
+  ],
+  "mtgo_id": 116428,
+  "arena_id": 86752,
+  "tcgplayer_id": 513888,
+  "cardmarket_id": 730003,
+  "name": "Obyra's Attendants // Desperate Parry",
+  "lang": "en",
+  "released_at": "2023-09-08",
+  "uri": "https://api.scryfall.com/cards/0001e77a-7fff-49d2-a55c-42f6fdf6db08",
+  "scryfall_uri": "https://scryfall.com/card/woe/63/obyras-attendants-desperate-parry?utm_source=api",
+  "layout": "adventure",
+  "highres_image": true,
+  "image_status": "highres_scan",
+  "image_uris": {
+    "small": "https://cards.scryfall.io/small/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+    "normal": "https://cards.scryfall.io/normal/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+    "large": "https://cards.scryfall.io/large/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+    "png": "https://cards.scryfall.io/png/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.png?1692937199",
+    "art_crop": "https://cards.scryfall.io/art_crop/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199",
+    "border_crop": "https://cards.scryfall.io/border_crop/front/0/0/0001e77a-7fff-49d2-a55c-42f6fdf6db08.jpg?1692937199"
+  },
+  "mana_cost": "{4}{U} // {1}{U}",
+  "cmc": 5.0,
+  "type_line": "Creature — Faerie Wizard // Instant — Adventure",
+  "power": "3",
+  "toughness": "4",
+  "colors": [
+    "U"
+  ],
+  "color_identity": [
+    "U"
+  ],
+  "keywords": [
+    "Flying"
+  ],
+  "card_faces": [
+    {
+      "object": "card_face",
+      "name": "Obyra's Attendants",
+      "mana_cost": "{4}{U}",
+      "type_line": "Creature — Faerie Wizard",
+      "oracle_text": "Flying",
+      "power": "3",
+      "toughness": "4",
+      "flavor_text": "Obyra's devoted servants shrieked as their sleeping mistress slashed at them, unseeing.",
+      "artist": "Andreas Zafiratos",
+      "artist_id": "e2f13a9a-57c5-40de-81d4-3b0723899cdf",
+      "illustration_id": "d1ea5321-62e2-4894-a79f-03b792daf2c8"
+    },
+    {
+      "object": "card_face",
+      "name": "Desperate Parry",
+      "mana_cost": "{1}{U}",
+      "type_line": "Instant — Adventure",
+      "oracle_text": "Target creature gets -4/-0 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+      "artist": "Andreas Zafiratos",
+      "artist_id": "e2f13a9a-57c5-40de-81d4-3b0723899cdf"
+    }
+  ],
+  "all_parts": [
+    {
+      "object": "related_card",
+      "id": "0001e77a-7fff-49d2-a55c-42f6fdf6db08",
+      "component": "combo_piece",
+      "name": "Obyra's Attendants // Desperate Parry",
+      "type_line": "Creature — Faerie Wizard // Instant — Adventure",
+      "uri": "https://api.scryfall.com/cards/0001e77a-7fff-49d2-a55c-42f6fdf6db08"
+    },
+    {
+      "object": "related_card",
+      "id": "fcf4c7fb-7859-4c11-8552-6817f5119d2e",
+      "component": "combo_piece",
+      "name": "On an Adventure",
+      "type_line": "Card",
+      "uri": "https://api.scryfall.com/cards/fcf4c7fb-7859-4c11-8552-6817f5119d2e"
+    }
+  ],
+  "legalities": {
+    "standard": "legal",
+    "future": "legal",
+    "historic": "legal",
+    "timeless": "legal",
+    "gladiator": "legal",
+    "pioneer": "legal",
+    "modern": "legal",
+    "legacy": "legal",
+    "pauper": "legal",
+    "vintage": "legal",
+    "penny": "not_legal",
+    "commander": "legal",
+    "oathbreaker": "legal",
+    "standardbrawl": "legal",
+    "brawl": "legal",
+    "alchemy": "not_legal",
+    "paupercommander": "legal",
+    "duel": "legal",
+    "oldschool": "not_legal",
+    "premodern": "not_legal",
+    "predh": "not_legal"
+  },
+  "games": [
+    "paper",
+    "arena",
+    "mtgo"
+  ],
+  "reserved": false,
+  "game_changer": false,
+  "foil": true,
+  "nonfoil": true,
+  "finishes": [
+    "nonfoil",
+    "foil"
+  ],
+  "oversized": false,
+  "promo": false,
+  "reprint": false,
+  "variation": false,
+  "set_id": "79139661-13ee-43c4-8bad-a8c069f1a1df",
+  "set": "woe",
+  "set_name": "Wilds of Eldraine",
+  "set_type": "expansion",
+  "set_uri": "https://api.scryfall.com/sets/79139661-13ee-43c4-8bad-a8c069f1a1df",
+  "set_search_uri": "https://api.scryfall.com/cards/search?order=set&q=e%3Awoe&unique=prints",
+  "scryfall_set_uri": "https://scryfall.com/sets/woe?utm_source=api",
+  "rulings_uri": "https://api.scryfall.com/cards/0001e77a-7fff-49d2-a55c-42f6fdf6db08/rulings",
+  "prints_search_uri": "https://api.scryfall.com/cards/search?order=released&q=oracleid%3A396b088d-f9af-4ee1-843f-dbe1633f9cc8&unique=prints",
+  "collector_number": "63",
+  "digital": false,
+  "rarity": "common",
+  "flavor_text": "Obyra's devoted servants shrieked as their sleeping mistress slashed at them, unseeing.",
+  "card_back_id": "0aeebaf5-8c7d-4636-9e82-8c27447861f7",
+  "artist": "Andreas Zafiratos",
+  "artist_ids": [
+    "e2f13a9a-57c5-40de-81d4-3b0723899cdf"
+  ],
+  "illustration_id": "d1ea5321-62e2-4894-a79f-03b792daf2c8",
+  "border_color": "black",
+  "frame": "2015",
+  "full_art": false,
+  "textless": false,
+  "booster": true,
+  "story_spotlight": false,
+  "edhrec_rank": 17702,
+  "prices": {
+    "usd": "0.09",
+    "usd_foil": "0.11",
+    "usd_etched": null,
+    "eur": "0.09",
+    "eur_foil": "0.15",
+    "tix": "0.03"
+  },
+  "related_uris": {
+    "gatherer": "https://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=629564&printed=false",
+    "tcgplayer_infinite_articles": "https://partner.tcgplayer.com/c/4931599/1830156/21018?subId1=api&trafcat=tcgplayer.com%2Fsearch%2Farticles&u=https%3A%2F%2Fwww.tcgplayer.com%2Fsearch%2Farticles%3FproductLineName%3Dmagic%26q%3DObyra%2527s%2BAttendants%2B%252F%252F%2BDesperate%2BParry",
+    "tcgplayer_infinite_decks": "https://partner.tcgplayer.com/c/4931599/1830156/21018?subId1=api&trafcat=tcgplayer.com%2Fsearch%2Fdecks&u=https%3A%2F%2Fwww.tcgplayer.com%2Fsearch%2Fdecks%3FproductLineName%3Dmagic%26q%3DObyra%2527s%2BAttendants%2B%252F%252F%2BDesperate%2BParry",
+    "edhrec": "https://edhrec.com/route/?cc=Obyra%27s+Attendants"
+  },
+  "purchase_uris": {
+    "tcgplayer": "https://partner.tcgplayer.com/c/4931599/1830156/21018?subId1=api&u=https%3A%2F%2Fwww.tcgplayer.com%2Fproduct%2F513888%3Fpage%3D1",
+    "cardmarket": "https://www.cardmarket.com/en/Magic/Products?idProduct=730003&referrer=scryfall&utm_campaign=card_prices&utm_medium=text&utm_source=scryfall",
+    "cardhoarder": "https://www.cardhoarder.com/cards/116428?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall"
+  }
+}

--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ XPGUSER=foouser
 HOSTNAME := $(shell hostname)
 
 html_files := $(shell find . -type f -name "*.html")
-js_files := $(shell find . -type f -name "*.js")
+js_files := $(shell find . -type f -name "*.js" | grep -v node_modules)
 
 S3_BUCKET=biblioplex
 
@@ -144,12 +144,13 @@ dockerclean:
 	docker images --format '{{.ID}}' | xargs $(MAYBENORUN) docker rmi --force
 
 dbconn: # @doc connect to the local database
+
 	@PGDATABASE=$(XPGDATABASE) \
 	PGHOST=127.0.0.1 \
 	PGPASSWORD=$(XPGPASSWORD) \
-	PGPORT=15432 \
+	PGPORT=25432 \
 	PGUSER=$(XPGUSER) \
-	psql
+	$(shell find /usr/bin /opt/homebrew -name psql)
 
 dump_schema: # @doc dump database schema to file using container's pg_dump
 	docker exec $(PROJECTNAME)postgres $(shell find /usr/bin /opt/homebrew -name pg_dump) -U $(XPGUSER) -d $(XPGDATABASE) -s


### PR DESCRIPTION
This PR extends card preprocessing and import flows to fully support double-faced/adventure Scryfall cards by treating each face as its own record while preserving a shared printing-level identity. It also tightens filtering rules and improves local dev tooling for JS asset discovery and DB access.

## Problem

Previously, `preprocess_card` only returned a single processed card (or `None`) and rejected any card with `card_faces`, which meant:
- Double-faced/adventure cards could not be imported or queried correctly.
- Some otherwise valid cards were dropped due to strict power/toughness handling on non-creature faces.
- Dev ergonomics were weaker: `make`-driven JS tasks would traverse `node_modules`, and the `dbconn` target assumed a specific `psql` location and port that don’t match the current Docker/Postgres setup on macOS.

## Solution

Card preprocessing/import:

1. `preprocess_card` now returns a list of processed card dicts instead of a single dict/`None`, so one Scryfall card can yield multiple records (one per face).
   - Filters invalid cards by returning an empty list instead of `None`.
   - Treats `Card` and `Token` type-lines as unplayable and drops them.
2. DFC/adventure support:
   - Detects `card_faces` and recursively preprocesses each face, merging face-specific data into the shared card scaffold.
   - Assigns `face_idx` and `face_name` per face while preserving `card_name` for the overall printing.
   - Ensures creature stats and CMC are derived correctly per face (front vs. back/adventure).
3. Non-creature faces with power/toughness:
   - Instead of rejecting these cards, cleans up `creature_power`/`creature_toughness` and their `*_text` fields on non-creature faces.
4. API integration:
   - `_get_cards_to_insert` now flattens the list of processed faces and deduplicates on `(scryfall_id, face_idx)` so each face of a DFC/adventure card is stored once.
   - The import-by-name flow builds its `cards` list from these expanded results and treats an empty list as “filtered out”.

Tests and sample data:

1. Updated existing tests in `api/tests/test_card_processing.py` and `api/tests/test_import_card_by_name.py` to:
   - Expect list-return semantics from `preprocess_card` (empty list for filtered cards).
   - Treat an empty list as a filtered-out card in import-by-name flows.
2. Added new tests for DFC/adventure coverage:
   - Synthetic DFC tests validating `face_idx`, `face_name`, `card_name`, creature stats, and CMC inheritance.
   - A real-world sample test for Obyra’s Attendants // Desperate Parry using `docs/sample_data/obyras_attendants.json`, asserting that:
     - The creature face has correct power/toughness and `card_types`.
     - The adventure face is typed as `Instant` with no creature stats.

Dev tooling:

1. `makefile`:
   - Updated `js_files` discovery to ignore `node_modules` when building the JS file list, speeding up and de-noising JS-related targets.
   - Updated the `dbconn` target to:
     - Use port `25432` (matching the current Docker/Postgres setup).
     - Resolve `psql` via `find` under `/opt/homebrew` to better match macOS Homebrew installations.

## Testing

Recommended commands:
- `pytest api/tests/test_card_processing.py api/tests/test_import_card_by_name.py`
- Optionally, run the broader API test suite or project-standard test targets if appropriate for this PR.

## Related Context

- Improves correctness and coverage for DFC/adventure cards in both bulk imports and import-by-name paths.
- Improves local developer experience for JS-related `make` targets and DB access on macOS.
