### PR TITLE
Evaluate Color and Type Predicates via Transposed Bitplanes

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -665,6 +665,8 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
 
 mod filter;
 use filter::*;
+mod planes;
+use planes::*;
 
 // ─── Trigram index ────────────────────────────────────────────────────────────
 
@@ -1454,6 +1456,7 @@ struct CardIndexes {
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
+    planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
 }
 
 impl Default for CardIndexes {
@@ -1480,6 +1483,7 @@ impl Default for CardIndexes {
             collector_number: Vec::new(),
             sort_perms:     SortPermutations::default(),
             artwork_groups: Vec::new(),
+            planes:         BitPlanes::default(),
         }
     }
 }
@@ -2027,6 +2031,7 @@ fn run_query<'a>(
     offsets: &AOffsets,
     strings: &AStrings,
     filter: &FilterExpr,
+    plane: Option<&PlaneExpr>,
     unique: &str,
     prefer: &str,
     orderby: &str,
@@ -2049,6 +2054,33 @@ fn run_query<'a>(
     // per-printing verification restores exactness for printing-space losses.
     let candidate_cards: Option<Vec<u32>> =
         narrow_candidates(filter, indexes, offsets).map(|c| c.into_cards(offsets));
+
+    // The plane bitmap is the exact card-level truth of the plane-consumed
+    // subexpression (split_planes), so it composes with the residual's postings
+    // candidates by intersection — and with no postings it IS the candidate
+    // list. Either way every surviving card still runs the residual through
+    // card_pass, which is what keeps printing-space losses and Null semantics
+    // with the residual, not the planes. The bitmap buffer is reused across
+    // queries (thread-local), same as the streamed counts buffer.
+    let candidate_cards: Option<Vec<u32>> = match plane {
+        None => candidate_cards,
+        Some(expr) => {
+            thread_local! {
+                static PLANE_BITMAP: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+            }
+            PLANE_BITMAP.with(|cell| {
+                let mut bitmap = cell.borrow_mut();
+                eval_planes(expr, &indexes.planes, &mut bitmap);
+                match candidate_cards {
+                    Some(mut v) => {
+                        v.retain(|&cid| bitmap_contains(&bitmap, cid));
+                        Some(v)
+                    }
+                    None => Some(bitmap_card_ids(&bitmap)),
+                }
+            })
+        }
+    };
     let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
         None    => Box::new(0..cards.len() as u32),
@@ -2337,7 +2369,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260712;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260714;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -2727,6 +2759,7 @@ impl QueryEngine {
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: build_artwork_group_counts(&printings, &offsets),
+            planes:         build_bit_planes(&cards),
         };
 
         #[cfg(feature = "alloc-counter")]
@@ -2864,8 +2897,20 @@ impl QueryEngine {
             .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
         filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.indexes.flavor, &data.strings);
 
