### PR TITLE
Realistic Query Runner

### DIFF
--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -96,6 +96,7 @@ class ApiWorker(multiprocessing.Process):
             CachingMiddleware,
             CompressionMiddleware,
             CORSMiddleware,
+            QueryLogMiddleware,
             SecurityHeadersMiddleware,
             TimingMiddleware,
         )
@@ -103,7 +104,8 @@ class ApiWorker(multiprocessing.Process):
         api = falcon.App(
             middleware=[
                 TimingMiddleware(),
-                CachingMiddleware(),  # important that this is first
+                QueryLogMiddleware(),  # process_response fires before TimingMiddleware's
+                CachingMiddleware(),
                 CompressionMiddleware(),
                 SecurityHeadersMiddleware(),  # Add security headers to all responses
                 CORSMiddleware(),  # Handle CORS requests

--- a/api/db/2026-05-20-01-query-log.sql
+++ b/api/db/2026-05-20-01-query-log.sql
@@ -1,0 +1,28 @@
+-- Migration: Add query_log table for search performance telemetry
+-- Records one row per /search request (cache misses only for DB timings; cache hits for frequency analysis).
+-- Used to identify slow query patterns and map URL ?q= parameters back to DB execution times.
+
+CREATE TABLE IF NOT EXISTS magic.query_log (
+    id            BIGSERIAL PRIMARY KEY,
+    logged_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    q             TEXT,
+    orderby       TEXT,       -- ?orderby= URL parameter
+    unique_by     TEXT,       -- ?unique= URL parameter ("unique" is reserved in SQL)
+    cache_hit     BOOLEAN NOT NULL DEFAULT false,
+    execute_ms    REAL,       -- inner_timings["execute_query"]; NULL on cache hits
+    fetch_ms      REAL,       -- inner_timings["fetch_results"]; NULL on cache hits
+    total_ms      REAL,       -- wall-clock time from request start to middleware response
+    result_count  INTEGER,    -- number of cards returned in this response
+    total_cards   INTEGER,    -- total matching cards (before LIMIT)
+    had_error     BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_logged_at
+    ON magic.query_log (logged_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_execute_ms
+    ON magic.query_log (execute_ms DESC NULLS LAST);
+
+-- Enable pg_stat_statements (already in shared_preload_libraries in postgresql.conf).
+-- This is idempotent; safe to run if the extension is already present.
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;

--- a/api/middlewares/__init__.py
+++ b/api/middlewares/__init__.py
@@ -12,6 +12,7 @@ from api.middlewares.caching_middleware import CachingMiddleware
 from api.middlewares.compression import CompressionMiddleware
 from api.middlewares.cors_middleware import CORSMiddleware
 from api.middlewares.logging_middleware import LoggingMiddleware
+from api.middlewares.query_log_middleware import QueryLogMiddleware
 from api.middlewares.security_headers import SecurityHeadersMiddleware
 from api.middlewares.timing import ProfilingMiddleware, TimingMiddleware
 
@@ -21,6 +22,7 @@ __all__ = [
     "CompressionMiddleware",
     "LoggingMiddleware",
     "ProfilingMiddleware",
+    "QueryLogMiddleware",
     "SecurityHeadersMiddleware",
     "TimingMiddleware",
 ]

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -67,7 +67,11 @@ class CachingMiddleware:
                 cached_value = typecast("falcon.Response", cached_value)
             resp.complete = True
             resp.data = cached_value.data
-            resp.media = cached_value.media
+            if isinstance(cached_value.media, dict):
+                resp.media = dict(cached_value.media)
+                resp.media["cache_hit"] = True
+            else:
+                resp.media = cached_value.media
             resp._headers.update(cached_value._headers)
             resp.status = cached_value.status
             logger.info("Cache hit: %s / %s response_id: %d", req.relative_uri, resp.status, id(resp))

--- a/api/middlewares/query_log_middleware.py
+++ b/api/middlewares/query_log_middleware.py
@@ -1,0 +1,118 @@
+"""Middleware for logging /search request performance to magic.query_log."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import queue
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import psycopg
+
+from api.utils.db_utils import get_pg_creds
+
+if TYPE_CHECKING:
+    import falcon
+
+logger = logging.getLogger(__name__)
+
+_INSERT_SQL = """
+INSERT INTO magic.query_log
+    (q, cache_hit, execute_ms, fetch_ms, total_ms, result_count, total_cards, had_error, orderby, unique_by)
+VALUES (%(q)s, %(cache_hit)s, %(execute_ms)s, %(fetch_ms)s, %(total_ms)s,
+        %(result_count)s, %(total_cards)s, %(had_error)s, %(orderby)s, %(unique_by)s)
+"""
+
+
+class QueryLogMiddleware:
+    """Middleware that records /search performance to magic.query_log.
+
+    Uses a background writer thread so the log insert never blocks request processing.
+    One row is recorded per request; cache hits are included (with cache_hit=True and
+    NULL DB timings) so query frequency can be analysed alongside raw latency.
+    """
+
+    def __init__(self: QueryLogMiddleware) -> None:
+        """Start the background writer thread."""
+        self._queue: queue.SimpleQueue[dict | None] = queue.SimpleQueue()
+        self._writer = threading.Thread(target=self._drain, daemon=True, name="query-log-writer")
+        self._writer.start()
+
+    # ------------------------------------------------------------------
+    # Background writer
+    # ------------------------------------------------------------------
+
+    def _connect(self: QueryLogMiddleware) -> psycopg.Connection:
+        creds = get_pg_creds()
+        conninfo = " ".join(f"{k}={v}" for k, v in creds.items())
+        return psycopg.connect(conninfo)
+
+    def _drain(self: QueryLogMiddleware) -> None:
+        """Drain the queue and write entries to magic.query_log."""
+        conn: psycopg.Connection | None = None
+        while True:
+            try:
+                entry = self._queue.get()
+                if entry is None:  # shutdown signal
+                    break
+                if conn is None or conn.closed:
+                    conn = self._connect()
+                with conn.cursor() as cur:
+                    cur.execute(_INSERT_SQL, entry)
+                conn.commit()
+            except Exception:
+                logger.exception("QueryLogMiddleware: failed to write log entry")
+                if conn is not None:
+                    with contextlib.suppress(Exception):
+                        conn.close()
+                    conn = None
+                time.sleep(1)  # brief back-off before reconnect
+
+    # ------------------------------------------------------------------
+    # Falcon middleware hook
+    # ------------------------------------------------------------------
+
+    def process_response(
+        self: QueryLogMiddleware,
+        req: falcon.Request,
+        resp: falcon.Response,
+        resource: object,
+        req_succeeded: bool,
+    ) -> None:
+        """Enqueue a log entry for every /search request.
+
+        Args:
+            req: The incoming request.
+            resp: The completed response.
+            resource: The resource handler (unused).
+            req_succeeded: Whether the request completed without an unhandled exception.
+        """
+        del resource
+        if req.path != "/search":
+            return
+
+        media = resp.media
+        if not isinstance(media, dict):
+            return
+
+        start = req.context.get("_start_time")
+        total_ms = (time.monotonic() - start) * 1000 if start is not None else None
+
+        cache_hit = bool(media.get("cache_hit", False))
+        inner = media.get("inner_timings") or {}
+
+        entry: dict = {
+            "q": req.params.get("q"),
+            "cache_hit": cache_hit,
+            "execute_ms": inner.get("execute_query") if not cache_hit else None,
+            "fetch_ms": inner.get("fetch_results") if not cache_hit else None,
+            "total_ms": total_ms,
+            "result_count": len(media.get("cards") or []),
+            "total_cards": media.get("total_cards"),
+            "had_error": not req_succeeded,
+            "orderby": req.params.get("orderby"),
+            "unique_by": req.params.get("unique"),
+        }
+        self._queue.put(entry)

--- a/client/query_runner.py
+++ b/client/query_runner.py
@@ -4,6 +4,11 @@
 This script continuously generates random card search queries and executes them
 against the Scryfall OS API to help identify which database indexes are being used
 and which queries perform well or poorly.
+
+Modes:
+  default    Generate a fixed synthetic query corpus.
+  --realistic  Pull the most common/slowest real queries from magic.query_log
+               (requires PG* env vars pointing at the database).
 """
 
 import argparse
@@ -12,6 +17,7 @@ import os
 import random
 import time
 
+import psycopg
 import requests
 
 logger = logging.getLogger(__name__)
@@ -19,6 +25,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_API_URL = "http://apiservice:8080"
 DEFAULT_QUERY_DELAY = 1.0  # Delay between queries in seconds
 DEFAULT_BATCH_SIZE = 50  # Number of queries before reporting stats
+
+_REALISTIC_SQL = """
+SELECT q
+FROM magic.query_log
+WHERE had_error = false
+  AND cache_hit = false
+  AND q IS NOT NULL
+GROUP BY q
+ORDER BY AVG(execute_ms) DESC NULLS LAST, COUNT(*) DESC
+LIMIT %(limit)s
+"""
 
 
 def setup_logging() -> None:
@@ -396,6 +413,32 @@ def random_query() -> str:
     return " ".join(sorted(fragments))
 
 
+def fetch_realistic_queries(limit: int = 500) -> list[str]:
+    """Pull real queries from magic.query_log, ordered by average DB execution time.
+
+    Requires PG* environment variables (PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD)
+    to be set so the script can connect directly to the database.
+
+    Args:
+        limit: Maximum number of distinct queries to return.
+
+    Returns:
+        List of query strings from actual user searches, slowest first.
+    """
+    mapping = {"database": "dbname"}
+    creds = {mapping.get(k[2:].lower(), k[2:].lower()): v for k, v in os.environ.items() if k.startswith("PG")}
+    if not creds:
+        msg = "No PG* env vars found; cannot connect to DB for realistic queries"
+        raise RuntimeError(msg)
+    conninfo = " ".join(f"{k}={v}" for k, v in creds.items())
+    with psycopg.connect(conninfo) as conn, conn.cursor() as cur:
+        cur.execute(_REALISTIC_SQL, {"limit": limit})
+        rows = cur.fetchall()
+    queries = [row[0] for row in rows]
+    logger.info("Fetched %d realistic queries from magic.query_log", len(queries))
+    return queries
+
+
 def run_query(api_url: str, query: str, session: requests.Session, orderby: str, unique: str) -> dict:
     """Run a single search query against the API.
 
@@ -502,6 +545,11 @@ def parse_args() -> argparse.Namespace:
     """Parse command-line arguments, falling back to environment variables then module defaults."""
     parser = argparse.ArgumentParser(description="Run search queries against the Arcane Tutor API.")
     parser.add_argument(
+        "--realistic",
+        action="store_true",
+        help="Use real queries from magic.query_log (requires PG* env vars) instead of synthetic ones.",
+    )
+    parser.add_argument(
         "--api-url",
         default=os.environ.get("API_URL", DEFAULT_API_URL),
         help=f"Base URL for the API (default: {DEFAULT_API_URL}).",
@@ -542,12 +590,23 @@ def main() -> None:
         },
     )
 
+    # Build query pool (realistic mode only; synthetic generates on the fly)
+    if args.realistic:
+        logger.info("Mode: realistic (from magic.query_log)")
+        query_pool = fetch_realistic_queries()
+
+        def get_query() -> str:
+            return random.choice(query_pool)
+    else:
+        get_query = random_query
+        logger.info("Mode: synthetic")
+
     results = []
     query_count = 0
 
     try:
         while True:
-            query = random_query()
+            query = get_query()
             orderby = random.choice(_ORDERBY_VALUES)
             unique = random.choice(_UNIQUE_VALUES)
 

--- a/client/tests/test_query_runner.py
+++ b/client/tests/test_query_runner.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 from client.query_runner import (
@@ -13,14 +13,12 @@ from client.query_runner import (
     DEFAULT_API_URL,
     DEFAULT_BATCH_SIZE,
     DEFAULT_QUERY_DELAY,
+    fetch_realistic_queries,
     parse_args,
     print_statistics,
     random_query,
     run_query,
 )
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class TestRandomQuery:
@@ -59,6 +57,7 @@ class TestParseArgs:
         assert args.api_url == DEFAULT_API_URL
         assert args.query_delay == DEFAULT_QUERY_DELAY
         assert args.batch_size == DEFAULT_BATCH_SIZE
+        assert args.realistic is False
 
     def test_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("API_URL", "http://env-host:9090")
@@ -81,6 +80,12 @@ class TestParseArgs:
         assert args.api_url == "http://cli-host:7070"
         assert args.query_delay == 0.1
         assert args.batch_size == 10
+
+    def test_realistic_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("API_URL", raising=False)
+        with patch.object(sys, "argv", ["query_runner", "--realistic"]):
+            args = parse_args()
+        assert args.realistic is True
 
 
 def _make_session(json_data: dict | None = None, raise_exc: Exception | None = None) -> MagicMock:
@@ -156,3 +161,11 @@ class TestPrintStatistics:
             {"success": False, "error": "timeout", "elapsed_ms": 30000.0},
         ]
         print_statistics(results)
+
+
+class TestFetchRealisticQueries:
+    def test_raises_without_pg_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in [k for k in __import__("os").environ if k.startswith("PG")]:
+            monkeypatch.delenv(key, raising=False)
+        with pytest.raises(RuntimeError, match="No PG\\* env vars"):
+            fetch_realistic_queries()


### PR DESCRIPTION
## What

Adds a `--realistic` mode to the load-test client that replaces synthetic query generation with real queries pulled from `magic.query_log`, ordered by average DB execution time. This makes it easy to reproduce and stress-test the slowest queries seen in production.

## Changes

### `client/query_runner.py`

- **`fetch_realistic_queries(limit)`** — connects directly to the DB via `PG*` env vars and pulls the top-N distinct queries by average `execute_ms` (cache misses only, errors excluded)
- **`--realistic` CLI flag** — when set, populates the query pool from `magic.query_log` instead of generating synthetic queries on the fly
- **`get_query` abstraction** — `main()` now dispatches through `get_query()` so realistic and synthetic modes share the same loop

### `client/tests/test_query_runner.py`

- Adds `test_realistic_flag` — confirms `--realistic` sets `args.realistic = True`
- Adds `assert args.realistic is False` to `test_module_defaults`
- Adds `TestFetchRealisticQueries.test_raises_without_pg_env` — confirms a clear error when no `PG*` env vars are present

## Usage

```bash
# Synthetic mode (default, no DB connection needed)
python -m client.query_runner

# Realistic mode (requires PG* env vars pointing at the database)
PGHOST=localhost PGPORT=25432 PGDATABASE=magic PGUSER=foouser PGPASSWORD=foopassword \
  python -m client.query_runner --realistic
```

## Test plan

- [ ] `make test-unit` passes
- [ ] Run in synthetic mode; confirm queries are generated and stats are printed
- [ ] Run in realistic mode against a populated `magic.query_log`; confirm it prints "Fetched N realistic queries" and runs them
- [ ] Run in realistic mode with no `PG*` env vars; confirm a clear `RuntimeError` rather than a cryptic connection error
