### PR TITLE
Add Columnar Cards Response Shape Option

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -36,7 +36,7 @@ from psycopg import Connection, Cursor
 
 from api.card_processing import preprocess_card
 from api.db.bulk_upsert import bulk_upsert as _bulk_upsert
-from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
@@ -574,6 +574,24 @@ def _build_routes_listing(action_map: dict[str, Callable]) -> dict[str, dict[str
             "kwargs": kwargs,
         }
     return routes
+
+
+def _columnarize_cards(cards: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    """Convert a list of card dicts into a dict of per-field value lists.
+
+    Every card in a result set carries the same keys (absent values are explicit
+    nulls), so the transform is a pure inversion: the client rebuilds row i by
+    taking element i from each field's list. Shipping one set of keys instead of
+    one per card cuts the serialized payload roughly 30% raw / 9% compressed.
+
+    Args:
+        cards: Card dicts sharing a common key set.
+
+    Returns:
+        Dict mapping each field name to that field's values in card order.
+    """
+    keys = list(cards[0]) if cards else []
+    return {k: [c[k] for c in cards] for k in keys}
 
 
 class APIResource:
@@ -1174,6 +1192,7 @@ class APIResource:
         prefer: PreferOrder = PreferOrder.DEFAULT,
         q: str | None = None,
         query: str | None = None,
+        shape: ResponseShape = ResponseShape.ROWS,
         unique: UniqueOn = UniqueOn.CARD,
     ) -> dict[str, Any]:
         """Run a search query and return results and metadata.
@@ -1188,6 +1207,8 @@ class APIResource:
                 oracle_text, set_name, type_line). See RESULT_FIELD_COLUMNS for the full vocabulary.
             limit: Maximum number of results to return.
             orderby: Field to sort by.
+            shape: Shape of the "cards" list: 'rows' (list of card objects, default) or
+                'columnar' (one list per field, keyed by field name — smaller on the wire).
             unique: Unique on field.
             prefer: Prefer order (oldest, newest, usd-low, usd-high, promo).
 
@@ -1195,7 +1216,7 @@ class APIResource:
             Dict containing search results and metadata.
         """
         set_cache_header(falcon_response, duration=timedelta(seconds=90))
-        return self._search(
+        results = self._search(
             query=query or q,
             orderby=orderby,
             direction=direction,
@@ -1204,6 +1225,10 @@ class APIResource:
             unique=unique,
             prefer=prefer,
         )
+        if shape == ResponseShape.COLUMNAR:
+            # Shallow copy: _search returns cached dicts, which must stay row-shaped.
+            results = {**results, "cards": _columnarize_cards(results["cards"])}
+        return results
 
     def _validate_limit(self, limit: int | None) -> int | None:
         """Validate the limit and return it if valid."""
@@ -1597,7 +1622,7 @@ class APIResource:
                     )
 
                 # Convert search results to JSON and embed for JavaScript enhancement
-                search_results_json = orjson.dumps(search_results, option=orjson.OPT_INDENT_2).decode("utf-8")
+                search_results_json = orjson.dumps(search_results).decode("utf-8")
                 embedded_data = f"""// Server-side embedded search results
       window.EMBEDDED_SEARCH_RESULTS = {search_results_json};
       """
@@ -2556,12 +2581,21 @@ class APIResource:
         with self._cache_generation.get_lock():
             self._cache_generation.value += 1
 
-    def random_search(self, *, falcon_response: falcon.Response | None = None, num_cards: int = 1, **_: object) -> dict[str, Any]:
+    def random_search(
+        self,
+        *,
+        falcon_response: falcon.Response | None = None,
+        num_cards: int = 1,
+        shape: ResponseShape = ResponseShape.ROWS,
+        **_: object,
+    ) -> dict[str, Any]:
         """Return one or more random cards in the same envelope shape as search().
 
         Args:
             falcon_response: The Falcon response object.
             num_cards: The number of random cards to return (default is 1).
+            shape: Shape of the "cards" list: 'rows' (list of card objects, default) or
+                'columnar' (one list per field, keyed by field name — smaller on the wire).
 
         Returns:
             A dict with a "cards" key (list of card dicts) and "total_cards" key,
@@ -2571,6 +2605,10 @@ class APIResource:
         num_cards = min(max(num_cards, 1), 1000)
         if self._engine.size() == 0:
             self._trigger_background_reload_if_needed()
-            return {"cards": [], "total_cards": 0}
-        cards = list(self._engine.sample_preferred(num_cards))
-        return {"cards": cards, "total_cards": len(cards)}
+            cards = []
+        else:
+            cards = list(self._engine.sample_preferred(num_cards))
+        total_cards = len(cards)
+        if shape == ResponseShape.COLUMNAR:
+            cards = _columnarize_cards(cards)
+        return {"cards": cards, "total_cards": total_cards}

--- a/api/enums.py
+++ b/api/enums.py
@@ -34,6 +34,13 @@ class CardOrdering(enum.StrEnum):
     USD = enum.auto()
 
 
+class ResponseShape(enum.StrEnum):
+    """Enum for the shape of the cards list in search responses."""
+
+    ROWS = enum.auto()  # list of card objects (default)
+    COLUMNAR = enum.auto()  # object mapping each field to a list of per-card values
+
+
 class SortDirection(enum.StrEnum):
     """Enum for the direction of the sort."""
 

--- a/api/static/app.js
+++ b/api/static/app.js
@@ -7,6 +7,17 @@ const HTML_ESCAPE_RE = /[&<>"]/g;
 const HTML_ESCAPE_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' };
 const htmlEscapeChar = c => HTML_ESCAPE_MAP[c];
 
+// Invert a columnar cards payload ({field: [values, ...]}) back into an array of
+// card objects. Row-shaped payloads (already arrays) pass through untouched, so
+// consumers are indifferent to which shape the server sent (e.g. a stale cached
+// row-shaped response, or the embedded no-JS payload).
+function columnsToRows(cards) {
+  if (!cards || Array.isArray(cards)) return cards || [];
+  const keys = Object.keys(cards);
+  const count = keys.length ? cards[keys[0]].length : 0;
+  return Array.from({ length: count }, (_, i) => Object.fromEntries(keys.map(k => [k, cards[k][i]])));
+}
+
 class CatalogMap {
   constructor(mapping) {
     this._words = Object.entries(mapping)
@@ -562,7 +573,7 @@ class CardSearch {
     const orderDirection = this.isAscending ? 'asc' : 'desc';
 
     // Generate the URL for this request
-    const url = `/search?q=${encodeURIComponent(normalizedQuery)}&orderby=${order}&direction=${orderDirection}&unique=${unique}&prefer=${prefer}`;
+    const url = `/search?q=${encodeURIComponent(normalizedQuery)}&orderby=${order}&direction=${orderDirection}&unique=${unique}&prefer=${prefer}&shape=columnar`;
 
     // Same URL already in-flight (and not already aborted) — let it finish
     if (this.currentRequestUrl === url && !this.currentController.signal.aborted) return;
@@ -658,7 +669,7 @@ class CardSearch {
   }
 
   displayResults(data, query, elapsed) {
-    const cards = data.cards || [];
+    const cards = columnsToRows(data.cards);
     const totalCards = data.total_cards || cards.length;
     const queryExplanation = data.query_explanation || '';
 
@@ -1072,7 +1083,7 @@ class CardSearch {
 
     this.showLoading();
     try {
-      const response = await fetch('/random_search?num_cards=12', {
+      const response = await fetch('/random_search?num_cards=12&shape=columnar', {
         method: 'GET',
         headers: { Accept: 'application/json' },
         signal: controller.signal,

--- a/api/static/app.test.js
+++ b/api/static/app.test.js
@@ -39,7 +39,9 @@ Object.defineProperty(global, 'performance', {
 
 const appCode = fs.readFileSync(path.resolve(__dirname, 'app.js'), 'utf8');
 // eslint-disable-next-line no-new-func
-const { CardSearch, CatalogMap } = Function(appCode + '; return {CardSearch, CatalogMap};')();
+const { CardSearch, CatalogMap, columnsToRows } = Function(
+  appCode + '; return {CardSearch, CatalogMap, columnsToRows};'
+)();
 
 // ---------------------------------------------------------------------------
 // Live fixture: fetched from https://sylvan-librarian.com/get_common_card_types
@@ -269,6 +271,32 @@ describe('autoCompleteQuery with typeMap', () => {
   it('works inside a compound query', () => {
     const result = search.autoCompleteQuery('c:r t:drag');
     expect(result).toBe('c:r t:dragon');
+  });
+});
+
+describe('columnsToRows', () => {
+  test('inverts a columnar payload into an array of card objects', () => {
+    const columnar = {
+      name: ['Elvish Mystic', 'Counterspell'],
+      power: ['1', null],
+      toughness: ['1', null],
+    };
+    expect(columnsToRows(columnar)).toEqual([
+      { name: 'Elvish Mystic', power: '1', toughness: '1' },
+      { name: 'Counterspell', power: null, toughness: null },
+    ]);
+  });
+
+  test('passes row-shaped payloads through untouched', () => {
+    const rows = [{ name: 'Elvish Mystic' }];
+    expect(columnsToRows(rows)).toBe(rows);
+  });
+
+  test('handles empty and missing payloads', () => {
+    expect(columnsToRows(undefined)).toEqual([]);
+    expect(columnsToRows(null)).toEqual([]);
+    expect(columnsToRows([])).toEqual([]);
+    expect(columnsToRows({})).toEqual([]);
   });
 });
 

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -17,6 +17,7 @@ import pytest
 
 import api.api_resource as api_resource_module
 from api.api_resource import FALLBACK_SITE_NAME, APIResource, _hostname_to_site_name, _split_words, hostname_to_site_name
+from api.enums import ResponseShape
 from api.settings import settings
 
 
@@ -401,6 +402,89 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
                 # Should call error monitoring
                 mock_error_handler.assert_called_once()
+
+
+class TestSearchResponseShape(TestBaseAPIResourceTest):
+    """Test the shape parameter that selects row-wise vs columnar cards payloads."""
+
+    @pytest.fixture(autouse=True)
+    def setup_search_results(self) -> None:
+        """Provide a canned row-shaped search result envelope."""
+        self.search_results = {
+            "cards": [
+                {"name": "Elvish Mystic", "power": "1", "toughness": "1"},
+                {"name": "Counterspell", "power": None, "toughness": None},
+            ],
+            "total_cards": 2,
+            "query": "test",
+        }
+
+    def test_search_defaults_to_row_shape(self) -> None:
+        """Without a shape parameter, cards stay a list of card objects."""
+        with patch.object(self.api_resource, "_search", return_value=self.search_results):
+            result = self.api_resource.search(falcon_response=MagicMock(), q="test")
+        assert result["cards"] == self.search_results["cards"]
+
+    def test_search_columnar_shape_inverts_cards(self) -> None:
+        """shape=columnar returns one list per field, keyed by field name."""
+        with patch.object(self.api_resource, "_search", return_value=self.search_results):
+            result = self.api_resource.search(falcon_response=MagicMock(), q="test", shape=ResponseShape.COLUMNAR)
+        assert result["cards"] == {
+            "name": ["Elvish Mystic", "Counterspell"],
+            "power": ["1", None],
+            "toughness": ["1", None],
+        }
+        # Envelope fields pass through untouched
+        assert result["total_cards"] == 2
+        assert result["query"] == "test"
+
+    def test_search_columnar_does_not_mutate_cached_results(self) -> None:
+        """_search returns cached dicts, so columnarizing must not modify them in place."""
+        with patch.object(self.api_resource, "_search", return_value=self.search_results):
+            self.api_resource.search(falcon_response=MagicMock(), q="test", shape=ResponseShape.COLUMNAR)
+        assert isinstance(self.search_results["cards"], list)
+        assert self.search_results["cards"][0] == {"name": "Elvish Mystic", "power": "1", "toughness": "1"}
+
+    def test_handle_converts_shape_query_param(self) -> None:
+        """The string 'columnar' from the query string is converted to the enum."""
+        mock_req = MagicMock()
+        mock_req.uri = mock_req.path = mock_req.relative_uri = "/search"
+        mock_req.params = {"q": "test", "shape": "columnar"}
+        mock_req.get_header.return_value = None
+        mock_req.host = "example.com"
+        mock_resp = MagicMock()
+        mock_resp.complete = False
+
+        with patch.object(self.api_resource, "_search", return_value=self.search_results):
+            self.api_resource._handle(mock_req, mock_resp)
+        assert mock_resp.media["cards"] == {
+            "name": ["Elvish Mystic", "Counterspell"],
+            "power": ["1", None],
+            "toughness": ["1", None],
+        }
+
+    def test_random_search_columnar_shape(self) -> None:
+        """random_search supports the same shape parameter."""
+        mock_engine = MagicMock()
+        mock_engine.size.return_value = 100
+        mock_engine.sample_preferred.return_value = iter(self.search_results["cards"])
+        with patch.object(self.api_resource, "_engine", mock_engine):
+            result = self.api_resource.random_search(
+                falcon_response=MagicMock(),
+                num_cards=2,
+                shape=ResponseShape.COLUMNAR,
+            )
+        assert result["cards"]["name"] == ["Elvish Mystic", "Counterspell"]
+        assert result["total_cards"] == 2
+
+    def test_columnarize_cards_empty_list(self) -> None:
+        """An empty result set columnarizes to an empty object."""
+        assert api_resource_module._columnarize_cards([]) == {}
+
+    def test_columnarize_cards_preserves_field_order(self) -> None:
+        """Field order follows the first card's key order."""
+        cards = [{"b": 1, "a": 2}, {"b": 3, "a": 4}]
+        assert list(api_resource_module._columnarize_cards(cards)) == ["b", "a"]
 
 
 class TestAPIResourceStaticFileServing(unittest.TestCase):

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -15,7 +15,7 @@ import pytest
 from testcontainers.postgres import PostgresContainer
 
 from api.api_resource import APIResource
-from api.enums import CardOrdering, SortDirection
+from api.enums import CardOrdering, ResponseShape, SortDirection
 from api.tests.helpers import search_kwargs
 from card_engine import QueryEngine
 
@@ -256,6 +256,21 @@ class TestContainerIntegration:
         assert random_card_keys == search_card_keys, (
             f"random_search card keys {random_card_keys} != search card keys {search_card_keys}"
         )
+
+    def test_search_columnar_shape_inverts_to_row_shape(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """shape=columnar returns per-field lists that invert back to the row-shaped cards."""
+        row_result = api_resource.search(q="cmc>=0", limit=10)
+        columnar_result = api_resource.search(q="cmc>=0", limit=10, shape=ResponseShape.COLUMNAR)
+
+        rows = row_result["cards"]
+        cols = columnar_result["cards"]
+        assert len(rows) >= 1
+        assert isinstance(cols, dict)
+        assert set(cols) == set(rows[0])
+        rebuilt = [dict(zip(cols, values, strict=True)) for values in zip(*cols.values(), strict=True)]
+        assert rebuilt == rows
+        # Envelope stays row-agnostic
+        assert columnar_result["total_cards"] == row_result["total_cards"]
 
     def test_get_pid(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test basic API functionality with real database."""

--- a/api/utils/type_conversions.py
+++ b/api/utils/type_conversions.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 from typing import Any
 
-from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, UniqueOn
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +42,7 @@ def _convert_string_to_type(str_value: str | None, param_type: Any) -> Any:  # n
         # enums
         "CardOrdering": CardOrdering,
         "PreferOrder": PreferOrder,
+        "ResponseShape": ResponseShape,
         "SortDirection": SortDirection,
         "UniqueOn": UniqueOn,
         # other stuffs


### PR DESCRIPTION
## What

Adds a `shape=columnar` query parameter to `/search` and `/random_search`. When set, the `cards` list is inverted from an array of per-card objects into one array per field (`{"name": [...], "power": [...], ...}`). The JS client requests `shape=columnar` on its own fetches and inverts it back in `displayResults` via `columnsToRows`.

Also drops `OPT_INDENT_2` from the embedded search-results JSON in the server-rendered HTML page — nothing reads that payload except JS, so pretty-printing it was pure byte overhead.

## Why

Measured on 5 random 100-card samples: the columnar shape is ~29% smaller uncompressed and ~8–9% smaller after gzip/brotli/zstd (the compressor already eats most of the repeated-key redundancy; the residual gain comes from removing 100 copies of the key strings and clustering similar values). Binary formats (CBOR, msgpack) were also measured and compress *worse* than JSON, so this is the only lever that survives compression.

## Design notes

- **Query param, not header**: `CachingMiddleware`'s cache key covers URI, params, and `Accept-Encoding` only — a param makes the two shapes distinct cache entries everywhere (middleware, nginx, browser, any CDN) with zero `Vary` machinery.
- **Pure inversion**: cards in a result set always carry the same keys with explicit nulls, so no key-omission convention is needed.
- **Client is shape-indifferent**: `columnsToRows` passes row-shaped payloads through untouched, covering stale cached responses and the embedded no-JS payload (which stays row-shaped in this PR).
- `search()` shallow-copies before transforming — `_search` returns cached dicts that must stay row-shaped.

## Testing

- 7 new unit tests (shape param on both endpoints, string→enum conversion through `_handle`, cache non-mutation, `_columnarize_cards` edge cases)
- 1 new testcontainers integration test: columnar result inverts exactly back to the row-shaped result against a real database
- 3 new jest tests for `columnsToRows`
- Full api suite: 1849 passed; jest: 1741 passed