### PR TITLE
Set / as the canonical path

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -204,7 +204,8 @@ class APIResource:
         self.action_map["_root"] = make_type_converting_wrapper(self._root)
 
         def redirect_to_root(**_: object) -> None:
-            raise falcon.HTTPMovedPermanently("/")
+            msg = "/"
+            raise falcon.HTTPMovedPermanently(msg)
 
         self.action_map["index"] = redirect_to_root
         self.action_map["index_html"] = redirect_to_root

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -201,7 +201,13 @@ class APIResource:
             method = getattr(self, method_name)
             if callable(method):
                 self.action_map[method_name] = make_type_converting_wrapper(method)
-        self.action_map["index"] = make_type_converting_wrapper(self.index_html)
+        self.action_map["_root"] = make_type_converting_wrapper(self._root)
+
+        def redirect_to_root(**_: object) -> None:
+            raise falcon.HTTPMovedPermanently("/")
+
+        self.action_map["index"] = redirect_to_root
+        self.action_map["index_html"] = redirect_to_root
 
         # add static file serving actions
         self.action_map["static/app_js"] = self.app_js
@@ -278,7 +284,7 @@ class APIResource:
             logger.info("Request already handled: %s", req.relative_uri)
             return
 
-        path = req.path.strip("/") or "index"
+        path = req.path.strip("/") or "_root"
 
         if path in ("db_ready", "pid"):
             return
@@ -957,7 +963,7 @@ class APIResource:
             "total_cards": total_cards,
         }
 
-    def index_html(  # noqa: PLR0913
+    def _root(  # noqa: PLR0913
         self,
         *,
         falcon_response: falcon.Response | None = None,

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -32,6 +32,7 @@
     />
     <meta property="og:type" content="website" />
     <title>Arcane Tutor - Magic: The Gathering Card Search</title>
+    <link rel="canonical" href="https://arcane-tutor.com/" />
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
     <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
     <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />
@@ -169,14 +170,14 @@
           <a href="https://github.com/jbylund/arcane_tutor" target="_blank" rel="noopener">GitHub</a>
           ·
           <a
-            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/terms_of_service.md"
+            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/user/terms_of_service.md"
             target="_blank"
             rel="noopener"
             >Terms of Service</a
           >
           ·
           <a
-            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/privacy_policy.md"
+            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/user/privacy_policy.md"
             target="_blank"
             rel="noopener"
             >Privacy Policy</a

--- a/api/tagger_client.py
+++ b/api/tagger_client.py
@@ -199,7 +199,7 @@ class TaggerClient:
         )
 
         def get_response() -> requests.Response:
-            time.sleep(0.43)
+            time.sleep(0.51)
             response = retryer(self.session.post)(
                 f"{self.base_url}/graphql",
                 json={

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -364,10 +364,10 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
             assert mock_response.text == "file content"
 
     def test_index_html_serves_static_file(self) -> None:
-        """Test index_html serves the index.html file."""
+        """Test _root serves the index.html file."""
         mock_response = MagicMock()
 
-        self.api_resource.index_html(falcon_response=mock_response)
+        self.api_resource._root(falcon_response=mock_response)
 
         # Verify the response contains HTML content
         assert mock_response.text is not None
@@ -377,7 +377,7 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         mock_response.set_header.assert_called_with("Cache-Control", "public, max-age=3600")
 
     def test_index_html_with_query_embeds_search_results(self) -> None:
-        """Test index_html embeds search results when query parameter is provided."""
+        """Test _root embeds search results when query parameter is provided."""
         mock_response = MagicMock()
 
         # Mock the _search method to return test results
@@ -388,8 +388,8 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         }
 
         with patch.object(self.api_resource, "_search", return_value=mock_search_results):
-            # Call index_html with a search query
-            self.api_resource.index_html(falcon_response=mock_response, q="elf")
+            # Call _root with a search query
+            self.api_resource._root(falcon_response=mock_response, q="elf")
 
         # Verify the response contains HTML content
         assert mock_response.text is not None


### PR DESCRIPTION
This PR updates the web entrypoint so the site’s homepage is treated as `/` (root) as the canonical URL, and updates the HTML to reflect that canonical path.

**Changes:**
- Add a canonical `<link>` tag pointing to `https://arcane-tutor.com/` and update footer links to the new docs locations.
- Change API request routing so `/` serves the homepage handler, while `/index` and `/index.html` permanently redirect to `/`.
- Slightly increase the fixed delay before Tagger GraphQL requests.