### PR TITLE
Replace ILIKE with lower() LIKE for text pattern matching

### DIFF
--- a/api/db/2026-05-20-02-lower-trgm-indexes.sql
+++ b/api/db/2026-05-20-02-lower-trgm-indexes.sql
@@ -1,0 +1,22 @@
+-- Replace ILIKE trigram indexes with lower() functional indexes.
+-- lower() LIKE has much lower planning overhead than ILIKE because PostgreSQL's
+-- LIKE selectivity estimator is cheaper than the case-folding ILIKE estimator.
+
+CREATE INDEX IF NOT EXISTS idx_cards_oracle_text_lower_trgm
+    ON magic.cards USING gin (lower(oracle_text) magic.gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_cards_cardname_lower_trgm
+    ON magic.cards USING gin (lower(card_name) magic.gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_cards_artist_lower_trgm
+    ON magic.cards USING gin (lower(card_artist) magic.gin_trgm_ops)
+    WHERE card_artist IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cards_flavor_text_lower_trgm
+    ON magic.cards USING gin (lower(flavor_text) magic.gin_trgm_ops)
+    WHERE flavor_text IS NOT NULL;
+
+DROP INDEX IF EXISTS magic.idx_cards_oracle_text_trgm;
+DROP INDEX IF EXISTS magic.idx_cards_cardname_trgm;
+DROP INDEX IF EXISTS magic.idx_cards_artist_trgm;
+DROP INDEX IF EXISTS magic.idx_cards_flavor_text_trgm;

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -438,6 +438,11 @@ def calculate_devotion(mana_cost_str: str) -> dict:
     return {color: color_devotion for color, color_devotion in devotion.items() if color_devotion}
 
 
+def _escape_like_pattern(value: str) -> str:
+    # Backslash must be escaped first; otherwise the \ added for % and _ would be re-escaped.
+    return value.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+
+
 class ExactNameNode(QueryNode):
     """Represents an exact card name search using the ! prefix syntax from Scryfall.
 
@@ -451,10 +456,10 @@ class ExactNameNode(QueryNode):
     def to_sql(self, context: dict) -> str:
         """Generate SQL for exact name matching (case-insensitive, no wildcards).
 
-        LIKE wildcard characters (% and _) are escaped so the value is matched
+        LIKE special characters (backslash, %, _) are escaped so the value is matched
         literally rather than as a pattern.
         """
-        escaped = self.value.lower().replace("%", r"\%").replace("_", r"\_")
+        escaped = _escape_like_pattern(self.value.lower())
         _param_name = param_name(escaped)
         context[_param_name] = escaped
         return f"(lower(card.card_name) LIKE %({_param_name})s)"
@@ -859,7 +864,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         else:
             msg = f"Unknown type: {type(self.rhs)}, {locals()}"
             raise TypeError(msg)
-        words = ["", *txt_val.lower().split(), ""]
+        words = ["", *(_escape_like_pattern(w) for w in txt_val.lower().split()), ""]
         pattern = "%".join(words)
         _param_name = param_name(pattern)
         context[_param_name] = pattern

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -451,14 +451,13 @@ class ExactNameNode(QueryNode):
     def to_sql(self, context: dict) -> str:
         """Generate SQL for exact name matching (case-insensitive, no wildcards).
 
-        ILIKE wildcard characters (% and _) are escaped so the value is matched
+        LIKE wildcard characters (% and _) are escaped so the value is matched
         literally rather than as a pattern.
         """
-        # Escape ILIKE special characters so the search is truly exact
-        escaped = self.value.replace("%", r"\%").replace("_", r"\_")
+        escaped = self.value.lower().replace("%", r"\%").replace("_", r"\_")
         _param_name = param_name(escaped)
         context[_param_name] = escaped
-        return f"(card.card_name ILIKE %({_param_name})s)"
+        return f"(lower(card.card_name) LIKE %({_param_name})s)"
 
     def __repr__(self) -> str:
         """Return a string representation of the ExactNameNode."""
@@ -853,7 +852,6 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             # Use PostgreSQL ~* operator for case-insensitive regex matching
             return f"({lhs_sql} ~* %({_param_name})s)"
 
-        # Regular text pattern matching with ILIKE
         if isinstance(self.rhs, StringValueNode | ManaValueNode):
             txt_val = self.rhs.value.strip()
         elif isinstance(self.rhs, str):
@@ -861,11 +859,11 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         else:
             msg = f"Unknown type: {type(self.rhs)}, {locals()}"
             raise TypeError(msg)
-        words = ["", *txt_val.split(), ""]
+        words = ["", *txt_val.lower().split(), ""]
         pattern = "%".join(words)
         _param_name = param_name(pattern)
         context[_param_name] = pattern
-        return f"({lhs_sql} ILIKE %({_param_name})s)"
+        return f"(lower({lhs_sql}) LIKE %({_param_name})s)"
 
     """
     col = query

--- a/api/parsing/tests/test_exact_name_search.py
+++ b/api/parsing/tests/test_exact_name_search.py
@@ -63,18 +63,18 @@ def test_exact_name_combined_with_other_conditions(query: str) -> None:
     argvalues=[
         (
             '!"Lightning Bolt"',
-            "(card.card_name ILIKE %(p_str_TGlnaHRuaW5nIEJvbHQ)s)",
-            {"p_str_TGlnaHRuaW5nIEJvbHQ": "Lightning Bolt"},
+            "(lower(card.card_name) LIKE %(p_str_bGlnaHRuaW5nIGJvbHQ)s)",
+            {"p_str_bGlnaHRuaW5nIGJvbHQ": "lightning bolt"},
         ),
         (
             "!bolt",
-            "(card.card_name ILIKE %(p_str_Ym9sdA)s)",
+            "(lower(card.card_name) LIKE %(p_str_Ym9sdA)s)",
             {"p_str_Ym9sdA": "bolt"},
         ),
         (
             '-!"Lightning Bolt"',
-            "NOT ((card.card_name ILIKE %(p_str_TGlnaHRuaW5nIEJvbHQ)s))",
-            {"p_str_TGlnaHRuaW5nIEJvbHQ": "Lightning Bolt"},
+            "NOT ((lower(card.card_name) LIKE %(p_str_bGlnaHRuaW5nIGJvbHQ)s))",
+            {"p_str_bGlnaHRuaW5nIGJvbHQ": "lightning bolt"},
         ),
     ],
 )

--- a/api/parsing/tests/test_layout_border_sql_generation.py
+++ b/api/parsing/tests/test_layout_border_sql_generation.py
@@ -43,16 +43,18 @@ class TestLayoutBorderSQLGeneration:
         assert param_value == expected_value
         assert "%" not in param_value  # No wildcards
 
-    def test_name_search_still_uses_ilike_pattern_matching(self) -> None:
-        """Test that regular text fields like name still use ILIKE pattern matching."""
+    def test_name_search_uses_lower_like_pattern_matching(self) -> None:
+        """Test that regular text fields like name use lower() LIKE pattern matching."""
         result = parse_scryfall_query("name:lightning")
         assert isinstance(result, Query)
 
         context: dict[str, Any] = {}
         sql = result.to_sql(context)
 
-        # Should generate ILIKE pattern matching
-        assert "ILIKE" in sql
+        # Should generate lower() LIKE pattern matching
+        assert "lower(" in sql
+        assert "LIKE" in sql
+        assert "ILIKE" not in sql
         assert "card.card_name" in sql
 
         # Context should contain wildcards

--- a/api/parsing/tests/test_like_escaping.py
+++ b/api/parsing/tests/test_like_escaping.py
@@ -1,0 +1,98 @@
+"""Tests for LIKE pattern escaping to prevent wildcard injection."""
+
+import pytest
+
+from api.parsing import parse_scryfall_query
+from api.parsing.card_query_nodes import ExactNameNode, _escape_like_pattern
+
+# ---------------------------------------------------------------------------
+# _escape_like_pattern unit tests
+# ---------------------------------------------------------------------------
+
+testcases_helper = {
+    "backslash_escaped": {"value": "a\\b", "expected": "a\\\\b"},
+    "backslash_before_percent_both_escaped": {"value": "\\%", "expected": r"\\\%"},
+    "all_three_special_chars": {"value": "a\\_b%", "expected": r"a\\\_b\%"},
+    "percent_escaped": {"value": "50%", "expected": r"50\%"},
+    "plain_text_unchanged": {"value": "lightning", "expected": "lightning"},
+    "underscore_escaped": {"value": "a_b", "expected": r"a\_b"},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_helper.values()))),
+    argvalues=[[v for k, v in sorted(testcases_helper[tc].items())] for tc in sorted(testcases_helper)],
+    ids=sorted(testcases_helper),
+)
+def test_escape_like_pattern(expected: str, value: str) -> None:
+    """_escape_like_pattern produces correctly escaped LIKE patterns."""
+    assert _escape_like_pattern(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# ExactNameNode — special characters are escaped literally (no wildcard bleed)
+# ---------------------------------------------------------------------------
+
+testcases_exact_name = {
+    "percent_does_not_become_wildcard": {
+        "input_value": "50%",
+        "expected_param": r"50\%",
+    },
+    "underscore_does_not_match_any_char": {
+        "input_value": "A_B",
+        "expected_param": r"a\_b",
+    },
+    "backslash_does_not_corrupt_escape_sequence": {
+        "input_value": "A\\B",
+        "expected_param": "a\\\\b",
+    },
+    "backslash_then_percent_both_escaped": {
+        "input_value": "\\%",
+        "expected_param": r"\\\%",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_exact_name.values()))),
+    argvalues=[[v for k, v in sorted(testcases_exact_name[tc].items())] for tc in sorted(testcases_exact_name)],
+    ids=sorted(testcases_exact_name),
+)
+def test_exact_name_node_escapes_special_chars(expected_param: str, input_value: str) -> None:
+    """ExactNameNode escapes backslash, % and _ so they never act as LIKE wildcards."""
+    context: dict = {}
+    node = ExactNameNode(input_value)
+    node.to_sql(context)
+    assert list(context.values()) == [expected_param]
+
+
+# ---------------------------------------------------------------------------
+# Pattern matching (name:, oracle:, etc.) — special chars inside words are escaped
+# but the surrounding % wildcards are preserved.
+# Note: the query parser consumes backslashes, so backslash is not reachable via
+# this path; it is covered by test_escape_like_pattern above.
+# ---------------------------------------------------------------------------
+
+testcases_pattern = {
+    "percent_in_search_term_escaped_inside_wildcards": {
+        "query": 'name:"50%"',
+        "expected_param": r"%50\%%",
+    },
+    "underscore_in_search_term_escaped_inside_wildcards": {
+        "query": 'name:"a_b"',
+        "expected_param": r"%a\_b%",
+    },
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_pattern.values()))),
+    argvalues=[[v for k, v in sorted(testcases_pattern[tc].items())] for tc in sorted(testcases_pattern)],
+    ids=sorted(testcases_pattern),
+)
+def test_pattern_matching_escapes_special_chars(expected_param: str, query: str) -> None:
+    """Pattern-matching queries escape % and _ so they never act as LIKE wildcards."""
+    parsed = parse_scryfall_query(query)
+    context: dict = {}
+    parsed.to_sql(context)
+    assert list(context.values()) == [expected_param]

