### PR TITLE
Order Verifier And/Or Children by Evaluation Cost

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -385,12 +385,12 @@ pub(crate) enum FilterExpr {
 ///       (ArtistMatch/FlavorMatch/NameMatch/OracleMatch) or a card collection
 ///       (CollectionCmp), and anchored-literal regexes (a memcmp at a known
 ///       position — see regex_tier)
-///   2 — per-candidate text/map scans of comparable cost: TextContains
-///       (substring scan; artist/flavor contains were rewritten to tier 1 at
-///       bind), unanchored-literal regexes, and the pip-map walks of
-///       Devotion / ManaCostCmp (string-keyed hashmap iteration — measured
-///       within ~2× of a substring scan, so no reliable gap to exploit)
-///   3 — TextRegex with real regex machinery — the single worst
+///   2 — pip-map walks of Devotion / ManaCostCmp: string-keyed hashmap
+///       iteration, measured ~3× cheaper than a text scan on the real corpus
+///   3 — per-candidate text scans: TextContains (substring search; artist /
+///       flavor contains were rewritten to tier 1 at bind) and
+///       unanchored-literal regexes, whose prefilter costs the same scan
+///   4 — TextRegex with real regex machinery — the single worst
 ///       per-candidate cost the engine has
 ///
 /// Composites take the max of their children: their short-circuit may have to
@@ -398,9 +398,8 @@ pub(crate) enum FilterExpr {
 fn verify_cost_tier(f: &FilterExpr) -> u8 {
     match f {
         FilterExpr::TextRegex { regex, .. } => regex_tier(regex.as_str()),
-        FilterExpr::TextContains { .. }
-        | FilterExpr::Devotion { .. }
-        | FilterExpr::ManaCostCmp { .. } => 2,
+        FilterExpr::TextContains { .. } => 3,
+        FilterExpr::Devotion { .. } | FilterExpr::ManaCostCmp { .. } => 2,
         FilterExpr::ArtistMatch { .. }
         | FilterExpr::FlavorMatch { .. }
         | FilterExpr::NameMatch { .. }
@@ -423,8 +422,8 @@ fn verify_cost_tier(f: &FilterExpr) -> u8 {
 /// `o:/^flying$/ oracle:sacrifice` 2.4× slower, so:
 ///
 ///   1 — literal with a ^ or $ anchor (starts_with/ends_with/equality)
-///   2 — bare literal (substring search, same tier as TextContains)
-///   3 — anything with live regex metacharacters
+///   3 — bare literal (substring search, same tier as TextContains)
+///   4 — anything with live regex metacharacters
 pub(crate) fn regex_tier(pattern: &str) -> u8 {
     let mut p = pattern.strip_prefix("(?i)").unwrap_or(pattern);
     let anchored_start = p.starts_with('^');
@@ -440,17 +439,93 @@ pub(crate) fn regex_tier(pattern: &str) -> u8 {
             // alphanumeric escape (\d \w \b \p…) is a class — real machinery.
             b'\\' => match bytes.get(i + 1) {
                 Some(c) if !c.is_ascii_alphanumeric() => i += 2,
-                _ => return 3,
+                _ => return 4,
             },
             b'$' if i == bytes.len() - 1 => {
                 anchored_end = true;
                 i += 1;
             }
-            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return 3,
+            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return 4,
             _ => i += 1,
         }
     }
-    if anchored_start || anchored_end { 1 } else { 2 }
+    if anchored_start || anchored_end { 1 } else { 3 }
+}
+
+/// Whether a node can NEVER settle the card-level pass — it compares only
+/// printing-level fields, so at card level it always returns PrintingDep and
+/// its evaluation there is pure deferral. Ordering such children after the
+/// card-level ones is a free win in both And and Or: they cannot reject an
+/// And or accept an Or at card level, so a card-level sibling that settles
+/// first skips their eval entirely, and nothing is lost when it doesn't.
+///
+/// Composites settle at card level when ANY child can (a card-level False
+/// settles an And, a card-level True settles an Or), so a composite is
+/// printing-dependent only when ALL its children are.
+fn printing_dependent(f: &FilterExpr) -> bool {
+    fn num_pdep(e: &NumExpr) -> bool {
+        match e {
+            NumExpr::Field(
+                NumField::RarityInt
+                | NumField::CollectorNumberInt
+                | NumField::PriceUsd
+                | NumField::PriceEur
+                | NumField::PriceTix
+                | NumField::PreferScore,
+            ) => true,
+            NumExpr::Arith(lhs, _, rhs) => num_pdep(lhs) || num_pdep(rhs),
+            _ => false,
+        }
+    }
+    match f {
+        FilterExpr::NumericCmp { lhs, rhs, .. } => num_pdep(lhs) || num_pdep(rhs),
+        FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => true,
+        FilterExpr::ArtistMatch { .. } | FilterExpr::FlavorMatch { .. } => true,
+        FilterExpr::TextContains { field: TextSearchField::FlavorTextLower, .. } => true,
+        FilterExpr::TextExact { field, .. } | FilterExpr::TextRegex { field, .. } => matches!(
+            field,
+            TextField::FlavorTextLower | TextField::SetCode | TextField::Border | TextField::Watermark | TextField::CollectorNumber
+        ),
+        FilterExpr::CollectionCmp { field, .. } => {
+            matches!(field, CollField::ArtTags | CollField::IsTags | CollField::FrameData)
+        }
+        // Divergent-legality cards defer to the printing, but they are a rare
+        // exception (non-tournament reprints); rank by the common card-level case.
+        FilterExpr::Legality { .. } => false,
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(printing_dependent),
+        FilterExpr::Not(inner) => printing_dependent(inner),
+        _ => false,
+    }
+}
+
+/// Or-child sort key. An Or short-circuits on acceptance, and acceptance
+/// rates — unlike costs — are unknowable statically, so ordering an Or by
+/// fine-grained cost backfires when a cheap child rarely accepts (measured
+/// twice: `oracle:vigilance or devotion:bbb` lost 1.2× to devotion-first,
+/// and a memoized name set jumping a contains lost 1.1×). The key therefore
+/// only separates classes with a decisive gap:
+///
+///   bucket 0 — card-level tier-0 checks: cheap enough (a few ns) that
+///              leading with them is near-free even when they rarely accept
+///   bucket 1 — everything else below regex machinery (set lookups, pip
+///              maps, text scans) in written order: costs within ~3× of
+///              each other, where acceptance dominates
+///   bucket 2 — regex machinery, always last
+///
+/// Within a bucket, printing-dependent children order last: they can never
+/// settle the Or at card level (see printing_dependent), so leading with
+/// them is pure deferral cost.
+fn or_child_key(f: &FilterExpr) -> (u8, bool) {
+    let tier = verify_cost_tier(f);
+    let pdep = printing_dependent(f);
+    let bucket = if tier >= 4 {
+        2
+    } else if tier == 0 && !pdep {
+        0
+    } else {
+        1
+    };
+    (bucket, pdep)
 }
 
 /// Within-tier refinement for And children: memoized sets know their own
@@ -701,14 +776,17 @@ impl FilterExpr {
     /// broad scan pays a regex before or after the cheap mask checks depends
     /// on how the user typed the query.
     ///
-    /// Within an And's memoized-set tier the sort key refines to ascending set
-    /// size: a smaller match set rejects more candidates per unit cost, and
-    /// the size is already known (ids.len()). Or children stop at the tier —
-    /// their short-circuit is acceptance, where small sets are the *worst*
-    /// lead, and there is no cheap acceptance-rate estimate to sort by.
+    /// And children sort card-level-first (a printing-dependent child cannot
+    /// reject at card level, so any card-level sibling that rejects first
+    /// skips its eval — free, never negative), then on the full cost tiers,
+    /// refined within the memoized-set tier to ascending set size: a smaller
+    /// match set rejects more candidates per unit cost, and the size is
+    /// already known (ids.len()). Or children sort on the coarser
+    /// or_child_key — their short-circuit is acceptance, which no static
+    /// cost model can see, so only decisive cost gaps reorder them.
     ///
-    /// The sort is stable, so equal-cost children keep written order and the
-    /// result is deterministic. Must run after memoize_text_predicates():
+    /// The sorts are stable, so equal-cost children keep written order and
+    /// the result is deterministic. Must run after memoize_text_predicates():
     /// memoization flips TextContains nodes from the scan tier to the set
     /// tier. The per-printing residual pass inherits the order too, since
     /// card_pass() pushes residual children in child order.
@@ -718,13 +796,13 @@ impl FilterExpr {
                 for c in children.iter_mut() {
                     c.order_children_by_verify_cost();
                 }
-                children.sort_by_key(|c| (verify_cost_tier(c), and_child_set_len(c)));
+                children.sort_by_key(|c| (printing_dependent(c), verify_cost_tier(c), and_child_set_len(c)));
             }
             FilterExpr::Or(children) => {
                 for c in children.iter_mut() {
                     c.order_children_by_verify_cost();
                 }
-                children.sort_by_key(verify_cost_tier);
+                children.sort_by_key(or_child_key);
             }
             FilterExpr::Not(inner) => inner.order_children_by_verify_cost(),
             _ => {}

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -376,6 +376,97 @@ pub(crate) enum FilterExpr {
     },
 }
 
+/// Per-candidate verification cost of a node in the tri walk, grouped into
+/// tiers wide enough that the ranking is safe without measurement:
+///
+///   0 — field loads and integer/float/mask compares (numerics, dates,
+///       colors, types, legality words, exact string equality)
+///   1 — bounded lookups: a binary search over a bind/memoize-resolved id set
+///       (ArtistMatch/FlavorMatch/NameMatch/OracleMatch) or a card collection
+///       (CollectionCmp), and anchored-literal regexes (a memcmp at a known
+///       position — see regex_tier)
+///   2 — per-candidate text/map scans of comparable cost: TextContains
+///       (substring scan; artist/flavor contains were rewritten to tier 1 at
+///       bind), unanchored-literal regexes, and the pip-map walks of
+///       Devotion / ManaCostCmp (string-keyed hashmap iteration — measured
+///       within ~2× of a substring scan, so no reliable gap to exploit)
+///   3 — TextRegex with real regex machinery — the single worst
+///       per-candidate cost the engine has
+///
+/// Composites take the max of their children: their short-circuit may have to
+/// evaluate every child, so the most expensive child bounds the cost.
+fn verify_cost_tier(f: &FilterExpr) -> u8 {
+    match f {
+        FilterExpr::TextRegex { regex, .. } => regex_tier(regex.as_str()),
+        FilterExpr::TextContains { .. }
+        | FilterExpr::Devotion { .. }
+        | FilterExpr::ManaCostCmp { .. } => 2,
+        FilterExpr::ArtistMatch { .. }
+        | FilterExpr::FlavorMatch { .. }
+        | FilterExpr::NameMatch { .. }
+        | FilterExpr::OracleMatch { .. }
+        | FilterExpr::CollectionCmp { .. } => 1,
+        FilterExpr::And(children) | FilterExpr::Or(children) => {
+            children.iter().map(verify_cost_tier).max().unwrap_or(0)
+        }
+        FilterExpr::Not(inner) => verify_cost_tier(inner),
+        _ => 0,
+    }
+}
+
+/// Classify a regex pattern's per-candidate cost by shape. The regex crate
+/// compiles literal-only patterns to memcmp-style matchers (with case
+/// folding for the (?i) every query regex carries), and anchors bound the
+/// scan to one position — measured on the real corpus, `^flying$` costs
+/// ~half a substring scan while an unanchored literal costs about the same
+/// as one. Ranking them as general regexes inverted real costs and made
+/// `o:/^flying$/ oracle:sacrifice` 2.4× slower, so:
+///
+///   1 — literal with a ^ or $ anchor (starts_with/ends_with/equality)
+///   2 — bare literal (substring search, same tier as TextContains)
+///   3 — anything with live regex metacharacters
+pub(crate) fn regex_tier(pattern: &str) -> u8 {
+    let mut p = pattern.strip_prefix("(?i)").unwrap_or(pattern);
+    let anchored_start = p.starts_with('^');
+    if anchored_start {
+        p = &p[1..];
+    }
+    let bytes = p.as_bytes();
+    let mut anchored_end = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            // An escape of punctuation (\{ \. \$) is a literal character; an
+            // alphanumeric escape (\d \w \b \p…) is a class — real machinery.
+            b'\\' => match bytes.get(i + 1) {
+                Some(c) if !c.is_ascii_alphanumeric() => i += 2,
+                _ => return 3,
+            },
+            b'$' if i == bytes.len() - 1 => {
+                anchored_end = true;
+                i += 1;
+            }
+            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return 3,
+            _ => i += 1,
+        }
+    }
+    if anchored_start || anchored_end { 1 } else { 2 }
+}
+
+/// Within-tier refinement for And children: memoized sets know their own
+/// size, and under an And a smaller set is more selective — it rejects more
+/// candidates per (identical) binary-search cost, so it should run first.
+/// Nodes without a known set size sort after sized ones in their tier and
+/// keep written order among themselves (the sort is stable).
+fn and_child_set_len(f: &FilterExpr) -> usize {
+    match f {
+        FilterExpr::ArtistMatch { ids } => ids.len(),
+        FilterExpr::NameMatch { ids } => ids.len(),
+        FilterExpr::FlavorMatch { gids, .. } | FilterExpr::OracleMatch { gids } => gids.len(),
+        _ => usize::MAX,
+    }
+}
+
 /// Vocab ids (ascending) whose artist string satisfies `pred`.
 fn artist_match_ids(artist_vocab: &AStrings, pred: impl Fn(&str) -> bool) -> Vec<u16> {
     artist_vocab
@@ -597,6 +688,45 @@ impl FilterExpr {
                 gids.sort_unstable();
                 *self = FilterExpr::OracleMatch { gids };
             }
+            _ => {}
+        }
+    }
+
+    /// Reorder And/Or children cheapest-verification-first so the tri walk's
+    /// short-circuit (first False settles an And, first True settles an Or)
+    /// runs the expensive text predicates on as few cards as possible. The tri
+    /// accumulation is commutative — False/True dominate and the Null /
+    /// PrintingDep flags just OR together — so any child order is
+    /// semantics-preserving; only the cost changes. Without this, whether a
+    /// broad scan pays a regex before or after the cheap mask checks depends
+    /// on how the user typed the query.
+    ///
+    /// Within an And's memoized-set tier the sort key refines to ascending set
+    /// size: a smaller match set rejects more candidates per unit cost, and
+    /// the size is already known (ids.len()). Or children stop at the tier —
+    /// their short-circuit is acceptance, where small sets are the *worst*
+    /// lead, and there is no cheap acceptance-rate estimate to sort by.
+    ///
+    /// The sort is stable, so equal-cost children keep written order and the
+    /// result is deterministic. Must run after memoize_text_predicates():
+    /// memoization flips TextContains nodes from the scan tier to the set
+    /// tier. The per-printing residual pass inherits the order too, since
+    /// card_pass() pushes residual children in child order.
+    pub(crate) fn order_children_by_verify_cost(&mut self) {
+        match self {
+            FilterExpr::And(children) => {
+                for c in children.iter_mut() {
+                    c.order_children_by_verify_cost();
+                }
+                children.sort_by_key(|c| (verify_cost_tier(c), and_child_set_len(c)));
+            }
+            FilterExpr::Or(children) => {
+                for c in children.iter_mut() {
+                    c.order_children_by_verify_cost();
+                }
+                children.sort_by_key(verify_cost_tier);
+            }
+            FilterExpr::Not(inner) => inner.order_children_by_verify_cost(),
             _ => {}
         }
     }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -264,6 +264,10 @@ fn text_field_value<'a>(
 
 // ─── FilterExpr ───────────────────────────────────────────────────────────────
 
+/// When adding a variant, check its classification in verify_cost_tier() and
+/// printing_dependent() (likewise num_pdep for new NumFields): their wildcard
+/// arms silently rank unknown nodes cheapest/card-level, which misorders the
+/// verifier walk — a perf bug no test will catch.
 pub(crate) enum FilterExpr {
     True,
     And(Vec<FilterExpr>),

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -264,10 +264,10 @@ fn text_field_value<'a>(
 
 // ─── FilterExpr ───────────────────────────────────────────────────────────────
 
-/// When adding a variant, check its classification in verify_cost_tier() and
-/// printing_dependent() (likewise num_pdep for new NumFields): their wildcard
-/// arms silently rank unknown nodes cheapest/card-level, which misorders the
-/// verifier walk — a perf bug no test will catch.
+/// verify_cost_tier() and printing_dependent() match on this enum
+/// exhaustively (no `_` arm), so adding a variant is a compile error until
+/// it's classified in both — deliberately, since a silent default there
+/// would misorder the verifier walk without failing any test.
 pub(crate) enum FilterExpr {
     True,
     And(Vec<FilterExpr>),
@@ -413,7 +413,17 @@ fn verify_cost_tier(f: &FilterExpr) -> u8 {
             children.iter().map(verify_cost_tier).max().unwrap_or(0)
         }
         FilterExpr::Not(inner) => verify_cost_tier(inner),
-        _ => 0,
+        // Exhaustive, not `_ => 0`: a new variant must get a considered tier
+        // here rather than silently inheriting tier 0 (cheapest).
+        FilterExpr::True
+        | FilterExpr::ExactName(_)
+        | FilterExpr::NumericCmp { .. }
+        | FilterExpr::TextExact { .. }
+        | FilterExpr::ColorCmp { .. }
+        | FilterExpr::TypeCmp { .. }
+        | FilterExpr::Legality { .. }
+        | FilterExpr::DateCmp { .. }
+        | FilterExpr::YearCmp { .. } => 0,
     }
 }
 
@@ -469,36 +479,58 @@ pub(crate) fn regex_tier(pattern: &str) -> u8 {
 fn printing_dependent(f: &FilterExpr) -> bool {
     fn num_pdep(e: &NumExpr) -> bool {
         match e {
-            NumExpr::Field(
+            NumExpr::Const(_) => false,
+            // Exhaustive over NumField, not `matches!` with a hidden `_ =>
+            // false`: a new field must get a considered answer here rather
+            // than silently inheriting "card-level".
+            NumExpr::Field(field) => match field {
                 NumField::RarityInt
                 | NumField::CollectorNumberInt
                 | NumField::PriceUsd
                 | NumField::PriceEur
                 | NumField::PriceTix
-                | NumField::PreferScore,
-            ) => true,
+                | NumField::PreferScore => true,
+                NumField::Cmc | NumField::Power | NumField::Toughness | NumField::Loyalty | NumField::EdhrEc => false,
+            },
             NumExpr::Arith(lhs, _, rhs) => num_pdep(lhs) || num_pdep(rhs),
-            _ => false,
         }
     }
     match f {
         FilterExpr::NumericCmp { lhs, rhs, .. } => num_pdep(lhs) || num_pdep(rhs),
         FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => true,
         FilterExpr::ArtistMatch { .. } | FilterExpr::FlavorMatch { .. } => true,
-        FilterExpr::TextContains { field: TextSearchField::FlavorTextLower, .. } => true,
-        FilterExpr::TextExact { field, .. } | FilterExpr::TextRegex { field, .. } => matches!(
-            field,
-            TextField::FlavorTextLower | TextField::SetCode | TextField::Border | TextField::Watermark | TextField::CollectorNumber
-        ),
-        FilterExpr::CollectionCmp { field, .. } => {
-            matches!(field, CollField::ArtTags | CollField::IsTags | CollField::FrameData)
-        }
+        // Exhaustive over TextSearchField (no `matches!`), same reason as num_pdep.
+        FilterExpr::TextContains { field, .. } => match field {
+            TextSearchField::FlavorTextLower => true,
+            TextSearchField::NameLower | TextSearchField::OracleTextLower | TextSearchField::ArtistLower => false,
+        },
+        // Exhaustive over TextField (no `matches!`), same reason as num_pdep.
+        FilterExpr::TextExact { field, .. } | FilterExpr::TextRegex { field, .. } => match field {
+            TextField::FlavorTextLower | TextField::SetCode | TextField::Border | TextField::Watermark | TextField::CollectorNumber => {
+                true
+            }
+            TextField::NameLower | TextField::OracleTextLower | TextField::ArtistLower | TextField::Layout => false,
+        },
+        // Exhaustive over CollField (no `matches!`), same reason as num_pdep.
+        FilterExpr::CollectionCmp { field, .. } => match field {
+            CollField::ArtTags | CollField::IsTags | CollField::FrameData => true,
+            CollField::Subtypes | CollField::Keywords | CollField::OracleTags => false,
+        },
         // Divergent-legality cards defer to the printing, but they are a rare
         // exception (non-tournament reprints); rank by the common card-level case.
         FilterExpr::Legality { .. } => false,
         FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(printing_dependent),
         FilterExpr::Not(inner) => printing_dependent(inner),
-        _ => false,
+        // Exhaustive, not `_ => false`: a new variant must get a considered
+        // answer here rather than silently inheriting "can settle at card level".
+        FilterExpr::True
+        | FilterExpr::ExactName(_)
+        | FilterExpr::NameMatch { .. }
+        | FilterExpr::OracleMatch { .. }
+        | FilterExpr::ColorCmp { .. }
+        | FilterExpr::TypeCmp { .. }
+        | FilterExpr::ManaCostCmp { .. }
+        | FilterExpr::Devotion { .. } => false,
     }
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2717,6 +2717,14 @@ fn push_card_matches(
 /// streaming's win grows fast (~1.8× by 8k), so the trigger stays put.
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));
 
+/// Whether run_query reorders And/Or children cheapest-verification-first
+/// before the evaluation walk (see FilterExpr::order_children_by_verify_cost).
+/// Unlike the guards above this is a binary A/B switch, not a threshold:
+/// cost-only ordering never adds work (when nothing short-circuits, every
+/// child ran anyway), so there is no crossover to calibrate — the off
+/// position exists for benchmarking written-order sensitivity.
+static VERIFY_ORDER: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_VERIFY_ORDER", 1));
+
 fn run_query<'a>(
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
@@ -2788,6 +2796,13 @@ fn run_query<'a>(
     // leaves the scan alone.
     let eval_domain = candidate_cards.as_ref().map_or(cards.len(), Vec::len);
     filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram, eval_domain);
+    // Sort And/Or children cheapest-verification-first so the walk's
+    // short-circuit spares the expensive text predicates (semantics-preserving;
+    // see order_children_by_verify_cost). After memoization, which flips
+    // TextContains nodes from the scan tier to the set tier.
+    if *VERIFY_ORDER != 0 {
+        filter.order_children_by_verify_cost();
+    }
     let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
         None    => Box::new(0..cards.len() as u32),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2265,15 +2265,15 @@ fn order_name_sorts_and_paginates() {
 
 // ─── Verifier cost ordering ───────────────────────────────────────────────────
 
-fn tier0_type() -> FilterExpr {
+fn type_mask() -> FilterExpr {
     FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }
 }
 
-fn tier2_contains() -> FilterExpr {
+fn contains_scan() -> FilterExpr {
     FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() }
 }
 
-fn tier3_regex() -> FilterExpr {
+fn machinery_regex() -> FilterExpr {
     FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: regex::Regex::new("draw .* cards?").unwrap() }
 }
 
@@ -2303,7 +2303,7 @@ fn verify_order_sorts_and_children_cheap_first() {
         op: CmpOp::Lt,
         rhs: NumExpr::Const(v),
     };
-    let mut f = FilterExpr::And(vec![tier3_regex(), cmc_lt(3.0), tier2_contains(), cmc_lt(5.0), tier0_type()]);
+    let mut f = FilterExpr::And(vec![machinery_regex(), cmc_lt(3.0), contains_scan(), cmc_lt(5.0), type_mask()]);
     f.order_children_by_verify_cost();
     let FilterExpr::And(children) = &f else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } if v == 3.0));
