### PR TITLE
Index Artist, Set Code, and Release Date Predicates

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use regex::Regex;
 use serde_json::Value;
-use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit};
+use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, ARTIST_NONE};
 use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, format_shift};
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
@@ -221,7 +221,8 @@ fn text_search_field_value<'a>(
         TextSearchField::NameLower       => StrVal::Known(card.card_name_lower.as_str()),
         TextSearchField::OracleTextLower => opt_sv(str_at(strings, u32::from(card.oracle_text_lower_id))),
         TextSearchField::FlavorTextLower => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.flavor_text_lower_id)))),
-        TextSearchField::ArtistLower     => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.card_artist_lower_id)))),
+        // Rewritten to ArtistMatch by bind(); printings carry no artist strings.
+        TextSearchField::ArtistLower     => StrVal::Null,
     }
 }
 
@@ -252,7 +253,8 @@ fn text_field_value<'a>(
         TextField::OracleTextLower => opt_sv(str_at(strings, u32::from(card.oracle_text_lower_id))),
         TextField::Layout          => opt_sv(str_at(strings, u32::from(card.card_layout_id))),
         TextField::FlavorTextLower => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.flavor_text_lower_id)))),
-        TextField::ArtistLower     => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.card_artist_lower_id)))),
+        // Rewritten to ArtistMatch by bind(); printings carry no artist strings.
+        TextField::ArtistLower     => StrVal::Null,
         TextField::SetCode         => printing.map_or(StrVal::PDep, |p| StrVal::Known(p.card_set_code.as_str())),
         TextField::Border          => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.card_border_id)))),
         TextField::Watermark       => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.card_watermark_id)))),
