### PR TITLE
Preferred-printing index fast path for card-level queries

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -729,6 +729,12 @@ enum NumField {
     PreferScore,
 }
 
+impl NumField {
+    fn is_card_level(self) -> bool {
+        matches!(self, NumField::Cmc | NumField::Power | NumField::Toughness | NumField::Loyalty | NumField::EdhrEc)
+    }
+}
+
 fn attr_to_num_field(attr: &str) -> Option<NumField> {
     match attr {
         "cmc"                  => Some(NumField::Cmc),
@@ -788,6 +794,14 @@ impl NumExpr {
             }
         }
     }
+
+    fn is_card_level(&self) -> bool {
+        match self {
+            NumExpr::Const(_) => true,
+            NumExpr::Field(f) => f.is_card_level(),
+            NumExpr::Arith(lhs, _, rhs) => lhs.is_card_level() && rhs.is_card_level(),
+        }
+    }
 }
 
 fn cmp(op: CmpOp, a: f64, b: f64) -> bool {
@@ -824,6 +838,12 @@ enum CollField {
     ArtTags,
     IsTags,
     FrameData,
+}
+
+impl CollField {
+    fn is_card_level(self) -> bool {
+        !matches!(self, CollField::ArtTags | CollField::FrameData)
+    }
 }
 
 fn card_collection<'a>(card: &'a ACard, f: CollField) -> CollRef<'a> {
@@ -871,6 +891,12 @@ enum TextSearchField {
     ArtistLower,
 }
 
+impl TextSearchField {
+    fn is_card_level(self) -> bool {
+        matches!(self, TextSearchField::NameLower | TextSearchField::OracleTextLower)
+    }
+}
+
 fn text_search_field_value<'a>(card: &'a ACard, strings: &'a AStrings, field: TextSearchField) -> Option<&'a str> {
     match field {
         TextSearchField::NameLower       => Some(card.card_name_lower.as_str()),
@@ -894,6 +920,12 @@ enum TextField {
     Border,
     Watermark,
     CollectorNumber,
+}
+
+impl TextField {
+    fn is_card_level(self) -> bool {
+        matches!(self, TextField::NameLower | TextField::OracleTextLower)
+    }
 }
 
 fn text_field_value<'a>(card: &'a ACard, strings: &'a AStrings, field: TextField) -> Option<&'a str> {
@@ -1212,6 +1244,26 @@ impl FilterExpr {
                     CmpOp::Le => card_year <= *year,
                 })
             }
+        }
+    }
+
+    /// Returns true if every leaf predicate touches only card-level attributes
+    /// (constant across all printings of the same oracle id). When true for a
+    /// `unique=card, prefer=default` query, the preferred-printing index covers
+    /// the full result set with no dedup needed.
+    fn is_card_level(&self) -> bool {
+        match self {
+            FilterExpr::True | FilterExpr::ExactName(_) => true,
+            FilterExpr::And(c) | FilterExpr::Or(c) => c.iter().all(|x| x.is_card_level()),
+            FilterExpr::Not(inner) => inner.is_card_level(),
+            FilterExpr::NumericCmp { lhs, rhs, .. } => lhs.is_card_level() && rhs.is_card_level(),
+            FilterExpr::TextContains { field, .. } => field.is_card_level(),
+            FilterExpr::TextExact   { field, .. } => field.is_card_level(),
+            FilterExpr::TextRegex   { field, .. } => field.is_card_level(),
+            FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => true,
+            FilterExpr::CollectionCmp { field, .. } => field.is_card_level(),
+            FilterExpr::Legality { .. } | FilterExpr::ManaCostCmp { .. } | FilterExpr::Devotion { .. } => true,
+            FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => false,
         }
     }
 }
@@ -2179,8 +2231,9 @@ fn run_query_no_dedup<'a>(
     (total, select_page(matched, offset, limit))
 }
 
-fn run_query<'a>(
+fn run_query<'a, B>(
     store: &'a [ACard],
+    preferred_indices: &[B],
     strings: &AStrings,
     filter: &FilterExpr,
     unique: &str,
@@ -2190,8 +2243,32 @@ fn run_query<'a>(
     limit: usize,
     offset: usize,
     indexes: &Archived<CardIndexes>,
