### PR TITLE
Narrow Two-Character Name Searches via a Two-Tier Bigram Index

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -491,6 +491,20 @@ impl FilterExpr {
     /// candidates exceed half the corpus stay unrewritten too — at that
     /// density a binary search costs about what contains() does, so the
     /// verify pass couldn't earn its keep.
+    /// Cost-based memoization gate, measured (bench_memo_crossover.py, six
+    /// needles spanning 493-11,933 candidate texts × eight candidate-domain
+    /// sizes, memoize-always vs memoize-never builds): the bind cost breaks
+    /// even when the evaluation domain reaches ~1.25× the needle's shortest
+    /// trigram posting list. The factor here is 2 — declining early forgoes a
+    /// small win, declining late pays on every query — with a floor below
+    /// which the whole effect sits inside measurement noise (scaled down for
+    /// tiny stores so tests and partial imports still exercise the rewrite).
+    fn memoize_pays(bind_bound: usize, eval_domain: usize, n_rows: usize) -> bool {
+        const MEMO_DOMAIN_FACTOR: usize = 2;
+        const MEMO_DOMAIN_FLOOR: usize = 2_048;
+        eval_domain >= (bind_bound * MEMO_DOMAIN_FACTOR).max(MEMO_DOMAIN_FLOOR.min(n_rows / 4))
+    }
+
     pub(crate) fn memoize_text_predicates(
         &mut self,
         cards: &[AOracleCard],
@@ -498,14 +512,15 @@ impl FilterExpr {
         name_trigram: &rkyv::Archived<TrigramIndex>,
         name_bigrams: &rkyv::Archived<NameBigramIndex>,
         oracle: &rkyv::Archived<OracleTextIndex>,
+        eval_domain: usize,
     ) {
         match self {
             FilterExpr::And(children) | FilterExpr::Or(children) => {
                 for c in children.iter_mut() {
-                    c.memoize_text_predicates(cards, strings, name_trigram, name_bigrams, oracle);
+                    c.memoize_text_predicates(cards, strings, name_trigram, name_bigrams, oracle, eval_domain);
                 }
             }
-            FilterExpr::Not(inner) => inner.memoize_text_predicates(cards, strings, name_trigram, name_bigrams, oracle),
+            FilterExpr::Not(inner) => inner.memoize_text_predicates(cards, strings, name_trigram, name_bigrams, oracle, eval_domain),
             FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => {
                 // 2-byte needles resolve exactly through the bigram index: the
                 // member cards are the complete match set (containment IS
@@ -515,6 +530,13 @@ impl FilterExpr {
                     return;
                 }
                 let bg = [word.as_bytes()[0], word.as_bytes()[1]];
+                let bind_bound = name_bigrams.postings.get(&bg).map_or_else(
+                    || name_bigrams.plane_of.get(&bg).map_or(0, |_| cards.len() / 8),
+                    |v| v.len(),
+                );
+                if !Self::memoize_pays(bind_bound, eval_domain, cards.len()) {
+                    return;
+                }
                 let mut ids: Vec<u32> = if let Some(p) = name_bigrams.plane_of.get(&bg) {
                     let wpp = cards.len().div_ceil(64);
                     let start = u32::from(*p) as usize * wpp;
@@ -546,7 +568,7 @@ impl FilterExpr {
                 // it can only happen when every trigram of the needle is
                 // ultra-common, where the match set is broad anyway.
                 match trigram_min_posting(name_trigram, word) {
-                    Some(min) if min <= cards.len() / 2 => {}
+                    Some(min) if min <= cards.len() / 2 && Self::memoize_pays(min, eval_domain, cards.len()) => {}
                     _ => return,
                 }
                 let Some(cand) = trigram_candidates(name_trigram, word) else { return };
@@ -561,7 +583,7 @@ impl FilterExpr {
             }
             FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word } => {
                 match trigram_min_posting(&oracle.trigrams, word) {
-                    Some(min) if min <= oracle.gids.len() / 2 => {}
+                    Some(min) if min <= oracle.gids.len() / 2 && Self::memoize_pays(min, eval_domain, cards.len()) => {}
                     _ => return,
                 }
                 let Some(dense) = trigram_candidates(&oracle.trigrams, word) else { return };

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use regex::Regex;
 use serde_json::Value;
-use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, OracleTextIndex, TrigramIndex, flavor_fingerprint, flavor_match_sets};
+use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, NameBigramIndex, OracleTextIndex, TrigramIndex, flavor_fingerprint, flavor_match_sets};
 use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, format_shift};
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
@@ -496,15 +496,48 @@ impl FilterExpr {
         cards: &[AOracleCard],
         strings: &AStrings,
         name_trigram: &rkyv::Archived<TrigramIndex>,
+        name_bigrams: &rkyv::Archived<NameBigramIndex>,
         oracle: &rkyv::Archived<OracleTextIndex>,
     ) {
         match self {
             FilterExpr::And(children) | FilterExpr::Or(children) => {
                 for c in children.iter_mut() {
-                    c.memoize_text_predicates(cards, strings, name_trigram, oracle);
+                    c.memoize_text_predicates(cards, strings, name_trigram, name_bigrams, oracle);
                 }
             }
-            FilterExpr::Not(inner) => inner.memoize_text_predicates(cards, strings, name_trigram, oracle),
+            FilterExpr::Not(inner) => inner.memoize_text_predicates(cards, strings, name_trigram, name_bigrams, oracle),
+            FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => {
+                // 2-byte needles resolve exactly through the bigram index: the
+                // member cards are the complete match set (containment IS
+                // bigram membership), so no contains() verification runs at
+                // all — the ids just re-key to card_name_id for eval.
+                if u32::from(name_bigrams.n_cards) as usize != cards.len() {
+                    return;
+                }
+                let bg = [word.as_bytes()[0], word.as_bytes()[1]];
+                let mut ids: Vec<u32> = if let Some(p) = name_bigrams.plane_of.get(&bg) {
+                    let wpp = cards.len().div_ceil(64);
+                    let start = u32::from(*p) as usize * wpp;
+                    let mut out = Vec::new();
+                    for (i, w) in name_bigrams.plane_words[start..start + wpp].iter().enumerate() {
+                        let mut w = u64::from(*w);
+                        while w != 0 {
+                            let cid = ((i as u32) << 6) | w.trailing_zeros();
+                            w &= w - 1;
+                            out.push(u32::from(cards[cid as usize].card_name_id));
+                        }
+                    }
+                    out
+                } else {
+                    name_bigrams
+                        .postings
+                        .get(&bg)
+                        .map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(cards[u16::from(*x) as usize].card_name_id)).collect())
+                };
+                ids.sort_unstable();
+                ids.dedup();
+                *self = FilterExpr::NameMatch { ids };
+            }
             FilterExpr::TextContains { field: TextSearchField::NameLower, word } => {
                 // The intersection is bounded by the shortest posting list, so
                 // checking that bound first makes the decline path free — no

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -772,6 +772,68 @@ fn expand_text_ids(idx: &Archived<OracleTextIndex>, text_ids: &[u32]) -> Vec<u32
     out
 }
 
+// ─── Name bigram index (#639 short-name narrowing) ──────────────────────────
+// Trigram narrowing needs a 3-byte needle, so 2-character name searches (the
+// typeahead shape: name:fi, name:dr) full-scanned with per-card substring
+// searches. For a 2-byte needle, containment IS bigram membership, so a
+// bigram index is not a prefilter but the exact answer — sets enter the
+// candidate algebra tight, with no verification pass to pay.
+//
+// Two-tier storage, split at the derived crossover where a card bitplane
+// (n_cards/8 bytes, flat) undercuts a u16 posting list (2 bytes/entry):
+// ~2k entries at 31.5k cards, 6.3% density. 74 of 951 corpus bigrams sit
+// above it, carrying 53% of all posting entries — promoting them saves ~22%
+// of the index and hands the #636 algebra pre-built bitmaps for exactly the
+// bigrams broad enough to want them. This is #630 phase 3's density-promotion
+// rule with the threshold derived from a storage identity instead of tuned.
+
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct NameBigramIndex {
+    /// Sparse tier: bigram → ascending card ids. u16 on purpose (cards fit;
+    /// see build); half the bytes of the u32 posting convention.
+    postings: HashMap<[u8; 2], Vec<u16>>,
+    /// Dense tier: bigram → plane index into `plane_words`.
+    plane_of: HashMap<[u8; 2], u32>,
+    /// plane_of.len() × words_per_plane(n_cards), flattened plane-major —
+    /// the BitPlanes layout.
+    plane_words: Vec<u64>,
+    n_cards: u32,
+}
+
+fn build_name_bigram_index(cards: &[OracleCard]) -> NameBigramIndex {
+    let mut lists: HashMap<[u8; 2], Vec<u32>> = HashMap::new();
+    for (i, card) in cards.iter().enumerate() {
+        let bytes = card.card_name_lower.as_str().as_bytes();
+        let mut seen: Vec<[u8; 2]> = Vec::new(); // names are short; a vec beats a set
+        for w in bytes.windows(2) {
+            let bg = [w[0], w[1]];
+            if !seen.contains(&bg) {
+                seen.push(bg);
+                lists.entry(bg).or_default().push(i as u32);
+            }
+        }
+    }
+    let wpp = cards.len().div_ceil(64);
+    let plane_bytes = wpp * 8;
+    let mut idx = NameBigramIndex { n_cards: cards.len() as u32, ..Default::default() };
+    // u16 ids require the card count to fit; past that every bigram promotes
+    // (a plane is valid at any count). Production is ~31.5k cards.
+    let u16_ok = cards.len() <= u16::MAX as usize + 1;
+    for (bg, ids) in lists {
+        if u16_ok && ids.len() * 2 <= plane_bytes {
+            idx.postings.insert(bg, ids.into_iter().map(|c| c as u16).collect());
+        } else {
+            let plane = idx.plane_of.len() as u32;
+            idx.plane_of.insert(bg, plane);
+            idx.plane_words.resize((plane as usize + 1) * wpp, 0);
+            for c in ids {
+                idx.plane_words[plane as usize * wpp + (c >> 6) as usize] |= 1u64 << (c & 63);
+            }
+        }
+    }
+    idx
+}
+
 // Named lifetime (not elided/HRTB) so get_text may return text borrowed from the
 // string table rather than from the card itself.
 fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str) -> TrigramIndex {
@@ -1530,6 +1592,7 @@ struct CardIndexes {
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
+    name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
 }
 
 impl Default for CardIndexes {
@@ -1557,6 +1620,7 @@ impl Default for CardIndexes {
             sort_perms:     SortPermutations::default(),
             artwork_groups: Vec::new(),
             planes:         BitPlanes::default(),
+            name_bigrams:   NameBigramIndex::default(),
         }
     }
 }
@@ -1861,6 +1925,8 @@ fn or_all(mut sets: Vec<Narrowed>, n: usize) -> Option<Narrowed> {
 fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
     match f {
         FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => Some(false),
+        // 2-byte name needles resolve exactly through the bigram index.
+        FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => Some(false),
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } => {
             Some(matches!(field, CollField::ArtTags | CollField::IsTags | CollField::FrameData))
         }
@@ -1953,6 +2019,29 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
     }
 
     match filter {
+        FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => {
+            // A 2-byte needle's containment IS bigram membership, so the tier
+            // lookup is the complete answer — tight, with no false positives
+            // for the walk to reject. A bigram absent from the index appears
+            // in no name, so the empty narrowing is exact too.
+            let idx = &indexes.name_bigrams;
+            if u32::from(idx.n_cards) as usize != n_cards {
+                return None; // archive without bigrams for this store
+            }
+            let bg = [word.as_bytes()[0], word.as_bytes()[1]];
+            if let Some(p) = idx.plane_of.get(&bg) {
+                let wpp = n_cards.div_ceil(64);
+                let start = u32::from(*p) as usize * wpp;
+                let bits: Vec<u64> = idx.plane_words[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
+                return Narrowed::tight(Candidates::CardBits(bits));
+            }
+            let ids: Vec<u32> = idx
+                .postings
+                .get(&bg)
+                .map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(u16::from(*x))).collect());
+            Narrowed::tight(Candidates::Cards(ids))
+        }
+
         FilterExpr::TextContains { field, word }
             if word.len() >= 3
                 && matches!(field, TextSearchField::NameLower | TextSearchField::OracleTextLower) =>
@@ -2583,7 +2672,7 @@ fn run_query<'a>(
     // turns those per-card substring searches into integer binary searches.
     // The half-corpus line mirrors memoize_text_predicates' decline guard.
     if candidate_cards.as_ref().is_none_or(|v| v.len() > cards.len() / 2) {
-        filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.oracle_trigram);
+        filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram);
     }
     let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
@@ -2873,7 +2962,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260715;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260716;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -3264,6 +3353,7 @@ impl QueryEngine {
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: build_artwork_group_counts(&printings, &offsets),
             planes:         build_bit_planes(&cards),
+            name_bigrams:   build_name_bigram_index(&cards),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2664,16 +2664,14 @@ fn run_query<'a>(
         }
     };
 
