### PR TITLE
Support Selecting a Custom Set of Fields from Rust Engine

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -49,9 +49,10 @@ from api.utils.timer import Timer
 from api.utils.type_conversions import _get_type_name, make_type_converting_wrapper
 from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
 from card_engine import QueryEngine as _QueryEngine
+from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterable, Iterator, Sequence
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
@@ -1138,19 +1139,28 @@ class APIResource:
         direction: SortDirection,
         limit: int,
         timer: Timer,
+        fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
         logger.info("Searching engine for %r", query)
         query_explanation = parsed_query.to_human_explanation() if query else ""
-        with timer("engine_query"):
-            total_cards, cards = self._engine.query(
-                filters=parsed_query,
-                unique=str(unique),
-                prefer=str(prefer),
-                orderby=str(orderby),
-                direction=str(direction),
-                # limit=None means "no limit"; the engine requires an int, so use a large number
-                limit=limit if limit is not None else 1_000_000,
-            )
+        try:
+            with timer("engine_query"):
+                total_cards, cards = self._engine.query(
+                    filters=parsed_query,
+                    unique=str(unique),
+                    prefer=str(prefer),
+                    orderby=str(orderby),
+                    direction=str(direction),
+                    # limit=None means "no limit"; the engine requires an int, so use a large number
+                    limit=limit if limit is not None else 1_000_000,
+                    fields=fields,
+                )
+        except _QueryError as err:
+            logger.info("QueryError caught for query '%s', raising BadRequest", query)
+            raise falcon.HTTPBadRequest(
+                title="Invalid Search Query",
+                description=f'Failed to parse query: "{query}"',
+            ) from err
         with timer("engine_collect"):
             cards = list(cards)
         return {

--- a/card_engine/Cargo.lock
+++ b/card_engine/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "regex",
  "rkyv",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -266,6 +267,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
+ "uuid",
 ]
 
 [[package]]

--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -16,10 +16,11 @@ alloc-counter = []
 [dependencies]
 # extension-module is enabled by maturin (see pyproject.toml [tool.maturin]) so that
 # plain `cargo test` can still link against libpython for Rust unit tests.
-pyo3 = { version = "0.29.0" }
+pyo3 = { version = "0.29.0", features = ["uuid"] }
 regex = "1"
 serde_json = "1"
 rkyv = "0.8"
 memmap2 = "0.9"
 libc = "0.2"
 rand = "0.10"
+uuid = "1.12"

--- a/card_engine/card_engine/__init__.py
+++ b/card_engine/card_engine/__init__.py
@@ -1,6 +1,39 @@
 """Rust-backed card filter engine (PyO3 extension)."""
 
+import enum
+
 from .card_engine import QueryEngine as QueryEngine
+from .card_engine import QueryError as QueryError
+from .card_engine import UnknownFieldError as UnknownFieldError
+
+
+class EngineField(enum.StrEnum):
+    """Enum for the fields selectable via the `fields` parameter of QueryEngine's query methods.
+
+    Mirrors FIELD_TABLE in src/lib.rs. Rust remains the source of truth for validation (an
+    unknown name raises UnknownFieldError there); this exists for discoverability and
+    typo-catching on the Python side, so it must be updated by hand whenever a field is added to
+    FIELD_TABLE.
+    """
+
+    NAME = enum.auto()
+    SET_CODE = enum.auto()
+    COLLECTOR_NUMBER = enum.auto()
+    POWER = enum.auto()
+    TOUGHNESS = enum.auto()
+    MANA_COST = enum.auto()
+    ORACLE_TEXT = enum.auto()
+    SET_NAME = enum.auto()
+    TYPE_LINE = enum.auto()
+    ILLUSTRATION_ID = enum.auto()
+    SCRYFALL_ID = enum.auto()
+    CARD_SUBTYPES = enum.auto()
+    CARD_KEYWORDS = enum.auto()
+    CARD_ORACLE_TAGS = enum.auto()
+    CARD_ART_TAGS = enum.auto()
+    CARD_IS_TAGS = enum.auto()
+    CARD_FRAME_DATA = enum.auto()
+
 
 # Columns fetched from magic.cards to populate the engine store.
 # Must match what card_from_pydict() reads in src/lib.rs.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1,3 +1,5 @@
+use pyo3::create_exception;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateAccess, PyDict, PyList, PyTuple};
 use rkyv::{Archive, Archived, Deserialize, Serialize};