@@ -278,6 +280,13 @@ pub(crate) enum FilterExpr {
     TextContains {
         field: TextSearchField,
         word: String,
+    },
+    /// An artist predicate (contains/exact/regex) after bind() resolved it
+    /// against the ~2.2k-entry artist vocab: sorted vocab ids whose artist
+    /// string satisfies the original predicate. Matching is an integer binary
+    /// search per printing instead of a string comparison.
+    ArtistMatch {
+        ids: Vec<u16>,
     },
     TextExact {
         field: TextField,
@@ -339,25 +348,62 @@ pub(crate) enum FilterExpr {
     },
 }
 
+/// Vocab ids (ascending) whose artist string satisfies `pred`.
+fn artist_match_ids(artist_vocab: &AStrings, pred: impl Fn(&str) -> bool) -> Vec<u16> {
+    artist_vocab
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| pred(s.as_str()))
+        .map(|(i, _)| i as u16)
+        .collect()
+}
+
 impl FilterExpr {
-    /// Resolve every CollectionCmp value to its vocab id (via the string-sorted
-    /// permutation of the vocab table — ~14 string compares per collection term).
-    /// Called once per query so matching never touches strings; a value absent
-    /// from the vocab resolves to None and can match no element.
-    pub(crate) fn bind_collection_ids(&mut self, vocab: &AStrings, sorted_ids: &rkyv::Archived<Vec<u16>>) {
+    /// Per-query binding against the store's vocab tables, called once before
+    /// matching. Two rewrites happen here:
+    ///
+    /// - CollectionCmp values resolve to their vocab id (binary search over the
+    ///   string-sorted permutation — ~14 string compares per term); a value
+    ///   absent from the vocab resolves to None and can match no element.
+    /// - Artist predicates (contains/exact/regex on ArtistLower) evaluate once
+    ///   against the ~2.2k distinct artist strings and become ArtistMatch nodes
+    ///   holding the sorted ids that satisfied them — per-printing matching is
+    ///   then an integer membership test, and narrow_candidates can expand the
+    ///   ids through the artist CSR index.
+    pub(crate) fn bind(&mut self, vocab: &AStrings, sorted_ids: &rkyv::Archived<Vec<u16>>, artist_vocab: &AStrings) {
         match self {
             FilterExpr::And(children) | FilterExpr::Or(children) => {
                 for c in children {
-                    c.bind_collection_ids(vocab, sorted_ids);
+                    c.bind(vocab, sorted_ids, artist_vocab);
                 }
             }
-            FilterExpr::Not(inner) => inner.bind_collection_ids(vocab, sorted_ids),
+            FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab),
             FilterExpr::CollectionCmp { value, value_id, .. } => {
                 let i = sorted_ids.partition_point(|id| vocab[u16::from(*id) as usize].as_str() < value.as_str());
                 *value_id = sorted_ids
                     .get(i)
                     .map(|id| u16::from(*id))
                     .filter(|&id| vocab[id as usize].as_str() == value.as_str());
+            }
+            FilterExpr::TextContains { field: TextSearchField::ArtistLower, word } => {
+                let ids = artist_match_ids(artist_vocab, |s| s.contains(word.as_str()));
+                *self = FilterExpr::ArtistMatch { ids };
+            }
+            FilterExpr::TextExact { field: TextField::ArtistLower, op, value } => {
+                let (op, value) = (*op, std::mem::take(value));
+                let ids = artist_match_ids(artist_vocab, |s| match op {
+                    CmpOp::Eq => s == value,
+                    CmpOp::Ne => s != value,
+                    CmpOp::Lt => s < value.as_str(),
+                    CmpOp::Le => s <= value.as_str(),
+                    CmpOp::Gt => s > value.as_str(),
+                    CmpOp::Ge => s >= value.as_str(),
+                });
+                *self = FilterExpr::ArtistMatch { ids };
+            }
+            FilterExpr::TextRegex { field: TextField::ArtistLower, regex } => {
+                let ids = artist_match_ids(artist_vocab, |s| regex.is_match(s));
+                *self = FilterExpr::ArtistMatch { ids };
             }
             _ => {}
         }
@@ -521,6 +567,16 @@ impl FilterExpr {
                     StrVal::Known(s) => tri_bool(s.contains(word.as_str())),
                     StrVal::Null => Tri::Null,
                     StrVal::PDep => Tri::PrintingDep,
+                }
+            }
+
+            FilterExpr::ArtistMatch { ids } => {
+                let Some(p) = printing else { return Tri::PrintingDep };
+                let vid = u16::from(p.card_artist_vid);
+                if vid == ARTIST_NONE {
+                    Tri::Null // no artist: SQL NULL, like the missing-string case before
+                } else {
+                    tri_bool(ids.binary_search(&vid).is_ok())
                 }
             }
 

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -410,14 +410,19 @@ impl FilterExpr {
     }
 
     /// True iff the filter matches this (card, printing) pair. With a printing
-    /// supplied, evaluation is exact — PrintingDep cannot occur.
+    /// supplied, evaluation is exact — PrintingDep cannot occur. The query
+    /// driver goes through card_pass()/residual_matches() instead; this is the
+    /// unfactored single-pair form, kept for tests.
+    #[cfg(test)]
     pub(crate) fn matches(&self, card: &AOracleCard, printing: &APrinting, strings: &AStrings) -> bool {
         self.tri(card, Some(printing), strings) == Tri::True
     }
 
     /// Card-level pass: evaluate with no printing. True means every printing of
     /// the card matches; False/Null mean none can; PrintingDep means the result
-    /// depends on printing-level fields and the driver must evaluate per printing.
+    /// depends on printing-level fields. The query driver uses card_pass()
+    /// (which adds residual extraction); this is the plain form, kept for tests.
+    #[cfg(test)]
     pub(crate) fn eval_card(&self, card: &AOracleCard, strings: &AStrings) -> Tri {
         self.tri(card, None, strings)
     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -224,8 +224,11 @@ struct Printing {
 
     flavor_text_id: u32,
     flavor_text_lower_id: u32,
-    card_artist_id: u32,
-    card_artist_lower_id: u32,
+    // Interned id into CardData.artist_vocab (~2.2k distinct lowercase artist
+    // names); ARTIST_NONE = absent. Artist predicates resolve their match set
+    // against the vocab once per query (FilterExpr::ArtistMatch), so no artist
+    // strings live on the printing.
+    card_artist_vid: u16,
     card_set_code: InlineStr<8>,
     card_border_id: u32,
     card_watermark_id: u32,
@@ -268,8 +271,7 @@ struct CardRow {
     oracle_text_lower_id: u32,
     flavor_text_id: u32,
     flavor_text_lower_id: u32,
-    card_artist_id: u32,
-    card_artist_lower_id: u32,
+    card_artist_vid: u16,
     card_set_code: InlineStr<8>,
     card_layout_id: u32,
     card_border_id: u32,
@@ -317,6 +319,9 @@ pub(crate) type AOffsets = Archived<Vec<u32>>;
 
 /// Sentinel id for absent optional strings (a card never has 4 billion distinct strings).
 const NONE_STR: u32 = u32::MAX;
+
+/// Sentinel for a printing with no artist (see Printing.card_artist_vid).
+pub(crate) const ARTIST_NONE: u16 = u16::MAX;
 
 /// Resolve an interned id against the archived string table; None for absent.
 pub(crate) fn str_at(strings: &AStrings, id: u32) -> Option<&str> {
@@ -586,7 +591,7 @@ fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>) -> ManaCost {
     ManaCost { pips, devotion, cmc: cmc_val.unwrap_or(0.0) }
 }
 
-fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInterner) -> PyResult<CardRow> {
+fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInterner, artists: &mut VocabInterner) -> PyResult<CardRow> {
     let released_at = opt_date_str(d, "released_at").unwrap_or_default();
     let released_at_int: Option<u32> = released_at.replace('-', "").parse().ok();
     // Raw strings from the dict; interned to ids as the struct is built below.
@@ -596,8 +601,10 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
     let oracle_text_lower_id = it.intern(oracle_text.to_lowercase());
     let flavor_text = opt_str(d, "flavor_text").unwrap_or_default();
     let flavor_text_lower_id = it.intern(flavor_text.to_lowercase());
-    let card_artist = opt_str(d, "card_artist");
-    let card_artist_lower_id = it.intern_opt(card_artist.as_ref().map(|s| s.to_lowercase()));
+    let card_artist_vid = match opt_str(d, "card_artist") {
+        Some(a) => artists.intern(a.to_lowercase())?,
+        None => ARTIST_NONE,
+    };
 
     Ok(CardRow {
         scryfall_id: opt_uuid(d, "scryfall_id"),
@@ -610,8 +617,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         oracle_text_id: it.intern(oracle_text),
         flavor_text_lower_id,
         flavor_text_id: it.intern(flavor_text),
-        card_artist_lower_id,
-        card_artist_id: it.intern_opt(card_artist),
+        card_artist_vid,
         card_set_code: InlineStr::<8>::from_str(&opt_str(d, "card_set_code").unwrap_or_default()),
         card_layout_id: it.intern(opt_str(d, "card_layout").unwrap_or_default()),
         card_border_id: it.intern(opt_str(d, "card_border").unwrap_or_default()),
@@ -913,6 +919,80 @@ fn build_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec
         .collect()
 }
 
+// ─── Artist index ─────────────────────────────────────────────────────────────
+// CSR from artist vocab id → printing ids (each row sorted; placement walks
+// store order). Artist predicates resolve their matching vocab ids once per
+// query (bind), then expand the surviving rows here to narrow in printing space.
+
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct ArtistIndex {
+    /// Row boundaries: printings of artist id `a` live at
+    /// `printings[offsets[a] .. offsets[a + 1]]`. Length n_artists + 1.
+    offsets: Vec<u32>,
+    printings: Vec<u32>,
+}
+
+fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
+    let mut offsets = vec![0u32; n_artists + 1];
+    for p in printings {
+        if p.card_artist_vid != ARTIST_NONE {
+            offsets[p.card_artist_vid as usize + 1] += 1;
+        }
+    }
+    for i in 1..offsets.len() {
+        offsets[i] += offsets[i - 1];
+    }
+    let mut cursor = offsets.clone();
+    let mut out = vec![0u32; offsets[n_artists] as usize];
+    for (i, p) in printings.iter().enumerate() {
+        if p.card_artist_vid != ARTIST_NONE {
+            let a = p.card_artist_vid as usize;
+            out[cursor[a] as usize] = i as u32;
+            cursor[a] += 1;
+        }
+    }
+    ArtistIndex { offsets, printings: out }
+}
+
+/// Expand matching artist vocab ids to sorted printing ids via the CSR table.
+fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32> {
+    let mut out: Vec<u32> = Vec::new();
+    for &a in artist_ids {
+        let start = u32::from(idx.offsets[a as usize]) as usize;
+        let end = u32::from(idx.offsets[a as usize + 1]) as usize;
+        out.extend(idx.printings[start..end].iter().map(|x| u32::from(*x)));
+    }
+    out.sort_unstable();
+    out
+}
+
+// ─── Released-at index ────────────────────────────────────────────────────────
+// Sorted (yyyymmdd, printing idx); binary-searched ranges answer date/year
+// filters in printing space. Printings without a date are absent (they can
+// never satisfy a date comparison — SQL NULL semantics).
+
+type DateIndex = Vec<(u32, u32)>;
+
+fn build_date_index(printings: &[Printing]) -> DateIndex {
+    let mut idx: DateIndex = printings
+        .iter()
+        .enumerate()
+        .filter_map(|(i, p)| p.released_at_int.map(|d| (d, i as u32)))
+        .collect();
+    idx.sort_unstable();
+    idx
+}
+
+/// Sorted printing ids with released_at in [lo, hi). Callers translate ops into
+/// half-open ranges; Ne is not selective and never narrows.
+fn date_range_candidates(idx: &Archived<DateIndex>, lo: u32, hi: u32) -> Vec<u32> {
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    let mut result: Vec<u32> = idx[s..e].iter().map(|p| u32::from(p.1)).collect();
+    result.sort_unstable();
+    result
+}
+
 // ─── Type bit index ───────────────────────────────────────────────────────────
 // One sorted Vec<u32> per type bit (14 bits, matching the TYPE_* constants).
 // Bit position N corresponds to TYPE_* = 1 << N.
@@ -950,6 +1030,9 @@ struct CardIndexes {
     oracle_tags:    TagIndex,        // card space
     art_tags:       TagIndex,        // printing space
     is_tags:        TagIndex,        // printing space
+    artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
+    set_codes:      TagIndex,        // printing space
+    released_at:    DateIndex,       // printing space
 }
 
 impl Default for CardIndexes {
@@ -966,6 +1049,9 @@ impl Default for CardIndexes {
             oracle_tags:    HashMap::new(),
             art_tags:       HashMap::new(),
             is_tags:        HashMap::new(),
+            artists:        ArtistIndex::default(),
+            set_codes:      HashMap::new(),
+            released_at:    Vec::new(),
         }
     }
 }
@@ -986,8 +1072,12 @@ struct CardData {
     // (see VocabInterner). ~16k entries / ~200 KB.
     coll_vocab: Vec<String>,
     // Permutation of 0..coll_vocab.len() sorted by string, so query values
-    // resolve to vocab ids by binary search (FilterExpr::bind_collection_ids).
+    // resolve to vocab ids by binary search (FilterExpr::bind).
     coll_vocab_sorted: Vec<u16>,
+    // Distinct lowercase artist names, indexed by Printing.card_artist_vid.
+    // Artist predicates (contains/exact/regex) evaluate against these ~2.2k
+    // strings once per query instead of per printing.
+    artist_vocab: Vec<String>,
     indexes: CardIndexes,
     // The writer's format→shift assignments. Persisted so reader processes —
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
@@ -1085,6 +1175,49 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 CollField::FrameData  => return None, // no index (low-selectivity values dominate)
             };
             idx.get(value.as_str()).map(|v| space(v.iter().map(|x| u32::from(*x)).collect()))
+        }
+
+        FilterExpr::ArtistMatch { ids } => {
+            // ids resolved at bind time; empty means no artist satisfies the
+            // predicate, which proves the empty candidate set.
+            Some(Candidates::Printings(expand_artist_ids(&indexes.artists, ids)))
+        }
+
+        FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
+            // A set code absent from the index appears on no printing: narrowing
+            // to the empty set is exact, matching the tag-index convention would
+            // be None, but unlike tags the index covers every non-empty code.
+            Some(Candidates::Printings(
+                indexes.set_codes.get(value.as_str()).map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(*x)).collect()),
+            ))
+        }
+
+        FilterExpr::DateCmp { op, value } => {
+            let (lo, hi) = match op {
+                CmpOp::Ne => return None,
+                CmpOp::Eq => (*value, value.saturating_add(1)),
+                CmpOp::Lt => (0, *value),
+                CmpOp::Le => (0, value.saturating_add(1)),
+                CmpOp::Gt => (value.saturating_add(1), u32::MAX),
+                CmpOp::Ge => (*value, u32::MAX),
+            };
+            Some(Candidates::Printings(date_range_candidates(&indexes.released_at, lo, hi)))
+        }
+
+        FilterExpr::YearCmp { op, year } => {
+            if *year < 0 || *year > 9999 {
+                return None;
+            }
+            let y = *year as u32;
+            let (lo, hi) = match op {
+                CmpOp::Ne => return None,
+                CmpOp::Eq => (y * 10_000, (y + 1) * 10_000),
+                CmpOp::Lt => (0, y * 10_000),
+                CmpOp::Le => (0, (y + 1) * 10_000),
+                CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
+                CmpOp::Ge => (y * 10_000, u32::MAX),
+            };
+            Some(Candidates::Printings(date_range_candidates(&indexes.released_at, lo, hi)))
         }
 
         FilterExpr::And(children) => {
@@ -1491,7 +1624,7 @@ fn card_to_pydict<'py>(
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change the struct sizes below wouldn't
 /// catch (e.g. reordering same-size fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260705;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260706;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -1524,6 +1657,7 @@ struct Staging {
     rows: Vec<CardRow>,
     interner: Interner,
     vocab: VocabInterner,
+    artists: VocabInterner,
     #[allow(dead_code)] // held for its flock; released on drop
     lock_file: std::fs::File,
 }
