### PR TITLE
Empty Search Returns All Cards Instead of Filtering by Empty Name

### DIFF
--- a/api/parsing/__init__.py
+++ b/api/parsing/__init__.py
@@ -12,6 +12,7 @@ from api.parsing.nodes import (
     QueryNode,
     RegexValueNode,
     StringValueNode,
+    TrueNode,
 )
 from api.parsing.parsing_f import balance_partial_query, generate_sql_query, parse_scryfall_query, parse_search_query
 
@@ -27,6 +28,7 @@ node_types = [
     QueryNode,
     RegexValueNode,
     StringValueNode,
+    TrueNode,
 ]
 functions = [parse_search_query, generate_sql_query, parse_scryfall_query, balance_partial_query]
 __all__ = [x.__name__ for x in node_types + functions]

--- a/api/parsing/nodes.py
+++ b/api/parsing/nodes.py
@@ -303,6 +303,27 @@ class NotNode(QueryNode):
         return hash(("Not", self.operand))
 
 
+class TrueNode(LeafNode):
+    """Represents an always-true condition, used for empty queries."""
+
+    def to_sql(self: TrueNode, context: dict) -> str:
+        """Serialize this node to the SQL literal TRUE."""
+        del context
+        return "TRUE"
+
+    def __repr__(self: TrueNode) -> str:
+        """Return a string representation of the TrueNode."""
+        return "TrueNode()"
+
+    def __eq__(self: TrueNode, other: object) -> bool:
+        """Check equality with another TrueNode."""
+        return isinstance(other, TrueNode)
+
+    def __hash__(self: TrueNode) -> int:
+        """Return a hash for TrueNode."""
+        return hash("TrueNode")
+
+
 class Query(QueryNode):
     """Top-level query container node for the AST."""
 

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -40,6 +40,7 @@ from api.parsing.nodes import (
     QueryNode,
     RegexValueNode,
     StringValueNode,
+    TrueNode,
 )
 
 if TYPE_CHECKING:
@@ -743,12 +744,11 @@ def parse_search_query(query: str) -> Query:
                        BinaryOperatorNode(AttributeNode("name"), ":", StringValueNode("creature"))]))
 
         >>> parse_search_query("")
-        Query(BinaryOperatorNode(AttributeNode("name"), ":", StringValueNode("")))
+        Query(TrueNode())
     """
     original_query = query
     if query is None or not query.strip():
-        # Return empty query
-        return Query(BinaryOperatorNode(CardAttributeNode("name", ParserClass.TEXT), ":", ""))
+        return Query(TrueNode())
 
     # Pre-process the query to handle implicit AND operations
     # Convert "a b" to "a AND b" when b is not an operator

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -727,8 +727,7 @@ def parse_search_query(query: str) -> Query:
 
     Returns:
         Query: A Query AST node containing the parsed query structure.
-            For empty queries, returns a default query that searches for
-            empty name values.
+            For empty queries, returns a default query that is always true.
 
     Raises:
         ValueError: If parsing fails due to syntax errors, invalid operators,

--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -708,7 +708,7 @@ def get_parse_expr() -> ParserElement:  # noqa: C901, PLR0915
     return expr
 
 
-def parse_search_query(query: str) -> Query:
+def parse_search_query(query: str | None) -> Query:
     """Parse a search query string into a Query AST.
 
     This function is the main entry point for parsing Scryfall-style search queries.

--- a/api/parsing/tests/test_parsing.py
+++ b/api/parsing/tests/test_parsing.py
@@ -281,15 +281,15 @@ def test_parse_combined_pricing_queries() -> None:
     assert result2.root == expected2
 
 
-def test_parse_empty_query() -> None:
-    """Test parsing empty or None queries."""
-    # Empty string
-    result = parsing.parse_search_query("")
+@pytest.mark.parametrize(
+    argnames="query",
+    argvalues=["", "   ", None],
+)
+def test_parse_empty_query(query: str | None) -> None:
+    """Test that empty/whitespace/None queries produce a TrueNode root."""
+    result = parsing.parse_search_query(query)
     assert isinstance(result, parsing.Query)
-
-    # None
-    result = parsing.parse_search_query(None)
-    assert isinstance(result, parsing.Query)
+    assert isinstance(result.root, parsing.TrueNode)
 
 
 def test_name_vs_name_attribute() -> None:

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -1121,3 +1121,14 @@ def test_name_titlecasing() -> None:
     observed_sql = parsed.to_sql(observed_params)
     assert observed_params == {"p_str_VXJ6YSdzIFNhZ2E": r"Urza's Saga"}
     assert observed_sql == r"(card.card_name = %(p_str_VXJ6YSdzIFNhZ2E)s)"
+
+
+@pytest.mark.parametrize(
+    argnames="query",
+    argvalues=["", "   ", None],
+)
+def test_empty_query_generates_true(query: str | None) -> None:
+    """Empty/whitespace/None queries should produce TRUE with no bound parameters."""
+    sql, params = generate_sql_query(parsing.parse_search_query(query))
+    assert sql == "TRUE"
+    assert params == {}


### PR DESCRIPTION
Previously, an empty or whitespace-only search query was handled by generating `name:""` — filtering cards by an empty name string. This was a bug: the intent of an empty search is to return all cards, not to run an unintentional name filter.

### Changes

- **`nodes.py`**: Added `TrueNode`, a leaf AST node that serializes to the SQL literal `TRUE` with no bound parameters.
- **`parsing_f.py`**: `parse_search_query` now returns `Query(TrueNode())` for empty/whitespace/`None` input instead of the old `name:""` fallback. Updated docstring and type signature to accept `str | None`.
- **`__init__.py`**: Exported `TrueNode` as part of the public API.
- **Tests**: Updated `test_parse_empty_query` to assert `TrueNode` is the root; added `test_empty_query_generates_true` in `test_sql_gen.py` to verify the SQL output is exactly `TRUE` with no params. Both use `parametrize` over `""`, `"   "`, and `None`.