### PR TITLE
Stream Broad Selections Through Precomputed Sort Permutations

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1147,6 +1147,75 @@ fn expand_flavor_ids(idx: &Archived<FlavorIndex>, dense_ids: &[u32]) -> Vec<u32>
     out
 }
 
+// ─── Sort permutations (streamed selection) ──────────────────────────────────
+// One precomputed card ordering per (card-level sort column, direction), used
+// by the streamed emission path (see run_query): walk the permutation, test
+// membership in the match bitmap, and only page cards are ever touched — no
+// sort keys, no quickselect, no prefer walk outside the page. Keys mirror
+// sort_key_bits with the card's store-preferred first printing standing in
+// for the query-chosen one: exact for the dominant unique=card default-prefer
+// case, and only orderable-differently inside blocks tied on both the primary
+// column and edhrec rank. Two permutations per column because direction folds
+// into the primary key only — secondaries keep their fixed order in both
+// directions, so a reversed ascending walk would be wrong inside ties.
+// 10 × ~126 kB ≈ 1.26 MB.
+
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct SortPermutations {
+    // [ascending, descending] per column
+    edhrec:    [Vec<u32>; 2],
+    cubecobra: [Vec<u32>; 2],
+    cmc:       [Vec<u32>; 2],
+    power:     [Vec<u32>; 2],
+    toughness: [Vec<u32>; 2],
+}
+
+impl ArchivedSortPermutations {
+    /// The permutation for a streamable column/direction; None for the
+    /// printing-keyed columns (rarity, usd), whose sort key depends on the
+    /// prefer-chosen printing and cannot be precomputed.
+    fn get(&self, col: SortCol, descending: bool) -> Option<&Archived<Vec<u32>>> {
+        let pair = match col {
+            SortCol::EdhrecRank => &self.edhrec,
+            SortCol::Cubecobra  => &self.cubecobra,
+            SortCol::Cmc        => &self.cmc,
+            SortCol::Power      => &self.power,
+            SortCol::Toughness  => &self.toughness,
+            SortCol::Rarity | SortCol::PriceUsd => return None,
+        };
+        Some(&pair[descending as usize])
+    }
+}
+
+fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets: &[u32]) -> SortPermutations {
+    let perm = |get: &dyn Fn(&OracleCard) -> Option<f32>, descending: bool| -> Vec<u32> {
+        let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
+        ids.sort_unstable_by_key(|&i| {
+            let c = &cards[i as usize];
+            let pk = get(c).map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
+            let e = c.edhrec_rank.unwrap_or(u32::MAX);
+            // Canonical secondary: the first (store-preferred) printing's
+            // default prefer score, matching sort_key_bits' third component
+            // for the printing the default prefer chooses.
+            let first = offsets[i as usize] as usize;
+            let sc = printings
+                .get(first)
+                .and_then(|p| p.prefer_score)
+                .map_or(u32::MAX, |v| f32_sort_bits(-v));
+            (((pk as u128) << 64) | ((e as u128) << 32) | (sc as u128), i)
+        });
+        ids
+    };
+    let both = |get: &dyn Fn(&OracleCard) -> Option<f32>| [perm(get, false), perm(get, true)];
+    SortPermutations {
+        edhrec:    both(&|c| c.edhrec_rank.map(|v| v as f32)),
+        cubecobra: both(&|c| c.cubecobra_score),
+        cmc:       both(&|c| c.cmc.map(|v| v as f32)),
+        power:     both(&|c| c.creature_power.map(|v| v as f32)),
+        toughness: both(&|c| c.creature_toughness.map(|v| v as f32)),
+    }
+}
+
 // ─── Printing-space range indexes (released_at, price, collector number) ─────
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
@@ -1364,6 +1433,7 @@ struct CardIndexes {
     released_at:    PrintingRangeIndex,       // printing space
     price_usd:      PrintingRangeIndex,       // printing space (f32_sort_bits of the price)
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
+    sort_perms:     SortPermutations,          // card space (streamed selection)
 }
 
 impl Default for CardIndexes {
@@ -1388,6 +1458,7 @@ impl Default for CardIndexes {
             released_at:    Vec::new(),
             price_usd:      Vec::new(),
             collector_number: Vec::new(),
+            sort_perms:     SortPermutations::default(),
         }
     }
 }
