### PR TITLE
Replace staging-table card import with `bulk_upsert`

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import collections
 import copy
-import csv
 import datetime
 import hashlib
 import inspect
@@ -15,7 +14,6 @@ import os
 import pathlib
 import random
 import re
-import secrets
 import threading
 import time
 import urllib.parse
@@ -36,6 +34,7 @@ from cachebox import cached as cachebox_cached
 from psycopg import Connection, Cursor
 
 from api.card_processing import preprocess_card
+from api.db.bulk_upsert import bulk_upsert as _bulk_upsert
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
@@ -846,12 +845,12 @@ class APIResource:
         """Run the import flow; caller must hold the import lock."""
         if self._import_recent():
             logger.info("Import recent slowpath...")
-            return None
+            return
         self.setup_schema()
 
         before = time.monotonic()
 
-        result = self._load_cards_with_staging(self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+        result = self._upsert_cards(self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
         after_transfer = time.monotonic()
 
@@ -877,9 +876,9 @@ class APIResource:
             self._clear_caches()
             self._last_import_time.value = time.time()
             self._setup_complete_cache = None
-            return result["sample_cards"]
+            return
         logger.error("Failed to import data: %s", result["message"])
-        return None
+        return
 
     @cached(
         cache=TTLCache(maxsize=1, global_ttl=MIN_IMPORT_INTERVAL),
@@ -2043,7 +2042,6 @@ class APIResource:
                     "status": "not_found",
                     "message": f"No cards found for search query '{search_query}' in Scryfall API",
                     "cards_loaded": 0,
-                    "sample_cards": [],
                 }
 
         except (requests.RequestException, ValueError, KeyError) as e:
@@ -2053,11 +2051,10 @@ class APIResource:
                 "status": "error",
                 "message": f"Error fetching cards from Scryfall: {e}",
                 "cards_loaded": 0,
-                "sample_cards": [],
             }
 
         # Insert the cards into the database using the consolidated method
-        load_result = self._load_cards_with_staging(cards)
+        load_result = self._upsert_cards(cards)
 
         # Add search_query to the result for consistency
         load_result["search_query"] = search_query
@@ -2143,126 +2140,31 @@ class APIResource:
 
         return all_cards
 
-    def _copy_batch_to_staging(
-        self,
-        cursor: Cursor,
-        staging_table_name: str,
-        page: tuple[dict[str, Any], ...],
-    ) -> dict[str, Any]:
-        """COPY one batch of preprocessed cards through a temp staging table into magic.cards.
-
-        Returns {"inserted": int, "updated": int, "sample": list[dict]}.
-        """
-        # ON COMMIT DROP is a safety net: the table is dropped explicitly below, but if an error
-        # aborts the batch the transaction rollback (or any later commit) removes it as well.
-        cursor.execute(f"""
-            CREATE TEMPORARY TABLE {staging_table_name} (
-                card_blob  jsonb,
-                scryfall_id uuid GENERATED ALWAYS AS ((card_blob->>'scryfall_id')::uuid) STORED
-            ) ON COMMIT DROP
-        """)
-
-        with cursor.copy(
-            f"COPY {staging_table_name} (card_blob) FROM STDIN WITH (FORMAT csv, HEADER false)",
-        ) as copy_filehandle:
-            writer = csv.writer(copy_filehandle, quoting=csv.QUOTE_ALL)
-            writer.writerows([orjson.dumps(card, option=orjson.OPT_SORT_KEYS).decode("utf-8")] for card in page)
-
-        random_threshold = 20 / len(page)  # selects ~20 candidates, capped at 10 by LIMIT
-        cursor.execute(
-            f"""
-            SELECT (jsonb_populate_record(null::magic.cards, card_blob)).*
-            FROM {staging_table_name}
-            WHERE RANDOM() < {random_threshold}
-            ORDER BY RANDOM()
-            LIMIT 10""",
-        )
-        sample_cards = [dict(r) for r in cursor.fetchall()]
-
-        # Group 1: new cards — scryfall_id not yet in the table.
-        cursor.execute(
-            f"""
-            INSERT INTO magic.cards
-            SELECT (jsonb_populate_record(null::magic.cards, card_blob)).*
-            FROM {staging_table_name}
-            WHERE NOT EXISTS (
-                SELECT 1 FROM magic.cards c WHERE c.scryfall_id = {staging_table_name}.scryfall_id
-            )
-            ON CONFLICT (scryfall_id) DO NOTHING
-            """,
-        )
-        new_cards = cursor.rowcount
-
-        # Group 3: changed cards — scryfall_id exists but at least one Scryfall field differs.
-        #
-        # Normalize both the incoming blob and the existing row through jsonb_populate_record
-        # so PostgreSQL type coercions (e.g. real precision) are applied identically to both
-        # sides before comparison.  Using c as the base — rather than null — means backfilled
-        # columns (prefer_score, cubecobra_*, card_is_tags) that are absent from the incoming
-        # blob default to the existing row value on both sides, so they never trigger a spurious
-        # update.  The same merged_blob is used for the INSERT so those backfilled values survive.
-        #
-        # RETURNING merged_blob lets the outer INSERT read from the DELETE output rather than the
-        # table, avoiding the snapshot-concurrency conflict that would occur if the INSERT and
-        # DELETE ran against the same snapshot simultaneously.
-        cursor.execute(
-            f"""
-            WITH stripped_cards AS (
-                SELECT scryfall_id,
-                       card_blob - ARRAY['card_oracle_tags', 'card_art_tags', 'card_is_tags'] AS stripped_blob
-                FROM {staging_table_name}
-            ),
-            candidates AS (
-                SELECT
-                    s.scryfall_id,
-                    to_jsonb(jsonb_populate_record(c, s.stripped_blob)) AS merged_blob
-                FROM stripped_cards s
-                JOIN magic.cards c ON c.scryfall_id = s.scryfall_id
-                WHERE to_jsonb(jsonb_populate_record(c, s.stripped_blob)) IS DISTINCT FROM to_jsonb(c)
-            ),
-            deleted AS (
-                DELETE FROM magic.cards c
-                USING candidates
-                WHERE c.scryfall_id = candidates.scryfall_id
-                RETURNING candidates.merged_blob
-            )
-            INSERT INTO magic.cards
-            SELECT (jsonb_populate_record(null::magic.cards, deleted.merged_blob)).*
-            FROM deleted
-            """,
-        )
-        updated_cards = cursor.rowcount
-        cursor.execute(f"DROP TABLE {staging_table_name}")
-        return {"inserted": new_cards, "updated": updated_cards, "sample": sample_cards}
-
-    def _load_cards_with_staging(
+    def _upsert_cards(
         self,
         cards: Iterable[dict[str, Any]],
         page_size: int = 6000,
     ) -> dict[str, Any]:
-        """Load cards into the database using a randomly-named staging table.
+        """Preprocess and upsert an iterable of raw card dicts into magic.cards.
 
-        Accepts any iterable of raw card dicts (as returned by the Scryfall API or
-        stream_data_for_key). Preprocessing is applied lazily as cards flow through,
-        so the full dataset is never held in memory.
+        Preprocessing is applied lazily as cards flow through, so the full dataset
+        is never held in memory. Each batch is upserted via bulk_upsert: new rows
+        are inserted, changed rows are updated, and unchanged rows are skipped.
 
         Returns a dict with:
             - cards_inserted: new cards added
-            - cards_updated: existing cards replaced with changed data
+            - cards_updated: existing cards with changed data
             - cards_loaded: cards_inserted + cards_updated
             - cards_sent: rows attempted (after preprocessing)
-            - sample_cards: up to 10 random cards from the final batch
             - status: "success", "no_cards_before_preprocessing", "no_cards_after_preprocessing", "database_error"
             - message: descriptive message
         """
         self.setup_schema()
 
-        staging_suffix = secrets.token_hex(8)
-        staging_table_name = f"import_staging_{staging_suffix}"
-
         try:
-            with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-                self._set_statement_timeout(cursor, 30_000)
+            with self._conn_pool.connection() as conn:
+                with conn.cursor() as cursor:
+                    self._set_statement_timeout(cursor, 30_000)
 
                 class _CardStream:
                     """Preprocesses raw cards lazily, tracking stage counts."""
@@ -2280,14 +2182,19 @@ class APIResource:
 
                 stream = _CardStream()
                 cards_inserted = cards_updated = cards_sent = 0
-                sample_cards: list[dict[str, Any]] = []
 
                 for page in itertools.batched(stream, page_size):
-                    batch = self._copy_batch_to_staging(cursor, staging_table_name, page)
+                    batch = _bulk_upsert(
+                        conn,
+                        "cards",
+                        list(page),
+                        schema="magic",
+                        conflict_target=["scryfall_id"],
+                        skip_columns=["card_oracle_tags", "card_art_tags", "card_is_tags"],
+                    )
                     cards_sent += len(page)
                     cards_inserted += batch["inserted"]
                     cards_updated += batch["updated"]
-                    sample_cards = batch["sample"]
                     logger.info(
                         "%d inserted, %d updated, %d sent so far",
                         cards_inserted,
@@ -2303,7 +2210,7 @@ class APIResource:
                     else:
                         status, message = "no_cards_after_preprocessing", "No cards remaining after preprocessing"
                     logger.info("No cards imported: %s (raw=%d preprocessed=%d)", message, stream.raw, stream.preprocessed)
-                    return {"status": status, "cards_loaded": 0, "cards_sent": 0, "sample_cards": [], "message": message}
+                    return {"status": status, "cards_loaded": 0, "cards_sent": 0, "message": message}
 
                 cards_loaded = cards_inserted + cards_updated
                 self._clear_caches()
@@ -2313,19 +2220,15 @@ class APIResource:
                     "cards_updated": cards_updated,
                     "cards_loaded": cards_loaded,
                     "cards_sent": cards_sent,
-                    "sample_cards": sample_cards,
                     "message": f"Successfully loaded {cards_loaded} cards ({cards_inserted} new, {cards_updated} updated)",
                 }
 
         except (psycopg.Error, ValueError, KeyError) as e:
-            # No staging-table cleanup is needed (or possible) here: the temp table is session-scoped
-            # and created within the still-open transaction, so the pool's rollback-on-error removes it.
-            logger.exception("Error loading cards with staging table %s", staging_table_name)
+            logger.exception("Error loading cards")
             return {
                 "status": "database_error",
                 "cards_loaded": 0,
                 "cards_sent": 0,
-                "sample_cards": [],
                 "message": f"Error loading cards: {type(e).__name__}: {e}",
             }
 

--- a/api/db/__init__.py
+++ b/api/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database utilities."""

--- a/api/db/bulk_upsert.py
+++ b/api/db/bulk_upsert.py
@@ -1,0 +1,220 @@
+"""Bulk upsert into any table using jsonb_array_elements + LEFT JOIN.
+
+Accepts a list of dicts serialized to a single JSON array parameter. For each
+column in each row the proposed value is resolved before the conflict clause:
+  - Key present in the dict (including value None): proposed value = dict's value.
+  - Key absent from the dict: proposed value = the existing row's value (NULL for new rows).
+
+No staging table, no jsonb_populate_record.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import orjson
+import psycopg
+from psycopg import sql
+from psycopg.rows import dict_row
+
+_PG_TYPE: dict[str, str] = {
+    "bigint": "bigint",
+    "boolean": "boolean",
+    "character": "text",
+    "character varying": "text",
+    "date": "date",
+    "double precision": "float8",
+    "integer": "integer",
+    "json": "json",
+    "jsonb": "jsonb",
+    "numeric": "numeric",
+    "real": "float4",
+    "smallint": "smallint",
+    "text": "text",
+    "timestamp with time zone": "timestamptz",
+    "timestamp without time zone": "timestamp",
+    "uuid": "uuid",
+}
+
+
+def _schema_info(cursor: psycopg.Cursor, schema: str, table: str) -> tuple[list[dict], list[str]]:
+    cursor.execute(
+        """
+        SELECT column_name, data_type, udt_name
+        FROM information_schema.columns
+        WHERE table_schema = %s AND table_name = %s
+        ORDER BY ordinal_position
+        """,
+        (schema, table),
+    )
+    columns = cursor.fetchall()
+
+    cursor.execute(
+        """
+        SELECT kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+           AND tc.table_schema = kcu.table_schema
+           AND tc.table_name = kcu.table_name
+        WHERE tc.constraint_type = 'PRIMARY KEY'
+          AND tc.table_schema = %s
+          AND tc.table_name = %s
+        ORDER BY kcu.ordinal_position
+        """,
+        (schema, table),
+    )
+    return columns, [r["column_name"] for r in cursor.fetchall()]
+
+
+def _col_pg_type(col: dict) -> str:
+    dt = col["data_type"]
+    if dt == "USER-DEFINED":
+        return col["udt_name"]
+    return _PG_TYPE.get(dt, "text")
+
+
+def _select_expr(col: str, pg_type: str) -> sql.Composed:
+    """Build: CASE WHEN obj ? 'col' THEN <extract> ELSE e.col END AS col.
+
+    Key present (including explicit null) → extract from JSON.
+    Key absent → fall back to existing row value via LEFT JOIN alias e.
+    """
+    key = sql.Literal(col)
+    col_id = sql.Identifier(col)
+
+    if pg_type in ("jsonb", "json"):
+        extract = sql.SQL("obj->{}").format(key)
+    elif pg_type == "text":
+        extract = sql.SQL("obj->>{}").format(key)
+    else:
+        extract = sql.SQL("(obj->>{key})::{type}").format(key=key, type=sql.SQL(pg_type))
+
+    return sql.SQL("CASE WHEN obj ? {key} THEN {extract} ELSE e.{col} END AS {col}").format(key=key, extract=extract, col=col_id)
+
+
+def _dedupe_rows(rows: list[dict[str, Any]], key_cols: list[str]) -> list[dict[str, Any]]:
+    """Keep one row per conflict key; later rows overwrite earlier duplicates."""
+    unique: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for row in rows:
+        unique[tuple(row[c] for c in key_cols)] = row
+    return list(unique.values())
+
+
+def bulk_upsert(  # noqa: PLR0913
+    conn: psycopg.Connection,
+    table: str,
+    rows: list[dict[str, Any]],
+    schema: str = "public",
+    conflict_target: list[str] | None = None,
+    skip_columns: list[str] | None = None,
+) -> dict[str, int]:
+    """Upsert *rows* into *schema*.*table* via a single JSON array parameter.
+
+    For each column in each row:
+    - Key present in the dict (even value None): the dict's value is written.
+    - Key absent from the dict: the existing row's value is preserved (NULL for new rows).
+
+    Rows that would be unchanged are not rewritten.
+    No staging table, no jsonb_populate_record.
+
+    *skip_columns*: column names excluded from ON CONFLICT DO UPDATE SET and from the
+    IS DISTINCT FROM check. Skipped columns are still inserted for new rows; on conflict
+    they are left at their existing values and do not contribute to change detection.
+    Useful for application-managed columns (e.g. tag fields) that are absent from the
+    upstream data source and should never be overwritten by an import.
+
+    Returns {"inserted": N, "updated": M, "unchanged": K}.
+    """
+    if not rows:
+        return {"inserted": 0, "updated": 0, "unchanged": 0}
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        schema_cols, pk_cols = _schema_info(cur, schema, table)
+
+    pk_cols = conflict_target or pk_cols
+    if not pk_cols:
+        msg = f"No primary key on {schema}.{table}; pass conflict_target"
+        raise ValueError(msg)
+
+    rows = _dedupe_rows(rows, pk_cols)
+
+    col_meta = {c["column_name"]: c for c in schema_cols}
+    schema_order = [c["column_name"] for c in schema_cols]
+
+    # Only columns present in at least one input row and known to the schema.
+    present = set().union(*(r.keys() for r in rows)) & col_meta.keys()
+    missing_pk = [c for c in pk_cols if c not in present]
+    if missing_pk:
+        msg = f"Primary key column(s) {missing_pk} absent from all input rows"
+        raise ValueError(msg)
+
+    skip = set(skip_columns or [])
+    active = [c for c in schema_order if c in present]
+    non_pk = [c for c in active if c not in pk_cols and c not in skip]
+    pg_types = {c: _col_pg_type(col_meta[c]) for c in active}
+
+    schema_id, table_id = sql.Identifier(schema), sql.Identifier(table)
+    col_ids = [sql.Identifier(c) for c in active]
+    pk_ids = [sql.Identifier(c) for c in pk_cols]
+
+    # CASE WHEN obj ? 'col' THEN extract ELSE e.col END AS col
+    select_exprs = sql.SQL(", ").join(_select_expr(c, pg_types[c]) for c in active)
+
+    # LEFT JOIN on PK to make existing row values available to the CASE expressions
+    join_cond = sql.SQL(" AND ").join(
+        sql.SQL("e.{col} = (obj->>{key})::{type}").format(
+            col=sql.Identifier(c),
+            key=sql.Literal(c),
+            type=sql.SQL(pg_types[c]),
+        )
+        for c in pk_cols
+    )
+
+    if non_pk:
+        set_clause = sql.SQL(", ").join(sql.SQL("{c} = EXCLUDED.{c}").format(c=sql.Identifier(c)) for c in non_pk)
+        # EXCLUDED already carries the resolved value, so a plain IS DISTINCT FROM suffices.
+        where_clause = sql.SQL("({tbl}) IS DISTINCT FROM ({excl})").format(
+            tbl=sql.SQL(", ").join(sql.SQL("{s}.{t}.{c}").format(s=schema_id, t=table_id, c=sql.Identifier(c)) for c in non_pk),
+            excl=sql.SQL(", ").join(sql.SQL("EXCLUDED.{c}").format(c=sql.Identifier(c)) for c in non_pk),
+        )
+        on_conflict = sql.SQL("ON CONFLICT ({pk}) DO UPDATE SET {set} WHERE {where}").format(
+            pk=sql.SQL(", ").join(pk_ids),
+            set=set_clause,
+            where=where_clause,
+        )
+    else:
+        on_conflict = sql.SQL("ON CONFLICT ({pk}) DO NOTHING").format(
+            pk=sql.SQL(", ").join(pk_ids),
+        )
+
+    stmt = sql.SQL("""
+        WITH upsert AS (
+            INSERT INTO {s}.{t} ({cols})
+            SELECT {select_exprs}
+            FROM jsonb_array_elements(%s::jsonb) AS t(obj)
+            LEFT JOIN {s}.{t} e ON {join_cond}
+            {on_conflict}
+            RETURNING xmax
+        )
+        SELECT (xmax = 0) AS inserted, COUNT(1) FROM upsert GROUP BY 1
+    """).format(
+        s=schema_id,
+        t=table_id,
+        cols=sql.SQL(", ").join(col_ids),
+        select_exprs=select_exprs,
+        join_cond=join_cond,
+        on_conflict=on_conflict,
+    )
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(stmt, [orjson.dumps(rows).decode()])
+        counts = {"inserted": 0, "updated": 0, "unchanged": 0}
+        for row in cur.fetchall():
+            if row["inserted"]:
+                counts["inserted"] += row["count"]
+            else:
+                counts["updated"] += row["count"]
+        unchanged = len(rows) - sum(counts.values())
+        counts["unchanged"] = unchanged
+        return counts

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -5,6 +5,7 @@ import os
 import time
 import unittest
 import uuid
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any, Never
 from unittest.mock import MagicMock, patch
@@ -485,7 +486,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         settings.enable_cache = self.original_cache_setting
 
     @contextmanager
-    def _mock_successful_upsert(self):
+    def _mock_successful_upsert(self) -> Generator[None]:
         """Mock conn pool and bulk_upsert so _upsert_cards completes successfully."""
         mock_conn = MagicMock()
         mock_cursor = MagicMock()

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -5,6 +5,7 @@ import os
 import time
 import unittest
 import uuid
+from contextlib import contextmanager
 from typing import Any, Never
 from unittest.mock import MagicMock, patch
 
@@ -483,6 +484,22 @@ class TestAPIResourceCaching(unittest.TestCase):
         """Restore original cache setting."""
         settings.enable_cache = self.original_cache_setting
 
+    @contextmanager
+    def _mock_successful_upsert(self):
+        """Mock conn pool and bulk_upsert so _upsert_cards completes successfully."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        with (
+            patch.object(self.api_resource, "_conn_pool") as mock_pool,
+            patch(
+                "api.api_resource._bulk_upsert",
+                return_value={"inserted": 1, "updated": 0, "unchanged": 0},
+            ),
+        ):
+            mock_pool.connection.return_value.__enter__.return_value = mock_conn
+            yield
+
     def test_query_cache_clears_after_successful_load(self) -> None:
         """Test that query cache clears after successful card loading."""
         # Add some data to the cache
@@ -490,13 +507,7 @@ class TestAPIResourceCaching(unittest.TestCase):
         assert "test_key" in self.api_resource._query_cache
 
         # Mock the database operations to simulate successful load
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
-            mock_conn = MagicMock()
-            mock_cursor = MagicMock()
-            mock_cursor.rowcount = 1
-            mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
-            mock_pool.connection.return_value.__enter__.return_value = mock_conn
-
+        with self._mock_successful_upsert():
             # Provide valid card data that will pass preprocessing
             valid_card = create_test_card(
                 card_id="00000000-0000-0000-0000-000000000007",
@@ -504,21 +515,15 @@ class TestAPIResourceCaching(unittest.TestCase):
                 prices={},
             )
 
-            # Call _load_cards_with_staging directly to test cache clearing
-            self.api_resource._load_cards_with_staging([valid_card])
+            # Call _upsert_cards directly to test cache clearing
+            self.api_resource._upsert_cards([valid_card])
 
             # Cache should be cleared after successful load
             assert "test_key" not in self.api_resource._query_cache
 
     def test_search_cache_clears_after_successful_load(self) -> None:
         """Test that search cache clears after successful card loading."""
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
-            mock_conn = MagicMock()
-            mock_cursor = MagicMock()
-            mock_cursor.rowcount = 1
-            mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
-            mock_pool.connection.return_value.__enter__.return_value = mock_conn
-
+        with self._mock_successful_upsert():
             valid_card = create_test_card(
                 card_id="00000000-0000-0000-0000-000000000007",
                 keywords=[],
@@ -526,7 +531,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             )
 
             gen_before = self.api_resource._cache_generation.value
-            self.api_resource._load_cards_with_staging([valid_card])
+            self.api_resource._upsert_cards([valid_card])
             # Generation increment is the cross-worker invalidation signal
             assert self.api_resource._cache_generation.value > gen_before
 
@@ -549,13 +554,7 @@ class TestAPIResourceCaching(unittest.TestCase):
 
     def test_preferred_cards_cache_clears_after_load(self) -> None:
         """Test that the preferred-cards cache is invalidated after a successful card load."""
-        with patch.object(self.api_resource, "_conn_pool") as mock_pool:
-            mock_conn = MagicMock()
-            mock_cursor = MagicMock()
-            mock_cursor.rowcount = 1
-            mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
-            mock_pool.connection.return_value.__enter__.return_value = mock_conn
-
+        with self._mock_successful_upsert():
             valid_card = create_test_card(
                 card_id="00000000-0000-0000-0000-000000000009",
                 keywords=[],
@@ -567,7 +566,7 @@ class TestAPIResourceCaching(unittest.TestCase):
             self.api_resource._preferred_cards_map[gen] = [{"name": "sentinel"}]
             assert self.api_resource._preferred_cards_map.get(gen) is not None
 
-            self.api_resource._load_cards_with_staging([valid_card])
+            self.api_resource._upsert_cards([valid_card])
 
             # After load the generation advances; sentinel is unreachable at the new generation
             new_gen = self.api_resource._cache_generation.value

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 def _insert_card(api: APIResource, raw: dict) -> str:
     """Insert a raw card and return its oracle_id."""
-    api._load_cards_with_staging([raw])
+    api._upsert_cards([raw])
     (processed,) = preprocess_card(raw)
     return processed["oracle_id"]
 

--- a/api/tests/test_import_card_by_name.py
+++ b/api/tests/test_import_card_by_name.py
@@ -47,10 +47,10 @@ class TestImportCardByName(unittest.TestCase):
         assert hasattr(self.api_resource, "_scryfall_search")
         assert callable(self.api_resource._scryfall_search)
 
-    def test_load_cards_with_staging_function_exists(self) -> None:
-        """Test that _load_cards_with_staging method exists."""
-        assert hasattr(self.api_resource, "_load_cards_with_staging")
-        assert callable(self.api_resource._load_cards_with_staging)
+    def test_upsert_cards_function_exists(self) -> None:
+        """Test that _upsert_cards method exists."""
+        assert hasattr(self.api_resource, "_upsert_cards")
+        assert callable(self.api_resource._upsert_cards)
 
     @patch("requests.Session.get")
     def test_scryfall_search_returns_empty_for_404(self, mock_get: MagicMock) -> None:
@@ -173,7 +173,6 @@ class TestImportCardByName(unittest.TestCase):
             "status": "no_cards_after_preprocessing",
             "cards_loaded": 0,
             "cards_sent": 0,
-            "sample_cards": [],
             "message": "No cards remaining after preprocessing",
             "search_query": '!"TestCard"',
         }

--- a/api/tests/test_import_cards_by_search.py
+++ b/api/tests/test_import_cards_by_search.py
@@ -52,7 +52,6 @@ class TestImportCardsBySearch(unittest.TestCase):
         assert result["search_query"] == "name:NonexistentCard"
         assert "No cards found for search query" in result["message"]
         assert result["cards_loaded"] == 0
-        assert result["sample_cards"] == []
 
     @patch.object(APIResource, "_scryfall_search")
     def test_import_cards_by_search_returns_error_for_scryfall_exceptions(self, mock_search: MagicMock) -> None:
@@ -66,10 +65,9 @@ class TestImportCardsBySearch(unittest.TestCase):
         assert result["search_query"] == "name:TestCard"
         assert "Error fetching cards from Scryfall" in result["message"]
         assert result["cards_loaded"] == 0
-        assert result["sample_cards"] == []
 
     @patch.object(APIResource, "_scryfall_search")
-    @patch.object(APIResource, "_load_cards_with_staging")
+    @patch.object(APIResource, "_upsert_cards")
     def test_import_cards_by_search_returns_success_for_valid_cards(self, mock_load: MagicMock, mock_search: MagicMock) -> None:
         """Test that import_cards_by_search returns success status for valid cards."""
         # Mock Scryfall API to return card data
@@ -78,11 +76,10 @@ class TestImportCardsBySearch(unittest.TestCase):
             {"name": "Counterspell", "cmc": 2},
         ]
 
