### PR TITLE
Simplify CORS middleware to allow all origins

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -16,16 +16,10 @@ jobs:
       github.event.comment.user.login == 'jbylund'
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR branch
-        id: pr
-        run: echo "ref=$(gh pr view ${{ github.event.issue.number }} --json headRefName -q .headRefName)" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.pr.outputs.ref }}
+          ref: refs/pull/${{ github.event.issue.number }}/head
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python 3.13
@@ -45,4 +39,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git diff --exit-code && echo "No changes to commit" || (git add -u && git commit -m "style: auto-fix ruff" && git push)
+          branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
+          git diff --exit-code && echo "No changes to commit" || (git add -u && git commit -m "style: auto-fix ruff" && git push origin HEAD:"$branch")
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/api/middlewares/cors_middleware.py
+++ b/api/middlewares/cors_middleware.py
@@ -9,11 +9,15 @@ if TYPE_CHECKING:
 
 
 class CORSMiddleware:
+    """Middleware to add CORS headers to all responses."""
+
     def process_response(
         self,
         req: falcon.Request,
         resp: falcon.Response,
-        resource: object,  # noqa: ARG002
-        req_succeeded: bool,  # noqa: ARG002
+        resource: object,
+        req_succeeded: bool,
     ) -> None:
+        """Add CORS headers to the response."""
+        del req, resource, req_succeeded
         resp.set_header("Access-Control-Allow-Origin", "*")

--- a/api/middlewares/cors_middleware.py
+++ b/api/middlewares/cors_middleware.py
@@ -2,55 +2,13 @@
 
 from __future__ import annotations
 
-import logging
-import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import falcon
 
-logger = logging.getLogger(__name__)
-
 
 class CORSMiddleware:
-    """Middleware to handle Cross-Origin Resource Sharing (CORS) headers.
-
-    This middleware adds CORS headers to responses, with configurable
-    allowed origins based on the environment.
-    """
-
-    def __init__(self) -> None:
-        """Initialize the CORS middleware with environment-specific settings."""
-        # Get environment from environment variable
-        environment = os.environ.get("ENVIRONMENT", "dev")
-
-        # Configure allowed origins based on environment
-        if environment == "prod":
-            # Production: Restrict to specific domains
-            self.allowed_origins = [
-                "https://arcane-tutor.com",
-                "https://www.arcane-tutor.com",
-            ]
-        else:
-            # Development: Allow localhost for testing
-            self.allowed_origins = [
-                "http://localhost:8080",
-                "http://localhost:28080",
-                "http://localhost:18080",
-                "http://127.0.0.1:8080",
-                "http://127.0.0.1:28080",
-                "http://127.0.0.1:18080",
-            ]
-
-        # Allow additional origins from environment variable (comma-separated)
-        extra_origins = os.environ.get("CORS_ALLOWED_ORIGINS", "")
-        if extra_origins:
-            # Filter and strip origins, avoiding duplicate strip() calls
-            stripped_origins = [s for origin in extra_origins.split(",") if (s := origin.strip())]
-            self.allowed_origins.extend(stripped_origins)
-
-        logger.info("CORS middleware initialized with allowed origins: %s", self.allowed_origins)
-
     def process_response(
         self,
         req: falcon.Request,
@@ -58,25 +16,4 @@ class CORSMiddleware:
         resource: object,  # noqa: ARG002
         req_succeeded: bool,  # noqa: ARG002
     ) -> None:
-        """Add CORS headers to the response if origin is allowed.
-
-        Args:
-            req: The request object
-            resp: The response object
-            resource: The resource handling the request
-            req_succeeded: Whether the request succeeded
-        """
-        origin = req.get_header("Origin")
-
-        # If no origin header, this is not a cross-origin request
-        if origin is None:
-            return
-
-        # Check if origin is allowed
-        if origin in self.allowed_origins:
-            resp.set_header("Access-Control-Allow-Origin", origin)
-            resp.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            resp.set_header("Access-Control-Allow-Headers", "Content-Type")
-            resp.set_header("Access-Control-Max-Age", "86400")  # 24 hours
-        else:
-            logger.warning("CORS request rejected - origin not in allowed list: %s", origin)
+        resp.set_header("Access-Control-Allow-Origin", "*")

