### PR TITLE
Sort by Name via a Precomputed Permutation and Binary-Search Exact-Name Lookups

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1417,6 +1417,8 @@ class APIResource:
             # what's in the query => the db column name
             CardOrdering.CMC: "cmc",
             CardOrdering.EDHREC: "edhrec_rank",
+            # lower() matches the engine, which sorts on card_name_lower
+            CardOrdering.NAME: "lower(card_name)",
             CardOrdering.POWER: "creature_power",
             CardOrdering.RARITY: "card_rarity_int",
             CardOrdering.TOUGHNESS: "creature_toughness",

--- a/api/enums.py
+++ b/api/enums.py
@@ -28,6 +28,7 @@ class CardOrdering(enum.StrEnum):
     CMC = enum.auto()
     CUBECOBRA = enum.auto()
     EDHREC = enum.auto()
+    NAME = enum.auto()
     POWER = enum.auto()
     RARITY = enum.auto()
     TOUGHNESS = enum.auto()

--- a/api/static/index.html
+++ b/api/static/index.html
@@ -119,6 +119,7 @@
           <label for="orderDropdown" class="dropdown-label">Order By:</label>
           <select class="order-dropdown" id="orderDropdown" name="orderby">
             <option value="edhrec">EDHREC</option>
+            <option value="name">Name</option>
             <option value="cubecobra">CubeCobra</option>
             <option value="cmc">CMC</option>
             <option value="power">Power</option>

--- a/api/tests/test_engine_property.py
+++ b/api/tests/test_engine_property.py
@@ -221,6 +221,8 @@ def _ref_leaf(frag: str, card: dict[str, Any]) -> bool | None:  # noqa: PLR0911,
             return ge
         # "=": exact per-color counts AND no devotion outside the queried colors
         return all(counts.get(c, 0) == k for c, k in want.items()) and all(c in want for c, n in counts.items() if n > 0)
+    if frag.startswith('!"'):
+        return card["card_name"].lower() == frag[2:-1].lower()
     if field == "name":
         return rest in card["card_name"].lower()
     if field == "o":
@@ -272,13 +274,27 @@ def _ref_totals(shape: Any, cards: list[dict[str, Any]]) -> tuple[int, int]:
 # ─── Query generation: fragments composed across every shape ─────────────────
 
 
-def _gen_queries(rng: random.Random, count: int) -> list[tuple[str, Any]]:
+def _exact_name_fragments(cards: list[dict[str, Any]]) -> list[str]:
+    """Exact-name lookups derived from the generated store.
+
+    A single-printing hit, a multi-printing hit, and a guaranteed miss (names
+    embed their card index, so no generated name matches it).
+    """
+    by_count: dict[str, int] = {}
+    for c in cards:
+        by_count[c["card_name"]] = by_count.get(c["card_name"], 0) + 1
+    single = next(n for n, k in by_count.items() if k == 1)
+    multi = next(n for n, k in by_count.items() if k >= 3)
+    return [f'!"{single}"', f'!"{multi}"', '!"zzz no such card"']
+
+
+def _gen_queries(rng: random.Random, count: int, fragments: list[str]) -> list[tuple[str, Any]]:
     """(query string, reference shape) pairs across single/and/or/nested/neg."""
     out: list[tuple[str, Any]] = []
     leaf = lambda f: ("leaf", f.lstrip("-")) if not f.startswith("-") else ("not", ("leaf", f[1:]))  # noqa: E731
     while len(out) < count:
         k = rng.random()
-        picks = rng.sample(FRAGMENTS, 4)
+        picks = rng.sample(fragments, 4)
         if k < 0.2:
             q, shape = picks[0], leaf(picks[0])
         elif k < 0.45:
@@ -337,7 +353,7 @@ class TestEnginePropertyParity:
 
     def test_totals_match_reference_across_shapes(self, property_setup: tuple[QueryEngine, list[dict[str, Any]]]) -> None:
         engine, cards = property_setup
-        queries = _gen_queries(random.Random(42), 250)
+        queries = _gen_queries(random.Random(42), 250, [*FRAGMENTS, *_exact_name_fragments(cards)])
         failures = []
         for q, shape in queries:
             want_card, want_printing = _ref_totals(shape, cards)
@@ -350,7 +366,7 @@ class TestEnginePropertyParity:
     def test_every_fragment_matches_reference_standalone(self, property_setup: tuple[QueryEngine, list[dict[str, Any]]]) -> None:
         engine, cards = property_setup
         failures = []
-        for frag in FRAGMENTS:
+        for frag in [*FRAGMENTS, *_exact_name_fragments(cards)]:
             shape = ("not", ("leaf", frag[1:])) if frag.startswith("-") else ("leaf", frag)
             want = _ref_totals(shape, cards)
             got = (_engine_total(engine, frag, "card"), _engine_total(engine, frag, "printing"))

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -197,6 +197,11 @@ struct OracleCard {
     planeswalker_loyalty: Option<u8>, // always 1-12
     edhrec_rank: Option<u32>,         // up to ~30k unique cards
     cubecobra_score: Option<f32>,
+    // Dense rank of card_name_lower in byte order (equal names share a rank so
+    // sort secondaries break their ties). Assigned post-load by
+    // assign_name_ranks; the sort key for SortCol::Name. Ranks stay below 2^24
+    // so the f32 sort-key conversion is exact.
+    name_rank: u32,
 
     // Collection elements interned as u16 ids into CardData.coll_vocab (see
     // VocabInterner). card_subtypes preserves the printed order; the set-like
@@ -1248,6 +1253,10 @@ struct SortPermutations {
     cmc:       [Vec<u32>; 2],
     power:     [Vec<u32>; 2],
     toughness: [Vec<u32>; 2],
+    // Keyed on name_rank, so the ascending permutation is also the sorted-name
+    // lookup table: equal-name blocks are contiguous (rank is the primary key)
+    // and narrow_rec's ExactName arm binary-searches it.
+    name:      [Vec<u32>; 2],
 }
 
 impl ArchivedSortPermutations {
@@ -1261,9 +1270,29 @@ impl ArchivedSortPermutations {
             SortCol::Cmc        => &self.cmc,
             SortCol::Power      => &self.power,
             SortCol::Toughness  => &self.toughness,
+            SortCol::Name       => &self.name,
             SortCol::Rarity | SortCol::PriceUsd => return None,
         };
         Some(&pair[descending as usize])
+    }
+}
+
+/// Dense byte-order rank of card_name_lower onto each card (equal names share
+/// a rank; the standard sort secondaries break their ties). Every card has a
+/// name, so unlike the other sort columns the rank is never absent.
+fn assign_name_ranks(cards: &mut [OracleCard]) {
+    let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
+    ids.sort_unstable_by(|&a, &b| {
+        cards[a as usize].card_name_lower.as_str().cmp(cards[b as usize].card_name_lower.as_str())
+    });
+    let mut rank = 0u32;
+    for i in 0..ids.len() {
+        if i > 0
+            && cards[ids[i - 1] as usize].card_name_lower.as_str() != cards[ids[i] as usize].card_name_lower.as_str()
+        {
+            rank += 1;
+        }
+        cards[ids[i] as usize].name_rank = rank;
     }
 }
 