@@ -1705,7 +1839,7 @@ impl QueryEngine {
         #[cfg(feature = "alloc-counter")]
         alloc_stats::reset_peak();
 
-        *staging = Some(Staging { rows: Vec::new(), interner: Interner::new(), vocab: VocabInterner::new(), lock_file });
+        *staging = Some(Staging { rows: Vec::new(), interner: Interner::new(), vocab: VocabInterner::new(), artists: VocabInterner::new(), lock_file });
         Ok(true)
     }
 
@@ -1717,7 +1851,7 @@ impl QueryEngine {
         })?;
         for item in db_rows.iter() {
             if let Ok(d) = item.cast::<PyDict>() {
-                staging.rows.push(card_from_pydict(&d, &mut staging.interner, &mut staging.vocab)?);
+                staging.rows.push(card_from_pydict(&d, &mut staging.interner, &mut staging.vocab, &mut staging.artists)?);
             }
         }
         Ok(())
@@ -1736,7 +1870,7 @@ impl QueryEngine {
         let staging = self.staging.lock().unwrap().take().ok_or_else(|| {
             pyo3::exceptions::PyRuntimeError::new_err("reload_commit called without reload_begin")
         })?;
-        let Staging { mut rows, interner, vocab, lock_file } = staging;
+        let Staging { mut rows, interner, vocab, artists, lock_file } = staging;
 
         // The store groups printings by oracle_id, so rows without one would all
         // collapse into a single card. The DB enforces NOT NULL; fail loudly here
@@ -1815,8 +1949,7 @@ impl QueryEngine {
                 illustration_id: row.illustration_id,
                 flavor_text_id: row.flavor_text_id,
                 flavor_text_lower_id: row.flavor_text_lower_id,
-                card_artist_id: row.card_artist_id,
-                card_artist_lower_id: row.card_artist_lower_id,
+                card_artist_vid: row.card_artist_vid,
                 card_set_code: row.card_set_code,
                 card_border_id: row.card_border_id,
                 card_watermark_id: row.card_watermark_id,
@@ -1844,6 +1977,8 @@ impl QueryEngine {
         drop(interner.map);
         let coll_vocab = vocab.strings;
         drop(vocab.map);
+        let artist_vocab = artists.strings;
+        drop(artists.map);
         // String-sorted permutation of the vocab ids; VocabInterner caps the
         // vocab at u16::MAX entries so the cast can't truncate.
         let mut coll_vocab_sorted: Vec<u16> = (0..coll_vocab.len() as u16).collect();
@@ -1860,6 +1995,18 @@ impl QueryEngine {
             oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
             art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
+            artists:        build_artist_index(&printings, artist_vocab.len()),
+            set_codes:      {
+                let mut idx: TagIndex = HashMap::new();
+                for (i, p) in printings.iter().enumerate() {
+                    let code = p.card_set_code.as_str();
+                    if !code.is_empty() {
+                        idx.entry(code.to_string()).or_default().push(i as u32);
+                    }
+                }
+                idx
+            },
+            released_at:    build_date_index(&printings),
         };
 
         #[cfg(feature = "alloc-counter")]
@@ -1868,7 +2015,7 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, printings, offsets, strings, coll_vocab, coll_vocab_sorted, indexes, format_shifts: format_shifts_snapshot };
+        let card_data = CardData { cards, printings, offsets, strings, coll_vocab, coll_vocab_sorted, artist_vocab, indexes, format_shifts: format_shifts_snapshot };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -1995,7 +2142,7 @@ impl QueryEngine {
         sync_format_shifts(&data.format_shifts);
         let mut filter_expr = build_filter(&json_val)
             .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
-        filter_expr.bind_collection_ids(&data.coll_vocab, &data.coll_vocab_sorted);
+        filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab);
 
         let (total, page) = run_query(
             &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -966,25 +966,41 @@ fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32
     out
 }
 
-// ─── Released-at index ────────────────────────────────────────────────────────
-// Sorted (yyyymmdd, printing idx); binary-searched ranges answer date/year
-// filters in printing space. Printings without a date are absent (they can
-// never satisfy a date comparison — SQL NULL semantics).
+// ─── Sorted-u32 range indexes (released_at, price) ───────────────────────────
+// Sorted (value, printing idx); binary-searched ranges answer range filters in
+// printing space. Printings without the value are absent (they can never
+// satisfy a comparison — SQL NULL semantics). Dates store yyyymmdd directly;
+// prices store f32_sort_bits(price), which orders like the float.
 
 type DateIndex = Vec<(u32, u32)>;
 
-fn build_date_index(printings: &[Printing]) -> DateIndex {
+fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u32>) -> DateIndex {
     let mut idx: DateIndex = printings
         .iter()
         .enumerate()
-        .filter_map(|(i, p)| p.released_at_int.map(|d| (d, i as u32)))
+        .filter_map(|(i, p)| get(p).map(|v| (v, i as u32)))
         .collect();
     idx.sort_unstable();
     idx
 }
 
-/// Sorted printing ids with released_at in [lo, hi). Callers translate ops into
-/// half-open ranges; Ne is not selective and never narrows.
+/// Sorted printing ids satisfying `price op value`, via the f32_sort_bits
+/// index. Query values are f64 while prices are f32, so bounds are widened by
+/// one position where rounding could otherwise exclude a real match —
+/// narrowing must stay a superset; the walk verifies exactly.
+fn price_candidates(idx: &Archived<DateIndex>, op: CmpOp, value: f64) -> Option<Vec<u32>> {
+    let b = f32_sort_bits(value as f32);
+    let (lo, hi) = match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => (b, b.saturating_add(1)),
+        CmpOp::Lt | CmpOp::Le => (0, b.saturating_add(1)),
+        CmpOp::Gt | CmpOp::Ge => (b, u32::MAX),
+    };
+    Some(date_range_candidates(idx, lo, hi))
+}
+
+/// Sorted printing ids with an indexed value in [lo, hi). Callers translate ops
+/// into half-open ranges; Ne is not selective and never narrows.
 fn date_range_candidates(idx: &Archived<DateIndex>, lo: u32, hi: u32) -> Vec<u32> {
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
@@ -1033,6 +1049,7 @@ struct CardIndexes {
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     set_codes:      TagIndex,        // printing space
     released_at:    DateIndex,       // printing space
+    price_usd:      DateIndex,       // printing space (f32_sort_bits of the price)
 }
 
 impl Default for CardIndexes {
@@ -1052,6 +1069,7 @@ impl Default for CardIndexes {
             artists:        ArtistIndex::default(),
             set_codes:      HashMap::new(),
             released_at:    Vec::new(),
+            price_usd:      Vec::new(),
         }
     }
 }
@@ -1148,6 +1166,10 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 numeric_candidates(&indexes.toughness, *op, *v).map(Candidates::Cards),
             (NumExpr::Const(v), NumExpr::Field(NumField::Toughness)) =>
                 numeric_candidates(&indexes.toughness, flip_op(*op), *v).map(Candidates::Cards),
+            (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) =>
+                price_candidates(&indexes.price_usd, *op, *v).map(Candidates::Printings),
+            (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) =>
+                price_candidates(&indexes.price_usd, flip_op(*op), *v).map(Candidates::Printings),
             _ => None,
         },
 
