### PR TITLE
Improve Scryfall tagger retry behavior on 429s

### DIFF
--- a/api/tagger_client.py
+++ b/api/tagger_client.py
@@ -188,11 +188,34 @@ class TaggerClient:
                 + tag_attrs
             )
 
-        def before_sleep_fn(*args: object, **kwargs: object) -> None:
-            logger.warning("Had failure talking to tagger api %s %s", args, kwargs)
+        def before_sleep_fn(retry_state: tenacity.RetryCallState) -> None:
+            exc = retry_state.outcome.exception()
+            if isinstance(exc, requests.HTTPError) and exc.response is not None:
+                retry_after = exc.response.headers.get("Retry-After")
+                logger.warning(
+                    "Tagger API request failed (attempt %s, status %s, retry-after: %s)",
+                    retry_state.attempt_number,
+                    exc.response.status_code,
+                    retry_after,
+                )
+            else:
+                logger.warning("Tagger API request failed (attempt %s): %s", retry_state.attempt_number, exc)
+
+        _exp_wait = tenacity.wait_exponential(multiplier=0.1, min=0.1, max=10)
+
+        def wait_fn(retry_state: tenacity.RetryCallState) -> float:
+            exc = retry_state.outcome.exception()
+            if isinstance(exc, requests.HTTPError) and exc.response is not None:
+                header = exc.response.headers.get("Retry-After")
+                if header is not None:
+                    try:
+                        return float(header)
+                    except (ValueError, TypeError):
+                        pass
+            return _exp_wait(retry_state)
 
         retryer = tenacity.retry(
-            wait=tenacity.wait_exponential(multiplier=0.1, min=0.1, max=2) + tenacity.wait_random(0, 0.1),
+            wait=wait_fn,
             reraise=True,
             stop=tenacity.stop_after_attempt(7),
             before_sleep=before_sleep_fn,

--- a/api/tagger_client.py
+++ b/api/tagger_client.py
@@ -15,6 +15,34 @@ logger = logging.getLogger(__name__)
 class TaggerClient:
     """Client for interacting with Scryfall Tagger GraphQL API."""
 
+    _exp_wait = tenacity.wait_exponential(multiplier=0.1, min=0.1, max=10)
+
+    @classmethod
+    def _before_sleep(cls, retry_state: tenacity.RetryCallState) -> None:
+        exc = retry_state.outcome.exception()
+        if isinstance(exc, requests.HTTPError) and exc.response is not None:
+            retry_after = exc.response.headers.get("Retry-After")
+            logger.warning(
+                "Tagger API request failed (attempt %s, status %s, retry-after: %s)",
+                retry_state.attempt_number,
+                exc.response.status_code,
+                retry_after,
+            )
+        else:
+            logger.warning("Tagger API request failed (attempt %s): %s", retry_state.attempt_number, exc)
+
+    @classmethod
+    def _wait(cls, retry_state: tenacity.RetryCallState) -> float:
+        exc = retry_state.outcome.exception()
+        if isinstance(exc, requests.HTTPError) and exc.response is not None:
+            header = exc.response.headers.get("Retry-After")
+            if header is not None:
+                try:
+                    return float(header)
+                except (ValueError, TypeError):
+                    pass
+        return cls._exp_wait(retry_state)
+
     def __init__(self) -> None:
         """Initialize the TaggerClient."""
         self.session = requests.Session()
@@ -188,37 +216,11 @@ class TaggerClient:
                 + tag_attrs
             )
 
-        def before_sleep_fn(retry_state: tenacity.RetryCallState) -> None:
-            exc = retry_state.outcome.exception()
-            if isinstance(exc, requests.HTTPError) and exc.response is not None:
-                retry_after = exc.response.headers.get("Retry-After")
-                logger.warning(
-                    "Tagger API request failed (attempt %s, status %s, retry-after: %s)",
-                    retry_state.attempt_number,
-                    exc.response.status_code,
-                    retry_after,
-                )
-            else:
-                logger.warning("Tagger API request failed (attempt %s): %s", retry_state.attempt_number, exc)
-
-        _exp_wait = tenacity.wait_exponential(multiplier=0.1, min=0.1, max=10)
-
-        def wait_fn(retry_state: tenacity.RetryCallState) -> float:
-            exc = retry_state.outcome.exception()
-            if isinstance(exc, requests.HTTPError) and exc.response is not None:
-                header = exc.response.headers.get("Retry-After")
-                if header is not None:
-                    try:
-                        return float(header)
-                    except (ValueError, TypeError):
-                        pass
-            return _exp_wait(retry_state)
-
         retryer = tenacity.retry(
-            wait=wait_fn,
+            wait=self._wait,
             reraise=True,
             stop=tenacity.stop_after_attempt(7),
-            before_sleep=before_sleep_fn,
+            before_sleep=self._before_sleep,
         )
 
         def get_response() -> requests.Response:

--- a/api/tagger_client.py
+++ b/api/tagger_client.py
@@ -1,9 +1,11 @@
 """Client for interacting with Scryfall Tagger GraphQL API."""
 
 import collections
+import datetime
 import logging
 import re
 import time
+from email.utils import parsedate_to_datetime
 
 import requests
 import tenacity
@@ -37,8 +39,15 @@ class TaggerClient:
         if isinstance(exc, requests.HTTPError) and exc.response is not None:
             header = exc.response.headers.get("Retry-After")
             if header is not None:
+                # RFC 9110: Retry-After is either delta-seconds or an HTTP-date.
                 try:
                     return float(header)
+                except (ValueError, TypeError):
+                    pass
+                try:
+                    retry_time = parsedate_to_datetime(header)
+                    delay = (retry_time - datetime.datetime.now(tz=datetime.UTC)).total_seconds()
+                    return max(0.0, delay)
                 except (ValueError, TypeError):
                     pass
         return cls._exp_wait(retry_state)

--- a/api/tests/test_tagger_client.py
+++ b/api/tests/test_tagger_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -66,6 +67,26 @@ class TestTaggerClient:
         result_1 = TaggerClient._wait(_make_retry_state(exc, attempt_number=1))
         result_2 = TaggerClient._wait(_make_retry_state(exc, attempt_number=2))
         assert result_2 > result_1
+
+    def test_wait_parses_http_date_in_future(self) -> None:
+        future = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(seconds=30)
+        header = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        exc = _make_http_error(429, {"Retry-After": header})
+        state = _make_retry_state(exc)
+        result = TaggerClient._wait(state)
+        assert 28.0 <= result <= 32.0
+
+    def test_wait_returns_zero_for_http_date_in_past(self) -> None:
+        past = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(seconds=10)
+        header = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        exc = _make_http_error(429, {"Retry-After": header})
+        state = _make_retry_state(exc)
+        assert TaggerClient._wait(state) == 0.0
+
+    def test_wait_falls_back_to_exponential_for_malformed_date(self) -> None:
+        exc = _make_http_error(429, {"Retry-After": "not-a-date-or-number"})
+        state = _make_retry_state(exc, attempt_number=1)
+        assert TaggerClient._wait(state) == pytest.approx(0.1)
 
     # ------------------------------------------------------------------
     # _before_sleep

