### PR TITLE
Use a Bitmap for Color Identity Subset Queries

### DIFF
--- a/api/db/2026-05-19-01-color-identity-mask.sql
+++ b/api/db/2026-05-19-01-color-identity-mask.sql
@@ -1,0 +1,17 @@
+-- color_identity_mask(jsonb) encodes color identity as a 5-bit integer (W=16, U=8, B=4, R=2, G=1).
+-- The expression index lets the planner serve id: / id<= / id< queries via = ANY(subset_array)
+-- point lookups instead of a full seq scan against the unindexable <@ JSONB containment direction.
+
+CREATE OR REPLACE FUNCTION magic.color_identity_mask(jsonb)
+RETURNS smallint LANGUAGE sql IMMUTABLE STRICT AS $$
+    SELECT (
+        CASE WHEN $1 ? 'W' THEN 16 ELSE 0 END +
+        CASE WHEN $1 ? 'U' THEN  8 ELSE 0 END +
+        CASE WHEN $1 ? 'B' THEN  4 ELSE 0 END +
+        CASE WHEN $1 ? 'R' THEN  2 ELSE 0 END +
+        CASE WHEN $1 ? 'G' THEN  1 ELSE 0 END
+    )::smallint
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_cards_color_identity_mask
+    ON magic.cards (magic.color_identity_mask(card_color_identity));

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -194,11 +194,11 @@ def _color_dict_to_mask(color_dict: dict[str, bool]) -> int:
 
 
 def _subset_masks(query_mask: int) -> list[int]:
-    return [v for v in range(32) if (v & ~query_mask) == 0]
+    return [v for v in range(32) if (v & ~query_mask) == 0]  # 5 colors => 2^5 possible bitmask values
 
 
 def _proper_subset_masks(query_mask: int) -> list[int]:
-    return [v for v in range(32) if (v & ~query_mask) == 0 and v != query_mask]
+    return [v for v in range(32) if (v & ~query_mask) == 0 and v != query_mask]  # 5 colors => 2^5 possible bitmask values
 
 
 def get_colors_comparison_object(val: str) -> dict[str, bool]:

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -901,12 +901,12 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
                 subsets = IntArray(_subset_masks(_color_dict_to_mask(rhs)))
                 pmask = param_name(subsets)
                 context[pmask] = subsets
-                return f"(magic.color_identity_mask(card.card_color_identity) = ANY(%({pmask})s))"
+                return f"(magic.color_identity_mask({lhs_sql}) = ANY(%({pmask})s))"
             if is_color_identity and self.operator == "<":
                 subsets = IntArray(_proper_subset_masks(_color_dict_to_mask(rhs)))
                 pmask = param_name(subsets)
                 context[pmask] = subsets
-                return f"(magic.color_identity_mask(card.card_color_identity) = ANY(%({pmask})s))"
+                return f"(magic.color_identity_mask({lhs_sql}) = ANY(%({pmask})s))"
             pname = param_name(rhs)
             context[pname] = rhs
         elif attr == "devotion":

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -901,12 +901,12 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
                 subsets = IntArray(_subset_masks(_color_dict_to_mask(rhs)))
                 pmask = param_name(subsets)
                 context[pmask] = subsets
-                return f"(magic.color_identity_mask({lhs_sql}) = ANY(%({pmask})s))"
+                return f"(magic.color_identity_mask({lhs_sql}) = ANY(%({pmask})s::smallint[]))"
             if is_color_identity and self.operator == "<":
                 subsets = IntArray(_proper_subset_masks(_color_dict_to_mask(rhs)))
                 pmask = param_name(subsets)
                 context[pmask] = subsets
-                return f"(magic.color_identity_mask({lhs_sql}) = ANY(%({pmask})s))"
+                return f"(magic.color_identity_mask({lhs_sql}) = ANY(%({pmask})s::smallint[]))"
             pname = param_name(rhs)
             context[pname] = rhs
         elif attr == "devotion":

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -32,6 +32,7 @@ from api.parsing.nodes import (
     ValueNode,
     param_name,
 )
+from api.utils.db_utils import IntArray
 
 """
 
@@ -183,6 +184,21 @@ class CardAttributeNode(AttributeNode):
             f"field_infos={self.field_infos}"
             ")"
         )
+
+
+_COLOR_BITS: dict[str, int] = {"W": 16, "U": 8, "B": 4, "R": 2, "G": 1}
+
+
+def _color_dict_to_mask(color_dict: dict[str, bool]) -> int:
+    return sum(bit for color, bit in _COLOR_BITS.items() if color_dict.get(color))
+
+
+def _subset_masks(query_mask: int) -> list[int]:
+    return [v for v in range(32) if (v & ~query_mask) == 0]
+
+
+def _proper_subset_masks(query_mask: int) -> list[int]:
+    return [v for v in range(32) if (v & ~query_mask) == 0 and v != query_mask]
 
 
 def get_colors_comparison_object(val: str) -> dict[str, bool]:
@@ -873,17 +889,26 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
     query ?& col AND not(col ?& query) # as array
     """
 
