### PR TITLE
Memoize Indexable Text Predicates at Bind Time in Full-Scan Queries

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use regex::Regex;
 use serde_json::Value;
-use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, ARTIST_NONE, NONE_STR, FlavorIndex, flavor_fingerprint, flavor_match_sets};
+use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, OracleTextIndex, TrigramIndex, flavor_fingerprint, flavor_match_sets};
 use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, format_shift};
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
@@ -297,6 +297,25 @@ pub(crate) enum FilterExpr {
         gids: Vec<u32>,
         dense_ids: Vec<u32>,
     },
+    /// A name contains-predicate after memoize_text_predicates() resolved it
+    /// through the name trigram index in a full-scan query: sorted
+    /// card_name_id values of the cards whose lowercase name contains the
+    /// needle. Names are always Known (missing names intern as ""), so
+    /// matching is a plain two-valued binary search. The ids are specific to
+    /// the store the rewrite ran against — a memoized filter must not outlive
+    /// that store or that query.
+    NameMatch {
+        ids: Vec<u32>,
+    },
+    /// An oracle-text contains-predicate after memoize_text_predicates()
+    /// resolved it through the oracle trigram index in a full-scan query:
+    /// sorted oracle_text_lower_id values whose text contains the needle.
+    /// Textless cards intern "" at load (never NONE_STR), so like TextContains
+    /// they evaluate False, not Null; the Null arm in tri() only mirrors the
+    /// str_at() contract defensively. Store-bound, same as NameMatch.
+    OracleMatch {
+        gids: Vec<u32>,
+    },
     TextExact {
         field: TextField,
         op: CmpOp,
@@ -382,6 +401,11 @@ impl FilterExpr {
     /// - Flavor predicates get the same treatment against the ~26.3k distinct
     ///   flavor texts (FlavorMatch), with a fingerprint prefilter skipping
     ///   texts that cannot contain the needle (see FLAVOR_FP_FEATURES).
+    ///
+    /// Name/oracle-text contains predicates are deliberately NOT rewritten
+    /// here: their rewrite is only profitable when the query full-scans, which
+    /// isn't known until run_query computes candidates — see
+    /// memoize_text_predicates().
     pub(crate) fn bind(
         &mut self,
         vocab: &AStrings,
@@ -447,6 +471,81 @@ impl FilterExpr {
             FilterExpr::TextRegex { field: TextField::FlavorTextLower, regex } => {
                 let (gids, dense_ids) = flavor_match_sets(flavor, strings, 0, |s| regex.is_match(s));
                 *self = FilterExpr::FlavorMatch { gids, dense_ids };
+            }
+            _ => {}
+        }
+    }
+
+    /// Memoize indexable text predicates in a query the driver is about to
+    /// evaluate against every card (#624) — the third instance of the
+    /// ArtistMatch/FlavorMatch pattern. Name/oracle contains-nodes resolve
+    /// through their trigram indexes: gather candidates (bounded by the
+    /// needle's rarest trigram), verify each with the real contains() once,
+    /// and rewrite to a sorted match-id set whose per-card evaluation is an
+    /// integer binary search instead of a substring search.
+    ///
+    /// Only called when the query has no candidates (no postings narrowing
+    /// and no plane bitmap): with candidates, the driver evaluates only those
+    /// cards and the bind-time verify would mostly be wasted work. Needles
+    /// under 3 bytes have no trigrams and keep the scan; needles whose
+    /// candidates exceed half the corpus stay unrewritten too — at that
+    /// density a binary search costs about what contains() does, so the
+    /// verify pass couldn't earn its keep.
+    pub(crate) fn memoize_text_predicates(
+        &mut self,
+        cards: &[AOracleCard],
+        strings: &AStrings,
+        name_trigram: &rkyv::Archived<TrigramIndex>,
+        oracle: &rkyv::Archived<OracleTextIndex>,
+    ) {
+        match self {
+            FilterExpr::And(children) | FilterExpr::Or(children) => {
+                for c in children.iter_mut() {
+                    c.memoize_text_predicates(cards, strings, name_trigram, oracle);
+                }
+            }
+            FilterExpr::Not(inner) => inner.memoize_text_predicates(cards, strings, name_trigram, oracle),
+            FilterExpr::TextContains { field: TextSearchField::NameLower, word } => {
+                // The intersection is bounded by the shortest posting list, so
+                // checking that bound first makes the decline path free — no
+                // gather, no intersection. Declining when only the *bound*
+                // (not the exact count) exceeds half the corpus is deliberate:
+                // it can only happen when every trigram of the needle is
+                // ultra-common, where the match set is broad anyway.
+                match trigram_min_posting(name_trigram, word) {
+                    Some(min) if min <= cards.len() / 2 => {}
+                    _ => return,
+                }
+                let Some(cand) = trigram_candidates(name_trigram, word) else { return };
+                let mut ids: Vec<u32> = cand
+                    .into_iter()
+                    .filter(|&cid| cards[cid as usize].card_name_lower.as_str().contains(word.as_str()))
+                    .map(|cid| u32::from(cards[cid as usize].card_name_id))
+                    .collect();
+                ids.sort_unstable();
+                ids.dedup();
+                *self = FilterExpr::NameMatch { ids };
+            }
+            FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word } => {
+                match trigram_min_posting(&oracle.trigrams, word) {
+                    Some(min) if min <= oracle.offsets.len().saturating_sub(1) / 2 => {}
+                    _ => return,
+                }
+                let Some(dense) = trigram_candidates(&oracle.trigrams, word) else { return };
+                let mut gids: Vec<u32> = Vec::with_capacity(dense.len());
+                for d in dense {
+                    // Every CSR row is non-empty by construction (dense ids are
+                    // only minted from cards), so the row's first card supplies
+                    // the text's global string id.
+                    debug_assert!(oracle.offsets[d as usize] < oracle.offsets[d as usize + 1]);
+                    let first_card = u32::from(oracle.card_indices[u32::from(oracle.offsets[d as usize]) as usize]);
+                    let gid = u32::from(cards[first_card as usize].oracle_text_lower_id);
+                    if str_at(strings, gid).is_some_and(|s| s.contains(word.as_str())) {
+                        gids.push(gid);
+                    }
+                }
+                gids.sort_unstable();
+                *self = FilterExpr::OracleMatch { gids };
             }
             _ => {}
         }
@@ -633,6 +732,25 @@ impl FilterExpr {
                 let gid = u32::from(p.flavor_text_lower_id);
                 if gid == NONE_STR {
                     Tri::Null // no flavor text: SQL NULL, matching the pre-bind semantics
+                } else {
+                    tri_bool(gids.binary_search(&gid).is_ok())
+                }
+            }
+
+            // Names are always present (TextContains on NameLower is always
+            // Known), so membership is two-valued: an id absent from `ids`
+            // means the name didn't contain the needle, exactly like
+            // contains() on the inline string.
+            FilterExpr::NameMatch { ids } => tri_bool(ids.binary_search(&u32::from(card.card_name_id)).is_ok()),
+
+            FilterExpr::OracleMatch { gids } => {
+                let gid = u32::from(card.oracle_text_lower_id);
+                if gid == NONE_STR {
+                    // Unreachable for loaded cards (missing text interns "" —
+                    // contains() on it is False, and so is a binary-search
+                    // miss); kept to mirror str_at()'s NONE_STR → None
+                    // contract, which TextContains maps to Null via opt_sv.
+                    Tri::Null
                 } else {
                     tri_bool(gids.binary_search(&gid).is_ok())
                 }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -528,18 +528,13 @@ impl FilterExpr {
             }
             FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word } => {
                 match trigram_min_posting(&oracle.trigrams, word) {
-                    Some(min) if min <= oracle.offsets.len().saturating_sub(1) / 2 => {}
+                    Some(min) if min <= oracle.gids.len() / 2 => {}
                     _ => return,
                 }
                 let Some(dense) = trigram_candidates(&oracle.trigrams, word) else { return };
                 let mut gids: Vec<u32> = Vec::with_capacity(dense.len());
                 for d in dense {
-                    // Every CSR row is non-empty by construction (dense ids are
-                    // only minted from cards), so the row's first card supplies
-                    // the text's global string id.
-                    debug_assert!(oracle.offsets[d as usize] < oracle.offsets[d as usize + 1]);
-                    let first_card = u32::from(oracle.card_indices[u32::from(oracle.offsets[d as usize]) as usize]);
-                    let gid = u32::from(cards[first_card as usize].oracle_text_lower_id);
+                    let gid = u32::from(oracle.gids[d as usize]);
                     if str_at(strings, gid).is_some_and(|s| s.contains(word.as_str())) {
                         gids.push(gid);
                     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -833,6 +833,18 @@ fn trigram_candidates(idx: &Archived<TrigramIndex>, word: &str) -> Option<Vec<u3
     Some(result)
 }
 
+/// Length of the needle's shortest trigram posting list — an upper bound on
+/// trigram_candidates()' result size, available without materializing or
+/// intersecting anything. None: needle under 3 bytes (no trigrams).
+/// Some(0): a trigram is absent from the index, so nothing can match.
+fn trigram_min_posting(idx: &Archived<TrigramIndex>, word: &str) -> Option<usize> {
+    let bytes = word.as_bytes();
+    if bytes.len() < 3 {
+        return None;
+    }
+    bytes.windows(3).map(|w| idx.get(&[w[0], w[1], w[2]]).map_or(0, |l| l.len())).min()
+}
+
 fn union_sorted(a: Vec<u32>, b: Vec<u32>) -> Vec<u32> {
     let mut out = Vec::with_capacity(a.len() + b.len());
     let (mut i, mut j) = (0, 0);
@@ -2030,7 +2042,7 @@ fn run_query<'a>(
     printings: &'a [APrinting],
     offsets: &AOffsets,
     strings: &AStrings,
-    filter: &FilterExpr,
+    filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
     unique: &str,
     prefer: &str,
@@ -2081,6 +2093,17 @@ fn run_query<'a>(
             })
         }
     };
+
+    // Memoize when the driver is about to evaluate the filter against (nearly)
+    // every card: no candidates at all, or a candidate set so broad it hardly
+    // narrows — a broad plane bitmap ANDed with an unnarrowable Or would
+    // otherwise run its substring scans over most of the corpus. Resolving the
+    // indexable text predicates through their trigram indexes once here (#624)
+    // turns those per-card substring searches into integer binary searches.
+    // The half-corpus line mirrors memoize_text_predicates' decline guard.
+    if candidate_cards.as_ref().is_none_or(|v| v.len() > cards.len() / 2) {
+        filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.oracle_trigram);
+    }
     let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
         None    => Box::new(0..cards.len() as u32),