-    // Memoize when the driver is about to evaluate the filter against (nearly)
-    // every card: no candidates at all, or a candidate set so broad it hardly
-    // narrows — a broad plane bitmap ANDed with an unnarrowable Or would
-    // otherwise run its substring scans over most of the corpus. Resolving the
-    // indexable text predicates through their trigram indexes once here (#624)
-    // turns those per-card substring searches into integer binary searches.
-    // The half-corpus line mirrors memoize_text_predicates' decline guard.
-    if candidate_cards.as_ref().is_none_or(|v| v.len() > cards.len() / 2) {
-        filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram);
-    }
+    // Resolve indexable text predicates through their indexes once (#624)
+    // when the per-card evaluation they'd replace outweighs the bind cost —
+    // the gate is per-node and cost-based (see memoize_pays): each predicate
+    // compares its own bind bound against the evaluation domain, so a broad
+    // candidate set with a selective needle memoizes while a narrow one
+    // leaves the scan alone.
+    let eval_domain = candidate_cards.as_ref().map_or(cards.len(), Vec::len);
+    filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram, eval_domain);
     let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
         None    => Box::new(0..cards.len() as u32),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    build_artwork_group_counts, build_bit_planes, flavor_fingerprint, flavor_match_sets,
+    build_artwork_group_counts, build_bit_planes, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
@@ -218,6 +218,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
     let indexes = CardIndexes {
         type_bits: build_type_index(&cards),
         planes: build_bit_planes(&cards),
+        name_bigrams: build_name_bigram_index(&cards),
         ..Default::default()
     };
     CardData {
@@ -657,6 +658,7 @@ fn bench_checked_vs_unchecked_access() {
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups: build_artwork_group_counts(&printings, &offsets),
         planes:         build_bit_planes(&cards),
+        name_bigrams:   build_name_bigram_index(&cards),
     };
     let data = CardData {
         cards,
@@ -1479,7 +1481,7 @@ fn memoize_text_predicates_parity() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let memo = |mut f: FilterExpr| {
-        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.oracle_trigram);
+        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram);
         f
     };
     let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
