### PR TITLE
Cache rendered response bytes instead of falcon.Response objects

### DIFF
--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -11,13 +11,22 @@ from cachebox import LRUCache
 from api.settings import settings
 
 if TYPE_CHECKING:
-    from collections.abc import MutableMapping
+    from collections.abc import Mapping, MutableMapping
 
     import falcon
 
 logger = logging.getLogger(__name__)
 
 CacheKey = tuple[str, tuple[tuple, ...], tuple[tuple, ...]]
+
+# Headers that depend on the request rather than the cached payload: CORSMiddleware varies
+# Access-Control-* on the request's Origin and re-sets them on every response, including hits.
+_UNCACHEABLE_HEADER_PREFIXES: tuple[str, ...] = ("access-control-",)
+
+
+def cacheable_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Return the subset of headers safe to replay on a cache hit for a different request."""
+    return {k: v for k, v in headers.items() if not k.lower().startswith(_UNCACHEABLE_HEADER_PREFIXES)}
 
 
 class CachedResponse(NamedTuple):
@@ -125,7 +134,7 @@ class CachingMiddleware:
         is_dict_media = isinstance(media, dict)
         self.cache[cache_key] = CachedResponse(
             status=resp.status,
-            headers=dict(resp._headers),
+            headers=cacheable_headers(resp._headers),
             body=resp.render_body(),
             result_count=len(media.get("cards") or []) if is_dict_media else None,
             total_cards=media.get("total_cards") if is_dict_media else None,

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 from typing import cast as typecast
 
 from cachebox import LRUCache
@@ -20,6 +20,22 @@ logger = logging.getLogger(__name__)
 CacheKey = tuple[str, tuple[tuple, ...], tuple[tuple, ...]]
 
 
+class CachedResponse(NamedTuple):
+    """Fully rendered response, detached from the falcon.Response that produced it.
+
+    The body is captured after the compression middleware has run, so it holds the final
+    (possibly compressed) bytes for the Accept-Encoding in the cache key. result_count and
+    total_cards exist solely so QueryLogMiddleware can log them on cache hits, where the
+    media dict is no longer available.
+    """
+
+    status: str
+    headers: dict[str, str]
+    body: bytes | None
+    result_count: int | None
+    total_cards: int | None
+
+
 class CachingMiddleware:
     """Middleware to cache the request and response."""
 
@@ -31,7 +47,7 @@ class CachingMiddleware:
         """
         if cache is None:
             cache = LRUCache(maxsize=10_000)