+        // Consume the plane-expressible part of the filter (colors/identity/
+        // types) into a bitmap expression; run_query evaluates it in a few
+        // hundred word ops instead of per-card dispatch. Guarded on the archive
+        // carrying planes for this card count — the format-version bump already
+        // rejects pre-plane archives, this is defense in depth.
+        let (plane_expr, filter_expr) =
+            if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
+                split_planes(filter_expr)
+            } else {
+                (None, filter_expr)
+            };
+
         let (total, page) = run_query(
-            &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr,
+            &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr, plane_expr.as_ref(),
             unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1,0 +1,297 @@
+//! Transposed card-space bitplanes for low-cardinality dimensions (issue #630).
+//!
+//! One bitset per (dimension, value): bit i of a plane says card i has that
+//! value. At ~31.5k cards a plane is ~4 kB of plain u64 words, so a filter
+//! subtree rewritten into word-wise AND/OR/NOT over cache-resident planes
+//! evaluates in microseconds — versus the ~31.5k filter-tree dispatches (and a
+//! cache line per card) the driver loop pays to prove the same bits one card
+//! at a time.
+//!
+//! Phase 1 covers the exactly-consumable dimensions: colors, color identity,
+//! and the card type bits. All three are card-level and two-valued (their
+//! tri() never returns Null or PrintingDep), so plane algebra — including
+//! complement for Not — reproduces the filter's card-level truth exactly.
+//! Produced mana is deliberately left out for now; `produces:` queries stay on
+//! the residual path. Rarity and legality need the narrowing/divergence
+//! machinery from later phases (see the issue).
+
+use rkyv::{Archive, Deserialize, Serialize};
+
+use super::filter::{CmpOp, ColorField, FilterExpr};
+use super::OracleCard;
+
+/// Plane layout, plane-major in BitPlanes.words: six color planes per color
+/// field (W U B R G C, bit order matching color_to_bit — C is always zero for
+/// colors/identity but keeps the mask algebra total over whatever mask the
+/// parser emits), then one plane per card type bit.
+const COLOR_PLANES: usize = 6;
+const TYPE_PLANES: usize = 14;
+const PLANE_COLORS: usize = 0;
+const PLANE_IDENTITY: usize = COLOR_PLANES;
+const PLANE_TYPES: usize = 2 * COLOR_PLANES;
+pub(crate) const PLANE_COUNT: usize = PLANE_TYPES + TYPE_PLANES;
+
+#[derive(Archive, Serialize, Deserialize, Default)]
+pub(crate) struct BitPlanes {
+    pub(crate) n_cards: u32,
+    /// PLANE_COUNT × words_per_plane, flattened plane-major; bit i of plane p
+    /// is words[p * wpp + i/64] >> (i%64) & 1.
+    pub(crate) words: Vec<u64>,
+}
+
+pub(crate) fn words_per_plane(n_cards: usize) -> usize {
+    n_cards.div_ceil(64)
+}
+
+pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
+    let wpp = words_per_plane(cards.len());
+    let mut words = vec![0u64; PLANE_COUNT * wpp];
+    for (i, card) in cards.iter().enumerate() {
+        let mut set = |plane: usize| words[plane * wpp + i / 64] |= 1u64 << (i % 64);
+        for b in 0..COLOR_PLANES {
+            if card.card_colors & (1 << b) != 0 {
+                set(PLANE_COLORS + b);
+            }
+            if card.card_color_identity & (1 << b) != 0 {
+                set(PLANE_IDENTITY + b);
+            }
+        }
+        let mut bits = card.card_types;
+        while bits != 0 {
+            set(PLANE_TYPES + bits.trailing_zeros() as usize);
+            bits &= bits - 1;
+        }
+    }
+    BitPlanes { n_cards: cards.len() as u32, words }
+}
+
+// ─── Plane expressions ────────────────────────────────────────────────────────
+
+/// A filter subtree compiled to mask algebra over planes. Evaluation is
+/// word-at-a-time (eval_word), one pass over the words with no per-node
+/// temporaries.
+pub(crate) enum PlaneExpr {
+    Plane(u16),
+    And(Vec<PlaneExpr>),
+    Or(Vec<PlaneExpr>),
+    Not(Box<PlaneExpr>),
+    Const(bool),
+}
+
+/// And over children, collapsing the empty (vacuously true) and singleton cases.
+fn and_of(mut children: Vec<PlaneExpr>) -> PlaneExpr {
+    match children.len() {
+        0 => PlaneExpr::Const(true),
+        1 => children.pop().unwrap(),
+        _ => PlaneExpr::And(children),
+    }
+}
+
+/// Or over children, collapsing the empty (vacuously false) and singleton cases.
+fn or_of(mut children: Vec<PlaneExpr>) -> PlaneExpr {
+    match children.len() {
+        0 => PlaneExpr::Const(false),
+        1 => children.pop().unwrap(),
+        _ => PlaneExpr::Or(children),
+    }
+}
+
+/// Split a plane range [base, base+width) by a value mask: planes for the mask's
+/// set bits, and planes for its clear bits.
+fn in_out_planes(base: usize, width: usize, mask: u16) -> (Vec<PlaneExpr>, Vec<PlaneExpr>) {
+    let mut inp = Vec::new();
+    let mut outp = Vec::new();
+    for b in 0..width {
+        let plane = PlaneExpr::Plane((base + b) as u16);
+        if mask & (1 << b) != 0 { inp.push(plane) } else { outp.push(plane) }
+    }
+    (inp, outp)
+}
+
+/// bits == mask over the planes of one field: every in-mask plane set, every
+/// out-of-mask plane clear.
+fn eq_expr(base: usize, width: usize, mask: u16) -> PlaneExpr {
+    let (inp, outp) = in_out_planes(base, width, mask);
+    and_of(inp.into_iter().chain(outp.into_iter().map(|p| PlaneExpr::Not(Box::new(p)))).collect())
+}
+
+/// bits & !mask == 0 (nothing outside the mask): every out-of-mask plane clear.
+fn le_expr(base: usize, width: usize, mask: u16) -> PlaneExpr {
+    let (_, outp) = in_out_planes(base, width, mask);
+    and_of(outp.into_iter().map(|p| PlaneExpr::Not(Box::new(p))).collect())
+}
+
+/// Compile one field's comparison to plane algebra. `ge_any` selects the Ge
+/// shape: ColorCmp's Ge is all-of (bits & mask == mask), TypeCmp's is any-of
+/// (bits & mask != 0) — see their tri() arms.
+fn cmp_expr(base: usize, width: usize, mask: u16, op: CmpOp, ge_any: bool) -> PlaneExpr {
+    let ge = || {
+        let (inp, _) = in_out_planes(base, width, mask);
+        if ge_any { or_of(inp) } else { and_of(inp) }
+    };
+    match op {
+        CmpOp::Ge => ge(),
+        CmpOp::Eq => eq_expr(base, width, mask),
+        CmpOp::Le => le_expr(base, width, mask),
+        CmpOp::Ne => PlaneExpr::Not(Box::new(eq_expr(base, width, mask))),
+        CmpOp::Lt => and_of(vec![le_expr(base, width, mask), PlaneExpr::Not(Box::new(eq_expr(base, width, mask)))]),
+        CmpOp::Gt => and_of(vec![ge(), PlaneExpr::Not(Box::new(eq_expr(base, width, mask)))]),
+    }
+}
+
+/// Compile a filter subtree to a plane expression, or None if any node in it
+/// is not plane-expressible. Only two-valued card-level nodes may compile:
+/// complement (Not) is only sound when the node can never be Null or
+/// PrintingDep, which holds for ColorCmp and TypeCmp by their tri() arms.
+pub(crate) fn compile_plane(filter: &FilterExpr) -> Option<PlaneExpr> {
+    match filter {
+        FilterExpr::True => Some(PlaneExpr::Const(true)),
+        FilterExpr::And(children) => children
+            .iter()
+            .map(compile_plane)
+            .collect::<Option<Vec<_>>>()
+            .map(and_of),
+        FilterExpr::Or(children) => children
+            .iter()
+            .map(compile_plane)
+            .collect::<Option<Vec<_>>>()
+            .map(or_of),
+        FilterExpr::Not(inner) => compile_plane(inner).map(|p| PlaneExpr::Not(Box::new(p))),
+        FilterExpr::ColorCmp { field, op, mask } => {
+            let base = match field {
+                ColorField::Colors => PLANE_COLORS,
+                ColorField::ColorIdentity => PLANE_IDENTITY,
+                // Deliberately unplaned for now (#630): produces: stays residual.
+                ColorField::ProducedMana => return None,
+            };
+            // color_to_bit only sets bits 0..6; anything else would make the
+            // plane complement unsound, so refuse rather than assume.
+            if u16::from(*mask) & !((1 << COLOR_PLANES) - 1) != 0 {
+                return None;
+            }
+            Some(cmp_expr(base, COLOR_PLANES, u16::from(*mask), *op, false))
+        }
+        FilterExpr::TypeCmp { mask, op } => {
+            if mask & !((1 << TYPE_PLANES) - 1) != 0 {
+                return None;
+            }
+            Some(cmp_expr(PLANE_TYPES, TYPE_PLANES, *mask, *op, true))
+        }
+        _ => None,
+    }
+}
+
+/// Consume the plane-expressible part of a bound filter. Returns the compiled
+/// plane expression (None when nothing compiled) and the residual filter the
+/// driver must still evaluate (FilterExpr::True when everything compiled).
+///
+/// Composition rules: a fully compilable tree is consumed whole. A top-level
+/// And partitions — compilable children move into the plane expression, the
+/// rest stay as the residual (the bulk analogue of card_pass's per-card
+/// residual extraction). An Or is all-or-nothing: mask ∨ residual is not a
+/// narrowing mask, so a partially compilable Or stays entirely residual.
+/// A bare True is left alone — the full-range scan beats materializing an
+/// all-ones bitmap into a candidate list.
+pub(crate) fn split_planes(filter: FilterExpr) -> (Option<PlaneExpr>, FilterExpr) {
+    if matches!(filter, FilterExpr::True) {
+        return (None, filter);
+    }
+    if let Some(pe) = compile_plane(&filter) {
+        return (Some(pe), FilterExpr::True);
+    }
+    match filter {
+        FilterExpr::And(children) => {
+            let mut planes: Vec<PlaneExpr> = Vec::new();
+            let mut rest: Vec<FilterExpr> = Vec::new();
+            for c in children {
+                match compile_plane(&c) {
+                    Some(pe) => planes.push(pe),
+                    None => rest.push(c),
+                }
+            }
+            if planes.is_empty() {
+                return (None, FilterExpr::And(rest));
+            }
+            // rest is nonempty here: had every child compiled, the whole-tree
+            // compile above would have consumed the And.
+            let residual = if rest.len() == 1 { rest.pop().unwrap() } else { FilterExpr::And(rest) };
+            (Some(and_of(planes)), residual)
+        }
+        other => (None, other),
+    }
+}
+
+// ─── Evaluation ───────────────────────────────────────────────────────────────
+
+impl PlaneExpr {
+    /// One 64-card word of the expression: recursive over the tree, so a full
+    /// evaluation is a single pass over the words with no intermediate bitmaps.
+    fn eval_word(&self, words: &rkyv::Archived<Vec<u64>>, wpp: usize, i: usize) -> u64 {
+        match self {
+            PlaneExpr::Plane(p) => u64::from(words[*p as usize * wpp + i]),
+            PlaneExpr::And(children) => {
+                let mut acc = !0u64;
+                for c in children {
+                    acc &= c.eval_word(words, wpp, i);
+                    if acc == 0 {
+                        break;
+                    }
+                }
+                acc
+            }
+            PlaneExpr::Or(children) => {
+                let mut acc = 0u64;
+                for c in children {
+                    acc |= c.eval_word(words, wpp, i);
+                    if acc == !0u64 {
+                        break;
+                    }
+                }
+                acc
+            }
+            PlaneExpr::Not(inner) => !inner.eval_word(words, wpp, i),
+            PlaneExpr::Const(b) => {
+                if *b {
+                    !0u64
+                } else {
+                    0u64
+                }
+            }
+        }
+    }
+}
+
+/// Evaluate a plane expression into a card bitmap (`out` is a reused buffer).
+/// The tail bits past n_cards are cleared — Not() would otherwise set them.
+pub(crate) fn eval_planes(expr: &PlaneExpr, planes: &rkyv::Archived<BitPlanes>, out: &mut Vec<u64>) {
+    let n_cards = u32::from(planes.n_cards) as usize;
+    let wpp = words_per_plane(n_cards);
+    out.clear();
+    out.reserve(wpp);
+    for i in 0..wpp {
+        out.push(expr.eval_word(&planes.words, wpp, i));
+    }
+    let tail = n_cards % 64;
+    if tail != 0 {
+        out[wpp - 1] &= (1u64 << tail) - 1;
+    }
+}
+
+/// True iff card `cid`'s bit is set in the bitmap.
+pub(crate) fn bitmap_contains(bitmap: &[u64], cid: u32) -> bool {
+    bitmap[(cid >> 6) as usize] >> (cid & 63) & 1 != 0
+}
+
+/// Materialize a bitmap's set bits as ascending card ids.
+pub(crate) fn bitmap_card_ids(bitmap: &[u64]) -> Vec<u32> {
+    let count: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
+    let mut out: Vec<u32> = Vec::with_capacity(count);
+    for (i, &word) in bitmap.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            out.push((i as u32) << 6 | w.trailing_zeros());
+            w &= w - 1;
+        }
+    }
+    out
+}

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,14 +1,15 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    build_artwork_group_counts, flavor_fingerprint, flavor_match_sets,
+    build_artwork_group_counts, build_bit_planes, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
-    ArtistIndex, CardData, CardIndexes, Candidates, NumExpr, NumField, RarityIndex,
+    bitmap_contains, compile_plane, eval_planes, split_planes,
+    ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
-    Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE, TYPE_INSTANT,
-    TYPE_LEGENDARY, TYPE_PLANESWALKER,
+    TextSearchField, Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
+    TYPE_ENCHANTMENT, TYPE_INSTANT, TYPE_LAND, TYPE_LEGENDARY, TYPE_PLANESWALKER, TYPE_SNOW, TYPE_SORCERY,
 };
 use rkyv::{rancor::Error, Archived};
 use std::collections::HashMap;
