### PR TITLE
Evaluate Devotion via Bit-Sliced Planes and Drop the Dead Type Postings

### DIFF
--- a/api/tests/test_engine_property.py
+++ b/api/tests/test_engine_property.py
@@ -90,6 +90,13 @@ FRAGMENTS = [
     "o:destroy",
     "o:flying",
     "o:xy",
+    # devotion: exact depths, the saturation boundary, Eq, and negation
+    "devotion:u",
+    "devotion:uu",
+    "devotion:uuu",
+    "devotion:uuuu",
+    "devotion=gg",
+    "-devotion:rr",
 ]
 
 
@@ -112,8 +119,22 @@ def _make_cards(rng: random.Random) -> list[dict[str, Any]]:
         # keywords are JSONB objects (the loader reads dict KEYS), types and
         # subtypes are capitalized lists (the parser capitalizes query values).
         # UUIDs start at 1 — the all-zero UUID is the loader's null sentinel.
+        # mana cost: sym -> positional array (count = len), ~10% hybrid pips
+        pips: dict[str, int] = {}
+        if "Land" not in types:
+            for c in colors:
+                pips[c] = rng.choice([1, 1, 2, 2, 3, 4])
+            if rng.random() < 0.1 and len(colors) >= 1:
+                other = rng.choice([x for x in "WUBRG" if x != colors[0]] or ["C"])
+                pips[f"{colors[0]}/{other}"] = rng.choice([1, 2])
+        pos = 1
+        mana_cost_jsonb: dict[str, list[int]] = {}
+        for sym, n in pips.items():
+            mana_cost_jsonb[sym] = list(range(pos, pos + n))
+            pos += n
         card = {
             "oracle_id": f"00000000-0000-0000-0000-{i + 1:012d}",
+            "mana_cost_jsonb": mana_cost_jsonb,
             "card_name": name,
             "oracle_text": oracle,
             "card_colors": dict.fromkeys(colors, True),
@@ -185,6 +206,21 @@ def _ref_leaf(frag: str, card: dict[str, Any]) -> bool | None:  # noqa: PLR0911,
             return year == int(rest)
         m = _split_num(frag, "year")
         return _tri_cmp(year, *m)
+    if frag.startswith(("devotion:", "devotion=")):
+        op = frag[len("devotion")]
+        counts: dict[str, int] = {}
+        for sym, positions in card["mana_cost_jsonb"].items():
+            for part in sym.split("/"):
+                if part in "WUBRGC":
+                    counts[part] = counts.get(part, 0) + len(positions)
+        want: dict[str, int] = {}
+        for ch in frag[len("devotion") + 1 :]:
+            want[ch.upper()] = want.get(ch.upper(), 0) + 1
+        ge = all(counts.get(c, 0) >= k for c, k in want.items())
+        if op == ":":
+            return ge
+        # "=": exact per-color counts AND no devotion outside the queried colors
+        return all(counts.get(c, 0) == k for c, k in want.items()) and all(c in want for c, n in counts.items() if n > 0)
     if field == "name":
         return rest in card["card_name"].lower()
     if field == "o":

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1465,25 +1465,6 @@ fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printi
     Narrowed::loose(Candidates::PrintingBits(bits))
 }
 
-// ─── Type bit index ───────────────────────────────────────────────────────────
-// One sorted Vec<u32> per type bit (14 bits, matching the TYPE_* constants).
-// Bit position N corresponds to TYPE_* = 1 << N.
-
-type TypeIndex = [Vec<u32>; 14];
-
-fn build_type_index(cards: &[OracleCard]) -> TypeIndex {
-    let mut idx: TypeIndex = Default::default();
-    for (i, card) in cards.iter().enumerate() {
-        let mut bits = card.card_types;
-        while bits != 0 {
-            let bit = bits.trailing_zeros() as usize;
-            idx[bit].push(i as u32);
-            bits &= bits - 1;
-        }
-    }
-    idx // lists are sorted: cards iterated in ascending index order
-}
-
 // ─── Rarity index ────────────────────────────────────────────────────────────
 // rarity int (0-5) -> sorted card ids with at least one printing at that
 // rarity. A card printed at several rarities appears in each of its lists
