### PR TITLE
Construct Site Title via Word Splitting

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -33,7 +33,8 @@ RUN apt-get update -qqq && apt-get install -qqq -y \
     libev-dev \
     libpq-dev \
     libpython3-dev \
-    python3 > /dev/null
+    python3 \
+    wamerican > /dev/null
 
 RUN python3 -V
 RUN ln -s $(python3 -c "import sys; print(sys.executable)") /usr/local/bin/python

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -186,6 +186,7 @@ _IP_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 
 _MIN_WORD_LEN = 3
 
+
 # TODO: supplement with words from https://api.scryfall.com/catalog/word-bank so MtG-specific
 # terms (e.g. "sylvan", "planeswalker") are recognized even on systems without a full dictionary.
 def _load_word_set() -> frozenset[str]:
@@ -234,11 +235,15 @@ def _split_words(s: str, words: frozenset[str]) -> list[str] | None:
     return list(res) if res is not None else None
 
 
-@lru_cache(maxsize=256)
 def hostname_to_site_name(raw_host: str) -> str:
     """Derive a display name from a Host header value, falling back to FALLBACK_SITE_NAME."""
     # urlparse requires a scheme; .hostname strips the port and lowercases.
     hostname = urllib.parse.urlparse(f"http://{raw_host}").hostname or ""
