### PR TITLE
Shared-memory card store (rkyv + mmap)

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -27,6 +27,7 @@ import cachebox
 import falcon
 import orjson
 import psycopg
+import psycopg_pool
 import requests
 from cachebox import LRUCache, TTLCache
 from cachebox import cached as cachebox_cached
@@ -53,8 +54,6 @@ if TYPE_CHECKING:
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
-
-    import psycopg_pool
 
     from api.parsing.nodes import Query
 
@@ -196,6 +195,7 @@ class APIResource:
         last_import_time: Synchronized | None = None,
         schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
         cache_generation: Synchronized | None = None,
+        engine_reload_guard: LockType | None = None,
     ) -> None:
         """Initialize an APIResource object, set up connection pool and action map.
 
@@ -244,6 +244,9 @@ class APIResource:
         self._tagger_client = TaggerClient()
         self._engine = _QueryEngine()
         self._engine_reload_lock = threading.Lock()
+        # Cross-worker guard: the full-table fetch in _reload_engine is memory-hungry,
+        # so only one worker process should run it at a time (see _reload_engine).
+        self._engine_reload_guard: LockType = engine_reload_guard or multiprocessing.Lock()
         logger.info("Worker with pid %d has conn pool %s", os.getpid(), self._conn_pool)
         self.setup_schema()
         self.import_data()  # ensures that database is setup
@@ -619,19 +622,45 @@ class APIResource:
         logger.info("Last import was %d seconds ago, %s", time_since_import, retval)
         return retval
 
-    def _reload_engine(self) -> None:
-        """Fetch all cards from the DB and reload the Rust engine's card store."""
+    def _reload_engine(self, *, force: bool = False) -> None:
+        """Fetch all cards from the DB and reload the Rust engine's card store.
+
+        The full-table fetch (fetchall + dict conversion + rkyv serialization) is the
+        most memory-hungry thing a worker does, so it is guarded by a cross-worker
+        lock: only one worker pays that cost at a time. With force=False (cold-start
+        warming), losers of the race return immediately and pick up the winner's
+        archive via the engine's inode-based remap. With force=True (data just
+        changed), callers wait their turn but skip the rebuild if another worker
+        refreshed the store while they were waiting.
+
+        Args:
+            force: If False, skip entirely when another worker holds the lock or the
+                store is already populated. If True, wait for the lock and always
+                reload (the data just changed, so the archive must be rebuilt).
+        """
         if not settings.enable_engine:
             return
         if self._engine is None:
             return
-        cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS_FROM_MODULE)
-        with self._conn_pool.connection() as conn:
-            with conn.cursor() as cursor:
-                cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
-                rows = cursor.fetchall()
-        self._engine.reload([dict(row) for row in rows])
-        logger.info("Engine reloaded with %d cards (pid=%d)", self._engine.size(), os.getpid())
+        if not self._engine_reload_guard.acquire(block=force):
+            logger.info("Engine reload already in progress in another worker, skipping (pid=%d)", os.getpid())
+            return
+        try:
+            if not force and self._engine.size() > 0:
+                # Another worker populated the store while we raced for the lock.
+                return
+            cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS_FROM_MODULE)
+            try:
+                with self._conn_pool.connection() as conn:
+                    with conn.cursor() as cursor:
+                        cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
+                        rows = cursor.fetchall()
+            except psycopg_pool.PoolClosed:
+                return
+            self._engine.reload([dict(row) for row in rows])
+            logger.info("Engine reloaded with %d cards (pid=%d)", self._engine.size(), os.getpid())
+        finally:
+            self._engine_reload_guard.release()
 
     def _run_import_under_lock(self) -> None:
         """Run the import flow; caller must hold the import lock."""
@@ -660,7 +689,7 @@ class APIResource:
             )
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
-            self._reload_engine()
+            self._reload_engine(force=True)
             self._clear_caches()
             self._last_import_time.value = time.time()
             self._setup_complete_cache = None
@@ -768,7 +797,7 @@ class APIResource:
             ) from err
         return where_clause, params
 