@@ -1575,7 +1556,6 @@ struct CardIndexes {
     cmc:            NumericIndex,    // card space
     power:          NumericIndex,    // card space
     toughness:      NumericIndex,    // card space
-    type_bits:      TypeIndex,       // card space
     rarity:         RarityIndex,     // card space (any-printing-at-rarity)
     subtypes:       TagIndex,        // card space
     keywords:       TagIndex,        // card space
@@ -1603,7 +1583,6 @@ impl Default for CardIndexes {
             cmc:            Vec::new(),
             power:          Vec::new(),
             toughness:      Vec::new(),
-            type_bits:      Default::default(),
             rarity:         Default::default(),
             subtypes:       HashMap::new(),
             keywords:       HashMap::new(),
@@ -2089,6 +2068,20 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
                 (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => cn(flip_op(*op), v),
                 _ => None,
             }
+        }
+
+        FilterExpr::Devotion { op: CmpOp::Ge | CmpOp::Gt, pips } => {
+            // The exact compiler (plane arm above) declined: some queried
+            // count exceeds the 2-bit saturation. The saturated bucket is a
+            // superset of every deeper match — ~0.5% of cards per color — so
+            // it narrows loosely and the driver verifies the real counts.
+            if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
+                return None;
+            }
+            let pe = compile_devotion_superset(pips)?;
+            let mut bits: Vec<u64> = Vec::new();
+            eval_planes(&pe, &indexes.planes, &mut bits);
+            Narrowed::loose(Candidates::CardBits(bits))
         }
 
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge) => {
@@ -2987,7 +2980,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260716;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260717;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -3352,7 +3345,6 @@ impl QueryEngine {
             cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
             toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
-            type_bits:      build_type_index(&cards),
             rarity:         build_rarity_index(&printings, &offsets),
             subtypes:       build_tag_index(&cards, &coll_vocab, |c| &c.card_subtypes),
             keywords:       build_tag_index(&cards, &coll_vocab, |c| &c.card_keywords),

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -7,10 +7,11 @@
 //! cache line per card) the driver loop pays to prove the same bits one card
 //! at a time.
 //!
-//! Phase 1 covers the exactly-consumable dimensions: colors, color identity,
-//! and the card type bits. All three are card-level and two-valued (their
-//! tri() never returns Null or PrintingDep), so plane algebra — including
-//! complement for Not — reproduces the filter's card-level truth exactly.
+//! The exactly-consumable dimensions: colors, color identity, the card type
+//! bits, and (bit-sliced, two saturating bits per color) devotion counts. All
+//! are card-level and two-valued (their tri() never returns Null or
+//! PrintingDep), so plane algebra — including complement for Not —
+//! reproduces the filter's card-level truth exactly.
 //! Produced mana is deliberately left out for now; `produces:` queries stay on
 //! the residual path. Rarity and legality need the narrowing/divergence
 //! machinery from later phases (see the issue).
@@ -29,7 +30,14 @@ const TYPE_PLANES: usize = 14;
 const PLANE_COLORS: usize = 0;
 const PLANE_IDENTITY: usize = COLOR_PLANES;
 const PLANE_TYPES: usize = 2 * COLOR_PLANES;
-pub(crate) const PLANE_COUNT: usize = PLANE_TYPES + TYPE_PLANES;
+/// Devotion is bit-sliced: two saturating bits per color (count clamped to
+/// 0..=3), so `devotion:uu` is one plane read and `devotion:uuu` is exactly
+/// the saturated bucket. Counts come from the same hybrid-expanded map the
+/// evaluator uses; the ~0.5% of cards at 3+ per color are the verification
+/// set for deeper queries (see the saturated-superset arm in narrow_rec).
+const PLANE_DEVOTION: usize = PLANE_TYPES + TYPE_PLANES;
+const DEVOTION_BITS: usize = 2;
+pub(crate) const PLANE_COUNT: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLANES;
 
 #[derive(Archive, Serialize, Deserialize, Default)]
 pub(crate) struct BitPlanes {
@@ -42,6 +50,16 @@ pub(crate) struct BitPlanes {
 pub(crate) fn words_per_plane(n_cards: usize) -> usize {
     n_cards.div_ceil(64)
 }
+
+/// A card's effective per-color devotion count, saturated to 0..=3 —
+/// exactly the map FilterExpr::Devotion evaluates (hybrid-expanded when
+/// hybrids are present, raw pips otherwise).
+fn devotion_count(card: &OracleCard, sym: &str) -> u8 {
+    let map = card.mana_cost.devotion.as_ref().unwrap_or(&card.mana_cost.pips);
+    map.get(sym).copied().unwrap_or(0).min(3)
+}
+
+const DEVOTION_SYMS: [&str; COLOR_PLANES] = ["W", "U", "B", "R", "G", "C"];
 
 pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
     let wpp = words_per_plane(cards.len());
@@ -60,6 +78,23 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
         while bits != 0 {
             set(PLANE_TYPES + bits.trailing_zeros() as usize);
             bits &= bits - 1;
+        }
+        for (b, sym) in DEVOTION_SYMS.iter().enumerate() {
+            let count = devotion_count(card, sym);
+            if count & 1 != 0 {
+                set(PLANE_DEVOTION + DEVOTION_BITS * b);
+            }
+            if count & 2 != 0 {
+                set(PLANE_DEVOTION + DEVOTION_BITS * b + 1);
+            }
+            // Data-integrity tripwire (verified corpus-wide 2026-07-08, zero
+            // violations): cost symbols feed color identity by rule, so
+            // colored devotion without the identity bit means a loading bug.
+            // C is exempt — {C} pips never join identity.
+            debug_assert!(
+                count == 0 || b == 5 || card.card_color_identity & (1 << b) != 0,
+                "devotion without identity: card {i} color {sym}"
+            );
         }
     }
     BitPlanes { n_cards: cards.len() as u32, words }
@@ -139,6 +174,83 @@ fn cmp_expr(base: usize, width: usize, mask: u16, op: CmpOp, ge_any: bool) -> Pl
     }
 }
 
+/// One color's devotion-count comparison over its two saturating bit-slices.
+/// Exactness boundaries: `>= k` is exact through k = 3 (the saturated value 3
+/// MEANS >= 3), `== k` and `<= k` through k = 2 (value 3 is a bucket, not a
+/// count). None past the boundary.
+fn dev_ge(color: usize, k: u8) -> Option<PlaneExpr> {
+    let b0 = || PlaneExpr::Plane((PLANE_DEVOTION + DEVOTION_BITS * color) as u16);
+    let b1 = || PlaneExpr::Plane((PLANE_DEVOTION + DEVOTION_BITS * color + 1) as u16);
+    match k {
+        0 => Some(PlaneExpr::Const(true)),
+        1 => Some(or_of(vec![b0(), b1()])),
+        2 => Some(b1()),
+        3 => Some(and_of(vec![b0(), b1()])),
+        _ => None,
+    }
+}
+
+fn dev_eq(color: usize, k: u8) -> Option<PlaneExpr> {
+    let b0 = || PlaneExpr::Plane((PLANE_DEVOTION + DEVOTION_BITS * color) as u16);
+    let b1 = || PlaneExpr::Plane((PLANE_DEVOTION + DEVOTION_BITS * color + 1) as u16);
+    match k {
+        0 => Some(PlaneExpr::Not(Box::new(or_of(vec![b0(), b1()])))),
+        1 => Some(and_of(vec![b0(), PlaneExpr::Not(Box::new(b1()))])),
+        2 => Some(and_of(vec![b1(), PlaneExpr::Not(Box::new(b0()))])),
+        _ => None,
+    }
+}
+
+fn dev_le(color: usize, k: u8) -> Option<PlaneExpr> {
+    // count <= k  ⟺  not (count >= k + 1); k <= 2 keeps >= k+1 exact.
+    if k > 2 {
+        return None;
+    }
+    dev_ge(color, k + 1).map(|ge| PlaneExpr::Not(Box::new(ge)))
+}
+
+fn devotion_color(sym: &str) -> Option<usize> {
+    DEVOTION_SYMS.iter().position(|s| *s == sym)
+}
+
+/// Compile a Devotion node exactly, mirroring FilterExpr::Devotion's tri():
+/// Ge constrains only the queried colors; Le/Eq additionally pin every
+/// unqueried color to zero (SQL devotion-column containment semantics).
+/// None whenever any needed comparison crosses the saturation boundary.
+fn compile_devotion(op: CmpOp, pips: &std::collections::HashMap<String, u8>) -> Option<PlaneExpr> {
+    let query: Vec<(usize, u8)> = pips
+        .iter()
+        .map(|(sym, &k)| devotion_color(sym).map(|c| (c, k)))
+        .collect::<Option<Vec<_>>>()?;
+    let ge = || query.iter().map(|&(c, k)| dev_ge(c, k)).collect::<Option<Vec<_>>>().map(and_of);
+    let all_colors = |f: &dyn Fn(usize, u8) -> Option<PlaneExpr>| {
+        (0..COLOR_PLANES)
+            .map(|c| f(c, query.iter().find(|&&(qc, _)| qc == c).map_or(0, |&(_, k)| k)))
+            .collect::<Option<Vec<_>>>()
+            .map(and_of)
+    };
+    let eq = || all_colors(&dev_eq);
+    match op {
+        CmpOp::Ge => ge(),
+        CmpOp::Le => all_colors(&dev_le),
+        CmpOp::Eq => eq(),
+        CmpOp::Ne => eq().map(|e| PlaneExpr::Not(Box::new(e))),
+        CmpOp::Gt => Some(and_of(vec![ge()?, PlaneExpr::Not(Box::new(eq()?))])),
+        CmpOp::Lt => Some(and_of(vec![all_colors(&dev_le)?, PlaneExpr::Not(Box::new(eq()?))])),
+    }
+}
+
+/// Saturated superset for devotion comparisons the exact compiler declines
+/// (Ge/Gt past the boundary): clamp each queried count to 3. Every real match
+/// has count >= k >= 3 per queried color, so it lands in the saturated bucket
+/// — a loose candidate set for the driver to verify (~0.5% of cards/color).
+pub(crate) fn compile_devotion_superset(pips: &std::collections::HashMap<String, u8>) -> Option<PlaneExpr> {
+    pips.iter()
+        .map(|(sym, &k)| devotion_color(sym).and_then(|c| dev_ge(c, k.min(3))))
+        .collect::<Option<Vec<_>>>()
+        .map(and_of)
+}
+
 /// Compile a filter subtree to a plane expression, or None if any node in it
 /// is not plane-expressible. Only two-valued card-level nodes may compile:
 /// complement (Not) is only sound when the node can never be Null or
@@ -177,6 +289,9 @@ pub(crate) fn compile_plane(filter: &FilterExpr) -> Option<PlaneExpr> {
             }
             Some(cmp_expr(PLANE_TYPES, TYPE_PLANES, *mask, *op, true))
         }
