### PR TITLE
Add Minimum-Selectivity Guard to Range-Index Narrowing

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -876,6 +876,10 @@ fn flip_op(op: CmpOp) -> CmpOp {
 
 /// Return sorted card indices satisfying `field op val` using the numeric index.
 /// Returns None for Ne (not selective) and Some(empty) when no cards can match.
+/// Card-space narrowing needs no selectivity guard (unlike MAX_NARROW_FRACTION
+/// for the printing-space indexes): candidates are bounded by the ~3× smaller
+/// card count, so even a slice covering the whole index measures at worst
+/// break-even against the per-printing scan it would replace.
 fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Option<Vec<u32>> {
     let (start, end) = match op {
         CmpOp::Ne => return None,
@@ -974,6 +978,25 @@ fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32
 
 type DateIndex = Vec<(u32, u32)>;
 
+// Printing-space range narrowing is a pessimization when the matched slice
+// covers too much of the index: gathering + sorting the candidate ids and
+// evaluating them by random access costs ~2× per element what the sequential
+// full scan pays, and unlike the card-space indexes the candidate set doesn't
+// shrink the eval domain. Measured break-even is around a third of the store;
+// past the fraction below the indexes decline to narrow and the query falls
+// back to the scan. Narrowing is advisory (eval verifies every candidate), so
+// this is purely a speed dial, not a correctness concern.
+const MAX_NARROW_FRACTION: f64 = 0.25;
+
+/// Below this many matched ids narrowing always wins regardless of fraction —
+/// gathering a handful of ids is microseconds. Also keeps tiny stores (tests,
+/// partial imports) narrowing, where any match trips the fraction.
+const NARROW_FLOOR: usize = 1_000;
+
+fn range_too_broad_to_narrow(matched: usize, index_len: usize) -> bool {
+    matched > NARROW_FLOOR && matched as f64 > index_len as f64 * MAX_NARROW_FRACTION
+}
+
 fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u32>) -> DateIndex {
     let mut idx: DateIndex = printings
         .iter()
@@ -996,17 +1019,21 @@ fn price_candidates(idx: &Archived<DateIndex>, op: CmpOp, value: f64) -> Option<
         CmpOp::Lt | CmpOp::Le => (0, b.saturating_add(1)),
         CmpOp::Gt | CmpOp::Ge => (b, u32::MAX),
     };
-    Some(date_range_candidates(idx, lo, hi))
+    date_range_candidates(idx, lo, hi)
 }
 
-/// Sorted printing ids with an indexed value in [lo, hi). Callers translate ops
-/// into half-open ranges; Ne is not selective and never narrows.
-fn date_range_candidates(idx: &Archived<DateIndex>, lo: u32, hi: u32) -> Vec<u32> {
+/// Sorted printing ids with an indexed value in [lo, hi), or None for ranges
+/// too broad to be worth narrowing (see MAX_NARROW_FRACTION). Callers translate
+/// ops into half-open ranges; Ne is not selective and never narrows.
+fn date_range_candidates(idx: &Archived<DateIndex>, lo: u32, hi: u32) -> Option<Vec<u32>> {
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    if range_too_broad_to_narrow(e - s, idx.len()) {
+        return None;
+    }
     let mut result: Vec<u32> = idx[s..e].iter().map(|p| u32::from(p.1)).collect();
     result.sort_unstable();
-    result
+    Some(result)
 }
 
 // ─── Type bit index ───────────────────────────────────────────────────────────
@@ -1223,7 +1250,7 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 CmpOp::Gt => (value.saturating_add(1), u32::MAX),
                 CmpOp::Ge => (*value, u32::MAX),
             };
-            Some(Candidates::Printings(date_range_candidates(&indexes.released_at, lo, hi)))
+            date_range_candidates(&indexes.released_at, lo, hi).map(Candidates::Printings)
         }
 
         FilterExpr::YearCmp { op, year } => {
@@ -1239,7 +1266,7 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
                 CmpOp::Ge => (y * 10_000, u32::MAX),
             };