@@ -1624,7 +1646,7 @@ fn card_to_pydict<'py>(
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change the struct sizes below wouldn't
 /// catch (e.g. reordering same-size fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260706;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260707;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2006,7 +2028,8 @@ impl QueryEngine {
                 }
                 idx
             },
-            released_at:    build_date_index(&printings),
+            released_at:    build_range_index(&printings, |p| p.released_at_int),
+            price_usd:      build_range_index(&printings, |p| p.price_usd.map(f32_sort_bits)),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,9 +1,10 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_type_index, cards_of_printings, count_common_keywords, count_common_types,
-    narrow_candidates, run_query, trigram_candidates, CardData, CardIndexes, Candidates,
+    build_artist_index, build_date_index, narrow_candidates, run_query, trigram_candidates,
+    ArtistIndex, CardData, CardIndexes, Candidates,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
-    Tri, TrigramIndex, VocabInterner, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
+    Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
     TYPE_LEGENDARY, TYPE_PLANESWALKER,
 };
 use rkyv::{rancor::Error, Archived};
@@ -168,8 +169,7 @@ fn stub_printing(scryfall_id: u128, illustration_id: u128, prefer_score: Option<
         illustration_id,
         flavor_text_id: NONE_STR,
         flavor_text_lower_id: NONE_STR,
-        card_artist_id: NONE_STR,
-        card_artist_lower_id: NONE_STR,
+        card_artist_vid: ARTIST_NONE,
         card_set_code: InlineStr::from_str(""),
         card_border_id: NONE_STR,
         card_watermark_id: NONE_STR,
@@ -218,6 +218,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         strings: vec![],
         coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
+        artist_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
     }
