### PR TITLE
Add Performance Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -1,0 +1,23 @@
+---
+name: Performance
+about: Query latency, memory footprint, or throughput work — a measured problem with a proposed mechanism
+title: ""
+labels: performance
+assignees: ""
+---
+
+**Measured problem**
+What is slow or too big, with numbers — query timings, archive bytes, RSS. Name the
+protocol (warmup/window, corpus size, build, machine) so the numbers are comparable later.
+
+**Where the cost is**
+The mechanism, not the symptom: full scan vs candidate gather, emission vs eval, allocation,
+lock contention, etc. If a decomposition experiment isolated it, describe the experiment.
+
+**Proposed approach**
+The design and its expected cost (archive bytes, build time, code paths touched). Include
+alternatives considered and why they lose — ideally with sizing, not vibes.
+
+**Acceptance**
+Which benchmark or survey re-run proves it, which queries must improve (by how much), and
+which controls must not regress.


### PR DESCRIPTION
## What this does

Adds `.github/ISSUE_TEMPLATE/performance.md` alongside the existing bug/feature templates, and pairs with the new `performance` label (created repo-side, auto-applied by the template).

## Why

A large fraction of recent PRs (#600, #605, #609, #612, #614, #618) and open issues (#619, #620) are performance work, and the good ones share a shape the bug/feature templates don't capture: a measured problem with a stated protocol, the cost mechanism (not the symptom), a proposed approach with sizing and rejected alternatives, and benchmark acceptance criteria. The template makes that shape the default.