-            Some(Candidates::Printings(date_range_candidates(&indexes.released_at, lo, hi)))
+            date_range_candidates(&indexes.released_at, lo, hi).map(Candidates::Printings)
         }
 
         FilterExpr::And(children) => {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_type_index, cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, narrow_candidates, run_query, trigram_candidates,
+    build_artist_index, build_range_index, date_range_candidates, narrow_candidates,
+    range_too_broad_to_narrow, run_query, trigram_candidates, DateIndex, NARROW_FLOOR,
     ArtistIndex, CardData, CardIndexes, Candidates,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
@@ -753,6 +754,26 @@ fn set_code_and_date_narrowing() {
     }
     // Ne is not selective and must not narrow.
     assert!(narrow_candidates(&FilterExpr::DateCmp { op: CmpOp::Ne, value: 19930805 }, &archived.indexes, &archived.offsets).is_none());
+}
+
+#[test]
+fn broad_ranges_decline_to_narrow() {
+    // Fraction rule: past MAX_NARROW_FRACTION of the index, gathering candidates
+    // costs more than the scan it replaces.
+    assert!(!range_too_broad_to_narrow(2_500, 10_000)); // exactly 25%: narrows
+    assert!(range_too_broad_to_narrow(2_501, 10_000)); // past it: scan
+    // Absolute floor: small candidate counts always narrow, even when they
+    // cover the whole index (tiny stores, tests, partial imports).
+    assert!(!range_too_broad_to_narrow(NARROW_FLOOR, 10));
+    assert!(range_too_broad_to_narrow(NARROW_FLOOR + 1, 10));
+
+    // End-to-end through the archived index: a broad slice returns None (fall
+    // back to the scan), a selective slice still narrows.
+    let idx: DateIndex = (0..8_000u32).map(|v| (v, v)).collect();
+    let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize");
+    let archived = rkyv::access::<Archived<DateIndex>, Error>(&bytes).expect("access");
+    assert!(date_range_candidates(archived, 0, u32::MAX).is_none());
+    assert_eq!(date_range_candidates(archived, 100, 200).map(|v| v.len()), Some(100));
 }
 
 #[test]


### PR DESCRIPTION
## What this does

Adds a minimum-selectivity guard to printing-space range-index narrowing (price, released-at/year).
When a range predicate matches more than `MAX_NARROW_FRACTION` (25%) of the index, the index
declines to narrow and the query falls back to the sequential scan. Narrowing is advisory — eval
verifies every candidate — so the guard is purely a speed dial, not a correctness change.

## Why

Narrowing gathers every candidate id in the matched slice, sorts them, and then evaluates
candidates by random access — measured ~2× the per-element cost of the sequential full scan,
and printing-space candidates don't shrink the eval domain the way card-space candidates do.
For broad ranges that's a net pessimization: `usd<50` (83% of priced printings) ran **2.6 ms
narrowed vs 0.6 ms scanned**, making `(t:goblin or usd<50)` the slowest query measured in the
post-#605 latency survey (3.1 ms).

A threshold sweep (index path vs scan path over the same match set) puts break-even at ~30–35k
gathered ids (~a third of the store); the index path is linear at ~0.03 µs/candidate while the
scan is flat:

| `usd<T` | matched printings | % store | index path | scan path |
|---|---|---|---|---|
| 0.05 | 1,122 | 1.2% | 0.13 ms | 1.36 ms |
| 0.10 | 6,102 | 6.3% | 0.36 ms | 1.39 ms |
| 0.25 | 28,518 | 29.3% | 0.88 ms *(unguarded: 0.96)* | 1.26 ms |
| 50 | 80,510 | 82.8% | **0.60 ms** *(unguarded: 2.57)* | 0.70 ms |

25% is deliberately on the conservative side of break-even: bailing out early costs at most a few
tenths of a ms, narrowing too late costs up to 2 ms. A `NARROW_FLOOR` of 1,000 ids keeps tiny
stores and selective ranges narrowing unconditionally (below the floor, gathering is microseconds
and always wins).

## Targeted queries (main vs this branch, same protocol/hardware)

