### PR TITLE
Fix Server-Side Results Count Injection Targeting Stale Div ID

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1589,11 +1589,11 @@ class APIResource:
                     results_html,
                 )
 
-                # Inject the results count with proper display style
+                # Inject the results count into the status message container
                 if results_count_html:
                     html_content = html_content.replace(
-                        '<div id="resultsCount" class="results-count" style="display: none"><!-- SERVER_SIDE_RESULTS_COUNT --></div>',
-                        f'<div id="resultsCount" class="results-count" style="display: block">{results_count_html}</div>',
+                        "<!-- SERVER_SIDE_RESULTS_COUNT -->",
+                        f'<div class="results-count">{results_count_html}</div>',
                     )
 
                 # Convert search results to JSON and embed for JavaScript enhancement

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -477,6 +477,30 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         # Verify it sets appropriate cache control header (shorter for search results)
         mock_response.set_header.assert_called_with("Cache-Control", "public, max-age=90")
 
+    def test_index_html_with_query_embeds_results_count_in_status_message(self) -> None:
+        """Test _root injects the results count into the #statusMessage container.
+
+        Regression test: the injection code used to target a stale `id="resultsCount"` div that
+        no longer exists in the template (which uses `id="statusMessage"`), so the count never
+        rendered for no-JS clients.
+        """
+        mock_response = MagicMock()
+
+        mock_search_results = {
+            "cards": [{"name": "Elvish Mystic", "set_code": "m14", "collector_number": "1"}],
+            "total_cards": 1,
+            "query": "elf",
+        }
+
+        with patch.object(self.api_resource, "_search", return_value=mock_search_results):
+            self.api_resource._root(falcon_response=mock_response, q="elf")
+
+        # HTML is minified before serving, which drops attribute quotes and unescapes quotes that
+        # are safe in text content (see test_index_html_serves_static_file).
+        assert "id=statusMessage" in mock_response.text
+        assert "<!-- SERVER_SIDE_RESULTS_COUNT -->" not in mock_response.text
+        assert 'Found 1 card matching "elf"' in mock_response.text
+
     def test_favicon_ico_serves_binary_content(self) -> None:
         """Test favicon_ico serves binary content correctly."""
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary
- The `_root()` results-count injection targeted a stale `id="resultsCount"` div with a `display: none/block` toggle, but the template's status container has been `id="statusMessage"` with no such div — the `.replace()` silently no-op'd, so the count never rendered for no-JS clients.
- Target the actual `<!-- SERVER_SIDE_RESULTS_COUNT -->` placeholder comment instead, matching the markup `app.js` already produces client-side.

Fixes #575.

## Test plan
- [x] Added `test_index_html_with_query_embeds_results_count_in_status_message`, which fails against the old code and passes with the fix.
- [x] `python -m pytest api/tests/test_api_resource.py -q` (66 passed)