### PR TITLE
Add Query Log + Realistic Load Testing Mode

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -29,7 +29,7 @@ import psycopg
 import requests
 from cachebox import LRUCache, TTLCache
 from cachebox import cached as cachebox_cached
-from psycopg import Connection, Cursor
+from psycopg import Cursor
 
 from api.card_processing import preprocess_card
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
@@ -584,7 +584,6 @@ class APIResource:
                 return result
         try:
             with self._conn_pool.connection() as conn:
-                conn = typecast("Connection", conn)
                 with conn.cursor() as cursor:
                     cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
                     cards_found = cursor.fetchall()[0]["num_cards"]
@@ -807,8 +806,7 @@ class APIResource:
         distinct_on = {
             UniqueOn.ARTWORK: "illustration_id",
             UniqueOn.CARD: "card_name",
-            UniqueOn.PRINTING: "scryfall_id",
-        }.get(unique, "card_name")
+        }.get(unique)  # None means unique=printing; scryfall_id is the PK so DISTINCT ON is a no-op
         # Map prefer values to SQL columns and directions
         prefer_mapping = {
             PreferOrder.OLDEST: ("released_at", "ASC"),
@@ -822,43 +820,62 @@ class APIResource:
             prefer,
             ("edhrec_rank", "ASC"),
         )
+        if distinct_on is not None:
+            distinct_clause = f"DISTINCT ON ({distinct_on})"
+            order_by_distinct = f"{distinct_on},"
+        else:
+            distinct_clause = ""
+            order_by_distinct = ""
+        inner_columns = {
+            "card_name",
+            "card_set_code",
+            "cmc",
+            "collector_number",
+            "creature_power_text",
+            "creature_toughness_text",
+            "edhrec_rank",
+            "mana_cost_text",
+            "oracle_text",
+            "set_name",
+            "type_line",
+            "prefer_score",
+        }
+        inner_columns.add(sql_orderby)
+        inner_columns_sql = ",\n    ".join(sorted(inner_columns))
+
+        outer_orderby_clauses = [
+            f"{sql_orderby} {sql_direction} NULLS LAST",
+        ]
+        if orderby not in (CardOrdering.EDHREC, CardOrdering.CUBECOBRA):
+            outer_orderby_clauses.append("edhrec_rank ASC NULLS LAST")
+        # there will only be multiple prefer scores per
+        # grouping if the grouping is card
+        if unique == UniqueOn.CARD:
+            outer_orderby_clauses.append("prefer_score DESC NULLS LAST")
+        outer_orderby_sql = ",\n    ".join(outer_orderby_clauses)
+
         query_sql = f"""
             WITH distinct_cards AS (
-                SELECT DISTINCT ON ({distinct_on})
-                    card_artist,
-                    card_name,
-                    card_set_code,
-                    cmc,
-                    collector_number,
-                    creature_power_text,
-                    creature_toughness_text,
-                    edhrec_rank,
-                    mana_cost_text,
-                    oracle_text,
-                    set_name,
-                    type_line,
-                    prefer_score,
-                    {sql_orderby} AS sort_value
+                SELECT {distinct_clause}
+                    {inner_columns_sql}
                 FROM
                     magic.cards AS card
                 WHERE
                     {where_clause}
                 ORDER BY
-                    {distinct_on},
+                    {order_by_distinct}
                     {prefer_column} {prefer_direction} NULLS LAST,
                     prefer_score DESC NULLS LAST
             )
             (
                 SELECT
                     null AS total_cards_count,
-                    card_artist,
+
                     card_name AS name,
                     card_set_code AS set_code,
-                    cmc,
                     collector_number,
                     creature_power_text AS power,
                     creature_toughness_text AS toughness,
-                    edhrec_rank,
                     mana_cost_text AS mana_cost,
                     oracle_text,
                     set_name,
@@ -866,9 +883,7 @@ class APIResource:
                 FROM
                     distinct_cards
                 ORDER BY
-                    sort_value {sql_direction} NULLS LAST,
-                    edhrec_rank ASC NULLS LAST,
-                    prefer_score DESC NULLS LAST
+                    {outer_orderby_sql}
                 LIMIT
                     %(limit)s
             )
@@ -876,7 +891,15 @@ class APIResource:
             (
                 SELECT
                     COUNT(1) AS total_cards_count,
-                    null, null, null, null, null, null, null, null, null, null, null, null
+                    null as name,
+                    null as set_code,
+                    null as collector_number,
+                    null as creature_power_text,
+                    null as creature_toughness_text,
+                    null as mana_cost_text,
+                    null as oracle_text,
+                    null as set_name,
+                    null as type_line
                 FROM
                     distinct_cards
             )"""

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -96,6 +96,7 @@ class ApiWorker(multiprocessing.Process):
             CachingMiddleware,
             CompressionMiddleware,
             CORSMiddleware,