-    def _handle_jsonb_object(self, context: dict) -> str:  # noqa: PLR0912
+    def _handle_jsonb_object(self, context: dict) -> str:  # noqa: PLR0912, PLR0915, C901
         # Produce the query as a jsonb object
         lhs_sql = self.lhs.to_sql(context)
         attr = self.lhs.attribute_name
         is_color_identity = False
         if attr in ("card_colors", "card_color_identity", "produced_mana"):
             rhs = get_colors_comparison_object(self.rhs.value.strip().lower())
+            is_color_identity = attr == "card_color_identity"
+            if is_color_identity and self.operator in (":", "<="):
+                subsets = IntArray(_subset_masks(_color_dict_to_mask(rhs)))
+                pmask = param_name(subsets)
+                context[pmask] = subsets
+                return f"(magic.color_identity_mask(card.card_color_identity) = ANY(%({pmask})s))"
+            if is_color_identity and self.operator == "<":
+                subsets = IntArray(_proper_subset_masks(_color_dict_to_mask(rhs)))
+                pmask = param_name(subsets)
+                context[pmask] = subsets
+                return f"(magic.color_identity_mask(card.card_color_identity) = ANY(%({pmask})s))"
             pname = param_name(rhs)
             context[pname] = rhs
-            # Color identity has inverted semantics for the : operator only
-            is_color_identity = attr == "card_color_identity"
         elif attr == "devotion":
             # Devotion uses mana cost syntax, so we need to convert it to color comparison
             # Extract color codes from mana cost syntax like {G}, {R}{G}, etc.
@@ -922,9 +947,6 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         if self.operator == "=":
             return f"({lhs_sql} = %({pname})s)"
         if self.operator in (">=", ":"):
