### PR TITLE
Add Card-Space Rarity Postings with a Union-Coverage Ceiling

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1060,8 +1060,8 @@ fn build_type_index(cards: &[OracleCard]) -> TypeIndex {
 // rarity. A card printed at several rarities appears in each of its lists
 // (~34.8k entries over ~31.5k cards; 91% of cards have a single rarity).
 // Card space deliberately: the per-rarity card lists shrink the evaluation
-// domain, so no selectivity guard is needed (see numeric_candidates) — even
-// the broadest bucket (rare, ~35% of cards) measures ahead of the scan.
+// domain, so even the broadest bucket (rare, ~35% of cards) measures ahead of
+// the scan. Near-total unions still lose — see MAX_UNION_FRACTION.
 
 type RarityIndex = [Vec<u32>; 6];
 
@@ -1087,11 +1087,28 @@ fn build_rarity_index(printings: &[Printing], offsets: &[u32]) -> RarityIndex {
     idx // lists are sorted: cards iterated in ascending index order
 }
 
+/// Ceiling for union-based card-space narrowing, as a fraction of the index's
+/// total posting entries. The card-space range indexes need no guard (their
+/// slice is a free contiguous window over an always-smaller domain), but a
+/// posting union pays a gather-and-merge per bucket, and at near-total
+/// coverage that buys nothing: measured on the live corpus with the default
+/// prefer, `rarity<=mythic` (99% of entries) ran 0.85× the scan while
+/// `rarity>=uncommon` (69%) won 1.44× — break-even ≈ 90%. Non-default
+/// prefers compress the win (the same 69% union wins only 1.10× under
+/// prefer=usd_high, extrapolating to break-even ≈ 72–75%), so the ceiling
+/// sits below the worst prefer's crossover, per the usual asymmetry argument
+/// (declining early forgoes a small win, declining late pays on every
+/// query). For rarity this is not restrictive: no bucket combination covers
+/// between 69% and 91% of entries, so any ceiling in that band admits the
+/// same unions.
+const MAX_UNION_FRACTION: f64 = 0.70;
+
 /// Union the rarity posting lists whose value satisfies `op val`. Returns None
 /// for Ne (matches nearly every card, same convention as numeric_candidates)
-/// and when every bucket qualifies (the union is the whole store — the scan
-/// costs the same without materializing it). An empty union is exact: no
-/// printing exists at a rarity satisfying the comparison.
+/// and when the qualifying buckets cover more than MAX_UNION_FRACTION of the
+/// index's entries (the scan costs the same without materializing the union).
+/// An empty union is exact: no printing exists at a rarity satisfying the
+/// comparison.
 fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option<Vec<u32>> {
     if matches!(op, CmpOp::Ne) {
         return None;
@@ -1105,7 +1122,9 @@ fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option
         CmpOp::Ne => false,
     };
     let buckets: Vec<usize> = (0..idx.len()).filter(|&r| keep(r as f64)).collect();
-    if buckets.len() == idx.len() {
+    let total: usize = idx.iter().map(|b| b.len()).sum();
+    let selected: usize = buckets.iter().map(|&b| idx[b].len()).sum();
+    if selected as f64 > total as f64 * MAX_UNION_FRACTION {
         return None;
     }
     let mut result: Vec<u32> = Vec::new();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1055,6 +1055,66 @@ fn build_type_index(cards: &[OracleCard]) -> TypeIndex {
     idx // lists are sorted: cards iterated in ascending index order
 }
 
+// ─── Rarity index ────────────────────────────────────────────────────────────
+// rarity int (0-5) -> sorted card ids with at least one printing at that
+// rarity. A card printed at several rarities appears in each of its lists
+// (~34.8k entries over ~31.5k cards; 91% of cards have a single rarity).
+// Card space deliberately: the per-rarity card lists shrink the evaluation
+// domain, so no selectivity guard is needed (see numeric_candidates) — even
+// the broadest bucket (rare, ~35% of cards) measures ahead of the scan.
+
+type RarityIndex = [Vec<u32>; 6];
+
+fn build_rarity_index(printings: &[Printing], offsets: &[u32]) -> RarityIndex {
+    let mut idx: RarityIndex = Default::default();
+    for card in 0..offsets.len().saturating_sub(1) {
+        let range = offsets[card] as usize..offsets[card + 1] as usize;
+        let mut mask: u8 = 0;
+        for p in &printings[range] {
+            if let Some(r) = p.card_rarity_int {
+                if (r as usize) < idx.len() {
+                    mask |= 1 << r;
+                }
+            }
+        }
+        let mut bits = mask;
+        while bits != 0 {
+            let bit = bits.trailing_zeros() as usize;
+            idx[bit].push(card as u32);
+            bits &= bits - 1;
+        }
+    }
+    idx // lists are sorted: cards iterated in ascending index order
+}
+
+/// Union the rarity posting lists whose value satisfies `op val`. Returns None
+/// for Ne (matches nearly every card, same convention as numeric_candidates)
+/// and when every bucket qualifies (the union is the whole store — the scan
+/// costs the same without materializing it). An empty union is exact: no
+/// printing exists at a rarity satisfying the comparison.
+fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option<Vec<u32>> {
+    if matches!(op, CmpOp::Ne) {
+        return None;
+    }
+    let keep = |r: f64| match op {
+        CmpOp::Eq => r == val,
+        CmpOp::Lt => r < val,
+        CmpOp::Le => r <= val,
+        CmpOp::Gt => r > val,
+        CmpOp::Ge => r >= val,
+        CmpOp::Ne => false,
+    };
+    let buckets: Vec<usize> = (0..idx.len()).filter(|&r| keep(r as f64)).collect();
+    if buckets.len() == idx.len() {
+        return None;
+    }
+    let mut result: Vec<u32> = Vec::new();
+    for b in buckets {
+        result = union_sorted(result, idx[b].iter().map(|x| u32::from(*x)).collect());
+    }
+    Some(result)
+}
+
 // ─── Combined indexes ────────────────────────────────────────────────────────
 
 // Postings live in two id spaces: card-level indexes post OracleCard indices
@@ -1068,6 +1128,7 @@ struct CardIndexes {
     power:          NumericIndex,    // card space
     toughness:      NumericIndex,    // card space
     type_bits:      TypeIndex,       // card space
+    rarity:         RarityIndex,     // card space (any-printing-at-rarity)
     subtypes:       TagIndex,        // card space
     keywords:       TagIndex,        // card space
     oracle_tags:    TagIndex,        // card space
@@ -1088,6 +1149,7 @@ impl Default for CardIndexes {
             power:          Vec::new(),
             toughness:      Vec::new(),
             type_bits:      Default::default(),
+            rarity:         Default::default(),
             subtypes:       HashMap::new(),
             keywords:       HashMap::new(),
             oracle_tags:    HashMap::new(),
@@ -1193,6 +1255,10 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 numeric_candidates(&indexes.toughness, *op, *v).map(Candidates::Cards),
             (NumExpr::Const(v), NumExpr::Field(NumField::Toughness)) =>
                 numeric_candidates(&indexes.toughness, flip_op(*op), *v).map(Candidates::Cards),
+            (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) =>
+                rarity_candidates(&indexes.rarity, *op, *v).map(Candidates::Cards),
+            (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) =>
+                rarity_candidates(&indexes.rarity, flip_op(*op), *v).map(Candidates::Cards),
             (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) =>
                 price_candidates(&indexes.price_usd, *op, *v).map(Candidates::Printings),
             (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) =>
@@ -1673,7 +1739,7 @@ fn card_to_pydict<'py>(
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change the struct sizes below wouldn't
 /// catch (e.g. reordering same-size fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260707;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260708;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2039,6 +2105,7 @@ impl QueryEngine {
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
             toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
             type_bits:      build_type_index(&cards),
+            rarity:         build_rarity_index(&printings, &offsets),
             subtypes:       build_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
             keywords:       build_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),
             oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,9 +1,9 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_type_index, cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, date_range_candidates, narrow_candidates,
+    build_type_index, build_rarity_index, cards_of_printings, count_common_keywords, count_common_types,
+    build_artist_index, build_range_index, date_range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, DateIndex, NARROW_FLOOR,
-    ArtistIndex, CardData, CardIndexes, Candidates,
+    ArtistIndex, CardData, CardIndexes, Candidates, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
     TYPE_LEGENDARY, TYPE_PLANESWALKER,
@@ -265,6 +265,83 @@ fn narrow_candidates_spaces() {
     match narrow_candidates(&and, archived, offsets) {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("mixed And must produce card-space candidates"),
+    }
+}
+
+// build_rarity_index posts each card once per distinct printing rarity;
+// rarity-less printings contribute nothing.
+#[test]
+fn rarity_index_posts_cards_per_distinct_rarity() {
+    // card 0: printings at common(0) and mythic(3); card 1: rare(2) twice
+    // (deduped by the mask); card 2: no rarity anywhere.
+    let mut printings: Vec<Printing> = (1..=5).map(|i| stub_printing(i, i, None)).collect();
+    printings[0].card_rarity_int = Some(0);
+    printings[1].card_rarity_int = Some(3);
+    printings[2].card_rarity_int = Some(2);
+    printings[3].card_rarity_int = Some(2);
+    let offsets = vec![0u32, 2, 4, 5];
+
+    let idx = build_rarity_index(&printings, &offsets);
+    assert_eq!(idx[0], vec![0]); // common: card 0
+    assert_eq!(idx[2], vec![1]); // rare: card 1, once despite two rare printings
+    assert_eq!(idx[3], vec![0]); // mythic: card 0
+    assert!(idx[1].is_empty() && idx[4].is_empty() && idx[5].is_empty());
+}
+
+// rarity_candidates unions the qualifying buckets, refuses Ne and all-bucket
+// unions, and proves empty sets for impossible comparisons.
+#[test]
+fn rarity_candidates_ops() {
+    // common {0,3}, uncommon {1}, rare {2,3}, mythic {4}, special {}, bonus {}
+    let idx: RarityIndex = [vec![0, 3], vec![1], vec![2, 3], vec![4], vec![], vec![]];
+    let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize");
+    let archived = rkyv::access::<Archived<RarityIndex>, Error>(&bytes).expect("access");
+
+    // Eq picks one bucket; a card in several buckets appears via each.
+    assert_eq!(rarity_candidates(archived, CmpOp::Eq, 2.0), Some(vec![2, 3]));
+    // Ge unions rare and above; card 3 (common+rare) appears once.
+    assert_eq!(rarity_candidates(archived, CmpOp::Ge, 2.0), Some(vec![2, 3, 4]));
+    // Lt 2 = common|uncommon.
+    assert_eq!(rarity_candidates(archived, CmpOp::Lt, 2.0), Some(vec![0, 1, 3]));
+    // Impossible comparisons prove the empty set (exact, not "no narrowing").
+    assert_eq!(rarity_candidates(archived, CmpOp::Eq, 2.5), Some(vec![]));
+    assert_eq!(rarity_candidates(archived, CmpOp::Gt, 5.0), Some(vec![]));
+    // Ne and all-bucket unions decline to narrow.
+    assert!(rarity_candidates(archived, CmpOp::Ne, 2.0).is_none());
+    assert!(rarity_candidates(archived, CmpOp::Ge, 0.0).is_none());
+    assert!(rarity_candidates(archived, CmpOp::Le, 5.0).is_none());
+}
+
+// The NumericCmp narrowing arm routes rarity through the index in card space,
+// for both operand orders.
+#[test]
+fn narrow_candidates_rarity_card_space() {
+    let rarity: RarityIndex = [vec![], vec![], vec![0, 2], vec![1], vec![], vec![]];
+    let indexes = CardIndexes { rarity, ..Default::default() };
+    let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
+    let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
+    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 2, 4, 6]).expect("serialize offsets");
+    let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
+
+    let cmp = FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::RarityInt),
+        op: CmpOp::Ge,
+        rhs: NumExpr::Const(2.0),
+    };
+    match narrow_candidates(&cmp, archived, offsets) {
+        Some(Candidates::Cards(v)) => assert_eq!(v, vec![0, 1, 2]),
+        _ => panic!("rarity must narrow in card space"),
+    }
+
+    // Flipped operand order: 3 <= rarity ≡ rarity >= 3.
+    let flipped = FilterExpr::NumericCmp {
+        lhs: NumExpr::Const(3.0),
+        op: CmpOp::Le,
+        rhs: NumExpr::Field(NumField::RarityInt),
+    };
+    match narrow_candidates(&flipped, archived, offsets) {
+        Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
+        _ => panic!("flipped rarity must narrow in card space"),
     }
 }
 