@@ -1293,6 +1322,7 @@ fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets
         cmc:       both(&|c| c.cmc.map(|v| v as f32)),
         power:     both(&|c| c.creature_power.map(|v| v as f32)),
         toughness: both(&|c| c.creature_toughness.map(|v| v as f32)),
+        name:      both(&|c| Some(c.name_rank as f32)),
     }
 }
 
@@ -1904,6 +1934,8 @@ fn or_all(mut sets: Vec<Narrowed>, n: usize) -> Option<Narrowed> {
 fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
     match f {
         FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => Some(false),
+        // Exact names resolve exactly through the sorted name permutation.
+        FilterExpr::ExactName(_) => Some(false),
         // 2-byte name needles resolve exactly through the bigram index.
         FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => Some(false),
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } => {
@@ -1935,10 +1967,15 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
     }
 }
 
-fn narrow_candidates(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AOffsets) -> Option<Candidates> {
+fn narrow_candidates(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    cards: &[AOracleCard],
+) -> Option<Candidates> {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-    narrow_rec(filter, indexes, offsets, false)
+    narrow_rec(filter, indexes, offsets, cards, false)
         .filter(|n| {
             // Near-total sets narrow nothing; dropping them here (a popcount,
             // before any projection or materialization) keeps broad composed
@@ -1975,7 +2012,13 @@ fn and_child_rank(f: &FilterExpr) -> u8 {
 /// trick needs it), false where nothing would — a lone broad set at the root
 /// or in a candidate-less And is discarded anyway, so the scatter would be
 /// pure waste (the 10x And regressions of the first benchmark round).
-fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AOffsets, broad_ok: bool) -> Option<Narrowed> {
+fn narrow_rec(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    cards: &[AOracleCard],
+    broad_ok: bool,
+) -> Option<Narrowed> {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
 
@@ -1998,6 +2041,22 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
     }
 
     match filter {
+        FilterExpr::ExactName(needle) => {
+            // The ascending name permutation is keyed on name_rank — i.e. on
+            // card_name_lower byte order — so equal-name blocks are contiguous
+            // and equality is a binary-searched range: an exact, tight card
+            // set. A miss proves the empty set (names are never null).
+            let perm = &indexes.sort_perms.name[0];
+            if perm.len() != n_cards || cards.len() != n_cards || n_cards == 0 {
+                return None; // store without name permutations
+            }
+            let name_of = |cid: &Archived<u32>| cards[u32::from(*cid) as usize].card_name_lower.as_str();
+            let lo = perm.partition_point(|cid| name_of(cid) < needle.as_str());
+            let width = perm[lo..].partition_point(|cid| name_of(cid) == needle.as_str());
+            let ids: Vec<u32> = perm[lo..lo + width].iter().map(|x| u32::from(*x)).collect();
+            Narrowed::tight(Candidates::Cards(ids))
+        }
+
         FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => {
             // A 2-byte needle's containment IS bigram membership, so the tier
             // lookup is the complete answer — tight, with no false positives
@@ -2222,7 +2281,7 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
                     1 => !printing_sets.is_empty(),
                     _ => broad_ok,
                 };
-                if let Some(n) = narrow_rec(c, indexes, offsets, child_broad_ok) {
+                if let Some(n) = narrow_rec(c, indexes, offsets, cards, child_broad_ok) {
                     // A child covering most of its domain barely narrows the
                     // intersection; skipping it is advisory-sound and avoids
                     // paying its projection/materialization for ~nothing.
@@ -2288,7 +2347,7 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
             // loosening-only, and the driver re-verifies).
             let mut sets: Vec<Narrowed> = Vec::with_capacity(children.len());
             for child in children {
-                let n = narrow_rec(child, indexes, offsets, true)?;
+                let n = narrow_rec(child, indexes, offsets, cards, true)?;
                 // One near-total child makes the union near-total: the
                 // \"candidates\" would visit almost every card while paying
                 // union, projection, and materialization on the way.
@@ -2330,7 +2389,7 @@ fn narrow_rec(filter: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AO
             // be computed to be discarded — sometimes at real cost (a
             // mixed-space Or pays vec sorts and a projection).
             tight_narrow_space(inner)?;
-            let n = narrow_rec(inner, indexes, offsets, true)?;
+            let n = narrow_rec(inner, indexes, offsets, cards, true)?;
             if !n.tight {
                 return None;
             }
@@ -2377,7 +2436,7 @@ fn prefer_score(card: &AOracleCard, p: &APrinting, prefer: Prefer) -> f64 {
 }
 
 #[derive(Clone, Copy)]
-enum SortCol { Cmc, Power, Toughness, Rarity, PriceUsd, Cubecobra, EdhrecRank }
+enum SortCol { Cmc, Power, Toughness, Rarity, PriceUsd, Cubecobra, EdhrecRank, Name }
 
 fn orderby_to_col(orderby: &str) -> SortCol {
     match orderby {
@@ -2387,6 +2446,7 @@ fn orderby_to_col(orderby: &str) -> SortCol {
         "toughness" => SortCol::Toughness,
         "usd"       => SortCol::PriceUsd,
         "cubecobra" => SortCol::Cubecobra,
+        "name"      => SortCol::Name,
         _           => SortCol::EdhrecRank,
     }
 }
@@ -2413,6 +2473,7 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
         SortCol::PriceUsd   => p.price_usd.as_ref().map(|v| f32::from(*v)),
         SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
         SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
+        SortCol::Name       => Some(u32::from(card.name_rank) as f32),
     };
     let pk = primary.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
     let e = card.edhrec_rank.as_ref().map(|v| u32::from(*v)).unwrap_or(u32::MAX);
@@ -2653,7 +2714,7 @@ fn run_query<'a>(
     // Broad-range bitmaps (#636) can produce such lists; treating them as
     // unnarrowed also keeps the #635 memoization trigger firing for these
     // queries exactly as before.
-    let candidate_cards: Option<Vec<u32>> = narrow_candidates(filter, indexes, offsets)
+    let candidate_cards: Option<Vec<u32>> = narrow_candidates(filter, indexes, offsets, cards)
         .map(|c| c.into_cards(offsets))
         .filter(|v| v.len() < cards.len() - cards.len() / 8);
 
@@ -2980,7 +3041,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260717;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260718;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -3289,6 +3350,8 @@ impl QueryEngine {
                     planeswalker_loyalty: row.planeswalker_loyalty,
                     edhrec_rank: row.edhrec_rank,
                     cubecobra_score: row.cubecobra_score,
+                    name_rank: 0, // assigned after grouping by assign_name_ranks
+
                     card_subtypes: std::mem::take(&mut row.card_subtypes),
                     card_keywords: std::mem::take(&mut row.card_keywords),
                     card_oracle_tags: std::mem::take(&mut row.card_oracle_tags),
@@ -3325,6 +3388,7 @@ impl QueryEngine {
             });
         }
         offsets.push(printings.len() as u32);
+        assign_name_ranks(&mut cards);
 
         #[cfg(feature = "alloc-counter")]
         let stats_after_cards = (alloc_stats::live(), alloc_stats::allocs());

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,4 +1,5 @@
 use super::{
+    assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     build_artwork_group_counts, build_bit_planes, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
@@ -156,6 +157,7 @@ fn stub_card(oracle_id: u128, card_types: u16, subtypes: &[&str], vocab: &mut Vo
         planeswalker_loyalty: None,
         edhrec_rank: None,
         cubecobra_score: None,
+        name_rank: 0,
         card_subtypes: subtypes.iter().map(|s| vocab.intern(s.to_string()).unwrap()).collect(),
         card_keywords: Vec::new(),
         card_oracle_tags: Vec::new(),
@@ -255,28 +257,28 @@ fn narrow_candidates_spaces() {
         value_id: None,
     };
 
-    match narrow_candidates(&coll(CollField::ArtTags, "wolf"), archived, offsets) {
+    match narrow_candidates(&coll(CollField::ArtTags, "wolf"), archived, offsets, &[]) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
         _ => panic!("art tag must narrow in printing space"),
     }
-    match narrow_candidates(&coll(CollField::Keywords, "Flying"), archived, offsets) {
+    match narrow_candidates(&coll(CollField::Keywords, "Flying"), archived, offsets, &[]) {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("keyword must narrow in card space"),
     }
     // A tag with no postings in a complete index proves the empty set (an
     // unbound value_id matches nothing at eval either).
-    match narrow_candidates(&coll(CollField::ArtTags, "zombie"), archived, offsets) {
+    match narrow_candidates(&coll(CollField::ArtTags, "zombie"), archived, offsets, &[]) {
         Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent tag narrows to the exact empty set"),
         _ => panic!("absent tag must narrow to empty, not decline"),
     }
     // frame_data is selectivity-thresholded (#628): dense values are absent by
     // design, so absence proves nothing and it must keep declining.
-    assert!(narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets).is_none());
+    assert!(narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]).is_none());
 
     // And of mixed spaces projects the printing product up and intersects in
     // card space: art printings {0,2} → cards {0,1}, ∩ keyword cards {1} = {1}.
     let and = FilterExpr::And(vec![coll(CollField::ArtTags, "wolf"), coll(CollField::Keywords, "Flying")]);
-    match narrow_candidates(&and, archived, offsets) {
+    match narrow_candidates(&and, archived, offsets, &[]) {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("mixed And must produce card-space candidates"),
     }
@@ -349,7 +351,7 @@ fn narrow_candidates_rarity_card_space() {
         op: CmpOp::Ge,
         rhs: NumExpr::Const(2.0),
     };
-    match narrow_candidates(&cmp, archived, offsets) {
+    match narrow_candidates(&cmp, archived, offsets, &[]) {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![0, 1, 2]),
         _ => panic!("rarity must narrow in card space"),
     }
@@ -360,7 +362,7 @@ fn narrow_candidates_rarity_card_space() {
         op: CmpOp::Le,
         rhs: NumExpr::Field(NumField::RarityInt),
     };
-    match narrow_candidates(&flipped, archived, offsets) {
+    match narrow_candidates(&flipped, archived, offsets, &[]) {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("flipped rarity must narrow in card space"),
     }
@@ -789,7 +791,7 @@ fn artist_predicates_bind_to_vocab_ids_and_narrow() {
     assert!(f.eval_card(card, &archived.strings) == Tri::PrintingDep);
 
     // narrowing expands the CSR rows to sorted printing ids
-    match narrow_candidates(&f, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
         _ => panic!("artist predicate must narrow in printing space"),
     }
@@ -800,7 +802,7 @@ fn artist_predicates_bind_to_vocab_ids_and_narrow() {
         word: "zzz".to_string(),
     };
     g.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
-    match narrow_candidates(&g, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&g, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert!(v.is_empty()),
         _ => panic!("empty artist match must narrow to the empty set"),
     }
@@ -878,7 +880,7 @@ fn flavor_match_bind_eval_and_narrow() {
 
     // Narrowing expands the matched texts' CSR rows to sorted printing ids —
     // this is what makes ft: participate in Or narrowing.
-    match narrow_candidates(&f, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
         _ => panic!("flavor predicate must narrow in printing space"),
     }
@@ -890,7 +892,7 @@ fn flavor_match_bind_eval_and_narrow() {
         value: "a quiet forest".to_string(),
     };
     bound(&mut ex);
-    match narrow_candidates(&ex, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&ex, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![1]),
         _ => panic!("exact flavor must narrow"),
     }
@@ -900,7 +902,7 @@ fn flavor_match_bind_eval_and_narrow() {
     };
     bound(&mut rx);
     assert!(rx.matches(card0, &archived.printings[1], &archived.strings));
-    match narrow_candidates(&rx, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&rx, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![1]),
         _ => panic!("regex flavor must narrow"),
     }
@@ -911,7 +913,7 @@ fn flavor_match_bind_eval_and_narrow() {
         word: "zzzqqq".to_string(),
     };
     bound(&mut none);
-    match narrow_candidates(&none, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&none, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert!(v.is_empty()),
         _ => panic!("empty flavor match must narrow to the empty set"),
     }
@@ -947,7 +949,7 @@ fn collector_number_narrowing() {
         op,
         rhs: NumExpr::Const(v),
     };
-    let narrow = |f: &FilterExpr| match narrow_candidates(f, &archived.indexes, &archived.offsets) {
+    let narrow = |f: &FilterExpr| match narrow_candidates(f, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => Some(v),
         // Bitmaps materialize in ascending id order, so both representations
         // compare against the same expected vectors.
@@ -1019,12 +1021,12 @@ fn frame_postings_thresholded_at_build() {
         value: value.to_string(),
         value_id: None,
     };
-    match narrow_candidates(&coll("Showcase"), archived, offsets) {
+    match narrow_candidates(&coll("Showcase"), archived, offsets, &[]) {
         Some(Candidates::Printings(v)) => assert_eq!(v.len(), 40),
         _ => panic!("selective frame value must narrow in printing space"),
     }
-    assert!(narrow_candidates(&coll("2015"), archived, offsets).is_none());
-    assert!(narrow_candidates(&coll("Zzz"), archived, offsets).is_none());
+    assert!(narrow_candidates(&coll("2015"), archived, offsets, &[]).is_none());
+    assert!(narrow_candidates(&coll("Zzz"), archived, offsets, &[]).is_none());
 }
 
 // Streamed selection must agree with the gathered path. Two stores identical
@@ -1155,7 +1157,7 @@ fn set_code_and_date_narrowing() {
         op: CmpOp::Eq,
         value: "lea".to_string(),
     };
-    match narrow_candidates(&lea, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&lea, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![0, 2]),
         _ => panic!("set code must narrow in printing space"),
     }
@@ -1165,23 +1167,23 @@ fn set_code_and_date_narrowing() {
         op: CmpOp::Eq,
         value: "zzz".to_string(),
     };
-    match narrow_candidates(&none, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&none, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert!(v.is_empty()),
         _ => panic!("unknown set code must narrow to the empty set"),
     }
 
     let year1993 = FilterExpr::YearCmp { op: CmpOp::Eq, year: 1993 };
-    match narrow_candidates(&year1993, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&year1993, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![0]),
         _ => panic!("year must narrow in printing space"),
     }
     let date_ge = FilterExpr::DateCmp { op: CmpOp::Ge, value: 20240101 };
-    match narrow_candidates(&date_ge, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&date_ge, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![1]),
         _ => panic!("date must narrow in printing space"),
     }
     // Ne is not selective and must not narrow.
-    assert!(narrow_candidates(&FilterExpr::DateCmp { op: CmpOp::Ne, value: 19930805 }, &archived.indexes, &archived.offsets).is_none());
+    assert!(narrow_candidates(&FilterExpr::DateCmp { op: CmpOp::Ne, value: 19930805 }, &archived.indexes, &archived.offsets, &archived.cards).is_none());
 }
 
 #[test]
@@ -1224,7 +1226,7 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
     };
     // 0.10f64 is not representable as f32; the widened bound may include the
     // boundary printing as a candidate, but must never lose printing 0.
-    match narrow_candidates(&cheap, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&cheap, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
             assert!(!v.contains(&2) && !v.contains(&3));
@@ -1241,7 +1243,7 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
         op: CmpOp::Lt,
         rhs: super::NumExpr::Field(super::NumField::PriceUsd),
     };
-    match narrow_candidates(&pricey, &archived.indexes, &archived.offsets) {
+    match narrow_candidates(&pricey, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
     }
@@ -1251,7 +1253,7 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
         op: CmpOp::Ne,
         rhs: super::NumExpr::Const(1.0),
     };
-    assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets).is_none());
+    assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets, &archived.cards).is_none());
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────
@@ -1693,7 +1695,7 @@ fn not_narrows_only_tight_children() {
     let data = narrow_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, true);
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
 
     // value_id bound as production's bind() would — narrowing keys on the
     // string, evaluation on the id, and they must agree.
@@ -1734,7 +1736,7 @@ fn or_composes_plane_and_complement_children() {
     let data = narrow_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, true);
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
 
     let goblin_id = archived.coll_vocab.iter().position(|s| s.as_str() == "goblin").map(|i| i as u16);
     let goblin = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".into(), value_id: goblin_id };
@@ -1813,7 +1815,7 @@ fn not_over_partial_and_is_blocked() {
     // Static check: And with an unrepresentable child can't be tight → Not
     // must refuse to narrow at all.
     let not_partial = FilterExpr::Not(Box::new(FilterExpr::And(vec![goblin(), unindexable()])));
-    assert!(super::narrow_rec(&not_partial, &archived.indexes, &archived.offsets, true).is_none());
+    assert!(super::narrow_rec(&not_partial, &archived.indexes, &archived.offsets, &archived.cards, true).is_none());
 
     // Dynamic check via run_query: totals must equal brute force. Every card
     // fails `name:q` here, so every card matches the negation — a complement
@@ -1892,7 +1894,7 @@ fn name_bigrams_tiers_and_exactness() {
 
     let rec = |w: &str| {
         let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: w.to_string() };
-        super::narrow_rec(&f, &archived.indexes, &archived.offsets, false)
+        super::narrow_rec(&f, &archived.indexes, &archived.offsets, &archived.cards, false)
     };
     // Dense tier: exact bitmap, tight.
     let n = rec("zz").expect("dense bigram narrows");
@@ -1913,7 +1915,7 @@ fn name_bigrams_tiers_and_exactness() {
     assert_eq!(n.set.len(), 0);
     // 1-char stays unindexable.
     let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: "z".to_string() };
-    assert!(super::narrow_rec(&f, &archived.indexes, &archived.offsets, false).is_none());
+    assert!(super::narrow_rec(&f, &archived.indexes, &archived.offsets, &archived.cards, false).is_none());
 }
 
 // The motivating composition: `name:xx or name:yy` previously full-scanned
@@ -1940,7 +1942,7 @@ fn name_bigrams_compose_and_memoize() {
 
     // Or of two bigram children composes: "fi" → {0,1,4}, "dr" → {0,2}.
     let or = FilterExpr::Or(vec![name2("fi"), name2("dr")]);
-    let n = super::narrow_rec(&or, &archived.indexes, &archived.offsets, false).expect("bigram Or composes");
+    let n = super::narrow_rec(&or, &archived.indexes, &archived.offsets, &archived.cards, false).expect("bigram Or composes");
     assert_eq!(n.set.into_cards(&archived.offsets), vec![0, 1, 2, 4]);
 
     // run_query parity across the new shapes, negation included.
@@ -1994,7 +1996,7 @@ fn broad_tag_postings_scatter_or_decline() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let tag = |v: &str| FilterExpr::CollectionCmp { field: CollField::IsTags, op: CmpOp::Ge, value: v.into(), value_id: None };
-    let rec = |f: &FilterExpr, broad_ok: bool| super::narrow_rec(f, &archived.indexes, &archived.offsets, broad_ok);
+    let rec = |f: &FilterExpr, broad_ok: bool| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, broad_ok);
 
     // Broad tag: bitmap under broad_ok, decline without.
     assert!(rec(&tag("spell"), false).is_none(), "broad tag without a consumer reverts to the scan");
@@ -2099,7 +2101,7 @@ fn devotion_plane_parity_and_boundaries() {
     assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)])).is_none());
     // ...and the saturated superset covers every deep match for narrowing.
     let deep = dev(CmpOp::Ge, &[("U", 5)]);
-    let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, false).expect("deep-k narrows loosely");
+    let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, &archived.cards, false).expect("deep-k narrows loosely");
     assert!(!n.tight);
     let cand = n.set.into_cards(&archived.offsets);
     for (cid, card) in archived.cards.iter().enumerate() {
@@ -2126,4 +2128,137 @@ fn hybrid_pip_counts_toward_both_colors() {
         eval_planes(&compile_plane(&f).unwrap(), &archived.indexes.planes, &mut bitmap);
         assert_eq!(bitmap_contains(&bitmap, rg_card), want);
     }
+}
+
+// ─── Sorted name index: order:name + exact-name narrowing ────────────────────
+
+/// Six single-printing cards with names out of store order, one duplicated
+/// ("sol ring" twice), ranks assigned and sort permutations built exactly as
+/// the real load path does. Sorted name order: atog, black lotus, cancel,
+/// fog, sol ring, sol ring — with the duplicate pair tied on name_rank and
+/// separated by their edhrec ranks.
+fn named_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let names = ["fog", "sol ring", "atog", "sol ring", "black lotus", "cancel"];
+    let mut cards: Vec<OracleCard> = names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let mut c = stub_card((i + 1) as u128, TYPE_CREATURE, &[], &mut vocab);
+            c.card_name_lower = InlineStr::from_str(name);
+            // Distinct, deliberately store-order-scrambled edhrec ranks: the
+            // second "sol ring" (card 3) outranks the first (card 1).
+            c.edhrec_rank = Some([40, 60, 10, 20, 30, 50][i]);
+            c
+        })
+        .collect();
+    assign_name_ranks(&mut cards);
+    let mut data = store_of(cards, &[1; 6], vocab);
+    data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+    data
+}
+
+// Equal names share a dense rank; distinct names rank in byte order.
+#[test]
+fn name_ranks_dense_and_shared_across_duplicates() {
+    let data = named_store();
+    let ranks: Vec<u32> = data.cards.iter().map(|c| c.name_rank).collect();
+    // fog=3, sol ring=4 (both copies), atog=0, black lotus=1, cancel=2
+    assert_eq!(ranks, vec![3, 4, 0, 4, 1, 2]);
+}
+
+// ExactName narrows to the exact, tight card set through the ascending name
+// permutation: hit (single), hit (duplicate pair), boundary names, and a miss
+// proving the empty set.
+#[test]
+fn exact_name_narrows_tight() {
+    let data = named_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let exact = |name: &str| FilterExpr::ExactName(name.to_string());
+    let narrow = |name: &str| {
+        super::narrow_rec(&exact(name), &archived.indexes, &archived.offsets, &archived.cards, false)
+            .expect("exact name must narrow")
+    };
+
+    for (name, mut want) in [
+        ("fog", vec![0u32]),
+        ("sol ring", vec![1, 3]),
+        ("atog", vec![2]),          // first in sorted order
+        ("cancel", vec![5]),        // adjacent to the last block
+        ("zzz past the end", vec![]),
+        ("aaa before the start", vec![]),
+        ("sol rin", vec![]),        // prefix of a real name is still a miss
+    ] {
+        let n = narrow(name);
+        assert!(n.tight, "{name}: equality through the sorted permutation is exact");
+        let mut got = n.set.into_cards(&archived.offsets);
+        got.sort_unstable();
+        want.sort_unstable();
+        assert_eq!(got, want, "candidates for {name:?}");
+    }
+
+    // Composition: the tight set participates in the candidate algebra, and
+    // run_query totals agree with a full scan on every shape.
+    let mut shapes: Vec<FilterExpr> = vec![
+        exact("sol ring"),
+        exact("no such card"),
+        FilterExpr::Or(vec![exact("sol ring"), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }]),
+        FilterExpr::And(vec![exact("fog"), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }]),
+        FilterExpr::Not(Box::new(exact("sol ring"))),
+    ];
+    for (i, f) in shapes.iter_mut().enumerate() {
+        let brute = archived
+            .cards
+            .iter()
+            .filter(|c| f.eval_card(c, &archived.strings) == Tri::True)
+            .count();
+        let (total, _) = run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        );
+        assert_eq!(total, brute, "totals parity for shape {i}");
+    }
+}
+
+// order:name sorts pages by name in both directions, breaks the duplicate-name
+// tie by edhrec rank in BOTH directions (direction folds into the primary key
+// only), and paginates consistently.
+#[test]
+fn order_name_sorts_and_paginates() {
+    let data = named_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let run = |direction: &str, limit: usize, offset: usize| -> Vec<String> {
+        let mut all = FilterExpr::True;
+        let (total, page) = run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut all, None, "card", "default", "name", direction, limit, offset, &archived.indexes,
+        );
+        assert_eq!(total, 6);
+        page.iter().map(|(c, _)| c.card_name_lower.as_str().to_string()).collect()
+    };
+
+    assert_eq!(run("asc", 100, 0), ["atog", "black lotus", "cancel", "fog", "sol ring", "sol ring"]);
+    assert_eq!(run("desc", 100, 0), ["sol ring", "sol ring", "fog", "cancel", "black lotus", "atog"]);
+    // Pagination: the page [2, 4) of the ascending order.
+    assert_eq!(run("asc", 2, 2), ["cancel", "fog"]);
+
+    // The duplicate pair ties on name and must break by edhrec rank ascending
+    // in both directions: card 3 (rank 20) before card 0 (rank 60).
+    let ids = |direction: &str| -> Vec<u128> {
+        let mut all = FilterExpr::True;
+        let (_, page) = run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut all, None, "card", "default", "name", direction, 100, 0, &archived.indexes,
+        );
+        page.iter()
+            .filter(|(c, _)| c.card_name_lower.as_str() == "sol ring")
+            .map(|(c, _)| u128::from(c.oracle_id))
+            .collect()
+    };
+    assert_eq!(ids("asc"), [4, 2], "within the tie: lower edhrec rank first");
+    assert_eq!(ids("desc"), [4, 2], "secondaries keep their order under desc");
 }

