### PR TITLE
Never Attempt to Pull Locally Built Images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       args:
         GIT_SHA: ${GIT_SHA:-unknown}
         GIT_BRANCH: ${GIT_BRANCH:-unknown}
+    pull_policy: never
     image: arcane_tutor/apiservice:${IMAGE_TAG:-latest}
     shm_size: 3000M
     cap_add:
@@ -115,6 +116,7 @@ services:
     build:
       context: ./
       dockerfile: ./client/Dockerfile
+    pull_policy: never
     image: arcane_tutor/client:${IMAGE_TAG:-latest}
     command:
       - dumb-init


### PR DESCRIPTION
Updates the Docker Compose configuration to prevent Docker Compose from attempting to pull images for services that are built locally, aligning runtime behavior with the intent of locally-built images in this repo’s Compose workflow.

**Changes:**
- Set `pull_policy: never` for the `apiservice` service.
- Set `pull_policy: never` for the `client` service.