--- a/api/tests/test_tagger_client.py
+++ b/api/tests/test_tagger_client.py
@@ -1,0 +1,99 @@
+"""Tests for TaggerClient retry helpers."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+import tenacity
+
+from api.tagger_client import TaggerClient
+
+
+def _make_retry_state(exc: Exception, attempt_number: int = 1) -> tenacity.RetryCallState:
+    """Build a RetryCallState with the given exception and attempt number."""
+    state = tenacity.RetryCallState(retry_object=MagicMock(), fn=None, args=(), kwargs={})
+    state.attempt_number = attempt_number
+    try:
+        raise exc
+    except Exception:  # noqa: BLE001
+        state.set_exception(sys.exc_info())
+    return state
+
+
+def _make_http_error(status_code: int, headers: dict | None = None) -> requests.HTTPError:
+    """Build an HTTPError with a mock response."""
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.headers = headers or {}
+    return requests.HTTPError(response=response)
+
+
+class TestTaggerClient:
+    """Tests for TaggerClient class methods."""
+
+    # ------------------------------------------------------------------
+    # _wait
+    # ------------------------------------------------------------------
+
+    def test_wait_returns_retry_after_when_present(self) -> None:
+        exc = _make_http_error(429, {"Retry-After": "15"})
+        state = _make_retry_state(exc)
+        assert TaggerClient._wait(state) == 15.0
+
+    def test_wait_falls_back_to_exponential_when_header_absent(self) -> None:
+        exc = _make_http_error(429, {})
+        state = _make_retry_state(exc, attempt_number=1)
+        result = TaggerClient._wait(state)
+        # exponential(multiplier=0.1, min=0.1, max=10) on attempt 1 → 0.1
+        assert result == pytest.approx(0.1)
+
+    def test_wait_falls_back_to_exponential_when_header_non_numeric(self) -> None:
+        exc = _make_http_error(429, {"Retry-After": "soon"})
+        state = _make_retry_state(exc, attempt_number=1)
+        result = TaggerClient._wait(state)
+        assert result == pytest.approx(0.1)
+
+    def test_wait_falls_back_to_exponential_for_non_http_exception(self) -> None:
+        state = _make_retry_state(ConnectionError("timeout"), attempt_number=1)
+        result = TaggerClient._wait(state)
+        assert result == pytest.approx(0.1)
+
+    def test_wait_exponential_grows_with_attempt_number(self) -> None:
+        exc = _make_http_error(503, {})
+        result_1 = TaggerClient._wait(_make_retry_state(exc, attempt_number=1))
+        result_2 = TaggerClient._wait(_make_retry_state(exc, attempt_number=2))
+        assert result_2 > result_1
+
+    # ------------------------------------------------------------------
+    # _before_sleep
+    # ------------------------------------------------------------------
+
+    def test_before_sleep_logs_status_and_retry_after_for_http_error(self) -> None:
+        exc = _make_http_error(429, {"Retry-After": "15"})
+        state = _make_retry_state(exc, attempt_number=2)
+        with patch("api.tagger_client.logger") as mock_logger:
+            TaggerClient._before_sleep(state)
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert 429 in call_args.args or 429 in str(call_args)
+        assert 2 in call_args.args or "2" in str(call_args)
+        assert "15" in str(call_args)
+
+    def test_before_sleep_logs_none_retry_after_when_header_absent(self) -> None:
+        exc = _make_http_error(429, {})
+        state = _make_retry_state(exc, attempt_number=1)
+        with patch("api.tagger_client.logger") as mock_logger:
+            TaggerClient._before_sleep(state)
+        mock_logger.warning.assert_called_once()
+        assert "None" in str(mock_logger.warning.call_args)
+
+    def test_before_sleep_logs_exception_for_non_http_error(self) -> None:
+        exc = ConnectionError("timeout")
+        state = _make_retry_state(exc, attempt_number=1)
+        with patch("api.tagger_client.logger") as mock_logger:
+            TaggerClient._before_sleep(state)
+        mock_logger.warning.assert_called_once()
+        assert "timeout" in str(mock_logger.warning.call_args)


### PR DESCRIPTION
## What

Two improvements to `TaggerClient.fetch_tag` retry handling:

**Respect `Retry-After` header.** When the tagger API returns a 429, it sets
`Retry-After: 15`. The old retry config used a capped exponential backoff (max 2s),
so all retry attempts fired within the rate-limit window and failed. The new `wait_fn`
reads the `Retry-After` header from the 429 response and waits that many seconds;
it falls back to exponential backoff when the header is absent.

**Better retry logging.** The old `before_sleep_fn` logged the raw tenacity
`RetryCallState` args, which was noisy and hard to read. The new version logs
attempt number, HTTP status code, and the `Retry-After` value explicitly — making
it easy to confirm the header is present and the right wait is being applied.

## Changes

**`api/tagger_client.py`**

- `before_sleep_fn` — typed to `RetryCallState`, logs `attempt`, `status`, and
  `retry-after` for HTTP errors; falls back to logging the exception for non-HTTP
  failures.
- `wait_fn` — custom wait callable that returns `float(Retry-After)` when the header
  is present on an `HTTPError` response, otherwise delegates to
  `wait_exponential(multiplier=0.1, min=0.1, max=10)`.
- Max exponential backoff increased from 2s → 10s for cases where no header is
  present.
