### PR TITLE
Compute Common Card Types from Engine

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1549,11 +1549,18 @@ class APIResource:
         falcon_response: falcon.Response | None = None,
         **_: object,
     ) -> list[dict[str, Any]]:
-        """Get the common card types from the database."""
+        """Get the common card types from the engine."""
+        if self._engine.size() == 0:
+            raise falcon.HTTPServiceUnavailable(
+                title="Service Unavailable",
+                description="Engine is not loaded, please try again later.",
+            ) from None
         set_cache_header(falcon_response, duration=timedelta(hours=1))
-        return self._run_query(
-            query=self.read_sql("get_common_card_types"),
-        )["result"]
+        counts: dict[str, int] = self._engine.common_card_types()
+        return sorted(
+            [{"t": t, "n": n} for t, n in counts.items()],
+            key=lambda x: x["t"],
+        )
 
     def get_common_keywords(self, **_: object) -> list[dict[str, Any]]:
         """Get the common keywords from the database."""

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1557,6 +1557,10 @@ class APIResource:
             ) from None
         set_cache_header(falcon_response, duration=timedelta(hours=1))
         counts: dict[str, int] = self._engine.common_card_types()
+        # tribal is the old name for kindred
+        kindred_count = counts.get("Kindred", 0)
+        if kindred_count:
+            counts["Tribal"] = kindred_count
         return sorted(
             [{"t": t, "n": n} for t, n in counts.items()],
             key=lambda x: x["t"],

--- a/api/sql/get_common_card_types.sql
+++ b/api/sql/get_common_card_types.sql
@@ -23,18 +23,17 @@ card_types_and_subtypes AS (
         subtype_name
     FROM card_subtypes
 ),
-with_min_count AS (
+counted AS (
     SELECT
         type_name,
         count(1) as num_occurrences
     FROM card_types_and_subtypes
     GROUP BY type_name
-    HAVING count(1) >= 5
 )
 SELECT
     type_name AS t,
     num_occurrences AS n
 FROM
-    with_min_count
+    counted
 ORDER BY
     type_name

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -11,15 +11,22 @@
           function fetchWithRetry() {
             return fetch('/get_common_card_types')
               .then(function (response) {
-                if (!response.ok) throw new Error('HTTP ' + response.status);
+                if (response.status === 503) {
+                  var delay = 30000 + Math.random() * 10000;
+                  console.warn('Common card types not ready, retrying in ' + Math.round(delay / 1000) + 's');
+                  return new Promise(function (resolve) {
+                    setTimeout(resolve, delay);
+                  }).then(fetchWithRetry);
+                }
+                if (!response.ok) {
+                  console.error('Failed to fetch common card types: HTTP ' + response.status);
+                  return [];
+                }
                 return response.json();
               })
               .catch(function (error) {
-                var delay = 30000 + Math.random() * 10000;
-                console.warn('Failed to fetch common card types, retrying in ' + Math.round(delay / 1000) + 's', error);
-                return new Promise(function (resolve) {
-                  setTimeout(resolve, delay);
-                }).then(fetchWithRetry);
+                console.error('Failed to fetch common card types:', error);
+                return [];
               });
           }
           window.commonCardTypesPromise = fetchWithRetry();

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -8,15 +8,21 @@
       // Start fetching as early as possible - before any other resources block execution
       (function () {
         if (!window.commonCardTypesPromise) {
-          window.commonCardTypesPromise = fetch('/get_common_card_types')
-            .then(response => {
-              if (!response.ok) throw new Error('Failed to fetch common card types');
-              return response.json();
-            })
-            .catch(error => {
-              console.error('Error fetching common card types:', error);
-              return [];
-            });
+          function fetchWithRetry() {
+            return fetch('/get_common_card_types')
+              .then(function (response) {
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                return response.json();
+              })
+              .catch(function (error) {
+                var delay = 30000 + Math.random() * 10000;
+                console.warn('Failed to fetch common card types, retrying in ' + Math.round(delay / 1000) + 's', error);
+                return new Promise(function (resolve) {
+                  setTimeout(resolve, delay);
+                }).then(fetchWithRetry);
+              });
+          }
+          window.commonCardTypesPromise = fetchWithRetry();
         }
       })();
     </script>

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -568,6 +568,50 @@ class TestAPIResourceCaching(unittest.TestCase):
         assert result == {"cards": [], "total_cards": 0}
         mock_engine.sample_preferred.assert_not_called()
 
+    def test_get_common_card_types_raises_503_when_engine_empty(self) -> None:
+        """get_common_card_types raises HTTPServiceUnavailable when engine.size() == 0.
+
+        This is the mechanism that prevents an empty 200 from being stored by
+        CachingMiddleware (which skips 5xx responses).
+        """
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        mock_engine = MagicMock()
+        mock_engine.size.return_value = 0
+
+        with patch.object(self.api_resource, "_engine", mock_engine):
+            with pytest.raises(falcon.HTTPServiceUnavailable):
+                self.api_resource.get_common_card_types()
+
+        mock_engine.common_card_types.assert_not_called()
+
+    def test_get_common_card_types_returns_sorted_list_when_engine_loaded(self) -> None:
+        """get_common_card_types returns [{t, n}] sorted by type name when engine is ready.
+
+        Kindred is aliased as Tribal in the response, so both keys appear.
+        """
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        mock_engine = MagicMock()
+        mock_engine.size.return_value = 4
+        mock_engine.common_card_types.return_value = {
+            "Creature": 5,
+            "Artifact": 2,
+            "Instant": 3,
+            "Kindred": 4,
+        }
+
+        with patch.object(self.api_resource, "_engine", mock_engine):
+            result = self.api_resource.get_common_card_types()
+
+        assert result == [
+            {"t": "Artifact", "n": 2},
+            {"t": "Creature", "n": 5},
+            {"t": "Instant", "n": 3},
+            {"t": "Kindred", "n": 4},
+            {"t": "Tribal", "n": 4},
+        ]
+
     def test_cache_clear_method_works(self) -> None:
         """Test that cache.clear() method works for cachebox caches."""
         # Test query cache clearing

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -966,3 +966,50 @@ class TestTags:
     def test_otag_no_match(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, "otag:ramp")
         assert total == 0
+
+
+class TestCommonCardTypes:
+    """Tests for engine.common_card_types().
+
+    Counts types and subtypes across preferred printings only (one per oracle card).
+    The fixture has 13 oracle cards; expected counts reflect the preferred printing
+    of each group, not all 87 printings.
+    """
+
+    def test_returns_dict(self, engine: QueryEngine) -> None:
+        result = engine.common_card_types()
+        assert isinstance(result, dict)
+
+    def test_type_counts(self, engine: QueryEngine) -> None:
+        result = engine.common_card_types()
+        # 13 oracle groups: 2 artifacts, 5 creatures, 3 instants, 2 legendary
+        # planeswalkers, 1 sorcery. Jace and Nicol Bolas are both Legendary+Planeswalker.
+        assert result["Artifact"] == 2
+        assert result["Creature"] == 5
+        assert result["Instant"] == 3
+        assert result["Legendary"] == 2
+        assert result["Planeswalker"] == 2
+        assert result["Sorcery"] == 1
+
+    def test_subtype_counts(self, engine: QueryEngine) -> None:
+        result = engine.common_card_types()
+        # One preferred printing per oracle group; each group has a unique subtype.
+        assert result["Angel"] == 1
+        assert result["Dragon"] == 1
+        assert result["Goblin"] == 1
+        assert result["Lhurgoyf"] == 1
+        assert result["Ouphe"] == 1
+        assert result["Warrior"] == 1
+
+    def test_absent_types_not_present(self, engine: QueryEngine) -> None:
+        result = engine.common_card_types()
+        # No lands, snow, or basic cards in the fixture.
+        assert "Land" not in result
+        assert "Basic" not in result
+        assert "Snow" not in result
+        assert "Battle" not in result
+
+    def test_empty_engine_size_is_zero(self, fresh_engine: Callable[[], QueryEngine]) -> None:
+        e = fresh_engine()
+        # get_common_card_types checks size() == 0 and raises HTTPServiceUnavailable.
+        assert e.size() == 0

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1243,6 +1243,47 @@ struct Staging {
     lock_file: std::fs::File,
 }
 
+// Names ordered by bit position matching the TYPE_* constants (bit 0 = index 0, …).
+const TYPE_BIT_NAMES: [&str; 14] = [
+    "Artifact", "Basic", "Battle", "Conspiracy", "Creature", "Enchantment",
+    "Instant", "Kindred", "Land", "Legendary", "Planeswalker", "Snow", "Sorcery", "World",
+];
+
+/// Count type and subtype occurrences across preferred printings (one per oracle card).
+/// Accumulates by integer key in the hot loop — bit position for types, &str borrowed
+/// from the archive for subtypes — then converts to owned strings once at the end.
+pub(crate) fn count_common_types(data: &Archived<CardData>) -> HashMap<String, u32> {
+    let mut type_counts = [0u32; 14];
+    let mut subtype_counts: HashMap<&str, u32> = HashMap::new();
+
+    let store: &[ACard] = &data.cards;
+    for &idx in data.preferred_indices.iter() {
+        let card = &store[u32::from(idx) as usize];
+
+        let mut bits = u16::from(card.card_types);
+        while bits != 0 {
+            let pos = bits.trailing_zeros() as usize;
+            type_counts[pos] += 1;
+            bits &= bits - 1;
+        }
+
+        for subtype in card.card_subtypes.iter() {
+            *subtype_counts.entry(subtype.as_str()).or_insert(0) += 1;
+        }
+    }
+
+    let mut result: HashMap<String, u32> = HashMap::new();
+    for (i, &count) in type_counts.iter().enumerate() {
+        if count > 0 {
+            result.insert(TYPE_BIT_NAMES[i].to_string(), count);
+        }
+    }
+    for (name, count) in subtype_counts {
+        result.insert(name.to_string(), count);
+    }
+    result
+}
+
 #[pyclass]
 struct QueryEngine {
     shm_path: PathBuf,
@@ -1732,6 +1773,21 @@ impl QueryEngine {
         PyList::new(py, dicts)
     }
 
+
+    /// Count type and subtype occurrences across preferred printings.
+    /// Returns {type_name: count} covering both supertypes/types (decoded from
+    /// the card_types bitmask) and subtypes (from card_subtypes strings).
+    fn common_card_types<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let mmap = self.get_mmap()?;
+        // Safety: see the access_unchecked justification in query().
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+        let counts = count_common_types(data);
+        let d = PyDict::new(py);
+        for (name, count) in &counts {
+            d.set_item(name, count)?;
+        }
+        Ok(d)
+    }
 
     /// Rust-heap allocator stats and reload() memory breakdown.
     /// Empty dict unless built with --features alloc-counter (measurement-only).

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     build_list_index, build_numeric_index, build_oracle_text_index, build_tag_index,
-    build_trigram_index, build_type_index, narrow_candidates, trigram_candidates,
-    Card, CardData, CardIndexes, CollField, CmpOp, FilterExpr, Interner, ManaCost,
-    InlineStr, TagIndex, TrigramIndex, NONE_STR, TYPE_CREATURE,
+    build_trigram_index, build_type_index, count_common_types, narrow_candidates,
+    trigram_candidates, Card, CardData, CardIndexes, CollField, CmpOp, FilterExpr, Interner,
+    ManaCost, InlineStr, TagIndex, TrigramIndex, NONE_STR,
+    TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT, TYPE_LEGENDARY, TYPE_PLANESWALKER,
 };
 use rkyv::{rancor::Error, Archived};
 use std::collections::{HashMap, HashSet};
@@ -275,4 +276,100 @@ fn narrow_candidates_art_tags() {
         value: "zombie".to_string(),
     };
     assert_eq!(narrow_candidates(&absent, archived), None);
+}
+
+/// Minimal card for tests that only care about card_types and card_subtypes.
+/// All interned-string IDs are NONE_STR; count_common_types never reads them.
+fn stub_card(card_types: u16, card_subtypes: Vec<String>) -> Card {
+    Card {
+        card_name_lower: InlineStr::from_str(""),
+        card_colors: 0,
+        card_color_identity: 0,
+        produced_mana: 0,
+        card_types,
+        scryfall_id: 0,
+        oracle_id: 0,
+        illustration_id: 0,
+        card_name_id: NONE_STR,
+        oracle_text_id: NONE_STR,
+        oracle_text_lower_id: NONE_STR,
+        flavor_text_id: NONE_STR,
+        flavor_text_lower_id: NONE_STR,
+        card_artist_id: NONE_STR,
+        card_artist_lower_id: NONE_STR,
+        card_set_code: InlineStr::from_str(""),
+        card_layout_id: NONE_STR,
+        card_border_id: NONE_STR,
+        card_watermark_id: NONE_STR,
+        collector_number_id: NONE_STR,
+        mana_cost_text_id: NONE_STR,
+        type_line_id: NONE_STR,
+        set_name_id: NONE_STR,
+        released_at_int: None,
+        cmc: None,
+        creature_power: None,
+        creature_toughness: None,
+        planeswalker_loyalty: None,
+        card_rarity_int: None,
+        collector_number_int: None,
+        edhrec_rank: None,
+        price_usd: None,
+        price_eur: None,
+        price_tix: None,
+        prefer_score: None,
+        cubecobra_score: None,
+        card_subtypes,
+        card_keywords: HashSet::new(),
+        card_legalities: 0,
+        card_oracle_tags: HashSet::new(),
+        card_art_tags: HashSet::new(),
+        card_is_tags: HashSet::new(),
+        card_frame_data: HashSet::new(),
+        mana_cost: ManaCost { pips: HashMap::new(), devotion: None, cmc: 0.0 },
+        creature_power_text_id: NONE_STR,
+        creature_toughness_text_id: NONE_STR,
+    }
+}
+
+#[test]
+fn count_common_types_sums_preferred_only() {
+    // card 0: Legendary Planeswalker, subtype "Jace"   — preferred
+    // card 1: Instant, no subtypes                     — not preferred (skipped)
+    // card 2: Artifact + Creature, subtype "Merfolk"   — preferred
+    // card 3: Creature, subtypes ["Warrior", "Merfolk"] — preferred
+    let cards = vec![
+        stub_card(TYPE_LEGENDARY | TYPE_PLANESWALKER, vec!["Jace".to_string()]),
+        stub_card(TYPE_INSTANT,                        vec![]),
+        stub_card(TYPE_ARTIFACT | TYPE_CREATURE,       vec!["Merfolk".to_string()]),
+        stub_card(TYPE_CREATURE,                       vec!["Warrior".to_string(), "Merfolk".to_string()]),
+    ];
+    let data = CardData {
+        cards,
+        strings: vec![],
+        indexes: CardIndexes::default(),
+        format_shifts: HashMap::new(),
+        preferred_indices: vec![0, 2, 3], // card 1 (Instant) excluded
+    };
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let counts = count_common_types(archived);
+
+    // Type bits decoded correctly from the bitmask.
+    assert_eq!(counts.get("Legendary"),    Some(&1));
+    assert_eq!(counts.get("Planeswalker"), Some(&1));
+    assert_eq!(counts.get("Artifact"),     Some(&1));
+    assert_eq!(counts.get("Creature"),     Some(&2)); // cards 2 and 3
+
+    // Card 1 (Instant) is not in preferred_indices — must be absent.
+    assert_eq!(counts.get("Instant"), None);
+
+    // Subtypes borrowed from archive strings; "Merfolk" appears in two preferred cards.
+    assert_eq!(counts.get("Merfolk"),  Some(&2));
+    assert_eq!(counts.get("Warrior"),  Some(&1));
+    assert_eq!(counts.get("Jace"),     Some(&1));
+
+    // Types with zero count are never emitted.
+    assert_eq!(counts.get("Land"),   None);
+    assert_eq!(counts.get("Sorcery"), None);
 }


