### PR TITLE
Add npm Dependencies to Copilot Setup and JS Tests to Instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,7 @@ make test              # full test suite (~1,900 tests); integration tests need 
 make test-unit         # unit tests only, no Docker (runs in seconds)
 make test-integration  # testcontainers-based integration tests (real PostgreSQL)
 python -m pytest -vvv -k "test_name"          # single test by name
+npx jest               # JS tests (jest + jsdom; frontend code in api/static/)
 make lint              # ruff (Python) + prettier (HTML/JS)
 make coverage          # HTML coverage report
 make dev-up            # start dev services via Docker Compose

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,6 +39,15 @@ jobs:
           python -m pip install --upgrade pip uv
           uv pip install --system --break-system-packages -r requirements/base.txt -r requirements/test.txt -r requirements/webserver.txt
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: 'npm'
+
+      - name: Install npm dependencies (jest, prettier)
+        run: npm ci
+
       - name: Cache card_engine wheel
         id: ce-cache
         uses: actions/cache@v5


### PR DESCRIPTION
Follow-up to #591, pairing with #592: the Copilot agent environment pre-installs Python and Rust dependencies but not npm ones, so an agent working on the frontend would have to install jest itself. This adds setup-node (Node 26, npm cache) + `npm ci` to `copilot-setup-steps.yml`, and mentions `npx jest` in the Build/Test section of the instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)