### PR TITLE
Timing spans + cross-process cache invalidation

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -2616,12 +2616,15 @@ class APIResource:
         except KeyError:
             stale = next(iter(self._preferred_cards_map.values()), None)
             if stale is not None:
-                # Stale-while-revalidate: serve old data instantly, refresh in background
-                threading.Thread(
-                    target=self._fetch_and_cache_preferred_cards,
-                    args=(gen,),
-                    daemon=True,
-                ).start()
+                # Stale-while-revalidate: serve old data instantly, refresh in background.
+                # Best-effort check: skip spawning if a refresh is already in progress so we
+                # don't create a flood of threads that immediately no-op on the inner lock.
+                if not self._preferred_cards_refresh_lock.locked():
+                    threading.Thread(
+                        target=self._fetch_and_cache_preferred_cards,
+                        args=(gen,),
+                        daemon=True,
+                    ).start()
                 return stale
             # No previous generation (startup): block until cards are loaded
             self._fetch_and_cache_preferred_cards(gen)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -33,6 +33,7 @@ from psycopg import Connection, Cursor
 
 from api.card_processing import preprocess_card
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
 from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
@@ -294,6 +295,7 @@ class APIResource:
             path,
             self._raise_not_found,
         )
+        res = None
         before = time.monotonic()
         try:
             res = action(falcon_response=resp, **req.params)
@@ -330,6 +332,13 @@ class APIResource:
         finally:
             duration = (time.monotonic() - before) * 1000
             logger.info("Request duration: %.1f ms / %s", duration, resp.status)
+            record_span(req, "handler", duration)
+            if isinstance(res, dict):
+                outer = res.get("outer_timings", {})
+                if "get_where_clause" in outer:
+                    record_span(req, "parse", outer["get_where_clause"].get("_meta", {}).get("duration_ms", 0))
+                if "run_query" in outer:
+                    record_span(req, "db", outer["run_query"].get("_meta", {}).get("duration_ms", 0))
 
     def _raise_not_found(self, **_: object) -> None:
         """Raise a Falcon HTTPNotFound error with available routes."""

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -15,6 +15,7 @@ import pathlib
 import random
 import re
 import secrets
+import threading
 import time
 import urllib.parse
 from datetime import timedelta
@@ -33,12 +34,14 @@ from psycopg import Connection, Cursor
 
 from api.card_processing import preprocess_card
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
 from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 from api.settings import settings
 from api.tagger_client import TaggerClient
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
+from api.utils.generation_cache import GenerationCache
 from api.utils.timer import Timer
 from api.utils.type_conversions import _get_type_name, make_type_converting_wrapper
 
@@ -186,6 +189,7 @@ class APIResource:
         import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
         last_import_time: Synchronized | None = None,
         schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