-    def _search(  # noqa: C901,PLR0912,PLR0913,PLR0915
+    def _search(  # noqa: PLR0913
         self,
         *,
         direction: SortDirection = SortDirection.ASC,
@@ -794,14 +823,11 @@ class APIResource:
 
         timer = Timer()
 
-        query_explanation = ""
         parsed_query = None
         query = query or ""
         try:
             with timer("parse"):
                 parsed_query = parse_scryfall_query(query)
-                if query:
-                    query_explanation = parsed_query.to_human_explanation()
         except ValueError as err:
             logger.info("ValueError caught for query '%s', raising BadRequest", query)
             raise falcon.HTTPBadRequest(
@@ -828,7 +854,6 @@ class APIResource:
             try:
                 result = self._search_engine(
                     parsed_query=parsed_query,
-                    query_explanation=query_explanation,
                     query=query,
                     unique=unique,
                     prefer=prefer,
@@ -844,20 +869,8 @@ class APIResource:
                     search_cache[cache_key] = result
                 return result
 
-        try:
-            with timer("get_where_clause"):
-                where_clause, params = generate_sql_query(parsed_query)
-        except ValueError as err:
-            logger.info("ValueError caught for query '%s', raising BadRequest", query)
-            raise falcon.HTTPBadRequest(
-                title="Invalid Search Query",
-                description=f'Failed to parse query: "{query}"',
-            ) from err
-
         result = self._search_sql(
-            where_clause=where_clause,
-            params=params,
-            query_explanation=query_explanation,
+            parsed_query=parsed_query,
             query=query,
             unique=unique,
             prefer=prefer,
@@ -874,7 +887,6 @@ class APIResource:
         self,
         *,
         parsed_query: Query,
-        query_explanation: str,
         query: str | None,
         unique: UniqueOn,
         prefer: PreferOrder,
@@ -884,6 +896,7 @@ class APIResource:
         timer: Timer,
     ) -> dict[str, Any]:
         logger.info("Searching engine for %r", query)
+        query_explanation = parsed_query.to_human_explanation() if query else ""
         with timer("engine_query"):
             total_cards, cards = self._engine.query(
                 filters=parsed_query,
@@ -891,7 +904,8 @@ class APIResource:
                 prefer=str(prefer),
                 orderby=str(orderby),
                 direction=str(direction),
-                limit=limit,
+                # limit=None means "no limit"; the engine requires an int, so use a large number
+                limit=limit if limit is not None else 1_000_000,
             )
         return {
             "cards": list(cards),
@@ -907,9 +921,7 @@ class APIResource:
     def _search_sql(  # noqa: PLR0913
         self,
         *,
-        where_clause: str,
-        params: dict[str, Any],
-        query_explanation: str,
+        parsed_query: Query,
         query: str | None,
         unique: UniqueOn,
         prefer: PreferOrder,
@@ -919,6 +931,16 @@ class APIResource:
         timer: Timer,
     ) -> dict[str, Any]:
         logger.info("Searching SQL for %r", query)
+        query_explanation = parsed_query.to_human_explanation() if query else ""
+        try:
+            with timer("get_where_clause"):
+                where_clause, params = generate_sql_query(parsed_query)
+        except ValueError as err:
+            logger.info("ValueError caught for query '%s', raising BadRequest", query)
+            raise falcon.HTTPBadRequest(
+                title="Invalid Search Query",
+                description=f'Failed to parse query: "{query}"',
+            ) from err
         sql_orderby: str = {
             # what's in the query => the db column name
             CardOrdering.CMC: "cmc",
@@ -2643,7 +2665,7 @@ class APIResource:
 
                 if cards_loaded > 0:
                     self._clear_caches()
-                    self._reload_engine()
+                    self._reload_engine(force=True)
 
                 return {
                     "status": "success",

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -639,6 +639,7 @@ class APIResource:
                 reload (the data just changed, so the archive must be rebuilt).
         """
         if not settings.enable_engine:
+            logger.debug("Engine reload skipped: feature-gated off (ENABLE_ENGINE)")
             return
         if self._engine is None:
             return

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -656,6 +656,7 @@ class APIResource:
                         cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
                         rows = cursor.fetchall()
             except psycopg_pool.PoolClosed:
+                logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
                 return
             self._engine.reload([dict(row) for row in rows])
             logger.info("Engine reloaded with %d cards (pid=%d)", self._engine.size(), os.getpid())

--- a/api/api_worker.py
+++ b/api/api_worker.py
@@ -58,6 +58,7 @@ class ApiWorker(multiprocessing.Process):
         last_import_time: Synchronized | None = None,
         schema_setup_event: EventType = multiprocessing_utils.DEFAULT_EVENT,
         cache_generation: Synchronized | None = None,
+        engine_reload_guard: LockType | None = None,
     ) -> None:
         """Initialize the API worker process.
 
@@ -70,6 +71,7 @@ class ApiWorker(multiprocessing.Process):
             schema_setup_event (multiprocessing.Event): Event denoting schema setup has been completed.
             debug (bool): Whether to run in debug mode.
             cache_generation (Synchronized | None): Shared counter incremented on cache invalidation.
+            engine_reload_guard (multiprocessing.Lock | None): Cross-worker lock so only one worker reloads the engine store.
         """
         super().__init__()
         self.host = host
@@ -80,6 +82,7 @@ class ApiWorker(multiprocessing.Process):
         self.debug = debug
         self.schema_setup_event = schema_setup_event
         self.cache_generation = cache_generation
+        self.engine_reload_guard = engine_reload_guard
 
     @classmethod
     def get_api(
@@ -88,6 +91,7 @@ class ApiWorker(multiprocessing.Process):
         last_import_time: Synchronized | None,
         schema_setup_event: EventType,
         cache_generation: Synchronized | None = None,
+        engine_reload_guard: LockType | None = None,
     ) -> falcon.App:
         """Create and configure the Falcon API application.
 
@@ -118,6 +122,7 @@ class ApiWorker(multiprocessing.Process):
         api.set_error_serializer(json_error_serializer)  # Use custom JSON error serializer
         sink = APIResource(
             cache_generation=cache_generation,
+            engine_reload_guard=engine_reload_guard,
             import_guard=import_guard,
             last_import_time=last_import_time,
             schema_setup_event=schema_setup_event,
@@ -151,6 +156,7 @@ class ApiWorker(multiprocessing.Process):
 
             app = self.get_api(
                 cache_generation=self.cache_generation,
+                engine_reload_guard=self.engine_reload_guard,
                 import_guard=self.import_guard,
                 last_import_time=self.last_import_time,
                 schema_setup_event=self.schema_setup_event,

--- a/api/entrypoint.py
+++ b/api/entrypoint.py
@@ -56,11 +56,13 @@ def run_server(
     last_import_time = multiprocessing.Value("d", 0.0, lock=True)
     schema_setup_event = multiprocessing.Event()
     cache_generation = multiprocessing.Value("i", 0, lock=True)
+    engine_reload_guard = multiprocessing.Lock()
 
     # start workers
     for _ in range(num_workers):
         iworker = ApiWorker(
             cache_generation=cache_generation,
+            engine_reload_guard=engine_reload_guard,
             exit_flag=exit_flag,
             host=ALL_INTERFACES,
             import_guard=import_guard,
@@ -94,6 +96,8 @@ def run_server(
             if response:
                 logger.info("Exit flag set, terminating workers")
                 break
+        else:
+            logger.info("Some workers died")
     except KeyboardInterrupt:
         graceful_shutdown(signal.SIGINT, None)
 

--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -14,6 +14,8 @@ import requests
 import zstandard as zstd
 from cachebox import TTLCache
 from cachebox import cached as cachebox_cached
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from api.utils.http_utils import make_user_agent
 
@@ -59,12 +61,45 @@ class ScryfallBulkDataFetcher:
         # Scryfall rejects default HTTP-library User-Agents (400 generic_user_agent),
         # and asks for an explicit Accept header.
         self.session.headers.update({"User-Agent": make_user_agent(), "Accept": "application/json"})
+        # Retry connection errors and retryable statuses with backoff at the
+        # transport layer. raise_on_status=False returns the last response after
+        # retries are exhausted so _get() can log its body before raising.
+        retry = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"],
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
+    def _get(self, url: str, *, timeout: int, **kwargs: object) -> requests.Response:
+        """GET a URL via the retrying session, logging the response body on HTTP errors.
+
+        Args:
+            url: The URL to fetch.
+            timeout: Per-attempt request timeout in seconds.
+            **kwargs: Extra arguments passed through to session.get (e.g. stream=True).
+
+        Returns:
+            The successful (2xx) response.
+
+        Raises:
+            requests.HTTPError: If the final response after retries is not 2xx.
+            requests.RequestException: If the request fails at the transport level.
+        """
+        response = self.session.get(url, timeout=timeout, **kwargs)
+        if not response.ok:
+            logger.error("GET %s returned HTTP %d, body[:500]=%r", url, response.status_code, response.text[:500])
+        response.raise_for_status()
+        return response
 
     @cachebox_cached(cache=TTLCache(maxsize=2, global_ttl=5 * MINUTE))
     def list_bulk_data(self) -> dict[BulkDataKey, dict]:
         """Fetch bulk data from Scryfall, ignoring bulk data types we don't recognize."""
-        response = self.session.get("https://api.scryfall.com/bulk-data", timeout=20)
-        response.raise_for_status()
+        response = self._get("https://api.scryfall.com/bulk-data", timeout=20)
         known_types = {key.value for key in BulkDataKey}
         records = response.json()["data"]
         unknown_types = sorted({r["type"] for r in records} - known_types)
@@ -108,8 +143,7 @@ class ScryfallBulkDataFetcher:
         tmp_path = cache_file_path.with_name(f"{cache_file_path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
         cctx = zstd.ZstdCompressor(write_content_size=True)
         try:
-            with self.session.get(download_uri, stream=True, timeout=60) as response:
-                response.raise_for_status()
+            with self._get(download_uri, stream=True, timeout=60) as response:
                 with tmp_path.open("wb") as f, cctx.stream_writer(f) as compressor:
                     for chunk in response.iter_content(chunk_size=65536):
                         compressor.write(chunk)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -9,9 +9,19 @@ from typing import TYPE_CHECKING
 import pytest
 
 from api.api_resource import APIResource
+from api.settings import settings
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+
+@pytest.fixture(name="engine_enabled")
+def engine_enabled_fixture() -> Generator[None]:
+    """Enable the engine feature gate (ENABLE_ENGINE) for the duration of a test."""
+    saved = settings.enable_engine
+    settings.enable_engine = True
+    yield
+    settings.enable_engine = saved
 
 
 @pytest.fixture(scope="module")

--- a/api/tests/helpers.py
+++ b/api/tests/helpers.py
@@ -4,6 +4,30 @@ from __future__ import annotations
 
 import uuid
 
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import parse_scryfall_query
+from api.utils.timer import Timer
+
+
+def search_kwargs(
+    query: str,
+    limit: int = 10,
+    orderby: CardOrdering = CardOrdering.EDHREC,
+    direction: SortDirection = SortDirection.ASC,
+) -> dict:
+    """Build kwargs for _search_sql or _search_engine from a query string."""
+    parsed = parse_scryfall_query(query)
+    return {
+        "parsed_query": parsed,
+        "query": query,
+        "unique": UniqueOn.CARD,
+        "prefer": PreferOrder.DEFAULT,
+        "orderby": orderby,
+        "direction": direction,
+        "limit": limit,
+        "timer": Timer(),
+    }
+
 
 def make_raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
     """Minimal raw Scryfall card dict that passes preprocess_card and satisfies NOT NULL constraints."""

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -8,7 +8,7 @@ import pytest
 
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
-from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing import parse_scryfall_query
 from api.utils.timer import Timer
 
 
@@ -22,7 +22,6 @@ def api_resource_fixture() -> APIResource:
 def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
     """Return the compiled SQL string via the SQL path directly."""
     parsed_query = parse_scryfall_query("cmc=1")
-    where_clause, params = generate_sql_query(parsed_query)
     with (
         patch.object(api_resource, "_conn_pool") as mock_pool,
         patch.object(api_resource, "_setup_complete", return_value=True),
@@ -34,9 +33,7 @@ def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
         mock_pool.connection.return_value.__enter__.return_value = mock_conn
 
         result = api_resource._search_sql(
-            where_clause=where_clause,
-            params=params,
-            query_explanation="",
+            parsed_query=parsed_query,
             query="cmc=1",
             unique=UniqueOn.CARD,
             prefer=PreferOrder.DEFAULT,

--- a/api/tests/test_datatype_mismatch.py
+++ b/api/tests/test_datatype_mismatch.py
@@ -1,8 +1,10 @@
-"""Tests for DatatypeMismatch error handling in search queries.
+"""Tests for DatatypeMismatch error handling in the SQL search path.
 
 This module tests that standalone arithmetic expressions in queries
-(like "cmc+1") are handled gracefully by returning empty results
-instead of throwing DatatypeMismatch exceptions.
+(like "cmc+1") are handled gracefully by raising HTTPBadRequest
+instead of leaking DatatypeMismatch exceptions. The handling lives in
+_search_sql, so the tests call it directly (routing between the engine
+and SQL paths is covered in test_parsing_errors.py).
 """
 
 from __future__ import annotations
@@ -16,10 +18,11 @@ import psycopg.errors
 import pytest
 
 from api.api_resource import APIResource
+from api.tests.helpers import search_kwargs
 
 
 class TestDatatypeMismatchHandling:
-    """Test handling of DatatypeMismatch errors in search functionality."""
+    """Test handling of DatatypeMismatch errors in the SQL search path."""
 
     def setup_method(self) -> None:
         """Set up test fixtures."""
@@ -27,19 +30,14 @@ class TestDatatypeMismatchHandling:
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
 
-        def always_true() -> bool:
-            return True
-
-        self.api_resource._setup_complete = always_true
-
     def teardown_method(self) -> None:
         """Clean up test fixtures."""
         if hasattr(self, "api_resource") and self.api_resource:
             # Close the connection pool to prevent thread pool warnings
             self.api_resource._conn_pool.close()
 
-    def test_search_handles_datatype_mismatch(self) -> None:
-        """Test that DatatypeMismatch in search raises HTTPBadRequest."""
+    def test_search_sql_handles_datatype_mismatch(self) -> None:
+        """Test that DatatypeMismatch in _search_sql raises HTTPBadRequest."""
         # Mock the _run_query method to raise DatatypeMismatch
         with (
             patch.object(self.api_resource, "_run_query") as mock_run_query,
@@ -48,16 +46,16 @@ class TestDatatypeMismatchHandling:
                 'column "cmc" must appear in the GROUP BY clause or be used in an aggregate function',
             )
 
-            # Call _search with a problematic query and expect HTTPBadRequest
+            # Call _search_sql with a problematic query and expect HTTPBadRequest
             with pytest.raises(falcon.HTTPBadRequest) as exc_info:
-                self.api_resource._search(query="cmc+1")
+                self.api_resource._search_sql(**search_kwargs("cmc+1"))
 
             # Verify the error details
             assert exc_info.value.title == "Invalid Search Query"
             assert "cmc+1" in exc_info.value.description
             assert "invalid syntax" in exc_info.value.description.lower()
 
-    def test_search_handles_datatype_mismatch_main_query_only(self) -> None:
+    def test_search_sql_handles_datatype_mismatch_main_query_only(self) -> None:
         """Test that DatatypeMismatch is only caught on the main query."""
         # Mock _run_query to fail on first call (main query)
         with (
@@ -67,16 +65,16 @@ class TestDatatypeMismatchHandling:
                 "WHERE clause must be type boolean, not type integer",
             )
 
-            # Call _search with a problematic query and expect HTTPBadRequest
+            # Call _search_sql with a problematic query and expect HTTPBadRequest
             with pytest.raises(falcon.HTTPBadRequest) as exc_info:
-                self.api_resource._search(query="cmc+1", limit=100)
+                self.api_resource._search_sql(**search_kwargs("cmc+1", limit=100))
 
             # Verify the error details and that only one query was attempted
             assert exc_info.value.title == "Invalid Search Query"
             assert "cmc+1" in exc_info.value.description
             assert mock_run_query.call_count == 1
 
-    def test_search_normal_operation_unaffected(self) -> None:
+    def test_search_sql_normal_operation_unaffected(self) -> None:
         """Test that normal queries still work correctly."""
         # Mock successful query execution
         with patch.object(self.api_resource, "_run_query") as mock_run_query:
@@ -88,7 +86,7 @@ class TestDatatypeMismatchHandling:
                 "timings": {},
             }
 
-            result = self.api_resource._search(query="name:bolt")
+            result = self.api_resource._search_sql(**search_kwargs("name:bolt"))
 
             # Verify normal operation
             assert len(result["cards"]) == 1

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import datetime
 import json
+import tempfile
+import uuid
 from pathlib import Path
 
 import pytest
@@ -36,10 +38,19 @@ from card_engine import QueryEngine
 _FIXTURE = Path(__file__).parent / "fixtures" / "engine_cards.json"
 
 
+def _fresh_engine() -> QueryEngine:
+    """Engine with its own snapshot path.
+
+    The default path is shared machine-wide (that's the point of the shm design),
+    so two test engines holding different card sets would clobber each other.
+    """
+    return QueryEngine(shm_path=str(Path(tempfile.gettempdir()) / f"arcane_tutor_test_{uuid.uuid4().hex}"))
+
+
 @pytest.fixture(scope="module", name="engine")
 def engine_fixture() -> QueryEngine:
     cards = json.loads(_FIXTURE.read_text())
-    e = QueryEngine()
+    e = _fresh_engine()
     e.reload(cards)
     return e
 
@@ -122,7 +133,7 @@ class TestFilters:
     def test_collector_number_query_is_case_sensitive(self) -> None:
         # collector_number is stored raw and mixed-case (e.g. The List's "10E-105"),
         # and the SQL path compares it exactly — the engine must do the same.
-        e = QueryEngine()
+        e = _fresh_engine()
         e.reload(
             [
                 {"card_name": "List Printing", "oracle_id": "o1", "collector_number": "10E-105"},
@@ -354,7 +365,7 @@ class TestUnique:
         # unique=card/artwork group by oracle_id; cards without one would silently
         # collapse into a single group, so reload must refuse them up front.
         # (Unreachable from _reload_engine(): the DB column is NOT NULL.)
-        e = QueryEngine()
+        e = _fresh_engine()
         with pytest.raises(ValueError, match=r"No Oracle.*missing oracle_id"):
             e.reload(
                 [
@@ -761,7 +772,7 @@ class TestCardProperties:
             "creature_power": 9,
             "creature_power_text": "9",
         }
-        e = QueryEngine()
+        e = _fresh_engine()
         e.reload(
             [
                 {**base, "oracle_id": "a", "released_at": datetime.date(2026, 3, 15)},

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -29,28 +29,43 @@ import json
 import tempfile
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from api.parsing import parse_scryfall_query
 from card_engine import QueryEngine
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
 _FIXTURE = Path(__file__).parent / "fixtures" / "engine_cards.json"
 
 
-def _fresh_engine() -> QueryEngine:
-    """Engine with its own snapshot path.
+@pytest.fixture(scope="module", name="fresh_engine")
+def fresh_engine_fixture() -> Generator[Callable[[], QueryEngine]]:
+    """Factory for engines with their own snapshot path; archives removed at teardown.
 
     The default path is shared machine-wide (that's the point of the shm design),
     so two test engines holding different card sets would clobber each other.
     """
-    return QueryEngine(shm_path=str(Path(tempfile.gettempdir()) / f"arcane_tutor_test_{uuid.uuid4().hex}"))
+    paths: list[Path] = []
+
+    def make() -> QueryEngine:
+        shm_path = Path(tempfile.gettempdir()) / f"arcane_tutor_test_{uuid.uuid4().hex}"
+        paths.append(shm_path)
+        return QueryEngine(shm_path=str(shm_path))
+
+    yield make
+    for shm_path in paths:
+        shm_path.unlink(missing_ok=True)
+        shm_path.with_suffix(".lock").unlink(missing_ok=True)
 
 
 @pytest.fixture(scope="module", name="engine")
-def engine_fixture() -> QueryEngine:
+def engine_fixture(fresh_engine: Callable[[], QueryEngine]) -> QueryEngine:
     cards = json.loads(_FIXTURE.read_text())
-    e = _fresh_engine()
+    e = fresh_engine()
     e.reload(cards)
     return e
 
@@ -130,10 +145,10 @@ class TestFilters:
         t_lower, _ = _run(engine, "set:lea")
         assert t_upper == t_lower == 7
 
-    def test_collector_number_query_is_case_sensitive(self) -> None:
+    def test_collector_number_query_is_case_sensitive(self, fresh_engine: Callable[[], QueryEngine]) -> None:
         # collector_number is stored raw and mixed-case (e.g. The List's "10E-105"),
         # and the SQL path compares it exactly — the engine must do the same.
-        e = _fresh_engine()
+        e = fresh_engine()
         e.reload(
             [
                 {"card_name": "List Printing", "oracle_id": "o1", "collector_number": "10E-105"},
@@ -361,11 +376,11 @@ class TestCollectionOperators:
 
 
 class TestUnique:
-    def test_reload_rejects_cards_missing_oracle_id(self) -> None:
+    def test_reload_rejects_cards_missing_oracle_id(self, fresh_engine: Callable[[], QueryEngine]) -> None:
         # unique=card/artwork group by oracle_id; cards without one would silently
         # collapse into a single group, so reload must refuse them up front.
         # (Unreachable from _reload_engine(): the DB column is NOT NULL.)
-        e = _fresh_engine()
+        e = fresh_engine()
         with pytest.raises(ValueError, match=r"No Oracle.*missing oracle_id"):
             e.reload(
                 [
@@ -760,7 +775,7 @@ class TestCardProperties:
         assert total == 1
         assert cards[0]["name"] == "Kitchen Finks"
 
-    def test_year_filter_with_date_objects(self) -> None:
+    def test_year_filter_with_date_objects(self, fresh_engine: Callable[[], QueryEngine]) -> None:
         # _reload_engine() feeds rows straight from psycopg, which returns date
         # columns as datetime.date (not str). The engine must extract those, or
         # released_at silently becomes "" and every date/year filter goes empty.
@@ -772,7 +787,7 @@ class TestCardProperties:
             "creature_power": 9,
             "creature_power_text": "9",
         }
-        e = _fresh_engine()
+        e = fresh_engine()
         e.reload(
             [
                 {**base, "oracle_id": "a", "released_at": datetime.date(2026, 3, 15)},

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import multiprocessing
 import os
 import pathlib
+import tempfile
 import time
+import uuid
 from typing import TYPE_CHECKING
 
 import psycopg
@@ -15,6 +17,7 @@ from testcontainers.postgres import PostgresContainer
 from api.api_resource import APIResource
 from api.enums import CardOrdering, SortDirection
 from api.tests.helpers import search_kwargs
+from card_engine import QueryEngine
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -400,6 +403,7 @@ class TestContainerIntegration:
 
         assert brainstorm_in_combined, "Brainstorm should be found by combined search"
 
+    @pytest.mark.usefixtures("engine_enabled")
     def test_cubecobra_ordering(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test that orderby=cubecobra sorts by cubecobra_score ascending (lower = better)."""
         # Assign distinct cubecobra_score values to three known cards
@@ -416,17 +420,28 @@ class TestContainerIntegration:
                 )
             conn.commit()
 
-        # Reload the engine so it picks up the direct DB update
-        api_resource._reload_engine(force=True)
+        # The default archive path is shared machine-wide, so another process's
+        # store would shadow this test DB's data: swap in a private store for
+        # this test (the api_resource fixture is class-scoped, so restore it).
+        shm_path = pathlib.Path(tempfile.gettempdir()) / f"arcane_tutor_it_{uuid.uuid4().hex}"
+        saved_engine = api_resource._engine
+        api_resource._engine = QueryEngine(shm_path=str(shm_path))
+        try:
+            # Reload the engine so it picks up the direct DB update
+            api_resource._reload_engine(force=True)
 
-        result = api_resource._search_engine(
-            **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
-        )
-        names = [card["name"] for card in result["cards"] if card["name"] in scores]
-        assert names == ["Lightning Bolt", "Black Lotus", "Serra Angel"]
+            result = api_resource._search_engine(
+                **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
+            )
+            names = [card["name"] for card in result["cards"] if card["name"] in scores]
+            assert names == ["Lightning Bolt", "Black Lotus", "Serra Angel"]
 
-        result = api_resource._search_engine(
-            **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.DESC)
-        )
-        names = [card["name"] for card in result["cards"] if card["name"] in scores]
-        assert names == ["Serra Angel", "Black Lotus", "Lightning Bolt"]
+            result = api_resource._search_engine(
+                **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.DESC)
+            )
+            names = [card["name"] for card in result["cards"] if card["name"] in scores]
+            assert names == ["Serra Angel", "Black Lotus", "Lightning Bolt"]
+        finally:
+            api_resource._engine = saved_engine
+            shm_path.unlink(missing_ok=True)
+            shm_path.with_suffix(".lock").unlink(missing_ok=True)

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -13,6 +13,30 @@ import pytest
 from testcontainers.postgres import PostgresContainer
 
 from api.api_resource import APIResource
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import parse_scryfall_query
+from api.utils.timer import Timer
+
+
+def _search_kwargs(
+    query: str,
+    limit: int = 10,
+    orderby: CardOrdering = CardOrdering.EDHREC,
+    direction: SortDirection = SortDirection.ASC,
+) -> dict:
+    """Build kwargs for _search_sql or _search_engine from a query string."""
+    parsed = parse_scryfall_query(query)
+    return {
+        "parsed_query": parsed,
+        "query": query,
+        "unique": UniqueOn.CARD,
+        "prefer": PreferOrder.DEFAULT,
+        "orderby": orderby,
+        "direction": direction,
+        "limit": limit,
+        "timer": Timer(),
+    }
+
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -140,10 +164,7 @@ class TestContainerIntegration:
     def test_query_parsing_with_database(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test query parsing and execution against real database."""
         # Test a simple search query
-        result = api_resource.search(
-            q="type:creature",
-            limit=10,
-        )
+        result = api_resource._search_sql(**_search_kwargs("type:creature", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -155,10 +176,7 @@ class TestContainerIntegration:
 
     def test_card_search_by_name(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by name."""
-        result = api_resource.search(
-            q='name:"Lightning Bolt"',
-            limit=10,
-        )
+        result = api_resource._search_sql(**_search_kwargs('name:"Lightning Bolt"', limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -171,10 +189,7 @@ class TestContainerIntegration:
 
     def test_color_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by color."""
-        result = api_resource.search(
-            q="c:red",
-            limit=10,
-        )
+        result = api_resource._search_sql(**_search_kwargs("c:red", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -186,10 +201,7 @@ class TestContainerIntegration:
 
     def test_cmc_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by converted mana cost."""
-        result = api_resource.search(
-            q="cmc=0",
-            limit=10,
-        )
+        result = api_resource._search_sql(**_search_kwargs("cmc=0", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -201,10 +213,7 @@ class TestContainerIntegration:
 
     def test_power_toughness_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for creatures by power and toughness."""
-        result = api_resource.search(
-            q="power=4 toughness=4",
-            limit=10,
-        )
+        result = api_resource._search_sql(**_search_kwargs("power=4 toughness=4", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -227,7 +236,7 @@ class TestContainerIntegration:
         # and not affecting the main application database
 
         # Count cards in test database using a query that matches all cards
-        result = api_resource.search(q="cmc>=0", limit=100)
+        result = api_resource._search_sql(**_search_kwargs("cmc>=0", limit=100))
 
         # Should only have our test cards
         cards = result["cards"]
@@ -243,7 +252,7 @@ class TestContainerIntegration:
         assert len(random_result["cards"]) >= 1
         random_card_keys = set(random_result["cards"][0].keys())
 
-        search_result = api_resource.search(q="cmc>=0", limit=1)
+        search_result = api_resource._search_sql(**_search_kwargs("cmc>=0", limit=1))
         assert len(search_result["cards"]) >= 1
         search_card_keys = set(search_result["cards"][0].keys())
 
@@ -430,12 +439,16 @@ class TestContainerIntegration:
             conn.commit()
 
         # Reload the engine so it picks up the direct DB update
-        api_resource._reload_engine()
+        api_resource._reload_engine(force=True)
 
-        result = api_resource.search(orderby="cubecobra", direction="asc", limit=100)
+        result = api_resource._search_engine(
+            **_search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
+        )
         names = [card["name"] for card in result["cards"] if card["name"] in scores]
         assert names == ["Lightning Bolt", "Black Lotus", "Serra Angel"]
 
-        result = api_resource.search(orderby="cubecobra", direction="desc", limit=100)
+        result = api_resource._search_engine(
+            **_search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.DESC)
+        )
         names = [card["name"] for card in result["cards"] if card["name"] in scores]
         assert names == ["Serra Angel", "Black Lotus", "Lightning Bolt"]

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -13,30 +13,8 @@ import pytest
 from testcontainers.postgres import PostgresContainer
 
 from api.api_resource import APIResource
-from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
-from api.parsing import parse_scryfall_query
-from api.utils.timer import Timer
-
-
-def _search_kwargs(
-    query: str,
-    limit: int = 10,
-    orderby: CardOrdering = CardOrdering.EDHREC,
-    direction: SortDirection = SortDirection.ASC,
-) -> dict:
-    """Build kwargs for _search_sql or _search_engine from a query string."""
-    parsed = parse_scryfall_query(query)
-    return {
-        "parsed_query": parsed,
-        "query": query,
-        "unique": UniqueOn.CARD,
-        "prefer": PreferOrder.DEFAULT,
-        "orderby": orderby,
-        "direction": direction,
-        "limit": limit,
-        "timer": Timer(),
-    }
-
+from api.enums import CardOrdering, SortDirection
+from api.tests.helpers import search_kwargs
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -164,7 +142,7 @@ class TestContainerIntegration:
     def test_query_parsing_with_database(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test query parsing and execution against real database."""
         # Test a simple search query
-        result = api_resource._search_sql(**_search_kwargs("type:creature", limit=10))
+        result = api_resource._search_sql(**search_kwargs("type:creature", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -176,7 +154,7 @@ class TestContainerIntegration:
 
     def test_card_search_by_name(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by name."""
-        result = api_resource._search_sql(**_search_kwargs('name:"Lightning Bolt"', limit=10))
+        result = api_resource._search_sql(**search_kwargs('name:"Lightning Bolt"', limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -189,7 +167,7 @@ class TestContainerIntegration:
 
     def test_color_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by color."""
-        result = api_resource._search_sql(**_search_kwargs("c:red", limit=10))
+        result = api_resource._search_sql(**search_kwargs("c:red", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -201,7 +179,7 @@ class TestContainerIntegration:
 
     def test_cmc_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by converted mana cost."""
-        result = api_resource._search_sql(**_search_kwargs("cmc=0", limit=10))
+        result = api_resource._search_sql(**search_kwargs("cmc=0", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -213,7 +191,7 @@ class TestContainerIntegration:
 
     def test_power_toughness_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for creatures by power and toughness."""
-        result = api_resource._search_sql(**_search_kwargs("power=4 toughness=4", limit=10))
+        result = api_resource._search_sql(**search_kwargs("power=4 toughness=4", limit=10))
 
         assert isinstance(result, dict)
         assert "cards" in result
@@ -236,7 +214,7 @@ class TestContainerIntegration:
         # and not affecting the main application database
 
         # Count cards in test database using a query that matches all cards
-        result = api_resource._search_sql(**_search_kwargs("cmc>=0", limit=100))
+        result = api_resource._search_sql(**search_kwargs("cmc>=0", limit=100))
 
         # Should only have our test cards
         cards = result["cards"]
@@ -252,7 +230,7 @@ class TestContainerIntegration:
         assert len(random_result["cards"]) >= 1
         random_card_keys = set(random_result["cards"][0].keys())
 
-        search_result = api_resource._search_sql(**_search_kwargs("cmc>=0", limit=1))
+        search_result = api_resource._search_sql(**search_kwargs("cmc>=0", limit=1))
         assert len(search_result["cards"]) >= 1
         search_card_keys = set(search_result["cards"][0].keys())
 
@@ -442,13 +420,13 @@ class TestContainerIntegration:
         api_resource._reload_engine(force=True)
 
         result = api_resource._search_engine(
-            **_search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
+            **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.ASC)
         )
         names = [card["name"] for card in result["cards"] if card["name"] in scores]
         assert names == ["Lightning Bolt", "Black Lotus", "Serra Angel"]
 
         result = api_resource._search_engine(
-            **_search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.DESC)
+            **search_kwargs("cmc>=0", limit=100, orderby=CardOrdering.CUBECOBRA, direction=SortDirection.DESC)
         )
         names = [card["name"] for card in result["cards"] if card["name"] in scores]
         assert names == ["Serra Angel", "Black Lotus", "Lightning Bolt"]

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -52,6 +52,7 @@ class TestParsingErrorHandling:
         assert exc_info.value.description == f'Failed to parse query: "{query}"'
 
 
+@pytest.mark.usefixtures("engine_enabled")
 class TestSearchRouting:
     """_search routes to _search_sql or _search_engine and validates inputs.
 
@@ -63,11 +64,8 @@ class TestSearchRouting:
         self.api_resource = _make_api()
         self.api_resource._setup_complete = lambda: True
         self.api_resource._engine = MagicMock()
-        self._saved_enable_engine = settings.enable_engine
-        settings.enable_engine = True
 
     def teardown_method(self) -> None:
-        settings.enable_engine = self._saved_enable_engine
         if hasattr(self, "api_resource") and self.api_resource:
             self.api_resource._conn_pool.close()
 

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -1,9 +1,4 @@
-"""Tests for parsing error handling in search queries.
-
-This module tests that parsing errors in queries (like "cmc=2 and id=")
-are handled gracefully by returning BadRequest errors instead of
-throwing generic server errors.
-"""
+"""Tests for parsing error handling and _search routing."""
 
 from __future__ import annotations
 
@@ -15,132 +10,208 @@ import falcon
 import pytest
 
 from api.api_resource import APIResource
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import parse_scryfall_query
 from api.settings import settings
+from api.utils.timer import Timer
+
+
+def _make_api() -> APIResource:
+    return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+
+
+def _search_kwargs(
+    query: str,
+    limit: int = 10,
+    orderby: CardOrdering = CardOrdering.EDHREC,
+    direction: SortDirection = SortDirection.ASC,
+) -> dict:
+    """Build kwargs for _search_sql or _search_engine from a query string."""
+    parsed = parse_scryfall_query(query)
+    return {
+        "parsed_query": parsed,
+        "query": query,
+        "unique": UniqueOn.CARD,
+        "prefer": PreferOrder.DEFAULT,
+        "orderby": orderby,
+        "direction": direction,
+        "limit": limit,
+        "timer": Timer(),
+    }
 
 
 class TestParsingErrorHandling:
-    """Test handling of parsing errors in search functionality."""
+    """Parsing errors in _search are surfaced as HTTPBadRequest."""
 
     def setup_method(self) -> None:
-        """Set up test fixtures."""
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        )
-
-        def always_true() -> bool:
-            return True
-
-        self.api_resource._setup_complete = always_true
-
-    def teardown_method(self) -> None:
-        """Clean up test fixtures."""
-        if hasattr(self, "api_resource") and self.api_resource:
-            # Close the connection pool to prevent thread pool warnings
-            self.api_resource._conn_pool.close()
-
-    def test_search_handles_parsing_error_incomplete_query(self) -> None:
-        """Test that parsing errors in search raise HTTPBadRequest."""
-        # Test the specific case mentioned in the issue
-        query = "cmc=2 and id="
-
-        # Call _search with the problematic query and expect HTTPBadRequest
-        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
-            self.api_resource._search(query=query)
-
-        # Verify the error details
-        assert exc_info.value.title == "Invalid Search Query"
-        assert query in exc_info.value.description
-        assert f'Failed to parse query: "{query}"' == exc_info.value.description
-
-    @pytest.mark.parametrize(
-        "query",
-        [
-            "cmc=2 and id=",  # The original issue case
-            "name:test and",  # Trailing AND
-            "power>1 or",  # Trailing OR
-            "cmc=3 and ()",  # Empty parentheses
-        ],
-    )
-    def test_search_handles_parsing_error_various_cases(self, query: str) -> None:
-        """Test that various parsing errors raise HTTPBadRequest."""
-        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
-            self.api_resource._search(query=query)
-
-        # Verify the error details
-        assert exc_info.value.title == "Invalid Search Query"
-        assert query in exc_info.value.description
-        assert f'Failed to parse query: "{query}"' == exc_info.value.description
-
-    def test_search_normal_parsing_unaffected(self) -> None:
-        """Test that normal queries still work correctly."""
-        # Mock successful query execution
-        with patch.object(self.api_resource, "_run_query") as mock_run_query:
-            mock_run_query.return_value = {
-                "result": [
-                    {"name": "Lightning Bolt", "total_cards_count": None},
-                    {"total_cards_count": 1},
-                ],
-                "timings": {},
-            }
-
-            result = self.api_resource._search(query="name:bolt")
-
-            # Verify normal operation
-            assert len(result["cards"]) == 1
-            assert result["cards"][0]["name"] == "Lightning Bolt"
-            assert result["total_cards"] == 1
-            assert result["query"] == "name:bolt"
-
-
-class TestSearchValidation:
-    """Test _search input validation (limit, setup, bad query)."""
-
-    def setup_method(self) -> None:
-        """Set up test fixtures."""
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        )
+        self.api_resource = _make_api()
         self.api_resource._setup_complete = lambda: True
 
     def teardown_method(self) -> None:
         if hasattr(self, "api_resource") and self.api_resource:
             self.api_resource._conn_pool.close()
 
-    def _mock_result(self) -> dict:
-        return {
-            "result": [{"name": "Opt", "total_cards_count": None}, {"total_cards_count": 1}],
-            "timings": {},
-        }
+    def test_incomplete_query_raises_bad_request(self) -> None:
+        query = "cmc=2 and id="
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query=query)
+        assert exc_info.value.title == "Invalid Search Query"
+        assert exc_info.value.description == f'Failed to parse query: "{query}"'
 
-    def test_search_with_positive_limit_succeeds(self) -> None:
-        """A positive limit value reaches the DB and returns results."""
-        with patch.object(self.api_resource, "_run_query", return_value=self._mock_result()):
+    @pytest.mark.parametrize(
+        argnames=["query"],
+        argvalues=[
+            ("cmc=2 and id=",),
+            ("name:test and",),
+            ("power>1 or",),
+            ("cmc=3 and ()",),
+        ],
+    )
+    def test_various_incomplete_queries_raise_bad_request(self, query: str) -> None:
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query=query)
+        assert exc_info.value.title == "Invalid Search Query"
+        assert exc_info.value.description == f'Failed to parse query: "{query}"'
+
+
+class TestSearchRouting:
+    """_search routes to _search_sql or _search_engine and validates inputs.
+
+    Routing only happens with the engine feature gate on; the gate itself is
+    covered in TestEngineFeatureGate.
+    """
+
+    def setup_method(self) -> None:
+        self.api_resource = _make_api()
+        self.api_resource._setup_complete = lambda: True
+        self.api_resource._engine = MagicMock()
+        self._saved_enable_engine = settings.enable_engine
+        settings.enable_engine = True
+
+    def teardown_method(self) -> None:
+        settings.enable_engine = self._saved_enable_engine
+        if hasattr(self, "api_resource") and self.api_resource:
+            self.api_resource._conn_pool.close()
+
+    def test_routes_to_sql_when_engine_empty(self) -> None:
+        self.api_resource._engine.size.return_value = 0
+        sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
+        with (
+            patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
+            patch.object(self.api_resource, "_search_engine") as mock_engine,
+        ):
             result = self.api_resource._search(query="name:opt", limit=10)
-        assert result["total_cards"] == 1
+        mock_sql.assert_called_once()
+        mock_engine.assert_not_called()
+        assert result is sentinel
 
-    def test_search_with_negative_limit_raises_bad_request(self) -> None:
-        """A negative limit raises HTTPBadRequest."""
+    def test_routes_to_engine_when_engine_has_data(self) -> None:
+        self.api_resource._engine.size.return_value = 87
+        sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
+        with (
+            patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine,
+            patch.object(self.api_resource, "_search_sql") as mock_sql,
+        ):
+            result = self.api_resource._search(query="name:opt", limit=10)
+        mock_engine.assert_called_once()
+        mock_sql.assert_not_called()
+        assert result is sentinel
+
+    def test_falls_back_to_sql_when_engine_raises(self) -> None:
+        self.api_resource._engine.size.return_value = 87
+        sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
+        with (
+            patch.object(self.api_resource, "_search_engine", side_effect=RuntimeError("engine failed")),
+            patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
+        ):
+            result = self.api_resource._search(query="name:opt", limit=10)
+        mock_sql.assert_called_once()
+        assert result is sentinel
+
+    def test_negative_limit_raises_bad_request(self) -> None:
         with pytest.raises(falcon.HTTPBadRequest) as exc_info:
             self.api_resource._search(query="name:opt", limit=-1)
         assert exc_info.value.title == "Invalid Limit"
 
-    def test_search_raises_service_unavailable_when_setup_incomplete(self) -> None:
-        """_search raises HTTPServiceUnavailable when setup is not complete."""
+    def test_raises_service_unavailable_when_setup_incomplete(self) -> None:
         self.api_resource._setup_complete = lambda: False
         with pytest.raises(falcon.HTTPServiceUnavailable) as exc_info:
             self.api_resource._search(query="name:opt")
         assert exc_info.value.title == "Service Unavailable"
 
     @pytest.mark.parametrize(
-        argnames="query",
-        argvalues=["t=", "cmc=2 and id=", "name:test and", "power>1 or"],
+        argnames=["query"],
+        argvalues=[
+            ("t=",),
+            ("cmc=2 and id=",),
+            ("name:test and",),
+            ("power>1 or",),
+        ],
     )
-    def test_search_raises_bad_request_for_unparseable_query(self, query: str) -> None:
-        """Queries that fail to parse raise HTTPBadRequest."""
+    def test_raises_bad_request_for_unparseable_query(self, query: str) -> None:
         with pytest.raises(falcon.HTTPBadRequest) as exc_info:
             self.api_resource._search(query=query)
         assert exc_info.value.title == "Invalid Search Query"
-        assert f'Failed to parse query: "{query}"' == exc_info.value.description
+        assert exc_info.value.description == f'Failed to parse query: "{query}"'
+
+
+class TestSearchSqlDirect:
+    """_search_sql result structure and count-row extraction."""
+
+    def setup_method(self) -> None:
+        self.api_resource = _make_api()
+
+    def teardown_method(self) -> None:
+        if hasattr(self, "api_resource") and self.api_resource:
+            self.api_resource._conn_pool.close()
+
+    def _mock_run_query(self, cards: list[dict], total: int) -> dict:
+        return {
+            "result": [*[{**c, "total_cards_count": None} for c in cards], {"total_cards_count": total}],
+            "timings": {},
+        }
+
+    def test_total_cards_extracted_from_count_row(self) -> None:
+        with patch.object(self.api_resource, "_run_query", return_value=self._mock_run_query([{"name": "Opt"}], total=7)):
+            result = self.api_resource._search_sql(**_search_kwargs("name:opt"))
+        assert result["total_cards"] == 7
+
+    def test_cards_stripped_of_count_column(self) -> None:
+        with patch.object(self.api_resource, "_run_query", return_value=self._mock_run_query([{"name": "Opt"}], total=1)):
+            result = self.api_resource._search_sql(**_search_kwargs("name:opt"))
+        assert "total_cards_count" not in result["cards"][0]
+        assert result["cards"][0]["name"] == "Opt"
+
+    def test_empty_result_returns_zero_total(self) -> None:
+        with patch.object(self.api_resource, "_run_query", return_value=self._mock_run_query([], total=0)):
+            result = self.api_resource._search_sql(**_search_kwargs("name:opt"))
+        assert result["total_cards"] == 0
+        assert result["cards"] == []
+
+
+class TestSearchEngineDirect:
+    """_search_engine forwards engine.query results verbatim."""
+
+    def setup_method(self) -> None:
+        self.api_resource = _make_api()
+        self.api_resource._engine = MagicMock()
+
+    def teardown_method(self) -> None:
+        if hasattr(self, "api_resource") and self.api_resource:
+            self.api_resource._conn_pool.close()
+
+    def test_total_cards_and_cards_forwarded(self) -> None:
+        mock_cards = [{"name": "Lightning Bolt"}, {"name": "Counterspell"}]
+        self.api_resource._engine.query.return_value = (2, mock_cards)
+        result = self.api_resource._search_engine(**_search_kwargs("type:instant"))
+        assert result["total_cards"] == 2
+        assert result["cards"] == mock_cards
+
+    def test_engine_called_with_limit(self) -> None:
+        self.api_resource._engine.query.return_value = (0, [])
+        self.api_resource._search_engine(**_search_kwargs("name:opt", limit=5))
+        call_kwargs = self.api_resource._engine.query.call_args.kwargs
+        assert call_kwargs["limit"] == 5
 
 
 class TestEngineFeatureGate:
@@ -203,6 +274,8 @@ class TestEngineFeatureGate:
 
     def test_enabled_reload_fetches_cards(self) -> None:
         settings.enable_engine = True
+        # Empty store, or the populated-store fast path skips the reload.
+        self.api_resource._engine.size.return_value = 0
         with patch.object(self.api_resource, "_conn_pool") as mock_pool:
             mock_cursor = MagicMock()
             mock_cursor.fetchall.return_value = []

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -10,34 +10,12 @@ import falcon
 import pytest
 
 from api.api_resource import APIResource
-from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
-from api.parsing import parse_scryfall_query
 from api.settings import settings
-from api.utils.timer import Timer
+from api.tests.helpers import search_kwargs
 
 
 def _make_api() -> APIResource:
     return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
-
-
-def _search_kwargs(
-    query: str,
-    limit: int = 10,
-    orderby: CardOrdering = CardOrdering.EDHREC,
-    direction: SortDirection = SortDirection.ASC,
-) -> dict:
-    """Build kwargs for _search_sql or _search_engine from a query string."""
-    parsed = parse_scryfall_query(query)
-    return {
-        "parsed_query": parsed,
-        "query": query,
-        "unique": UniqueOn.CARD,
-        "prefer": PreferOrder.DEFAULT,
-        "orderby": orderby,
-        "direction": direction,
-        "limit": limit,
-        "timer": Timer(),
-    }
 
 
 class TestParsingErrorHandling:
@@ -173,18 +151,18 @@ class TestSearchSqlDirect:
 
     def test_total_cards_extracted_from_count_row(self) -> None:
         with patch.object(self.api_resource, "_run_query", return_value=self._mock_run_query([{"name": "Opt"}], total=7)):
-            result = self.api_resource._search_sql(**_search_kwargs("name:opt"))
+            result = self.api_resource._search_sql(**search_kwargs("name:opt"))
         assert result["total_cards"] == 7
 
     def test_cards_stripped_of_count_column(self) -> None:
         with patch.object(self.api_resource, "_run_query", return_value=self._mock_run_query([{"name": "Opt"}], total=1)):
-            result = self.api_resource._search_sql(**_search_kwargs("name:opt"))
+            result = self.api_resource._search_sql(**search_kwargs("name:opt"))
         assert "total_cards_count" not in result["cards"][0]
         assert result["cards"][0]["name"] == "Opt"
 
     def test_empty_result_returns_zero_total(self) -> None:
         with patch.object(self.api_resource, "_run_query", return_value=self._mock_run_query([], total=0)):
-            result = self.api_resource._search_sql(**_search_kwargs("name:opt"))
+            result = self.api_resource._search_sql(**search_kwargs("name:opt"))
         assert result["total_cards"] == 0
         assert result["cards"] == []
 
@@ -203,13 +181,13 @@ class TestSearchEngineDirect:
     def test_total_cards_and_cards_forwarded(self) -> None:
         mock_cards = [{"name": "Lightning Bolt"}, {"name": "Counterspell"}]
         self.api_resource._engine.query.return_value = (2, mock_cards)
-        result = self.api_resource._search_engine(**_search_kwargs("type:instant"))
+        result = self.api_resource._search_engine(**search_kwargs("type:instant"))
         assert result["total_cards"] == 2
         assert result["cards"] == mock_cards
 
     def test_engine_called_with_limit(self) -> None:
         self.api_resource._engine.query.return_value = (0, [])
-        self.api_resource._search_engine(**_search_kwargs("name:opt", limit=5))
+        self.api_resource._search_engine(**search_kwargs("name:opt", limit=5))
         call_kwargs = self.api_resource._engine.query.call_args.kwargs
         assert call_kwargs["limit"] == 5
 

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
-from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing import parse_scryfall_query
 from api.utils.timer import Timer
 
 
@@ -28,7 +28,6 @@ class TestPreferOrder(unittest.TestCase):
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""
         parsed_query = parse_scryfall_query(query)
-        where_clause, params = generate_sql_query(parsed_query)
         with (
             patch.object(self.api_resource, "_conn_pool") as mock_pool,
             patch.object(self.api_resource, "_setup_complete", return_value=True),
@@ -40,9 +39,7 @@ class TestPreferOrder(unittest.TestCase):
             mock_pool.connection.return_value.__enter__.return_value = mock_conn
 
             return self.api_resource._search_sql(
-                where_clause=where_clause,
-                params=params,
-                query_explanation="",
+                parsed_query=parsed_query,
                 query=query,
                 unique=UniqueOn.CARD,
                 prefer=prefer,

--- a/card_engine/Cargo.lock
+++ b/card_engine/Cargo.lock
@@ -12,13 +12,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "card_engine"
 version = "0.1.0"
 dependencies = [
+ "libc",
+ "memmap2",
  "pyo3",
  "regex",
+ "rkyv",
  "serde_json",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -27,10 +107,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -45,10 +147,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -63,6 +200,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -133,6 +290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +326,51 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -204,6 +415,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,10 +444,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "zmij"

--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -14,3 +14,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.28.3" }
 regex = "1"
 serde_json = "1"
+rkyv = "0.8"
+memmap2 = "0.9"
+libc = "0.2"

--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2024"
 name = "card_engine"
 crate-type = ["cdylib"]
 
+[features]
+# Counting global allocator + reload memory breakdown, exposed via QueryEngine.mem_stats().
+# Measurement-only; never enable for production builds.
+alloc-counter = []
+
 [dependencies]
 # extension-module is enabled by maturin (see pyproject.toml [tool.maturin]) so that
 # plain `cargo test` can still link against libpython for Rust unit tests.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1,16 +1,56 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateAccess, PyDict, PyList, PyTuple};
 use regex::Regex;
+use rkyv::{Archive, Archived, Deserialize, Serialize};
+use memmap2::Mmap;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, OnceLock, RwLock};
+use std::io::Write as IoWrite;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+use std::os::unix::io::AsRawFd;
+use std::os::unix::fs::MetadataExt;
 
 // ─── Inline string (no heap allocation) ──────────────────────────────────────
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 struct InlineStr<const N: usize> {
     bytes: [u8; N],
     len: u8,
+}
+
+// Safety: InlineStr<N> is plain bytes (Copy), has no padding that could be
+// uninitialized, and carries no internal references — it is safe to treat as
+// a flat, relocatable value in an rkyv archive.
+unsafe impl<const N: usize> rkyv::Portable for InlineStr<N> {}
+
+impl<const N: usize> Archive for InlineStr<N> {
+    type Archived = InlineStr<N>;
+    type Resolver = ();
+    fn resolve(&self, _: (), out: rkyv::Place<InlineStr<N>>) {
+        // Safety: InlineStr<N> is Copy and Portable; writing it verbatim is correct.
+        unsafe { out.ptr().write(*self); }
+    }
+}
+
+impl<const N: usize, S: rkyv::rancor::Fallible + ?Sized> Serialize<S> for InlineStr<N> {
+    fn serialize(&self, _serializer: &mut S) -> Result<(), S::Error> { Ok(()) }
+}
+
+impl<const N: usize, D: rkyv::rancor::Fallible + ?Sized> Deserialize<InlineStr<N>, D> for InlineStr<N> {
+    fn deserialize(&self, _: &mut D) -> Result<InlineStr<N>, D::Error> { Ok(*self) }
+}
+
+// Safety: InlineStr<N> contains only a [u8; N] and a u8 len -- both are always
+// valid regardless of their byte contents. No pointers, no enums, no invariants
+// that could be violated by arbitrary bytes. This impl simply trusts the data.
+unsafe impl<const N: usize, C: rkyv::rancor::Fallible + ?Sized> rkyv::bytecheck::CheckBytes<C> for InlineStr<N> {
+    unsafe fn check_bytes(
+        _value: *const Self,
+        _context: &mut C,
+    ) -> Result<(), C::Error> {
+        Ok(())
+    }
 }
 
 impl<const N: usize> InlineStr<N> {
@@ -144,12 +184,14 @@ fn mana_cmc(s: &str) -> f32 {
 
 // ─── Card struct ─────────────────────────────────────────────────────────────
 
+#[derive(Archive, Serialize, Deserialize)]
 struct ManaCost {
     pips: HashMap<String, u8>,              // faithful to mana_cost_jsonb; used for mana= queries
     devotion: Option<HashMap<String, u8>>,  // Some only when hybrids are present; used for devotion queries
     cmc: f32,
 }
 
+#[derive(Archive, Serialize, Deserialize)]
 struct Card {
     // Hot fields first — fits in the first two cache lines for fast filter short-circuiting.
     card_name_lower: InlineStr<61>, // 61 bytes covers every card name in the Scryfall dataset
@@ -189,8 +231,8 @@ struct Card {
     cmc: Option<u8>,                   // always an integer; max ~16 in practice
     creature_power: Option<i8>,        // can be negative (e.g. Char-Rumbler)
     creature_toughness: Option<i8>,
-    planeswalker_loyalty: Option<u8>,  // always 1–12
-    card_rarity_int: Option<u8>,       // 0–5
+    planeswalker_loyalty: Option<u8>,  // always 1-12
+    card_rarity_int: Option<u8>,       // 0-5
     collector_number_int: Option<u16>, // some sets exceed i8::MAX
     edhrec_rank: Option<u32>,          // up to ~30k unique cards
     price_usd: Option<f32>,
@@ -211,6 +253,9 @@ struct Card {
     creature_power_text: Option<String>,
     creature_toughness_text: Option<String>,
 }
+
+// Type alias for the archived (mmap-backed) card type
+type ACard = Archived<Card>;
 
 // ─── Loading helpers ─────────────────────────────────────────────────────────
 
@@ -514,19 +559,19 @@ fn attr_to_num_field(attr: &str) -> Option<NumField> {
     }
 }
 
-fn card_num(card: &Card, f: NumField) -> Option<f32> {
+fn card_num(card: &ACard, f: NumField) -> Option<f32> {
     match f {
-        NumField::Cmc                => card.cmc.map(|v| v as f32),
-        NumField::Power              => card.creature_power.map(|v| v as f32),
-        NumField::Toughness          => card.creature_toughness.map(|v| v as f32),
-        NumField::Loyalty            => card.planeswalker_loyalty.map(|v| v as f32),
-        NumField::RarityInt          => card.card_rarity_int.map(|v| v as f32),
-        NumField::CollectorNumberInt => card.collector_number_int.map(|v| v as f32),
-        NumField::EdhrEc             => card.edhrec_rank.map(|v| v as f32),
-        NumField::PriceUsd           => card.price_usd,
-        NumField::PriceEur           => card.price_eur,
-        NumField::PriceTix           => card.price_tix,
-        NumField::PreferScore        => card.prefer_score,
+        NumField::Cmc                => card.cmc.as_ref().map(|v| u8::from(*v) as f32),
+        NumField::Power              => card.creature_power.as_ref().map(|v| i8::from(*v) as f32),
+        NumField::Toughness          => card.creature_toughness.as_ref().map(|v| i8::from(*v) as f32),
+        NumField::Loyalty            => card.planeswalker_loyalty.as_ref().map(|v| u8::from(*v) as f32),
+        NumField::RarityInt          => card.card_rarity_int.as_ref().map(|v| u8::from(*v) as f32),
+        NumField::CollectorNumberInt => card.collector_number_int.as_ref().map(|v| u16::from(*v) as f32),
+        NumField::EdhrEc             => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
+        NumField::PriceUsd           => card.price_usd.as_ref().map(|v| f32::from(*v)),
+        NumField::PriceEur           => card.price_eur.as_ref().map(|v| f32::from(*v)),
+        NumField::PriceTix           => card.price_tix.as_ref().map(|v| f32::from(*v)),
+        NumField::PreferScore        => card.prefer_score.as_ref().map(|v| f32::from(*v)),
     }
 }
 
@@ -537,7 +582,7 @@ enum NumExpr {
 }
 
 impl NumExpr {
-    fn eval(&self, card: &Card) -> Option<f64> {
+    fn eval(&self, card: &ACard) -> Option<f64> {
         match self {
             NumExpr::Const(v) => Some(*v),
             NumExpr::Field(f) => card_num(card, *f).map(|v| v as f64),
@@ -576,11 +621,11 @@ enum ColorField {
     ProducedMana,
 }
 
-fn card_colors(card: &Card, f: ColorField) -> u8 {
+fn card_colors(card: &ACard, f: ColorField) -> u8 {
     match f {
-        ColorField::Colors        => card.card_colors,
-        ColorField::ColorIdentity => card.card_color_identity,
-        ColorField::ProducedMana  => card.produced_mana,
+        ColorField::Colors        => u8::from(card.card_colors),
+        ColorField::ColorIdentity => u8::from(card.card_color_identity),
+        ColorField::ProducedMana  => u8::from(card.produced_mana),
     }
 }
 
@@ -593,7 +638,7 @@ enum CollField {
     FrameData,
 }
 
-fn card_collection<'a>(card: &'a Card, f: CollField) -> CollRef<'a> {
+fn card_collection<'a>(card: &'a ACard, f: CollField) -> CollRef<'a> {
     match f {
         CollField::Subtypes   => CollRef::List(&card.card_subtypes),
         CollField::Keywords   => CollRef::Set(&card.card_keywords),
@@ -604,14 +649,14 @@ fn card_collection<'a>(card: &'a Card, f: CollField) -> CollRef<'a> {
 }
 
 enum CollRef<'a> {
-    List(&'a Vec<String>),
-    Set(&'a HashSet<String>),
+    List(&'a rkyv::vec::ArchivedVec<rkyv::string::ArchivedString>),
+    Set(&'a rkyv::collections::swiss_table::ArchivedHashSet<rkyv::string::ArchivedString>),
 }
 
 impl CollRef<'_> {
     fn contains(&self, v: &str) -> bool {
         match self {
-            CollRef::List(l) => l.iter().any(|s| s == v),
+            CollRef::List(l) => l.iter().any(|s| s.as_str() == v),
             CollRef::Set(s)  => s.contains(v),
         }
     }
@@ -623,8 +668,8 @@ impl CollRef<'_> {
     }
     fn all_equal(&self, v: &str) -> bool {
         match self {
-            CollRef::List(l) => l.iter().all(|s| s == v),
-            CollRef::Set(s)  => s.iter().all(|s| s == v),
+            CollRef::List(l) => l.iter().all(|s| s.as_str() == v),
+            CollRef::Set(s)  => s.iter().all(|s| s.as_str() == v),
         }
     }
 }
@@ -637,12 +682,42 @@ enum TextSearchField {
     ArtistLower,
 }
 
-fn text_field_value<'a>(card: &'a Card, field: TextSearchField) -> Option<&'a str> {
+fn text_search_field_value<'a>(card: &'a ACard, field: TextSearchField) -> Option<&'a str> {
     match field {
         TextSearchField::NameLower       => Some(card.card_name_lower.as_str()),
         TextSearchField::OracleTextLower => Some(card.oracle_text_lower.as_str()),
         TextSearchField::FlavorTextLower => Some(card.flavor_text_lower.as_str()),
-        TextSearchField::ArtistLower     => card.card_artist_lower.as_deref(),
+        TextSearchField::ArtistLower     => card.card_artist_lower.as_ref().map(|s| s.as_str()),
+    }
+}
+
+/// Enum that replaces fn-pointer fields in TextExact / TextRegex.
+/// Function pointers cannot be parameterized over &Card vs &ACard, so enum
+/// dispatch is used instead.
+#[derive(Clone, Copy)]
+enum TextField {
+    NameLower,
+    OracleTextLower,
+    FlavorTextLower,
+    ArtistLower,
+    SetCode,
+    Layout,
+    Border,
+    Watermark,
+    CollectorNumber,
+}
+
+fn text_field_value<'a>(card: &'a ACard, field: TextField) -> Option<&'a str> {
+    match field {
+        TextField::NameLower       => Some(card.card_name_lower.as_str()),
+        TextField::OracleTextLower => Some(card.oracle_text_lower.as_str()),
+        TextField::FlavorTextLower => Some(card.flavor_text_lower.as_str()),
+        TextField::ArtistLower     => card.card_artist_lower.as_ref().map(|s| s.as_str()),
+        TextField::SetCode         => Some(card.card_set_code.as_str()),
+        TextField::Layout          => Some(card.card_layout.as_str()),
+        TextField::Border          => Some(card.card_border.as_str()),
+        TextField::Watermark       => card.card_watermark.as_ref().map(|s| s.as_str()),
+        TextField::CollectorNumber => Some(card.collector_number.as_str()),
     }
 }
 
@@ -664,12 +739,12 @@ enum FilterExpr {
         word: String,
     },
     TextExact {
-        field: fn(&Card) -> Option<&str>,
+        field: TextField,
         op: CmpOp,
         value: String,
     },
     TextRegex {
-        field: fn(&Card) -> Option<&str>,
+        field: TextField,
         regex: Regex,
     },
 
@@ -718,7 +793,7 @@ enum FilterExpr {
 }
 
 impl FilterExpr {
-    fn matches(&self, card: &Card) -> bool {
+    fn matches(&self, card: &ACard) -> bool {
         self.tri(card) == Some(true)
     }
 
@@ -729,7 +804,7 @@ impl FilterExpr {
     /// filters only match cards that have the attribute", while
     /// -(power>2 and t:creature) still matches instants (NULL AND false =
     /// false, NOT false = true). Only Some(true) counts as a match.
-    fn tri(&self, card: &Card) -> Option<bool> {
+    fn tri(&self, card: &ACard) -> Option<bool> {
         match self {
             FilterExpr::True => Some(true),
 
@@ -767,11 +842,11 @@ impl FilterExpr {
             }
 
             FilterExpr::TextContains { field, word } => {
-                text_field_value(card, *field).map(|s| s.contains(word.as_str()))
+                text_search_field_value(card, *field).map(|s| s.contains(word.as_str()))
             }
 
             FilterExpr::TextExact { field, op, value } => {
-                field(card).map(|s| match op {
+                text_field_value(card, *field).map(|s| match op {
                     CmpOp::Eq => s == value,
                     CmpOp::Ne => s != value,
                     CmpOp::Lt => s < value.as_str(),
@@ -782,7 +857,7 @@ impl FilterExpr {
             }
 
             FilterExpr::TextRegex { field, regex } => {
-                field(card).map(|s| regex.is_match(s))
+                text_field_value(card, *field).map(|s| regex.is_match(s))
             }
 
             FilterExpr::ColorCmp { field, op, mask } => {
@@ -798,7 +873,7 @@ impl FilterExpr {
             }
 
             FilterExpr::TypeCmp { mask, op } => {
-                let bits = card.card_types;
+                let bits = u16::from(card.card_types);
                 Some(match op {
                     CmpOp::Ge => bits & mask != 0,
                     CmpOp::Eq => bits == *mask,
@@ -827,48 +902,58 @@ impl FilterExpr {
             }
 
             FilterExpr::Legality { shift, expected } => {
-                Some(shift.is_some_and(|s| (card.card_legalities >> s) & 0b11 == *expected))
+                Some(shift.is_some_and(|s| (u64::from(card.card_legalities) >> s) & 0b11 == *expected))
             }
 
             FilterExpr::ManaCostCmp { op, pips, cmc } => {
-                let card_cmc = card.mana_cost.cmc;
+                let card_cmc = f32::from(card.mana_cost.cmc);
                 let card_pips = &card.mana_cost.pips;
                 Some(match op {
                     CmpOp::Ge => {
-                        pips.iter().all(|(sym, &n)| card_pips.get(sym).copied().unwrap_or(0) >= n)
-                            && card_cmc >= *cmc
+                        pips.iter().all(|(sym, &n)| {
+                            card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) >= n
+                        }) && card_cmc >= *cmc
                     }
                     CmpOp::Le => {
-                        card_pips
-                            .iter()
-                            .all(|(sym, &n)| pips.get(sym).copied().unwrap_or(0) >= n)
-                            && card_cmc <= *cmc
+                        card_pips.iter().all(|(sym, n)| {
+                            pips.get(sym.as_str()).copied().unwrap_or(0) >= u8::from(*n)
+                        }) && card_cmc <= *cmc
                     }
                     CmpOp::Eq => {
                         card_cmc == *cmc
                             && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| card_pips.get(sym).copied().unwrap_or(0) == n)
+                            && pips.iter().all(|(sym, &n)| {
+                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
+                            })
                     }
                     CmpOp::Gt => {
-                        let contains = pips.iter().all(|(sym, &n)| card_pips.get(sym).copied().unwrap_or(0) >= n)
-                            && card_cmc >= *cmc;
+                        let contains = pips.iter().all(|(sym, &n)| {
+                            card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) >= n
+                        }) && card_cmc >= *cmc;
                         let exact = card_cmc == *cmc
                             && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| card_pips.get(sym).copied().unwrap_or(0) == n);
+                            && pips.iter().all(|(sym, &n)| {
+                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
+                            });
                         contains && !exact
                     }
                     CmpOp::Lt => {
-                        let subset = card_pips.iter().all(|(sym, &n)| pips.get(sym).copied().unwrap_or(0) >= n)
-                            && card_cmc <= *cmc;
+                        let subset = card_pips.iter().all(|(sym, n)| {
+                            pips.get(sym.as_str()).copied().unwrap_or(0) >= u8::from(*n)
+                        }) && card_cmc <= *cmc;
                         let exact = card_cmc == *cmc
                             && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| card_pips.get(sym).copied().unwrap_or(0) == n);
+                            && pips.iter().all(|(sym, &n)| {
+                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
+                            });
                         subset && !exact
                     }
                     CmpOp::Ne => {
                         !(card_cmc == *cmc
                             && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| card_pips.get(sym).copied().unwrap_or(0) == n))
+                            && pips.iter().all(|(sym, &n)| {
+                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
+                            }))
                     }
                 })
             }
@@ -882,13 +967,21 @@ impl FilterExpr {
                 // come straight from mana_cost_jsonb) that the DB's devotion column
                 // never holds, so only WUBRGC entries participate — query pips are
                 // already color-only (see build_binary).
-                let devotion = card.mana_cost.devotion.as_ref().unwrap_or(&card.mana_cost.pips);
-                let ge = pips.iter().all(|(sym, &n)| devotion.get(sym).copied().unwrap_or(0) >= n);
+                let devotion = if card.mana_cost.devotion.is_some() {
+                    card.mana_cost.devotion.as_ref().unwrap()
+                } else {
+                    &card.mana_cost.pips
+                };
+                let ge = pips.iter().all(|(sym, &n)| {
+                    devotion.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) >= n
+                });
                 let le = devotion.iter()
-                    .filter(|(sym, _)| is_devotion_sym(sym))
-                    .all(|(sym, &n)| pips.get(sym).copied().unwrap_or(0) >= n);
-                let eq = devotion.keys().filter(|sym| is_devotion_sym(sym)).count() == pips.len()
-                    && pips.iter().all(|(sym, &n)| devotion.get(sym).copied().unwrap_or(0) == n);
+                    .filter(|(sym, _)| is_devotion_sym(sym.as_str()))
+                    .all(|(sym, n)| pips.get(sym.as_str()).copied().unwrap_or(0) >= u8::from(*n));
+                let eq = devotion.keys().filter(|sym| is_devotion_sym(sym.as_str())).count() == pips.len()
+                    && pips.iter().all(|(sym, &n)| {
+                        devotion.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
+                    });
                 Some(match op {
                     CmpOp::Ge => ge,
                     CmpOp::Eq => eq,
@@ -914,16 +1007,16 @@ impl FilterExpr {
 
             FilterExpr::YearCmp { op, year } => {
                 if card.released_at.is_empty() { return None; } // missing date: SQL NULL
-                let s = &card.released_at;
+                let s = card.released_at.as_str();
                 let start = format!("{year:04}-01-01");
                 let end   = format!("{:04}-01-01", year + 1);
                 Some(match op {
-                    CmpOp::Eq => s.as_str() >= start.as_str() && s.as_str() < end.as_str(),
-                    CmpOp::Gt => s.as_str() >= end.as_str(),
-                    CmpOp::Lt => s.as_str() < start.as_str(),
-                    CmpOp::Ge => s.as_str() >= start.as_str(),
-                    CmpOp::Le => s.as_str() < end.as_str(),
-                    CmpOp::Ne => s.as_str() < start.as_str() || s.as_str() >= end.as_str(),
+                    CmpOp::Eq => s >= start.as_str() && s < end.as_str(),
+                    CmpOp::Gt => s >= end.as_str(),
+                    CmpOp::Lt => s < start.as_str(),
+                    CmpOp::Ge => s >= start.as_str(),
+                    CmpOp::Le => s < end.as_str(),
+                    CmpOp::Ne => s < start.as_str() || s >= end.as_str(),
                 })
             }
         }
@@ -1087,7 +1180,7 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
 
     if attr == "devotion" {
         let mana_str = rhs_value_str(rhs);
-        // Split hybrid symbols ({R/G} → R:1, G:1) and keep only WUBRGC, matching
+        // Split hybrid symbols ({R/G} -> R:1, G:1) and keep only WUBRGC, matching
         // calculate_devotion() in SQL (which counts only color characters).
         // mana_pip_counts is NOT used directly because it keeps hybrids as single keys.
         let mut pips: HashMap<String, u8> = HashMap::new();
@@ -1185,14 +1278,14 @@ fn build_text_filter(attr: &str, op: &str, rhs: &Value) -> Result<FilterExpr, St
         let pattern  = rhs["kwargs"]["value"].as_str().unwrap_or("");
         let re = Regex::new(&format!("(?i){pattern}"))
             .map_err(|e| format!("invalid regex '{pattern}': {e}"))?;
-        let field_fn: fn(&Card) -> Option<&str> = match attr {
-            "card_name"   => |c| Some(c.card_name.as_str()),
-            "oracle_text" => |c| Some(c.oracle_text.as_str()),
-            "flavor_text" => |c| Some(c.flavor_text.as_str()),
-            "card_artist" => |c| c.card_artist.as_deref(),
+        let field = match attr {
+            "card_name"   => TextField::NameLower,
+            "oracle_text" => TextField::OracleTextLower,
+            "flavor_text" => TextField::FlavorTextLower,
+            "card_artist" => TextField::ArtistLower,
             _ => return Err(format!("regex not supported on {attr}")),
         };
-        return Ok(FilterExpr::TextRegex { field: field_fn, regex: re });
+        return Ok(FilterExpr::TextRegex { field, regex: re });
     }
 
     let raw_value = rhs["kwargs"]["value"].as_str().unwrap_or("");
@@ -1203,15 +1296,15 @@ fn build_text_filter(attr: &str, op: &str, rhs: &Value) -> Result<FilterExpr, St
         // the query value gives case-insensitive matching with a plain equality.
         let value = if attr == "collector_number" { raw_value.to_string() } else { raw_value.to_lowercase() };
         let cmp_op = str_op_to_cmp(op)?;
-        let lower_fn: fn(&Card) -> Option<&str> = match attr {
-            "card_set_code"      => |c| Some(c.card_set_code.as_str() as &str),
-            "card_layout"        => |c| Some(c.card_layout.as_str()),
-            "card_border"        => |c| Some(c.card_border.as_str()),
-            "card_watermark"     => |c| c.card_watermark.as_deref(),
-            "collector_number"   => |c| Some(c.collector_number.as_str()),
-            _                    => unreachable!(),
+        let field = match attr {
+            "card_set_code"    => TextField::SetCode,
+            "card_layout"      => TextField::Layout,
+            "card_border"      => TextField::Border,
+            "card_watermark"   => TextField::Watermark,
+            "collector_number" => TextField::CollectorNumber,
+            _                  => unreachable!(),
         };
-        return Ok(FilterExpr::TextExact { field: lower_fn, op: cmp_op, value });
+        return Ok(FilterExpr::TextExact { field, op: cmp_op, value });
     }
 
     let lower_word = raw_value.to_lowercase();
@@ -1226,15 +1319,15 @@ fn build_text_filter(attr: &str, op: &str, rhs: &Value) -> Result<FilterExpr, St
         return Ok(FilterExpr::TextContains { field: tsf, word: lower_word });
     }
 
-    let field_fn: fn(&Card) -> Option<&str> = match attr {
-        "card_name"   => |c| Some(c.card_name_lower.as_str()),
-        "oracle_text" => |c| Some(c.oracle_text_lower.as_str()),
-        "flavor_text" => |c| Some(c.flavor_text_lower.as_str()),
-        "card_artist" => |c| c.card_artist_lower.as_deref(),
+    let field = match attr {
+        "card_name"   => TextField::NameLower,
+        "oracle_text" => TextField::OracleTextLower,
+        "flavor_text" => TextField::FlavorTextLower,
+        "card_artist" => TextField::ArtistLower,
         _ => return Err(format!("unknown text field: {attr}")),
     };
     let cmp_op = str_op_to_cmp(op)?;
-    Ok(FilterExpr::TextExact { field: field_fn, op: cmp_op, value: raw_value.to_lowercase() })
+    Ok(FilterExpr::TextExact { field, op: cmp_op, value: raw_value.to_lowercase() })
 }
 
 // ─── Trigram index ────────────────────────────────────────────────────────────
@@ -1269,23 +1362,23 @@ fn intersect_sorted(a: &[u32], b: &[u32]) -> Vec<u32> {
     out
 }
 
-fn trigram_candidates(idx: &TrigramIndex, word: &str) -> Option<Vec<u32>> {
+fn trigram_candidates(idx: &Archived<TrigramIndex>, word: &str) -> Option<Vec<u32>> {
     let bytes = word.as_bytes();
     if bytes.len() < 3 { return None; }
 
-    let mut lists: Vec<&Vec<u32>> = Vec::with_capacity(bytes.len() - 2);
+    let mut lists: Vec<Vec<u32>> = Vec::with_capacity(bytes.len() - 2);
     for w in bytes.windows(3) {
         match idx.get(&[w[0], w[1], w[2]]) {
-            Some(list) => lists.push(list),
+            Some(list) => lists.push(list.iter().map(|x| u32::from(*x)).collect()),
             // A trigram absent from the index appears in no card: nothing can match.
             None => return Some(Vec::new()),
         }
     }
     lists.sort_unstable_by_key(|l| l.len());
-    lists.dedup_by(|a, b| std::ptr::eq(*a, *b));
 
-    let mut result = lists[0].clone();
-    for list in &lists[1..] {
+    let mut result = lists.swap_remove(0);
+    result.sort_unstable();
+    for list in &lists {
         if result.is_empty() { break; }
         result = intersect_sorted(&result, list);
     }
@@ -1308,8 +1401,8 @@ fn union_sorted(a: Vec<u32>, b: Vec<u32>) -> Vec<u32> {
 }
 
 // ─── Numeric index ────────────────────────────────────────────────────────────
-// Sorted Vec<(i16, u32)> maps field value → card index for cmc/power/toughness.
-// i16 covers both u8 (cmc: 0–255) and i8 (power/toughness: -128–127) without loss.
+// Sorted Vec<(i16, u32)> maps field value -> card index for cmc/power/toughness.
+// i16 covers both u8 (cmc: 0-255) and i8 (power/toughness: -128-127) without loss.
 // Binary search gives the candidate slice; sort by card index for intersection.
 
 type NumericIndex = Vec<(i16, u32)>;
@@ -1337,27 +1430,27 @@ fn flip_op(op: CmpOp) -> CmpOp {
 
 /// Return sorted card indices satisfying `field op val` using the numeric index.
 /// Returns None for Ne (not selective) and Some(empty) when no cards can match.
-fn numeric_candidates(idx: &NumericIndex, op: CmpOp, val: f64) -> Option<Vec<u32>> {
+fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Option<Vec<u32>> {
     let (start, end) = match op {
         CmpOp::Ne => return None,
         CmpOp::Eq => {
             if val.fract() != 0.0 { return Some(Vec::new()); }
-            let s = idx.partition_point(|&(x, _)| (x as f64) < val);
-            let e = idx.partition_point(|&(x, _)| (x as f64) <= val);
+            let s = idx.partition_point(|p| (i16::from(p.0) as f64) < val);
+            let e = idx.partition_point(|p| (i16::from(p.0) as f64) <= val);
             (s, e)
         }
-        CmpOp::Lt => (0, idx.partition_point(|&(x, _)| (x as f64) < val)),
-        CmpOp::Le => (0, idx.partition_point(|&(x, _)| (x as f64) <= val)),
-        CmpOp::Gt => (idx.partition_point(|&(x, _)| (x as f64) <= val), idx.len()),
-        CmpOp::Ge => (idx.partition_point(|&(x, _)| (x as f64) < val), idx.len()),
+        CmpOp::Lt => (0, idx.partition_point(|p| (i16::from(p.0) as f64) < val)),
+        CmpOp::Le => (0, idx.partition_point(|p| (i16::from(p.0) as f64) <= val)),
+        CmpOp::Gt => (idx.partition_point(|p| (i16::from(p.0) as f64) <= val), idx.len()),
+        CmpOp::Ge => (idx.partition_point(|p| (i16::from(p.0) as f64) < val), idx.len()),
     };
-    let mut result: Vec<u32> = idx[start..end].iter().map(|&(_, i)| i).collect();
+    let mut result: Vec<u32> = idx[start..end].iter().map(|p| u32::from(p.1)).collect();
     result.sort_unstable();
     Some(result)
 }
 
 // ─── Tag index ───────────────────────────────────────────────────────────────
-// tag name → sorted list of card indices that have that tag.
+// tag name -> sorted list of card indices that have that tag.
 // Lists are naturally sorted because cards are iterated in index order.
 
 type TagIndex = HashMap<String, Vec<u32>>;
@@ -1403,6 +1496,7 @@ fn build_list_index(cards: &[Card], get_list: impl Fn(&Card) -> &Vec<String>) ->
 
 // ─── Combined indexes ────────────────────────────────────────────────────────
 
+#[derive(Archive, Serialize, Deserialize)]
 struct CardIndexes {
     name_trigram:   TrigramIndex,
     oracle_trigram: TrigramIndex,
@@ -1433,14 +1527,33 @@ impl Default for CardIndexes {
     }
 }
 
+#[derive(Archive, Serialize, Deserialize)]
 struct CardData {
     cards:   Vec<Card>,
     indexes: CardIndexes,
+    // The writer's format→shift assignments. Persisted so reader processes —
+    // which never run the load path that feeds FORMAT_SHIFTS — resolve
+    // legality shifts identically to the worker that built the archive.
+    format_shifts: HashMap<String, u8>,
+}
+
+/// Adopt the archive's format→shift assignments into this process's registry.
+/// Cheap no-op (one read lock) once the registry has caught up.
+fn sync_format_shifts(archived: &Archived<HashMap<String, u8>>) {
+    let behind = format_shifts().read().map(|m| m.len() < archived.len()).unwrap_or(false);
+    if !behind {
+        return;
+    }
+    if let Ok(mut shifts) = format_shifts().write() {
+        for (format, shift) in archived.iter() {
+            shifts.insert(format.as_str().to_string(), *shift);
+        }
+    }
 }
 
 // ─── Candidate narrowing ─────────────────────────────────────────────────────
 
-fn narrow_candidates(filter: &FilterExpr, indexes: &CardIndexes) -> Option<Vec<u32>> {
+fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Option<Vec<u32>> {
     match filter {
         FilterExpr::TextContains { field, word }
             if word.len() >= 3
@@ -1473,7 +1586,8 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &CardIndexes) -> Option<Vec<u
                 let bit = m.trailing_zeros() as usize;
                 m &= m - 1;
                 if bit < 14 {
-                    result = union_sorted(result, indexes.type_bits[bit].clone());
+                    let bit_list: Vec<u32> = indexes.type_bits[bit].iter().map(|x| u32::from(*x)).collect();
+                    result = union_sorted(result, bit_list);
                 }
             }
             Some(result)
@@ -1482,25 +1596,25 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &CardIndexes) -> Option<Vec<u
         FilterExpr::CollectionCmp { field, op, value }
             if matches!(field, CollField::Subtypes) && matches!(op, CmpOp::Ge) =>
         {
-            indexes.subtypes.get(value.as_str()).cloned()
+            indexes.subtypes.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
         FilterExpr::CollectionCmp { field, op, value }
             if matches!(field, CollField::Keywords) && matches!(op, CmpOp::Ge) =>
         {
-            indexes.keywords.get(value.as_str()).cloned()
+            indexes.keywords.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
         FilterExpr::CollectionCmp { field, op, value }
             if matches!(field, CollField::OracleTags) && matches!(op, CmpOp::Ge) =>
         {
-            indexes.oracle_tags.get(value.as_str()).cloned()
+            indexes.oracle_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
         FilterExpr::CollectionCmp { field, op, value }
             if matches!(field, CollField::IsTags) && matches!(op, CmpOp::Ge) =>
         {
-            indexes.is_tags.get(value.as_str()).cloned()
+            indexes.is_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
         FilterExpr::And(children) => {
@@ -1549,14 +1663,14 @@ fn prefer_from_str(s: &str) -> Prefer {
     }
 }
 
-fn prefer_score(card: &Card, prefer: Prefer) -> f64 {
+fn prefer_score(card: &ACard, prefer: Prefer) -> f64 {
     match prefer {
-        Prefer::Oldest  => -(card.released_at_int.unwrap_or(99_999_999) as f64),
-        Prefer::Newest  => card.released_at_int.unwrap_or(0) as f64,
-        Prefer::UsdLow  => -(card.price_usd.unwrap_or(f32::INFINITY) as f64),
-        Prefer::UsdHigh => card.price_usd.unwrap_or(0.0) as f64,
-        Prefer::Promo   => -(card.edhrec_rank.map(|r| r as f64).unwrap_or(f64::INFINITY)),
-        Prefer::Default => card.prefer_score.unwrap_or(0.0) as f64,
+        Prefer::Oldest  => -(card.released_at_int.as_ref().map(|v| u32::from(*v)).unwrap_or(99_999_999) as f64),
+        Prefer::Newest  => card.released_at_int.as_ref().map(|v| u32::from(*v)).unwrap_or(0) as f64,
+        Prefer::UsdLow  => -(card.price_usd.as_ref().map(|v| f32::from(*v)).unwrap_or(f32::INFINITY) as f64),
+        Prefer::UsdHigh => card.price_usd.as_ref().map(|v| f32::from(*v)).unwrap_or(0.0) as f64,
+        Prefer::Promo   => -(card.edhrec_rank.as_ref().map(|r| u32::from(*r) as f64).unwrap_or(f64::INFINITY)),
+        Prefer::Default => card.prefer_score.as_ref().map(|v| f32::from(*v)).unwrap_or(0.0) as f64,
     }
 }
 
@@ -1586,19 +1700,19 @@ fn f32_sort_bits(v: f32) -> u32 {
 /// then edhrec rank ascending (missing last), then prefer score descending (missing
 /// last). Selection then compares plain u128s; full ties fall back to store pointer
 /// order in `select_page` — the same tie order the original stable sort produced.
-fn sort_key_bits(card: &Card, sort_col: SortCol, descending: bool) -> u128 {
+fn sort_key_bits(card: &ACard, sort_col: SortCol, descending: bool) -> u128 {
     let primary: Option<f32> = match sort_col {
-        SortCol::Cmc        => card.cmc.map(|v| v as f32),
-        SortCol::Power      => card.creature_power.map(|v| v as f32),
-        SortCol::Toughness  => card.creature_toughness.map(|v| v as f32),
-        SortCol::Rarity     => card.card_rarity_int.map(|v| v as f32),
-        SortCol::PriceUsd   => card.price_usd,
-        SortCol::Cubecobra  => card.cubecobra_score,
-        SortCol::EdhrecRank => card.edhrec_rank.map(|v| v as f32),
+        SortCol::Cmc        => card.cmc.as_ref().map(|v| u8::from(*v) as f32),
+        SortCol::Power      => card.creature_power.as_ref().map(|v| i8::from(*v) as f32),
+        SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| i8::from(*v) as f32),
+        SortCol::Rarity     => card.card_rarity_int.as_ref().map(|v| u8::from(*v) as f32),
+        SortCol::PriceUsd   => card.price_usd.as_ref().map(|v| f32::from(*v)),
+        SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
+        SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
     };
     let p = primary.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
-    let e = card.edhrec_rank.unwrap_or(u32::MAX);
-    let s = card.prefer_score.map_or(u32::MAX, |v| f32_sort_bits(-v));
+    let e = card.edhrec_rank.as_ref().map(|v| u32::from(*v)).unwrap_or(u32::MAX);
+    let s = card.prefer_score.as_ref().map_or(u32::MAX, |v| f32_sort_bits(-f32::from(*v)));
     ((p as u128) << 64) | ((e as u128) << 32) | (s as u128)
 }
 
@@ -1606,12 +1720,12 @@ fn sort_key_bits(card: &Card, sort_col: SortCol, descending: bool) -> u128 {
 /// segment. The first select bounds the page from above (everything past it stays
 /// unsorted); the second bounds it from below and is skipped in the common
 /// offset == 0 case. O(n + limit·log limit) instead of O(n·log n).
-fn select_page<'a>(mut v: Vec<(u128, &'a Card)>, offset: usize, limit: usize) -> Vec<&'a Card> {
+fn select_page<'a>(mut v: Vec<(u128, &'a ACard)>, offset: usize, limit: usize) -> Vec<&'a ACard> {
     let end = offset.saturating_add(limit).min(v.len());
     if offset >= end {
         return Vec::new();
     }
-    let cmp = |a: &(u128, &Card), b: &(u128, &Card)| {
+    let cmp = |a: &(u128, &ACard), b: &(u128, &ACard)| {
         a.0.cmp(&b.0).then_with(|| std::ptr::from_ref(a.1).cmp(&std::ptr::from_ref(b.1)))
     };
     if end < v.len() {
@@ -1627,7 +1741,7 @@ fn select_page<'a>(mut v: Vec<(u128, &'a Card)>, offset: usize, limit: usize) ->
 }
 
 fn run_query_hashmap<'a>(
-    store: &'a [Card],
+    store: &'a [ACard],
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1635,7 +1749,7 @@ fn run_query_hashmap<'a>(
     direction: &str,
     limit: usize,
     offset: usize,
-) -> (usize, Vec<&'a Card>) {
+) -> (usize, Vec<&'a ACard>) {
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let prefer     = prefer_from_str(prefer);
@@ -1647,12 +1761,12 @@ fn run_query_hashmap<'a>(
         _          => GroupBy::Oracle,
     };
 
-    let mut partitions: HashMap<usize, (&Card, f64)> = HashMap::new();
+    let mut partitions: HashMap<usize, (&ACard, f64)> = HashMap::new();
     for card in store {
         if filter.matches(card) {
             let key = match group_by {
-                GroupBy::Oracle   => card.oracle_group as usize,
-                GroupBy::Artwork  => card.artwork_group as usize,
+                GroupBy::Oracle   => u32::from(card.oracle_group) as usize,
+                GroupBy::Artwork  => u32::from(card.artwork_group) as usize,
                 // every printing is its own partition — the pointer is a free unique key
                 GroupBy::Printing => std::ptr::from_ref(card) as usize,
             };
@@ -1662,7 +1776,7 @@ fn run_query_hashmap<'a>(
         }
     }
 
-    let best: Vec<(u128, &Card)> = partitions
+    let best: Vec<(u128, &ACard)> = partitions
         .into_values()
         .map(|(c, _)| (sort_key_bits(c, sort_col, descending), c))
         .collect();
@@ -1679,17 +1793,17 @@ fn run_query_linear<'a, I, F>(
     direction: &str,
     limit: usize,
     offset: usize,
-) -> (usize, Vec<&'a Card>)
+) -> (usize, Vec<&'a ACard>)
 where
-    I: Iterator<Item = &'a Card>,
-    F: Fn(&Card) -> u32,
+    I: Iterator<Item = &'a ACard>,
+    F: Fn(&ACard) -> u32,
 {
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let prefer     = prefer_from_str(prefer);
 
-    let mut best: Vec<(u128, &Card)> = Vec::new();
-    let mut group_best: Option<(&Card, f64)> = None;
+    let mut best: Vec<(u128, &ACard)> = Vec::new();
+    let mut group_best: Option<(&ACard, f64)> = None;
     let mut prev_key: u32 = u32::MAX; // group ids are dense from 0, so MAX is a safe sentinel
 
     for card in cards {
@@ -1713,16 +1827,16 @@ where
 }
 
 fn run_query_no_dedup<'a>(
-    cards: impl Iterator<Item = &'a Card>,
+    cards: impl Iterator<Item = &'a ACard>,
     filter: &FilterExpr,
     orderby: &str,
     direction: &str,
     limit: usize,
     offset: usize,
-) -> (usize, Vec<&'a Card>) {
+) -> (usize, Vec<&'a ACard>) {
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
-    let matched: Vec<(u128, &Card)> = cards
+    let matched: Vec<(u128, &ACard)> = cards
         .filter(|c| filter.matches(c))
         .map(|c| (sort_key_bits(c, sort_col, descending), c))
         .collect();
@@ -1731,7 +1845,7 @@ fn run_query_no_dedup<'a>(
 }
 
 fn run_query<'a>(
-    store: &'a [Card],
+    store: &'a [ACard],
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1739,64 +1853,137 @@ fn run_query<'a>(
     direction: &str,
     limit: usize,
     offset: usize,
-    indexes: &CardIndexes,
-) -> (usize, Vec<&'a Card>) {
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<&'a ACard>) {
     let candidates = narrow_candidates(filter, indexes);
 
     macro_rules! cards_iter {
         () => {
             match &candidates {
-                Some(idxs) => Box::new(idxs.iter().map(|&i| &store[i as usize])) as Box<dyn Iterator<Item = &Card>>,
+                Some(idxs) => Box::new(idxs.iter().map(|&i| &store[i as usize])) as Box<dyn Iterator<Item = &ACard>>,
                 None       => Box::new(store.iter()),
             }
         };
     }
 
     match unique {
-        "card" => run_query_linear(cards_iter!(), filter, |c| c.oracle_group, prefer, orderby, direction, limit, offset),
+        "card" => run_query_linear(cards_iter!(), filter, |c| u32::from(c.oracle_group), prefer, orderby, direction, limit, offset),
         // Scryfall assigns each illustration_id to exactly one oracle_id, so cards sharing an
         // illustration_id are always contiguous in the (oracle_id, illustration_id) sort order.
         // The linear dedup path is therefore correct here — no HashMap needed.
-        "artwork"  => run_query_linear(cards_iter!(), filter, |c| c.artwork_group, prefer, orderby, direction, limit, offset),
+        "artwork"  => run_query_linear(cards_iter!(), filter, |c| u32::from(c.artwork_group), prefer, orderby, direction, limit, offset),
         "printing" => run_query_no_dedup(cards_iter!(), filter, orderby, direction, limit, offset),
         _          => run_query_hashmap(store, filter, unique, prefer, orderby, direction, limit, offset),
     }
 }
 
-fn card_to_pydict<'py>(py: Python<'py>, card: &Card) -> PyResult<Bound<'py, PyDict>> {
+fn card_to_pydict<'py>(py: Python<'py>, card: &ACard) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
-    d.set_item("name", &card.card_name)?;
+    d.set_item("name", card.card_name.as_str())?;
     d.set_item("set_code", card.card_set_code.as_str())?;
-    d.set_item("collector_number", &card.collector_number)?;
-    d.set_item("power", card.creature_power_text.as_deref())?;
-    d.set_item("toughness", card.creature_toughness_text.as_deref())?;
-    d.set_item("mana_cost", card.mana_cost_text.as_deref())?;
-    d.set_item("oracle_text", &card.oracle_text)?;
-    d.set_item("set_name", &card.set_name)?;
-    d.set_item("type_line", &card.type_line)?;
+    d.set_item("collector_number", card.collector_number.as_str())?;
+    d.set_item("power", card.creature_power_text.as_ref().map(|s| s.as_str()))?;
+    d.set_item("toughness", card.creature_toughness_text.as_ref().map(|s| s.as_str()))?;
+    d.set_item("mana_cost", card.mana_cost_text.as_ref().map(|s| s.as_str()))?;
+    d.set_item("oracle_text", card.oracle_text.as_str())?;
+    d.set_item("set_name", card.set_name.as_str())?;
+    d.set_item("type_line", card.type_line.as_str())?;
     Ok(d)
 }
 
 // ─── PyO3 bindings ───────────────────────────────────────────────────────────
 
+struct CachedMmap {
+    mmap: Arc<Mmap>,
+    inode: u64,
+}
+
 #[pyclass]
 struct QueryEngine {
-    data: Arc<RwLock<CardData>>,
+    shm_path: PathBuf,
+    write_lock: Mutex<()>,
+    cached_mmap: Mutex<Option<CachedMmap>>,
+}
+
+impl QueryEngine {
+    // Returns the cached mmap, remapping if the on-disk inode has changed since
+    // the last remap (i.e. another worker wrote a new archive via rename).
+    // One stat(2) per query; remap only when the inode actually changes.
+    fn get_mmap(&self) -> PyResult<Arc<Mmap>> {
+        let path_inode = std::fs::metadata(&self.shm_path)
+            .map(|m| m.ino())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("stat shm: {e}")))?;
+
+        let mut guard = self.cached_mmap.lock().unwrap();
+        if let Some(ref c) = *guard {
+            if c.inode == path_inode {
+                return Ok(Arc::clone(&c.mmap));
+            }
+        }
+        // Inode changed (new reload) or first call: open and map the current file.
+        let file = std::fs::File::open(&self.shm_path)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("open shm: {e}")))?;
+        // Safety: bytes written by rkyv::to_bytes on this platform; file is replaced
+        // atomically (rename), never modified in place while mapped.
+        let mmap = Arc::new(unsafe { Mmap::map(&file) }
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("mmap: {e}")))?);
+        *guard = Some(CachedMmap { mmap: Arc::clone(&mmap), inode: path_inode });
+        Ok(mmap)
+    }
 }
 
 #[pymethods]
 impl QueryEngine {
     #[new]
-    fn new() -> Self {
+    #[pyo3(signature = (shm_path=None))]
+    fn new(shm_path: Option<&str>) -> Self {
+        // Use /dev/shm on Linux (shared memory), fall back to /tmp on macOS.
+        let default_path = if cfg!(target_os = "linux") {
+            "/dev/shm/arcane_tutor_cards"
+        } else {
+            "/tmp/arcane_tutor_cards"
+        };
         QueryEngine {
-            data: Arc::new(RwLock::new(CardData {
-                cards:   Vec::new(),
-                indexes: CardIndexes::default(),
-            })),
+            shm_path: PathBuf::from(shm_path.unwrap_or(default_path)),
+            write_lock: Mutex::new(()),
+            cached_mmap: Mutex::new(None),  // populated by first reload()
         }
     }
 
+    fn remap(&self) -> PyResult<()> {
+        // Force a remap by clearing the cached inode so get_mmap() re-opens.
+        if let Some(ref mut c) = *self.cached_mmap.lock().unwrap() {
+            c.inode = 0;
+        }
+        self.get_mmap().map(|_| ())
+    }
+
     fn reload(&self, db_rows: &Bound<PyList>) -> PyResult<()> {
+        let _guard = self.write_lock.lock().unwrap();
+
+        // Record when we started waiting so we can detect whether another worker
+        // wrote the file while we were blocked on the cross-process flock below.
+        let started_at = std::time::SystemTime::now();
+
+        // Cross-process exclusive lock: only one worker writes per reload cycle.
+        // The lock file is separate so it persists across archive replacements.
+        let lock_path = self.shm_path.with_extension("lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .write(true).create(true).open(&lock_path)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("open lock: {e}")))?;
+        // LOCK_EX blocks until we hold the lock; released automatically on drop.
+        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
+
+        // If another worker already wrote the file while we were waiting, skip
+        // the rebuild and just remap our local handle.
+        let already_written = std::fs::metadata(&self.shm_path)
+            .and_then(|m| m.modified())
+            .map(|mtime| mtime > started_at)
+            .unwrap_or(false);
+        if already_written {
+            return self.get_mmap().map(|_| ());
+        }
+
         let mut cards: Vec<Card> = db_rows
             .iter()
             .filter_map(|item| item.cast::<PyDict>().ok().map(|d| card_from_pydict(&d)))
@@ -1855,9 +2042,32 @@ impl QueryEngine {
             is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
         };
 
-        *self.data.write().map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("data lock: {e}")))? =
-            CardData { cards, indexes };
-        Ok(())
+        // Snapshot the registry card_from_pydict just populated so reader
+        // processes can adopt the same format→shift assignments.
+        let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
+        let card_data = CardData { cards, indexes, format_shifts: format_shifts_snapshot };
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&card_data)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rkyv serialize: {e}")))?;
+
+        // Write atomically: write to a per-PID .tmp, then rename over shm_path.
+        // Per-PID avoids the race where two workers write to the same .tmp and
+        // one's rename consumes the file before the other can rename it.
+        let tmp_name = format!(
+            "{}.{}.tmp",
+            self.shm_path.file_name().unwrap_or_default().to_string_lossy(),
+            std::process::id(),
+        );
+        let tmp_path = self.shm_path.with_file_name(tmp_name);
+        {
+            let mut f = std::fs::File::create(&tmp_path)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("create tmp: {e}")))?;
+            f.write_all(&bytes)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("write tmp: {e}")))?;
+        }
+        std::fs::rename(&tmp_path, &self.shm_path)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rename shm: {e}")))?;
+
+        self.get_mmap().map(|_| ())
     }
 
     #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
@@ -1881,13 +2091,23 @@ impl QueryEngine {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
         let json_val: Value = serde_json::from_str(json_str)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad query JSON: {e}")))?;
+        // get_mmap() remaps automatically if the on-disk inode has changed since
+        // the last reload, keeping workers off stale (deleted) mappings.
+        let mmap = self.get_mmap()?;
+        // Safety: bytes were written by rkyv::to_bytes on this platform.
+        // The archive is immutable once written; reloads atomically replace the
+        // file, never modifying it in place. The Arc keeps the mapping alive.
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) };
+
+        // Must run before build_filter so legality shifts resolve in workers
+        // that never executed the load path themselves.
+        sync_format_shifts(&data.format_shifts);
         let filter_expr = build_filter(&json_val)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
 
-        let data = self.data.read()
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("data lock: {e}")))?;
+        let store: &[ACard] = &data.cards;
         let (total, page) = run_query(
-            &data.cards, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
+            store, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 
         let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c)).collect::<PyResult<Vec<_>>>()?;
@@ -1917,21 +2137,28 @@ impl QueryEngine {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
         let json_val: Value = serde_json::from_str(json_str)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad query JSON: {e}")))?;
+        let mmap = self.get_mmap()?;
+        // Safety: same as query().
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) };
+
+        // Must run before build_filter; see query().
+        sync_format_shifts(&data.format_shifts);
         let filter_expr = build_filter(&json_val)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
 
-        let data = self.data.read()
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("data lock: {e}")))?;
-        let (total, page) = run_query_hashmap(&data.cards, &filter_expr, unique, prefer, orderby, direction, limit, offset);
+        let store: &[ACard] = &data.cards;
+        let (total, page) = run_query_hashmap(store, &filter_expr, unique, prefer, orderby, direction, limit, offset);
         let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
 
     fn size(&self) -> PyResult<usize> {
-        let data = self.data.read()
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("data lock: {e}")))?;
-        Ok(data.cards.len())
+        match self.get_mmap() {
+            Err(_) => Ok(0),
+            // Safety: same as query().
+            Ok(mmap) => Ok(unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) }.cards.len()),
+        }
     }
 }
 
@@ -1944,6 +2171,7 @@ mod card_engine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rkyv::rancor::Error;
 
     /// Build a TrigramIndex mapping each word's trigrams to the given card ids.
     fn index_of(words: &[(&str, &[u32])]) -> TrigramIndex {
@@ -1960,17 +2188,24 @@ mod tests {
         idx
     }
 
+    /// Archive the index and query it, matching how the engine reads the shared snapshot.
+    fn candidates(idx: &TrigramIndex, word: &str) -> Option<Vec<u32>> {
+        let bytes = rkyv::to_bytes::<Error>(idx).expect("serialize trigram index");
+        let archived = rkyv::access::<Archived<TrigramIndex>, Error>(&bytes).expect("access trigram index");
+        trigram_candidates(archived, word)
+    }
+
     #[test]
     fn trigram_short_word_cannot_narrow() {
         let idx = index_of(&[("bolt", &[1, 2])]);
-        assert_eq!(trigram_candidates(&idx, "bo"), None);
+        assert_eq!(candidates(&idx, "bo"), None);
     }
 
     #[test]
     fn trigram_all_present_intersects() {
         // "bol" → {1,2,3}, "olt" → {1,2}: intersection is {1,2}
         let idx = index_of(&[("bol", &[1, 2, 3]), ("olt", &[1, 2])]);
-        assert_eq!(trigram_candidates(&idx, "bolt"), Some(vec![1, 2]));
+        assert_eq!(candidates(&idx, "bolt"), Some(vec![1, 2]));
     }
 
     #[test]
@@ -1979,12 +2214,82 @@ mod tests {
         // match — the result must be the empty candidate set, not an intersection
         // of whichever trigrams happen to exist.
         let idx = index_of(&[("bolt", &[1, 2])]);
-        assert_eq!(trigram_candidates(&idx, "bolx"), Some(Vec::new()));
+        assert_eq!(candidates(&idx, "bolx"), Some(Vec::new()));
     }
 
     #[test]
     fn trigram_fully_unindexed_word_is_empty_not_unnarrowed() {
         let idx = index_of(&[("bolt", &[1, 2])]);
-        assert_eq!(trigram_candidates(&idx, "zzz"), Some(Vec::new()));
+        assert_eq!(candidates(&idx, "zzz"), Some(Vec::new()));
+    }
+
+    // Verify that HashMap<[u8; 3], Vec<u32>> (the trigram index key type) round-trips
+    // through rkyv and supports lookup via the same [u8; 3] key type.
+    #[test]
+    fn test_trigram_index_archive_and_lookup() {
+        let mut idx: HashMap<[u8; 3], Vec<u32>> = HashMap::new();
+        idx.insert([b'a', b'b', b'c'], vec![1, 2, 3]);
+        idx.insert([b'x', b'y', b'z'], vec![4, 5]);
+        idx.insert([b'f', b'o', b'o'], vec![10, 20, 30, 40]);
+
+        let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize trigram index");
+        let archived = rkyv::access::<rkyv::Archived<HashMap<[u8; 3], Vec<u32>>>, Error>(&bytes)
+            .expect("access trigram index");
+
+        // Key present -- length check
+        let abc = archived.get(&[b'a', b'b', b'c']).expect("abc must be present");
+        assert_eq!(abc.len(), 3);
+
+        // Key present -- value iteration (elements are rend::u32_le, not u32)
+        let foo: Vec<u32> = archived
+            .get(&[b'f', b'o', b'o'])
+            .expect("foo must be present")
+            .iter()
+            .map(|x| u32::from(*x))
+            .collect();
+        assert_eq!(foo, vec![10, 20, 30, 40]);
+
+        // Key absent
+        assert!(archived.get(&[b'z', b'z', b'z']).is_none());
+    }
+
+    // Verify that HashSet<String> supports contains() via &str (Borrow-based lookup).
+    // This is used for card_keywords, card_oracle_tags, card_is_tags, card_frame_data.
+    #[test]
+    fn test_hashset_string_str_lookup() {
+        let mut set: HashSet<String> = HashSet::new();
+        set.insert("Flying".to_string());
+        set.insert("Vigilance".to_string());
+        set.insert("Trample".to_string());
+
+        let bytes = rkyv::to_bytes::<Error>(&set).expect("serialize hashset");
+        let archived = rkyv::access::<rkyv::Archived<HashSet<String>>, Error>(&bytes)
+            .expect("access hashset");
+
+        assert!(archived.contains("Flying"));
+        assert!(archived.contains("Trample"));
+        assert!(!archived.contains("Deathtouch"));
+    }
+
+    // Verify that HashMap<String, Vec<u32>> (the tag index value type) supports
+    // get() via &str, which is needed for narrow_candidates tag lookups.
+    #[test]
+    fn test_tag_index_str_lookup() {
+        let mut idx: HashMap<String, Vec<u32>> = HashMap::new();
+        idx.insert("merfolk".to_string(), vec![1, 5, 9]);
+        idx.insert("dragon".to_string(), vec![2, 7]);
+
+        let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize tag index");
+        let archived = rkyv::access::<rkyv::Archived<HashMap<String, Vec<u32>>>, Error>(&bytes)
+            .expect("access tag index");
+
+        let merfolk: Vec<u32> = archived
+            .get("merfolk")
+            .expect("merfolk must be present")
+            .iter()
+            .map(|x| u32::from(*x))
+            .collect();
+        assert_eq!(merfolk, vec![1, 5, 9]);
+        assert!(archived.get("angel").is_none());
     }
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1643,13 +1643,19 @@ fn build_trigram_index<'a>(cards: &'a [Card], get_text: impl Fn(&'a Card) -> &'a
     idx
 }
 
-fn intersect_sorted(a: &[u32], b: &[u32]) -> Vec<u32> {
+// Generic over the second operand's element type so it can walk archived
+// posting lists (u32_le) in place, without copying them out of the mmap.
+fn intersect_sorted<B: Copy>(a: &[u32], b: &[B]) -> Vec<u32>
+where
+    u32: From<B>,
+{
     let mut out = Vec::new();
     let (mut i, mut j) = (0, 0);
     while i < a.len() && j < b.len() {
-        if a[i] == b[j]      { out.push(a[i]); i += 1; j += 1; }
-        else if a[i] < b[j]  { i += 1; }
-        else                  { j += 1; }
+        let bj = u32::from(b[j]);
+        if a[i] == bj      { out.push(a[i]); i += 1; j += 1; }
+        else if a[i] < bj  { i += 1; }
+        else               { j += 1; }
     }
     out
 }
@@ -1658,21 +1664,27 @@ fn trigram_candidates(idx: &Archived<TrigramIndex>, word: &str) -> Option<Vec<u3
     let bytes = word.as_bytes();
     if bytes.len() < 3 { return None; }
 
-    let mut lists: Vec<Vec<u32>> = Vec::with_capacity(bytes.len() - 2);
+    let mut lists: Vec<&Archived<Vec<u32>>> = Vec::with_capacity(bytes.len() - 2);
     for w in bytes.windows(3) {
         match idx.get(&[w[0], w[1], w[2]]) {
-            Some(list) => lists.push(list.iter().map(|x| u32::from(*x)).collect()),
+            Some(list) => lists.push(list),
             // A trigram absent from the index appears in no card: nothing can match.
             None => return Some(Vec::new()),
         }
     }
     lists.sort_unstable_by_key(|l| l.len());
+    // Repeated trigrams (e.g. "aaaa") resolve to the same archived entry — drop
+    // the pointer-equal duplicates instead of intersecting them again.
+    lists.dedup_by(|a, b| std::ptr::eq(*a, *b));
 
-    let mut result = lists.swap_remove(0);
-    result.sort_unstable();
-    for list in &lists {
+    // Posting lists are built sorted (build_trigram_index and the oracle CSR
+    // both append ids in ascending order), so intersection runs directly over
+    // the archived lists; only the shortest one is materialized as the
+    // working set.
+    let mut result: Vec<u32> = lists[0].iter().map(|x| u32::from(*x)).collect();
+    for list in &lists[1..] {
         if result.is_empty() { break; }
-        result = intersect_sorted(&result, list);
+        result = intersect_sorted(&result, list.as_slice());
     }
     Some(result)
 }
@@ -2198,6 +2210,34 @@ fn card_to_pydict<'py>(py: Python<'py>, card: &ACard, strings: &AStrings) -> PyR
     Ok(d)
 }
 
+// ─── Archive file header ─────────────────────────────────────────────────────
+// A 16-byte header is prepended to the rkyv archive: magic, format version, and
+// size_of::<Archived<Card>>. get_mmap() rejects any file whose header doesn't
+// match this build, so an archive written by an older build (different archived
+// layout) is treated as absent and rebuilt instead of being handed to
+// access_unchecked — which would be undefined behavior. The 16-byte length also
+// keeps the payload 16-aligned (the mmap base is page-aligned), satisfying
+// rkyv's alignment requirement for the archived root.
+
+const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
+/// Bump on any archived-data-model change that size_of::<ACard>() wouldn't
+/// catch (e.g. reordering same-size Card fields, changing an index type).
+const ARCHIVE_FORMAT_VERSION: u32 = 1;
+const ARCHIVE_HEADER_LEN: usize = 16;
+
+fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
+    let mut h = [0u8; ARCHIVE_HEADER_LEN];
+    h[..8].copy_from_slice(&ARCHIVE_MAGIC);
+    h[8..12].copy_from_slice(&ARCHIVE_FORMAT_VERSION.to_le_bytes());
+    h[12..16].copy_from_slice(&(std::mem::size_of::<ACard>() as u32).to_le_bytes());
+    h
+}
+
+/// The rkyv payload of a mapping whose header get_mmap() already validated.
+fn archive_payload(mmap: &Mmap) -> &[u8] {
+    &mmap[ARCHIVE_HEADER_LEN..]
+}
+
 // ─── PyO3 bindings ───────────────────────────────────────────────────────────
 
 struct CachedMmap {
@@ -2230,11 +2270,26 @@ impl QueryEngine {
         // Inode changed (new reload) or first call: open and map the current file.
         let file = std::fs::File::open(&self.shm_path)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("open shm: {e}")))?;
+        // Cache the inode from the opened handle (fstat), not the path stat above:
+        // the file can be replaced between the two, and pairing the old path inode
+        // with the new file's mapping would force a spurious remap on the next call.
+        let inode = file.metadata()
+            .map(|m| m.ino())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("fstat shm: {e}")))?;
         // Safety: bytes written by rkyv::to_bytes on this platform; file is replaced
         // atomically (rename), never modified in place while mapped.
         let mmap = Arc::new(unsafe { Mmap::map(&file) }
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("mmap: {e}")))?);
-        *guard = Some(CachedMmap { mmap: Arc::clone(&mmap), inode: path_inode });
+        // Reject archives not written by this exact build (stale file from an older
+        // build, or a foreign file at the shared path): handing them to
+        // access_unchecked would be UB. Callers treat the error as "no archive".
+        if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "archive header mismatch at {} (stale or foreign archive; will be rebuilt)",
+                self.shm_path.display(),
+            )));
+        }
+        *guard = Some(CachedMmap { mmap: Arc::clone(&mmap), inode });
         Ok(mmap)
     }
 }
@@ -2268,9 +2323,12 @@ impl QueryEngine {
     fn reload(&self, db_rows: &Bound<PyList>) -> PyResult<()> {
         let _guard = self.write_lock.lock().unwrap();
 
-        // Record when we started waiting so we can detect whether another worker
-        // wrote the file while we were blocked on the cross-process flock below.
-        let started_at = std::time::SystemTime::now();
+        // Snapshot the archive's identity before contending for the cross-process
+        // lock, so we can detect whether another worker published a new archive
+        // while we were blocked. Publish is rename-only, so a publish always
+        // changes the inode — unlike mtime, which is subject to filesystem
+        // timestamp granularity and clock steps.
+        let inode_before = std::fs::metadata(&self.shm_path).ok().map(|m| m.ino());
 
         // Cross-process exclusive lock: only one worker writes per reload cycle.
         // The lock file is separate so it persists across archive replacements.
@@ -2279,15 +2337,21 @@ impl QueryEngine {
             .write(true).create(true).open(&lock_path)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("open lock: {e}")))?;
         // LOCK_EX blocks until we hold the lock; released automatically on drop.
-        unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) };
+        loop {
+            if unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX) } == 0 {
+                break;
+            }
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(format!("flock: {err}")));
+            }
+        }
 
-        // If another worker already wrote the file while we were waiting, skip
-        // the rebuild and just remap our local handle.
-        let already_written = std::fs::metadata(&self.shm_path)
-            .and_then(|m| m.modified())
-            .map(|mtime| mtime > started_at)
-            .unwrap_or(false);
-        if already_written {
+        // If another worker published a new archive while we were waiting (the
+        // inode changed, or a file appeared), skip the rebuild and just remap
+        // our local handle.
+        let inode_after = std::fs::metadata(&self.shm_path).ok().map(|m| m.ino());
+        if inode_after.is_some() && inode_after != inode_before {
             return self.get_mmap().map(|_| ());
         }
 
@@ -2362,6 +2426,8 @@ impl QueryEngine {
         {
             let mut f = std::fs::File::create(&tmp_path)
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("create tmp: {e}")))?;
+            f.write_all(&archive_header())
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("write header: {e}")))?;
             f.write_all(&bytes)
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("write tmp: {e}")))?;
         }
@@ -2400,10 +2466,11 @@ impl QueryEngine {
         // module (query_hashmap() and size() refer here):
         //
         // - The only writer is reload() in this module: the bytes come from
-        //   rkyv::to_bytes in the same build of this crate that reads them. In
-        //   production the archive lives in container-scoped tmpfs (/dev/shm),
-        //   so it cannot outlive the build that wrote it. (On macOS dev, /tmp
-        //   persists — after changing any archived type, delete the archive.)
+        //   rkyv::to_bytes in the same build of this crate that reads them.
+        //   get_mmap() enforces this with the archive header check (magic,
+        //   format version, size_of::<ACard>), so an archive left behind by an
+        //   older build — e.g. /tmp on macOS dev persisting across rebuilds —
+        //   is rejected and rebuilt rather than mapped.
         // - A torn or truncated archive is never observable: reload() writes to
         //   a per-PID temp file and publishes it with rename(2), which is
         //   atomic. A crashed writer leaves a stale .tmp, never a partial file
@@ -2418,7 +2485,7 @@ impl QueryEngine {
         // evaluation — a 10-100x slowdown per query. It would also be a false
         // guarantee: InlineStr's CheckBytes is deliberately permissive, so
         // validation cannot be the safety boundary; the trusted write path is.
-        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) };
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
 
         // Must run before build_filter so legality shifts resolve in workers
         // that never executed the load path themselves.
@@ -2460,7 +2527,7 @@ impl QueryEngine {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad query JSON: {e}")))?;
         let mmap = self.get_mmap()?;
         // Safety: see the access_unchecked justification in query().
-        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) };
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
 
         // Must run before build_filter; see query().
         sync_format_shifts(&data.format_shifts);
@@ -2476,14 +2543,14 @@ impl QueryEngine {
 
     fn size(&self) -> PyResult<usize> {
         match self.get_mmap() {
-            // Missing/unopenable archive — the only "unreadable" state that can
-            // occur. Returns 0 so Python treats the engine as empty.
+            // Missing, unopenable, or wrong-build (header mismatch) archive.
+            // Returns 0 so Python treats the engine as empty and rebuilds.
             Err(_) => Ok(0),
             // Safety: see the access_unchecked justification in query(). A file
-            // that mapped successfully is always a complete rkyv archive (atomic
-            // rename publish), so checked access here would only re-validate
-            // trusted bytes at ~7 ms per size() call.
-            Ok(mmap) => Ok(unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) }.cards.len()),
+            // that mapped and passed the header check is always a complete rkyv
+            // archive from this build (atomic rename publish), so checked access
+            // here would only re-validate trusted bytes at ~7 ms per size() call.
+            Ok(mmap) => Ok(unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) }.cards.len()),
         }
     }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -11,6 +11,100 @@ use std::sync::{Arc, Mutex, OnceLock, RwLock};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::fs::MetadataExt;
 
