### PR TITLE
Add Selectivity-Thresholded Frame Postings

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -936,6 +936,19 @@ struct ArtistIndex {
     printings: Vec<u32>,
 }
 
+/// build_tag_index with the printing-space selectivity threshold applied at
+/// build time: values whose posting would be declined by the range guard
+/// anyway (frame:2015 covers 66% of printings) are simply not stored — the
+/// absent-key convention already means "no narrowing", so dropped and unknown
+/// values both fall back to the scan. Third application of the threshold
+/// after the range guard (#609) and rarity's union ceiling (#618).
+fn build_thresholded_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> TagIndex {
+    let mut idx = build_tag_index(rows, vocab, get_ids);
+    let n = rows.len();
+    idx.retain(|_, postings| !range_too_broad_to_narrow(postings.len(), n));
+    idx
+}
+
 fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
     let mut offsets = vec![0u32; n_artists + 1];
     for p in printings {
@@ -1344,6 +1357,7 @@ struct CardIndexes {
     oracle_tags:    TagIndex,        // card space
     art_tags:       TagIndex,        // printing space
     is_tags:        TagIndex,        // printing space
+    frame_data:     TagIndex,        // printing space (selectivity-thresholded)
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
@@ -1367,6 +1381,7 @@ impl Default for CardIndexes {
             oracle_tags:    HashMap::new(),
             art_tags:       HashMap::new(),
             is_tags:        HashMap::new(),
+            frame_data:     HashMap::new(),
             artists:        ArtistIndex::default(),
             flavor:         FlavorIndex::default(),
             set_codes:      HashMap::new(),
@@ -1505,7 +1520,7 @@ fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offse
                 CollField::OracleTags => (&indexes.oracle_tags, Candidates::Cards),
                 CollField::ArtTags    => (&indexes.art_tags,    Candidates::Printings),
                 CollField::IsTags     => (&indexes.is_tags,     Candidates::Printings),
-                CollField::FrameData  => return None, // no index (low-selectivity values dominate)
+                CollField::FrameData  => (&indexes.frame_data,  Candidates::Printings),
             };
             idx.get(value.as_str()).map(|v| space(v.iter().map(|x| u32::from(*x)).collect()))
         }
@@ -1976,7 +1991,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260710;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260711;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2348,6 +2363,7 @@ impl QueryEngine {
             oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
             art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
+            frame_data:     build_thresholded_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
             artists:        build_artist_index(&printings, artist_vocab.len()),
             flavor:         build_flavor_index(&printings, &strings),
             set_codes:      {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_type_index, build_rarity_index, build_flavor_index, flavor_fingerprint, flavor_match_sets,
+    build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
@@ -640,6 +640,7 @@ fn bench_checked_vs_unchecked_access() {
         oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
         art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
+        frame_data:     HashMap::new(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),
@@ -962,6 +963,49 @@ fn collector_number_narrowing() {
     // narrowable now that cn has an index (this was the post-#622 worst query).
     let or = FilterExpr::Or(vec![cn(CmpOp::Eq, 228.0), cn(CmpOp::Eq, 100.0)]);
     assert_eq!(narrow(&or), Some(vec![0, 1]));
+}
+
+// Frame postings are selectivity-thresholded at build: values covering more
+// of printing space than the range guard would accept are not stored, and the
+// absent-key convention makes them (and unknown values) fall back to the scan.
+#[test]
+fn frame_postings_thresholded_at_build() {
+    let mut vocab = VocabInterner::new();
+    let modern = vocab_ids(&mut vocab, &["2015"]);
+    let showcase = vocab_ids(&mut vocab, &["Showcase"]);
+    // 2,000 printings: all carry "2015" (dominant, must be dropped: >1,000 and
+    // >25%), the first 40 also carry "Showcase" (selective, must be kept).
+    let mut printings: Vec<Printing> = (1..=2000u128).map(|i| stub_printing(i, i, None)).collect();
+    for (i, p) in printings.iter_mut().enumerate() {
+        p.card_frame_data = modern.clone();
+        if i < 40 {
+            p.card_frame_data = [modern.clone(), showcase.clone()].concat();
+            p.card_frame_data.sort_unstable();
+        }
+    }
+    let idx = build_thresholded_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
+    assert!(idx.get("2015").is_none(), "dominant value must be dropped by the threshold");
+    assert_eq!(idx.get("Showcase").map(|v| v.len()), Some(40));
+
+    // Wired into narrowing: selective value narrows in printing space, the
+    // dropped value declines (None, not empty — the scan still answers it).
+    let indexes = CardIndexes { frame_data: idx, ..Default::default() };
+    let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
+    let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
+    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 2000]).expect("serialize offsets");
+    let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
+    let coll = |value: &str| FilterExpr::CollectionCmp {
+        field: CollField::FrameData,
+        op: CmpOp::Ge,
+        value: value.to_string(),
+        value_id: None,
+    };
+    match narrow_candidates(&coll("Showcase"), archived, offsets) {
+        Some(Candidates::Printings(v)) => assert_eq!(v.len(), 40),
+        _ => panic!("selective frame value must narrow in printing space"),
+    }
+    assert!(narrow_candidates(&coll("2015"), archived, offsets).is_none());
+    assert!(narrow_candidates(&coll("Zzz"), archived, offsets).is_none());
 }
 
 #[test]


### PR DESCRIPTION
## What this does

Frame was the last predicate excluded from the tag indexes, with the comment `no index (low-selectivity values dominate)`. The measured distribution says the domination is singular: `2015` (the modern frame) covers **66% of printings**, while every other value is ≤17% and the ones users query (`showcase` 3.1%, `extendedart` 4.3%, `etched` 0.9%) are deeply selective.

So: build the frame tag index like `art_tags`/`is_tags`, then **drop postings at build time** that the range guard would decline at query time anyway (`range_too_broad_to_narrow`, reusing the #609 fraction and floor — the third application of the printing-space selectivity threshold after #609 and #618). Only `2015` gets dropped on the live corpus. The tag-index absent-key convention already means "no narrowing", so dropped and unknown values both fall back to the scan unchanged.

## Measured (main vs branch, 97,206-printing corpus, 20 warmup + 3 s window, unique=card)

| query | main | branch | |
|---|---|---|---|
| `ft:fire or frame:showcase` | 1.287 ms | **0.350 ms** | **3.7× — the last Or-pathology row in the post-#622 survey** |
| `frame:showcase` | 0.712 ms | **0.203 ms** | 3.5× |
| `frame:extendedart` | 0.672 ms | **0.159 ms** | 4.2× |
| `frame:etched` | 0.715 ms | **0.093 ms** | 7.7× |
| `t:creature frame:showcase` | 0.493 ms | **0.195 ms** | 2.5× |
| `frame:2015` (dropped, declines) | 0.577 ms | 0.587 ms | parity ✓ |
| controls (`t:goblin`, `t:creature`, `usd>50`) | 0.061 / 0.231 / 0.114 | 0.063 / 0.234 / 0.116 | unchanged |

With this, the survey tail contains no Or-with-unindexable-child rows at all — every remaining slow config belongs to the emission-streaming cluster (#619) or legality postings.

## Cost

~246 kB of archive (61,611 below-threshold posting entries × 4 B; the 64k-entry `2015` list is deliberately not stored), ~0.34% of the 73 MB archive. Format version bumped.

## Tests

New `frame_postings_thresholded_at_build` unit test: dominant value dropped, selective value kept and narrowing in printing space, dropped/unknown values declining (None, not empty). `cargo test`: 27 passed. Python: 1,462 unit + 464 integration passed.