### PR TITLE
Train the Flavor Fingerprint on a 4,500-Word Split

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -985,27 +985,27 @@ fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32
 // minimize residual pass rate on a corpus-vocabulary needle workload, with
 // enough tail slots backfilled with the unchosen letters that every needle
 // fires at least one bit (worst case degrades to the letter-mask floor, never
-// to an unfiltered scan). Measured: ~3% of texts survive typical needles.
+// to an unfiltered scan). Measured: ~2% of texts survive typical needles (held-out 500-word split).
 // Regenerate with scripts/generate_flavor_fingerprint.py if selectivity
 // drifts; staleness costs selectivity, never correctness.
 
 const FLAVOR_FP_FEATURES: [&str; 128] = [
-    "ed", "se", "ch", "tr", "ss", "te", "la", "ing",
-    "ad", "rs", "ns", "ec", "har", "ne", "el", "ts",
-    "am", "gi", "ous", "re", "sh", "p", "ra", "un",
-    "ay", "ol", "ce", "ge", "si", "di", "ca", "es",
-    "nt", "ni", "end", "mi", "ee", "al", "ro", "tir",
-    "on", "ds", "is", "mb", "mer", "v", "gh", "ga",
-    "po", "sa", "hin", "ob", "ste", "oi", "le", "ur",
-    "ild", "ls", "br", "ea", "red", "ri", "pe", "oo",
-    "ul", "ya", "ba", "de", "pa", "mas", "et", "li",
-    "hu", "ha", "rd", "em", "cl", "su", "aw", "rk",
-    "oy", "ser", "so", "ly", "ta", "om", "ty", "fe",
-    "ot", "uys", "ac", "sp", "are", "va", "ag", "pi",
-    "bos", "alf", "fou", "liq", "nto", "en", "rc", "ze",
-    "a", "b", "c", "d", "e", "f", "g", "h",
-    "i", "j", "k", "l", "m", "n", "o", "q",
-    "r", "s", "t", "u", "w", "x", "y", "z",
+    "ed", "ri", "ra", "es", "te", "le", "p", "ng",
+    "nt", "de", "al", "el", "ns", "ar", "v", "k",
+    "ti", "la", "ce", "se", "ro", "ta", "ch", "ea",
+    "co", "sh", "li", "rs", "ni", "di", "mi", "ol",
+    "ur", "un", "si", "ts", "lo", "ne", "or", "ai",
+    "ge", "st", "me", "il", "en", "ec", "ly", "b",
+    "tr", "ma", "sa", "z", "ds", "ic", "ss", "pe",
+    "io", "ie", "re", "ul", "na", "ho", "ee", "us",
+    "fa", "rd", "oo", "ca", "x", "et", "cr", "su",
+    "ia", "wa", "so", "ga", "rt", "id", "mo", "ty",
+    "ls", "er", "ad", "bo", "sp", "gh", "j", "ru",
+    "am", "cl", "fi", "ow", "pr", "fe", "gi", "da",
+    "is", "ac", "gr", "ha", "rn", "dr", "gu", "as",
+    "em", "ir", "lu", "at", "vi", "a", "c", "d",
+    "e", "f", "g", "h", "i", "l", "m", "n",
+    "o", "q", "r", "s", "t", "u", "w", "y",
 ];
 
 static FLAVOR_FP_MAP: std::sync::OnceLock<HashMap<&'static [u8], u32>> = std::sync::OnceLock::new();

--- a/scripts/generate_flavor_fingerprint.py
+++ b/scripts/generate_flavor_fingerprint.py
@@ -1,9 +1,11 @@
 """Generate the frozen 128-feature table for the flavor-text fingerprint.
 
 Selects 128 ASCII-alpha 1/2/3-grams over the distinct lowercase flavor texts:
-greedy selection minimizing residual pass rate over a needle workload sampled
-from the corpus vocabulary, with a backfill invariant that reserves enough
-tail slots for every unchosen letter of the alphabet — so every possible
+greedy selection minimizing residual pass rate over a needle workload — the
+4,500-word training half of a seeded random split of the corpus vocabulary's
+5,000 most common words (the held-out 500 validate selectivity) — with a
+backfill invariant that reserves enough tail slots for every unchosen letter
+of the alphabet — so every possible
 needle fires at least one bit and the filter can forgo benefit but never
 regress to worse than the letter-mask floor.
 
@@ -32,8 +34,8 @@ import numpy as np
 
 BITS = 128
 SEED = 7
-TRAIN_NEEDLES = 300
-VOCAB_POOL = 4000
+TRAIN_NEEDLES = 4500
+VOCAB_POOL = 5000
 CANDIDATE_POOL = 1000
 MIN_TEXT_DF = 20  # ignore grams rarer than this many texts (too corpus-specific)
 MIN_NEEDLE_COVERAGE = 2  # unless the gram is rare enough to be a filter on its own
@@ -85,7 +87,8 @@ def select_features(texts: list[str], text_grams: list[set], df: Counter) -> lis
             vocab[w] += 1
     rng = random.Random(SEED)
     words = [w for w, _ in vocab.most_common(VOCAB_POOL)]
-    train = rng.sample(words, TRAIN_NEEDLES)
+    rng.shuffle(words)
+    train = words[:TRAIN_NEEDLES]
 
     cands, train_contains = candidate_grams(df, n_texts, train)
     pres = {g: np.zeros(n_texts, dtype=bool) for g in cands}


### PR DESCRIPTION
Follow-up to #622. The fingerprint's 300-needle training workload was a runtime-conservative choice from the interactive selection experiments; its tail picks memorized one- and two-needle coincidences (grams like `uys`/`bos`/`liq` at ~0% df).

## What this does

Retrains the frozen `FLAVOR_FP_FEATURES` table on the 4,500-word half of a seeded random split of the corpus vocabulary's 5,000 most common words, holding out 500 for validation. The generator script carries the new split; the mechanism (128 bits, one u128 AND-compare, letter-backfill invariant) is unchanged.

## Measured

| trained on | held-out geomean pass | worst held-out needle | unfiltered needles |
|---|---|---|---|
| 300 needles (#622) | 3.08% | 89% | 0 |
| **4,500 needles** | **1.81%** | **67%** | 0 |

The train/held-out gap closes entirely (1.98% / 1.81% — no memorization left), and with enough needles the greedy earns 7 letters organically and selects essentially no 3-grams: broad-coverage 2-grams dominate once coverage is measured properly. `ft:fire` — the weakest probe under the old table (46.8% pass) — improves 0.210 → 0.118 ms; other flavor queries hold or improve slightly.

Also checked: extending the pool to 10,000 words (9,000/1,000 split) changes nothing — 1.80%/1.48% vs 1.81%/1.48% cross-evaluated on both test distributions. The learning curve saturates at 4,500 needles; the 128-bit budget is the binding constraint now. Greedy costs 54 s, run offline via `scripts/generate_flavor_fingerprint.py`.

No archive format change (the fingerprint array has the same shape; staleness costs selectivity, never correctness), `cargo test`: 25 passed.