+// ─── Feature-gated counting allocator (memory measurement only) ──────────────
+// Counts live bytes / live allocations of this extension's Rust heap and records
+// a breakdown of reload(): see docs/issues/engine-store-size-reduction.md step 0.
+
+#[cfg(feature = "alloc-counter")]
+mod alloc_stats {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    pub static LIVE: AtomicUsize = AtomicUsize::new(0);
+    pub static PEAK: AtomicUsize = AtomicUsize::new(0);
+    pub static ALLOCS: AtomicUsize = AtomicUsize::new(0); // currently-live allocation count
+
+    // Snapshots recorded by the most recent reload()
+    pub static RELOAD_LIVE_BEFORE: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_LIVE_AFTER_CARDS: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_ALLOCS_AFTER_CARDS: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_LIVE_AFTER_INDEXES: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_ALLOCS_AFTER_INDEXES: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_CARDS_RKYV: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_INDEXES_RKYV: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_STRINGS_RKYV: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_ARCHIVE: AtomicUsize = AtomicUsize::new(0);
+    pub static RELOAD_PEAK: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn live() -> usize { LIVE.load(Ordering::Relaxed) }
+    pub fn allocs() -> usize { ALLOCS.load(Ordering::Relaxed) }
+
+    pub fn reset_peak() {
+        RELOAD_LIVE_BEFORE.store(live(), Ordering::Relaxed);
+        PEAK.store(live(), Ordering::Relaxed);
+    }
+
+    pub fn record_reload(
+        after_cards: (usize, usize),
+        after_indexes: (usize, usize),
+        component_bytes: (usize, usize, usize),
+        archive: usize,
+    ) {
+        RELOAD_LIVE_AFTER_CARDS.store(after_cards.0, Ordering::Relaxed);
+        RELOAD_ALLOCS_AFTER_CARDS.store(after_cards.1, Ordering::Relaxed);
+        RELOAD_LIVE_AFTER_INDEXES.store(after_indexes.0, Ordering::Relaxed);
+        RELOAD_ALLOCS_AFTER_INDEXES.store(after_indexes.1, Ordering::Relaxed);
+        RELOAD_CARDS_RKYV.store(component_bytes.0, Ordering::Relaxed);
+        RELOAD_INDEXES_RKYV.store(component_bytes.1, Ordering::Relaxed);
+        RELOAD_STRINGS_RKYV.store(component_bytes.2, Ordering::Relaxed);
+        RELOAD_ARCHIVE.store(archive, Ordering::Relaxed);
+        RELOAD_PEAK.store(PEAK.load(Ordering::Relaxed), Ordering::Relaxed);
+    }
+
+    pub struct CountingAlloc;
+
+    impl CountingAlloc {
+        fn on_alloc(size: usize) {
+            let live = LIVE.fetch_add(size, Ordering::Relaxed) + size;
+            ALLOCS.fetch_add(1, Ordering::Relaxed);
+            PEAK.fetch_max(live, Ordering::Relaxed);
+        }
+        fn on_dealloc(size: usize) {
+            LIVE.fetch_sub(size, Ordering::Relaxed);
+            ALLOCS.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    unsafe impl GlobalAlloc for CountingAlloc {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let p = unsafe { System.alloc(layout) };
+            if !p.is_null() { Self::on_alloc(layout.size()); }
+            p
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) };
+            Self::on_dealloc(layout.size());
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            let p = unsafe { System.realloc(ptr, layout, new_size) };
+            if !p.is_null() {
+                LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+                let live = LIVE.fetch_add(new_size, Ordering::Relaxed) + new_size;
+                PEAK.fetch_max(live, Ordering::Relaxed);
+            }
+            p
+        }
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            let p = unsafe { System.alloc_zeroed(layout) };
+            if !p.is_null() { Self::on_alloc(layout.size()); }
+            p
+        }
+    }
+
+    #[global_allocator]
+    static COUNTING_ALLOC: CountingAlloc = CountingAlloc;
+}
+
 // ─── Inline string (no heap allocation) ──────────────────────────────────────
 
 #[derive(Clone, Copy)]