@@ -212,8 +213,13 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         offsets.push(printings.len() as u32);
     }
     // Real type index so TypeCmp narrowing sees the cards (an empty Default
-    // index would narrow every type query to zero candidates).
-    let indexes = CardIndexes { type_bits: build_type_index(&cards), ..Default::default() };
+    // index would narrow every type query to zero candidates), and real planes
+    // so plane-path tests see the same store shape reload_commit builds.
+    let indexes = CardIndexes {
+        type_bits: build_type_index(&cards),
+        planes: build_bit_planes(&cards),
+        ..Default::default()
+    };
     CardData {
         cards,
         printings,
@@ -530,7 +536,7 @@ fn run_query_walk_dedups_and_prefers() {
     let run = |unique: &str, prefer: &str| {
         run_query(
             &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &creatures, unique, prefer, "edhrec", "asc", 100, 0, &archived.indexes,
+            &creatures, None, unique, prefer, "edhrec", "asc", 100, 0, &archived.indexes,
         )
     };
 
@@ -572,7 +578,7 @@ fn run_query_artwork_groups_shared_illustrations() {
     let all = FilterExpr::True;
     let (total, page) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &all, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        &all, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, 3); // illustrations {1, 2, 4}
     // Group {printings 0, 2}: printing 0 has the higher prefer score (desc order)
@@ -650,6 +656,7 @@ fn bench_checked_vs_unchecked_access() {
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups: build_artwork_group_counts(&printings, &offsets),
+        planes:         build_bit_planes(&cards),
     };
     let data = CardData {
         cards,
@@ -1061,11 +1068,11 @@ fn streamed_selection_matches_gathered() {
                         let f = filt();
                         let (tg, pg) = run_query(
                             &gathered.cards, &gathered.printings, &gathered.offsets, &gathered.strings,
-                            &f, unique, prefer, orderby, direction, 10, offset, &gathered.indexes,
+                            &f, None, unique, prefer, orderby, direction, 10, offset, &gathered.indexes,
                         );
                         let (ts, ps) = run_query(
                             &streamed.cards, &streamed.printings, &streamed.offsets, &streamed.strings,
-                            &f, unique, prefer, orderby, direction, 10, offset, &streamed.indexes,
+                            &f, None, unique, prefer, orderby, direction, 10, offset, &streamed.indexes,
                         );
                         let ids = |v: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<(u128, u128)> {
                             v.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
@@ -1234,4 +1241,190 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
         rhs: super::NumExpr::Const(1.0),
     };
     assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets).is_none());
+}
+
+// ─── Bitplanes (#630) ─────────────────────────────────────────────────────────
+
+/// A color/type-diverse store for plane parity: colorless, mono, guild pairs,
+/// lands whose identity exceeds their colors, multi-type cards — and Fallaji
+/// Wayfarer, the one real card (of 97,206 printings, checked 2026-07-07) whose
+/// colors are NOT a subset of its color identity ("is all colors" CDA vs. a
+/// {G} mana cost). Any plane scheme assuming colors ⊆ identity must fail here.
+const FALLAJI_CID: usize = 5;
+fn plane_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    // (card_colors, card_color_identity, card_types); color bits W=1 U=2 B=4 R=8 G=16 C=32
+    let specs: &[(u8, u8, u16)] = &[
+        (0, 0, TYPE_ARTIFACT),                     // colorless artifact
+        (16, 16, TYPE_CREATURE),                   // mono G creature
+        (1, 1, TYPE_CREATURE | TYPE_LEGENDARY),    // mono W legendary creature
+        (3, 3, TYPE_INSTANT),                      // WU instant
+        (0, 24, TYPE_LAND),                        // land: no colors, RG identity (Taiga)
+        (31, 16, TYPE_CREATURE),                   // Fallaji Wayfarer (see FALLAJI_CID)
+        (2, 3, TYPE_SORCERY),                      // U sorcery with WU identity
+        (24, 31, TYPE_CREATURE | TYPE_ARTIFACT),   // RG artifact creature, WUBRG identity
+        (4, 4, TYPE_ENCHANTMENT | TYPE_SNOW),      // mono B snow enchantment
+        (0, 32, TYPE_LAND),                        // C-bit identity, exercising the C plane
+    ];
+    let cards = specs
+        .iter()
+        .enumerate()
+        .map(|(i, &(colors, identity, types))| {
+            let mut c = stub_card(i as u128 + 1, types, &[], &mut vocab);
+            c.card_colors = colors;
+            c.card_color_identity = identity;
+            c
+        })
+        .collect();
+    store_of(cards, &[1usize; 10], vocab)
+}
+
+// Every plane-expressible op on every color/type mask must reproduce the
+// filter's card-level truth bit for bit — including Not/And/Or composition.
+#[test]
+fn plane_parity_color_and_type_ops() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut bitmap: Vec<u64> = Vec::new();
+    let mut check = |f: &FilterExpr| {
+        let pe = compile_plane(f).expect("filter must be plane-expressible");
+        eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
+        for (cid, card) in archived.cards.iter().enumerate() {
+            let want = f.eval_card(card, &archived.strings) == Tri::True;
+            assert_eq!(
+                bitmap_contains(&bitmap, cid as u32),
+                want,
+                "plane/filter mismatch at card {cid}"
+            );
+        }
+    };
+
+    let ops = [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge];
+    let color_masks: [u8; 8] = [0, 1, 2, 16, 3, 24, 31, 32];
+    let type_masks: [u16; 6] = [
+        0, TYPE_CREATURE, TYPE_ARTIFACT | TYPE_CREATURE, TYPE_INSTANT,
+        TYPE_LEGENDARY | TYPE_CREATURE, TYPE_SNOW,
+    ];
+    for op in ops {
+        for mask in color_masks {
+            check(&FilterExpr::ColorCmp { field: ColorField::Colors, op, mask });
+            check(&FilterExpr::ColorCmp { field: ColorField::ColorIdentity, op, mask });
+        }
+        for mask in type_masks {
+            check(&FilterExpr::TypeCmp { mask, op });
+        }
+    }
+
+    let green = || FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 16 };
+    let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    check(&FilterExpr::And(vec![green(), creature()]));
+    check(&FilterExpr::Or(vec![green(), creature()]));
+    check(&FilterExpr::Not(Box::new(FilterExpr::Or(vec![green(), creature()]))));
+}
+
+// The Fallaji shape specifically: color planes and identity planes must be
+// independent transpositions, not derived from one another.
+#[test]
+fn plane_fallaji_colors_not_subset_of_identity() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut bitmap: Vec<u64> = Vec::new();
+    let mut matches = |field: ColorField, op: CmpOp, mask: u8| {
+        let f = FilterExpr::ColorCmp { field, op, mask };
+        eval_planes(&compile_plane(&f).unwrap(), &archived.indexes.planes, &mut bitmap);
+        bitmap_contains(&bitmap, FALLAJI_CID as u32)
+    };
+    assert!(matches(ColorField::Colors, CmpOp::Ge, 1)); // c>=W: colors carry W
+    assert!(!matches(ColorField::ColorIdentity, CmpOp::Ge, 1)); // id>=W: identity is only G
+    assert!(matches(ColorField::ColorIdentity, CmpOp::Le, 16)); // id<=G holds
+    assert!(!matches(ColorField::Colors, CmpOp::Le, 16)); // c<=G does not
+}
+
+// split_planes composition rules: And partitions, Or is all-or-nothing,
+// produced mana and bare True stay residual.
+#[test]
+fn split_planes_composition_rules() {
+    let green = || FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 16 };
+    let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let text = || FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
+
+    // And(plane, plane, text): planes consumed, the lone leftover unwraps.
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]));
+    assert!(pe.is_some());
+    assert!(matches!(residual, FilterExpr::TextContains { .. }));
+
+    // Fully plane-expressible tree is consumed whole.
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]));
+    assert!(pe.is_some());
+    assert!(matches!(residual, FilterExpr::True));
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]));
+    assert!(pe.is_some());
+    assert!(matches!(residual, FilterExpr::True));
+
+    // Or mixing plane and non-plane children stays entirely residual:
+    // mask ∨ residual is not a narrowing mask.
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]));
+    assert!(pe.is_none());
+    assert!(matches!(residual, FilterExpr::Or(ref v) if v.len() == 2));
+
+    // Produced mana is deliberately unplaned in phase 1.
+    let produces = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 16 };
+    let (pe, residual) = split_planes(produces);
+    assert!(pe.is_none());
+    assert!(matches!(residual, FilterExpr::ColorCmp { field: ColorField::ProducedMana, .. }));
+
+    // Bare True keeps the range-scan path (no all-ones bitmap materialization).
+    let (pe, residual) = split_planes(FilterExpr::True);
+    assert!(pe.is_none());
+    assert!(matches!(residual, FilterExpr::True));
+}
+
+// End-to-end: run_query through the plane path returns the same totals and
+// pages as the plain filter path, across uniques and a mixed filter.
+#[test]
+fn run_query_plane_path_parity() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let filters: Vec<Box<dyn Fn() -> FilterExpr>> = vec![
+        Box::new(|| FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 16 }),
+        Box::new(|| FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ne, mask: 0 }),
+        Box::new(|| {
+            FilterExpr::And(vec![
+                FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 16 },
+                FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
+            ])
+        }),
+        Box::new(|| {
+            // Mixed: the type check planes out, the numeric check stays residual.
+            FilterExpr::And(vec![
+                FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
+                FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Ne, rhs: NumExpr::Const(1.0) },
+            ])
+        }),
+    ];
+    for make in &filters {
+        for unique in ["card", "printing", "artwork"] {
+            let plain = make();
+            let (t0, p0) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            let (pe, residual) = split_planes(make());
+            let (t1, p1) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            assert_eq!(t0, t1, "totals must agree (unique={unique})");
+            let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
+                page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+            };
+            assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
+        }
+    }
 }