@@ -9,6 +11,16 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::fs::MetadataExt;
+
+// Raised for malformed query input (bad filter JSON, unbuildable filter expression). Subclasses
+// ValueError so existing `except ValueError` call sites keep working; new call sites can catch
+// this specifically to distinguish "the query was bad" from unrelated ValueErrors.
+create_exception!(card_engine, QueryError, PyValueError, "Raised when a query cannot be parsed or built.");
+
+// Subclass of QueryError (not a sibling) so `except QueryError` already catches it; callers that
+// need to distinguish "requested a field that doesn't exist" from other query errors can catch
+// this specifically instead.
+create_exception!(card_engine, UnknownFieldError, QueryError, "Raised when `fields` names an unknown field.");
 
 // ─── Feature-gated counting allocator (memory measurement only) ──────────────
 // Counts live bytes / live allocations of this extension's Rust heap and records
@@ -156,7 +168,6 @@ struct Card {
     // UUIDs packed as u128, 0 = null. Real UUIDs keep their exact bit value (so
     // future lookup-by-id can match Scryfall's); non-UUID strings from hand-built
     // test dicts are hashed deterministically — see parse_uuid_or_hash().
-    #[allow(dead_code)] // primary key; kept for future result payloads (printing dedup keys on pointer)
     scryfall_id: u128,
     oracle_id: u128,
     illustration_id: u128,
@@ -300,6 +311,19 @@ fn parse_uuid_or_hash(s: &str) -> u128 {
 
 fn opt_uuid(d: &Bound<PyDict>, key: &str) -> u128 {
     opt_str(d, key).map(|s| parse_uuid_or_hash(&s)).unwrap_or(0)
+}
+
+/// Inverse of `parse_uuid_or_hash` for genuine UUIDs: rebuilds a `Uuid` from the exact bit value
+/// (converted to Python's `uuid.UUID` via pyo3's `uuid` feature). 0 is the null sentinel. Only
+/// meaningful for real UUID input — non-UUID strings went through the FNV-1a fallback in
+/// `parse_uuid_or_hash` and can't be recovered from their hash, which matters only for
+/// hand-built test ids, never real card data.
+fn uuid_from_u128(v: u128) -> Option<uuid::Uuid> {
+    if v == 0 {
+        None
+    } else {
+        Some(uuid::Uuid::from_u128(v))
+    }
 }
 
 // Accepts ISO strings or datetime.date (psycopg returns date columns as datetime.date).
@@ -1182,17 +1206,77 @@ where
     }
 }
 