--- a/api/middlewares/tests/test_cors_middleware.py
+++ b/api/middlewares/tests/test_cors_middleware.py
@@ -2,84 +2,28 @@
 
 from __future__ import annotations
 
-import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from api.middlewares.cors_middleware import CORSMiddleware
 
 
 class TestCORSMiddleware:
-    """Tests for CORS middleware."""
-
-    def test_init_production_environment(self) -> None:
-        """Test CORS middleware initialization in production environment."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "prod"}):
-            middleware = CORSMiddleware()
-            assert "https://arcane-tutor.com" in middleware.allowed_origins
-            assert "https://www.arcane-tutor.com" in middleware.allowed_origins
-            assert "http://localhost:8080" not in middleware.allowed_origins
-
-    def test_init_development_environment(self) -> None:
-        """Test CORS middleware initialization in development environment."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "dev"}):
-            middleware = CORSMiddleware()
-            assert "http://localhost:8080" in middleware.allowed_origins
-            assert "http://localhost:28080" in middleware.allowed_origins
-            assert "http://127.0.0.1:8080" in middleware.allowed_origins
-            assert "https://arcane-tutor.com" not in middleware.allowed_origins
-
-    def test_init_with_extra_origins(self) -> None:
-        """Test CORS middleware with additional origins from environment."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "dev", "CORS_ALLOWED_ORIGINS": "https://example.com, https://test.com"}):
-            middleware = CORSMiddleware()
-            assert "https://example.com" in middleware.allowed_origins
-            assert "https://test.com" in middleware.allowed_origins
-
-    def test_init_with_empty_extra_origins(self) -> None:
-        """Test CORS middleware with empty CORS_ALLOWED_ORIGINS."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "dev", "CORS_ALLOWED_ORIGINS": ""}):
-            middleware = CORSMiddleware()
-            assert "http://localhost:8080" in middleware.allowed_origins
-
-    def test_process_response_allowed_origin(self) -> None:
-        """Test CORS headers are added for allowed origin."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "prod"}):
-            middleware = CORSMiddleware()
-
+    def test_process_response_sets_wildcard_origin(self) -> None:
+        middleware = CORSMiddleware()
         req = MagicMock()
-        req.get_header.return_value = "https://arcane-tutor.com"
+        req.get_header.return_value = "https://example.com"
         resp = MagicMock()
 
         middleware.process_response(req, resp, None, True)
 
-        resp.set_header.assert_any_call("Access-Control-Allow-Origin", "https://arcane-tutor.com")
-        resp.set_header.assert_any_call("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        resp.set_header.assert_any_call("Access-Control-Allow-Headers", "Content-Type")
-        resp.set_header.assert_any_call("Access-Control-Max-Age", "86400")
-
-    def test_process_response_disallowed_origin(self) -> None:
-        """Test CORS headers are not added for disallowed origin."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "prod"}):
-            middleware = CORSMiddleware()
-
-        req = MagicMock()
-        req.get_header.return_value = "https://malicious-site.com"
-        resp = MagicMock()
-
-        middleware.process_response(req, resp, None, True)
-
-        # Verify no CORS headers were set
-        resp.set_header.assert_not_called()
+        resp.set_header.assert_called_once_with("Access-Control-Allow-Origin", "*")
 
     def test_process_response_no_origin_header(self) -> None:
-        """Test no CORS headers are added when Origin header is missing."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "prod"}):
-            middleware = CORSMiddleware()
-
+        middleware = CORSMiddleware()
         req = MagicMock()
         req.get_header.return_value = None
         resp = MagicMock()
 
         middleware.process_response(req, resp, None, True)
 
-        resp.set_header.assert_not_called()
+        resp.set_header.assert_called_once_with("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
## Summary

- Replaces the per-environment origin allowlist with a single `Access-Control-Allow-Origin: *` header
- Arcane Tutor is a public read-only API with no auth cookies, so wildcard CORS is safe and the allowlist adds complexity with no security benefit
- Removes `__init__`, env var logic, logging, and all origin-matching code — middleware is now ~5 lines

Closes #546

## Test plan
- [ ] `python -m pytest api/middlewares/tests/test_cors_middleware.py -vvv` passes