--- a/scripts/bench_name_order.py
+++ b/scripts/bench_name_order.py
@@ -1,0 +1,94 @@
+"""Engine-vs-engine benchmark for the sorted name index (order:name + exact-name lookups).
+
+Same protocol as bench_devotion.py. Targeted rows split in two:
+
+* exact  — `!"Name"` lookups (the #1 real-traffic shape per the wild-query
+  corpus), currently a per-card full scan with no narrowing arm.
+* order-name — queries sorted by name. NOTE: on main there is no name sort
+  column, so these rows silently fall back to edhrec — their main-side times
+  measure the fallback, not a comparable sort. Totals must still match.
+
+Controls are the usual suspects plus non-name orderings, which must not move.
+
+    .venv/bin/python scripts/bench_name_order.py --out benchmarks/name-order/baseline-main.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# Each config row is (group, query, unique, orderby, prefer).
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Targeted: exact-name lookups across name lengths, hit/miss, duplicates
+    ("exact", '!"Sol Ring"', "card", "edhrec", "default"),
+    ("exact", '!"Lightning Bolt"', "card", "edhrec", "default"),
+    ("exact", '!"Fog"', "card", "edhrec", "default"),
+    ("exact", '!"Circle of Protection: Green"', "card", "edhrec", "default"),
+    ("exact", '!"Ulamog, the Ceaseless Hunger"', "card", "edhrec", "default"),
+    ("exact", '!"No Such Card Exists Anywhere"', "card", "edhrec", "default"),
+    ("exact", '!"Sol Ring"', "printing", "edhrec", "default"),
+    # Targeted: exact-name in composition (candidate algebra)
+    ("exact-mix", '!"Sol Ring" or t:goblin', "card", "edhrec", "default"),
+    ("exact-mix", '-!"Sol Ring" t:artifact', "card", "edhrec", "default"),
+    ("exact-mix", '!"Sol Ring" usd<5', "printing", "usd", "default"),
+    # Targeted: order:name (main-side = edhrec fallback, branch = real name sort)
+    ("order-name", "t:creature", "card", "name", "default"),
+    ("order-name", "c:g", "card", "name", "default"),
+    ("order-name", "o:draw", "card", "name", "default"),
+    ("order-name", "f:modern", "card", "name", "default"),
+    ("order-name", "t:creature", "printing", "name", "default"),
+    ("order-name", "t:creature", "artwork", "name", "default"),
+    ("order-name", "name:storm", "card", "name", "default"),
+    ("order-name", "t:creature", "card", "name", "newest"),
+    # Controls: other orderings and the usual suspects — must not move
+    ("control", "t:creature", "card", "edhrec", "default"),
+    ("control", "c:g", "card", "edhrec", "default"),
+    ("control", "o:draw", "card", "edhrec", "default"),
+    ("control", "f:modern", "card", "edhrec", "default"),
+    ("control", "name:soldier", "card", "edhrec", "default"),
+    ("control", "name:fi", "card", "edhrec", "default"),
+    ("control", "usd<5", "printing", "usd", "default"),
+    ("control", "devotion:uu", "card", "edhrec", "default"),
+    ("control", "t:creature pow>3", "card", "cmc", "default"),
+]
+
+
+def main() -> None:
+    """Time every config against the local engine build and write the CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    hdr = f"{'group':<11} {'query':<34} {'uniq':<8} {'order':<7} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<11} {query:<34} {unique:<8} {orderby:<7} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_wild_corpus.py
+++ b/scripts/build_wild_corpus.py
@@ -1,0 +1,121 @@
+"""Distill the Common Crawl scryfall.com/search harvest into a wild-query corpus.
+
+Input:  benchmarks/wild-queries/cc-raw.jsonl  (one {"url": ...} per line, from the
+        index.commoncrawl.org URL-index harvest)
+Output: benchmarks/wild-queries/wild-corpus.jsonl — one row per distinct query that
+        our parser accepts: {"q", "weight", "unique", "order"}. weight is the raw
+        URL-occurrence count across crawls; unique/order are the modal accompanying
+        params (falling back to card/edhrec, the API defaults we benchmark with).
+
+Cleaning is deliberately minimal: HTML-unescape, Unicode quote/dash/nbsp
+normalization (encoding artifacts of how the URLs were embedded), and a spam
+filter. Queries are never rewritten — anything our parser rejects is dropped and
+tallied in the gap census printed at the end, which doubles as a list of
+real-world syntax we don't support.
+
+    .venv/bin/python scripts/build_wild_corpus.py
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import pathlib
+import re
+import sys
+from collections import Counter, defaultdict
+from urllib.parse import parse_qs, urlparse
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+
+RAW = REPO_ROOT / "benchmarks/wild-queries/cc-raw.jsonl"
+OUT = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
+
+# Encoding artifacts only — never touches query semantics.
+_TRANSLATE = str.maketrans(
+    {
+        "\u201c": '"',  # left double quote
+        "\u201d": '"',  # right double quote
+        "\u2018": "'",  # left single quote
+        "\u2019": "'",  # right single quote
+        "\u2013": "-",  # en dash
+        "\u2014": "-",  # em dash
+        "\u00a0": " ",  # no-break space
+    }
+)
+MAX_Q_LEN = 200
+_SPAM_RE = re.compile(r"[Ѐ-ӿ฀-๿一-鿿가-힯]")
+_OP_RE = re.compile(r"[a-z]+[:<>=]", re.I)
+_VALID_UNIQUE = {"card", "cards", "prints", "art"}
+_VALID_ORDER = {"name", "released", "set", "edhrec", "color", "cmc", "usd", "rarity", "power", "toughness", "artist", "random"}
+
+
+def clean(q: str) -> str | None:
+    """Normalize one raw q value; None means drop (spam / oversized / empty)."""
+    q = html.unescape(html.unescape(q)).translate(_TRANSLATE)
+    q = " ".join(q.split())
+    if not q or len(q) > MAX_Q_LEN or _SPAM_RE.search(q):
+        return None
+    return q
+
+
+def main() -> None:
+    """Read the raw harvest, parse-check every distinct query, write the corpus."""
+    weights: Counter[str] = Counter()
+    params: dict[str, Counter[tuple[str, str]]] = defaultdict(Counter)
+    with RAW.open() as fh:
+        for line in fh:
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            qs = parse_qs(urlparse(row["url"]).query)
+            raw_q = qs.get("q", [None])[0]
+            if raw_q is None:
+                continue
+            q = clean(raw_q)
+            if q is None:
+                continue
+            weights[q] += 1
+            for key in ("unique", "order"):
+                val = qs.get(key, [None])[0]
+                if val:
+                    params[q][(key, val.lower())] += 1
+
+    kept: list[dict] = []
+    gap_census: Counter[str] = Counter()
+    rejected_ops = 0
+    for q, weight in weights.items():
+        try:
+            parse_scryfall_query(q)
+        except Exception:  # noqa: BLE001 -- any parser rejection goes to the census
+            ops = _OP_RE.findall(q.lower())
+            if ops:
+                rejected_ops += 1
+                for op in set(ops):
+                    gap_census[op] += 1
+            continue
+        modal = params.get(q, Counter())
+        unique = next((v for (k, v), _ in modal.most_common() if k == "unique" and v in _VALID_UNIQUE), "card")
+        order = next((v for (k, v), _ in modal.most_common() if k == "order" and v in _VALID_ORDER), "edhrec")
+        kept.append({"q": q, "weight": weight, "unique": "card" if unique == "cards" else unique, "order": order})
+
+    kept.sort(key=lambda r: (-r["weight"], r["q"]))
+    with OUT.open("w") as fh:
+        for row in kept:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    n_ops = sum(1 for r in kept if _OP_RE.search(r["q"]))
+    print(f"kept {len(kept):,} distinct queries ({n_ops:,} with operators, {len(kept) - n_ops:,} name lookups)")
+    print(f"rejected {rejected_ops:,} operator queries our parser does not accept")
+    print("gap census (operators present in rejected queries):")
+    for op, n in gap_census.most_common(20):
+        print(f"  {op:<14} {n:>5}")
+    print(f"\nwrote {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -1,9 +1,17 @@
 """Broad-distribution query survey against the local engine build.
 
