### PR TITLE
Cache Build Artifacts in CI Pipeline

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.13
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -37,11 +38,29 @@ jobs:
           fi
           uv pip install --system --break-system-packages -r requirements/base.txt -r requirements/test.txt
 
+      - name: Cache card_engine wheel
+        id: ce-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/card-engine-wheel
+          key: card-engine-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('card_engine/**') }}
+
       - name: Install Rust toolchain
+        if: steps.ce-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build and install card_engine extension
-        run: pip install ./card_engine
+      - name: Cache Cargo registry and build artifacts
+        if: steps.ce-cache.outputs.cache-hit != 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: card_engine
+
+      - name: Build card_engine wheel
+        if: steps.ce-cache.outputs.cache-hit != 'true'
+        run: pip wheel ./card_engine -w /tmp/card-engine-wheel
+
+      - name: Install card_engine extension
+        run: pip install /tmp/card-engine-wheel/card_engine*.whl
 
       - name: Run tests
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache card_engine wheel
         id: ce-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/card-engine-wheel
           key: card-engine-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('card_engine/**') }}


### PR DESCRIPTION
This PR speeds up CI by caching the compiled Rust/PyO3 `card_engine` build output so unit test runs can skip rebuilding the extension when the `card_engine/` sources haven’t changed.

**Changes:**
- Adds a cache for a prebuilt `card_engine` wheel keyed by OS, resolved Python version, and a hash of `card_engine/**`.
- Adds conditional Rust toolchain setup + `Swatinem/rust-cache` usage only when the wheel cache misses.
- Switches from `pip install ./card_engine` to a two-step `pip wheel` + `pip install` from the cached wheel directory.