@@ -1761,6 +1832,171 @@ fn select_page(mut v: Vec<Match>, offset: usize, limit: usize) -> Vec<(u32, u32)
 // reconstruct per query. Per candidate card the filter is evaluated once at card
 // level; only when it depends on printing-level fields (Tri::PrintingDep) are the
 // card's printings evaluated individually.
+//
+// Selection runs in one of two shapes:
+//
+// - Gathered (the pre-#619 path): every match gets a sort key pushed into a
+//   Vec and select_page quickselects the page. Kept for the printing-keyed
+//   orderbys (rarity, usd) and for small match counts, where it is exact and
+//   already microseconds.
+// - Streamed: a match phase records per-card match counts (total = their sum,
+//   exact), then the orderby's precomputed permutation is walked, skipping
+//   counts until page_offset is consumed and emitting only page cards. No
+//   sort keys, no quickselect, and the prefer walk runs on ~limit cards
+//   instead of every match — the emission cost measured at 47-65% of broad
+//   non-default-prefer/artwork queries disappears. The match phase stays
+//   sequential (the #609-measured ~2x random-access penalty is why evaluation
+//   never happens in permutation order).
+
+#[derive(Clone, Copy)]
+enum Mode { Card, Artwork, Printing }
+
+/// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
+/// passing printings for Printing mode, distinct illustrations with a passing
+/// printing for Artwork mode. `ills` is a reused scratch buffer.
+#[allow(clippy::too_many_arguments)]
+fn card_match_count(
+    card: &AOracleCard,
+    printings: &[APrinting],
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    strings: &AStrings,
+    ills: &mut Vec<u128>,
+) -> u32 {
+    match mode {
+        Mode::Card => {
+            if all_match {
+                return u32::from(start < end);
+            }
+            for pid in start..end {
+                if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                    return 1;
+                }
+            }
+            0
+        }
+        Mode::Printing => {
+            if all_match {
+                return (end - start) as u32;
+            }
+            let mut n = 0u32;
+            for pid in start..end {
+                if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                    n += 1;
+                }
+            }
+            n
+        }
+        Mode::Artwork => {
+            ills.clear();
+            for pid in start..end {
+                if !all_match && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                    continue;
+                }
+                let ill = u128::from(printings[pid].illustration_id);
+                if !ills.contains(&ill) {
+                    ills.push(ill);
+                }
+            }
+            ills.len() as u32
+        }
+    }
+}
+
+/// Emit this card's matches as (sort key, cid, pid) tuples — the per-card body
+/// of the gathered path, shared by the streamed path for page cards.
+#[allow(clippy::too_many_arguments)]
+fn push_card_matches(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    strings: &AStrings,
+    out: &mut Vec<Match>,
+    groups: &mut Vec<(u128, u32, f64)>,
+) {
+    match mode {
+        Mode::Card => {
+            // Printings are stored in descending default-prefer order, so
+            // for the default prefer the first matching printing IS the
+            // chosen one — O(1) when the card pass already said True.
+            let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
+                let mut found: Option<u32> = None;
+                for pid in start..end {
+                    if all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                        found = Some(pid as u32);
+                        break;
+                    }
+                }
+                found
+            } else {
+                let mut chosen: Option<(u32, f64)> = None;
+                for pid in start..end {
+                    let p = &printings[pid];
+                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
+                    let score = prefer_score(card, p, prefer);
+                    if chosen.is_none_or(|(_, s)| score > s) {
+                        chosen = Some((pid as u32, score));
+                    }
+                }
+                chosen.map(|(pid, _)| pid)
+            };
+            if let Some(pid) = chosen {
+                out.push((sort_key_bits(card, &printings[pid as usize], sort_col, descending), cid, pid));
+            }
+        }
+        Mode::Printing => {
+            for pid in start..end {
+                let p = &printings[pid];
+                if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
+                out.push((sort_key_bits(card, p, sort_col, descending), cid, pid as u32));
+            }
+        }
+        Mode::Artwork => {
+            // Within-range order is prefer-score-desc (not illustration),
+            // so group by illustration with a small per-card scan — ranges
+            // are tiny (median 2 printings). `groups` is reused across
+            // cards to avoid per-card allocation.
+            groups.clear();
+            for pid in start..end {
+                let p = &printings[pid];
+                if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
+                let ill = u128::from(p.illustration_id);
+                let score = prefer_score(card, p, prefer);
+                match groups.iter_mut().find(|g: &&mut (u128, u32, f64)| g.0 == ill) {
+                    Some(g) => {
+                        if score > g.2 {
+                            g.1 = pid as u32;
+                            g.2 = score;
+                        }
+                    }
+                    None => groups.push((ill, pid as u32, score)),
+                }
+            }
+            for &(_, bp, _) in groups.iter() {
+                out.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
+            }
+        }
+    }
+}
+
+/// Below this many matches the gathered path is already microseconds and
+/// byte-identical to the pre-streaming behavior; above it, walking the
+/// permutation (a fixed ~n bit-tests over the counts array) plus per-page-card
+/// emission wins. Same measured-constant philosophy as MAX_NARROW_FRACTION.
+const STREAM_MIN_MATCHES: usize = 1_024;
 
 fn run_query<'a>(
     cards: &'a [AOracleCard],
