### PR TITLE
Add Card HTML Parity Test and Converge JS/No-JS Renderers

### DIFF
--- a/api/noscript_helpers.py
+++ b/api/noscript_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 MAX_ORACLE_TEXT_LENGTH = 200
+MAX_ALT_TEXT_LENGTH = 300  # oracle text truncation length in image alt/title text
 _EAGER_LOAD_COUNT = 4  # covers a full first row at the widest common grid (4 columns)
 
 
@@ -19,7 +20,9 @@ def escape_html(text: str) -> str:
     -------
         HTML-escaped text
     """
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")
+    # Matches the JS escapeHtml character set. Single quotes don't need escaping:
+    # all attributes use double quotes and single quotes are safe in HTML text content.
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
 
 
 def convert_mana_symbols(text: str, is_modal: bool = False) -> str:
@@ -126,6 +129,92 @@ def convert_mana_symbols(text: str, is_modal: bool = False) -> str:
     return re.sub(r"\{[^}]{1,5}\}", replace_symbol, text)
 
 
+# Unicode text representations of mana symbols — matches JavaScript manaTextMap
+_MANA_TEXT_MAP = {
+    "{W}": "☀️",
+    "{U}": "💧",
+    "{B}": "💀",
+    "{R}": "🔥",
+    "{G}": "🌳",
+    "{C}": "◇",
+    "{T}": "↻",
+    "{Q}": "↺",
+    "{E}": "⚡",
+    "{P}": "Φ",
+    "{S}": "❄",
+    "{X}": "X",
+    "{Y}": "Y",
+    "{Z}": "Z",
+    "{0}": "⓪",
+    "{1}": "①",
+    "{2}": "②",
+    "{3}": "③",
+    "{4}": "④",
+    "{5}": "⑤",
+    "{6}": "⑥",
+    "{7}": "⑦",
+    "{8}": "⑧",
+    "{9}": "⑨",
+    "{10}": "⑩",
+    "{11}": "⑪",
+    "{12}": "⑫",
+    "{13}": "⑬",
+    "{14}": "⑭",
+    "{15}": "⑮",
+    "{16}": "⑯",
+    "{CHAOS}": "🌀",
+    "{PW}": "PW",
+    "{∞}": "♾︎",
+    "{W/U}": "(☀️/💧)",
+    "{U/B}": "(💧/💀)",
+    "{B/R}": "(💀/🔥)",
+    "{R/G}": "(🔥/🌳)",
+    "{G/W}": "(🌳/☀️)",
+    "{W/B}": "(☀️/💀)",
+    "{U/R}": "(💧/🔥)",
+    "{B/G}": "(💀/🌳)",
+    "{R/W}": "(🔥/☀️)",
+    "{G/U}": "(🌳/💧)",
+    "{2/W}": "(②/☀️)",
+    "{2/U}": "(②/💧)",
+    "{2/B}": "(②/💀)",
+    "{2/R}": "(②/🔥)",
+    "{2/G}": "(②/🌳)",
+    "{W/P}": "(☀️/Φ)",
+    "{U/P}": "(💧/Φ)",
+    "{B/P}": "(💀/Φ)",
+    "{R/P}": "(🔥/Φ)",
+    "{G/P}": "(🌳/Φ)",
+    "{W/U/P}": "(☀️/💧/Φ)",
+    "{W/B/P}": "(☀️/💀/Φ)",
+    "{U/B/P}": "(💧/💀/Φ)",
+    "{U/R/P}": "(💧/🔥/Φ)",
+    "{B/R/P}": "(💀/🔥/Φ)",
+    "{B/G/P}": "(💀/🌳/Φ)",
+    "{R/W/P}": "(🔥/☀️/Φ)",
+    "{R/G/P}": "(🔥/🌳/Φ)",
+    "{G/W/P}": "(🌳/☀️/Φ)",
+    "{G/U/P}": "(🌳/💧/Φ)",
+}
+
+
+def convert_mana_symbols_to_text(text: str) -> str:
+    """Convert mana symbols to Unicode text (for alt text) — matches JS convertManaSymbolsToText.
+
+    Args:
+    ----
+        text: Text containing mana symbols like {W}, {U}, etc.
+
+    Returns:
+    -------
+        Text with mana symbols replaced by Unicode representations
+    """
+    if not text:
+        return ""
+
+    return re.sub(r"\{[^}]{1,5}\}", lambda match: _MANA_TEXT_MAP.get(match.group(0), match.group(0)), text)
+
+
 def format_oracle_text(oracle_text: str, is_modal: bool = False) -> str:
     """Format oracle text with mana symbols and line breaks.
 
