### PR TITLE
Search history and back/forward support

### DIFF
--- a/api/static/app.js
+++ b/api/static/app.js
@@ -26,8 +26,6 @@ class CardSearch {
     this.isAscending = true; // Track order direction
     this.currentCardCount = 0; // Track current number of cards displayed for resize handling
 
-    // History / back-forward: arrival time and "saved" flag in history.state
-
     // Autocomplete properties
     this.commonCardTypes = []; // Will store the common card types
 


### PR DESCRIPTION
Back/forward buttons now move between meaningful search states (previous queries and results) instead of leaving the SPA or doing nothing useful. A new history entry is added only when the user stays on a result view longer than 2.5s before changing the search.

## Behavior

- **When results are shown** we record an arrival timestamp in `history.state` and update the URL with `replaceState`. The URL reflects the query that produced the current results (not every keystroke), so the browser history UI doesn’t show an entry for every URL passed through while typing.
- **When the user navigates away** (new query or dropdown change), we only push the current state if: it’s not already saved, they’ve been on it longer than `DWELL_MS` (2.5s), and the new URL is different. If so, we `pushState` that URL with `saved: true` then `replaceState` the new one, so Back from the next search returns to this state. No timer: the check happens at leave time using the stored arrival time.
- **Back/forward** A `popstate` listener restores the search input and dropdowns from the URL and re-fetches results (or clears results if the restored URL has no query).

## Implementation details

- **`buildSearchUrlFromParams` / `buildCurrentSearchUrl`** – Build the search URL from form state; used for replace/push and for the “stayed long enough” logic.
- **`history.state.arrivalTime`** – Set when we show results (in `displayResults` and on initial load with a query). Read in `updateURL` to decide whether to push when leaving. No separate dwell timer or `setTimeout`/`clearTimeout`.
- **`history.state.saved`** – Set to `true` when we push an entry. When the user has gone Back to a previously pushed entry, we see `saved: true` and don’t push again when they navigate away, avoiding duplicate history entries.
- **URL updates** – URL is updated when results are displayed and when order/unique/prefer/direction change; it is not updated on every input keystroke, to avoid cluttering the browser’s history/recent-URL UI.
- **Initial load** – If the page loads with `?q=...`, we set `arrivalTime` on the current entry so a later “navigate away” can push it after the dwell threshold.
- **Restoring from history** – On Back/Forward, `popstate` restores the form and re-fetches; `displayResults` then does `replaceState({ arrivalTime: Date.now() }, '', url)`, so the restored entry gets a fresh arrival time and we don’t push when leaving unless they dwell again.

## Files changed

- `api/static/app.js` – History logic, URL helpers, popstate handler, removal of per-keystroke URL updates from the input handler.