### PR TITLE
Index Collector Numbers and Rename the Printing-Space Range Index

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1134,13 +1134,14 @@ fn expand_flavor_ids(idx: &Archived<FlavorIndex>, dense_ids: &[u32]) -> Vec<u32>
     out
 }
 
-// ─── Sorted-u32 range indexes (released_at, price) ───────────────────────────
+// ─── Printing-space range indexes (released_at, price, collector number) ─────
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
 // satisfy a comparison — SQL NULL semantics). Dates store yyyymmdd directly;
-// prices store f32_sort_bits(price), which orders like the float.
+// collector numbers store the extracted int; prices store
+// f32_sort_bits(price), which orders like the float.
 
-type DateIndex = Vec<(u32, u32)>;
+type PrintingRangeIndex = Vec<(u32, u32)>;
 
 // Printing-space range narrowing is a pessimization when the matched slice
 // covers too much of the index: gathering + sorting the candidate ids and
@@ -1161,8 +1162,8 @@ fn range_too_broad_to_narrow(matched: usize, index_len: usize) -> bool {
     matched > NARROW_FLOOR && matched as f64 > index_len as f64 * MAX_NARROW_FRACTION
 }
 
-fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u32>) -> DateIndex {
-    let mut idx: DateIndex = printings
+fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u32>) -> PrintingRangeIndex {
+    let mut idx: PrintingRangeIndex = printings
         .iter()
         .enumerate()
         .filter_map(|(i, p)| get(p).map(|v| (v, i as u32)))
@@ -1175,7 +1176,7 @@ fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u
 /// index. Query values are f64 while prices are f32, so bounds are widened by
 /// one position where rounding could otherwise exclude a real match —
 /// narrowing must stay a superset; the walk verifies exactly.
-fn price_candidates(idx: &Archived<DateIndex>, op: CmpOp, value: f64) -> Option<Vec<u32>> {
+fn price_candidates(idx: &Archived<PrintingRangeIndex>, op: CmpOp, value: f64) -> Option<Vec<u32>> {
     let b = f32_sort_bits(value as f32);
     let (lo, hi) = match op {
         CmpOp::Ne => return None,
@@ -1183,13 +1184,39 @@ fn price_candidates(idx: &Archived<DateIndex>, op: CmpOp, value: f64) -> Option<
         CmpOp::Lt | CmpOp::Le => (0, b.saturating_add(1)),
         CmpOp::Gt | CmpOp::Ge => (b, u32::MAX),
     };
-    date_range_candidates(idx, lo, hi)
+    range_candidates(idx, lo, hi)
+}
+
+/// Sorted printing ids satisfying `int_value op value`, for indexes over plain
+/// integers (collector number). Query values are f64 and may be fractional or
+/// out of range; bounds are chosen so the half-open [lo, hi) range is exact
+/// for every op — `cn<100.5` means value <= 100, `cn:100.5` matches nothing
+/// (an exact empty narrowing, not "no index").
+fn int_range_candidates(idx: &Archived<PrintingRangeIndex>, op: CmpOp, value: f64) -> Option<Vec<u32>> {
+    const TOP: i64 = u32::MAX as i64;
+    let (lo, hi): (i64, i64) = match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => {
+            if value.fract() != 0.0 || value < 0.0 || value > TOP as f64 {
+                return Some(Vec::new());
+            }
+            (value as i64, value as i64 + 1)
+        }
+        CmpOp::Lt => (0, value.ceil().clamp(0.0, TOP as f64) as i64),
+        CmpOp::Le => (0, value.floor().clamp(-1.0, TOP as f64) as i64 + 1),
+        CmpOp::Gt => (value.floor().clamp(-1.0, TOP as f64) as i64 + 1, TOP),
+        CmpOp::Ge => (value.ceil().clamp(0.0, TOP as f64) as i64, TOP),
+    };
+    if hi <= lo {
+        return Some(Vec::new());
+    }
+    range_candidates(idx, lo as u32, hi as u32)
 }
 
 /// Sorted printing ids with an indexed value in [lo, hi), or None for ranges
 /// too broad to be worth narrowing (see MAX_NARROW_FRACTION). Callers translate
 /// ops into half-open ranges; Ne is not selective and never narrows.
-fn date_range_candidates(idx: &Archived<DateIndex>, lo: u32, hi: u32) -> Option<Vec<u32>> {
+fn range_candidates(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32) -> Option<Vec<u32>> {
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
     if range_too_broad_to_narrow(e - s, idx.len()) {
@@ -1320,8 +1347,9 @@ struct CardIndexes {
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
-    released_at:    DateIndex,       // printing space
-    price_usd:      DateIndex,       // printing space (f32_sort_bits of the price)
+    released_at:    PrintingRangeIndex,       // printing space
+    price_usd:      PrintingRangeIndex,       // printing space (f32_sort_bits of the price)
+    collector_number: PrintingRangeIndex,     // printing space (extracted int)
 }
 
 impl Default for CardIndexes {
@@ -1344,6 +1372,7 @@ impl Default for CardIndexes {
             set_codes:      HashMap::new(),
             released_at:    Vec::new(),
             price_usd:      Vec::new(),
+            collector_number: Vec::new(),
         }
     }
 }
@@ -1448,6 +1477,10 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 price_candidates(&indexes.price_usd, *op, *v).map(Candidates::Printings),
             (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) =>
                 price_candidates(&indexes.price_usd, flip_op(*op), *v).map(Candidates::Printings),
+            (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) =>
+                int_range_candidates(&indexes.collector_number, *op, *v).map(Candidates::Printings),
+            (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) =>
+                int_range_candidates(&indexes.collector_number, flip_op(*op), *v).map(Candidates::Printings),
             _ => None,
         },
 
@@ -1518,7 +1551,7 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 CmpOp::Gt => (value.saturating_add(1), u32::MAX),
                 CmpOp::Ge => (*value, u32::MAX),
             };
-            date_range_candidates(&indexes.released_at, lo, hi).map(Candidates::Printings)
+            range_candidates(&indexes.released_at, lo, hi).map(Candidates::Printings)
         }
 
         FilterExpr::YearCmp { op, year } => {
@@ -1534,7 +1567,7 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
                 CmpOp::Ge => (y * 10_000, u32::MAX),
             };
