### PR TITLE
Prove Empty Sets for Absent Tags and Guard Broad Tag Postings

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2092,19 +2092,46 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
         }
 
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge) => {
-            let (idx, card_space) = match field {
-                CollField::Subtypes   => (&indexes.subtypes,    true),
-                CollField::Keywords   => (&indexes.keywords,    true),
-                CollField::OracleTags => (&indexes.oracle_tags, true),
-                CollField::ArtTags    => (&indexes.art_tags,    false),
-                CollField::IsTags     => (&indexes.is_tags,     false),
-                CollField::FrameData  => (&indexes.frame_data,  false),
+            // `complete` marks indexes that post every occurrence of every
+            // value — all of them except frame_data, whose dense values are
+            // deliberately dropped at build (#628), so absence proves nothing
+            // there.
+            let (idx, card_space, complete) = match field {
+                CollField::Subtypes   => (&indexes.subtypes,    true,  true),
+                CollField::Keywords   => (&indexes.keywords,    true,  true),
+                CollField::OracleTags => (&indexes.oracle_tags, true,  true),
+                CollField::ArtTags    => (&indexes.art_tags,    false, true),
+                CollField::IsTags     => (&indexes.is_tags,     false, true),
+                CollField::FrameData  => (&indexes.frame_data,  false, false),
             };
-            // Ge is containment: every posted row carries the tag — tight.
-            idx.get(value.as_str()).and_then(|v| {
-                let ids: Vec<u32> = v.iter().map(|x| u32::from(*x)).collect();
-                Narrowed::tight(if card_space { Candidates::Cards(ids) } else { Candidates::Printings(ids) })
-            })
+            match idx.get(value.as_str()) {
+                // Ge is containment, so a value with no postings in a complete
+                // index matches no row: an exact empty narrowing, not "cannot
+                // narrow" — `is:permanent` spent 0.6 ms full-scanning to
+                // return zero results.
+                None if complete => {
+                    Narrowed::tight(if card_space { Candidates::Cards(Vec::new()) } else { Candidates::Printings(Vec::new()) })
+                }
+                None => None,
+                Some(v) => {
+                    // Broad printing-space postings pay the same gather cost
+                    // the range indexes guard against (is:spell is ~60k ids);
+                    // past the fraction they scatter to a bitmap when
+                    // something will consume it and decline otherwise. Every
+                    // posted row carries the tag, so both paths stay tight.
+                    // Card-space lists need no guard — same argument as
+                    // numeric_candidates.
+                    if !card_space && range_too_broad_to_narrow(v.len(), n_printings) {
+                        if !broad_ok {
+                            return None;
+                        }
+                        let bits = scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings);
+                        return Narrowed::tight(Candidates::PrintingBits(bits));
+                    }
+                    let ids: Vec<u32> = v.iter().map(|x| u32::from(*x)).collect();
+                    Narrowed::tight(if card_space { Candidates::Cards(ids) } else { Candidates::Printings(ids) })
+                }
+            }
         }
 
         FilterExpr::ArtistMatch { ids } => {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -265,8 +265,15 @@ fn narrow_candidates_spaces() {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("keyword must narrow in card space"),
     }
-    // A tag not in the index cannot narrow; the eval step handles correctness.
-    assert!(narrow_candidates(&coll(CollField::ArtTags, "zombie"), archived, offsets).is_none());
+    // A tag with no postings in a complete index proves the empty set (an
+    // unbound value_id matches nothing at eval either).
+    match narrow_candidates(&coll(CollField::ArtTags, "zombie"), archived, offsets) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent tag narrows to the exact empty set"),
+        _ => panic!("absent tag must narrow to empty, not decline"),
+    }
+    // frame_data is selectivity-thresholded (#628): dense values are absent by
+    // design, so absence proves nothing and it must keep declining.
+    assert!(narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets).is_none());
 
     // And of mixed spaces projects the printing product up and intersects in
     // card space: art printings {0,2} → cards {0,1}, ∩ keyword cards {1} = {1}.
@@ -1967,4 +1974,43 @@ fn name_bigrams_compose_and_memoize() {
         let want = card.card_name_lower.as_str().contains("fi");
         assert!((f.eval_card(card, &archived.strings) == Tri::True) == want, "NameMatch parity at card {cid}");
     }
