### PR TITLE
SQL Generation Refactor

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -29,7 +29,7 @@ import psycopg
 import requests
 from cachebox import LRUCache, TTLCache
 from cachebox import cached as cachebox_cached
-from psycopg import Connection, Cursor
+from psycopg import Cursor
 
 from api.card_processing import preprocess_card
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
@@ -584,7 +584,6 @@ class APIResource:
                 return result
         try:
             with self._conn_pool.connection() as conn:
-                conn = typecast("Connection", conn)
                 with conn.cursor() as cursor:
                     cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
                     cards_found = cursor.fetchall()[0]["num_cards"]
@@ -807,8 +806,7 @@ class APIResource:
         distinct_on = {
             UniqueOn.ARTWORK: "illustration_id",
             UniqueOn.CARD: "card_name",
-            UniqueOn.PRINTING: "scryfall_id",
-        }.get(unique, "card_name")
+        }.get(unique)  # None means unique=printing; scryfall_id is the PK so DISTINCT ON is a no-op
         # Map prefer values to SQL columns and directions
         prefer_mapping = {
             PreferOrder.OLDEST: ("released_at", "ASC"),
@@ -822,43 +820,62 @@ class APIResource:
             prefer,
             ("edhrec_rank", "ASC"),
         )
+        if distinct_on is not None:
+            distinct_clause = f"DISTINCT ON ({distinct_on})"
+            order_by_distinct = f"{distinct_on},"
+        else:
+            distinct_clause = ""
+            order_by_distinct = ""
+        inner_columns = {
+            "card_name",
+            "card_set_code",
+            "cmc",
+            "collector_number",
+            "creature_power_text",
+            "creature_toughness_text",
+            "edhrec_rank",
+            "mana_cost_text",
+            "oracle_text",
+            "set_name",
+            "type_line",
+            "prefer_score",
+        }
+        inner_columns.add(sql_orderby)
+        inner_columns_sql = ",\n    ".join(sorted(inner_columns))
+
+        outer_orderby_clauses = [
+            f"{sql_orderby} {sql_direction} NULLS LAST",
+        ]
+        if orderby not in (CardOrdering.EDHREC, CardOrdering.CUBECOBRA):
+            outer_orderby_clauses.append("edhrec_rank ASC NULLS LAST")
+        # there will only be multiple prefer scores per
+        # grouping if the grouping is card
+        if unique == UniqueOn.CARD:
+            outer_orderby_clauses.append("prefer_score DESC NULLS LAST")
+        outer_orderby_sql = ",\n    ".join(outer_orderby_clauses)
+
         query_sql = f"""
             WITH distinct_cards AS (
-                SELECT DISTINCT ON ({distinct_on})
-                    card_artist,
-                    card_name,
-                    card_set_code,
-                    cmc,
-                    collector_number,
-                    creature_power_text,
-                    creature_toughness_text,
-                    edhrec_rank,
-                    mana_cost_text,
-                    oracle_text,
-                    set_name,
-                    type_line,
-                    prefer_score,
-                    {sql_orderby} AS sort_value
+                SELECT {distinct_clause}
+                    {inner_columns_sql}
                 FROM
                     magic.cards AS card
                 WHERE
                     {where_clause}
                 ORDER BY
-                    {distinct_on},
+                    {order_by_distinct}
                     {prefer_column} {prefer_direction} NULLS LAST,
                     prefer_score DESC NULLS LAST
             )
             (
                 SELECT
                     null AS total_cards_count,
-                    card_artist,
+
                     card_name AS name,
                     card_set_code AS set_code,
-                    cmc,
                     collector_number,
                     creature_power_text AS power,
                     creature_toughness_text AS toughness,
-                    edhrec_rank,
                     mana_cost_text AS mana_cost,
                     oracle_text,
                     set_name,
@@ -866,9 +883,7 @@ class APIResource:
                 FROM
                     distinct_cards
                 ORDER BY
-                    sort_value {sql_direction} NULLS LAST,
-                    edhrec_rank ASC NULLS LAST,
-                    prefer_score DESC NULLS LAST
+                    {outer_orderby_sql}
                 LIMIT
                     %(limit)s
             )
@@ -876,7 +891,15 @@ class APIResource:
             (
                 SELECT
                     COUNT(1) AS total_cards_count,
-                    null, null, null, null, null, null, null, null, null, null, null, null
+                    null as name,
+                    null as set_code,
+                    null as collector_number,
+                    null as creature_power_text,
+                    null as creature_toughness_text,
+                    null as mana_cost_text,
+                    null as oracle_text,
+                    null as set_name,
+                    null as type_line
                 FROM
                     distinct_cards
             )"""

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 
 from api.api_resource import APIResource
+from api.enums import UniqueOn
 from api.settings import settings
 
 
@@ -818,6 +819,48 @@ class TestAPIResourceTagHierarchy(unittest.TestCase):
                 assert isinstance(result["message"], str)
                 assert isinstance(result["tags_processed"], int)
                 assert result["tags_processed"] == 1