-            date_range_candidates(&indexes.released_at, lo, hi).map(Candidates::Printings)
+            range_candidates(&indexes.released_at, lo, hi).map(Candidates::Printings)
         }
 
         FilterExpr::And(children) => {
@@ -1940,8 +1973,10 @@ fn card_to_pydict<'py>(
 
 const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// Bump on any archived-data-model change the struct sizes below wouldn't
-/// catch (e.g. reordering same-size fields, changing an index type).
-const ARCHIVE_FORMAT_VERSION: u32 = 20260709;
+/// catch (e.g. reordering same-size fields, changing an index type) — and on
+/// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
+/// table, so a new table reading old fingerprints breaks the superset test.
+const ARCHIVE_FORMAT_VERSION: u32 = 20260710;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2327,6 +2362,7 @@ impl QueryEngine {
             },
             released_at:    build_range_index(&printings, |p| p.released_at_int),
             price_usd:      build_range_index(&printings, |p| p.price_usd.map(f32_sort_bits)),
+            collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,8 +2,8 @@ use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_type_index, build_rarity_index, build_flavor_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, date_range_candidates, narrow_candidates, rarity_candidates,
-    range_too_broad_to_narrow, run_query, trigram_candidates, DateIndex, NARROW_FLOOR,
+    build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
+    range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
     ArtistIndex, CardData, CardIndexes, Candidates, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
@@ -645,6 +645,7 @@ fn bench_checked_vs_unchecked_access() {
         set_codes:      HashMap::new(),
         released_at:    Vec::new(),
         price_usd:      Vec::new(),
+        collector_number: Vec::new(),
     };
     let data = CardData {
         cards,
@@ -907,6 +908,62 @@ fn flavor_match_bind_eval_and_narrow() {
     assert_eq!(with, without);
 }
 
+// Collector numbers index the extracted int; fractional and out-of-range
+// query values resolve to exact half-open ranges (or exact empty sets), and
+// printings without a numeric part are absent (SQL NULL semantics).
+#[test]
+fn collector_number_narrowing() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 2], vocab);
+    data.printings[0].collector_number_int = Some(100);
+    data.printings[1].collector_number_int = Some(228); // "228s" extracts to 228
+    data.printings[2].collector_number_int = Some(101);
+    // printings[3] has no numeric part: absent from the index
+    data.indexes.collector_number =
+        build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let cn = |op, v| FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::CollectorNumberInt),
+        op,
+        rhs: NumExpr::Const(v),
+    };
+    let narrow = |f: &FilterExpr| match narrow_candidates(f, &archived.indexes, &archived.offsets) {
+        Some(Candidates::Printings(v)) => Some(v),
+        Some(Candidates::Cards(_)) => panic!("cn must narrow in printing space"),
+        None => None,
+    };
+
+    assert_eq!(narrow(&cn(CmpOp::Eq, 100.0)), Some(vec![0]));
+    assert_eq!(narrow(&cn(CmpOp::Ge, 101.0)), Some(vec![1, 2]));
+    assert_eq!(narrow(&cn(CmpOp::Gt, 101.0)), Some(vec![1]));
+    // Fractional bounds are exact: cn<100.5 means cn<=100; cn>100.5 means cn>=101.
+    assert_eq!(narrow(&cn(CmpOp::Lt, 100.5)), Some(vec![0]));
+    assert_eq!(narrow(&cn(CmpOp::Gt, 100.5)), Some(vec![1, 2]));
+    // Fractional equality and out-of-range comparisons prove the empty set.
+    assert_eq!(narrow(&cn(CmpOp::Eq, 100.5)), Some(vec![]));
+    assert_eq!(narrow(&cn(CmpOp::Lt, -3.0)), Some(vec![]));
+    // Negative lower bounds cover everything indexed (printing 3 stays absent).
+    assert_eq!(narrow(&cn(CmpOp::Ge, -3.0)), Some(vec![0, 1, 2]));
+    // Ne never narrows.
+    assert_eq!(narrow(&cn(CmpOp::Ne, 100.0)), None);
+
+    // Flipped operand order: 101 <= cn.
+    let flipped = FilterExpr::NumericCmp {
+        lhs: NumExpr::Const(101.0),
+        op: CmpOp::Le,
+        rhs: NumExpr::Field(NumField::CollectorNumberInt),
+    };
+    assert_eq!(narrow(&flipped), Some(vec![1, 2]));
+
+    // The structural payoff: an Or with a trigram-narrowable sibling stays
+    // narrowable now that cn has an index (this was the post-#622 worst query).
+    let or = FilterExpr::Or(vec![cn(CmpOp::Eq, 228.0), cn(CmpOp::Eq, 100.0)]);
+    assert_eq!(narrow(&or), Some(vec![0, 1]));
+}
+
 #[test]
 fn set_code_and_date_narrowing() {
     let mut vocab = VocabInterner::new();
@@ -975,11 +1032,11 @@ fn broad_ranges_decline_to_narrow() {
 
     // End-to-end through the archived index: a broad slice returns None (fall
     // back to the scan), a selective slice still narrows.
-    let idx: DateIndex = (0..8_000u32).map(|v| (v, v)).collect();
+    let idx: PrintingRangeIndex = (0..8_000u32).map(|v| (v, v)).collect();
     let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize");
-    let archived = rkyv::access::<Archived<DateIndex>, Error>(&bytes).expect("access");
-    assert!(date_range_candidates(archived, 0, u32::MAX).is_none());
-    assert_eq!(date_range_candidates(archived, 100, 200).map(|v| v.len()), Some(100));
+    let archived = rkyv::access::<Archived<PrintingRangeIndex>, Error>(&bytes).expect("access");
+    assert!(range_candidates(archived, 0, u32::MAX).is_none());
+    assert_eq!(range_candidates(archived, 100, 200).map(|v| v.len()), Some(100));
 }
 
 #[test]


### PR DESCRIPTION
## What this does

Adds a printing-space range index over `collector_number_int` — the third tenant of the sorted `(u32, printing id)` shape after released-at (#600-era) and price (#605) — and renames the shared alias from `DateIndex` to `PrintingRangeIndex` (`date_range_candidates` → `range_candidates`), since the old name described one tenant of three.

## The odd-shape non-problem

Collector numbers are only mostly numeric (`228s`, `12a`), which is why this index didn't exist yet. But the hard decision was already made in the schema: `extract_collector_number_int` strips non-digits (only **1 of 97,206 printings** has none), eval already compares that extracted int with SQL NULL for the digit-less, and the range indexes already handle missing values **by omission**. The index mirrors eval exactly; the string-form queries (`cn:"228s"` exact) stay on the eval path as before.

Fractional / out-of-range query values resolve to exact half-open integer ranges: `cn<100.5` ⇔ `cn<=100`, `cn:100.5` proves the empty set. Broad ranges (`cn<=300` covers most of the store) decline under the existing `MAX_NARROW_FRACTION` guard and fall back to the scan at parity.

## Measured (main vs branch, 97,206-printing corpus, 20 warmup + 3 s window, unique=card)

| query | main | branch | |
|---|---|---|---|
| `o:draw or cn:100` | 2.070 ms | **0.216 ms** | **9.6× — the post-#622 survey's worst query** |
| `cn:100` | 0.784 ms | **0.070 ms** | 11.2× |
| `cn>=1 cn<=10` | 1.247 ms | **0.329 ms** | 3.8× |
| `t:creature or cn:100` | 0.786 ms | **0.268 ms** | 2.9× |
| `cn>=350` | 0.744 ms | 0.651 ms | 1.1× (matches 14.4% of printings — the flat part of the #609 crossover curve, not a selective range: modern variant-heavy sets push collector numbers into the many hundreds) |
| `cn<=300` (broad, declines) | 0.575 ms | 0.583 ms | parity ✓ |
| controls (`t:goblin`, `o:draw`, `usd>50`) | 0.064 / 0.212 / 0.117 | 0.062 / 0.203 / 0.117 | unchanged |

The headline is the Or-narrowing restoration: a `cn:` child no longer voids narrowing for the whole node, the same structural fix #622 made for `ft:`.

## Version bump note

`ARCHIVE_FORMAT_VERSION` is bumped — which also retroactively covers #626: that PR changed `FLAVOR_FP_FEATURES` without a bump, and archived fingerprints are built with that table, so a new binary reading an old archive would mask needles against stale bit assignments and silently drop matching flavor texts. The version-constant comment now documents that the fingerprint table is part of the archive contract.

## Tests

New `collector_number_narrowing` unit test: exact/fractional/negative/out-of-range bounds, flipped operands, Ne declining, NULL-by-omission, and Or-composition. `cargo test`: 26 passed. Python: 1,462 unit + 464 integration passed.