@@ -1518,7 +1520,7 @@ fn memoize_text_predicates_guards() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let memo = |mut f: FilterExpr| {
-        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.oracle_trigram);
+        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram);
         f
     };
     let short = memo(FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "dr".to_string() });
@@ -1694,7 +1696,8 @@ fn not_narrows_only_tight_children() {
     let goblin_id = archived.coll_vocab.iter().position(|s| s.as_str() == "goblin").map(|i| i as u16);
     let goblin = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".into(), value_id: goblin_id };
     let rarity = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(0.0) };
-    let name2 = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "da".into() };
+    // 1-char: below even the bigram floor, so genuinely unindexable.
+    let name1 = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() };
 
     // Tight leaf → complement narrows, loose, and covers every ¬-match.
     let n = rec(&FilterExpr::Not(Box::new(goblin()))).expect("Not(subtype) must narrow");
@@ -1710,7 +1713,7 @@ fn not_narrows_only_tight_children() {
 
     // Loose children block the Not arm entirely.
     assert!(rec(&FilterExpr::Not(Box::new(rarity()))).is_none(), "rarity existence sets are not complement-safe");
-    assert!(rec(&FilterExpr::Not(Box::new(name2()))).is_none(), "trigram-less text cannot narrow at all");
+    assert!(rec(&FilterExpr::Not(Box::new(name1()))).is_none(), "sub-bigram text cannot narrow at all");
     let double_not = FilterExpr::Not(Box::new(FilterExpr::Not(Box::new(goblin()))));
     assert!(rec(&double_not).is_none(), "complements are loose, so double negation stops narrowing");
 
@@ -1739,8 +1742,9 @@ fn or_composes_plane_and_complement_children() {
     let cand = n.set.into_cards(&archived.offsets);
     assert_eq!(cand, vec![0, 1, 3], "goblins ∪ green");
 
-    // An unindexable child still vetoes: nothing can represent it.
-    let or = FilterExpr::Or(vec![goblin(), FilterExpr::TextContains { field: TextSearchField::NameLower, word: "da".into() }]);
+    // An unindexable child still vetoes: nothing can represent it (1-char is
+    // below even the bigram floor).
+    let or = FilterExpr::Or(vec![goblin(), FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() }]);
     assert!(rec(&or).is_none());
 }
 