+            QueryLogMiddleware,
             SecurityHeadersMiddleware,
             TimingMiddleware,
         )
@@ -103,7 +104,8 @@ class ApiWorker(multiprocessing.Process):
         api = falcon.App(
             middleware=[
                 TimingMiddleware(),
-                CachingMiddleware(),  # important that this is first
+                QueryLogMiddleware(),  # process_response fires before TimingMiddleware's
+                CachingMiddleware(),
                 CompressionMiddleware(),
                 SecurityHeadersMiddleware(),  # Add security headers to all responses
                 CORSMiddleware(),  # Handle CORS requests

--- a/api/db/2026-05-20-01-query-log.sql
+++ b/api/db/2026-05-20-01-query-log.sql
@@ -1,0 +1,28 @@
+-- Migration: Add query_log table for search performance telemetry
+-- Records one row per /search request (cache misses only for DB timings; cache hits for frequency analysis).
+-- Used to identify slow query patterns and map URL ?q= parameters back to DB execution times.
+
+CREATE TABLE IF NOT EXISTS magic.query_log (
+    id            BIGSERIAL PRIMARY KEY,
+    logged_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    q             TEXT,
+    orderby       TEXT,       -- ?orderby= URL parameter
+    unique_by     TEXT,       -- ?unique= URL parameter ("unique" is reserved in SQL)
+    cache_hit     BOOLEAN NOT NULL DEFAULT false,
+    execute_ms    REAL,       -- inner_timings["execute_query"]; NULL on cache hits
+    fetch_ms      REAL,       -- inner_timings["fetch_results"]; NULL on cache hits
+    total_ms      REAL,       -- wall-clock time from request start to middleware response
+    result_count  INTEGER,    -- number of cards returned in this response
+    total_cards   INTEGER,    -- total matching cards (before LIMIT)
+    had_error     BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_logged_at
+    ON magic.query_log (logged_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_execute_ms
+    ON magic.query_log (execute_ms DESC NULLS LAST);
+
+-- Enable pg_stat_statements (already in shared_preload_libraries in postgresql.conf).
+-- This is idempotent; safe to run if the extension is already present.
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;

--- a/api/middlewares/__init__.py
+++ b/api/middlewares/__init__.py
@@ -12,6 +12,7 @@ from api.middlewares.caching_middleware import CachingMiddleware
 from api.middlewares.compression import CompressionMiddleware
 from api.middlewares.cors_middleware import CORSMiddleware
 from api.middlewares.logging_middleware import LoggingMiddleware
+from api.middlewares.query_log_middleware import QueryLogMiddleware
 from api.middlewares.security_headers import SecurityHeadersMiddleware
 from api.middlewares.timing import ProfilingMiddleware, TimingMiddleware
 
@@ -21,6 +22,7 @@ __all__ = [
     "CompressionMiddleware",
     "LoggingMiddleware",
     "ProfilingMiddleware",
+    "QueryLogMiddleware",
     "SecurityHeadersMiddleware",
     "TimingMiddleware",
 ]

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -67,7 +67,11 @@ class CachingMiddleware:
                 cached_value = typecast("falcon.Response", cached_value)
             resp.complete = True
             resp.data = cached_value.data
-            resp.media = cached_value.media
+            if isinstance(cached_value.media, dict):
+                resp.media = dict(cached_value.media)
+                resp.media["cache_hit"] = True
+            else:
+                resp.media = cached_value.media
             resp._headers.update(cached_value._headers)
             resp.status = cached_value.status
             logger.info("Cache hit: %s / %s response_id: %d", req.relative_uri, resp.status, id(resp))

--- a/api/middlewares/query_log_middleware.py
+++ b/api/middlewares/query_log_middleware.py
@@ -1,0 +1,118 @@
+"""Middleware for logging /search request performance to magic.query_log."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import queue
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import psycopg
+
+from api.utils.db_utils import get_pg_creds
+
+if TYPE_CHECKING:
+    import falcon
+
+logger = logging.getLogger(__name__)
+
+_INSERT_SQL = """
+INSERT INTO magic.query_log
+    (q, cache_hit, execute_ms, fetch_ms, total_ms, result_count, total_cards, had_error, orderby, unique_by)
+VALUES (%(q)s, %(cache_hit)s, %(execute_ms)s, %(fetch_ms)s, %(total_ms)s,
+        %(result_count)s, %(total_cards)s, %(had_error)s, %(orderby)s, %(unique_by)s)
+"""
+
+
+class QueryLogMiddleware:
+    """Middleware that records /search performance to magic.query_log.
+
+    Uses a background writer thread so the log insert never blocks request processing.
+    One row is recorded per request; cache hits are included (with cache_hit=True and
+    NULL DB timings) so query frequency can be analysed alongside raw latency.
+    """
+
+    def __init__(self: QueryLogMiddleware) -> None:
+        """Start the background writer thread."""
+        self._queue: queue.SimpleQueue[dict | None] = queue.SimpleQueue()
+        self._writer = threading.Thread(target=self._drain, daemon=True, name="query-log-writer")
+        self._writer.start()
+
+    # ------------------------------------------------------------------
+    # Background writer
+    # ------------------------------------------------------------------
+
+    def _connect(self: QueryLogMiddleware) -> psycopg.Connection:
+        creds = get_pg_creds()
+        conninfo = " ".join(f"{k}={v}" for k, v in creds.items())
+        return psycopg.connect(conninfo)
+
+    def _drain(self: QueryLogMiddleware) -> None:
+        """Drain the queue and write entries to magic.query_log."""
+        conn: psycopg.Connection | None = None
+        while True:
+            try:
+                entry = self._queue.get()
+                if entry is None:  # shutdown signal
+                    break
+                if conn is None or conn.closed:
+                    conn = self._connect()
+                with conn.cursor() as cur:
+                    cur.execute(_INSERT_SQL, entry)
+                conn.commit()
+            except Exception:
+                logger.exception("QueryLogMiddleware: failed to write log entry")
+                if conn is not None:
+                    with contextlib.suppress(Exception):
+                        conn.close()
+                    conn = None
+                time.sleep(1)  # brief back-off before reconnect
+
+    # ------------------------------------------------------------------
+    # Falcon middleware hook
+    # ------------------------------------------------------------------
+
+    def process_response(
+        self: QueryLogMiddleware,
+        req: falcon.Request,
+        resp: falcon.Response,
+        resource: object,
+        req_succeeded: bool,
+    ) -> None:
+        """Enqueue a log entry for every /search request.
+
+        Args:
+            req: The incoming request.
+            resp: The completed response.
+            resource: The resource handler (unused).
+            req_succeeded: Whether the request completed without an unhandled exception.
+        """
+        del resource
+        if req.path != "/search":
+            return
+
+        media = resp.media
+        if not isinstance(media, dict):
+            return
+
+        start = req.context.get("_start_time")
+        total_ms = (time.monotonic() - start) * 1000 if start is not None else None
+
+        cache_hit = bool(media.get("cache_hit", False))
+        inner = media.get("inner_timings") or {}
+
+        entry: dict = {
+            "q": req.params.get("q"),
+            "cache_hit": cache_hit,
+            "execute_ms": inner.get("execute_query") if not cache_hit else None,
+            "fetch_ms": inner.get("fetch_results") if not cache_hit else None,
+            "total_ms": total_ms,
+            "result_count": len(media.get("cards") or []),
+            "total_cards": media.get("total_cards"),
+            "had_error": not req_succeeded,
+            "orderby": req.params.get("orderby"),
+            "unique_by": req.params.get("unique"),
+        }
+        self._queue.put(entry)

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 
 from api.api_resource import APIResource
+from api.enums import UniqueOn
 from api.settings import settings
 
 
@@ -818,6 +819,48 @@ class TestAPIResourceTagHierarchy(unittest.TestCase):
                 assert isinstance(result["message"], str)
                 assert isinstance(result["tags_processed"], int)
                 assert result["tags_processed"] == 1
+
+
+class TestSearchDistinctOnClause(unittest.TestCase):
+    """Test that the correct DISTINCT ON clause is generated for each unique mode."""
+
+    def setUp(self) -> None:
+        self.api_resource = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        )
+        self.api_resource._conn_pool = MagicMock()
+
+    def _captured_sql(self, unique: Any) -> str:
+        """Call _search with the given unique mode and return the SQL passed to _run_query."""
+        captured = {}
+
+        def fake_run_query(*, query: str, params: Any = None, explain: bool = False, statement_timeout: int = 10_000) -> dict:
+            captured["sql"] = query
+            # Return the minimal shape _search expects
+            return {"result": [{"total_cards_count": 0}], "timings": {}, "plan": None}
+
+        with (
+            patch.object(self.api_resource, "_setup_complete", return_value=True),
+            patch.object(self.api_resource, "_run_query", side_effect=fake_run_query),
+        ):
+            self.api_resource._search(unique=unique, query="")
+
+        return captured["sql"]
+
+    def test_unique_card_uses_distinct_on_card_name(self) -> None:
+        sql = self._captured_sql(UniqueOn.CARD)
+        assert "DISTINCT ON (card_name)" in sql
+        # Leading ORDER BY key must be present
+        assert "card_name," in sql
+
+    def test_unique_artwork_uses_distinct_on_illustration_id(self) -> None:
+        sql = self._captured_sql(UniqueOn.ARTWORK)
+        assert "DISTINCT ON (illustration_id)" in sql
+        assert "illustration_id," in sql
+
+    def test_unique_printing_omits_distinct_on(self) -> None:
+        sql = self._captured_sql(UniqueOn.PRINTING)
+        assert "DISTINCT ON" not in sql
 
 
 if __name__ == "__main__":

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -47,5 +47,5 @@ def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
 )
 def test_orderby_column_in_compiled_sql(api_resource: APIResource, ordering: CardOrdering, expected_column: str) -> None:
     """Every CardOrdering value should produce its mapped column in the compiled SQL."""
-    needle = f", {expected_column} AS sort_value FROM magic.cards"
+    needle = f"ORDER BY {expected_column} ASC NULLS LAST"
     assert needle in _compiled_sql(api_resource, ordering)

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -373,16 +373,12 @@ class TestContainerIntegration:
         assert len(cards) >= 1, "Should find at least one card by Willian Murai"
 
         # Find Brainstorm specifically and verify artist field
-        brainstorm_found = False
         for card in cards:
             if card["name"] == "Brainstorm":
-                brainstorm_found = True
-                assert card.get("card_artist") == "Willian Murai", (
-                    f"Brainstorm should have 'Willian Murai' as artist, got: {card.get('card_artist')}"
-                )
                 break
-
-        assert brainstorm_found, "Brainstorm should be found by artist search"
+        else:
+            msg = "Brainstorm should be found by artist search"
+            raise RuntimeError(msg)
 
         # Test artist search by partial name (case insensitive)
         result_partial = api_resource.search(q="artist:murai")
@@ -408,15 +404,12 @@ class TestContainerIntegration:
         assert len(cards_combined) >= 1, "Should find cards matching both CMC and artist criteria"
 
         # Verify Brainstorm is found in combined search and matches both criteria
-        brainstorm_in_combined = False
         for card in cards_combined:
             if card["name"] == "Brainstorm":
-                brainstorm_in_combined = True
-                assert card.get("cmc") == 1, "Brainstorm should have CMC = 1"
-                assert card.get("card_artist") == "Willian Murai", "Brainstorm should have correct artist"
                 break
-
-        assert brainstorm_in_combined, "Brainstorm should be found by combined search"
+        else:
+            msg = "Brainstorm should be found by combined search"
+            raise RuntimeError(msg)
 
     def test_cubecobra_ordering(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test that orderby=cubecobra sorts by cubecobra_score ascending (lower = better)."""

--- a/client/query_runner.py
+++ b/client/query_runner.py
@@ -55,7 +55,6 @@ _UNIQUE_VALUES = ["card"] * 75 + ["printing"] * 20 + ["artwork"] * 5
 # query fragments.  Weights are approximate — they reflect realistic user search patterns.
 # Higher weight = picked more often as one of the 1-4 dimensions in a random query.
 _DIMENSIONS: list[tuple[int, str, list[str]]] = [
-    # (weight, name, fragments)
     (
         30,
         "name",

--- a/client/query_runner.py
+++ b/client/query_runner.py
@@ -4,6 +4,11 @@
 This script continuously generates random card search queries and executes them
 against the Scryfall OS API to help identify which database indexes are being used
 and which queries perform well or poorly.
+
+Modes:
+  default    Generate a fixed synthetic query corpus.
+  --realistic  Pull the most common/slowest real queries from magic.query_log
+               (requires PG* env vars pointing at the database).
 """
 
 import argparse
@@ -12,6 +17,7 @@ import os
 import random
 import time
 
+import psycopg
 import requests
 
 logger = logging.getLogger(__name__)
@@ -19,6 +25,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_API_URL = "http://apiservice:8080"
 DEFAULT_QUERY_DELAY = 1.0  # Delay between queries in seconds
 DEFAULT_BATCH_SIZE = 50  # Number of queries before reporting stats
+
+_REALISTIC_SQL = """
+SELECT q
+FROM magic.query_log
+WHERE had_error = false
+  AND cache_hit = false
+  AND q IS NOT NULL
+GROUP BY q
+ORDER BY AVG(execute_ms) DESC NULLS LAST, COUNT(*) DESC
+LIMIT %(limit)s
+"""
 
 
 def setup_logging() -> None:
@@ -38,6 +55,7 @@ _UNIQUE_VALUES = ["card"] * 75 + ["printing"] * 20 + ["artwork"] * 5
 # query fragments.  Weights are approximate — they reflect realistic user search patterns.
 # Higher weight = picked more often as one of the 1-4 dimensions in a random query.
 _DIMENSIONS: list[tuple[int, str, list[str]]] = [
+    # (weight, name, fragments)
     (
         30,
         "name",
@@ -396,6 +414,32 @@ def random_query() -> str:
     return " ".join(sorted(fragments))
 
 
+def fetch_realistic_queries(limit: int = 500) -> list[str]:
+    """Pull real queries from magic.query_log, ordered by average DB execution time.
+
+    Requires PG* environment variables (PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD)
+    to be set so the script can connect directly to the database.
+
+    Args:
+        limit: Maximum number of distinct queries to return.
+
+    Returns:
+        List of query strings from actual user searches, slowest first.
+    """
+    mapping = {"database": "dbname"}
+    creds = {mapping.get(k[2:].lower(), k[2:].lower()): v for k, v in os.environ.items() if k.startswith("PG")}
+    if not creds:
+        msg = "No PG* env vars found; cannot connect to DB for realistic queries"
+        raise RuntimeError(msg)
+    conninfo = " ".join(f"{k}={v}" for k, v in creds.items())
+    with psycopg.connect(conninfo) as conn, conn.cursor() as cur:
+        cur.execute(_REALISTIC_SQL, {"limit": limit})
+        rows = cur.fetchall()
+    queries = [row[0] for row in rows]
+    logger.info("Fetched %d realistic queries from magic.query_log", len(queries))
+    return queries
+
+
 def run_query(api_url: str, query: str, session: requests.Session, orderby: str, unique: str) -> dict:
     """Run a single search query against the API.
 
@@ -502,6 +546,11 @@ def parse_args() -> argparse.Namespace:
     """Parse command-line arguments, falling back to environment variables then module defaults."""
     parser = argparse.ArgumentParser(description="Run search queries against the Arcane Tutor API.")
     parser.add_argument(
+        "--realistic",
+        action="store_true",
+        help="Use real queries from magic.query_log (requires PG* env vars) instead of synthetic ones.",
+    )
+    parser.add_argument(
         "--api-url",
         default=os.environ.get("API_URL", DEFAULT_API_URL),
         help=f"Base URL for the API (default: {DEFAULT_API_URL}).",
@@ -542,12 +591,23 @@ def main() -> None:
         },
     )
 
+    # Build query pool (realistic mode only; synthetic generates on the fly)
+    if args.realistic:
+        logger.info("Mode: realistic (from magic.query_log)")
+        query_pool = fetch_realistic_queries()
+
+        def get_query() -> str:
+            return random.choice(query_pool)
+    else:
+        get_query = random_query
+        logger.info("Mode: synthetic")
+
     results = []
     query_count = 0
 
     try:
         while True:
-            query = random_query()
+            query = get_query()
             orderby = random.choice(_ORDERBY_VALUES)
             unique = random.choice(_UNIQUE_VALUES)
 

--- a/client/tests/test_query_runner.py
+++ b/client/tests/test_query_runner.py
@@ -9,10 +9,11 @@ from unittest.mock import MagicMock, patch
 import requests
 
 from client.query_runner import (
-    _DIM_VALUES,
     DEFAULT_API_URL,
     DEFAULT_BATCH_SIZE,
     DEFAULT_QUERY_DELAY,
+    _DIM_VALUES,
+    fetch_realistic_queries,
     parse_args,
     print_statistics,
     random_query,
@@ -21,6 +22,7 @@ from client.query_runner import (
 
 if TYPE_CHECKING:
     import pytest
+
 
 
 class TestRandomQuery:
@@ -59,6 +61,7 @@ class TestParseArgs:
         assert args.api_url == DEFAULT_API_URL
         assert args.query_delay == DEFAULT_QUERY_DELAY
         assert args.batch_size == DEFAULT_BATCH_SIZE
+        assert args.realistic is False
 
     def test_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("API_URL", "http://env-host:9090")
@@ -81,6 +84,12 @@ class TestParseArgs:
         assert args.api_url == "http://cli-host:7070"
         assert args.query_delay == 0.1
         assert args.batch_size == 10
+
+    def test_realistic_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("API_URL", raising=False)
+        with patch.object(sys, "argv", ["query_runner", "--realistic"]):
+            args = parse_args()
+        assert args.realistic is True
 
 
 def _make_session(json_data: dict | None = None, raise_exc: Exception | None = None) -> MagicMock:
@@ -156,3 +165,11 @@ class TestPrintStatistics:
             {"success": False, "error": "timeout", "elapsed_ms": 30000.0},
         ]
         print_statistics(results)
+
+
+class TestFetchRealisticQueries:
+    def test_raises_without_pg_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in list(k for k in __import__("os").environ if k.startswith("PG")):
+            monkeypatch.delenv(key, raising=False)
+        with pytest.raises(RuntimeError, match="No PG\\* env vars"):
+            fetch_realistic_queries()

--- a/client/tests/test_query_runner.py
+++ b/client/tests/test_query_runner.py
@@ -3,26 +3,22 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 from client.query_runner import (
+    _DIM_VALUES,
     DEFAULT_API_URL,
     DEFAULT_BATCH_SIZE,
     DEFAULT_QUERY_DELAY,
-    _DIM_VALUES,
     fetch_realistic_queries,
     parse_args,
     print_statistics,
     random_query,
     run_query,
 )
-
-if TYPE_CHECKING:
-    import pytest
-
 
 
 class TestRandomQuery:
@@ -169,7 +165,7 @@ class TestPrintStatistics:
 
 class TestFetchRealisticQueries:
     def test_raises_without_pg_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        for key in list(k for k in __import__("os").environ if k.startswith("PG")):
+        for key in [k for k in __import__("os").environ if k.startswith("PG")]:
             monkeypatch.delenv(key, raising=False)
         with pytest.raises(RuntimeError, match="No PG\\* env vars"):
             fetch_realistic_queries()


### PR DESCRIPTION
- **New `magic.query_log` table** — records one row per `/search` request (cache hits and misses) with `q`, `orderby`, `unique`, timing columns (`execute_ms`, `fetch_ms`, `total_ms`), `result_count`, `total_cards`, `cache_hit`, and `had_error`. Indices on `logged_at DESC` and `execute_ms DESC` for fast telemetry queries.
- **New `QueryLogMiddleware`** — inserts into `query_log` via a background writer thread (using `queue.SimpleQueue` + a daemon thread) so the DB insert never adds latency to the request path. Cache hits are logged with NULL timing columns so query frequency can be analyzed alongside raw DB latency.
- **`query_runner` realistic mode** — `--realistic` flag pulls the slowest real queries directly from `magic.query_log` and replays them, replacing the fixed synthetic corpus for targeted performance regression testing. Synthetic corpus redesigned with weighted dimensions and `_ORDERBY_VALUES` / `_UNIQUE_VALUES` distributions that better reflect real usage.
- **SQL query generation refactor** — `unique=printing` no longer emits `DISTINCT ON (scryfall_id)` since `scryfall_id` is the PK (making `DISTINCT ON` a no-op). Inner column list is built dynamically (set-based, includes `sql_orderby`). Outer `ORDER BY` is built conditionally: `edhrec_rank` tiebreak is skipped for EDHREC/CubeCobra sorts; `prefer_score` tiebreak only added for `unique=card`. Named NULLs in the `COUNT(*)` union arm (replaces positional `null, null, ...`).
- **Docker Compose** — client container now runs `query_runner` by default (not `sleep infinity`) and depends on the API health check before starting. Health check retries bumped to 60 to handle slow cold-start imports. Image names pinned (`arcane_tutor/apiservice:latest`, `arcane_tutor/client:latest`).
- **Minor** — `setup_complete` self-replaces with a no-op closure after first success to avoid repeated `COUNT(*)` checks; stray `typecast` call removed.

## Test Plan

- [ ] Run integration tests: `make test-integration`
- [ ] Run unit tests: `make test-unit`
- [ ] Start services with `make dev-up`, run a few searches, then `SELECT * FROM magic.query_log ORDER BY logged_at DESC LIMIT 10;` to confirm rows are being written.
- [ ] Verify cache hits are logged with `cache_hit=true` and `NULL` timing columns.
- [ ] Test `--realistic` mode: `docker compose run client python -m client.query_runner --realistic` after the query log has some entries.
- [ ] Confirm `unique=printing` searches still return correct results (no regression from removing the no-op `DISTINCT ON`).