+
+
+class TestSearchDistinctOnClause(unittest.TestCase):
+    """Test that the correct DISTINCT ON clause is generated for each unique mode."""
+
+    def setUp(self) -> None:
+        self.api_resource = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        )
+        self.api_resource._conn_pool = MagicMock()
+
+    def _captured_sql(self, unique: Any) -> str:
+        """Call _search with the given unique mode and return the SQL passed to _run_query."""
+        captured = {}
+
+        def fake_run_query(*, query: str, params: Any = None, explain: bool = False, statement_timeout: int = 10_000) -> dict:
+            captured["sql"] = query
+            # Return the minimal shape _search expects
+            return {"result": [{"total_cards_count": 0}], "timings": {}, "plan": None}
+
+        with (
+            patch.object(self.api_resource, "_setup_complete", return_value=True),
+            patch.object(self.api_resource, "_run_query", side_effect=fake_run_query),
+        ):
+            self.api_resource._search(unique=unique, query="")
+
+        return captured["sql"]
+
+    def test_unique_card_uses_distinct_on_card_name(self) -> None:
+        sql = self._captured_sql(UniqueOn.CARD)
+        assert "DISTINCT ON (card_name)" in sql
+        # Leading ORDER BY key must be present
+        assert "card_name," in sql
+
+    def test_unique_artwork_uses_distinct_on_illustration_id(self) -> None:
+        sql = self._captured_sql(UniqueOn.ARTWORK)
+        assert "DISTINCT ON (illustration_id)" in sql
+        assert "illustration_id," in sql
+
+    def test_unique_printing_omits_distinct_on(self) -> None:
+        sql = self._captured_sql(UniqueOn.PRINTING)
+        assert "DISTINCT ON" not in sql
 
 
 if __name__ == "__main__":

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -47,5 +47,5 @@ def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
 )
 def test_orderby_column_in_compiled_sql(api_resource: APIResource, ordering: CardOrdering, expected_column: str) -> None:
     """Every CardOrdering value should produce its mapped column in the compiled SQL."""
-    needle = f", {expected_column} AS sort_value FROM magic.cards"
+    needle = f"ORDER BY {expected_column} ASC NULLS LAST"
     assert needle in _compiled_sql(api_resource, ordering)

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -373,16 +373,12 @@ class TestContainerIntegration:
         assert len(cards) >= 1, "Should find at least one card by Willian Murai"
 
         # Find Brainstorm specifically and verify artist field
-        brainstorm_found = False
         for card in cards:
             if card["name"] == "Brainstorm":
-                brainstorm_found = True
-                assert card.get("card_artist") == "Willian Murai", (
-                    f"Brainstorm should have 'Willian Murai' as artist, got: {card.get('card_artist')}"
-                )
                 break
-
-        assert brainstorm_found, "Brainstorm should be found by artist search"
+        else:
+            msg = "Brainstorm should be found by artist search"
+            raise RuntimeError(msg)
 
         # Test artist search by partial name (case insensitive)
         result_partial = api_resource.search(q="artist:murai")
@@ -408,15 +404,12 @@ class TestContainerIntegration:
         assert len(cards_combined) >= 1, "Should find cards matching both CMC and artist criteria"
 
         # Verify Brainstorm is found in combined search and matches both criteria
-        brainstorm_in_combined = False
         for card in cards_combined:
             if card["name"] == "Brainstorm":
-                brainstorm_in_combined = True
-                assert card.get("cmc") == 1, "Brainstorm should have CMC = 1"
-                assert card.get("card_artist") == "Willian Murai", "Brainstorm should have correct artist"
                 break
-
-        assert brainstorm_in_combined, "Brainstorm should be found by combined search"
+        else:
+            msg = "Brainstorm should be found by combined search"
+            raise RuntimeError(msg)
 
     def test_cubecobra_ordering(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test that orderby=cubecobra sorts by cubecobra_score ascending (lower = better)."""


### PR DESCRIPTION
## What

Fixes a DISTINCT ON no-op for `unique=printing` and refactors the search query SQL to be easier to read and extend.

## Changes

### `api/api_resource.py`

- **DISTINCT ON fix** — `unique=printing` was using `DISTINCT ON (scryfall_id)`, which is a no-op since `scryfall_id` is the primary key. It now omits DISTINCT ON entirely, which is both correct and slightly cheaper.
- **Dynamic inner column set** — inner SELECT columns are now built as a sorted set rather than a hardcoded list, making it easier to add or remove columns without touching the ORDER BY or UNION structure.
- **Dynamic outer ORDER BY** — outer ORDER BY clauses are assembled from a list rather than hardcoded; `edhrec_rank` and `prefer_score` tiebreakers are now added conditionally only where they apply.
- **Named nulls in COUNT row** — the COUNT union row now uses `null as name`, `null as set_code`, etc. instead of a bare `null, null, null, …` list, making column alignment explicit.
- **Removed from API response** — `card_artist`, `cmc`, and `edhrec_rank` are no longer returned in search results.

### Tests

- `test_api_resource.py` — adds `TestSearchDistinctOnClause` verifying that `unique=card` and `unique=artwork` produce `DISTINCT ON (card_name)` / `DISTINCT ON (illustration_id)`, and that `unique=printing` produces no `DISTINCT ON`
- `test_card_ordering.py` — updates SQL needle to match the new `ORDER BY` shape
- `test_integration_testcontainers.py` — removes assertions on `card_artist` and `cmc` fields that are no longer returned

## Test plan

- [ ] `make test-unit` passes
- [ ] `make test-integration` passes
- [ ] Spot-check `/search?q=type:creature&unique=printing` — verify results look correct and no duplicate cards appear
- [ ] Spot-check `/search?q=lightning+bolt&unique=card` — verify deduplication by card name still works
- [ ] Spot-check `/search?q=type:creature&unique=artwork` — verify deduplication by illustration ID still works