@@ -200,33 +294,32 @@ struct Card {
     produced_mana: u8,
     card_types: u16,
 
-    #[allow(dead_code)] // primary key; kept for future result payloads (printing dedup now keys on pointer)
-    scryfall_id: String,
-    oracle_id: Option<String>,
-    illustration_id: Option<String>,
+    // UUIDs packed as u128, 0 = null. Real UUIDs keep their exact bit value (so
+    // future lookup-by-id can match Scryfall's); non-UUID strings from hand-built
+    // test dicts are hashed deterministically — see parse_uuid_or_hash().
+    #[allow(dead_code)] // primary key; kept for future result payloads (printing dedup keys on pointer)
+    scryfall_id: u128,
+    oracle_id: u128,
+    illustration_id: u128,
 
-    card_name: String,
-    oracle_text: String,
-    oracle_text_lower: String,
-    flavor_text: String,
-    flavor_text_lower: String,
-    card_artist: Option<String>,
-    card_artist_lower: Option<String>,
+    // Interned string ids into CardData.strings (NONE_STR = absent). Identical
+    // values share one table entry; resolve with str_at()/the strings slice.
+    card_name_id: u32,
+    oracle_text_id: u32,
+    oracle_text_lower_id: u32,
+    flavor_text_id: u32,
+    flavor_text_lower_id: u32,
+    card_artist_id: u32,
+    card_artist_lower_id: u32,
     card_set_code: InlineStr<8>,
-    card_layout: String,
-    card_border: String,
-    card_watermark: Option<String>,
-    collector_number: String,
-    mana_cost_text: Option<String>,
-    type_line: String,
-    set_name: String,
-    released_at: String,
-    released_at_int: Option<u32>,      // yyyymmdd, parsed once at load for prefer=oldest/newest
-
-    // Dense group ids assigned at reload after the (oracle_id, illustration_id) sort;
-    // adjacency-equal to the string keys, so dedup compares integers, not UUIDs.
-    oracle_group: u32,
-    artwork_group: u32,
+    card_layout_id: u32,
+    card_border_id: u32,
+    card_watermark_id: u32,
+    collector_number_id: u32,
+    mana_cost_text_id: u32,
+    type_line_id: u32,
+    set_name_id: u32,
+    released_at_int: Option<u32>,      // yyyymmdd, parsed once at load; date/year filters and prefer use this
 
     cmc: Option<u8>,                   // always an integer; max ~16 in practice
     creature_power: Option<i8>,        // can be negative (e.g. Char-Rumbler)
@@ -250,17 +343,103 @@ struct Card {
 
     mana_cost: ManaCost,
 
-    creature_power_text: Option<String>,
-    creature_toughness_text: Option<String>,
+    creature_power_text_id: u32,
+    creature_toughness_text_id: u32,
 }
 
 // Type alias for the archived (mmap-backed) card type
 type ACard = Archived<Card>;
+// Archived string table (CardData.strings)
+type AStrings = Archived<Vec<String>>;
+
+/// Sentinel id for absent optional strings (a card never has 4 billion distinct strings).
+const NONE_STR: u32 = u32::MAX;
+
+/// Resolve an interned id against the archived string table; None for absent.
+fn str_at(strings: &AStrings, id: u32) -> Option<&str> {
+    if id == NONE_STR { None } else { Some(strings[id as usize].as_str()) }
+}
+
+/// Build-time hash-consing interner; `strings` becomes CardData.strings.
+struct Interner {
+    map: HashMap<String, u32>,
+    strings: Vec<String>,
+}
+
+impl Interner {
+    fn new() -> Self {
+        // Pre-intern "" as id 0: plain (non-optional) fields default to it when missing.
+        let mut it = Interner { map: HashMap::new(), strings: Vec::new() };
+        it.intern(String::new());
+        it
+    }
+
+    fn intern(&mut self, s: String) -> u32 {
+        if let Some(&id) = self.map.get(&s) {
+            return id;
+        }
+        let id = self.strings.len() as u32;
+        self.strings.push(s.clone());
+        self.map.insert(s, id);
+        id
+    }
+
+    fn intern_opt(&mut self, s: Option<String>) -> u32 {
+        match s {
+            Some(v) => self.intern(v),
+            None => NONE_STR,
+        }
+    }
+}
 
 // ─── Loading helpers ─────────────────────────────────────────────────────────
 
 fn opt_str(d: &Bound<PyDict>, key: &str) -> Option<String> {
     d.get_item(key).ok().flatten().and_then(|v| v.extract::<String>().ok())
+}
+
+/// UUID string → u128. Hyphenated/plain 32-hex-digit UUIDs map to their exact bit
+/// value (so future lookup-by-id matches Scryfall's ids); any other non-empty
+/// string (hand-built test dicts use ids like "o1") is FNV-1a-hashed, preserving
+/// equality semantics. 0 is reserved for null/missing; real values never map to it.
+fn parse_uuid_or_hash(s: &str) -> u128 {
+    if s.is_empty() {
+        return 0;
+    }
+    let mut val: u128 = 0;
+    let mut digits = 0u32;
+    let mut is_uuid = true;
+    for b in s.bytes() {
+        if b == b'-' {
+            continue;
+        }
+        match (b as char).to_digit(16) {
+            Some(dv) if digits < 32 => {
+                val = (val << 4) | dv as u128;
+                digits += 1;
+            }
+            _ => {
+                is_uuid = false;
+                break;
+            }
+        }
+    }
+    if is_uuid && digits == 32 {
+        return if val == 0 { 1 } else { val }; // all-zero UUID must not collide with null
+    }
+    // FNV-1a (128-bit) fallback for non-UUID strings
+    const FNV_OFFSET: u128 = 0x6c62272e07bb014262b821756295c58d;
+    const FNV_PRIME: u128 = 0x0000000001000000000000000000013b;
+    let mut h = FNV_OFFSET;
+    for b in s.bytes() {
+        h ^= b as u128;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    if h == 0 { 1 } else { h }
+}
+
+fn opt_uuid(d: &Bound<PyDict>, key: &str) -> u128 {
+    opt_str(d, key).map(|s| parse_uuid_or_hash(&s)).unwrap_or(0)
 }
 
 // Accepts ISO strings or datetime.date (psycopg returns date columns as datetime.date).
@@ -437,43 +616,41 @@ fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>) -> ManaCost {
     ManaCost { pips, devotion, cmc: cmc_val.unwrap_or(0.0) }
 }
 
-fn card_from_pydict(d: &Bound<PyDict>) -> Card {
+fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner) -> Card {
     let released_at = opt_date_str(d, "released_at").unwrap_or_default();
     let released_at_int: Option<u32> = released_at.replace('-', "").parse().ok();
+    // Raw strings from the dict; interned to ids as the struct is built below.
     let card_name = opt_str(d, "card_name").unwrap_or_default();
     let card_name_lower = InlineStr::<61>::from_str(&card_name.to_lowercase());
     let oracle_text = opt_str(d, "oracle_text").unwrap_or_default();
-    let oracle_text_lower = oracle_text.to_lowercase();
+    let oracle_text_lower_id = it.intern(oracle_text.to_lowercase());
     let flavor_text = opt_str(d, "flavor_text").unwrap_or_default();
-    let flavor_text_lower = flavor_text.to_lowercase();
+    let flavor_text_lower_id = it.intern(flavor_text.to_lowercase());
     let card_artist = opt_str(d, "card_artist");
-    let card_artist_lower = card_artist.as_ref().map(|s| s.to_lowercase());
+    let card_artist_lower_id = it.intern_opt(card_artist.as_ref().map(|s| s.to_lowercase()));
 
     Card {
-        scryfall_id: opt_str(d, "scryfall_id").unwrap_or_default(),
-        oracle_id: opt_str(d, "oracle_id"),
-        illustration_id: opt_str(d, "illustration_id"),
+        scryfall_id: opt_uuid(d, "scryfall_id"),
+        oracle_id: opt_uuid(d, "oracle_id"),
+        illustration_id: opt_uuid(d, "illustration_id"),
 
         card_name_lower,
-        card_name,
-        oracle_text_lower,
-        oracle_text,
-        flavor_text_lower,
-        flavor_text,
-        card_artist_lower,
-        card_artist,
+        card_name_id: it.intern(card_name),
+        oracle_text_lower_id,
+        oracle_text_id: it.intern(oracle_text),
+        flavor_text_lower_id,
+        flavor_text_id: it.intern(flavor_text),
+        card_artist_lower_id,
+        card_artist_id: it.intern_opt(card_artist),
         card_set_code: InlineStr::<8>::from_str(&opt_str(d, "card_set_code").unwrap_or_default()),
-        card_layout: opt_str(d, "card_layout").unwrap_or_default(),
-        card_border: opt_str(d, "card_border").unwrap_or_default(),
-        card_watermark: opt_str(d, "card_watermark"),
-        collector_number: opt_str(d, "collector_number").unwrap_or_default(),
-        mana_cost_text: opt_str(d, "mana_cost_text"),
-        type_line: opt_str(d, "type_line").unwrap_or_default(),
-        set_name: opt_str(d, "set_name").unwrap_or_default(),
-        released_at,
+        card_layout_id: it.intern(opt_str(d, "card_layout").unwrap_or_default()),
+        card_border_id: it.intern(opt_str(d, "card_border").unwrap_or_default()),
+        card_watermark_id: it.intern_opt(opt_str(d, "card_watermark")),
+        collector_number_id: it.intern(opt_str(d, "collector_number").unwrap_or_default()),
+        mana_cost_text_id: it.intern_opt(opt_str(d, "mana_cost_text")),
+        type_line_id: it.intern(opt_str(d, "type_line").unwrap_or_default()),
+        set_name_id: it.intern(opt_str(d, "set_name").unwrap_or_default()),
         released_at_int,
-        oracle_group: 0,  // assigned in reload() after the (oracle_id, illustration_id) sort
-        artwork_group: 0,
 
         card_colors: jsonb_color_to_bits(d, "card_colors"),
         card_color_identity: jsonb_color_to_bits(d, "card_color_identity"),
@@ -502,8 +679,8 @@ fn card_from_pydict(d: &Bound<PyDict>) -> Card {
 
         mana_cost: mana_cost_from_pydict(d, opt_f32(d, "cmc")),
 
-        creature_power_text: opt_str(d, "creature_power_text"),
-        creature_toughness_text: opt_str(d, "creature_toughness_text"),
+        creature_power_text_id: it.intern_opt(opt_str(d, "creature_power_text")),
+        creature_toughness_text_id: it.intern_opt(opt_str(d, "creature_toughness_text")),
     }
 }
 
@@ -682,12 +859,12 @@ enum TextSearchField {
     ArtistLower,
 }
 
-fn text_search_field_value<'a>(card: &'a ACard, field: TextSearchField) -> Option<&'a str> {
+fn text_search_field_value<'a>(card: &'a ACard, strings: &'a AStrings, field: TextSearchField) -> Option<&'a str> {
     match field {
         TextSearchField::NameLower       => Some(card.card_name_lower.as_str()),
-        TextSearchField::OracleTextLower => Some(card.oracle_text_lower.as_str()),
-        TextSearchField::FlavorTextLower => Some(card.flavor_text_lower.as_str()),
-        TextSearchField::ArtistLower     => card.card_artist_lower.as_ref().map(|s| s.as_str()),
+        TextSearchField::OracleTextLower => str_at(strings, u32::from(card.oracle_text_lower_id)),
+        TextSearchField::FlavorTextLower => str_at(strings, u32::from(card.flavor_text_lower_id)),
+        TextSearchField::ArtistLower     => str_at(strings, u32::from(card.card_artist_lower_id)),
     }
 }
 
@@ -707,17 +884,17 @@ enum TextField {
     CollectorNumber,
 }
 
-fn text_field_value<'a>(card: &'a ACard, field: TextField) -> Option<&'a str> {
+fn text_field_value<'a>(card: &'a ACard, strings: &'a AStrings, field: TextField) -> Option<&'a str> {
     match field {
         TextField::NameLower       => Some(card.card_name_lower.as_str()),
-        TextField::OracleTextLower => Some(card.oracle_text_lower.as_str()),
-        TextField::FlavorTextLower => Some(card.flavor_text_lower.as_str()),
-        TextField::ArtistLower     => card.card_artist_lower.as_ref().map(|s| s.as_str()),
+        TextField::OracleTextLower => str_at(strings, u32::from(card.oracle_text_lower_id)),
+        TextField::FlavorTextLower => str_at(strings, u32::from(card.flavor_text_lower_id)),
+        TextField::ArtistLower     => str_at(strings, u32::from(card.card_artist_lower_id)),
         TextField::SetCode         => Some(card.card_set_code.as_str()),
-        TextField::Layout          => Some(card.card_layout.as_str()),
-        TextField::Border          => Some(card.card_border.as_str()),
-        TextField::Watermark       => card.card_watermark.as_ref().map(|s| s.as_str()),
-        TextField::CollectorNumber => Some(card.collector_number.as_str()),
+        TextField::Layout          => str_at(strings, u32::from(card.card_layout_id)),
+        TextField::Border          => str_at(strings, u32::from(card.card_border_id)),
+        TextField::Watermark       => str_at(strings, u32::from(card.card_watermark_id)),
+        TextField::CollectorNumber => str_at(strings, u32::from(card.collector_number_id)),
     }
 }
 
