### PR TITLE
Narrow Flavor-Text Predicates via Distinct-Text Bind Scan and CSR

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use regex::Regex;
 use serde_json::Value;
-use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, ARTIST_NONE};
+use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, ARTIST_NONE, NONE_STR, FlavorIndex, flavor_fingerprint, flavor_match_sets};
 use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, format_shift};
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
@@ -288,6 +288,15 @@ pub(crate) enum FilterExpr {
     ArtistMatch {
         ids: Vec<u16>,
     },
+    /// A flavor-text predicate (contains/exact/regex) after bind() resolved it
+    /// against the ~26.3k distinct flavor texts (fingerprint-prefiltered scan):
+    /// sorted global string ids whose text satisfies the predicate — matching
+    /// is an integer binary search per printing — plus the dense text ids for
+    /// CSR narrowing in printing space.
+    FlavorMatch {
+        gids: Vec<u32>,
+        dense_ids: Vec<u32>,
+    },
     TextExact {
         field: TextField,
         op: CmpOp,
@@ -370,14 +379,24 @@ impl FilterExpr {
     ///   holding the sorted ids that satisfied them — per-printing matching is
     ///   then an integer membership test, and narrow_candidates can expand the
     ///   ids through the artist CSR index.
-    pub(crate) fn bind(&mut self, vocab: &AStrings, sorted_ids: &rkyv::Archived<Vec<u16>>, artist_vocab: &AStrings) {
+    /// - Flavor predicates get the same treatment against the ~26.3k distinct
+    ///   flavor texts (FlavorMatch), with a fingerprint prefilter skipping
+    ///   texts that cannot contain the needle (see FLAVOR_FP_FEATURES).
+    pub(crate) fn bind(
+        &mut self,
+        vocab: &AStrings,
+        sorted_ids: &rkyv::Archived<Vec<u16>>,
+        artist_vocab: &AStrings,
+        flavor: &rkyv::Archived<FlavorIndex>,
+        strings: &AStrings,
+    ) {
         match self {
             FilterExpr::And(children) | FilterExpr::Or(children) => {
                 for c in children {
-                    c.bind(vocab, sorted_ids, artist_vocab);
+                    c.bind(vocab, sorted_ids, artist_vocab, flavor, strings);
                 }
             }
-            FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab),
+            FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, flavor, strings),
             FilterExpr::CollectionCmp { value, value_id, .. } => {
                 let i = sorted_ids.partition_point(|id| vocab[u16::from(*id) as usize].as_str() < value.as_str());
                 *value_id = sorted_ids
@@ -404,6 +423,30 @@ impl FilterExpr {
             FilterExpr::TextRegex { field: TextField::ArtistLower, regex } => {
                 let ids = artist_match_ids(artist_vocab, |s| regex.is_match(s));
                 *self = FilterExpr::ArtistMatch { ids };
+            }
+            FilterExpr::TextContains { field: TextSearchField::FlavorTextLower, word } => {
+                let mask = flavor_fingerprint(word.as_str());
+                let (gids, dense_ids) = flavor_match_sets(flavor, strings, mask, |s| s.contains(word.as_str()));
+                *self = FilterExpr::FlavorMatch { gids, dense_ids };
+            }
+            FilterExpr::TextExact { field: TextField::FlavorTextLower, op, value } => {
+                let (op, value) = (*op, std::mem::take(value));
+                // Equality implies containment, so Eq can use the fingerprint;
+                // the other comparisons carry no containment implication.
+                let mask = if op == CmpOp::Eq { flavor_fingerprint(value.as_str()) } else { 0 };
+                let (gids, dense_ids) = flavor_match_sets(flavor, strings, mask, |s| match op {
+                    CmpOp::Eq => s == value,
+                    CmpOp::Ne => s != value,
+                    CmpOp::Lt => s < value.as_str(),
+                    CmpOp::Le => s <= value.as_str(),
+                    CmpOp::Gt => s > value.as_str(),
+                    CmpOp::Ge => s >= value.as_str(),
+                });
+                *self = FilterExpr::FlavorMatch { gids, dense_ids };
+            }
+            FilterExpr::TextRegex { field: TextField::FlavorTextLower, regex } => {
+                let (gids, dense_ids) = flavor_match_sets(flavor, strings, 0, |s| regex.is_match(s));
+                *self = FilterExpr::FlavorMatch { gids, dense_ids };
             }
             _ => {}
         }
@@ -582,6 +625,16 @@ impl FilterExpr {
                     Tri::Null // no artist: SQL NULL, like the missing-string case before
                 } else {
                     tri_bool(ids.binary_search(&vid).is_ok())
+                }
+            }
+
+            FilterExpr::FlavorMatch { gids, .. } => {
+                let Some(p) = printing else { return Tri::PrintingDep };
+                let gid = u32::from(p.flavor_text_lower_id);
+                if gid == NONE_STR {
+                    Tri::Null // no flavor text: SQL NULL, matching the pre-bind semantics
+                } else {
+                    tri_bool(gids.binary_search(&gid).is_ok())
                 }
             }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -970,6 +970,170 @@ fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32
     out
 }
 
+// ─── Flavor-text index ────────────────────────────────────────────────────────
+// Flavor is the last unindexed text field: predicates used to run per printing
+// (52k contains over 26.3k distinct texts) and could never narrow, voiding Or
+// narrowing for the whole node. Instead of a trigram index (measured ~5-9 MB),
+// bind() evaluates the predicate once over the distinct texts and rewrites the
+// node to FlavorMatch (the ArtistMatch pattern at 12x the vocab size); the CSR
+// here expands matched texts to printing candidates for narrowing (~0.4 MB).
+//
+// The bind scan is prefiltered by a 128-bit learned fingerprint per distinct
+// text: one bit per feature gram, and a text can contain the needle only if it
+// contains every feature gram the needle contains — `(text & needle) == needle`
+// in one u128 compare. Features were selected greedily over the live corpus to
+// minimize residual pass rate on a corpus-vocabulary needle workload, with
+// enough tail slots backfilled with the unchosen letters that every needle
+// fires at least one bit (worst case degrades to the letter-mask floor, never
+// to an unfiltered scan). Measured: ~3% of texts survive typical needles.
+// Regenerate with scripts/generate_flavor_fingerprint.py if selectivity
+// drifts; staleness costs selectivity, never correctness.
+
+const FLAVOR_FP_FEATURES: [&str; 128] = [
+    "ed", "se", "ch", "tr", "ss", "te", "la", "ing",
+    "ad", "rs", "ns", "ec", "har", "ne", "el", "ts",
+    "am", "gi", "ous", "re", "sh", "p", "ra", "un",
+    "ay", "ol", "ce", "ge", "si", "di", "ca", "es",
+    "nt", "ni", "end", "mi", "ee", "al", "ro", "tir",
+    "on", "ds", "is", "mb", "mer", "v", "gh", "ga",
+    "po", "sa", "hin", "ob", "ste", "oi", "le", "ur",
+    "ild", "ls", "br", "ea", "red", "ri", "pe", "oo",
+    "ul", "ya", "ba", "de", "pa", "mas", "et", "li",
+    "hu", "ha", "rd", "em", "cl", "su", "aw", "rk",
+    "oy", "ser", "so", "ly", "ta", "om", "ty", "fe",
+    "ot", "uys", "ac", "sp", "are", "va", "ag", "pi",
+    "bos", "alf", "fou", "liq", "nto", "en", "rc", "ze",
+    "a", "b", "c", "d", "e", "f", "g", "h",
+    "i", "j", "k", "l", "m", "n", "o", "q",
+    "r", "s", "t", "u", "w", "x", "y", "z",
+];
+
+static FLAVOR_FP_MAP: std::sync::OnceLock<HashMap<&'static [u8], u32>> = std::sync::OnceLock::new();
+
+/// 128-bit feature mask of a (lowercase) string: bit i set iff the string
+/// contains FLAVOR_FP_FEATURES[i]. Both distinct texts (at build) and needles
+/// (at bind) are masked with this same table, which is what makes the superset
+/// test sound. ASCII-alpha byte windows only, so multi-byte UTF-8 is skipped
+/// harmlessly (features are all ASCII).
+pub(crate) fn flavor_fingerprint(s: &str) -> u128 {
+    let map = FLAVOR_FP_MAP
+        .get_or_init(|| FLAVOR_FP_FEATURES.iter().enumerate().map(|(i, f)| (f.as_bytes(), i as u32)).collect());
+    let b = s.as_bytes();
+    let mut fp = 0u128;
+    for n in 1..=3usize {
+        if b.len() < n {
+            break;
+        }
+        for w in b.windows(n) {
+            if w.iter().all(|c| c.is_ascii_lowercase()) {
+                if let Some(&i) = map.get(w) {
+                    fp |= 1u128 << i;
+                }
+            }
+        }
+    }
+    fp
+}
+
+#[derive(Archive, Serialize, Deserialize, Default)]
+pub(crate) struct FlavorIndex {
+    /// Dense flavor text id → global string id (CardData.strings) of the
+    /// distinct lowercase flavor text, in first-seen printing order.
+    gids: Vec<u32>,
+    /// Parallel to gids: [lo, hi] halves of the text's u128 fingerprint.
+    fingerprints: Vec<[u64; 2]>,
+    /// CSR: printings carrying text `d` live at
+    /// `printings[offsets[d] .. offsets[d + 1]]`. Length gids.len() + 1.
+    offsets: Vec<u32>,
+    printings: Vec<u32>,
+}
+
+fn build_flavor_index(printings: &[Printing], strings: &[String]) -> FlavorIndex {
+    let mut dense_of: HashMap<u32, u32> = HashMap::new();
+    let mut gids: Vec<u32> = Vec::new();
+    let mut counts: Vec<u32> = Vec::new();
+    for p in printings {
+        let gid = p.flavor_text_lower_id;
+        if gid == NONE_STR {
+            continue;
+        }
+        let d = *dense_of.entry(gid).or_insert_with(|| {
+            gids.push(gid);
+            counts.push(0);
+            (gids.len() - 1) as u32
+        });
+        counts[d as usize] += 1;
+    }
+    let n = gids.len();
+    let mut offsets = vec![0u32; n + 1];
+    for i in 0..n {
+        offsets[i + 1] = offsets[i] + counts[i];
+    }
+    let mut cursor = offsets.clone();
+    let mut out = vec![0u32; offsets[n] as usize];
+    for (i, p) in printings.iter().enumerate() {
+        let gid = p.flavor_text_lower_id;
+        if gid == NONE_STR {
+            continue;
+        }
+        let d = dense_of[&gid] as usize;
+        out[cursor[d] as usize] = i as u32;
+        cursor[d] += 1;
+    }
+    let fingerprints = gids
+        .iter()
+        .map(|&g| {
+            let fp = flavor_fingerprint(strings[g as usize].as_str());
+            [fp as u64, (fp >> 64) as u64]
+        })
+        .collect();
+    FlavorIndex { gids, fingerprints, offsets, printings: out }
+}
+
+/// Resolve a flavor predicate against the distinct texts: (sorted global
+/// string ids for per-printing membership, dense text ids for CSR narrowing).
+/// `needle_mask` skips texts that cannot contain the needle (0 = no prefilter,
+/// e.g. regex or non-containment comparisons).
+pub(crate) fn flavor_match_sets(
+    flavor: &Archived<FlavorIndex>,
+    strings: &AStrings,
+    needle_mask: u128,
+    pred: impl Fn(&str) -> bool,
+) -> (Vec<u32>, Vec<u32>) {
+    let mut gids: Vec<u32> = Vec::new();
+    let mut dense: Vec<u32> = Vec::new();
+    for (d, gid) in flavor.gids.iter().enumerate() {
+        if needle_mask != 0 {
+            let fp = &flavor.fingerprints[d];
+            let mask = u64::from(fp[0]) as u128 | ((u64::from(fp[1]) as u128) << 64);
+            if mask & needle_mask != needle_mask {
+                continue;
+            }
+        }
+        let g = u32::from(*gid);
+        if pred(strings[g as usize].as_str()) {
+            gids.push(g);
+            dense.push(d as u32);
+        }
+    }
+    // Dense ids are ascending by construction; global ids follow interner
+    // order, not first-seen printing order — sort for binary-search membership.
+    gids.sort_unstable();
+    (gids, dense)
+}
+
+/// Expand matched dense flavor text ids to sorted printing ids via the CSR.
+fn expand_flavor_ids(idx: &Archived<FlavorIndex>, dense_ids: &[u32]) -> Vec<u32> {
+    let mut out: Vec<u32> = Vec::new();
+    for &d in dense_ids {
+        let start = u32::from(idx.offsets[d as usize]) as usize;
+        let end = u32::from(idx.offsets[d as usize + 1]) as usize;
+        out.extend(idx.printings[start..end].iter().map(|x| u32::from(*x)));
+    }
+    out.sort_unstable();
+    out
+}
+
 // ─── Sorted-u32 range indexes (released_at, price) ───────────────────────────
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
@@ -1154,6 +1318,7 @@ struct CardIndexes {
     art_tags:       TagIndex,        // printing space
     is_tags:        TagIndex,        // printing space
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
+    flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
     released_at:    DateIndex,       // printing space
     price_usd:      DateIndex,       // printing space (f32_sort_bits of the price)
@@ -1175,6 +1340,7 @@ impl Default for CardIndexes {
             art_tags:       HashMap::new(),
             is_tags:        HashMap::new(),
             artists:        ArtistIndex::default(),
+            flavor:         FlavorIndex::default(),
             set_codes:      HashMap::new(),
             released_at:    Vec::new(),
             price_usd:      Vec::new(),
@@ -1315,6 +1481,23 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
             // ids resolved at bind time; empty means no artist satisfies the
             // predicate, which proves the empty candidate set.
             Some(Candidates::Printings(expand_artist_ids(&indexes.artists, ids)))
+        }
+
+        FilterExpr::FlavorMatch { dense_ids, .. } => {
+            // Resolved at bind; empty proves the empty candidate set (printings
+            // without flavor evaluate to Null and can never match). Printing-
+            // space candidates, so near-total match sets (e.g. `ft!=x`) fall
+            // under the same broad-range guard as the price index — size the
+            // expansion from the CSR offsets before materializing it.
+            let flavor = &indexes.flavor;
+            let total: usize = dense_ids
+                .iter()
+                .map(|&d| (u32::from(flavor.offsets[d as usize + 1]) - u32::from(flavor.offsets[d as usize])) as usize)
+                .sum();
+            if range_too_broad_to_narrow(total, flavor.printings.len()) {
+                return None;
+            }
+            Some(Candidates::Printings(expand_flavor_ids(flavor, dense_ids)))
         }
 
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
@@ -1758,7 +1941,7 @@ fn card_to_pydict<'py>(
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change the struct sizes below wouldn't
 /// catch (e.g. reordering same-size fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260708;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260709;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2131,6 +2314,7 @@ impl QueryEngine {
             art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
             artists:        build_artist_index(&printings, artist_vocab.len()),
+            flavor:         build_flavor_index(&printings, &strings),
             set_codes:      {
                 let mut idx: TagIndex = HashMap::new();
                 for (i, p) in printings.iter().enumerate() {
@@ -2278,7 +2462,7 @@ impl QueryEngine {
         sync_format_shifts(&data.format_shifts);
         let mut filter_expr = build_filter(&json_val)
             .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
-        filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab);
+        filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.indexes.flavor, &data.strings);
 
         let (total, page) = run_query(
             &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_type_index, build_rarity_index, cards_of_printings, count_common_keywords, count_common_types,
+    build_type_index, build_rarity_index, build_flavor_index, flavor_fingerprint, flavor_match_sets,
+    cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, date_range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, DateIndex, NARROW_FLOOR,
     ArtistIndex, CardData, CardIndexes, Candidates, NumExpr, NumField, RarityIndex,
@@ -438,7 +439,7 @@ fn collection_cmp_binds_vocab_ids_and_matches() {
             value: value.to_string(),
             value_id: None,
         };
-        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
         archived.cards.iter().map(|c| f.eval_card(c, &archived.strings) == Tri::True).collect()
     };
 
@@ -468,7 +469,7 @@ fn printing_level_predicates_are_printing_dep_in_card_pass() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
 
     let card = &archived.cards[0];
     // Card pass can't decide an art-tag predicate...
@@ -640,6 +641,7 @@ fn bench_checked_vs_unchecked_access() {
         art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
         artists:        ArtistIndex::default(),
+        flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),
         released_at:    Vec::new(),
         price_usd:      Vec::new(),
@@ -697,7 +699,7 @@ fn card_pass_extracts_residual_and_matches() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    wolf.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    wolf.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
 
     // And[t:creature, art:wolf]: the type check is proven at card level and
@@ -725,7 +727,7 @@ fn card_pass_extracts_residual_and_matches() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    wolf2.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    wolf2.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
     let or = FilterExpr::Or(vec![creature(), wolf2]);
     let t = or.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or);
     assert!(t == Tri::True && residual.is_empty());
@@ -756,7 +758,7 @@ fn artist_predicates_bind_to_vocab_ids_and_narrow() {
         field: super::TextSearchField::ArtistLower,
         word: "rebecca".to_string(),
     };
-    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
     // bind rewrites the contains into an id-set match
     let FilterExpr::ArtistMatch { ref ids } = f else { panic!("expected ArtistMatch after bind") };
     assert_eq!(ids, &vec![rebecca]);
@@ -779,11 +781,130 @@ fn artist_predicates_bind_to_vocab_ids_and_narrow() {
         field: super::TextSearchField::ArtistLower,
         word: "zzz".to_string(),
     };
-    g.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab);
+    g.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
     match narrow_candidates(&g, &archived.indexes, &archived.offsets) {
         Some(Candidates::Printings(v)) => assert!(v.is_empty()),
         _ => panic!("empty artist match must narrow to the empty set"),
     }
+}
+
+// The fingerprint is a sound necessary-condition filter: a text containing the
+// needle carries every feature bit the needle carries.
+#[test]
+fn flavor_fingerprint_superset_property() {
+    let text = flavor_fingerprint("the dream of fire never dies");
+    for needle in ["dream", "fire", "never", "the dream", "re", "e"] {
+        let n = flavor_fingerprint(needle);
+        assert_eq!(text & n, n, "contained needle {needle:?} must be a mask subset");
+    }
+    // A non-contained needle with rare features is filterable.
+    let z = flavor_fingerprint("zombie");
+    assert_ne!(text & z, z);
+    // Non-ASCII and non-alpha bytes contribute no bits on either side.
+    assert_eq!(flavor_fingerprint("¡0—9!"), 0);
+}
+
+// FlavorMatch mirrors ArtistMatch at flavor scale: bind resolves the predicate
+// once over the distinct texts (fingerprint-prefiltered), eval is integer
+// membership with SQL NULL for flavorless printings, and narrowing expands the
+// CSR in printing space.
+#[test]
+fn flavor_match_bind_eval_and_narrow() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 2], vocab);
+    let mut interner = Interner::new();
+    let shared = interner.intern("the dream of fire".to_string());
+    data.printings[0].flavor_text_lower_id = shared;
+    data.printings[2].flavor_text_lower_id = shared; // same text on two printings
+    data.printings[1].flavor_text_lower_id = interner.intern("a quiet forest".to_string());
+    // printings[3] keeps NONE_STR: no flavor text at all
+    data.strings = interner.strings;
+    data.indexes.flavor = build_flavor_index(&data.printings, &data.strings);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let bound = |f: &mut FilterExpr| {
+        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+    };
+
+    let mut f = FilterExpr::TextContains {
+        field: super::TextSearchField::FlavorTextLower,
+        word: "dream".to_string(),
+    };
+    bound(&mut f);
+    let FilterExpr::FlavorMatch { ref gids, ref dense_ids } = f else { panic!("expected FlavorMatch after bind") };
+    assert_eq!(gids, &vec![shared]);
+    assert_eq!(dense_ids, &vec![0]); // dense ids are first-seen order
+
+    // Per-printing evaluation: membership on the shared text, Null (no match)
+    // for the flavorless printing, printing-dependent at the card level.
+    let card0 = &archived.cards[0];
+    let card1 = &archived.cards[1];
+    assert!(f.matches(card0, &archived.printings[0], &archived.strings));
+    assert!(!f.matches(card0, &archived.printings[1], &archived.strings));
+    assert!(f.matches(card1, &archived.printings[2], &archived.strings));
+    assert!(!f.matches(card1, &archived.printings[3], &archived.strings));
+    assert!(f.eval_card(card0, &archived.strings) == Tri::PrintingDep);
+
+    // NOT keeps NULL semantics: a flavorless printing matches neither ft:dream
+    // nor its negation.
+    let mut inner = FilterExpr::TextContains {
+        field: super::TextSearchField::FlavorTextLower,
+        word: "dream".to_string(),
+    };
+    bound(&mut inner);
+    let neg = FilterExpr::Not(Box::new(inner));
+    assert!(!neg.matches(card1, &archived.printings[3], &archived.strings));
+    assert!(neg.matches(card0, &archived.printings[1], &archived.strings));
+
+    // Narrowing expands the matched texts' CSR rows to sorted printing ids —
+    // this is what makes ft: participate in Or narrowing.
+    match narrow_candidates(&f, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
+        _ => panic!("flavor predicate must narrow in printing space"),
+    }
+
+    // Exact and regex forms resolve through the same mechanism.
+    let mut ex = FilterExpr::TextExact {
+        field: super::TextField::FlavorTextLower,
+        op: CmpOp::Eq,
+        value: "a quiet forest".to_string(),
+    };
+    bound(&mut ex);
+    match narrow_candidates(&ex, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![1]),
+        _ => panic!("exact flavor must narrow"),
+    }
+    let mut rx = FilterExpr::TextRegex {
+        field: super::TextField::FlavorTextLower,
+        regex: regex::Regex::new("qu.et").unwrap(),
+    };
+    bound(&mut rx);
+    assert!(rx.matches(card0, &archived.printings[1], &archived.strings));
+    match narrow_candidates(&rx, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![1]),
+        _ => panic!("regex flavor must narrow"),
+    }
+
+    // A needle matching nothing proves the empty candidate set.
+    let mut none = FilterExpr::TextContains {
+        field: super::TextSearchField::FlavorTextLower,
+        word: "zzzqqq".to_string(),
+    };
+    bound(&mut none);
+    match narrow_candidates(&none, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty()),
+        _ => panic!("empty flavor match must narrow to the empty set"),
+    }
+
+    // The fingerprint prefilter must not change results: same sets with the
+    // prefilter on (mask of the needle) and off (mask 0).
+    let mask = flavor_fingerprint("dream");
+    assert_ne!(mask, 0);
+    let with = flavor_match_sets(&archived.indexes.flavor, &archived.strings, mask, |s| s.contains("dream"));
+    let without = flavor_match_sets(&archived.indexes.flavor, &archived.strings, 0, |s| s.contains("dream"));
+    assert_eq!(with, without);
 }
 
 #[test]