+        cache_generation: Synchronized | None = None,
     ) -> None:
         """Initialize an APIResource object, set up connection pool and action map.
 
@@ -216,10 +220,14 @@ class APIResource:
         self.action_map["static/favicon_ico"] = self.favicon_ico
         self.action_map["static/styles_css"] = self.styles_css
 
-        self._query_cache = LRUCache(maxsize=1_000)
-        if not settings.enable_cache:
-            # cachebox doesn't support ttl=0, so we use a minimal cache when disabled
-            self._query_cache = LRUCache(maxsize=1)
+        self._cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
+        self._query_cache: GenerationCache = GenerationCache(
+            factory=lambda: LRUCache(maxsize=1_000 if settings.enable_cache else 1),
+            generation=self._cache_generation,
+        )
+        self._search_gen_cache: LRUCache = LRUCache(maxsize=1)  # generation → TTLCache
+        self._preferred_cards_map: LRUCache = LRUCache(maxsize=1)  # generation → list
+        self._preferred_cards_refresh_lock = threading.Lock()
         self._session = requests.Session()
         self._import_guard: LockType = import_guard
         self._last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
@@ -233,6 +241,7 @@ class APIResource:
         logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)
         self.setup_schema()
         self.import_data()  # ensures that database is setup
+        self._get_all_preferred_cards()  # warm preferred cards cache eagerly
 
     @cached(cache={}, key=lambda args, kwds: args[1] if len(args) > 1 else kwds.get("filename"))
     def read_sql(self, filename: str) -> str:
@@ -301,6 +310,7 @@ class APIResource:
             path,
             self._raise_not_found,
         )
+        res = None
         before = time.monotonic()
         try:
             res = action(falcon_response=resp, **req.params)
@@ -337,6 +347,13 @@ class APIResource:
         finally:
             duration = (time.monotonic() - before) * 1000
             logger.info("Request duration: %.1f ms / %s", duration, resp.status)
+            record_span(req, "handler", duration)
+            if isinstance(res, dict):
+                outer = res.get("outer_timings", {})
+                if "get_where_clause" in outer:
+                    record_span(req, "parse", outer["get_where_clause"].get("_meta", {}).get("duration_ms", 0))
+                if "run_query" in outer:
+                    record_span(req, "db", outer["run_query"].get("_meta", {}).get("duration_ms", 0))
 
     def _raise_not_found(self, **_: object) -> None:
         """Raise a Falcon HTTPNotFound error with available routes."""
@@ -760,11 +777,7 @@ class APIResource:
             ) from err
         return where_clause, params
 
-    @cached(
-        cache=TTLCache(maxsize=1000, ttl=60),
-        key=lambda args, kwds: (args, tuple(sorted(kwds.items()))),
-    )
-    def _search(  # noqa: PLR0913
+    def _search(  # noqa: PLR0913,PLR0915
         self,
         *,
         direction: SortDirection = SortDirection.ASC,
@@ -776,6 +789,17 @@ class APIResource:
     ) -> dict[str, Any]:
         self._require_setup_complete()
         limit = self._validate_limit(limit)
+
+        if settings.enable_cache:
+            cache_key = (direction, limit, orderby, prefer, query, unique)
+            gen = self._cache_generation.value
+            try:
+                search_cache = self._search_gen_cache[gen]
+            except KeyError:
+                search_cache = TTLCache(maxsize=1000, ttl=60)
+                self._search_gen_cache[gen] = search_cache
+            if cache_key in search_cache:
+                return search_cache[cache_key]
 
         timer = Timer()
 
@@ -953,7 +977,7 @@ class APIResource:
         total_cards = count_row["total_cards_count"]
         for icard in cards:
             icard.pop("total_cards_count")
-        return {
+        result = {
             "cards": cards,
             "compiled": query_sql,
             "params": params,
@@ -963,6 +987,9 @@ class APIResource:
             "inner_timings": result_bag.pop("timings"),
             "total_cards": total_cards,
         }
+        if settings.enable_cache:
+            search_cache[cache_key] = result
+        return result
 
     def _root(  # noqa: PLR0913
         self,
@@ -2274,6 +2301,7 @@ class APIResource:
                         conn.commit()
 
                         logger.info("Import completed successfully")
+                        self._clear_caches()
                         return {
                             "status": "success",
                             "timestamp": timestamp,
@@ -2567,18 +2595,37 @@ class APIResource:
             }
 
     def _clear_caches(self) -> None:
-        self._query_cache.clear()
-        # Clear the search cache by accessing its cache attribute
-        getattr(self._search, "cache", {}).clear()
-        getattr(self._get_all_preferred_cards, "cache", {}).clear()
+        with self._cache_generation.get_lock():
+            self._cache_generation.value += 1
 
-    @cached(cache=TTLCache(maxsize=1, ttl=600))
+    def _fetch_and_cache_preferred_cards(self, gen: int) -> None:
+        if not self._preferred_cards_refresh_lock.acquire(blocking=False):
+            return
+        try:
+            cards = self._search(query="", limit=None)["cards"]
+            self._preferred_cards_map[gen] = cards
+        except Exception:
+            logger.exception("Background preferred cards refresh failed for generation %d", gen)
+        finally:
+            self._preferred_cards_refresh_lock.release()
+
     def _get_all_preferred_cards(self) -> list[dict[str, Any]]:
-        """Return all preferred printings (one per card name), cached for 10 minutes."""
-        # if _search is wrapped, use the inner function to avoid
-        # double caching of all records in the normal _search cache
-        search_method = getattr(self._search, "__wrapped__", self._search)
-        return search_method(self, query="", limit=None)["cards"]
+        gen = self._cache_generation.value
+        try:
+            return self._preferred_cards_map[gen]
+        except KeyError:
+            stale = next(iter(self._preferred_cards_map.values()), None)
+            if stale is not None:
+                # Stale-while-revalidate: serve old data instantly, refresh in background
+                threading.Thread(
+                    target=self._fetch_and_cache_preferred_cards,
+                    args=(gen,),
+                    daemon=True,
+                ).start()
+                return stale
+            # No previous generation (startup): block until cards are loaded
+            self._fetch_and_cache_preferred_cards(gen)
+            return self._preferred_cards_map.get(gen, [])
 
     def random_search(self, *, num_cards: int = 1, **_: object) -> dict[str, Any]:
         """Return one or more random cards in the same envelope shape as search().

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -241,7 +241,6 @@ class APIResource:
         logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)
         self.setup_schema()
         self.import_data()  # ensures that database is setup