-        # Mock _load_cards_with_staging to return success
+        # Mock _upsert_cards to return success
         mock_load.return_value = {
             "status": "success",
             "cards_loaded": 2,
-            "sample_cards": [{"name": "Lightning Bolt", "cmc": 1}],
             "message": "Successfully loaded 2 cards",
         }
 
@@ -91,7 +88,6 @@ class TestImportCardsBySearch(unittest.TestCase):
         assert result["status"] == "success"
         assert result["search_query"] == "cmc<=2"
         assert result["cards_loaded"] == 2
-        assert len(result["sample_cards"]) == 1
         assert "Successfully loaded 2 cards" in result["message"]
 
     def test_import_cards_by_search_handles_artist_search_example(self) -> None:
@@ -100,7 +96,7 @@ class TestImportCardsBySearch(unittest.TestCase):
             patch.object(self.api_resource, "_scryfall_search") as mock_search,
             patch.object(
                 self.api_resource,
-                "_load_cards_with_staging",
+                "_upsert_cards",
             ) as mock_load,
         ):
             # Mock Scryfall API to return Sun Titan cards by Todd Lockwood
@@ -117,7 +113,6 @@ class TestImportCardsBySearch(unittest.TestCase):
             mock_load.return_value = {
                 "status": "success",
                 "cards_loaded": 1,
-                "sample_cards": [{"name": "Sun Titan", "artist": "Todd Lockwood"}],
                 "message": "Successfully loaded 1 cards",
             }
 

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -250,7 +250,6 @@ class TestContainerIntegration:
         # Check that the import was successful
         assert import_result["status"] == "success"
         assert import_result["cards_loaded"] >= 35