Engine timings, 20 warmup + 3 s timed window, `unique=card`, `limit=100`, edhrec ordering,
97,199 printings. Main baseline measured in a container from the pre-change image.

| Query | matches | main | branch | |
|---|---|---|---|---|
| `usd<50` | 31,220 | 2.607 ms | **0.582 ms** | 4.5× — guard trips, scan path |
| `(t:goblin or usd<50)` | 31,221 | 3.105 ms | **1.002 ms** | 3.1× — was the slowest surveyed query |
| `usd>50` | 553 | 0.105 ms | 0.106 ms | selective: still narrows |
| `(t:goblin or usd>50)` | 1,048 | 0.139 ms | 0.139 ms | unchanged |
| `usd>5` | 4,122 | 0.452 ms | 0.448 ms | unchanged |
| `(t:goblin or usd>5)` | 4,572 | 0.548 ms | 0.572 ms | unchanged |

## The suspected downside is also a win

The one structural case where the guard could plausibly lose: an And where the broad range was
the **only** narrowable child shielding an expensive predicate. Pre-guard, `usd<50` narrowed the
candidate set to 31k printings, so an unindexed flavor-text contains only evaluated 31k instead
of 97k; the guard removes that shield. Measured, removing it is faster anyway — the ~1 ms
gather+sort of 31k ids plus random-access evaluation (~2× the per-element cost of the sequential
scan) exceeded the benefit of skipping two-thirds of a cheap scan:

| Query | matches | main | branch | |
|---|---|---|---|---|
| `usd<50 ft:fire` | 453 | 4.183 ms | **2.111 ms** | broad range no longer "shields" the flavor scan — and it's 2× faster |
| `ft:fire usd<50` | 453 | 3.989 ms | **1.839 ms** | ~at parity with bare `ft:fire` (1.69 ms) |
| `usd<0.1 ft:fire` | 84 | 0.534 ms | 0.527 ms | selective range still narrows |
| `usd<50 o:draw` | 4,128 | 2.279 ms | **0.378 ms** | 6× — the broad gather was polluting an intersection the oracle-trigram index was already winning |

## Broad common queries (PR #490 suite — no regressions)

| Query | main | branch |
|---|---|---|
| `name:soldier` | 0.024 ms | 0.023 ms |
| `t:merfolk and name:tide` | 0.014 ms | 0.014 ms |
| `id:g` | 0.330 ms | 0.316 ms |
| `t:creature` | 0.336 ms | 0.308 ms |
| `cmc>3` | 0.322 ms | 0.305 ms |
| `cmc>6` | 0.072 ms | 0.073 ms |
| `format:legacy` | 0.491 ms | 0.469 ms |
| `(t:bird color:blue) or (t:beast color:green)` | 0.089 ms | 0.086 ms |
| `(name:forest) or (name:mountain)` | 0.027 ms | 0.027 ms |
| `power+toughness>8` | 0.502 ms | 0.491 ms |
| `power>4` | 0.098 ms | 0.094 ms |
| **geometric mean** | **0.116 ms** | **0.112 ms** |

## Why cmc/power/toughness are exempt

The card-space numeric indexes deliberately do **not** get the guard. Their candidate sets are
bounded by the ~3× smaller card count and shrink the eval domain relative to the per-printing
scan, so narrowing measures at worst break-even even at 100% index coverage — and an earlier
draft that guarded them regressed `cmc>3` from 0.32 ms to 0.49 ms:

| Query | matched cards | index path | scan path |
|---|---|---|---|
| `cmc>3` | 13,007 | 0.31 ms | 1.27 ms |
| `cmc>1` | 27,263 | 0.66 ms | 0.92 ms |
| `cmc>=0` (entire index) | 31,508 | 0.72 ms | 0.74 ms |
| `power>0` | 16,551 | 0.40 ms | 1.20 ms |

## Tests

- New `broad_ranges_decline_to_narrow` unit test: fraction boundary, absolute floor, and
  end-to-end through an archived index (broad slice → `None`, selective slice narrows).
- `cargo test`: 21 passed. Python suite (`api/`, incl. engine parity): 1,828 passed.