@@ -2337,10 +2337,10 @@ fn verify_order_and_refines_by_set_size() {
 #[test]
 fn verify_order_or_sorts_by_bucket_only() {
     let mut f = FilterExpr::Or(vec![
-        tier3_regex(),
+        machinery_regex(),
         FilterExpr::NameMatch { ids: vec![1, 2, 3, 4, 5] },
         FilterExpr::OracleMatch { gids: vec![7, 9] },
-        tier0_type(),
+        type_mask(),
     ]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
@@ -2357,7 +2357,7 @@ fn verify_order_or_sorts_by_bucket_only() {
 #[test]
 fn verify_order_or_keeps_scan_cost_band_in_written_order() {
     let devotion = || FilterExpr::Devotion { op: CmpOp::Ge, pips: HashMap::from([("B".to_string(), 3u8)]) };
-    let mut f = FilterExpr::Or(vec![tier2_contains(), devotion()]);
+    let mut f = FilterExpr::Or(vec![contains_scan(), devotion()]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TextContains { .. }), "contains keeps its written lead");
@@ -2365,7 +2365,7 @@ fn verify_order_or_keeps_scan_cost_band_in_written_order() {
 
     // In an And the same pair DOES reorder: rejection is what And children
     // short-circuit on, and the pip walk measures ~3× under the text scan.
-    let mut g = FilterExpr::And(vec![tier2_contains(), devotion()]);
+    let mut g = FilterExpr::And(vec![contains_scan(), devotion()]);
     g.order_children_by_verify_cost();
     let FilterExpr::And(children) = &g else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::Devotion { .. }), "And sorts the cheaper pip walk first");
@@ -2378,7 +2378,7 @@ fn verify_order_or_keeps_scan_cost_band_in_written_order() {
 // (oracle:token or name:storm)` lost 1.1× to set-first ordering).
 #[test]
 fn verify_order_or_keeps_sets_and_scans_in_written_order() {
-    let mut f = FilterExpr::Or(vec![tier2_contains(), FilterExpr::NameMatch { ids: vec![1, 2] }]);
+    let mut f = FilterExpr::Or(vec![contains_scan(), FilterExpr::NameMatch { ids: vec![1, 2] }]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TextContains { .. }));
@@ -2405,7 +2405,7 @@ fn verify_order_and_defers_printing_dependent_children() {
 
     // Or(usd, type) can settle at card level through its type member (a True
     // settles an Or), so it is not printing-dependent and leads the contains.
-    let mut g = FilterExpr::And(vec![tier2_contains(), FilterExpr::Or(vec![usd(), tier0_type()])]);
+    let mut g = FilterExpr::And(vec![contains_scan(), FilterExpr::Or(vec![usd(), type_mask()])]);
     g.order_children_by_verify_cost();
     let FilterExpr::And(children) = &g else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::Or(_)), "mixed composite can settle: stays card-level");
@@ -2422,14 +2422,14 @@ fn verify_order_or_defers_printing_dependent_children() {
         op: CmpOp::Gt,
         rhs: NumExpr::Const(20.0),
     };
-    let mut f = FilterExpr::Or(vec![tier2_contains(), usd()]);
+    let mut f = FilterExpr::Or(vec![contains_scan(), usd()]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TextContains { .. }), "card-level scan stays ahead of pdep numeric");
     assert!(matches!(children[1], FilterExpr::NumericCmp { .. }));
 
     // A card-level mask still moves ahead of a printing-dependent set lookup.
-    let mut g = FilterExpr::Or(vec![FilterExpr::FlavorMatch { gids: vec![3], dense_ids: vec![] }, tier0_type()]);
+    let mut g = FilterExpr::Or(vec![FilterExpr::FlavorMatch { gids: vec![3], dense_ids: vec![] }, type_mask()]);
     g.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &g else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));
