### PR TITLE
Delete Landed Branches Daily Instead of on Merge

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -12,7 +12,7 @@ name: Branch Cleanup
 
 on:
   schedule:
-    - cron: "17 6 * * 1" # weekly, Monday 06:17 UTC
+    - cron: "17 6 * * *" # daily, 06:17 UTC — the 3-day grace period is the safety margin; frequency just bounds cleanup latency
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,54 @@
+name: Branch Cleanup
+
+# Deletes remote branches whose work has landed. The repo squash-merges, so
+# "0 commits ahead" can never identify a landed branch (the squash is a new
+# commit and the branch's commits are never ancestors of main) — PR state is
+# the source of truth instead: a branch is deletable iff it is the head of a
+# merged PR, is not the head or base of any open PR (stacked PRs keep their
+# parents alive), and its PR merged more than three days ago (grace period so
+# an in-flight stack is never yanked mid-train). Replaces the repo's
+# delete-branch-on-merge setting, which closed stacked dependent PRs when a
+# parent landed.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1" # weekly, Monday 06:17 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const graceMs = 3 * 24 * 60 * 60 * 1000;
+
+            const openPrs = await github.paginate(github.rest.pulls.list, { owner, repo, state: "open", per_page: 100 });
+            const inUse = new Set();
+            for (const pr of openPrs) {
+              inUse.add(pr.head.ref);
+              inUse.add(pr.base.ref);
+            }
+
+            const branches = await github.paginate(github.rest.repos.listBranches, { owner, repo, per_page: 100 });
+            for (const branch of branches) {
+              const name = branch.name;
+              if (name === "main" || branch.protected || inUse.has(name)) continue;
+
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: "closed", head: `${owner}:${name}`, per_page: 100,
+              });
+              const merged = prs.filter((p) => p.merged_at !== null);
+              if (merged.length === 0) continue; // never merged: not ours to judge
+              const newest = Math.max(...merged.map((p) => Date.parse(p.merged_at)));
+              if (Date.now() - newest < graceMs) continue;
+
+              core.info(`deleting ${name} (merged PR #${merged.map((p) => p.number).join(", #")})`);
+              await github.rest.git.deleteRef({ owner, repo, ref: `heads/${name}` });
+            }


### PR DESCRIPTION
Companion to turning off the repo's **delete branch on merge** setting (done — it was what closed stacked dependent PRs the moment a parent landed during today's merge train; reopening required restoring both the old base branch and the old head SHA).

## Why not "0 commits ahead"

The repo squash-merges, so a landed branch's commits are never ancestors of main — ancestry-based cleanup (`git branch --merged`, ahead/behind counts) would never match anything. PR state is the source of truth the workflow actually maintains.

## The rule

Daily (plus manual dispatch), delete a branch iff **all** of:
- it is the head of a **merged** PR,
- it is **not** the head or base of any **open** PR (keeps stacked parents alive),
- the newest merged PR on it landed **more than 3 days ago** (the grace period is the safety margin; run frequency just bounds cleanup latency).

Branches with no merged PR are never touched — abandoned experiments are a human decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)