@@ -1780,7 +2016,6 @@ fn run_query<'a>(
     let descending = direction == "desc";
     let prefer     = prefer_from_str(prefer);
 
-    enum Mode { Card, Artwork, Printing }
     let mode = match unique {
         "artwork"  => Mode::Artwork,
         "printing" => Mode::Printing,
@@ -1796,6 +2031,17 @@ fn run_query<'a>(
         None    => Box::new(0..cards.len() as u32),
     };
 
+    // Streamed selection when the orderby has a precomputed permutation.
+    if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
+        if perm.len() == cards.len() && !cards.is_empty() {
+            return run_query_streamed(
+                cards, printings, offsets, strings, filter, mode, prefer, sort_col, descending, limit,
+                page_offset, perm, card_ids,
+            );
+        }
+    }
+
+    // Gathered path (printing-keyed orderbys, or stores without permutations).
     let mut best: Vec<Match> = Vec::new();
     let mut groups: Vec<(u128, u32, f64)> = Vec::new(); // artwork-mode scratch, reused per card
     // card_pass residual: the top-level children still printing-dependent for
@@ -1811,70 +2057,10 @@ fn run_query<'a>(
         };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
-
-        match mode {
-            Mode::Card => {
-                // Printings are stored in descending default-prefer order, so
-                // for the default prefer the first matching printing IS the
-                // chosen one — O(1) when the card pass already said True.
-                let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
-                    let mut found: Option<u32> = None;
-                    for pid in start..end {
-                        if all_match || FilterExpr::residual_matches(card, &printings[pid], strings, &residual, residual_is_or) {
-                            found = Some(pid as u32);
-                            break;
-                        }
-                    }
-                    found
-                } else {
-                    let mut chosen: Option<(u32, f64)> = None;
-                    for pid in start..end {
-                        let p = &printings[pid];
-                        if !all_match && !FilterExpr::residual_matches(card, p, strings, &residual, residual_is_or) { continue; }
-                        let score = prefer_score(card, p, prefer);
-                        if chosen.is_none_or(|(_, s)| score > s) {
-                            chosen = Some((pid as u32, score));
-                        }
-                    }
-                    chosen.map(|(pid, _)| pid)
-                };
-                if let Some(pid) = chosen {
-                    best.push((sort_key_bits(card, &printings[pid as usize], sort_col, descending), cid, pid));
-                }
-            }
-            Mode::Printing => {
-                for pid in start..end {
-                    let p = &printings[pid];
-                    if !all_match && !FilterExpr::residual_matches(card, p, strings, &residual, residual_is_or) { continue; }
-                    best.push((sort_key_bits(card, p, sort_col, descending), cid, pid as u32));
-                }
-            }
-            Mode::Artwork => {
-                // Within-range order is prefer-score-desc (not illustration),
-                // so group by illustration with a small per-card scan — ranges
-                // are tiny (median 2 printings). `groups` is reused across
-                // cards to avoid per-card allocation.
-                groups.clear();
-                for pid in start..end {
-                    let p = &printings[pid];
-                    if !all_match && !FilterExpr::residual_matches(card, p, strings, &residual, residual_is_or) { continue; }
-                    let ill = u128::from(p.illustration_id);
-                    let score = prefer_score(card, p, prefer);
-                    match groups.iter_mut().find(|g: &&mut (u128, u32, f64)| g.0 == ill) {
-                        Some(g) => {
-                            if score > g.2 {
-                                g.1 = pid as u32;
-                                g.2 = score;
-                            }
-                        }
-                        None => groups.push((ill, pid as u32, score)),
-                    }
-                }
-                for &(_, bp, _) in groups.iter() {
-                    best.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
-                }
-            }
-        }
+        push_card_matches(
+            card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+            sort_col, descending, strings, &mut best, &mut groups,
+        );
     }
 
     let total = best.len();
