### PR TITLE
Fancy Upsert: Update Changed Cards on Import

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -63,6 +63,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _rss_mb() -> str:
+    """Return current RSS in MB as a string, or 'unknown' if /proc is unavailable."""
+    try:
+        with pathlib.Path("/proc/self/status").open() as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return f"{int(line.split()[1]) // 1024} MB"
+    except OSError:
+        pass
+    return "unknown"
+
+
 FALLBACK_SITE_NAME = "MTG Search"
 
 # Selectors extracted from styles.css and inlined in the HTML <style> block to prevent
@@ -795,6 +808,7 @@ class APIResource:
             return
         if self._engine is None:
             return
+        logger.info("Engine reload requested (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
         if not self._engine_reload_guard.acquire(block=force):
             logger.info("Engine reload already in progress in another worker, skipping (pid=%d)", os.getpid())
             return
@@ -802,6 +816,7 @@ class APIResource:
             if not force and self._engine.size() > 0:
                 # Another worker populated the store while we raced for the lock.
                 return
+            logger.info("Engine reload starting (force=%s, pid=%d, rss=%s)", force, os.getpid(), _rss_mb())
             cols_sql = ", ".join(f"card.{col}" for col in _ENGINE_COLUMNS_FROM_MODULE)
             try:
                 with self._conn_pool.connection() as conn:
@@ -823,7 +838,7 @@ class APIResource:
             except psycopg_pool.PoolClosed:
                 logger.debug("Connection pool closed during engine reload, skipping (pid=%d)", os.getpid())
                 return
-            logger.info("Engine reloaded with %d cards (pid=%d)", self._engine.size(), os.getpid())
+            logger.info("Engine reloaded with %d cards (pid=%d, rss=%s)", self._engine.size(), os.getpid(), _rss_mb())
         finally:
             self._engine_reload_guard.release()
 
@@ -1515,20 +1530,21 @@ class APIResource:
             # Validate and set statement timeout
             self._set_statement_timeout(cursor, statement_timeout)
             cursor.execute(backfill_sql)
+            updated_count = cursor.rowcount
 
             # Get count of updated cards
             cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE prefer_score IS NOT NULL")
             result = cursor.fetchone()
-            count = result["count"] if result else 0
+            total_cards = result["count"] if result else 0
 
             conn.commit()
 
-        logger.info("Prefer score backfill complete: %d cards updated", count)
+        logger.info("Prefer score backfill complete: %d of %d cards updated", updated_count, total_cards)
 
         return {
             "status": "success",
-            "cards_updated": count,
-            "message": f"Successfully backfilled prefer scores for {count} cards",
+            "cards_updated": updated_count,
+            "message": f"Successfully backfilled prefer scores for {updated_count} of {total_cards} cards",
         }
 
     def _fetch_cubecobra_data(self, db_oracle_ids: set[str]) -> dict[str, dict[str, Any]]:
@@ -2290,10 +2306,6 @@ class APIResource:
                     return {"status": status, "cards_loaded": 0, "cards_sent": 0, "sample_cards": [], "message": message}
 
                 cards_loaded = cards_inserted + cards_updated
-                if cards_loaded > 0:
-                    self._clear_caches()
-                    self._reload_engine(force=True)
-
                 return {
                     "status": "success",
                     "cards_inserted": cards_inserted,

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -847,8 +847,10 @@ class APIResource:
             cards_sent = result.get("cards_sent", result["cards_loaded"])
             rate = cards_sent / total_time if total_time > 0 else 0
             logger.info(
-                "Loaded %d cards in %.2f seconds, rate: %.2f cards/s...",
+                "Loaded %d cards (%d new, %d updated) in %.2f seconds, rate: %.2f cards/s...",
                 result["cards_loaded"],
+                result.get("cards_inserted", 0),
+                result.get("cards_updated", 0),
                 total_time,
                 rate,
             )
@@ -2130,14 +2132,19 @@ class APIResource:
         cursor: Cursor,
         staging_table_name: str,
         page: tuple[dict[str, Any], ...],
-    ) -> tuple[int, list[dict[str, Any]]]:
+    ) -> dict[str, Any]:
         """COPY one batch of preprocessed cards through a temp staging table into magic.cards.
 
-        Returns (rows_inserted, sample_cards).
+        Returns {"inserted": int, "updated": int, "sample": list[dict]}.
         """
         # ON COMMIT DROP is a safety net: the table is dropped explicitly below, but if an error
         # aborts the batch the transaction rollback (or any later commit) removes it as well.