+}
+
+// Broad printing-space tag postings behave like broad ranges (#640): scatter
+// to a tight bitmap when a consumer exists (broad_ok), decline otherwise —
+// never gather tens of thousands of ids raw. Sparse tags keep the vec path.
+#[test]
+fn broad_tag_postings_scatter_or_decline() {
+    let mut vocab = VocabInterner::new();
+    let spell = vocab.intern("spell".to_string()).unwrap();
+    let rare_tag = vocab.intern("etched".to_string()).unwrap();
+    let cards: Vec<OracleCard> = (0..1200u32).map(|i| stub_card(u128::from(i) + 1, TYPE_CREATURE, &[], &mut vocab)).collect();
+    let mut data = store_of(cards, &vec![4usize; 1200], vocab); // 4,800 printings
+    for (i, p) in data.printings.iter_mut().enumerate() {
+        // "spell" on half of all printings (2,400 = 50% > MAX_NARROW_FRACTION);
+        // "etched" on 1 in 100 (48, sparse).
+        if i % 2 == 0 { p.card_is_tags.push(spell); }
+        if i % 100 == 0 { p.card_is_tags.push(rare_tag); }
+    }
+    data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let tag = |v: &str| FilterExpr::CollectionCmp { field: CollField::IsTags, op: CmpOp::Ge, value: v.into(), value_id: None };
+    let rec = |f: &FilterExpr, broad_ok: bool| super::narrow_rec(f, &archived.indexes, &archived.offsets, broad_ok);
+
+    // Broad tag: bitmap under broad_ok, decline without.
+    assert!(rec(&tag("spell"), false).is_none(), "broad tag without a consumer reverts to the scan");
+    let n = rec(&tag("spell"), true).expect("broad tag scatters for a consumer");
+    assert!(n.tight, "every posted printing carries the tag");
+    match &n.set {
+        Candidates::PrintingBits(b) => assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 2400),
+        _ => panic!("broad tag must be a bitmap"),
+    }
+    // Sparse tag: vec either way.
+    let n = rec(&tag("etched"), false).expect("sparse tag narrows in any context");
+    assert!(matches!(n.set, Candidates::Printings(ref v) if v.len() == 48));
+    // Absent tag: exact empty.
+    let n = rec(&tag("foil"), false).expect("absent tag proves the empty set");
+    assert_eq!(n.set.len(), 0);
 }


### PR DESCRIPTION
Stacked on #639 (short-name bigrams), which stacks on #637 — rebase down the chain as each lands. Two fixes to `CollectionCmp` narrowing, from the post-#639 slow-tail review.

## 1. Absent tags prove the empty set

`Ge` is containment and every tag index except `frame_data` posts every occurrence, so a value with no postings matches no row — and evaluation agrees, since an unbound `value_id` matches nothing. The arm previously returned "cannot narrow," so **`is:permanent` spent 0.605 ms full-scanning 97k printings to return zero results; it now answers in 3 µs** (201×). `frame_data` keeps declining on absence: its dense values are deliberately dropped at build (#628), so absence proves nothing there.

## 2. Broad tag postings behave like broad ranges

The arm had no selectivity guard, so a dense printing-space tag would gather tens of thousands of ids raw — the exact cost `MAX_NARROW_FRACTION` protects the range indexes from. Past the fraction, tag postings now scatter to a **tight** bitmap when a consumer exists (`broad_ok`: Or-union, Not-complement, printing-space And partner) and decline otherwise. Card-space lists stay unguarded, same argument as `numeric_candidates`.

Honest scoping note: in the current corpus, the headline `is:` values (`spell`, `permanent`, `token`, `historic`, `commander`) turn out to have **no postings at all** — so fix 1 does the measured heavy lifting and fix 2 is insurance with synthetic-fixture coverage. The vocabulary mismatch between the query runner's `is:` fragments and the data's actual `card_is_tags` values may deserve its own data ticket (Scryfall computes several of these as derived properties).

## Measured (stack tip #639 vs branch, 400-query seeded survey, 0.5 s windows, totals identical on all 400)

| percentile | base | branch | |
|---|---|---|---|
| p50 | 0.088 ms | **0.083 ms** | 1.06× |
| p75 | 0.142 ms | **0.133 ms** | 1.07× |
| p90 | 0.273 ms | **0.243 ms** | 1.12× |
| p95 | 0.354 ms | **0.330 ms** | 1.07× |
| p99 | 0.844 ms | **0.769 ms** | 1.10× |

Geomean over the 15 `is:`-containing rows: **5.31×**. Highlights:

| query | base | branch | speedup |
|---|---|---|---|
| `is:permanent` | 0.605 ms | **0.003 ms** | **202×** |
| `is:historic year:2024` | 0.287 ms | **0.006 ms** | **51×** |
| `type:planeswalker or is:spell` | 0.786 ms | **0.071 ms** | **11.1×** |
| `name:fo or is:token` | 0.844 ms | **0.084 ms** | **10.1×** |
| `id:wu or is:permanent` | 0.732 ms | **0.128 ms** | **5.7×** |

Three rows measure >1.15× slower, all on paths this diff doesn't touch and inside the noise band (worst +71 µs).

## Tests

`cargo test`: 47 passed — absent-tag exact-empty (and `frame_data` still declining), broad-tag scatter/decline per `broad_ok` with tightness, sparse tags unchanged, plus the updated `narrow_candidates_spaces` expectations. Python: 1,868 unit passed.