@@ -140,8 +229,6 @@ def format_oracle_text(oracle_text: str, is_modal: bool = False) -> str:
     """
     if not oracle_text:
         return ""
-
-    oracle_text = oracle_text.strip()
 
     # Convert mana symbols first
     formatted = convert_mana_symbols(oracle_text, is_modal)
@@ -168,6 +255,32 @@ def build_image_url(card: dict, size: str) -> str:
     return f"https://d1hot9ps2xugbc.cloudfront.net/img/{set_code}/{collector_number}/{face}/{size}.webp"
 
 
+def _build_alt_text(card: dict) -> str:
+    """Build descriptive image alt text with card name, mana cost, and oracle text.
+
+    Matches the alt text built in JS createCardHTML.
+
+    Args:
+    ----
+        card: Card dictionary with name, mana_cost, and oracle_text
+
+    Returns:
+    -------
+        HTML-escaped alt text
+    """
+    alt_text = escape_html(card.get("name") or "Unknown Card")
+    if card.get("mana_cost"):
+        mana_text_representation = convert_mana_symbols_to_text(card["mana_cost"])
+        alt_text += f" / {escape_html(mana_text_representation)}"
+    alt_text += "\n\n"
+    if card.get("oracle_text"):
+        oracle_text_with_symbols = convert_mana_symbols_to_text(card["oracle_text"])
+        if len(oracle_text_with_symbols) > MAX_ALT_TEXT_LENGTH:
+            oracle_text_with_symbols = oracle_text_with_symbols[:MAX_ALT_TEXT_LENGTH] + "..."
+        alt_text += escape_html(oracle_text_with_symbols)
+    return alt_text
+
+
 def create_card_html(card: dict, index: int) -> str:
     """Generate HTML for a single card (server-side rendering).
 
@@ -188,8 +301,7 @@ def create_card_html(card: dict, index: int) -> str:
     image_538 = build_image_url(card, "538")
     image_745 = build_image_url(card, "745")
 
-    # Create alt text
-    alt_text = escape_html(card.get("name", "Unknown Card"))
+    alt_text = _build_alt_text(card)
 
     # Build srcset and sizes for responsive images
     # sizes breakpoints are one below the CSS grid min-width thresholds (< not <=):
@@ -213,7 +325,7 @@ def create_card_html(card: dict, index: int) -> str:
     # Use 388px as default src (good middle ground for initial load)
     priority_attr = ' fetchpriority="high"' if index == 0 else ""
     lazy_attr = "" if index < _EAGER_LOAD_COUNT else ' loading="lazy"'