@@ -1800,7 +1804,7 @@ fn not_over_partial_and_is_blocked() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let goblin_id = archived.coll_vocab.iter().position(|s| s.as_str() == "goblin").map(|i| i as u16);
     let goblin = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".into(), value_id: goblin_id };
-    let unindexable = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "da".into() };
+    let unindexable = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() };
 
     // Static check: And with an unrepresentable child can't be tight → Not
     // must refuse to narrow at all.
@@ -1808,7 +1812,7 @@ fn not_over_partial_and_is_blocked() {
     assert!(super::narrow_rec(&not_partial, &archived.indexes, &archived.offsets, true).is_none());
 
     // Dynamic check via run_query: totals must equal brute force. Every card
-    // fails `name:da` here, so every card matches the negation — a complement
+    // fails `name:q` here, so every card matches the negation — a complement
     // of the goblins-only set would have dropped cards 0 and 1.
     let brute = archived
         .cards
@@ -1825,7 +1829,7 @@ fn not_over_partial_and_is_blocked() {
         &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, brute);
-    assert_eq!(total, 6, "every card matches -(goblin and name:da)");
+    assert_eq!(total, 6, "every card matches -(goblin and name:q)");
 }
 
 
@@ -1856,4 +1860,111 @@ fn not_over_price_range_keeps_boundary_matches() {
         &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, 1, "the boundary-priced card matches -usd>5 and must not be complemented away");