-Generates a seeded corpus of queries from client/query_runner.py's weighted
-dimension table (the realistic-traffic bias used for load testing), mixed
-across shapes — single predicates, 2-4 way ANDs, ORs, nested parens, and
-negations — times each against the engine, and prints a distribution report:
+Two sections, both seeded:
+
+* generated — queries from client/query_runner.py's weighted dimension table
+  (the realistic-traffic bias used for load testing), mixed across shapes —
+  single predicates, 2-4 way ANDs, ORs, nested parens, and negations.
+* wild — real searches sampled (weight-proportionally, without replacement)
+  from benchmarks/wild-queries/wild-corpus.jsonl, the cleaned Common Crawl
+  harvest of scryfall.com/search URLs (see scripts/build_wild_corpus.py).
+  Wild rows use the unique/order params that accompanied them in the wild,
+  mapped onto what the engine supports.
+
+Times each query against the engine and prints a distribution report:
 percentiles, the slowest tail, and per-dimension / per-shape aggregates.
 
     .venv/bin/python scripts/survey_queries.py --out benchmarks/survey/survey.csv
@@ -15,9 +23,11 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import math
 import pathlib
 import random
+import re
 import sys
 import time
 
@@ -37,13 +47,69 @@ _DIM_WEIGHTS = [w for w, n in zip(_DIM_WEIGHTS, _DIM_NAMES, strict=False) if n n
 _DIM_NAMES = [n for n in _DIM_NAMES if n not in _EXCLUDED_DIMS]
 
 # Realistic parameter biases: UI default ordering dominates; unique matches
-# query_runner's 75/20/5 split.
+# query_runner's 75/20/5 split. prefer/direction/offset skew hard to their
+# defaults but are sampled so non-default paths stay on the radar.
 _ORDERBYS = ["edhrec"] * 55 + ["usd"] * 10 + ["cmc"] * 10 + ["rarity"] * 8 + ["cubecobra"] * 7 + ["power"] * 5 + ["toughness"] * 5
 _UNIQUES = ["card"] * 75 + ["printing"] * 20 + ["artwork"] * 5
+_PREFERS = ["default"] * 85 + ["newest"] * 6 + ["oldest"] * 4 + ["usd_low"] * 3 + ["usd_high"] * 2
+_DIRECTIONS = ["asc"] * 85 + ["desc"] * 15
+_OFFSETS = [0] * 90 + [100] * 7 + [700] * 3
+
+# Fragment pools for shapes query_runner's dimension table has no coverage of:
+# arithmetic comparisons (our syntax extension) and regex predicates.
+_ARITH_FRAGS = ["power+toughness>8", "cmc+1<power", "pow>=tou", "power+toughness<4", "cmc>=power", "toughness>power"]
+_REGEX_FRAGS = ["name:/^gob/", "o:/draw .* cards?/", "name:/dragon$/", "o:/^flying$/", "name:/^[aeiou]/", "o:/sacrifice a/"]
+_ANCHOR_P = 0.5  # chance an arith/regex fragment gets a dimension-fragment anchor
 
 WARMUP = 3
 WINDOW_S = 0.15
 MAX_ITERS = 500
+
+WILD_CORPUS = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
+# Fraction of the wild sample drawn from bare name lookups. They dominate the
+# wild corpus by weight but are a single engine code path, so they get one
+# sixth of the slots and operator queries (many distinct paths) get the rest.
+WILD_NAME_LOOKUP_FRACTION = 1 / 6
+_OP_RE = re.compile(r"[a-z]+[:<>=]", re.I)
+# Wild params → engine params. Orders the engine has no sort column for
+# (released, set, color) fall back to edhrec, mirroring orderby_to_col in the
+# engine itself. name is Scryfall's default order, which is why it dominates
+# the wild data.
+_WILD_UNIQUE = {"card": "card", "prints": "printing", "art": "artwork"}
+_ENGINE_ORDERS = {"cmc", "power", "rarity", "toughness", "usd", "cubecobra", "edhrec", "name"}
+
+
+def sample_wild(rng: random.Random, count: int) -> list[dict]:
+    """Sample `count` wild queries, weight-proportionally without replacement.
+
+    Name lookups get WILD_NAME_LOOKUP_FRACTION of the slots; operator queries
+    take the rest. Uses the Efraimidis-Spirakis reservoir key (rand ** 1/weight)
+    for the weighted without-replacement draw.
+    """
+    ops: list[dict] = []
+    names: list[dict] = []
+    with WILD_CORPUS.open() as fh:
+        for line in fh:
+            row = json.loads(line)
+            (ops if _OP_RE.search(row["q"]) else names).append(row)
+    n_names = int(count * WILD_NAME_LOOKUP_FRACTION)
+    picked: list[dict] = []
+    for pool, k in ((ops, count - n_names), (names, n_names)):
+        keyed = sorted(pool, key=lambda r: rng.random() ** (1 / r["weight"]), reverse=True)
+        picked.extend(keyed[:k])
+    return [
+        {
+            "query": r["q"],
+            "shape": "wild-op" if _OP_RE.search(r["q"]) else "wild-name",
+            "dims": "wild",
+            "orderby": r["order"] if r["order"] in _ENGINE_ORDERS else "edhrec",
+            "unique": _WILD_UNIQUE[r["unique"]],
+            "prefer": "default",
+            "direction": "asc",
+            "offset": 0,
+        }
+        for r in picked
+    ]
 
 
 def _pick_fragments(rng: random.Random, k: int) -> list[tuple[str, str]]:
@@ -62,15 +128,19 @@ def _pick_fragments(rng: random.Random, k: int) -> list[tuple[str, str]]:
 def generate(rng: random.Random, count: int) -> list[dict]:
     """Generate `count` query specs across shapes, biased to common patterns."""
     shapes = (
-        ["single"] * 25
-        + ["and2"] * 20
-        + ["and3"] * 13
-        + ["and4"] * 7
-        + ["or2"] * 10
-        + ["paren-or"] * 10
-        + ["and-or"] * 8
-        + ["neg-and"] * 5
+        ["single"] * 23
+        + ["and2"] * 18
+        + ["and3"] * 12
+        + ["and4"] * 6
+        + ["or2"] * 9
+        + ["or3"] * 4
+        + ["paren-or"] * 9
+        + ["and-of-ors"] * 3
+        + ["and-or"] * 7
+        + ["neg-and"] * 4
         + ["neg-or"] * 2
+        + ["arith"] * 2
+        + ["regex"] * 1
     )
     specs: list[dict] = []
     seen: set[str] = set()
@@ -82,21 +152,32 @@ def generate(rng: random.Random, count: int) -> list[dict]:
         elif shape in ("and2", "and3", "and4"):
             picks = _pick_fragments(rng, int(shape[-1]))
             q = " ".join(f for _, f in picks)
-        elif shape == "or2":
-            picks = _pick_fragments(rng, 2)
-            q = f"{picks[0][1]} or {picks[1][1]}"
+        elif shape in ("or2", "or3"):
+            picks = _pick_fragments(rng, int(shape[-1]))
+            q = " or ".join(f for _, f in picks)
         elif shape == "paren-or":  # (a b) or (c d)
             picks = _pick_fragments(rng, 4)
             q = f"({picks[0][1]} {picks[1][1]}) or ({picks[2][1]} {picks[3][1]})"
+        elif shape == "and-of-ors":  # (a or b) (c or d)
+            picks = _pick_fragments(rng, 4)
+            q = f"({picks[0][1]} or {picks[1][1]}) ({picks[2][1]} or {picks[3][1]})"
         elif shape == "and-or":  # a (b or c)
             picks = _pick_fragments(rng, 3)
             q = f"{picks[0][1]} ({picks[1][1]} or {picks[2][1]})"
         elif shape == "neg-and":  # -a b
             picks = _pick_fragments(rng, 2)
             q = f"-{picks[0][1]} {picks[1][1]}"
-        else:  # neg-or: a -(b or c)
+        elif shape == "neg-or":  # a -(b or c)
             picks = _pick_fragments(rng, 3)
             q = f"{picks[0][1]} -({picks[1][1]} or {picks[2][1]})"
+        else:  # arith / regex: the special fragment alone, or anchored by one dim fragment
+            frag = rng.choice(_ARITH_FRAGS if shape == "arith" else _REGEX_FRAGS)
+            picks = [(shape, frag)]
+            q = frag
+            if rng.random() < _ANCHOR_P:
+                anchor = _pick_fragments(rng, 1)
+                q = f"{frag} {anchor[0][1]}"
+                picks.extend(anchor)
         if q in seen:
             continue
         seen.add(q)
@@ -107,6 +188,9 @@ def generate(rng: random.Random, count: int) -> list[dict]:
                 "dims": "+".join(sorted({d for d, _ in picks})),
                 "orderby": rng.choice(_ORDERBYS),
                 "unique": rng.choice(_UNIQUES),
+                "prefer": rng.choice(_PREFERS),
+                "direction": rng.choice(_DIRECTIONS),
+                "offset": rng.choice(_OFFSETS),
             }
         )
     return specs