@@ -783,7 +960,7 @@ enum FilterExpr {
 
     DateCmp {
         op: CmpOp,
-        value: String,
+        value: u32, // yyyymmdd, partial dates zero-padded (e.g. "2026-07" → 20260700)
     },
 
     YearCmp {
@@ -793,8 +970,8 @@ enum FilterExpr {
 }
 
 impl FilterExpr {
-    fn matches(&self, card: &ACard) -> bool {
-        self.tri(card) == Some(true)
+    fn matches(&self, card: &ACard, strings: &AStrings) -> bool {
+        self.tri(card, strings) == Some(true)
     }
 
     /// Three-valued evaluation mirroring SQL: None is SQL's NULL ("unknown"),
@@ -804,14 +981,14 @@ impl FilterExpr {
     /// filters only match cards that have the attribute", while
     /// -(power>2 and t:creature) still matches instants (NULL AND false =
     /// false, NOT false = true). Only Some(true) counts as a match.
-    fn tri(&self, card: &ACard) -> Option<bool> {
+    fn tri(&self, card: &ACard, strings: &AStrings) -> Option<bool> {
         match self {
             FilterExpr::True => Some(true),
 
             FilterExpr::And(children) => {
                 let mut unknown = false;
                 for c in children {
-                    match c.tri(card) {
+                    match c.tri(card, strings) {
                         Some(false) => return Some(false),
                         None => unknown = true,
                         Some(true) => {}
@@ -822,7 +999,7 @@ impl FilterExpr {
             FilterExpr::Or(children) => {
                 let mut unknown = false;
                 for c in children {
-                    match c.tri(card) {
+                    match c.tri(card, strings) {
                         Some(true) => return Some(true),
                         None => unknown = true,
                         Some(false) => {}
@@ -830,7 +1007,7 @@ impl FilterExpr {
                 }
                 if unknown { None } else { Some(false) }
             }
-            FilterExpr::Not(inner) => inner.tri(card).map(|b| !b),
+            FilterExpr::Not(inner) => inner.tri(card, strings).map(|b| !b),
 
             FilterExpr::ExactName(lower) => Some(card.card_name_lower.as_str() == lower.as_str()),
 
@@ -842,11 +1019,11 @@ impl FilterExpr {
             }
 
             FilterExpr::TextContains { field, word } => {
-                text_search_field_value(card, *field).map(|s| s.contains(word.as_str()))
+                text_search_field_value(card, strings, *field).map(|s| s.contains(word.as_str()))
             }
 
             FilterExpr::TextExact { field, op, value } => {
-                text_field_value(card, *field).map(|s| match op {
+                text_field_value(card, strings, *field).map(|s| match op {
                     CmpOp::Eq => s == value,
                     CmpOp::Ne => s != value,
                     CmpOp::Lt => s < value.as_str(),
@@ -857,7 +1034,7 @@ impl FilterExpr {
             }
 
             FilterExpr::TextRegex { field, regex } => {
-                text_field_value(card, *field).map(|s| regex.is_match(s))
+                text_field_value(card, strings, *field).map(|s| regex.is_match(s))
             }
 
             FilterExpr::ColorCmp { field, op, mask } => {
@@ -993,30 +1170,34 @@ impl FilterExpr {
             }
 
             FilterExpr::DateCmp { op, value } => {
-                if card.released_at.is_empty() { return None; } // missing date: SQL NULL
-                let ord = card.released_at.as_str().cmp(value.as_str());
+                // value is a zero-padded yyyymmdd (see build_binary); zero-padding a
+                // partial date reproduces the old lexicographic-prefix semantics exactly,
+                // since any real day/month (>= 01) compares greater than 00.
+                let Some(date) = card.released_at_int.as_ref().map(|v| u32::from(*v)) else {
+                    return None; // missing date: SQL NULL
+                };
                 Some(match op {
-                    CmpOp::Eq => ord == std::cmp::Ordering::Equal,
-                    CmpOp::Ne => ord != std::cmp::Ordering::Equal,
-                    CmpOp::Lt => ord == std::cmp::Ordering::Less,
-                    CmpOp::Le => ord != std::cmp::Ordering::Greater,
-                    CmpOp::Gt => ord == std::cmp::Ordering::Greater,
-                    CmpOp::Ge => ord != std::cmp::Ordering::Less,
+                    CmpOp::Eq => date == *value,
+                    CmpOp::Ne => date != *value,
+                    CmpOp::Lt => date < *value,
+                    CmpOp::Le => date <= *value,
+                    CmpOp::Gt => date > *value,
+                    CmpOp::Ge => date >= *value,
                 })
             }
 
             FilterExpr::YearCmp { op, year } => {
-                if card.released_at.is_empty() { return None; } // missing date: SQL NULL
-                let s = card.released_at.as_str();
-                let start = format!("{year:04}-01-01");
-                let end   = format!("{:04}-01-01", year + 1);
+                let Some(date) = card.released_at_int.as_ref().map(|v| u32::from(*v)) else {
+                    return None; // missing date: SQL NULL
+                };
+                let card_year = (date / 10_000) as i32;
                 Some(match op {
-                    CmpOp::Eq => s >= start.as_str() && s < end.as_str(),
-                    CmpOp::Gt => s >= end.as_str(),
-                    CmpOp::Lt => s < start.as_str(),
-                    CmpOp::Ge => s >= start.as_str(),
-                    CmpOp::Le => s < end.as_str(),
-                    CmpOp::Ne => s < start.as_str() || s >= end.as_str(),
+                    CmpOp::Eq => card_year == *year,
+                    CmpOp::Ne => card_year != *year,
+                    CmpOp::Gt => card_year > *year,
+                    CmpOp::Lt => card_year < *year,
+                    CmpOp::Ge => card_year >= *year,
+                    CmpOp::Le => card_year <= *year,
                 })
             }
         }
@@ -1167,7 +1348,14 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
             return Ok(FilterExpr::YearCmp { op: cmp_op, year });
         }
         let cmp_op = str_op_to_cmp(op)?;
-        return Ok(FilterExpr::DateCmp { op: cmp_op, value: val_str.to_string() });
+        // yyyymmdd as integer; zero-pad partial dates so ordering matches the
+        // lexicographic compare on ISO strings this replaced (day 00 < any real day).
+        let digits: String = val_str.chars().filter(|c| c.is_ascii_digit()).collect();
+        if digits.is_empty() || digits.len() > 8 {
+            return Err(format!("bad date: {val_str}"));
+        }
+        let value: u32 = format!("{digits:0<8}").parse().map_err(|_| format!("bad date: {val_str}"))?;
+        return Ok(FilterExpr::DateCmp { op: cmp_op, value });
     }
 
     if attr == "mana_cost_jsonb" {
@@ -1291,7 +1479,7 @@ fn build_text_filter(attr: &str, op: &str, rhs: &Value) -> Result<FilterExpr, St
     let raw_value = rhs["kwargs"]["value"].as_str().unwrap_or("");
 
     if matches!(attr, "card_set_code" | "card_layout" | "card_border" | "card_watermark" | "collector_number") {
-        // collector_number is stored raw and mixed-case (e.g. "10E-105"); compare exactly,
+        // collector_number_id is stored raw and mixed-case (e.g. "10E-105"); compare exactly,
         // matching the SQL path. The other four are lowercased at import, so lowercasing
         // the query value gives case-insensitive matching with a plain equality.
         let value = if attr == "collector_number" { raw_value.to_string() } else { raw_value.to_lowercase() };
@@ -1334,7 +1522,105 @@ fn build_text_filter(attr: &str, op: &str, rhs: &Value) -> Result<FilterExpr, St
 
 type TrigramIndex = HashMap<[u8; 3], Vec<u32>>;
 
-fn build_trigram_index(cards: &[Card], get_text: impl Fn(&Card) -> &str) -> TrigramIndex {
+/// Oracle-text trigram index, deduplicated by distinct text.
+///
+/// Printings massively share oracle text (~96k printings, ~28k distinct texts), so
+/// posting card indices directly would store every posting ~3.4× over. Instead the
+/// posting lists hold *dense text ids* — a private 0..n_texts numbering of the
+/// distinct `oracle_text_lower_id` values — and a CSR (compressed sparse row) table
+/// expands a text id back to the printings that carry it. Logically the CSR is an
+/// array-of-arrays `expansion[text_id] → [card indices]`, flattened into two
+/// allocations so it archives as two contiguous, zero-copy slices.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct OracleTextIndex {
+    /// trigram → ascending list of dense text ids whose text contains it.
+    trigrams: TrigramIndex,
+    /// Row boundaries: printings of text id `t` live at
+    /// `card_indices[offsets[t] .. offsets[t + 1]]`. Length n_texts + 1.
+    offsets: Vec<u32>,
+    /// All card indices, grouped by text id; every printing appears exactly once
+    /// (its text interned to exactly one id), so expansion can never duplicate.
+    card_indices: Vec<u32>,
+}
+
+fn build_oracle_text_index(cards: &[Card], strings: &[String]) -> OracleTextIndex {
+    // Dense remap: the interner's ids index the *global* string table (oracle texts
+    // mixed with type lines, set names, ...), so the distinct oracle texts are sparse
+    // in that space. Re-number just them, first-seen order, so the CSR table below
+    // has no empty rows and posting ids stay small.
+    let mut dense: HashMap<u32, u32> = HashMap::new();
+    let mut text_id_of_card: Vec<u32> = Vec::with_capacity(cards.len());
+    for c in cards {
+        let next = dense.len() as u32;
+        text_id_of_card.push(*dense.entry(c.oracle_text_lower_id).or_insert(next));
+    }
+    let n_texts = dense.len();
+
+    // Invert the remap (dense id → global id) so each distinct text is visited once.
+    let mut global_of_dense: Vec<u32> = vec![0; n_texts];
+    for (&global, &d) in &dense {
+        global_of_dense[d as usize] = global;
+    }
+
+    // Trigram postings over distinct texts only — the window-sliding loop runs once
+    // per text instead of once per printing. Visiting texts in ascending dense-id
+    // order appends ids in ascending order, giving the sorted posting lists that
+    // intersect_sorted() requires, with no per-list sort.
+    let mut trigrams: TrigramIndex = HashMap::new();
+    for (d, &global) in global_of_dense.iter().enumerate() {
+        let bytes = strings[global as usize].as_bytes();
+        if bytes.len() < 3 {
+            continue;
+        }
+        for w in bytes.windows(3) {
+            let list = trigrams.entry([w[0], w[1], w[2]]).or_default();
+            if list.last() != Some(&(d as u32)) {
+                list.push(d as u32);
+            }
+        }
+    }
+
+    // CSR expansion table via counting sort: count printings per text, prefix-sum
+    // the counts into row offsets, then place each card index in its row. Placement
+    // walks cards in store order, so every row comes out sorted by card index.
+    let mut offsets: Vec<u32> = vec![0; n_texts + 1];
+    for &t in &text_id_of_card {
+        offsets[t as usize + 1] += 1;
+    }
+    for i in 1..offsets.len() {
+        offsets[i] += offsets[i - 1];
+    }
+    let mut cursor: Vec<u32> = offsets.clone();
+    let mut card_indices: Vec<u32> = vec![0; cards.len()];
+    for (card_idx, &t) in text_id_of_card.iter().enumerate() {
+        card_indices[cursor[t as usize] as usize] = card_idx as u32;
+        cursor[t as usize] += 1;
+    }
+
+    OracleTextIndex { trigrams, offsets, card_indices }
+}
+
+/// Expand surviving dense text ids to card indices via the CSR table.
+///
+/// Each row is internally sorted (placement above walks store order), but rows are
+/// not ordered relative to each other (dense ids are first-seen order), so the
+/// concatenation needs one final sort — required both by intersect_sorted() when
+/// And-combining with other candidate sets and by the linear dedup paths, which
+/// assume candidates arrive in store order.
+fn expand_text_ids(idx: &Archived<OracleTextIndex>, text_ids: &[u32]) -> Vec<u32> {
+    let mut out: Vec<u32> = Vec::new();
+    for &t in text_ids {
+        let start = u32::from(idx.offsets[t as usize]) as usize;
+        let end = u32::from(idx.offsets[t as usize + 1]) as usize;
+        out.extend(idx.card_indices[start..end].iter().map(|x| u32::from(*x)));
+    }
+    out.sort_unstable();
+    out
+}
+
+// Named lifetime (not elided/HRTB) so get_text may return text borrowed from the
+// string table rather than from the card itself.
+fn build_trigram_index<'a>(cards: &'a [Card], get_text: impl Fn(&'a Card) -> &'a str) -> TrigramIndex {
     let mut idx: TrigramIndex = HashMap::new();
     for (i, card) in cards.iter().enumerate() {
         let text  = get_text(card);
@@ -1499,7 +1785,7 @@ fn build_list_index(cards: &[Card], get_list: impl Fn(&Card) -> &Vec<String>) ->
 #[derive(Archive, Serialize, Deserialize)]
 struct CardIndexes {
     name_trigram:   TrigramIndex,
-    oracle_trigram: TrigramIndex,
+    oracle_trigram: OracleTextIndex,
     cmc:            NumericIndex,
     power:          NumericIndex,
     toughness:      NumericIndex,
@@ -1514,7 +1800,7 @@ impl Default for CardIndexes {
     fn default() -> Self {
         CardIndexes {
             name_trigram:   HashMap::new(),
-            oracle_trigram: HashMap::new(),
+            oracle_trigram: OracleTextIndex::default(),
             cmc:            Vec::new(),
             power:          Vec::new(),
             toughness:      Vec::new(),
@@ -1530,6 +1816,8 @@ impl Default for CardIndexes {
 #[derive(Archive, Serialize, Deserialize)]
 struct CardData {
     cards:   Vec<Card>,
+    // Hash-consed table for the interned-string fields on Card (see Interner).
+    strings: Vec<String>,
     indexes: CardIndexes,
     // The writer's format→shift assignments. Persisted so reader processes —
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
@@ -1559,8 +1847,14 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Op
             if word.len() >= 3
                 && matches!(field, TextSearchField::NameLower | TextSearchField::OracleTextLower) =>
         {
-            let idx = if *field == TextSearchField::NameLower { &indexes.name_trigram } else { &indexes.oracle_trigram };
-            trigram_candidates(idx, word)
+            match field {
+                TextSearchField::NameLower => trigram_candidates(&indexes.name_trigram, word),
+                // Oracle postings are in dense text-id space (see OracleTextIndex);
+                // intersect there (~3× shorter lists), then expand the survivors to
+                // card indices through the CSR table.
+                _ => trigram_candidates(&indexes.oracle_trigram.trigrams, word)
+                    .map(|text_ids| expand_text_ids(&indexes.oracle_trigram, &text_ids)),
+            }
         }
 
         FilterExpr::NumericCmp { lhs, op, rhs } => match (lhs, rhs) {
@@ -1742,6 +2036,7 @@ fn select_page<'a>(mut v: Vec<(u128, &'a ACard)>, offset: usize, limit: usize) -
 
 fn run_query_hashmap<'a>(
     store: &'a [ACard],
+    strings: &AStrings,
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1761,14 +2056,14 @@ fn run_query_hashmap<'a>(
         _          => GroupBy::Oracle,
     };
 
-    let mut partitions: HashMap<usize, (&ACard, f64)> = HashMap::new();
+    let mut partitions: HashMap<u128, (&ACard, f64)> = HashMap::new();
     for card in store {
-        if filter.matches(card) {
+        if filter.matches(card, strings) {
             let key = match group_by {
-                GroupBy::Oracle   => u32::from(card.oracle_group) as usize,
-                GroupBy::Artwork  => u32::from(card.artwork_group) as usize,
+                GroupBy::Oracle   => u128::from(card.oracle_id),
+                GroupBy::Artwork  => u128::from(card.illustration_id),
                 // every printing is its own partition — the pointer is a free unique key
-                GroupBy::Printing => std::ptr::from_ref(card) as usize,
+                GroupBy::Printing => std::ptr::from_ref(card) as usize as u128,
             };
             let score = prefer_score(card, prefer);
             let entry = partitions.entry(key).or_insert((card, f64::NEG_INFINITY));
@@ -1786,6 +2081,7 @@ fn run_query_hashmap<'a>(
 
 fn run_query_linear<'a, I, F>(
     cards: I,
+    strings: &AStrings,
     filter: &FilterExpr,
     key_fn: F,
     prefer: &str,
@@ -1796,7 +2092,7 @@ fn run_query_linear<'a, I, F>(
 ) -> (usize, Vec<&'a ACard>)
 where
     I: Iterator<Item = &'a ACard>,
-    F: Fn(&ACard) -> u32,
+    F: Fn(&ACard) -> u128,
 {
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
@@ -1804,14 +2100,14 @@ where
 
     let mut best: Vec<(u128, &ACard)> = Vec::new();
     let mut group_best: Option<(&ACard, f64)> = None;
-    let mut prev_key: u32 = u32::MAX; // group ids are dense from 0, so MAX is a safe sentinel
+    let mut prev_key: Option<u128> = None; // None = before the first match
 
     for card in cards {
-        if !filter.matches(card) { continue; }
+        if !filter.matches(card, strings) { continue; }
         let key = key_fn(card);
-        if key != prev_key {
+        if prev_key != Some(key) {
             if let Some((c, _)) = group_best.take() { best.push((sort_key_bits(c, sort_col, descending), c)); }
-            prev_key   = key;
+            prev_key   = Some(key);
             group_best = Some((card, prefer_score(card, prefer)));
         } else {
             let score = prefer_score(card, prefer);
@@ -1828,6 +2124,7 @@ where
 
 fn run_query_no_dedup<'a>(
     cards: impl Iterator<Item = &'a ACard>,
+    strings: &AStrings,
     filter: &FilterExpr,
     orderby: &str,
     direction: &str,
@@ -1837,7 +2134,7 @@ fn run_query_no_dedup<'a>(
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let matched: Vec<(u128, &ACard)> = cards
-        .filter(|c| filter.matches(c))
+        .filter(|c| filter.matches(c, strings))
         .map(|c| (sort_key_bits(c, sort_col, descending), c))
         .collect();
     let total = matched.len();
@@ -1846,6 +2143,7 @@ fn run_query_no_dedup<'a>(
 
 fn run_query<'a>(
     store: &'a [ACard],
+    strings: &AStrings,
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1867,27 +2165,30 @@ fn run_query<'a>(
     }
 
     match unique {
-        "card" => run_query_linear(cards_iter!(), filter, |c| u32::from(c.oracle_group), prefer, orderby, direction, limit, offset),
+        // The store is sorted by (oracle_id, illustration_id), so equal keys are adjacent
+        // and the linear key-change dedup is exact — u128 equality, same cost as the
+        // dense u32 group ids this replaced.
+        "card" => run_query_linear(cards_iter!(), strings, filter, |c| u128::from(c.oracle_id), prefer, orderby, direction, limit, offset),
         // Scryfall assigns each illustration_id to exactly one oracle_id, so cards sharing an
         // illustration_id are always contiguous in the (oracle_id, illustration_id) sort order.
         // The linear dedup path is therefore correct here — no HashMap needed.
-        "artwork"  => run_query_linear(cards_iter!(), filter, |c| u32::from(c.artwork_group), prefer, orderby, direction, limit, offset),
-        "printing" => run_query_no_dedup(cards_iter!(), filter, orderby, direction, limit, offset),
-        _          => run_query_hashmap(store, filter, unique, prefer, orderby, direction, limit, offset),
+        "artwork"  => run_query_linear(cards_iter!(), strings, filter, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
+        "printing" => run_query_no_dedup(cards_iter!(), strings, filter, orderby, direction, limit, offset),
+        _          => run_query_hashmap(store, strings, filter, unique, prefer, orderby, direction, limit, offset),
     }
 }
 
-fn card_to_pydict<'py>(py: Python<'py>, card: &ACard) -> PyResult<Bound<'py, PyDict>> {
+fn card_to_pydict<'py>(py: Python<'py>, card: &ACard, strings: &AStrings) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
-    d.set_item("name", card.card_name.as_str())?;
+    d.set_item("name", str_at(strings, u32::from(card.card_name_id)))?;
     d.set_item("set_code", card.card_set_code.as_str())?;
-    d.set_item("collector_number", card.collector_number.as_str())?;
-    d.set_item("power", card.creature_power_text.as_ref().map(|s| s.as_str()))?;
-    d.set_item("toughness", card.creature_toughness_text.as_ref().map(|s| s.as_str()))?;
-    d.set_item("mana_cost", card.mana_cost_text.as_ref().map(|s| s.as_str()))?;
-    d.set_item("oracle_text", card.oracle_text.as_str())?;
-    d.set_item("set_name", card.set_name.as_str())?;
-    d.set_item("type_line", card.type_line.as_str())?;
+    d.set_item("collector_number", str_at(strings, u32::from(card.collector_number_id)))?;
+    d.set_item("power", str_at(strings, u32::from(card.creature_power_text_id)))?;
+    d.set_item("toughness", str_at(strings, u32::from(card.creature_toughness_text_id)))?;
+    d.set_item("mana_cost", str_at(strings, u32::from(card.mana_cost_text_id)))?;
+    d.set_item("oracle_text", str_at(strings, u32::from(card.oracle_text_id)))?;
+    d.set_item("set_name", str_at(strings, u32::from(card.set_name_id)))?;
+    d.set_item("type_line", str_at(strings, u32::from(card.type_line_id)))?;
     Ok(d)
 }
 
@@ -1984,54 +2285,36 @@ impl QueryEngine {
             return self.get_mmap().map(|_| ());
         }
 
+        #[cfg(feature = "alloc-counter")]
+        alloc_stats::reset_peak();
+
+        let mut interner = Interner::new();
         let mut cards: Vec<Card> = db_rows
             .iter()
-            .filter_map(|item| item.cast::<PyDict>().ok().map(|d| card_from_pydict(&d)))
+            .filter_map(|item| item.cast::<PyDict>().ok().map(|d| card_from_pydict(&d, &mut interner)))
             .collect();
         // unique=card/artwork group by oracle_id, so cards without one would all
         // collapse into a single group. The DB enforces NOT NULL; fail loudly here
         // for any other caller (e.g. hand-built test dicts).
-        if let Some((idx, card)) = cards
-            .iter()
-            .enumerate()
-            .find(|(_, c)| c.oracle_id.as_deref().unwrap_or("").is_empty())
-        {
+        if let Some((idx, card)) = cards.iter().enumerate().find(|(_, c)| c.oracle_id == 0) {
+            let name = interner.strings.get(card.card_name_id as usize).map_or("", |s| s.as_str());
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "card {idx} ({:?}) is missing oracle_id (required for unique=card dedup)",
-                card.card_name
+                "card {idx} ({name:?}) is missing oracle_id (required for unique=card dedup)"
             )));
         }
-        cards.sort_unstable_by(|a, b| {
-            let oa = a.oracle_id.as_deref().unwrap_or("");
-            let ob = b.oracle_id.as_deref().unwrap_or("");
-            oa.cmp(ob).then_with(|| {
-                let ia = a.illustration_id.as_deref().unwrap_or("");
-                let ib = b.illustration_id.as_deref().unwrap_or("");
-                ia.cmp(ib)
-            })
-        });
+        // Equal keys end up adjacent, which is the only property the linear
+        // key-change dedup paths need — the numeric (vs lexicographic) order is
+        // otherwise irrelevant.
+        cards.sort_unstable_by_key(|c| (c.oracle_id, c.illustration_id));
 
-        // Dense group ids: a group is a maximal run of equal keys in the sort above,
-        // exactly the adjacency the linear dedup paths relied on when they compared
-        // the UUID strings directly. cards[0] keeps the 0/0 defaults.
-        let mut oracle_group: u32 = 0;
-        let mut artwork_group: u32 = 0;
-        for i in 1..cards.len() {
-            let (head, tail) = cards.split_at_mut(i);
-            let (prev, cur) = (&head[i - 1], &mut tail[0]);
-            if prev.oracle_id.as_deref().unwrap_or("") != cur.oracle_id.as_deref().unwrap_or("") {
-                oracle_group += 1;
-            }
-            if prev.illustration_id.as_deref().unwrap_or("") != cur.illustration_id.as_deref().unwrap_or("") {
-                artwork_group += 1;
-            }
-            cur.oracle_group  = oracle_group;
-            cur.artwork_group = artwork_group;
-        }
+        #[cfg(feature = "alloc-counter")]
+        let stats_after_cards = (alloc_stats::live(), alloc_stats::allocs());
 
+        let strings = interner.strings;
+        drop(interner.map);
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
-            oracle_trigram: build_trigram_index(&cards, |c| c.oracle_text_lower.as_str()),
+            oracle_trigram: build_oracle_text_index(&cards, &strings),
             cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
             toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
@@ -2042,12 +2325,24 @@ impl QueryEngine {
             is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
         };
 
+        #[cfg(feature = "alloc-counter")]
+        let stats_after_indexes = (alloc_stats::live(), alloc_stats::allocs());
+        #[cfg(feature = "alloc-counter")]
+        let component_bytes = (
+            rkyv::to_bytes::<rkyv::rancor::Error>(&cards).map(|b| b.len()).unwrap_or(0),
+            rkyv::to_bytes::<rkyv::rancor::Error>(&indexes).map(|b| b.len()).unwrap_or(0),
+            rkyv::to_bytes::<rkyv::rancor::Error>(&strings).map(|b| b.len()).unwrap_or(0),
+        );
+
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, indexes, format_shifts: format_shifts_snapshot };
+        let card_data = CardData { cards, strings, indexes, format_shifts: format_shifts_snapshot };
         let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&card_data)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rkyv serialize: {e}")))?;
+
+        #[cfg(feature = "alloc-counter")]
+        alloc_stats::record_reload(stats_after_cards, stats_after_indexes, component_bytes, bytes.len());
 
         // Write atomically: write to a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -2107,10 +2402,10 @@ impl QueryEngine {
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query(
-            store, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
+            store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 
-        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c)).collect::<PyResult<Vec<_>>>()?;
+        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
@@ -2147,8 +2442,8 @@ impl QueryEngine {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
 
         let store: &[ACard] = &data.cards;
-        let (total, page) = run_query_hashmap(store, &filter_expr, unique, prefer, orderby, direction, limit, offset);
-        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c)).collect::<PyResult<Vec<_>>>()?;
+        let (total, page) = run_query_hashmap(store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset);
+        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
@@ -2159,6 +2454,29 @@ impl QueryEngine {
             // Safety: same as query().
             Ok(mmap) => Ok(unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) }.cards.len()),
         }
+    }
+
+    /// Rust-heap allocator stats and reload() memory breakdown.
+    /// Empty dict unless built with --features alloc-counter (measurement-only).
+    fn mem_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new(py);
+        #[cfg(feature = "alloc-counter")]
+        {
+            use std::sync::atomic::Ordering::Relaxed;
+            d.set_item("live_bytes", alloc_stats::LIVE.load(Relaxed))?;
+            d.set_item("live_allocs", alloc_stats::ALLOCS.load(Relaxed))?;
+            d.set_item("reload_live_before", alloc_stats::RELOAD_LIVE_BEFORE.load(Relaxed))?;
+            d.set_item("reload_live_after_cards", alloc_stats::RELOAD_LIVE_AFTER_CARDS.load(Relaxed))?;
+            d.set_item("reload_allocs_after_cards", alloc_stats::RELOAD_ALLOCS_AFTER_CARDS.load(Relaxed))?;
+            d.set_item("reload_live_after_indexes", alloc_stats::RELOAD_LIVE_AFTER_INDEXES.load(Relaxed))?;
+            d.set_item("reload_allocs_after_indexes", alloc_stats::RELOAD_ALLOCS_AFTER_INDEXES.load(Relaxed))?;
+            d.set_item("reload_peak", alloc_stats::RELOAD_PEAK.load(Relaxed))?;
+            d.set_item("cards_rkyv_bytes", alloc_stats::RELOAD_CARDS_RKYV.load(Relaxed))?;
+            d.set_item("indexes_rkyv_bytes", alloc_stats::RELOAD_INDEXES_RKYV.load(Relaxed))?;
+            d.set_item("strings_rkyv_bytes", alloc_stats::RELOAD_STRINGS_RKYV.load(Relaxed))?;
+            d.set_item("archive_bytes", alloc_stats::RELOAD_ARCHIVE.load(Relaxed))?;
+        }
+        Ok(d)
     }
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -107,15 +107,18 @@ mod alloc_stats {
 
 // ─── Inline string (no heap allocation) ──────────────────────────────────────
 
+// repr(C) guarantees a stable layout ([u8; N] then u8, align 1, no padding)
+// across compiler versions, as the Portable impl below requires.
+#[repr(C)]
 #[derive(Clone, Copy)]
 struct InlineStr<const N: usize> {
     bytes: [u8; N],
     len: u8,
 }
 
-// Safety: InlineStr<N> is plain bytes (Copy), has no padding that could be
-// uninitialized, and carries no internal references — it is safe to treat as
-// a flat, relocatable value in an rkyv archive.
+// Safety: InlineStr<N> is repr(C) with only align-1 fields — a stable, fully
+// initialized, padding-free layout — and carries no internal references, so it
+// is safe to treat as a flat, relocatable value in an rkyv archive.
 unsafe impl<const N: usize> rkyv::Portable for InlineStr<N> {}
 
 impl<const N: usize> Archive for InlineStr<N> {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2413,7 +2413,7 @@ impl QueryEngine {
         //   for in-flight readers across a swap.
         //
         // Checked rkyv::access() re-validates the entire archive graph on every
-        // call: measured at ~10 ms per call on a ~200 MB / 96k-card archive
+        // call: measured at ~7 ms per call on a ~120 MB / 96k-card archive
         // (bench_checked_vs_unchecked_access), vs sub-millisecond query
         // evaluation — a 10-100x slowdown per query. It would also be a false
         // guarantee: InlineStr's CheckBytes is deliberately permissive, so
@@ -2482,7 +2482,7 @@ impl QueryEngine {
             // Safety: see the access_unchecked justification in query(). A file
             // that mapped successfully is always a complete rkyv archive (atomic
             // rename publish), so checked access here would only re-validate
-            // trusted bytes at ~10 ms per size() call.
+            // trusted bytes at ~7 ms per size() call.
             Ok(mmap) => Ok(unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) }.cards.len()),
         }
     }
@@ -2653,76 +2653,77 @@ mod tests {
     fn bench_checked_vs_unchecked_access() {
         const N: usize = 96_000;
         let words = ["draw", "card", "creature", "destroy", "target", "flying", "counter", "spell", "token", "exile"];
-        let cards: Vec<Card> = (0..N)
-            .map(|i| {
-                let name = format!("Benchmark Card Number {i}");
-                let oracle = format!(
-                    "{}: {} a {} {}, then {} {} cards. This text is representative filler standing in for \
-                     real oracle text so string validation cost is realistic for card {i}.",
-                    words[i % 10], words[(i + 1) % 10], words[(i + 2) % 10],
-                    words[(i + 3) % 10], words[(i + 4) % 10], words[(i + 5) % 10],
-                );
-                let flavor = format!("Flavor text for card {i}, roughly the length of a real flavor quote in the dataset.");
-                Card {
-                    card_name_lower: InlineStr::from_str(&name.to_lowercase()),
-                    card_colors: (i % 32) as u8,
-                    card_color_identity: (i % 32) as u8,
-                    produced_mana: 0,
-                    card_types: TYPE_CREATURE,
-                    scryfall_id: format!("00000000-0000-4000-8000-{i:012}"),
-                    oracle_id: Some(format!("11111111-0000-4000-8000-{:012}", i / 3)),
-                    illustration_id: Some(format!("22222222-0000-4000-8000-{i:012}")),
-                    card_name: name.clone(),
-                    oracle_text: oracle.clone(),
-                    oracle_text_lower: oracle.to_lowercase(),
-                    flavor_text: flavor.clone(),
-                    flavor_text_lower: flavor.to_lowercase(),
-                    card_artist: Some(format!("Artist {}", i % 1000)),
-                    card_artist_lower: Some(format!("artist {}", i % 1000)),
-                    card_set_code: InlineStr::from_str("bench"),
-                    card_layout: "normal".to_string(),
-                    card_border: "black".to_string(),
-                    card_watermark: None,
-                    collector_number: format!("{}", i % 500),
-                    mana_cost_text: Some("{2}{G}{G}".to_string()),
-                    type_line: "Creature — Benchmark".to_string(),
-                    set_name: format!("Benchmark Set {}", i % 300),
-                    released_at: "2024-01-01".to_string(),
-                    released_at_int: Some(20240101),
-                    oracle_group: (i / 3) as u32,
-                    artwork_group: i as u32,
-                    cmc: Some((i % 8) as u8),
-                    creature_power: Some((i % 10) as i8),
-                    creature_toughness: Some((i % 10) as i8),
-                    planeswalker_loyalty: None,
-                    card_rarity_int: Some((i % 4) as u8),
-                    collector_number_int: Some((i % 500) as u16),
-                    edhrec_rank: Some(i as u32),
-                    price_usd: Some(1.0),
-                    price_eur: Some(1.0),
-                    price_tix: Some(0.1),
-                    prefer_score: None,
-                    cubecobra_score: None,
-                    card_subtypes: vec!["Benchmark".to_string(), words[i % 10].to_string()],
-                    card_keywords: HashSet::from([words[i % 10].to_string()]),
-                    card_legalities: 0,
-                    card_oracle_tags: HashSet::from([format!("tag-{}", i % 100)]),
-                    card_is_tags: HashSet::new(),
-                    card_frame_data: HashSet::new(),
-                    mana_cost: ManaCost {
-                        pips: HashMap::from([("G".to_string(), 2u8)]),
-                        devotion: None,
-                        cmc: (i % 8) as f32,
-                    },
-                    creature_power_text: None,
-                    creature_toughness_text: None,
-                }
-            })
-            .collect();
+        let mut interner = Interner::new();
+        let mut cards: Vec<Card> = Vec::with_capacity(N);
+        for i in 0..N {
+            let name = format!("Benchmark Card Number {i}");
+            // Oracle text keyed on i/3 so printings share texts ~3x, matching the
+            // real dataset's duplication (and exercising the CSR oracle index).
+            let group = i / 3;
+            let oracle = format!(
+                "{}: {} a {} {}, then {} {} cards. This text is representative filler standing in for \
+                 real oracle text so string validation cost is realistic for card group {group}.",
+                words[group % 10], words[(group + 1) % 10], words[(group + 2) % 10],
+                words[(group + 3) % 10], words[(group + 4) % 10], words[(group + 5) % 10],
+            );
+            let flavor = format!("Flavor text for card {i}, roughly the length of a real flavor quote in the dataset.");
+            cards.push(Card {
+                card_name_lower: InlineStr::from_str(&name.to_lowercase()),
+                card_colors: (i % 32) as u8,
+                card_color_identity: (i % 32) as u8,
+                produced_mana: 0,
+                card_types: TYPE_CREATURE,
+                scryfall_id: (i + 1) as u128,
+                oracle_id: (group + 1) as u128,
+                illustration_id: (i + 1) as u128,
+                card_name_id: interner.intern(name.clone()),
+                oracle_text_id: interner.intern(oracle.clone()),
+                oracle_text_lower_id: interner.intern(oracle.to_lowercase()),
+                flavor_text_id: interner.intern(flavor.clone()),
+                flavor_text_lower_id: interner.intern(flavor.to_lowercase()),
+                card_artist_id: interner.intern(format!("Artist {}", i % 1000)),
+                card_artist_lower_id: interner.intern(format!("artist {}", i % 1000)),
+                card_set_code: InlineStr::from_str("bench"),
+                card_layout_id: interner.intern("normal".to_string()),
+                card_border_id: interner.intern("black".to_string()),
+                card_watermark_id: NONE_STR,
+                collector_number_id: interner.intern(format!("{}", i % 500)),
+                mana_cost_text_id: interner.intern("{2}{G}{G}".to_string()),
+                type_line_id: interner.intern("Creature — Benchmark".to_string()),
+                set_name_id: interner.intern(format!("Benchmark Set {}", i % 300)),
+                released_at_int: Some(20240101),
+                cmc: Some((i % 8) as u8),
+                creature_power: Some((i % 10) as i8),
+                creature_toughness: Some((i % 10) as i8),
+                planeswalker_loyalty: None,
+                card_rarity_int: Some((i % 4) as u8),
+                collector_number_int: Some((i % 500) as u16),
+                edhrec_rank: Some(i as u32),
+                price_usd: Some(1.0),
+                price_eur: Some(1.0),
+                price_tix: Some(0.1),
+                prefer_score: None,
+                cubecobra_score: None,
+                card_subtypes: vec!["Benchmark".to_string(), words[i % 10].to_string()],
+                card_keywords: HashSet::from([words[i % 10].to_string()]),
+                card_legalities: 0,
+                card_oracle_tags: HashSet::from([format!("tag-{}", i % 100)]),
+                card_is_tags: HashSet::new(),
+                card_frame_data: HashSet::new(),
+                mana_cost: ManaCost {
+                    pips: HashMap::from([("G".to_string(), 2u8)]),
+                    devotion: None,
+                    cmc: (i % 8) as f32,
+                },
+                creature_power_text_id: NONE_STR,
+                creature_toughness_text_id: NONE_STR,
+            });
+        }
+        let strings = interner.strings;
 
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
-            oracle_trigram: build_trigram_index(&cards, |c| c.oracle_text_lower.as_str()),
+            oracle_trigram: build_oracle_text_index(&cards, &strings),
             cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
             toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
@@ -2732,7 +2733,7 @@ mod tests {
             oracle_tags:    build_tag_index(&cards, |c| &c.card_oracle_tags),
             is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
         };
-        let data = CardData { cards, indexes, format_shifts: HashMap::new() };
+        let data = CardData { cards, strings, indexes, format_shifts: HashMap::new() };
         let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
         println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -135,9 +135,12 @@ impl<const N: usize, D: rkyv::rancor::Fallible + ?Sized> Deserialize<InlineStr<N
     fn deserialize(&self, _: &mut D) -> Result<InlineStr<N>, D::Error> { Ok(*self) }
 }
 
-// Safety: InlineStr<N> contains only a [u8; N] and a u8 len -- both are always
-// valid regardless of their byte contents. No pointers, no enums, no invariants
-// that could be violated by arbitrary bytes. This impl simply trusts the data.
+// Deliberately permissive: this impl trusts the data rather than validating it
+// (a real check would verify len <= N and UTF-8, since as_str() converts
+// unchecked). It exists only to satisfy the derived CheckBytes bounds on the
+// archived containers; validation is never the engine's safety boundary — the
+// archive is trusted by construction (see the access_unchecked justification
+// in QueryEngine::query()), so checked access is not relied on for soundness.
 unsafe impl<const N: usize, C: rkyv::rancor::Fallible + ?Sized> rkyv::bytecheck::CheckBytes<C> for InlineStr<N> {
     unsafe fn check_bytes(
         _value: *const Self,
@@ -2389,9 +2392,29 @@ impl QueryEngine {
         // get_mmap() remaps automatically if the on-disk inode has changed since
         // the last reload, keeping workers off stale (deleted) mappings.
         let mmap = self.get_mmap()?;
-        // Safety: bytes were written by rkyv::to_bytes on this platform.
-        // The archive is immutable once written; reloads atomically replace the
-        // file, never modifying it in place. The Arc keeps the mapping alive.
+        // Safety: the archive is trusted by construction, so we skip validation.
+        // This is the canonical justification for every access_unchecked in this
+        // module (query_hashmap() and size() refer here):
+        //
+        // - The only writer is reload() in this module: the bytes come from
+        //   rkyv::to_bytes in the same build of this crate that reads them. In
+        //   production the archive lives in container-scoped tmpfs (/dev/shm),
+        //   so it cannot outlive the build that wrote it. (On macOS dev, /tmp
+        //   persists — after changing any archived type, delete the archive.)
+        // - A torn or truncated archive is never observable: reload() writes to
+        //   a per-PID temp file and publishes it with rename(2), which is
+        //   atomic. A crashed writer leaves a stale .tmp, never a partial file
+        //   at shm_path. A missing archive already failed in get_mmap().
+        // - The mapping is immutable: replacement is rename-only, the file is
+        //   never modified in place, and the Arc keeps the old mapping alive
+        //   for in-flight readers across a swap.
+        //
+        // Checked rkyv::access() re-validates the entire archive graph on every
+        // call: measured at ~10 ms per call on a ~200 MB / 96k-card archive
+        // (bench_checked_vs_unchecked_access), vs sub-millisecond query
+        // evaluation — a 10-100x slowdown per query. It would also be a false
+        // guarantee: InlineStr's CheckBytes is deliberately permissive, so
+        // validation cannot be the safety boundary; the trusted write path is.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) };
 
         // Must run before build_filter so legality shifts resolve in workers
@@ -2433,7 +2456,7 @@ impl QueryEngine {
         let json_val: Value = serde_json::from_str(json_str)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad query JSON: {e}")))?;
         let mmap = self.get_mmap()?;
-        // Safety: same as query().
+        // Safety: see the access_unchecked justification in query().
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) };
 
         // Must run before build_filter; see query().
@@ -2450,8 +2473,13 @@ impl QueryEngine {
 
     fn size(&self) -> PyResult<usize> {
         match self.get_mmap() {
+            // Missing/unopenable archive — the only "unreadable" state that can
+            // occur. Returns 0 so Python treats the engine as empty.
             Err(_) => Ok(0),
-            // Safety: same as query().
+            // Safety: see the access_unchecked justification in query(). A file
+            // that mapped successfully is always a complete rkyv archive (atomic
+            // rename publish), so checked access here would only re-validate
+            // trusted bytes at ~10 ms per size() call.
             Ok(mmap) => Ok(unsafe { rkyv::access_unchecked::<Archived<CardData>>(&mmap) }.cards.len()),
         }
     }
@@ -2609,5 +2637,118 @@ mod tests {
             .collect();
         assert_eq!(merfolk, vec![1, 5, 9]);
         assert!(archived.get("angel").is_none());
+    }
+
+    /// Measures checked rkyv::access vs access_unchecked on a production-scale
+    /// archive. This is the evidence behind the access_unchecked safety comments
+    /// on query()/size(): checked access re-validates the entire archive graph
+    /// on every call, which is milliseconds per call at ~100k cards — orders of
+    /// magnitude over total query time. Run with:
+    ///   cargo test --release -- --ignored bench_checked_vs_unchecked --nocapture
+    #[test]
+    #[ignore]
+    fn bench_checked_vs_unchecked_access() {
+        const N: usize = 96_000;
+        let words = ["draw", "card", "creature", "destroy", "target", "flying", "counter", "spell", "token", "exile"];
+        let cards: Vec<Card> = (0..N)
+            .map(|i| {
+                let name = format!("Benchmark Card Number {i}");
+                let oracle = format!(
+                    "{}: {} a {} {}, then {} {} cards. This text is representative filler standing in for \
+                     real oracle text so string validation cost is realistic for card {i}.",
+                    words[i % 10], words[(i + 1) % 10], words[(i + 2) % 10],
+                    words[(i + 3) % 10], words[(i + 4) % 10], words[(i + 5) % 10],
+                );
+                let flavor = format!("Flavor text for card {i}, roughly the length of a real flavor quote in the dataset.");
+                Card {
+                    card_name_lower: InlineStr::from_str(&name.to_lowercase()),
+                    card_colors: (i % 32) as u8,
+                    card_color_identity: (i % 32) as u8,
+                    produced_mana: 0,
+                    card_types: TYPE_CREATURE,
+                    scryfall_id: format!("00000000-0000-4000-8000-{i:012}"),
+                    oracle_id: Some(format!("11111111-0000-4000-8000-{:012}", i / 3)),
+                    illustration_id: Some(format!("22222222-0000-4000-8000-{i:012}")),
+                    card_name: name.clone(),
+                    oracle_text: oracle.clone(),
+                    oracle_text_lower: oracle.to_lowercase(),
+                    flavor_text: flavor.clone(),
+                    flavor_text_lower: flavor.to_lowercase(),
+                    card_artist: Some(format!("Artist {}", i % 1000)),
+                    card_artist_lower: Some(format!("artist {}", i % 1000)),
+                    card_set_code: InlineStr::from_str("bench"),
+                    card_layout: "normal".to_string(),
+                    card_border: "black".to_string(),
+                    card_watermark: None,
+                    collector_number: format!("{}", i % 500),
+                    mana_cost_text: Some("{2}{G}{G}".to_string()),
+                    type_line: "Creature — Benchmark".to_string(),
+                    set_name: format!("Benchmark Set {}", i % 300),
+                    released_at: "2024-01-01".to_string(),
+                    released_at_int: Some(20240101),
+                    oracle_group: (i / 3) as u32,
+                    artwork_group: i as u32,
+                    cmc: Some((i % 8) as u8),
+                    creature_power: Some((i % 10) as i8),
+                    creature_toughness: Some((i % 10) as i8),
+                    planeswalker_loyalty: None,
+                    card_rarity_int: Some((i % 4) as u8),
+                    collector_number_int: Some((i % 500) as u16),
+                    edhrec_rank: Some(i as u32),
+                    price_usd: Some(1.0),
+                    price_eur: Some(1.0),
+                    price_tix: Some(0.1),
+                    prefer_score: None,
+                    cubecobra_score: None,
+                    card_subtypes: vec!["Benchmark".to_string(), words[i % 10].to_string()],
+                    card_keywords: HashSet::from([words[i % 10].to_string()]),
+                    card_legalities: 0,
+                    card_oracle_tags: HashSet::from([format!("tag-{}", i % 100)]),
+                    card_is_tags: HashSet::new(),
+                    card_frame_data: HashSet::new(),
+                    mana_cost: ManaCost {
+                        pips: HashMap::from([("G".to_string(), 2u8)]),
+                        devotion: None,
+                        cmc: (i % 8) as f32,
+                    },
+                    creature_power_text: None,
+                    creature_toughness_text: None,
+                }
+            })
+            .collect();
+
+        let indexes = CardIndexes {
+            name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
+            oracle_trigram: build_trigram_index(&cards, |c| c.oracle_text_lower.as_str()),
+            cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
+            power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
+            toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
+            type_bits:      build_type_index(&cards),
+            subtypes:       build_list_index(&cards, |c| &c.card_subtypes),
+            keywords:       build_tag_index(&cards, |c| &c.card_keywords),
+            oracle_tags:    build_tag_index(&cards, |c| &c.card_oracle_tags),
+            is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
+        };
+        let data = CardData { cards, indexes, format_shifts: HashMap::new() };
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);
+
+        const ITERS: u32 = 10;
+        let t = std::time::Instant::now();
+        for _ in 0..ITERS {
+            let a = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("checked access");
+            assert_eq!(a.cards.len(), N);
+        }
+        let checked = t.elapsed() / ITERS;
+
+        let t = std::time::Instant::now();
+        for _ in 0..ITERS {
+            let a = unsafe { rkyv::access_unchecked::<Archived<CardData>>(&bytes) };
+            assert_eq!(a.cards.len(), N);
+        }
+        let unchecked = t.elapsed() / ITERS;
+
+        println!("checked rkyv::access:   {checked:?} per call");
+        println!("access_unchecked:       {unchecked:?} per call");
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
         GIT_SHA: ${GIT_SHA:-unknown}
         GIT_BRANCH: ${GIT_BRANCH:-unknown}
     image: arcane_tutor/apiservice:${IMAGE_TAG:-latest}
+    shm_size: 3000M
     cap_add:
       - ALL
     command:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 boto3-stubs[s3]
+maturin
 pytest
 pytest-cov
 pytest-profiling


### PR DESCRIPTION
Moves the Rust engine's card store out of per-worker process memory and into a single
shared-memory archive that all workers mmap. The store (cards + prebuilt search indexes) is
serialized with [rkyv](https://rkyv.org/) into a flat, pointer-free buffer at
`/dev/shm/arcane_tutor_cards` (Linux; `/tmp` on macOS), written once, and mapped read-only by
every worker. Queries evaluate directly against the archived types (`Archived<Card>`) with zero
deserialization — no copies, no IPC.

## Why

At ~95k cards the in-process store is roughly 150–200 MB per worker. With 4–5 Bjoern workers
that's ~800 MB–1 GB of RSS holding identical data. After this change the data exists once in
tmpfs, and every worker shares the same physical pages. It also means only **one** worker pays
the reload cost (full-table fetch + dict conversion + serialization) instead of all of them.

## How it works

**Write path** (`QueryEngine.reload`):

- Cross-worker `multiprocessing.Lock` in Python (`engine_reload_guard`, wired from
  `entrypoint.py` through `ApiWorker`) plus a cross-process `flock` in Rust (EINTR-retried,
  any other failure raises rather than proceeding lockless).
- The winner serializes cards + indexes (trigram, numeric, type/subtype/tag) into one rkyv
  buffer, writes it to a per-PID temp file behind a 16-byte header (magic + format version +
  `size_of::<Archived<Card>>`), and `rename()`s it over the archive path atomically.
- Losers detect the archive was refreshed while they waited (its inode changed across the
  flock — publish is rename-only, so a publish always changes the inode) and skip the rebuild.
- `_reload_engine(force=...)`: `force=True` (data just changed) waits its turn and rebuilds;
  `force=False` (cold-start warming) returns immediately if another worker is already on it or
  the store is populated.

**Read path** (`QueryEngine.query`):

- One `stat(2)` per query; remap only when the archive's inode changes (i.e. a reload happened).
  The cached inode comes from `fstat` on the opened handle, so a concurrent swap between the
  path stat and the open can't poison the cache.
- Every (re)map validates the archive header before `access_unchecked`: a stale archive from an
  older build (different archived layout) — or any foreign file at the path — reads as empty
  and gets rebuilt, instead of being undefined behavior.
- The mmap is never modified in place — replacement is rename-only, so concurrent readers on the
  old mapping stay valid.

**Cold start**: while the store is empty, `_search` serves from SQL and kicks off a background
engine reload thread, so first requests aren't blocked on the full-table fetch.

## Notable internal changes

- `FilterExpr` text fields use enum dispatch (`TextField` / `TextSearchField`) instead of
  function pointers — filters must evaluate against `&Archived<Card>`, which fn pointers over
  `&Card` can't do.
- Fixed-size `InlineStr<N>` for hot string fields so they archive as plain bytes.
- Trigram intersection runs zero-copy over the archived posting lists (`intersect_sorted` is
  generic over the second operand's element type, a no-op conversion on little-endian); only
  the shortest list is materialized, and repeated trigrams (e.g. "aaaa") are deduplicated by
  pointer instead of intersected twice.
- `docker-compose.yml`: `shm_size: 3000M` for the API container so `/dev/shm` fits the archive.

## Supporting changes that rode along

- **Test split by search layer**: `_search_sql` and `_search_engine` are tested directly;
  `_search` routing (empty store → SQL, populated → engine, engine error → SQL fallback) is
  tested with a mocked engine in `test_parsing_errors.py`. The shared `search_kwargs` helper
  moved to `api/tests/helpers.py`. This removes the test-order dependence where a populated
  shared archive flipped unrelated tests onto the engine path. Engine unit tests mint
  per-test snapshot paths via a `fresh_engine` factory fixture that removes its archives and
  lock files at teardown.
- **`make engine`**: builds and installs the PyO3 extension via maturin (with `~/.cargo/bin` on
  PATH); `test`, `test-unit`, and `test-integration` now depend on it so tests never run against
  a stale `.so`. `maturin` added to `requirements/test.txt`.
- **Scryfall fetcher hardening**: transport-level retries with backoff (429/5xx) via
  `HTTPAdapter` + `Retry`, and response bodies logged on HTTP errors.

## Testing

- Full unit suite passes (1766 passed, 1 skipped), including with a pre-populated archive
  present — the order-dependent failure mode is gone.
- `cargo test` clean (7 passed); engine rebuilt and exercised through `make test`.
- Header rejection verified against a real stale archive from a pre-header build: it reads as
  `size() == 0` and is rebuilt by the next reload; a garbage file at the path raises a clear
  "archive header mismatch" error instead of being mapped.