-        cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb) ON COMMIT DROP")
+        cursor.execute(f"""
+            CREATE TEMPORARY TABLE {staging_table_name} (
+                card_blob  jsonb,
+                scryfall_id uuid GENERATED ALWAYS AS ((card_blob->>'scryfall_id')::uuid) STORED
+            ) ON COMMIT DROP
+        """)
 
         with cursor.copy(
             f"COPY {staging_table_name} (card_blob) FROM STDIN WITH (FORMAT csv, HEADER false)",
@@ -2156,17 +2163,61 @@ class APIResource:
         )
         sample_cards = [dict(r) for r in cursor.fetchall()]
 
+        # Group 1: new cards — scryfall_id not yet in the table.
         cursor.execute(
             f"""
             INSERT INTO magic.cards
             SELECT (jsonb_populate_record(null::magic.cards, card_blob)).*
             FROM {staging_table_name}
-            ON CONFLICT DO NOTHING
+            WHERE NOT EXISTS (
+                SELECT 1 FROM magic.cards c WHERE c.scryfall_id = {staging_table_name}.scryfall_id
+            )
+            ON CONFLICT (scryfall_id) DO NOTHING
             """,
         )
-        rows_inserted = cursor.rowcount
+        new_cards = cursor.rowcount
+
+        # Group 3: changed cards — scryfall_id exists but at least one Scryfall field differs.
+        #
+        # Normalize both the incoming blob and the existing row through jsonb_populate_record
+        # so PostgreSQL type coercions (e.g. real precision) are applied identically to both
+        # sides before comparison.  Using c as the base — rather than null — means backfilled
+        # columns (prefer_score, cubecobra_*, card_is_tags) that are absent from the incoming
+        # blob default to the existing row value on both sides, so they never trigger a spurious
+        # update.  The same merged_blob is used for the INSERT so those backfilled values survive.
+        #
+        # RETURNING merged_blob lets the outer INSERT read from the DELETE output rather than the
+        # table, avoiding the snapshot-concurrency conflict that would occur if the INSERT and
+        # DELETE ran against the same snapshot simultaneously.
+        cursor.execute(
+            f"""
+            WITH stripped_cards AS (
+                SELECT scryfall_id,
+                       card_blob - ARRAY['card_oracle_tags', 'card_art_tags', 'card_is_tags'] AS stripped_blob
+                FROM {staging_table_name}
+            ),
+            candidates AS (
+                SELECT
+                    s.scryfall_id,
+                    to_jsonb(jsonb_populate_record(c, s.stripped_blob)) AS merged_blob
+                FROM stripped_cards s
+                JOIN magic.cards c ON c.scryfall_id = s.scryfall_id
+                WHERE to_jsonb(jsonb_populate_record(c, s.stripped_blob)) IS DISTINCT FROM to_jsonb(c)
+            ),
+            deleted AS (
+                DELETE FROM magic.cards c
+                USING candidates
+                WHERE c.scryfall_id = candidates.scryfall_id
+                RETURNING candidates.merged_blob
+            )
+            INSERT INTO magic.cards
+            SELECT (jsonb_populate_record(null::magic.cards, deleted.merged_blob)).*
+            FROM deleted
+            """,
+        )
+        updated_cards = cursor.rowcount
         cursor.execute(f"DROP TABLE {staging_table_name}")