@@ -549,6 +626,7 @@ fn bench_checked_vs_unchecked_access() {
         power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
         toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
         type_bits:      build_type_index(&cards),
+        rarity:         build_rarity_index(&printings, &offsets),
         subtypes:       build_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
         keywords:       build_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
         oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -288,8 +288,9 @@ fn rarity_index_posts_cards_per_distinct_rarity() {
     assert!(idx[1].is_empty() && idx[4].is_empty() && idx[5].is_empty());
 }
 
-// rarity_candidates unions the qualifying buckets, refuses Ne and all-bucket
-// unions, and proves empty sets for impossible comparisons.
+// rarity_candidates unions the qualifying buckets, refuses Ne and unions past
+// MAX_UNION_FRACTION of posting entries, and proves empty sets for impossible
+// comparisons.
 #[test]
 fn rarity_candidates_ops() {
     // common {0,3}, uncommon {1}, rare {2,3}, mythic {4}, special {}, bonus {}
@@ -306,17 +307,23 @@ fn rarity_candidates_ops() {
     // Impossible comparisons prove the empty set (exact, not "no narrowing").
     assert_eq!(rarity_candidates(archived, CmpOp::Eq, 2.5), Some(vec![]));
     assert_eq!(rarity_candidates(archived, CmpOp::Gt, 5.0), Some(vec![]));
-    // Ne and all-bucket unions decline to narrow.
+    // Ne and over-ceiling unions decline to narrow.
     assert!(rarity_candidates(archived, CmpOp::Ne, 2.0).is_none());
     assert!(rarity_candidates(archived, CmpOp::Ge, 0.0).is_none());
     assert!(rarity_candidates(archived, CmpOp::Le, 5.0).is_none());
+    // The ceiling is entries-based, not bucket-count: Le 3 selects only 4 of
+    // 6 buckets but 100% of posting entries (special/bonus are empty), which
+    // exceeds MAX_UNION_FRACTION and must decline.
+    assert!(rarity_candidates(archived, CmpOp::Le, 3.0).is_none());
 }
 
 // The NumericCmp narrowing arm routes rarity through the index in card space,
 // for both operand orders.
 #[test]
 fn narrow_candidates_rarity_card_space() {
-    let rarity: RarityIndex = [vec![], vec![], vec![0, 2], vec![1], vec![], vec![]];
+    // All three cards also at common, so the rare/mythic unions stay under
+    // MAX_UNION_FRACTION of the six entries.
+    let rarity: RarityIndex = [vec![0, 1, 2], vec![], vec![0, 2], vec![1], vec![], vec![]];
     let indexes = CardIndexes { rarity, ..Default::default() };
     let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
     let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");


### PR DESCRIPTION
## What this does

Adds a card-space rarity posting index: six sorted card-id lists, one per rarity int, where a
card is posted once per **distinct printing rarity** (a card printed at common and mythic
appears in both lists). All rarity comparison shapes (`r:mythic`, `rarity>=rare`,
`rarity<=uncommon`, both operand orders) narrow through unions of the qualifying buckets.
Narrowing stays advisory — eval verifies every candidate against its printing's exact rarity —
so the any-printing-at-rarity semantics can only loosen candidates, never change results.

Unions covering more than `MAX_UNION_FRACTION` (70%) of the index's posting entries decline to
narrow and fall back to the scan, and `Ne` declines outright (same convention as
`numeric_candidates`). Archive cost is ~140 kB (~34.8k entries over 31.5k cards — 91% of cards
have a single rarity, so the multi-rarity duplication is ~10%). Archive format version bumped.

## Why

Rarity scans were flagged in the post-#605 broad survey (`r:common` 0.80 ms, `r:mythic`
0.76 ms), and a rarity term in an Or voids narrowing for the whole node — the same pathology as
the flavor-text scans. The original plan (thresholded **printing-space** postings, from the
legality-postings write-up) dies on the actual distribution: reprint products make rare the
single most common rarity by printings, so under the 25% printing-space threshold only mythic
would qualify.

| rarity | printings | % printing space | cards | % card space |
|---|---|---|---|---|
| rare | 36,764 | 37.8% | 10,982 | 34.9% |
| common | 27,523 | 28.3% | 10,630 | 33.7% |
| uncommon | 23,604 | 24.3% | 10,217 | 32.4% |
| mythic | 8,924 | 9.2% | 2,568 | 8.2% |
| special | 391 | 0.4% | 370 | 1.2% |

Card space changes the economics (the PR #609 finding: card-space candidates shrink the eval
domain relative to the per-printing scan, so there's no 25% cliff): every single-rarity bucket
wins, including `r:common` at 33.7% of cards, and `rarity>=rare` (40.9%) — which printing space
could not serve — wins too. Mythic's posting is also 3.5× shorter as card ids (2,568 vs 8,924).

## Targeted queries (main vs this branch)

Engine timings, 20 warmup + 3 s timed window, `unique=card`, `limit=100`, edhrec ordering,
97,206 printings from the live corpus, same protocol/hardware both sides.

| Query | main | branch | | usd_high: main | branch | |
|---|---|---|---|---|---|---|
| `r:mythic` | 0.777 ms | **0.128 ms** | 6.1× | 0.842 | **0.189** | 4.5× |
| `r:rare` | 0.751 ms | **0.296 ms** | 2.5× | 0.992 | **0.538** | 1.9× |
| `r:common` | 0.794 ms | **0.230 ms** | 3.5× | 0.974 | **0.434** | 2.2× |
| `rarity>=rare` | 0.749 ms | **0.349 ms** | 2.1× | 1.018 | **0.627** | 1.6× |
| `rarity<=uncommon` | 0.762 ms | **0.419 ms** | 1.8× | 1.065 | **0.727** | 1.5× |
| `f:modern r:rare` | 0.718 ms | **0.301 ms** | 2.4× | 0.921 | **0.477** | 1.9× |
| `t:goblin or r:mythic` | 1.230 ms | **0.180 ms** | 6.8× | 1.310 | **0.243** | 5.4× |
| `rarity<=mythic` (declines) | 0.498 ms | 0.546 ms | parity† | 1.010 | 1.092 | parity† |
| controls (`t:goblin`, `cmc>3`, `usd>50`, `t:creature`) | — | — | 0.98–1.04× | — | — | 0.98–1.02× |

**Geomean over the 15 rarity-affected queries (including the ones that decline): 2.65× at
default prefer, 2.15× at usd_high.** Controls geomean exactly 1.00×. `f:modern r:rare` was the
survey's most expensive *common* pattern; it halves with legality still unindexed because the
rarity candidates now shield the legality scan.

† The apparent 0.91× on declined queries in the 3 s windows is sampling noise: re-measured with
10 s windows × 3 reps, the branch/main distributions fully overlap (e.g. `rarity<=mythic`
0.500–0.514 vs 0.500–0.501; main's own rep spread is wider than any cross-build gap). A declined
narrow is six list-length sums followed by exactly main's scan path.

## The union ceiling, and why 70%

Unlike the card-space **range** indexes (contiguous slice, never lose — the PR #609 exemption),
a posting union pays a gather-and-merge per bucket, and near-total coverage buys nothing.
Measured on the live corpus against the unguarded build:

| union | % of posting entries | prefer=default | prefer=usd_high |
|---|---|---|---|
| `rarity<=uncommon` | 60% | 2.0× win | 1.4× win |
| `rarity>=uncommon` | 69% | 1.44× win | **1.10× win** |
| `rarity<=mythic` | 99% | **0.85× (loses)** | — |

Default-prefer break-even interpolates to ~90% of entries, but non-default prefers compress the
win (both paths pay the heavier per-card walk), extrapolating to ~72–75%. The ceiling sits at
70%, below the worst prefer's crossover. For rarity the exact value is not load-bearing: no
bucket combination covers between 69% and 91.5% of entries, so any ceiling in that band admits
identical unions — but the measured crossovers are recorded on the constant for when this union
mechanism is reused on a denser posting family (legality is the obvious next one).

## Tests

- New unit tests: `build_rarity_index` (multi-rarity posting, dedup, rarity-less printings),
  `rarity_candidates` (all ops, empty-set proofs, Ne/over-ceiling declines, entries-based — not
  bucket-count — ceiling), and card-space routing through `narrow_candidates` for both operand
  orders.
- `cargo test`: 23 passed. Python suite: 1,462 unit + 464 integration (incl. engine parity)
  passed.