@@ -2440,8 +2440,8 @@ fn verify_order_or_defers_printing_dependent_children() {
 // run every child), and the sort recurses through And/Or/Not nesting.
 #[test]
 fn verify_order_recurses_and_ranks_composites() {
-    let inner_or = FilterExpr::Or(vec![tier3_regex(), tier0_type()]);
-    let mut f = FilterExpr::Not(Box::new(FilterExpr::And(vec![inner_or, tier2_contains(), tier0_type()])));
+    let inner_or = FilterExpr::Or(vec![machinery_regex(), type_mask()]);
+    let mut f = FilterExpr::Not(Box::new(FilterExpr::And(vec![inner_or, contains_scan(), type_mask()])));
     f.order_children_by_verify_cost();
     let FilterExpr::Not(inner) = &f else { panic!("still a Not") };
     let FilterExpr::And(children) = inner.as_ref() else { panic!("still an And") };
@@ -2481,14 +2481,14 @@ fn verify_order_spellings_agree_end_to_end() {
         let ids: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
         (total, ids)
     };
-    let expensive_first = FilterExpr::And(vec![tier3_regex(), tier0_type()]);
-    let cheap_first = FilterExpr::And(vec![tier0_type(), tier3_regex()]);
+    let expensive_first = FilterExpr::And(vec![machinery_regex(), type_mask()]);
+    let cheap_first = FilterExpr::And(vec![type_mask(), machinery_regex()]);
     let (t1, p1) = run(expensive_first);
     let (t2, p2) = run(cheap_first);
     assert_eq!(t1, 4, "creatures with draw-a-card text: cards 3, 5, 9, 11");
     assert_eq!((t1, p1), (t2, p2));
 
-    let or_a = FilterExpr::Or(vec![tier3_regex(), tier0_type()]);
-    let or_b = FilterExpr::Or(vec![tier0_type(), tier3_regex()]);
+    let or_a = FilterExpr::Or(vec![machinery_regex(), type_mask()]);
+    let or_b = FilterExpr::Or(vec![type_mask(), machinery_regex()]);
     assert_eq!(run(or_a), run(or_b));
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2286,12 +2286,12 @@ fn regex_tier_classifies_pattern_shapes() {
     assert_eq!(regex_tier("dragon$"), 1);
     assert_eq!(regex_tier("(?i)^\\{t\\}: add"), 1, "escaped punctuation is literal");
     assert_eq!(regex_tier("^gob"), 1);
-    assert_eq!(regex_tier("(?i)flying"), 2, "unanchored literal = contains cost");
-    assert_eq!(regex_tier("draw .* cards?"), 3);
-    assert_eq!(regex_tier("^[aeiou]"), 3);
-    assert_eq!(regex_tier("(?i)^\\d+$"), 3, "class escapes are machinery");
-    assert_eq!(regex_tier("a|b"), 3);
-    assert_eq!(regex_tier("ends with backslash\\"), 3, "dangling escape: not literal");
+    assert_eq!(regex_tier("(?i)flying"), 3, "unanchored literal = contains cost");
+    assert_eq!(regex_tier("draw .* cards?"), 4);
+    assert_eq!(regex_tier("^[aeiou]"), 4);
+    assert_eq!(regex_tier("(?i)^\\d+$"), 4, "class escapes are machinery");
+    assert_eq!(regex_tier("a|b"), 4);
+    assert_eq!(regex_tier("ends with backslash\\"), 4, "dangling escape: not literal");
 }
 
 // And children reorder cheapest-tier-first regardless of written order, and
@@ -2331,10 +2331,11 @@ fn verify_order_and_refines_by_set_size() {
     assert!(matches!(children[2], FilterExpr::CollectionCmp { .. }));
 }
 
-// Or children sort by tier only: acceptance short-circuits an Or, and a small
-// set is the worst acceptance lead, so set size must NOT reorder Or children.
+// Or children sort by coarse buckets: acceptance short-circuits an Or, and a
+// small set is the worst acceptance lead, so neither set size nor fine cost
+// tiers may reorder Or children — only decisive gaps do.
 #[test]
-fn verify_order_or_sorts_by_tier_only() {
+fn verify_order_or_sorts_by_bucket_only() {
     let mut f = FilterExpr::Or(vec![
         tier3_regex(),
         FilterExpr::NameMatch { ids: vec![1, 2, 3, 4, 5] },
@@ -2347,6 +2348,92 @@ fn verify_order_or_sorts_by_tier_only() {
     assert!(matches!(&children[1], FilterExpr::NameMatch { ids } if ids.len() == 5), "written order kept within tier");
     assert!(matches!(&children[2], FilterExpr::OracleMatch { gids } if gids.len() == 2));
     assert!(matches!(children[3], FilterExpr::TextRegex { .. }));
+}
+
+// Within an Or, nodes of text-scan-adjacent cost (pip maps, contains, bare
+// literals) keep written order: their cost gap is too small to outweigh the
+// unknowable acceptance rates (devotion-first cost `oracle:vigilance or
+// devotion:bbb` 1.2× when measured).
+#[test]
+fn verify_order_or_keeps_scan_cost_band_in_written_order() {
+    let devotion = || FilterExpr::Devotion { op: CmpOp::Ge, pips: HashMap::from([("B".to_string(), 3u8)]) };
+    let mut f = FilterExpr::Or(vec![tier2_contains(), devotion()]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::Or(children) = &f else { panic!("still an Or") };
+    assert!(matches!(children[0], FilterExpr::TextContains { .. }), "contains keeps its written lead");
+    assert!(matches!(children[1], FilterExpr::Devotion { .. }));
+
+    // In an And the same pair DOES reorder: rejection is what And children
+    // short-circuit on, and the pip walk measures ~3× under the text scan.
+    let mut g = FilterExpr::And(vec![tier2_contains(), devotion()]);
+    g.order_children_by_verify_cost();
+    let FilterExpr::And(children) = &g else { panic!("still an And") };
+    assert!(matches!(children[0], FilterExpr::Devotion { .. }), "And sorts the cheaper pip walk first");
+    assert!(matches!(children[1], FilterExpr::TextContains { .. }));
+}
+
+// Within an Or, a memoized set must NOT jump ahead of a contains: the ~3×
+// cost gap between a binary search and a substring scan is smaller than the
+// acceptance-rate swing it gambles on (measured: `(… or color:g)
+// (oracle:token or name:storm)` lost 1.1× to set-first ordering).
+#[test]
+fn verify_order_or_keeps_sets_and_scans_in_written_order() {
+    let mut f = FilterExpr::Or(vec![tier2_contains(), FilterExpr::NameMatch { ids: vec![1, 2] }]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::Or(children) = &f else { panic!("still an Or") };
+    assert!(matches!(children[0], FilterExpr::TextContains { .. }));
+    assert!(matches!(children[1], FilterExpr::NameMatch { .. }));
+}
+
+// And children that can reject at card level run before printing-dependent
+// ones, which never can: `usd>20 t:dragon` must check the subtype first so
+// rejected cards skip the price eval entirely. A composite with any
+// card-level member can still settle at card level, so it stays early.
+#[test]
+fn verify_order_and_defers_printing_dependent_children() {
+    let usd = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::PriceUsd),
+        op: CmpOp::Gt,
+        rhs: NumExpr::Const(20.0),
+    };
+    let dragon = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "dragon".to_string(), value_id: None };
+    let mut f = FilterExpr::And(vec![usd(), dragon()]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::And(children) = &f else { panic!("still an And") };
+    assert!(matches!(children[0], FilterExpr::CollectionCmp { .. }), "card-level rejector first");
+    assert!(matches!(children[1], FilterExpr::NumericCmp { .. }));
+
+    // Or(usd, type) can settle at card level through its type member (a True
+    // settles an Or), so it is not printing-dependent and leads the contains.
+    let mut g = FilterExpr::And(vec![tier2_contains(), FilterExpr::Or(vec![usd(), tier0_type()])]);
+    g.order_children_by_verify_cost();
+    let FilterExpr::And(children) = &g else { panic!("still an And") };
+    assert!(matches!(children[0], FilterExpr::Or(_)), "mixed composite can settle: stays card-level");
+    assert!(matches!(children[1], FilterExpr::TextContains { .. }));
+}
+
+// Printing-dependent Or children can never settle the Or during the card
+// pass, so a cheap tier never pulls them ahead of card-level children —
+// `usd>20` must not jump ahead of the contains it can't short-circuit.
+#[test]
+fn verify_order_or_defers_printing_dependent_children() {
+    let usd = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::PriceUsd),
+        op: CmpOp::Gt,
+        rhs: NumExpr::Const(20.0),
+    };
+    let mut f = FilterExpr::Or(vec![tier2_contains(), usd()]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::Or(children) = &f else { panic!("still an Or") };
+    assert!(matches!(children[0], FilterExpr::TextContains { .. }), "card-level scan stays ahead of pdep numeric");
+    assert!(matches!(children[1], FilterExpr::NumericCmp { .. }));
+
+    // A card-level mask still moves ahead of a printing-dependent set lookup.
+    let mut g = FilterExpr::Or(vec![FilterExpr::FlavorMatch { gids: vec![3], dense_ids: vec![] }, tier0_type()]);
+    g.order_children_by_verify_cost();
+    let FilterExpr::Or(children) = &g else { panic!("still an Or") };
+    assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));
+    assert!(matches!(children[1], FilterExpr::FlavorMatch { .. }));
 }
 
 // Composites rank as the max of their children (their evaluation may have to

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2262,3 +2262,146 @@ fn order_name_sorts_and_paginates() {
     assert_eq!(ids("asc"), [4, 2], "within the tie: lower edhrec rank first");
     assert_eq!(ids("desc"), [4, 2], "secondaries keep their order under desc");
 }
+
+// ─── Verifier cost ordering ───────────────────────────────────────────────────
+
+fn tier0_type() -> FilterExpr {
+    FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }
+}
+
+fn tier2_contains() -> FilterExpr {
+    FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() }
+}
+
+fn tier3_regex() -> FilterExpr {
+    FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: regex::Regex::new("draw .* cards?").unwrap() }
+}
+
+// Pattern-shape cost classification: anchored literals are memcmp-cheap,
+// bare literals cost a substring scan, real machinery gets the top tier.
+#[test]
+fn regex_tier_classifies_pattern_shapes() {
+    use super::regex_tier;
+    assert_eq!(regex_tier("(?i)^flying$"), 1);
+    assert_eq!(regex_tier("dragon$"), 1);
+    assert_eq!(regex_tier("(?i)^\\{t\\}: add"), 1, "escaped punctuation is literal");
+    assert_eq!(regex_tier("^gob"), 1);
+    assert_eq!(regex_tier("(?i)flying"), 2, "unanchored literal = contains cost");
+    assert_eq!(regex_tier("draw .* cards?"), 3);
+    assert_eq!(regex_tier("^[aeiou]"), 3);
+    assert_eq!(regex_tier("(?i)^\\d+$"), 3, "class escapes are machinery");
+    assert_eq!(regex_tier("a|b"), 3);
+    assert_eq!(regex_tier("ends with backslash\\"), 3, "dangling escape: not literal");
+}
+
+// And children reorder cheapest-tier-first regardless of written order, and
+// equal-tier children keep their written order (stable sort).
+#[test]
+fn verify_order_sorts_and_children_cheap_first() {
+    let cmc_lt = |v: f64| FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Cmc),
+        op: CmpOp::Lt,
+        rhs: NumExpr::Const(v),
+    };
+    let mut f = FilterExpr::And(vec![tier3_regex(), cmc_lt(3.0), tier2_contains(), cmc_lt(5.0), tier0_type()]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::And(children) = &f else { panic!("still an And") };
+    assert!(matches!(children[0], FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } if v == 3.0));
+    assert!(matches!(children[1], FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } if v == 5.0));
+    assert!(matches!(children[2], FilterExpr::TypeCmp { .. }));
+    assert!(matches!(children[3], FilterExpr::TextContains { .. }));
+    assert!(matches!(children[4], FilterExpr::TextRegex { .. }));
+}
+
+// Within the memoized-set tier, And children refine to ascending set size
+// (smaller set = more rejections per identical binary-search cost); tier-1
+// children without a known size (collections) come after the sized sets.
+#[test]
+fn verify_order_and_refines_by_set_size() {
+    let coll = FilterExpr::CollectionCmp { field: CollField::Keywords, op: CmpOp::Ge, value: "flying".to_string(), value_id: None };
+    let mut f = FilterExpr::And(vec![
+        coll,
+        FilterExpr::NameMatch { ids: vec![1, 2, 3, 4, 5] },
+        FilterExpr::OracleMatch { gids: vec![7, 9] },
+    ]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::And(children) = &f else { panic!("still an And") };
+    assert!(matches!(&children[0], FilterExpr::OracleMatch { gids } if gids.len() == 2));
+    assert!(matches!(&children[1], FilterExpr::NameMatch { ids } if ids.len() == 5));
+    assert!(matches!(children[2], FilterExpr::CollectionCmp { .. }));
+}
+
+// Or children sort by tier only: acceptance short-circuits an Or, and a small
+// set is the worst acceptance lead, so set size must NOT reorder Or children.
+#[test]
+fn verify_order_or_sorts_by_tier_only() {
+    let mut f = FilterExpr::Or(vec![
+        tier3_regex(),
+        FilterExpr::NameMatch { ids: vec![1, 2, 3, 4, 5] },
+        FilterExpr::OracleMatch { gids: vec![7, 9] },
+        tier0_type(),
+    ]);
+    f.order_children_by_verify_cost();
+    let FilterExpr::Or(children) = &f else { panic!("still an Or") };
+    assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));
+    assert!(matches!(&children[1], FilterExpr::NameMatch { ids } if ids.len() == 5), "written order kept within tier");
+    assert!(matches!(&children[2], FilterExpr::OracleMatch { gids } if gids.len() == 2));
+    assert!(matches!(children[3], FilterExpr::TextRegex { .. }));
+}
+
+// Composites rank as the max of their children (their evaluation may have to
+// run every child), and the sort recurses through And/Or/Not nesting.
+#[test]
+fn verify_order_recurses_and_ranks_composites() {
+    let inner_or = FilterExpr::Or(vec![tier3_regex(), tier0_type()]);
+    let mut f = FilterExpr::Not(Box::new(FilterExpr::And(vec![inner_or, tier2_contains(), tier0_type()])));
+    f.order_children_by_verify_cost();
+    let FilterExpr::Not(inner) = &f else { panic!("still a Not") };
+    let FilterExpr::And(children) = inner.as_ref() else { panic!("still an And") };
+    assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));
+    assert!(matches!(children[1], FilterExpr::TextContains { .. }));
+    let FilterExpr::Or(or_children) = &children[2] else { panic!("Or ranks tier 3, last") };
+    assert!(matches!(or_children[0], FilterExpr::TypeCmp { .. }), "nested Or sorted too");
+    assert!(matches!(or_children[1], FilterExpr::TextRegex { .. }));
+}
+
+// End-to-end: the two spellings of a mixed-cost conjunction return identical
+// totals and pages through run_query — ordering is a speed dial, not a
+// semantics change.
+#[test]
+fn verify_order_spellings_agree_end_to_end() {
+    let mut vocab = VocabInterner::new();
+    let mut strings = Interner::new();
+    let mut cards = Vec::new();
+    for i in 0..12u32 {
+        let types = if i % 2 == 0 { TYPE_CREATURE } else { TYPE_INSTANT };
+        let mut c = stub_card((i + 1) as u128, types, &[], &mut vocab);
+        let text = if i % 3 == 0 { "flying" } else { "draw a card" };
+        c.oracle_text_lower_id = strings.intern(text.to_string());
+        c.edhrec_rank = Some(i + 1);
+        cards.push(c);
+    }
+    let mut data = store_of(cards, &vec![2usize; 12], vocab);
+    data.strings = strings.strings;
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let run = |mut filter: FilterExpr| {
+        let (total, page) = run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut filter, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        );
+        let ids: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
+        (total, ids)
+    };
+    let expensive_first = FilterExpr::And(vec![tier3_regex(), tier0_type()]);
+    let cheap_first = FilterExpr::And(vec![tier0_type(), tier3_regex()]);
+    let (t1, p1) = run(expensive_first);
+    let (t2, p2) = run(cheap_first);
+    assert_eq!(t1, 4, "creatures with draw-a-card text: cards 3, 5, 9, 11");
+    assert_eq!((t1, p1), (t2, p2));
+
+    let or_a = FilterExpr::Or(vec![tier3_regex(), tier0_type()]);
+    let or_b = FilterExpr::Or(vec![tier0_type(), tier3_regex()]);
+    assert_eq!(run(or_a), run(or_b));
+}

