### PR TITLE
Art Tag Search (`art:`, `art_tags:`)

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -312,6 +312,19 @@ def get_oracle_tags_comparison_object(val: str) -> dict[str, bool]:
     return {normalized_tag: True}
 
 
+def get_art_tags_comparison_object(val: str) -> dict[str, bool]:
+    """Convert art tag string to comparison object for database queries.
+
+    Args:
+        val: Art tag string to normalize.
+
+    Returns:
+        Dictionary mapping normalized art tag to True.
+    """
+    normalized_tag = val.strip().lower()
+    return {normalized_tag: True}
+
+
 def get_is_tags_comparison_object(val: str) -> dict[str, bool]:
     """Convert is: tag string to comparison object for database queries.
 
@@ -543,6 +556,8 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
                 return list(get_frame_data_comparison_object(val).keys())
             if attr == "card_oracle_tags":
                 return list(get_oracle_tags_comparison_object(val).keys())
+            if attr == "card_art_tags":
+                return list(get_art_tags_comparison_object(val).keys())
             if attr == "card_is_tags":
                 return list(get_is_tags_comparison_object(val).keys())
             if attr == "card_legalities":
@@ -971,6 +986,9 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         elif attr == "card_oracle_tags":
             # Oracle tags are stored in lowercase, unlike keywords
             rhs = get_oracle_tags_comparison_object(self.rhs.value.strip())
+            placeholder = context.add(rhs)
+        elif attr == "card_art_tags":
+            rhs = get_art_tags_comparison_object(self.rhs.value.strip())
             placeholder = context.add(rhs)
         elif attr == "card_is_tags":
             # is: tags are stored in lowercase, similar to oracle tags

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -200,6 +200,12 @@ DB_COLUMNS = [
         parser_class=ParserClass.TEXT,
     ),
     FieldInfo(
+        db_column_name="card_art_tags",
+        field_type=FieldType.JSONB_OBJECT,
+        search_aliases=["art_tags", "art"],
+        parser_class=ParserClass.TEXT,
+    ),
+    FieldInfo(
         db_column_name="card_is_tags",
         field_type=FieldType.JSONB_OBJECT,
         search_aliases=["is"],

--- a/api/parsing/tests/test_pyparsing_parser.py
+++ b/api/parsing/tests/test_pyparsing_parser.py
@@ -1133,6 +1133,16 @@ def test_parse_combined_produces_queries() -> None:
             "oracle_tags:dual-land",
             BinaryOperatorNode(CardAttributeNode("oracle_tags", ParserClass.TEXT), ":", StringValueNode("dual-land")),
         ),
+        # Art tag short alias
+        (
+            "art:wolf",
+            BinaryOperatorNode(CardAttributeNode("art", ParserClass.TEXT), ":", StringValueNode("wolf")),
+        ),
+        # Art tag full alias with hyphenated slug
+        (
+            "art_tags:cycle-abu-dual-land",
+            BinaryOperatorNode(CardAttributeNode("art_tags", ParserClass.TEXT), ":", StringValueNode("cycle-abu-dual-land")),
+        ),
         # Hyphenated term in 'is' attribute
         (
             "is:modal-dfc",

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -422,6 +422,35 @@ def test_oracle_tag_sql_translation(parse_query, input_query: str, expected_sql:
 
 
 @pytest.mark.parametrize(
+    argnames=["input_query", "expected_sql", "expected_parameters"],
+    argvalues=[
+        (
+            "art:wolf",
+            r"(card.card_art_tags @> %(p_dict_eyd3b2xmJzogVHJ1ZX0)s)",
+            {"p_dict_eyd3b2xmJzogVHJ1ZX0": {"wolf": True}},
+        ),
+        (
+            "art_tags:wolf",
+            r"(card.card_art_tags @> %(p_dict_eyd3b2xmJzogVHJ1ZX0)s)",
+            {"p_dict_eyd3b2xmJzogVHJ1ZX0": {"wolf": True}},
+        ),
+        (
+            "art:cycle-abu-dual-land",
+            r"(card.card_art_tags @> %(p_dict_eydjeWNsZS1hYnUtZHVhbC1sYW5kJzogVHJ1ZX0)s)",
+            {"p_dict_eydjeWNsZS1hYnUtZHVhbC1sYW5kJzogVHJ1ZX0": {"cycle-abu-dual-land": True}},
+        ),
+    ],
+)
+def test_art_tag_sql_translation(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:
+    """Test that art tag search generates correct SQL with lowercase tags."""
+    parsed = parse_query(input_query)
+    context = QueryContext()
+    observed_sql = parsed.to_sql(context)
+    assert observed_sql == expected_sql, f"\nExpected: {expected_sql}\nObserved: {observed_sql}"
+    assert context == expected_parameters, f"\nExpected params: {expected_parameters}\nObserved params: {context}"
+
+
+@pytest.mark.parametrize(
     argnames=("input_query", "expected_sql", "expected_parameters"),
     argvalues=[
         # Basic is: tag search (should be lowercase)

--- a/card_engine/card_engine/__init__.py
+++ b/card_engine/card_engine/__init__.py
@@ -18,6 +18,7 @@ ENGINE_COLUMNS: list[str] = [
     "card_layout",
     "card_legalities",
     "card_name",
+    "card_art_tags",
     "card_oracle_tags",
     "card_rarity_int",
     "card_set_code",

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -346,6 +346,7 @@ struct Card {
     card_keywords: HashSet<String>,
     card_legalities: u64, // 2 bits per format, positions from the FORMAT_SHIFTS registry
     card_oracle_tags: HashSet<String>,
+    card_art_tags: HashSet<String>,
     card_is_tags: HashSet<String>,
     card_frame_data: HashSet<String>,
 
@@ -682,6 +683,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner) -> Card {
         card_keywords: jsonb_obj_to_hashset(d, "card_keywords"),
         card_legalities: jsonb_obj_to_legality_bits(d, "card_legalities"),
         card_oracle_tags: jsonb_obj_to_hashset(d, "card_oracle_tags"),
+        card_art_tags: jsonb_obj_to_hashset(d, "card_art_tags"),
         card_is_tags: jsonb_obj_to_hashset(d, "card_is_tags"),
         card_frame_data: jsonb_obj_to_hashset(d, "card_frame_data"),
 
@@ -819,6 +821,7 @@ enum CollField {
     Subtypes,
     Keywords,
     OracleTags,
+    ArtTags,
     IsTags,
     FrameData,
 }
@@ -828,6 +831,7 @@ fn card_collection<'a>(card: &'a ACard, f: CollField) -> CollRef<'a> {
         CollField::Subtypes   => CollRef::List(&card.card_subtypes),
         CollField::Keywords   => CollRef::Set(&card.card_keywords),
         CollField::OracleTags => CollRef::Set(&card.card_oracle_tags),
+        CollField::ArtTags    => CollRef::Set(&card.card_art_tags),
         CollField::IsTags     => CollRef::Set(&card.card_is_tags),
         CollField::FrameData  => CollRef::Set(&card.card_frame_data),
     }
@@ -1449,9 +1453,10 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
         return Ok(FilterExpr::CollectionCmp { field: CollField::Keywords, op: cmp_op, value });
     }
 
-    if matches!(attr, "card_oracle_tags" | "card_is_tags" | "card_frame_data") {
+    if matches!(attr, "card_oracle_tags" | "card_art_tags" | "card_is_tags" | "card_frame_data") {
         let coll_field = match attr {
             "card_oracle_tags" => CollField::OracleTags,
+            "card_art_tags"    => CollField::ArtTags,
             "card_is_tags"     => CollField::IsTags,
             _                  => CollField::FrameData,
         };
@@ -1813,6 +1818,7 @@ struct CardIndexes {
     subtypes:       TagIndex,
     keywords:       TagIndex,
     oracle_tags:    TagIndex,
+    art_tags:       TagIndex,
     is_tags:        TagIndex,
 }
 
@@ -1828,6 +1834,7 @@ impl Default for CardIndexes {
             subtypes:       HashMap::new(),
             keywords:       HashMap::new(),
             oracle_tags:    HashMap::new(),
+            art_tags:       HashMap::new(),
             is_tags:        HashMap::new(),
         }
     }
@@ -1923,6 +1930,12 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Op
             if matches!(field, CollField::OracleTags) && matches!(op, CmpOp::Ge) =>
         {
             indexes.oracle_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
+        }
+
+        FilterExpr::CollectionCmp { field, op, value }
+            if matches!(field, CollField::ArtTags) && matches!(op, CmpOp::Ge) =>
+        {
+            indexes.art_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
         FilterExpr::CollectionCmp { field, op, value }
@@ -2443,6 +2456,7 @@ impl QueryEngine {
             subtypes:       build_list_index(&cards, |c| &c.card_subtypes),
             keywords:       build_tag_index(&cards, |c| &c.card_keywords),
             oracle_tags:    build_tag_index(&cards, |c| &c.card_oracle_tags),
+            art_tags:       build_tag_index(&cards, |c| &c.card_art_tags),
             is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
         };
 
@@ -2859,6 +2873,7 @@ mod tests {
                 card_keywords: HashSet::from([words[i % 10].to_string()]),
                 card_legalities: 0,
                 card_oracle_tags: HashSet::from([format!("tag-{}", i % 100)]),
+                card_art_tags: HashSet::new(),
                 card_is_tags: HashSet::new(),
                 card_frame_data: HashSet::new(),
                 mana_cost: ManaCost {
@@ -2882,6 +2897,7 @@ mod tests {
             subtypes:       build_list_index(&cards, |c| &c.card_subtypes),
             keywords:       build_tag_index(&cards, |c| &c.card_keywords),
             oracle_tags:    build_tag_index(&cards, |c| &c.card_oracle_tags),
+            art_tags:       build_tag_index(&cards, |c| &c.card_art_tags),
             is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
         };
         let data = CardData { cards, strings, indexes, format_shifts: HashMap::new() };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2922,4 +2922,32 @@ mod tests {
         println!("checked rkyv::access:   {checked:?} per call");
         println!("access_unchecked:       {unchecked:?} per call");
     }
+
+    // Verify that narrow_candidates returns the correct card ids for an art tag
+    // that is present in the index, and returns None (no narrowing) for an absent tag.
+    #[test]
+    fn narrow_candidates_art_tags() {
+        let mut art_tags: TagIndex = HashMap::new();
+        art_tags.insert("wolf".to_string(), vec![0, 2]);
+        art_tags.insert("dragon".to_string(), vec![1]);
+
+        let indexes = CardIndexes { art_tags, ..Default::default() };
+        let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
+        let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
+
+        let present = FilterExpr::CollectionCmp {
+            field: CollField::ArtTags,
+            op: CmpOp::Ge,
+            value: "wolf".to_string(),
+        };
+        assert_eq!(narrow_candidates(&present, archived), Some(vec![0, 2]));
+
+        // A tag not in the index cannot narrow; the eval step handles correctness.
+        let absent = FilterExpr::CollectionCmp {
+            field: CollField::ArtTags,
+            op: CmpOp::Ge,
+            value: "zombie".to_string(),
+        };
+        assert_eq!(narrow_candidates(&absent, archived), None);
+    }
 }


### PR DESCRIPTION
Adds `art:<slug>` and `art_tags:<slug>` filter syntax that searches `card_art_tags`, the
JSONB column populated by the bulk art tag import added in the base branch.

Depends on: `joe/bulk_tag_imports`

## Changes

### Parser / SQL path

- `db_info.py` — new `FieldInfo` for `card_art_tags` with aliases `art` and `art_tags`
- `card_query_nodes.py` — `get_art_tags_comparison_object()` normalises the slug and returns
  `{"<slug>": True}`; wired into both the `to_json()` and SQL generation branches so
  `art:wolf` emits `card.card_art_tags @> '{"wolf": true}'`

### Rust engine path

- `card_engine/src/lib.rs` — adds `card_art_tags: HashSet<String>` to the `Card` struct,
  loads it from the DB row, adds a `CollField::ArtTags` variant with its filter and
  `narrow_candidates` fast-path, and builds an `art_tags: TagIndex` alongside the existing
  `oracle_tags` index
- `card_engine/card_engine/__init__.py` — adds `card_art_tags` to `ENGINE_COLUMNS` so the
  column is fetched when the engine store is populated

Art tag queries now execute entirely in the Rust engine without falling back to SQL.

### Tests

- `test_pyparsing_parser.py` — two new parse cases: `art:wolf` and `art_tags:cycle-abu-dual-land`
- `test_sql_gen.py` — three new SQL-generation cases covering `art:`, `art_tags:`, and a
  hyphenated slug

## Search examples

```
art:wolf
art_tags:dragon
-art:zombie t:creature
```