@@ -2902,7 +2925,7 @@ impl QueryEngine {
         // hundred word ops instead of per-card dispatch. Guarded on the archive
         // carrying planes for this card count — the format-version bump already
         // rejects pre-plane archives, this is defense in depth.
-        let (plane_expr, filter_expr) =
+        let (plane_expr, mut filter_expr) =
             if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
                 split_planes(filter_expr)
             } else {
@@ -2910,7 +2933,7 @@ impl QueryEngine {
             };
 
         let (total, page) = run_query(
-            &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr, plane_expr.as_ref(),
+            &data.cards, &data.printings, &data.offsets, &data.strings, &mut filter_expr, plane_expr.as_ref(),
             unique, prefer, orderby, direction, limit, offset, &data.indexes,
         );
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -685,6 +685,10 @@ type TrigramIndex = HashMap<[u8; 3], Vec<u32>>;
 struct OracleTextIndex {
     /// trigram → ascending list of dense text ids whose text contains it.
     trigrams: TrigramIndex,
+    /// Dense text id → global string id (CardData.strings) of the distinct
+    /// lowercase oracle text, in first-seen card order — same shape as
+    /// FlavorIndex.gids. Length n_texts.
+    gids: Vec<u32>,
     /// Row boundaries: cards of text id `t` live at
     /// `card_indices[offsets[t] .. offsets[t + 1]]`. Length n_texts + 1.
     offsets: Vec<u32>,
@@ -747,7 +751,7 @@ fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTe
         cursor[t as usize] += 1;
     }
 
-    OracleTextIndex { trigrams, offsets, card_indices }
+    OracleTextIndex { trigrams, gids: global_of_dense, offsets, card_indices }
 }
 
 /// Expand surviving dense text ids to card indices via the CSR table.
