### PR TITLE
Fix false CI-failure noise from GitHub's dependency graph submission

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,4 @@
+-r base.txt
+-r webserver.txt
+-r test.txt
+-r fonts.txt


### PR DESCRIPTION
## Summary
- Root cause of #577 (and likely most other spurious `ci-monitor` issues): GitHub's automatic Dependency Graph submission job for pip only recognizes manifest filenames matching `requirements*.txt`/`require*.txt`/`depend*.txt`. This repo splits deps into `base.txt`, `webserver.txt`, `test.txt`, `fonts.txt`, none of which match, so the grapher has failed with `No supported dependency file present` on every push.
- `scripts/ci_monitor.py` treats *any* workflow failure (including this GitHub-native, code-unrelated check) as a CI failure, which is why the auto-filed issues' remediation steps (`ruff check --fix`, `pytest`) never actually apply — there's nothing in the code to fix.
- Adds `requirements/requirements.txt`, a thin aggregator (`-r base.txt`, `-r webserver.txt`, `-r test.txt`, `-r fonts.txt`) so the grapher finds an exact-name match. No Dockerfile or workflow references change.

## Test plan
- [x] `pip install --dry-run -r requirements/requirements.txt` resolves cleanly
- [x] Confirmed the filename satisfies dependabot-core's `Python::DependencyGrapher#pip_requirements_file` exact-match check (`file.name == "requirements.txt"`)
- [ ] Confirm the "Dependency Graph" check goes green on this branch/after merge to main

Closes #577