### PR TITLE
Sort Catalog Keys and Defer Its Fetch Out of the Critical Chain

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1800,9 +1800,13 @@ class APIResource:
             type_counts["Tribal"] = kindred_count
         keyword_counts: dict[str, int] = self._engine.common_card_keywords()
         keyword_catalog = {keyword.lower(): count for keyword, count in keyword_counts.items()}
+        # Sorted keys compress ~5% smaller (adjacent keys share prefixes, so the
+        # compressor's back-references stay short) and make the payload deterministic.
+        # orjson preserves insertion order, so sorting here is what clients receive.
+        # Sorting must happen after the Tribal alias is inserted above.
         return {
-            "types": type_counts,
-            "keywords": keyword_catalog,
+            "types": dict(sorted(type_counts.items())),
+            "keywords": dict(sorted(keyword_catalog.items())),
         }
 
     def get_common_keywords(self, **_: object) -> list[dict[str, Any]]:

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -3,34 +3,60 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Start fetching common card types and keywords immediately (as early as possible in head) -->
+    <!-- Warm the autocomplete catalog WITHOUT joining the critical request chain:
+         the promise exists immediately (consumers await it), but the ~9KB /get_catalog
+         fetch — larger than app.min.js — starts only once the browser is idle or the
+         user reaches for the search box, whichever comes first. Nothing needs it
+         before first paint. -->
     <script>