--- a/scripts/generate_flavor_fingerprint.py
+++ b/scripts/generate_flavor_fingerprint.py
@@ -1,0 +1,149 @@
+"""Generate the frozen 128-feature table for the flavor-text fingerprint.
+
+Selects 128 ASCII-alpha 1/2/3-grams over the distinct lowercase flavor texts:
+greedy selection minimizing residual pass rate over a needle workload sampled
+from the corpus vocabulary, with a backfill invariant that reserves enough
+tail slots for every unchosen letter of the alphabet — so every possible
+needle fires at least one bit and the filter can forgo benefit but never
+regress to worse than the letter-mask floor.
+
+The output is the FLAVOR_FP_FEATURES const for card_engine/src/lib.rs.
+Staleness only costs selectivity, never correctness (the fingerprint is a
+necessary-condition filter, and texts and needles are masked with the same
+table), so re-running this is only warranted when measured selectivity drifts.
+
+Usage:
+    # export the corpus (or reuse an engine-columns export)
+    docker exec sylvan_blue-postgres-1 psql -U foouser -d magic -X -At \
+      -c "SELECT row_to_json(t) FROM (SELECT flavor_text FROM magic.cards) t" > /tmp/flavor.jsonl
+    python scripts/generate_flavor_fingerprint.py /tmp/flavor.jsonl
+
+Deterministic for a given corpus (fixed seed, sorted tie-breaks).
+"""
+
+import json
+import math
+import random
+import re
+import sys
+from collections import Counter
+
+import numpy as np
+
+BITS = 128
+SEED = 7
+TRAIN_NEEDLES = 300
+VOCAB_POOL = 4000
+CANDIDATE_POOL = 1000
+MIN_TEXT_DF = 20  # ignore grams rarer than this many texts (too corpus-specific)
+MIN_NEEDLE_COVERAGE = 2  # unless the gram is rare enough to be a filter on its own
+RARE_DF_FRACTION = 0.15
+ALPHABET = set("abcdefghijklmnopqrstuvwxyz")
+
+
+def grams_of(s: str) -> set:
+    """All ASCII-alpha 1/2/3-grams of `s`."""
+    out = set()
+    for n in (1, 2, 3):
+        for i in range(len(s) - n + 1):
+            g = s[i : i + n]
+            if g.isalpha() and g.isascii():
+                out.add(g)
+    return out
+
+
+def load_distinct_texts(corpus_path: str) -> list[str]:
+    """Distinct lowercase flavor texts from a JSONL export with a flavor_text field."""
+    texts = set()
+    with open(corpus_path) as fh:
+        for line in fh:
+            ft = json.loads(line).get("flavor_text")
+            if ft:
+                texts.add(ft.lower())
+    return sorted(texts)
+
+
+def candidate_grams(df: Counter, n_texts: int, train: list[str]) -> tuple[list[str], dict[str, list[str]]]:
+    """Grams worth considering.
+
+    Common enough in texts, and either present in the training workload or rare
+    enough to filter hard whenever they fire.
+    """
+    cands = [g for g, c in df.items() if c >= MIN_TEXT_DF]
+    train_contains = {g: [w for w in train if g in w] for g in cands}
+    cands = [g for g in cands if len(train_contains[g]) >= MIN_NEEDLE_COVERAGE or df[g] / n_texts <= RARE_DF_FRACTION]
+    cands.sort(key=lambda g: (-len(train_contains[g]) * -math.log(max(df[g] / n_texts, 1e-6)), g))
+    return cands[:CANDIDATE_POOL], train_contains
+
+
+def select_features(texts: list[str], text_grams: list[set], df: Counter) -> list[str]:
+    """Greedy residual selection with the letter-backfill invariant."""
+    n_texts = len(texts)
+    vocab = Counter()
+    for t in texts:
+        for w in re.findall(r"[a-z]{4,}", t):
+            vocab[w] += 1
+    rng = random.Random(SEED)
+    words = [w for w, _ in vocab.most_common(VOCAB_POOL)]
+    train = rng.sample(words, TRAIN_NEEDLES)
+
+    cands, train_contains = candidate_grams(df, n_texts, train)
+    pres = {g: np.zeros(n_texts, dtype=bool) for g in cands}
+    for i, gs in enumerate(text_grams):
+        for g in gs:
+            if g in pres:
+                pres[g][i] = True
+
+    masks = {w: np.ones(n_texts, dtype=bool) for w in train}
+    chosen: list[str] = []
+    pool = list(cands)
+    while True:
+        uncovered = ALPHABET - {g for g in chosen if len(g) == 1}
+        if BITS - len(chosen) <= len(uncovered):
+            chosen.extend(sorted(uncovered))
+            return chosen
+        best_g, best_obj = None, None
+        for g in pool:
+            delta = 0.0
+            for w in train_contains[g]:
+                old = masks[w]
+                old_n = old.sum()
+                if old_n == 0:
+                    continue
+                delta += math.log(max((old & pres[g]).sum(), 1) / old_n)
+            if best_obj is None or delta < best_obj or (delta == best_obj and g < best_g):
+                best_g, best_obj = g, delta
+        chosen.append(best_g)
+        for w in train_contains[best_g]:
+            masks[w] &= pres[best_g]
+        pool.remove(best_g)
+
+
+def main(corpus_path: str) -> None:
+    """Print the Rust const to stdout, selection stats to stderr."""
+    texts = load_distinct_texts(corpus_path)
+    print(f"// {len(texts):,} distinct flavor texts", file=sys.stderr)
+
+    df = Counter()
+    text_grams = []
+    for t in texts:
+        gs = grams_of(t)
+        text_grams.append(gs)
+        df.update(gs)
+
+    chosen = select_features(texts, text_grams, df)
+    if len(chosen) != BITS or len(set(chosen)) != BITS:
+        msg = f"selection produced {len(chosen)} features ({len(set(chosen))} distinct), expected {BITS}"
+        raise RuntimeError(msg)
+    n_single = sum(1 for g in chosen if len(g) == 1)
+    print(f"// {n_single} single letters, {BITS - n_single} multi-grams", file=sys.stderr)
+
+    print(f"const FLAVOR_FP_FEATURES: [&str; {BITS}] = [")
+    for i in range(0, BITS, 8):
+        row = ", ".join(f'"{g}"' for g in chosen[i : i + 8])
+        print(f"    {row},")
+    print("];")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])