--- a/scripts/bench_bitplanes.py
+++ b/scripts/bench_bitplanes.py
@@ -1,0 +1,158 @@
+"""Engine-vs-engine benchmark for the bitplane match phase (#630).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export,
+so the same script run on two builds (main baseline vs. bitplanes) produces
+directly comparable CSVs. No SQL side, no Docker: build the engine locally
+(`maturin develop --release -m card_engine/Cargo.toml`) and run:
+
+    .venv/bin/python scripts/bench_bitplanes.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/bitplanes/baseline-main.csv
+
+Export the corpus once from the blue DB (see docs/issues/engine-card-bitplanes.md):
+
+    COLS=$(.venv/bin/python -c "import card_engine; print(', '.join(card_engine.ENGINE_COLUMNS))")
+    docker exec sylvan_blue-postgres-1 psql -U foouser -d magic -X -At \
+        -c "SELECT row_to_json(t) FROM (SELECT $COLS FROM magic.cards) t" > benchmarks/bitplanes/corpus.jsonl
+
+The `total` column doubles as a parity check: it must be identical across
+builds for every config, or the comparison is void.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import card_engine
+
+from api.parsing import parse_scryfall_query
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+# Groups map to the #630 phases; "control" rows are selective queries that must not regress.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Phase 1: pure-plane colors — the motivating case, across uniques and ops
+    ("p1-color", "c:g", "card", "edhrec", "default"),
+    ("p1-color", "c:g", "printing", "edhrec", "default"),
+    ("p1-color", "c:g", "artwork", "edhrec", "default"),
+    ("p1-color", "id:g", "card", "edhrec", "default"),
+    ("p1-color", "c>=uw", "card", "edhrec", "default"),
+    ("p1-color", "c=uw", "card", "edhrec", "default"),
+    ("p1-color", "-c:g", "card", "edhrec", "default"),
+    ("p1-color", "c:r or c:g", "card", "edhrec", "default"),
+    # Phase 1: pure-plane types
+    ("p1-type", "t:creature", "card", "edhrec", "default"),
+    ("p1-type", "t:creature", "artwork", "edhrec", "default"),
+    ("p1-type", "t:instant", "card", "edhrec", "default"),
+    ("p1-type", "t:artifact", "card", "edhrec", "default"),
+    ("p1-conj", "c:g t:creature", "card", "edhrec", "default"),
+    # Phase 1: paths outside permutation streaming (gathered orderby, non-default prefer)
+    ("p1-path", "c:g", "card", "usd", "default"),
+    ("p1-path", "t:creature", "card", "edhrec", "usd_high"),
+    # Phase 2: legality
+    ("p2-legal", "f:modern", "card", "edhrec", "default"),
+    ("p2-legal", "f:commander", "card", "edhrec", "default"),
+    ("p2-legal", "c:g t:creature f:modern", "card", "edhrec", "default"),
+    # Phase 3: rarity (narrowing mode) and dense keywords
+    ("p3-rarity", "r:mythic", "card", "edhrec", "default"),
+    ("p3-rarity", "rarity<=mythic", "card", "edhrec", "default"),
+    ("p3-rarity", "rarity>=common", "card", "edhrec", "default"),
+    ("p3-keyword", "keyword:flying", "card", "edhrec", "default"),
+    # Mixed filters: plane bitmap as candidate mask, residual eval over set bits
+    ("mixed", "t:creature o:draw", "card", "edhrec", "default"),
+    ("mixed", "c:g o:draw", "card", "edhrec", "default"),
+    ("mixed", "t:creature c:g o:draw", "card", "edhrec", "default"),
+    # Or mixing plane and non-plane children: stays all-residual, must not regress
+    ("or-mixed", "c:g or o:draw", "card", "edhrec", "default"),
+    # Selective controls: planner must keep these off the plane path unchanged
+    ("control", "name:soldier", "card", "edhrec", "default"),
+    ("control", "t:merfolk name:tide", "card", "edhrec", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+    ("control", "power>4", "card", "power", "default"),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> card_engine.QueryEngine:
+    """Build a fresh engine store from the corpus JSONL via the staged reload API."""
+    engine = card_engine.QueryEngine(str(shm_path))
+    if not engine.reload_begin():
+        raise RuntimeError("reload_begin returned False (stale archive published concurrently?)")
+    t0 = time.monotonic()
+    batch: list[dict] = []
+    with corpus.open() as fh:
+        for line in fh:
+            batch.append(json.loads(line))
+            if len(batch) == BATCH_SIZE:
+                engine.add_batch(batch)
+                batch.clear()
+    if batch:
+        engine.add_batch(batch)
+    engine.reload_commit()
+    print(f"Engine loaded: {engine.size():,} printings in {time.monotonic() - t0:.1f}s", flush=True)
+    return engine
+
+
+def bench_one(engine: card_engine.QueryEngine, query: str, unique: str, orderby: str, prefer: str, window: float):
+    """Return (total, n, avg_ms, min_ms) for one config over a fixed timed window."""
+    filters = parse_scryfall_query(query)
+    kw = dict(filters=filters, unique=unique, prefer=prefer, orderby=orderby, direction="asc", limit=100, offset=0)
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n = 0
+    best = float("inf")
+    t_start = time.monotonic()
+    deadline = t_start + window
+    now = t_start
+    while now < deadline:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1_000, best * 1_000
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<11} {'query':<26} {'unique':<9} {'orderby':<8} {'prefer':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, query, unique, orderby, prefer, args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<11} {query:<26} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_bitplanes.py
+++ b/scripts/bench_bitplanes.py
@@ -32,9 +32,8 @@ import time
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-import card_engine
-
-from api.parsing import parse_scryfall_query
+import card_engine  # noqa: E402
+from api.parsing import parse_scryfall_query  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # Groups map to the #630 phases; "control" rows are selective queries that must not regress.
@@ -87,7 +86,8 @@ def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> card_engine.Que
     """Build a fresh engine store from the corpus JSONL via the staged reload API."""
     engine = card_engine.QueryEngine(str(shm_path))
     if not engine.reload_begin():
-        raise RuntimeError("reload_begin returned False (stale archive published concurrently?)")
+        msg = "reload_begin returned False (stale archive published concurrently?)"
+        raise RuntimeError(msg)
     t0 = time.monotonic()
     batch: list[dict] = []
     with corpus.open() as fh:
@@ -103,10 +103,19 @@ def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> card_engine.Que
     return engine
 
 
-def bench_one(engine: card_engine.QueryEngine, query: str, unique: str, orderby: str, prefer: str, window: float):
-    """Return (total, n, avg_ms, min_ms) for one config over a fixed timed window."""
+def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str, str], window: float) -> tuple[int, int, float, float]:
+    """Return (total, n, avg_ms, min_ms) for one (query, unique, orderby, prefer) config over a fixed timed window."""
+    query, unique, orderby, prefer = config
     filters = parse_scryfall_query(query)
-    kw = dict(filters=filters, unique=unique, prefer=prefer, orderby=orderby, direction="asc", limit=100, offset=0)
+    kw = {
+        "filters": filters,
+        "unique": unique,
+        "prefer": prefer,
+        "orderby": orderby,
+        "direction": "asc",
+        "limit": 100,
+        "offset": 0,
+    }
     total = engine.query(**kw)[0]
     for _ in range(WARMUP):
         engine.query(**kw)
@@ -125,6 +134,7 @@ def bench_one(engine: card_engine.QueryEngine, query: str, unique: str, orderby:
 
 
 def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
@@ -146,10 +156,12 @@ def main() -> None:
         writer = csv.writer(fh)
         writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
         for group, query, unique, orderby, prefer in CONFIGS:
-            total, n, avg_ms, min_ms = bench_one(engine, query, unique, orderby, prefer, args.window)
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
             writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
             fh.flush()
-            print(f"{group:<11} {query:<26} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+            print(
+                f"{group:<11} {query:<26} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
 
     print(f"\nWrote {args.out}")
 


### PR DESCRIPTION
Phase 1 of #630 (colors + types; legality, rarity, and keyword promotion are later phases).

## What this does

Post-#632, broad low-cardinality queries are all match-phase: `c:g` is a one-cycle mask test that costs 0.25 ms to deliver — 31.5k driver iterations, filter-tree dispatch, and a ~250 B cache line per card to read one byte. Colors have no narrowing index at all, so even `c=uw` (370 matches) paid the full scan.

This transposes the exactly-consumable card dimensions into **bitplanes**: one bitset per (dimension, value) — 6 color planes × {colors, identity} + 14 type-bit planes = 26 planes, ~4 kB each, ~103 kB total, built in one pass at reload.

At bind, `split_planes()` consumes the plane-expressible part of the filter into a `PlaneExpr`:

- **Whole trees** when every node compiles (all six `CmpOp`s on `ColorCmp`/`TypeCmp` are mask algebra; And/Or/Not compose freely — both nodes are two-valued, never Null/PrintingDep, so complement is sound).
- **Top-level And** partitions: compilable children move into the plane expression, the rest stay as the residual — the bulk analogue of `card_pass`'s per-card residual extraction.
- **Or is all-or-nothing**: mask ∨ residual is not a narrowing mask, so a partially compilable Or stays entirely residual.

The expression evaluates word-at-a-time over the cache-resident planes (no intermediate bitmaps) into a reused thread-local buffer — ~1–2 µs. The resulting bitmap is *exact card-level truth* for the consumed part: for pure color/type filters it becomes the candidate list outright (residual `True`, `all_match` fast paths apply); for mixed filters it intersects the postings candidates and the residual evaluates only over surviving cards.

Deliberately **not** in this PR: produced-mana planes (`produces:` stays residual), legality (needs the `legality_divergent` carve-out), rarity (printing-level, narrowing-only semantics), keyword promotion — see the phase plan on #630.

## Measured (main d3c5e58 vs branch, 97,206-printing corpus, 20 warmup + 3 s window per config)

Full 30-config suite in `scripts/bench_bitplanes.py`; the `total` column matched baseline on every config (built-in parity check).

**Targeted queries** — plane-expressible filters and mixed filters that use the bitmap as a candidate mask. **Geomean 1.89×** (19 configs):

| targeted query | matches | main | branch | speedup |
|---|---|---|---|---|
| `c:g` | 6,407 | 0.257 ms | **0.089 ms** | **2.87×** |
| `c:g` (printing) | 18,621 | 0.253 ms | **0.082 ms** | **3.07×** |
| `c:g` (artwork) | 8,909 | 0.248 ms | **0.084 ms** | **2.95×** |
| `id:g` | 7,242 | 0.260 ms | **0.096 ms** | **2.72×** |
| `c>=uw` | 658 | 0.228 ms | **0.068 ms** | **3.34×** |
| `c=uw` | 370 | 0.221 ms | **0.066 ms** | **3.33×** |
| `-c:g` | 25,101 | 0.328 ms | **0.186 ms** | **1.77×** |
| `c:r or c:g` | 12,391 | 0.394 ms | **0.125 ms** | **3.14×** |
| `t:creature` | 17,317 | 0.148 ms | 0.149 ms | 1.00× |
| `t:creature` (artwork) | 22,510 | 0.139 ms | 0.138 ms | 1.01× |
| `t:instant` | 3,646 | 0.072 ms | 0.072 ms | 0.99× |
| `t:artifact` | 3,501 | 0.071 ms | 0.071 ms | 0.99× |
| `c:g t:creature` | 4,166 | 0.196 ms | **0.084 ms** | **2.33×** |
| `c:g` (usd orderby) | 6,407 | 0.255 ms | **0.114 ms** | **2.23×** |
| `t:creature` (usd_high) | 17,317 | 0.152 ms | 0.152 ms | 1.00× |
| `c:g t:creature f:modern` | 2,928 | 0.200 ms | **0.100 ms** | **2.00×** |
| `t:creature o:draw` | 1,804 | 0.175 ms | 0.133 ms | 1.32× |
| `c:g o:draw` | 684 | 0.184 ms | **0.113 ms** | **1.63×** |
| `t:creature c:g o:draw` | 384 | 0.204 ms | **0.111 ms** | **1.84×** |

**Controls** — dimensions this phase doesn't plane (legality, rarity, keywords), the or-mixed shape that must stay residual, and selective queries the planner must leave alone. **Geomean 0.99×** (11 configs):

| control query | matches | main | branch | speedup |
|---|---|---|---|---|
| `f:modern` | 22,264 | 0.260 ms | 0.258 ms | 1.01× |
| `f:commander` | 31,451 | 0.208 ms | 0.207 ms | 1.00× |
| `r:mythic` | 2,568 | 0.124 ms | 0.124 ms | 1.00× |
| `rarity<=mythic` | 31,506 | 0.404 ms | 0.405 ms | 1.00× |
| `rarity>=common` | 31,508 | 0.406 ms | 0.402 ms | 1.01× |
| `keyword:flying` | 3,113 | 0.095 ms | 0.095 ms | 0.99× |
| `c:g or o:draw` | 9,900 | 0.944 ms | 0.967 ms | 0.98× |
| `name:soldier` | 41 | 0.031 ms | 0.033 ms | 0.96× |
| `t:merfolk name:tide` | 11 | 0.018 ms | 0.019 ms | 0.96× |
| `cmc>6` (cmc orderby) | 1,344 | 0.086 ms | 0.087 ms | 0.98× |
| `power>4` (power orderby) | 2,248 | 0.091 ms | 0.091 ms | 1.00× |

## Honest notes

- **Type-only queries didn't move** (`t:creature` 1.00×): type postings already narrowed them to the same candidate set, and the remaining cost is the counts fill + page emission floor, which planes can't touch. The type planes earn their keep in conjunctions, where they fold into the bitmap for free instead of a postings union — `c:g t:creature` is 2.33×, and `c:g t:creature f:modern` runs the legality residual over 4.1k plane candidates instead of 31.5k cards (2.00×).
- **Selective color queries won biggest** (`c=uw` 3.33×), not broad ones — colors had no index of any kind, so selectivity never helped them before.
- `id:g` is subset semantics (`Le`): it compiles to ¬W ∧ ¬U ∧ ¬B ∧ ¬R ∧ ¬C over identity planes — the G plane is never read, and colorless cards match, per Scryfall commander-identity behavior.
- Colors ⊆ identity is **not** an invariant this design assumes — Fallaji Wayfarer (colors WUBRG via "is all colors" CDA, identity {G}) violates it, and is pinned as a parity fixture so no future plane-sharing "optimization" can assume it.

## Cost

~103 kB archive (26 planes at 31.5k cards). Format version bumped.

## Tests

`cargo test`: 34 passed — op-level parity sweep (6 ops × 8 color masks × 2 fields + 6 type masks) against `eval_card` over a color/type-diverse fixture including the Fallaji and Taiga shapes, split-composition rules, and end-to-end `run_query` plane-path vs filter-path parity across uniques. Python: 1,868 unit + 15 integration passed.