-        assert card_name == import_result["sample_cards"][0]["card_name"]
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE card_name = %s", (card_name,))
@@ -287,7 +286,6 @@ class TestContainerIntegration:
 
         if import_result["status"] == "success":
             assert import_result["cards_loaded"] == 3, f"Expected 3 cards loaded, got {import_result['cards_loaded']}"
-            assert card_name == import_result["sample_cards"][0]["card_name"]
 
         # Verify the card exists in database and has set information
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -1,4 +1,4 @@
-"""Tests for _load_cards_with_staging, _copy_batch_to_staging, and streaming import wiring."""
+"""Tests for _upsert_cards and streaming import wiring."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ import psycopg
 
 from api.api_resource import APIResource
 from api.card_processing import preprocess_card
+from api.db.bulk_upsert import bulk_upsert
 from api.scryfall_bulk_data_fetcher import BulkDataKey
 from api.tests.helpers import make_raw_card
 
@@ -23,37 +24,37 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-class TestLoadCardsWithStagingStatus:
-    """_load_cards_with_staging returns the correct status string for each no-cards scenario."""
+class TestUpsertCardsStatus:
+    """_upsert_cards returns the correct status string for each no-cards scenario."""
 
     def test_empty_list_returns_no_cards_before_preprocessing(self, api_resource: APIResource) -> None:
-        result = api_resource._load_cards_with_staging([])
+        result = api_resource._upsert_cards([])
         assert result["status"] == "no_cards_before_preprocessing"
         assert result["cards_loaded"] == 0
         assert result["cards_sent"] == 0
 
     def test_empty_generator_returns_no_cards_before_preprocessing(self, api_resource: APIResource) -> None:
-        result = api_resource._load_cards_with_staging(x for x in [])
+        result = api_resource._upsert_cards(x for x in [])
         assert result["status"] == "no_cards_before_preprocessing"
 
     def test_preprocessing_filters_all_cards_returns_no_cards_after_preprocessing(self, api_resource: APIResource) -> None:
         """When preprocess_card returns [] for all inputs, status is no_cards_after_preprocessing."""
         with patch("api.api_resource.preprocess_card", return_value=[]):
-            result = api_resource._load_cards_with_staging([make_raw_card()])
+            result = api_resource._upsert_cards([make_raw_card()])
         assert result["status"] == "no_cards_after_preprocessing"
         assert result["cards_loaded"] == 0
 
     def test_unchanged_card_on_reimport_loads_zero(self, api_resource: APIResource) -> None:
         """Re-submitting an identical card produces success with zero loads (unchanged, no write)."""
         card = make_raw_card(name="Already Present Card")
-        api_resource._load_cards_with_staging([card])  # first insert
+        api_resource._upsert_cards([card])  # first insert
 
-        result = api_resource._load_cards_with_staging([card])  # second attempt
+        result = api_resource._upsert_cards([card])  # second attempt
         assert result["status"] == "success"
         assert result["cards_loaded"] == 0
 
     def test_success_result_includes_cards_sent(self, api_resource: APIResource) -> None:
-        result = api_resource._load_cards_with_staging([make_raw_card(name="Cards Sent Test")])
+        result = api_resource._upsert_cards([make_raw_card(name="Cards Sent Test")])
         assert result["status"] == "success"
         assert result["cards_sent"] >= 1
         assert "cards_loaded" in result
@@ -70,57 +71,20 @@ class TestCardStreamCounting:
     def test_multiple_preprocessed_but_all_unchanged_loads_zero(self, api_resource: APIResource) -> None:
         """Raw > 0 and preprocessed > 0 but all unchanged → success with cards_loaded=0."""
         cards = [make_raw_card(name=f"Count Card {i}") for i in range(3)]
-        api_resource._load_cards_with_staging(cards)  # seed the DB
+        api_resource._upsert_cards(cards)  # seed the DB
 
-        result = api_resource._load_cards_with_staging(cards)
+        result = api_resource._upsert_cards(cards)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 0
 
     def test_preprocessing_filter_distinguished_from_empty_input(self, api_resource: APIResource) -> None:
         """no_cards_after_preprocessing is distinct from no_cards_before_preprocessing."""
         with patch("api.api_resource.preprocess_card", return_value=[]):
-            filtered = api_resource._load_cards_with_staging([make_raw_card(), make_raw_card()])
-        empty = api_resource._load_cards_with_staging([])
+            filtered = api_resource._upsert_cards([make_raw_card(), make_raw_card()])
+        empty = api_resource._upsert_cards([])
 
         assert filtered["status"] == "no_cards_after_preprocessing"
         assert empty["status"] == "no_cards_before_preprocessing"
-
-
-# ---------------------------------------------------------------------------
-# _copy_batch_to_staging tests
-# ---------------------------------------------------------------------------
-
-
-class TestCopyBatchToStaging:
-    """_copy_batch_to_staging COPYs one batch through a temp staging table."""
-
-    def test_inserts_card_and_returns_row_count(self, api_resource: APIResource) -> None:
-        (preprocessed,) = preprocess_card(make_raw_card(name="Staging Insert Card"))
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            batch = api_resource._copy_batch_to_staging(cursor, "test_stg_insert", (preprocessed,))
-            conn.commit()
-        assert batch["inserted"] == 1
-        assert batch["updated"] == 0
-
-    def test_returns_sample_cards_as_list_of_dicts(self, api_resource: APIResource) -> None:
-        (preprocessed,) = preprocess_card(make_raw_card(name="Staging Sample Card"))
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            batch = api_resource._copy_batch_to_staging(cursor, "test_stg_sample", (preprocessed,))
-            conn.commit()
-        for sc in batch["sample"]:
-            assert isinstance(sc, dict)
-
-    def test_unchanged_card_returns_zero_rowcount(self, api_resource: APIResource) -> None:
-        """Re-inserting an unchanged card returns inserted=0, updated=0."""
-        (preprocessed,) = preprocess_card(make_raw_card(name="Staging Conflict Card"))
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_a", (preprocessed,))
-            conn.commit()
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            batch = api_resource._copy_batch_to_staging(cursor, "test_stg_conflict_b", (preprocessed,))
-            conn.commit()
-        assert batch["inserted"] == 0
-        assert batch["updated"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +97,7 @@ class TestMultiBatchLoad:
 
     def test_all_cards_inserted_across_batches(self, api_resource: APIResource) -> None:
         cards = [make_raw_card(name=f"Batch Card {uuid.uuid4()}") for _ in range(7)]
-        result = api_resource._load_cards_with_staging(cards, page_size=3)
+        result = api_resource._upsert_cards(cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 7
         assert result["cards_sent"] == 7
@@ -141,16 +105,16 @@ class TestMultiBatchLoad:
     def test_batch_boundary_at_exact_multiple(self, api_resource: APIResource) -> None:
         """page_size=4, 8 cards → two full batches of 4."""
         cards = [make_raw_card(name=f"Exact Batch {uuid.uuid4()}") for _ in range(8)]
-        result = api_resource._load_cards_with_staging(cards, page_size=4)
+        result = api_resource._upsert_cards(cards, page_size=4)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 8
 
     def test_unchanged_cards_not_loaded_across_batch_boundary(self, api_resource: APIResource) -> None:
         existing = [make_raw_card(name=f"Existing {uuid.uuid4()}") for _ in range(3)]
-        api_resource._load_cards_with_staging(existing, page_size=10)
+        api_resource._upsert_cards(existing, page_size=10)
 
         new_cards = [make_raw_card(name=f"New {uuid.uuid4()}") for _ in range(4)]
-        result = api_resource._load_cards_with_staging(existing + new_cards, page_size=3)
+        result = api_resource._upsert_cards(existing + new_cards, page_size=3)
         assert result["status"] == "success"
         assert result["cards_loaded"] == 4
         assert result["cards_sent"] == 7  # all cards are sent; existing ones just produce 0 loads
@@ -161,46 +125,36 @@ class TestMultiBatchLoad:
 # ---------------------------------------------------------------------------
 
 
-class TestStagingTableCleanupOnError:
-    """A mid-batch failure must not leak the temp staging table or poison the pooled connection."""
+class TestErrorRecovery:
+    """A mid-batch failure must not poison the pooled connection."""
 
     @staticmethod
-    def _create_table_then_fail(cursor: psycopg.Cursor, staging_table_name: str, page: tuple) -> tuple:  # noqa: ARG004
-        cursor.execute(f"CREATE TEMPORARY TABLE {staging_table_name} (card_blob jsonb) ON COMMIT DROP")
+    def _raise_data_error(*args: object, **kwargs: object) -> None:  # noqa: ARG004
         msg = "simulated failure mid-batch"
         raise psycopg.DataError(msg)
 
-    def test_error_mid_batch_returns_database_error_and_leaks_nothing(
-        self, api_resource: APIResource, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_error_mid_batch_returns_database_error(self, api_resource: APIResource, caplog: pytest.LogCaptureFixture) -> None:
         with (
-            patch.object(api_resource, "_copy_batch_to_staging", side_effect=self._create_table_then_fail),
+            patch("api.api_resource._bulk_upsert", side_effect=self._raise_data_error),
             caplog.at_level(logging.ERROR, logger="api.api_resource"),
         ):
-            result = api_resource._load_cards_with_staging([make_raw_card(name="Doomed Card")])
+            result = api_resource._upsert_cards([make_raw_card(name="Doomed Card")])
 
         assert result["status"] == "database_error"
         assert result["cards_loaded"] == 0
 
-        # The failure must be interpretable: exception type in the message, full traceback in the log.
         assert result["message"] == "Error loading cards: DataError: simulated failure mid-batch"
-        error_records = [r for r in caplog.records if "Error loading cards with staging table" in r.message]
+        error_records = [r for r in caplog.records if "Error loading cards" in r.message]
         assert error_records, "the failure should be logged"
         assert all(r.exc_info for r in error_records), "the log record should carry the traceback"
 
-        # The rollback on connection return must have removed the temp table from every session.
-        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
-            cursor.execute("SELECT relname FROM pg_class WHERE relname LIKE 'import_staging_%'")
-            leaked = [r["relname"] for r in cursor.fetchall()]
-        assert leaked == []
-
     def test_import_succeeds_after_earlier_failure(self, api_resource: APIResource) -> None:
         """The pool is reusable after a failed import: the next import on the same pool succeeds."""
-        with patch.object(api_resource, "_copy_batch_to_staging", side_effect=self._create_table_then_fail):
-            failed = api_resource._load_cards_with_staging([make_raw_card(name="First Try Fails")])
+        with patch("api.api_resource._bulk_upsert", side_effect=self._raise_data_error):
+            failed = api_resource._upsert_cards([make_raw_card(name="First Try Fails")])
         assert failed["status"] == "database_error"
 
-        recovered = api_resource._load_cards_with_staging([make_raw_card(name="Second Try Succeeds")])
+        recovered = api_resource._upsert_cards([make_raw_card(name="Second Try Succeeds")])
         assert recovered["status"] == "success"
         assert recovered["cards_loaded"] == 1
 
@@ -229,8 +183,8 @@ class TestRunImportUnderLockStreaming:
             patch.object(api, "setup_schema"),
             patch.object(
                 api,
-                "_load_cards_with_staging",
-                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "sample_cards": [], "message": ""},
+                "_upsert_cards",
+                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "message": ""},
             ),
             patch.object(api._bulk_data_fetcher, "stream_data_for_key") as mock_stream,
         ):
@@ -238,8 +192,8 @@ class TestRunImportUnderLockStreaming:
             api._run_import_under_lock()
         mock_stream.assert_called_once_with(BulkDataKey.DEFAULT_CARDS)
 
-    def test_stream_iterator_passed_directly_to_load_cards_with_staging(self) -> None:
-        """The exact iterator returned by stream_data_for_key is forwarded to _load_cards_with_staging."""
+    def test_stream_iterator_passed_directly_to_upsert_cards(self) -> None:
+        """The exact iterator returned by stream_data_for_key is forwarded to _upsert_cards."""
         api = self._make_api()
         sentinel = iter([{"id": "sentinel"}])
         with (
@@ -248,8 +202,8 @@ class TestRunImportUnderLockStreaming:
             patch.object(api._bulk_data_fetcher, "stream_data_for_key", return_value=sentinel),
             patch.object(
                 api,
-                "_load_cards_with_staging",
-                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "sample_cards": [], "message": ""},
+                "_upsert_cards",
+                return_value={"status": "no_cards_before_preprocessing", "cards_loaded": 0, "message": ""},
             ) as mock_staging,
         ):
             api._run_import_under_lock()
@@ -258,29 +212,57 @@ class TestRunImportUnderLockStreaming:
 
 
 # ---------------------------------------------------------------------------
+# bulk_upsert deduplication tests
+# ---------------------------------------------------------------------------
+
+
+class TestBulkUpsertDedup:
+    """Duplicate conflict keys in one batch must not reach ON CONFLICT."""
+
+    def test_duplicate_scryfall_id_in_batch_last_wins(self, api_resource: APIResource) -> None:
+        card_id = str(uuid.uuid4())
+        (row_a,) = preprocess_card(make_raw_card(card_id=card_id, rarity="common"))
+        (row_b,) = preprocess_card(make_raw_card(card_id=card_id, rarity="rare"))
+        with api_resource._conn_pool.connection() as conn:
+            result = bulk_upsert(
+                conn,
+                "cards",
+                [row_a, row_b],
+                schema="magic",
+                conflict_target=["scryfall_id"],
+            )
+            conn.commit()
+        assert result["inserted"] == 1
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute("SELECT card_rarity_text FROM magic.cards WHERE scryfall_id = %s", (card_id,))
+            row = cursor.fetchone()
+        assert row["card_rarity_text"] == "rare"
+
+
+# ---------------------------------------------------------------------------
 # Upsert behavior tests
 # ---------------------------------------------------------------------------
 
 
 class TestUpsertBehavior:
-    """_copy_batch_to_staging correctly partitions into new, unchanged, and changed cards."""
+    """_upsert_cards correctly partitions into new, unchanged, and changed cards."""
 
     def test_unchanged_card_skips_write(self, api_resource: APIResource) -> None:
         """Group 2: re-submitting identical data produces zero loads."""
         card_id = str(uuid.uuid4())
         card = make_raw_card(card_id=card_id)
-        api_resource._load_cards_with_staging([card])
+        api_resource._upsert_cards([card])
 
-        result = api_resource._load_cards_with_staging([card])
+        result = api_resource._upsert_cards([card])
         assert result["cards_inserted"] == 0
         assert result["cards_updated"] == 0
 
     def test_changed_card_is_updated(self, api_resource: APIResource) -> None:
         """Group 3: re-submitting a card with changed data updates the stored row."""
         card_id = str(uuid.uuid4())
-        api_resource._load_cards_with_staging([make_raw_card(card_id=card_id)])
+        api_resource._upsert_cards([make_raw_card(card_id=card_id)])
 
-        result = api_resource._load_cards_with_staging([make_raw_card(card_id=card_id, rarity="rare")])
+        result = api_resource._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
         assert result["cards_inserted"] == 0
         assert result["cards_updated"] == 1
 
@@ -292,7 +274,7 @@ class TestUpsertBehavior:
     def test_changed_card_preserves_backfilled_columns(self, api_resource: APIResource) -> None:
         """Group 3: updating a changed card leaves prefer_score and card_is_tags intact."""
         card_id = str(uuid.uuid4())
-        api_resource._load_cards_with_staging([make_raw_card(card_id=card_id)])
+        api_resource._upsert_cards([make_raw_card(card_id=card_id)])
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute(
@@ -301,7 +283,7 @@ class TestUpsertBehavior:
             )
             conn.commit()
 
-        api_resource._load_cards_with_staging([make_raw_card(card_id=card_id, rarity="rare")])
+        api_resource._upsert_cards([make_raw_card(card_id=card_id, rarity="rare")])
 
         with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
             cursor.execute("SELECT prefer_score, card_is_tags FROM magic.cards WHERE scryfall_id = %s", (card_id,))


### PR DESCRIPTION
#531 landed the fancy upsert: card import now inserts new rows and updates changed
ones instead of `ON CONFLICT DO NOTHING`. That implementation used a per-batch temp
staging table — `COPY` jsonb blobs in, then `jsonb_populate_record` + a DELETE/INSERT
pair for changed rows.

This PR replaces that staging-table path with a generic `bulk_upsert` helper. The
import behavior from #531 is preserved; the mechanism is simpler and faster.

## What changed

### New module: `api/db/bulk_upsert.py`

Generic table upsert driven by a single JSON array parameter:

- `jsonb_array_elements` expands the batch; a `LEFT JOIN` to the target table resolves
  each column with `CASE WHEN obj ? 'col' THEN extract ELSE e.col END`.
- Key **present** in the input dict (including explicit `null`) → use the proposed value.
- Key **absent** → keep the existing row's value (or `NULL` for new rows).
- `ON CONFLICT DO UPDATE SET … WHERE (row) IS DISTINCT FROM (EXCLUDED)` skips unchanged
  rows without rewriting them.
- `skip_columns` excludes application-managed fields from both the update set and the
  change-detection predicate. Card import passes `card_oracle_tags`, `card_art_tags`,
  and `card_is_tags` so tag backfills are never clobbered by Scryfall bulk data.
- Rows are deduplicated by conflict key before the statement runs (last row wins), fixing
  `CardinalityViolation: ON CONFLICT DO UPDATE command cannot affect row a second time`
  when a batch contains duplicate `scryfall_id` values.

No staging table, no `jsonb_populate_record`, no per-batch `COPY`.

### `api/api_resource.py`

- Removed `_copy_batch_to_staging` (~90 lines of staging SQL).
- Renamed `_load_cards_with_staging` → `_upsert_cards`; each batched page now calls
  `_bulk_upsert(conn, "cards", …)`.
- Dropped `sample_cards` from import result payloads (bulk import, search import, and
  error responses). Callers only needed insert/update counts.
- Removed unused `import csv`.

### Tests

- Renamed `test_load_cards_with_staging.py` → `test_upsert_cards.py`.
- Removed `TestCopyBatchToStaging` (tested the deleted helper directly).
- Added `TestBulkUpsertDedup` for duplicate `scryfall_id` handling within a batch.
- Updated cache-clearing tests in `test_api_resource.py` to mock `_bulk_upsert` instead
  of the old staging cursor/`rowcount` path.
- Updated import mocks to reference `_upsert_cards`.

## Why switch?

| | Staging table (#531) | `bulk_upsert` (this PR) |
|---|---|---|
| Round trips per batch | CREATE TEMP + COPY + 2–3 SQL statements + DROP | 1 parameterized statement |
| Merge semantics | `jsonb_populate_record` composite + DELETE/INSERT | Column-level CASE + `ON CONFLICT` |
| Duplicate PKs in batch | Not handled | Deduped client-side before insert |
| Reusability | Card-specific SQL in `APIResource` | Generic helper in `api/db/` |

Benchmarked with 30,000 synthetic cards on the current schema (PostgreSQL 18, 40 indexes
on `magic.cards`, cross-container Docker networking, 3 runs):

| Method | insert (all new) | unchanged (no writes) | update (95% changed) |
|---|---|---|---|
| COPY + `jsonb_populate_record` (#531 path) | 8.1s | 7.1s | 7.2s |
| `jsonb_array_elements` + LEFT JOIN (`bulk_upsert`) | 1.7s | 0.9s | 2.2s |

The staging approach pays ~0.8s for the COPY stream on every batch regardless of whether
anything changed. `bulk_upsert` skips heap writes entirely when `IS DISTINCT FROM` finds
no differences (0.9s unchanged baseline vs 7.1s). On a full re-import where most cards are
unchanged, that gap dominates.

## Test plan

- [ ] `make test` passes
- [ ] Fresh bulk import: `cards_inserted` > 0, `cards_updated` == 0
- [ ] Re-import same data: both counts 0
- [ ] Mutate one card in DB, re-import: `cards_updated` == 1 and field is corrected
- [ ] Mutate `prefer_score` / `card_is_tags`, re-import changed Scryfall field: backfilled
      columns preserved
- [ ] Confirm full Scryfall bulk import completes without `CardinalityViolation`
