### PR TITLE
Stream Scryfall Bulk Data Import to Reduce Memory Spike

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -500,16 +500,6 @@ class APIResource:
         existing_tables = {r["relname"] for r in records}
         return "migrations" in existing_tables
 
-    def get_data(self) -> list[dict]:
-        """Retrieve card data from cache or Scryfall API.
-
-        Returns:
-        -------
-            Any: The card data (likely a list of dicts).
-
-        """
-        return self._bulk_data_fetcher.get_data_for_key(data_key=BulkDataKey.DEFAULT_CARDS)
-
     def setup_schema(self, *_: object, **__: object) -> None:
         """Set up the database schema and apply migrations as needed."""
         if self._schema_setup_event.is_set():
@@ -572,28 +562,12 @@ class APIResource:
             self._schema_setup_event.set()
             logger.info("Schema setup complete in pid %d", os.getpid())
 
-    def _get_cards_to_insert(self) -> list[dict[str, Any]]:
-        """Get the cards to insert into the database.
-
-        For DFCs (Double-Faced Cards), each face is returned as a separate dictionary.
-        The deduplication key is (scryfall_id, face_idx) to support multiple faces per printing.
-        """
-        all_cards = self.get_data()
-        key_to_card: dict[tuple[str, int], dict[str, Any]] = {}
-        for card in all_cards:
-            processed_cards = preprocess_card(card)
-            for processed_card in processed_cards:
-                scryfall_id = processed_card["scryfall_id"]
-                face_idx = processed_card["face_idx"]
-                key_to_card[(scryfall_id, face_idx)] = processed_card
-        return list(key_to_card.values())
-
     def get_stats(self, **_: object) -> dict[str, Any]:
         """Get stats about the cards."""
-        to_insert = self._get_cards_to_insert()
         key_frequency = collections.Counter()
-        for card in to_insert:
-            key_frequency.update(k for k, v in card.items() if v not in [None, [], {}])
+        for raw_card in self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS):
+            for processed in preprocess_card(raw_card):
+                key_frequency.update(k for k, v in processed.items() if v not in [None, [], {}])
         return key_frequency.most_common()
 
     _SETUP_COMPLETE_TTL = 60 * 60  # 1 hour; also invalidated when _last_import_time changes

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -2478,6 +2478,7 @@ class APIResource:
     def _load_cards_with_staging(
         self,
         cards: Iterable[dict[str, Any]],
+        page_size: int = 6000,
     ) -> dict[str, Any]:
         """Load cards into the database using a randomly-named staging table.
 
@@ -2523,7 +2524,7 @@ class APIResource:
                 cards_loaded = cards_sent = 0
                 sample_cards: list[dict[str, Any]] = []
 
-                for page in itertools.batched(stream, 6000):
+                for page in itertools.batched(stream, page_size):
                     rows, sample_cards = self._copy_batch_to_staging(cursor, staging_table_name, page)
                     cards_sent += len(page)
                     cards_loaded += rows

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -46,6 +46,7 @@ from api.utils.timer import Timer
 from api.utils.type_conversions import _get_type_name, make_type_converting_wrapper
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
@@ -649,11 +650,9 @@ class APIResource:
             return None
         self.setup_schema()
 
-        to_insert = self._get_cards_to_insert()
-
         before = time.monotonic()
 
-        result = self._load_cards_with_staging(to_insert)
+        result = self._load_cards_with_staging(self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
         after_transfer = time.monotonic()
 
@@ -661,7 +660,8 @@ class APIResource:
             if self._last_import_time is not None:
                 self._last_import_time.value = time.time()
             total_time = after_transfer - before
-            rate = len(to_insert) / total_time if total_time > 0 else 0
+            cards_sent = result.get("cards_sent", result["cards_loaded"])
+            rate = cards_sent / total_time if total_time > 0 else 0
             logger.info(
                 "Loaded %d cards in %.2f seconds, rate: %.2f cards/s...",
                 result["cards_loaded"],
@@ -2434,151 +2434,126 @@ class APIResource:
 
             return import_results
 
+    def _copy_batch_to_staging(
+        self,
+        cursor: Cursor,
+        staging_table_name: str,
+        page: tuple[dict[str, Any], ...],
+    ) -> tuple[int, list[dict[str, Any]]]:
+        """COPY one batch of preprocessed cards through a temp staging table into magic.cards.
+
+        Returns (rows_inserted, sample_cards).
+        """
+        cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb)")
+
+        with cursor.copy(
+            f"COPY {staging_table_name} (card_blob) FROM STDIN WITH (FORMAT csv, HEADER false)",
+        ) as copy_filehandle:
+            writer = csv.writer(copy_filehandle, quoting=csv.QUOTE_ALL)
+            writer.writerows([orjson.dumps(card, option=orjson.OPT_SORT_KEYS).decode("utf-8")] for card in page)
+
+        random_threshold = 20 / len(page)  # targets ~10 samples
+        cursor.execute(
+            f"""
+            SELECT (jsonb_populate_record(null::magic.cards, card_blob)).*
+            FROM {staging_table_name}
+            WHERE RANDOM() < {random_threshold}
+            ORDER BY RANDOM()
+            LIMIT 10""",
+        )
+        sample_cards = [dict(r) for r in cursor.fetchall()]
+
+        cursor.execute(
+            f"""
+            INSERT INTO magic.cards
+            SELECT (jsonb_populate_record(null::magic.cards, card_blob)).*
+            FROM {staging_table_name}
+            ON CONFLICT DO NOTHING
+            """,
+        )
+        rows_inserted = cursor.rowcount
+        cursor.execute(f"DROP TABLE {staging_table_name}")
+        return rows_inserted, sample_cards
+
     def _load_cards_with_staging(
         self,
-        cards: list[dict[str, Any]],
+        cards: Iterable[dict[str, Any]],
     ) -> dict[str, Any]:
         """Load cards into the database using a randomly-named staging table.
 
-        This method consolidates card loading functionality by:
-        1. Creating a staging table with a randomly generated suffix
-        2. Loading card data into the staging table using COPY for efficiency
-        3. Transferring data from staging to the main magic.cards table
-        4. Returning random sample cards from staging before cleanup
-        5. Dropping the staging table
+        Accepts any iterable of raw card dicts (as returned by the Scryfall API or
+        stream_data_for_key). Preprocessing and already-imported filtering are applied
+        lazily as cards flow through, so the full dataset is never held in memory.
 
-        Args:
-        ----
-            cards (List[Dict[str, Any]]): List of card data to load.
-
-        Returns:
-        -------
-            Dict[str, Any]: Result with:
-                - cards_loaded: number of cards successfully loaded
-                - sample_cards: list of up to 10 random cards from staging
-                - status: "success", "no_cards", or "database_error"
-                - message: descriptive message
-
+        Returns a dict with:
+            - cards_loaded: rows actually inserted (after ON CONFLICT DO NOTHING)
+            - cards_sent: rows attempted (after preprocessing + filtering)
+            - sample_cards: up to 10 random cards from the final batch
+            - status: "success", "no_new_cards", "database_error"
+            - message: descriptive message
         """
-        if not cards:
-            return {
-                "status": "no_cards_before_preprocessing",
-                "cards_loaded": 0,
-                "sample_cards": [],
-                "message": "No cards provided for loading",
-            }
-
         self.setup_schema()
 
-        processed_cards = []
-        for icard in cards:
-            processed_cards.extend(preprocess_card(icard))
-        cards = processed_cards
-
-        if not cards:
-            return {
-                "status": "no_cards_after_preprocessing",
-                "cards_loaded": 0,
-                "sample_cards": [],
-                "message": "No cards remaining after preprocessing",
-            }
-
-        # Generate random staging table name
         staging_suffix = secrets.token_hex(8)
         staging_table_name = f"import_staging_{staging_suffix}"
 
         try:
             with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-                statement_timeout = 30_000
-                # Validate and set statement timeout
-                self._set_statement_timeout(cursor, statement_timeout)
+                self._set_statement_timeout(cursor, 30_000)
 
-                # fetch already imported cards...
                 cursor.execute("SELECT scryfall_id FROM magic.cards GROUP BY scryfall_id")
-                already_imported_cards = {r["scryfall_id"] for r in cursor.fetchall()}
+                already_imported_ids = {r["scryfall_id"] for r in cursor.fetchall()}
 
-                # filter cards to only those which are not already imported
-                num_before_filtering = len(cards)
-                cards = [card for card in cards if card["scryfall_id"] not in already_imported_cards]
-                logger.info("Filtered %d cards to %d cards to import", num_before_filtering, len(cards))
-                if not cards:
-                    logger.info("No remaining cards to import")
-                    return {
-                        "status": "all_cards_already_present",
-                        "cards_loaded": 0,
-                        "sample_cards": [],
-                        "message": "All cards already present",
-                    }
+                class _CardStream:
+                    """Preprocesses and filters raw cards lazily, tracking stage counts."""
 
-                page_size = 6000
+                    def __init__(self) -> None:
+                        self.raw = 0
+                        self.preprocessed = 0
+
+                    def __iter__(self) -> Iterator[dict[str, Any]]:
+                        for card in cards:
+                            self.raw += 1
+                            for processed in preprocess_card(card):
+                                self.preprocessed += 1
+                                if processed["scryfall_id"] not in already_imported_ids:
+                                    yield processed
+
+                stream = _CardStream()
                 cards_loaded = cards_sent = 0
-                for page in itertools.batched(cards, page_size):
-                    # Create staging table with unique name
-                    cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb)")
+                sample_cards: list[dict[str, Any]] = []
 
-                    # Load cards into staging table using COPY for efficiency
-                    with cursor.copy(
-                        f"COPY {staging_table_name} (card_blob) FROM STDIN WITH (FORMAT csv, HEADER false)",
-                    ) as copy_filehandle:
-                        writer = csv.writer(copy_filehandle, quoting=csv.QUOTE_ALL)
-                        writer.writerows([orjson.dumps(card, option=orjson.OPT_SORT_KEYS).decode("utf-8")] for card in page)
-
-                    target_sample_size = 10
-                    random_threshold = 2 * target_sample_size / len(page)
-                    cursor.execute(
-                        f"""
-                        SELECT
-                            (jsonb_populate_record(null::magic.cards, card_blob)).*
-                        FROM
-                            {staging_table_name}
-                        WHERE
-                            RANDOM() < {random_threshold}
-                        ORDER BY RANDOM()
-                        LIMIT {target_sample_size}""",
-                    )
-                    sample_cards = [dict(r) for r in cursor.fetchall()]
-
-                    # Transfer from staging to main table using direct jsonb_populate_record
-                    insert_query = f"""
-                        INSERT INTO magic.cards
-                        SELECT
-                            (jsonb_populate_record(null::magic.cards, card_blob)).*
-                        FROM
-                            {staging_table_name}
-                        ON CONFLICT DO NOTHING
-                    """
-                    # could we update the on conflict to replace?
-
-                    cursor.execute(insert_query)
+                for page in itertools.batched(stream, 6000):
+                    rows, sample_cards = self._copy_batch_to_staging(cursor, staging_table_name, page)
                     cards_sent += len(page)
-                    cards_loaded += cursor.rowcount
-
-                    # Drop the staging table
-                    cursor.execute(f"DROP TABLE {staging_table_name}")
-                    logger.info(
-                        "%d cards loaded, %d cards sent, of %d cards",
-                        cards_loaded,
-                        cards_sent,
-                        len(cards),
-                    )
+                    cards_loaded += rows
+                    logger.info("%d cards loaded, %d cards sent so far", cards_loaded, cards_sent)
 
                 conn.commit()
 
-                result = {
+                if cards_sent == 0:
+                    if stream.raw == 0:
+                        status, message = "no_cards_before_preprocessing", "No cards provided for loading"
+                    elif stream.preprocessed == 0:
+                        status, message = "no_cards_after_preprocessing", "No cards remaining after preprocessing"
+                    else:
+                        status, message = "all_cards_already_present", "All cards already present"
+                    logger.info("No cards imported: %s (raw=%d preprocessed=%d)", message, stream.raw, stream.preprocessed)
+                    return {"status": status, "cards_loaded": 0, "cards_sent": 0, "sample_cards": [], "message": message}
+
+                if cards_loaded > 0:
+                    self._clear_caches()
+
+                return {
                     "status": "success",
                     "cards_loaded": cards_loaded,
+                    "cards_sent": cards_sent,
                     "sample_cards": sample_cards,
                     "message": f"Successfully loaded {cards_loaded} cards",
                 }
 
-                # Clear caches when cards are successfully loaded
-                if cards_loaded > 0:
-                    self._clear_caches()
-                return result
-
         except (psycopg.Error, ValueError, KeyError) as e:
             logger.error("Error loading cards with staging table %s: %s", staging_table_name, e)
-            # Try to clean up staging table on error
             try:
                 with self._conn_pool.connection() as conn, conn.cursor() as cursor:
                     cursor.execute(f"DROP TABLE IF EXISTS {staging_table_name}")
@@ -2589,6 +2564,7 @@ class APIResource:
             return {
                 "status": "database_error",
                 "cards_loaded": 0,
+                "cards_sent": 0,
                 "sample_cards": [],
                 "message": f"Error loading cards: {e}",
             }

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -42,6 +42,7 @@ from api.settings import settings
 from api.tagger_client import TaggerClient
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.generation_cache import GenerationCache
+from api.utils.http_utils import make_user_agent
 from api.utils.timer import Timer
 from api.utils.type_conversions import _get_type_name, make_type_converting_wrapper
 
@@ -234,9 +235,7 @@ class APIResource:
         self._last_import_time: Synchronized = last_import_time or multiprocessing.Value("d", 0.0, lock=True)
         self._schema_setup_event: EventType = schema_setup_event
 
-        version = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d")
-        version = f"magic-api/{version}"
-        self._session.headers.update({"User-Agent": version})
+        self._session.headers.update({"User-Agent": make_user_agent()})
         # Initialize Tagger client for GraphQL API access
         self._tagger_client = TaggerClient()
         logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -2418,7 +2418,9 @@ class APIResource:
 
         Returns (rows_inserted, sample_cards).
         """