@@ -1882,6 +2068,121 @@ fn run_query<'a>(
         .into_iter()
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
         .collect();
+    (total, page)
+}
+
+/// Streamed selection: match phase records per-card match counts (total is
+/// their sum), then either gathers (small totals — byte-identical to the
+/// gathered path) or walks the orderby permutation emitting only page cards.
+#[allow(clippy::too_many_arguments)]
+fn run_query_streamed<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    perm: &Archived<Vec<u32>>,
+    card_ids: Box<dyn Iterator<Item = u32> + '_>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let mut residual: Vec<&FilterExpr> = Vec::new();
+    let mut residual_is_or = false;
+    let mut ills: Vec<u128> = Vec::new();
+
+    // Match phase: sequential (candidate-order) evaluation into per-card
+    // counts. Exact total = sum of counts, known before emission strategy.
+    let mut counts: Vec<u32> = vec![0; cards.len()];
+    let mut total: usize = 0;
+    for cid in card_ids {
+        let card = &cards[cid as usize];
+        let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+            Tri::False | Tri::Null => continue,
+            Tri::True => true,
+            Tri::PrintingDep => false,
+        };
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end   = u32::from(offsets[cid as usize + 1]) as usize;
+        let c = card_match_count(card, printings, start, end, all_match, &residual, residual_is_or, mode, strings, &mut ills);
+        counts[cid as usize] = c;
+        total += c as usize;
+    }
+    if total == 0 || page_offset >= total {
+        return (total, Vec::new());
+    }
+
+    let mut groups: Vec<(u128, u32, f64)> = Vec::new();
+    let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
+
+    // Small totals: gather and quickselect — same result as the gathered path.
+    if total <= STREAM_MIN_MATCHES {
+        let mut best: Vec<Match> = Vec::with_capacity(total);
+        for cid in 0..cards.len() as u32 {
+            if counts[cid as usize] == 0 {
+                continue;
+            }
+            let card = &cards[cid as usize];
+            let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                Tri::True => true,
+                Tri::PrintingDep => false,
+                _ => continue,
+            };
+            let start = u32::from(offsets[cid as usize]) as usize;
+            let end   = u32::from(offsets[cid as usize + 1]) as usize;
+            push_card_matches(
+                card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+                sort_col, descending, strings, &mut best, &mut groups,
+            );
+        }
+        let page = select_page(best, page_offset, limit)
+            .into_iter()
+            .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
+            .collect();
+        return (total, page);
+    }
+
+    // Stream: walk the permutation, consume page_offset from the counts, emit
+    // page cards only. Within a card, items order by (sort key, pid) — the
+    // same comparator select_page uses; across cards the permutation supplies
+    // the order.
+    let mut skip = page_offset;
+    let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+    let mut scratch: Vec<Match> = Vec::new();
+    'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
+        let c = counts[cid as usize] as usize;
+        if c == 0 {
+            continue;
+        }
+        if skip >= c {
+            skip -= c;
+            continue;
+        }
+        let card = &cards[cid as usize];
+        let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+            Tri::True => true,
+            Tri::PrintingDep => false,
+            _ => continue,
+        };
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end   = u32::from(offsets[cid as usize + 1]) as usize;
+        scratch.clear();
+        push_card_matches(
+            card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+            sort_col, descending, strings, &mut scratch, &mut groups,
+        );
+        scratch.sort_unstable_by(cmp);
+        for m in scratch.iter().skip(skip) {
+            page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
+            if page.len() == limit {
+                break 'walk;
+            }
+        }
+        skip = 0;
+    }
     (total, page)
 }
 