--- a/docs/changelog/2026-07-09-verifier-cost-ordering.md
+++ b/docs/changelog/2026-07-09-verifier-cost-ordering.md
@@ -5,7 +5,7 @@ The narrowing pass has ordered And children by materialization cost since
 query that full-scans (regex conjuncts, legality/arithmetic partners), whether
 each card paid the expensive text predicate before or after the cheap mask
 checks depended on how the user typed the query — `o:/draw .* cards?/
-f:pauper` and `f:pauper o:/draw .* cards?/` differed by ~2.4×.
+f:pauper` and `f:pauper o:/draw .* cards?/` differed by ~2.1×.
 
 `run_query` now sorts And/Or children cheapest-verification-tier-first after
 text-predicate memoization (which changes tiers), using a stable sort so

--- a/docs/changelog/2026-07-09-verifier-cost-ordering.md
+++ b/docs/changelog/2026-07-09-verifier-cost-ordering.md
@@ -1,0 +1,19 @@
+# Verifier orders And/Or children by evaluation cost
+
+The narrowing pass has ordered And children by materialization cost since
+#637, but the verifier still walked And/Or children in written order. For a
+query that full-scans (regex conjuncts, legality/arithmetic partners), whether
+each card paid the expensive text predicate before or after the cheap mask
+checks depended on how the user typed the query — `o:/draw .* cards?/
+f:pauper` and `f:pauper o:/draw .* cards?/` differed by ~2.4×.
+
+`run_query` now sorts And/Or children cheapest-verification-tier-first after
+text-predicate memoization (which changes tiers), using a stable sort so
+equal-cost children keep written order. Within an And's memoized-set tier,
+children refine to ascending set size — a smaller set rejects more per
+identical binary-search cost. The tri accumulation is commutative, so
+reordering is semantics-preserving; totals are unchanged on every benchmarked
+query. `CARD_ENGINE_VERIFY_ORDER=0` restores written order for A/B runs.
+
+See `docs/issues/engine-verifier-cost-ordering.md` for the design discussion
+and the PR for measured results.

--- a/scripts/bench_verify_order.py
+++ b/scripts/bench_verify_order.py
@@ -44,7 +44,13 @@ import scripts.survey_queries as sq  # noqa: E402
 
 OUTDIR = REPO_ROOT / "benchmarks/verify-order"
 
+# Both branches set the toggle explicitly and to equal-length values: an env
+# var present in one branch only shifts the process memory layout enough to
+# move sub-100us queries a consistent ~15% either way (classic measurement-
+# bias artifact; reproduced here on single-predicate queries the toggle
+# cannot affect, and eliminated by equalizing the environment).
 OLD_ENV = {"CARD_ENGINE_VERIFY_ORDER": "0"}
+NEW_ENV = {"CARD_ENGINE_VERIFY_ORDER": "1"}
 
 # Same seeded survey corpus as the standing baselines (survey_queries.py --seed 42).
 BROAD_SEED = 42
@@ -66,7 +72,7 @@ MAX_ITERS = 400
 #                 (candidates already cover the cheap child), single
 #                 predicates, name lookups
 _PAIRS: list[tuple[str, str, str]] = [
-    # (family, expensive-first, cheap-first)
+    # family name, then the expensive-first and cheap-first spellings
     ("regex-legality", "o:/^\\{t\\}: add/ f:standard", "f:standard o:/^\\{t\\}: add/"),
     ("regex-legality", "o:/draw .* cards?/ f:pauper", "f:pauper o:/draw .* cards?/"),
     ("regex-legality-broad", "o:/^\\{t\\}: add/ f:commander", "f:commander o:/^\\{t\\}: add/"),
@@ -78,7 +84,7 @@ _PAIRS: list[tuple[str, str, str]] = [
     ("or-mixed", "o:/enters the battlefield tapped/ or t:land", "t:land or o:/enters the battlefield tapped/"),
     ("or-mixed", "o:/^flying$/ or c:g", "c:g or o:/^flying$/"),
     ("set-size", "o:creature flavor:dragon", "flavor:dragon o:creature"),
-    ("set-size", "artist:\"rebecca guay\" o:enchant", "o:enchant artist:\"rebecca guay\""),
+    ("set-size", 'artist:"rebecca guay" o:enchant', 'o:enchant artist:"rebecca guay"'),
     ("control-narrowed", "o:/^\\{t\\}: add/ t:land c:g", "t:land c:g o:/^\\{t\\}: add/"),
     ("control-narrowed", "o:/storm/ cmc>9", "cmc>9 o:/storm/"),
 ]
@@ -131,7 +137,7 @@ def build_spec_set(store: pathlib.Path, path: pathlib.Path) -> None:
     print(f"spec set: {len(kept)} specs ({n_broad} broad, {len(kept) - n_broad} enrich) -> {path}")
 
 
-def bench_one(engine, spec: dict, window: float) -> tuple[int, int, float, float]:
+def bench_one(engine: object, spec: dict, window: float) -> tuple[int, int, float, float]:
     """Return (total, n, median_ms, min_ms) for one query spec over a timed window."""
     from api.parsing import parse_scryfall_query  # noqa: PLC0415 — worker-only import
 
@@ -199,7 +205,7 @@ def cmd_run(args: argparse.Namespace) -> None:
     if not args.out.exists():
         args.out.write_text("branch,rep,qid,query,section,family,pair,variant,total,n,med_ms,min_ms\n")
     for rep in range(1, args.reps + 1):
-        branches = [("old", OLD_ENV), ("new", {})]
+        branches = [("old", OLD_ENV), ("new", NEW_ENV)]
         if rep % 2 == 0:
             branches.reverse()
         for branch, env in branches:
@@ -207,12 +213,18 @@ def cmd_run(args: argparse.Namespace) -> None:
                 sys.executable,
                 str(pathlib.Path(__file__)),
                 "worker",
-                "--branch", branch,
-                "--rep", str(rep),
-                "--store", str(store),
-                "--queries", str(queries),
-                "--out", str(args.out),
-                "--window", str(args.window),
+                "--branch",
+                branch,
+                "--rep",
+                str(rep),
+                "--store",
+                str(store),
+                "--queries",
+                str(queries),
+                "--out",
+                str(args.out),
+                "--window",
+                str(args.window),
             ]
             subprocess.run(cmd, check=True, env={**os.environ, **env}, cwd=REPO_ROOT)
     cmd_analyze(args)
@@ -268,25 +280,31 @@ def cmd_analyze(args: argparse.Namespace) -> None:
             r = meta[q]
             print(f"  {ratios[q]:6.2f}x  {old[q]:8.3f} -> {new[q]:8.3f} ms  total={r['total']:>6}  {r['query']!r}")
 
-    # Spelling-pair symmetry: on the new branch the two spellings of a pair
-    # must cost the same; the old branch's spread IS the written-order bug.
+    _print_pair_symmetry(qids, meta, old, new, ratios)
+
+
+def _print_pair_symmetry(qids: list[str], meta: dict, old: dict, new: dict, ratios: dict) -> None:
+    """Print the spelling-pair symmetry table.
+
+    On the new branch the two spellings of a pair must cost the same; the old
+    branch's spread IS the written-order bug.
+    """
     pairs: dict[str, dict[str, str]] = {}
     for q in qids:
         r = meta[q]
         if r["pair"]:
             pairs.setdefault(r["pair"], {})[r["variant"]] = q
-    if pairs:
-        print("\n=== spelling pairs: expensive-first / cheap-first cost ratio ===")
-        print(f"  {'family':<22} {'old spread':>10} {'new spread':>10} {'exp-first speedup':>18}  query")
-        for pid, variants in sorted(pairs.items(), key=lambda kv: int(kv[0])):
-            if set(variants) != {"expensive-first", "cheap-first"}:
-                continue
-            qe, qc = variants["expensive-first"], variants["cheap-first"]
-            old_spread = old[qe] / old[qc]
-            new_spread = new[qe] / new[qc]
-            print(
-                f"  {meta[qe]['family']:<22} {old_spread:>9.2f}x {new_spread:>9.2f}x {ratios[qe]:>17.2f}x  {meta[qe]['query']!r}"
-            )
+    if not pairs:
+        return
+    print("\n=== spelling pairs: expensive-first / cheap-first cost ratio ===")
+    print(f"  {'family':<22} {'old spread':>10} {'new spread':>10} {'exp-first speedup':>18}  query")
+    for variants in (kv[1] for kv in sorted(pairs.items(), key=lambda kv: int(kv[0]))):
+        if set(variants) != {"expensive-first", "cheap-first"}:
+            continue
+        qe, qc = variants["expensive-first"], variants["cheap-first"]
+        old_spread = old[qe] / old[qc]
+        new_spread = new[qe] / new[qc]
+        print(f"  {meta[qe]['family']:<22} {old_spread:>9.2f}x {new_spread:>9.2f}x {ratios[qe]:>17.2f}x  {meta[qe]['query']!r}")
 
 
 def main() -> None:

--- a/scripts/bench_verify_order.py
+++ b/scripts/bench_verify_order.py
@@ -1,0 +1,313 @@
+"""A/B benchmark for verifier cost ordering (CARD_ENGINE_VERIFY_ORDER).
+
+Two sections, one frozen query set:
+
+* broad — the survey generator's realistic mix (weighted single predicates,
+  2-4 way ANDs, ORs, parens, negations, arithmetic, regex) plus wild-corpus
+  queries, exactly as scripts/survey_queries.py samples them. This is the
+  "did anything regress" net.
+* enrich — constructed shapes where child ordering should matter: full-scan
+  conjunctions pairing an expensive text predicate (regex / memo-declined
+  contains) with a cheap non-narrowable partner (legality, arithmetic, mana
+  cost), Or chains mixing tiers, memoized-set size pairs, and controls that
+  narrowing already covers (where ordering must change nothing). Conjunction
+  shapes appear as spelling PAIRS — expensive-first vs cheap-first — because
+  written-order sensitivity is the point: the two spellings differ on the old
+  branch and must not on the new one.
+
+Branches run in interleaved fresh subprocesses (the toggle is a
+once-per-process LazyLock): old = CARD_ENGINE_VERIFY_ORDER=0 (written order),
+new = defaults (cost-ordered). Totals must be identical old-vs-new for every
+query — ordering is a pure speed dial.
+
+    .venv/bin/python scripts/bench_verify_order.py run --reps 5
+    .venv/bin/python scripts/bench_verify_order.py analyze
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import pathlib
+import statistics
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.survey_queries as sq  # noqa: E402
+
+OUTDIR = REPO_ROOT / "benchmarks/verify-order"
+
+OLD_ENV = {"CARD_ENGINE_VERIFY_ORDER": "0"}
+
+# Same seeded survey corpus as the standing baselines (survey_queries.py --seed 42).
+BROAD_SEED = 42
+BROAD_GENERATED = 400
+BROAD_WILD = 120
+
+WARMUP = 3
+MAX_ITERS = 400
+
+# Constructed enrichment shapes. Pairs are (expensive-first, cheap-first)
+# spellings of the same conjunction/disjunction; singles have no order to vary.
+# Families:
+#   regex-*     — regex conjunct + cheap full-scan partner (legality / arith /
+#                 mana cost); the issue's headline shape
+#   contains-*  — memo-declined contains (common needle) + cheap partner
+#   or-mixed    — Or chains mixing cost tiers (short-circuit on cheap accepts)
+#   set-size    — And of two memoized/bound sets of very different sizes
+#   control-*   — shapes ordering must NOT change: narrowed conjunctions
+#                 (candidates already cover the cheap child), single
+#                 predicates, name lookups
+_PAIRS: list[tuple[str, str, str]] = [
+    # (family, expensive-first, cheap-first)
+    ("regex-legality", "o:/^\\{t\\}: add/ f:standard", "f:standard o:/^\\{t\\}: add/"),
+    ("regex-legality", "o:/draw .* cards?/ f:pauper", "f:pauper o:/draw .* cards?/"),
+    ("regex-legality-broad", "o:/^\\{t\\}: add/ f:commander", "f:commander o:/^\\{t\\}: add/"),
+    ("regex-arith", "o:/draw .* cards?/ power+toughness>8", "power+toughness>8 o:/draw .* cards?/"),
+    ("regex-arith", "name:/^[aeiou].*ing$/ cmc+1<power", "cmc+1<power name:/^[aeiou].*ing$/"),
+    ("regex-mana", "o:/sacrifice a creature/ mana:{b}{b}", "mana:{b}{b} o:/sacrifice a creature/"),
+    ("contains-legality", "o:the f:standard", "f:standard o:the"),
+    ("contains-arith", "o:and power+toughness>10", "power+toughness>10 o:and"),
+    ("or-mixed", "o:/enters the battlefield tapped/ or t:land", "t:land or o:/enters the battlefield tapped/"),
+    ("or-mixed", "o:/^flying$/ or c:g", "c:g or o:/^flying$/"),
+    ("set-size", "o:creature flavor:dragon", "flavor:dragon o:creature"),
+    ("set-size", "artist:\"rebecca guay\" o:enchant", "o:enchant artist:\"rebecca guay\""),
+    ("control-narrowed", "o:/^\\{t\\}: add/ t:land c:g", "t:land c:g o:/^\\{t\\}: add/"),
+    ("control-narrowed", "o:/storm/ cmc>9", "cmc>9 o:/storm/"),
+]
+_SINGLES: list[tuple[str, str]] = [
+    ("control-single", "c:g"),
+    ("control-single", "t:creature c:g"),
+    ("control-single", '!"lightning bolt"'),
+    ("control-single", "lightning"),
+    ("control-single", "o:/^\\{t\\}: add/"),  # lone regex: ordering has nothing to reorder
+    ("control-single", "f:modern"),
+]
+
+
+def enrichment_specs() -> list[dict]:
+    """Build the constructed-family specs, spelling pairs tagged for symmetry analysis."""
+    specs: list[dict] = []
+    for pair_id, (family, expensive_first, cheap_first) in enumerate(_PAIRS):
+        for variant, q in (("expensive-first", expensive_first), ("cheap-first", cheap_first)):
+            specs.append({"query": q, "section": "enrich", "family": family, "pair": pair_id, "variant": variant})
+    for family, q in _SINGLES:
+        specs.append({"query": q, "section": "enrich", "family": family, "pair": None, "variant": None})
+    for s in specs:
+        s.update({"unique": "card", "prefer": "default", "orderby": "edhrec", "direction": "asc", "offset": 0})
+    return specs
+
+
+def build_spec_set(store: pathlib.Path, path: pathlib.Path) -> None:
+    """Freeze broad (survey-sampled) + enrichment specs that parse and run."""
+    import card_engine  # noqa: PLC0415 — heavy import, only run needs it
+
+    rng = __import__("random").Random(BROAD_SEED)
+    broad = sq.generate(rng, BROAD_GENERATED) + sq.sample_wild(rng, BROAD_WILD)
+    for s in broad:
+        s.update({"section": "broad", "family": s["shape"], "pair": None, "variant": None})
+    specs = broad + enrichment_specs()
+    engine = card_engine.QueryEngine(str(store))
+    kept, seen = [], set()
+    for spec in specs:
+        if spec["query"] in seen:
+            continue
+        seen.add(spec["query"])
+        try:
+            bench_one(engine, spec, 0.0)
+        except Exception as oops:  # noqa: BLE001 — wild strings include unsupported syntax
+            print(f"SKIP {spec['query']!r}: {oops}")
+            continue
+        kept.append(spec)
+    path.write_text(json.dumps(kept, indent=1) + "\n")
+    n_broad = sum(1 for s in kept if s["section"] == "broad")
+    print(f"spec set: {len(kept)} specs ({n_broad} broad, {len(kept) - n_broad} enrich) -> {path}")
+
+
+def bench_one(engine, spec: dict, window: float) -> tuple[int, int, float, float]:
+    """Return (total, n, median_ms, min_ms) for one query spec over a timed window."""
+    from api.parsing import parse_scryfall_query  # noqa: PLC0415 — worker-only import
+
+    kw = {
+        "filters": parse_scryfall_query(spec["query"]),
+        "unique": spec["unique"],
+        "prefer": spec.get("prefer", "default"),
+        "orderby": spec["orderby"],
+        "direction": spec.get("direction", "asc"),
+        "limit": 100,
+        "offset": spec.get("offset", 0),
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    samples: list[float] = []
+    deadline = time.monotonic() + window
+    while not samples or (time.monotonic() < deadline and len(samples) < MAX_ITERS):
+        t0 = time.perf_counter_ns()
+        engine.query(**kw)
+        samples.append((time.perf_counter_ns() - t0) / 1e6)
+    return total, len(samples), statistics.median(samples), min(samples)
+
+
+def cmd_worker(args: argparse.Namespace) -> None:
+    """Time every spec in this process (one branch, one rep); append rows."""
+    import card_engine  # noqa: PLC0415 — import after the parent set the env
+
+    engine = card_engine.QueryEngine(str(args.store))
+    specs = json.loads(args.queries.read_text())
+    with args.out.open("a", newline="") as fh:
+        writer = csv.writer(fh)
+        for qid, spec in enumerate(specs):
+            total, n, med_ms, min_ms = bench_one(engine, spec, args.window)
+            writer.writerow(
+                [
+                    args.branch,
+                    args.rep,
+                    qid,
+                    spec["query"],
+                    spec["section"],
+                    spec["family"],
+                    "" if spec["pair"] is None else spec["pair"],
+                    spec["variant"] or "",
+                    total,
+                    n,
+                    f"{med_ms:.5f}",
+                    f"{min_ms:.5f}",
+                ]
+            )
+    print(f"  {args.branch:<4} rep{args.rep}: {len(specs)} queries", flush=True)
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    """Build the store + frozen spec set, then run interleaved old/new reps."""
+    from scripts.bench_bitplanes import load_engine  # noqa: PLC0415 — heavy loader, workers don't need it
+
+    store = OUTDIR / "real.store"
+    queries = OUTDIR / "specs.json"
+    OUTDIR.mkdir(parents=True, exist_ok=True)
+    if not store.exists():
+        load_engine(args.corpus, store)
+    if not queries.exists():
+        build_spec_set(store, queries)
+    if not args.out.exists():
+        args.out.write_text("branch,rep,qid,query,section,family,pair,variant,total,n,med_ms,min_ms\n")
+    for rep in range(1, args.reps + 1):
+        branches = [("old", OLD_ENV), ("new", {})]
+        if rep % 2 == 0:
+            branches.reverse()
+        for branch, env in branches:
+            cmd = [
+                sys.executable,
+                str(pathlib.Path(__file__)),
+                "worker",
+                "--branch", branch,
+                "--rep", str(rep),
+                "--store", str(store),
+                "--queries", str(queries),
+                "--out", str(args.out),
+                "--window", str(args.window),
+            ]
+            subprocess.run(cmd, check=True, env={**os.environ, **env}, cwd=REPO_ROOT)
+    cmd_analyze(args)
+
+
+def _percentile(sorted_vals: list[float], p: float) -> float:
+    idx = min(len(sorted_vals) - 1, max(0, math.ceil(p / 100 * len(sorted_vals)) - 1))
+    return sorted_vals[idx]
+
+
+def cmd_analyze(args: argparse.Namespace) -> None:
+    """Parity-check totals, then print percentile, ratio, and pair-symmetry tables."""
+    with args.out.open() as fh:
+        rows = list(csv.DictReader(fh))
+    bad = {}
+    totals: dict[str, set] = {}
+    for r in rows:
+        totals.setdefault(r["qid"], set()).add(r["total"])
+    bad = {k: v for k, v in totals.items() if len(v) > 1}
+    if bad:
+        for k, v in sorted(bad.items()):
+            print(f"PARITY FAILURE qid={k}: totals {sorted(v)}", file=sys.stderr)
+        sys.exit(1)
+    print(f"parity OK: {len(totals)} queries, totals identical old vs new")
+
+    med: dict[tuple[str, str], list[float]] = {}  # (qid, branch) -> per-rep medians
+    meta: dict[str, dict] = {}
+    for r in rows:
+        med.setdefault((r["qid"], r["branch"]), []).append(float(r["med_ms"]))
+        meta[r["qid"]] = r
+    qids = sorted({q for q, _ in med}, key=int)
+    old = {q: statistics.median(med[(q, "old")]) for q in qids}
+    new = {q: statistics.median(med[(q, "new")]) for q in qids}
+    ratios = {q: old[q] / new[q] for q in qids}
+
+    for section in ("broad", "enrich"):
+        sect = [q for q in qids if meta[q]["section"] == section]
+        if not sect:
+            continue
+        geomean = math.exp(statistics.fmean(math.log(ratios[q]) for q in sect))
+        print(f"\n=== {section}: {len(sect)} queries, geomean speedup (old/new) {geomean:.4f}x ===")
+        o = sorted(old[q] for q in sect)
+        n = sorted(new[q] for q in sect)
+        print(f"  {'pct':<5} {'old':>9} {'new':>9}")
+        for p in (50, 75, 90, 95, 99, 100):
+            print(f"  p{p:<4} {_percentile(o, p):>9.3f} {_percentile(n, p):>9.3f}")
+        print(f"\n  top improvements ({section}):")
+        for q in sorted(sect, key=lambda q: -ratios[q])[:12]:
+            r = meta[q]
+            print(f"  {ratios[q]:6.2f}x  {old[q]:8.3f} -> {new[q]:8.3f} ms  total={r['total']:>6}  {r['query']!r}")
+        print(f"\n  top regressions ({section}):")
+        for q in sorted(sect, key=lambda q: ratios[q])[:8]:
+            r = meta[q]
+            print(f"  {ratios[q]:6.2f}x  {old[q]:8.3f} -> {new[q]:8.3f} ms  total={r['total']:>6}  {r['query']!r}")
+
+    # Spelling-pair symmetry: on the new branch the two spellings of a pair
+    # must cost the same; the old branch's spread IS the written-order bug.
+    pairs: dict[str, dict[str, str]] = {}
+    for q in qids:
+        r = meta[q]
+        if r["pair"]:
+            pairs.setdefault(r["pair"], {})[r["variant"]] = q
+    if pairs:
+        print("\n=== spelling pairs: expensive-first / cheap-first cost ratio ===")
+        print(f"  {'family':<22} {'old spread':>10} {'new spread':>10} {'exp-first speedup':>18}  query")
+        for pid, variants in sorted(pairs.items(), key=lambda kv: int(kv[0])):
+            if set(variants) != {"expensive-first", "cheap-first"}:
+                continue
+            qe, qc = variants["expensive-first"], variants["cheap-first"]
+            old_spread = old[qe] / old[qc]
+            new_spread = new[qe] / new[qc]
+            print(
+                f"  {meta[qe]['family']:<22} {old_spread:>9.2f}x {new_spread:>9.2f}x {ratios[qe]:>17.2f}x  {meta[qe]['query']!r}"
+            )
+
+
+def main() -> None:
+    """Dispatch the run / worker / analyze subcommands."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    for name in ("run", "worker", "analyze"):
+        p = sub.add_parser(name)
+        p.add_argument("--out", type=pathlib.Path, default=OUTDIR / "verify-order.csv")
+        p.add_argument("--window", type=float, default=0.15)
+        if name == "run":
+            p.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+            p.add_argument("--reps", type=int, default=5)
+        if name == "worker":
+            p.add_argument("--branch", required=True)
+            p.add_argument("--rep", type=int, required=True)
+            p.add_argument("--store", type=pathlib.Path, required=True)
+            p.add_argument("--queries", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    {"run": cmd_run, "worker": cmd_worker, "analyze": cmd_analyze}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_verify_order.py
+++ b/scripts/bench_verify_order.py
@@ -32,6 +32,7 @@ import json
 import math
 import os
 import pathlib
+import random
 import statistics
 import subprocess
 import sys
@@ -115,7 +116,7 @@ def build_spec_set(store: pathlib.Path, path: pathlib.Path) -> None:
     """Freeze broad (survey-sampled) + enrichment specs that parse and run."""
     import card_engine  # noqa: PLC0415 — heavy import, only run needs it
 
-    rng = __import__("random").Random(BROAD_SEED)
+    rng = random.Random(BROAD_SEED)
     broad = sq.generate(rng, BROAD_GENERATED) + sq.sample_wild(rng, BROAD_WILD)
     for s in broad:
         s.update({"section": "broad", "family": s["shape"], "pair": None, "variant": None})
@@ -239,7 +240,6 @@ def cmd_analyze(args: argparse.Namespace) -> None:
     """Parity-check totals, then print percentile, ratio, and pair-symmetry tables."""
     with args.out.open() as fh:
         rows = list(csv.DictReader(fh))
-    bad = {}
     totals: dict[str, set] = {}
     for r in rows:
         totals.setdefault(r["qid"], set()).add(r["total"])
@@ -256,6 +256,12 @@ def cmd_analyze(args: argparse.Namespace) -> None:
         med.setdefault((r["qid"], r["branch"]), []).append(float(r["med_ms"]))
         meta[r["qid"]] = r
     qids = sorted({q for q, _ in med}, key=int)
+    # An interrupted run can leave a qid with rows from only one branch;
+    # ratios need both, so drop the stragglers rather than KeyError.
+    incomplete = [q for q in qids if (q, "old") not in med or (q, "new") not in med]
+    if incomplete:
+        print(f"skipping {len(incomplete)} queries with rows from only one branch (interrupted run?)", file=sys.stderr)
+        qids = [q for q in qids if q not in set(incomplete)]
     old = {q: statistics.median(med[(q, "old")]) for q in qids}
     new = {q: statistics.median(med[(q, "new")]) for q in qids}
     ratios = {q: old[q] / new[q] for q in qids}


### PR DESCRIPTION
# Order Verifier And/Or Children by Evaluation Cost

Implements `docs/issues/engine-verifier-cost-ordering.md` (2026-07-08 discussion), including the set-size refinement.

## What this does

The narrowing pass has ordered And children by materialization cost since #637 (`and_child_rank`), but the verifier still walked And/Or children in **written order**, short-circuiting on the first False (And) / True (Or). For queries where verification is the cost — broad drivers and full scans with regex/contains conjuncts — that made performance a function of how the user typed the query: `o:/draw .* cards?/ f:pauper` cost 2.1× more than `f:pauper o:/draw .* cards?/` for identical results.

`run_query` now stable-sorts And/Or children cheapest-verification-first, immediately after `memoize_text_predicates` (memoization flips a `TextContains` from the scan tier to the set tier, so ranking must run after it). The tri accumulation is commutative — False/True dominate, the Null/PrintingDep flags just OR together — so reordering is semantics-preserving; **totals are identical old-vs-new on all 554 benchmarked configs**. The per-printing residual pass inherits the And's child order, so one sort fixes both phases. `CARD_ENGINE_VERIFY_ORDER=0` (same `LazyLock` pattern as the #647 guards) restores written order for A/B runs.

## The cost model — three rounds of measurement, four inversions fixed

The first cut used the issue's four tiers verbatim and the A/B suite caught every place static judgment got costs or asymmetries wrong:

- **Anchored-literal regexes are cheap, not expensive.** The regex crate compiles `^flying$` / `dragon$` to memcmp-style matchers; ranking them as general regexes made `o:/^flying$/ oracle:sacrifice` **2.4× slower** (the "expensive" regex was rejecting candidates for ~half the cost of the substring scan it was moved behind). `regex_tier()` now classifies pattern shape: anchored literal (tier 1) / bare literal (tier 3, same as contains) / live metacharacters (tier 4).
- **Pip-map walks are mid-cost.** `Devotion` / `ManaCostCmp` iterate string-keyed hashmaps — measured ~3× under a text scan, far above a mask compare. They get their own tier; that ordering is what buys `o:/sacrifice a creature/ mana:{b}{b}` its 3.2×.
- **Or children sort on coarse buckets only.** An Or short-circuits on *acceptance*, which no static cost model can see. Both fine-grained Or reorderings the suite measured lost: `devotion:bbb` ahead of `oracle:vigilance` (1.2× worse — the pip walk almost never accepts) and a memoized name set ahead of a contains (1.1× worse). Or children now sort into just three classes — card-level tier-0 checks first, regex machinery last, everything else in written order.
- **Printing-dependent children defer.** A child comparing only printing-level fields (`usd>20`, `year:`, `artist:`) can never settle the card-level pass in either direction, so it orders after card-level siblings in both And and Or — a card-level rejector/acceptor that fires first skips its eval entirely, and nothing is lost when it doesn't (`oracle:draw or usd>20` was 1.16× worse before this rule). Composites are printing-dependent only when **all** children are: any card-level child can settle the composite (False settles an And, True settles an Or).

Within an And's memoized-set tier, children refine to **ascending set size** (`ids.len()` is already known; a smaller set rejects more per identical binary-search cost). It's free and principled, but honest scoping: the wild shapes that reach it verify cheap binary searches either way, and the family built to exercise it measured 1.00–1.02× — it's insurance, not a win.

## Measured (survey + enrichment A/B, 97,206-printing corpus, 5 interleaved reps)

`scripts/bench_verify_order.py`: 520 **broad** queries — the seeded survey mix from `scripts/survey_queries.py` (weighted single predicates, 2–4-way ANDs, ORs, parens, negations, arithmetic, regex; 400 generated + 120 wild-corpus) — plus 34 **enrichment** queries for the shapes this branch targets, written as expensive-first/cheap-first spelling pairs. Old = `CARD_ENGINE_VERIFY_ORDER=0`, new = `=1`, fresh interleaved subprocesses, per-query median of 5 rep-medians. **Parity: totals identical on all 554 configs.**

The headline is written-order sensitivity, which this PR eliminates:

| spelling pair | old spread | new spread | expensive-first speedup |
|---|---|---|---|
| `o:/sacrifice a creature/ mana:{b}{b}` | 3.16× | **1.01×** | **3.15×** |
| `o:/draw .* cards?/ power+toughness>8` | 2.74× | **1.00×** | **2.74×** |
| `o:and power+toughness>10` | 2.62× | **1.01×** | **2.61×** |
| `o:the f:standard` | 2.20× | **1.01×** | **2.19×** |
| `o:/draw .* cards?/ f:pauper` | 2.10× | **1.01×** | **2.10×** |
| `o:/^\{t\}: add/ f:standard` | 2.06× | **1.00×** | **2.03×** |
| `name:/^[aeiou].*ing$/ cmc+1<power` | 1.50× | **1.00×** | **1.50×** |
| `o:/^flying$/ or c:g` | 1.23× | **1.00×** | 1.07× |
| controls (narrowed / set-size / broad-legality) | 0.95–1.02× | 0.99–1.02× | ~1.00× |

Broad survey (the did-anything-regress net; geomean **1.012×**):

| percentile | old | new | |
|---|---|---|---|
| p50 | 0.069 ms | 0.068 ms | 1.01× |
| p75 | 0.140 ms | **0.137 ms** | 1.02× |
| p90 | 0.279 ms | **0.260 ms** | 1.07× |
| p95 | 0.400 ms | **0.389 ms** | 1.03× |
| p99 | 0.974 ms | **0.919 ms** | 1.06× |
| max | 1.723 ms | **1.635 ms** | 1.05× |

| top broad improvements | matches | old | new | speedup |
|---|---|---|---|---|
| `is:permanent or oracle:destroy or type:creature` | 18,581 | 0.445 ms | **0.291 ms** | **1.53×** |
| `name:fo or color:w` | 7,369 | 0.161 ms | **0.119 ms** | **1.36×** |
| `name:bo or tou>2` | 27,660 | 0.279 ms | **0.212 ms** | **1.32×** |
| `type:vampire or pow<2` | 4,391 | 0.157 ms | **0.120 ms** | **1.31×** |
| `type:goblin or format:legacy` | 96,445 | 1.026 ms | **0.801 ms** | **1.28×** |
| `oracle:destroy format:standard` | 274 | 0.146 ms | **0.116 ms** | **1.26×** |
| `flavor:light or format:commander` | 31,451 | 0.323 ms | **0.264 ms** | **1.22×** |

The worst broad regression is 0.94× — exclusively 2–50 µs exact-name lookups with **nothing to reorder**, i.e. sub-microsecond absolute deltas inside process-placement noise (verified bimodal per-process timing states on identical evaluation orders).

## Two measurement traps worth recording

- **Env-var size bias.** The first A/B set the toggle in one branch only. Single-predicate queries the toggle cannot touch regressed a *consistent* 15% (`type:planeswalker`, five reps, min and median alike) — an env var present in one branch shifts process memory layout enough to move sub-100 µs queries either way. Reproduced, then eliminated by giving both branches equal-length values (`=0` / `=1`). The harness documents this.
- **Concurrent load.** A smoke run with test suites running alongside inflated the old branch ~1.4× on queries with identical work. All reported numbers come from runs with the machine otherwise idle.

## Honest notes

- **Acceptance stays unknowable.** Cost-ordering an And ahead of a *broad-acceptance* cheap partner can lose a few percent: `o:/^\{t\}: add/ f:commander` (commander-legal ≈ most cards, so legality-first rejects little) sits at ~0.92–0.99× across runs, and `o:/^flying$/ format:pioneer` ~0.95× (that regex is unusually selective). Bounded by the cheap child's cost × domain — tens of µs — while the same rule earns 2–3× when the cheap partner rejects. Acceptance-aware ordering needs per-predicate counts (e.g. the legality-postings issue), not guesses.
- **Single-expensive-predicate queries get nothing** (`o:/^\{t\}: add/` alone: 1.01×) — there's nothing to reorder. Regex needs index-side attacks (trigram prefilter on extracted literals), tracked separately.
- **The set-size refinement is unmeasurable in wild shapes** (see above) — kept because it's free, principled, and deterministic.
- Broad geomean is ~1.01×, as expected: most survey traffic narrows before the verifier matters. The value is the p90/p99 shape and the elimination of the 2–3× spellings tax on the shapes that don't.

## Tests

`cargo test`: 62 passed — tier ordering (stable, recursive, composite max), `regex_tier` pattern-shape classification, Or bucket coarseness (scan-band written order, set-vs-scan written order), printing-dependent deferral in both And and Or with the composite any-child-settles rule, set-size refinement, and end-to-end spelling parity through `run_query`. Python: 1,347 parser + 467 api unit + 3 differential-oracle property tests pass. The 554-config A/B doubles as an end-to-end parity suite (identical totals).