+}
+
+// ─── Name bigram index (#639) ─────────────────────────────────────────────────
+
+// Tier assignment at the derived crossover (plane bytes vs 2 bytes/entry),
+// and exactness on both tiers: for a 2-byte needle, the set IS the answer.
+#[test]
+fn name_bigrams_tiers_and_exactness() {
+    // 4,096 cards: every card contains "zz" (dense → plane tier); every 64th
+    // contains "qx" (64 entries × 2 B ≤ the 512 B plane cost at this store
+    // size → u16 postings tier; the crossover scales with n_cards).
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = (0..4096u32).map(|i| {
+        let mut c = stub_card(u128::from(i) + 1, TYPE_CREATURE, &[], &mut vocab);
+        let name = if i % 64 == 0 { format!("azz qx{i}") } else { format!("azz b{i}") };
+        c.card_name_lower = InlineStr::from_str(&name);
+        c
+    }).collect();
+    let data = store_of(cards, &vec![1usize; 4096], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let idx = &archived.indexes.name_bigrams;
+
+    assert!(idx.plane_of.get(&[b'z', b'z']).is_some(), "4,096-name bigram must promote to a plane");
+    assert!(idx.postings.get(&[b'q', b'x']).is_some(), "64-name bigram stays a posting list");
+
+    let rec = |w: &str| {
+        let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: w.to_string() };
+        super::narrow_rec(&f, &archived.indexes, &archived.offsets, false)
+    };
+    // Dense tier: exact bitmap, tight.
+    let n = rec("zz").expect("dense bigram narrows");
+    assert!(n.tight);
+    assert!(matches!(n.set, Candidates::CardBits(_)));
+    assert_eq!(n.set.len(), 4096);
+    // Sparse tier: exact vec, tight, and byte-for-byte the contains() answer.
+    let n = rec("qx").expect("sparse bigram narrows");
+    assert!(n.tight);
+    let cand = n.set.into_cards(&archived.offsets);
+    let brute: Vec<u32> = archived.cards.iter().enumerate()
+        .filter(|(_, c)| c.card_name_lower.as_str().contains("qx"))
+        .map(|(i, _)| i as u32)
+        .collect();
+    assert_eq!(cand, brute, "bigram membership IS containment for 2-byte needles");
+    // Absent bigram: exact empty (no name contains it), not None.
+    let n = rec("vw").expect("absent bigram is an exact empty narrowing");
+    assert_eq!(n.set.len(), 0);
+    // 1-char stays unindexable.
+    let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: "z".to_string() };
+    assert!(super::narrow_rec(&f, &archived.indexes, &archived.offsets, false).is_none());
+}
+
+// The motivating composition: `name:xx or name:yy` previously full-scanned
+// (two per-card substring searches); both children now contribute exact sets.
+// Also: Not(bigram) is a sound complement, and memoize rewrites 2-byte needles
+// to NameMatch with zero contains() calls in full-scan contexts.
+#[test]
+fn name_bigrams_compose_and_memoize() {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let names = ["fire drake", "field agent", "drone", "bear", "firm hand", "quiet"];
+    let cards: Vec<OracleCard> = names.iter().enumerate().map(|(i, name)| {
+        let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+        c.card_name_lower = InlineStr::from_str(name);
+        c.card_name_id = interner.intern(name.to_string());
+        c
+    }).collect();
+    let mut data = store_of(cards, &[1usize; 6], vocab);
+    data.strings = interner.strings;
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let name2 = |w: &str| FilterExpr::TextContains { field: TextSearchField::NameLower, word: w.to_string() };
+
+    // Or of two bigram children composes: "fi" → {0,1,4}, "dr" → {0,2}.
+    let or = FilterExpr::Or(vec![name2("fi"), name2("dr")]);
+    let n = super::narrow_rec(&or, &archived.indexes, &archived.offsets, false).expect("bigram Or composes");
+    assert_eq!(n.set.into_cards(&archived.offsets), vec![0, 1, 2, 4]);
+
+    // run_query parity across the new shapes, negation included.
+    for f in [or, FilterExpr::Not(Box::new(name2("fi")))] {
+        let brute = archived.cards.iter().enumerate()
+            .filter(|(cid, card)| {
+                (u32::from(archived.offsets[*cid])..u32::from(archived.offsets[cid + 1]))
+                    .any(|p| f.matches(card, &archived.printings[p as usize], &archived.strings))
+            })
+            .count();
+        let mut f2 = f;
+        let (total, _) = run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut f2, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        );
+        assert_eq!(total, brute);
+    }
+
+    // Memoize path: a 2-byte needle in a full-scan context becomes NameMatch
+    // through the bigram index (exact — no contains() verification).
+    let mut f = name2("fi");
+    f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram);
+    match &f {
+        FilterExpr::NameMatch { ids } => assert_eq!(ids.len(), 3),
+        _ => panic!("2-byte needle must memoize via bigrams"),
+    }
+    for (cid, card) in archived.cards.iter().enumerate() {
+        let want = card.card_name_lower.as_str().contains("fi");
+        assert!((f.eval_card(card, &archived.strings) == Tri::True) == want, "NameMatch parity at card {cid}");
+    }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1481,7 +1481,7 @@ fn memoize_text_predicates_parity() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let memo = |mut f: FilterExpr| {
-        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram);
+        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram, archived.cards.len());
         f
     };
     let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