-            # For color identity, : should behave like <=, but >= should still be >=
-            if is_color_identity and self.operator == ":":
-                return f"({lhs_sql} <@ %({pname})s)"
             return f"({lhs_sql} @> %({pname})s)"
         if self.operator == "<=":
             return f"({lhs_sql} <@ %({pname})s)"

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -145,12 +145,12 @@ def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, 
     argvalues=[
         (
             "color_identity:g",
-            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDFd)s))",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDFd)s::smallint[]))",
             {"p_IntArray_WzAsIDFd": [0, 1]},
         ),  # : uses bitmask subset lookup; G=1, subsets of 1 are [0,1]
         (
             "id:rg",
-            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDNd)s))",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDNd)s::smallint[]))",
             {"p_IntArray_WzAsIDEsIDIsIDNd": [0, 1, 2, 3]},
         ),  # RG mask=3, subsets=[0,1,2,3]
         (
@@ -165,7 +165,7 @@ def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, 
         ),  # >= uses @> against JSONB column (GIN index)
         (
             "color_identity<=rg",
-            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDNd)s))",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDNd)s::smallint[]))",
             {"p_IntArray_WzAsIDEsIDIsIDNd": [0, 1, 2, 3]},
         ),  # <= uses bitmask subset lookup same as :
         (
@@ -175,7 +175,7 @@ def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, 
         ),  # > uses @> against JSONB column (GIN index)
         (
             "id<rg",
-            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDJd)s))",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDJd)s::smallint[]))",
             {"p_IntArray_WzAsIDEsIDJd": [0, 1, 2]},
         ),  # < uses proper subsets; RG mask=3, proper subsets=[0,1,2]
         (
@@ -185,12 +185,12 @@ def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, 
         ),  # colorless identity = {} (empty), not {"C": True}
         (
             "id:c",
-            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s))",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s::smallint[]))",
             {"p_IntArray_WzBd": [0]},
         ),  # colorless mask=0, subsets=[0] — only colorless cards
         (
             "id:colorless",
-            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s))",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s::smallint[]))",
             {"p_IntArray_WzBd": [0]},
         ),  # 'colorless' name resolves to same mask=0
         (

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -3,7 +3,7 @@
 import pytest
 
 from api import parsing
-from api.parsing.card_query_nodes import get_legality_comparison_object
+from api.parsing.card_query_nodes import _color_dict_to_mask, _proper_subset_masks, _subset_masks, get_legality_comparison_object
 from api.parsing.parsing_f import generate_sql_query
 
 
@@ -145,39 +145,39 @@ def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, 
     argvalues=[
         (
             "color_identity:g",
-            r"(card.card_color_identity <@ %(p_dict_eydHJzogVHJ1ZX0)s)",
-            {"p_dict_eydHJzogVHJ1ZX0": {"G": True}},
-        ),  # : maps to <= for color identity
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDFd)s))",
+            {"p_IntArray_WzAsIDFd": [0, 1]},
+        ),  # : uses bitmask subset lookup; G=1, subsets of 1 are [0,1]
         (
             "id:rg",
-            r"(card.card_color_identity <@ %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
-            {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
-        ),  # id is an alias for color_identity
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDNd)s))",
+            {"p_IntArray_WzAsIDEsIDIsIDNd": [0, 1, 2, 3]},
+        ),  # RG mask=3, subsets=[0,1,2,3]
         (
             "identity=rg",
             r"(card.card_color_identity = %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
             {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
-        ),  # = still means equality
+        ),  # = still means JSONB equality
         (
             "coloridentity>=rg",
             r"(card.card_color_identity @> %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
             {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
-        ),  # >= maps to >= (no inversion for >=)
+        ),  # >= uses @> against JSONB column (GIN index)
         (
             "color_identity<=rg",
-            r"(card.card_color_identity <@ %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
-            {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
-        ),  # <= maps to <= (no inversion for <=)
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDNd)s))",
+            {"p_IntArray_WzAsIDEsIDIsIDNd": [0, 1, 2, 3]},
+        ),  # <= uses bitmask subset lookup same as :
         (
             "identity>g",
             r"(card.card_color_identity @> %(p_dict_eydHJzogVHJ1ZX0)s AND card.card_color_identity <> %(p_dict_eydHJzogVHJ1ZX0)s)",
             {"p_dict_eydHJzogVHJ1ZX0": {"G": True}},
-        ),  # > maps to > (no inversion for >)
+        ),  # > uses @> against JSONB column (GIN index)
         (
             "id<rg",
-            r"(card.card_color_identity <@ %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s AND card.card_color_identity <> %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
-            {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
-        ),  # < maps to < (no inversion for <)
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDJd)s))",
+            {"p_IntArray_WzAsIDEsIDJd": [0, 1, 2]},
+        ),  # < uses proper subsets; RG mask=3, proper subsets=[0,1,2]
         (
             "id=c",
             r"(card.card_color_identity = %(p_dict_e30)s)",
@@ -185,14 +185,14 @@ def test_full_sql_translation_jsonb_colors(input_query: str, expected_sql: str, 
         ),  # colorless identity = {} (empty), not {"C": True}
         (
             "id:c",
-            r"(card.card_color_identity <@ %(p_dict_e30)s)",
-            {"p_dict_e30": {}},
-        ),  # colorless: cards whose identity is contained by {} (i.e. only colorless)
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s))",
+            {"p_IntArray_WzBd": [0]},
+        ),  # colorless mask=0, subsets=[0] — only colorless cards
         (
             "id:colorless",
-            r"(card.card_color_identity <@ %(p_dict_e30)s)",
-            {"p_dict_e30": {}},
-        ),  # 'colorless' name resolves to same empty dict
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s))",
+            {"p_IntArray_WzBd": [0]},
+        ),  # 'colorless' name resolves to same mask=0
         (
             "id=colorless",
             r"(card.card_color_identity = %(p_dict_e30)s)",
@@ -1132,3 +1132,54 @@ def test_empty_query_generates_true(query: str | None) -> None:
     sql, params = generate_sql_query(parsing.parse_search_query(query))
     assert sql == "TRUE"
     assert params == {}
+
+
+testcases_color_dict_to_mask = {
+    "colorless": {"color_dict": {}, "expected": 0},
+    "white_only": {"color_dict": {"W": True}, "expected": 16},
+    "red_green": {"color_dict": {"R": True, "G": True}, "expected": 3},
+    "all_five": {"color_dict": {"W": True, "U": True, "B": True, "R": True, "G": True}, "expected": 31},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_color_dict_to_mask.values()))),
+    argvalues=[[v for k, v in sorted(testcases_color_dict_to_mask[t].items())] for t in sorted(testcases_color_dict_to_mask)],
+    ids=sorted(testcases_color_dict_to_mask),
+)
+def test_color_dict_to_mask(color_dict: dict, expected: int) -> None:
+    assert _color_dict_to_mask(color_dict) == expected
+
+
+testcases_subset_masks = {
+    "colorless": {"query_mask": 0, "expected": [0]},
+    "white_only": {"query_mask": 16, "expected": [0, 16]},
+    "red_green": {"query_mask": 3, "expected": [0, 1, 2, 3]},
+    "wub": {"query_mask": 28, "expected": [0, 4, 8, 12, 16, 20, 24, 28]},
+    "all_five": {"query_mask": 31, "expected": list(range(32))},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_subset_masks.values()))),
+    argvalues=[[v for k, v in sorted(testcases_subset_masks[t].items())] for t in sorted(testcases_subset_masks)],
+    ids=sorted(testcases_subset_masks),
+)
+def test_subset_masks(query_mask: int, expected: list[int]) -> None:
+    assert _subset_masks(query_mask) == expected
+
+
+testcases_proper_subset_masks = {
+    "colorless": {"query_mask": 0, "expected": []},
+    "white_only": {"query_mask": 16, "expected": [0]},
+    "red_green": {"query_mask": 3, "expected": [0, 1, 2]},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_proper_subset_masks.values()))),
+    argvalues=[[v for k, v in sorted(testcases_proper_subset_masks[t].items())] for t in sorted(testcases_proper_subset_masks)],
+    ids=sorted(testcases_proper_subset_masks),
+)
+def test_proper_subset_masks(query_mask: int, expected: list[int]) -> None:
+    assert _proper_subset_masks(query_mask) == expected

