### PR TITLE
Combine Query Explanation and Query Result

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+.git/
+.github/
+
+# python
+.venv/
+venv/
+**/__pycache__/
+*venv*
+.pytest_cache/
+.ruff_cache/
+.coverage
+
+# rust build output (nested under card_engine/, shared_cache/, etc.)
+**/target/
+
+# node
+node_modules/
+
+# large/local data not needed in image builds
+data/
+ignored/
+gatherer_data/
+gatherer_import/
+
+# editor/tooling cruft
+.vscode/
+.cursor/
+.cursorignore
+.tmp/
+prof/
+
+# docs & misc project files not needed at build time
+docs/
+benchmarks/
+client/benchmark_results.csv
+NOTES.md
+README.md
+screenshot.webp
+
+# secrets - never send these to the daemon
+.env
+env.json
+github.pat

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -91,6 +91,7 @@ _CRITICAL_SELECTORS = frozenset(
         ".container",
         ".spacer",
         ".spacer-30",
+        ".spacer-20",
         ".header",
         ".theme-toggle",
         ".header h1",

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -1,5 +1,6 @@
 const UNIQUE_PRINTING = 'printing';
 const DWELL_MS = 2500; // milliseconds user must stay on results before adding a history entry
+const MAX_EXPLANATION_LENGTH = 140; // truncate very long query explanations (e.g. giant OR chains)
 
 // Hoisted so escapeHtml() doesn't allocate a new RegExp or callback on every call.
 const HTML_ESCAPE_RE = /[&<>"]/g;
@@ -68,7 +69,6 @@ class CardSearch {
     this.resultsContainer = document.getElementById('results');
     this.loadingIndicator = document.getElementById('loading');
     this.statusMessage = document.getElementById('statusMessage');
-    this.queryExplanation = document.getElementById('queryExplanation');
     this.orderDropdown = document.getElementById('orderDropdown');
     this.uniqueDropdown = document.getElementById('uniqueDropdown');
     this.preferDropdown = document.getElementById('preferDropdown');
@@ -562,7 +562,7 @@ class CardSearch {
     this.currentRequestUrl = url;
     this.lastCompletedUrl = null; // cleared until this search successfully completes
 
-    this.showLoading();
+    this.showLoading(normalizedQuery);
 
     try {
       // Clear any previous resource timing entries for this URL
@@ -649,12 +649,9 @@ class CardSearch {
     const queryExplanation = data.query_explanation || '';
 
     if (cards.length === 0) {
-      this.showNoResults();
+      this.showResults(totalCards, query, queryExplanation, elapsed);
       return;
     }
-
-    // Display query explanation if available
-    this.showQueryExplanation(queryExplanation);
 
     // Clear previous card data and store new cards
     this.cardsData.clear();
@@ -667,7 +664,7 @@ class CardSearch {
     console.debug('Total cards stored in cardsData:', this.cardsData.size);
     console.debug('CardsData keys:', Array.from(this.cardsData.keys()));
 
-    this.showResultsCount(totalCards, query, elapsed);
+    this.showResults(totalCards, query, queryExplanation, elapsed);
 
     // Store card count for resize handling
     this.currentCardCount = cards.length;
@@ -964,11 +961,14 @@ class CardSearch {
     }
   };
 
-  showLoading() {
+  showLoading(query) {
     console.debug('Showing loading');
     // Do not toggle card/result visibility; only update the status container
     if (this.statusMessage) {
-      this.statusMessage.innerHTML = '<div class="results-count">Loading…</div>';
+      const inner = query
+        ? `Searching <code class="raw-query">${this.escapeHtml(query)}</code>…`
+        : 'Loading…';
+      this.statusMessage.innerHTML = `<div class="results-count">${inner}</div>`;
     }
     this.clearResultsContainer();
   }
@@ -981,27 +981,38 @@ class CardSearch {
     this.clearResultsContainer();
   }
 
-  showNoResults() {
-    console.log('Showing no results');
-    if (this.statusMessage) {
-      this.statusMessage.innerHTML = '<div class="no-results">No cards found matching your search.</div>';
-    }
-    this.clearResultsContainer();
-  }
-
   clearResultsContainer() {
     this.resultsContainer.innerHTML = '';
   }
 
-  showResultsCount(count, query, elapsed) {
-    console.log(`Showing results: count: ${count}, query: ${query}, elapsed: ${elapsed}`);
+  // Truncates an overly long query explanation (e.g. a giant OR chain) at a word boundary,
+  // Scryfall-style, rather than letting the status line wrap across many lines.
+  truncateExplanation(explanation) {
+    if (explanation.length <= MAX_EXPLANATION_LENGTH) {
+      return explanation;
+    }
+    const cut = explanation.slice(0, MAX_EXPLANATION_LENGTH);
+    const lastSpace = cut.lastIndexOf(' ');
+    return `${cut.slice(0, lastSpace > 0 ? lastSpace : MAX_EXPLANATION_LENGTH)}…`;
+  }
+
+  // Renders the single status line for a completed search: result count merged with the
+  // server's human-readable explanation of the parsed query (falls back to echoing the raw
+  // query text when no explanation is available, e.g. an empty/trivial query).
+  showResults(count, query, explanation, elapsed) {
+    console.log(`Showing results: count: ${count}, query: ${query}, explanation: ${explanation}, elapsed: ${elapsed}`);
     const formattedCount = count.toLocaleString();
     const uniqueValue = this.uniqueDropdown.value;
     const itemType = uniqueValue + (count !== 1 ? 's' : '');
 
     let msg;
     if (query) {
-      msg = `Found ${formattedCount} ${itemType} matching "${query}"`;
+      const truncatedExplanation = explanation ? this.truncateExplanation(explanation) : explanation;
+      if (truncatedExplanation) {
+        msg = count === 0 ? `No ${itemType} found where ${truncatedExplanation}` : `${formattedCount} ${itemType} where ${truncatedExplanation}`;
+      } else {
+        msg = count === 0 ? `No ${itemType} found matching "${query}"` : `Found ${formattedCount} ${itemType} matching "${query}"`;
+      }
       if (typeof elapsed === 'number') {
         msg += ` (completed in ${elapsed}ms)`;
       }
@@ -1009,7 +1020,8 @@ class CardSearch {
       msg = `Showing a random selection of ${formattedCount} ${itemType}`;
     }
     if (this.statusMessage) {
-      this.statusMessage.innerHTML = `<div class="results-count">${this.escapeHtml(msg)}</div>`;
+      const cssClass = count === 0 ? 'no-results' : 'results-count';
+      this.statusMessage.innerHTML = `<div class="${cssClass}">${this.escapeHtml(msg)}</div>`;
     }
   }
 
@@ -1045,21 +1057,6 @@ class CardSearch {
     }
   }
 
-  showQueryExplanation(explanation) {
-    if (!this.queryExplanation) {
-      return;
-    }
-
-    if (explanation && explanation.trim()) {
-      // Display the explanation
-      this.queryExplanation.textContent = explanation;
-      this.queryExplanation.style.display = 'block';
-    } else {
-      // Hide the explanation if empty
-      this.queryExplanation.style.display = 'none';
-    }
-  }
-
   clearResults() {
     // Disconnect observer to clean up
     if (this.imageObserver) {
@@ -1068,10 +1065,6 @@ class CardSearch {
     this.resultsContainer.innerHTML = '';
     this.currentCardCount = 0; // Reset card count
     this.clearMessages();
-    // Clear query explanation
-    if (this.queryExplanation) {
-      this.queryExplanation.style.display = 'none';
-    }
   }
 
   clearSearch() {

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -65,7 +65,7 @@
         <p>Search for Magic: The Gathering cards</p>
       </div>
 
-      <div class="spacer spacer-30"></div>
+      <div class="spacer spacer-20"></div>
 
       <form method="GET" action="" class="search-container">
         <div class="search-box">
@@ -115,12 +115,10 @@
         </div>
       </form>
 
-      <div id="queryExplanation" class="query-explanation" style="display: none"></div>
-
-      <div class="spacer spacer-30"></div>
+      <div class="spacer spacer-20"></div>
 
       <div id="statusMessage" aria-live="polite"><!-- SERVER_SIDE_RESULTS_COUNT --></div>
-      <div class="spacer spacer-30"></div>
+      <div class="spacer spacer-20"></div>
       <div id="results" class="results-container"><!-- SERVER_SIDE_RESULTS --></div>
 
       <!-- FOOTER -->

--- a/api/static/styles.css
+++ b/api/static/styles.css
@@ -110,6 +110,10 @@ body {
   height: 30px;
 }
 
+.spacer-20 {
+  height: 20px;
+}
+
 .header {
   text-align: center;
   color: var(--color-text-inverted);
@@ -642,6 +646,7 @@ body {
   border-radius: 10px;
   text-align: center;
   margin-top: 0;
+  text-wrap: balance;
 }
 
 .no-results {
@@ -650,6 +655,7 @@ body {
   font-size: 1.38rem;
   margin-top: 0;
   opacity: 0.8;
+  text-wrap: balance;
 }
 
 /* Card page */
@@ -737,18 +743,14 @@ body {
   text-align: center;
   margin-bottom: 0;
   font-size: 1.27rem;
+  text-wrap: balance;
 }
 
-.query-explanation {
-  color: var(--color-text-secondary);
-  text-align: center;
-  margin: 0.5rem auto;
-  font-size: 1rem;
-  font-style: italic;
-  padding: 0.5rem 1rem;
-  background-color: rgba(255, 255, 255, 0.05);
+.raw-query {
+  font-family: monospace;
+  background-color: rgba(255, 255, 255, 0.08);
+  padding: 0.1rem 0.4rem;
   border-radius: 4px;
-  max-width: 90%;
 }
 
 #statusMessage {


### PR DESCRIPTION
# Combine Query Explanation and Query Result

The search results page showed the parsed-query explanation ("the name contains
fire") and the result count ("Found 311 cards matching \"fire\"") as two
separate lines, each with its own spacer. They were largely redundant — both
just restate the query — and together with the header/search-box spacing they
pushed the actual card grid further down the page than it needed to be.

## What changed

**Single status line** (`api/static/app.js`) — `showResultsCount`,
`showNoResults`, and `showQueryExplanation` are replaced by one `showResults`
method that renders a single message for every state:

- Results: `311 cards where the name contains fire`
- No results: `No cards found where the name contains fire`
- Random browse (no query): `Showing a random selection of 12 cards`
- No explanation available (e.g. trivial query): falls back to the old
  `Found 1,500 cards matching "*"` phrasing

`showLoading` now takes the in-flight query and echoes it verbatim in
monospace (`Searching t:beast power=4…`), since the server-side explanation
for the *new* query isn't available until the request resolves — showing the
*previous* query's explanation during loading would be misleading.

**Truncation for long explanations** — queries with many clauses (giant `OR`
chains, etc.) can produce explanations hundreds of characters long. These are
now truncated at a word boundary to 140 characters with a trailing `…`,
Scryfall-style, so the message stays readable and the result count is never
pushed out of view.

**Balanced wrapping** (`api/static/styles.css`) — added `text-wrap: balance`
to `.results-count`, `.no-results`, and `.error-message` so that when a
message does wrap to two lines, the lines are close to equal width instead of
leaving a short orphaned fragment (e.g. `...riverpyre…`) dangling alone on the
second line.

**Tighter vertical spacing** (`api/static/index.html`, `api/static/styles.css`,
`api/api_resource.py`) — the query-explanation `<div>` and its spacer are
removed entirely, and the three remaining spacers on the homepage
(header→search box, search box→status line, status line→results) are reduced
from 30px to 20px via a new `.spacer-20` class. This is a separate class
rather than changing `.spacer-30` in place because `.spacer-30` is also used
on the per-card page (`card.html`), which isn't part of this change.
`.spacer-20` is added to `_CRITICAL_SELECTORS` in `api_resource.py` so it's
included in the inlined above-the-fold CSS and doesn't cause a layout shift.

**Also included:** a `.dockerignore` (unrelated to the above) that excludes
`target/`, virtualenvs, `node_modules/`, local data directories, and other
build-irrelevant files from the Docker build context.

## Known pre-existing issue (not touched by this PR)

The no-JS SSR path in `api_resource.py` tries to inject the results count
into a `<div id="resultsCount">`, but no element with that id exists in
`index.html` (the status line's id is `statusMessage`) — so the
server-rendered count silently never appears for users without JS. This bug
predates this PR and isn't fixed here.

## Test plan

- [x] `npx jest api/static/app.test.js` — passes (5 pre-existing failures in
      unrelated `CatalogMap` tests, present before and after this change)
- [x] `python -m ruff check` / `npx prettier --check` — clean
- [x] Manually verified every status state (results, no-results, random
      browse, loading, error, truncated long-query) in a real browser at
      1920px and 1370px viewports
- [x] Verified locally that `_build_critical_css()` includes the new
      `.spacer-20` rule