@@ -1520,7 +1520,7 @@ fn memoize_text_predicates_guards() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let memo = |mut f: FilterExpr| {
-        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram);
+        f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram, archived.cards.len());
         f
     };
     let short = memo(FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "dr".to_string() });
@@ -1958,7 +1958,7 @@ fn name_bigrams_compose_and_memoize() {
     // Memoize path: a 2-byte needle in a full-scan context becomes NameMatch
     // through the bigram index (exact — no contains() verification).
     let mut f = name2("fi");
-    f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram);
+    f.memoize_text_predicates(&archived.cards, &archived.strings, &archived.indexes.name_trigram, &archived.indexes.name_bigrams, &archived.indexes.oracle_trigram, archived.cards.len());
     match &f {
         FilterExpr::NameMatch { ids } => assert_eq!(ids.len(), 3),
         _ => panic!("2-byte needle must memoize via bigrams"),

--- a/scripts/bench_memo_crossover.py
+++ b/scripts/bench_memo_crossover.py
@@ -1,0 +1,78 @@
+"""Measure the memoize-trigger crossover for text predicates (#624 follow-up).
+
+Query family: `cmc<=K -(oracle:NEEDLE or color:w)` — the cmc index supplies an
+exact candidate set whose size K dials (the fabricated variable), while the
+Not(Or(text, color)) residual is unnarrowable, so the text predicate runs
+either as per-candidate contains() or, when the run_query trigger fires, as a
+memoized binary search. Run against a memoize-ALWAYS build and a
+memoize-NEVER build; the crossover per needle is where the curves meet, and
+needles of different trigram breadth expose how it scales with bind cost.
+
+    .venv/bin/python scripts/bench_memo_crossover.py --label always --out benchmarks/memo-crossover/always.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+NEEDLES = ["deathtouch", "vigilance", "trample", "sacrifice", "draw", "target"]
+CMC_STEPS = [0, 1, 2, 3, 4, 5, 6, 8]
+
+
+def main() -> None:
+    """Time the sweep grid and write one CSV row per (needle, K)."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--window", type=float, default=0.4)
+    args = parser.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    def run(q: str) -> tuple[int, float]:
+        f = parse_scryfall_query(q)
+        kw = {
+            "filters": f,
+            "unique": "card",
+            "prefer": "default",
+            "orderby": "edhrec",
+            "direction": "asc",
+            "limit": 100,
+            "offset": 0,
+        }
+        total = engine.query(**kw)[0]
+        for _ in range(10):
+            engine.query(**kw)
+        n, t0 = 0, time.monotonic()
+        while time.monotonic() < t0 + args.window:
+            engine.query(**kw)
+            n += 1
+        return total, (time.monotonic() - t0) / n * 1000
+
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["label", "needle", "cmc_k", "domain", "total", "avg_ms"])
+        for needle in NEEDLES:
+            for k in CMC_STEPS:
+                domain, _ = run(f"cmc<={k}")
+                q = f"cmc<={k} -(oracle:{needle} or color:w)"
+                total, ms = run(q)
+                writer.writerow([args.label, needle, k, domain, total, f"{ms:.4f}"])
+                print(f"{args.label:<7} {needle:<11} cmc<={k} domain={domain:>6} {ms:7.3f} ms", flush=True)
+    print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -28,6 +28,14 @@ from api.parsing import parse_scryfall_query  # noqa: E402
 from client.query_runner import _DIM_NAMES, _DIM_VALUES, _DIM_WEIGHTS  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 