+        // Devotion is card-level and two-valued (tri_bool always), so its
+        // bit-sliced planes compile exactly within the saturation boundary.
+        FilterExpr::Devotion { op, pips } => compile_devotion(*op, pips),
         _ => None,
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_type_index, build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     build_artwork_group_counts, build_bit_planes, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
@@ -212,11 +212,9 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         }
         offsets.push(printings.len() as u32);
     }
-    // Real type index so TypeCmp narrowing sees the cards (an empty Default
-    // index would narrow every type query to zero candidates), and real planes
-    // so plane-path tests see the same store shape reload_commit builds.
+    // Real planes and bigrams so narrowing tests see the same store shape
+    // reload_commit builds (type narrowing goes through the planes since #637).
     let indexes = CardIndexes {
-        type_bits: build_type_index(&cards),
         planes: build_bit_planes(&cards),
         name_bigrams: build_name_bigram_index(&cards),
         ..Default::default()
@@ -648,7 +646,6 @@ fn bench_checked_vs_unchecked_access() {
         cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
         power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
         toughness:      build_numeric_index(&cards, |c| c.creature_toughness.map(|v| v as i16)),
-        type_bits:      build_type_index(&cards),
         rarity:         build_rarity_index(&printings, &offsets),
         subtypes:       build_tag_index(&cards, &vocab.strings, |c| &c.card_subtypes),
         keywords:       build_tag_index(&cards, &vocab.strings, |c| &c.card_keywords),
@@ -2013,4 +2010,120 @@ fn broad_tag_postings_scatter_or_decline() {
     // Absent tag: exact empty.
     let n = rec(&tag("foil"), false).expect("absent tag proves the empty set");
     assert_eq!(n.set.len(), 0);
+}
+
+// ─── Devotion bit-sliced planes ───────────────────────────────────────────────
+
+/// Cards with controlled mana costs, hybrids included. A {R/G} pip counts
+/// toward BOTH red and green devotion (the loader's hybrid expansion), which
+/// the planes must reproduce.
+fn devotion_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let costs: &[(&[(&str, u8)], bool)] = &[
+        (&[], false),                       // no cost
+        (&[("U", 1)], false),               // {U}
+        (&[("U", 2)], false),               // {U}{U}
+        (&[("U", 3)], false),               // {U}{U}{U}
+        (&[("U", 5)], false),               // deep: saturates
+        (&[("R/G", 1)], true),              // {R/G}: 1 red AND 1 green
+        (&[("R/G", 2), ("R", 1)], true),    // {R/G}{R/G}{R}: R=3, G=2
+        (&[("W", 1), ("U", 1)], false),     // {W}{U}
+        (&[("C", 2)], false),               // {C}{C}: colorless devotion
+    ];
+    let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &(pips, hybrid))| {
+        let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+        let pip_map: HashMap<String, u8> = pips.iter().map(|&(s, n)| (s.to_string(), n)).collect();
+        let devotion = if hybrid {
+            let mut d: HashMap<String, u8> = HashMap::new();
+            for (sym, &n) in &pip_map {
+                if sym.contains('/') {
+                    for part in sym.split('/') {
+                        *d.entry(part.to_string()).or_insert(0) += n;
+                    }
+                } else {
+                    *d.entry(sym.clone()).or_insert(0) += n;
+                }
+            }
+            Some(d)
+        } else {
+            None
+        };
+        // identity must cover devotion colors (the build tripwire enforces it)
+        let mut ident = 0u8;
+        for sym in ["W", "U", "B", "R", "G"] {
+            let m = devotion.as_ref().unwrap_or(&pip_map);
+            if m.get(sym).copied().unwrap_or(0) > 0 {
+                ident |= super::color_list_to_mask(&[sym]);
+            }
+        }
+        c.card_color_identity = ident;
+        c.mana_cost = ManaCost { pips: pip_map, devotion, cmc: 0.0 };
+        c
+    }).collect();
+    store_of(cards, &[1usize; 9], vocab)
+}
+
+// Every devotion op agrees with tri() through the planes, at every saturation
+// depth — and past the boundary the compiler declines rather than guesses.
+#[test]
+fn devotion_plane_parity_and_boundaries() {
+    let data = devotion_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let dev = |op, pips: &[(&str, u8)]| FilterExpr::Devotion {
+        op,
+        pips: pips.iter().map(|&(s, n)| (s.to_string(), n)).collect(),
+    };
+    let mut bitmap: Vec<u64> = Vec::new();
+    let mut check_exact = |f: &FilterExpr| {
+        let pe = compile_plane(f).expect("must compile exactly");
+        eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
+        for (cid, card) in archived.cards.iter().enumerate() {
+            let want = f.eval_card(card, &archived.strings) == Tri::True;
+            assert_eq!(bitmap_contains(&bitmap, cid as u32), want, "devotion parity at card {cid}");
+        }
+    };
+    for op in [CmpOp::Ge, CmpOp::Eq, CmpOp::Le, CmpOp::Ne, CmpOp::Gt, CmpOp::Lt] {
+        for k in 1..=2u8 {
+            check_exact(&dev(op, &[("U", k)]));
+        }
+    }
+    check_exact(&dev(CmpOp::Ge, &[("U", 3)])); // saturated value 3 means >= 3: exact
+    check_exact(&dev(CmpOp::Ge, &[("R", 1), ("G", 1)])); // multi-color, hybrid cards in play
+    check_exact(&dev(CmpOp::Ge, &[("C", 2)])); // colorless devotion
+    check_exact(&dev(CmpOp::Ge, &[("R", 3)])); // {R/G}{R/G}{R} card reaches R=3
+
+    // Past the saturation boundary the exact compiler declines...
+    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)])).is_none());
+    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)])).is_none());
+    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)])).is_none());
+    // ...and the saturated superset covers every deep match for narrowing.
+    let deep = dev(CmpOp::Ge, &[("U", 5)]);
+    let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, false).expect("deep-k narrows loosely");
+    assert!(!n.tight);
+    let cand = n.set.into_cards(&archived.offsets);
+    for (cid, card) in archived.cards.iter().enumerate() {
+        if deep.eval_card(card, &archived.strings) == Tri::True {
+            assert!(cand.contains(&(cid as u32)), "superset must cover card {cid}");
+        }
+    }
+}
+
+// The user-specified hybrid invariant, pinned: a card costing {R/G} has one
+// red devotion AND one green devotion.
+#[test]
+fn hybrid_pip_counts_toward_both_colors() {
+    let data = devotion_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let dev = |sym: &str, k: u8| FilterExpr::Devotion {
+        op: CmpOp::Ge,
+        pips: std::iter::once((sym.to_string(), k)).collect(),
+    };
+    let mut bitmap: Vec<u64> = Vec::new();
+    let rg_card = 5; // {R/G}
+    for (f, want) in [(dev("R", 1), true), (dev("G", 1), true), (dev("R", 2), false), (dev("U", 1), false)] {
+        eval_planes(&compile_plane(&f).unwrap(), &archived.indexes.planes, &mut bitmap);
+        assert_eq!(bitmap_contains(&bitmap, rg_card), want);
+    }
 }

