### PR TITLE
Genericize Site Title

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -64,12 +64,16 @@ FALLBACK_SITE_NAME = "MTG Search"
 # TLDs in this set are stripped from the hostname; others are concatenated into the word.
 # e.g. arcane-tutor.com -> "Arcane Tutor"; tolarian-acade.my -> "Tolarian Academy"
 _STRIP_TLDS = frozenset(["app", "biz", "co", "com", "dev", "edu", "gov", "info", "io", "me", "net", "org", "us"])
+# Allowlist: only valid hostname characters (letters, digits, hyphens, dots) after urlparse extracts the host.
+_SAFE_HOSTNAME_RE = re.compile(r"^[a-z0-9.\-]+$")
 _IP_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 
 
-def hostname_to_site_name(hostname: str) -> str:
-    """Derive a display name from a hostname, falling back to FALLBACK_SITE_NAME."""
-    if not hostname or hostname == "localhost" or _IP_RE.match(hostname):
+def hostname_to_site_name(raw_host: str) -> str:
+    """Derive a display name from a Host header value, falling back to FALLBACK_SITE_NAME."""
+    # urlparse requires a scheme; .hostname strips the port and lowercases.
+    hostname = urllib.parse.urlparse(f"http://{raw_host}").hostname or ""
+    if not hostname or hostname == "localhost" or _IP_RE.match(hostname) or not _SAFE_HOSTNAME_RE.match(hostname):
         return FALLBACK_SITE_NAME
     name = hostname.removeprefix("www.")
     parts = name.split(".")
@@ -1254,7 +1258,7 @@ class APIResource:
         self._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
         falcon_response.content_type = "text/html"
 
-    def favicon_ico(self, *, falcon_response: falcon.Response | None = None) -> None:
+    def favicon_ico(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the favicon.ico file.
 
         Args:
@@ -1273,7 +1277,7 @@ class APIResource:
         # Cache favicon for 7 days - it rarely changes
         set_cache_header(falcon_response, duration=timedelta(days=7))
 
-    def styles_css(self, *, falcon_response: falcon.Response | None = None) -> None:
+    def styles_css(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the styles.css file.
 
         Args:
@@ -1287,7 +1291,7 @@ class APIResource:
         # Cache CSS for 1 hour - it changes infrequently
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
-    def app_js(self, *, falcon_response: falcon.Response | None = None) -> None:
+    def app_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the app.js file.
 
         Args:
@@ -1301,7 +1305,7 @@ class APIResource:
         # Cache JavaScript for 1 hour - it changes infrequently
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
-    def app_min_js(self, *, falcon_response: falcon.Response | None = None) -> None:
+    def app_min_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the app.min.js file.
 
         Args:

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -79,12 +79,13 @@ def hostname_to_site_name(raw_host: str) -> str:
     parts = name.split(".")
     tld = parts[-1].lower()
     name = ".".join(parts[:-1]) if tld in _STRIP_TLDS else name
-    name = name.replace(".", "").replace("-", " ")
-    return name.title() or FALLBACK_SITE_NAME
+    name = name.replace(".", "").replace("-", " ").strip()
+    name = name.title()
+    return name if any(c.isalnum() for c in name) else FALLBACK_SITE_NAME
 
 
 # Query parameters that must not be forwarded to action handlers.
-DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["request_host"])
+DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["falcon_response", "request_host"])
 
 # pylint: disable=c-extension-no-member
 NOT_FOUND = 404

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -83,6 +83,9 @@ def hostname_to_site_name(raw_host: str) -> str:
     return name.title() or FALLBACK_SITE_NAME
 
 
+# Query parameters that must not be forwarded to action handlers.
+DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["request_host"])
+
 # pylint: disable=c-extension-no-member
 NOT_FOUND = 404
 IMPORT_EXPORT = True
@@ -349,7 +352,8 @@ class APIResource:
         res = None
         before = time.monotonic()
         try:
-            res = action(falcon_response=resp, request_host=req.host, **req.params)
+            params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
+            res = action(falcon_response=resp, request_host=req.host, **params)
             resp.media = res
         except TypeError as oops:
             logger.error("Error handling request: %s", oops, exc_info=True)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -60,6 +60,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+FALLBACK_SITE_NAME = "MTG Search"