@@ -1991,7 +2292,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260711;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260712;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2379,6 +2680,7 @@ impl QueryEngine {
             released_at:    build_range_index(&printings, |p| p.released_at_int),
             price_usd:      build_range_index(&printings, |p| p.price_usd.map(f32_sort_bits)),
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
+            sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1216,6 +1216,25 @@ fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets
     }
 }
 
+/// Distinct illustration groups per card (u16: max printings per card is ~1k).
+/// The streamed match phase uses this when the card pass already proved every
+/// printing matches: the artwork-mode contribution is then a build-time
+/// constant and the per-printing grouping walk is skipped entirely.
+fn build_artwork_group_counts(printings: &[Printing], offsets: &[u32]) -> Vec<u16> {
+    let mut counts = Vec::with_capacity(offsets.len().saturating_sub(1));
+    let mut ills: Vec<u128> = Vec::new();
+    for w in offsets.windows(2) {
+        ills.clear();
+        for p in &printings[w[0] as usize..w[1] as usize] {
+            if !ills.contains(&p.illustration_id) {
+                ills.push(p.illustration_id);
+            }
+        }
+        counts.push(ills.len() as u16);
+    }
+    counts
+}
+
 // ─── Printing-space range indexes (released_at, price, collector number) ─────
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
@@ -1434,6 +1453,7 @@ struct CardIndexes {
     price_usd:      PrintingRangeIndex,       // printing space (f32_sort_bits of the price)
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
     sort_perms:     SortPermutations,          // card space (streamed selection)
+    artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
 }
 
 impl Default for CardIndexes {
@@ -1459,6 +1479,7 @@ impl Default for CardIndexes {
             price_usd:      Vec::new(),
             collector_number: Vec::new(),
             sort_perms:     SortPermutations::default(),
+            artwork_groups: Vec::new(),
         }
     }
 }
@@ -2043,7 +2064,7 @@ fn run_query<'a>(
         if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
             return run_query_streamed(
                 cards, printings, offsets, strings, filter, mode, prefer, sort_col, descending, limit,
-                page_offset, perm, card_ids,
+                page_offset, perm, card_ids, &indexes.artwork_groups,
             );
         }
     }
@@ -2096,6 +2117,7 @@ fn run_query_streamed<'a>(
     page_offset: usize,
     perm: &Archived<Vec<u32>>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
+    artwork_groups: &Archived<Vec<u16>>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
@@ -2103,7 +2125,16 @@ fn run_query_streamed<'a>(
 
     // Match phase: sequential (candidate-order) evaluation into per-card
     // counts. Exact total = sum of counts, known before emission strategy.
-    let mut counts: Vec<u32> = vec![0; cards.len()];
+    // The counts buffer is reused across queries (thread-local) — the
+    // per-query ~126 kB allocation was measurable on selective queries.
+    thread_local! {
+        static COUNTS: std::cell::RefCell<Vec<u32>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+    COUNTS.with(|counts_cell| {
+    let mut counts = counts_cell.borrow_mut();
+    counts.clear();
+    counts.resize(cards.len(), 0);
+    let have_group_counts = artwork_groups.len() == cards.len();
     let mut total: usize = 0;
     for cid in card_ids {
         let card = &cards[cid as usize];
@@ -2114,7 +2145,13 @@ fn run_query_streamed<'a>(
         };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
-        let c = card_match_count(card, printings, start, end, all_match, &residual, residual_is_or, mode, strings, &mut ills);
+        // Every printing matches: card/printing counts are O(1) inside the
+        // helper, and the artwork group count is a build-time constant.
+        let c = if all_match && matches!(mode, Mode::Artwork) && have_group_counts {
+            u32::from(u16::from(artwork_groups[cid as usize]))
+        } else {
+            card_match_count(card, printings, start, end, all_match, &residual, residual_is_or, mode, strings, &mut ills)
+        };
         counts[cid as usize] = c;
         total += c as usize;
     }
@@ -2191,6 +2228,7 @@ fn run_query_streamed<'a>(
         skip = 0;
     }
     (total, page)
+    }) // COUNTS.with
 }
 
 // ─── Result field selection ───────────────────────────────────────────────────