### PR DESCRIPTION
Closes #620.

## What this does

Flavor text was the last unindexed text field: `ft:` predicates evaluated per printing (52k `contains` calls over only 26.3k distinct texts) and could never narrow — and because one unindexable Or child voids narrowing for the whole node, `ft:` Or-combos were the engine's worst measured queries (2.0–2.4 ms).

`bind()` now resolves `ft:` contains/exact/regex **once against the distinct texts** and rewrites the node to `FlavorMatch` — the `ArtistMatch` pattern (#605) at 12× the vocabulary size. Per-printing matching becomes an integer binary search (SQL NULL for flavorless printings, preserving `NOT ft:` semantics), and a dense-text-id CSR expands matched texts to printing candidates, so `ft:` participates in Or narrowing. Near-total match sets (`ft!=x`) decline under the existing printing-space broad guard (`range_too_broad_to_narrow`), sized from the CSR offsets before materializing anything.

## The fingerprint fastpath

The bind scan is prefiltered by a **128-bit learned fingerprint** per distinct text: one bit per feature gram, and a text can contain the needle only if it carries every feature bit the needle carries — `(text & needle) == needle`, one u128 compare per text over a 421 kB cache-resident array.

Features are 1/2/3-grams selected greedily on the live corpus to minimize residual pass rate over a corpus-vocabulary needle workload, with a backfill invariant that reserves tail slots for every unchosen letter — so every needle fires at least one bit and the filter can forgo benefit but never regress below the letter-mask floor (a zero-mask needle skips the filter entirely). Selection lessons that shaped it, all measured: near-50%-df corpus entropy is the wrong objective (rare grams are the best filters when they fire); bits must be trained on the residual after earlier bits or they duplicate each other; and high-df letters like `e` (98.9%) are worthless — only 2 letters earned seats on merit. Held-out geomean pass: **3.0%** of texts (letter-mask baseline: 48.9%).

The frozen table regenerates deterministically via `scripts/generate_flavor_fingerprint.py`; staleness costs selectivity, never correctness, since texts and needles are masked with the same table.

## Measured (main vs this branch)

97,206-printing live corpus, 20 warmup + 3 s timed window, `unique=card`, default prefer, edhrec ordering, limit 100, same protocol/hardware both sides.

| Query | main | branch | |
|---|---|---|---|
| `ft:dream` | 1.441 ms | **0.096 ms** | 15.0× |
| `ft:fire` | 1.465 ms | **0.210 ms** | 7.0× |
| `ft:sword` | 1.459 ms | **0.103 ms** | 14.2× |
| `ft:"the dream"` | 1.440 ms | **0.038 ms** | 37.9× |
| `(o:flying or ft:dream)` | 2.336 ms | **0.293 ms** | **8.0× — the #620 acceptance case** |
| `t:creature ft:dream` | 0.834 ms | **0.128 ms** | 6.5× |
| `ft:zzzqqq` (matches nothing) | 1.565 ms | **0.017 ms** | 92× — proves the empty candidate set |
| `(ft:fire or frame:showcase)` | 2.013 ms | 1.397 ms | 1.4× — frame is still unindexed, so the Or can't narrow; eval win only |
| controls: `t:goblin`, `t:creature`, `o:draw` | 0.061 / 0.251 / 0.199 | 0.063 / 0.248 / 0.208 | unchanged |

Both #620 acceptance criteria land well past their targets (bare `ft:` expected ~0.3–0.5 ms, measured ~0.1–0.2; Or-combo expected "well under 1 ms", measured 0.29). The remaining `frame:` combo is #620's successor problem, not this one — frame narrowing was explicitly rejected in the field's index review (low-selectivity values dominate).

## Cost

~1.0 MB archive (71.6 → 72.6 MB): dense-id remap 105 kB + fingerprints 421 kB + CSR offsets 105 kB + CSR printing ids ~210 kB + rkyv overhead — vs. the ~5–9 MB trigram index the issue rejected. Archive format version bumped (readers reject and rebuild older archives).

## Tests

- New unit tests: fingerprint superset-soundness property (contained needle ⇒ mask subset, non-ASCII contributes nothing), and an end-to-end `FlavorMatch` test through an archived store — bind rewrite shape, shared-text membership, NULL semantics for flavorless printings under `NOT`, printing-space narrowing for contains/exact/regex, empty-set proof, and prefilter-on/off result equality.
- `cargo test`: 25 passed. Python suite: 1,462 unit + 464 integration (incl. engine/SQL parity) passed.