--- a/api/parsing/tests/test_regex_patterns.py
+++ b/api/parsing/tests/test_regex_patterns.py
@@ -129,13 +129,15 @@ class TestRegexSQLGeneration:
         # Should have two parameters
         assert len(params) == 2
 
-    def test_regular_text_search_still_uses_ilike(self) -> None:
-        """Test that regular text searches still use ILIKE, not regex."""
+    def test_regular_text_search_uses_lower_like(self) -> None:
+        """Test that regular text searches use lower() LIKE, not regex."""
         result = parsing.parse_scryfall_query("name:lightning")
         sql, params = generate_sql_query(result)
 
-        # Should use ILIKE pattern matching, not regex
-        assert "ILIKE" in sql
+        # Should use lower() LIKE pattern matching, not regex
+        assert "lower(" in sql
+        assert "LIKE" in sql
+        assert "ILIKE" not in sql
         assert "~*" not in sql
 
         # Should have wildcards in the parameter

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -28,12 +28,12 @@ from api.parsing.parsing_f import generate_sql_query
         # Test field-specific : operator behavior
         (
             "name:lightning",
-            r"(card.card_name ILIKE %(p_str_JWxpZ2h0bmluZyU)s)",
+            r"(lower(card.card_name) LIKE %(p_str_JWxpZ2h0bmluZyU)s)",
             {"p_str_JWxpZ2h0bmluZyU": r"%lightning%"},
         ),
         (
             "name:'lightning bolt'",
-            r"(card.card_name ILIKE %(p_str_JWxpZ2h0bmluZyVib2x0JQ)s)",
+            r"(lower(card.card_name) LIKE %(p_str_JWxpZ2h0bmluZyVib2x0JQ)s)",
             {"p_str_JWxpZ2h0bmluZyVib2x0JQ": r"%lightning%bolt%"},
         ),
         ("cmc:3", "(card.cmc = %(p_int_Mw)s)", {"p_int_Mw": 3}),  # Numeric field uses exact equality