-        self._get_all_preferred_cards()  # warm preferred cards cache eagerly
 
     @cached(cache={}, key=lambda args, kwds: args[1] if len(args) > 1 else kwds.get("filename"))
     def read_sql(self, filename: str) -> str:

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -122,6 +122,7 @@ class ApiWorker(multiprocessing.Process):
             last_import_time=last_import_time,
             schema_setup_event=schema_setup_event,
         )  # Create the main API resource
+        sink._get_all_preferred_cards()  # warm preferred-cards cache before serving traffic
         api.add_sink(sink._handle, prefix="/")  # Route all requests to the sink handler
 
         json_handler = falcon.media.JSONHandler(

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -57,6 +57,7 @@ class ApiWorker(multiprocessing.Process):
         import_guard: LockType = multiprocessing_utils.DEFAULT_LOCK,
         last_import_time: Synchronized | None = None,
         schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
+        cache_generation: Synchronized | None = None,
     ) -> None:
         """Initialize the API worker process.
 
@@ -68,6 +69,7 @@ class ApiWorker(multiprocessing.Process):
             last_import_time (Synchronized | None): Shared value for last bulk import timestamp (Unix time).
             schema_setup_event (multiprocessing.Event): Event denoting schema setup has been completed.
             debug (bool): Whether to run in debug mode.
+            cache_generation (Synchronized | None): Shared counter incremented on cache invalidation.
         """
         super().__init__()
         self.host = host
@@ -77,6 +79,7 @@ class ApiWorker(multiprocessing.Process):
         self.last_import_time = last_import_time
         self.debug = debug
         self.schema_setup_event = schema_setup_event
