### PR TITLE
Allow Planner to not Materialize CTE

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1035,7 +1035,7 @@ class APIResource:
             # scryfall_id is the PK — every row is already unique, no dedup needed.
             # The CTE has no ORDER BY; only the LIMIT branch sorts.
             query_sql = f"""
-            WITH matching_cards AS (
+            WITH matching_cards AS NOT MATERIALIZED (
                 SELECT
                     {_select_cols}
                     {sql_orderby} AS sort_value


### PR DESCRIPTION
Add `NOT MATERIALIZED` to the `matching_cards` CTE in the PRINTING path (`unique=printing`).

By default, PostgreSQL treats CTEs as optimization fences — it materializes the full result set before the outer query can access it. This is a problem for the non-dedup path because the LIMIT branch and COUNT branch want opposite index strategies:

- The LIMIT branch wants to walk the `edhrec_rank` B-tree index in sorted order and stop after 100 rows.
- The COUNT branch wants to use a condition index (e.g. GIN on `card_legalities`) to count all matches directly.

A materialized CTE forces the planner to pick one access strategy for both. `NOT MATERIALIZED` lets the planner inline the CTE into each branch and plan them independently.

## Query plan evidence (`format:modern`, PostgreSQL 18)

**Before (materialized CTE) — 70ms:** planner materializes all 73,336 matching rows before either branch runs.

**After (NOT MATERIALIZED) — 49ms:** LIMIT branch uses `idx_cards_edhrec_rank_btree`, exits after ~235 rows (1ms); COUNT branch uses `idx_cards_legalities` GIN index (48ms).

```
Append  (actual time=1.037..48.806 rows=101)
  ->  Limit  (actual time=1.036..1.045 rows=100)
        ->  Incremental Sort  (actual time=1.035..1.038 rows=100)
              Presorted Key: card.edhrec_rank
              ->  Index Scan using idx_cards_edhrec_rank_btree  (actual time=0.605..0.992 rows=107)
                    Filter: (card_legalities @> '{"modern": "legal"}')
                    Rows Removed by Filter: 128
  ->  Aggregate  (actual time=47.745..47.746 rows=1)
        ->  Bitmap Heap Scan on cards  (actual time=7.791..45.673 rows=73336)
              Recheck Cond: (card_legalities @> '{"modern": "legal"}')
              Rows Removed by Index Recheck: 23197
              ->  Bitmap Index Scan on idx_cards_legalities
Execution Time: 48.982 ms
```

| Query | Materialized CTE | NOT MATERIALIZED |
|---|---|---|
| `format:modern` | 70ms | 49ms |
| `power>4` | 14ms | 9ms |

Note: the dedup paths (`unique=card`, `unique=artwork`) intentionally keep a materialized CTE — those use `DISTINCT ON`, and materializing once to serve both branches is the right call there.