+    return _hostname_to_site_name(hostname[:64])
+
+
+@lru_cache(maxsize=256)
+def _hostname_to_site_name(hostname: str) -> str:
     if not hostname or hostname == "localhost" or _IP_RE.match(hostname) or not _SAFE_HOSTNAME_RE.match(hostname):
         return FALLBACK_SITE_NAME
     parts = hostname.split(".")[-2:]

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -206,21 +206,32 @@ def _split_words(s: str, words: frozenset[str]) -> list[str] | None:
 
     Returns a list of words on success, or None if the string cannot be fully partitioned.
     """
-    if s in words:
-        return [s]
-    n = len(s)
-    mid = n // 2
-    for k in sorted(range(1, n), key=lambda k: abs(k - mid)):
-        left, right = s[:k], s[k:]
-        if left in words:
-            rest = _split_words(right, words)
-            if rest is not None:
-                return [left, *rest]
-        if right in words:
-            rest = _split_words(left, words)
-            if rest is not None:
-                return [*rest, right]
-    return None
+    # Only attempt dictionary splitting for purely alphabetic strings.
+    if not s.isalpha():
+        return None
+
+    @lru_cache(maxsize=4096)
+    def _split(sub: str) -> tuple[str, ...] | None:
+        if sub in words:
+            return (sub,)
+        n = len(sub)
+        if n < _MIN_WORD_LEN:
+            return None
+        mid = n // 2
+        for k in sorted(range(1, n), key=lambda k: abs(k - mid)):
+            left, right = sub[:k], sub[k:]
+            if left in words:
+                rest = _split(right)
+                if rest is not None:
+                    return (left, *rest)
+            if right in words:
+                rest = _split(left)
+                if rest is not None:
+                    return (*rest, right)
+        return None
+
+    res = _split(s)
+    return list(res) if res is not None else None
 
 
 @lru_cache(maxsize=256)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -17,7 +17,7 @@ import threading
 import time
 import urllib.parse
 from datetime import timedelta
-from functools import wraps
+from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any
 from typing import cast as typecast
 
@@ -184,6 +184,46 @@ _SAFE_HOSTNAME_RE = re.compile(r"^[a-z0-9.\-]+$")
 _IP_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 
 
+_MIN_WORD_LEN = 3
+
+# TODO: supplement with words from https://api.scryfall.com/catalog/word-bank so MtG-specific
+# terms (e.g. "sylvan", "planeswalker") are recognized even on systems without a full dictionary.
+def _load_word_set() -> frozenset[str]:
+    for path in ("/usr/share/dict/american-english", "/usr/share/dict/words"):
+        try:
+            with pathlib.Path(path).open() as f:
+                return frozenset(w.lower() for w in f.read().splitlines() if w.isalpha() and len(w) >= _MIN_WORD_LEN)
+        except OSError:
+            continue
+    return frozenset()
+
+
+_WORDS: frozenset[str] = _load_word_set()
+
+
+def _split_words(s: str, words: frozenset[str]) -> list[str] | None:
+    """Split s into dictionary words by searching split points from the middle outward.
+
+    Returns a list of words on success, or None if the string cannot be fully partitioned.
+    """
+    if s in words:
+        return [s]
+    n = len(s)
+    mid = n // 2
+    for k in sorted(range(1, n), key=lambda k: abs(k - mid)):
+        left, right = s[:k], s[k:]
+        if left in words:
+            rest = _split_words(right, words)
+            if rest is not None:
+                return [left, *rest]
+        if right in words:
+            rest = _split_words(left, words)
+            if rest is not None:
+                return [*rest, right]
+    return None
+
+
+@lru_cache(maxsize=256)
 def hostname_to_site_name(raw_host: str) -> str:
     """Derive a display name from a Host header value, falling back to FALLBACK_SITE_NAME."""
     # urlparse requires a scheme; .hostname strips the port and lowercases.
@@ -194,6 +234,10 @@ def hostname_to_site_name(raw_host: str) -> str:
     tld = parts[-1].lower()
     name = parts[0] if tld in _STRIP_TLDS else ".".join(parts)
     name = name.replace(".", "").replace("-", " ").strip()
+    if " " not in name and _WORDS:
+        split = _split_words(name, _WORDS)
+        if split is not None:
+            name = " ".join(split)
     name = name.title()
     return name if any(c.isalnum() for c in name) else FALLBACK_SITE_NAME
 

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import falcon
 import pytest
 
-from api.api_resource import FALLBACK_SITE_NAME, APIResource, hostname_to_site_name
+from api.api_resource import _WORDS, FALLBACK_SITE_NAME, APIResource, _split_words, hostname_to_site_name
 from api.settings import settings
 
 
@@ -641,6 +641,72 @@ _HOSTNAME_TESTCASES = {
         "raw_host": "...",
     },
 }
+
+
+_SPLIT_WORDS_TESTCASES: dict[str, dict] = {
+    "whole_word": {
+        "s": "apple",
+        "expected": ["apple"],
+    },
+    "two_words": {
+        "s": "applepie",
+        "expected": ["apple", "pie"],
+    },
+    "three_words": {
+        "s": "applebananacherry",
+        "expected": ["apple", "banana", "cherry"],
+    },
+    "no_split_possible": {
+        "s": "xyzqwerty",
+        "expected": None,
+    },
+    "split_prefers_middle": {
+        # "the" (len 3) at position 0 and "oak" (len 3) at end; "lion" in the middle is found first
+        "s": "thelionoak",
+        "expected": ["the", "lion", "oak"],
+    },
+    "prefers_fewest_words": {
+        # Two valid splits: ["abcde", "fghij"] (k=5, center) and ["abc", "de", "fghij"] (k=3).
+        # Middle-out tries k=5 first and commits to the 2-word split.
+        "s": "abcdefghij",
+        "expected": ["abcde", "fghij"],
+    },
+}
+
+_SMALL_WORDS: frozenset[str] = frozenset(["apple", "pie", "banana", "cherry", "the", "lion", "oak", "abcde", "fghij", "abc", "de"])
+
+
+class TestSplitWords:
+    """Tests for _split_words() using a controlled word set."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(_SPLIT_WORDS_TESTCASES.values()))),
+        argvalues=[[v for k, v in sorted(_SPLIT_WORDS_TESTCASES[name].items())] for name in sorted(_SPLIT_WORDS_TESTCASES)],
+        ids=sorted(_SPLIT_WORDS_TESTCASES),
+    )
+    def test_split_words(self, expected: list[str] | None, s: str) -> None:
+        assert _split_words(s, _SMALL_WORDS) == expected
+
+
+_HOSTNAME_DICT_TESTCASES: dict[str, dict] = {
+    "no_dash_splits_into_words": {
+        "expected": "Sylvan Librarian",
+        "raw_host": "sylvanlibrarian.com",
+    },
+}
+
+
+class TestHostnameSiteNameWithDict:
+    """Tests for hostname_to_site_name() that require a system dictionary."""
+
+    @pytest.mark.skipif(not _WORDS, reason="no system dictionary found")
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(_HOSTNAME_DICT_TESTCASES.values()))),
+        argvalues=[[v for k, v in sorted(_HOSTNAME_DICT_TESTCASES[name].items())] for name in sorted(_HOSTNAME_DICT_TESTCASES)],
+        ids=sorted(_HOSTNAME_DICT_TESTCASES),
+    )
+    def test_hostname_to_site_name_with_dict(self, expected: str, raw_host: str) -> None:
+        assert hostname_to_site_name(raw_host) == expected
 
 
 class TestHostnameSiteName:

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import falcon
 import pytest
 