+        self.cache_generation = cache_generation
 
     @classmethod
     def get_api(
@@ -84,6 +87,7 @@ class ApiWorker(multiprocessing.Process):
         import_guard: LockType,
         last_import_time: Synchronized | None,
         schema_setup_event: EventType,
+        cache_generation: Synchronized | None = None,
     ) -> falcon.App:
         """Create and configure the Falcon API application.
 
@@ -113,6 +117,7 @@ class ApiWorker(multiprocessing.Process):
         )
         api.set_error_serializer(json_error_serializer)  # Use custom JSON error serializer
         sink = APIResource(
+            cache_generation=cache_generation,
             import_guard=import_guard,
             last_import_time=last_import_time,
             schema_setup_event=schema_setup_event,
@@ -144,6 +149,7 @@ class ApiWorker(multiprocessing.Process):
             import bjoern
 
             app = self.get_api(
+                cache_generation=self.cache_generation,
                 import_guard=self.import_guard,
                 last_import_time=self.last_import_time,
                 schema_setup_event=self.schema_setup_event,

--- a/api/entrypoint.py
+++ b/api/entrypoint.py
@@ -55,10 +55,12 @@ def run_server(
     import_guard = multiprocessing.RLock()
     last_import_time = multiprocessing.Value("d", 0.0, lock=True)
     schema_setup_event = multiprocessing.Event()
+    cache_generation = multiprocessing.Value("i", 0, lock=True)
 
     # start workers
     for _ in range(num_workers):
         iworker = ApiWorker(
+            cache_generation=cache_generation,
             exit_flag=exit_flag,
             host=ALL_INTERFACES,
             import_guard=import_guard,

--- a/api/middlewares/compression/compression_mod.py
+++ b/api/middlewares/compression/compression_mod.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 from api.middlewares.compression.compressors import BrotliCompressor, GzipCompressor, ZstdCompressor
+from api.middlewares.timing import record_span
 
 if TYPE_CHECKING:
     import falcon
@@ -127,6 +128,7 @@ class CompressionMiddleware:
             after_compression = time.monotonic()
             resp.text = None
             size_after_compression = len(compressed)
+            compress_ms = 1000 * (after_compression - before_compression)
             logger.info(
                 "%s: Compressed %s bytes to %s bytes using %s (%.2f x compression) in %.2f ms - %s",
                 req.url,
@@ -134,9 +136,10 @@ class CompressionMiddleware:
                 f"{size_after_compression:,}",
                 compressor.encoding,
                 size_before_compression / size_after_compression,
-                1000 * (after_compression - before_compression),
+                compress_ms,
                 req.get_header("User-Agent"),
             )
+            record_span(req, "compress", compress_ms)
 
         resp.set_header("Content-Encoding", compressor.encoding)
         resp.append_header("Vary", "Accept-Encoding")

--- a/api/middlewares/timing.py
+++ b/api/middlewares/timing.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def record_span(req: falcon.Request, name: str, dur_ms: float) -> None:
+    """Record a named timing span on the request context for inclusion in Server-Timing."""
+    req.context.setdefault("_timing_spans", []).append((name, dur_ms))
+
+
 class TimingMiddleware:
     """Middleware to log the duration, status, URL, and user agent for each request."""
 
@@ -46,14 +51,18 @@ class TimingMiddleware:
         del resource, req_succeeded
         start = req.context.get("_start_time")
         duration = time.monotonic() - start if start is not None else -1.0
+        duration_ms = duration * 1000
         logger.info(
             "[timing] %.2f ms | pid: %d | %s | %s | %s",
-            duration * 1000,
+            duration_ms,
             os.getpid(),
             resp.status,
             req.relative_uri,
             req.get_header("User-Agent", "-"),
         )
+        spans = req.context.get("_timing_spans", [])
+        spans.append(("total", duration_ms))
+        resp.set_header("Server-Timing", ", ".join(f"{name};dur={dur:.1f}" for name, dur in spans))
 
 
 class ProfilingMiddleware:

--- a/api/middlewares/timing.py
+++ b/api/middlewares/timing.py
@@ -50,7 +50,10 @@ class TimingMiddleware:
         """
         del resource, req_succeeded
         start = req.context.get("_start_time")
-        duration = time.monotonic() - start if start is not None else -1.0
+        if start is None:
+            logger.warning("TimingMiddleware: start time not found for request %s", req.relative_uri)
+            return
+        duration = time.monotonic() - start
         duration_ms = duration * 1000
         logger.info(
             "[timing] %.2f ms | pid: %d | %s | %s | %s",

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -525,7 +525,6 @@ class TestAPIResourceCaching(unittest.TestCase):
 
     def test_search_cache_clears_after_successful_load(self) -> None:
         """Test that search cache clears after successful card loading."""
-        # Mock the database operations to simulate successful load
         with patch.object(self.api_resource, "_conn_pool") as mock_pool:
             mock_conn = MagicMock()
             mock_cursor = MagicMock()
@@ -533,22 +532,16 @@ class TestAPIResourceCaching(unittest.TestCase):
             mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
             mock_pool.connection.return_value.__enter__.return_value = mock_conn
 
-            # Provide valid card data that will pass preprocessing
             valid_card = create_test_card(
                 card_id="00000000-0000-0000-0000-000000000007",
                 keywords=[],
                 prices={},
             )
 
-            # Add some data to the search cache
-            self.api_resource._search.cache["test_key"] = "test_value"
-            assert "test_key" in self.api_resource._search.cache
-
-            # Call _load_cards_with_staging directly to test cache clearing
+            gen_before = self.api_resource._cache_generation.value
             self.api_resource._load_cards_with_staging([valid_card])
-
-            # Search cache should be cleared after successful load
-            assert "test_key" not in self.api_resource._search.cache
+            # Generation increment is the cross-worker invalidation signal
+            assert self.api_resource._cache_generation.value > gen_before
 
     def test_repeated_random_search_calls_search_once(self) -> None:
         """Test that repeated random_search calls only invoke _search once when the preferred-cards cache is warm."""
@@ -556,7 +549,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         fake_search_result = {"cards": fake_cards, "total_cards": 2}
 
         # Ensure the preferred-cards cache starts empty for this test
-        self.api_resource._get_all_preferred_cards.cache.clear()
+        self.api_resource._preferred_cards_map.clear()
 
         with patch.object(self.api_resource, "_search", return_value=fake_search_result) as mock_search:
             result1 = self.api_resource.random_search(num_cards=1)
@@ -582,14 +575,17 @@ class TestAPIResourceCaching(unittest.TestCase):
                 prices={},
             )
 