@@ -2392,7 +2396,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260714;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260715;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -532,11 +532,11 @@ fn run_query_walk_dedups_and_prefers() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    let creatures = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let run = |unique: &str, prefer: &str| {
+    let mut creatures = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let mut run = |unique: &str, prefer: &str| {
         run_query(
             &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &creatures, None, unique, prefer, "edhrec", "asc", 100, 0, &archived.indexes,
+            &mut creatures, None, unique, prefer, "edhrec", "asc", 100, 0, &archived.indexes,
         )
     };
 
@@ -575,10 +575,10 @@ fn run_query_artwork_groups_shared_illustrations() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    let all = FilterExpr::True;
+    let mut all = FilterExpr::True;
     let (total, page) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &all, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        &mut all, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, 3); // illustrations {1, 2, 4}
     // Group {printings 0, 2}: printing 0 has the higher prefer score (desc order)
@@ -1065,14 +1065,16 @@ fn streamed_selection_matches_gathered() {
             for orderby in ["edhrec", "cmc"] {
                 for direction in ["asc", "desc"] {
                     for offset in [0usize, 7, 1120] {
-                        let f = filt();
+                        // Fresh filter per store: run_query may memoize text
+                        // predicates into store-specific string ids, so a
+                        // filter must never outlive the store it ran against.
                         let (tg, pg) = run_query(
                             &gathered.cards, &gathered.printings, &gathered.offsets, &gathered.strings,
-                            &f, None, unique, prefer, orderby, direction, 10, offset, &gathered.indexes,
+                            &mut filt(), None, unique, prefer, orderby, direction, 10, offset, &gathered.indexes,
                         );
                         let (ts, ps) = run_query(
                             &streamed.cards, &streamed.printings, &streamed.offsets, &streamed.strings,
-                            &f, None, unique, prefer, orderby, direction, 10, offset, &streamed.indexes,
+                            &mut filt(), None, unique, prefer, orderby, direction, 10, offset, &streamed.indexes,
                         );
                         let ids = |v: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<(u128, u128)> {
                             v.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
@@ -1410,15 +1412,15 @@ fn run_query_plane_path_parity() {
     ];
     for make in &filters {
         for unique in ["card", "printing", "artwork"] {
-            let plain = make();
+            let mut plain = make();
             let (t0, p0) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                &plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+                &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, residual) = split_planes(make());
+            let (pe, mut residual) = split_planes(make());
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                &residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+                &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
             assert_eq!(t0, t1, "totals must agree (unique={unique})");
             let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
@@ -1427,4 +1429,158 @@ fn run_query_plane_path_parity() {
             assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
         }
     }
+}
+
+// ─── Bind-time text-predicate memoization (#624) ─────────────────────────────
+
+/// Store with real interned oracle texts and a name trigram index, for the
+/// memoization tests. Card 3 has no oracle text — interned as "" exactly like
+/// card_from_pydict does (contains on it is False, not NULL); card 4's text is
+/// a trigram candidate for "abcde" that contains() must reject; four texts
+/// share the marker "xyz" so a needle can exceed the half-corpus guard.
+fn text_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let specs: &[(&str, Option<&str>)] = &[
+        ("lightning bolt", Some("deal 3 damage to any target xyz")),
+        ("healing angel", Some("when this enters, you gain 3 life xyz")),
+        ("goblin token maker", Some("create two 1/1 red goblin creature tokens xyz")),
+        ("vanilla bear", None),
+        ("trigram trap", Some("abcbcde xyz")),
+        ("draw engine", Some("draw a card. draw another card")),
+    ];
+    let cards: Vec<OracleCard> = specs
+        .iter()
+        .enumerate()
+        .map(|(i, &(name, text))| {
+            let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+            c.card_name_lower = InlineStr::from_str(name);
+            c.card_name_id = interner.intern(name.to_string());
+            c.oracle_text_lower_id = interner.intern(text.unwrap_or_default().to_string());
+            c
+        })
+        .collect();
+    let mut data = store_of(cards, &[1usize; 6], vocab);
+    data.strings = interner.strings;
+    data.indexes.name_trigram = build_trigram_index(&data.cards, |c| c.card_name_lower.as_str());
+    data.indexes.oracle_trigram = build_oracle_text_index(&data.cards, &data.strings);
+    data
+}
+
+// Memoized nodes must reproduce TextContains truth for every card — including
+// NULL on textless cards, trigram false positives rejected by the verify, and
+// negation (Not(Null) stays Null, so `-o:x` still excludes textless cards).
+#[test]
+fn memoize_text_predicates_parity() {
+    let data = text_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let memo = |mut f: FilterExpr| {
+        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.oracle_trigram);
+        f
+    };
+    let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
+    let name = |w: &str| FilterExpr::TextContains { field: TextSearchField::NameLower, word: w.to_string() };
+
+    for needle in ["damage", "draw", "goblin", "abcde", "card.", "zzz"] {
+        let rewritten = memo(oracle(needle));
+        assert!(matches!(rewritten, FilterExpr::OracleMatch { .. }), "oracle:{needle} must rewrite");
+        let neg = memo(FilterExpr::Not(Box::new(oracle(needle))));
+        let neg_orig = FilterExpr::Not(Box::new(oracle(needle)));
+        for card in archived.cards.iter() {
+            assert!(rewritten.eval_card(card, &archived.strings) == oracle(needle).eval_card(card, &archived.strings));
+            assert!(neg.eval_card(card, &archived.strings) == neg_orig.eval_card(card, &archived.strings));
+        }
+    }
+    for needle in ["angel", "goblin", "trap", "zzz"] {
+        let rewritten = memo(name(needle));
+        assert!(matches!(rewritten, FilterExpr::NameMatch { .. }), "name:{needle} must rewrite");
+        for card in archived.cards.iter() {
+            assert!(rewritten.eval_card(card, &archived.strings) == name(needle).eval_card(card, &archived.strings));
+        }
+    }
+    // "abcde"'s trigrams all exist in "abcbcde" but the text does not contain
+    // it: the verify must reject, leaving an empty match set.
+    match memo(oracle("abcde")) {
+        FilterExpr::OracleMatch { gids } => assert!(gids.is_empty(), "trigram false positive must be verified away"),
+        _ => panic!("must rewrite"),
+    }
+}
+
+// The rewrite must refuse: sub-trigram needles, non-card text fields, and
+// needles whose candidates exceed half the corpus (binary search stops paying).
+#[test]
+fn memoize_text_predicates_guards() {
+    let data = text_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let memo = |mut f: FilterExpr| {
+        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.oracle_trigram);
+        f
+    };
+    let short = memo(FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "dr".to_string() });
+    assert!(matches!(short, FilterExpr::TextContains { .. }), "2-char needle has no trigrams");
+    let flavor = memo(FilterExpr::TextContains { field: TextSearchField::FlavorTextLower, word: "damage".to_string() });
+    assert!(matches!(flavor, FilterExpr::TextContains { .. }), "flavor is printing-level, not ours");
+    // "xyz" appears in 4 of the 6 distinct texts (> half): guard keeps the scan.
+    let broad = memo(FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "xyz".to_string() });
+    assert!(matches!(broad, FilterExpr::TextContains { .. }), "broad needle stays unrewritten");
+}
+
+// End-to-end trigger: a full-scan Or (unnarrowable sibling) memoizes inside
+// run_query and returns the brute-force result; a narrowable query is left
+// untouched.
+#[test]
+fn run_query_memoizes_only_full_scans() {
+    let data = text_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
+    // Keywords <= "flying": no narrowing arm for Le, true for keyword-less cards.
+    let broad_sibling = || FilterExpr::CollectionCmp {
+        field: CollField::Keywords,
+        op: CmpOp::Le,
+        value: "flying".to_string(),
+        value_id: None,
+    };
+
+    let mut f = FilterExpr::Or(vec![oracle("draw"), broad_sibling()]);
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 6, "every card matches the Or (empty keywords pass Le)");
+    match &f {
+        FilterExpr::Or(children) => assert!(
+            matches!(children[0], FilterExpr::OracleMatch { .. }),
+            "full-scan Or must memoize its oracle child"
+        ),
+        _ => panic!("shape preserved"),
+    }
+
+    // Narrowable single predicate: candidates exist, no rewrite.
+    let mut g = oracle("draw");
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut g, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 1);
+    assert!(matches!(g, FilterExpr::TextContains { .. }), "narrowable query stays unrewritten");
+}
+
+// The NONE_STR → Null defense in OracleMatch mirrors TextContains exactly.
+// Loaded cards can't produce this state (missing text interns ""), but stub
+// cards can, and both paths must agree there too.
+#[test]
+fn oracle_match_none_str_mirrors_text_contains() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab); // oracle_text_lower_id = NONE_STR
+    let data = store_of(vec![card], &[1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let memoized = FilterExpr::OracleMatch { gids: Vec::new() };
+    let plain = FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
+    assert!(memoized.eval_card(&archived.cards[0], &archived.strings) == Tri::Null);
+    assert!(plain.eval_card(&archived.cards[0], &archived.strings) == Tri::Null);
 }

--- a/scripts/bench_text_memo.py
+++ b/scripts/bench_text_memo.py
@@ -1,0 +1,82 @@
+"""Engine-vs-engine benchmark for bind-time text-predicate memoization (#624).
+
+Same protocol as bench_bitplanes.py (corpus JSONL, local maturin build, fixed
+configs, totals as a cross-build parity check). Targeted rows are full-scan
+queries carrying an indexable text predicate — Or-shapes whose sibling can't
+narrow (broad-guarded usd, arithmetic, devotion, 2-char names, plane-mixed
+Ors). Controls are narrowable/pure-plane queries the trigger must leave
+untouched, plus full-scan queries with no text predicate (pass overhead).
+
+    .venv/bin/python scripts/bench_text_memo.py --out benchmarks/text-memo/baseline-main.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query) — unique=card, orderby=edhrec, prefer=default throughout.
+CONFIGS: list[tuple[str, str]] = [
+    # Targeted: full-scan Or with a broad-guarded / unindexable sibling
+    ("target", "oracle:deathtouch or usd<5"),
+    ("target", "oracle:draw or usd<5"),
+    ("target", "oracle:draw or power+toughness>8"),
+    ("target", "oracle:lifelink or devotion:g"),
+    ("target", "oracle:flying or name:fi"),
+    ("target", "name:dragon or usd<5"),
+    ("target", "c:g or o:draw"),
+    ("target", "oracle:sacrifice or frame:showcase"),
+    ("target", "o:the or devotion:g"),
+    ("target", "name:angel or power+toughness>9"),
+    # Controls: narrowable / pure-plane / no-text full scans — must not move
+    ("control", "o:draw"),
+    ("control", "o:draw t:creature"),
+    ("control", "c:g"),
+    ("control", "name:soldier"),
+    ("control", "t:merfolk name:tide"),
+    ("control", "usd<5"),
+    ("control", "power+toughness>8"),
+    ("control", "(t:bird c:u) or (t:beast c:g)"),
+    ("control", "c=uw o:draw"),
+    ("control", "f:modern"),
+]
+
+
+def main() -> None:
+    """Time every config against the local engine build and write the CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    hdr = f"{'group':<8} {'query':<36} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "total", "n", "avg_ms", "min_ms"])
+        for group, query in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, "card", "edhrec", "default"), args.window)
+            writer.writerow([rev, group, query, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<8} {query:<36} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -1,0 +1,215 @@
+"""Broad-distribution query survey against the local engine build.
+
+Generates a seeded corpus of queries from client/query_runner.py's weighted
+dimension table (the realistic-traffic bias used for load testing), mixed
+across shapes — single predicates, 2-4 way ANDs, ORs, nested parens, and
+negations — times each against the engine, and prints a distribution report:
+percentiles, the slowest tail, and per-dimension / per-shape aggregates.
+
+    .venv/bin/python scripts/survey_queries.py --out benchmarks/survey/survey.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import pathlib
+import random
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from client.query_runner import _DIM_NAMES, _DIM_VALUES, _DIM_WEIGHTS  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+# Realistic parameter biases: UI default ordering dominates; unique matches
+# query_runner's 75/20/5 split.
+_ORDERBYS = ["edhrec"] * 55 + ["usd"] * 10 + ["cmc"] * 10 + ["rarity"] * 8 + ["cubecobra"] * 7 + ["power"] * 5 + ["toughness"] * 5
+_UNIQUES = ["card"] * 75 + ["printing"] * 20 + ["artwork"] * 5
+
+WARMUP = 3
+WINDOW_S = 0.15
+MAX_ITERS = 500
+
+
+def _pick_fragments(rng: random.Random, k: int) -> list[tuple[str, str]]:
+    """Pick k distinct (dimension, fragment) pairs, dimension-weighted."""
+    out: list[tuple[str, str]] = []
+    frags: set[str] = set()
+    while len(out) < k:
+        dim = rng.choices(_DIM_NAMES, weights=_DIM_WEIGHTS, k=1)[0]
+        frag = rng.choice(_DIM_VALUES[dim])
+        if frag not in frags:
+            frags.add(frag)
+            out.append((dim, frag))
+    return out
+
+
+def generate(rng: random.Random, count: int) -> list[dict]:
+    """Generate `count` query specs across shapes, biased to common patterns."""
+    shapes = (
+        ["single"] * 25
+        + ["and2"] * 20
+        + ["and3"] * 13
+        + ["and4"] * 7
+        + ["or2"] * 10
+        + ["paren-or"] * 10
+        + ["and-or"] * 8
+        + ["neg-and"] * 5
+        + ["neg-or"] * 2
+    )
+    specs: list[dict] = []
+    seen: set[str] = set()
+    while len(specs) < count:
+        shape = rng.choice(shapes)
+        if shape == "single":
+            picks = _pick_fragments(rng, 1)
+            q = picks[0][1]
+        elif shape in ("and2", "and3", "and4"):
+            picks = _pick_fragments(rng, int(shape[-1]))
+            q = " ".join(f for _, f in picks)
+        elif shape == "or2":
+            picks = _pick_fragments(rng, 2)
+            q = f"{picks[0][1]} or {picks[1][1]}"
+        elif shape == "paren-or":  # (a b) or (c d)
+            picks = _pick_fragments(rng, 4)
+            q = f"({picks[0][1]} {picks[1][1]}) or ({picks[2][1]} {picks[3][1]})"
+        elif shape == "and-or":  # a (b or c)
+            picks = _pick_fragments(rng, 3)
+            q = f"{picks[0][1]} ({picks[1][1]} or {picks[2][1]})"
+        elif shape == "neg-and":  # -a b
+            picks = _pick_fragments(rng, 2)
+            q = f"-{picks[0][1]} {picks[1][1]}"
+        else:  # neg-or: a -(b or c)
+            picks = _pick_fragments(rng, 3)
+            q = f"{picks[0][1]} -({picks[1][1]} or {picks[2][1]})"
+        if q in seen:
+            continue
+        seen.add(q)
+        specs.append(
+            {
+                "query": q,
+                "shape": shape,
+                "dims": "+".join(sorted({d for d, _ in picks})),
+                "orderby": rng.choice(_ORDERBYS),
+                "unique": rng.choice(_UNIQUES),
+            }
+        )
+    return specs
+
+
+def time_query(engine: object, spec: dict) -> tuple[int, int, float, float]:
+    """Return (total, n, avg_ms, min_ms) for one spec."""
+    filters = parse_scryfall_query(spec["query"])
+    kw = {
+        "filters": filters,
+        "unique": spec["unique"],
+        "prefer": "default",
+        "orderby": spec["orderby"],
+        "direction": "asc",
+        "limit": 100,
+        "offset": 0,
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n, best = 0, float("inf")
+    t_start = time.monotonic()
+    now = t_start
+    while now < t_start + WINDOW_S and n < MAX_ITERS:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1_000, best * 1_000
+
+
+def percentile(sorted_vals: list[float], p: float) -> float:
+    """Nearest-rank percentile of an ascending list."""
+    idx = min(len(sorted_vals) - 1, max(0, math.ceil(p / 100 * len(sorted_vals)) - 1))
+    return sorted_vals[idx]
+
+
+def report(rows: list[dict]) -> None:
+    """Print percentiles, the slow tail, and per-dimension / per-shape aggregates."""
+    times = sorted(r["avg_ms"] for r in rows)
+    print(f"\n=== {len(rows)} queries ===")
+    for p in (50, 75, 90, 95, 99):
+        print(f"  p{p}: {percentile(times, p):7.3f} ms")
+    print(f"  max: {times[-1]:7.3f} ms")
+
+    print("\n=== slowest 30 ===")
+    for r in sorted(rows, key=lambda r: -r["avg_ms"])[:30]:
+        print(f"  {r['avg_ms']:7.3f} ms  {r['total']:>6}  {r['unique']:<8} {r['orderby']:<9} [{r['shape']:<8}] {r['query']}")
+
+    def agg(key: str) -> None:
+        groups: dict[str, list[float]] = {}
+        for r in rows:
+            for g in r[key].split("+") if key == "dims" else [r[key]]:
+                groups.setdefault(g, []).append(r["avg_ms"])
+        print(f"\n=== by {key} ===")
+        print(f"  {'group':<16} {'n':>4} {'median':>8} {'p90':>8} {'max':>8}")
+        for g, vals in sorted(groups.items(), key=lambda kv: -percentile(sorted(kv[1]), 90)):
+            sv = sorted(vals)
+            print(f"  {g:<16} {len(sv):>4} {percentile(sv, 50):>8.3f} {percentile(sv, 90):>8.3f} {sv[-1]:>8.3f}")
+
+    agg("dims")
+    agg("shape")
+    agg("orderby")
+    agg("unique")
+
+
+def main() -> None:
+    """Generate the survey corpus, time it, write CSV, print the report."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--count", type=int, default=400, help="number of queries to generate")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    specs = generate(rng, args.count)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    rows: list[dict] = []
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["query", "shape", "dims", "unique", "orderby", "total", "n", "avg_ms", "min_ms"])
+        for i, spec in enumerate(specs):
+            try:
+                total, n, avg_ms, min_ms = time_query(engine, spec)
+            except Exception as oops:  # noqa: BLE001 — survey must survive odd fragments
+                print(f"SKIP {spec['query']!r}: {oops}")
+                continue
+            rows.append({**spec, "total": total, "avg_ms": avg_ms, "min_ms": min_ms})
+            writer.writerow(
+                [
+                    spec["query"],
+                    spec["shape"],
+                    spec["dims"],
+                    spec["unique"],
+                    spec["orderby"],
+                    total,
+                    n,
+                    f"{avg_ms:.4f}",
+                    f"{min_ms:.4f}",
+                ]
+            )
+            if (i + 1) % 50 == 0:
+                print(f"  …{i + 1}/{len(specs)}", flush=True)
+
+    report(rows)
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #624.