@@ -239,28 +239,28 @@ def test_full_sql_translation_jsonb_card_types(input_query: str, expected_sql: s
     argnames=("input_query", "expected_sql", "expected_parameters"),
     argvalues=[
         # Oracle text search tests
-        ("oracle:flying", "(card.oracle_text ILIKE %(p_str_JWZseWluZyU)s)", {"p_str_JWZseWluZyU": "%flying%"}),
+        ("oracle:flying", "(lower(card.oracle_text) LIKE %(p_str_JWZseWluZyU)s)", {"p_str_JWZseWluZyU": "%flying%"}),
         (
             "oracle:'gain life'",
-            "(card.oracle_text ILIKE %(p_str_JWdhaW4lbGlmZSU)s)",
+            "(lower(card.oracle_text) LIKE %(p_str_JWdhaW4lbGlmZSU)s)",
             {"p_str_JWdhaW4lbGlmZSU": "%gain%life%"},
         ),
         (
             'oracle:"gain life"',
-            "(card.oracle_text ILIKE %(p_str_JWdhaW4lbGlmZSU)s)",
+            "(lower(card.oracle_text) LIKE %(p_str_JWdhaW4lbGlmZSU)s)",
             {"p_str_JWdhaW4lbGlmZSU": "%gain%life%"},
         ),
-        ("oracle:haste", "(card.oracle_text ILIKE %(p_str_JWhhc3RlJQ)s)", {"p_str_JWhhc3RlJQ": "%haste%"}),
+        ("oracle:haste", "(lower(card.oracle_text) LIKE %(p_str_JWhhc3RlJQ)s)", {"p_str_JWhhc3RlJQ": "%haste%"}),
         # Test oracle search with complex phrases
         (
             "oracle:'tap target creature'",
-            "(card.oracle_text ILIKE %(p_str_JXRhcCV0YXJnZXQlY3JlYXR1cmUl)s)",
+            "(lower(card.oracle_text) LIKE %(p_str_JXRhcCV0YXJnZXQlY3JlYXR1cmUl)s)",
             {"p_str_JXRhcCV0YXJnZXQlY3JlYXR1cmUl": "%tap%target%creature%"},
         ),
     ],
 )
 def test_oracle_text_sql_translation(input_query: str, expected_sql: str, expected_parameters: dict) -> None:
-    """Test that oracle text search generates correct SQL with ILIKE patterns."""
+    """Test that oracle text search generates correct SQL with LIKE patterns."""
     parsed = parsing.parse_scryfall_query(input_query)
     context = {}
     observed_sql = parsed.to_sql(context)
@@ -272,28 +272,28 @@ def test_oracle_text_sql_translation(input_query: str, expected_sql: str, expect
     argnames=("input_query", "expected_sql", "expected_parameters"),
     argvalues=[
         # Flavor text search tests
-        ("flavor:exile", "(card.flavor_text ILIKE %(p_str_JWV4aWxlJQ)s)", {"p_str_JWV4aWxlJQ": "%exile%"}),
+        ("flavor:exile", "(lower(card.flavor_text) LIKE %(p_str_JWV4aWxlJQ)s)", {"p_str_JWV4aWxlJQ": "%exile%"}),
         (
             "flavor:'ancient power'",
-            "(card.flavor_text ILIKE %(p_str_JWFuY2llbnQlcG93ZXIl)s)",
+            "(lower(card.flavor_text) LIKE %(p_str_JWFuY2llbnQlcG93ZXIl)s)",
             {"p_str_JWFuY2llbnQlcG93ZXIl": "%ancient%power%"},
         ),
         (
             'flavor:"ancient power"',
-            "(card.flavor_text ILIKE %(p_str_JWFuY2llbnQlcG93ZXIl)s)",
+            "(lower(card.flavor_text) LIKE %(p_str_JWFuY2llbnQlcG93ZXIl)s)",
             {"p_str_JWFuY2llbnQlcG93ZXIl": "%ancient%power%"},
         ),
-        ("flavor:magic", "(card.flavor_text ILIKE %(p_str_JW1hZ2ljJQ)s)", {"p_str_JW1hZ2ljJQ": "%magic%"}),
+        ("flavor:magic", "(lower(card.flavor_text) LIKE %(p_str_JW1hZ2ljJQ)s)", {"p_str_JW1hZ2ljJQ": "%magic%"}),
         # Test flavor search with complex phrases
         (
             "flavor:'power of darkness'",
-            "(card.flavor_text ILIKE %(p_str_JXBvd2VyJW9mJWRhcmtuZXNzJQ)s)",
+            "(lower(card.flavor_text) LIKE %(p_str_JXBvd2VyJW9mJWRhcmtuZXNzJQ)s)",
             {"p_str_JXBvd2VyJW9mJWRhcmtuZXNzJQ": "%power%of%darkness%"},
         ),
     ],
 )
 def test_flavor_text_sql_translation(input_query: str, expected_sql: str, expected_parameters: dict) -> None:
-    """Test that flavor text search generates correct SQL with ILIKE patterns."""
+    """Test that flavor text search generates correct SQL with LIKE patterns."""
     parsed = parsing.parse_scryfall_query(input_query)
     context = {}
     observed_sql = parsed.to_sql(context)
@@ -722,15 +722,15 @@ def test_rarity_case_insensitive() -> None:
 @pytest.mark.parametrize(
     argnames=("input_query", "expected_sql", "expected_parameters"),
     argvalues=[
-        ("artist:moeller", r"(card.card_artist ILIKE %(p_str_JW1vZWxsZXIl)s)", {"p_str_JW1vZWxsZXIl": r"%moeller%"}),
-        ("a:moeller", r"(card.card_artist ILIKE %(p_str_JW1vZWxsZXIl)s)", {"p_str_JW1vZWxsZXIl": r"%moeller%"}),
+        ("artist:moeller", r"(lower(card.card_artist) LIKE %(p_str_JW1vZWxsZXIl)s)", {"p_str_JW1vZWxsZXIl": r"%moeller%"}),
+        ("a:moeller", r"(lower(card.card_artist) LIKE %(p_str_JW1vZWxsZXIl)s)", {"p_str_JW1vZWxsZXIl": r"%moeller%"}),
         (
             'artist:"Christopher Moeller"',
-            r"(card.card_artist ILIKE %(p_str_JUNocmlzdG9waGVyJU1vZWxsZXIl)s)",
-            {"p_str_JUNocmlzdG9waGVyJU1vZWxsZXIl": r"%Christopher%Moeller%"},
+            r"(lower(card.card_artist) LIKE %(p_str_JWNocmlzdG9waGVyJW1vZWxsZXIl)s)",
+            {"p_str_JWNocmlzdG9waGVyJW1vZWxsZXIl": r"%christopher%moeller%"},
         ),
-        ("artist:nielsen", r"(card.card_artist ILIKE %(p_str_JW5pZWxzZW4l)s)", {"p_str_JW5pZWxzZW4l": r"%nielsen%"}),
-        ("ARTIST:moeller", r"(card.card_artist ILIKE %(p_str_JW1vZWxsZXIl)s)", {"p_str_JW1vZWxsZXIl": r"%moeller%"}),
+        ("artist:nielsen", r"(lower(card.card_artist) LIKE %(p_str_JW5pZWxzZW4l)s)", {"p_str_JW5pZWxzZW4l": r"%nielsen%"}),
+        ("ARTIST:moeller", r"(lower(card.card_artist) LIKE %(p_str_JW1vZWxsZXIl)s)", {"p_str_JW1vZWxsZXIl": r"%moeller%"}),
         (
             'artist="todd lockwood"',
             r"(card.card_artist = %(p_str_VG9kZCBMb2Nrd29vZA)s)",

--- a/api/parsing/tests/test_watermark_sql_generation.py
+++ b/api/parsing/tests/test_watermark_sql_generation.py
@@ -49,16 +49,18 @@ class TestWatermarkSQLGeneration:
         assert param_value == expected_value
         assert "%" not in param_value  # No wildcards
 
-    def test_watermark_search_still_uses_ilike_pattern_matching(self) -> None:
-        """Test that regular text fields like name still use ILIKE pattern matching."""
+    def test_name_search_uses_lower_like_pattern_matching(self) -> None:
+        """Test that regular text fields like name use lower() LIKE pattern matching."""
         result = parse_scryfall_query("name:lightning")
         assert isinstance(result, Query)
 
         context: dict[str, Any] = {}
         sql = result.to_sql(context)
 
-        # Should generate ILIKE pattern matching
-        assert "ILIKE" in sql
+        # Should generate lower() LIKE pattern matching
+        assert "lower(" in sql
+        assert "LIKE" in sql
+        assert "ILIKE" not in sql
         assert "card.card_name" in sql
 
         # Context should contain wildcards


### PR DESCRIPTION
## What

Replaces all `ILIKE` pattern-matching SQL with `lower(col) LIKE lower_pattern` across the query
parser, and swaps the corresponding GIN trigram indexes from ILIKE indexes to `lower()`
functional indexes.

Affected fields: `card_name`, `oracle_text`, `flavor_text`, `card_artist`.

## Why

PostgreSQL's selectivity estimator for `LIKE` is cheaper than the one for `ILIKE`. When the
planner evaluates a query it calls the estimator to decide whether to use an index; `ILIKE`
triggers a case-folding estimator that adds measurable overhead per query. Pushing the
`lower()` call into the indexed expression and the query literal instead lets the planner use
the cheaper `LIKE` estimator while preserving full case-insensitive matching.

## Changes

### `api/db/2026-05-20-02-lower-trgm-indexes.sql`

Migration that:
- Creates new GIN trigram indexes on `lower(col)` for oracle_text, card_name, card_artist
  (partial — `WHERE card_artist IS NOT NULL`), and flavor_text (partial — `WHERE flavor_text IS NOT NULL`).
- Drops the old ILIKE-style GIN trigram indexes they replace.

### `api/parsing/card_query_nodes.py`

- New `_escape_like_pattern(value)` helper escapes `\`, `%`, and `_` (in that order) so user
  input is always treated as a literal string, never as LIKE metacharacters.
- `ExactNameNode.to_sql`: lowercases the value, applies `_escape_like_pattern`, and emits
  `lower(card.card_name) LIKE %(...)s` instead of `card.card_name ILIKE %(...)s`.
- `CardBinaryOperatorNode.to_sql`: lowercases and escapes each word before building the
  `%word%` pattern, and emits `lower(col) LIKE %(...)s` instead of `col ILIKE %(...)s`.

### Tests

Updated expected SQL strings and parameter values throughout:
- `test_sql_gen.py` — name, oracle, flavor, and artist search cases
- `test_exact_name_search.py` — exact-name (`!`) syntax
- `test_layout_border_sql_generation.py`, `test_watermark_sql_generation.py`,
  `test_regex_patterns.py` — assertion strings updated from `ILIKE` checks to `lower(` + `LIKE`
  + `not ILIKE` checks
- `test_like_escaping.py` (new) — focused tests for `_escape_like_pattern` and for `%`/`_`/`\`
  in both exact-name and pattern-matching queries

## Correctness

Case-insensitive matching is fully preserved. There is one intentional semantic change:

**`%` and `_` in search terms are now treated as literals, not wildcards.**

Previously, `name:"50%"` generated `ILIKE '%50%%'`, making the user's `%` a live SQL wildcard
that extended the trailing match. Now it generates `LIKE '%50\%%'`, matching the literal string
`50%`. Likewise, `name:"a_b"` previously matched `aXb` (underscore = any character); it now
matches only `a_b`.

This aligns with Scryfall's behaviour, where `%` and `_` in text searches are not wildcards.
The `\` escape character is also neutralised so that user input containing backslashes cannot
corrupt the pattern (e.g. `\%` previously reintroduced a wildcard; now it is matched
literally).
