### PR TITLE
Auto-label PRs based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,62 @@
+parser:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/parsing/**"
+
+engine:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "card_engine/**"
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/static/**"
+
+api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/**"
+          - "!api/parsing/**"
+          - "!api/static/**"
+          - "!api/tests/**"
+          - "!api/parsing/tests/**"
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/db/**"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "api/tests/**"
+          - "api/parsing/tests/**"
+          - "conftest.py"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/PULL_REQUEST_TEMPLATE.md"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - "makefile"
+          - "docker-compose.yml"
+          - "envs/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "requirements/**"
+          - "package.json"
+          - "package-lock.json"
+          - "uv.lock"
+          - "card_engine/Cargo.toml"
+          - "card_engine/Cargo.lock"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,10 +17,6 @@ api:
   - changed-files:
       - any-glob-to-any-file:
           - "api/**"
-          - "!api/parsing/**"
-          - "!api/static/**"
-          - "!api/tests/**"
-          - "!api/parsing/tests/**"
 
 database:
   - changed-files:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,18 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
## Summary

- Adds `.github/labeler.yml` mapping 9 labels (`parser`, `engine`, `frontend`, `api`, `database`, `tests`, `docs`, `ci`, `dependencies`) to file glob patterns
- Adds `.github/workflows/label-pr.yml` running `actions/labeler@v5` on PR open/push/reopen

Labels are additive only (`sync-labels: false`) — manually applied labels are never removed.