@@ -352,7 +353,7 @@ fn collection_cmp_binds_vocab_ids_and_matches() {
             value: value.to_string(),
             value_id: None,
         };
-        f.bind_collection_ids(&archived.coll_vocab, &archived.coll_vocab_sorted);
+        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
         archived.cards.iter().map(|c| f.eval_card(c, &archived.strings) == Tri::True).collect()
     };
 
@@ -382,7 +383,7 @@ fn printing_level_predicates_are_printing_dep_in_card_pass() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    f.bind_collection_ids(&archived.coll_vocab, &archived.coll_vocab_sorted);
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
 
     let card = &archived.cards[0];
     // Card pass can't decide an art-tag predicate...
@@ -532,7 +533,6 @@ fn bench_checked_vs_unchecked_access() {
             let mut p = stub_printing(pid, pid, Some((PRINTINGS_PER_CARD - k) as f32));
             p.flavor_text_id = interner.intern(flavor.clone());
             p.flavor_text_lower_id = interner.intern(flavor.to_lowercase());
-            p.card_artist_id = interner.intern(format!("Artist {}", i % 1000));
             p.set_name_id = interner.intern(format!("Benchmark Set {}", i % 300));
             printings.push(p);
         }
@@ -553,6 +553,9 @@ fn bench_checked_vs_unchecked_access() {
         oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
         art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
+        artists:        ArtistIndex::default(),
+        set_codes:      HashMap::new(),
+        released_at:    Vec::new(),
     };
     let data = CardData {
         cards,
@@ -561,6 +564,7 @@ fn bench_checked_vs_unchecked_access() {
         strings,
         coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
+        artist_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
     };
@@ -606,7 +610,7 @@ fn card_pass_extracts_residual_and_matches() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    wolf.bind_collection_ids(&archived.coll_vocab, &archived.coll_vocab_sorted);
+    wolf.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
 
     // And[t:creature, art:wolf]: the type check is proven at card level and
@@ -634,11 +638,118 @@ fn card_pass_extracts_residual_and_matches() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    wolf2.bind_collection_ids(&archived.coll_vocab, &archived.coll_vocab_sorted);
+    wolf2.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
     let or = FilterExpr::Or(vec![creature(), wolf2]);
     let t = or.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or);
     assert!(t == Tri::True && residual.is_empty());
     let t = or.card_pass(&archived.cards[1], &archived.strings, &mut residual, &mut is_or);
     assert!(t == Tri::PrintingDep && residual.len() == 1 && is_or);
     assert!(!FilterExpr::residual_matches(&archived.cards[1], &archived.printings[2], &archived.strings, &residual, is_or));