+# tix/eur are excluded from the survey (issue #638, priority low): they are not
+# part of our real search traffic, and they have no index, so they'd dominate
+# the tail with rows we've decided not to optimize. NOTE: changing this list
+# changes the seeded corpus — regenerate baselines when it changes.
+_EXCLUDED_DIMS = {"price_tix", "price_eur"}
+_DIM_WEIGHTS = [w for w, n in zip(_DIM_WEIGHTS, _DIM_NAMES) if n not in _EXCLUDED_DIMS]
+_DIM_NAMES = [n for n in _DIM_NAMES if n not in _EXCLUDED_DIMS]
+
 # Realistic parameter biases: UI default ordering dominates; unique matches
 # query_runner's 75/20/5 split.
 _ORDERBYS = ["edhrec"] * 55 + ["usd"] * 10 + ["cmc"] * 10 + ["rarity"] * 8 + ["cubecobra"] * 7 + ["power"] * 5 + ["toughness"] * 5

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -33,7 +33,7 @@ from scripts.bench_bitplanes import load_engine  # noqa: E402
 # the tail with rows we've decided not to optimize. NOTE: changing this list
 # changes the seeded corpus — regenerate baselines when it changes.
 _EXCLUDED_DIMS = {"price_tix", "price_eur"}
-_DIM_WEIGHTS = [w for w, n in zip(_DIM_WEIGHTS, _DIM_NAMES) if n not in _EXCLUDED_DIMS]
+_DIM_WEIGHTS = [w for w, n in zip(_DIM_WEIGHTS, _DIM_NAMES, strict=False) if n not in _EXCLUDED_DIMS]
 _DIM_NAMES = [n for n in _DIM_NAMES if n not in _EXCLUDED_DIMS]
 
 # Realistic parameter biases: UI default ordering dominates; unique matches


### PR DESCRIPTION
Stacked on #637 (adaptive candidate sets) — rebase onto main after #637 lands. Two changes: the two-tier name bigram index, and a measured cost-based gate for text-predicate memoization (see below).

## What this does

Trigram narrowing needs a 3-byte needle, so 2-character name searches — the typeahead shape, and **84 of 400 rows** in the realistic-traffic survey — full-scanned with per-card substring searches, and vetoed any Or containing one. They were the largest remaining tail cluster after #637.

For a 2-byte needle, **containment is bigram membership** — `name` contains "fi" ⟺ the bigram "fi" occurs in it — so a bigram index is not a prefilter but the exact answer. Its sets enter the #637 candidate algebra *tight* (Or-composable, Not-complementable) with no verification pass to pay, and `memoize_text_predicates` resolves 2-byte needles to exact `NameMatch` sets with zero `contains()` calls in the full-scan contexts an unindexable sibling still forces. A bigram absent from the index is an exact empty narrowing; 1-byte needles remain unindexed (rare, broad).

**Two-tier storage, split at a derived crossover.** A card bitplane costs `n_cards/8` bytes flat; a u16 posting list (card ids fit in u16) costs 2 bytes per entry — so a plane wins above ~2k entries (6.3% density) at production size. Measured on the corpus: 74 of 951 bigrams sit above the line, carrying 53% of the 472,865 posting entries. Dense bigrams ship as pre-built bitmaps (zero scatter when they enter an Or), sparse ones as u16 vecs. **Measured archive delta: +728 KB (0.95%)** against the 717 KB prediction. This is #630 phase 3's density-promotion rule with the threshold derived from a storage identity rather than tuned — the same split subtypes/keywords promotion will reuse.