+# TLDs in this set are stripped from the hostname; others are concatenated into the word.
+# e.g. arcane-tutor.com -> "Arcane Tutor"; tolarian-acade.my -> "Tolarian Academy"
+_STRIP_TLDS = frozenset(["app", "biz", "co", "com", "dev", "edu", "gov", "info", "io", "me", "net", "org", "us"])
+_IP_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+
+
+def hostname_to_site_name(hostname: str) -> str:
+    """Derive a display name from a hostname, falling back to FALLBACK_SITE_NAME."""
+    if not hostname or hostname == "localhost" or _IP_RE.match(hostname):
+        return FALLBACK_SITE_NAME
+    name = hostname.removeprefix("www.")
+    parts = name.split(".")
+    tld = parts[-1].lower()
+    name = ".".join(parts[:-1]) if tld in _STRIP_TLDS else name
+    name = name.replace(".", "").replace("-", " ")
+    return name.title() or FALLBACK_SITE_NAME
+
+
 # pylint: disable=c-extension-no-member
 NOT_FOUND = 404
 IMPORT_EXPORT = True
@@ -326,7 +345,7 @@ class APIResource:
         res = None
         before = time.monotonic()
         try:
-            res = action(falcon_response=resp, **req.params)
+            res = action(falcon_response=resp, request_host=req.host, **req.params)
             resp.media = res
         except TypeError as oops:
             logger.error("Error handling request: %s", oops, exc_info=True)
@@ -1135,6 +1154,7 @@ class APIResource:
         self,
         *,
         falcon_response: falcon.Response | None = None,
+        request_host: str = "",
         q: str | None = None,
         query: str | None = None,
         orderby: CardOrdering | None = None,
@@ -1148,6 +1168,7 @@ class APIResource:
         Args:
         ----
             falcon_response (falcon.Response): The Falcon response to write to.
+            request_host (str): Value of the Host header, used to derive the site name.
             q (str): Search query (alternative to query parameter).
             query (str): Search query (alternative to q parameter).
             orderby (CardOrdering): Field to sort by.
@@ -1160,6 +1181,10 @@ class APIResource:
         full_filename = pathlib.Path(__file__).parent / "static" / "index.html"
         with pathlib.Path(full_filename).open() as f:
             html_content = f.read()
+
+        site_name = hostname_to_site_name(request_host)
+        if site_name != FALLBACK_SITE_NAME:
+            html_content = html_content.replace(FALLBACK_SITE_NAME, site_name)
 
         # Check if we have a search query
         search_query = query or q

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -32,6 +32,7 @@
     />
     <meta property="og:type" content="website" />
     <title>MTG Search - Magic: The Gathering Card Search</title>
+    <link rel="canonical" href="/" />
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
     <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
     <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -25,14 +25,13 @@
       content="Search for Magic: The Gathering cards. Find MTG cards by name, type, text, mana cost, and more. Open source Scryfall implementation."
     />
     <meta name="theme-color" content="#2b8fdf" />
-    <meta property="og:title" content="Arcane Tutor - Magic: The Gathering Card Search" />
+    <meta property="og:title" content="MTG Search - Magic: The Gathering Card Search" />
     <meta
       property="og:description"
       content="Search for Magic: The Gathering cards by name, type, text, mana cost, and more."
     />
     <meta property="og:type" content="website" />
-    <title>Arcane Tutor - Magic: The Gathering Card Search</title>
-    <link rel="canonical" href="https://arcane-tutor.com/" />
+    <title>MTG Search - Magic: The Gathering Card Search</title>
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
     <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
     <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />
@@ -96,7 +95,7 @@
         <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
           <span id="themeIcon">☀️</span>
         </button>
-        <h1>Arcane Tutor</h1>
+        <h1 id="site-title">MTG Search</h1>
         <p>Search for Magic: The Gathering cards</p>
       </div>
 

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -12,7 +12,7 @@ import falcon
 import pytest
 import requests
 
-from api.api_resource import APIResource
+from api.api_resource import FALLBACK_SITE_NAME, APIResource, hostname_to_site_name
 from api.settings import settings
 
 
@@ -895,6 +895,83 @@ class TestAPIResourceTagHierarchy(unittest.TestCase):
                 assert isinstance(result["message"], str)
                 assert isinstance(result["tags_processed"], int)
                 assert result["tags_processed"] == 1