-        cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb)")
+        # ON COMMIT DROP is a safety net: the table is dropped explicitly below, but if an error
+        # aborts the batch the transaction rollback (or any later commit) removes it as well.
+        cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb) ON COMMIT DROP")
 
         with cursor.copy(
             f"COPY {staging_table_name} (card_blob) FROM STDIN WITH (FORMAT csv, HEADER false)",
@@ -2528,20 +2530,15 @@ class APIResource:
                 }
 
         except (psycopg.Error, ValueError, KeyError) as e:
-            logger.error("Error loading cards with staging table %s: %s", staging_table_name, e)
-            try:
-                with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-                    cursor.execute(f"DROP TABLE IF EXISTS {staging_table_name}")
-                    conn.commit()
-            except (psycopg.Error, ValueError) as cleanup_error:
-                logger.warning("Failed to cleanup staging table %s: %s", staging_table_name, cleanup_error)
-
+            # No staging-table cleanup is needed (or possible) here: the temp table is session-scoped
+            # and created within the still-open transaction, so the pool's rollback-on-error removes it.
+            logger.exception("Error loading cards with staging table %s", staging_table_name)
             return {
                 "status": "database_error",
                 "cards_loaded": 0,
                 "cards_sent": 0,
                 "sample_cards": [],
-                "message": f"Error loading cards: {e}",
+                "message": f"Error loading cards: {type(e).__name__}: {e}",
             }
 
     def _clear_caches(self) -> None:

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -2452,7 +2452,7 @@ class APIResource:
             writer = csv.writer(copy_filehandle, quoting=csv.QUOTE_ALL)
             writer.writerows([orjson.dumps(card, option=orjson.OPT_SORT_KEYS).decode("utf-8")] for card in page)
 