-      // Start fetching as early as possible - before any other resources block execution
       (function () {
-        if (!window.commonCardTypesPromise) {
-          function fetchWithRetry() {
-            return fetch('/get_catalog')
-              .then(function (response) {
-                if (response.status === 503) {
-                  var delay = 10000 + Math.random() * 5000;
-                  console.warn('Common card types not ready, retrying in ' + Math.round(delay / 1000) + 's');
-                  return new Promise(function (resolve) {
-                    setTimeout(resolve, delay);
-                  }).then(fetchWithRetry);
-                }
-                if (!response.ok) {
-                  console.error('Failed to fetch common card types and keywords: HTTP ' + response.status);
-                  return { types: {}, keywords: {} };
-                }
-                return response.json();
-              })
-              .catch(function (error) {
-                console.error('Failed to fetch common card types and keywords:', error);
-                return { types: {}, keywords: {} };
-              });
-          }
-          window.commonCardTypesPromise = fetchWithRetry();
+        if (window.commonCardTypesPromise) {
+          return;
         }
+        function fetchWithRetry() {
+          return fetch('/get_catalog')
+            .then(function (response) {
+              if (response.status === 503) {
+                var delay = 10000 + Math.random() * 5000;
+                console.warn('Common card types not ready, retrying in ' + Math.round(delay / 1000) + 's');
+                return new Promise(function (resolve) {
+                  setTimeout(resolve, delay);
+                }).then(fetchWithRetry);
+              }
+              if (!response.ok) {
+                console.error('Failed to fetch common card types and keywords: HTTP ' + response.status);
+                return { types: {}, keywords: {} };
+              }
+              return response.json();
+            })
+            .catch(function (error) {
+              console.error('Failed to fetch common card types and keywords:', error);
+              return { types: {}, keywords: {} };
+            });
+        }
+        var resolveCatalog;
+        window.commonCardTypesPromise = new Promise(function (resolve) {
+          resolveCatalog = resolve;
+        });
+        var started = false;
+        function start() {
+          if (started) {
+            return;
+          }
+          started = true;
+          fetchWithRetry().then(resolveCatalog);
+        }
+        if (window.requestIdleCallback) {
+          window.requestIdleCallback(start, { timeout: 2000 });
+        } else {
+          setTimeout(start, 2000);
+        }
+        // focusin delegates: the search input doesn't exist yet at head-parse time
+        document.addEventListener('focusin', function (event) {
+          if (event.target && event.target.id === 'searchInput') {
+            start();
+          }
+        });
       })();
     </script>
     <meta

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -3,12 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Warm the autocomplete catalog WITHOUT joining the critical request chain:
-         the promise exists immediately (consumers await it), but the ~9KB /get_catalog
-         fetch — larger than app.min.js — starts only once the browser is idle or the
-         user reaches for the search box, whichever comes first. Nothing needs it
-         before first paint. -->
     <script>
+      // Warm the autocomplete catalog WITHOUT joining the critical request chain:
+      // the promise exists immediately (consumers await it), but the ~9KB /get_catalog
+      // fetch - larger than app.min.js - starts only once the browser is idle or the
+      // user reaches for the search box, whichever comes first. Nothing needs it
+      // before first paint. (JS comments are stripped by minify_js; HTML comments
+      // would ship - keep_comments=True protects the SERVER_SIDE_* splice anchors.)
       (function () {
         if (window.commonCardTypesPromise) {
           return;
@@ -156,11 +157,8 @@
       <!-- FOOTER -->
     </div>
 
-    <!-- Modal for card details -->
     <div id="modalOverlay" class="modal-overlay">
-      <div id="modalContent" class="modal-content">
-        <!-- Modal content will be dynamically inserted here -->
-      </div>
+      <div id="modalContent" class="modal-content"></div>
     </div>
     <script>
       <!-- SERVER_SIDE_EMBEDDED_DATA -->

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -776,6 +776,34 @@ class TestAPIResourceCaching(unittest.TestCase):
             },
         }
 
+    def test_get_catalog_keys_are_sorted(self) -> None:
+        """Catalog keys come back sorted, including the post-hoc Tribal alias.
+
+        Sorted output is deterministic and compresses ~5% smaller (adjacent keys
+        share prefixes); the engine returns arbitrary (insertion) order.
+        """
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        mock_engine = MagicMock()
+        mock_engine.size.return_value = 4
+        mock_engine.common_card_types.return_value = {
+            "Wall": 1,
+            "Kindred": 4,
+            "Aurochs": 2,
+            "Aura": 7,
+        }
+        mock_engine.common_card_keywords.return_value = {
+            "Vigilance": 5,
+            "Flying": 10,
+            "Deathtouch": 2,
+        }
+
+        with patch.object(self.api_resource, "_engine", mock_engine):
+            result = self.api_resource.get_catalog()
+
+        assert list(result["types"]) == ["Aura", "Aurochs", "Kindred", "Tribal", "Wall"]
+        assert list(result["keywords"]) == ["deathtouch", "flying", "vigilance"]
+
     def test_cache_clear_method_works(self) -> None:
         """Test that cache.clear() method works for cachebox caches."""
         # Test query cache clearing


### PR DESCRIPTION
## What

Two small `/get_catalog` changes from digging into the PageSpeed mobile report (FCP 1.8s):

1. **Sort the type/keyword maps at construction.** Adjacent keys share prefixes (`Aura`, `Aurochs`…), so compression back-references stay short: measured **8,567B → 8,090B brotli (−5.6%)**, similar under gzip/zstd. Output becomes deterministic as a bonus (stable ETags, reproducible snapshots). The sort lives in the endpoint that benefits — not a global `OPT_SORT_KEYS` on the shared JSON handler — so `/search` keeps its requested-field ordering (which #612's columnar shape inherits as column order) and no other endpoint pays a per-request sort. Sorting happens after the `Kindred → Tribal` alias insertion; a new unit test pins the order including the alias.

2. **Take the fetch out of the critical request chain.** The inline head script fired `fetch('/get_catalog')` during HTML parse, making it part of the document's critical chain per Lighthouse — and at ~9KB compressed it's the *largest* resource in the critical window, bigger than `app.min.js` (7.6KB). But it only feeds autocomplete, which nothing needs before first paint. The rewrite preserves the promise contract exactly — `window.commonCardTypesPromise` exists immediately and consumers `await` it unchanged, retry logic intact — while the network fetch starts on `requestIdleCallback` (2s timeout, `setTimeout` fallback) or on first focus of the search input (delegated `focusin`, since the input doesn't exist at head-parse time), whichever comes first.

## Expected effect

- Clears the "avoid chaining critical requests" PSI audit.
- Frees ~9KB of contended bandwidth during the simulated slow-4G load window for the resources that are actually critical — a modest LCP/Speed Index improvement, compounding with any future homepage-SSR work.
- No FCP change (the fetch never blocked parsing) and no behavior change for autocomplete: idle fires within ~2s of load, and a user who focuses search immediately triggers the fetch ahead of their first keystroke.

## Testing

- New `test_get_catalog_keys_are_sorted` (deliberately unsorted engine mocks, asserts full key order including the Tribal alias); existing catalog tests unchanged and passing (67 api tests)
- Jest suite green (1,738) — the promise-contract guard (`if (window.commonCardTypesPromise) return`) keeps test setups that pre-seed the promise working
- Prettier/ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)