-from api.api_resource import _WORDS, FALLBACK_SITE_NAME, APIResource, _split_words, hostname_to_site_name
+from api.api_resource import FALLBACK_SITE_NAME, APIResource, _hostname_to_site_name, _split_words, hostname_to_site_name
 from api.settings import settings
 
 
@@ -673,7 +673,9 @@ _SPLIT_WORDS_TESTCASES: dict[str, dict] = {
     },
 }
 
-_SMALL_WORDS: frozenset[str] = frozenset(["apple", "pie", "banana", "cherry", "the", "lion", "oak", "abcde", "fghij", "abc", "de"])
+_SMALL_WORDS: frozenset[str] = frozenset(
+    ["apple", "pie", "banana", "cherry", "the", "lion", "oak", "abcde", "fghij", "abc", "de", "sylvan", "librarian"]
+)
 
 
 class TestSplitWords:
@@ -697,15 +699,16 @@ _HOSTNAME_DICT_TESTCASES: dict[str, dict] = {
 
 
 class TestHostnameSiteNameWithDict:
-    """Tests for hostname_to_site_name() that require a system dictionary."""
+    """Tests for hostname_to_site_name() with a controlled word set patched in."""
 
-    @pytest.mark.skipif(not _WORDS, reason="no system dictionary found")
     @pytest.mark.parametrize(
         argnames=sorted(next(iter(_HOSTNAME_DICT_TESTCASES.values()))),
         argvalues=[[v for k, v in sorted(_HOSTNAME_DICT_TESTCASES[name].items())] for name in sorted(_HOSTNAME_DICT_TESTCASES)],
         ids=sorted(_HOSTNAME_DICT_TESTCASES),
     )
-    def test_hostname_to_site_name_with_dict(self, expected: str, raw_host: str) -> None:
+    def test_hostname_to_site_name_with_dict(self, monkeypatch: pytest.MonkeyPatch, expected: str, raw_host: str) -> None:
+        monkeypatch.setattr("api.api_resource._WORDS", _SMALL_WORDS)
+        _hostname_to_site_name.cache_clear()
         assert hostname_to_site_name(raw_host) == expected
 
 


### PR DESCRIPTION
This PR improves how the API derives a human-friendly site title from the request Host header by attempting to split dashless hostnames into dictionary words (e.g., `sylvanlibrarian.com` → “Sylvan Librarian”), with accompanying tests and a Docker image dependency to supply a system dictionary.

**Changes:**
- Add dictionary loading and a recursive word-splitting helper, and integrate it into `hostname_to_site_name()`.
- Add unit tests for `_split_words()` and for dictionary-based hostname splitting.
- Install a system dictionary package (`wamerican`) in the API Docker image.