-            # Seed the preferred-cards cache with a sentinel value
-            self.api_resource._get_all_preferred_cards.cache[None] = [{"name": "sentinel"}]
-            assert None in self.api_resource._get_all_preferred_cards.cache
+            # Seed the preferred-cards map at the current generation
+            gen = self.api_resource._cache_generation.value
+            self.api_resource._preferred_cards_map[gen] = [{"name": "sentinel"}]
+            assert self.api_resource._preferred_cards_map.get(gen) is not None
 
             self.api_resource._load_cards_with_staging([valid_card])
 
-            # Cache should be cleared after successful load
-            assert None not in self.api_resource._get_all_preferred_cards.cache
+            # After load the generation advances; sentinel is unreachable at the new generation
+            new_gen = self.api_resource._cache_generation.value
+            assert new_gen > gen
+            assert self.api_resource._preferred_cards_map.get(new_gen) is None
 
     def test_cache_clear_method_works(self) -> None:
         """Test that cache.clear() method works for cachebox caches."""
@@ -600,12 +596,94 @@ class TestAPIResourceCaching(unittest.TestCase):
         self.api_resource._query_cache.clear()
         assert "test_key" not in self.api_resource._query_cache
 
-        # Test search cache clearing
-        self.api_resource._search.cache["test_key"] = "test_value"
-        assert "test_key" in self.api_resource._search.cache
+        # Test that generation increment invalidates the search gen cache
+        gen_before = self.api_resource._cache_generation.value
+        self.api_resource._clear_caches()
+        assert self.api_resource._cache_generation.value == gen_before + 1
 
