### PR TITLE
Per Card Pages

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -164,6 +164,9 @@ def _build_critical_css() -> str:
 
 
 _INDEX_HTML_PATH = pathlib.Path(__file__).parent / "static" / "index.html"
+_CARD_HTML_PATH = pathlib.Path(__file__).parent / "static" / "card.html"
+
+_CARD_PAGE_RE = re.compile(r"^card/([^/]+)/([^/]+)$")
 
 
 def _static_hash(filename: str) -> str | None:
@@ -175,6 +178,7 @@ def _static_hash(filename: str) -> str | None:
 
 _STYLES_CSS_HASH = _static_hash("styles.css")
 _APP_MIN_JS_HASH = _static_hash("app.min.js")
+_CARD_JS_HASH = _static_hash("card.js")
 
 
 # TLDs in this set are stripped from the hostname; others are concatenated into the word.
@@ -379,6 +383,18 @@ def _build_base_html(critical_css: str, site_name: str) -> str:
     return html
 
 
+@cached(cache=LRUCache(maxsize=4))
+def _build_card_html(critical_css: str) -> str:
+    """Read card.html and inject critical CSS and versioned asset URLs."""
+    html = _CARD_HTML_PATH.read_text()
+    html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
+    if _STYLES_CSS_HASH:
+        html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
+    if _CARD_JS_HASH:
+        html = html.replace("/static/card.js", f"/static/card.js?v={_CARD_JS_HASH}")
+    return html
+
+
 @cached(cache=LRUCache(maxsize=10_000))
 def get_where_clause(query: str) -> tuple[str, dict]:
     """Generate SQL WHERE clause and parameters from a search query.
@@ -444,6 +460,7 @@ class APIResource:
         # add static file serving actions
         self.action_map["static/app_js"] = self.app_js
         self.action_map["static/app_min_js"] = self.app_min_js
+        self.action_map["static/card_js"] = self.card_js
         self.action_map["static/favicon_ico"] = self.favicon_ico
         self.action_map["static/social-preview_webp"] = self.social_preview_webp
         self.action_map["static/styles_css"] = self.styles_css
@@ -532,14 +549,18 @@ class APIResource:
             id(resp),
         )
         path = path.replace(".", "_")
-        action = self.action_map.get(
-            path,
-            self._raise_not_found,
-        )
+        _card_match = _CARD_PAGE_RE.fullmatch(path)
+        if _card_match:
+            action = self.action_map["card_page"]
+        else:
+            action = self.action_map.get(path, self._raise_not_found)
         res = None
         before = time.monotonic()
         try:
             params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
+            if _card_match:
+                params["set_code"] = _card_match.group(1)
+                params["collector_number"] = _card_match.group(2)
             res = action(falcon_response=resp, request_host=req.get_header("X-Proxy-Host") or req.host, **params)
             resp.media = res
         except TypeError as oops:
@@ -1540,6 +1561,42 @@ class APIResource:
             return
         self._serve_static_file(filename="robots.txt", falcon_response=falcon_response)
         falcon_response.content_type = "text/plain"
+
+    def card_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
+        """Return the card.js file.
+
+        Args:
+        ----
+            falcon_response (falcon.Response): The Falcon response to write to.
+        """
+        if falcon_response is None:
+            return
+        self._serve_static_file(filename="card.js", falcon_response=falcon_response)
+        falcon_response.content_type = "application/javascript"
+        set_cache_header(falcon_response, duration=timedelta(hours=1))
+
+    def card_page(
+        self,
+        *,
+        falcon_response: falcon.Response | None = None,
+        set_code: str = "",
+        collector_number: str = "",
+        **_: object,
+    ) -> None:
+        """Serve the per-card page for /card/{set_code}/{collector_number}.
+
+        Args:
+        ----
+            falcon_response (falcon.Response): The Falcon response to write to.
+            set_code (str): The card set code extracted from the URL path.
+            collector_number (str): The collector number extracted from the URL path.
+        """
+        if falcon_response is None:
+            return
+        html = _build_card_html(self._critical_css)
+        falcon_response.text = html
+        falcon_response.content_type = "text/html"
+        set_cache_header(falcon_response, duration=timedelta(hours=1))
 
     def _serve_static_file(self, *, filename: str, falcon_response: falcon.Response) -> None:
         """Serve a static file to the Falcon response.

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -166,8 +166,6 @@ def _build_critical_css() -> str:
 _INDEX_HTML_PATH = pathlib.Path(__file__).parent / "static" / "index.html"
 _CARD_HTML_PATH = pathlib.Path(__file__).parent / "static" / "card.html"
 
-_CARD_PAGE_RE = re.compile(r"^card/([^/]+)/([^/]+)$")
-
 
 def _static_hash(filename: str) -> str | None:
     try:
@@ -1348,10 +1346,7 @@ class APIResource:
             dict.fromkeys([RESULT_FIELD_COLUMNS[name] for name in resolved_fields] + ["edhrec_rank", "prefer_score"]),
         )
         _select_cols = "".join(f"\n                    {col}," for col in _cte_columns)
-        _result_cols = ",\n                    ".join(
-            RESULT_FIELD_COLUMNS[name] if RESULT_FIELD_COLUMNS[name] == name else f"{RESULT_FIELD_COLUMNS[name]} AS {name}"
-            for name in resolved_fields
-        )
+        _result_cols = ",\n                    ".join(f"{RESULT_FIELD_COLUMNS[name]} AS {name}" for name in resolved_fields)
         _order_by = f"""sort_value {sql_direction} NULLS LAST,
                     edhrec_rank ASC NULLS LAST,
                     prefer_score DESC NULLS LAST"""
@@ -1661,6 +1656,7 @@ class APIResource:
             set_code (str): The card set code extracted from the URL path.
             collector_number (str): The collector number extracted from the URL path.
         """
+        del set_code, collector_number
         if falcon_response is None:
             return
         html = _build_card_html(self._critical_css)

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -23,6 +23,7 @@ from typing import cast as typecast
 
 import cachebox
 import falcon
+import minify_html
 import orjson
 import psycopg
 import psycopg_pool
@@ -135,7 +136,7 @@ def _selector_is_critical(selector: str) -> bool:
 
 def _build_critical_css() -> str:
     """Extract and minify critical selectors from styles.css at startup."""
-    styles_path = pathlib.Path(__file__).parent / "static" / "styles.css"
+    styles_path = _STATIC_DIR / "styles.css"
     rules = tinycss2.parse_stylesheet(styles_path.read_text(), skip_comments=True, skip_whitespace=True)
     parts: list[str] = []
     for rule in rules:
@@ -163,13 +164,15 @@ def _build_critical_css() -> str:
     return raw.strip()
 
 
-_INDEX_HTML_PATH = pathlib.Path(__file__).parent / "static" / "index.html"
-_CARD_HTML_PATH = pathlib.Path(__file__).parent / "static" / "card.html"
+_STATIC_DIR = pathlib.Path(__file__).parent / "static"
+_INDEX_HTML_PATH = _STATIC_DIR / "index.html"
+_CARD_HTML_PATH = _STATIC_DIR / "card.html"
+_FRAGMENTS_DIR = _STATIC_DIR / "fragments"
 
 
 def _static_hash(filename: str) -> str | None:
     try:
-        return hashlib.sha256((pathlib.Path(__file__).parent / "static" / filename).read_bytes()).hexdigest()[:12]
+        return hashlib.sha256((_STATIC_DIR / filename).read_bytes()).hexdigest()[:12]
     except FileNotFoundError:
         return None
 
@@ -177,6 +180,46 @@ def _static_hash(filename: str) -> str | None:
 _STYLES_CSS_HASH = _static_hash("styles.css")
 _APP_MIN_JS_HASH = _static_hash("app.min.js")
 _CARD_JS_HASH = _static_hash("card.js")
+
+# Markup identical across index.html and card.html — read once at import time and spliced into
+# each template's own placeholder comment (<!-- FAVICON --> etc.) by _build_base_html /
+# _build_card_html. Fragments live in fragments/ rather than static/ directly since they are not
+# complete documents and are never served on their own (only files with an action_map entry are
+# reachable over HTTP).
+_FAVICON_HTML = (_FRAGMENTS_DIR / "favicon.html").read_text()
+_PRECONNECTS_HTML = (_FRAGMENTS_DIR / "preconnects.html").read_text()
+_FONTS_HTML = (_FRAGMENTS_DIR / "fonts.html").read_text()
+_CSS_HTML = (_FRAGMENTS_DIR / "css.html").read_text()
+_FOOTER_HTML = (_FRAGMENTS_DIR / "footer.html").read_text()
+
+
+def _inject_shared_fragments(html: str) -> str:
+    """Splice the shared head/footer fragments into their placeholder comments.
+
+    Must run before the CRITICAL_CSS/asset-hash substitutions below: the CSS fragment carries its
+    own inner <!-- CRITICAL_CSS --> placeholder, which only exists in `html` after this replace.
+    """
+    html = html.replace("<!-- FAVICON -->", _FAVICON_HTML)
+    html = html.replace("<!-- PRECONNECTS -->", _PRECONNECTS_HTML)
+    html = html.replace("<!-- FONTS -->", _FONTS_HTML)
+    html = html.replace("<!-- CSS -->", _CSS_HTML)
+    return html.replace("<!-- FOOTER -->", _FOOTER_HTML)
+
+
+# Flip to False to disable HTML minification (e.g. while debugging a minifier-induced issue).
+_MINIFY_HTML_ENABLED = True
+
+
+def _minify_html(html: str) -> str:
+    """Minify HTML to shave a bit more off the page weight on top of gzip/brotli/zstd compression.
+
+    keep_comments=True is required: `_build_base_html`'s cached output still carries per-request
+    placeholders (SERVER_SIDE_RESULTS, SERVER_SIDE_EMBEDDED_DATA) substituted by `search()` after
+    this function returns, and those are plain HTML comments that must survive intact.
+    """
+    if not _MINIFY_HTML_ENABLED:
+        return html
+    return minify_html.minify(html, minify_js=True, minify_css=True, keep_comments=True)
 
 
 # TLDs in this set are stripped from the hostname; others are concatenated into the word.
@@ -403,6 +446,7 @@ def set_cache_header(falcon_response: falcon.Response | None, duration: timedelt
 def _build_base_html(critical_css: str, site_name: str) -> str:
     """Read index.html and inject critical CSS and site name. Cached per (critical_css, site_name) pair."""
     html = _INDEX_HTML_PATH.read_text()
+    html = _inject_shared_fragments(html)
     html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
     if _STYLES_CSS_HASH:
         html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
@@ -410,19 +454,20 @@ def _build_base_html(critical_css: str, site_name: str) -> str:
         html = html.replace("/static/app.min.js", f"/static/app.min.js?v={_APP_MIN_JS_HASH}")
     if site_name != FALLBACK_SITE_NAME:
         html = html.replace(FALLBACK_SITE_NAME, site_name)
-    return html
+    return _minify_html(html)
 
 
 @cached(cache=LRUCache(maxsize=4))
 def _build_card_html(critical_css: str) -> str:
     """Read card.html and inject critical CSS and versioned asset URLs."""
     html = _CARD_HTML_PATH.read_text()
+    html = _inject_shared_fragments(html)
     html = html.replace("<!-- CRITICAL_CSS -->", critical_css)
     if _STYLES_CSS_HASH:
         html = html.replace("/static/styles.css", f"/static/styles.css?v={_STYLES_CSS_HASH}")
     if _CARD_JS_HASH:
         html = html.replace("/static/card.js", f"/static/card.js?v={_CARD_JS_HASH}")
-    return html
+    return _minify_html(html)
 
 
 @cached(cache=LRUCache(maxsize=10_000))
@@ -1558,7 +1603,7 @@ class APIResource:
         """
         if falcon_response is None:
             return