-        self.cache: MutableMapping[CacheKey, falcon.Response] = cache
+        self.cache: MutableMapping[CacheKey, CachedResponse] = cache
 
     def _cache_key(self: CachingMiddleware, req: falcon.Request) -> CacheKey:
         cached_headers = [
@@ -61,19 +77,18 @@ class CachingMiddleware:
             return
 
         cache_key = self._cache_key(req)
-        cached_value: falcon.Response | None = self.cache.get(cache_key)
-        if cached_value is not None:
+        cached: CachedResponse | None = self.cache.get(cache_key)
+        if cached is not None:
             if TYPE_CHECKING:
-                cached_value = typecast("falcon.Response", cached_value)
+                cached = typecast("CachedResponse", cached)
             resp.complete = True
-            resp.data = cached_value.data
-            if isinstance(cached_value.media, dict):
-                resp.media = dict(cached_value.media)
-                resp.media["cache_hit"] = True
-            else:
-                resp.media = cached_value.media
-            resp._headers.update(cached_value._headers)
-            resp.status = cached_value.status
+            resp.status = cached.status
+            resp.data = cached.body
+            resp._headers.update(cached.headers)
+            resp.set_header("X-Cache", "hit")
+            req.context["cache_hit"] = True
+            req.context["cached_result_count"] = cached.result_count
+            req.context["cached_total_cards"] = cached.total_cards
             logger.info("Cache hit: %s / %s response_id: %d", req.relative_uri, resp.status, id(resp))
             return
         logger.info("Cache miss: %s / %s", req.relative_uri, cache_key)
@@ -99,11 +114,20 @@ class CachingMiddleware:
             return
 
         del resource, req_succeeded
+        if req.context.get("cache_hit"):
+            return
         if resp.status and resp.status.startswith("5"):
             return
         cache_key = self._cache_key(req)
-        cached_val = self.cache.get(cache_key)
-        if cached_val is None:
-            resp.complete = True
-            self.cache[cache_key] = resp
-            logger.info("Cache updated: %s / %s", req.relative_uri, cache_key)
+        if self.cache.get(cache_key) is not None:
+            return
+        media = resp.media
+        is_dict_media = isinstance(media, dict)
+        self.cache[cache_key] = CachedResponse(
+            status=resp.status,
+            headers=dict(resp._headers),
+            body=resp.render_body(),
+            result_count=len(media.get("cards") or []) if is_dict_media else None,
+            total_cards=media.get("total_cards") if is_dict_media else None,
+        )
+        logger.info("Cache updated: %s / %s", req.relative_uri, cache_key)

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -20,8 +20,9 @@ logger = logging.getLogger(__name__)
 CacheKey = tuple[str, tuple[tuple, ...], tuple[tuple, ...]]
 
 # Headers that depend on the request rather than the cached payload: CORSMiddleware varies
-# Access-Control-* on the request's Origin and re-sets them on every response, including hits.
-_UNCACHEABLE_HEADER_PREFIXES: tuple[str, ...] = ("access-control-",)
+# Access-Control-* on the request's Origin and re-sets them on every response, including hits;
+# X-Cache describes this request's cache outcome, so a stored "miss" must never be replayed.
+_UNCACHEABLE_HEADER_PREFIXES: tuple[str, ...] = ("access-control-", "x-cache")
 
 
 def cacheable_headers(headers: Mapping[str, str]) -> dict[str, str]:
@@ -100,6 +101,7 @@ class CachingMiddleware:
             req.context["cached_total_cards"] = cached.total_cards
             logger.info("Cache hit: %s / %s response_id: %d", req.relative_uri, resp.status, id(resp))
             return
+        resp.set_header("X-Cache", "miss")
         logger.info("Cache miss: %s / %s", req.relative_uri, cache_key)
 
     def process_response(

--- a/api/middlewares/query_log_middleware.py
+++ b/api/middlewares/query_log_middleware.py
@@ -146,25 +146,34 @@ class QueryLogMiddleware:
         if req.path.strip("/") != "search":
             return
 
-        media = resp.media
-        if not isinstance(media, dict):
-            logger.warning("QueryLogMiddleware: unexpected response media type %s for %s", type(media), req.path)
-            return
+        cache_hit = bool(req.context.get("cache_hit"))
+        if cache_hit:
+            # The cached response is rendered bytes; counts were captured at cache-store time.
+            execute_ms = fetch_ms = None
+            result_count = req.context.get("cached_result_count")
+            total_cards = req.context.get("cached_total_cards")
+        else:
+            media = resp.media
+            if not isinstance(media, dict):
+                logger.warning("QueryLogMiddleware: unexpected response media type %s for %s", type(media), req.path)
+                return
+            children = (media.get("inner_timings") or {}).get("_children") or {}
+            execute_ms = children.get("execute_query", {}).get("_meta", {}).get("duration_ms")
+            fetch_ms = children.get("fetch_results", {}).get("_meta", {}).get("duration_ms")
+            result_count = len(media.get("cards") or [])
+            total_cards = media.get("total_cards")
 
         start = req.context.get("_start_time")
         total_ms = (time.monotonic() - start) * 1000 if start is not None else None
 
-        cache_hit = media.get("cache_hit", False)
-        children = (media.get("inner_timings") or {}).get("_children") or {}
-
         entry: dict = {
             "q": req.params.get("q"),
             "cache_hit": cache_hit,
-            "execute_ms": children.get("execute_query", {}).get("_meta", {}).get("duration_ms") if not cache_hit else None,
-            "fetch_ms": children.get("fetch_results", {}).get("_meta", {}).get("duration_ms") if not cache_hit else None,
+            "execute_ms": execute_ms,
+            "fetch_ms": fetch_ms,
             "total_ms": total_ms,
-            "result_count": len(media.get("cards") or []),
-            "total_cards": media.get("total_cards"),
+            "result_count": result_count,
+            "total_cards": total_cards,
             "had_error": not req_succeeded or (resp.status or "").startswith(("4", "5")),
             "orderby": req.params.get("orderby"),
             "unique_by": req.params.get("unique"),

--- a/api/middlewares/tests/test_caching_middleware.py
+++ b/api/middlewares/tests/test_caching_middleware.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.middlewares.caching_middleware import CachingMiddleware
+from api.middlewares.caching_middleware import CachedResponse, CachingMiddleware
 
 
 class TestCachingMiddleware:
@@ -18,16 +18,22 @@ class TestCachingMiddleware:
         req.relative_uri = uri
         req.params = {"q": "lightning bolt"}
         req.headers = {}
+        req.context = {}
         return req
 
     def _make_resp(self, status: str = "200 OK") -> MagicMock:
         resp = MagicMock()
         resp.status = status
-        resp._headers = {}
+        resp._headers = {"content-type": "application/json"}
+        resp.media = {"cards": [1, 2, 3], "total_cards": 42}
+        resp.render_body.return_value = b"rendered body"
         return resp
 
-    def test_2xx_response_is_cached(self) -> None:
-        """Successful responses should be stored in the cache."""
+    def _cache_key(self) -> tuple:
+        return ("/search?q=lightning+bolt", (("q", "lightning bolt"),), (("ACCEPT-ENCODING", None),))
+
+    def test_2xx_response_is_cached_as_rendered_bytes(self) -> None:
+        """Successful responses should be stored as a CachedResponse, not the Response object."""
         cache = {}
         middleware = CachingMiddleware(cache=cache)
         req = self._make_req()
@@ -38,14 +44,38 @@ class TestCachingMiddleware:
             middleware.process_response(req, resp, None, True)
 
         assert len(cache) == 1
+        cached = cache[self._cache_key()]
+        assert isinstance(cached, CachedResponse)
+        assert cached.status == "200 OK"
+        assert cached.headers == {"content-type": "application/json"}
+        assert cached.body == b"rendered body"
+        assert cached.result_count == 3
+        assert cached.total_cards == 42
+
+    def test_non_dict_media_cached_without_counts(self) -> None:
+        """Responses without a media dict (e.g. static files) cache with None counts."""
+        cache = {}
+        middleware = CachingMiddleware(cache=cache)
+        req = self._make_req()
+        resp = self._make_resp()
+        resp.media = None
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            middleware.process_response(req, resp, None, True)
+
+        cached = cache[self._cache_key()]
+        assert cached.body == b"rendered body"
+        assert cached.result_count is None
+        assert cached.total_cards is None
 
     @pytest.mark.parametrize(
-        argnames="status",
+        argnames=["status"],
         argvalues=[
-            "500 Internal Server Error",
-            "502 Bad Gateway",
-            "503 Service Unavailable",
-            "504 Gateway Timeout",
+            ("500 Internal Server Error",),
+            ("502 Bad Gateway",),
+            ("503 Service Unavailable",),
+            ("504 Gateway Timeout",),
         ],
     )
     def test_5xx_status_not_cached(self, status: str) -> None:
@@ -61,46 +91,48 @@ class TestCachingMiddleware:
 
         assert len(cache) == 0
 
-    def test_cache_hit_sets_cache_hit_flag(self) -> None:
-        """A cache hit should inject cache_hit=True into the response media."""
-        cached_resp = MagicMock()
-        cached_resp.status = "200 OK"
-        cached_resp._headers = {}
-        cached_resp.media = {"cards": [], "total_cards": 0}
-        cached_resp.data = None
-
-        cache_key = ("/search?q=lightning+bolt", (("q", "lightning bolt"),), (("ACCEPT-ENCODING", None),))
-        cache = {cache_key: cached_resp}
+    def test_cache_hit_populates_response_from_cached_bytes(self) -> None:
+        """A cache hit replays status, headers, and body, and flags the hit on req.context."""
+        cached = CachedResponse(
+            status="200 OK",
+            headers={"content-type": "application/json", "content-encoding": "br"},
+            body=b"cached body",
+            result_count=7,
+            total_cards=99,
+        )
+        cache = {self._cache_key(): cached}
 
         middleware = CachingMiddleware(cache=cache)
         req = self._make_req()
         resp = self._make_resp()
-        resp.media = None
+        resp._headers = {}
 
         with patch("api.middlewares.caching_middleware.settings") as mock_settings:
             mock_settings.enable_cache = True
             middleware.process_request(req, resp)
 
-        assert resp.media["cache_hit"] is True
+        assert resp.complete is True
+        assert resp.status == "200 OK"
+        assert resp.data == b"cached body"
+        assert resp._headers == {"content-type": "application/json", "content-encoding": "br"}
+        resp.set_header.assert_called_once_with("X-Cache", "hit")
+        assert req.context["cache_hit"] is True
+        assert req.context["cached_result_count"] == 7
+        assert req.context["cached_total_cards"] == 99
 
-    def test_cache_hit_does_not_mutate_cached_media(self) -> None:
-        """A cache hit should copy the media dict, not mutate the stored response."""
-        original_media = {"cards": [], "total_cards": 0}
-        cached_resp = MagicMock()
-        cached_resp.status = "200 OK"
-        cached_resp._headers = {}
-        cached_resp.media = original_media
-        cached_resp.data = None
-
-        cache_key = ("/search?q=lightning+bolt", (("q", "lightning bolt"),), (("ACCEPT-ENCODING", None),))
-        cache = {cache_key: cached_resp}
+    def test_hit_request_is_not_restored(self) -> None:
+        """process_response after a hit must not re-render or overwrite the cached entry."""
+        cached = CachedResponse(status="200 OK", headers={}, body=b"cached body", result_count=0, total_cards=0)
+        cache = {self._cache_key(): cached}
 
         middleware = CachingMiddleware(cache=cache)
         req = self._make_req()
+        req.context["cache_hit"] = True
         resp = self._make_resp()
 
         with patch("api.middlewares.caching_middleware.settings") as mock_settings:
             mock_settings.enable_cache = True
-            middleware.process_request(req, resp)
+            middleware.process_response(req, resp, None, True)
 
-        assert "cache_hit" not in original_media
+        assert cache[self._cache_key()] is cached
+        resp.render_body.assert_not_called()

--- a/api/middlewares/tests/test_caching_middleware.py
+++ b/api/middlewares/tests/test_caching_middleware.py
@@ -64,6 +64,7 @@ class TestCachingMiddleware:
             "access-control-allow-methods": "GET, POST, OPTIONS",
             "access-control-allow-headers": "Content-Type",
             "access-control-max-age": "86400",
+            "x-cache": "miss",
         }
 
         with patch("api.middlewares.caching_middleware.settings") as mock_settings:
@@ -140,6 +141,38 @@ class TestCachingMiddleware:
         assert req.context["cache_hit"] is True
         assert req.context["cached_result_count"] == 7
         assert req.context["cached_total_cards"] == 99
+
+    def test_cache_miss_sets_miss_header(self) -> None:
+        """A consulted-but-empty cache should mark the response with X-Cache: miss."""
+        middleware = CachingMiddleware(cache={})
+        req = self._make_req()
+        resp = self._make_resp()
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            middleware.process_request(req, resp)
+
+        resp.set_header.assert_called_once_with("X-Cache", "miss")
+
+    @pytest.mark.parametrize(
+        argnames=["enable_cache", "path"],
+        argvalues=[
+            (False, "/search"),
+            (True, "/random_search"),
+        ],
+        ids=["cache_disabled", "uncached_path"],
+    )
+    def test_cache_bypass_sets_no_header(self, enable_cache: bool, path: str) -> None:
+        """When the cache is never consulted there is no hit/miss to report."""
+        middleware = CachingMiddleware(cache={})
+        req = self._make_req(path=path)
+        resp = self._make_resp()
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = enable_cache
+            middleware.process_request(req, resp)
+
+        resp.set_header.assert_not_called()
 
     def test_hit_request_is_not_restored(self) -> None:
         """process_response after a hit must not re-render or overwrite the cached entry."""

--- a/api/middlewares/tests/test_caching_middleware.py
+++ b/api/middlewares/tests/test_caching_middleware.py
@@ -52,6 +52,27 @@ class TestCachingMiddleware:
         assert cached.result_count == 3
         assert cached.total_cards == 42
 
+    def test_request_dependent_headers_are_not_cached(self) -> None:
+        """CORS headers vary on the request's Origin and must not be replayed from cache."""
+        cache = {}
+        middleware = CachingMiddleware(cache=cache)
+        req = self._make_req()
+        resp = self._make_resp()
+        resp._headers = {
+            "content-type": "application/json",
+            "access-control-allow-origin": "http://localhost:8080",
+            "access-control-allow-methods": "GET, POST, OPTIONS",
+            "access-control-allow-headers": "Content-Type",
+            "access-control-max-age": "86400",
+        }
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            middleware.process_response(req, resp, None, True)
+
+        cached = cache[self._cache_key()]
+        assert cached.headers == {"content-type": "application/json"}
+
     def test_non_dict_media_cached_without_counts(self) -> None:
         """Responses without a media dict (e.g. static files) cache with None counts."""
         cache = {}

--- a/api/middlewares/tests/test_query_log_middleware.py
+++ b/api/middlewares/tests/test_query_log_middleware.py
@@ -65,20 +65,19 @@ class TestQueryLogMiddlewareProcessResponse:
         assert entry["had_error"] is False
 
     def test_cache_hit_nulls_db_timings(self) -> None:
+        """On a hit the response body is rendered bytes — fields come from req.context, not media."""
         mw = _make_middleware()
-        resp = _make_resp(
-            media={
-                "cards": [],
-                "total_cards": 5,
-                "cache_hit": True,
-                "inner_timings": {"_children": {"execute_query": {"_meta": {"duration_ms": 99.0}}}},
-            }
-        )
-        mw.process_response(_make_req(), resp, None, True)
+        req = _make_req()
+        req.context.update({"cache_hit": True, "cached_result_count": 7, "cached_total_cards": 5})
+        resp = _make_resp()
+        resp.media = None
+        mw.process_response(req, resp, None, True)
         entry = mw._queue.get_nowait()
         assert entry["cache_hit"] is True
         assert entry["execute_ms"] is None
         assert entry["fetch_ms"] is None
+        assert entry["result_count"] == 7
+        assert entry["total_cards"] == 5
 
     def test_timing_extraction_from_nested_structure(self) -> None:
         mw = _make_middleware()


### PR DESCRIPTION
`CachingMiddleware` now stores a small `CachedResponse` NamedTuple — `(status, headers,
body bytes, result_count, total_cards)` — instead of the whole `falcon.Response` object. A
cache hit replays the stored bytes directly; nothing is re-rendered or re-compressed.

This is the prep step for moving the response cache into shared memory, where entries must
be plain bytes — but it stands on its own as a per-worker memory reduction.

## Why: each cache entry held three copies of the response

Middleware `process_response` runs in reverse registration order, so the caching middleware
stores the response *after* compression has run. At that point the `falcon.Response` object
retains three representations of the same payload:

1. **`resp._media`** — the full Python object graph: the response dict with every card dict,
   name, oracle text, and legality map as live objects. A dict graph typically costs 5–10×
   its JSON serialization (object headers, pointers, dict hash tables).
2. **`resp._media_rendered`** — the uncompressed JSON bytes; falcon caches these when the
   compression middleware calls `render_body()`.
3. **`resp.data`** — the compressed bytes, the only thing a hit actually sends.

For a response with a ~30 KB compressed body, the entry could hold ~100–300 KB of rendered
JSON plus several times that in dict graph — roughly an order of magnitude more than needed.
With `LRUCache(maxsize=10_000)` per worker across ~10 workers, the ceiling difference is GBs
vs hundreds of MBs (realized savings depend on how full the caches actually run).

Secondary effect: large dict graphs are traversed by the cyclic GC on every full collection;
`bytes` are leaf objects it skips. Less cached object graph means less GC pause pressure,
not just less RSS.

## Behavior changes

- **`cache_hit` is no longer injected into the response media.** It had two consumers:
  - `QueryLogMiddleware` — now reads `req.context["cache_hit"]`; the `result_count` /
    `total_cards` it logs on hits are captured at cache-store time and carried in the entry
    (the columns were already nullable).
  - Clients, but only on responses small enough (<200 bytes) to skip compression — compressed
    responses never exposed the flag because `resp.data` takes precedence over media. Hits now
    send an **`X-Cache: hit`** header instead, uniformly, which is also visible with curl.
- A hit request's `process_response` returns early via the context flag, so hits never
  re-render or overwrite the stored entry.

## Testing

- Middleware unit tests rewritten: entries are stored as `CachedResponse` with rendered body
  and counts; hits replay status/headers/body, set `X-Cache`, and flag `req.context`; hit
  requests don't re-store; 5xx still excluded; non-dict media caches with `None` counts.
- `QueryLogMiddleware` hit test now drives `req.context` instead of a media flag.
- Full unit suite: 1645 passed, 1 skipped. `ruff` clean.