-        self.api_resource._search.cache.clear()
-        assert "test_key" not in self.api_resource._search.cache
+    def test_get_all_preferred_cards_returns_stale_on_generation_miss(self) -> None:
+        """On a cache miss, returns the previous generation's cards immediately."""
+        stale_cards = [{"name": "Stale Card"}]
+        gen = self.api_resource._cache_generation.value
+        self.api_resource._preferred_cards_map[gen] = stale_cards
+
+        # Advance generation so current gen has no data
+        self.api_resource._cache_generation.value += 1
+
+        with patch.object(self.api_resource, "_search"):
+            result = self.api_resource._get_all_preferred_cards()
+
+        assert result == stale_cards
+        # _search is called in the background thread, not the calling thread, so it
+        # may or may not have fired yet — we only assert the return value here.
+
+    def test_get_all_preferred_cards_spawns_background_refresh(self) -> None:
+        """Spawns exactly one background thread to populate the new generation's cache."""
+        import threading  # noqa: PLC0415
+
+        stale_cards = [{"name": "Stale Card"}]
+        gen = self.api_resource._cache_generation.value
+        self.api_resource._preferred_cards_map[gen] = stale_cards
+        self.api_resource._cache_generation.value += 1
+
+        threads_started: list = []
+        real_thread_init = threading.Thread.__init__
+
+        def tracking_init(self_thread: threading.Thread, **kwargs: object) -> None:
+            threads_started.append(kwargs.get("target"))
+            real_thread_init(self_thread, **kwargs)
+
+        with (
+            patch.object(threading.Thread, "__init__", tracking_init),
+            patch.object(self.api_resource, "_search", return_value={"cards": []}),
+        ):
+            self.api_resource._get_all_preferred_cards()
+
+        assert len(threads_started) == 1
+        assert threads_started[0] == self.api_resource._fetch_and_cache_preferred_cards
+
+    def test_get_all_preferred_cards_blocks_synchronously_at_startup(self) -> None:
+        """With no stale data, blocks until cards are fetched (startup path)."""
+        fresh_cards = [{"name": "Fresh Card"}]
+        self.api_resource._preferred_cards_map.clear()
+
+        with patch.object(self.api_resource, "_search", return_value={"cards": fresh_cards}):
+            result = self.api_resource._get_all_preferred_cards()
+
+        assert result == fresh_cards
+
+    def test_fetch_and_cache_skips_if_lock_held(self) -> None:
+        """_fetch_and_cache_preferred_cards returns without calling _search if the lock is held."""
+        gen = self.api_resource._cache_generation.value
+        self.api_resource._preferred_cards_refresh_lock.acquire()
+        try:
+            with patch.object(self.api_resource, "_search") as mock_search:
+                self.api_resource._fetch_and_cache_preferred_cards(gen)
+            mock_search.assert_not_called()
+        finally:
+            self.api_resource._preferred_cards_refresh_lock.release()
+
+    def test_background_refresh_populates_new_generation(self) -> None:
+        """Background thread eventually populates the new generation's cache."""
+        import time  # noqa: PLC0415
+
+        fresh_cards = [{"name": "Fresh Card"}]
+        stale_cards = [{"name": "Stale Card"}]
+        gen = self.api_resource._cache_generation.value
+        self.api_resource._preferred_cards_map[gen] = stale_cards
+        new_gen = gen + 1
+        self.api_resource._cache_generation.value = new_gen
+
+        with patch.object(self.api_resource, "_search", return_value={"cards": fresh_cards}):
+            self.api_resource._get_all_preferred_cards()
+            # Give the daemon thread time to complete
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                if self.api_resource._preferred_cards_map.get(new_gen) is not None:
+                    break
+                time.sleep(0.01)
+
+        assert self.api_resource._preferred_cards_map.get(new_gen) == fresh_cards
 
 
 class TestAPIResourceTagHierarchy(unittest.TestCase):

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -635,6 +635,7 @@ class TestAPIResourceCaching(unittest.TestCase):
 
         with (
             patch.object(threading.Thread, "__init__", tracking_init),
+            patch.object(threading.Thread, "start", lambda _: None),
             patch.object(self.api_resource, "_search", return_value={"cards": []}),
         ):
             self.api_resource._get_all_preferred_cards()

--- a/api/utils/generation_cache.py
+++ b/api/utils/generation_cache.py
@@ -1,0 +1,57 @@
+"""Generation-aware cache proxy for cross-process cache invalidation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cachebox import LRUCache
+
+if TYPE_CHECKING:
+    from multiprocessing.sharedctypes import Synchronized
+
+
+class GenerationCache:
+    """Cache proxy that auto-invalidates across workers when a shared generation counter advances.
+
+    Wraps an LRUCache(maxsize=1) as a map from generation → inner cache.
+    When the generation advances, the next access creates a fresh inner cache
+    and the LRU evicts the old one, freeing its memory.
+    """
+
+    def __init__(self, factory: Any, generation: Synchronized) -> None:  # noqa: ANN401
+        """Initialize with a cache factory callable and a shared generation counter."""
+        self._factory = factory
+        self._generation = generation
+        self._map: LRUCache = LRUCache(maxsize=1)
+
+    def _current(self) -> Any:  # noqa: ANN401
+        gen = self._generation.value
+        try:
+            return self._map[gen]
+        except KeyError:
+            cache = self._factory()
+            self._map[gen] = cache
+            return cache
+
+    def __getitem__(self, key: Any) -> Any:  # noqa: ANN401
+        """Return item from the current generation's cache."""
+        return self._current()[key]
+
+    def __setitem__(self, key: Any, value: Any) -> None:  # noqa: ANN401
+        """Store item in the current generation's cache."""
+        self._current()[key] = value
+
+    def __contains__(self, key: object) -> bool:
+        """Return whether key exists in the current generation's cache."""
+        return key in self._current()
+
+    def get(self, key: Any, default: Any = None) -> Any:  # noqa: ANN401
+        """Return item or default if not present in the current generation's cache."""
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def clear(self) -> None:
+        """Clear the current generation's inner cache."""
+        self._current().clear()