@@ -118,11 +202,11 @@ def time_query(engine: object, spec: dict) -> tuple[int, int, float, float]:
     kw = {
         "filters": filters,
         "unique": spec["unique"],
-        "prefer": "default",
+        "prefer": spec["prefer"],
         "orderby": spec["orderby"],
-        "direction": "asc",
+        "direction": spec["direction"],
         "limit": 100,
-        "offset": 0,
+        "offset": spec["offset"],
     }
     total = engine.query(**kw)[0]
     for _ in range(WARMUP):
@@ -180,18 +264,23 @@ def main() -> None:
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
     parser.add_argument("--count", type=int, default=400, help="number of queries to generate")
+    parser.add_argument("--wild", type=int, default=120, help="number of wild-corpus queries to sample")
     parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
 
     rng = random.Random(args.seed)
     specs = generate(rng, args.count)
+    if args.wild:
+        specs.extend(sample_wild(rng, args.wild))
     args.out.parent.mkdir(parents=True, exist_ok=True)
     engine = load_engine(args.corpus, args.out.with_suffix(".store"))
 
     rows: list[dict] = []
     with args.out.open("w", newline="") as fh:
         writer = csv.writer(fh)
-        writer.writerow(["query", "shape", "dims", "unique", "orderby", "total", "n", "avg_ms", "min_ms"])
+        writer.writerow(
+            ["query", "shape", "dims", "unique", "orderby", "prefer", "direction", "offset", "total", "n", "avg_ms", "min_ms"]
+        )
         for i, spec in enumerate(specs):
             try:
                 total, n, avg_ms, min_ms = time_query(engine, spec)