@@ -2688,6 +2726,7 @@ impl QueryEngine {
             price_usd:      build_range_index(&printings, |p| p.price_usd.map(f32_sort_bits)),
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
+            artwork_groups: build_artwork_group_counts(&printings, &offsets),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1855,6 +1855,7 @@ enum Mode { Card, Artwork, Printing }
 /// passing printings for Printing mode, distinct illustrations with a passing
 /// printing for Artwork mode. `ills` is a reused scratch buffer.
 #[allow(clippy::too_many_arguments)]
+#[inline(always)]
 fn card_match_count(
     card: &AOracleCard,
     printings: &[APrinting],
@@ -1910,6 +1911,7 @@ fn card_match_count(
 /// Emit this card's matches as (sort key, cid, pid) tuples — the per-card body
 /// of the gathered path, shared by the streamed path for page cards.
 #[allow(clippy::too_many_arguments)]
+#[inline(always)]
 fn push_card_matches(
     card: &AOracleCard,
     cid: u32,
@@ -2031,9 +2033,14 @@ fn run_query<'a>(
         None    => Box::new(0..cards.len() as u32),
     };
 
-    // Streamed selection when the orderby has a precomputed permutation.
+    // Streamed selection when the orderby has a precomputed permutation — and
+    // the query is broad enough for the match/emit split to pay: a narrowed
+    // candidate list at or below the gather threshold can't produce more
+    // matches than that, so the fused path is already microseconds and the
+    // match phase would be pure overhead.
+    let maybe_broad = candidate_cards.as_ref().is_none_or(|v| v.len() > STREAM_MIN_MATCHES);
     if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
-        if perm.len() == cards.len() && !cards.is_empty() {
+        if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
             return run_query_streamed(
                 cards, printings, offsets, strings, filter, mode, prefer, sort_col, descending, limit,
                 page_offset, perm, card_ids,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, flavor_fingerprint, flavor_match_sets,
+    build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
@@ -647,6 +647,7 @@ fn bench_checked_vs_unchecked_access() {
         released_at:    Vec::new(),
         price_usd:      Vec::new(),
         collector_number: Vec::new(),
+        sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
     };
     let data = CardData {
         cards,
@@ -1006,6 +1007,92 @@ fn frame_postings_thresholded_at_build() {
     }
     assert!(narrow_candidates(&coll("2015"), archived, offsets).is_none());
     assert!(narrow_candidates(&coll("Zzz"), archived, offsets).is_none());
+}
+
+// Streamed selection must agree with the gathered path. Two stores identical
+// except for the presence of sort permutations: the perm-less store takes the
+// gathered path, the other streams (matches > STREAM_MIN_MATCHES). Distinct
+// edhrec ranks everywhere, so no full-key tie blocks (the one place the
+// canonical-secondary permutation is allowed to order differently).
+#[test]
+fn streamed_selection_matches_gathered() {
+    const N: usize = 1_500;
+    let build = |with_perms: bool| {
+        let mut vocab = VocabInterner::new();
+        let mut cards = Vec::with_capacity(N);
+        for i in 0..N {
+            let mut c = stub_card((i + 1) as u128, TYPE_CREATURE, &[], &mut vocab);
+            c.cmc = Some((i % 8) as u8);
+            c.edhrec_rank = Some(((i * 37) % N) as u32 + 1); // distinct, shuffled
+            if i % 11 == 0 {
+                c.edhrec_rank = None; // a null block, ordered by canonical secondary
+            }
+            cards.push(c);
+        }
+        let mut data = store_of(cards, &vec![3usize; N], vocab);
+        // vary prices so prefer=usd_high picks different printings
+        for (pid, p) in data.printings.iter_mut().enumerate() {
+            p.price_usd = Some((pid % 7) as f32 + 0.5);
+        }
+        if with_perms {
+            data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+        }
+        rkyv::to_bytes::<Error>(&data).expect("serialize")
+    };
+    let gathered_bytes = build(false);
+    let streamed_bytes = build(true);
+    let gathered = rkyv::access::<Archived<CardData>, Error>(&gathered_bytes).expect("access");
+    let streamed = rkyv::access::<Archived<CardData>, Error>(&streamed_bytes).expect("access");
+
+    // cmc >= 2 matches 6/8 of cards (1,125 > STREAM_MIN_MATCHES streams).
+    let filt = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Cmc),
+        op: CmpOp::Ge,
+        rhs: NumExpr::Const(2.0),
+    };
+    for unique in ["card", "printing", "artwork"] {
+        for prefer in ["default", "usd_high"] {
+            for orderby in ["edhrec", "cmc"] {
+                for direction in ["asc", "desc"] {
+                    for offset in [0usize, 7, 1120] {
+                        let f = filt();
+                        let (tg, pg) = run_query(
+                            &gathered.cards, &gathered.printings, &gathered.offsets, &gathered.strings,
+                            &f, unique, prefer, orderby, direction, 10, offset, &gathered.indexes,
+                        );
+                        let (ts, ps) = run_query(
+                            &streamed.cards, &streamed.printings, &streamed.offsets, &streamed.strings,
+                            &f, unique, prefer, orderby, direction, 10, offset, &streamed.indexes,
+                        );
+                        let ids = |v: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<(u128, u128)> {
+                            v.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
+                        };
+                        assert_eq!(tg, ts, "total {unique}/{prefer}/{orderby}/{direction}/{offset}");
+                        assert_eq!(ids(&pg), ids(&ps), "page {unique}/{prefer}/{orderby}/{direction}/{offset}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Permutations put missing sort values last in both directions and reverse
+// only the non-null primary order, matching sort_key_bits semantics.
+#[test]
+fn sort_permutations_nulls_last_both_directions() {
+    let mut vocab = VocabInterner::new();
+    let mut cards = vec![
+        stub_card(1, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(2, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(3, TYPE_CREATURE, &[], &mut vocab),
+    ];
+    cards[0].cmc = Some(5);
+    cards[1].cmc = None;
+    cards[2].cmc = Some(1);
+    let data = store_of(cards, &[1, 1, 1], vocab);
+    let perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+    assert_eq!(perms.cmc[0], vec![2, 0, 1], "asc: 1, 5, null");
+    assert_eq!(perms.cmc[1], vec![0, 2, 1], "desc: 5, 1, null");
 }
 
 #[test]

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations, flavor_fingerprint, flavor_match_sets,
+    build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
+    build_artwork_group_counts, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
@@ -648,6 +649,7 @@ fn bench_checked_vs_unchecked_access() {
         price_usd:      Vec::new(),
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
+        artwork_groups: build_artwork_group_counts(&printings, &offsets),
     };
     let data = CardData {
         cards,
@@ -1036,6 +1038,7 @@ fn streamed_selection_matches_gathered() {
         }
         if with_perms {
             data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+            data.indexes.artwork_groups = build_artwork_group_counts(&data.printings, &data.offsets);
         }
         rkyv::to_bytes::<Error>(&data).expect("serialize")
     };
@@ -1074,6 +1077,19 @@ fn streamed_selection_matches_gathered() {
             }
         }
     }
+}
+
+// Group counts collapse duplicate illustrations within a card.
+#[test]
+fn artwork_group_counts_dedup_illustrations() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[4], vocab);
+    data.printings[0].illustration_id = 7;
+    data.printings[1].illustration_id = 7; // same art, different printing
+    data.printings[2].illustration_id = 9;
+    data.printings[3].illustration_id = 7;
+    assert_eq!(build_artwork_group_counts(&data.printings, &data.offsets), vec![2]);
 }
 
 // Permutations put missing sort values last in both directions and reverse


### PR DESCRIPTION
Closes #619.

## What this does

For broad queries, emission — sort keys per match, the `best` vector, quickselect, and the prefer walk over every matching card's printings — measured at 47–65% of query cost under non-default prefers and artwork mode, all spent on matches outside the returned page ([the emission probe](https://github.com/jbylund/sylvan_librarian/issues/619)).

Selection now splits **match** from **order**:

1. **Match phase** (sequential, candidate-order, unchanged eval): records per-card match counts — existence for `unique=card`, passing printings for `printing`, distinct illustration groups for `artwork`. The exact total is their sum, known before any emission work. The match phase deliberately never runs in permutation order: the ~2× random-access penalty measured in #609 is the reason it stays sequential.
2. **Order phase**: below `STREAM_MIN_MATCHES` (1,024), gather + quickselect — byte-identical to the old path. Above it, walk a precomputed permutation for the orderby column, consuming `page_offset` from the counts and touching only page cards: no sort keys, no `best` vector, no quickselect, and the prefer-ordered printing walk runs on ~`limit` cards instead of every match. Deep pagination is a counts walk — effectively free.

**Permutations** exist per (card-level sort column, direction): edhrec, cubecobra, cmc, power, toughness × asc/desc (~1.26 MB), keyed by (direction-folded primary with nulls last, edhrec, first-printing prefer score, card id) — mirroring `sort_key_bits` plus `select_page`'s pid tiebreak, with the store-preferred printing standing in for the query-chosen one. `orderby=rarity`/`usd` key off the prefer-chosen printing, so no permutation can be exact — they keep the gathered path.

Two refinements that the first benchmark round forced:

- **Planner gate**: narrowed candidate lists at or below the threshold dispatch straight to the fused path (the match/emit split was measurable overhead on selective queries), and the counts buffer is thread-local (the per-query ~126 kB allocation showed up on `t:goblin`).
- **Precomputed artwork group counts** (~63 kB, `u16` per card): when the card pass proves every printing matches — every card-level filter — the artwork-mode contribution is a build-time constant and the per-printing grouping walk is skipped entirely. This took `t:creature` artwork from 1.5× to 2.8×.

## Measured (main vs branch, 97,206-printing corpus, 15 warmup + 2.5 s window per config)

35 configs: 6 broad filters × {card, artwork} × {default, usd_high}, plus printing mode, cmc asc/desc, deep offsets, non-streamable `usd` orderby, and selective controls.

| geomean | |
|---|---|
| **streamed cluster (29 configs)** | **1.66×** |
| selective controls (4) | 1.09× — parity, planner keeps them fused |
| non-streamable `usd` orderby (2) | 0.97× |
| **all 35** | **1.53×** |

| highlight configs | main | branch | |
|---|---|---|---|
| `rarity>=common` card usd_high | 1.647 ms | **0.420 ms** | **3.92×** |
| `usd<50` card usd_high | 1.468 ms | **0.450 ms** | 3.26× |
| `t:creature` artwork usd_high | 0.421 ms | **0.138 ms** | 3.05× |
| `t:creature` artwork default | 0.389 ms | **0.137 ms** | 2.84× |
| `t:creature` card usd_high | 0.362 ms | **0.153 ms** | 2.37× |
| `-t:creature` artwork | 0.804–0.834 ms | **0.366–0.371 ms** | 2.2–2.3× |
| `f:modern` artwork | 0.811–0.864 ms | **0.444–0.446 ms** | 1.8–1.9× |
| `t:creature` card, offset +5000 | 0.253 ms | **0.158 ms** | 1.61× — deep pagination is free |
| `rarity>=common` printing | 1.239 ms | **0.831 ms** | 1.49× |
| `t:goblin` (control) | 0.063 ms | 0.063 ms | 1.00× |

## Honest notes

- **Printing-dependent artwork rows** (`usd<50`, `rarity>=common` artwork) stay at 1.2–1.3×: exact totals force the match phase to evaluate printings and count groups; only the sort-key/quickselect/prefer share was eliminable. Follow-up: #629 (per-printing dense group-id bitmasks).
- **One residual regression**: `t:creature orderby=usd` (gathered path) 0.233 → 0.252 ms (−8%, ~19 µs) — extracting the per-card emission into a shared helper cost some codegen even with `inline(always)`. Rare orderby, broad query only; a `macro_rules!` body-duplication would recover it if it ever matters.
- **Tie-order semantics**: results can order differently from the old path only inside blocks tied on *both* the primary sort column and edhrec rank (the permutation canonicalizes that tiebreak on the store-preferred printing). The 72-config equivalence matrix — twin stores differing only in permutations, uniques × prefers × orderbys × directions × offsets — passes, including a null-edhrec block, and the full engine/SQL parity suite is green.
- Exact totals and exact pagination are preserved throughout; this is not an approximate-counts design.

## Cost

~1.33 MB archive (10 permutations + artwork group counts). Format version bumped.

## Tests

`cargo test`: 30 passed (equivalence matrix, nulls-last permutation ordering, artwork group-count dedup). Python: 1,462 unit + 464 integration (incl. engine/SQL parity) passed.
