### PR TITLE
Double backfill prefer scores statement timeout

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1585,7 +1585,7 @@ class APIResource:
 
         backfill_sql = self.read_sql("backfill_prefer_scores")
         with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            statement_timeout = 60_000
+            statement_timeout = 120_000
             # Validate and set statement timeout
             self._set_statement_timeout(cursor, statement_timeout)
             cursor.execute(backfill_sql)


### PR DESCRIPTION
## Summary

- Doubles the `statement_timeout` in `backfill_prefer_scores` from 60s to 120s to prevent timeouts on large datasets.

Fixes #537