@@ -206,6 +295,9 @@ def main() -> None:
                     spec["dims"],
                     spec["unique"],
                     spec["orderby"],
+                    spec["prefer"],
+                    spec["direction"],
+                    spec["offset"],
                     total,
                     n,
                     f"{avg_ms:.4f}",


### PR DESCRIPTION
# Sort by Name via a Precomputed Permutation and Binary-Search Exact-Name Lookups

## What this does

Two features from one artifact. A permutation of card ids keyed on
`card_name_lower` byte order becomes:

1. **`order:name`** — a new sort column (engine `SortCol::Name`, API
   `CardOrdering.NAME`, UI dropdown entry). Cards get a dense `name_rank`
   (equal names share a rank, so the standard edhrec/prefer secondaries break
   ties identically in both directions), and the rank feeds the existing
   streamed-selection machinery like any card-keyed column. It is Scryfall's
   *default* sort order, which our engine had no column for — every
   `order=name` request silently fell back to edhrec.
2. **Exact-name lookups** — `!"Sol Ring"` is the single most common query
   shape in the wild-query corpus (real searches harvested from the Common
   Crawl URL index), and `FilterExpr::ExactName` had no narrowing arm: every
   lookup was a full scan comparing 31.5k names. The ascending name
   permutation *is* a sorted-name lookup table — equal-name blocks are
   contiguous because rank is the primary sort key — so a new `narrow_rec`
   arm binary-searches it into an exact, **tight** candidate set. Hits and
   misses both resolve in ~two dozen string compares, and the set composes in
   the candidate algebra (Or/And/Not), retiring exact-name as an Or-poisoner.

