### PR TITLE
Stream the engine reload: incremental loading + serialize-to-file

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -66,6 +66,11 @@ IMPORT_EXPORT = True
 MIN_IMPORT_INTERVAL = 300
 IMPORT_LOCK_TIMEOUT = 2
 MIN_IMPORT_CARDS = 90_000
+# Rows per batch streamed into the engine during a reload. The reload's memory
+# floor is the Rust-side build (~305 MB), so the batch only needs to be small
+# relative to that: ~2k rows ≈ 18 MB of dicts. Smaller adds round trips for no
+# measurable gain (see docs/issues/engine-incremental-loading.md).
+_ENGINE_RELOAD_BATCH_SIZE = 2_000
 
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
@@ -623,15 +628,19 @@ class APIResource:
         return retval
 
     def _reload_engine(self, *, force: bool = False) -> None:
-        """Fetch all cards from the DB and reload the Rust engine's card store.
+        """Stream all cards from the DB into the Rust engine's card store in batches.
 
-        The full-table fetch (fetchall + dict conversion + rkyv serialization) is the
-        most memory-hungry thing a worker does, so it is guarded by a cross-worker
-        lock: only one worker pays that cost at a time. With force=False (cold-start
-        warming), losers of the race return immediately and pick up the winner's
-        archive via the engine's inode-based remap. With force=True (data just
-        changed), callers wait their turn but skip the rebuild if another worker
-        refreshed the store while they were waiting.
+        A server-side cursor feeds the engine's staged reload API
+        (reload_begin / add_batch / reload_commit) one batch at a time, so the
+        Python-side transient is one batch of row dicts (~18 MB at 2k rows)
+        instead of the whole corpus (~840 MB) — measurements in
+        docs/issues/engine-incremental-loading.md. The reload is guarded by a
+        cross-worker lock so only one worker pays the build cost at a time.
+        With force=False (cold-start warming), losers of the race return
+        immediately and pick up the winner's archive via the engine's
+        inode-based remap. With force=True (data just changed), callers wait
+        their turn but skip the rebuild if another worker refreshed the store
+        while they were waiting.
 
         Args:
             force: If False, skip entirely when another worker holds the lock or the
@@ -653,13 +662,24 @@ class APIResource:
             cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS_FROM_MODULE)
             try:
                 with self._conn_pool.connection() as conn:
-                    with conn.cursor() as cursor:
+                    # Named cursor => server-side: psycopg buffers one batch, not the full result.
+                    with conn.cursor(name="engine_reload") as cursor:
+                        cursor.itersize = _ENGINE_RELOAD_BATCH_SIZE
                         cursor.execute(f"SELECT {cols_sql} FROM magic.cards AS card")
-                        rows = cursor.fetchall()
+                        if not self._engine.reload_begin():
+                            # Another process published a fresh archive while we
+                            # waited for the engine's write lock; it was remapped.
+                            return
+                        try:
+                            while batch := cursor.fetchmany(_ENGINE_RELOAD_BATCH_SIZE):
+                                self._engine.add_batch(batch)
+                            self._engine.reload_commit()
+                        except BaseException:
+                            self._engine.reload_abort()
+                            raise
             except psycopg_pool.PoolClosed:
                 logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
                 return
-            self._engine.reload([dict(row) for row in rows])
             logger.info("Engine reloaded with %d cards (pid=%d)", self._engine.size(), os.getpid())
         finally:
             self._engine_reload_guard.release()

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -375,6 +375,79 @@ class TestCollectionOperators:
         assert total_sol == 5
 
 