-        random_threshold = 20 / len(page)  # targets ~10 samples
+        random_threshold = 20 / len(page)  # selects ~20 candidates, capped at 10 by LIMIT
         cursor.execute(
             f"""
             SELECT (jsonb_populate_record(null::magic.cards, card_blob)).*
@@ -2490,7 +2490,7 @@ class APIResource:
             - cards_loaded: rows actually inserted (after ON CONFLICT DO NOTHING)
             - cards_sent: rows attempted (after preprocessing + filtering)
             - sample_cards: up to 10 random cards from the final batch
-            - status: "success", "no_new_cards", "database_error"
+            - status: "success", "no_cards_before_preprocessing", "no_cards_after_preprocessing", "all_cards_already_present", "database_error"
             - message: descriptive message
         """
         self.setup_schema()

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -1,8 +1,10 @@
 """Fetcher for Scryfall bulk data."""
 
+import io
 import logging
 import pathlib
 import time
+from collections.abc import Iterator
 from enum import StrEnum
 
 import orjson
@@ -110,6 +112,57 @@ class ScryfallBulkDataFetcher:
             f.write(compressed_data)
 
         return _load_data(response.content)
+
+    def _cache_file_path_for_key(self, data_key: BulkDataKey) -> pathlib.Path:
+        download_uri = self.get_download_uri_for_key(data_key)
+        suffix = download_uri.rpartition("/")[-1]
+        cache_file_path = self.cache_directory / data_key / suffix
+        return cache_file_path.with_suffix(".json.zstd")
+
+    def _ensure_cached(self, data_key: BulkDataKey, cache_file_path: pathlib.Path) -> None:
+        """Download and cache the bulk data file if not already present."""
+        cache_file_path.parent.mkdir(parents=True, exist_ok=True)
+        if cache_file_path.exists():
+            return
+
+        for ifile in cache_file_path.parent.iterdir():
+            ifile.unlink()
+
+        download_uri = self.get_download_uri_for_key(data_key)
+        before = time.monotonic()
+        response = self.session.get(download_uri, stream=True, timeout=60)
+        response.raise_for_status()
+        cctx = zstd.ZstdCompressor()
+        with cache_file_path.open("wb") as f, cctx.stream_writer(f) as compressor:
+            for chunk in response.iter_content(chunk_size=65536):
+                compressor.write(chunk)
+        logger.info("Downloaded and cached %s in %.3f seconds", cache_file_path, time.monotonic() - before)
+
+    def stream_data_for_key(self, data_key: BulkDataKey) -> Iterator[dict]:
+        """Yield card dicts one at a time without loading the full file into memory.
+
+        Reads the cached .json.zstd file line-by-line; downloads and caches first if needed.
+        Each line that starts with '{' is treated as one card JSON object (trailing comma stripped).
+        Unparseable lines are logged and skipped rather than raising.
+        """
+        cache_file_path = self._cache_file_path_for_key(data_key)
+        self._ensure_cached(data_key, cache_file_path)
+
+        before = time.monotonic()
+        card_count = 0
+        dctx = zstd.ZstdDecompressor()
+        with cache_file_path.open("rb") as f, dctx.stream_reader(f) as reader:
+            text_reader = io.TextIOWrapper(io.BufferedReader(reader), encoding="utf-8")
+            for raw_line in text_reader:
+                stripped = raw_line.strip().rstrip(",")
+                if not stripped.startswith("{"):
+                    continue
+                try:
+                    yield orjson.loads(stripped)
+                    card_count += 1
+                except orjson.JSONDecodeError:
+                    logger.warning("Skipping unparseable line: %.120s", stripped)
+        logger.info("Streamed %d cards from %s in %.3f seconds", card_count, cache_file_path, time.monotonic() - before)
 
 
 def main() -> None:

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -1,8 +1,11 @@
 """Fetcher for Scryfall bulk data."""
 
+import datetime
 import io
 import logging
+import os
 import pathlib
+import secrets
 import time
 from collections.abc import Iterator
 from enum import StrEnum
@@ -15,6 +18,21 @@ from cachebox import cached as cachebox_cached
 
 logger = logging.getLogger(__name__)
 MINUTE = 60
+
+# A healthy dump is one card object per line, so nearly every byte belongs to a successfully
+# parsed card. Files at least this large must reach the coverage threshold or streaming raises.
+_PARSE_COVERAGE_MIN_CHARS = 1_000_000
+_PARSE_COVERAGE_THRESHOLD = 0.8
+
+# .tmp files younger than this may be another worker's in-flight download; only prune older ones.
+_TMP_PRUNE_AGE_SECONDS = 15 * MINUTE
+
+# Log at most this many individual unparseable lines; beyond that only the final summary reports them.
+_MAX_UNPARSEABLE_LINE_LOGS = 5
+
+
+class BulkDataParseError(Exception):
+    """Raised when a bulk data file yields implausibly little card data for its size."""
 
 
 class BulkDataKey(StrEnum):
@@ -37,13 +55,22 @@ class ScryfallBulkDataFetcher:
             self.cache_directory = pathlib.Path("/tmp/api")  # noqa: S108
             self.cache_directory.mkdir(parents=True, exist_ok=True)
         self.session = requests.Session()
+        # Scryfall rejects default HTTP-library User-Agents (400 generic_user_agent),
+        # and asks for an explicit Accept header.
+        version = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d")
+        self.session.headers.update({"User-Agent": f"magic-api/{version}", "Accept": "application/json"})
 
     @cachebox_cached(cache=TTLCache(maxsize=2, global_ttl=5 * MINUTE))
     def list_bulk_data(self) -> dict[BulkDataKey, dict]:
-        """Fetch bulk data from Scryfall."""
-        return {
-            BulkDataKey(r["type"]): r for r in self.session.get("https://api.scryfall.com/bulk-data", timeout=20).json()["data"]
-        }
+        """Fetch bulk data from Scryfall, ignoring bulk data types we don't recognize."""
+        response = self.session.get("https://api.scryfall.com/bulk-data", timeout=20)
+        response.raise_for_status()
+        known_types = {key.value for key in BulkDataKey}
+        records = response.json()["data"]
+        unknown_types = sorted({r["type"] for r in records} - known_types)
+        if unknown_types:
+            logger.info("Ignoring unrecognized bulk data types: %s", unknown_types)
+        return {BulkDataKey(r["type"]): r for r in records if r["type"] in known_types}
 
     def get_download_uri_for_key(self, data_key: BulkDataKey) -> str:
         """Get the download URI for a given data key."""
@@ -56,18 +83,26 @@ class ScryfallBulkDataFetcher:
         return cache_file_path.with_suffix(".json.zstd")
 
     def _ensure_cached(self, data_key: BulkDataKey, cache_file_path: pathlib.Path) -> None:
-        """Download and cache the bulk data file if not already present."""
+        """Download and cache the bulk data file if not already present.
+
+        Safe to call concurrently from multiple worker processes: each writes to its own
+        uniquely-named .tmp file and atomically renames it into place, so racers waste a
+        duplicate download but never corrupt the cache file.
+        """
         cache_file_path.parent.mkdir(parents=True, exist_ok=True)
         if cache_file_path.exists():
             return
 
         for ifile in cache_file_path.parent.iterdir():
-            if ifile.is_file():
-                ifile.unlink()
+            if not ifile.is_file():
+                continue
+            if ifile.suffix == ".tmp" and time.time() - ifile.stat().st_mtime < _TMP_PRUNE_AGE_SECONDS:
+                continue  # likely another worker's in-flight download
+            ifile.unlink()
 
         download_uri = self.get_download_uri_for_key(data_key)
         before = time.monotonic()
-        tmp_path = cache_file_path.with_suffix(".zstd.tmp")
+        tmp_path = cache_file_path.with_name(f"{cache_file_path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
         cctx = zstd.ZstdCompressor(write_content_size=True)
         try:
             with self.session.get(download_uri, stream=True, timeout=60) as response:
@@ -86,28 +121,52 @@ class ScryfallBulkDataFetcher:
 
         Reads the cached .json.zstd file line-by-line; downloads and caches first if needed.
         Each line that starts with '{' is treated as one card JSON object (trailing comma stripped).
-        Unparseable lines are logged and skipped rather than raising.
+        Unparseable lines are logged and skipped, but if a non-trivially-sized file ends up with
+        less than _PARSE_COVERAGE_THRESHOLD of its content parsed into cards (e.g. the dump is no
+        longer one-object-per-line), BulkDataParseError is raised instead of silently under-yielding.
         """
         cache_file_path = self._cache_file_path_for_key(data_key)
         self._ensure_cached(data_key, cache_file_path)
 
         before = time.monotonic()
         card_count = 0
+        total_chars = 0
+        parsed_chars = 0
+        skipped_lines = 0
         dctx = zstd.ZstdDecompressor()
-        with (
-            cache_file_path.open("rb") as f,
-            dctx.stream_reader(f) as reader,
-            io.TextIOWrapper(io.BufferedReader(reader), encoding="utf-8") as text_reader,
-        ):
-            for raw_line in text_reader:
-                stripped = raw_line.strip().rstrip(",")
-                if not stripped.startswith("{"):
-                    continue
-                try:
-                    yield orjson.loads(stripped)
+        try:
+            with (
+                cache_file_path.open("rb") as f,
+                dctx.stream_reader(f) as reader,
+                io.TextIOWrapper(io.BufferedReader(reader), encoding="utf-8") as text_reader,
+            ):
+                for raw_line in text_reader:
+                    total_chars += len(raw_line)
+                    stripped = raw_line.strip().rstrip(",")
+                    if not stripped.startswith("{"):
+                        continue
+                    try:
+                        card = orjson.loads(stripped)
+                    except orjson.JSONDecodeError:
+                        skipped_lines += 1
+                        if skipped_lines <= _MAX_UNPARSEABLE_LINE_LOGS:
+                            logger.warning("Skipping unparseable line: %.120s", stripped)
+                        continue
                     card_count += 1
-                except orjson.JSONDecodeError:
-                    logger.warning("Skipping unparseable line: %.120s", stripped)
+                    parsed_chars += len(raw_line)
+                    yield card
+        except zstd.ZstdError:
+            logger.exception("Corrupt cache file %s; deleting it so the next call re-downloads", cache_file_path)
+            cache_file_path.unlink(missing_ok=True)
+            raise
+        if skipped_lines:
+            logger.warning("Skipped %d unparseable lines total in %s", skipped_lines, cache_file_path)
+        if total_chars >= _PARSE_COVERAGE_MIN_CHARS and parsed_chars < _PARSE_COVERAGE_THRESHOLD * total_chars:
+            msg = (
+                f"Parsed only {card_count} cards covering {parsed_chars} of {total_chars} characters "
+                f"in {cache_file_path}; the bulk data file format may have changed"
+            )
+            raise BulkDataParseError(msg)
         logger.info("Streamed %d cards from %s in %.3f seconds", card_count, cache_file_path, time.monotonic() - before)
 
 

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -1,6 +1,5 @@
 """Fetcher for Scryfall bulk data."""
 
-import datetime
 import io
 import logging
 import os
@@ -15,6 +14,8 @@ import requests
 import zstandard as zstd
 from cachebox import TTLCache
 from cachebox import cached as cachebox_cached
+
+from api.utils.http_utils import make_user_agent
 
 logger = logging.getLogger(__name__)
 MINUTE = 60
@@ -57,8 +58,7 @@ class ScryfallBulkDataFetcher:
         self.session = requests.Session()
         # Scryfall rejects default HTTP-library User-Agents (400 generic_user_agent),
         # and asks for an explicit Accept header.
-        version = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d")
-        self.session.headers.update({"User-Agent": f"magic-api/{version}", "Accept": "application/json"})
+        self.session.headers.update({"User-Agent": make_user_agent(), "Accept": "application/json"})
 
     @cachebox_cached(cache=TTLCache(maxsize=2, global_ttl=5 * MINUTE))
     def list_bulk_data(self) -> dict[BulkDataKey, dict]:
@@ -94,11 +94,14 @@ class ScryfallBulkDataFetcher:
             return
 
         for ifile in cache_file_path.parent.iterdir():
-            if not ifile.is_file():
-                continue
-            if ifile.suffix == ".tmp" and time.time() - ifile.stat().st_mtime < _TMP_PRUNE_AGE_SECONDS:
-                continue  # likely another worker's in-flight download
-            ifile.unlink()
+            try:
+                if not ifile.is_file():
+                    continue
+                if ifile.suffix == ".tmp" and time.time() - ifile.stat().st_mtime < _TMP_PRUNE_AGE_SECONDS:
+                    continue  # likely another worker's in-flight download
+                ifile.unlink(missing_ok=True)
+            except FileNotFoundError:
+                continue  # another worker pruned it between iterdir() and stat()
 
         download_uri = self.get_download_uri_for_key(data_key)
         before = time.monotonic()
@@ -124,6 +127,10 @@ class ScryfallBulkDataFetcher:
         Unparseable lines are logged and skipped, but if a non-trivially-sized file ends up with
         less than _PARSE_COVERAGE_THRESHOLD of its content parsed into cards (e.g. the dump is no
         longer one-object-per-line), BulkDataParseError is raised instead of silently under-yielding.
+
+        Note: the coverage check runs after the last line is read, so it only fires for consumers
+        that iterate to exhaustion. A consumer that stops early (break, islice, etc.) gets no
+        integrity guarantee about the portion it consumed.
         """
         cache_file_path = self._cache_file_path_for_key(data_key)
         self._ensure_cached(data_key, cache_file_path)
@@ -155,7 +162,9 @@ class ScryfallBulkDataFetcher:
                     card_count += 1
                     parsed_chars += len(raw_line)
                     yield card
-        except zstd.ZstdError:
+        except (zstd.ZstdError, UnicodeDecodeError):
+            # ZstdError: not a valid zstd stream. UnicodeDecodeError: valid zstd whose
+            # decompressed bytes are not valid UTF-8 (e.g. truncated mid-character).
             logger.exception("Corrupt cache file %s; deleting it so the next call re-downloads", cache_file_path)
             cache_file_path.unlink(missing_ok=True)
             raise

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -49,70 +49,6 @@ class ScryfallBulkDataFetcher:
         """Get the download URI for a given data key."""
         return self.list_bulk_data()[data_key]["download_uri"]
 
-    def get_data_for_key(self, data_key: BulkDataKey) -> list[dict]:
-        """Get the data for a given data key."""
-
-        def _load_data(decompressed_data: bytes) -> list[dict]:
-            """Load data from a bytes object."""
-            before = time.monotonic()
-            data = orjson.loads(decompressed_data)
-            logger.info(
-                "Parsed %d bytes to objects in %.3f seconds using orjson",
-                len(decompressed_data),
-                time.monotonic() - before,
-            )
-            return data
-
-        download_uri = self.get_download_uri_for_key(data_key)
-        suffix = download_uri.rpartition("/")[-1]
-        cache_file_path = self.cache_directory / data_key / suffix
-        cache_file_path = cache_file_path.with_suffix(".json.zstd")
-        cache_file_path.parent.mkdir(parents=True, exist_ok=True)
-        # if it exists, load and return
-        try:
-            with cache_file_path.open("rb") as f:
-                before = time.monotonic()
-                compressed_data = f.read()
-                logger.info(
-                    "Read %d bytes from %s in %.3f seconds",
-                    len(compressed_data),
-                    cache_file_path,
-                    time.monotonic() - before,
-                )
-
-            # decompress
-            before = time.monotonic()
-            decompressed_data = zstd.decompress(compressed_data)
-            logger.info(
-                "Decompressed %d bytes from %s in %.3f seconds",
-                len(decompressed_data),
-                cache_file_path,
-                time.monotonic() - before,
-            )
-            return _load_data(decompressed_data)
-        except FileNotFoundError:
-            pass
-
-        # prune other files from the directory - they've been superseded
-        for ifile in cache_file_path.parent.iterdir():
-            ifile.unlink()
-
-        # if it doesn't exist, download and cache
-        before = time.monotonic()
-        response = self.session.get(download_uri, timeout=30)
-        response.raise_for_status()
-        logger.info(
-            "Downloaded %d bytes from %s in %.3f seconds",
-            len(response.content),
-            download_uri,
-            time.monotonic() - before,
-        )
-        compressed_data = zstd.compress(data=response.content)
-        with cache_file_path.open("wb") as f:
-            f.write(compressed_data)
-
-        return _load_data(response.content)
-
     def _cache_file_path_for_key(self, data_key: BulkDataKey) -> pathlib.Path:
         download_uri = self.get_download_uri_for_key(data_key)
         suffix = download_uri.rpartition("/")[-1]
@@ -176,12 +112,11 @@ class ScryfallBulkDataFetcher:
 
 
 def main() -> None:
-    """Main function."""
+    """Stream and count cards from the default bulk data dump."""
     logging.basicConfig(level=logging.INFO)
     fetcher = ScryfallBulkDataFetcher()
-    fetcher.get_data_for_key(BulkDataKey.DEFAULT_CARDS)
-    fetcher.get_data_for_key(BulkDataKey.DEFAULT_CARDS)
-    fetcher.get_data_for_key(BulkDataKey.DEFAULT_CARDS)
+    count = sum(1 for _ in fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+    logger.info("Total cards: %d", count)
 
 
 if __name__ == "__main__":

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -131,12 +131,18 @@ class ScryfallBulkDataFetcher:
 
         download_uri = self.get_download_uri_for_key(data_key)
         before = time.monotonic()
-        cctx = zstd.ZstdCompressor()
-        with self.session.get(download_uri, stream=True, timeout=60) as response:
-            response.raise_for_status()
-            with cache_file_path.open("wb") as f, cctx.stream_writer(f) as compressor:
-                for chunk in response.iter_content(chunk_size=65536):
-                    compressor.write(chunk)
+        tmp_path = cache_file_path.with_suffix(".zstd.tmp")
+        cctx = zstd.ZstdCompressor(write_content_size=True)
+        try:
+            with self.session.get(download_uri, stream=True, timeout=60) as response:
+                response.raise_for_status()
+                with tmp_path.open("wb") as f, cctx.stream_writer(f) as compressor:
+                    for chunk in response.iter_content(chunk_size=65536):
+                        compressor.write(chunk)
+            tmp_path.rename(cache_file_path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
         logger.info("Downloaded and cached %s in %.3f seconds", cache_file_path, time.monotonic() - before)
 
     def stream_data_for_key(self, data_key: BulkDataKey) -> Iterator[dict]:

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -126,16 +126,17 @@ class ScryfallBulkDataFetcher:
             return
 
         for ifile in cache_file_path.parent.iterdir():
-            ifile.unlink()
+            if ifile.is_file():
+                ifile.unlink()
 
         download_uri = self.get_download_uri_for_key(data_key)
         before = time.monotonic()
-        response = self.session.get(download_uri, stream=True, timeout=60)
-        response.raise_for_status()
         cctx = zstd.ZstdCompressor()
-        with cache_file_path.open("wb") as f, cctx.stream_writer(f) as compressor:
-            for chunk in response.iter_content(chunk_size=65536):
-                compressor.write(chunk)
+        with self.session.get(download_uri, stream=True, timeout=60) as response:
+            response.raise_for_status()
+            with cache_file_path.open("wb") as f, cctx.stream_writer(f) as compressor:
+                for chunk in response.iter_content(chunk_size=65536):
+                    compressor.write(chunk)
         logger.info("Downloaded and cached %s in %.3f seconds", cache_file_path, time.monotonic() - before)
 
     def stream_data_for_key(self, data_key: BulkDataKey) -> Iterator[dict]:
@@ -151,8 +152,11 @@ class ScryfallBulkDataFetcher:
         before = time.monotonic()
         card_count = 0
         dctx = zstd.ZstdDecompressor()
-        with cache_file_path.open("rb") as f, dctx.stream_reader(f) as reader:
-            text_reader = io.TextIOWrapper(io.BufferedReader(reader), encoding="utf-8")
+        with (
+            cache_file_path.open("rb") as f,
+            dctx.stream_reader(f) as reader,
+            io.TextIOWrapper(io.BufferedReader(reader), encoding="utf-8") as text_reader,
+        ):
             for raw_line in text_reader:
                 stripped = raw_line.strip().rstrip(",")
                 if not stripped.startswith("{"):

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for api integration tests."""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from api.api_resource import APIResource
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture(scope="module")
+def api_resource(postgres_container: None) -> Generator[APIResource]:
+    """APIResource wired to the session-scoped postgres container, with the schema set up.
+
+    The root conftest's session container exports the PG* env vars, so the database is shared
+    across the whole test session: tests using this fixture must make assertions only about
+    rows they created themselves (unique card names / oracle_ids), never about global counts.
+    """
+    api = APIResource(
+        last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        schema_setup_event=multiprocessing.Event(),
+    )
+    api._setup_complete = lambda: True
+    api._import_recent = lambda: True
+    api.setup_schema()
+    yield api
+    api._conn_pool.close()

--- a/api/tests/helpers.py
+++ b/api/tests/helpers.py
@@ -1,0 +1,35 @@
+"""Shared helpers for api tests."""
+
+from __future__ import annotations
+
+import uuid
+
+
+def make_raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
+    """Minimal raw Scryfall card dict that passes preprocess_card and satisfies NOT NULL constraints."""
+    cid = card_id or str(uuid.uuid4())
+    jpg = f"{cid[0]}/{cid[1]}/{cid}.jpg"
+    return {
+        "id": cid,
+        "oracle_id": str(uuid.uuid4()),
+        "name": name,
+        "released_at": "2020-01-01",
+        "legalities": {"vintage": "legal"},
+        "games": ["paper"],
+        "type_line": "Instant",
+        "colors": [],
+        "color_identity": [],
+        "keywords": [],
+        "prices": {"usd": "0.10"},
+        "set": "tst",
+        "rarity": "common",
+        "collector_number": "1",
+        "image_uris": {
+            "small": f"https://cards.scryfall.io/small/front/{jpg}",
+            "normal": f"https://cards.scryfall.io/normal/front/{jpg}",
+            "large": f"https://cards.scryfall.io/large/front/{jpg}",
+            "png": f"https://cards.scryfall.io/png/front/{jpg}",
+            "art_crop": f"https://cards.scryfall.io/art_crop/front/{jpg}",
+            "border_crop": f"https://cards.scryfall.io/border_crop/front/{jpg}",
+        },
+    }

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -1,0 +1,246 @@
+"""Tests for _fetch_cubecobra_data, _insert_cubecobra_data, and backfill_prefer_scores."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+from api.api_resource import APIResource
+from api.card_processing import preprocess_card
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
+    cid = card_id or str(uuid.uuid4())
+    jpg = f"{cid[0]}/{cid[1]}/{cid}.jpg"
+    return {
+        "id": cid,
+        "oracle_id": str(uuid.uuid4()),
+        "name": name,
+        "released_at": "2020-01-01",
+        "legalities": {"vintage": "legal"},
+        "games": ["paper"],
+        "type_line": "Instant",
+        "colors": [],
+        "color_identity": [],
+        "keywords": [],
+        "prices": {"usd": "0.10"},
+        "set": "tst",
+        "rarity": "common",
+        "collector_number": "1",
+        "image_uris": {
+            "small": f"https://cards.scryfall.io/small/front/{jpg}",
+            "normal": f"https://cards.scryfall.io/normal/front/{jpg}",
+            "large": f"https://cards.scryfall.io/large/front/{jpg}",
+            "png": f"https://cards.scryfall.io/png/front/{jpg}",
+            "art_crop": f"https://cards.scryfall.io/art_crop/front/{jpg}",
+            "border_crop": f"https://cards.scryfall.io/border_crop/front/{jpg}",
+        },
+    }
+
+
+def _insert_card(api: APIResource, raw: dict) -> str:
+    """Insert a raw card and return its oracle_id."""
+    api._load_cards_with_staging([raw])
+    (processed,) = preprocess_card(raw)
+    return processed["oracle_id"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def postgres_container() -> Generator[PostgresContainer]:
+    container = PostgresContainer(
+        image="postgres:18",
+        username="testuser",
+        password="testpass",  # noqa: S106
+        dbname="testdb",
+    )
+    with container as pg:
+        yield pg
+
+
+@pytest.fixture(scope="class")
+def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource]:
+    host = postgres_container.get_container_host_ip()
+    port = postgres_container.get_exposed_port(5432)
+    original = {k: os.environ.get(k) for k in ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"]}
+    os.environ.update({"PGHOST": host, "PGPORT": str(port), "PGDATABASE": "testdb", "PGUSER": "testuser", "PGPASSWORD": "testpass"})
+    try:
+        api = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            schema_setup_event=multiprocessing.Event(),
+        )
+        api._setup_complete = lambda: True
+        api._import_recent = lambda: True
+        api.setup_schema()
+        yield api
+    finally:
+        for k, v in original.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        if hasattr(api, "_conn_pool"):
+            api._conn_pool.close()
+
+
+# ---------------------------------------------------------------------------
+# _insert_cubecobra_data
+# ---------------------------------------------------------------------------
+
+
+class TestInsertCubecobraData:
+    def test_updates_matching_oracle_id(self, api_resource: APIResource) -> None:
+        oracle_id = _insert_card(api_resource, _raw_card(name="Cubecobra Insert Test"))
+
+        cubecobra_data = {oracle_id: {"elo": 1200.5, "cube_count": 42, "pick_count": 100}}
+        rows_updated = api_resource._insert_cubecobra_data(cubecobra_data)
+
+        assert rows_updated >= 1
+
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT cubecobra_elo, cubecobra_cube_count, cubecobra_pick_count FROM magic.cards WHERE oracle_id = %s LIMIT 1",
+                (oracle_id,),
+            )
+            row = cursor.fetchone()
+
+        assert row is not None
+        assert abs(row["cubecobra_elo"] - 1200.5) < 0.01
+        assert row["cubecobra_cube_count"] == 42
+        assert row["cubecobra_pick_count"] == 100
+
+    def test_unknown_oracle_id_updates_zero_rows(self, api_resource: APIResource) -> None:
+        unknown = str(uuid.uuid4())
+        rows_updated = api_resource._insert_cubecobra_data({unknown: {"elo": 999.0, "cube_count": 1, "pick_count": 1}})
+        assert rows_updated == 0
+
+    def test_empty_dict_updates_zero_rows(self, api_resource: APIResource) -> None:
+        rows_updated = api_resource._insert_cubecobra_data({})
+        assert rows_updated == 0
+
+    def test_multiple_cards_updated_in_one_call(self, api_resource: APIResource) -> None:
+        oid1 = _insert_card(api_resource, _raw_card(name=f"Multi CubeCobra A {uuid.uuid4()}"))
+        oid2 = _insert_card(api_resource, _raw_card(name=f"Multi CubeCobra B {uuid.uuid4()}"))
+
+        cubecobra_data = {
+            oid1: {"elo": 1100.0, "cube_count": 10, "pick_count": 20},
+            oid2: {"elo": 900.0, "cube_count": 5, "pick_count": 8},
+        }
+        rows_updated = api_resource._insert_cubecobra_data(cubecobra_data)
+        assert rows_updated == 2
+
+
+# ---------------------------------------------------------------------------
+# _fetch_cubecobra_data
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCubecobraData:
+    def _mock_response(self, cards: list[dict]) -> MagicMock:
+        resp = MagicMock()
+        resp.json.return_value = {"data": cards}
+        return resp
+
+    def test_yields_matching_cards_and_stops_on_empty_page(self, api_resource: APIResource) -> None:
+        oracle_id = str(uuid.uuid4())
+        page1 = [{"oracle_id": oracle_id, "elo": 1500, "cubeCount": 30, "pickCount": 60}]
+
+        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+            mock_session.get.side_effect = [
+                self._mock_response(page1),
+                self._mock_response([]),  # empty page terminates
+            ]
+            pages = list(api_resource._fetch_cubecobra_data({oracle_id}))
+
+        assert len(pages) == 1
+        assert oracle_id in pages[0]
+        assert pages[0][oracle_id] == {"elo": 1500, "cube_count": 30, "pick_count": 60}
+
+    def test_filters_out_oracle_ids_not_in_db(self, api_resource: APIResource) -> None:
+        known = str(uuid.uuid4())
+        unknown = str(uuid.uuid4())
+        page1 = [
+            {"oracle_id": known, "elo": 1000, "cubeCount": 5, "pickCount": 10},
+            {"oracle_id": unknown, "elo": 800, "cubeCount": 2, "pickCount": 4},
+        ]
+
+        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+            mock_session.get.side_effect = [self._mock_response(page1), self._mock_response([])]
+            pages = list(api_resource._fetch_cubecobra_data({known}))
+
+        assert known in pages[0]
+        assert unknown not in pages[0]
+
+    def test_paginates_until_empty_page(self, api_resource: APIResource) -> None:
+        oids = [str(uuid.uuid4()) for _ in range(3)]
+        pages_data = [
+            [{"oracle_id": oids[0], "elo": 1, "cubeCount": 1, "pickCount": 1}],
+            [{"oracle_id": oids[1], "elo": 2, "cubeCount": 2, "pickCount": 2}],
+            [{"oracle_id": oids[2], "elo": 3, "cubeCount": 3, "pickCount": 3}],
+            [],  # terminator
+        ]
+
+        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+            mock_session.get.side_effect = [self._mock_response(p) for p in pages_data]
+            pages = list(api_resource._fetch_cubecobra_data(set(oids)))
+
+        assert len(pages) == 3
+
+    def test_empty_db_oracle_ids_yields_empty_pages(self, api_resource: APIResource) -> None:
+        page1 = [{"oracle_id": str(uuid.uuid4()), "elo": 1, "cubeCount": 1, "pickCount": 1}]
+
+        with patch.object(api_resource, "_session") as mock_session, patch("api.api_resource.time.sleep"):
+            mock_session.get.side_effect = [self._mock_response(page1), self._mock_response([])]
+            pages = list(api_resource._fetch_cubecobra_data(set()))
+
+        # All cards filtered out, but we still get one page dict (empty)
+        assert all(len(p) == 0 for p in pages)
+
+
+# ---------------------------------------------------------------------------
+# backfill_prefer_scores
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillPreferScores:
+    def test_returns_success_status(self, api_resource: APIResource) -> None:
+        result = api_resource.backfill_prefer_scores()
+        assert result["status"] == "success"
+
+    def test_returns_cards_updated_count(self, api_resource: APIResource) -> None:
+        _insert_card(api_resource, _raw_card(name=f"Prefer Score Card {uuid.uuid4()}"))
+        result = api_resource.backfill_prefer_scores()
+        assert result["cards_updated"] >= 1
+
+    def test_message_includes_count(self, api_resource: APIResource) -> None:
+        result = api_resource.backfill_prefer_scores()
+        assert str(result["cards_updated"]) in result["message"]
+
+    def test_prefer_score_populated_in_db(self, api_resource: APIResource) -> None:
+        oracle_id = _insert_card(api_resource, _raw_card(name=f"Prefer Score Check {uuid.uuid4()}"))
+        api_resource.backfill_prefer_scores()
+
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT prefer_score FROM magic.cards WHERE oracle_id = %s LIMIT 1", (oracle_id,))
+            row = cursor.fetchone()
+
+        assert row is not None
+        assert row["prefer_score"] is not None

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -2,54 +2,19 @@
 
 from __future__ import annotations
 
-import multiprocessing
-import os
-import time
 import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import pytest
-from testcontainers.postgres import PostgresContainer
-
-from api.api_resource import APIResource
 from api.card_processing import preprocess_card
+from api.tests.helpers import make_raw_card
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from api.api_resource import APIResource
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
-    cid = card_id or str(uuid.uuid4())
-    jpg = f"{cid[0]}/{cid[1]}/{cid}.jpg"
-    return {
-        "id": cid,
-        "oracle_id": str(uuid.uuid4()),
-        "name": name,
-        "released_at": "2020-01-01",
-        "legalities": {"vintage": "legal"},
-        "games": ["paper"],
-        "type_line": "Instant",
-        "colors": [],
-        "color_identity": [],
-        "keywords": [],
-        "prices": {"usd": "0.10"},
-        "set": "tst",
-        "rarity": "common",
-        "collector_number": "1",
-        "image_uris": {
-            "small": f"https://cards.scryfall.io/small/front/{jpg}",
-            "normal": f"https://cards.scryfall.io/normal/front/{jpg}",
-            "large": f"https://cards.scryfall.io/large/front/{jpg}",
-            "png": f"https://cards.scryfall.io/png/front/{jpg}",
-            "art_crop": f"https://cards.scryfall.io/art_crop/front/{jpg}",
-            "border_crop": f"https://cards.scryfall.io/border_crop/front/{jpg}",
-        },
-    }
 
 
 def _insert_card(api: APIResource, raw: dict) -> str:
@@ -60,56 +25,13 @@ def _insert_card(api: APIResource, raw: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def postgres_container() -> Generator[PostgresContainer]:
-    container = PostgresContainer(
-        image="postgres:18",
-        username="testuser",
-        password="testpass",  # noqa: S106
-        dbname="testdb",
-    )
-    with container as pg:
-        yield pg
-
-
-@pytest.fixture(scope="module")
-def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource]:
-    host = postgres_container.get_container_host_ip()
-    port = postgres_container.get_exposed_port(5432)
-    original = {k: os.environ.get(k) for k in ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"]}
-    os.environ.update({"PGHOST": host, "PGPORT": str(port), "PGDATABASE": "testdb", "PGUSER": "testuser", "PGPASSWORD": "testpass"})
-    api = None
-    try:
-        api = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            schema_setup_event=multiprocessing.Event(),
-        )
-        api._setup_complete = lambda: True
-        api._import_recent = lambda: True
-        api.setup_schema()
-        yield api
-    finally:
-        for k, v in original.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        if api is not None and hasattr(api, "_conn_pool"):
-            api._conn_pool.close()
-
-
-# ---------------------------------------------------------------------------
 # _insert_cubecobra_data
 # ---------------------------------------------------------------------------
 
 
 class TestInsertCubecobraData:
     def test_updates_matching_oracle_id(self, api_resource: APIResource) -> None:
-        oracle_id = _insert_card(api_resource, _raw_card(name="Cubecobra Insert Test"))
+        oracle_id = _insert_card(api_resource, make_raw_card(name="Cubecobra Insert Test"))
 
         cubecobra_data = {oracle_id: {"elo": 1200.5, "cube_count": 42, "pick_count": 100}}
         rows_updated = api_resource._insert_cubecobra_data(cubecobra_data)
@@ -138,8 +60,8 @@ class TestInsertCubecobraData:
         assert rows_updated == 0
 
     def test_multiple_cards_updated_in_one_call(self, api_resource: APIResource) -> None:
-        oid1 = _insert_card(api_resource, _raw_card(name=f"Multi CubeCobra A {uuid.uuid4()}"))
-        oid2 = _insert_card(api_resource, _raw_card(name=f"Multi CubeCobra B {uuid.uuid4()}"))
+        oid1 = _insert_card(api_resource, make_raw_card(name=f"Multi CubeCobra A {uuid.uuid4()}"))
+        oid2 = _insert_card(api_resource, make_raw_card(name=f"Multi CubeCobra B {uuid.uuid4()}"))
 
         cubecobra_data = {
             oid1: {"elo": 1100.0, "cube_count": 10, "pick_count": 20},
@@ -227,7 +149,7 @@ class TestBackfillPreferScores:
         assert result["status"] == "success"
 
     def test_returns_cards_updated_count(self, api_resource: APIResource) -> None:
-        _insert_card(api_resource, _raw_card(name=f"Prefer Score Card {uuid.uuid4()}"))
+        _insert_card(api_resource, make_raw_card(name=f"Prefer Score Card {uuid.uuid4()}"))
         result = api_resource.backfill_prefer_scores()
         assert result["cards_updated"] >= 1
 
@@ -236,7 +158,7 @@ class TestBackfillPreferScores:
         assert str(result["cards_updated"]) in result["message"]
 
     def test_prefer_score_populated_in_db(self, api_resource: APIResource) -> None:
-        oracle_id = _insert_card(api_resource, _raw_card(name=f"Prefer Score Check {uuid.uuid4()}"))
+        oracle_id = _insert_card(api_resource, make_raw_card(name=f"Prefer Score Check {uuid.uuid4()}"))
         api_resource.backfill_prefer_scores()
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -64,7 +64,7 @@ def _insert_card(api: APIResource, raw: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def postgres_container() -> Generator[PostgresContainer]:
     container = PostgresContainer(
         image="postgres:18",
@@ -76,7 +76,7 @@ def postgres_container() -> Generator[PostgresContainer]:
         yield pg
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource]:
     host = postgres_container.get_container_host_ip()
     port = postgres_container.get_exposed_port(5432)

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -82,6 +82,7 @@ def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource
     port = postgres_container.get_exposed_port(5432)
     original = {k: os.environ.get(k) for k in ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"]}
     os.environ.update({"PGHOST": host, "PGPORT": str(port), "PGDATABASE": "testdb", "PGUSER": "testuser", "PGPASSWORD": "testpass"})
+    api = None
     try:
         api = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
@@ -97,7 +98,7 @@ def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
-        if hasattr(api, "_conn_pool"):
+        if api is not None and hasattr(api, "_conn_pool"):
             api._conn_pool.close()
 
 

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -172,6 +172,7 @@ class TestImportCardByName(unittest.TestCase):
         assert result == {
             "status": "no_cards_after_preprocessing",
             "cards_loaded": 0,
+            "cards_sent": 0,
             "sample_cards": [],
             "message": "No cards remaining after preprocessing",
             "search_query": '!"TestCard"',

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -59,7 +59,7 @@ def _raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def postgres_container() -> Generator[PostgresContainer]:
     container = PostgresContainer(
         image="postgres:18",
@@ -71,7 +71,7 @@ def postgres_container() -> Generator[PostgresContainer]:
         yield pg
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource]:
     host = postgres_container.get_container_host_ip()
     port = postgres_container.get_exposed_port(5432)

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -77,6 +77,7 @@ def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource
     port = postgres_container.get_exposed_port(5432)
     original = {k: os.environ.get(k) for k in ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"]}
     os.environ.update({"PGHOST": host, "PGPORT": str(port), "PGDATABASE": "testdb", "PGUSER": "testuser", "PGPASSWORD": "testpass"})
+    api = None
     try:
         api = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
@@ -92,7 +93,7 @@ def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
-        if hasattr(api, "_conn_pool"):
+        if api is not None and hasattr(api, "_conn_pool"):
             api._conn_pool.close()
 
 

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -2,100 +2,21 @@
 
 from __future__ import annotations
 
+import logging
 import multiprocessing
-import os
-import time
 import uuid
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import pytest
-from testcontainers.postgres import PostgresContainer
+import psycopg
 
 from api.api_resource import APIResource
-from api.card_processing import preprocess_card
-from api.scryfall_bulk_data_fetcher import BulkDataKey
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
-    """Minimal raw Scryfall card dict that passes preprocess_card and satisfies NOT NULL constraints."""
-    cid = card_id or str(uuid.uuid4())
-    jpg = f"{cid[0]}/{cid[1]}/{cid}.jpg"
-    return {
-        "id": cid,
-        "oracle_id": str(uuid.uuid4()),
-        "name": name,
-        "released_at": "2020-01-01",
-        "legalities": {"vintage": "legal"},
-        "games": ["paper"],
-        "type_line": "Instant",
-        "colors": [],
-        "color_identity": [],
-        "keywords": [],
-        "prices": {"usd": "0.10"},
-        "set": "tst",
-        "rarity": "common",
-        "collector_number": "1",
-        "image_uris": {
-            "small": f"https://cards.scryfall.io/small/front/{jpg}",
-            "normal": f"https://cards.scryfall.io/normal/front/{jpg}",
-            "large": f"https://cards.scryfall.io/large/front/{jpg}",
-            "png": f"https://cards.scryfall.io/png/front/{jpg}",
-            "art_crop": f"https://cards.scryfall.io/art_crop/front/{jpg}",
-            "border_crop": f"https://cards.scryfall.io/border_crop/front/{jpg}",
-        },
-    }
-
-
-# ---------------------------------------------------------------------------
-# Testcontainer fixtures (class-scoped — one container per test class)
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def postgres_container() -> Generator[PostgresContainer]:
-    container = PostgresContainer(
-        image="postgres:18",
-        username="testuser",
-        password="testpass",  # noqa: S106
-        dbname="testdb",
-    )
-    with container as pg:
-        yield pg
-
-
-@pytest.fixture(scope="module")
-def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource]:
-    host = postgres_container.get_container_host_ip()
-    port = postgres_container.get_exposed_port(5432)
-    original = {k: os.environ.get(k) for k in ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"]}
-    os.environ.update({"PGHOST": host, "PGPORT": str(port), "PGDATABASE": "testdb", "PGUSER": "testuser", "PGPASSWORD": "testpass"})
-    api = None
-    try:
-        api = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-            schema_setup_event=multiprocessing.Event(),
-        )
-        api._setup_complete = lambda: True
-        api._import_recent = lambda: True
-        api.setup_schema()
-        yield api
-    finally:
-        for k, v in original.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        if api is not None and hasattr(api, "_conn_pool"):
-            api._conn_pool.close()
-
+    import pytest
+from api.card_processing import preprocess_card
+from api.scryfall_bulk_data_fetcher import BulkDataKey
+from api.tests.helpers import make_raw_card
 
 # ---------------------------------------------------------------------------
 # Status-code tests
@@ -118,13 +39,13 @@ class TestLoadCardsWithStagingStatus:
     def test_preprocessing_filters_all_cards_returns_no_cards_after_preprocessing(self, api_resource: APIResource) -> None:
         """When preprocess_card returns [] for all inputs, status is no_cards_after_preprocessing."""
         with patch("api.api_resource.preprocess_card", return_value=[]):
-            result = api_resource._load_cards_with_staging([_raw_card()])
+            result = api_resource._load_cards_with_staging([make_raw_card()])
         assert result["status"] == "no_cards_after_preprocessing"
         assert result["cards_loaded"] == 0
 
     def test_already_imported_cards_return_all_cards_already_present(self, api_resource: APIResource) -> None:
         """Cards already in the DB are skipped; if all are skipped the status is all_cards_already_present."""
-        card = _raw_card(name="Already Present Card")
+        card = make_raw_card(name="Already Present Card")
         api_resource._load_cards_with_staging([card])  # first insert
 
         result = api_resource._load_cards_with_staging([card])  # second attempt
@@ -132,7 +53,7 @@ class TestLoadCardsWithStagingStatus:
         assert result["cards_loaded"] == 0
 
     def test_success_result_includes_cards_sent(self, api_resource: APIResource) -> None:
-        result = api_resource._load_cards_with_staging([_raw_card(name="Cards Sent Test")])
+        result = api_resource._load_cards_with_staging([make_raw_card(name="Cards Sent Test")])
         assert result["status"] == "success"
         assert result["cards_sent"] >= 1
         assert "cards_loaded" in result
@@ -148,7 +69,7 @@ class TestCardStreamCounting:
 
     def test_multiple_preprocessed_but_all_already_imported_gives_correct_status(self, api_resource: APIResource) -> None:
         """Raw > 0 and preprocessed > 0 but all filtered by already_imported_ids → all_cards_already_present."""
-        cards = [_raw_card(name=f"Count Card {i}") for i in range(3)]
+        cards = [make_raw_card(name=f"Count Card {i}") for i in range(3)]
         api_resource._load_cards_with_staging(cards)  # seed the DB
 
         result = api_resource._load_cards_with_staging(cards)
@@ -160,7 +81,7 @@ class TestCardStreamCounting:
     def test_preprocessing_filter_distinguished_from_empty_input(self, api_resource: APIResource) -> None:
         """no_cards_after_preprocessing is distinct from no_cards_before_preprocessing."""
         with patch("api.api_resource.preprocess_card", return_value=[]):
-            filtered = api_resource._load_cards_with_staging([_raw_card(), _raw_card()])
+            filtered = api_resource._load_cards_with_staging([make_raw_card(), make_raw_card()])
         empty = api_resource._load_cards_with_staging([])
 
         assert filtered["status"] == "no_cards_after_preprocessing"
@@ -176,14 +97,14 @@ class TestCopyBatchToStaging:
     """_copy_batch_to_staging COPYs one batch through a temp staging table."""
 
     def test_inserts_card_and_returns_row_count(self, api_resource: APIResource) -> None:
-        (preprocessed,) = preprocess_card(_raw_card(name="Staging Insert Card"))
+        (preprocessed,) = preprocess_card(make_raw_card(name="Staging Insert Card"))
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             rows, _ = api_resource._copy_batch_to_staging(cursor, "test_stg_insert", (preprocessed,))
             conn.commit()
         assert rows == 1
 
     def test_returns_sample_cards_as_list_of_dicts(self, api_resource: APIResource) -> None:
-        (preprocessed,) = preprocess_card(_raw_card(name="Staging Sample Card"))
+        (preprocessed,) = preprocess_card(make_raw_card(name="Staging Sample Card"))
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             _, sample_cards = api_resource._copy_batch_to_staging(cursor, "test_stg_sample", (preprocessed,))
             conn.commit()
@@ -192,7 +113,7 @@ class TestCopyBatchToStaging:
 
     def test_on_conflict_does_nothing_returns_zero(self, api_resource: APIResource) -> None:
         """Re-inserting the same card returns rowcount 0 (ON CONFLICT DO NOTHING)."""
-        (preprocessed,) = preprocess_card(_raw_card(name="Staging Conflict Card"))
+        (preprocessed,) = preprocess_card(make_raw_card(name="Staging Conflict Card"))
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_a", (preprocessed,))
             conn.commit()
@@ -211,7 +132,7 @@ class TestMultiBatchLoad:
     """Cards spanning multiple batches are fully inserted."""
 
     def test_all_cards_inserted_across_batches(self, api_resource: APIResource) -> None:
-        cards = [_raw_card(name=f"Batch Card {uuid.uuid4()}") for _ in range(7)]
+        cards = [make_raw_card(name=f"Batch Card {uuid.uuid4()}") for _ in range(7)]
         result = api_resource._load_cards_with_staging(cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 7
@@ -219,20 +140,69 @@ class TestMultiBatchLoad:
 
     def test_batch_boundary_at_exact_multiple(self, api_resource: APIResource) -> None:
         """page_size=4, 8 cards → two full batches of 4."""
-        cards = [_raw_card(name=f"Exact Batch {uuid.uuid4()}") for _ in range(8)]
+        cards = [make_raw_card(name=f"Exact Batch {uuid.uuid4()}") for _ in range(8)]
         result = api_resource._load_cards_with_staging(cards, page_size=4)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 8
 
     def test_already_imported_cards_skipped_across_batch_boundary(self, api_resource: APIResource) -> None:
-        existing = [_raw_card(name=f"Existing {uuid.uuid4()}") for _ in range(3)]
+        existing = [make_raw_card(name=f"Existing {uuid.uuid4()}") for _ in range(3)]
         api_resource._load_cards_with_staging(existing, page_size=10)
 
-        new_cards = [_raw_card(name=f"New {uuid.uuid4()}") for _ in range(4)]
+        new_cards = [make_raw_card(name=f"New {uuid.uuid4()}") for _ in range(4)]
         result = api_resource._load_cards_with_staging(existing + new_cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 4
         assert result["cards_sent"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Error-path cleanup tests
+# ---------------------------------------------------------------------------
+
+
+class TestStagingTableCleanupOnError:
+    """A mid-batch failure must not leak the temp staging table or poison the pooled connection."""
+
+    @staticmethod
+    def _create_table_then_fail(cursor: psycopg.Cursor, staging_table_name: str, page: tuple) -> tuple:  # noqa: ARG004
+        cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb) ON COMMIT DROP")
+        msg = "simulated failure mid-batch"
+        raise psycopg.DataError(msg)
+
+    def test_error_mid_batch_returns_database_error_and_leaks_nothing(
+        self, api_resource: APIResource, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with (
+            patch.object(api_resource, "_copy_batch_to_staging", side_effect=self._create_table_then_fail),
+            caplog.at_level(logging.ERROR, logger="api.api_resource"),
+        ):
+            result = api_resource._load_cards_with_staging([make_raw_card(name="Doomed Card")])
+
+        assert result["status"] == "database_error"
+        assert result["cards_loaded"] == 0
+
+        # The failure must be interpretable: exception type in the message, full traceback in the log.
+        assert result["message"] == "Error loading cards: DataError: simulated failure mid-batch"
+        error_records = [r for r in caplog.records if "Error loading cards with staging table" in r.message]
+        assert error_records, "the failure should be logged"
+        assert all(r.exc_info for r in error_records), "the log record should carry the traceback"
+
+        # The rollback on connection return must have removed the temp table from every session.
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT relname FROM pg_class WHERE relname LIKE 'import_staging_%'")
+            leaked = [r["relname"] for r in cursor.fetchall()]
+        assert leaked == []
+
+    def test_import_succeeds_after_earlier_failure(self, api_resource: APIResource) -> None:
+        """The pool is reusable after a failed import: the next import on the same pool succeeds."""
+        with patch.object(api_resource, "_copy_batch_to_staging", side_effect=self._create_table_then_fail):
+            failed = api_resource._load_cards_with_staging([make_raw_card(name="First Try Fails")])
+        assert failed["status"] == "database_error"
+
+        recovered = api_resource._load_cards_with_staging([make_raw_card(name="Second Try Succeeds")])
+        assert recovered["status"] == "success"
+        assert recovered["cards_loaded"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +214,11 @@ class TestRunImportUnderLockStreaming:
     """_run_import_under_lock must delegate to stream_data_for_key, not _get_cards_to_insert."""
 
     def _make_api(self) -> APIResource:
-        api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
+        # Patch out setup_schema and import_data during construction: __init__ calls both, and an
+        # unpatched import_data with last_import_time=0.0 performs a real full Scryfall import.
+        with patch.object(APIResource, "setup_schema"), patch.object(APIResource, "import_data"):
+            api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
+        api._conn_pool.close()
         api._conn_pool = MagicMock()
         return api
 

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -11,12 +11,12 @@ from unittest.mock import MagicMock, patch
 import psycopg
 
 from api.api_resource import APIResource
-
-if TYPE_CHECKING:
-    import pytest
 from api.card_processing import preprocess_card
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
+
+if TYPE_CHECKING:
+    import pytest
 
 # ---------------------------------------------------------------------------
 # Status-code tests

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -264,22 +264,6 @@ class TestRunImportUnderLockStreaming:
             api._run_import_under_lock()
         mock_stream.assert_called_once_with(BulkDataKey.DEFAULT_CARDS)
 
-    def test_does_not_call_get_cards_to_insert(self) -> None:
-        api = self._make_api()
-        with (
-            patch.object(api, "_import_recent", return_value=False),
-            patch.object(api, "setup_schema"),
-            patch.object(
-                api,
-                "_load_cards_with_staging",
-                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "sample_cards": [], "message": ""},
-            ),
-            patch.object(api._bulk_data_fetcher, "stream_data_for_key", return_value=iter([])),
-            patch.object(api, "_get_cards_to_insert") as mock_old_path,
-        ):
-            api._run_import_under_lock()
-        mock_old_path.assert_not_called()
-
     def test_stream_iterator_passed_directly_to_load_cards_with_staging(self) -> None:
         """The exact iterator returned by stream_data_for_key is forwarded to _load_cards_with_staging."""
         api = self._make_api()

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -1,0 +1,298 @@
+"""Tests for _load_cards_with_staging, _copy_batch_to_staging, and streaming import wiring."""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import time
+import uuid
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+from api.api_resource import APIResource
+from api.card_processing import preprocess_card
+from api.scryfall_bulk_data_fetcher import BulkDataKey
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
+    """Minimal raw Scryfall card dict that passes preprocess_card and satisfies NOT NULL constraints."""
+    cid = card_id or str(uuid.uuid4())
+    jpg = f"{cid[0]}/{cid[1]}/{cid}.jpg"
+    return {
+        "id": cid,
+        "oracle_id": str(uuid.uuid4()),
+        "name": name,
+        "released_at": "2020-01-01",
+        "legalities": {"vintage": "legal"},
+        "games": ["paper"],
+        "type_line": "Instant",
+        "colors": [],
+        "color_identity": [],
+        "keywords": [],
+        "prices": {"usd": "0.10"},
+        "set": "tst",
+        "rarity": "common",
+        "collector_number": "1",
+        "image_uris": {
+            "small": f"https://cards.scryfall.io/small/front/{jpg}",
+            "normal": f"https://cards.scryfall.io/normal/front/{jpg}",
+            "large": f"https://cards.scryfall.io/large/front/{jpg}",
+            "png": f"https://cards.scryfall.io/png/front/{jpg}",
+            "art_crop": f"https://cards.scryfall.io/art_crop/front/{jpg}",
+            "border_crop": f"https://cards.scryfall.io/border_crop/front/{jpg}",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Testcontainer fixtures (class-scoped — one container per test class)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def postgres_container() -> Generator[PostgresContainer]:
+    container = PostgresContainer(
+        image="postgres:18",
+        username="testuser",
+        password="testpass",  # noqa: S106
+        dbname="testdb",
+    )
+    with container as pg:
+        yield pg
+
+
+@pytest.fixture(scope="class")
+def api_resource(postgres_container: PostgresContainer) -> Generator[APIResource]:
+    host = postgres_container.get_container_host_ip()
+    port = postgres_container.get_exposed_port(5432)
+    original = {k: os.environ.get(k) for k in ["PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD"]}
+    os.environ.update({"PGHOST": host, "PGPORT": str(port), "PGDATABASE": "testdb", "PGUSER": "testuser", "PGPASSWORD": "testpass"})
+    try:
+        api = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+            schema_setup_event=multiprocessing.Event(),
+        )
+        api._setup_complete = lambda: True
+        api._import_recent = lambda: True
+        api.setup_schema()
+        yield api
+    finally:
+        for k, v in original.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        if hasattr(api, "_conn_pool"):
+            api._conn_pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Status-code tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCardsWithStagingStatus:
+    """_load_cards_with_staging returns the correct status string for each no-cards scenario."""
+
+    def test_empty_list_returns_no_cards_before_preprocessing(self, api_resource: APIResource) -> None:
+        result = api_resource._load_cards_with_staging([])
+        assert result["status"] == "no_cards_before_preprocessing"
+        assert result["cards_loaded"] == 0
+        assert result["cards_sent"] == 0
+
+    def test_empty_generator_returns_no_cards_before_preprocessing(self, api_resource: APIResource) -> None:
+        result = api_resource._load_cards_with_staging(x for x in [])
+        assert result["status"] == "no_cards_before_preprocessing"
+
+    def test_preprocessing_filters_all_cards_returns_no_cards_after_preprocessing(self, api_resource: APIResource) -> None:
+        """When preprocess_card returns [] for all inputs, status is no_cards_after_preprocessing."""
+        with patch("api.api_resource.preprocess_card", return_value=[]):
+            result = api_resource._load_cards_with_staging([_raw_card()])
+        assert result["status"] == "no_cards_after_preprocessing"
+        assert result["cards_loaded"] == 0
+
+    def test_already_imported_cards_return_all_cards_already_present(self, api_resource: APIResource) -> None:
+        """Cards already in the DB are skipped; if all are skipped the status is all_cards_already_present."""
+        card = _raw_card(name="Already Present Card")
+        api_resource._load_cards_with_staging([card])  # first insert
+
+        result = api_resource._load_cards_with_staging([card])  # second attempt
+        assert result["status"] == "all_cards_already_present"
+        assert result["cards_loaded"] == 0
+
+    def test_success_result_includes_cards_sent(self, api_resource: APIResource) -> None:
+        result = api_resource._load_cards_with_staging([_raw_card(name="Cards Sent Test")])
+        assert result["status"] == "success"
+        assert result["cards_sent"] >= 1
+        assert "cards_loaded" in result
+
+
+# ---------------------------------------------------------------------------
+# _CardStream counting tests
+# ---------------------------------------------------------------------------
+
+
+class TestCardStreamCounting:
+    """_CardStream tallies stage counts that drive the status string selection."""
+
+    def test_multiple_preprocessed_but_all_already_imported_gives_correct_status(self, api_resource: APIResource) -> None:
+        """Raw > 0 and preprocessed > 0 but all filtered by already_imported_ids → all_cards_already_present."""
+        cards = [_raw_card(name=f"Count Card {i}") for i in range(3)]
+        api_resource._load_cards_with_staging(cards)  # seed the DB
+
+        result = api_resource._load_cards_with_staging(cards)
+        # Would be no_cards_before_preprocessing if raw==0,
+        # or no_cards_after_preprocessing if preprocessed==0.
+        # Only reaches all_cards_already_present when both counts are > 0.
+        assert result["status"] == "all_cards_already_present"
+
+    def test_preprocessing_filter_distinguished_from_empty_input(self, api_resource: APIResource) -> None:
+        """no_cards_after_preprocessing is distinct from no_cards_before_preprocessing."""
+        with patch("api.api_resource.preprocess_card", return_value=[]):
+            filtered = api_resource._load_cards_with_staging([_raw_card(), _raw_card()])
+        empty = api_resource._load_cards_with_staging([])
+
+        assert filtered["status"] == "no_cards_after_preprocessing"
+        assert empty["status"] == "no_cards_before_preprocessing"
+
+
+# ---------------------------------------------------------------------------
+# _copy_batch_to_staging tests
+# ---------------------------------------------------------------------------
+
+
+class TestCopyBatchToStaging:
+    """_copy_batch_to_staging COPYs one batch through a temp staging table."""
+
+    def test_inserts_card_and_returns_row_count(self, api_resource: APIResource) -> None:
+        (preprocessed,) = preprocess_card(_raw_card(name="Staging Insert Card"))
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            rows, _ = api_resource._copy_batch_to_staging(cursor, "test_stg_insert", (preprocessed,))
+            conn.commit()
+        assert rows == 1
+
+    def test_returns_sample_cards_as_list_of_dicts(self, api_resource: APIResource) -> None:
+        (preprocessed,) = preprocess_card(_raw_card(name="Staging Sample Card"))
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            _, sample_cards = api_resource._copy_batch_to_staging(cursor, "test_stg_sample", (preprocessed,))
+            conn.commit()
+        for sc in sample_cards:
+            assert isinstance(sc, dict)
+
+    def test_on_conflict_does_nothing_returns_zero(self, api_resource: APIResource) -> None:
+        """Re-inserting the same card returns rowcount 0 (ON CONFLICT DO NOTHING)."""
+        (preprocessed,) = preprocess_card(_raw_card(name="Staging Conflict Card"))
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_a", (preprocessed,))
+            conn.commit()
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            rows, _ = api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_b", (preprocessed,))
+            conn.commit()
+        assert rows == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBatchLoad:
+    """Cards spanning multiple batches are fully inserted."""
+
+    def test_all_cards_inserted_across_batches(self, api_resource: APIResource) -> None:
+        cards = [_raw_card(name=f"Batch Card {uuid.uuid4()}") for _ in range(7)]
+        result = api_resource._load_cards_with_staging(cards, page_size=3)
+        assert result["status"] == "success"
+        assert result["cards_loaded"] == 7
+        assert result["cards_sent"] == 7
+
+    def test_batch_boundary_at_exact_multiple(self, api_resource: APIResource) -> None:
+        """page_size=4, 8 cards → two full batches of 4."""
+        cards = [_raw_card(name=f"Exact Batch {uuid.uuid4()}") for _ in range(8)]
+        result = api_resource._load_cards_with_staging(cards, page_size=4)
+        assert result["status"] == "success"
+        assert result["cards_loaded"] == 8
+
+    def test_already_imported_cards_skipped_across_batch_boundary(self, api_resource: APIResource) -> None:
+        existing = [_raw_card(name=f"Existing {uuid.uuid4()}") for _ in range(3)]
+        api_resource._load_cards_with_staging(existing, page_size=10)
+
+        new_cards = [_raw_card(name=f"New {uuid.uuid4()}") for _ in range(4)]
+        result = api_resource._load_cards_with_staging(existing + new_cards, page_size=3)
+        assert result["status"] == "success"
+        assert result["cards_loaded"] == 4
+        assert result["cards_sent"] == 4
+
+
+# ---------------------------------------------------------------------------
+# _run_import_under_lock streaming wiring (mocked — tests control flow only)
+# ---------------------------------------------------------------------------
+
+
+class TestRunImportUnderLockStreaming:
+    """_run_import_under_lock must delegate to stream_data_for_key, not _get_cards_to_insert."""
+
+    def _make_api(self) -> APIResource:
+        api = APIResource(last_import_time=multiprocessing.Value("d", 0.0, lock=True))
+        api._conn_pool = MagicMock()
+        return api
+
+    def test_calls_stream_data_for_key(self) -> None:
+        api = self._make_api()
+        with (
+            patch.object(api, "_import_recent", return_value=False),
+            patch.object(api, "setup_schema"),
+            patch.object(
+                api,
+                "_load_cards_with_staging",
+                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "sample_cards": [], "message": ""},
+            ),
+            patch.object(api._bulk_data_fetcher, "stream_data_for_key") as mock_stream,
+        ):
+            mock_stream.return_value = iter([])
+            api._run_import_under_lock()
+        mock_stream.assert_called_once_with(BulkDataKey.DEFAULT_CARDS)
+
+    def test_does_not_call_get_cards_to_insert(self) -> None:
+        api = self._make_api()
+        with (
+            patch.object(api, "_import_recent", return_value=False),
+            patch.object(api, "setup_schema"),
+            patch.object(
+                api,
+                "_load_cards_with_staging",
+                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "sample_cards": [], "message": ""},
+            ),
+            patch.object(api._bulk_data_fetcher, "stream_data_for_key", return_value=iter([])),
+            patch.object(api, "_get_cards_to_insert") as mock_old_path,
+        ):
+            api._run_import_under_lock()
+        mock_old_path.assert_not_called()
+
+    def test_stream_iterator_passed_directly_to_load_cards_with_staging(self) -> None:
+        """The exact iterator returned by stream_data_for_key is forwarded to _load_cards_with_staging."""
+        api = self._make_api()
+        sentinel = iter([{"id": "sentinel"}])
+        with (
+            patch.object(api, "_import_recent", return_value=False),
+            patch.object(api, "setup_schema"),
+            patch.object(api._bulk_data_fetcher, "stream_data_for_key", return_value=sentinel),
+            patch.object(
+                api,
+                "_load_cards_with_staging",
+                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "sample_cards": [], "message": ""},
+            ) as mock_staging,
+        ):
+            api._run_import_under_lock()
+        args, _ = mock_staging.call_args
+        assert args[0] is sentinel

--- a/api/tests/test_scryfall_bulk_data_fetcher.py
+++ b/api/tests/test_scryfall_bulk_data_fetcher.py
@@ -3,14 +3,22 @@
 from __future__ import annotations
 
 import logging
+import os
+import time
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import orjson
 import pytest
+import requests
 import zstandard as zstd
 
-from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
+from api.scryfall_bulk_data_fetcher import (
+    _MAX_UNPARSEABLE_LINE_LOGS,
+    BulkDataKey,
+    BulkDataParseError,
+    ScryfallBulkDataFetcher,
+)
 
 if TYPE_CHECKING:
     import pathlib
@@ -41,6 +49,15 @@ def _scryfall_json(cards: list[dict]) -> bytes:
         lines.append(orjson.dumps(card).decode() + comma + "\n")
     lines.append("]\n")
     return "".join(lines).encode()
+
+
+def _mock_streaming_response(chunks: list[bytes] | object) -> MagicMock:
+    """Mock requests response usable as a context manager, yielding chunks from iter_content."""
+    mock_response = MagicMock()
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+    mock_response.iter_content.return_value = chunks
+    return mock_response
 
 
 class TestStreamDataForKeyHappyPath:
@@ -133,11 +150,7 @@ class TestStreamDataForKeyCacheMiss:
     def test_downloads_and_caches_on_miss(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """When no cache file exists, the file is downloaded and written as zstd-compressed cache."""
         raw_json = _scryfall_json([{"id": "dl-1", "name": "Downloaded Card"}])
-        mock_response = MagicMock()
-        mock_response.__enter__ = lambda s: s
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_response.iter_content.return_value = [raw_json]
-        fetcher.session.get.return_value = mock_response
+        fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
@@ -168,14 +181,199 @@ class TestStreamDataForKeyCacheMiss:
 
         raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
         uri = "https://data.scryfall.io/default-cards/default-cards-new.json"
-        mock_response = MagicMock()
-        mock_response.__enter__ = lambda s: s
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_response.iter_content.return_value = [raw_json]
-        fetcher.session.get.return_value = mock_response
+        fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
         bulk_data = {BulkDataKey.DEFAULT_CARDS: {"download_uri": uri}}
         with patch.object(fetcher, "list_bulk_data", return_value=bulk_data):
             list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
         assert not stale.exists(), "stale file should have been deleted"
+
+    def test_prune_spares_fresh_tmp_files(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A recent .tmp file may be another worker's in-flight download and must survive pruning."""
+        fresh_tmp = tmp_path / "default_cards" / "default-cards-other.json.zstd.12345.abcd.tmp"
+        fresh_tmp.parent.mkdir(parents=True, exist_ok=True)
+        fresh_tmp.write_bytes(b"in-flight download")
+
+        raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
+        fetcher.session.get.return_value = _mock_streaming_response([raw_json])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert fresh_tmp.exists(), "fresh tmp file should have been spared"
+
+    def test_prune_deletes_abandoned_tmp_files(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """An old .tmp file is an abandoned download (crashed worker) and gets pruned."""
+        old_tmp = tmp_path / "default_cards" / "default-cards-other.json.zstd.12345.abcd.tmp"
+        old_tmp.parent.mkdir(parents=True, exist_ok=True)
+        old_tmp.write_bytes(b"abandoned download")
+        two_hours_ago = time.time() - 2 * 60 * 60
+        os.utime(old_tmp, (two_hours_ago, two_hours_ago))
+
+        raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
+        fetcher.session.get.return_value = _mock_streaming_response([raw_json])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert not old_tmp.exists(), "abandoned tmp file should have been pruned"
+
+    def test_tmp_file_name_is_unique_per_process(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """The in-flight tmp file name embeds the pid and a random token, so concurrent workers never share it."""
+        cache_dir = tmp_path / "default_cards"
+        seen_names: list[str] = []
+
+        def _chunks() -> object:
+            seen_names.extend(p.name for p in cache_dir.iterdir())
+            yield _scryfall_json([{"id": "c1", "name": "A"}])
+
+        fetcher.session.get.return_value = _mock_streaming_response(_chunks())
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        tmp_names = [n for n in seen_names if n.endswith(".tmp")]
+        assert tmp_names, "a .tmp file should exist while the download is in flight"
+        assert all(f".{os.getpid()}." in n for n in tmp_names)
+
+
+class TestScryfallApiSession:
+    def test_session_does_not_use_default_user_agent(self) -> None:
+        """Scryfall rejects default HTTP-library User-Agents with 400 generic_user_agent."""
+        fetcher = ScryfallBulkDataFetcher()
+        user_agent = fetcher.session.headers["User-Agent"]
+        assert not user_agent.startswith("python-requests")
+        assert fetcher.session.headers["Accept"] == "application/json"
+
+    def test_list_bulk_data_raises_on_http_error(self, tmp_path: pathlib.Path) -> None:
+        """A non-2xx bulk-data response raises HTTPError instead of KeyError('data') on the error body."""
+        fetcher = _make_fetcher(tmp_path)
+        error_response = MagicMock()
+        error_response.raise_for_status.side_effect = requests.HTTPError("400 Client Error: Bad Request")
+        fetcher.session.get.return_value = error_response
+
+        with pytest.raises(requests.HTTPError):
+            fetcher.list_bulk_data()
+
+    def test_list_bulk_data_ignores_unrecognized_types(self, tmp_path: pathlib.Path) -> None:
+        """Bulk data types Scryfall adds later (e.g. art_tags) are skipped, not a ValueError crash."""
+        fetcher = _make_fetcher(tmp_path)
+        response = MagicMock()
+        response.json.return_value = {
+            "data": [
+                {"type": "default_cards", "download_uri": _FAKE_URI},
+                {"type": "art_tags", "download_uri": "https://data.scryfall.io/art-tags/whatever.json"},
+            ],
+        }
+        fetcher.session.get.return_value = response
+
+        result = fetcher.list_bulk_data()
+
+        assert result == {BulkDataKey.DEFAULT_CARDS: {"type": "default_cards", "download_uri": _FAKE_URI}}
+
+
+class TestStreamDataForKeyCorruptCache:
+    @pytest.fixture
+    def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
+        return _make_fetcher(tmp_path)
+
+    def test_corrupt_cache_file_is_deleted_and_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A cache file that fails zstd decompression is deleted so the next call can re-download."""
+        cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_bytes(b"this is not a zstd stream")
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), pytest.raises(zstd.ZstdError):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert not cache_file.exists(), "corrupt cache file should have been deleted"
+
+    def test_call_after_corruption_re_downloads(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """After a corrupt cache file is deleted, the next call downloads a fresh copy and succeeds."""
+        cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_bytes(b"this is not a zstd stream")
+
+        raw_json = _scryfall_json([{"id": "c1", "name": "Recovered"}])
+        fetcher.session.get.return_value = _mock_streaming_response([raw_json])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            with pytest.raises(zstd.ZstdError):
+                list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        fetcher.session.get.assert_called_once()
+        assert result == [{"id": "c1", "name": "Recovered"}]
+
+
+def _padded_card(idx: int, pad_chars: int = 1000) -> dict:
+    """Card dict padded to roughly pad_chars so tests can cheaply build files past the coverage-check minimum size."""
+    return {"id": f"card-{idx}", "name": f"Card {idx}", "pad": "x" * pad_chars}
+
+
+class TestStreamDataForKeyParseCoverage:
+    """Large files must parse at least the coverage threshold of their content into cards."""
+
+    @pytest.fixture
+    def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
+        return _make_fetcher(tmp_path)
+
+    def test_minified_single_line_array_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A large dump minified onto one line yields zero cards and must raise, not silently return nothing."""
+        cards = [_padded_card(i) for i in range(1200)]  # ~1.2MB as a single line
+        _write_cache_file(tmp_path, orjson.dumps(cards) + b"\n")
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), pytest.raises(BulkDataParseError):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+    def test_mostly_unparseable_large_file_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A large file whose content is mostly garbage lines raises even though some cards parsed."""
+        good_lines = [orjson.dumps(_padded_card(i)).decode() for i in range(400)]
+        garbage_lines = ["{not valid json " + "y" * 1000 for _ in range(800)]
+        raw = ("[\n" + ",\n".join(good_lines + garbage_lines) + "\n]\n").encode()
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), pytest.raises(BulkDataParseError):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+    def test_small_fraction_of_garbage_in_large_file_is_tolerated(
+        self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path
+    ) -> None:
+        """Garbage below the threshold is skipped with warnings, as for small files."""
+        good_lines = [orjson.dumps(_padded_card(i)).decode() for i in range(1000)]
+        garbage_lines = ["{not valid json " + "y" * 1000 for _ in range(100)]
+        raw = ("[\n" + ",\n".join(good_lines + garbage_lines) + "\n]\n").encode()
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert len(result) == 1000
+
+    def test_unparseable_line_warnings_are_capped(
+        self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Per-line warnings stop after the cap; a single summary line reports the total."""
+        good_lines = [orjson.dumps(_padded_card(i)).decode() for i in range(1000)]
+        garbage_lines = ["{not valid json " + "y" * 1000 for _ in range(100)]
+        raw = ("[\n" + ",\n".join(good_lines + garbage_lines) + "\n]\n").encode()
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), caplog.at_level(logging.WARNING):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        per_line_warnings = [r for r in caplog.records if "Skipping unparseable" in r.message]
+        summaries = [r for r in caplog.records if "unparseable lines total" in r.message]
+        assert len(per_line_warnings) == _MAX_UNPARSEABLE_LINE_LOGS
+        assert len(summaries) == 1
+        assert "100" in summaries[0].message
+
+    def test_small_files_are_exempt_from_coverage_check(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """Files below the minimum size never trigger the coverage check, even at 0% coverage."""
+        _write_cache_file(tmp_path, b"[\n{bad json}\n]\n")
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == []

--- a/api/tests/test_scryfall_bulk_data_fetcher.py
+++ b/api/tests/test_scryfall_bulk_data_fetcher.py
@@ -134,6 +134,8 @@ class TestStreamDataForKeyCacheMiss:
         """When no cache file exists, the file is downloaded and written as zstd-compressed cache."""
         raw_json = _scryfall_json([{"id": "dl-1", "name": "Downloaded Card"}])
         mock_response = MagicMock()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
         mock_response.iter_content.return_value = [raw_json]
         fetcher.session.get.return_value = mock_response
 
@@ -167,6 +169,8 @@ class TestStreamDataForKeyCacheMiss:
         raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
         uri = "https://data.scryfall.io/default-cards/default-cards-new.json"
         mock_response = MagicMock()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
         mock_response.iter_content.return_value = [raw_json]
         fetcher.session.get.return_value = mock_response
 

--- a/api/tests/test_scryfall_bulk_data_fetcher.py
+++ b/api/tests/test_scryfall_bulk_data_fetcher.py
@@ -157,7 +157,7 @@ class TestStreamDataForKeyCacheMiss:
 
         cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
         assert cache_file.exists(), "cache file should have been written"
-        # The streaming compressor omits content size, so use ZstdDecompressor instead of zstd.decompress()
+        # Use ZstdDecompressor so we can bound output size via max_output_size.
         dctx = zstd.ZstdDecompressor()
         decompressed = dctx.decompress(cache_file.read_bytes(), max_output_size=10 * 1024 * 1024)
         assert b"Downloaded Card" in decompressed

--- a/api/tests/test_scryfall_bulk_data_fetcher.py
+++ b/api/tests/test_scryfall_bulk_data_fetcher.py
@@ -289,6 +289,16 @@ class TestStreamDataForKeyCorruptCache:
 
         assert not cache_file.exists(), "corrupt cache file should have been deleted"
 
+    def test_invalid_utf8_cache_file_is_deleted_and_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A valid zstd file whose content is not valid UTF-8 is also treated as corrupt and deleted."""
+        invalid_utf8 = b'[\n{"id":"c1","name":"truncated \xe2\x82'  # multibyte char cut short
+        cache_file = _write_cache_file(tmp_path, invalid_utf8)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), pytest.raises(UnicodeDecodeError):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert not cache_file.exists(), "invalid-utf8 cache file should have been deleted"
+
     def test_call_after_corruption_re_downloads(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """After a corrupt cache file is deleted, the next call downloads a fresh copy and succeeds."""
         cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"

--- a/api/tests/test_scryfall_bulk_data_fetcher.py
+++ b/api/tests/test_scryfall_bulk_data_fetcher.py
@@ -1,0 +1,177 @@
+"""Tests for ScryfallBulkDataFetcher streaming methods."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import orjson
+import pytest
+import zstandard as zstd
+
+from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
+
+if TYPE_CHECKING:
+    import pathlib
+
+_FAKE_URI = "https://data.scryfall.io/default-cards/default-cards-test.json"
+_FAKE_BULK_DATA = {BulkDataKey.DEFAULT_CARDS: {"download_uri": _FAKE_URI}}
+
+
+def _make_fetcher(cache_directory: pathlib.Path) -> ScryfallBulkDataFetcher:
+    fetcher = ScryfallBulkDataFetcher.__new__(ScryfallBulkDataFetcher)
+    fetcher.cache_directory = cache_directory
+    fetcher.session = MagicMock()
+    return fetcher
+
+
+def _write_cache_file(cache_dir: pathlib.Path, raw_json: bytes) -> pathlib.Path:
+    cache_file = cache_dir / "default_cards" / "default-cards-test.json.zstd"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_bytes(zstd.compress(raw_json))
+    return cache_file
+
+
+def _scryfall_json(cards: list[dict]) -> bytes:
+    """Produce a Scryfall-style newline-delimited JSON array."""
+    lines = ["[\n"]
+    for i, card in enumerate(cards):
+        comma = "," if i < len(cards) - 1 else ""
+        lines.append(orjson.dumps(card).decode() + comma + "\n")
+    lines.append("]\n")
+    return "".join(lines).encode()
+
+
+class TestStreamDataForKeyHappyPath:
+    @pytest.fixture
+    def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
+        return _make_fetcher(tmp_path)
+
+    def test_streams_all_cards_from_cache(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        cards = [{"id": "c1", "name": "Lightning Bolt"}, {"id": "c2", "name": "Counterspell"}]
+        _write_cache_file(tmp_path, _scryfall_json(cards))
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert len(result) == 2
+        assert result[0] == {"id": "c1", "name": "Lightning Bolt"}
+        assert result[1] == {"id": "c2", "name": "Counterspell"}
+
+    def test_single_card_file(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        _write_cache_file(tmp_path, _scryfall_json([{"id": "only", "name": "Dark Ritual"}]))
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert len(result) == 1
+        assert result[0]["name"] == "Dark Ritual"
+
+    def test_empty_array_yields_nothing(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        _write_cache_file(tmp_path, _scryfall_json([]))
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == []
+
+
+class TestStreamDataForKeyLineParsing:
+    @pytest.fixture
+    def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
+        return _make_fetcher(tmp_path)
+
+    def test_skips_opening_and_closing_bracket_lines(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """[ and ] delimiter lines must not be parsed as cards."""
+        raw = b'[\n{"id":"c1","name":"A"}\n]\n'
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == [{"id": "c1", "name": "A"}]
+
+    def test_strips_trailing_comma_from_card_lines(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """Trailing commas on all-but-last card lines must be stripped before parsing."""
+        raw = b'[\n{"id":"c1","name":"A"},\n{"id":"c2","name":"B"},\n{"id":"c3","name":"C"}\n]\n'
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert [r["name"] for r in result] == ["A", "B", "C"]
+
+    def test_skips_malformed_lines_and_logs_warning(
+        self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Malformed JSON lines are skipped; a WARNING is emitted and parsing continues."""
+        raw = b'[\n{"id":"good1","name":"Good"},\n{bad json here},\n{"id":"good2","name":"Also Good"}\n]\n'
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), caplog.at_level(logging.WARNING):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert [r["name"] for r in result] == ["Good", "Also Good"]
+        assert any("Skipping unparseable" in r.message for r in caplog.records)
+
+    def test_ignores_blank_lines(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        raw = b'[\n\n{"id":"c1","name":"A"}\n\n]\n'
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert len(result) == 1
+
+
+class TestStreamDataForKeyCacheMiss:
+    @pytest.fixture
+    def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
+        return _make_fetcher(tmp_path)
+
+    def test_downloads_and_caches_on_miss(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """When no cache file exists, the file is downloaded and written as zstd-compressed cache."""
+        raw_json = _scryfall_json([{"id": "dl-1", "name": "Downloaded Card"}])
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [raw_json]
+        fetcher.session.get.return_value = mock_response
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
+        assert cache_file.exists(), "cache file should have been written"
+        # The streaming compressor omits content size, so use ZstdDecompressor instead of zstd.decompress()
+        dctx = zstd.ZstdDecompressor()
+        decompressed = dctx.decompress(cache_file.read_bytes(), max_output_size=10 * 1024 * 1024)
+        assert b"Downloaded Card" in decompressed
+        assert result == [{"id": "dl-1", "name": "Downloaded Card"}]
+
+    def test_second_call_does_not_re_download(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """Once the cache file exists, subsequent calls must not make HTTP requests."""
+        _write_cache_file(tmp_path, _scryfall_json([{"id": "c1", "name": "Cached"}]))
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        fetcher.session.get.assert_not_called()
+
+    def test_prunes_stale_cache_files_before_download(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """Stale cache files in the directory are deleted before writing a new one."""
+        stale = tmp_path / "default_cards" / "old-file.json.zstd"
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_bytes(b"stale data")
+
+        raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
+        uri = "https://data.scryfall.io/default-cards/default-cards-new.json"
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [raw_json]
+        fetcher.session.get.return_value = mock_response
+
+        bulk_data = {BulkDataKey.DEFAULT_CARDS: {"download_uri": uri}}
+        with patch.object(fetcher, "list_bulk_data", return_value=bulk_data):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert not stale.exists(), "stale file should have been deleted"

--- a/api/utils/http_utils.py
+++ b/api/utils/http_utils.py
@@ -1,0 +1,11 @@
+"""HTTP helpers shared across outbound clients."""
+
+from __future__ import annotations
+
+import datetime
+
+
+def make_user_agent() -> str:
+    """Identifying User-Agent for outbound HTTP requests (Scryfall rejects HTTP-library defaults)."""
+    version = datetime.datetime.now(tz=datetime.UTC).strftime("%Y%m%d")
+    return f"magic-api/{version}"


### PR DESCRIPTION
## Problem

On startup, the API service fetches ~114k cards from the Scryfall bulk data dump
and imports them into PostgreSQL. The previous path loaded everything into memory
at once: decompress the full file → parse the full JSON array → build a Python list
of 114k dicts → filter → batch into 6000-card pages for COPY.

Measured peak RSS (114,247 cards, 55 MB zstd / 514 MB JSON, isolated processes):

| Path | Peak RSS | Elapsed |
|---|---|---|
| Before (decompress all + `orjson.loads` on 514 MB string) | **~3.0 GB** | 0.91 s |
| After — streaming only (no batching) | **~23 MB** | 1.14 s |
| After — streaming + 6000-card COPY batches | **~182 MB** | — |

The 6000-card batch size is kept from the previous implementation; with streaming it now
represents the peak rather than an additive cost on top of the full dataset. Rough
batch-size comparison:

| page_size | peak RSS |
|---|---|
| 1000 | ~51 MB |
| 3000 | ~104 MB |
| 6000 | ~182 MB |

All fit comfortably inside the 2 GB container limit.

The 130× reduction matters because the service runs inside a 2 GB container
(`joe/limit_memory`). The spike was causing OOM kills on the first import after a
fresh deploy.

## What changed

### `api/scryfall_bulk_data_fetcher.py`

- **`stream_data_for_key()`** — new public method that yields one card dict at a time.
  Opens the cached `.json.zstd` file, wraps it in `ZstdDecompressor.stream_reader` →
  `BufferedReader` → `TextIOWrapper`, and parses each `{…}` line with `orjson.loads`.
  Trailing commas and bracket lines are stripped; malformed lines are logged and skipped.
- **`_ensure_cached()`** — extracted helper that streams the HTTP download through a
  `ZstdCompressor.stream_writer` directly to disk, so the full payload is never buffered
  in memory during download either.
- **`_cache_file_path_for_key()`** — extracted path-derivation helper shared by both
  `get_data_for_key` and `stream_data_for_key`.

### `api/api_resource.py`

- **`_run_import_under_lock()`** — calls `stream_data_for_key()` instead of
  `_get_cards_to_insert()`, passing the iterator directly to `_load_cards_with_staging`.
  The full card list is never materialised.
- **`_load_cards_with_staging(cards, page_size=6000)`** — signature changed from
  `list[dict]` to `Iterable[dict]`. Preprocessing and already-imported filtering are
  applied lazily via an inner `_CardStream` class (replaces `nonlocal` counters).
  `itertools.batched(stream, page_size)` drives the loop.
- **`_copy_batch_to_staging()`** — extracted helper (one batch → COPY → staging table →
  INSERT … ON CONFLICT DO NOTHING → DROP). Keeps statement count under the ruff
  `PLR0915` limit and makes each step independently testable.
- Result dict now includes `"cards_sent"` (cards that entered the DB layer) alongside
  `"cards_loaded"` (rows actually inserted after conflict resolution).

## Tests

26 new unit/integration tests across three new files. All DB assertions use testcontainers
(real PostgreSQL, not mocks):

- **`test_scryfall_bulk_data_fetcher.py`** (10 tests) — cache-hit streaming, line-parsing
  edge cases (bracket lines, trailing commas, malformed JSON, blank lines), cache-miss
  download-and-cache, no-re-download on second call, stale-file pruning.
- **`test_load_cards_with_staging.py`** (16 tests) — all four status codes
  (`no_cards_before_preprocessing`, `no_cards_after_preprocessing`,
  `all_cards_already_present`, `success`), `_CardStream` stage counts,
  `_copy_batch_to_staging` insert/sample/conflict behaviour, multi-batch loads using
  configurable `page_size`, and wiring tests confirming `_run_import_under_lock` calls
  `stream_data_for_key` and not `_get_cards_to_insert`.
- **`test_cubecobra_and_prefer_scores.py`** (12 tests, same session) — while in the area,
  added coverage for `_insert_cubecobra_data`, `_fetch_cubecobra_data`, and
  `backfill_prefer_scores`, which were previously untested.

Overall test suite: 1,631 passing, 87% line coverage.