--- a/scripts/bench_devotion.py
+++ b/scripts/bench_devotion.py
@@ -1,0 +1,90 @@
+"""Engine-vs-engine benchmark for devotion bit-sliced planes + TypeIndex removal.
+
+Same protocol as bench_bitplanes.py. Targeted rows are devotion queries (the
+per-card HashMap walk this replaces) across ops, saturation depths, and
+compositions. Controls split in two: type-narrowing rows that must not move
+when the dead TypeIndex postings are removed, and the usual selective /
+broad / plane rows.
+
+    .venv/bin/python scripts/bench_devotion.py --out benchmarks/devotion/baseline-main.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query) — unique=card, orderby=edhrec, prefer=default throughout.
+CONFIGS: list[tuple[str, str]] = [
+    # Targeted: pure devotion across ops and saturation depths
+    ("devotion", "devotion:u"),
+    ("devotion", "devotion:uu"),
+    ("devotion", "devotion:uuu"),
+    ("devotion", "devotion:www"),
+    ("devotion", "devotion:bbb"),
+    ("devotion", "devotion:uuuu"),
+    ("devotion", "devotion=uu"),
+    ("devotion", "-devotion:uu"),
+    ("devotion", "devotion:wwu"),
+    # Targeted: devotion in composition (the Or-veto class)
+    ("devotion-mix", "type:instant or devotion:b"),
+    ("devotion-mix", "pow>2 devotion:bbb"),
+    ("devotion-mix", "c:u devotion:uu"),
+    ("devotion-mix", "devotion:uu or devotion:bb"),
+    ("devotion-mix", "o:draw devotion:gg"),
+    # Controls: type rows (TypeIndex removal must be invisible — planes served
+    # these since #637)
+    ("type-ctl", "t:creature"),
+    ("type-ctl", "t:instant"),
+    ("type-ctl", "-t:creature"),
+    ("type-ctl", "c:g t:creature"),
+    ("type-ctl", "t:creature o:draw"),
+    ("type-ctl", "t:goblin or t:merfolk"),
+    # Controls: the usual suspects
+    ("control", "c:g"),
+    ("control", "name:fi"),
+    ("control", "o:draw"),
+    ("control", "usd<5"),
+    ("control", "f:modern"),
+    ("control", "name:soldier"),
+]
+
+
+def main() -> None:
+    """Time every config against the local engine build and write the CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    hdr = f"{'group':<13} {'query':<28} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "total", "n", "avg_ms", "min_ms"])
+        for group, query in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, "card", "edhrec", "default"), args.window)
+            writer.writerow([rev, group, query, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<13} {query:<28} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Devotion had no index and the most expensive per-card evaluation in the engine — a heap `HashMap` walk over mana pips, 31.5k times per query. The flat-cost signature was stark: `devotion:uuu` cost **0.936 ms to find 126 cards**, every devotion row sat at 0.85–1.0 ms regardless of selectivity, and a devotion child vetoed any Or (`type:instant or devotion:b` full-scanned despite the instant plane).

**Two saturating bits per color** (count clamped to 0..=3) as bitplanes — 12 planes, 47 kB — make every realistic op *exact* plane algebra:

| predicate | expression | exact? |
|---|---|---|
| `devotion:u` (≥1) | b0 ∨ b1 | ✓ |
| `devotion:uu` (≥2) | b1 | ✓ |
| `devotion:uuu` (≥3) | b0 ∧ b1 | ✓ — saturated 3 *means* ≥3 |
| `devotion=uu`, `<=`, `!=`, `<`, `>` | masks/complements; Le/Eq pin unqueried colors to zero, mirroring the evaluator's containment semantics | ✓ to k=2 |
| `devotion:uuuu` (≥4) | b0 ∧ b1 as a loose superset (~0.5% of cards/color), driver verifies | narrowing only |
| `devotion:wwu` | per-color ANDs | ✓ |

Counts come from the **same hybrid-expanded map the evaluator uses** — `{R/G}` counts one red *and* one green devotion, pinned by a dedicated test — so pure devotion queries take the exact-consumption path (skip `card_pass` entirely) and devotion children compose in the candidate algebra like any color/type child, retiring devotion as an Or-poisoner. A build-time debug assert pins the rule-derived invariant that colored devotion implies the identity bit (measured corpus-wide: zero violations; `{C}` exempt — colorless pips never join identity).

**Also removes the `TypeIndex` postings** (~145 kB): write-only since the #637 plane feed-in replaced their only consumer. Net archive change: **−96 kB**. Archive format version bumped.

## Measured (main 4ac96d7 vs branch, 97,206-printing corpus, 3 s window per config, totals identical on every row)

| targeted query | matches | main | branch | speedup |
|---|---|---|---|---|
| `devotion:uu or devotion:bb` | 2,960 | 1.564 ms | **0.077 ms** | **20.3×** |
| `devotion:wwu` | 50 | 1.022 ms | **0.033 ms** | **31.0×** |
| `devotion:uuuu` (superset + verify) | 21 | 0.845 ms | **0.022 ms** | **38.4×** |
| `devotion:uuu` | 126 | 0.936 ms | **0.059 ms** | **15.9×** |
| `devotion:www` | 112 | 0.950 ms | **0.058 ms** | **16.4×** |
| `devotion:bbb` | 179 | 0.956 ms | **0.061 ms** | **15.7×** |
| `devotion:uu` | 1,442 | 0.950 ms | **0.065 ms** | **14.6×** |
| `devotion=uu` | 1,156 | 0.892 ms | **0.077 ms** | **11.6×** |
| `devotion:u` | 6,435 | 0.879 ms | **0.088 ms** | **10.0×** |
| `type:instant or devotion:b` (was Or-vetoed) | 9,442 | 0.804 ms | **0.107 ms** | **7.5×** |
| `-devotion:uu` (30k matches) | 30,066 | 0.945 ms | **0.211 ms** | **4.5×** |
| `c:u devotion:uu` | 1,439 | 0.302 ms | **0.071 ms** | 4.3× |
| `o:draw devotion:gg` | 126 | 0.375 ms | **0.099 ms** | 3.8× |
| `pow>2 devotion:bbb` | 89 | 0.382 ms | **0.105 ms** | 3.6× |

**Type controls** (the TypeIndex removal must be invisible): `t:creature` 0.151→0.153, `t:instant` 0.073→0.073, `-t:creature` 0.128→0.131, `c:g t:creature` 0.084→0.084, `t:goblin or t:merfolk` 0.082→0.075 — parity, as expected for deleting write-only data. Standard controls (`c:g`, `usd<5`, `f:modern`, `o:draw`, names) all at parity; the #633 bitplane suite holds.

**400-query survey** (0.5 s windows): totals identical on all 400; **p99 0.769 → 0.491 ms**. Two nominal regressions (`produces:r` +55 µs, one +5 µs And) touch no changed code path and probe at baseline with longer windows — survey noise, no reproducible regressions.

## Tests

`cargo test`: 49 — op-level parity against `tri()` at every saturation depth (all six ops, multi-color, colorless `{C}` devotion), the compiler *declining* past the exactness boundary rather than guessing, the deep-k superset covering every real match, and the `{R/G}`-counts-toward-both-colors invariant pinned explicitly. The property harness (#641) now generates mana costs — hybrids included — and checks six devotion fragments (`devotion:u/uu/uuu/uuuu`, `devotion=gg`, `-devotion:rr`) against the independent reference evaluator at threshold-crossing scale. Python: 1,871 unit + 15 integration passed.