--- a/api/utils/db_utils.py
+++ b/api/utils/db_utils.py
@@ -151,7 +151,7 @@ class IntArray(list):
 
 
 def maybe_json(v: object) -> object:
-    """Wrap a value in a Jsonb object if it is a list or dict."""
+    """Wrap plain list/dict values in Jsonb, but pass IntArray through unchanged."""
     if isinstance(v, IntArray):
         return v
     if isinstance(v, list | dict):

--- a/api/utils/db_utils.py
+++ b/api/utils/db_utils.py
@@ -146,8 +146,14 @@ def get_migrations() -> list[dict[str, str]]:
     return migrations
 
 
+class IntArray(list):
+    """A list that psycopg sends as a native PostgreSQL integer array, not JSONB."""
+
+
 def maybe_json(v: object) -> object:
     """Wrap a value in a Jsonb object if it is a list or dict."""
+    if isinstance(v, IntArray):
+        return v
     if isinstance(v, list | dict):
         return psycopg.types.json.Jsonb(v)
     return v

--- a/makefile
+++ b/makefile
@@ -160,9 +160,9 @@ dockerclean:
 dbconn-%:
 	test -f ~/.psqlrc || touch ~/.psqlrc
 	test -f ~/.psql_history || touch ~/.psql_history
-	docker compose --project-name arcane_$* --env-file .env --env-file envs/$* --file $(BASE_COMPOSE) \
+	cd $(GIT_ROOT) && docker compose --project-name arcane_$* --env-file .env --env-file envs/$* --file $(BASE_COMPOSE) \
 	  exec -e PSQLRC=/var/lib/postgresql/.psqlrc -e PSQL_HISTORY=/var/lib/postgresql/.psql_history \
-	  postgres psql -U $(XPGUSER) -d $(XPGDATABASE)
+	  postgres psql -U $(XPGUSER) -d $(XPGDATABASE) --host=localhost
 
 reset-%:
 	docker compose --project-name arcane_$* --env-file .env --env-file envs/$* --file $(BASE_COMPOSE) down --volumes --remove-orphans


### PR DESCRIPTION
## Summary

Color identity `:` / `<=` / `<` queries previously used JSONB `<@` containment against `card.card_color_identity`. The problem: `<@` in this direction (card's identity must be contained *by* the query) cannot be served by a GIN index, so every such query fell back to a full sequential scan.

This PR replaces those cases with a bitmask-based `= ANY(array)` lookup backed by an expression index.

## How it works

A new SQL function `magic.color_identity_mask(jsonb)` encodes color identity as a 5-bit integer (W=16, U=8, B=4, R=2, G=1). An expression index on that function is created on `magic.cards`.

At query time, the Python layer precomputes the full set of valid bitmask values (all subsets of the query mask) and emits:

```sql
magic.color_identity_mask(card.card_color_identity) = ANY(%(mask_array)s)
```

The planner can serve this with a B-tree index scan against the expression index rather than a seq scan.

- `:` and `<=` → `_subset_masks()` (all masks where `v & ~query == 0`)
- `<` → `_proper_subset_masks()` (same, excluding the query mask itself)
- `=`, `>=`, `>` — unchanged, still use JSONB `@>` / `<@` against the GIN index

## Changes

- [api/db/2026-05-19-01-color-identity-mask.sql](api/db/2026-05-19-01-color-identity-mask.sql) — new `color_identity_mask` function and expression index
- [api/parsing/card_query_nodes.py](api/parsing/card_query_nodes.py) — bitmap helpers + updated `_handle_jsonb_object` to route `:`, `<=`, `<` through the new path
- [api/utils/db_utils.py](api/utils/db_utils.py) — `IntArray` subclass so psycopg sends integer arrays as native arrays rather than JSONB
- [api/parsing/tests/test_sql_gen.py](api/parsing/tests/test_sql_gen.py) — updated SQL snapshot tests + unit tests for the three helper functions