-    image_html = (
+    img_tag = (
         f'<img class="card-image" '
         f'src="{escape_html(image_388)}" '
         f'srcset="{srcset}" '
@@ -221,8 +333,14 @@ def create_card_html(card: dict, index: int) -> str:
         f'alt="{alt_text}" title="{alt_text}"{priority_attr}{lazy_attr} />'
     )
 
+    # Link the image to the card detail page — matches JS createCardHTML
+    if card.get("set_code") and card.get("collector_number"):
+        image_html = f'<a href="/card/{card["set_code"]}/{card["collector_number"]}" class="card-page-link">{img_tag}</a>'
+    else:
+        image_html = img_tag
+
     # Build card components
-    name_html = f'<div class="card-name">{escape_html(card.get("name", "Unknown Card"))}</div>'
+    name_html = f'<div class="card-name">{escape_html(card.get("name") or "Unknown Card")}</div>'
 
     mana_html = ""
     if card.get("mana_cost"):

--- a/api/noscript_helpers.py
+++ b/api/noscript_helpers.py
@@ -335,7 +335,8 @@ def create_card_html(card: dict, index: int) -> str:
 
     # Link the image to the card detail page — matches JS createCardHTML
     if card.get("set_code") and card.get("collector_number"):
-        image_html = f'<a href="/card/{card["set_code"]}/{card["collector_number"]}" class="card-page-link">{img_tag}</a>'
+        card_page_path = f"/card/{escape_html(card['set_code'])}/{escape_html(card['collector_number'])}"
+        image_html = f'<a href="{card_page_path}" class="card-page-link">{img_tag}</a>'
     else:
         image_html = img_tag
 

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -777,9 +777,14 @@ class CardSearch {
       // and the cutoff matches Python string slicing in noscript_helpers.
       const oracleTextWithSymbols = this.convertManaSymbolsToText(card.oracle_text);
       const maxLength = 300;
-      const codePoints = Array.from(oracleTextWithSymbols);
-      const truncatedText =
-        codePoints.length > maxLength ? codePoints.slice(0, maxLength).join('') + '...' : oracleTextWithSymbols;
+      let truncatedText = oracleTextWithSymbols;
+      // Code-point count is always <= UTF-16 length, so short strings can skip the array
+      if (oracleTextWithSymbols.length > maxLength) {
+        const codePoints = Array.from(oracleTextWithSymbols);
+        if (codePoints.length > maxLength) {
+          truncatedText = codePoints.slice(0, maxLength).join('') + '...';
+        }
+      }
       altText += this.escapeHtml(truncatedText);
     }
 
@@ -802,7 +807,7 @@ class CardSearch {
     const imgTag = `<img class="card-image" src="${this.escapeHtml(image388)}" srcset="${srcset}" sizes="${sizes}" alt="${altText}" title="${altText}"${fetchPriorityAttr}${loadingAttr} />`;
     const imageHtml =
       card.set_code && card.collector_number
-        ? `<a href="/card/${card.set_code}/${card.collector_number}" class="card-page-link">${imgTag}</a>`
+        ? `<a href="/card/${this.escapeHtml(card.set_code)}/${this.escapeHtml(card.collector_number)}" class="card-page-link">${imgTag}</a>`
         : imgTag;
 
     // Truncate oracle text without cutting a mana symbol in half — matches Python create_card_html

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -772,13 +772,14 @@ class CardSearch {
     }
     altText += '\n\n';
     if (card.oracle_text) {
-      // Convert mana symbols in oracle text to Unicode for alt text first, then truncate
+      // Convert mana symbols in oracle text to Unicode for alt text first, then truncate.
+      // Truncate on code points (not UTF-16 units) so an emoji can't be split in half
+      // and the cutoff matches Python string slicing in noscript_helpers.
       const oracleTextWithSymbols = this.convertManaSymbolsToText(card.oracle_text);
       const maxLength = 300;
+      const codePoints = Array.from(oracleTextWithSymbols);
       const truncatedText =
-        oracleTextWithSymbols.length > maxLength
-          ? oracleTextWithSymbols.substring(0, maxLength) + '...'
-          : oracleTextWithSymbols;
+        codePoints.length > maxLength ? codePoints.slice(0, maxLength).join('') + '...' : oracleTextWithSymbols;
       altText += this.escapeHtml(truncatedText);
     }
 
@@ -804,6 +805,21 @@ class CardSearch {
         ? `<a href="/card/${card.set_code}/${card.collector_number}" class="card-page-link">${imgTag}</a>`
         : imgTag;
 
+    // Truncate oracle text without cutting a mana symbol in half — matches Python create_card_html
+    let oracleHtml = '';
+    if (card.oracle_text) {
+      if (card.oracle_text.length > 200) {
+        let truncated = card.oracle_text.substring(0, 200);
+        // If we're in the middle of a mana symbol (unclosed brace), back up to before it
+        if ((truncated.match(/\{/g) || []).length > (truncated.match(/\}/g) || []).length) {
+          truncated = truncated.substring(0, truncated.lastIndexOf('{'));
+        }
+        oracleHtml = `<div class="card-text">${this.formatOracleText(truncated, false)}...</div>`;
+      } else {
+        oracleHtml = `<div class="card-text">${this.formatOracleText(card.oracle_text, false)}</div>`;
+      }
+    }
+
     return `
        <div class="card-item" data-card-id="${this.escapeHtml(cardId)}">
            ${imageHtml}
@@ -812,7 +828,7 @@ class CardSearch {
                ${card.mana_cost ? `<div class="card-mana">${this.convertManaSymbols(card.mana_cost, false)}</div>` : ''}
            </div>
            ${card.type_line ? `<div class="card-type">${this.escapeHtml(card.type_line)}</div>` : ''}
-           ${card.oracle_text ? `<div class="card-text">${this.formatOracleText(card.oracle_text.substring(0, 200), false)}${card.oracle_text.length > 200 ? '...' : ''}</div>` : ''}
+           ${oracleHtml}
            ${(() => {
              const hasPowerToughness =
                card.power !== null &&

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -48,6 +48,7 @@ const { CardSearch, CatalogMap } = Function(appCode + '; return {CardSearch, Cat
 
 const LIVE_CARD_TYPES = require('./fixtures/common_card_types.json');
 const BALANCE_QUERIES = require('./fixtures/balance_queries.json');
+const CARD_HTML_CASES = require('./fixtures/card_html_cases.json');
 
 // Derived fixture: new catalog format expected by the /get_catalog endpoint
 const LIVE_TYPES_MAP = Object.fromEntries(LIVE_CARD_TYPES.map(({ t, n }) => [t, n]));
@@ -370,6 +371,24 @@ describe('CardSearch balanceQuery', () => {
   it.each(BALANCE_QUERIES)('matches parity fixture for $input', ({ input, suffix }) => {
     expect(search.balanceSuffix(input)).toBe(suffix);
     expect(search.balanceQuery(input)).toBe(suffix === null ? input : input + suffix);
+  });
+});
+
+describe('CardSearch createCardHTML no-JS parity', () => {
+  // Keep in sync with normalize_card_html in api/tests/test_noscript_parity.py.
+  // Strips the loading-hint attributes (fetchpriority/loading logic intentionally
+  // differs between the JS and no-JS paths) and inter-tag whitespace (template
+  // indentation differs).
+  function normalizeCardHtml(html) {
+    return html
+      .replaceAll(' fetchpriority="high"', '')
+      .replaceAll(' loading="lazy"', '')
+      .replace(/>\s+</g, '><')
+      .trim();
+  }
+
+  it.each(CARD_HTML_CASES)('matches parity fixture for $id', ({ card, index, html }) => {
+    expect(normalizeCardHtml(search.createCardHTML(card, index, false))).toBe(html);
   });
 });
 

--- a/api/static/fixtures/card_html_cases.json
+++ b/api/static/fixtures/card_html_cases.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "mana-cost-instant",
+    "index": 0,
+    "card": {
+      "name": "Lightning Bolt",
+      "mana_cost": "{R}",
+      "type_line": "Instant",
+      "oracle_text": "Lightning Bolt deals 3 damage to any target.",
+      "set_name": "Magic 2011",
+      "set_code": "m11",
+      "collector_number": "149"
+    },
+    "html": "<div class=\"card-item\" data-card-id=\"0\"><a href=\"/card/m11/149\" class=\"card-page-link\"><img class=\"card-image\" src=\"https://d1hot9ps2xugbc.cloudfront.net/img/m11/149/1/388.webp\" srcset=\"https://d1hot9ps2xugbc.cloudfront.net/img/m11/149/1/280.webp 280w, https://d1hot9ps2xugbc.cloudfront.net/img/m11/149/1/388.webp 388w, https://d1hot9ps2xugbc.cloudfront.net/img/m11/149/1/538.webp 538w, https://d1hot9ps2xugbc.cloudfront.net/img/m11/149/1/745.webp 745w\" sizes=\"(max-width: 409px) calc(100vw - 3.6em), (max-width: 749px) calc(50vw - 2.6em - 7.5px), (max-width: 1369px) calc(33.33vw - 2.27em - 10px), (max-width: 2499px) calc(25vw - 2.1em - 11.25px), calc(20vw - 2em - 12px)\" alt=\"Lightning Bolt / 🔥\n\nLightning Bolt deals 3 damage to any target.\" title=\"Lightning Bolt / 🔥\n\nLightning Bolt deals 3 damage to any target.\" /></a><div class=\"card-name-mana-row\"><div class=\"card-name\">Lightning Bolt</div><div class=\"card-mana\"><span class=\"mana-symbol ms ms-r ms-cost\"></span></div></div><div class=\"card-type\">Instant</div><div class=\"card-text\">Lightning Bolt deals 3 damage to any target.</div><div class=\"card-set-power-row\"><div class=\"card-set\">Magic 2011</div></div></div>"
+  },
+  {
+    "id": "long-oracle-symbol-at-cutoff",
+    "index": 1,
+    "card": {
+      "name": "Sunlit Archivist",
+      "mana_cost": "{2}{W}{W}",
+      "type_line": "Creature — Human Cleric",
+      "oracle_text": "Flying, vigilance\nWhenever Sunlit Archivist attacks, look at the top five cards of your library. You may reveal a Plains card from among them and put it into your hand. Put the others on the bottoms{W} of your library in a random order. If you revealed a card this way, you gain 3 life and scry 2 at the beginning of the next end step.",
+      "power": "2",
+      "toughness": "4",
+      "set_name": "Testament of Parity",
+      "set_code": "top",
+      "collector_number": "12"
+    },
+    "html": "<div class=\"card-item\" data-card-id=\"1\"><a href=\"/card/top/12\" class=\"card-page-link\"><img class=\"card-image\" src=\"https://d1hot9ps2xugbc.cloudfront.net/img/top/12/1/388.webp\" srcset=\"https://d1hot9ps2xugbc.cloudfront.net/img/top/12/1/280.webp 280w, https://d1hot9ps2xugbc.cloudfront.net/img/top/12/1/388.webp 388w, https://d1hot9ps2xugbc.cloudfront.net/img/top/12/1/538.webp 538w, https://d1hot9ps2xugbc.cloudfront.net/img/top/12/1/745.webp 745w\" sizes=\"(max-width: 409px) calc(100vw - 3.6em), (max-width: 749px) calc(50vw - 2.6em - 7.5px), (max-width: 1369px) calc(33.33vw - 2.27em - 10px), (max-width: 2499px) calc(25vw - 2.1em - 11.25px), calc(20vw - 2em - 12px)\" alt=\"Sunlit Archivist / ②☀️☀️\n\nFlying, vigilance\nWhenever Sunlit Archivist attacks, look at the top five cards of your library. You may reveal a Plains card from among them and put it into your hand. Put the others on the bottoms☀️ of your library in a random order. If you revealed a card this way, you gain 3 life and scry 2 at t...\" title=\"Sunlit Archivist / ②☀️☀️\n\nFlying, vigilance\nWhenever Sunlit Archivist attacks, look at the top five cards of your library. You may reveal a Plains card from among them and put it into your hand. Put the others on the bottoms☀️ of your library in a random order. If you revealed a card this way, you gain 3 life and scry 2 at t...\" /></a><div class=\"card-name-mana-row\"><div class=\"card-name\">Sunlit Archivist</div><div class=\"card-mana\"><span class=\"mana-symbol ms ms-2 ms-cost\"></span><span class=\"mana-symbol ms ms-w ms-cost\"></span><span class=\"mana-symbol ms ms-w ms-cost\"></span></div></div><div class=\"card-type\">Creature — Human Cleric</div><div class=\"card-text\">Flying, vigilance<br>Whenever Sunlit Archivist attacks, look at the top five cards of your library. You may reveal a Plains card from among them and put it into your hand. Put the others on the bottoms...</div><div class=\"card-set-power-row\"><div class=\"card-set\">Testament of Parity</div><div class=\"card-power-toughness\">2 / 4</div></div></div>"
+  },
+  {
+    "id": "vanilla-creature-power-toughness",
+    "index": 2,
+    "card": {
+      "name": "Grizzly Bears",
+      "mana_cost": "{1}{G}",
+      "type_line": "Creature — Bear",
+      "oracle_text": "",
+      "power": "2",
+      "toughness": "2",
+      "set_name": "Limited Edition Alpha",
+      "set_code": "lea",
+      "collector_number": "197"
+    },
+    "html": "<div class=\"card-item\" data-card-id=\"2\"><a href=\"/card/lea/197\" class=\"card-page-link\"><img class=\"card-image\" src=\"https://d1hot9ps2xugbc.cloudfront.net/img/lea/197/1/388.webp\" srcset=\"https://d1hot9ps2xugbc.cloudfront.net/img/lea/197/1/280.webp 280w, https://d1hot9ps2xugbc.cloudfront.net/img/lea/197/1/388.webp 388w, https://d1hot9ps2xugbc.cloudfront.net/img/lea/197/1/538.webp 538w, https://d1hot9ps2xugbc.cloudfront.net/img/lea/197/1/745.webp 745w\" sizes=\"(max-width: 409px) calc(100vw - 3.6em), (max-width: 749px) calc(50vw - 2.6em - 7.5px), (max-width: 1369px) calc(33.33vw - 2.27em - 10px), (max-width: 2499px) calc(25vw - 2.1em - 11.25px), calc(20vw - 2em - 12px)\" alt=\"Grizzly Bears / ①🌳\n\n\" title=\"Grizzly Bears / ①🌳\n\n\" /></a><div class=\"card-name-mana-row\"><div class=\"card-name\">Grizzly Bears</div><div class=\"card-mana\"><span class=\"mana-symbol ms ms-1 ms-cost\"></span><span class=\"mana-symbol ms ms-g ms-cost\"></span></div></div><div class=\"card-type\">Creature — Bear</div><div class=\"card-set-power-row\"><div class=\"card-set\">Limited Edition Alpha</div><div class=\"card-power-toughness\">2 / 2</div></div></div>"
+  },
+  {
+    "id": "alt-truncation-emoji-code-points",
+    "index": 3,
+    "card": {
+      "name": "Verdant Chorus",
+      "mana_cost": "{G}{G}",
+      "type_line": "Enchantment",
+      "oracle_text": "{G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows. {G} grows.",
+      "set_name": "Testament of Parity",
+      "set_code": "top",
+      "collector_number": "33"
+    },
+    "html": "<div class=\"card-item\" data-card-id=\"3\"><a href=\"/card/top/33\" class=\"card-page-link\"><img class=\"card-image\" src=\"https://d1hot9ps2xugbc.cloudfront.net/img/top/33/1/388.webp\" srcset=\"https://d1hot9ps2xugbc.cloudfront.net/img/top/33/1/280.webp 280w, https://d1hot9ps2xugbc.cloudfront.net/img/top/33/1/388.webp 388w, https://d1hot9ps2xugbc.cloudfront.net/img/top/33/1/538.webp 538w, https://d1hot9ps2xugbc.cloudfront.net/img/top/33/1/745.webp 745w\" sizes=\"(max-width: 409px) calc(100vw - 3.6em), (max-width: 749px) calc(50vw - 2.6em - 7.5px), (max-width: 1369px) calc(33.33vw - 2.27em - 10px), (max-width: 2499px) calc(25vw - 2.1em - 11.25px), calc(20vw - 2em - 12px)\" alt=\"Verdant Chorus / 🌳🌳\n\n🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 g...\" title=\"Verdant Chorus / 🌳🌳\n\n🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 grows. 🌳 g...\" /></a><div class=\"card-name-mana-row\"><div class=\"card-name\">Verdant Chorus</div><div class=\"card-mana\"><span class=\"mana-symbol ms ms-g ms-cost\"></span><span class=\"mana-symbol ms ms-g ms-cost\"></span></div></div><div class=\"card-type\">Enchantment</div><div class=\"card-text\"><span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. <span class=\"mana-symbol ms ms-g ms-cost\"></span> grows. ...</div><div class=\"card-set-power-row\"><div class=\"card-set\">Testament of Parity</div></div></div>"
+  },
+  {
+    "id": "no-oracle-no-mana-cost",
+    "index": 5,
+    "card": {
+      "name": "Blank Slate",
+      "type_line": "Artifact",
+      "set_code": "top",
+      "collector_number": "77"
+    },
+    "html": "<div class=\"card-item\" data-card-id=\"5\"><a href=\"/card/top/77\" class=\"card-page-link\"><img class=\"card-image\" src=\"https://d1hot9ps2xugbc.cloudfront.net/img/top/77/1/388.webp\" srcset=\"https://d1hot9ps2xugbc.cloudfront.net/img/top/77/1/280.webp 280w, https://d1hot9ps2xugbc.cloudfront.net/img/top/77/1/388.webp 388w, https://d1hot9ps2xugbc.cloudfront.net/img/top/77/1/538.webp 538w, https://d1hot9ps2xugbc.cloudfront.net/img/top/77/1/745.webp 745w\" sizes=\"(max-width: 409px) calc(100vw - 3.6em), (max-width: 749px) calc(50vw - 2.6em - 7.5px), (max-width: 1369px) calc(33.33vw - 2.27em - 10px), (max-width: 2499px) calc(25vw - 2.1em - 11.25px), calc(20vw - 2em - 12px)\" alt=\"Blank Slate\n\n\" title=\"Blank Slate\n\n\" /></a><div class=\"card-name-mana-row\"><div class=\"card-name\">Blank Slate</div></div><div class=\"card-type\">Artifact</div></div>"
+  },
+  {
+    "id": "escaping-quotes-and-hybrid-mana",
+    "index": 7,
+    "card": {
+      "name": "Urza's \"Bauble\" <Prototype>",
+      "mana_cost": "{W/U}{W/U}",
+      "type_line": "Artifact",
+      "oracle_text": "{T}, Sacrifice this artifact: Look at a card & say \"done\".",
+      "set_name": "Ice Age",
+      "set_code": "ice",
+      "collector_number": "6"
+    },
+    "html": "<div class=\"card-item\" data-card-id=\"7\"><a href=\"/card/ice/6\" class=\"card-page-link\"><img class=\"card-image\" src=\"https://d1hot9ps2xugbc.cloudfront.net/img/ice/6/1/388.webp\" srcset=\"https://d1hot9ps2xugbc.cloudfront.net/img/ice/6/1/280.webp 280w, https://d1hot9ps2xugbc.cloudfront.net/img/ice/6/1/388.webp 388w, https://d1hot9ps2xugbc.cloudfront.net/img/ice/6/1/538.webp 538w, https://d1hot9ps2xugbc.cloudfront.net/img/ice/6/1/745.webp 745w\" sizes=\"(max-width: 409px) calc(100vw - 3.6em), (max-width: 749px) calc(50vw - 2.6em - 7.5px), (max-width: 1369px) calc(33.33vw - 2.27em - 10px), (max-width: 2499px) calc(25vw - 2.1em - 11.25px), calc(20vw - 2em - 12px)\" alt=\"Urza's &quot;Bauble&quot; &lt;Prototype&gt; / (☀️/💧)(☀️/💧)\n\n↻, Sacrifice this artifact: Look at a card &amp; say &quot;done&quot;.\" title=\"Urza's &quot;Bauble&quot; &lt;Prototype&gt; / (☀️/💧)(☀️/💧)\n\n↻, Sacrifice this artifact: Look at a card &amp; say &quot;done&quot;.\" /></a><div class=\"card-name-mana-row\"><div class=\"card-name\">Urza's &quot;Bauble&quot; &lt;Prototype&gt;</div><div class=\"card-mana\"><span class=\"mana-symbol ms ms-wu ms-cost\"></span><span class=\"mana-symbol ms ms-wu ms-cost\"></span></div></div><div class=\"card-type\">Artifact</div><div class=\"card-text\"><span class=\"mana-symbol ms ms-tap\"></span>, Sacrifice this artifact: Look at a card & say \"done\".</div><div class=\"card-set-power-row\"><div class=\"card-set\">Ice Age</div></div></div>"
+  }
+]

--- a/api/tests/test_noscript_parity.py
+++ b/api/tests/test_noscript_parity.py
@@ -1,0 +1,42 @@
+"""Parity tests for the server-side (no-JS) card renderer against the shared fixture.
+
+The fixture is the contract both renderers must satisfy: this test checks
+create_card_html(), and the Jest suite in api/static/app.test.js checks
+createCardHTML() against the same file. Regenerate it with
+scripts/generate_card_html_fixture.py after an intentional rendering change.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from api.noscript_helpers import create_card_html
+
+CARD_HTML_CASES = json.loads(
+    (Path(__file__).resolve().parents[1] / "static" / "fixtures" / "card_html_cases.json").read_text(encoding="utf-8")
+)
+
+
+def normalize_card_html(html: str) -> str:
+    """Reduce card HTML to a render-equivalent form for parity comparison.
+
+    Keep in sync with normalizeCardHtml in app.test.js. Strips the loading-hint
+    attributes (fetchpriority/loading logic intentionally differs between the JS and
+    no-JS paths) and inter-tag whitespace (template indentation differs).
+    """
+    html = html.replace(' fetchpriority="high"', "").replace(' loading="lazy"', "")
+    return re.sub(r">\s+<", "><", html).strip()
+
+
+@pytest.mark.parametrize(
+    argnames=["card", "index", "expected_html"],
+    argvalues=[(case["card"], case["index"], case["html"]) for case in CARD_HTML_CASES],
+    ids=[case["id"] for case in CARD_HTML_CASES],
+)
+def test_create_card_html_matches_shared_fixture(card: dict, index: int, expected_html: str) -> None:
+    """The Python renderer must match the shared JS/Python card HTML contract."""
+    assert normalize_card_html(create_card_html(card, index)) == expected_html

--- a/scripts/generate_card_html_fixture.py
+++ b/scripts/generate_card_html_fixture.py
@@ -1,0 +1,147 @@
+"""Regenerate the shared card-HTML parity fixture from the Python renderer.
+
+The fixture (api/static/fixtures/card_html_cases.json) is the contract both renderers
+must satisfy: test_noscript_parity.py checks create_card_html() against it, and the
+Jest suite (app.test.js) checks createCardHTML() against it. Rerun this script after
+an intentional rendering change, then confirm the Jest side still passes.
+
+Usage: python scripts/generate_card_html_fixture.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api.noscript_helpers import create_card_html
+
+FIXTURE_PATH = Path(__file__).resolve().parents[1] / "api" / "static" / "fixtures" / "card_html_cases.json"
+
+# Oracle text engineered so the 200-character card-text cutoff lands inside the {W}
+# symbol (exercising the back-up-before-unclosed-brace logic on both sides) and the
+# converted text exceeds the 300-character alt-text cutoff.
+_LONG_ORACLE_PREFIX = (
+    "Flying, vigilance\n"
+    "Whenever Sunlit Archivist attacks, look at the top five cards of your library. "
+    "You may reveal a Plains card from among them and put it into your hand. "
+    "Put the others on the bottoms"
+)
+_LONG_ORACLE_TEXT = (
+    _LONG_ORACLE_PREFIX
+    + "{W} of your library in a random order. If you revealed a card this way, you gain 3 life and scry 2 at the beginning of the next end step."
+)
+
+CASES = [
+    {
+        "id": "mana-cost-instant",
+        "index": 0,
+        "card": {
+            "name": "Lightning Bolt",
+            "mana_cost": "{R}",
+            "type_line": "Instant",
+            "oracle_text": "Lightning Bolt deals 3 damage to any target.",
+            "set_name": "Magic 2011",
+            "set_code": "m11",
+            "collector_number": "149",
+        },
+    },
+    {
+        "id": "long-oracle-symbol-at-cutoff",
+        "index": 1,
+        "card": {
+            "name": "Sunlit Archivist",
+            "mana_cost": "{2}{W}{W}",
+            "type_line": "Creature — Human Cleric",
+            "oracle_text": _LONG_ORACLE_TEXT,
+            "power": "2",
+            "toughness": "4",
+            "set_name": "Testament of Parity",
+            "set_code": "top",
+            "collector_number": "12",
+        },
+    },
+    {
+        "id": "vanilla-creature-power-toughness",
+        "index": 2,
+        "card": {
+            "name": "Grizzly Bears",
+            "mana_cost": "{1}{G}",
+            "type_line": "Creature — Bear",
+            "oracle_text": "",
+            "power": "2",
+            "toughness": "2",
+            "set_name": "Limited Edition Alpha",
+            "set_code": "lea",
+            "collector_number": "197",
+        },
+    },
+    {
+        # 🌳 is a surrogate pair in JS — guards that the 300-char alt-text cutoff
+        # counts code points on both sides, not UTF-16 units
+        "id": "alt-truncation-emoji-code-points",
+        "index": 3,
+        "card": {
+            "name": "Verdant Chorus",
+            "mana_cost": "{G}{G}",
+            "type_line": "Enchantment",
+            "oracle_text": ("{G} grows. " * 40).strip(),
+            "set_name": "Testament of Parity",
+            "set_code": "top",
+            "collector_number": "33",
+        },
+    },
+    {
+        "id": "no-oracle-no-mana-cost",
+        "index": 5,
+        "card": {
+            "name": "Blank Slate",
+            "type_line": "Artifact",
+            "set_code": "top",
+            "collector_number": "77",
+        },
+    },
+    {
+        "id": "escaping-quotes-and-hybrid-mana",
+        "index": 7,
+        "card": {
+            "name": 'Urza\'s "Bauble" <Prototype>',
+            "mana_cost": "{W/U}{W/U}",
+            "type_line": "Artifact",
+            "oracle_text": '{T}, Sacrifice this artifact: Look at a card & say "done".',
+            "set_name": "Ice Age",
+            "set_code": "ice",
+            "collector_number": "6",
+        },
+    },
+]
+
+
+def normalize_card_html(html: str) -> str:
+    """Reduce card HTML to a render-equivalent form for parity comparison.
+
+    Keep in sync with normalizeCardHtml in app.test.js. Strips the loading-hint
+    attributes (fetchpriority/loading logic intentionally differs between the JS and
+    no-JS paths) and inter-tag whitespace (template indentation differs).
+    """
+    html = html.replace(' fetchpriority="high"', "").replace(' loading="lazy"', "")
+    return re.sub(r">\s+<", "><", html).strip()
+
+
+def main() -> None:
+    """Render each case through the Python renderer and write the fixture."""
+    truncated = _LONG_ORACLE_TEXT[:200]
+    if truncated.count("{") <= truncated.count("}"):
+        message = f"200-char cutoff must land inside a mana symbol (prefix is {len(_LONG_ORACLE_PREFIX)} chars, need 198)"
+        raise ValueError(message)
+
+    fixture = [{**case, "html": normalize_card_html(create_card_html(case["card"], case["index"]))} for case in CASES]
+    FIXTURE_PATH.write_text(json.dumps(fixture, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {len(fixture)} cases to {FIXTURE_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`createCardHTML()` in `app.js` and `create_card_html()` in `noscript_helpers.py` must produce equivalent card HTML, but nothing enforced it and they had drifted in several ways (alt text, card-page link, truncation behavior, escaping). Silent divergence here only gets noticed by screen reader and CLI browser users, so it tends to stay broken.

This converges the two renderers and adds a shared-fixture parity test, following the pattern established by the balance-query fixtures (#597): one fixture consumed by both the Jest suite and a pytest.

## Renderer convergence

- **Python** gains the descriptive image alt text (name + Unicode mana cost + oracle text truncated at 300 chars) and the card-detail-page `<a>` around the image, matching JS
- **Both sides** now back up before an unclosed `{` when truncating oracle text at 200 chars, so a mana symbol is never rendered half-cut
- **Python** `escape_html` no longer escapes single quotes (matches JS; safe since all attributes are double-quoted) and `format_oracle_text` no longer strips whitespace (matches JS)
- **JS** alt-text truncation counts code points instead of UTF-16 units, so emoji mana symbols can't be split by the cutoff and it matches Python string slicing

The `fetchpriority`/`loading` logic intentionally still differs between the two paths; the test's normalizer strips those attributes (plus inter-tag whitespace) pending a decision on converging them.

## The test

- `api/static/fixtures/card_html_cases.json` — 6 representative cards (mana cost, oracle text engineered so the 200-char cutoff lands inside a `{W}`, power/toughness, no-text/no-cost edge case, HTML-escaping + hybrid mana, and non-BMP emoji before the 300-char alt cutoff), regenerated by `scripts/generate_card_html_fixture.py`
- `api/tests/test_noscript_parity.py` checks the Python renderer against the fixture
- A new describe block in `api/static/app.test.js` checks the JS renderer against the same fixture

## Test plan

- [x] `python -m pytest api/tests api/parsing/tests` — 1,781 passed (excluding testcontainers integration)
- [x] `npx jest api/static/app.test.js` — 1,738 passed, including 6 new parity cases
- [x] Verified in Node that the old UTF-16 `substring` truncation cuts the emoji fixture case at a different spot, so the test genuinely guards the code-point fix
- [x] ruff + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)