Archive: +252 KB (+0.32%) — exactly the two u32 permutations; `name_rank`
fit in existing `OracleCard` padding. Format version bumped.

## Measured (matched back-to-back runs, main 9144c5b vs branch, 97,206-printing corpus, 3 s window per config, totals identical on every row)

| targeted query | total | main | branch | speedup |
|---|---|---|---|---|
| `!"Lightning Bolt"` | 1 | 0.177 ms | **0.003 ms** | **70.6×** |
| `!"Sol Ring"` | 1 | 0.155 ms | **0.003 ms** | **62.0×** |
| `!"Fog"` (short name) | 1 | 0.150 ms | **0.003 ms** | **60.0×** |
| `!"Circle of Protection: Green"` | 1 | 0.155 ms | **0.003 ms** | **62.0×** |
| `!"No Such Card Exists Anywhere"` (miss) | 0 | 0.123 ms | **0.002 ms** | **64.7×** |
| `!"Sol Ring" or t:goblin` (was Or-vetoed) | 502 | 0.465 ms | **0.062 ms** | **7.5×** |
| `!"Sol Ring" usd<5` (printing) | 61 | 0.158 ms | **0.031 ms** | **5.0×** |
| `!"Sol Ring"` (printing mode) | 129 | 0.204 ms | **0.045 ms** | **4.5×** |
| `-!"Sol Ring" t:artifact` (complement) | 3,500 | 0.078 ms | 0.076 ms | par |