--- a/api/utils/tests/__init__.py
+++ b/api/utils/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for api.utils modules."""

--- a/api/utils/tests/test_generation_cache.py
+++ b/api/utils/tests/test_generation_cache.py
@@ -1,0 +1,108 @@
+"""Tests for GenerationCache."""
+
+from __future__ import annotations
+
+import multiprocessing
+
+import pytest
+
+from api.utils.generation_cache import GenerationCache
+
+
+@pytest.fixture
+def generation() -> multiprocessing.Value:
+    return multiprocessing.Value("i", 0, lock=True)
+
+
+@pytest.fixture
+def cache(generation: multiprocessing.Value) -> GenerationCache:
+    return GenerationCache(factory=dict, generation=generation)
+
+
+class TestGenerationCacheBasicAccess:
+    def test_set_and_get(self, cache: GenerationCache) -> None:
+        cache["key"] = "value"
+        assert cache["key"] == "value"
+
+    def test_contains_true(self, cache: GenerationCache) -> None:
+        cache["key"] = "value"
+        assert "key" in cache
+
+    def test_contains_false(self, cache: GenerationCache) -> None:
+        assert "missing" not in cache
+
+    def test_get_present(self, cache: GenerationCache) -> None:
+        cache["key"] = "value"
+        assert cache.get("key") == "value"
+
+    def test_get_missing_returns_default(self, cache: GenerationCache) -> None:
+        assert cache.get("missing") is None
+        assert cache.get("missing", "fallback") == "fallback"
+
+    def test_getitem_missing_raises(self, cache: GenerationCache) -> None:
+        with pytest.raises(KeyError):
+            _ = cache["missing"]
+
+    def test_clear_removes_keys(self, cache: GenerationCache) -> None:
+        cache["key"] = "value"
+        cache.clear()
+        assert "key" not in cache
+
+
+class TestGenerationCacheInvalidation:
+    def test_value_inaccessible_after_generation_advances(self, cache: GenerationCache, generation: multiprocessing.Value) -> None:
+        cache["key"] = "value"
+        assert "key" in cache
+
+        generation.value += 1
+
+        assert "key" not in cache
+
+    def test_new_generation_starts_empty(self, cache: GenerationCache, generation: multiprocessing.Value) -> None:
+        cache["key"] = "value"
+        generation.value += 1
+
+        with pytest.raises(KeyError):
+            _ = cache["key"]
+
+    def test_independent_values_per_generation(self, cache: GenerationCache, generation: multiprocessing.Value) -> None:
+        cache["key"] = "gen0"
+        generation.value += 1
+        cache["key"] = "gen1"
+
+        assert cache["key"] == "gen1"
+
+        generation.value -= 1
+        assert cache.get("key") is None  # gen0 cache was evicted by LRU(maxsize=1)
+
+    def test_factory_called_once_per_generation(self, generation: multiprocessing.Value) -> None:
+        call_count = 0
+
+        def counting_factory() -> dict:
+            nonlocal call_count
+            call_count += 1
+            return {}
+
+        cache = GenerationCache(factory=counting_factory, generation=generation)
+
+        cache["a"] = 1
+        cache["b"] = 2
+        _ = cache["a"]
+
+        assert call_count == 1  # one cache created for gen 0
+
+        generation.value += 1
+        cache["c"] = 3
+
+        assert call_count == 2  # new cache created for gen 1
+
+    def test_generation_advance_evicts_old_inner_cache(self, generation: multiprocessing.Value) -> None:
+        # Populate gen 0, advance to gen 1, then go back — old cache should be gone (LRU evicted it)
+        cache = GenerationCache(factory=dict, generation=generation)
+        cache["key"] = "gen0_value"
+
+        generation.value += 1
+        cache["other"] = "gen1_value"  # causes LRU to evict gen0's cache
+
+        generation.value -= 1
+        assert "key" not in cache  # gen0 cache was evicted


### PR DESCRIPTION
## What

Two independent improvements:

1. **Server-Timing spans** — emit a `Server-Timing` response header so browser devtools and
   monitoring tools can see per-phase breakdown (parse, DB, compress, total) without reading logs.

2. **Cross-process cache invalidation** — replace per-process TTL caches with a shared generation
   counter so a data import on any worker immediately invalidates the search and preferred-cards
   caches on all other workers.

## Changes

### Timing spans (`c915793`)

**`api/middlewares/timing.py`**

- `record_span(req, name, dur_ms)` — attaches a `(name, ms)` tuple to `req.context._timing_spans`.
- `TimingMiddleware.process_response` reads `_timing_spans`, appends a `total` entry, and emits
  `Server-Timing: parse;dur=…, db;dur=…, compress;dur=…, total;dur=…`.

**`api/middlewares/compression/compression_mod.py`**

Calls `record_span(req, "compress", compress_ms)` after each compression so the compression cost
appears in `Server-Timing`.

**`api/api_resource.py`**

`_handle` records a `handler` span over the full action dispatch. The search path additionally
records `parse` and `db` spans extracted from the inner timing tree.

### Cross-process cache invalidation (`dd7d025`, `c32bac0`)

**`api/utils/generation_cache.py`** (new)

`GenerationCache` — a dict-like proxy that wraps `LRUCache(maxsize=1)` as a
`generation → inner_cache` map. When the shared generation counter advances, the next access
creates a fresh inner cache; the LRU automatically evicts the old one. See
[per-worker-cache-staleness.md](../../issues/per-worker-cache-staleness.md) for the problem this
solves.

**`api/entrypoint.py`**

Creates `cache_generation = multiprocessing.Value("i", 0, lock=True)` and passes it to every
`ApiWorker`.

**`api/api_worker.py`**

Threads `cache_generation` through `get_api()` into `APIResource`.

**`api/api_resource.py`**

- `_query_cache` replaced with `GenerationCache` — `_run_query` is unchanged, the proxy is
  drop-in.
- `_search` decorator replaced with inline generation-aware caching using `_search_gen_cache`
  (`LRUCache(maxsize=1)` keyed by generation → `TTLCache(maxsize=1000, ttl=60)`).
- `_get_all_preferred_cards` uses stale-while-revalidate: on a generation miss, returns the
  previous generation's card list immediately and spawns a daemon thread to populate the new
  generation. A `threading.Lock` with `acquire(blocking=False)` ensures only one thread runs the
  DB fetch at a time. On startup (no stale data), blocks synchronously so the server is warm
  before serving traffic.
- `_clear_caches` reduced to a single generation increment (under lock). All workers observe the
  new generation lazily on their next request.
- `import_card_data` now calls `_clear_caches()` after a successful commit — this was a pre-existing
  bug where that mutation path never invalidated any cache.

### Tests

**`api/utils/tests/test_generation_cache.py`** (new)

Unit tests for `GenerationCache` in isolation: basic access, `clear`, cross-generation
inaccessibility, factory-called-once-per-generation, LRU eviction of old inner caches.

**`api/tests/test_api_resource.py`**

Five new tests in `TestAPIResourceCaching`:
- stale data returned on generation miss
- exactly one background thread spawned on miss
- synchronous block at startup (no stale)
- lock prevents duplicate DB fetches
- background thread eventually populates new generation's cache

## Test plan

- [ ] `make test-unit` passes
- [ ] Browser devtools Network tab shows `Server-Timing` header with `parse`, `db`, `compress`,
  `total` entries on `/search` requests
- [ ] After a bulk import, subsequent searches on all workers return updated results within one
  request (not after 10 minutes)
- [ ] `random_search` returns cards immediately after an import (stale list) and serves the updated
  list within ~500 ms