+class TestStagedReload:
+    """reload_begin / add_batch / reload_commit — the streaming reload API.
+
+    _reload_engine feeds these from a server-side cursor so only one batch of
+    row dicts is alive at a time; the one-shot reload() is a wrapper over them.
+    """
+
+    def test_staged_equals_one_shot(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        cards = json.loads(_FIXTURE.read_text())
+        staged = fresh_engine()
+        assert staged.reload_begin() is True
+        # Split into 3 uneven batches to exercise accumulation across calls
+        staged.add_batch(cards[:10])
+        staged.add_batch(cards[10:50])
+        staged.add_batch(cards[50:])
+        staged.reload_commit()
+
+        one_shot = fresh_engine()
+        one_shot.reload(cards)
+
+        assert staged.size() == one_shot.size() == 87
+        for q in ("t:creature", "name:bolt", "devotion:{R}", "cmc>=4"):
+            t_staged, c_staged = _run(staged, q, orderby="cmc")
+            t_one, c_one = _run(one_shot, q, orderby="cmc")
+            assert t_staged == t_one
+            assert _names(c_staged) == _names(c_one)
+
+    def test_add_batch_without_begin_raises(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        e = fresh_engine()
+        with pytest.raises(RuntimeError, match="without reload_begin"):
+            e.add_batch([{"card_name": "X", "oracle_id": "o1"}])
+
+    def test_commit_without_begin_raises(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        e = fresh_engine()
+        with pytest.raises(RuntimeError, match="without reload_begin"):
+            e.reload_commit()
+
+    def test_abort_discards_staging(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        cards = json.loads(_FIXTURE.read_text())
+        e = fresh_engine()
+        e.reload(cards)
+        # Stage a different (smaller) corpus, then abort: store must be unchanged
+        assert e.reload_begin() is True
+        e.add_batch(cards[:5])
+        e.reload_abort()
+        assert e.size() == 87
+        # And the lock must have been released: a fresh cycle works
+        e.reload(cards[:5])
+        assert e.size() == 5
+
+    def test_begin_resets_abandoned_staging(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        cards = json.loads(_FIXTURE.read_text())
+        e = fresh_engine()
+        # First cycle abandoned mid-staging (no commit, no abort)
+        assert e.reload_begin() is True
+        e.add_batch(cards[:50])
+        # Second begin discards the abandoned buffer and its lock
+        assert e.reload_begin() is True
+        e.add_batch(cards[:5])
+        e.reload_commit()
+        assert e.size() == 5
+
+    def test_missing_oracle_id_rejected_at_commit(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        e = fresh_engine()
+        assert e.reload_begin() is True
+        e.add_batch([{"card_name": "No Oracle"}])
+        with pytest.raises(ValueError, match="missing oracle_id"):
+            e.reload_commit()
+        # Commit consumed the staging even on failure; the engine is reusable
+        e.reload([{"card_name": "Ok Card", "oracle_id": "o1"}])
+        assert e.size() == 1
+
+
 class TestUnique:
     def test_reload_rejects_cards_missing_oracle_id(self, fresh_engine: Callable[[], QueryEngine]) -> None:
         # unique=card/artwork group by oracle_id; cards without one would silently

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -248,16 +248,47 @@ class TestEngineFeatureGate:
         mock_engine.assert_called_once()
         assert result is sentinel
 
-    def test_enabled_reload_fetches_cards(self) -> None:
+    def test_enabled_reload_streams_batches(self) -> None:
         settings.enable_engine = True
         # Empty store, or the populated-store fast path skips the reload.
         self.api_resource._engine.size.return_value = 0
+        self.api_resource._engine.reload_begin.return_value = True
+        batch1, batch2 = [{"card_name": "A"}], [{"card_name": "B"}]
         with patch.object(self.api_resource, "_conn_pool") as mock_pool:
             mock_cursor = MagicMock()
-            mock_cursor.fetchall.return_value = []
+            mock_cursor.fetchmany.side_effect = [batch1, batch2, []]
             mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
             self.api_resource._reload_engine()
-        self.api_resource._engine.reload.assert_called_once_with([])
+        engine = self.api_resource._engine
+        engine.reload_begin.assert_called_once()
+        assert [c.args[0] for c in engine.add_batch.call_args_list] == [batch1, batch2]
+        engine.reload_commit.assert_called_once()
+        engine.reload_abort.assert_not_called()
+
+    def test_enabled_reload_skips_when_another_worker_published(self) -> None:
+        settings.enable_engine = True
+        self.api_resource._engine.size.return_value = 0
+        self.api_resource._engine.reload_begin.return_value = False
+        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+            mock_cursor = MagicMock()
+            mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            self.api_resource._reload_engine()
+        self.api_resource._engine.add_batch.assert_not_called()
+        self.api_resource._engine.reload_commit.assert_not_called()
+
+    def test_enabled_reload_aborts_on_failure(self) -> None:
+        settings.enable_engine = True
+        self.api_resource._engine.size.return_value = 0
+        self.api_resource._engine.reload_begin.return_value = True
+        self.api_resource._engine.add_batch.side_effect = RuntimeError("boom")
+        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
+            mock_cursor = MagicMock()
+            mock_cursor.fetchmany.side_effect = [[{"card_name": "A"}], []]
+            mock_pool.connection.return_value.__enter__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
+            with pytest.raises(RuntimeError, match="boom"):
+                self.api_resource._reload_engine()
+        self.api_resource._engine.reload_abort.assert_called_once()
+        self.api_resource._engine.reload_commit.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -38,6 +38,7 @@ mod alloc_stats {
 
     pub fn live() -> usize { LIVE.load(Ordering::Relaxed) }
     pub fn allocs() -> usize { ALLOCS.load(Ordering::Relaxed) }
+    pub fn peak() -> usize { PEAK.load(Ordering::Relaxed) }
 
     pub fn reset_peak() {
         RELOAD_LIVE_BEFORE.store(live(), Ordering::Relaxed);
@@ -49,6 +50,7 @@ mod alloc_stats {
         after_indexes: (usize, usize),
         component_bytes: (usize, usize, usize),
         archive: usize,
+        peak: usize, // caller snapshots before diagnostics inflate the high-water mark
     ) {
         RELOAD_LIVE_AFTER_CARDS.store(after_cards.0, Ordering::Relaxed);
         RELOAD_ALLOCS_AFTER_CARDS.store(after_cards.1, Ordering::Relaxed);
@@ -58,7 +60,7 @@ mod alloc_stats {
         RELOAD_INDEXES_RKYV.store(component_bytes.1, Ordering::Relaxed);
         RELOAD_STRINGS_RKYV.store(component_bytes.2, Ordering::Relaxed);
         RELOAD_ARCHIVE.store(archive, Ordering::Relaxed);
-        RELOAD_PEAK.store(PEAK.load(Ordering::Relaxed), Ordering::Relaxed);
+        RELOAD_PEAK.store(peak, Ordering::Relaxed);
     }
 
     pub struct CountingAlloc;
@@ -2446,26 +2448,19 @@ impl QueryEngine {
 
         #[cfg(feature = "alloc-counter")]
         let stats_after_indexes = (alloc_stats::live(), alloc_stats::allocs());
-        #[cfg(feature = "alloc-counter")]
-        let component_bytes = (
-            rkyv::to_bytes::<rkyv::rancor::Error>(&cards).map(|b| b.len()).unwrap_or(0),
-            rkyv::to_bytes::<rkyv::rancor::Error>(&indexes).map(|b| b.len()).unwrap_or(0),
-            rkyv::to_bytes::<rkyv::rancor::Error>(&strings).map(|b| b.len()).unwrap_or(0),
-        );
 
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
         let card_data = CardData { cards, strings, indexes, format_shifts: format_shifts_snapshot };
-        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&card_data)
-            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rkyv serialize: {e}")))?;
 
-        #[cfg(feature = "alloc-counter")]
-        alloc_stats::record_reload(stats_after_cards, stats_after_indexes, component_bytes, bytes.len());
-
-        // Write atomically: write to a per-PID .tmp, then rename over shm_path.
+        // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
         // one's rename consumes the file before the other can rename it.
+        // Streaming the serialization straight into the file means the archive
+        // bytes exist only as file pages — there is no second copy of the
+        // archive as a heap buffer, and no realloc-doubling spike while it
+        // grows (see docs/issues/engine-reload-publish-transient.md).
         let tmp_name = format!(
             "{}.{}.tmp",
             self.shm_path.file_name().unwrap_or_default().to_string_lossy(),
@@ -2473,13 +2468,37 @@ impl QueryEngine {
         );
         let tmp_path = self.shm_path.with_file_name(tmp_name);
         {
-            let mut f = std::fs::File::create(&tmp_path)
+            let f = std::fs::File::create(&tmp_path)
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("create tmp: {e}")))?;
-            f.write_all(&archive_header())
+            let mut buf = std::io::BufWriter::with_capacity(1 << 20, f);
+            buf.write_all(&archive_header())
                 .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("write header: {e}")))?;
-            f.write_all(&bytes)
-                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("write tmp: {e}")))?;
+            rkyv::api::high::to_bytes_in::<_, rkyv::rancor::Error>(
+                &card_data,
+                rkyv::ser::writer::IoWriter::new(&mut buf),
+            )
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rkyv serialize: {e}")))?;
+            buf.flush()
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("flush tmp: {e}")))?;
         }
+
+        #[cfg(feature = "alloc-counter")]
+        {
+            // Snapshot the build peak before the component-size diagnostics
+            // below re-serialize pieces into heap buffers and inflate it.
+            let build_peak = alloc_stats::peak();
+            let archive_len = std::fs::metadata(&tmp_path)
+                .map(|m| m.len() as usize)
+                .unwrap_or(0)
+                .saturating_sub(ARCHIVE_HEADER_LEN);
+            let component_bytes = (
+                rkyv::to_bytes::<rkyv::rancor::Error>(&card_data.cards).map(|b| b.len()).unwrap_or(0),
+                rkyv::to_bytes::<rkyv::rancor::Error>(&card_data.indexes).map(|b| b.len()).unwrap_or(0),
+                rkyv::to_bytes::<rkyv::rancor::Error>(&card_data.strings).map(|b| b.len()).unwrap_or(0),
+            );
+            alloc_stats::record_reload(stats_after_cards, stats_after_indexes, component_bytes, archive_len, build_peak);
+        }
+
         std::fs::rename(&tmp_path, &self.shm_path)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rename shm: {e}")))?;
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2245,10 +2245,22 @@ struct CachedMmap {
     inode: u64,
 }
 
+/// In-progress staged reload: cards accumulated across add_batch() calls plus
+/// the cross-process flock, held from reload_begin() until reload_commit() /
+/// reload_abort() so no other process can interleave a write. Dropping the
+/// staging (commit, abort, or a fresh reload_begin after an abandoned cycle)
+/// closes the lock file, which releases the flock.
+struct Staging {
+    cards: Vec<Card>,
+    interner: Interner,
+    #[allow(dead_code)] // held for its flock; released on drop
+    lock_file: std::fs::File,
+}
+
 #[pyclass]
 struct QueryEngine {
     shm_path: PathBuf,
-    write_lock: Mutex<()>,
+    staging: Mutex<Option<Staging>>,
     cached_mmap: Mutex<Option<CachedMmap>>,
 }
 
@@ -2307,7 +2319,7 @@ impl QueryEngine {
         };
         QueryEngine {
             shm_path: PathBuf::from(shm_path.unwrap_or(default_path)),
-            write_lock: Mutex::new(()),
+            staging: Mutex::new(None),
             cached_mmap: Mutex::new(None),  // populated by first reload()
         }
     }
@@ -2320,8 +2332,15 @@ impl QueryEngine {
         self.get_mmap().map(|_| ())
     }
 
-    fn reload(&self, db_rows: &Bound<PyList>) -> PyResult<()> {
-        let _guard = self.write_lock.lock().unwrap();
+    /// Start a staged reload: acquire the cross-process write lock and reset
+    /// the staging buffer. Returns false (and refreshes the local mapping) if
+    /// another worker published a new archive while we waited for the lock —
+    /// the caller should skip fetching entirely. Any staging abandoned by a
+    /// previous failed cycle is discarded here.
+    fn reload_begin(&self) -> PyResult<bool> {
+        let mut staging = self.staging.lock().unwrap();
+        // Drop an abandoned cycle's buffer and its flock before re-acquiring.
+        *staging = None;
 
         // Snapshot the archive's identity before contending for the cross-process
         // lock, so we can detect whether another worker published a new archive
@@ -2332,6 +2351,7 @@ impl QueryEngine {
 
         // Cross-process exclusive lock: only one worker writes per reload cycle.
         // The lock file is separate so it persists across archive replacements.
+        // Held until reload_commit()/reload_abort() drops the Staging.
         let lock_path = self.shm_path.with_extension("lock");
         let lock_file = std::fs::OpenOptions::new()
             .write(true).create(true).open(&lock_path)
@@ -2352,17 +2372,46 @@ impl QueryEngine {
         // our local handle.
         let inode_after = std::fs::metadata(&self.shm_path).ok().map(|m| m.ino());
         if inode_after.is_some() && inode_after != inode_before {
-            return self.get_mmap().map(|_| ());
+            self.get_mmap().map(|_| ())?;
+            return Ok(false);
         }
 
         #[cfg(feature = "alloc-counter")]
         alloc_stats::reset_peak();
 
-        let mut interner = Interner::new();
-        let mut cards: Vec<Card> = db_rows
-            .iter()
-            .filter_map(|item| item.cast::<PyDict>().ok().map(|d| card_from_pydict(&d, &mut interner)))
-            .collect();
+        *staging = Some(Staging { cards: Vec::new(), interner: Interner::new(), lock_file });
+        Ok(true)
+    }
+
+    /// Append one batch of card dicts to the staging buffer.
+    fn add_batch(&self, db_rows: &Bound<PyList>) -> PyResult<()> {
+        let mut guard = self.staging.lock().unwrap();
+        let staging = guard.as_mut().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("add_batch called without reload_begin")
+        })?;
+        for item in db_rows.iter() {
+            if let Ok(d) = item.cast::<PyDict>() {
+                staging.cards.push(card_from_pydict(&d, &mut staging.interner));
+            }
+        }
+        Ok(())
+    }
+
+    /// Discard an in-progress staged reload, releasing the cross-process lock.
+    fn reload_abort(&self) -> PyResult<()> {
+        self.staging.lock().unwrap().take();
+        Ok(())
+    }
+
+    /// Sort, index, serialize, and atomically publish the staged cards, then
+    /// release the cross-process lock. Queries keep serving the old archive
+    /// until the rename lands.
+    fn reload_commit(&self) -> PyResult<()> {
+        let staging = self.staging.lock().unwrap().take().ok_or_else(|| {
+            pyo3::exceptions::PyRuntimeError::new_err("reload_commit called without reload_begin")
+        })?;
+        let Staging { mut cards, interner, lock_file } = staging;
+
         // unique=card/artwork group by oracle_id, so cards without one would all
         // collapse into a single group. The DB enforces NOT NULL; fail loudly here
         // for any other caller (e.g. hand-built test dicts).
@@ -2434,7 +2483,23 @@ impl QueryEngine {
         std::fs::rename(&tmp_path, &self.shm_path)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("rename shm: {e}")))?;
 
+        // The new archive is published; release the cross-process write lock.
+        drop(lock_file);
+
         self.get_mmap().map(|_| ())
+    }
+
+    /// One-shot reload: the staged API as a single call. Kept for tests and
+    /// for callers that already hold the full corpus in memory.
+    fn reload(&self, db_rows: &Bound<PyList>) -> PyResult<()> {
+        if !self.reload_begin()? {
+            return Ok(()); // another worker just published; we picked up theirs
+        }
+        if let Err(e) = self.add_batch(db_rows) {
+            self.reload_abort()?;
+            return Err(e);
+        }
+        self.reload_commit()
     }
 
     #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]


### PR DESCRIPTION
Rebuilds `_reload_engine` (DB → Rust card store) as a streaming pipeline, attacking the reload
memory spike from both ends:

1. **Incremental loading (Python side).** A server-side cursor feeds the engine in 2,000-row
   batches through a new staged reload API (`reload_begin` / `add_batch` / `reload_commit` /
   `reload_abort`), so one batch of row dicts (~18 MB) is alive at a time instead of the whole
   corpus as Python objects, twice (~837 MB).
2. **Streaming serialization (Rust side).** `reload_commit` serializes the archive directly
   into the `.tmp` file (`rkyv::api::high::to_bytes_in` through a 1 MB `BufWriter`) instead of
   building an ~89 MB heap buffer and copying it out with `write_all`. The archive bytes exist
   exactly once, as file pages.

## Why

This reload transient is what OOM-killed the apiservice on atlas and why the engine is
feature-gated off (`ENABLE_ENGINE=false`). This PR is the prerequisite for flipping the gate:
it takes the building worker's peak from ~1.3 GB to ~350 MB, which fits the 1875m container
alongside the sibling workers with ample headroom.

## Measured impact

Blue DB, 96,139 cards, `alloc-counter` instrumentation + RSS, macOS arm64, 2026-06-12:

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| Building-worker process peak | 1308 MB | **346 MB** | −74% |
| RSS while rows load | 894 MB | 186 MB | −79% |
| Rust allocator peak at commit | 304.7 MB | **171.6 MB** | −44% |
| Archive size / query results | 88.6 MB | identical | — |

The remaining Rust peak is the live staging structures (`Vec<Card>` + interner, ~162 MB) plus
rkyv arena scratch — shrinking those is store-size-reduction territory, not this PR.

## How it works

**Rust staged API** (`card_engine/src/lib.rs`):

- `reload_begin() -> bool` — discards any staging abandoned by a crashed cycle (releasing its
  flock), acquires the cross-process flock, and returns `False` if another worker published a
  new archive while we waited (the caller skips fetching entirely; previously this skip
  happened silently inside `reload()`).
- `add_batch(rows)` — appends to the staging `Vec<Card>` + interner.
- `reload_commit()` — the existing validate → sort → index → serialize → 16-byte header →
  per-PID tmp → `rename()` pipeline, now serializing straight into the file; releases the
  flock after publish. Queries serve the old archive until the rename lands, exactly as before.
- `reload_abort()` — discards staging and releases the lock; the Python loop calls it on any
  failure mid-stream.
- `reload(list)` survives as a one-shot wrapper, so existing callers and the ~130 engine unit
  tests are unchanged.

**Python** (`api_resource.py`): the `fetchall()` + dict-copy body of `_reload_engine` is
replaced by a named (server-side) cursor and a `fetchmany` loop; the `ENABLE_ENGINE` gate,
`force=` semantics, cross-worker reload guard, and `PoolClosed` handling are untouched. The
old `[dict(row) for row in rows]` copy is gone too — `dict_row` rows pass straight through
(that copy was the ×2 in the measurements).

**Batch size** (2,000 rows): the memory floor is the Rust-side staging, so the batch only
needs to be small relative to that; smaller batches add round trips for no measurable gain.

**Instrumentation**: the `alloc-counter` component-size diagnostics moved after the publish
(with the build peak snapshotted first) so they no longer inflate the reported reload peak now
that the real serialize allocates nothing.

## Testing

- New `TestStagedReload` engine tests: staged ≡ one-shot equivalence across query shapes,
  `add_batch`/`reload_commit` without `begin` raise, abort discards staging and releases the
  lock, a fresh `begin` resets an abandoned cycle, missing-oracle_id validation still fires at
  commit.
- Reworked feature-gate tests: batch order through the cursor loop, skip-when-another-worker-
  published, `reload_abort` on mid-stream failure.
- Full unit suite passes (1806 passed, 1 skipped); integration suite passes (14) — the
  cubecobra ordering test exercises the real streaming path end-to-end against a containerized
  PostgreSQL.
- `cargo test` clean in both feature configurations; memory results above measured with the
  instrumented build against the full blue dataset, with identical archives and query results.

## What this unblocks

With this merged, the remaining steps to enable the engine are operational: size atlas's
worker count, flip `ENABLE_ENGINE=true`, and shrink `shm_size` (or move the archive to a
disk-backed path — see the publish-transient doc's open items).