**`order:name` costs the same as edhrec** — same permutation walk:
`t:creature` 0.149 vs 0.147 ms, `f:modern` 0.267 vs 0.256, printing/artwork
modes and `desc` at parity. **Controls** (edhrec/cmc/usd orderings, names,
devotion, `usd<5`) all at parity; totals identical on all 27 configs.

**520-query survey** (0.5 s windows, incl. 120 wild rows): totals identical
on all 520; percentiles at parity (p99 0.985 → 0.981 ms); the nine
`order:name` rows (wild rows that carried Scryfall's default sort) run at a
0.118 ms median, in line with edhrec.

## Provenance: the wild-query corpus

This PR also lands the survey tooling that found the gap:
`scripts/build_wild_corpus.py` distills 20,265 Common Crawl
`scryfall.com/search` URLs into 14,473 distinct real queries
(`benchmarks/wild-queries/`, untracked), and `scripts/survey_queries.py`
gains a wild section (weight-proportional seeded sampling) plus generator
dimensions it never covered: sampled `prefer`/`direction`/`offset`, 3-way
ors, and-of-ors, arithmetic, and regex shapes. Exact-name lookups dominate
the wild corpus and were invisible to the old generated-only survey.

## Honest limits

- Name order is `card_name_lower` **byte order**: accented names (`Éowyn…`)
  sort after `z`, diverging from locale collation (Scryfall sorts them near
  `E`). The SQL fallback (`lower(card_name)`) follows the database collation,
  which may disagree with the engine on those cards. A collation-key column
  would fix both; not worth it until someone notices.
- `order:released` (the other wild sort param we lack) is untouched — it is
  printing-keyed, so it needs the rarity/usd gathered treatment, not a card
  permutation.

## Tests

`cargo test`: 52 — dense-rank assignment (duplicates share, byte order),
tight hit/miss/boundary/prefix narrowing through the permutation, totals
parity across Or/And/Not compositions, and page-order/pagination/direction
checks including the duplicate-name tie breaking by edhrec in both
directions. Python: property harness gains exact-name fragments (single-
printing hit, multi-printing hit, guaranteed miss) checked against the
independent reference evaluator standalone and inside 250 compound shapes.