## What this does

The query survey's worst tail cluster is the Or-with-unnarrowable-sibling shape: `narrow_candidates` on an Or requires every child to narrow, so one broad-guarded or unindexable sibling (`usd<5`, arithmetic, devotion, a 2-char name) forces a full scan — and during that scan, every one of 31.5k cards pays a substring search for each text predicate, even though the predicate's own trigram index could bound it to a few hundred cards. Anatomy of `oracle:deathtouch or usd<5` (1.67 ms): 1.19 ms is `contains("deathtouch")` × 31,508, for a predicate whose trigram candidates number ~525. Reordering the Or's children doesn't help — `card_pass` evaluates every card-level child per card regardless of order (measured: 1.689 vs 1.700 ms).

This is the third instance of the ArtistMatch (#605) / FlavorMatch (#622) pattern: when the driver is about to evaluate the filter against (nearly) every card, `memoize_text_predicates()` resolves name/oracle contains-nodes through their trigram indexes **once** — gather candidates, verify each with the real `contains()`, rewrite to a sorted match-id set (`NameMatch { card_name_id }` / `OracleMatch { oracle_text_lower_id }`). Per-card evaluation becomes an integer binary search (~5 ns) instead of a substring search (~38 ns), and the bind-time verify is bounded by the candidate count, not the corpus.

Gating, from outermost in:

- **Trigger** (in `run_query`, after candidates fold in the plane bitmap): memoize only when the candidate set is `None` or covers more than half the corpus. Narrowed queries never pay the rewrite — the driver only evaluates candidates there, so the verify would be wasted work.
- **No trigrams, no rewrite**: needles under 3 bytes keep the scan (nothing to gather).
- **Broad-needle decline is free**: the intersection is bounded by the shortest posting list, so a new `trigram_min_posting()` check declines needles like `the` before materializing anything — the old scan behavior, at zero added cost.

Semantics are preserved exactly: both node types are card-level; names are always Known (missing names intern `""`), so `NameMatch` is two-valued; textless cards also intern `""` (never `NONE_STR`), so `-o:x` still *includes* them via False — the `Null` arm on `OracleMatch` only mirrors the `str_at` contract defensively, and the comments say so. The rewrite is per-query and the match-id sets are store-bound by construction.

`OracleTextIndex` gains a `gids` table (dense text id → global string id, ~116 kB at 29k distinct texts — the same shape `FlavorIndex.gids` already has), so the verify loop reads each candidate text directly instead of recovering its id through the CSR's first card. Archive format version bumped.

## Measured (main 48b259c vs branch, 97,206-printing corpus, 20 warmup + 3 s window per config, unique=card orderby=edhrec)

`scripts/bench_text_memo.py`; the `total` column matched baseline on all 20 configs.

**Targeted** — full-scan queries with an indexable text predicate. **Geomean 1.49×** (10 configs; 1.66× over the 8 the rewrite accepts):

| targeted query | matches | main | branch | speedup |
|---|---|---|---|---|
| `oracle:deathtouch or usd<5` | 29,370 | 1.673 ms | **0.870 ms** | **1.92×** |
| `name:angel or power+toughness>9` | 2,085 | 1.045 ms | **0.602 ms** | **1.74×** |
| `oracle:lifelink or devotion:g` | 6,910 | 1.592 ms | **0.937 ms** | **1.70×** |
| `oracle:draw or power+toughness>8` | 6,385 | 1.385 ms | **0.830 ms** | **1.67×** |
| `oracle:draw or usd<5` | 29,651 | 1.609 ms | **0.978 ms** | **1.65×** |
| `name:dragon or usd<5` | 29,358 | 1.222 ms | **0.749 ms** | **1.63×** |
| `c:g or o:draw` | 9,900 | 0.912 ms | **0.595 ms** | **1.53×** |
| `oracle:flying or name:fi` | 5,312 | 1.651 ms | **1.102 ms** | **1.50×** |
| `oracle:sacrifice or frame:showcase` | 5,969 | 0.430 ms | 0.437 ms | 0.98× |
| `o:the or devotion:g` | 19,190 | 1.664 ms | 1.720 ms | 0.97× |

The two 1.0× rows are the boundaries working as designed: `frame:showcase` turns out to narrow (thresholded frame postings), so that Or composes candidates and never triggers the rewrite; `o:the` hits the broad-needle decline (its shortest trigram posting exceeds half the distinct texts) and keeps the scan.

**Controls** — narrowable, pure-plane, and no-text full scans that must not move. **Geomean 1.00×** (10 configs):

| control query | matches | main | branch | speedup |
|---|---|---|---|---|
| `o:draw` | 4,177 | 0.175 ms | 0.178 ms | 0.98× |
| `o:draw t:creature` | 1,804 | 0.134 ms | 0.134 ms | 1.00× |
| `c:g` | 6,407 | 0.090 ms | 0.090 ms | 1.01× |
| `name:soldier` | 41 | 0.032 ms | 0.032 ms | 1.00× |
| `t:merfolk name:tide` | 11 | 0.018 ms | 0.018 ms | 0.99× |
| `usd<5` | 29,335 | 0.498 ms | 0.492 ms | 1.01× |
| `power+toughness>8` | 2,503 | 0.483 ms | 0.491 ms | 0.98× |
| `(t:bird c:u) or (t:beast c:g)` | 478 | 0.090 ms | 0.090 ms | 1.01× |
| `c=uw o:draw` | 97 | 0.103 ms | 0.103 ms | 0.99× |
| `f:modern` | 22,264 | 0.260 ms | 0.262 ms | 0.99× |

## Honest notes

- **The remaining cost on the winners is the sibling, not the text.** `oracle:draw or usd<5` at 0.978 ms sits just above bare `usd<5` (0.492) — the per-printing price residual and the 29k-match emission floor are what's left, and no text rewrite can touch them.
- **2-char needles stay slow.** `oracle:flying or name:fi` improves only via its oracle side (1.50×); `name:fi` has no trigrams and keeps its per-card scan. Short-name narrowing is a separate follow-up from the survey.
- **A memoized filter is store-bound and no longer narrowable** (`NameMatch`/`OracleMatch` fall through `narrow_candidates`' wildcard). Irrelevant in production — filters are built per query and the rewrite only fires after the narrowing decision — but the equivalence-matrix test was reusing one `&mut` filter across two stores and now builds a fresh filter per call, with a comment explaining why.

## Tests

`cargo test`: 38 passed — op parity over a real-interned fixture (incl. a trigram false positive `contains()` must reject, textless-card semantics, `Not` composition), decline guards (short needle, flavor field, broad needle), end-to-end trigger conditions (full-scan Or rewrites, narrowable single doesn't), and the defensive `NONE_STR` arm. Python: 1,868 unit + 15 integration passed. Self-review (8-angle) findings all addressed: fresh-filter-per-store in the equivalence matrix, free decline path, broadened trigger for near-total candidate sets, corrected NULL-semantics comments, `bind()` breadcrumb.