+}
+
+#[test]
+fn artist_predicates_bind_to_vocab_ids_and_narrow() {
+    // Two artists; printings 0,2 by "rebecca guay", printing 1 by "john avon",
+    // printing 3 has no artist.
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 2], vocab);
+    let mut artists = VocabInterner::new();
+    let rebecca = artists.intern("rebecca guay".to_string()).unwrap();
+    let avon = artists.intern("john avon".to_string()).unwrap();
+    data.printings[0].card_artist_vid = rebecca;
+    data.printings[1].card_artist_vid = avon;
+    data.printings[2].card_artist_vid = rebecca;
+    data.artist_vocab = artists.strings;
+    data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut f = FilterExpr::TextContains {
+        field: super::TextSearchField::ArtistLower,
+        word: "rebecca".to_string(),
+    };
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    // bind rewrites the contains into an id-set match
+    let FilterExpr::ArtistMatch { ref ids } = f else { panic!("expected ArtistMatch after bind") };
+    assert_eq!(ids, &vec![rebecca]);
+
+    // per-printing evaluation: integer membership; missing artist is Null (no match)
+    let card = &archived.cards[0];
+    assert!(f.matches(card, &archived.printings[0], &archived.strings));
+    assert!(!f.matches(card, &archived.printings[1], &archived.strings));
+    assert!(!f.matches(card, &archived.printings[3], &archived.strings));
+    assert!(f.eval_card(card, &archived.strings) == Tri::PrintingDep);
+
+    // narrowing expands the CSR rows to sorted printing ids
+    match narrow_candidates(&f, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
+        _ => panic!("artist predicate must narrow in printing space"),
+    }
+
+    // an artist matching nothing narrows to the exact empty set
+    let mut g = FilterExpr::TextContains {
+        field: super::TextSearchField::ArtistLower,
+        word: "zzz".to_string(),
+    };
+    g.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    match narrow_candidates(&g, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty()),
+        _ => panic!("empty artist match must narrow to the empty set"),
+    }
+}
+
+#[test]
+fn set_code_and_date_narrowing() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 1], vocab);
+    data.printings[0].card_set_code = InlineStr::from_str("lea");
+    data.printings[1].card_set_code = InlineStr::from_str("fdn");
+    data.printings[2].card_set_code = InlineStr::from_str("lea");
+    data.printings[0].released_at_int = Some(19930805);
+    data.printings[1].released_at_int = Some(20241115);
+    data.printings[2].released_at_int = None; // dateless printings never satisfy date filters
+    // set_codes / released_at built the way reload_commit builds them
+    let mut set_codes: TagIndex = HashMap::new();
+    for (i, p) in data.printings.iter().enumerate() {
+        set_codes.entry(p.card_set_code.as_str().to_string()).or_default().push(i as u32);
+    }
+    data.indexes.set_codes = set_codes;
+    data.indexes.released_at = build_date_index(&data.printings);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let lea = FilterExpr::TextExact {
+        field: super::TextField::SetCode,
+        op: CmpOp::Eq,
+        value: "lea".to_string(),
+    };
+    match narrow_candidates(&lea, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
+        _ => panic!("set code must narrow in printing space"),
+    }
+    // Unknown set code: exact empty narrowing (the index covers every code).
+    let none = FilterExpr::TextExact {
+        field: super::TextField::SetCode,
+        op: CmpOp::Eq,
+        value: "zzz".to_string(),
+    };
+    match narrow_candidates(&none, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty()),
+        _ => panic!("unknown set code must narrow to the empty set"),
+    }
+
+    let year1993 = FilterExpr::YearCmp { op: CmpOp::Eq, year: 1993 };
+    match narrow_candidates(&year1993, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![0]),
+        _ => panic!("year must narrow in printing space"),
+    }
+    let date_ge = FilterExpr::DateCmp { op: CmpOp::Ge, value: 20240101 };
+    match narrow_candidates(&date_ge, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![1]),
+        _ => panic!("date must narrow in printing space"),
+    }
+    // Ne is not selective and must not narrow.
+    assert!(narrow_candidates(&FilterExpr::DateCmp { op: CmpOp::Ne, value: 19930805 }, &archived.indexes, &archived.offsets).is_none());
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_type_index, cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_date_index, narrow_candidates, run_query, trigram_candidates,
+    build_artist_index, build_range_index, narrow_candidates, run_query, trigram_candidates,
     ArtistIndex, CardData, CardIndexes, Candidates,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
