### PR TITLE
Vocab-Intern Engine Collection Fields (Keywords, Subtypes, Tags, Frame Data)

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -276,6 +276,12 @@ pub(crate) enum FilterExpr {
         field: CollField,
         op: CmpOp,
         value: String,
+        /// `value` resolved to its vocab id by bind_collection_ids(), which the
+        /// query entry points call once per query before matching; None means
+        /// absent from the vocab (matches no element). Matching compares ids
+        /// only — never strings — so an unbound filter behaves as if the value
+        /// were unknown.
+        value_id: Option<u16>,
     },
 
     Legality {
@@ -306,8 +312,31 @@ pub(crate) enum FilterExpr {
 }
 
 impl FilterExpr {
-    pub(crate) fn matches(&self, card: &ACard, strings: &AStrings, vocab: &AStrings) -> bool {
-        self.tri(card, strings, vocab) == Some(true)
+    /// Resolve every CollectionCmp value to its vocab id (via the string-sorted
+    /// permutation of the vocab table — ~14 string compares per collection term).
+    /// Called once per query so matching never touches strings; a value absent
+    /// from the vocab resolves to None and can match no element.
+    pub(crate) fn bind_collection_ids(&mut self, vocab: &AStrings, sorted_ids: &rkyv::Archived<Vec<u16>>) {
+        match self {
+            FilterExpr::And(children) | FilterExpr::Or(children) => {
+                for c in children {
+                    c.bind_collection_ids(vocab, sorted_ids);
+                }
+            }
+            FilterExpr::Not(inner) => inner.bind_collection_ids(vocab, sorted_ids),
+            FilterExpr::CollectionCmp { value, value_id, .. } => {
+                let i = sorted_ids.partition_point(|id| vocab[u16::from(*id) as usize].as_str() < value.as_str());
+                *value_id = sorted_ids
+                    .get(i)
+                    .map(|id| u16::from(*id))
+                    .filter(|&id| vocab[id as usize].as_str() == value.as_str());
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn matches(&self, card: &ACard, strings: &AStrings) -> bool {
+        self.tri(card, strings) == Some(true)
     }
 
     /// Three-valued evaluation mirroring SQL: None is SQL's NULL ("unknown"),
@@ -317,14 +346,14 @@ impl FilterExpr {
     /// filters only match cards that have the attribute", while
     /// -(power>2 and t:creature) still matches instants (NULL AND false =
     /// false, NOT false = true). Only Some(true) counts as a match.
-    fn tri(&self, card: &ACard, strings: &AStrings, vocab: &AStrings) -> Option<bool> {
+    fn tri(&self, card: &ACard, strings: &AStrings) -> Option<bool> {
         match self {
             FilterExpr::True => Some(true),
 
             FilterExpr::And(children) => {
                 let mut unknown = false;
                 for c in children {
-                    match c.tri(card, strings, vocab) {
+                    match c.tri(card, strings) {
                         Some(false) => return Some(false),
                         None => unknown = true,
                         Some(true) => {}
@@ -335,7 +364,7 @@ impl FilterExpr {
             FilterExpr::Or(children) => {
                 let mut unknown = false;
                 for c in children {
-                    match c.tri(card, strings, vocab) {
+                    match c.tri(card, strings) {
                         Some(true) => return Some(true),
                         None => unknown = true,
                         Some(false) => {}
@@ -343,7 +372,7 @@ impl FilterExpr {
                 }
                 if unknown { None } else { Some(false) }
             }
-            FilterExpr::Not(inner) => inner.tri(card, strings, vocab).map(|b| !b),
+            FilterExpr::Not(inner) => inner.tri(card, strings).map(|b| !b),
 
             FilterExpr::ExactName(lower) => Some(card.card_name_lower.as_str() == lower.as_str()),
 
@@ -397,21 +426,33 @@ impl FilterExpr {
                 })
             }
 
-            FilterExpr::CollectionCmp { field, op, value } => {
+            FilterExpr::CollectionCmp { field, op, value_id, .. } => {
                 // Set-containment semantics against the single-value query {value},
                 // mirroring the SQL path's jsonb operators (@>, <@, =, <> and the
                 // strict variants). Lt (proper subset of a one-element set) can only
                 // be the empty collection; Ne is not-exactly-equal, NOT "lacks value"
                 // (that's what negation is for).
+                //
+                // Ids only: bind_collection_ids() resolved the value up front, and
+                // vocab ids are unique per string, so id equality is string equality.
                 let coll = card_collection(card, *field);
-                let elem = |id: &rkyv::rend::u16_le| vocab[u16::from(*id) as usize].as_str();
-                let contains = || coll.iter().any(|id| elem(id) == value.as_str());
+                let contains = || match (*value_id, *field) {
+                    (None, _) => false,
+                    // card_subtypes keeps the printed order, so it is not id-sorted.
+                    (Some(id), CollField::Subtypes) => coll.iter().any(|x| u16::from(*x) == id),
+                    // The set-like collections are sorted by id at load.
+                    (Some(id), _) => coll.binary_search(&id.into()).is_ok(),
+                };
+                let all_equal = || match *value_id {
+                    None => coll.is_empty(),
+                    Some(id) => coll.iter().all(|x| u16::from(*x) == id),
+                };
                 Some(match op {
                     CmpOp::Ge => contains(),
                     CmpOp::Eq => coll.len() == 1 && contains(),
                     CmpOp::Gt => contains() && coll.len() > 1,
-                    CmpOp::Le => coll.iter().all(|id| elem(id) == value.as_str()),
-                    CmpOp::Lt => coll.len() == 0,
+                    CmpOp::Le => all_equal(),
+                    CmpOp::Lt => coll.is_empty(),
                     CmpOp::Ne => !(coll.len() == 1 && contains()),
                 })
             }
@@ -790,13 +831,13 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
 
     if attr == "card_subtypes" {
         let value = rhs.as_array().and_then(|a| a.first()).and_then(|v| v.as_str()).unwrap_or("").to_string();
-        return Ok(FilterExpr::CollectionCmp { field: CollField::Subtypes, op: op_to_collection_cmp(op), value });
+        return Ok(FilterExpr::CollectionCmp { field: CollField::Subtypes, op: op_to_collection_cmp(op), value, value_id: None });
     }
 
     if attr == "card_keywords" {
         let value  = rhs.as_array().and_then(|a| a.first()).and_then(|v| v.as_str()).unwrap_or("").to_string();
         let cmp_op = op_to_collection_cmp(op);
-        return Ok(FilterExpr::CollectionCmp { field: CollField::Keywords, op: cmp_op, value });
+        return Ok(FilterExpr::CollectionCmp { field: CollField::Keywords, op: cmp_op, value, value_id: None });
     }
 
     if matches!(attr, "card_oracle_tags" | "card_art_tags" | "card_is_tags" | "card_frame_data") {
@@ -808,7 +849,7 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
         };
         let value  = rhs.as_array().and_then(|a| a.first()).and_then(|v| v.as_str()).unwrap_or("").to_string();
         let cmp_op = op_to_collection_cmp(op);
-        return Ok(FilterExpr::CollectionCmp { field: coll_field, op: cmp_op, value });
+        return Ok(FilterExpr::CollectionCmp { field: coll_field, op: cmp_op, value, value_id: None });
     }
 
     build_text_filter(attr, op, rhs)

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -160,40 +160,16 @@ impl CollField {
     }
 }
 
-fn card_collection<'a>(card: &'a ACard, f: CollField) -> CollRef<'a> {
+/// Collections are interned vocab ids (see VocabInterner); resolving an element
+/// for comparison is an index into the archived coll_vocab table.
+fn card_collection<'a>(card: &'a ACard, f: CollField) -> &'a rkyv::vec::ArchivedVec<rkyv::rend::u16_le> {
     match f {
-        CollField::Subtypes   => CollRef::List(&card.card_subtypes),
-        CollField::Keywords   => CollRef::Set(&card.card_keywords),
-        CollField::OracleTags => CollRef::Set(&card.card_oracle_tags),
-        CollField::ArtTags    => CollRef::Set(&card.card_art_tags),
-        CollField::IsTags     => CollRef::Set(&card.card_is_tags),
-        CollField::FrameData  => CollRef::Set(&card.card_frame_data),
-    }
-}
-
-enum CollRef<'a> {
-    List(&'a rkyv::vec::ArchivedVec<rkyv::string::ArchivedString>),
-    Set(&'a rkyv::collections::swiss_table::ArchivedHashSet<rkyv::string::ArchivedString>),
-}
-
-impl CollRef<'_> {
-    fn contains(&self, v: &str) -> bool {
-        match self {
-            CollRef::List(l) => l.iter().any(|s| s.as_str() == v),
-            CollRef::Set(s)  => s.contains(v),
-        }
-    }
-    fn len(&self) -> usize {
-        match self {
-            CollRef::List(l) => l.len(),
-            CollRef::Set(s)  => s.len(),
-        }
-    }
-    fn all_equal(&self, v: &str) -> bool {
-        match self {
-            CollRef::List(l) => l.iter().all(|s| s.as_str() == v),
-            CollRef::Set(s)  => s.iter().all(|s| s.as_str() == v),
-        }
+        CollField::Subtypes   => &card.card_subtypes,
+        CollField::Keywords   => &card.card_keywords,
+        CollField::OracleTags => &card.card_oracle_tags,
+        CollField::ArtTags    => &card.card_art_tags,
+        CollField::IsTags     => &card.card_is_tags,
+        CollField::FrameData  => &card.card_frame_data,
     }
 }
 
@@ -330,8 +306,8 @@ pub(crate) enum FilterExpr {
 }
 
 impl FilterExpr {
-    pub(crate) fn matches(&self, card: &ACard, strings: &AStrings) -> bool {
-        self.tri(card, strings) == Some(true)
+    pub(crate) fn matches(&self, card: &ACard, strings: &AStrings, vocab: &AStrings) -> bool {
+        self.tri(card, strings, vocab) == Some(true)
     }
 
     /// Three-valued evaluation mirroring SQL: None is SQL's NULL ("unknown"),
@@ -341,14 +317,14 @@ impl FilterExpr {
     /// filters only match cards that have the attribute", while
     /// -(power>2 and t:creature) still matches instants (NULL AND false =
     /// false, NOT false = true). Only Some(true) counts as a match.
-    fn tri(&self, card: &ACard, strings: &AStrings) -> Option<bool> {
+    fn tri(&self, card: &ACard, strings: &AStrings, vocab: &AStrings) -> Option<bool> {
         match self {
             FilterExpr::True => Some(true),
 
             FilterExpr::And(children) => {
                 let mut unknown = false;
                 for c in children {
-                    match c.tri(card, strings) {
+                    match c.tri(card, strings, vocab) {
                         Some(false) => return Some(false),
                         None => unknown = true,
                         Some(true) => {}
@@ -359,7 +335,7 @@ impl FilterExpr {
             FilterExpr::Or(children) => {
                 let mut unknown = false;
                 for c in children {
-                    match c.tri(card, strings) {
+                    match c.tri(card, strings, vocab) {
                         Some(true) => return Some(true),
                         None => unknown = true,
                         Some(false) => {}
@@ -367,7 +343,7 @@ impl FilterExpr {
                 }
                 if unknown { None } else { Some(false) }
             }
-            FilterExpr::Not(inner) => inner.tri(card, strings).map(|b| !b),
+            FilterExpr::Not(inner) => inner.tri(card, strings, vocab).map(|b| !b),
 
             FilterExpr::ExactName(lower) => Some(card.card_name_lower.as_str() == lower.as_str()),
 
@@ -428,13 +404,15 @@ impl FilterExpr {
                 // be the empty collection; Ne is not-exactly-equal, NOT "lacks value"
                 // (that's what negation is for).
                 let coll = card_collection(card, *field);
+                let elem = |id: &rkyv::rend::u16_le| vocab[u16::from(*id) as usize].as_str();
+                let contains = || coll.iter().any(|id| elem(id) == value.as_str());
                 Some(match op {
-                    CmpOp::Ge => coll.contains(value),
-                    CmpOp::Eq => coll.len() == 1 && coll.contains(value),
-                    CmpOp::Gt => coll.contains(value) && coll.len() > 1,
-                    CmpOp::Le => coll.all_equal(value),
+                    CmpOp::Ge => contains(),
+                    CmpOp::Eq => coll.len() == 1 && contains(),
+                    CmpOp::Gt => contains() && coll.len() > 1,
+                    CmpOp::Le => coll.iter().all(|id| elem(id) == value.as_str()),
                     CmpOp::Lt => coll.len() == 0,
-                    CmpOp::Ne => !(coll.len() == 1 && coll.contains(value)),
+                    CmpOp::Ne => !(coll.len() == 1 && contains()),
                 })
             }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -204,13 +204,19 @@ struct Card {
     prefer_score: Option<f32>,
     cubecobra_score: Option<f32>,
 
-    card_subtypes: Vec<String>,
-    card_keywords: HashSet<String>,
+    // Collection elements interned as u16 ids into CardData.coll_vocab (separate
+    // from the u32-id strings table: the combined collection vocabulary is ~16k
+    // distinct values vs 65,536 addressable, while strings holds >65k entries —
+    // see docs/issues/engine-collection-vocab-interning.md). card_subtypes
+    // preserves the printed order; the set-like collections are sorted by id and
+    // deduped at load.
+    card_subtypes: Vec<u16>,
+    card_keywords: Vec<u16>,
     card_legalities: u64, // 2 bits per format, positions from the FORMAT_SHIFTS registry
-    card_oracle_tags: HashSet<String>,
-    card_art_tags: HashSet<String>,
-    card_is_tags: HashSet<String>,
-    card_frame_data: HashSet<String>,
+    card_oracle_tags: Vec<u16>,
+    card_art_tags: Vec<u16>,
+    card_is_tags: Vec<u16>,
+    card_frame_data: Vec<u16>,
 
     mana_cost: ManaCost,
 
@@ -260,6 +266,35 @@ impl Interner {
             Some(v) => self.intern(v),
             None => NONE_STR,
         }
+    }
+}
+
+/// Build-time interner for collection elements (subtypes, keywords, tags, frame
+/// data); `strings` becomes CardData.coll_vocab. Ids are u16 — the combined
+/// vocabulary is ~16k distinct values, so 65,536 leaves ~4× headroom; interning
+/// fails loudly rather than silently truncating if that is ever exceeded.
+struct VocabInterner {
+    map: HashMap<String, u16>,
+    strings: Vec<String>,
+}
+
+impl VocabInterner {
+    fn new() -> Self {
+        VocabInterner { map: HashMap::new(), strings: Vec::new() }
+    }
+
+    fn intern(&mut self, s: String) -> PyResult<u16> {
+        if let Some(&id) = self.map.get(&s) {
+            return Ok(id);
+        }
+        let id = u16::try_from(self.strings.len()).map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err(
+                "collection vocabulary exceeded u16::MAX distinct values; widen Card's collection ids to u32",
+            )
+        })?;
+        self.strings.push(s.clone());
+        self.map.insert(s, id);
+        Ok(id)
     }
 }
 
@@ -393,16 +428,33 @@ fn jsonb_color_to_bits(d: &Bound<PyDict>, key: &str) -> u8 {
     color_list_to_mask(&colors.iter().map(|s| s.as_str()).collect::<Vec<_>>())
 }
 
-fn jsonb_obj_to_hashset(d: &Bound<PyDict>, key: &str) -> HashSet<String> {
-    d.get_item(key)
+/// Interned vocab ids of a JSON list of strings, preserving element order
+/// (card_subtypes keeps the printed subtype order).
+fn str_list_to_ids(d: &Bound<PyDict>, key: &str, vocab: &mut VocabInterner) -> PyResult<Vec<u16>> {
+    str_list(d, key).into_iter().map(|s| vocab.intern(s)).collect()
+}
+
+/// Interned vocab ids of a JSONB object's keys, sorted and deduped — the set-like
+/// collections (keywords, tags, frame data) as sorted `Vec<u16>`.
+fn jsonb_obj_to_ids(d: &Bound<PyDict>, key: &str, vocab: &mut VocabInterner) -> PyResult<Vec<u16>> {
+    let mut ids: Vec<u16> = d
+        .get_item(key)
         .ok()
         .flatten()
         .and_then(|v| {
-            v.cast::<PyDict>()
-                .ok()
-                .map(|m| m.keys().iter().filter_map(|k| k.extract::<String>().ok()).collect())
+            v.cast::<PyDict>().ok().map(|m| {
+                m.keys()
+                    .iter()
+                    .filter_map(|k| k.extract::<String>().ok())
+                    .map(|s| vocab.intern(s))
+                    .collect::<PyResult<Vec<u16>>>()
+            })
         })
-        .unwrap_or_default()
+        .transpose()?
+        .unwrap_or_default();
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(ids)
 }
 
 // ─── Format legality bitmap ──────────────────────────────────────────────────
@@ -448,7 +500,7 @@ fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>) -> ManaCost {
     ManaCost { pips, devotion, cmc: cmc_val.unwrap_or(0.0) }
 }
 
-fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner) -> Card {
+fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInterner) -> PyResult<Card> {
     let released_at = opt_date_str(d, "released_at").unwrap_or_default();
     let released_at_int: Option<u32> = released_at.replace('-', "").parse().ok();
     // Raw strings from the dict; interned to ids as the struct is built below.
@@ -461,7 +513,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner) -> Card {
     let card_artist = opt_str(d, "card_artist");
     let card_artist_lower_id = it.intern_opt(card_artist.as_ref().map(|s| s.to_lowercase()));
 
-    Card {
+    Ok(Card {
         scryfall_id: opt_uuid(d, "scryfall_id"),
         oracle_id: opt_uuid(d, "oracle_id"),
         illustration_id: opt_uuid(d, "illustration_id"),
@@ -502,19 +554,19 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner) -> Card {
         cubecobra_score: opt_f32(d, "cubecobra_score"),
 
         card_types: card_types_list_to_bits(&str_list(d, "card_types")),
-        card_subtypes: str_list(d, "card_subtypes"),
-        card_keywords: jsonb_obj_to_hashset(d, "card_keywords"),
+        card_subtypes: str_list_to_ids(d, "card_subtypes", vocab)?,
+        card_keywords: jsonb_obj_to_ids(d, "card_keywords", vocab)?,
         card_legalities: jsonb_obj_to_legality_bits(d, "card_legalities"),
-        card_oracle_tags: jsonb_obj_to_hashset(d, "card_oracle_tags"),
-        card_art_tags: jsonb_obj_to_hashset(d, "card_art_tags"),
-        card_is_tags: jsonb_obj_to_hashset(d, "card_is_tags"),
-        card_frame_data: jsonb_obj_to_hashset(d, "card_frame_data"),
+        card_oracle_tags: jsonb_obj_to_ids(d, "card_oracle_tags", vocab)?,
+        card_art_tags: jsonb_obj_to_ids(d, "card_art_tags", vocab)?,
+        card_is_tags: jsonb_obj_to_ids(d, "card_is_tags", vocab)?,
+        card_frame_data: jsonb_obj_to_ids(d, "card_frame_data", vocab)?,
 
         mana_cost: mana_cost_from_pydict(d, opt_f32(d, "cmc")),
 
         creature_power_text_id: it.intern_opt(opt_str(d, "creature_power_text")),
         creature_toughness_text_id: it.intern_opt(opt_str(d, "creature_toughness_text")),
-    }
+    })
 }
 
 // ─── Filter expression & builder ─────────────────────────────────────────────
@@ -757,14 +809,20 @@ fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Opti
 
 type TagIndex = HashMap<String, Vec<u32>>;
 
-fn build_tag_index(cards: &[Card], get_tags: impl Fn(&Card) -> &HashSet<String>) -> TagIndex {
-    let mut idx: TagIndex = HashMap::new();
+/// Build a tag/list index from interned collection ids. Accumulates postings by
+/// vocab id in the hot loop (integer keys, no per-element string hashing), then
+/// resolves each id to its owned String key once at the end.
+fn build_tag_index(cards: &[Card], vocab: &[String], get_ids: impl Fn(&Card) -> &Vec<u16>) -> TagIndex {
+    let mut by_id: HashMap<u16, Vec<u32>> = HashMap::new();
     for (i, card) in cards.iter().enumerate() {
-        for tag in get_tags(card) {
-            idx.entry(tag.clone()).or_default().push(i as u32);
+        for &id in get_ids(card) {
+            by_id.entry(id).or_default().push(i as u32);
         }
     }
-    idx
+    by_id
+        .into_iter()
+        .map(|(id, postings)| (vocab[id as usize].clone(), postings))
+        .collect()
 }
 
 // ─── Type bit index ───────────────────────────────────────────────────────────
@@ -784,16 +842,6 @@ fn build_type_index(cards: &[Card]) -> TypeIndex {
         }
     }
     idx // lists are sorted: cards iterated in ascending index order
-}
-
-fn build_list_index(cards: &[Card], get_list: impl Fn(&Card) -> &Vec<String>) -> TagIndex {
-    let mut idx: TagIndex = HashMap::new();
-    for (i, card) in cards.iter().enumerate() {
-        for item in get_list(card) {
-            idx.entry(item.clone()).or_default().push(i as u32);
-        }
-    }
-    idx
 }
 
 // ─── Combined indexes ────────────────────────────────────────────────────────
@@ -836,6 +884,9 @@ struct CardData {
     cards:   Vec<Card>,
     // Hash-consed table for the interned-string fields on Card (see Interner).
     strings: Vec<String>,
+    // Vocab table for Card's collection fields, indexed by their u16 ids
+    // (see VocabInterner). ~16k entries / ~200 KB.
+    coll_vocab: Vec<String>,
     indexes: CardIndexes,
     // The writer's format→shift assignments. Persisted so reader processes —
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
@@ -1052,6 +1103,7 @@ fn select_page<'a>(mut v: Vec<(u128, &'a ACard)>, offset: usize, limit: usize) -
 fn run_query_hashmap<'a>(
     store: &'a [ACard],
     strings: &AStrings,
+    vocab: &AStrings,
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1073,7 +1125,7 @@ fn run_query_hashmap<'a>(
 
     let mut partitions: HashMap<u128, (&ACard, f64)> = HashMap::new();
     for card in store {
-        if filter.matches(card, strings) {
+        if filter.matches(card, strings, vocab) {
             let key = match group_by {
                 GroupBy::Oracle   => u128::from(card.oracle_id),
                 GroupBy::Artwork  => u128::from(card.illustration_id),
@@ -1097,6 +1149,7 @@ fn run_query_hashmap<'a>(
 fn run_query_linear<'a, I, F>(
     cards: I,
     strings: &AStrings,
+    vocab: &AStrings,
     filter: &FilterExpr,
     key_fn: F,
     prefer: &str,
@@ -1118,7 +1171,7 @@ where
     let mut prev_key: Option<u128> = None; // None = before the first match
 
     for card in cards {
-        if !filter.matches(card, strings) { continue; }
+        if !filter.matches(card, strings, vocab) { continue; }
         let key = key_fn(card);
         if prev_key != Some(key) {
             if let Some((c, _)) = group_best.take() { best.push((sort_key_bits(c, sort_col, descending), c)); }
@@ -1140,6 +1193,7 @@ where
 fn run_query_no_dedup<'a>(
     cards: impl Iterator<Item = &'a ACard>,
     strings: &AStrings,
+    vocab: &AStrings,
     filter: &FilterExpr,
     orderby: &str,
     direction: &str,
@@ -1149,7 +1203,7 @@ fn run_query_no_dedup<'a>(
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let matched: Vec<(u128, &ACard)> = cards
-        .filter(|c| filter.matches(c, strings))
+        .filter(|c| filter.matches(c, strings, vocab))
         .map(|c| (sort_key_bits(c, sort_col, descending), c))
         .collect();
     let total = matched.len();
@@ -1160,6 +1214,7 @@ fn run_query<'a, B>(
     store: &'a [ACard],
     preferred_indices: &[B],
     strings: &AStrings,
+    vocab: &AStrings,
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1186,11 +1241,11 @@ where
         return match candidates {
             Some(existing) => {
                 let fast = intersect_sorted(&existing, preferred_indices);
-                run_query_no_dedup(fast.into_iter().map(|i| &store[i as usize]), strings, filter, orderby, direction, limit, offset)
+                run_query_no_dedup(fast.into_iter().map(|i| &store[i as usize]), strings, vocab, filter, orderby, direction, limit, offset)
             }
             None => run_query_no_dedup(
                 preferred_indices.iter().map(|&i| &store[u32::from(i) as usize]),
-                strings, filter, orderby, direction, limit, offset,
+                strings, vocab, filter, orderby, direction, limit, offset,
             ),
         };
     }
@@ -1208,13 +1263,13 @@ where
         // The store is sorted by (oracle_id, illustration_id), so equal keys are adjacent
         // and the linear key-change dedup is exact — u128 equality, same cost as the
         // dense u32 group ids this replaced.
-        "card" => run_query_linear(cards_iter!(), strings, filter, |c| u128::from(c.oracle_id), prefer, orderby, direction, limit, offset),
+        "card" => run_query_linear(cards_iter!(), strings, vocab, filter, |c| u128::from(c.oracle_id), prefer, orderby, direction, limit, offset),
         // Scryfall assigns each illustration_id to exactly one oracle_id, so cards sharing an
         // illustration_id are always contiguous in the (oracle_id, illustration_id) sort order.
         // The linear dedup path is therefore correct here — no HashMap needed.
-        "artwork"  => run_query_linear(cards_iter!(), strings, filter, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
-        "printing" => run_query_no_dedup(cards_iter!(), strings, filter, orderby, direction, limit, offset),
-        _          => run_query_hashmap(store, strings, filter, unique, prefer, orderby, direction, limit, offset),
+        "artwork"  => run_query_linear(cards_iter!(), strings, vocab, filter, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
+        "printing" => run_query_no_dedup(cards_iter!(), strings, vocab, filter, orderby, direction, limit, offset),
+        _          => run_query_hashmap(store, strings, vocab, filter, unique, prefer, orderby, direction, limit, offset),
     }
 }
 
@@ -1224,38 +1279,46 @@ where
 // `fields` list is validated and deduped against this same table by resolve_fields(). There is
 // no separate hardcoded path for "the old fields" vs. "the new fields" — everything is an entry
 // in FIELD_TABLE.
-type FieldExtractor = for<'a> fn(Python<'a>, &'a ACard, &'a AStrings) -> PyResult<Bound<'a, PyAny>>;
+type FieldExtractor = for<'a> fn(Python<'a>, &'a ACard, &'a AStrings, &'a AStrings) -> PyResult<Bound<'a, PyAny>>;
 
 const FIELD_TABLE: &[(&str, FieldExtractor)] = &[
-    ("name", |py, c, s| Ok(str_at(s, u32::from(c.card_name_id)).into_pyobject(py)?.into_any())),
-    ("set_code", |py, c, _s| Ok(c.card_set_code.as_str().into_pyobject(py)?.into_any())),
-    ("collector_number", |py, c, s| Ok(str_at(s, u32::from(c.collector_number_id)).into_pyobject(py)?.into_any())),
-    ("power", |py, c, s| Ok(str_at(s, u32::from(c.creature_power_text_id)).into_pyobject(py)?.into_any())),
-    ("toughness", |py, c, s| Ok(str_at(s, u32::from(c.creature_toughness_text_id)).into_pyobject(py)?.into_any())),
-    ("mana_cost", |py, c, s| Ok(str_at(s, u32::from(c.mana_cost_text_id)).into_pyobject(py)?.into_any())),
-    ("oracle_text", |py, c, s| Ok(str_at(s, u32::from(c.oracle_text_id)).into_pyobject(py)?.into_any())),
-    ("set_name", |py, c, s| Ok(str_at(s, u32::from(c.set_name_id)).into_pyobject(py)?.into_any())),
-    ("type_line", |py, c, s| Ok(str_at(s, u32::from(c.type_line_id)).into_pyobject(py)?.into_any())),
-    ("illustration_id", |py, c, _s| Ok(uuid_from_u128(u128::from(c.illustration_id)).into_pyobject(py)?.into_any())),
-    ("scryfall_id", |py, c, _s| Ok(uuid_from_u128(u128::from(c.scryfall_id)).into_pyobject(py)?.into_any())),
-    ("price_usd", |py, c, _s| Ok(c.price_usd.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
-    ("prefer_score", |py, c, _s| Ok(c.prefer_score.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
-    // card_subtypes is a Vec, so insertion order is already deterministic; the rest are
-    // HashSets and get sorted for deterministic output.
-    ("card_subtypes", |py, c, _s| {
-        let items: Vec<&str> = c.card_subtypes.iter().map(|v| v.as_str()).collect();
+    ("name", |py, c, s, _v| Ok(str_at(s, u32::from(c.card_name_id)).into_pyobject(py)?.into_any())),
+    ("set_code", |py, c, _s, _v| Ok(c.card_set_code.as_str().into_pyobject(py)?.into_any())),
+    ("collector_number", |py, c, s, _v| Ok(str_at(s, u32::from(c.collector_number_id)).into_pyobject(py)?.into_any())),
+    ("power", |py, c, s, _v| Ok(str_at(s, u32::from(c.creature_power_text_id)).into_pyobject(py)?.into_any())),
+    ("toughness", |py, c, s, _v| Ok(str_at(s, u32::from(c.creature_toughness_text_id)).into_pyobject(py)?.into_any())),
+    ("mana_cost", |py, c, s, _v| Ok(str_at(s, u32::from(c.mana_cost_text_id)).into_pyobject(py)?.into_any())),
+    ("oracle_text", |py, c, s, _v| Ok(str_at(s, u32::from(c.oracle_text_id)).into_pyobject(py)?.into_any())),
+    ("set_name", |py, c, s, _v| Ok(str_at(s, u32::from(c.set_name_id)).into_pyobject(py)?.into_any())),
+    ("type_line", |py, c, s, _v| Ok(str_at(s, u32::from(c.type_line_id)).into_pyobject(py)?.into_any())),
+    ("illustration_id", |py, c, _s, _v| Ok(uuid_from_u128(u128::from(c.illustration_id)).into_pyobject(py)?.into_any())),
+    ("scryfall_id", |py, c, _s, _v| Ok(uuid_from_u128(u128::from(c.scryfall_id)).into_pyobject(py)?.into_any())),
+    ("price_usd", |py, c, _s, _v| Ok(c.price_usd.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
+    ("prefer_score", |py, c, _s, _v| Ok(c.prefer_score.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
+    // card_subtypes preserves the printed order; the set-like collections are stored
+    // sorted by vocab id (first-seen order), so they get re-sorted lexicographically
+    // for deterministic output.
+    ("card_subtypes", |py, c, _s, v| {
+        let items: Vec<&str> = c.card_subtypes.iter().map(|id| coll_str(v, u16::from(*id))).collect();
         Ok(items.into_pyobject(py)?.into_any())
     }),
-    ("card_keywords", |py, c, _s| Ok(sorted_strs(c.card_keywords.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
-    ("card_oracle_tags", |py, c, _s| Ok(sorted_strs(c.card_oracle_tags.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
-    ("card_art_tags", |py, c, _s| Ok(sorted_strs(c.card_art_tags.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
-    ("card_is_tags", |py, c, _s| Ok(sorted_strs(c.card_is_tags.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
-    ("card_frame_data", |py, c, _s| Ok(sorted_strs(c.card_frame_data.iter().map(|v| v.as_str())).into_pyobject(py)?.into_any())),
+    ("card_keywords", |py, c, _s, v| Ok(sorted_strs(v, &c.card_keywords).into_pyobject(py)?.into_any())),
+    ("card_oracle_tags", |py, c, _s, v| Ok(sorted_strs(v, &c.card_oracle_tags).into_pyobject(py)?.into_any())),
+    ("card_art_tags", |py, c, _s, v| Ok(sorted_strs(v, &c.card_art_tags).into_pyobject(py)?.into_any())),
+    ("card_is_tags", |py, c, _s, v| Ok(sorted_strs(v, &c.card_is_tags).into_pyobject(py)?.into_any())),
+    ("card_frame_data", |py, c, _s, v| Ok(sorted_strs(v, &c.card_frame_data).into_pyobject(py)?.into_any())),
 ];
 
-/// Collects a `HashSet<&str>` iterator into a sorted `Vec<&str>` for deterministic field output.
-fn sorted_strs<'a>(iter: impl Iterator<Item = &'a str>) -> Vec<&'a str> {
-    let mut v: Vec<&str> = iter.collect();
+/// Resolve one interned collection-element id against the archived vocab table.
+/// Every id is a real entry (there is no absent sentinel for collection elements).
+pub(crate) fn coll_str(vocab: &AStrings, id: u16) -> &str {
+    vocab[id as usize].as_str()
+}
+
+/// Resolves interned collection ids to a lexicographically sorted `Vec<&str>` for
+/// deterministic field output.
+fn sorted_strs<'a>(vocab: &'a AStrings, ids: &Archived<Vec<u16>>) -> Vec<&'a str> {
+    let mut v: Vec<&str> = ids.iter().map(|id| coll_str(vocab, u16::from(*id))).collect();
     v.sort_unstable();
     v
 }
@@ -1286,10 +1349,16 @@ fn resolve_fields(fields: Option<Vec<String>>) -> PyResult<Vec<(&'static str, Fi
     Ok(resolved)
 }
 
-fn card_to_pydict<'py>(py: Python<'py>, card: &ACard, strings: &AStrings, fields: &[(&'static str, FieldExtractor)]) -> PyResult<Bound<'py, PyDict>> {
+fn card_to_pydict<'py>(
+    py: Python<'py>,
+    card: &ACard,
+    strings: &AStrings,
+    vocab: &AStrings,
+    fields: &[(&'static str, FieldExtractor)],
+) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
     for (name, extractor) in fields {
-        d.set_item(*name, extractor(py, card, strings)?)?;
+        d.set_item(*name, extractor(py, card, strings, vocab)?)?;
     }
     Ok(d)
 }
@@ -1306,7 +1375,7 @@ fn card_to_pydict<'py>(py: Python<'py>, card: &ACard, strings: &AStrings, fields
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change that size_of::<ACard>() wouldn't
 /// catch (e.g. reordering same-size Card fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260623;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260703;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -1337,6 +1406,7 @@ struct CachedMmap {
 struct Staging {
     cards: Vec<Card>,
     interner: Interner,
+    vocab: VocabInterner,
     #[allow(dead_code)] // held for its flock; released on drop
     lock_file: std::fs::File,
 }
@@ -1348,11 +1418,11 @@ const TYPE_BIT_NAMES: [&str; 14] = [
 ];
 
 /// Count type and subtype occurrences across preferred printings (one per oracle card).
-/// Accumulates by integer key in the hot loop — bit position for types, &str borrowed
-/// from the archive for subtypes — then converts to owned strings once at the end.
+/// Accumulates by integer key in the hot loop — bit position for types, interned vocab
+/// id for subtypes — then converts to owned strings once at the end.
 pub(crate) fn count_common_types(data: &Archived<CardData>) -> HashMap<String, u32> {
     let mut type_counts = [0u32; 14];
-    let mut subtype_counts: HashMap<&str, u32> = HashMap::new();
+    let mut subtype_counts: HashMap<u16, u32> = HashMap::new();
 
     let store: &[ACard] = &data.cards;
     for &idx in data.preferred_indices.iter() {
@@ -1365,8 +1435,8 @@ pub(crate) fn count_common_types(data: &Archived<CardData>) -> HashMap<String, u
             bits &= bits - 1;
         }
 
-        for subtype in card.card_subtypes.iter() {
-            *subtype_counts.entry(subtype.as_str()).or_insert(0) += 1;
+        for id in card.card_subtypes.iter() {
+            *subtype_counts.entry(u16::from(*id)).or_insert(0) += 1;
         }
     }
 
@@ -1376,25 +1446,28 @@ pub(crate) fn count_common_types(data: &Archived<CardData>) -> HashMap<String, u
             result.insert(TYPE_BIT_NAMES[i].to_string(), count);
         }
     }
-    for (name, count) in subtype_counts {
-        result.insert(name.to_string(), count);
+    for (id, count) in subtype_counts {
+        result.insert(coll_str(&data.coll_vocab, id).to_string(), count);
     }
     result
 }
 
 /// Count keyword occurrences across preferred printings (one per oracle card).
 pub(crate) fn count_common_keywords(data: &Archived<CardData>) -> HashMap<String, u32> {
-    let mut keyword_counts: HashMap<&str, u32> = HashMap::new();
+    let mut keyword_counts: HashMap<u16, u32> = HashMap::new();
 
     let store: &[ACard] = &data.cards;
     for &idx in data.preferred_indices.iter() {
         let card = &store[u32::from(idx) as usize];
-        for keyword in card.card_keywords.iter() {
-            *keyword_counts.entry(keyword.as_str()).or_insert(0) += 1;
+        for id in card.card_keywords.iter() {
+            *keyword_counts.entry(u16::from(*id)).or_insert(0) += 1;
         }
     }
 
-    keyword_counts.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+    keyword_counts
+        .into_iter()
+        .map(|(id, v)| (coll_str(&data.coll_vocab, id).to_string(), v))
+        .collect()
 }
 
 #[pyclass]
@@ -1519,7 +1592,7 @@ impl QueryEngine {
         #[cfg(feature = "alloc-counter")]
         alloc_stats::reset_peak();
 
-        *staging = Some(Staging { cards: Vec::new(), interner: Interner::new(), lock_file });
+        *staging = Some(Staging { cards: Vec::new(), interner: Interner::new(), vocab: VocabInterner::new(), lock_file });
         Ok(true)
     }
 
@@ -1531,7 +1604,7 @@ impl QueryEngine {
         })?;
         for item in db_rows.iter() {
             if let Ok(d) = item.cast::<PyDict>() {
-                staging.cards.push(card_from_pydict(&d, &mut staging.interner));
+                staging.cards.push(card_from_pydict(&d, &mut staging.interner, &mut staging.vocab)?);
             }
         }
         Ok(())
@@ -1550,7 +1623,7 @@ impl QueryEngine {
         let staging = self.staging.lock().unwrap().take().ok_or_else(|| {
             pyo3::exceptions::PyRuntimeError::new_err("reload_commit called without reload_begin")
         })?;
-        let Staging { mut cards, interner, lock_file } = staging;
+        let Staging { mut cards, interner, vocab, lock_file } = staging;
 
         // unique=card/artwork group by oracle_id, so cards without one would all
         // collapse into a single group. The DB enforces NOT NULL; fail loudly here
@@ -1597,6 +1670,8 @@ impl QueryEngine {
 
         let strings = interner.strings;
         drop(interner.map);
+        let coll_vocab = vocab.strings;
+        drop(vocab.map);
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
@@ -1604,11 +1679,11 @@ impl QueryEngine {
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
             toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
             type_bits:      build_type_index(&cards),
-            subtypes:       build_list_index(&cards, |c| &c.card_subtypes),
-            keywords:       build_tag_index(&cards, |c| &c.card_keywords),
-            oracle_tags:    build_tag_index(&cards, |c| &c.card_oracle_tags),
-            art_tags:       build_tag_index(&cards, |c| &c.card_art_tags),
-            is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
+            subtypes:       build_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
+            keywords:       build_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),
+            oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
+            art_tags:       build_tag_index(&cards, &coll_vocab, |c| &c.card_art_tags),
+            is_tags:        build_tag_index(&cards, &coll_vocab, |c| &c.card_is_tags),
         };
 
         #[cfg(feature = "alloc-counter")]
@@ -1617,7 +1692,7 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, strings, indexes, format_shifts: format_shifts_snapshot, preferred_indices };
+        let card_data = CardData { cards, strings, coll_vocab, indexes, format_shifts: format_shifts_snapshot, preferred_indices };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -1746,11 +1821,11 @@ impl QueryEngine {
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query(
-            store, &data.preferred_indices[..], &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
+            store, &data.preferred_indices[..], &data.strings, &data.coll_vocab, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 
         let matches: Vec<Bound<PyDict>> =
-            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
+            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &data.coll_vocab, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
@@ -1789,9 +1864,9 @@ impl QueryEngine {
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
 
         let store: &[ACard] = &data.cards;
-        let (total, page) = run_query_hashmap(store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset);
+        let (total, page) = run_query_hashmap(store, &data.strings, &data.coll_vocab, &filter_expr, unique, prefer, orderby, direction, limit, offset);
         let matches: Vec<Bound<PyDict>> =
-            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
+            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &data.coll_vocab, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
@@ -1844,12 +1919,12 @@ impl QueryEngine {
             };
         }
         let (total, page) = match unique {
-            "card"    => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.oracle_id),       prefer, orderby, direction, limit, offset),
-            "artwork" => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
-            _         => run_query_no_dedup(cards_iter_linear!(), &data.strings, &filter_expr, orderby, direction, limit, offset),
+            "card"    => run_query_linear(cards_iter_linear!(), &data.strings, &data.coll_vocab, &filter_expr, |c| u128::from(c.oracle_id),       prefer, orderby, direction, limit, offset),
+            "artwork" => run_query_linear(cards_iter_linear!(), &data.strings, &data.coll_vocab, &filter_expr, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
+            _         => run_query_no_dedup(cards_iter_linear!(), &data.strings, &data.coll_vocab, &filter_expr, orderby, direction, limit, offset),
         };
         let matches: Vec<Bound<PyDict>> =
-            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
+            page.iter().map(|c| card_to_pydict(py, c, &data.strings, &data.coll_vocab, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
     }
@@ -1890,7 +1965,7 @@ impl QueryEngine {
         let dicts: Vec<Bound<PyDict>> = chosen.iter()
             .map(|&pos| {
                 let card_idx = u32::from(data.preferred_indices[pos]) as usize;
-                card_to_pydict(py, &data.cards[card_idx], &data.strings, &resolved_fields)
+                card_to_pydict(py, &data.cards[card_idx], &data.strings, &data.coll_vocab, &resolved_fields)
             })
             .collect::<PyResult<_>>()?;
         PyList::new(py, dicts)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -887,6 +887,9 @@ struct CardData {
     // Vocab table for Card's collection fields, indexed by their u16 ids
     // (see VocabInterner). ~16k entries / ~200 KB.
     coll_vocab: Vec<String>,
+    // Permutation of 0..coll_vocab.len() sorted by string, so query values
+    // resolve to vocab ids by binary search (FilterExpr::bind_collection_ids).
+    coll_vocab_sorted: Vec<u16>,
     indexes: CardIndexes,
     // The writer's format→shift assignments. Persisted so reader processes —
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
@@ -947,31 +950,31 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Op
             Some(result)
         }
 
-        FilterExpr::CollectionCmp { field, op, value }
+        FilterExpr::CollectionCmp { field, op, value, .. }
             if matches!(field, CollField::Subtypes) && matches!(op, CmpOp::Ge) =>
         {
             indexes.subtypes.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
-        FilterExpr::CollectionCmp { field, op, value }
+        FilterExpr::CollectionCmp { field, op, value, .. }
             if matches!(field, CollField::Keywords) && matches!(op, CmpOp::Ge) =>
         {
             indexes.keywords.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
-        FilterExpr::CollectionCmp { field, op, value }
+        FilterExpr::CollectionCmp { field, op, value, .. }
             if matches!(field, CollField::OracleTags) && matches!(op, CmpOp::Ge) =>
         {
             indexes.oracle_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
-        FilterExpr::CollectionCmp { field, op, value }
+        FilterExpr::CollectionCmp { field, op, value, .. }
             if matches!(field, CollField::ArtTags) && matches!(op, CmpOp::Ge) =>
         {
             indexes.art_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
         }
 
-        FilterExpr::CollectionCmp { field, op, value }
+        FilterExpr::CollectionCmp { field, op, value, .. }
             if matches!(field, CollField::IsTags) && matches!(op, CmpOp::Ge) =>
         {
             indexes.is_tags.get(value.as_str()).map(|v| v.iter().map(|x| u32::from(*x)).collect())
@@ -1103,7 +1106,6 @@ fn select_page<'a>(mut v: Vec<(u128, &'a ACard)>, offset: usize, limit: usize) -
 fn run_query_hashmap<'a>(
     store: &'a [ACard],
     strings: &AStrings,
-    vocab: &AStrings,
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1125,7 +1127,7 @@ fn run_query_hashmap<'a>(
 
     let mut partitions: HashMap<u128, (&ACard, f64)> = HashMap::new();
     for card in store {
-        if filter.matches(card, strings, vocab) {
+        if filter.matches(card, strings) {
             let key = match group_by {
                 GroupBy::Oracle   => u128::from(card.oracle_id),
                 GroupBy::Artwork  => u128::from(card.illustration_id),
@@ -1149,7 +1151,6 @@ fn run_query_hashmap<'a>(
 fn run_query_linear<'a, I, F>(
     cards: I,
     strings: &AStrings,
-    vocab: &AStrings,
     filter: &FilterExpr,
     key_fn: F,
     prefer: &str,
@@ -1171,7 +1172,7 @@ where
     let mut prev_key: Option<u128> = None; // None = before the first match
 
     for card in cards {
-        if !filter.matches(card, strings, vocab) { continue; }
+        if !filter.matches(card, strings) { continue; }
         let key = key_fn(card);
         if prev_key != Some(key) {
             if let Some((c, _)) = group_best.take() { best.push((sort_key_bits(c, sort_col, descending), c)); }
@@ -1193,7 +1194,6 @@ where
 fn run_query_no_dedup<'a>(
     cards: impl Iterator<Item = &'a ACard>,
     strings: &AStrings,
-    vocab: &AStrings,
     filter: &FilterExpr,
     orderby: &str,
     direction: &str,
@@ -1203,7 +1203,7 @@ fn run_query_no_dedup<'a>(
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let matched: Vec<(u128, &ACard)> = cards
-        .filter(|c| filter.matches(c, strings, vocab))
+        .filter(|c| filter.matches(c, strings))
         .map(|c| (sort_key_bits(c, sort_col, descending), c))
         .collect();
     let total = matched.len();
@@ -1214,7 +1214,6 @@ fn run_query<'a, B>(
     store: &'a [ACard],
     preferred_indices: &[B],
     strings: &AStrings,
-    vocab: &AStrings,
     filter: &FilterExpr,
     unique: &str,
     prefer: &str,
@@ -1241,11 +1240,11 @@ where
         return match candidates {
             Some(existing) => {
                 let fast = intersect_sorted(&existing, preferred_indices);
-                run_query_no_dedup(fast.into_iter().map(|i| &store[i as usize]), strings, vocab, filter, orderby, direction, limit, offset)
+                run_query_no_dedup(fast.into_iter().map(|i| &store[i as usize]), strings, filter, orderby, direction, limit, offset)
             }
             None => run_query_no_dedup(
                 preferred_indices.iter().map(|&i| &store[u32::from(i) as usize]),
-                strings, vocab, filter, orderby, direction, limit, offset,
+                strings, filter, orderby, direction, limit, offset,
             ),
         };
     }
@@ -1263,13 +1262,13 @@ where
         // The store is sorted by (oracle_id, illustration_id), so equal keys are adjacent
         // and the linear key-change dedup is exact — u128 equality, same cost as the
         // dense u32 group ids this replaced.
-        "card" => run_query_linear(cards_iter!(), strings, vocab, filter, |c| u128::from(c.oracle_id), prefer, orderby, direction, limit, offset),
+        "card" => run_query_linear(cards_iter!(), strings, filter, |c| u128::from(c.oracle_id), prefer, orderby, direction, limit, offset),
         // Scryfall assigns each illustration_id to exactly one oracle_id, so cards sharing an
         // illustration_id are always contiguous in the (oracle_id, illustration_id) sort order.
         // The linear dedup path is therefore correct here — no HashMap needed.
-        "artwork"  => run_query_linear(cards_iter!(), strings, vocab, filter, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
-        "printing" => run_query_no_dedup(cards_iter!(), strings, vocab, filter, orderby, direction, limit, offset),
-        _          => run_query_hashmap(store, strings, vocab, filter, unique, prefer, orderby, direction, limit, offset),
+        "artwork"  => run_query_linear(cards_iter!(), strings, filter, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
+        "printing" => run_query_no_dedup(cards_iter!(), strings, filter, orderby, direction, limit, offset),
+        _          => run_query_hashmap(store, strings, filter, unique, prefer, orderby, direction, limit, offset),
     }
 }
 
@@ -1375,7 +1374,7 @@ fn card_to_pydict<'py>(
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change that size_of::<ACard>() wouldn't
 /// catch (e.g. reordering same-size Card fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260703;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260704;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -1672,6 +1671,10 @@ impl QueryEngine {
         drop(interner.map);
         let coll_vocab = vocab.strings;
         drop(vocab.map);
+        // String-sorted permutation of the vocab ids; VocabInterner caps the
+        // vocab at u16::MAX entries so the cast can't truncate.
+        let mut coll_vocab_sorted: Vec<u16> = (0..coll_vocab.len() as u16).collect();
+        coll_vocab_sorted.sort_unstable_by(|&a, &b| coll_vocab[a as usize].cmp(&coll_vocab[b as usize]));
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
@@ -1692,7 +1695,7 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, strings, coll_vocab, indexes, format_shifts: format_shifts_snapshot, preferred_indices };
+        let card_data = CardData { cards, strings, coll_vocab, coll_vocab_sorted, indexes, format_shifts: format_shifts_snapshot, preferred_indices };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -1816,12 +1819,13 @@ impl QueryEngine {
         // Must run before build_filter so legality shifts resolve in workers
         // that never executed the load path themselves.
         sync_format_shifts(&data.format_shifts);
-        let filter_expr = build_filter(&json_val)
+        let mut filter_expr = build_filter(&json_val)
             .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
+        filter_expr.bind_collection_ids(&data.coll_vocab, &data.coll_vocab_sorted);
 
         let store: &[ACard] = &data.cards;
         let (total, page) = run_query(
-            store, &data.preferred_indices[..], &data.strings, &data.coll_vocab, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
+            store, &data.preferred_indices[..], &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 
         let matches: Vec<Bound<PyDict>> =
@@ -1860,11 +1864,12 @@ impl QueryEngine {
 
         // Must run before build_filter; see query().
         sync_format_shifts(&data.format_shifts);
-        let filter_expr = build_filter(&json_val)
+        let mut filter_expr = build_filter(&json_val)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
+        filter_expr.bind_collection_ids(&data.coll_vocab, &data.coll_vocab_sorted);
 
         let store: &[ACard] = &data.cards;
-        let (total, page) = run_query_hashmap(store, &data.strings, &data.coll_vocab, &filter_expr, unique, prefer, orderby, direction, limit, offset);
+        let (total, page) = run_query_hashmap(store, &data.strings, &filter_expr, unique, prefer, orderby, direction, limit, offset);
         let matches: Vec<Bound<PyDict>> =
             page.iter().map(|c| card_to_pydict(py, c, &data.strings, &data.coll_vocab, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
@@ -1902,8 +1907,9 @@ impl QueryEngine {
 
         // Must run before build_filter; see query().
         sync_format_shifts(&data.format_shifts);
-        let filter_expr = build_filter(&json_val)
+        let mut filter_expr = build_filter(&json_val)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("build_filter: {e}")))?;
+        filter_expr.bind_collection_ids(&data.coll_vocab, &data.coll_vocab_sorted);
 
         let store: &[ACard] = &data.cards;
         // Use narrow_candidates so this exactly replicates the pre-optimization run_query
@@ -1919,9 +1925,9 @@ impl QueryEngine {
             };
         }
         let (total, page) = match unique {
-            "card"    => run_query_linear(cards_iter_linear!(), &data.strings, &data.coll_vocab, &filter_expr, |c| u128::from(c.oracle_id),       prefer, orderby, direction, limit, offset),
-            "artwork" => run_query_linear(cards_iter_linear!(), &data.strings, &data.coll_vocab, &filter_expr, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
-            _         => run_query_no_dedup(cards_iter_linear!(), &data.strings, &data.coll_vocab, &filter_expr, orderby, direction, limit, offset),
+            "card"    => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.oracle_id),       prefer, orderby, direction, limit, offset),
+            "artwork" => run_query_linear(cards_iter_linear!(), &data.strings, &filter_expr, |c| u128::from(c.illustration_id), prefer, orderby, direction, limit, offset),
+            _         => run_query_no_dedup(cards_iter_linear!(), &data.strings, &filter_expr, orderby, direction, limit, offset),
         };
         let matches: Vec<Bound<PyDict>> =
             page.iter().map(|c| card_to_pydict(py, c, &data.strings, &data.coll_vocab, &resolved_fields)).collect::<PyResult<Vec<_>>>()?;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -17,6 +17,13 @@ fn vocab_ids(vocab: &mut VocabInterner, items: &[&str]) -> Vec<u16> {
     ids
 }
 
+/// String-sorted permutation of the vocab ids, as reload_commit builds it.
+fn sorted_vocab_ids(vocab: &[String]) -> Vec<u16> {
+    let mut ids: Vec<u16> = (0..vocab.len() as u16).collect();
+    ids.sort_unstable_by(|&a, &b| vocab[a as usize].cmp(&vocab[b as usize]));
+    ids
+}
+
 /// Build a TrigramIndex mapping each word's trigrams to the given card ids.
 fn index_of(words: &[(&str, &[u32])]) -> TrigramIndex {
     let mut idx: TrigramIndex = HashMap::new();
@@ -219,6 +226,7 @@ fn bench_checked_vs_unchecked_access() {
     let data = CardData {
         cards,
         strings,
+        coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
         indexes,
         format_shifts: HashMap::new(),
@@ -262,6 +270,7 @@ fn narrow_candidates_art_tags() {
         field: CollField::ArtTags,
         op: CmpOp::Ge,
         value: "wolf".to_string(),
+        value_id: None,
     };
     assert_eq!(narrow_candidates(&present, archived), Some(vec![0, 2]));
 
@@ -270,6 +279,7 @@ fn narrow_candidates_art_tags() {
         field: CollField::ArtTags,
         op: CmpOp::Ge,
         value: "zombie".to_string(),
+        value_id: None,
     };
     assert_eq!(narrow_candidates(&absent, archived), None);
 }
@@ -345,6 +355,7 @@ fn count_common_types_sums_preferred_only() {
     let data = CardData {
         cards,
         strings: vec![],
+        coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
         indexes: CardIndexes::default(),
         format_shifts: HashMap::new(),
@@ -393,6 +404,7 @@ fn count_common_keywords_sums_preferred_only() {
     let data = CardData {
         cards: vec![card0, card1, card2, card3],
         strings: vec![],
+        coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
         indexes: CardIndexes::default(),
         format_shifts: HashMap::new(),
@@ -411,4 +423,49 @@ fn count_common_keywords_sums_preferred_only() {
     assert_eq!(counts.get("Vigilance"), Some(&1));
     // Trample on card 1 — not preferred, must be absent.
     assert_eq!(counts.get("Trample"), None);
+}
+
+#[test]
+fn collection_cmp_binds_vocab_ids_and_matches() {
+    // First-seen intern order ("Trample" before "Flying") differs from the
+    // alphabetical order the sorted permutation provides, so this exercises
+    // the binary-search resolution rather than a trivial identity mapping.
+    let mut vocab = VocabInterner::new();
+    let mut card0 = stub_card(TYPE_CREATURE, &[], &mut vocab);
+    card0.card_keywords = vocab_ids(&mut vocab, &["Trample", "Flying"]);
+    let mut card1 = stub_card(TYPE_CREATURE, &[], &mut vocab);
+    card1.card_keywords = vocab_ids(&mut vocab, &["Haste"]);
+    let card2 = stub_card(TYPE_CREATURE, &[], &mut vocab); // no keywords
+
+    let data = CardData {
+        cards: vec![card0, card1, card2],
+        strings: vec![],
+        coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
+        coll_vocab: vocab.strings,
+        indexes: CardIndexes::default(),
+        format_shifts: HashMap::new(),
+        preferred_indices: vec![],
+    };
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let run = |value: &str, op: CmpOp| -> Vec<bool> {
+        let mut f = FilterExpr::CollectionCmp {
+            field: CollField::Keywords,
+            op,
+            value: value.to_string(),
+            value_id: None,
+        };
+        f.bind_collection_ids(&archived.coll_vocab, &archived.coll_vocab_sorted);
+        archived.cards.iter().map(|c| f.matches(c, &archived.strings)).collect()
+    };
+
+    assert_eq!(run("Flying", CmpOp::Ge),  vec![true, false, false]);
+    assert_eq!(run("Haste", CmpOp::Ge),   vec![false, true, false]);
+    assert_eq!(run("Haste", CmpOp::Eq),   vec![false, true, false]); // exactly {Haste}
+    assert_eq!(run("Flying", CmpOp::Eq),  vec![false, false, false]); // card0 has two keywords
+    assert_eq!(run("Flying", CmpOp::Ne),  vec![true, true, true]);
+    // A value absent from the vocab matches no element: Ge nothing, Le only empty.
+    assert_eq!(run("Deathtouch", CmpOp::Ge), vec![false, false, false]);
+    assert_eq!(run("Deathtouch", CmpOp::Le), vec![false, false, true]);
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,12 +1,21 @@
 use super::{
-    build_list_index, build_numeric_index, build_oracle_text_index, build_tag_index,
-    build_trigram_index, build_type_index, count_common_keywords, count_common_types,
-    narrow_candidates, trigram_candidates, Card, CardData, CardIndexes, CollField, CmpOp,
-    FilterExpr, InlineStr, Interner, ManaCost, TagIndex, TrigramIndex, NONE_STR, TYPE_ARTIFACT,
+    build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
+    build_type_index, count_common_keywords, count_common_types, narrow_candidates,
+    trigram_candidates, Card, CardData, CardIndexes, CollField, CmpOp, FilterExpr, InlineStr,
+    Interner, ManaCost, TagIndex, TrigramIndex, VocabInterner, NONE_STR, TYPE_ARTIFACT,
     TYPE_CREATURE, TYPE_INSTANT, TYPE_LEGENDARY, TYPE_PLANESWALKER,
 };
 use rkyv::{rancor::Error, Archived};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+/// Intern a list of collection elements as sorted, deduped vocab ids (the load-time
+/// shape of the set-like collections).
+fn vocab_ids(vocab: &mut VocabInterner, items: &[&str]) -> Vec<u16> {
+    let mut ids: Vec<u16> = items.iter().map(|s| vocab.intern(s.to_string()).unwrap()).collect();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
 
 /// Build a TrigramIndex mapping each word's trigrams to the given card ids.
 fn index_of(words: &[(&str, &[u32])]) -> TrigramIndex {
@@ -88,24 +97,6 @@ fn test_trigram_index_archive_and_lookup() {
     assert!(archived.get(&[b'z', b'z', b'z']).is_none());
 }
 
-// Verify that HashSet<String> supports contains() via &str (Borrow-based lookup).
-// This is used for card_keywords, card_oracle_tags, card_is_tags, card_frame_data.
-#[test]
-fn test_hashset_string_str_lookup() {
-    let mut set: HashSet<String> = HashSet::new();
-    set.insert("Flying".to_string());
-    set.insert("Vigilance".to_string());
-    set.insert("Trample".to_string());
-
-    let bytes = rkyv::to_bytes::<Error>(&set).expect("serialize hashset");
-    let archived = rkyv::access::<rkyv::Archived<HashSet<String>>, Error>(&bytes)
-        .expect("access hashset");
-
-    assert!(archived.contains("Flying"));
-    assert!(archived.contains("Trample"));
-    assert!(!archived.contains("Deathtouch"));
-}
-
 // Verify that HashMap<String, Vec<u32>> (the tag index value type) supports
 // get() via &str, which is needed for narrow_candidates tag lookups.
 #[test]
@@ -140,6 +131,7 @@ fn bench_checked_vs_unchecked_access() {
     const N: usize = 96_000;
     let words = ["draw", "card", "creature", "destroy", "target", "flying", "counter", "spell", "token", "exile"];
     let mut interner = Interner::new();
+    let mut vocab = VocabInterner::new();
     let mut cards: Vec<Card> = Vec::with_capacity(N);
     for i in 0..N {
         let name = format!("Benchmark Card Number {i}");
@@ -190,13 +182,16 @@ fn bench_checked_vs_unchecked_access() {
             price_tix: Some(0.1),
             prefer_score: None,
             cubecobra_score: None,
-            card_subtypes: vec!["Benchmark".to_string(), words[i % 10].to_string()],
-            card_keywords: HashSet::from([words[i % 10].to_string()]),
+            card_subtypes: vec![
+                vocab.intern("Benchmark".to_string()).unwrap(),
+                vocab.intern(words[i % 10].to_string()).unwrap(),
+            ],
+            card_keywords: vocab_ids(&mut vocab, &[words[i % 10]]),
             card_legalities: 0,
-            card_oracle_tags: HashSet::from([format!("tag-{}", i % 100)]),
-            card_art_tags: HashSet::new(),
-            card_is_tags: HashSet::new(),
-            card_frame_data: HashSet::new(),
+            card_oracle_tags: vocab_ids(&mut vocab, &[&format!("tag-{}", i % 100)]),
+            card_art_tags: Vec::new(),
+            card_is_tags: Vec::new(),
+            card_frame_data: Vec::new(),
             mana_cost: ManaCost {
                 pips: HashMap::from([("G".to_string(), 2u8)]),
                 devotion: None,
@@ -215,15 +210,16 @@ fn bench_checked_vs_unchecked_access() {
         power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
         toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
         type_bits:      build_type_index(&cards),
-        subtypes:       build_list_index(&cards, |c| &c.card_subtypes),
-        keywords:       build_tag_index(&cards, |c| &c.card_keywords),
-        oracle_tags:    build_tag_index(&cards, |c| &c.card_oracle_tags),
-        art_tags:       build_tag_index(&cards, |c| &c.card_art_tags),
-        is_tags:        build_tag_index(&cards, |c| &c.card_is_tags),
+        subtypes:       build_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
+        keywords:       build_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
+        oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
+        art_tags:       build_tag_index(&cards, &vocab.strings, |c| &c.card_art_tags),
+        is_tags:        build_tag_index(&cards, &vocab.strings, |c| &c.card_is_tags),
     };
     let data = CardData {
         cards,
         strings,
+        coll_vocab: vocab.strings,
         indexes,
         format_shifts: HashMap::new(),
         preferred_indices: Vec::new(),
@@ -280,7 +276,9 @@ fn narrow_candidates_art_tags() {
 
 /// Minimal card for tests that only care about card_types and card_subtypes.
 /// All interned-string IDs are NONE_STR; count_common_types never reads them.
-fn stub_card(card_types: u16, card_subtypes: Vec<String>) -> Card {
+/// Subtypes are interned into `vocab`, which must become the CardData's coll_vocab.
+fn stub_card(card_types: u16, subtypes: &[&str], vocab: &mut VocabInterner) -> Card {
+    let card_subtypes = subtypes.iter().map(|s| vocab.intern(s.to_string()).unwrap()).collect();
     Card {
         card_name_lower: InlineStr::from_str(""),
         card_colors: 0,
@@ -319,12 +317,12 @@ fn stub_card(card_types: u16, card_subtypes: Vec<String>) -> Card {
         prefer_score: None,
         cubecobra_score: None,
         card_subtypes,
-        card_keywords: HashSet::new(),
+        card_keywords: Vec::new(),
         card_legalities: 0,
-        card_oracle_tags: HashSet::new(),
-        card_art_tags: HashSet::new(),
-        card_is_tags: HashSet::new(),
-        card_frame_data: HashSet::new(),
+        card_oracle_tags: Vec::new(),
+        card_art_tags: Vec::new(),
+        card_is_tags: Vec::new(),
+        card_frame_data: Vec::new(),
         mana_cost: ManaCost { pips: HashMap::new(), devotion: None, cmc: 0.0 },
         creature_power_text_id: NONE_STR,
         creature_toughness_text_id: NONE_STR,
@@ -337,15 +335,17 @@ fn count_common_types_sums_preferred_only() {
     // card 1: Instant, no subtypes                     — not preferred (skipped)
     // card 2: Artifact + Creature, subtype "Merfolk"   — preferred
     // card 3: Creature, subtypes ["Warrior", "Merfolk"] — preferred
+    let mut vocab = VocabInterner::new();
     let cards = vec![
-        stub_card(TYPE_LEGENDARY | TYPE_PLANESWALKER, vec!["Jace".to_string()]),
-        stub_card(TYPE_INSTANT,                        vec![]),
-        stub_card(TYPE_ARTIFACT | TYPE_CREATURE,       vec!["Merfolk".to_string()]),
-        stub_card(TYPE_CREATURE,                       vec!["Warrior".to_string(), "Merfolk".to_string()]),
+        stub_card(TYPE_LEGENDARY | TYPE_PLANESWALKER, &["Jace"], &mut vocab),
+        stub_card(TYPE_INSTANT,                        &[], &mut vocab),
+        stub_card(TYPE_ARTIFACT | TYPE_CREATURE,       &["Merfolk"], &mut vocab),
+        stub_card(TYPE_CREATURE,                       &["Warrior", "Merfolk"], &mut vocab),
     ];
     let data = CardData {
         cards,
         strings: vec![],
+        coll_vocab: vocab.strings,
         indexes: CardIndexes::default(),
         format_shifts: HashMap::new(),
         preferred_indices: vec![0, 2, 3], // card 1 (Instant) excluded
@@ -380,31 +380,20 @@ fn count_common_keywords_sums_preferred_only() {
     // card 1: Trample         — not preferred (skipped)
     // card 2: Flying          — preferred
     // card 3: Vigilance       — preferred
-    let mut kw_flying_haste = HashSet::new();
-    kw_flying_haste.insert("Flying".to_string());
-    kw_flying_haste.insert("Haste".to_string());
-
-    let mut kw_trample = HashSet::new();
-    kw_trample.insert("Trample".to_string());
-
-    let mut kw_flying = HashSet::new();
-    kw_flying.insert("Flying".to_string());
-
-    let mut kw_vigilance = HashSet::new();
-    kw_vigilance.insert("Vigilance".to_string());
-
-    let mut card0 = stub_card(TYPE_CREATURE, vec![]);
-    card0.card_keywords = kw_flying_haste;
-    let mut card1 = stub_card(TYPE_INSTANT, vec![]);
-    card1.card_keywords = kw_trample;
-    let mut card2 = stub_card(TYPE_CREATURE, vec![]);
-    card2.card_keywords = kw_flying;
-    let mut card3 = stub_card(TYPE_ARTIFACT, vec![]);
-    card3.card_keywords = kw_vigilance;
+    let mut vocab = VocabInterner::new();
+    let mut card0 = stub_card(TYPE_CREATURE, &[], &mut vocab);
+    card0.card_keywords = vocab_ids(&mut vocab, &["Flying", "Haste"]);
+    let mut card1 = stub_card(TYPE_INSTANT, &[], &mut vocab);
+    card1.card_keywords = vocab_ids(&mut vocab, &["Trample"]);
+    let mut card2 = stub_card(TYPE_CREATURE, &[], &mut vocab);
+    card2.card_keywords = vocab_ids(&mut vocab, &["Flying"]);
+    let mut card3 = stub_card(TYPE_ARTIFACT, &[], &mut vocab);
+    card3.card_keywords = vocab_ids(&mut vocab, &["Vigilance"]);
 
     let data = CardData {
         cards: vec![card0, card1, card2, card3],
         strings: vec![],
+        coll_vocab: vocab.strings,
         indexes: CardIndexes::default(),
         format_shifts: HashMap::new(),
         preferred_indices: vec![0, 2, 3], // card 1 (Instant) excluded


### PR DESCRIPTION
Closes #598. Item 5 of the store-size reduction series (#504 items 1–3, #505).

## What

The per-card collection fields (`card_subtypes`, `card_keywords`, `card_oracle_tags`, `card_art_tags`, `card_is_tags`, `card_frame_data`) were owned `Vec<String>` / `HashSet<String>` collections. They are now sorted `Vec<u16>` of interned ids into a dedicated per-store vocab table (`CardData.coll_vocab`, built by a new `VocabInterner`), following the same pattern as the #504 string interning. `card_subtypes` keeps the printed order; the set-like collections are sorted by id and deduped at load.

The vocab table is separate from the u32-id `strings` table so ids fit in **u16**: the combined collection vocabulary is ~16k distinct values against 65,536 addressable (~4× headroom), while `strings` holds >65k entries. Halving the id width saves ~6.4 MB across the ~3.2M collection elements. If the vocabulary ever exceeds `u16::MAX`, interning fails loudly (instructing to widen to u32) rather than silently truncating; the error propagates through `add_batch`, which the reload path already handles with `reload_abort`.

Query-time matching is id-only: the query entry points resolve each collection value to its vocab id once per query (`FilterExpr::bind_collection_ids`, binary search over a string-sorted permutation of the vocab archived as `coll_vocab_sorted`, +32 KB), and per-card checks binary-search the sorted id lists — no string comparisons per card. A value absent from the vocab matches no element, so misspelled tags short-circuit for free, and `matches()` no longer needs the vocab table at all.

Also included: `build_tag_index` and `build_list_index` collapse into one id-based builder that accumulates postings by integer id (no per-element string hashing) and resolves each id to its String key once at the end; `count_common_types`/`count_common_keywords` likewise count by id. `TagIndex` still keys by `String`, so query-time index lookups are unchanged. Archive format version bumped to 20260704.

## Re-measured collection columns (tagged blue DB, 97,199 cards)

The issue's first task — the tag columns were empty at the 2026-06-12 measurement. Fully tagged, the collections are ~12× larger than measured then:

| Column | Elements | Vocab | As-stored | Distinct bytes |
| --- | ---: | ---: | ---: | ---: |
| card_art_tags | 1,750,849 | 10,756 | 14 MB | 104 kB |
| card_oracle_tags | 1,172,238 | 4,162 | 16 MB | 71 kB |
| card_frame_data | 125,735 | 29 | 629 kB | 237 B |
| card_subtypes | 90,649 | 425 | 523 kB | 2.6 kB |
| card_keywords | 59,001 | 770 | 422 kB | 8.8 kB |
| card_is_tags | 0 | 0 | — | — |

`card_art_tags` — absent from the issue's field list because it was unmeasurable then — turned out to be the largest column, so it is interned too.

## Measured impact: memory (alloc-counter protocol from #504)

Same corpus exported from the tagged blue DB, before/after on the same machine (re-baselined on current main per the issue, since the tagged corpus dwarfs the 2026-06-12 baseline):

| Metric | Baseline (main) | This PR | Δ |
| --- | ---: | ---: | ---: |
| **Archive file** | 160.7 MB | **99.2 MB** | −38% |
| — archived cards | 108.6 | 46.8 | −57% |
| — strings table | 16.4 | 16.4 | par |
| — archived indexes | 35.7 | 35.7 | par |
| Rust reload peak | 347.5 MB | **174.6 MB** | −50% |
| Build allocations (after cards) | 4.09 M | 0.92 M | −78% |
| Reload wall time | 2.1 s | 1.7 s | −19% |

## Measured impact: query latency

20-query mix (keyword/subtype/oracle-tag/art-tag/frame queries plus trigram, numeric, color, legality, mana, artist regression guards; unique=card/artwork/printing; all collection fields in the output), production builds of both sides run back-to-back, 5 warmup + 100 timed iterations per query. **Identical totals and card payloads on every query.**

| Metric | Value |
| --- | ---: |
| **Geometric mean speedup (median)** | **1.23×** |
| Geometric mean speedup (min) | 1.14× |
| Faster / par / slower (0.95–1.05× band) | 12 / 8 / **0** |

Notable rows (median):

| Query | main | PR | Speedup | Why |
| --- | ---: | ---: | ---: | --- |
| `frame:2015` | 2.405 ms | 1.049 ms | 2.29× | full scan; 57% smaller cards → cache density |
| `a:rebecca` | 5.242 ms | 2.290 ms | 2.29× | full scan, same effect |
| `kw:flying` (unique=printing) | 0.379 ms | 0.192 ms | 1.97× | filter re-verified across 9,060 printings, now integer-only |
| `f:modern r:rare` | 1.444 ms | 0.894 ms | 1.62× | full scan |
| `otag:removal` | 0.304 ms | 0.276 ms | 1.10× | was 0.80× before the id-binding commit; regression eliminated |

Full per-query tables (min/median/p90 for all 20 queries) are in the comments: [pre-bind](https://github.com/jbylund/sylvan_librarian/pull/600#issuecomment-4872646216), [final](https://github.com/jbylund/sylvan_librarian/pull/600#issuecomment-4872740915).

## Tests

- `cargo test`: 10 passed (includes a bind/id-matching test covering all six collection operators and the absent-value case)
- `python -m pytest api/`: 1836 passed (includes testcontainers integration)
- No new clippy warnings

Note: #599 is a Copilot draft against the same issue; it uses u32 ids and per-collection vocab tables and has no corpus measurements. This PR supersedes it if accepted.
