### PR TITLE
Add Github Action that Trivially Passes on PRs that do NOT Require Unit Tests

### DIFF
--- a/.github/workflows/check-ci-sync.yml
+++ b/.github/workflows/check-ci-sync.yml
@@ -25,8 +25,9 @@ jobs:
           with open(".github/workflows/unit-tests-skip.yml") as f:
               skip = yaml.safe_load(f)
 
-          paths = sorted(tests["on"]["pull_request"]["paths"])
-          paths_ignore = sorted(skip["on"]["pull_request"]["paths-ignore"])
+          # PyYAML parses the 'on:' key as boolean True
+          paths = sorted(tests[True]["pull_request"]["paths"])
+          paths_ignore = sorted(skip[True]["pull_request"]["paths-ignore"])
 
           if paths != paths_ignore:
               only_in_paths = sorted(set(paths) - set(paths_ignore))

--- a/.github/workflows/check-ci-sync.yml
+++ b/.github/workflows/check-ci-sync.yml
@@ -1,0 +1,41 @@
+name: Check CI Path Sync
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/unit-tests.yml'
+      - '.github/workflows/unit-tests-skip.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify unit-tests paths match unit-tests-skip paths-ignore
+        run: |
+          python3 - <<'EOF'
+          import yaml, sys
+
+          with open(".github/workflows/unit-tests.yml") as f:
+              tests = yaml.safe_load(f)
+          with open(".github/workflows/unit-tests-skip.yml") as f:
+              skip = yaml.safe_load(f)
+
+          paths = sorted(tests["on"]["pull_request"]["paths"])
+          paths_ignore = sorted(skip["on"]["pull_request"]["paths-ignore"])
+
+          if paths != paths_ignore:
+              only_in_paths = sorted(set(paths) - set(paths_ignore))
+              only_in_ignore = sorted(set(paths_ignore) - set(paths))
+              if only_in_paths:
+                  print(f"Only in unit-tests.yml paths: {only_in_paths}")
+              if only_in_ignore:
+                  print(f"Only in unit-tests-skip.yml paths-ignore: {only_in_ignore}")
+              sys.exit(1)
+
+          print(f"OK: {len(paths)} paths match")
+          EOF

--- a/.github/workflows/unit-tests-skip.yml
+++ b/.github/workflows/unit-tests-skip.yml
@@ -1,0 +1,21 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.py'
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'requirements/**'
+      - '**/pyproject.toml'
+      - '.github/workflows/unit-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No code changes, skipping tests"


### PR DESCRIPTION
Unit tests only trigger if code files were edited. For other prs (like docs only changes) we don't run tests - but we'd like tests to be a required check. This requires a "fastpath" for PRs that don't touch tests. This fast path fires on the complement of PR's that require tests, and that it fires on the complement is enforced via another check.