+
+
+_HOSTNAME_TESTCASES = {
+    "tolarian_acade_my": {
+        "expected": "Tolarian Academy",
+        "raw_host": "tolarian-acade.my",
+    },
+    "strips_com_tld": {
+        "expected": "Arcane Tutor",
+        "raw_host": "arcane-tutor.com",
+    },
+    "strips_port": {
+        "expected": "Arcane Tutor",
+        "raw_host": "arcane-tutor.com:443",
+    },
+    "strips_www_prefix": {
+        "expected": "Arcane Tutor",
+        "raw_host": "www.arcane-tutor.com",
+    },
+    "localhost_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "localhost",
+    },
+    "localhost_with_port_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "localhost:8080",
+    },
+    "ip_address_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "192.168.1.1",
+    },
+    "ip_with_port_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "192.168.1.1:5000",
+    },
+    "empty_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "",
+    },
+    "invalid_chars_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": 'evil"><script>.com',
+    },
+}
+
+
+class TestHostnameSiteName:
+    """Tests for hostname_to_site_name()."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(_HOSTNAME_TESTCASES.values()))),
+        argvalues=[[v for k, v in sorted(_HOSTNAME_TESTCASES[name].items())] for name in sorted(_HOSTNAME_TESTCASES)],
+        ids=sorted(_HOSTNAME_TESTCASES),
+    )
+    def test_hostname_to_site_name(self, expected: str, raw_host: str) -> None:
+        assert hostname_to_site_name(raw_host) == expected
+
+
+class TestRootSiteNameInjection(unittest.TestCase):
+    """Tests that _root injects the derived site name into the HTML."""
+
+    def setUp(self) -> None:
+        self.api_resource = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        )
+        self.api_resource._conn_pool = MagicMock()
+
+    def test_valid_hostname_replaces_fallback_in_html(self) -> None:
+        mock_response = MagicMock()
+        self.api_resource._root(falcon_response=mock_response, request_host="tolarian-acade.my")
+        assert "Tolarian Academy" in mock_response.text
+        assert FALLBACK_SITE_NAME not in mock_response.text
+
+    def test_localhost_keeps_fallback_in_html(self) -> None:
+        mock_response = MagicMock()
+        self.api_resource._root(falcon_response=mock_response, request_host="localhost")
+        assert FALLBACK_SITE_NAME in mock_response.text
 
 
 if __name__ == "__main__":

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -297,6 +297,21 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
         with pytest.raises(falcon.HTTPNotFound):
             self.api_resource._handle(mock_req, mock_resp)
 
+    def test_disallowed_query_params_do_not_cause_type_error(self) -> None:
+        """Query params named after internal kwargs must be stripped before dispatch."""
+        mock_req = MagicMock()
+        mock_req.path = mock_req.relative_uri = "/"
+        mock_req.params = {"falcon_response": "injected", "request_host": "evil.com"}
+        mock_req.host = "localhost"
+        mock_resp = MagicMock()
+        mock_resp.complete = False
+
+        with patch("api.api_resource.logger"):
+            # Must not raise TypeError or return a 400
+            self.api_resource._handle(mock_req, mock_resp)
+
+        assert mock_resp.text is not None
+
     def test_handle_handles_type_errors(self) -> None:
         """Test _handle handles TypeError exceptions."""
         mock_req = MagicMock()
@@ -937,6 +952,14 @@ _HOSTNAME_TESTCASES = {
     "invalid_chars_returns_fallback": {
         "expected": FALLBACK_SITE_NAME,
         "raw_host": 'evil"><script>.com',
+    },
+    "all_hyphens_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "----",
+    },
+    "all_dots_returns_fallback": {
+        "expected": FALLBACK_SITE_NAME,
+        "raw_host": "...",
     },
 }
 


### PR DESCRIPTION
This PR genericizes the web UI’s branding by replacing the hard-coded “Arcane Tutor” site title with a default “MTG Search” and adds server-side logic to derive a display name from the request host when serving the index page.

**Changes:**
- Updated the static index page’s title/OG title/header to use a generic fallback name (“MTG Search”).
- Added `hostname_to_site_name()` and related constants in `api_resource.py`, and replaced the fallback name in the served HTML based on `Host`.
- Modified request dispatch to pass `request_host` to handlers (currently unconditionally).