@@ -556,6 +556,7 @@ fn bench_checked_vs_unchecked_access() {
         artists:        ArtistIndex::default(),
         set_codes:      HashMap::new(),
         released_at:    Vec::new(),
+        price_usd:      Vec::new(),
     };
     let data = CardData {
         cards,
@@ -716,7 +717,7 @@ fn set_code_and_date_narrowing() {
         set_codes.entry(p.card_set_code.as_str().to_string()).or_default().push(i as u32);
     }
     data.indexes.set_codes = set_codes;
-    data.indexes.released_at = build_date_index(&data.printings);
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -752,4 +753,54 @@ fn set_code_and_date_narrowing() {
     }
     // Ne is not selective and must not narrow.
     assert!(narrow_candidates(&FilterExpr::DateCmp { op: CmpOp::Ne, value: 19930805 }, &archived.indexes, &archived.offsets).is_none());
+}
+
+#[test]
+fn price_narrowing_is_a_superset_under_f32_rounding() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[4], vocab);
+    data.printings[0].price_usd = Some(0.05);
+    data.printings[1].price_usd = Some(0.1); // sits at the query boundary
+    data.printings[2].price_usd = Some(60.0);
+    data.printings[3].price_usd = None; // priceless printings never satisfy price filters
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd.map(super::f32_sort_bits));
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let cheap = FilterExpr::NumericCmp {
+        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
+        op: CmpOp::Lt,
+        rhs: super::NumExpr::Const(0.10),
+    };
+    // 0.10f64 is not representable as f32; the widened bound may include the
+    // boundary printing as a candidate, but must never lose printing 0.
+    match narrow_candidates(&cheap, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => {
+            assert!(v.contains(&0));
+            assert!(!v.contains(&2) && !v.contains(&3));
+        }
+        _ => panic!("usd must narrow in printing space"),
+    }
+    // ...and the walk's exact evaluation rejects the boundary printing.
+    let card = &archived.cards[0];
+    assert!(cheap.matches(card, &archived.printings[0], &archived.strings));
+    assert!(!cheap.matches(card, &archived.printings[1], &archived.strings));
+
+    let pricey = FilterExpr::NumericCmp {
+        lhs: super::NumExpr::Const(50.0),
+        op: CmpOp::Lt,
+        rhs: super::NumExpr::Field(super::NumField::PriceUsd),
+    };
+    match narrow_candidates(&pricey, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
+        _ => panic!("flipped usd comparison must narrow"),
+    }
+    // Ne is not selective.
+    let ne = FilterExpr::NumericCmp {
+        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
+        op: CmpOp::Ne,
+        rhs: super::NumExpr::Const(1.0),
+    };
+    assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets).is_none());
 }