### PR DESCRIPTION
## What this does

Replaces the `get_common_card_types` SQL query with a Rust engine computation, fixes a caching bug where an empty response could get stuck in the cache, and adds a frontend retry loop so the autocomplete data loads correctly after a cold start.

## The SQL path

The old implementation ran a CTE over the full `magic.cards` table to unnest `card_types` and `card_subtypes` JSONB arrays and count occurrences across every printing. This PR removes that DB round-trip entirely.

## The engine path

`count_common_types` walks `preferred_indices` — one entry per unique oracle card — and counts:

- **Type bits**: each card's `card_types` bitmask is consumed with `trailing_zeros` + `bits &= bits - 1`, accumulating into a `[u32; 14]` array indexed by bit position. No string work in the hot loop.
- **Subtypes**: `&str` slices borrowed directly from the mmap archive are accumulated into a `HashMap<&str, u32>`. Again, no allocation per card.

Both are converted to owned strings once at the end. This counts unique oracle cards rather than all printings, which is the correct semantic for "how common is this type."

## The caching bug

`CachingMiddleware` caches any non-5xx response unconditionally — it does not inspect the `Cache-Control` header. Before this PR, if `get_common_card_types` was called before the engine finished loading, it returned an empty list which was cached for an hour. The fix is a 503 when `engine.size() == 0`, which `CachingMiddleware` explicitly skips.

## The frontend retry

The inline script in `index.html` previously caught the fetch error and resolved to `[]`, leaving autocomplete permanently broken until the next page load. It now retries after `30 + random() * 10` seconds (30–40s jitter), keeping `window.commonCardTypesPromise` pending until the engine is ready. `fetchCommonCardTypes()` in `app.js` is unaffected — it just awaits the promise however long it takes.

## Tests

- **Rust** (`card_engine/src/tests.rs`): `count_common_types_sums_preferred_only` — 4 cards, 3 preferred, verifies bit decoding, multi-bit types, subtype accumulation across cards, and that non-preferred cards are excluded.
- **Python** (`api/tests/test_engine_unit.py`): `TestCommonCardTypes` — 5 tests against the 87-printing fixture; checks return type, exact type counts (per oracle card, not per printing), exact subtype counts, absent types excluded.