Considered and rejected: a flavor-style fingerprint for names — fingerprints are prefilters for open needle vocabularies over documents too numerous to index exactly; here the needle space is closed (length-2), the index is 1% of the archive, and the posting list is already the exact answer, so a signature scan would be strictly slower machinery.

## The memoization gate, re-derived from measurement

While probing survey noise we found `id:gw -(oracle:trample or color:w)` running 12.5k per-card substring searches while sitting just *under* the #635 memoize trigger (candidates > half the corpus). The crossover was then measured directly (`scripts/bench_memo_crossover.py`): memoize-always vs memoize-never builds over a fabricated `cmc<=K -(oracle:NEEDLE or color:w)` grid — K dials the candidate domain through the cmc index, the needle dials the bind cost (six needles spanning 493–11,933 candidate texts). Result: **bind cost breaks even when the evaluation domain reaches ~1.25× the needle's shortest trigram posting list**, linearly across the whole breadth range — nowhere near half the corpus.

The trigger is now per-node and cost-based: memoize iff `eval_domain ≥ max(2 × bind_bound, noise floor)`, factor 2 over the measured 1.25 per the usual decline-early asymmetry. The motivating query drops **0.65 → 0.34 ms**; selective controls are unchanged.

## Measured (stacked base #637 vs branch tip, 400-query seeded survey, matched corpus, 0.5 s timed window per config)

Totals identical on all 400 configs. tix/eur fragments are excluded from the survey as of this branch (#638, priority low).

| percentile | base (#637) | branch | |
|---|---|---|---|
| p50 | 0.091 ms | **0.088 ms** | 1.03× |
| p75 | 0.191 ms | **0.142 ms** | 1.35× |
| p90 | 0.603 ms | **0.273 ms** | **2.21×** |
| p95 | 0.886 ms | **0.354 ms** | **2.50×** |
| p99 | 1.194 ms | **0.844 ms** | 1.41× |
| max | 1.863 ms | **0.980 ms** | 1.90× |

All-400 geomean **1.22×**; over the 84 rows with a 2-char name fragment, **2.54×**; 68 queries >1.15× faster, 6 slower.

| top improvements | base | branch | speedup |
|---|---|---|---|
| `is:commander name:fi` | 0.880 ms | **0.046 ms** | **19.1×** |
| `(name:fo is:historic) or (color:u id:rg)` | 1.194 ms | **0.099 ms** | **12.1×** |
| `(name:da name:fo) or (color:w type:sorcery)` | 1.185 ms | **0.101 ms** | **11.7×** |
| `name:fi or name:dr` | 1.635 ms | **0.142 ms** | **11.5×** |
| `color:br or name:fo` | 0.941 ms | **0.091 ms** | **10.3×** |
| `color:gw or name:fo` | 0.927 ms | **0.090 ms** | **10.3×** |
| `-set:m21 name:da` | 1.067 ms | **0.106 ms** | **10.1×** |
| `name:da` | 0.819 ms | **0.084 ms** | **9.8×** |
| `type:elf or name:bo` | 1.005 ms | **0.105 ms** | **9.6×** |
| `name:fo` | 0.872 ms | **0.092 ms** | **9.5×** |

| every remaining regression | base | branch | slowdown | absolute |
|---|---|---|---|---|
| `name:fi type:vampire type:planeswalker` | 0.011 ms | 0.015 ms | 1.30× | +3 µs |
| `artist:foglio oracle:counter` | 0.159 ms | 0.198 ms | 1.25× | +39 µs |
| `id:ub type:planeswalker` | 0.060 ms | 0.073 ms | 1.22× | +13 µs |
| `tou=0 color:ub id:r` | 0.015 ms | 0.017 ms | 1.20× | +3 µs |
| `name:path type:merfolk` | 0.011 ms | 0.013 ms | 1.18× | +2 µs |
| `tou=0 type:wizard name:bo year:2019` | 0.015 ms | 0.018 ms | 1.18× | +3 µs |

The cumulative picture across the stack: main sat at p90 0.862 / p99 1.454 before #637; this branch tip is at **p90 0.273 / p99 0.844**.

## Tests

`cargo test`: 46 passed — tier assignment at the (store-size-scaled) crossover, exactness on both tiers against brute-force `contains()`, absent-bigram exact-empty, 1-char unindexable, Or composition (`name:fi or name:dr`), negation parity through `run_query`, and the memoize rewrite producing verified-free `NameMatch` sets. Three pre-existing tests that used `name:da` as their "unindexable" example now use 1-char needles — the feature made the old examples indexable. Python: 1,868 unit + 15 integration passed.