### PR DESCRIPTION
Three of the four items from the unindexed-predicates follow-up to #604 (the expensive-pattern list its benchmarks surfaced).

## What

**Artist vocab.** Printings store a `u16` id into a ~2.2k-entry distinct-artist table instead of two interned string ids (−6 B/printing, and the artist strings leave the interned strings table). `bind()` evaluates artist predicates — contains, exact (all six ops), and regex — against the vocab **once per query** and rewrites the node to `ArtistMatch { ids }`; per-printing matching becomes an integer binary search, and `narrow_candidates` expands the matching ids through a CSR artist index so `a:` queries narrow in printing space. A predicate matching no artist proves the empty candidate set.

**Set-code index.** `TagIndex` from set code → sorted printing ids; exact `set:` queries narrow instead of scanning, and an unknown code narrows to the exact empty set (the index covers every non-empty code, unlike the tag indexes where absence means "can't narrow").

**Released-at index.** Sorted `(yyyymmdd, printing)` pairs; `date` and `year` comparisons narrow to binary-searched ranges in printing space (Ne stays unnarrowed; dateless printings are absent from the index and can never satisfy a date filter, matching SQL NULL semantics).

**Price index (usd).** Added after a 452-config predicate survey put unindexed printing predicates at the top of the remaining slow tail, with `usd` the most common Or ingredient that voids narrowing. Prices reuse the released-at range-index shape via `f32_sort_bits`; op bounds carry one position of slack where f64→f32 rounding could otherwise exclude a real match (narrowing stays a superset, the walk verifies exactly). Survey deltas: bare `usd<0.10` 2.3×, `(t:goblin or usd>50)` **7.0×** (the Or becomes fully narrowable), geomean 1.38× over the 20 usd configs; survey-wide p90 1.09 → 1.03 ms, p99 1.88 → 1.78 ms.

Archive format version bumped.

## Measured impact (targeted suite, branch vs main, 97,199-printing corpus)

| Query | Matches | main med (ms) | branch med (ms) | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `a:guay` | 182 | 2.338 | 0.221 | **10.6×** |
| `a:rebecca` | 163 | 2.143 | 0.234 | **9.2×** |
| `t:creature (set:lea or set:leb or set:2ed)` | 92 | 1.312 | 0.163 | **8.1×** |
| `set:lea` | 287 | 0.849 | 0.139 | 6.1× |
| `a:rebecca t:creature` | 69 | 1.290 | 0.231 | 5.6× |
| `t:creature (o:"draw a card" or a:rebecca)` | 1,459 | 2.366 | 0.506 | **4.7×** |
| `year=1993` | 365 | 0.562 | 0.139 | 4.1× |
| `t:creature set:lea` | 92 | 0.588 | 0.147 | 4.0× |
| `year=1994` | 890 | 0.569 | 0.159 | 3.6× |
| `t:creature year<=1995` | 635 | 0.574 | 0.242 | 2.4× |
| `date>=2025-01-01` | 5,781 | 0.579 | 0.472 | 1.2× |
| `f:modern r:rare` (untouched, guard) | 6,518 | 0.776 | 0.739 | 1.05× |

Geomean **4.2×** over the targeted suite. The compound-Or row was #604's worst pattern: one unindexable Or child (`a:rebecca`) used to void the sibling's trigram narrowing; with artists narrowable the whole Or narrows and the query collapses to a small intersection.

Regression guards: the #604 34-config suite runs at 1.20× geomean vs main (its former index-less rows — `a:rebecca` 12.6×, `year=1994` 3.6×, `t:creature set:lea` 3.4× — account for the lift) and the nested suite at 1.96× with **no config below 0.95×**. Two configs that flickered slow in one suite round (`mana:{2}{G}{G}`, `o:"draw a card"`) were A/B-verified identical at min (0.453 vs 0.456 ms; 0.364 vs 0.348) — suite-run noise, their code paths are untouched.

**Parity: identical totals and card-name sequences on all 60 configs across the three suites.**

## Memory

Archive 72.7 → 74.2 MB: +~1.6 MB for the three index tables net of the artist-string savings. Reload peak 163.3 → 161.3 MB.

## Tests

- `cargo test`: 19 passed (new: artist bind-rewrite/membership/narrowing incl. empty-match and missing-artist Null; set-code and date/year narrowing incl. unknown-code empty set and Ne non-narrowing; usd narrowing incl. the f32-rounding boundary superset)
- `python -m pytest api/`: 1836 passed

Remaining from the follow-up ticket: legality postings with the ~25% selectivity threshold. Post-survey, the slow tail is flavor-text scans (`ft:`, ~1.4–2.4 ms in Or-combos, would need a flavor trigram index — several MB for a rarely-searched field), border/frame/legality Or-combos, and artwork-mode emission over 20–45k groups; details in docs/issues/engine-unindexed-predicates.md.
