### PR TITLE
Respect Effective Hostname

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -75,10 +75,9 @@ def hostname_to_site_name(raw_host: str) -> str:
     hostname = urllib.parse.urlparse(f"http://{raw_host}").hostname or ""
     if not hostname or hostname == "localhost" or _IP_RE.match(hostname) or not _SAFE_HOSTNAME_RE.match(hostname):
         return FALLBACK_SITE_NAME
-    name = hostname.removeprefix("www.")
-    parts = name.split(".")
+    parts = hostname.split(".")[-2:]
     tld = parts[-1].lower()
-    name = ".".join(parts[:-1]) if tld in _STRIP_TLDS else name
+    name = parts[0] if tld in _STRIP_TLDS else ".".join(parts)
     name = name.replace(".", "").replace("-", " ").strip()
     name = name.title()
     return name if any(c.isalnum() for c in name) else FALLBACK_SITE_NAME

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -354,7 +354,7 @@ class APIResource:
         before = time.monotonic()
         try:
             params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
-            res = action(falcon_response=resp, request_host=req.host, **params)
+            res = action(falcon_response=resp, request_host=req.get_header("X-Proxy-Host") or req.host, **params)
             resp.media = res
         except TypeError as oops:
             logger.error("Error handling request: %s", oops, exc_info=True)

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -64,6 +64,7 @@ class CachingMiddleware:
             "ACCEPT-ENCODING",
         ]
         host = req.headers.get("X-PROXY-HOST") or req.headers.get("HOST")
+        host = host.strip().lower() if isinstance(host, str) and host else None
         return (
             req.relative_uri,
             tuple(sorted(req.params.items())),

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-CacheKey = tuple[str, tuple[tuple, ...], tuple[tuple, ...]]
+CacheKey = tuple[str, tuple[tuple, ...], tuple[tuple, ...], str | None]
 
 # Headers that depend on the request rather than the cached payload: CORSMiddleware varies
 # Access-Control-* on the request's Origin and re-sets them on every response, including hits;
@@ -63,10 +63,12 @@ class CachingMiddleware:
         cached_headers = [
             "ACCEPT-ENCODING",
         ]
+        host = req.headers.get("X-PROXY-HOST") or req.headers.get("HOST")
         return (
             req.relative_uri,
             tuple(sorted(req.params.items())),
             tuple(sorted({k: req.headers.get(k) for k in cached_headers}.items())),
+            host,
         )
 
     _UNCACHED_PATHS: frozenset[str] = frozenset({x.strip("/") for x in ["/random_search"]})

--- a/api/middlewares/tests/test_caching_middleware.py
+++ b/api/middlewares/tests/test_caching_middleware.py
@@ -29,8 +29,13 @@ class TestCachingMiddleware:
         resp.render_body.return_value = b"rendered body"
         return resp
 
-    def _cache_key(self) -> tuple:
-        return ("/search?q=lightning+bolt", (("q", "lightning bolt"),), (("ACCEPT-ENCODING", None),))
+    def _cache_key(self, host: str | None = None) -> tuple:
+        return (
+            "/search?q=lightning+bolt",
+            (("q", "lightning bolt"),),
+            (("ACCEPT-ENCODING", None),),
+            host,
+        )
 
     def test_2xx_response_is_cached_as_rendered_bytes(self) -> None:
         """Successful responses should be stored as a CachedResponse, not the Response object."""
@@ -173,6 +178,38 @@ class TestCachingMiddleware:
             middleware.process_request(req, resp)
 
         resp.set_header.assert_not_called()
+
+    def test_different_hosts_have_separate_cache_entries(self) -> None:
+        """Responses for the same query on different hostnames must not share a cache entry."""
+        cache = {}
+        middleware = CachingMiddleware(cache=cache)
+
+        for host in ("scryfall.crestcourt.com", "tolarian-acade.my"):
+            req = self._make_req()
+            req.headers = {"X-PROXY-HOST": host}
+            resp = self._make_resp()
+            with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+                mock_settings.enable_cache = True
+                middleware.process_response(req, resp, None, True)
+
+        assert len(cache) == 2
+        assert cache[self._cache_key("scryfall.crestcourt.com")] is not cache[self._cache_key("tolarian-acade.my")]
+
+    def test_direct_access_uses_host_header_as_cache_key(self) -> None:
+        """When accessed directly (no X-Proxy-Host), the Host header discriminates the cache key."""
+        cache = {}
+        middleware = CachingMiddleware(cache=cache)
+
+        for host in ("localhost:9876", "staging.example.com"):
+            req = self._make_req()
+            req.headers = {"HOST": host}
+            resp = self._make_resp()
+            with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+                mock_settings.enable_cache = True
+                middleware.process_response(req, resp, None, True)
+
+        assert len(cache) == 2
+        assert cache[self._cache_key("localhost:9876")] is not cache[self._cache_key("staging.example.com")]
 
     def test_hit_request_is_not_restored(self) -> None:
         """process_response after a hit must not re-render or overwrite the cached entry."""

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -929,6 +929,14 @@ _HOSTNAME_TESTCASES = {
         "expected": "Arcane Tutor",
         "raw_host": "www.arcane-tutor.com",
     },
+    "strips_subdomain_com": {
+        "expected": "Arcane Tutor",
+        "raw_host": "foo.arcane-tutor.com",
+    },
+    "strips_subdomain_non_strip_tld": {
+        "expected": "Tolarian Academy",
+        "raw_host": "foo.tolarian-acade.my",
+    },
     "localhost_returns_fallback": {
         "expected": FALLBACK_SITE_NAME,
         "raw_host": "localhost",


### PR DESCRIPTION
Updates request handling and caching to respect the effective request hostname (including reverse-proxy scenarios), preventing cache collisions and ensuring host-derived behavior (like site naming) uses the intended host.

**Changes:**
- Extend the caching middleware’s cache key to include the request host (preferring `X-Proxy-Host`/`X-PROXY-HOST`, falling back to `Host`).
- Add test coverage ensuring different hosts do not share cache entries.
- Pass the proxied host through to API action handlers via `request_host`.