-) -> (usize, Vec<&'a ACard>) {
+) -> (usize, Vec<&'a ACard>)
+where
+    B: Copy,
+    u32: From<B>,
+{
     let candidates = narrow_candidates(filter, indexes);
+
+    // For card-level queries with default prefer, substitute the preferred-printing
+    // index as the candidate set: one entry per oracle id, no dedup needed.
+    // When narrow_candidates already narrowed, intersect so both optimizations compose
+    // (e.g. trigram → 500 printings, intersect preferred → ~165, no dedup).
+    if unique == "card"
+        && !matches!(prefer, "oldest" | "newest" | "usd_low" | "usd_high" | "promo")
+        && filter.is_card_level()
+    {
+        return match candidates {
+            Some(existing) => {
+                let fast = intersect_sorted(&existing, preferred_indices);
+                run_query_no_dedup(fast.into_iter().map(|i| &store[i as usize]), strings, filter, orderby, direction, limit, offset)
+            }
+            None => run_query_no_dedup(
+                preferred_indices.iter().map(|&i| &store[u32::from(i) as usize]),
+                strings, filter, orderby, direction, limit, offset,
+            ),
+        };
+    }
 
     macro_rules! cards_iter {
         () => {
@@ -2624,7 +2701,7 @@ impl QueryEngine {
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query(
-            store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
+            store, &data.preferred_indices[..], &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 
         let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
@@ -2665,6 +2742,61 @@ impl QueryEngine {
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query_hashmap(store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset);
+        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
+        let matches_list = PyList::new(py, matches)?;
+        PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
+    }
+
+    /// Same as query() but forces the linear-dedup path over all printings.
+    /// Use alongside query() to measure the benefit of the preferred-index fast path.
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    fn query_linear<'py>(
+        &self,
+        py: Python<'py>,
+        filters: &Bound<PyAny>,
+        unique: &str,
+        prefer: &str,
+        orderby: &str,
+        direction: &str,
+        limit: usize,
+        offset: usize,
+    ) -> PyResult<Bound<'py, PyTuple>> {
+        let to_json    = filters.call_method0("to_json")?;
+        let json_bytes: Vec<u8> = py
+            .import("orjson")?
+            .call_method1("dumps", (to_json,))?
+            .extract()?;
+        let json_str = std::str::from_utf8(&json_bytes)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
+        let json_val: Value = serde_json::from_str(json_str)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad query JSON: {e}")))?;
+        let mmap = self.get_mmap()?;
+        // Safety: see the access_unchecked justification in query().
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+
+        // Must run before build_filter; see query().
+        sync_format_shifts(&data.format_shifts);
+        let filter_expr = build_filter(&json_val)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
+
+        let store: &[ACard] = &data.cards;
+        // Use narrow_candidates so this exactly replicates the pre-optimization run_query
+        // path: any query that had an index hit (trigram, type_bits, cmc, etc.) should
+        // see the same narrowed candidate set here as it did before this PR.
+        let candidates = narrow_candidates(&filter_expr, &data.indexes);
+        macro_rules! cards_iter_linear {
+            () => {
+                match &candidates {
+                    Some(idxs) => Box::new(idxs.iter().map(|&i| &store[i as usize])) as Box<dyn Iterator<Item = &ACard>>,
+                    None       => Box::new(store.iter()),
+                }
+            };
+        }
+        let (total, page) = match unique {
+            "card"    => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.oracle_id),       prefer, orderby, direction, limit, offset),
+            "artwork" => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
+            _         => run_query_no_dedup(cards_iter_linear!(), &data.strings, &filter_expr, orderby, direction, limit, offset),
+        };
         let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -842,7 +842,7 @@ enum CollField {
 
 impl CollField {
     fn is_card_level(self) -> bool {
-        !matches!(self, CollField::ArtTags | CollField::FrameData)
+        !matches!(self, CollField::ArtTags | CollField::FrameData | CollField::IsTags)
     }
 }
 

--- a/scripts/bench_preferred_index.py
+++ b/scripts/bench_preferred_index.py
@@ -9,6 +9,7 @@ engine.query_linear() (always scans all printings with linear dedup), for a mix
 of card-level queries (fast path fires) and printing-level queries (falls back).
 """
 
+# pylint: disable=protected-access
 from __future__ import annotations
 
 import multiprocessing

--- a/scripts/bench_preferred_index.py
+++ b/scripts/bench_preferred_index.py
@@ -1,0 +1,89 @@
+"""Benchmark query() (preferred-index fast path) vs query_linear() (full scan).
+
+Run inside the API container:
+
+    docker exec arcane_blue-apiservice-1 python3 /app/scripts/bench_preferred_index.py
+
+Compares engine.query() (uses preferred-printing index when applicable) against
+engine.query_linear() (always scans all printings with linear dedup), for a mix
+of card-level queries (fast path fires) and printing-level queries (falls back).
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import sys
+import time
+
+sys.path.insert(0, "/app")
+
+from api.api_resource import APIResource
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import parse_scryfall_query
+
+# ─── Queries ──────────────────────────────────────────────────────────────────
+
+# (label, query_string, ordering, is_card_level)
+QUERIES = [
+    # Card-level: fast path should fire
+    ("format:modern",   "format:modern",         CardOrdering.EDHREC, True),
+    ("format:legacy",   "format:legacy",          CardOrdering.EDHREC, True),
+    ("c:r",             "c:r",                    CardOrdering.EDHREC, True),
+    ("t:creature",      "t:creature",             CardOrdering.EDHREC, True),
+    ("o:flying",        "o:flying",               CardOrdering.EDHREC, True),
+    ("cmc>5",           "cmc>5",                  CardOrdering.CMC,    True),
+    ("t:merfolk o:draw","t:merfolk o:draw",        CardOrdering.EDHREC, True),
+    # Printing-level: fast path should NOT fire
+    ("a:terese",        'a:"terese"',             CardOrdering.EDHREC, False),
+    ("year>2023",       "year>2023",              CardOrdering.EDHREC, False),
+]
+
+WARMUP    = 30    # iterations discarded
+WINDOW_S  = 5.0  # seconds per timed window
+
+# ─── Setup ────────────────────────────────────────────────────────────────────
+
+print("Loading engine from DB…", flush=True)
+api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+api._import_recent = lambda: True
+api._setup_complete = lambda: True
+api._reload_engine(force=True)
+print(f"Engine loaded: {api._engine.size():,} cards\n", flush=True)
+
+# ─── Bench helper ─────────────────────────────────────────────────────────────
+
+def bench(method, q, unique, orderby) -> float:
+    """Return average µs per call."""
+    parsed = parse_scryfall_query(q)
+    kwargs = dict(
+        filters=parsed,
+        unique=str(unique),
+        prefer=str(PreferOrder.DEFAULT),
+        orderby=str(orderby),
+        direction=str(SortDirection.ASC),
+        limit=100,
+    )
+    for _ in range(WARMUP):
+        method(**kwargs)
+    n = 0
+    t0 = time.monotonic()
+    deadline = t0 + WINDOW_S
+    while time.monotonic() < deadline:
+        method(**kwargs)
+        n += 1
+    return (time.monotonic() - t0) / n * 1_000_000  # µs
+
+# ─── Run ──────────────────────────────────────────────────────────────────────
+
+HDR = f"{'query':<22} {'card-level':<11} {'query() µs':>11} {'linear µs':>11}  speedup"
+print(HDR)
+print("─" * len(HDR))
+
+for label, q_str, orderby, card_level in QUERIES:
+    new_us  = bench(api._engine.query,        q_str, UniqueOn.CARD, orderby)
+    old_us  = bench(api._engine.query_linear, q_str, UniqueOn.CARD, orderby)
+    speedup = old_us / new_us
+    flag    = "✓" if card_level else "✗"
+    print(f"{label:<22} {flag:<11} {new_us:>11.1f} {old_us:>11.1f}  {speedup:.2f}x")
+
+print(f"\nWarmup: {WARMUP} calls  |  Timed window: {WINDOW_S:.0f}s per cell")

--- a/scripts/bench_preferred_index.py
+++ b/scripts/bench_preferred_index.py
@@ -52,7 +52,7 @@ api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=
 api._import_recent = lambda: True
 api._setup_complete = lambda: True
 api._reload_engine(force=True)
-print(f"Engine loaded: {api._engine.size():,} cards\n", flush=True)
+print(f"Engine loaded: {api._engine.size():,} printings\n", flush=True)
 
 # ─── Bench helper ─────────────────────────────────────────────────────────────
 

--- a/scripts/bench_preferred_index.py
+++ b/scripts/bench_preferred_index.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import multiprocessing
 import sys
 import time
+from typing import TYPE_CHECKING, Any
 
 sys.path.insert(0, "/app")
 
@@ -21,25 +22,27 @@ from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 # ─── Queries ──────────────────────────────────────────────────────────────────
 
-# (label, query_string, ordering, is_card_level)
 QUERIES = [
     # Card-level: fast path should fire
-    ("format:modern",   "format:modern",         CardOrdering.EDHREC, True),
-    ("format:legacy",   "format:legacy",          CardOrdering.EDHREC, True),
-    ("c:r",             "c:r",                    CardOrdering.EDHREC, True),
-    ("t:creature",      "t:creature",             CardOrdering.EDHREC, True),
-    ("o:flying",        "o:flying",               CardOrdering.EDHREC, True),
-    ("cmc>5",           "cmc>5",                  CardOrdering.CMC,    True),
-    ("t:merfolk o:draw","t:merfolk o:draw",        CardOrdering.EDHREC, True),
+    ("format:modern", "format:modern", CardOrdering.EDHREC, True),
+    ("format:legacy", "format:legacy", CardOrdering.EDHREC, True),
+    ("c:r", "c:r", CardOrdering.EDHREC, True),
+    ("t:creature", "t:creature", CardOrdering.EDHREC, True),
+    ("o:flying", "o:flying", CardOrdering.EDHREC, True),
+    ("cmc>5", "cmc>5", CardOrdering.CMC, True),
+    ("t:merfolk o:draw", "t:merfolk o:draw", CardOrdering.EDHREC, True),
     # Printing-level: fast path should NOT fire
-    ("a:terese",        'a:"terese"',             CardOrdering.EDHREC, False),
-    ("year>2023",       "year>2023",              CardOrdering.EDHREC, False),
+    ("a:terese", 'a:"terese"', CardOrdering.EDHREC, False),
+    ("year>2023", "year>2023", CardOrdering.EDHREC, False),
 ]
 
-WARMUP    = 30    # iterations discarded
-WINDOW_S  = 5.0  # seconds per timed window
+WARMUP = 30  # iterations discarded
+WINDOW_S = 5.0  # seconds per timed window
 
 # ─── Setup ────────────────────────────────────────────────────────────────────
 
@@ -52,17 +55,18 @@ print(f"Engine loaded: {api._engine.size():,} cards\n", flush=True)
 
 # ─── Bench helper ─────────────────────────────────────────────────────────────
 
-def bench(method, q, unique, orderby) -> float:
+
+def bench(method: Callable[..., Any], q: str, unique: UniqueOn, orderby: CardOrdering) -> float:
     """Return average µs per call."""
     parsed = parse_scryfall_query(q)
-    kwargs = dict(
-        filters=parsed,
-        unique=str(unique),
-        prefer=str(PreferOrder.DEFAULT),
-        orderby=str(orderby),
-        direction=str(SortDirection.ASC),
-        limit=100,
-    )
+    kwargs = {
+        "filters": parsed,
+        "unique": str(unique),
+        "prefer": str(PreferOrder.DEFAULT),
+        "orderby": str(orderby),
+        "direction": str(SortDirection.ASC),
+        "limit": 100,
+    }
     for _ in range(WARMUP):
         method(**kwargs)
     n = 0
@@ -73,6 +77,7 @@ def bench(method, q, unique, orderby) -> float:
         n += 1
     return (time.monotonic() - t0) / n * 1_000_000  # µs
 
+
 # ─── Run ──────────────────────────────────────────────────────────────────────
 
 HDR = f"{'query':<22} {'card-level':<11} {'query() µs':>11} {'linear µs':>11}  speedup"
@@ -80,10 +85,10 @@ print(HDR)
 print("─" * len(HDR))
 
 for label, q_str, orderby, card_level in QUERIES:
-    new_us  = bench(api._engine.query,        q_str, UniqueOn.CARD, orderby)
-    old_us  = bench(api._engine.query_linear, q_str, UniqueOn.CARD, orderby)
+    new_us = bench(api._engine.query, q_str, UniqueOn.CARD, orderby)
+    old_us = bench(api._engine.query_linear, q_str, UniqueOn.CARD, orderby)
     speedup = old_us / new_us
-    flag    = "✓" if card_level else "✗"
+    flag = "✓" if card_level else "✗"
     print(f"{label:<22} {flag:<11} {new_us:>11.1f} {old_us:>11.1f}  {speedup:.2f}x")
 
 print(f"\nWarmup: {WARMUP} calls  |  Timed window: {WINDOW_S:.0f}s per cell")

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -11,6 +11,7 @@ sample_reservoir()    Single-pass bounded min-heap.                     O(total 
 sample_indexed()      Floyd's index set + targeted single walk.         O(total) time, O(n) mem.
 """
 
+# pylint: disable=protected-access
 from __future__ import annotations
 
 import multiprocessing

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -14,18 +14,21 @@ sample_indexed()      Floyd's index set + targeted single walk.         O(total)
 # pylint: disable=protected-access
 from __future__ import annotations
 
-from collections.abc import Callable
 import multiprocessing
 import random
 import sys
 import time
 import tracemalloc
+from typing import TYPE_CHECKING
 
 sys.path.insert(0, "/app")
 
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ─── Config ───────────────────────────────────────────────────────────────────
 

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -69,7 +69,7 @@ print(f"Prebuilt list: {len(prebuilt):,} unique cards, ~{list_bytes / 1024 / 102
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
-def _time_fn(fn: callable, warmup: int, window: float) -> float:
+def _time_fn(fn: Callable[[], object], warmup: int, window: float) -> float:
     """Return average µs per call after warmup."""
     for _ in range(warmup):
         fn()

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -14,6 +14,7 @@ sample_indexed()      Floyd's index set + targeted single walk.         O(total)
 # pylint: disable=protected-access
 from __future__ import annotations
 
+from collections.abc import Callable
 import multiprocessing
 import random
 import sys

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -1,0 +1,105 @@
+"""Benchmark reservoir vs indexed random-sampling on the Rust card engine.
+
+Plus Python random.sample on a prebuilt list (the old approach's hot path).
+
+Run inside the API container so card_engine is available:
+
+    docker exec arcane_blue-apiservice-1 python3 /app/scripts/bench_random.py
+
+random.sample(list)   Old hot path: O(n) on prebuilt ~30k-dict list.   O(unique_cards) mem (always resident).
+sample_reservoir()    Single-pass bounded min-heap.                     O(total x log n) time, O(n) mem.
+sample_indexed()      Floyd's index set + targeted single walk.         O(total) time, O(n) mem.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import random
+import sys
+import time
+import tracemalloc
+
+sys.path.insert(0, "/app")
+
+from api.api_resource import APIResource
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import parse_scryfall_query
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+
+NS = [1, 12, 30, 60]
+WARMUP = 50  # calls to discard before timing
+WINDOW = 3.0  # seconds to run per cell
+REPEATS = 3  # independent timed windows per cell (report min to reduce noise)
+
+# ─── Setup ────────────────────────────────────────────────────────────────────
+
+print("Connecting to DB and loading engine store…", flush=True)
+api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+api._import_recent = lambda: True
+api._setup_complete = lambda: True
+api._reload_engine(force=True)
+total_printings = api._engine.size()
+print(f"Engine loaded: {total_printings:,} printings", flush=True)
+
+# Build the prebuilt list that the old implementation kept in memory.
+# This mirrors exactly what _fetch_and_cache_preferred_cards() stored.
+print("Building prebuilt card list (old approach)…", flush=True)
+tracemalloc.start()
+snapshot_before = tracemalloc.take_snapshot()
+_, prebuilt = api._engine.query(
+    filters=parse_scryfall_query(""),
+    unique=str(UniqueOn.CARD),
+    prefer=str(PreferOrder.DEFAULT),
+    orderby=str(CardOrdering.EDHREC),
+    direction=str(SortDirection.ASC),
+    limit=1_000_000,
+)
+prebuilt = list(prebuilt)
+snapshot_after = tracemalloc.take_snapshot()
+tracemalloc.stop()
+
+top_stats = snapshot_after.compare_to(snapshot_before, "lineno")
+list_bytes = sum(s.size_diff for s in top_stats if s.size_diff > 0)
+print(f"Prebuilt list: {len(prebuilt):,} unique cards, ~{list_bytes / 1024 / 1024:.1f} MB\n", flush=True)
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _time_fn(fn: callable, warmup: int, window: float) -> float:
+    """Return average µs per call after warmup."""
+    for _ in range(warmup):
+        fn()
+    n_calls = 0
+    t0 = time.monotonic()
+    deadline = t0 + window
+    while time.monotonic() < deadline:
+        fn()
+        n_calls += 1
+    return (time.monotonic() - t0) / n_calls * 1_000_000  # µs
+
+
+def bench(n: int) -> tuple[float, float, float, float]:
+    """Return (py_sample_us, preferred_us, reservoir_us, indexed_us) as min over REPEATS windows."""
+    py_timings = [_time_fn(lambda: random.sample(prebuilt, n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    pref_timings = [_time_fn(lambda: api._engine.sample_preferred(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    res_timings = [_time_fn(lambda: api._engine.sample_reservoir(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    idx_timings = [_time_fn(lambda: api._engine.sample_indexed(n), WARMUP, WINDOW) for _ in range(REPEATS)]
+    return min(py_timings), min(pref_timings), min(res_timings), min(idx_timings)
+
+
+# ─── Run ──────────────────────────────────────────────────────────────────────
+
+header = f"{'n':>6}  {'python sample µs':>18}  {'preferred µs':>14}  {'reservoir µs':>14}  {'indexed µs':>12}"
+print(header)
+print("-" * len(header))
+
+for n in NS:
+    py_us, pref_us, res_us, idx_us = bench(n)
+    print(f"{n:>6}  {py_us:>18.1f}  {pref_us:>14.1f}  {res_us:>14.1f}  {idx_us:>12.1f}")
+
+print(f"\n{WARMUP} warmup + {REPEATS}x{WINDOW:.0f}s windows, best-of-{REPEATS} reported")
+print(
+    f"Store: {total_printings:,} total printings  |  prebuilt list: {len(prebuilt):,} unique cards  ~{list_bytes / 1024 / 1024:.1f} MB"
+)


### PR DESCRIPTION
## Summary

- Adds `is_card_level()` classification to `FilterExpr` and all its leaf field types (`NumField`, `NumExpr`, `TextSearchField`, `TextField`, `CollField`). Returns true when every predicate in the filter only touches attributes that are constant across all printings of the same oracle id (name, oracle text, color, type, subtype, format legality, power/toughness/cmc/loyalty, keywords, oracle tags, etc.).
- For `unique=card` + default prefer + card-level filter, `run_query` now substitutes the preferred-printing index (~31k entries) as the candidate set instead of scanning all ~97k printings. One entry per oracle id means no dedup step is needed.
- When `narrow_candidates` already produced a narrowed candidate set (trigram, type_bits, cmc index hits), the preferred index is intersected with it — both optimizations compose.
- Adds `query_linear()` Python method that replicates the pre-optimization path (same `narrow_candidates` narrowing, then linear dedup) for ongoing benchmarking.

## Benchmark results

`query()` (new) vs `query_linear()` (old), `unique=card`, `prefer=default`:

| query | new (µs) | old (µs) | speedup | notes |
|---|---|---|---|---|
| `format:legacy` | 330 | 1252 | 3.8x | no index hit — full scan; 31k preferred vs 97k printings |
| `format:modern` | 388 | 1101 | 2.8x | same |
| `c:r` | 240 | 511 | 2.1x | no index hit |
| `t:creature` | 348 | 674 | 1.9x | type_bits index narrows, preferred intersect narrows further |
| `o:flying` | 361 | 510 | 1.4x | trigram index + preferred intersection |
| `cmc>5` | 174 | 232 | 1.3x | cmc index + preferred intersection |
| `t:merfolk o:draw` | 148 | 141 | ~0.95x | index already narrows to ~20 cards; `intersect_sorted` overhead > savings |
| `a:terese` (printing-level) | 2065 | 2139 | ~1.0x | fast path correctly does not fire |
| `year>2023` (printing-level) | 836 | 893 | ~1.0x | fast path correctly does not fire |

The `t:merfolk o:draw` slight regression is expected: when `narrow_candidates` already returns a tiny set, paying `intersect_sorted` against 31k preferred entries costs more than the dedup savings. Could be addressed with a candidate-count threshold guard if it becomes a concern.

## Test plan

- [ ] Run existing test suite (`make test`) — no behavioral changes expected, only scan width
- [ ] Run `bench_preferred_index.py` inside the API container to confirm speedups hold after deploy
- [ ] Spot-check result counts for `format:modern`, `t:creature`, `o:flying` match SQL path