-        return rows_inserted, sample_cards
+        return {"inserted": new_cards, "updated": updated_cards, "sample": sample_cards}
 
     def _load_cards_with_staging(
         self,
@@ -2176,14 +2227,16 @@ class APIResource:
         """Load cards into the database using a randomly-named staging table.
 
         Accepts any iterable of raw card dicts (as returned by the Scryfall API or
-        stream_data_for_key). Preprocessing and already-imported filtering are applied
-        lazily as cards flow through, so the full dataset is never held in memory.
+        stream_data_for_key). Preprocessing is applied lazily as cards flow through,
+        so the full dataset is never held in memory.
 
         Returns a dict with:
-            - cards_loaded: rows actually inserted (after ON CONFLICT DO NOTHING)
-            - cards_sent: rows attempted (after preprocessing + filtering)
+            - cards_inserted: new cards added
+            - cards_updated: existing cards replaced with changed data
+            - cards_loaded: cards_inserted + cards_updated
+            - cards_sent: rows attempted (after preprocessing)
             - sample_cards: up to 10 random cards from the final batch
-            - status: "success", "no_cards_before_preprocessing", "no_cards_after_preprocessing", "all_cards_already_present", "database_error"
+            - status: "success", "no_cards_before_preprocessing", "no_cards_after_preprocessing", "database_error"
             - message: descriptive message
         """
         self.setup_schema()
@@ -2195,11 +2248,8 @@ class APIResource:
             with self._conn_pool.connection() as conn, conn.cursor() as cursor:
                 self._set_statement_timeout(cursor, 30_000)
 
-                cursor.execute("SELECT scryfall_id FROM magic.cards GROUP BY scryfall_id")
-                already_imported_ids = {r["scryfall_id"] for r in cursor.fetchall()}
-
                 class _CardStream:
-                    """Preprocesses and filters raw cards lazily, tracking stage counts."""
+                    """Preprocesses raw cards lazily, tracking stage counts."""
 
                     def __init__(self) -> None:
                         self.raw = 0
@@ -2210,41 +2260,48 @@ class APIResource:
                             self.raw += 1
                             for processed in preprocess_card(card):
                                 self.preprocessed += 1
-                                if processed["scryfall_id"] not in already_imported_ids:
-                                    yield processed
+                                yield processed
 
                 stream = _CardStream()
-                cards_loaded = cards_sent = 0
+                cards_inserted = cards_updated = cards_sent = 0
                 sample_cards: list[dict[str, Any]] = []
 
                 for page in itertools.batched(stream, page_size):
-                    rows, sample_cards = self._copy_batch_to_staging(cursor, staging_table_name, page)
+                    batch = self._copy_batch_to_staging(cursor, staging_table_name, page)
                     cards_sent += len(page)
-                    cards_loaded += rows
-                    logger.info("%d cards loaded, %d cards sent so far", cards_loaded, cards_sent)
+                    cards_inserted += batch["inserted"]
+                    cards_updated += batch["updated"]
+                    sample_cards = batch["sample"]
+                    logger.info(
+                        "%d inserted, %d updated, %d sent so far",
+                        cards_inserted,
+                        cards_updated,
+                        cards_sent,
+                    )
 
                 conn.commit()
 
                 if cards_sent == 0:
                     if stream.raw == 0:
                         status, message = "no_cards_before_preprocessing", "No cards provided for loading"
-                    elif stream.preprocessed == 0:
-                        status, message = "no_cards_after_preprocessing", "No cards remaining after preprocessing"
                     else:
-                        status, message = "all_cards_already_present", "All cards already present"
+                        status, message = "no_cards_after_preprocessing", "No cards remaining after preprocessing"
                     logger.info("No cards imported: %s (raw=%d preprocessed=%d)", message, stream.raw, stream.preprocessed)
                     return {"status": status, "cards_loaded": 0, "cards_sent": 0, "sample_cards": [], "message": message}
 
+                cards_loaded = cards_inserted + cards_updated
                 if cards_loaded > 0:
                     self._clear_caches()
                     self._reload_engine(force=True)
 
                 return {
                     "status": "success",
+                    "cards_inserted": cards_inserted,
+                    "cards_updated": cards_updated,
                     "cards_loaded": cards_loaded,
                     "cards_sent": cards_sent,
                     "sample_cards": sample_cards,
-                    "message": f"Successfully loaded {cards_loaded} cards",
+                    "message": f"Successfully loaded {cards_loaded} cards ({cards_inserted} new, {cards_updated} updated)",
                 }
 
         except (psycopg.Error, ValueError, KeyError) as e:

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -2306,6 +2306,7 @@ class APIResource:
                     return {"status": status, "cards_loaded": 0, "cards_sent": 0, "sample_cards": [], "message": message}
 
                 cards_loaded = cards_inserted + cards_updated
+                self._clear_caches()
                 return {
                     "status": "success",
                     "cards_inserted": cards_inserted,

--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -164,10 +164,12 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
         card["creature_power_text"] = card.get("power")
         card["creature_toughness_text"] = card.get("toughness")
     else:
-        # Non-creature face with power/toughness - clean up these fields instead of rejecting
-        # The pop calls set these to None implicitly, and we explicitly reset creature_power/toughness
-        card.pop("creature_power_text", None)
-        card.pop("creature_toughness_text", None)
+        # Explicit None (not pop) so these keys appear as JSON null in the processed blob.
+        # An absent key falls through to the existing DB row's value during upsert merging;
+        # an explicit null overrides it, keeping creature_power_text/creature_toughness_text
+        # in sync with creature_power/creature_toughness for the check constraint.
+        card["creature_power_text"] = None
+        card["creature_toughness_text"] = None
         card["creature_power"] = None
         card["creature_toughness"] = None
 

--- a/api/entrypoint.py
+++ b/api/entrypoint.py
@@ -25,6 +25,31 @@ def get_args() -> dict:
     return vars(parser.parse_args())
 
 
+def _kill_workers(workers: list[ApiWorker]) -> None:
+    for iworker in workers:
+        if iworker.pid is None:
+            logger.warning("Worker %s has no pid", iworker)
+            continue
+        if iworker.is_alive():
+            logger.info("Killing worker %d", iworker.pid)
+            iworker.kill()
+
+
+def _all_workers_alive(workers: list[ApiWorker], exit_flag: multiprocessing.Event) -> bool:
+    if exit_flag.is_set():
+        return False
+    for iworker in workers:
+        if not iworker.is_alive():
+            logger.error(
+                "Worker %s (pid=%s) died with exitcode %s",
+                iworker.name,
+                iworker.pid,
+                iworker.exitcode,
+            )
+            return False
+    return True
+
+
 def run_server(
     *,
     port: int = DEFAULT_PORT,
@@ -39,16 +64,9 @@ def run_server(
     exit_flag = multiprocessing.Event()
 
     def graceful_shutdown(signum: int, frame: FrameType) -> None:
-        """Graceful shutdown."""
         del frame
         logger.info("Received signal %d in pid %d, setting exit flag", signum, os.getpid())
-        for iworker in workers:
-            if iworker.pid is None:
-                logger.warning("Worker %s has no pid", iworker)
-                continue
-            if iworker.is_alive():
-                logger.info("Killing worker %d", iworker.pid)
-                iworker.kill()
+        _kill_workers(workers)
         logger.info("Shutdown complete")
 
     # Create shared objects for all workers
@@ -79,18 +97,8 @@ def run_server(
     signal.signal(signal.SIGTERM, graceful_shutdown)
     signal.signal(signal.SIGINT, graceful_shutdown)
 
-    def all_workers_alive() -> bool:
-        if exit_flag.is_set():
-            return False
-        for iworker in workers:
-            if iworker.is_alive():
-                pass
-            else:
-                return False
-        return True
-
     try:
-        while all_workers_alive():
+        while _all_workers_alive(workers, exit_flag):
             # block for up to 1 second on exit flag being set
             response = exit_flag.wait(1 / 20)
             if response:
@@ -100,6 +108,15 @@ def run_server(
             logger.info("Some workers died")
     except KeyboardInterrupt:
         graceful_shutdown(signal.SIGINT, None)
+
+    exit_flag.set()
+    for iworker in workers:
+        if iworker.is_alive():
+            logger.warning("Worker %s is still alive, killing it", iworker)
+            iworker.kill()
+    for iworker in workers:
+        if iworker.is_alive():
+            iworker.join(timeout=1)
 
     logger.info("Main server process exiting")
 

--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -7,7 +7,7 @@ WITH computed_components AS (
         JSONB_BUILD_OBJECT(
             'illustration_count', (
                 SELECT
-                    (23 * LN(1 + COUNT(*)) / LN(40))::real
+                    ROUND((23 * LN(1 + COUNT(*)) / LN(40))::numeric, 4)
                 FROM magic.cards query_target_cards
                 WHERE (
                     query_target_cards.illustration_id = source.illustration_id AND
@@ -112,4 +112,7 @@ SET
     prefer_score = computed_scores.new_score
 FROM computed_scores
 WHERE magic.cards.scryfall_id = computed_scores.scryfall_id
-  AND magic.cards.prefer_score IS DISTINCT FROM computed_scores.new_score;
+  AND (
+      magic.cards.prefer_score_components IS DISTINCT FROM computed_scores.new_components
+      OR magic.cards.prefer_score IS DISTINCT FROM computed_scores.new_score
+  );

--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -1,111 +1,115 @@
 -- Backfill prefer_score and prefer_score_components for all cards
 -- This script recalculates the prefer score for all existing cards based on multiple attributes
 
-UPDATE magic.cards update_target_cards
-SET prefer_score_components = JSONB_BUILD_OBJECT(
-    'illustration_count', (
-        SELECT 
-            23 * LN(1 + COUNT(*)) / LN(40)
-        FROM magic.cards query_target_cards
-        WHERE (
-            query_target_cards.illustration_id = update_target_cards.illustration_id AND 
-            query_target_cards.illustration_id IS NOT NULL AND
-            query_target_cards.card_name = update_target_cards.card_name
-        )
-    ),
-    'rarity', (
-        SELECT 
-            CASE 
-                WHEN card_rarity_int = 0 THEN 16  -- common
-                WHEN card_rarity_int = 1 THEN 16  -- uncommon
-                WHEN card_rarity_int = 2 THEN 11  -- rare
-                WHEN card_rarity_int = 3 THEN 0   -- mythic
-                ELSE 0
-            END
-    ),
-    'border', (
-        SELECT 
-            CASE 
-                WHEN card_border = 'black' THEN 14
-                WHEN card_border = 'white' THEN 0
-                WHEN card_border = 'borderless' THEN 0
-                ELSE 0
-            END
-    ),
-    'frame', (
-        SELECT 
-            CASE 
-                WHEN card_frame_data ? '2015' THEN 42
-                WHEN card_frame_data ? '2003' THEN 30
-                WHEN card_frame_data ? '1997' THEN 25
-                WHEN card_frame_data ? '1993' THEN 10
-                ELSE 0
-            END
-    ),
-    'extended_art', (
-        SELECT 
-            CASE 
-                WHEN card_frame_data ? 'Extendedart' THEN 12
-                ELSE 0
-            END
-    ),
-    'highres_scan', (
-        SELECT 
-            CASE 
-                WHEN raw_card_blob ->> 'image_status' = 'highres_scan' THEN 16
-                ELSE 0
-            END
-    ),
-    'has_paper', (
-        SELECT 
-            CASE 
-                WHEN raw_card_blob -> 'games' ? 'paper' THEN 6
-                ELSE 0
-            END
-    ),
-    'language', (
-        SELECT 
-            CASE 
-                WHEN raw_card_blob ->> 'lang' = 'en' THEN 40
-                ELSE 0
-            END
-    ),
-    'legendary_frame', (
-        SELECT 
-            CASE 
-                WHEN raw_card_blob -> 'frame_effects' ? 'legendary' THEN 5
-                ELSE 0
-            END
-    ),
-    'non_showcase', (
-        SELECT 
-            CASE 
-                WHEN NOT (COALESCE(raw_card_blob -> 'frame_effects', '[]'::jsonb) ? 'showcase') THEN 10
-                ELSE 0
-            END
-    ),
-    'finish', (
-        SELECT 
-            CASE 
-                WHEN raw_card_blob -> 'finishes' ? 'nonfoil' THEN 10
-                WHEN raw_card_blob -> 'finishes' ? 'foil' THEN 5
-                WHEN raw_card_blob -> 'finishes' ? 'etched' THEN 0
-                ELSE 0
-            END
-    ),
-    'artwork_set', (
-        SELECT 
-            CASE 
-                WHEN card_set_code IS NULL OR card_set_code NOT IN ('dbl') THEN 20
-                ELSE 0
-            END
-    )
-);
-
-
--- Update prefer_score to be the sum of all component values
-UPDATE magic.cards 
-SET prefer_score = (
-    SELECT SUM(value::numeric)
-    FROM jsonb_each(prefer_score_components)
-);
+WITH computed_components AS (
+    SELECT
+        scryfall_id,
+        JSONB_BUILD_OBJECT(
+            'illustration_count', (
+                SELECT
+                    (23 * LN(1 + COUNT(*)) / LN(40))::real
+                FROM magic.cards query_target_cards
+                WHERE (
+                    query_target_cards.illustration_id = source.illustration_id AND
+                    query_target_cards.illustration_id IS NOT NULL AND
+                    query_target_cards.card_name = source.card_name
+                )
+            ),
+            'rarity', (
+                CASE
+                    WHEN card_rarity_int = 0 THEN 16  -- common
+                    WHEN card_rarity_int = 1 THEN 16  -- uncommon
+                    WHEN card_rarity_int = 2 THEN 11  -- rare
+                    WHEN card_rarity_int = 3 THEN 0   -- mythic
+                    ELSE 0
+                END
+            ),
+            'border', (
+                CASE
+                    WHEN card_border = 'black' THEN 14
+                    WHEN card_border = 'white' THEN 0
+                    WHEN card_border = 'borderless' THEN 0
+                    ELSE 0
+                END
+            ),
+            'frame', (
+                CASE
+                    WHEN card_frame_data ? '2015' THEN 42
+                    WHEN card_frame_data ? '2003' THEN 30
+                    WHEN card_frame_data ? '1997' THEN 25
+                    WHEN card_frame_data ? '1993' THEN 10
+                    ELSE 0
+                END
+            ),
+            'extended_art', (
+                CASE
+                    WHEN card_frame_data ? 'Extendedart' THEN 12
+                    ELSE 0
+                END
+            ),
+            'highres_scan', (
+                CASE
+                    WHEN raw_card_blob ->> 'image_status' = 'highres_scan' THEN 16
+                    ELSE 0
+                END
+            ),
+            'has_paper', (
+                CASE
+                    WHEN raw_card_blob -> 'games' ? 'paper' THEN 6
+                    ELSE 0
+                END
+            ),
+            'language', (
+                CASE
+                    WHEN raw_card_blob ->> 'lang' = 'en' THEN 40
+                    ELSE 0
+                END
+            ),
+            'legendary_frame', (
+                CASE
+                    WHEN raw_card_blob -> 'frame_effects' ? 'legendary' THEN 5
+                    ELSE 0
+                END
+            ),
+            'non_showcase', (
+                CASE
+                    WHEN NOT (COALESCE(raw_card_blob -> 'frame_effects', '[]'::jsonb) ? 'showcase') THEN 10
+                    ELSE 0
+                END
+            ),
+            'finish', (
+                CASE
+                    WHEN raw_card_blob -> 'finishes' ? 'nonfoil' THEN 10
+                    WHEN raw_card_blob -> 'finishes' ? 'foil' THEN 5
+                    WHEN raw_card_blob -> 'finishes' ? 'etched' THEN 0
+                    ELSE 0
+                END
+            ),
+            'artwork_set', (
+                CASE
+                    WHEN card_set_code IS NULL OR card_set_code NOT IN ('dbl') THEN 20
+                    ELSE 0
+                END
+            )
+        ) AS new_components
+    FROM magic.cards source
+),
+computed_scores AS (
+    SELECT
+        scryfall_id,
+        new_components,
+        (
+            SELECT
+                SUM(value::numeric)
+            FROM
+                jsonb_each(new_components)
+        )::real AS new_score
+    FROM computed_components
+)
+UPDATE magic.cards
+SET
+    prefer_score_components = computed_scores.new_components,
+    prefer_score = computed_scores.new_score
+FROM computed_scores
+WHERE magic.cards.scryfall_id = computed_scores.scryfall_id
+  AND magic.cards.prefer_score IS DISTINCT FROM computed_scores.new_score;

--- a/api/tests/helpers.py
+++ b/api/tests/helpers.py
@@ -29,7 +29,7 @@ def search_kwargs(
     }
 
 
-def make_raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
+def make_raw_card(card_id: str | None = None, name: str = "Test Card", rarity: str = "common") -> dict:
     """Minimal raw Scryfall card dict that passes preprocess_card and satisfies NOT NULL constraints."""
     cid = card_id or str(uuid.uuid4())
     jpg = f"{cid[0]}/{cid[1]}/{cid}.jpg"
@@ -46,7 +46,7 @@ def make_raw_card(card_id: str | None = None, name: str = "Test Card") -> dict:
         "keywords": [],
         "prices": {"usd": "0.10"},
         "set": "tst",
-        "rarity": "common",
+        "rarity": rarity,
         "collector_number": "1",
         "image_uris": {
             "small": f"https://cards.scryfall.io/small/front/{jpg}",

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -167,3 +167,12 @@ class TestBackfillPreferScores:
 
         assert row is not None
         assert row["prefer_score"] is not None
+
+    def test_second_run_updates_zero_rows(self, api_resource: APIResource) -> None:
+        """Re-running the backfill on already-scored cards should touch no rows."""
+        _insert_card(api_resource, make_raw_card(name=f"Idempotent Score Card {uuid.uuid4()}"))
+        api_resource.backfill_prefer_scores()
+
+        result = api_resource.backfill_prefer_scores()
+
+        assert result["cards_updated"] == 0

--- a/api/tests/test_load_cards_with_staging.py
+++ b/api/tests/test_load_cards_with_staging.py
@@ -43,13 +43,13 @@ class TestLoadCardsWithStagingStatus:
         assert result["status"] == "no_cards_after_preprocessing"
         assert result["cards_loaded"] == 0
 
-    def test_already_imported_cards_return_all_cards_already_present(self, api_resource: APIResource) -> None:
-        """Cards already in the DB are skipped; if all are skipped the status is all_cards_already_present."""
+    def test_unchanged_card_on_reimport_loads_zero(self, api_resource: APIResource) -> None:
+        """Re-submitting an identical card produces success with zero loads (unchanged, no write)."""
         card = make_raw_card(name="Already Present Card")
         api_resource._load_cards_with_staging([card])  # first insert
 
         result = api_resource._load_cards_with_staging([card])  # second attempt
-        assert result["status"] == "all_cards_already_present"
+        assert result["status"] == "success"
         assert result["cards_loaded"] == 0
 
     def test_success_result_includes_cards_sent(self, api_resource: APIResource) -> None:
@@ -67,16 +67,14 @@ class TestLoadCardsWithStagingStatus:
 class TestCardStreamCounting:
     """_CardStream tallies stage counts that drive the status string selection."""
 
-    def test_multiple_preprocessed_but_all_already_imported_gives_correct_status(self, api_resource: APIResource) -> None:
-        """Raw > 0 and preprocessed > 0 but all filtered by already_imported_ids → all_cards_already_present."""
+    def test_multiple_preprocessed_but_all_unchanged_loads_zero(self, api_resource: APIResource) -> None:
+        """Raw > 0 and preprocessed > 0 but all unchanged → success with cards_loaded=0."""
         cards = [make_raw_card(name=f"Count Card {i}") for i in range(3)]
         api_resource._load_cards_with_staging(cards)  # seed the DB
 
         result = api_resource._load_cards_with_staging(cards)
-        # Would be no_cards_before_preprocessing if raw==0,
-        # or no_cards_after_preprocessing if preprocessed==0.
-        # Only reaches all_cards_already_present when both counts are > 0.
-        assert result["status"] == "all_cards_already_present"
+        assert result["status"] == "success"
+        assert result["cards_loaded"] == 0
 
     def test_preprocessing_filter_distinguished_from_empty_input(self, api_resource: APIResource) -> None:
         """no_cards_after_preprocessing is distinct from no_cards_before_preprocessing."""
@@ -99,28 +97,30 @@ class TestCopyBatchToStaging:
     def test_inserts_card_and_returns_row_count(self, api_resource: APIResource) -> None:
         (preprocessed,) = preprocess_card(make_raw_card(name="Staging Insert Card"))
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            rows, _ = api_resource._copy_batch_to_staging(cursor, "test_stg_insert", (preprocessed,))
+            batch = api_resource._copy_batch_to_staging(cursor, "test_stg_insert", (preprocessed,))
             conn.commit()
-        assert rows == 1
+        assert batch["inserted"] == 1
+        assert batch["updated"] == 0
 
     def test_returns_sample_cards_as_list_of_dicts(self, api_resource: APIResource) -> None:
         (preprocessed,) = preprocess_card(make_raw_card(name="Staging Sample Card"))
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            _, sample_cards = api_resource._copy_batch_to_staging(cursor, "test_stg_sample", (preprocessed,))
+            batch = api_resource._copy_batch_to_staging(cursor, "test_stg_sample", (preprocessed,))
             conn.commit()
-        for sc in sample_cards:
+        for sc in batch["sample"]:
             assert isinstance(sc, dict)
 
-    def test_on_conflict_does_nothing_returns_zero(self, api_resource: APIResource) -> None:
-        """Re-inserting the same card returns rowcount 0 (ON CONFLICT DO NOTHING)."""
+    def test_unchanged_card_returns_zero_rowcount(self, api_resource: APIResource) -> None:
+        """Re-inserting an unchanged card returns inserted=0, updated=0."""
         (preprocessed,) = preprocess_card(make_raw_card(name="Staging Conflict Card"))
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_a", (preprocessed,))
             conn.commit()
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            rows, _ = api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_b", (preprocessed,))
+            batch = api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_b", (preprocessed,))
             conn.commit()
-        assert rows == 0
+        assert batch["inserted"] == 0
+        assert batch["updated"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ class TestMultiBatchLoad:
         assert result["status"] == "success"
         assert result["cards_loaded"] == 8
 
-    def test_already_imported_cards_skipped_across_batch_boundary(self, api_resource: APIResource) -> None:
+    def test_unchanged_cards_not_loaded_across_batch_boundary(self, api_resource: APIResource) -> None:
         existing = [make_raw_card(name=f"Existing {uuid.uuid4()}") for _ in range(3)]
         api_resource._load_cards_with_staging(existing, page_size=10)
 
@@ -153,7 +153,7 @@ class TestMultiBatchLoad:
         result = api_resource._load_cards_with_staging(existing + new_cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 4
-        assert result["cards_sent"] == 4
+        assert result["cards_sent"] == 7  # all cards are sent; existing ones just produce 0 loads
 
 
 # ---------------------------------------------------------------------------
@@ -255,3 +255,56 @@ class TestRunImportUnderLockStreaming:
             api._run_import_under_lock()
         args, _ = mock_staging.call_args
         assert args[0] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Upsert behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertBehavior:
+    """_copy_batch_to_staging correctly partitions into new, unchanged, and changed cards."""
+
+    def test_unchanged_card_skips_write(self, api_resource: APIResource) -> None:
+        """Group 2: re-submitting identical data produces zero loads."""
+        card_id = str(uuid.uuid4())
+        card = make_raw_card(card_id=card_id)
+        api_resource._load_cards_with_staging([card])
+
+        result = api_resource._load_cards_with_staging([card])
+        assert result["cards_inserted"] == 0
+        assert result["cards_updated"] == 0
+
+    def test_changed_card_is_updated(self, api_resource: APIResource) -> None:
+        """Group 3: re-submitting a card with changed data updates the stored row."""
+        card_id = str(uuid.uuid4())
+        api_resource._load_cards_with_staging([make_raw_card(card_id=card_id)])
+
+        result = api_resource._load_cards_with_staging([make_raw_card(card_id=card_id, rarity="rare")])
+        assert result["cards_inserted"] == 0
+        assert result["cards_updated"] == 1
+
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT card_rarity_text FROM magic.cards WHERE scryfall_id = %s", (card_id,))
+            row = cursor.fetchone()
+        assert row["card_rarity_text"] == "rare"
+
+    def test_changed_card_preserves_backfilled_columns(self, api_resource: APIResource) -> None:
+        """Group 3: updating a changed card leaves prefer_score and card_is_tags intact."""
+        card_id = str(uuid.uuid4())
+        api_resource._load_cards_with_staging([make_raw_card(card_id=card_id)])
+
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "UPDATE magic.cards SET prefer_score = 42.0, card_is_tags = '{\"is:instant\": true}'::jsonb WHERE scryfall_id = %s",
+                (card_id,),
+            )
+            conn.commit()
+
+        api_resource._load_cards_with_staging([make_raw_card(card_id=card_id, rarity="rare")])
+
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT prefer_score, card_is_tags FROM magic.cards WHERE scryfall_id = %s", (card_id,))
+            row = cursor.fetchone()
+        assert row["prefer_score"] == 42.0
+        assert row["card_is_tags"] == {"is:instant": True}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,8 +101,8 @@ services:
     deploy:
       resources:
         limits:
-          memory: 1875m
-    memswap_limit: 1875m
+          memory: 2813m
+    memswap_limit: 2813m
     ports:
       - "${API_PORT:-28080}:8080"
     ulimits:


### PR DESCRIPTION
Previously the card import pipeline used `INSERT ... ON CONFLICT DO NOTHING`,
which meant re-running an import after a Scryfall data update silently dropped
all changes to existing cards. This PR replaces that with a proper upsert that
inserts new cards and updates existing ones when Scryfall data has changed.

## What Changed

### Core upsert logic (`api_resource.py` — `_copy_batch_to_staging`)

The staging table now includes a generated stored column for `scryfall_id`
(computed from `card_blob`) so the upsert logic can join on it efficiently
without re-parsing JSON at query time.

The old single-statement insert is replaced with two steps:

1. **Insert new cards** — rows whose `scryfall_id` is not yet in `magic.cards`.
2. **Update changed cards** — for rows that already exist, normalize both the
   incoming blob and the existing row through `jsonb_populate_record` so
   PostgreSQL type coercions are applied identically to both sides before
   comparison. If they differ, the row is deleted and re-inserted with a merged
   blob that preserves backfilled columns (`prefer_score`, `cubecobra_*`,
   `card_is_tags`) that are absent from the incoming Scryfall data.

The DELETE+INSERT pattern (via `WITH deleted AS (DELETE ... RETURNING ...)`)
sidesteps the snapshot-concurrency conflict that would arise if the INSERT and
DELETE ran against the live table in the same statement.

### Removed the pre-import "already imported" filter

The old code fetched all existing `scryfall_id` values into a Python set before
each import and filtered them out of the stream. This is now unnecessary — the
staging SQL handles skipping unchanged cards — so that query and the filter are
removed.

### `card_processing.py` — explicit `None` for creature fields

When a non-creature face has `creature_power`/`creature_toughness` cleared, the
old code used `dict.pop` to remove the keys from the blob. With the new merge
logic, an absent key falls through to the existing row's value, leaving
`creature_power_text`/`creature_toughness_text` stale. Changed to explicit
`None` assignment so these keys appear as JSON null and override the existing
row.

### Backfill SQL (`backfill_prefer_scores.sql`)

Rewrote the two-pass `UPDATE` as a single CTE-based statement:
- `computed_components` builds the score component JSONB once per row.
- `computed_scores` sums the components once per row.
- The final `UPDATE` skips rows where `prefer_score` is already correct, so
  re-running the backfill is a no-op for unchanged cards.

Fixed the backfill endpoint to report actual rows updated (from
`cursor.rowcount`) rather than re-counting the table after the fact.

### Observability

- `_rss_mb()` helper reads `/proc/self/status` and logs RSS before, during, and
  after each engine reload so memory growth is visible in logs.
- Import logs now report inserted and updated counts separately.

### Incidental cleanup (`entrypoint.py`)

Extracted two nested closures (`all_workers_alive`, the kill loop inside
`graceful_shutdown`) to module-level helpers to satisfy the ruff C901 complexity
limit.