-fn card_to_pydict<'py>(py: Python<'py>, card: &ACard, strings: &AStrings) -> PyResult<Bound<'py, PyDict>> {
+// ─── Result field selection ───────────────────────────────────────────────────
+// The vocabulary of fields a query result row can carry. `fields=None` resolves to
+// DEFAULT_FIELDS (the 9 fields every caller got before field selection existed); an explicit
+// `fields` list is validated and deduped against this same table by resolve_fields(). There is
+// no separate hardcoded path for "the old fields" vs. "the new fields" — everything is an entry
+// in FIELD_TABLE.
+type FieldExtractor = for<'a> fn(Python<'a>, &'a ACard, &'a AStrings) -> PyResult<Bound<'a, PyAny>>;
+
+const FIELD_TABLE: &[(&str, FieldExtractor)] = &[
+    ("name", |py, c, s| Ok(str_at(s, u32::from(c.card_name_id)).into_pyobject(py)?.into_any())),
+    ("set_code", |py, c, _s| Ok(c.card_set_code.as_str().into_pyobject(py)?.into_any())),
+    ("collector_number", |py, c, s| Ok(str_at(s, u32::from(c.collector_number_id)).into_pyobject(py)?.into_any())),
+    ("power", |py, c, s| Ok(str_at(s, u32::from(c.creature_power_text_id)).into_pyobject(py)?.into_any())),
+    ("toughness", |py, c, s| Ok(str_at(s, u32::from(c.creature_toughness_text_id)).into_pyobject(py)?.into_any())),
+    ("mana_cost", |py, c, s| Ok(str_at(s, u32::from(c.mana_cost_text_id)).into_pyobject(py)?.into_any())),
+    ("oracle_text", |py, c, s| Ok(str_at(s, u32::from(c.oracle_text_id)).into_pyobject(py)?.into_any())),
+    ("set_name", |py, c, s| Ok(str_at(s, u32::from(c.set_name_id)).into_pyobject(py)?.into_any())),
+    ("type_line", |py, c, s| Ok(str_at(s, u32::from(c.type_line_id)).into_pyobject(py)?.into_any())),
+    ("illustration_id", |py, c, _s| Ok(uuid_from_u128(u128::from(c.illustration_id)).into_pyobject(py)?.into_any())),
+    ("scryfall_id", |py, c, _s| Ok(uuid_from_u128(u128::from(c.scryfall_id)).into_pyobject(py)?.into_any())),
+    // card_subtypes is a Vec, so insertion order is already deterministic; the rest are
+    // HashSets and get sorted for deterministic output.
+    ("card_subtypes", |py, c, _s| {
+        let items: Vec<&str> = c.card_subtypes.iter().map(|v| v.as_str()).collect();
+        Ok(items.into_pyobject(py)?.into_any())
+    }),
+    ("card_keywords", |py, c, _s| Ok(sorted_strs(c.card_keywords.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
+    ("card_oracle_tags", |py, c, _s| Ok(sorted_strs(c.card_oracle_tags.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
+    ("card_art_tags", |py, c, _s| Ok(sorted_strs(c.card_art_tags.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
+    ("card_is_tags", |py, c, _s| Ok(sorted_strs(c.card_is_tags.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
+    ("card_frame_data", |py, c, _s| Ok(sorted_strs(c.card_frame_data.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
+];
+
+/// Collects a `HashSet<&str>` iterator into a sorted `Vec<&str>` for deterministic field output.
+fn sorted_strs<'a>(iter: impl Iterator<Item = &'a str>) -> Vec<&'a str> {
+    let mut v: Vec<&str> = iter.collect();
+    v.sort_unstable();
+    v
+}
+
+const DEFAULT_FIELDS: &[&str] =
+    &["name", "set_code", "collector_number", "power", "toughness", "mana_cost", "oracle_text", "set_name", "type_line"];
+
+/// Resolves a caller-requested field list into FIELD_TABLE entries, deduping repeats (a name
+/// requested twice is only fetched/emitted once) and rejecting anything outside the vocabulary.
+/// `None` resolves to DEFAULT_FIELDS. Called once per query, before the per-row loop, so the
+/// per-row cost is a flat list of closure calls rather than a name comparison per field per card.
+fn resolve_fields(fields: Option<Vec<String>>) -> PyResult<Vec<(&'static str, FieldExtractor)>> {
+    let requested: Vec<&str> = match &fields {
+        Some(v) => v.iter().map(String::as_str).collect(),
+        None => DEFAULT_FIELDS.to_vec(),
+    };
+    let mut seen = HashSet::with_capacity(requested.len());
+    let mut resolved = Vec::with_capacity(requested.len());
+    for name in requested {
+        if !seen.insert(name) {
+            continue;
+        }
+        match FIELD_TABLE.iter().find(|(n, _)| *n == name) {
+            Some(entry) => resolved.push(*entry),
+            None => return Err(UnknownFieldError::new_err(format!("unknown field: {name:?}"))),
+        }
+    }
+    Ok(resolved)
+}
+
+fn card_to_pydict<'py>(py: Python<'py>, card: &ACard, strings: &AStrings, fields: &[(&'static str, FieldExtractor)]) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
-    d.set_item("name", str_at(strings, u32::from(card.card_name_id)))?;
-    d.set_item("set_code", card.card_set_code.as_str())?;
-    d.set_item("collector_number", str_at(strings, u32::from(card.collector_number_id)))?;
-    d.set_item("power", str_at(strings, u32::from(card.creature_power_text_id)))?;
-    d.set_item("toughness", str_at(strings, u32::from(card.creature_toughness_text_id)))?;
-    d.set_item("mana_cost", str_at(strings, u32::from(card.mana_cost_text_id)))?;
-    d.set_item("oracle_text", str_at(strings, u32::from(card.oracle_text_id)))?;
-    d.set_item("set_name", str_at(strings, u32::from(card.set_name_id)))?;
-    d.set_item("type_line", str_at(strings, u32::from(card.type_line_id)))?;
+    for (name, extractor) in fields {
+        d.set_item(*name, extractor(py, card, strings)?)?;
+    }
     Ok(d)
 }
 
@@ -1588,7 +1672,7 @@ impl QueryEngine {
         self.reload_commit()
     }
 
-    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0, fields=None))]
     fn query<'py>(
         &self,
         py: Python<'py>,
@@ -1599,16 +1683,18 @@ impl QueryEngine {
         direction: &str,
         limit: usize,
         offset: usize,
+        fields: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyTuple>> {
+        let resolved_fields = resolve_fields(fields)?;
         let to_json    = filters.call_method0("to_json")?;
         let json_bytes: Vec<u8> = py
             .import("orjson")?
             .call_method1("dumps", (to_json,))?
             .extract()?;
         let json_str = std::str::from_utf8(&json_bytes)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
+            .map_err(|e| QueryError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
         let json_val: Value = serde_json::from_str(json_str)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad query JSON: {e}")))?;
+            .map_err(|e| QueryError::new_err(format!("bad query JSON: {e}")))?;
         // get_mmap() remaps automatically if the on-disk inode has changed since
         // the last reload, keeping workers off stale (deleted) mappings.
         let mmap = self.get_mmap()?;
@@ -1642,20 +1728,21 @@ impl QueryEngine {
         // that never executed the load path themselves.
         sync_format_shifts(&data.format_shifts);
         let filter_expr = build_filter(&json_val)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
+            .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query(
             store, &data.preferred_indices[..], &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 
-        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
+        let matches: Vec<Bound<PyDict>> =
+            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
 
     /// Same as query() but forces the HashMap dedup path. Used for benchmarking.
-    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0, fields=None))]
     fn query_hashmap<'py>(
         &self,
         py: Python<'py>,
@@ -1666,7 +1753,9 @@ impl QueryEngine {
         direction: &str,
         limit: usize,
         offset: usize,
+        fields: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyTuple>> {
+        let resolved_fields = resolve_fields(fields)?;
         let to_json    = filters.call_method0("to_json")?;
         let json_bytes: Vec<u8> = py
             .import("orjson")?
@@ -1687,14 +1776,15 @@ impl QueryEngine {
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query_hashmap(store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset);
-        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
+        let matches: Vec<Bound<PyDict>> =
+            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
 
     /// Same as query() but forces the linear-dedup path over all printings.
     /// Use alongside query() to measure the benefit of the preferred-index fast path.
-    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0, fields=None))]
     fn query_linear<'py>(
         &self,
         py: Python<'py>,
@@ -1705,7 +1795,9 @@ impl QueryEngine {
         direction: &str,
         limit: usize,
         offset: usize,
+        fields: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyTuple>> {
+        let resolved_fields = resolve_fields(fields)?;
         let to_json    = filters.call_method0("to_json")?;
         let json_bytes: Vec<u8> = py
             .import("orjson")?
@@ -1742,7 +1834,8 @@ impl QueryEngine {
             "artwork" => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
             _         => run_query_no_dedup(cards_iter_linear!(), &data.strings, &filter_expr, orderby, direction, limit, offset),
         };
-        let matches: Vec<Bound<PyDict>> = page.iter().map(|c| card_to_pydict(py, c, &data.strings)).collect::<PyResult<Vec<_>>>()?;
+        let matches: Vec<Bound<PyDict>> =
+            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
@@ -1763,8 +1856,9 @@ impl QueryEngine {
     /// Return `n` randomly sampled cards from the preferred-printing index.
     /// O(n) time, zero per-worker heap overhead — preferred_indices lives in the
     /// shared mmap so all workers read the same ~124 KB of file pages.
-    #[pyo3(signature = (n))]
-    fn sample_preferred<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyList>> {
+    #[pyo3(signature = (n, fields=None))]
+    fn sample_preferred<'py>(&self, py: Python<'py>, n: usize, fields: Option<Vec<String>>) -> PyResult<Bound<'py, PyList>> {
+        let resolved_fields = resolve_fields(fields)?;
         let mmap = self.get_mmap()?;
         // Safety: see the access_unchecked justification in query().
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
@@ -1782,7 +1876,7 @@ impl QueryEngine {
         let dicts: Vec<Bound<PyDict>> = chosen.iter()
             .map(|&pos| {
                 let card_idx = u32::from(data.preferred_indices[pos]) as usize;
-                card_to_pydict(py, &data.cards[card_idx], &data.strings)
+                card_to_pydict(py, &data.cards[card_idx], &data.strings, &resolved_fields)
             })
             .collect::<PyResult<_>>()?;
         PyList::new(py, dicts)
@@ -1844,8 +1938,16 @@ impl QueryEngine {
 
 #[pymodule]
 mod card_engine {
+    use pyo3::prelude::*;
+
     #[pymodule_export]
     use super::QueryEngine;
+
+    #[pymodule_init]
+    fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add("QueryError", m.py().get_type::<super::QueryError>())?;
+        m.add("UnknownFieldError", m.py().get_type::<super::UnknownFieldError>())
+    }
 }
 
 #[cfg(test)]

--- a/makefile
+++ b/makefile
@@ -27,8 +27,8 @@ HOSTNAME := $(shell hostname)
 
 S3_BUCKET=biblioplex
 
-html_files := $(shell find . -type f -name "*.html")
-js_files := $(shell find . -type f -name "*.js" | grep -v node_modules)
+html_files := $(shell git ls-files "*.html")
+js_files := $(shell git ls-files "*.js")
 
 requirements_sources := $(shell find requirements -type f -name "*.txt")
 PYTHON_DIRS := $(shell git ls-files "*.py" | cut -f 1 -d/ | sort -u)


### PR DESCRIPTION
Lets callers of the Rust engine choose which fields come back per card instead of always paying for a fixed 9-field `PyDict` build. Motivating case: we need `illustration_id` back from the engine to group cards by illustration client-side, and it wasn't reachable from a query result at all — only usable as a filter/sort/dedup key.

## Engine (`card_engine/src/lib.rs`)

- `FIELD_TABLE`: a `(name, extractor)` vocabulary covering the original 9 fields (`name`, `set_code`, `collector_number`, `power`, `toughness`, `mana_cost`, `oracle_text`, `set_name`, `type_line`) plus `illustration_id`, `scryfall_id`, and the 6 collection fields (`card_subtypes`, `card_keywords`, `card_oracle_tags`, `card_art_tags`, `card_is_tags`, `card_frame_data`). The original 9 were migrated in rather than kept as a separate hardcoded path.
- `resolve_fields()`: validates a requested field list against `FIELD_TABLE` and dedupes repeats (a name requested twice is only extracted once). Runs once per query call, before the per-row loop, so per-row cost is a flat list of closure calls rather than a string comparison per field per card.
- `fields: Option<Vec<String>>` threaded through all four card-producing entry points — `query()`, `query_hashmap()`, `query_linear()`, `sample_preferred()` — all defaulting to `None`, which resolves to the original 9 fields (`DEFAULT_FIELDS`). No existing caller's output changes.
- `illustration_id`/`scryfall_id` come back as real `uuid.UUID` objects, not strings, via pyo3's built-in `uuid` feature (new `uuid` crate dependency). `0` (the null sentinel) maps to `None`.
- `card_keywords`/`card_oracle_tags`/`card_art_tags`/`card_is_tags`/`card_frame_data` (all `HashSet<String>`) come back sorted for deterministic output; `card_subtypes` (`Vec<String>`) keeps its existing insertion order.
- New exception hierarchy: `QueryError` (subclasses `ValueError`, raised for malformed filter/query input — bad filter JSON, unbuildable filter expression) and `UnknownFieldError(QueryError)` (raised when `fields` names something outside `FIELD_TABLE`). Both registered on the module via `#[pymodule_init]`.

## Python (`card_engine/card_engine/__init__.py`, `api/api_resource.py`)

- `EngineField`: a `StrEnum` in the `card_engine` package listing all currently-selectable field names, for discoverability/typo-catching on the Python side. Rust remains the source of truth for validation — this has to be kept in sync by hand.
- `_search_engine()` gained `fields: Sequence[str] | None = None`, passed straight through to `self._engine.query(fields=fields, ...)`.
- `_search_engine()` now catches `QueryError` and raises `falcon.HTTPBadRequest`, matching the existing pattern in `_search_sql()`. Note: its only caller wraps the whole call in a blanket `except Exception` that falls back to the SQL path regardless of exception type (a deliberate safety net for engine/SQL feature-parity gaps), so this mostly matters for direct callers of `_search_engine`/`self._engine.query()` rather than changing `/search`'s external behavior.

## Incidental

- `makefile`: `html_files`/`js_files` now come from `git ls-files` instead of `find`, so stray untracked `.html`/`.js` files in the working tree (e.g. local scratch files) aren't picked up by lint/minify targets.

## Not in this PR

- Nothing outside the engine actually passes a custom `fields` list yet — this PR is the mechanism, not a consumer. The per-card-page work that motivated this hasn't landed.
- `card_legalities` (bitpacked `u64`) isn't selectable yet — unlike the other collection fields, it needs an actual bit-unpacking decoder that doesn't exist, so it's punted until there's a concrete caller.

## Test plan

- [x] `cargo test --release` (card_engine unit tests)
- [x] `python -m pytest api/parsing/tests/ api/tests/test_engine_unit.py` (1481 tests)
- [x] Manual smoke test: default fields unchanged, explicit field subset, duplicate field names dedupe to one entry, unknown field name raises `UnknownFieldError`, `illustration_id`/`scryfall_id` round-trip as `uuid.UUID`, all 6 collection fields round-trip as sorted `list[str]`