-        full_filename = pathlib.Path(__file__).parent / "static" / "favicon.ico"
+        full_filename = _STATIC_DIR / "favicon.ico"
         with pathlib.Path(full_filename).open(mode="rb") as f:
             falcon_response.data = contents = f.read()
         falcon_response.content_type = "image/vnd.microsoft.icon"
@@ -1572,7 +1617,7 @@ class APIResource:
         """Return the social preview image."""
         if falcon_response is None:
             return
-        full_filename = pathlib.Path(__file__).parent / "static" / "social-preview.webp"
+        full_filename = _STATIC_DIR / "social-preview.webp"
         with full_filename.open(mode="rb") as f:
             contents = f.read()
         falcon_response.data = contents
@@ -1673,7 +1718,7 @@ class APIResource:
             falcon_response (falcon.Response): The Falcon response to write to.
 
         """
-        full_filename = pathlib.Path(__file__).parent / "static" / filename
+        full_filename = _STATIC_DIR / filename
         try:
             with pathlib.Path(full_filename).open() as f:
                 falcon_response.text = f.read()

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -53,7 +53,7 @@ from card_engine import QueryEngine as _QueryEngine
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
@@ -318,9 +318,12 @@ MIN_IMPORT_CARDS = 90_000
 # measurable gain (see docs/issues/engine-incremental-loading.md).
 _ENGINE_RELOAD_BATCH_SIZE = 2_000
 
-# Public field name -> magic.cards column. Shared vocabulary for `fields=` on /search across the
-# SQL and engine paths — must stay in sync with FIELD_TABLE in card_engine/src/lib.rs so a request
-# gets identically-shaped results regardless of which path serves it.
+# Public field name -> magic.cards column. The `fields=` vocabulary for /search. This is
+# deliberately a subset of FIELD_TABLE in card_engine/src/lib.rs, not a mirror of it — not
+# everything the engine can extract needs to be a public API field. Every key here must still
+# have a same-named entry in FIELD_TABLE with matching semantics, so a `fields=` request for one
+# of these names gets identically-shaped results regardless of which path serves it; FIELD_TABLE
+# is free to have entries with no counterpart here.
 RESULT_FIELD_COLUMNS: dict[str, str] = {
     "name": "card_name",
     "set_code": "card_set_code",
@@ -496,6 +499,72 @@ def rewrap(query: str) -> str:
     return " ".join(query.strip().split())
 
 
+def _max_positional_args(func: Any) -> float:  # noqa: ANN401
+    """Return how many positional args `func` accepts; inf if it takes *args.
+
+    Computed once per registered action at APIResource.__init__ time (not per-request):
+    inspect.signature() follows a make_type_converting_wrapper wrapper's __wrapped__ link
+    (set by functools.update_wrapper), so this sees the real underlying handler's signature.
+    """
+    try:
+        params = inspect.signature(func).parameters.values()
+    except (TypeError, ValueError):
+        return 0.0
+    if any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params):
+        return float("inf")
+    return float(sum(1 for p in params if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)))
+
+
+def _build_routes_listing(action_map: dict[str, Callable]) -> dict[str, dict[str, Any]]:
+    """Build the {route: {doc, args, kwargs}} listing served in 404 responses.
+
+    Depends only on `action_map`'s contents, which are fixed once APIResource.__init__ finishes —
+    computed once there rather than on every 404 (inspect.signature() per route isn't free).
+    """
+    routes = {}
+    for endpoint_name, wrapped_func in action_map.items():
+        # Get the original function from the wrapper
+        original_func = wrapped_func.__wrapped__ if hasattr(wrapped_func, "__wrapped__") else wrapped_func
+
+        # Get function signature
+        sig = inspect.signature(original_func)
+
+        # Extract docstring
+        doc = original_func.__doc__ or ""
+
+        # Parse arguments
+        args = []
+        kwargs = {}
+
+        for param_name, param in sig.parameters.items():
+            if param_name.startswith("_"):
+                continue
+            if param_name in ("self", "falcon_response"):
+                continue
+
+            param_info = {
+                "name": param_name,
+                "type": _get_type_name(param.annotation),
+            }
+
+            if param.default != inspect.Parameter.empty:
+                # It's a keyword argument with default
+                kwargs[param_name] = {
+                    "type": _get_type_name(param.annotation),
+                    "default": param.default,
+                }
+            else:
+                # It's a positional argument
+                args.append(param_info)
+
+        routes[endpoint_name] = {
+            "doc": doc,
+            "args": args,
+            "kwargs": kwargs,
+        }
+    return routes
+
+
 class APIResource:
     """Class implementing request handling for our simple API."""
 
@@ -515,15 +584,21 @@ class APIResource:
         self._bulk_data_fetcher = ScryfallBulkDataFetcher()
         self._critical_css: str = _build_critical_css()
         self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
-        # Create action map with type-converting wrappers for all public methods
+        # Create action map with type-converting wrappers for all public methods. Alongside it,
+        # _action_positional_capacity records how many positional path-segment args (beyond the
+        # action word) each action accepts, computed once here rather than per-request in
+        # _handle — see _max_positional_args.
         self.action_map = {}
+        self._action_positional_capacity: dict[str, float] = {}
         for method_name in dir(self):
             if method_name.startswith("_"):
                 continue
             method = getattr(self, method_name)
             if callable(method):
                 self.action_map[method_name] = make_type_converting_wrapper(method)
+                self._action_positional_capacity[method_name] = _max_positional_args(method)
         self.action_map["_root"] = make_type_converting_wrapper(self._root)
+        self._action_positional_capacity["_root"] = _max_positional_args(self._root)
 
         def redirect_to_root(**_: object) -> None:
             msg = "/"
@@ -531,6 +606,8 @@ class APIResource:
 
         self.action_map["index"] = redirect_to_root
         self.action_map["index_html"] = redirect_to_root
+        self._action_positional_capacity["index"] = _max_positional_args(redirect_to_root)
+        self._action_positional_capacity["index_html"] = _max_positional_args(redirect_to_root)
 
         # add static file serving actions
         self.action_map["static/app_js"] = self.app_js
@@ -539,6 +616,9 @@ class APIResource:
         self.action_map["static/favicon_ico"] = self.favicon_ico
         self.action_map["static/social-preview_webp"] = self.social_preview_webp
         self.action_map["static/styles_css"] = self.styles_css
+
+        # Static once action_map is fully populated — see _build_routes_listing.
+        self._not_found_routes = _build_routes_listing(self.action_map)
 
         self._cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
         self._query_cache: GenerationCache = GenerationCache(
@@ -633,6 +713,10 @@ class APIResource:
         else:
             action_word, *action_args = path.split("/")
             action = self.action_map.get(action_word, self._raise_not_found)
+            # A matched action that can't absorb this many trailing segments (e.g. /robots.txt/x)
+            # means the path doesn't identify anything — 404, not a 400 from a TypeError inside it.
+            if len(action_args) > self._action_positional_capacity.get(action_word, 0):
+                action, action_args = self._raise_not_found, []
         res = None
         before = time.monotonic()
         try:
@@ -678,53 +762,10 @@ class APIResource:
 
     def _raise_not_found(self, *_args: object, **_: object) -> None:
         """Raise a Falcon HTTPNotFound error with available routes."""
-        routes = {}
-
-        for endpoint_name, wrapped_func in self.action_map.items():
-            # Get the original function from the wrapper
-            original_func = wrapped_func.__wrapped__ if hasattr(wrapped_func, "__wrapped__") else wrapped_func
-
-            # Get function signature
-            sig = inspect.signature(original_func)
-
-            # Extract docstring
-            doc = original_func.__doc__ or ""
-
-            # Parse arguments
-            args = []
-            kwargs = {}
-
-            for param_name, param in sig.parameters.items():
-                if param_name.startswith("_"):
-                    continue
-                if param_name in ("self", "falcon_response"):
-                    continue
-
-                param_info = {
-                    "name": param_name,
-                    "type": _get_type_name(param.annotation),
-                }
-
-                if param.default != inspect.Parameter.empty:
-                    # It's a keyword argument with default
-                    kwargs[param_name] = {
-                        "type": _get_type_name(param.annotation),
-                        "default": param.default,
-                    }
-                else:
-                    # It's a positional argument
-                    args.append(param_info)
-
-            routes[endpoint_name] = {
-                "doc": doc,
-                "args": args,
-                "kwargs": kwargs,
-            }
-
         raise falcon.HTTPNotFound(
             title="Not Found",
             description={
-                "routes": routes,
+                "routes": self._not_found_routes,
             },
         )
 

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -277,6 +277,38 @@ MIN_IMPORT_CARDS = 90_000
 # measurable gain (see docs/issues/engine-incremental-loading.md).
 _ENGINE_RELOAD_BATCH_SIZE = 2_000
 
+# Public field name -> magic.cards column. Shared vocabulary for `fields=` on /search across the
+# SQL and engine paths — must stay in sync with FIELD_TABLE in card_engine/src/lib.rs so a request
+# gets identically-shaped results regardless of which path serves it.
+RESULT_FIELD_COLUMNS: dict[str, str] = {
+    "name": "card_name",
+    "set_code": "card_set_code",
+    "collector_number": "collector_number",
+    "power": "creature_power_text",
+    "toughness": "creature_toughness_text",
+    "mana_cost": "mana_cost_text",
+    "oracle_text": "oracle_text",
+    "set_name": "set_name",
+    "type_line": "type_line",
+    "illustration_id": "illustration_id",
+    "scryfall_id": "scryfall_id",
+    "price_usd": "price_usd",
+    "prefer_score": "prefer_score",
+}
+# `fields=None` resolves to these 9 — the fixed set every caller got before field selection
+# existed. Order/membership must match DEFAULT_FIELDS in card_engine/src/lib.rs.
+DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
+    "name",
+    "set_code",
+    "collector_number",
+    "power",
+    "toughness",
+    "mana_cost",
+    "oracle_text",
+    "set_name",
+    "type_line",
+)
+
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
     "pathway",  # land and name contains pathway
@@ -548,20 +580,21 @@ class APIResource:
             path,
             id(resp),
         )
+
         path = path.replace(".", "_")
-        _card_match = _CARD_PAGE_RE.fullmatch(path)
-        if _card_match:
-            action = self.action_map["card_page"]
+        if path in self.action_map:
+            # Flat routes like "static/favicon_ico" register their full slash-containing path as
+            # the action_map key — check that exact match before treating "/" as an arg separator.
+            action = self.action_map[path]
+            action_args: list[str] = []
         else:
-            action = self.action_map.get(path, self._raise_not_found)
+            action_word, *action_args = path.split("/")
+            action = self.action_map.get(action_word, self._raise_not_found)
         res = None
         before = time.monotonic()
         try:
             params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
-            if _card_match:
-                params["set_code"] = _card_match.group(1)
-                params["collector_number"] = _card_match.group(2)
-            res = action(falcon_response=resp, request_host=req.get_header("X-Proxy-Host") or req.host, **params)
+            res = action(*action_args, falcon_response=resp, request_host=req.get_header("X-Proxy-Host") or req.host, **params)
             resp.media = res
         except TypeError as oops:
             logger.error("Error handling request: %s", oops, exc_info=True)
@@ -600,7 +633,7 @@ class APIResource:
                 for span_name, span_data in res.get("outer_timings", {}).items():
                     record_span(req, span_name, span_data.get("_meta", {}).get("duration_ms", 0))
 
-    def _raise_not_found(self, **_: object) -> None:
+    def _raise_not_found(self, *_args: object, **_: object) -> None:
         """Raise a Falcon HTTPNotFound error with available routes."""
         routes = {}
 
@@ -825,6 +858,12 @@ class APIResource:
         if self._setup_complete_cache is not None:
             result, expires_at, cached_import_time = self._setup_complete_cache
             if now < expires_at and current_import_time == cached_import_time:
+                logger.debug(
+                    "_setup_complete cache hit: result=%s, expires in %.0fs, pid %d",
+                    result,
+                    expires_at - now,
+                    os.getpid(),
+                )
                 return result
         try:
             with self._conn_pool.connection() as conn:
@@ -832,10 +871,24 @@ class APIResource:
                 with conn.cursor() as cursor:
                     cursor.execute("SELECT COUNT(1) AS num_cards FROM magic.cards")
                     cards_found = cursor.fetchall()[0]["num_cards"]
-                    logger.info("Found %d cards in pid %d", cards_found, os.getpid())
                     result = cards_found > MIN_IMPORT_CARDS
+                    if result:
+                        logger.info("Found %d cards in pid %d", cards_found, os.getpid())
+                    else:
+                        logger.warning(
+                            "Setup not complete: found %d cards, need more than %d (pid %d)",
+                            cards_found,
+                            MIN_IMPORT_CARDS,
+                            os.getpid(),
+                        )
         except Exception as oops:
-            logger.error("Error checking if setup is complete: %s", oops, exc_info=True)
+            logger.error(
+                "Error checking if setup is complete (pid %d): %s: %s",
+                os.getpid(),
+                type(oops).__name__,
+                oops,
+                exc_info=True,
+            )
             result = False
         self._setup_complete_cache = (result, now + self._SETUP_COMPLETE_TTL, current_import_time)
         return result
@@ -843,6 +896,7 @@ class APIResource:
     def _require_setup_complete(self) -> None:
         """Require that setup is complete or raise a ServiceUnavailable error."""
         if not self._setup_complete():
+            logger.warning("Rejecting request in pid %d: setup is not complete", os.getpid())
             raise falcon.HTTPServiceUnavailable(
                 title="Service Unavailable",
                 description="Setup is not complete, please try again later.",
@@ -1006,12 +1060,36 @@ class APIResource:
         finally:
             import_lock.release()
 
+    def _resolve_result_fields(self, fields: Sequence[str] | None) -> list[str]:
+        """Validate a `fields=` request against RESULT_FIELD_COLUMNS, deduping repeats.
+
+        `None` resolves to DEFAULT_RESULT_FIELDS, mirroring `resolve_fields()` in
+        card_engine/src/lib.rs so the SQL and engine paths agree on what "the usual fields" means.
+        An explicit empty list is rejected rather than silently producing a fieldless SELECT.
+        """
+        if fields is None:
+            return list(DEFAULT_RESULT_FIELDS)
+        resolved = list(dict.fromkeys(fields))
+        if not resolved:
+            raise falcon.HTTPBadRequest(
+                title="Invalid Fields",
+                description="fields must include at least one field name.",
+            )
+        for name in resolved:
+            if name not in RESULT_FIELD_COLUMNS:
+                raise falcon.HTTPBadRequest(
+                    title="Invalid Fields",
+                    description=f"Unknown field: {name!r}",
+                )
+        return resolved
+
     def search(  # noqa: PLR0913
         self,
         *,
         falcon_response: falcon.Response | None = None,
         # search parameters
         direction: SortDirection = SortDirection.ASC,
+        fields: Sequence[str] | None = None,
         limit: int = 100,
         orderby: CardOrdering = CardOrdering.EDHREC,
         prefer: PreferOrder = PreferOrder.DEFAULT,
@@ -1026,6 +1104,9 @@ class APIResource:
             q: Query string (alternative to query parameter).
             query: Query string (alternative to q parameter).
             direction: Sort direction ('asc' or 'desc').
+            fields: Which fields to return per card (comma-separated in the query string). Defaults
+                to the usual 9 (name, set_code, collector_number, power, toughness, mana_cost,
+                oracle_text, set_name, type_line). See RESULT_FIELD_COLUMNS for the full vocabulary.
             limit: Maximum number of results to return.
             orderby: Field to sort by.
             unique: Unique on field.
@@ -1039,6 +1120,7 @@ class APIResource:
             query=query or q,
             orderby=orderby,
             direction=direction,
+            fields=fields,
             limit=limit,
             unique=unique,
             prefer=prefer,
@@ -1077,6 +1159,7 @@ class APIResource:
         self,
         *,
         direction: SortDirection = SortDirection.ASC,
+        fields: Sequence[str] | None = None,
         limit: int = 100,
         orderby: CardOrdering = CardOrdering.EDHREC,
         prefer: PreferOrder = PreferOrder.DEFAULT,
@@ -1085,9 +1168,13 @@ class APIResource:
     ) -> dict[str, Any]:
         self._require_setup_complete()
         limit = self._validate_limit(limit)
+        # Resolved once here (rather than inside _search_sql/_search_engine) so an unknown field
+        # name always raises HTTPBadRequest instead of being swallowed by the engine's blanket
+        # except-and-fall-back-to-SQL below.
+        resolved_fields = self._resolve_result_fields(fields)
 
         if settings.enable_cache:
-            cache_key = (direction, limit, orderby, prefer, query, unique)
+            cache_key = (direction, limit, orderby, prefer, query, unique, tuple(resolved_fields))
             gen = self._cache_generation.value
             try:
                 search_cache = self._search_gen_cache[gen]
@@ -1127,6 +1214,7 @@ class APIResource:
                     direction=direction,
                     limit=limit,
                     timer=timer,
+                    fields=resolved_fields,
                 )
             except Exception as e:  # noqa: BLE001
                 logger.warning("Engine query failed for %r, falling back to SQL: %s", query, e, exc_info=True)
@@ -1144,6 +1232,7 @@ class APIResource:
             direction=direction,
             limit=limit,
             timer=timer,
+            fields=resolved_fields,
         )
         if settings.enable_cache:
             search_cache[cache_key] = result
@@ -1206,8 +1295,10 @@ class APIResource:
         direction: SortDirection,
         limit: int,
         timer: Timer,
+        fields: Sequence[str] | None = None,
     ) -> dict[str, Any]:
         logger.info("Searching SQL for %r", query)
+        resolved_fields = self._resolve_result_fields(fields)
         query_explanation = parsed_query.to_human_explanation() if query else ""
         try:
             with timer("get_where_clause"):
@@ -1251,41 +1342,20 @@ class APIResource:
             prefer,
             ("edhrec_rank", "ASC"),
         )
-        _select_cols = """
-                    card_name,
-                    card_set_code,
-                    collector_number,
-                    creature_power_text,
-                    creature_toughness_text,
-                    edhrec_rank,
-                    mana_cost_text,
-                    oracle_text,
-                    set_name,
-                    type_line,
-                    prefer_score,"""
-        _result_cols = """
-                    card_name AS name,
-                    card_set_code AS set_code,
-                    collector_number,
-                    creature_power_text AS power,
-                    creature_toughness_text AS toughness,
-                    mana_cost_text AS mana_cost,
-                    oracle_text,
-                    set_name,
-                    type_line"""
+        # edhrec_rank and prefer_score are always pulled into the CTE for the ORDER BY tiebreak
+        # below, whether or not the caller asked for them as output fields.
+        _cte_columns = list(
+            dict.fromkeys([RESULT_FIELD_COLUMNS[name] for name in resolved_fields] + ["edhrec_rank", "prefer_score"]),
+        )
+        _select_cols = "".join(f"\n                    {col}," for col in _cte_columns)
+        _result_cols = ",\n                    ".join(
+            RESULT_FIELD_COLUMNS[name] if RESULT_FIELD_COLUMNS[name] == name else f"{RESULT_FIELD_COLUMNS[name]} AS {name}"
+            for name in resolved_fields
+        )
         _order_by = f"""sort_value {sql_direction} NULLS LAST,
                     edhrec_rank ASC NULLS LAST,
                     prefer_score DESC NULLS LAST"""
-        _count_nulls = """
-                    null AS name,
-                    null AS set_code,
-                    null AS collector_number,
-                    null AS power,
-                    null AS toughness,
-                    null AS mana_cost,
-                    null AS oracle_text,
-                    null AS set_name,
-                    null AS type_line"""
+        _count_nulls = ",\n                    ".join(f"null AS {name}" for name in resolved_fields)
         if unique == UniqueOn.PRINTING:
             # scryfall_id is the PK — every row is already unique, no dedup needed.
             # The CTE has no ORDER BY; only the LIMIT branch sorts.
@@ -1575,12 +1645,12 @@ class APIResource:
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
-    def card_page(
+    def card(
         self,
-        *,
-        falcon_response: falcon.Response | None = None,
         set_code: str = "",
         collector_number: str = "",
+        *,
+        falcon_response: falcon.Response | None = None,
         **_: object,
     ) -> None:
         """Serve the per-card page for /card/{set_code}/{collector_number}.

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -346,9 +346,12 @@ class CardSearch {
     // Add event delegation for card clicks
     this.resultsContainer.addEventListener('click', e => {
       const cardItem = e.target.closest('.card-item');
-      if (cardItem) {
-        this.handleCardClick(cardItem);
-      }
+      if (!cardItem) return;
+      // Modifier clicks (ctrl/cmd) on the card-page link open the card page in a new tab.
+      // Middle-click fires auxclick, not click, so it also passes through naturally.
+      if ((e.ctrlKey || e.metaKey) && e.target.closest('.card-page-link')) return;
+      e.preventDefault();
+      this.handleCardClick(cardItem);
     });
 
     // Add click handler for header to clear search
@@ -784,7 +787,11 @@ class CardSearch {
     // Add loading="lazy" for non-first-row images to improve initial load
     const fetchPriorityAttr = isFirstRow ? ' fetchpriority="high"' : '';
     const loadingAttr = isFirstRow ? '' : ' loading="lazy"';
-    const imageHtml = `<img class="card-image" src="${this.escapeHtml(image388)}" srcset="${srcset}" sizes="${sizes}" alt="${altText}" title="${altText}"${fetchPriorityAttr}${loadingAttr} />`;
+    const imgTag = `<img class="card-image" src="${this.escapeHtml(image388)}" srcset="${srcset}" sizes="${sizes}" alt="${altText}" title="${altText}"${fetchPriorityAttr}${loadingAttr} />`;
+    const imageHtml =
+      card.set_code && card.collector_number
+        ? `<a href="/card/${card.set_code}/${card.collector_number}" class="card-page-link">${imgTag}</a>`
+        : imgTag;
 
     return `
        <div class="card-item" data-card-id="${this.escapeHtml(cardId)}">

--- a/api/static/card.html
+++ b/api/static/card.html
@@ -70,15 +70,15 @@
         <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
           <span id="themeIcon">☀️</span>
         </button>
-        <h1 id="site-title"><a href="/" style="text-decoration:none;color:inherit">MTG Search</a></h1>
+        <h1 id="site-title"><a href="/" style="text-decoration: none; color: inherit">MTG Search</a></h1>
       </div>
 
       <div class="spacer spacer-30"></div>
 
       <div id="card-page">
         <div id="card-loading" class="card-page-loading">Loading...</div>
-        <div id="card-face" class="card-page-face" style="display:none"></div>
-        <div id="other-printings" class="card-page-printings" style="display:none">
+        <div id="card-face" class="card-page-face" style="display: none"></div>
+        <div id="other-printings" class="card-page-printings" style="display: none">
           <h2 class="printings-heading">Other Printings</h2>
           <div id="printings-list" class="printings-strip"></div>
         </div>

--- a/api/static/card.html
+++ b/api/static/card.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#2b8fdf" />
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
+    <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
+    <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.woff2"
+      crossorigin
+    />
+    <link
+      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
+      rel="stylesheet"
+      type="text/css"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <noscript>
+      <link
+        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
+        rel="stylesheet"
+        type="text/css"
+      />
+    </noscript>
+    <link
+      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
+      rel="stylesheet"
+      type="text/css"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <noscript>
+      <link
+        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
+        rel="stylesheet"
+        type="text/css"
+      />
+    </noscript>
+    <link
+      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
+      rel="stylesheet"
+      type="text/css"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <noscript>
+      <link
+        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
+        rel="stylesheet"
+        type="text/css"
+      />
+    </noscript>
+    <style>
+      <!-- CRITICAL_CSS -->
+    </style>
+    <link href="/static/styles.css" rel="stylesheet" type="text/css" media="print" onload="this.media = 'all'" />
+    <noscript><link href="/static/styles.css" rel="stylesheet" type="text/css" /></noscript>
+    <title>MTG Search</title>
+    <script src="/static/card.js" defer></script>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+          <span id="themeIcon">☀️</span>
+        </button>
+        <h1 id="site-title"><a href="/" style="text-decoration:none;color:inherit">MTG Search</a></h1>
+      </div>
+
+      <div class="spacer spacer-30"></div>
+
+      <div id="card-page">
+        <div id="card-loading" class="card-page-loading">Loading...</div>
+        <div id="card-face" class="card-page-face" style="display:none"></div>
+        <div id="other-printings" class="card-page-printings" style="display:none">
+          <h2 class="printings-heading">Other Printings</h2>
+          <div id="printings-list" class="printings-strip"></div>
+        </div>
+      </div>
+
+      <footer class="footer">
+        <p class="footer-legal">
+          Magic: The Gathering™ is a trademark of Wizards of the Coast LLC, a subsidiary of Hasbro, Inc.
+          <br />
+          © Wizards of the Coast LLC. Not approved/endorsed by Wizards of the Coast.
+        </p>
+        <p class="footer-attribution">
+          Card data provided by <a href="https://scryfall.com" target="_blank" rel="noopener">Scryfall</a>. Not
+          affiliated with Scryfall.
+        </p>
+        <p class="footer-links">
+          <a href="https://github.com/jbylund/arcane_tutor" target="_blank" rel="noopener">GitHub</a>
+          ·
+          <a
+            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/user/terms_of_service.md"
+            target="_blank"
+            rel="noopener"
+            >Terms of Service</a
+          >
+          ·
+          <a
+            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/user/privacy_policy.md"
+            target="_blank"
+            rel="noopener"
+            >Privacy Policy</a
+          >
+          ·
+          <a href="https://company.wizards.com/en/legal/fancontentpolicy" target="_blank" rel="noopener"
+            >Wizards Fan Content Policy</a
+          >
+        </p>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/api/static/card.html
+++ b/api/static/card.html
@@ -4,63 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#2b8fdf" />
-    <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
-    <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
-    <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />
-    <link
-      rel="preload"
-      as="font"
-      type="font/woff2"
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.woff2"
-      crossorigin
-    />
-    <link
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
-      rel="stylesheet"
-      type="text/css"
-      media="print"
-      onload="this.media = 'all'"
-    />
-    <noscript>
-      <link
-        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
-        rel="stylesheet"
-        type="text/css"
-      />
-    </noscript>
-    <link
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
-      rel="stylesheet"
-      type="text/css"
-      media="print"
-      onload="this.media = 'all'"
-    />
-    <noscript>
-      <link
-        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
-        rel="stylesheet"
-        type="text/css"
-      />
-    </noscript>
-    <link
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
-      rel="stylesheet"
-      type="text/css"
-      media="print"
-      onload="this.media = 'all'"
-    />
-    <noscript>
-      <link
-        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
-        rel="stylesheet"
-        type="text/css"
-      />
-    </noscript>
-    <style>
-      <!-- CRITICAL_CSS -->
-    </style>
-    <link href="/static/styles.css" rel="stylesheet" type="text/css" media="print" onload="this.media = 'all'" />
-    <noscript><link href="/static/styles.css" rel="stylesheet" type="text/css" /></noscript>
+    <!-- FAVICON -->
+    <!-- PRECONNECTS -->
+    <!-- FONTS -->
+    <!-- CSS -->
     <title>MTG Search</title>
     <script src="/static/card.js" defer></script>
   </head>
@@ -84,38 +31,7 @@
         </div>
       </div>
 
-      <footer class="footer">
-        <p class="footer-legal">
-          Magic: The Gathering™ is a trademark of Wizards of the Coast LLC, a subsidiary of Hasbro, Inc.
-          <br />
-          © Wizards of the Coast LLC. Not approved/endorsed by Wizards of the Coast.
-        </p>
-        <p class="footer-attribution">
-          Card data provided by <a href="https://scryfall.com" target="_blank" rel="noopener">Scryfall</a>. Not
-          affiliated with Scryfall.
-        </p>
-        <p class="footer-links">
-          <a href="https://github.com/jbylund/arcane_tutor" target="_blank" rel="noopener">GitHub</a>
-          ·
-          <a
-            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/user/terms_of_service.md"
-            target="_blank"
-            rel="noopener"
-            >Terms of Service</a
-          >
-          ·
-          <a
-            href="https://github.com/jbylund/arcane_tutor/blob/main/docs/user/privacy_policy.md"
-            target="_blank"
-            rel="noopener"
-            >Privacy Policy</a
-          >
-          ·
-          <a href="https://company.wizards.com/en/legal/fancontentpolicy" target="_blank" rel="noopener"
-            >Wizards Fan Content Policy</a
-          >
-        </p>
-      </footer>
+      <!-- FOOTER -->
     </div>
   </body>
 </html>

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -1,0 +1,193 @@
+const HTML_ESCAPE_RE = /[&<>"]/g;
+const HTML_ESCAPE_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' };
+
+function escapeHtml(str) {
+  if (str == null) return '';
+  return String(str).replace(HTML_ESCAPE_RE, c => HTML_ESCAPE_MAP[c]);
+}
+
+function buildImageUrl(card, size) {
+  const face = card.face_idx || 1;
+  return `https://d1hot9ps2xugbc.cloudfront.net/img/${card.set_code}/${card.collector_number}/${face}/${size}.webp`;
+}
+
+const MANA_SYMBOLS = new Map([
+  ['{W}', 'ms ms-w ms-cost'],
+  ['{U}', 'ms ms-u ms-cost'],
+  ['{B}', 'ms ms-b ms-cost'],
+  ['{R}', 'ms ms-r ms-cost'],
+  ['{G}', 'ms ms-g ms-cost'],
+  ['{C}', 'ms ms-c ms-cost'],
+  ['{0}', 'ms ms-0 ms-cost'],
+  ['{1}', 'ms ms-1 ms-cost'],
+  ['{2}', 'ms ms-2 ms-cost'],
+  ['{3}', 'ms ms-3 ms-cost'],
+  ['{4}', 'ms ms-4 ms-cost'],
+  ['{5}', 'ms ms-5 ms-cost'],
+  ['{6}', 'ms ms-6 ms-cost'],
+  ['{7}', 'ms ms-7 ms-cost'],
+  ['{8}', 'ms ms-8 ms-cost'],
+  ['{9}', 'ms ms-9 ms-cost'],
+  ['{10}', 'ms ms-10 ms-cost'],
+  ['{11}', 'ms ms-11 ms-cost'],
+  ['{12}', 'ms ms-12 ms-cost'],
+  ['{13}', 'ms ms-13 ms-cost'],
+  ['{14}', 'ms ms-14 ms-cost'],
+  ['{15}', 'ms ms-15 ms-cost'],
+  ['{16}', 'ms ms-16 ms-cost'],
+  ['{X}', 'ms ms-x ms-cost'],
+  ['{Y}', 'ms ms-y ms-cost'],
+  ['{Z}', 'ms ms-z ms-cost'],
+  ['{T}', 'ms ms-tap'],
+  ['{Q}', 'ms ms-untap'],
+  ['{E}', 'ms ms-energy'],
+  ['{P}', 'ms ms-p ms-cost'],
+  ['{S}', 'ms ms-s ms-cost'],
+  ['{CHAOS}', 'ms ms-chaos'],
+  ['{PW}', 'ms ms-pw'],
+  ['{∞}', 'ms ms-infinity'],
+  ['{W/U}', 'ms ms-wu ms-cost'],
+  ['{U/B}', 'ms ms-ub ms-cost'],
+  ['{B/R}', 'ms ms-br ms-cost'],
+  ['{R/G}', 'ms ms-rg ms-cost'],
+  ['{G/W}', 'ms ms-gw ms-cost'],
+  ['{W/B}', 'ms ms-wb ms-cost'],
+  ['{U/R}', 'ms ms-ur ms-cost'],
+  ['{B/G}', 'ms ms-bg ms-cost'],
+  ['{R/W}', 'ms ms-rw ms-cost'],
+  ['{G/U}', 'ms ms-gu ms-cost'],
+  ['{2/W}', 'ms ms-2w ms-cost'],
+  ['{2/U}', 'ms ms-2u ms-cost'],
+  ['{2/B}', 'ms ms-2b ms-cost'],
+  ['{2/R}', 'ms ms-2r ms-cost'],
+  ['{2/G}', 'ms ms-2g ms-cost'],
+  ['{W/P}', 'ms ms-wp ms-cost'],
+  ['{U/P}', 'ms ms-up ms-cost'],
+  ['{B/P}', 'ms ms-bp ms-cost'],
+  ['{R/P}', 'ms ms-rp ms-cost'],
+  ['{G/P}', 'ms ms-gp ms-cost'],
+  ['{W/U/P}', 'ms ms-wup ms-cost'],
+  ['{W/B/P}', 'ms ms-wbp ms-cost'],
+  ['{U/B/P}', 'ms ms-ubp ms-cost'],
+  ['{U/R/P}', 'ms ms-urp ms-cost'],
+  ['{B/R/P}', 'ms ms-brp ms-cost'],
+  ['{B/G/P}', 'ms ms-bgp ms-cost'],
+  ['{R/W/P}', 'ms ms-rwp ms-cost'],
+  ['{R/G/P}', 'ms ms-rgp ms-cost'],
+  ['{G/W/P}', 'ms ms-gwp ms-cost'],
+  ['{G/U/P}', 'ms ms-gup ms-cost'],
+]);
+const MANA_RE = /\{[^}]{1,5}\}/g;
+
+function convertManaSymbols(text) {
+  if (!text) return '';
+  return text.replace(MANA_RE, match => {
+    const cls = MANA_SYMBOLS.get(match);
+    return cls ? `<span class="modal-mana-symbol ${cls}"></span>` : escapeHtml(match);
+  });
+}
+
+function formatOracleText(text) {
+  if (!text) return '';
+  return convertManaSymbols(escapeHtml(text)).replace(/\n/g, '<br>');
+}
+
+function renderCardFace(card) {
+  const imageLarge = buildImageUrl(card, '745');
+  const imageHtml = `<div class="modal-image-wrapper"><img class="modal-image" src="${escapeHtml(imageLarge)}" width="745" height="1040" alt="${escapeHtml(card.name || '')}" /></div>`;
+
+  const hasPT = card.power != null && card.toughness != null;
+
+  return `
+    ${imageHtml}
+    <div class="modal-card-info">
+      <div class="modal-card-name-mana-row">
+        <div class="modal-card-name">${escapeHtml(card.name || 'Unknown Card')}</div>
+        ${card.mana_cost ? `<div class="modal-card-mana">${convertManaSymbols(card.mana_cost)}</div>` : ''}
+      </div>
+      ${card.type_line ? `<div class="modal-card-type">${escapeHtml(card.type_line)}</div>` : ''}
+      ${card.oracle_text ? `<div class="modal-card-text">${formatOracleText(card.oracle_text)}</div>` : ''}
+      ${card.set_name || hasPT ? `
+      <div class="modal-card-set-power-row">
+        ${card.set_name ? `<div class="modal-card-set">${escapeHtml(card.set_name)}</div>` : '<div class="modal-card-set"></div>'}
+        ${hasPT ? `<div class="modal-card-power-toughness">${escapeHtml(card.power)} / ${escapeHtml(card.toughness)}</div>` : ''}
+      </div>` : ''}
+    </div>
+  `;
+}
+
+function renderPrintingsStrip(cards) {
+  return cards
+    .map(card => {
+      const thumb = buildImageUrl(card, '280');
+      const url = `/card/${card.set_code}/${card.collector_number}`;
+      const label = escapeHtml(card.set_name || card.set_code || '');
+      return `<a href="${escapeHtml(url)}" class="printing-thumb" title="${label}"><img src="${escapeHtml(thumb)}" alt="${label}" loading="lazy" /></a>`;
+    })
+    .join('');
+}
+
+async function main() {
+  const parts = window.location.pathname.split('/').filter(Boolean);
+  if (parts.length < 3 || parts[0] !== 'card') {
+    document.getElementById('card-loading').textContent = 'Invalid card URL.';
+    return;
+  }
+  const [, setCode, collectorNumber] = parts;
+
+  let card;
+  try {
+    const resp = await fetch(`/search?q=${encodeURIComponent(`set:${setCode} cn:${collectorNumber}`)}&unique=printing`);
+    const data = await resp.json();
+    card = data.cards?.[0];
+  } catch (_) {
+    document.getElementById('card-loading').textContent = 'Failed to load card.';
+    return;
+  }
+
+  if (!card) {
+    document.getElementById('card-loading').textContent = 'Card not found.';
+    return;
+  }
+
+  document.title = `${card.name} - MTG Search`;
+
+  const cardFace = document.getElementById('card-face');
+  cardFace.innerHTML = renderCardFace(card);
+  cardFace.style.display = '';
+  document.getElementById('card-loading').style.display = 'none';
+
+  try {
+    const resp = await fetch(`/search?q=${encodeURIComponent(`!"${card.name}"`)}&unique=printing`);
+    const data = await resp.json();
+    const others = (data.cards || []).filter(
+      p => !(p.set_code === setCode && p.collector_number === collectorNumber),
+    );
+    if (others.length > 0) {
+      document.getElementById('printings-list').innerHTML = renderPrintingsStrip(others);
+      document.getElementById('other-printings').style.display = '';
+    }
+  } catch (_) {
+    // Other printings are non-critical; fail silently.
+  }
+}
+
+(function initTheme() {
+  const saved = localStorage.getItem('theme');
+  if (saved) document.documentElement.setAttribute('data-theme', saved);
+  const toggle = document.getElementById('themeToggle');
+  const icon = document.getElementById('themeIcon');
+  if (!toggle || !icon) return;
+  function updateIcon() {
+    icon.textContent = document.documentElement.getAttribute('data-theme') === 'dark' ? '☀️' : '🌙';
+  }
+  updateIcon();
+  toggle.addEventListener('click', () => {
+    const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    updateIcon();
+  });
+})();
+
+main();

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -94,7 +94,15 @@ function formatOracleText(text) {
 
 function renderCardFace(card) {
   const imageLarge = buildImageUrl(card, '745');
-  const imageHtml = `<div class="modal-image-wrapper"><img class="modal-image" src="${escapeHtml(imageLarge)}" width="745" height="1040" alt="${escapeHtml(card.name || '')}" /></div>`;
+  const imgTag = `<img class="modal-image" src="${escapeHtml(imageLarge)}" width="745" height="1040" alt="${escapeHtml(card.name || '')}" />`;
+  let imageHtml;
+  if (card.set_code && card.collector_number) {
+    // Build manapool.com referral URL — set codes and collector numbers from our database are safe for URLs
+    const manapoolUrl = `https://manapool.com/card/${card.set_code.toLowerCase()}/${card.collector_number}?ref=sylvan-librarian`;
+    imageHtml = `<div class="modal-image-wrapper"><a href="${manapoolUrl}" target="_blank" rel="noopener noreferrer" class="modal-image-link">${imgTag}</a></div>`;
+  } else {
+    imageHtml = `<div class="modal-image-wrapper">${imgTag}</div>`;
+  }
 
   const hasPT = card.power != null && card.toughness != null;
 
@@ -107,22 +115,53 @@ function renderCardFace(card) {
       </div>
       ${card.type_line ? `<div class="modal-card-type">${escapeHtml(card.type_line)}</div>` : ''}
       ${card.oracle_text ? `<div class="modal-card-text">${formatOracleText(card.oracle_text)}</div>` : ''}
-      ${card.set_name || hasPT ? `
+      ${
+        card.set_name || hasPT
+          ? `
       <div class="modal-card-set-power-row">
         ${card.set_name ? `<div class="modal-card-set">${escapeHtml(card.set_name)}</div>` : '<div class="modal-card-set"></div>'}
         ${hasPT ? `<div class="modal-card-power-toughness">${escapeHtml(card.power)} / ${escapeHtml(card.toughness)}</div>` : ''}
-      </div>` : ''}
+      </div>`
+          : ''
+      }
     </div>
   `;
 }
 
-function renderPrintingsStrip(cards) {
-  return cards
-    .map(card => {
+function formatUsd(value) {
+  return value == null ? '' : ` ($${Number(value).toFixed(2)})`;
+}
+
+// Printings that share the same illustration_id are collapsed into a single thumbnail — the one
+// with the highest prefer_score represents the group, badged with how many others it stands in
+// for. Groups are then sorted by that max prefer_score, highest first.
+function groupPrintingsByArt(cards) {
+  const groups = new Map();
+  for (const card of cards) {
+    const key = card.illustration_id || `${card.set_code}/${card.collector_number}`;
+    const group = groups.get(key);
+    if (!group) {
+      groups.set(key, { representative: card, count: 1 });
+    } else {
+      group.count += 1;
+      if ((card.prefer_score ?? -Infinity) > (group.representative.prefer_score ?? -Infinity)) {
+        group.representative = card;
+      }
+    }
+  }
+  return [...groups.values()].sort(
+    (a, b) => (b.representative.prefer_score ?? -Infinity) - (a.representative.prefer_score ?? -Infinity)
+  );
+}
+
+function renderPrintingsStrip(groups) {
+  return groups
+    .map(({ representative: card, count }) => {
       const thumb = buildImageUrl(card, '280');
       const url = `/card/${card.set_code}/${card.collector_number}`;
-      const label = escapeHtml(card.set_name || card.set_code || '');
-      return `<a href="${escapeHtml(url)}" class="printing-thumb" title="${label}"><img src="${escapeHtml(thumb)}" alt="${label}" loading="lazy" /></a>`;
+      const label = escapeHtml(`${card.set_name || card.set_code || ''}${formatUsd(card.price_usd)}`);
+      const badge = count > 1 ? `<span class="printing-thumb-count">+${count - 1}</span>` : '';
+      return `<a href="${escapeHtml(url)}" class="printing-thumb" title="${label}"><img src="${escapeHtml(thumb)}" alt="${label}" loading="lazy" />${badge}</a>`;
     })
     .join('');
 }
@@ -158,13 +197,15 @@ async function main() {
   document.getElementById('card-loading').style.display = 'none';
 
   try {
-    const resp = await fetch(`/search?q=${encodeURIComponent(`!"${card.name}"`)}&unique=printing`);
-    const data = await resp.json();
-    const others = (data.cards || []).filter(
-      p => !(p.set_code === setCode && p.collector_number === collectorNumber),
+    const printingFields = 'set_code,collector_number,set_name,illustration_id,price_usd,prefer_score';
+    const resp = await fetch(
+      `/search?q=${encodeURIComponent(`!"${card.name}"`)}&unique=printing&fields=${printingFields}`
     );
+    const data = await resp.json();
+    const others = (data.cards || []).filter(p => !(p.set_code === setCode && p.collector_number === collectorNumber));
     if (others.length > 0) {
-      document.getElementById('printings-list').innerHTML = renderPrintingsStrip(others);
+      const groups = groupPrintingsByArt(others);
+      document.getElementById('printings-list').innerHTML = renderPrintingsStrip(groups);
       document.getElementById('other-printings').style.display = '';
     }
   } catch (_) {

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -132,6 +132,14 @@ function formatUsd(value) {
   return value == null ? '' : ` ($${Number(value).toFixed(2)})`;
 }
 
+// Escapes \ and " for embedding in a double-quoted exact-name query literal (e.g. !"...").
+// The query grammar (api/parsing/hand_parser.py) treats \ as an escape char inside quoted
+// strings, so a name containing a literal " — e.g. Kongming, "Sleeping Dragon" — would otherwise
+// terminate the string early and get parsed as several unrelated AND clauses.
+function escapeExactName(name) {
+  return name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 // Printings that share the same illustration_id are collapsed into a single thumbnail — the one
 // with the highest prefer_score represents the group, badged with how many others it stands in
 // for. Groups are then sorted by that max prefer_score, highest first.
@@ -200,7 +208,7 @@ async function main() {
   try {
     const printingFields = 'set_code,collector_number,set_name,illustration_id,price_usd,prefer_score';
     const resp = await fetch(
-      `/search?q=${encodeURIComponent(`!"${card.name}"`)}&unique=printing&fields=${printingFields}`
+      `/search?q=${encodeURIComponent(`!"${escapeExactName(card.name)}"`)}&unique=printing&fields=${printingFields}`
     );
     const data = await resp.json();
     const others = (data.cards || []).filter(p => !(p.set_code === setCode && p.collector_number === collectorNumber));

--- a/api/static/card.js
+++ b/api/static/card.js
@@ -172,7 +172,8 @@ async function main() {
     document.getElementById('card-loading').textContent = 'Invalid card URL.';
     return;
   }
-  const [, setCode, collectorNumber] = parts;
+  const [, rawSetCode, collectorNumber] = parts;
+  const setCode = rawSetCode.toLowerCase();
 
   let card;
   try {

--- a/api/static/fragments/css.html
+++ b/api/static/fragments/css.html
@@ -1,0 +1,5 @@
+<style>
+  <!-- CRITICAL_CSS -->
+</style>
+<link href="/static/styles.css" rel="stylesheet" type="text/css" media="print" onload="this.media = 'all'" />
+<noscript><link href="/static/styles.css" rel="stylesheet" type="text/css" /></noscript>

--- a/api/static/fragments/favicon.html
+++ b/api/static/fragments/favicon.html
@@ -1,0 +1,1 @@
+<link rel="icon" type="image/x-icon" href="/static/favicon.ico" />

--- a/api/static/fragments/fonts.html
+++ b/api/static/fragments/fonts.html
@@ -1,0 +1,45 @@
+<link
+  rel="preload"
+  as="font"
+  type="font/woff2"
+  href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.woff2"
+  crossorigin
+/>
+<link
+  href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
+  rel="stylesheet"
+  type="text/css"
+  media="print"
+  onload="this.media = 'all'"
+/>
+<noscript>
+  <link href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css" rel="stylesheet" type="text/css" />
+</noscript>
+<link
+  href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
+  rel="stylesheet"
+  type="text/css"
+  media="print"
+  onload="this.media = 'all'"
+/>
+<noscript>
+  <link
+    href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
+    rel="stylesheet"
+    type="text/css"
+  />
+</noscript>
+<link
+  href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
+  rel="stylesheet"
+  type="text/css"
+  media="print"
+  onload="this.media = 'all'"
+/>
+<noscript>
+  <link
+    href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
+    rel="stylesheet"
+    type="text/css"
+  />
+</noscript>

--- a/api/static/fragments/footer.html
+++ b/api/static/fragments/footer.html
@@ -1,0 +1,32 @@
+<footer class="footer">
+  <p class="footer-legal">
+    Magic: The Gathering™ is a trademark of Wizards of the Coast LLC, a subsidiary of Hasbro, Inc.
+    <br />
+    © Wizards of the Coast LLC. Not approved/endorsed by Wizards of the Coast.
+  </p>
+  <p class="footer-attribution">
+    Card data provided by <a href="https://scryfall.com" target="_blank" rel="noopener">Scryfall</a>. Not affiliated
+    with Scryfall.
+  </p>
+  <p class="footer-links">
+    <a href="https://github.com/jbylund/sylvan_librarian" target="_blank" rel="noopener">GitHub</a>
+    ·
+    <a
+      href="https://github.com/jbylund/sylvan_librarian/blob/main/docs/user/terms_of_service.md"
+      target="_blank"
+      rel="noopener"
+      >Terms of Service</a
+    >
+    ·
+    <a
+      href="https://github.com/jbylund/sylvan_librarian/blob/main/docs/user/privacy_policy.md"
+      target="_blank"
+      rel="noopener"
+      >Privacy Policy</a
+    >
+    ·
+    <a href="https://company.wizards.com/en/legal/fancontentpolicy" target="_blank" rel="noopener"
+      >Wizards Fan Content Policy</a
+    >
+  </p>
+</footer>

--- a/api/static/fragments/preconnects.html
+++ b/api/static/fragments/preconnects.html
@@ -1,0 +1,2 @@
+<link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
+<link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -49,63 +49,10 @@
     <meta property="og:image:height" content="630" />
     <title>MTG Search - Magic: The Gathering Card Search</title>
     <link rel="canonical" href="/" />
-    <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
-    <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" />
-    <link rel="preconnect" href="https://d1hot9ps2xugbc.cloudfront.net" crossorigin />
-    <link
-      rel="preload"
-      as="font"
-      type="font/woff2"
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.woff2"
-      crossorigin
-    />
-    <link
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
-      rel="stylesheet"
-      type="text/css"
-      media="print"
-      onload="this.media = 'all'"
-    />
-    <noscript>
-      <link
-        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mana/mana-subset.css"
-        rel="stylesheet"
-        type="text/css"
-      />
-    </noscript>
-    <link
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
-      rel="stylesheet"
-      type="text/css"
-      media="print"
-      onload="this.media = 'all'"
-    />
-    <noscript>
-      <link
-        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/beleren/beleren-subset.css"
-        rel="stylesheet"
-        type="text/css"
-      />
-    </noscript>
-    <link
-      href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
-      rel="stylesheet"
-      type="text/css"
-      media="print"
-      onload="this.media = 'all'"
-    />
-    <noscript>
-      <link
-        href="https://d1hot9ps2xugbc.cloudfront.net/cdn/fonts/mplantin/mplantin-subset.css"
-        rel="stylesheet"
-        type="text/css"
-      />
-    </noscript>
-    <style>
-      <!-- CRITICAL_CSS -->
-    </style>
-    <link href="/static/styles.css" rel="stylesheet" type="text/css" media="print" onload="this.media = 'all'" />
-    <noscript><link href="/static/styles.css" rel="stylesheet" type="text/css" /></noscript>
+    <!-- FAVICON -->
+    <!-- PRECONNECTS -->
+    <!-- FONTS -->
+    <!-- CSS -->
     <script src="/static/app.min.js" defer></script>
   </head>
   <body>
@@ -176,38 +123,7 @@
       <div class="spacer spacer-30"></div>
       <div id="results" class="results-container"><!-- SERVER_SIDE_RESULTS --></div>
 
-      <footer class="footer">
-        <p class="footer-legal">
-          Magic: The Gathering™ is a trademark of Wizards of the Coast LLC, a subsidiary of Hasbro, Inc.
-          <br />
-          © Wizards of the Coast LLC. Not approved/endorsed by Wizards of the Coast.
-        </p>
-        <p class="footer-attribution">
-          Card data provided by <a href="https://scryfall.com" target="_blank" rel="noopener">Scryfall</a>. Not
-          affiliated with Scryfall.
-        </p>
-        <p class="footer-links">
-          <a href="https://github.com/jbylund/sylvan_librarian" target="_blank" rel="noopener">GitHub</a>
-          ·
-          <a
-            href="https://github.com/jbylund/sylvan_librarian/blob/main/docs/user/terms_of_service.md"
-            target="_blank"
-            rel="noopener"
-            >Terms of Service</a
-          >
-          ·
-          <a
-            href="https://github.com/jbylund/sylvan_librarian/blob/main/docs/user/privacy_policy.md"
-            target="_blank"
-            rel="noopener"
-            >Privacy Policy</a
-          >
-          ·
-          <a href="https://company.wizards.com/en/legal/fancontentpolicy" target="_blank" rel="noopener"
-            >Wizards Fan Content Policy</a
-          >
-        </p>
-      </footer>
+      <!-- FOOTER -->
     </div>
 
     <!-- Modal for card details -->

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -672,7 +672,7 @@ body {
 }
 
 .card-page-printings {
-  max-width: 900px;
+  max-width: 90%;
   margin: 2rem auto 0;
 }
 
@@ -683,15 +683,13 @@ body {
 }
 
 .printings-strip {
-  display: flex;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 0.5rem;
-  overflow-x: auto;
-  padding-bottom: 0.5rem;
 }
 
 .printing-thumb {
-  flex-shrink: 0;
+  position: relative;
   display: block;
   border-radius: 6px;
   overflow: hidden;
@@ -705,9 +703,21 @@ body {
 
 .printing-thumb img {
   display: block;
-  width: 80px;
+  width: 100%;
   height: auto;
   border-radius: 6px;
+}
+
+.printing-thumb-count {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  font-size: 0.7rem;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
 }
 
 .card-page-link {

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -652,6 +652,76 @@ body {
   opacity: 0.8;
 }
 
+/* Card page */
+
+.card-page-loading {
+  text-align: center;
+  color: var(--color-text-secondary);
+  padding: 2rem;
+  font-size: 1.1rem;
+}
+
+.card-page-face {
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+  align-items: flex-start;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem 0;
+}
+
+.card-page-printings {
+  max-width: 900px;
+  margin: 2rem auto 0;
+}
+
+.printings-heading {
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.printings-strip {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.printing-thumb {
+  flex-shrink: 0;
+  display: block;
+  border-radius: 6px;
+  overflow: hidden;
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+
+.printing-thumb:hover {
+  opacity: 1;
+}
+
+.printing-thumb img {
+  display: block;
+  width: 80px;
+  height: auto;
+  border-radius: 6px;
+}
+
+.card-page-link {
+  display: block;
+  line-height: 0;
+}
+
+@media (max-width: 600px) {
+  .card-page-face {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
 .results-count {
   color: var(--color-text-inverted);
   text-align: center;

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -15,6 +15,7 @@ import falcon
 import falcon.testing
 import pytest
 
+import api.api_resource as api_resource_module
 from api.api_resource import FALLBACK_SITE_NAME, APIResource, _hostname_to_site_name, _split_words, hostname_to_site_name
 from api.settings import settings
 
@@ -419,13 +420,18 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         assert mock_response.text is not None
         assert len(mock_response.text) > 0
         assert mock_response.content_type == "text/html"
-        assert 'autocapitalize="off"' in mock_response.text
-        assert 'autocorrect="off"' in mock_response.text
+        # HTML is minified before serving (see _minify_html), which may drop attribute quotes and
+        # reorder attributes — check for the substantive content rather than exact tag formatting.
+        assert "autocapitalize" in mock_response.text
+        assert "autocorrect" in mock_response.text
         # Verify it sets cache control header
         mock_response.set_header.assert_called_with("Cache-Control", "public, max-age=3600")
-        assert '<meta property="og:image" content="/static/social-preview.webp" />' in mock_response.text
-        assert '<meta property="og:image:width" content="1200" />' in mock_response.text
-        assert '<meta property="og:image:height" content="630" />' in mock_response.text
+        assert "og:image" in mock_response.text
+        assert "/static/social-preview.webp" in mock_response.text
+        assert "og:image:width" in mock_response.text
+        assert "1200" in mock_response.text
+        assert "og:image:height" in mock_response.text
+        assert "630" in mock_response.text
 
     def test_index_html_with_query_embeds_search_results(self) -> None:
         """Test _root embeds search results when query parameter is provided."""
@@ -495,6 +501,53 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
 
         assert mock_response.text == expected_contents
         assert mock_response.content_type == "text/plain"
+
+
+class TestHtmlMinification(unittest.TestCase):
+    """_minify_html reduces page weight.
+
+    Must not corrupt the per-request placeholders that _build_base_html's cached output still
+    needs substituted afterward (SERVER_SIDE_RESULTS, SERVER_SIDE_EMBEDDED_DATA).
+    """
+
+    def setUp(self) -> None:
+        self.mock_conn_pool = MagicMock()
+        self.api_resource = APIResource(
+            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
+        )
+        self.api_resource._conn_pool = self.mock_conn_pool
+
+    def test_minifies_whitespace_by_default(self) -> None:
+        # minify_html also drops the redundant closing </p> (valid HTML5 tag-omission), hence
+        # "<div><p>x</div>" rather than a literal whitespace-only collapse.
+        assert api_resource_module._minify_html("<div>   <p>x</p>   </div>") == "<div><p>x</div>"
+
+    def test_disabled_flag_returns_input_unchanged(self) -> None:
+        original = api_resource_module._MINIFY_HTML_ENABLED
+        api_resource_module._MINIFY_HTML_ENABLED = False
+        try:
+            html = "<div>   <p>x</p>   </div>"
+            assert api_resource_module._minify_html(html) == html
+        finally:
+            api_resource_module._MINIFY_HTML_ENABLED = original
+
+    def test_server_side_placeholders_survive_minification(self) -> None:
+        mock_response = MagicMock()
+        self.api_resource._root(falcon_response=mock_response)
+        assert "<!-- SERVER_SIDE_RESULTS -->" in mock_response.text
+        assert "<!-- SERVER_SIDE_EMBEDDED_DATA -->" in mock_response.text
+
+    def test_search_results_still_embed_after_minification(self) -> None:
+        mock_response = MagicMock()
+        mock_search_results = {
+            "cards": [{"name": "Elvish Mystic", "set_code": "m14", "collector_number": "1"}],
+            "total_cards": 1,
+            "query": "elf",
+        }
+        with patch.object(self.api_resource, "_search", return_value=mock_search_results):
+            self.api_resource._root(falcon_response=mock_response, q="elf")
+        assert "window.EMBEDDED_SEARCH_RESULTS = {" in mock_response.text
+        assert "Elvish Mystic" in mock_response.text
 
 
 class TestAPIResourceErrorHandling(unittest.TestCase):

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -12,6 +12,7 @@ from typing import Any, Never
 from unittest.mock import MagicMock, patch
 
 import falcon
+import falcon.testing
 import pytest
 
 from api.api_resource import FALLBACK_SITE_NAME, APIResource, _hostname_to_site_name, _split_words, hostname_to_site_name
@@ -169,6 +170,35 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
 
         for method in public_methods:
             assert method in api_resource.action_map
+
+
+class TestRequestDispatch(TestBaseAPIResourceTest):
+    """_handle() routes both flat "static/x" action keys and positional path segments.
+
+    Regression coverage for a dispatch rewrite that split every path on "/" to derive
+    (action_word, *action_args): it broke the "static/x" actions (registered under a single
+    slash-containing key, not action_word "static") and crashed on unmatched routes with extra
+    segments (_raise_not_found only accepted **kwargs, not positional args).
+    """
+
+    def _dispatch(self, path: str) -> falcon.Response:
+        req = falcon.Request(falcon.testing.create_environ(path=path))
+        resp = falcon.Response()
+        self.api_resource._handle(req, resp)
+        return resp
+
+    def test_flat_static_route_is_matched_by_full_path(self) -> None:
+        resp = self._dispatch("/static/favicon.ico")
+        assert resp.status == falcon.HTTP_200
+
+    def test_positional_path_segments_reach_the_action(self) -> None:
+        resp = self._dispatch("/card/eoc/104")
+        assert resp.status == falcon.HTTP_200
+        assert resp.content_type == "text/html"
+
+    def test_unmatched_route_with_extra_segments_raises_not_found(self) -> None:
+        with pytest.raises(falcon.HTTPNotFound):
+            self._dispatch("/nonexistent/thing/other")
 
 
 class TestAPIResourceCoreMethods(unittest.TestCase):

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -178,8 +178,11 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
 
     Regression coverage for a dispatch rewrite that split every path on "/" to derive
     (action_word, *action_args): it broke the "static/x" actions (registered under a single
-    slash-containing key, not action_word "static") and crashed on unmatched routes with extra
-    segments (_raise_not_found only accepted **kwargs, not positional args).
+    slash-containing key, not action_word "static"), crashed on unmatched routes with extra
+    segments (_raise_not_found only accepted **kwargs, not positional args), and — the one fixed
+    here — returned 400 instead of 404 for any *matched* route hit with more trailing segments
+    than its handler accepts (e.g. /get_pid/extra), since the mismatch surfaced as a TypeError
+    inside the handler rather than being recognized as "no route matches this" beforehand.
     """
 
     def _dispatch(self, path: str) -> falcon.Response:
@@ -200,6 +203,41 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
     def test_unmatched_route_with_extra_segments_raises_not_found(self) -> None:
         with pytest.raises(falcon.HTTPNotFound):
             self._dispatch("/nonexistent/thing/other")
+
+    def test_known_zero_arg_route_with_extra_segment_raises_not_found(self) -> None:
+        # Regression: a matched action_word that can't absorb a trailing segment (get_pid takes
+        # no positional args) used to reach the handler anyway, raising a TypeError that _handle
+        # converted to 400 — the extra segment means the path doesn't identify anything, so this
+        # should 404 like any other unmatched path.
+        with pytest.raises(falcon.HTTPNotFound):
+            self._dispatch("/get_pid/extra")
+
+    def test_positional_route_with_too_many_segments_raises_not_found(self) -> None:
+        # card() accepts exactly 2 positional args (set_code, collector_number); a 3rd segment
+        # should 404 rather than reach the handler.
+        with pytest.raises(falcon.HTTPNotFound):
+            self._dispatch("/card/eoc/104/extra")
+
+    def test_positional_capacity_computed_at_init_not_per_request(self) -> None:
+        assert self.api_resource._action_positional_capacity["get_pid"] == 0
+        assert self.api_resource._action_positional_capacity["card"] == 2
+
+    def test_not_found_routes_precomputed_not_rebuilt_per_request(self) -> None:
+        # _not_found_routes is built once in __init__ (see _build_routes_listing) from the fixed
+        # action_map contents, not recomputed on every 404 — inspect.signature() per route isn't
+        # free, and the listing can't change without action_map changing.
+        listing_before = self.api_resource._not_found_routes
+        with pytest.raises(falcon.HTTPNotFound) as exc_info:
+            self.api_resource._raise_not_found()
+        assert exc_info.value.description["routes"] is listing_before
+        assert "get_pid" in listing_before
+        assert "card" in listing_before
+
+    def test_no_inspect_signature_calls_on_successful_request(self) -> None:
+        with patch("api.api_resource.inspect.signature") as mock_signature:
+            resp = self._dispatch("/card/a25/141")
+        assert resp.status == falcon.HTTP_200
+        mock_signature.assert_not_called()
 
 
 class TestAPIResourceCoreMethods(unittest.TestCase):

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from api.parsing import parse_scryfall_query
-from card_engine import QueryEngine
+from card_engine import QueryEngine, UnknownFieldError
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -79,6 +79,7 @@ def _run(
     orderby: str = "edhrec",
     direction: str = "asc",
     limit: int = 200,
+    fields: list[str] | None = None,
 ) -> tuple[int, list[dict]]:
     """Parse q, run engine.query(), return (total, cards). q='' matches all."""
     filters = parse_scryfall_query(q)
@@ -89,6 +90,7 @@ def _run(
         orderby=orderby,
         direction=direction,
         limit=limit,
+        fields=fields,
     )
     return total, list(cards)
 
@@ -1036,3 +1038,57 @@ class TestCommonCardKeywords:
         result = engine.common_card_keywords()
         for keyword, count in result.items():
             assert count > 0, f"Keyword {keyword!r} has non-positive count {count}"
+
+
+class TestFieldSelection:
+    """fields= selects which keys come back per card; None keeps the historical 9."""
+
+    def test_default_fields_omit_illustration_and_price(self, engine: QueryEngine) -> None:
+        _, cards = _run(engine, 'name="Lightning Bolt"', unique="printing", limit=1)
+        assert cards[0].keys() == {
+            "name",
+            "set_code",
+            "collector_number",
+            "power",
+            "toughness",
+            "mana_cost",
+            "oracle_text",
+            "set_name",
+            "type_line",
+        }
+
+    def test_requested_fields_returned_exactly(self, engine: QueryEngine) -> None:
+        _, cards = _run(
+            engine,
+            'name="Lightning Bolt"',
+            unique="printing",
+            limit=1,
+            fields=["name", "illustration_id", "price_usd", "prefer_score"],
+        )
+        assert cards[0].keys() == {"name", "illustration_id", "price_usd", "prefer_score"}
+
+    def test_illustration_id_groups_shared_art(self, engine: QueryEngine) -> None:
+        # Lightning Bolt has 10 printings across 6 distinct illustration_ids.
+        _, cards = _run(
+            engine,
+            'name="Lightning Bolt"',
+            unique="printing",
+            fields=["set_code", "illustration_id"],
+        )
+        assert len({c["illustration_id"] for c in cards}) == 6
+
+    def test_price_usd_matches_prefer_ordering(self, engine: QueryEngine) -> None:
+        # Cheapest Lightning Bolt is m11 at $1.47 (see TestPrefer.test_prefer_usd_low...).
+        _, cards = _run(
+            engine,
+            'name="Lightning Bolt"',
+            unique="card",
+            prefer="usd_low",
+            fields=["set_code", "price_usd"],
+        )
+        assert cards[0]["set_code"] == "m11"
+        assert cards[0]["price_usd"] == pytest.approx(1.47)
+
+    def test_unknown_field_raises(self, engine: QueryEngine) -> None:
+        with pytest.raises(UnknownFieldError):
+            _run(engine, unique="printing", fields=["not_a_real_field"])

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -206,6 +206,32 @@ class TestContainerIntegration:
         assert len(cards) == 1
         assert cards[0]["name"] == "Serra Angel"
 
+    def test_search_sql_default_fields(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """Omitting fields= keeps the historical 9-key shape."""
+        result = api_resource._search_sql(**search_kwargs("name:bolt", limit=10))
+        assert result["cards"][0].keys() == {
+            "name",
+            "set_code",
+            "collector_number",
+            "power",
+            "toughness",
+            "mana_cost",
+            "oracle_text",
+            "set_name",
+            "type_line",
+        }
+
+    def test_search_sql_with_custom_fields(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """fields= selects exactly the requested columns, including the newly-added ones."""
+        result = api_resource._search_sql(
+            **search_kwargs("name:bolt", limit=10),
+            fields=["name", "illustration_id", "price_usd", "prefer_score"],
+        )
+        cards = result["cards"]
+        assert len(cards) == 1
+        assert cards[0].keys() == {"name", "illustration_id", "price_usd", "prefer_score"}
+        assert cards[0]["name"] == "Lightning Bolt"
+
     def test_database_operations_isolation(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test that database operations are properly isolated."""
         # This test verifies that we're working with the test database

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -190,6 +190,65 @@ class TestSearchEngineDirect:
         assert call_kwargs["limit"] == 5
 
 
+class TestResultFieldSelection:
+    """`fields=` validation on `_search`, independent of which backend serves the request."""
+
+    def setup_method(self) -> None:
+        self.api_resource = _make_api()
+        self.api_resource._setup_complete = lambda: True
+
+    def teardown_method(self) -> None:
+        if hasattr(self, "api_resource") and self.api_resource:
+            self.api_resource._conn_pool.close()
+
+    def test_unknown_field_raises_bad_request(self) -> None:
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query="", fields=["not_a_real_field"])
+        assert exc_info.value.title == "Invalid Fields"
+
+    def test_empty_fields_list_raises_bad_request(self) -> None:
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self.api_resource._search(query="", fields=[])
+        assert exc_info.value.title == "Invalid Fields"
+
+    def test_duplicate_fields_are_deduped_in_order(self) -> None:
+        resolved = self.api_resource._resolve_result_fields(["price_usd", "name", "price_usd"])
+        assert resolved == ["price_usd", "name"]
+
+    def test_none_resolves_to_default_fields(self) -> None:
+        from api.api_resource import DEFAULT_RESULT_FIELDS  # noqa: PLC0415
+
+        assert self.api_resource._resolve_result_fields(None) == list(DEFAULT_RESULT_FIELDS)
+
+
+@pytest.mark.usefixtures("engine_enabled")
+class TestResultFieldRouting:
+    """The fields resolved by _search are threaded to whichever backend serves the request."""
+
+    def setup_method(self) -> None:
+        self.api_resource = _make_api()
+        self.api_resource._setup_complete = lambda: True
+        self.api_resource._engine = MagicMock()
+
+    def teardown_method(self) -> None:
+        if hasattr(self, "api_resource") and self.api_resource:
+            self.api_resource._conn_pool.close()
+
+    def test_fields_passed_to_sql_path(self) -> None:
+        self.api_resource._engine.size.return_value = 0
+        sentinel = {"cards": [], "total_cards": 0, "query": ""}
+        with patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql:
+            self.api_resource._search(query="", fields=["name", "illustration_id"])
+        assert mock_sql.call_args.kwargs["fields"] == ["name", "illustration_id"]
+
+    def test_fields_passed_to_engine_path(self) -> None:
+        self.api_resource._engine.size.return_value = 87
+        sentinel = {"cards": [], "total_cards": 0, "query": ""}
+        with patch.object(self.api_resource, "_search_engine", return_value=sentinel) as mock_engine:
+            self.api_resource._search(query="", fields=["name", "price_usd"])
+        assert mock_engine.call_args.kwargs["fields"] == ["name", "price_usd"]
+
+
 class TestEngineFeatureGate:
     """ENABLE_ENGINE gates the engine path: off (default) means the engine is inert."""
 

--- a/api/tests/test_type_conversion.py
+++ b/api/tests/test_type_conversion.py
@@ -7,6 +7,8 @@ import time
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from api.api_resource import APIResource
 from api.utils.type_conversions import make_type_converting_wrapper
 
@@ -175,6 +177,31 @@ class TestTypeConversion:
 
         assert wrapped_no_params is no_params_func
         assert wrapped_only_self is only_self_func
+
+    def test_positional_args_are_mapped_to_parameter_names(self) -> None:
+        """Path segments (e.g. /card/{set_code}/{collector_number}) arrive as positional args."""
+
+        def card(set_code: str = "", collector_number: str = "", *, falcon_response: Any = None) -> dict[str, Any]:
+            return {"set_code": set_code, "collector_number": collector_number, "falcon_response": falcon_response}
+
+        wrapped = make_type_converting_wrapper(card)
+        result = wrapped("eoc", "104", falcon_response="resp")
+        assert result == {"set_code": "eoc", "collector_number": "104", "falcon_response": "resp"}
+
+    def test_positional_args_are_type_converted(self) -> None:
+        def paged(page: int = 0, *, falcon_response: Any = None) -> int:
+            return page
+
+        wrapped = make_type_converting_wrapper(paged)
+        assert wrapped("3", falcon_response=None) == 3
+
+    def test_too_many_positional_args_raises_type_error(self) -> None:
+        def card(set_code: str = "") -> str:
+            return set_code
+
+        wrapped = make_type_converting_wrapper(card)
+        with pytest.raises(TypeError, match="takes 1 positional arguments but 2 were given"):
+            wrapped("eoc", "104")
 
     def test_string_boolean_parameters_are_converted(self) -> None:
         """Test that make_type_converting_wrapper converts string booleans to bool."""

--- a/api/utils/type_conversions.py
+++ b/api/utils/type_conversions.py
@@ -20,6 +20,11 @@ def convert_to_bool(x: str) -> bool:
     return x.lower() in ("true", "1", "yes", "on", "t")
 
 
+def convert_to_str_list(x: str) -> list[str]:
+    """Convert a comma-separated query string value into a list of strings."""
+    return [part.strip() for part in x.split(",") if part.strip()]
+
+
 def _convert_string_to_type(str_value: str | None, param_type: Any) -> Any:  # noqa: ANN401
     """Convert a string value to the specified type.
 
@@ -44,6 +49,7 @@ def _convert_string_to_type(str_value: str | None, param_type: Any) -> Any:  # n
         "float": float,
         "int": int,
         "str": identity,
+        "Sequence[str]": convert_to_str_list,
     }
     if isinstance(param_type, str):
         pass
@@ -110,8 +116,22 @@ def make_type_converting_wrapper(func: callable) -> callable:
 
         return converted_kwargs
 
-    def wrapper(**raw_kwargs: Any) -> Any:  # noqa: ANN401
+    # Positional-or-keyword parameter names, in declaration order — used to map path-segment
+    # positional args (e.g. /card/{set_code}/{collector_number}) onto their parameter names so
+    # they go through the same string-to-type conversion as query-string keyword args.
+    positional_names = [
+        name
+        for name, p in sig.parameters.items()
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+
+    def wrapper(*args: Any, **raw_kwargs: Any) -> Any:  # noqa: ANN401
         """Wrapper function that converts arguments and calls the original function."""
+        if len(args) > len(positional_names):
+            msg = f"{func.__qualname__}() takes {len(positional_names)} positional arguments but {len(args)} were given"
+            raise TypeError(msg)
+        raw_kwargs = {**dict(zip(positional_names, args, strict=False)), **raw_kwargs}
+
         # Filter out string parameters that need conversion
         str_params = {k: v for k, v in raw_kwargs.items() if isinstance(v, str)}
         non_str_params = {k: v for k, v in raw_kwargs.items() if not isinstance(v, str)}

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1226,6 +1226,8 @@ const FIELD_TABLE: &[(&str, FieldExtractor)] = &[
     ("type_line", |py, c, s| Ok(str_at(s, u32::from(c.type_line_id)).into_pyobject(py)?.into_any())),
     ("illustration_id", |py, c, _s| Ok(uuid_from_u128(u128::from(c.illustration_id)).into_pyobject(py)?.into_any())),
     ("scryfall_id", |py, c, _s| Ok(uuid_from_u128(u128::from(c.scryfall_id)).into_pyobject(py)?.into_any())),
+    ("price_usd", |py, c, _s| Ok(c.price_usd.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
+    ("prefer_score", |py, c, _s| Ok(c.prefer_score.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
     // card_subtypes is a Vec, so insertion order is already deterministic; the rest are
     // HashSets and get sorted for deterministic output.
     ("card_subtypes", |py, c, _s| {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,7 @@ brotli
 cachebox>=6.0.0
 falcon
 honeybadger
+minify-html
 orjson
 psycopg[binary,pool]
 pyparsing


### PR DESCRIPTION
## Summary

- Adds a shareable per-card page at `/card/{set_code}/{collector_number}` (`api/static/card.html` + `card.js`), rendered with the same markup/CSS as the search-results modal. The main card image links out to `manapool.com`, matching the existing modal behavior.
- The page's "Other Printings" section fetches sibling printings, groups them client-side by shared `illustration_id` (badged `+N` for collapsed count, highest-`prefer_score` printing per group chosen as the representative), and renders them as a wrapping grid sorted by each group's max `prefer_score`.
- Exposes a `fields=` query param on `/search` (e.g. `illustration_id`, `price_usd`, `prefer_score`) with matching support added to both the Rust engine (`FIELD_TABLE` in `card_engine/src/lib.rs`) and the SQL path (`RESULT_FIELD_COLUMNS`/`_resolve_result_fields` in `api/api_resource.py`), so the card page can pull exactly the fields it needs.
- Fixes two request-dispatch bugs found while building the above: `make_type_converting_wrapper` couldn't accept positional path-segment args, and the dispatcher's `path.split("/")` broke the flat `static/x` action-map keys.
- Dedupes markup identical across `index.html` and `card.html` (favicon, preconnects, font loading, critical-CSS/styles.css wrapper, footer) into `api/static/fragments/`, spliced in at build time — and fixes a real bug found in the process: `card.html`'s footer linked to `github.com/jbylund/arcane_tutor` (an old repo name) instead of `sylvan_librarian`.
- Minifies the assembled HTML (`minify-html`) before serving, on top of the existing gzip/brotli/zstd compression, for a further ~6-10% off the wire size. Gated behind `_MINIFY_HTML_ENABLED` for a one-line disable.