### PR TITLE
Pack Mana Pip Counts Into u64 Lanes, Replacing the Pip HashMaps

### DIFF
--- a/card_engine/src/bench_mana.rs
+++ b/card_engine/src/bench_mana.rs
@@ -1,0 +1,349 @@
+//! Micro-benchmark for mana-comparison representations (issue #650).
+//!
+//! Times the comparison kernels directly — no query machinery, no
+//! subprocesses — over the real distribution of mana costs (one row per
+//! oracle card, exported from the corpus by
+//! `python - <<… benchmarks/mana/mana_costs.tsv`). Three contenders, all
+//! built from the same cost strings in one process:
+//!
+//!   hashmap — the shipped representation this branch replaces:
+//!             HashMap<String, u8> pips + Option<HashMap> devotion, with the
+//!             evaluation loops lifted verbatim from the old filter arms
+//!   sortvec — sorted (interned symbol id, count) pairs, merge-walk compares
+//!   packed  — 8-bit lanes in a u64 (WUBRGC/S/X) + hybrid overflow vec,
+//!             SWAR compares (what ManaCost now ships)
+//!
+//! Every contender is asserted result-identical on every (card, query) pair
+//! before anything is timed, so the run doubles as a parity suite over the
+//! full real-data distribution.
+//!
+//!     cargo test --release bench_mana -- --ignored --nocapture
+
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::time::Instant;
+
+use super::{lane_add, lanes_ge, mana_lane, CmpOp, LANES6_HI, LANES8_HI};
+
+const ITERS: usize = 50;
+
+fn is_devotion_sym(s: &str) -> bool {
+    s.len() == 1 && "WUBRGC".contains(s)
+}
+
+/// Card-side pip parse, mirroring api's mana_cost_str_to_dict: braced symbols
+/// keep everything non-numeric (X and S included), unbraced color characters
+/// count too.
+fn card_pip_counts(cost: &str) -> HashMap<String, u8> {
+    let upper = cost.to_uppercase();
+    let mut pips: HashMap<String, u8> = HashMap::new();
+    let mut rest = String::new();
+    let mut chars = upper.chars();
+    while let Some(c) = chars.next() {
+        if c == '{' {
+            let sym: String = chars.by_ref().take_while(|&c| c != '}').collect();
+            if sym.parse::<u32>().is_err() {
+                *pips.entry(sym).or_insert(0) += 1;
+            }
+        } else {
+            rest.push(c);
+        }
+    }
+    for c in rest.chars() {
+        if "WUBRGC".contains(c) {
+            *pips.entry(c.to_string()).or_insert(0) += 1;
+        }
+    }
+    pips
+}
+
+// ─── Contender: hashmap (the old ManaCost, eval loops verbatim) ──────────────
+
+struct OldCost {
+    pips: HashMap<String, u8>,
+    devotion: Option<HashMap<String, u8>>,
+    cmc: f32,
+}
+
+fn old_cost(pips: HashMap<String, u8>, cmc: f32) -> OldCost {
+    let devotion = if pips.keys().any(|s| s.contains('/')) {
+        let mut d: HashMap<String, u8> = HashMap::new();
+        for (sym, &n) in &pips {
+            if sym.contains('/') {
+                for part in sym.split('/') {
+                    if is_devotion_sym(part) {
+                        *d.entry(part.to_string()).or_insert(0) += n;
+                    }
+                }
+            } else {
+                *d.entry(sym.clone()).or_insert(0) += n;
+            }
+        }
+        Some(d)
+    } else {
+        None
+    };
+    OldCost { pips, devotion, cmc }
+}
+
+fn old_mana_cmp(card: &OldCost, op: CmpOp, pips: &HashMap<String, u8>, cmc: f32) -> bool {
+    let card_cmc = card.cmc;
+    let card_pips = &card.pips;
+    let contains = || pips.iter().all(|(sym, &n)| card_pips.get(sym.as_str()).copied().unwrap_or(0) >= n) && card_cmc >= cmc;
+    let subset = || card_pips.iter().all(|(sym, n)| pips.get(sym.as_str()).copied().unwrap_or(0) >= *n) && card_cmc <= cmc;
+    let exact = || {
+        card_cmc == cmc
+            && card_pips.len() == pips.len()
+            && pips.iter().all(|(sym, &n)| card_pips.get(sym.as_str()).copied().unwrap_or(0) == n)
+    };
+    match op {
+        CmpOp::Ge => contains(),
+        CmpOp::Le => subset(),
+        CmpOp::Eq => exact(),
+        CmpOp::Gt => contains() && !exact(),
+        CmpOp::Lt => subset() && !exact(),
+        CmpOp::Ne => !exact(),
+    }
+}
+
+fn old_devotion_cmp(card: &OldCost, op: CmpOp, pips: &HashMap<String, u8>) -> bool {
+    let devotion = card.devotion.as_ref().unwrap_or(&card.pips);
+    let ge = pips.iter().all(|(sym, &n)| devotion.get(sym.as_str()).copied().unwrap_or(0) >= n);
+    let le = devotion
+        .iter()
+        .filter(|(sym, _)| is_devotion_sym(sym.as_str()))
+        .all(|(sym, n)| pips.get(sym.as_str()).copied().unwrap_or(0) >= *n);
+    let eq = devotion.keys().filter(|sym| is_devotion_sym(sym.as_str())).count() == pips.len()
+        && pips.iter().all(|(sym, &n)| devotion.get(sym.as_str()).copied().unwrap_or(0) == n);
+    match op {
+        CmpOp::Ge => ge,
+        CmpOp::Eq => eq,
+        CmpOp::Le => le,
+        CmpOp::Gt => ge && !eq,
+        CmpOp::Lt => le && !eq,
+        CmpOp::Ne => !eq,
+    }
+}
+
+// ─── Contender: sortvec (interned ids, merge-walk compares) ──────────────────
+
+struct VecCost {
+    pips: Vec<(u8, u8)>, // (symbol id, count), sorted by id — every symbol interned
+    cmc: f32,
+}
+
+fn vec_count(pips: &[(u8, u8)], id: u8) -> u8 {
+    pips.iter().find(|e| e.0 == id).map_or(0, |e| e.1)
+}
+
+fn vec_mana_cmp(card: &VecCost, op: CmpOp, pips: &[(u8, u8)], cmc: f32) -> bool {
+    let contains = || pips.iter().all(|&(id, n)| vec_count(&card.pips, id) >= n) && card.cmc >= cmc;
+    let subset = || card.pips.iter().all(|&(id, n)| vec_count(pips, id) >= n) && card.cmc <= cmc;
+    let exact = || card.cmc == cmc && card.pips == pips;
+    match op {
+        CmpOp::Ge => contains(),
+        CmpOp::Le => subset(),
+        CmpOp::Eq => exact(),
+        CmpOp::Gt => contains() && !exact(),
+        CmpOp::Lt => subset() && !exact(),
+        CmpOp::Ne => !exact(),
+    }
+}
+
+// ─── Contender: packed (what ManaCost now ships) ─────────────────────────────
+
+struct PackedCost {
+    core: u64,
+    hybrids: Vec<(u8, u8)>,
+    devotion: u64,
+    cmc: f32,
+}
+
+fn packed_cost(pips: &HashMap<String, u8>, cmc: f32, vocab: &mut Vec<String>) -> PackedCost {
+    let mut core = 0u64;
+    let mut devotion = 0u64;
+    let mut hybrids: Vec<(u8, u8)> = Vec::new();
+    for (sym, &n) in pips {
+        match mana_lane(sym) {
+            Some(lane) => {
+                core = lane_add(core, lane, n);
+                if lane < 6 {
+                    devotion = lane_add(devotion, lane, n);
+                }
+            }
+            None => {
+                let id = vocab.iter().position(|v| v == sym).unwrap_or_else(|| {
+                    vocab.push(sym.clone());
+                    vocab.len() - 1
+                });
+                hybrids.push((id as u8, n));
+                for part in sym.split('/') {
+                    if let Some(lane) = mana_lane(part).filter(|&l| l < 6) {
+                        devotion = lane_add(devotion, lane, n);
+                    }
+                }
+            }
+        }
+    }
+    hybrids.sort_unstable();
+    PackedCost { core, hybrids, devotion, cmc }
+}
+
+fn packed_mana_cmp(card: &PackedCost, op: CmpOp, core: u64, hybrid_ids: &[(u8, u8)], cmc: f32) -> bool {
+    let hyb_count = |id: u8| card.hybrids.iter().find(|e| e.0 == id).map_or(0, |e| e.1);
+    let contains = || {
+        lanes_ge(card.core, core, LANES8_HI)
+            && hybrid_ids.iter().all(|&(id, n)| hyb_count(id) >= n)
+            && card.cmc >= cmc
+    };
+    let subset = || {
+        lanes_ge(core, card.core, LANES8_HI)
+            && card.hybrids.iter().all(|e| hybrid_ids.iter().find(|q| q.0 == e.0).map_or(0, |q| q.1) >= e.1)
+            && card.cmc <= cmc
+    };
+    let exact = || card.cmc == cmc && card.core == core && card.hybrids == hybrid_ids;
+    match op {
+        CmpOp::Ge => contains(),
+        CmpOp::Le => subset(),
+        CmpOp::Eq => exact(),
+        CmpOp::Gt => contains() && !exact(),
+        CmpOp::Lt => subset() && !exact(),
+        CmpOp::Ne => !exact(),
+    }
+}
+
+fn packed_devotion_cmp(card: &PackedCost, op: CmpOp, pips: u64) -> bool {
+    let ge = lanes_ge(card.devotion, pips, LANES6_HI);
+    let le = lanes_ge(pips, card.devotion, LANES6_HI);
+    let eq = card.devotion == pips;
+    match op {
+        CmpOp::Ge => ge,
+        CmpOp::Eq => eq,
+        CmpOp::Le => le,
+        CmpOp::Gt => ge && !eq,
+        CmpOp::Lt => le && !eq,
+        CmpOp::Ne => !eq,
+    }
+}
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+fn time_kernel(name: &str, n_cards: usize, mut kernel: impl FnMut() -> u32) {
+    let mut best = u128::MAX;
+    let mut matches = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        matches = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    println!("  {name:<52} {:>7.2} ns/card  ({matches} matches)", best as f64 / n_cards as f64);
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/mana/mana_costs.tsv"]
+fn bench_mana_representations() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/mana/mana_costs.tsv");
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        eprintln!("SKIP: {path} not found (see module docs)");
+        return;
+    };
+    let rows: Vec<(HashMap<String, u8>, f32)> = raw
+        .lines()
+        .map(|l| {
+            let (cost, cmc) = l.split_once('\t').unwrap_or((l, "0"));
+            (card_pip_counts(cost), cmc.parse().unwrap_or(0.0))
+        })
+        .collect();
+    let n = rows.len();
+    println!("\n{n} oracle-card cost rows from {path}");
+
+    // Build all three representations, plus the sortvec interner (which also
+    // covers the lane symbols — sortvec interns *every* symbol).
+    let mut packed_vocab: Vec<String> = Vec::new();
+    let mut vec_vocab: Vec<String> = Vec::new();
+    let mut vec_intern = |sym: &str| -> u8 {
+        let id = vec_vocab.iter().position(|v| v == sym).unwrap_or_else(|| {
+            vec_vocab.push(sym.to_string());
+            vec_vocab.len() - 1
+        });
+        id as u8
+    };
+    let old: Vec<OldCost> = rows.iter().map(|(p, c)| old_cost(p.clone(), *c)).collect();
+    let packed: Vec<PackedCost> = rows.iter().map(|(p, c)| packed_cost(p, *c, &mut packed_vocab)).collect();
+    let vecs: Vec<VecCost> = rows
+        .iter()
+        .map(|(p, c)| {
+            let mut pips: Vec<(u8, u8)> = p.iter().map(|(sym, &n)| (vec_intern(sym), n)).collect();
+            pips.sort_unstable();
+            VecCost { pips, cmc: *c }
+        })
+        .collect();
+
+    // Query specs: (label, pips, cmc) — mana= uses all ops, devotion the
+    // color lanes only. Distribution-realistic shapes.
+    let mana_queries: &[(&str, &[(&str, u8)], f32)] = &[
+        ("mana ge {B}{B}", &[("B", 2)], 2.0),
+        ("mana ge {W}", &[("W", 1)], 1.0),
+        ("mana ge {R/G}", &[("R/G", 1)], 1.0),
+        ("mana eq {W}{U}", &[("W", 1), ("U", 1)], 2.0),
+        ("mana le {2}{W}{W}", &[("W", 2)], 4.0),
+        ("mana ne {G}", &[("G", 1)], 1.0),
+    ];
+    let dev_queries: &[(&str, &[(&str, u8)])] = &[
+        ("devotion ge B=1", &[("B", 1)]),
+        ("devotion ge G=2", &[("G", 2)]),
+        ("devotion ge U=3", &[("U", 3)]),
+        ("devotion eq W=1", &[("W", 1)]),
+        ("devotion le R=1", &[("R", 1)]),
+    ];
+    let op_of = |label: &str| match label.split_whitespace().nth(1).unwrap() {
+        "ge" => CmpOp::Ge,
+        "le" => CmpOp::Le,
+        "eq" => CmpOp::Eq,
+        "ne" => CmpOp::Ne,
+        other => panic!("unknown op {other}"),
+    };
+
+    for &(label, qpips, qcmc) in mana_queries {
+        let op = op_of(label);
+        let qmap: HashMap<String, u8> = qpips.iter().map(|&(s, n)| (s.to_string(), n)).collect();
+        let mut qvec: Vec<(u8, u8)> = qpips.iter().map(|&(s, n)| (vec_intern(s), n)).collect();
+        qvec.sort_unstable();
+        let mut qcore = 0u64;
+        let mut qhyb: Vec<(u8, u8)> = Vec::new();
+        for &(s, n) in qpips {
+            match mana_lane(s) {
+                Some(lane) => qcore = lane_add(qcore, lane, n),
+                None => qhyb.push((packed_vocab.iter().position(|v| v == s).map_or(u8::MAX, |i| i as u8), n)),
+            }
+        }
+        qhyb.sort_unstable();
+
+        // Parity across the full distribution before timing anything.
+        for i in 0..n {
+            let want = old_mana_cmp(&old[i], op, &qmap, qcmc);
+            assert_eq!(vec_mana_cmp(&vecs[i], op, &qvec, qcmc), want, "{label}: sortvec diverges at row {i}");
+            assert_eq!(packed_mana_cmp(&packed[i], op, qcore, &qhyb, qcmc), want, "{label}: packed diverges at row {i}");
+        }
+        println!("{label}");
+        time_kernel("hashmap", n, || old.iter().filter(|c| old_mana_cmp(c, op, &qmap, qcmc)).count() as u32);
+        time_kernel("sortvec", n, || vecs.iter().filter(|c| vec_mana_cmp(c, op, &qvec, qcmc)).count() as u32);
+        time_kernel("packed", n, || packed.iter().filter(|c| packed_mana_cmp(c, op, qcore, &qhyb, qcmc)).count() as u32);
+    }
+
+    for &(label, qpips) in dev_queries {
+        let op = op_of(label);
+        let qmap: HashMap<String, u8> = qpips.iter().map(|&(s, n)| (s.to_string(), n)).collect();
+        let mut qpacked = 0u64;
+        for &(s, n) in qpips {
+            qpacked = lane_add(qpacked, mana_lane(s).unwrap(), n);
+        }
+        for i in 0..n {
+            let want = old_devotion_cmp(&old[i], op, &qmap);
+            assert_eq!(packed_devotion_cmp(&packed[i], op, qpacked), want, "{label}: packed diverges at row {i}");
+        }
+        println!("{label}");
+        time_kernel("hashmap", n, || old.iter().filter(|c| old_devotion_cmp(c, op, &qmap)).count() as u32);
+        time_kernel("packed", n, || packed.iter().filter(|c| packed_devotion_cmp(c, op, qpacked)).count() as u32);
+    }
+}

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
 use regex::Regex;
 use serde_json::Value;
-use super::{AOracleCard, APrinting, AStrings, str_at, is_devotion_sym, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, NameBigramIndex, OracleTextIndex, TrigramIndex, flavor_fingerprint, flavor_match_sets};
+use super::{AOracleCard, APrinting, AStrings, str_at, mana_lane, lane_add, lanes_ge, LANES6_HI, LANES8_HI, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, NameBigramIndex, OracleTextIndex, TrigramIndex, flavor_fingerprint, flavor_match_sets};
 use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, format_shift};
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
@@ -360,13 +359,27 @@ pub(crate) enum FilterExpr {
 
     ManaCostCmp {
         op: CmpOp,
-        pips: HashMap<String, u8>,
+        /// Single-symbol pip counts of the query cost, packed into the same
+        /// 8-bit lanes as ManaCost.core (see the packed-pip-lanes section).
+        core: u64,
+        /// The query's hybrid '/' symbols as (symbol, count), sorted; kept as
+        /// strings so bind() can resolve them against the store's mana vocab.
+        hybrids: Vec<(String, u8)>,
+        /// `hybrids` resolved to sorted (mana_vocab id, count) by bind().
+        /// Symbols absent from the vocab — which no card can carry — merge
+        /// into the reserved MANA_SYM_UNKNOWN id, preserving exact match
+        /// semantics. Built all-unknown, so an unbound filter behaves as if
+        /// every hybrid symbol were unknown (mirroring CollectionCmp).
+        hybrid_ids: Vec<(u8, u8)>,
         cmc: f32,
     },
 
     Devotion {
         op: CmpOp,
-        pips: HashMap<String, u8>,
+        /// Queried WUBRGC devotion counts in the low six 8-bit lanes,
+        /// hybrid query pips expanded at build — same layout as
+        /// ManaCost.devotion, so every comparison is lane arithmetic.
+        pips: u64,
     },
 
     DateCmp {
@@ -387,14 +400,13 @@ pub(crate) enum FilterExpr {
 ///       colors, types, legality words, exact string equality)
 ///   1 — bounded lookups: a binary search over a bind/memoize-resolved id set
 ///       (ArtistMatch/FlavorMatch/NameMatch/OracleMatch) or a card collection
-///       (CollectionCmp), and anchored-literal regexes (a memcmp at a known
-///       position — see regex_tier)
-///   2 — pip-map walks of Devotion / ManaCostCmp: string-keyed hashmap
-///       iteration, measured ~3× cheaper than a text scan on the real corpus
-///   3 — per-candidate text scans: TextContains (substring search; artist /
+///       (CollectionCmp), anchored-literal regexes (a memcmp at a known
+///       position — see regex_tier), and the packed-lane pip compares of
+///       Devotion / ManaCostCmp (SWAR plus a usually-empty hybrid walk)
+///   2 — per-candidate text scans: TextContains (substring search; artist /
 ///       flavor contains were rewritten to tier 1 at bind) and
 ///       unanchored-literal regexes, whose prefilter costs the same scan
-///   4 — TextRegex with real regex machinery — the single worst
+///   3 — TextRegex with real regex machinery — the single worst
 ///       per-candidate cost the engine has
 ///
 /// Composites take the max of their children: their short-circuit may have to
@@ -402,8 +414,8 @@ pub(crate) enum FilterExpr {
 fn verify_cost_tier(f: &FilterExpr) -> u8 {
     match f {
         FilterExpr::TextRegex { regex, .. } => regex_tier(regex.as_str()),
-        FilterExpr::TextContains { .. } => 3,
-        FilterExpr::Devotion { .. } | FilterExpr::ManaCostCmp { .. } => 2,
+        FilterExpr::TextContains { .. } => 2,
+        FilterExpr::Devotion { .. } | FilterExpr::ManaCostCmp { .. } => 1,
         FilterExpr::ArtistMatch { .. }
         | FilterExpr::FlavorMatch { .. }
         | FilterExpr::NameMatch { .. }
@@ -436,8 +448,8 @@ fn verify_cost_tier(f: &FilterExpr) -> u8 {
 /// `o:/^flying$/ oracle:sacrifice` 2.4× slower, so:
 ///
 ///   1 — literal with a ^ or $ anchor (starts_with/ends_with/equality)
-///   3 — bare literal (substring search, same tier as TextContains)
-///   4 — anything with live regex metacharacters
+///   2 — bare literal (substring search, same tier as TextContains)
+///   3 — anything with live regex metacharacters
 pub(crate) fn regex_tier(pattern: &str) -> u8 {
     let mut p = pattern.strip_prefix("(?i)").unwrap_or(pattern);
     let anchored_start = p.starts_with('^');
@@ -453,17 +465,17 @@ pub(crate) fn regex_tier(pattern: &str) -> u8 {
             // alphanumeric escape (\d \w \b \p…) is a class — real machinery.
             b'\\' => match bytes.get(i + 1) {
                 Some(c) if !c.is_ascii_alphanumeric() => i += 2,
-                _ => return 4,
+                _ => return 3,
             },
             b'$' if i == bytes.len() - 1 => {
                 anchored_end = true;
                 i += 1;
             }
-            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return 4,
+            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return 3,
             _ => i += 1,
         }
     }
-    if anchored_start || anchored_end { 1 } else { 3 }
+    if anchored_start || anchored_end { 1 } else { 2 }
 }
 
 /// Whether a node can NEVER settle the card-level pass — it compares only
@@ -554,7 +566,7 @@ fn printing_dependent(f: &FilterExpr) -> bool {
 fn or_child_key(f: &FilterExpr) -> (u8, bool) {
     let tier = verify_cost_tier(f);
     let pdep = printing_dependent(f);
-    let bucket = if tier >= 4 {
+    let bucket = if tier >= 3 {
         2
     } else if tier == 0 && !pdep {
         0
@@ -576,6 +588,51 @@ fn and_child_set_len(f: &FilterExpr) -> usize {
         FilterExpr::FlavorMatch { gids, .. } | FilterExpr::OracleMatch { gids } => gids.len(),
         _ => usize::MAX,
     }
+}
+
+/// Reserved ManaCost hybrid id for query symbols absent from the store's
+/// mana vocab: no card carries it, so containment fails and exactness fails
+/// against any card, exactly like a HashMap key nothing else holds. Distinct
+/// unknown symbols merge into one entry — safe for the same reason.
+pub(crate) const MANA_SYM_UNKNOWN: u8 = u8::MAX;
+
+type AHybrids = rkyv::Archived<Vec<(u8, u8)>>;
+
+/// Resolve the query's hybrid symbols to sorted (mana_vocab id, count).
+fn bind_mana_hybrids(hybrids: &[(String, u8)], mana_vocab: &AStrings) -> Vec<(u8, u8)> {
+    let mut out = Vec::with_capacity(hybrids.len());
+    let mut unknown = 0u8;
+    for (sym, n) in hybrids {
+        // Linear scan: the vocab is ~29 entries and queries carry 0-2 hybrids.
+        match mana_vocab.iter().position(|v| v.as_str() == sym.as_str()) {
+            Some(i) => out.push((i as u8, *n)),
+            None => unknown = unknown.saturating_add(*n),
+        }
+    }
+    out.sort_unstable();
+    if unknown > 0 {
+        out.push((MANA_SYM_UNKNOWN, unknown)); // sorts last: real ids are < 255
+    }
+    out
+}
+
+fn hybrid_count(card: &AHybrids, id: u8) -> u8 {
+    card.iter().find(|e| e.0 == id).map_or(0, |e| e.1)
+}
+
+/// Every query hybrid is contained in the card's (query ⊆ card).
+fn hybrids_ge(card: &AHybrids, query: &[(u8, u8)]) -> bool {
+    query.iter().all(|&(id, n)| hybrid_count(card, id) >= n)
+}
+
+/// Every card hybrid is contained in the query's (card ⊆ query).
+fn hybrids_le(card: &AHybrids, query: &[(u8, u8)]) -> bool {
+    card.iter().all(|e| query.iter().find(|q| q.0 == e.0).map_or(0, |q| q.1) >= e.1)
+}
+
+/// Same hybrid multiset — both sides sorted, so pairwise equality suffices.
+fn hybrids_eq(card: &AHybrids, query: &[(u8, u8)]) -> bool {
+    card.len() == query.len() && card.iter().zip(query).all(|(c, q)| c.0 == q.0 && c.1 == q.1)
 }
 
 /// Vocab ids (ascending) whose artist string satisfies `pred`.
@@ -613,16 +670,20 @@ impl FilterExpr {
         vocab: &AStrings,
         sorted_ids: &rkyv::Archived<Vec<u16>>,
         artist_vocab: &AStrings,
+        mana_vocab: &AStrings,
         flavor: &rkyv::Archived<FlavorIndex>,
         strings: &AStrings,
     ) {
         match self {
             FilterExpr::And(children) | FilterExpr::Or(children) => {
                 for c in children {
-                    c.bind(vocab, sorted_ids, artist_vocab, flavor, strings);
+                    c.bind(vocab, sorted_ids, artist_vocab, mana_vocab, flavor, strings);
                 }
             }
-            FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, flavor, strings),
+            FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, mana_vocab, flavor, strings),
+            FilterExpr::ManaCostCmp { hybrids, hybrid_ids, .. } if !hybrids.is_empty() => {
+                *hybrid_ids = bind_mana_hybrids(hybrids, mana_vocab);
+            }
             FilterExpr::CollectionCmp { value, value_id, .. } => {
                 let i = sorted_ids.partition_point(|id| vocab[u16::from(*id) as usize].as_str() < value.as_str());
                 *value_id = sorted_ids
@@ -1146,56 +1207,23 @@ impl FilterExpr {
                 tri_bool((word >> shift) & 0b11 == *expected)
             }
 
-            FilterExpr::ManaCostCmp { op, pips, cmc } => {
-                let card_cmc = f32::from(card.mana_cost.cmc);
-                let card_pips = &card.mana_cost.pips;
+            FilterExpr::ManaCostCmp { op, core, hybrid_ids, cmc, .. } => {
+                // Containment/equality over the pip multiset = the same test
+                // per lane (SWAR, all eight at once) and per hybrid entry
+                // (sorted-slice walks; both sides empty on ~97% of cards).
+                let mc = &card.mana_cost;
+                let card_core = u64::from(mc.core);
+                let card_cmc = f32::from(mc.cmc);
+                let ge = || lanes_ge(card_core, *core, LANES8_HI) && hybrids_ge(&mc.hybrids, hybrid_ids) && card_cmc >= *cmc;
+                let le = || lanes_ge(*core, card_core, LANES8_HI) && hybrids_le(&mc.hybrids, hybrid_ids) && card_cmc <= *cmc;
+                let eq = || card_cmc == *cmc && card_core == *core && hybrids_eq(&mc.hybrids, hybrid_ids);
                 tri_bool(match op {
-                    CmpOp::Ge => {
-                        pips.iter().all(|(sym, &n)| {
-                            card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) >= n
-                        }) && card_cmc >= *cmc
-                    }
-                    CmpOp::Le => {
-                        card_pips.iter().all(|(sym, n)| {
-                            pips.get(sym.as_str()).copied().unwrap_or(0) >= u8::from(*n)
-                        }) && card_cmc <= *cmc
-                    }
-                    CmpOp::Eq => {
-                        card_cmc == *cmc
-                            && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| {
-                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
-                            })
-                    }
-                    CmpOp::Gt => {
-                        let contains = pips.iter().all(|(sym, &n)| {
-                            card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) >= n
-                        }) && card_cmc >= *cmc;
-                        let exact = card_cmc == *cmc
-                            && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| {
-                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
-                            });
-                        contains && !exact
-                    }
-                    CmpOp::Lt => {
-                        let subset = card_pips.iter().all(|(sym, n)| {
-                            pips.get(sym.as_str()).copied().unwrap_or(0) >= u8::from(*n)
-                        }) && card_cmc <= *cmc;
-                        let exact = card_cmc == *cmc
-                            && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| {
-                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
-                            });
-                        subset && !exact
-                    }
-                    CmpOp::Ne => {
-                        !(card_cmc == *cmc
-                            && card_pips.len() == pips.len()
-                            && pips.iter().all(|(sym, &n)| {
-                                card_pips.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
-                            }))
-                    }
+                    CmpOp::Ge => ge(),
+                    CmpOp::Le => le(),
+                    CmpOp::Eq => eq(),
+                    CmpOp::Gt => ge() && !eq(),
+                    CmpOp::Lt => le() && !eq(),
+                    CmpOp::Ne => !eq(),
                 })
             }
 
@@ -1203,26 +1231,13 @@ impl FilterExpr {
                 // Mirrors the SQL path's JSONB containment on the devotion column
                 // (devotion @> query, <@, =, and the strict/negated variants):
                 // per-color positional arrays contain each other iff the counts
-                // compare, so containment reduces to count comparisons here.
-                // The card-side map can carry non-color keys (generic pips like "1"
-                // come straight from mana_cost_jsonb) that the DB's devotion column
-                // never holds, so only WUBRGC entries participate — query pips are
-                // already color-only (see build_binary).
-                let devotion = if card.mana_cost.devotion.is_some() {
-                    card.mana_cost.devotion.as_ref().unwrap()
-                } else {
-                    &card.mana_cost.pips
-                };
-                let ge = pips.iter().all(|(sym, &n)| {
-                    devotion.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) >= n
-                });
-                let le = devotion.iter()
-                    .filter(|(sym, _)| is_devotion_sym(sym.as_str()))
-                    .all(|(sym, n)| pips.get(sym.as_str()).copied().unwrap_or(0) >= u8::from(*n));
-                let eq = devotion.keys().filter(|sym| is_devotion_sym(sym.as_str())).count() == pips.len()
-                    && pips.iter().all(|(sym, &n)| {
-                        devotion.get(sym.as_str()).map(|v| u8::from(*v)).unwrap_or(0) == n
-                    });
+                // compare, so containment is per-lane count comparison — one
+                // SWAR op across all six colors — and equality is integer
+                // equality (a zero lane and an absent key are the same thing).
+                let d = u64::from(card.mana_cost.devotion);
+                let ge = lanes_ge(d, *pips, LANES6_HI);
+                let le = lanes_ge(*pips, d, LANES6_HI);
+                let eq = d == *pips;
                 tri_bool(match op {
                     CmpOp::Ge => ge,
                     CmpOp::Eq => eq,
@@ -1426,27 +1441,39 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
 
     if attr == "mana_cost_jsonb" {
         let mana_str = rhs_value_str(rhs);
-        let pips = mana_pip_counts(mana_str);
-        let cmc  = mana_cmc(mana_str);
+        let mut core = 0u64;
+        let mut hybrids: Vec<(String, u8)> = Vec::new();
+        for (sym, n) in mana_pip_counts(mana_str) {
+            match mana_lane(&sym) {
+                Some(lane) => core = lane_add(core, lane, n),
+                None => hybrids.push((sym, n)),
+            }
+        }
+        hybrids.sort_unstable();
+        // Until bind() resolves them against the store's vocab, hybrid
+        // symbols count as unknown — one merged entry no card can match.
+        let hybrid_ids = if hybrids.is_empty() { Vec::new() } else { vec![(MANA_SYM_UNKNOWN, 1)] };
+        let cmc = mana_cmc(mana_str);
         let cmp_op = match op { ":" => CmpOp::Ge, _ => str_op_to_cmp(op)? };
-        return Ok(FilterExpr::ManaCostCmp { op: cmp_op, pips, cmc });
+        return Ok(FilterExpr::ManaCostCmp { op: cmp_op, core, hybrids, hybrid_ids, cmc });
     }
 
     if attr == "devotion" {
         let mana_str = rhs_value_str(rhs);
-        // Split hybrid symbols ({R/G} -> R:1, G:1) and keep only WUBRGC, matching
-        // calculate_devotion() in SQL (which counts only color characters).
-        // mana_pip_counts is NOT used directly because it keeps hybrids as single keys.
-        let mut pips: HashMap<String, u8> = HashMap::new();
+        // Split hybrid symbols ({R/G} -> R:1, G:1) and keep only the WUBRGC
+        // lanes, matching calculate_devotion() in SQL (which counts only
+        // color characters). mana_pip_counts is NOT used lane-directly
+        // because it keeps hybrids as single keys.
+        let mut pips = 0u64;
         for (sym, n) in mana_pip_counts(mana_str) {
             if sym.contains('/') {
                 for part in sym.split('/') {
-                    if is_devotion_sym(part) {
-                        *pips.entry(part.to_string()).or_insert(0) += n;
+                    if let Some(lane) = mana_lane(part).filter(|&l| l < 6) {
+                        pips = lane_add(pips, lane, n);
                     }
                 }
-            } else if is_devotion_sym(&sym) {
-                *pips.entry(sym).or_insert(0) += n;
+            } else if let Some(lane) = mana_lane(&sym).filter(|&l| l < 6) {
+                pips = lane_add(pips, lane, n);
             }
         }
         let cmp_op = match op { ":" => CmpOp::Ge, _ => str_op_to_cmp(op)? };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1483,16 +1483,6 @@ fn price_bounds(op: CmpOp, value: f64) -> Option<(u32, u32)> {
     }
 }
 
-/// Sorted printing ids satisfying `price op value`, via the f32_sort_bits index.
-/// The query driver goes through range_narrowed() (which never declines);
-/// this vec-only form is kept as the tests' reference for the bounds/guard
-/// semantics, like FilterExpr::matches().
-#[cfg(test)]
-fn price_candidates(idx: &Archived<PrintingRangeIndex>, op: CmpOp, value: f64) -> Option<Vec<u32>> {
-    let (lo, hi) = price_bounds(op, value)?;
-    range_candidates(idx, lo, hi)
-}
-
 /// Half-open [lo, hi) bounds for indexes over plain integers (collector
 /// number). Query values are f64 and may be fractional or out of range; bounds
 /// are chosen so the range is exact for every op — `cn<100.5` means
@@ -1517,16 +1507,6 @@ fn int_range_bounds(op: CmpOp, value: f64) -> Option<Option<(u32, u32)>> {
         return Some(None);
     }
     Some(Some((lo as u32, hi as u32)))
-}
-
-/// Sorted printing ids satisfying `int_value op value`. Test-only reference,
-/// see price_candidates().
-#[cfg(test)]
-fn int_range_candidates(idx: &Archived<PrintingRangeIndex>, op: CmpOp, value: f64) -> Option<Vec<u32>> {
-    match int_range_bounds(op, value)? {
-        None => Some(Vec::new()),
-        Some((lo, hi)) => range_candidates(idx, lo, hi),
-    }
 }
 
 /// Sorted printing ids with an indexed value in [lo, hi), or None for ranges
@@ -1927,9 +1907,9 @@ impl Narrowed {
 }
 
 /// Intersect same-space sets. All-vec inputs keep today's sort-by-length merge
-/// chain; any bitmap input (or a later promotion) runs word-wise AND. `n` is
-/// the domain size of the space. Tight iff every input is tight.
-fn and_all(mut sets: Vec<Narrowed>, n: usize) -> Option<Narrowed> {
+/// chain; any bitmap input (or a later promotion) runs word-wise AND. Tight
+/// iff every input is tight.
+fn and_all(mut sets: Vec<Narrowed>) -> Option<Narrowed> {
     if sets.is_empty() {
         return None;
     }
@@ -2399,8 +2379,8 @@ fn narrow_rec(
                     every_child_included = false;
                 }
             }
-            let cards = and_all(card_sets, n_cards);
-            let printings = and_all(printing_sets, n_printings);
+            let cards = and_all(card_sets);
+            let printings = and_all(printing_sets);
             let seal = |mut n: Narrowed| {
                 n.tight &= every_child_included;
                 n
@@ -2435,7 +2415,7 @@ fn narrow_rec(
                         }
                         _ => {
                             let pc = p.into_card_space(offsets);
-                            and_all(vec![c, pc], n_cards).map(seal)
+                            and_all(vec![c, pc]).map(seal)
                         }
                     }
                 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -96,10 +96,48 @@ pub(crate) fn color_list_to_mask(colors: &[&str]) -> u8 {
 
 // ─── Mana cost helpers ───────────────────────────────────────────────────────
 
-/// Symbols that contribute to devotion, matching calculate_devotion() in SQL
-/// (which counts only WUBRGC characters of the mana cost string).
-pub(crate) fn is_devotion_sym(s: &str) -> bool {
-    s.len() == 1 && "WUBRGC".contains(s)
+// ─── Packed pip lanes ────────────────────────────────────────────────────────
+// Pip counts pack into a u64 as eight 8-bit lanes (chosen over the jsonb-
+// mirroring HashMap it replaces — that shape existed to make the Postgres
+// query easy to write, not because the engine needed it). The eight
+// single-symbol keys of mana_cost_jsonb (WUBRGC + snow + X; generic numbers
+// are dropped by mana_cost_str_to_dict on the card side and mana_pip_counts
+// on the query side) each own a lane; the ~29 hybrid '/' symbols overflow to
+// a small sorted (vocab id, count) vec that is empty on ~97% of cards.
+// Per-lane comparisons are three branchless ops (see lanes_ge), and pip-set
+// equality is integer equality — a zero lane and an absent HashMap key are
+// the same thing, which is what makes `mana=`'s distinct-key semantics fall
+// out for free. Lane counts saturate at 127 so the borrow trick stays sound
+// (real costs peak around 16 pips).
+
+pub(crate) const MANA_LANE_SYMS: [&str; 8] = ["W", "U", "B", "R", "G", "C", "S", "X"];
+/// High bit of each of the 8 core-pip lanes / the 6 devotion lanes.
+pub(crate) const LANES8_HI: u64 = 0x8080_8080_8080_8080;
+pub(crate) const LANES6_HI: u64 = 0x0000_8080_8080_8080;
+const LANE_MAX: u8 = 0x7f;
+
+pub(crate) fn mana_lane(sym: &str) -> Option<usize> {
+    MANA_LANE_SYMS.iter().position(|s| *s == sym)
+}
+
+pub(crate) fn lane_get(packed: u64, lane: usize) -> u8 {
+    (packed >> (8 * lane)) as u8
+}
+
+/// Add `n` to a lane, saturating at LANE_MAX so lanes can never borrow into
+/// their neighbor and the SWAR compares stay per-lane exact.
+pub(crate) fn lane_add(packed: u64, lane: usize, n: u8) -> u64 {
+    let cur = lane_get(packed, lane);
+    let new = cur.saturating_add(n).min(LANE_MAX);
+    (packed & !(0xffu64 << (8 * lane))) | ((new as u64) << (8 * lane))
+}
+
+/// Per-lane a >= b across every lane of `hi` (the SWAR borrow trick): setting
+/// each lane's high bit in `a` guarantees the per-lane subtraction cannot
+/// borrow out of the lane, and the high bit survives exactly when that lane's
+/// a >= b. Sound because lane values are saturated below 0x80.
+pub(crate) fn lanes_ge(a: u64, b: u64, hi: u64) -> bool {
+    ((a | hi).wrapping_sub(b)) & hi == hi
 }
 
 pub(crate) fn mana_pip_counts(s: &str) -> HashMap<String, u8> {
@@ -160,8 +198,17 @@ pub(crate) fn mana_cmc(s: &str) -> f32 {
 
 #[derive(Archive, Serialize, Deserialize, Clone)]
 struct ManaCost {
-    pips: HashMap<String, u8>,              // faithful to mana_cost_jsonb; used for mana= queries
-    devotion: Option<HashMap<String, u8>>,  // Some only when hybrids are present; used for devotion queries
+    /// Single-symbol pip counts (WUBRGC/S/X) packed into 8-bit lanes — see
+    /// the packed-pip-lanes section. Together with `hybrids` this is the
+    /// faithful multiset of mana_cost_jsonb's keys, used for mana= queries.
+    core: u64,
+    /// Hybrid '/' pips as (mana_vocab id, count), sorted by id; empty on
+    /// ~97% of cards. Any future non-hybrid symbol Scryfall invents lands
+    /// here too — the vocab interns whatever the data contains.
+    hybrids: Vec<(u8, u8)>,
+    /// WUBRGC devotion counts (hybrids expanded) in the low six lanes,
+    /// always materialized; used for devotion queries.
+    devotion: u64,
     cmc: f32,
 }
 
@@ -394,6 +441,36 @@ impl VocabInterner {
     }
 }
 
+/// Build-time interner for hybrid mana symbols; `strings` becomes
+/// CardData.mana_vocab. The real-data universe is ~29 hybrid symbols, so u8
+/// ids leave ample headroom; id 255 is reserved for query symbols absent
+/// from the vocab (see MANA_SYM_UNKNOWN), hence the 254 cap.
+struct ManaVocabInterner {
+    map: HashMap<String, u8>,
+    strings: Vec<String>,
+}
+
+impl ManaVocabInterner {
+    fn new() -> Self {
+        ManaVocabInterner { map: HashMap::new(), strings: Vec::new() }
+    }
+
+    fn intern(&mut self, s: &str) -> PyResult<u8> {
+        if let Some(&id) = self.map.get(s) {
+            return Ok(id);
+        }
+        if self.strings.len() >= 255 {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "mana symbol vocabulary exceeded 254 distinct values; widen ManaCost hybrid ids",
+            ));
+        }
+        let id = self.strings.len() as u8;
+        self.strings.push(s.to_string());
+        self.map.insert(s.to_string(), id);
+        Ok(id)
+    }
+}
+
 // ─── Loading helpers ─────────────────────────────────────────────────────────
 
 fn opt_str(d: &Bound<PyDict>, key: &str) -> Option<String> {
@@ -558,45 +635,38 @@ fn jsonb_obj_to_ids(d: &Bound<PyDict>, key: &str, vocab: &mut VocabInterner) -> 
 mod legality;
 use legality::*;
 
-fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>) -> ManaCost {
-    let pips: HashMap<String, u8> = d
-        .get_item("mana_cost_jsonb")
-        .ok()
-        .flatten()
-        .and_then(|v| {
-            v.cast::<PyDict>().ok().map(|m| {
-                m.iter()
-                    .filter_map(|(k, v)| {
-                        let sym = k.extract::<String>().ok()?;
-                        let count = v.cast::<PyList>().ok().map(|l| l.len() as u8).unwrap_or(0);
-                        Some((sym, count))
-                    })
-                    .collect()
-            })
-        })
-        .unwrap_or_default();
-    let devotion = if pips.keys().any(|s| s.contains('/')) {
-        let mut d: HashMap<String, u8> = HashMap::new();
-        for (sym, &n) in &pips {
-            if sym.contains('/') {
-                for part in sym.split('/') {
-                    // WUBRGC: SQL's calculate_devotion counts C too ({C/W} hybrids)
-                    if is_devotion_sym(part) {
-                        *d.entry(part.to_string()).or_insert(0) += n;
+fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>, mana_vocab: &mut ManaVocabInterner) -> PyResult<ManaCost> {
+    let mut core = 0u64;
+    let mut devotion = 0u64;
+    let mut hybrids: Vec<(u8, u8)> = Vec::new();
+    if let Some(m) = d.get_item("mana_cost_jsonb").ok().flatten().and_then(|v| v.cast_into::<PyDict>().ok()) {
+        for (k, v) in m.iter() {
+            let Ok(sym) = k.extract::<String>() else { continue };
+            let count = v.cast::<PyList>().ok().map(|l| l.len().min(127) as u8).unwrap_or(0);
+            match mana_lane(&sym) {
+                Some(lane) => {
+                    core = lane_add(core, lane, count);
+                    if lane < 6 {
+                        devotion = lane_add(devotion, lane, count);
                     }
                 }
-            } else {
-                *d.entry(sym.clone()).or_insert(0) += n;
+                None => {
+                    hybrids.push((mana_vocab.intern(&sym)?, count));
+                    for part in sym.split('/') {
+                        // WUBRGC: SQL's calculate_devotion counts C too ({C/W} hybrids)
+                        if let Some(lane) = mana_lane(part).filter(|&l| l < 6) {
+                            devotion = lane_add(devotion, lane, count);
+                        }
+                    }
+                }
             }
         }
-        Some(d)
-    } else {
-        None
-    };
-    ManaCost { pips, devotion, cmc: cmc_val.unwrap_or(0.0) }
+    }
+    hybrids.sort_unstable();
+    Ok(ManaCost { core, hybrids, devotion, cmc: cmc_val.unwrap_or(0.0) })
 }
 
-fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInterner, artists: &mut VocabInterner) -> PyResult<CardRow> {
+fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInterner, artists: &mut VocabInterner, mana: &mut ManaVocabInterner) -> PyResult<CardRow> {
     let released_at = opt_date_str(d, "released_at").unwrap_or_default();
     let released_at_int: Option<u32> = released_at.replace('-', "").parse().ok();
     // Raw strings from the dict; interned to ids as the struct is built below.
@@ -659,7 +729,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         card_is_tags: jsonb_obj_to_ids(d, "card_is_tags", vocab)?,
         card_frame_data: jsonb_obj_to_ids(d, "card_frame_data", vocab)?,
 
-        mana_cost: mana_cost_from_pydict(d, opt_f32(d, "cmc")),
+        mana_cost: mana_cost_from_pydict(d, opt_f32(d, "cmc"), mana)?,
 
         creature_power_text_id: it.intern_opt(opt_str(d, "creature_power_text")),
         creature_toughness_text_id: it.intern_opt(opt_str(d, "creature_toughness_text")),
@@ -1672,6 +1742,10 @@ struct CardData {
     // Artist predicates (contains/exact/regex) evaluate against these ~2.2k
     // strings once per query instead of per printing.
     artist_vocab: Vec<String>,
+    // Distinct hybrid mana symbols, indexed by ManaCost.hybrids ids (~29
+    // entries). ManaCostCmp binds query symbols against these (see
+    // MANA_SYM_UNKNOWN for symbols no card carries).
+    mana_vocab: Vec<String>,
     indexes: CardIndexes,
     // The writer's format→shift assignments. Persisted so reader processes —
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
@@ -2167,7 +2241,7 @@ fn narrow_rec(
             if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
                 return None;
             }
-            let pe = compile_devotion_superset(pips)?;
+            let pe = compile_devotion_superset(*pips)?;
             let mut bits: Vec<u64> = Vec::new();
             eval_planes(&pe, &indexes.planes, &mut bits);
             Narrowed::loose(Candidates::CardBits(bits))
@@ -3091,7 +3165,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260718;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260719;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -3125,6 +3199,7 @@ struct Staging {
     interner: Interner,
     vocab: VocabInterner,
     artists: VocabInterner,
+    mana: ManaVocabInterner,
     #[allow(dead_code)] // held for its flock; released on drop
     lock_file: std::fs::File,
 }
@@ -3306,7 +3381,7 @@ impl QueryEngine {
         #[cfg(feature = "alloc-counter")]
         alloc_stats::reset_peak();
 
-        *staging = Some(Staging { rows: Vec::new(), interner: Interner::new(), vocab: VocabInterner::new(), artists: VocabInterner::new(), lock_file });
+        *staging = Some(Staging { rows: Vec::new(), interner: Interner::new(), vocab: VocabInterner::new(), artists: VocabInterner::new(), mana: ManaVocabInterner::new(), lock_file });
         Ok(true)
     }
 
@@ -3318,7 +3393,7 @@ impl QueryEngine {
         })?;
         for item in db_rows.iter() {
             if let Ok(d) = item.cast::<PyDict>() {
-                staging.rows.push(card_from_pydict(&d, &mut staging.interner, &mut staging.vocab, &mut staging.artists)?);
+                staging.rows.push(card_from_pydict(&d, &mut staging.interner, &mut staging.vocab, &mut staging.artists, &mut staging.mana)?);
             }
         }
         Ok(())
@@ -3337,7 +3412,7 @@ impl QueryEngine {
         let staging = self.staging.lock().unwrap().take().ok_or_else(|| {
             pyo3::exceptions::PyRuntimeError::new_err("reload_commit called without reload_begin")
         })?;
-        let Staging { mut rows, interner, vocab, artists, lock_file } = staging;
+        let Staging { mut rows, interner, vocab, artists, mana, lock_file } = staging;
 
         // The store groups printings by oracle_id, so rows without one would all
         // collapse into a single card. The DB enforces NOT NULL; fail loudly here
@@ -3449,6 +3524,8 @@ impl QueryEngine {
         drop(vocab.map);
         let artist_vocab = artists.strings;
         drop(artists.map);
+        let mana_vocab = mana.strings;
+        drop(mana.map);
         // String-sorted permutation of the vocab ids; VocabInterner caps the
         // vocab at u16::MAX entries so the cast can't truncate.
         let mut coll_vocab_sorted: Vec<u16> = (0..coll_vocab.len() as u16).collect();
@@ -3493,7 +3570,7 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, printings, offsets, strings, coll_vocab, coll_vocab_sorted, artist_vocab, indexes, format_shifts: format_shifts_snapshot };
+        let card_data = CardData { cards, printings, offsets, strings, coll_vocab, coll_vocab_sorted, artist_vocab, mana_vocab, indexes, format_shifts: format_shifts_snapshot };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -3620,7 +3697,7 @@ impl QueryEngine {
         sync_format_shifts(&data.format_shifts);
         let mut filter_expr = build_filter(&json_val)
             .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
-        filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.indexes.flavor, &data.strings);
+        filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
 
         // Consume the plane-expressible part of the filter (colors/identity/
         // types) into a bitmap expression; run_query evaluates it in a few
@@ -3762,3 +3839,5 @@ mod card_engine {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod bench_mana;

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -19,7 +19,7 @@
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::filter::{CmpOp, ColorField, FilterExpr};
-use super::OracleCard;
+use super::{lane_get, OracleCard};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
 /// field (W U B R G C, bit order matching color_to_bit — C is always zero for
@@ -51,15 +51,11 @@ pub(crate) fn words_per_plane(n_cards: usize) -> usize {
     n_cards.div_ceil(64)
 }
 
-/// A card's effective per-color devotion count, saturated to 0..=3 —
-/// exactly the map FilterExpr::Devotion evaluates (hybrid-expanded when
-/// hybrids are present, raw pips otherwise).
-fn devotion_count(card: &OracleCard, sym: &str) -> u8 {
-    let map = card.mana_cost.devotion.as_ref().unwrap_or(&card.mana_cost.pips);
-    map.get(sym).copied().unwrap_or(0).min(3)
+/// A card's effective devotion count for one color lane, saturated to 0..=3
+/// — exactly the packed lanes FilterExpr::Devotion evaluates.
+fn devotion_count(card: &OracleCard, lane: usize) -> u8 {
+    lane_get(card.mana_cost.devotion, lane).min(3)
 }
-
-const DEVOTION_SYMS: [&str; COLOR_PLANES] = ["W", "U", "B", "R", "G", "C"];
 
 pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
     let wpp = words_per_plane(cards.len());
@@ -79,8 +75,8 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
             set(PLANE_TYPES + bits.trailing_zeros() as usize);
             bits &= bits - 1;
         }
-        for (b, sym) in DEVOTION_SYMS.iter().enumerate() {
-            let count = devotion_count(card, sym);
+        for b in 0..COLOR_PLANES {
+            let count = devotion_count(card, b);
             if count & 1 != 0 {
                 set(PLANE_DEVOTION + DEVOTION_BITS * b);
             }
@@ -93,7 +89,7 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
             // C is exempt — {C} pips never join identity.
             debug_assert!(
                 count == 0 || b == 5 || card.card_color_identity & (1 << b) != 0,
-                "devotion without identity: card {i} color {sym}"
+                "devotion without identity: card {i} color lane {b}"
             );
         }
     }
@@ -209,19 +205,18 @@ fn dev_le(color: usize, k: u8) -> Option<PlaneExpr> {
     dev_ge(color, k + 1).map(|ge| PlaneExpr::Not(Box::new(ge)))
 }
 
-fn devotion_color(sym: &str) -> Option<usize> {
-    DEVOTION_SYMS.iter().position(|s| *s == sym)
-}
-
 /// Compile a Devotion node exactly, mirroring FilterExpr::Devotion's tri():
-/// Ge constrains only the queried colors; Le/Eq additionally pin every
-/// unqueried color to zero (SQL devotion-column containment semantics).
-/// None whenever any needed comparison crosses the saturation boundary.
-fn compile_devotion(op: CmpOp, pips: &std::collections::HashMap<String, u8>) -> Option<PlaneExpr> {
-    let query: Vec<(usize, u8)> = pips
-        .iter()
-        .map(|(sym, &k)| devotion_color(sym).map(|c| (c, k)))
-        .collect::<Option<Vec<_>>>()?;
+/// Ge constrains only the queried colors (the nonzero lanes); Le/Eq
+/// additionally pin every unqueried color to zero (SQL devotion-column
+/// containment semantics). None whenever any needed comparison crosses the
+/// saturation boundary.
+fn compile_devotion(op: CmpOp, pips: u64) -> Option<PlaneExpr> {
+    let query: Vec<(usize, u8)> = (0..COLOR_PLANES)
+        .filter_map(|c| {
+            let k = lane_get(pips, c);
+            (k > 0).then_some((c, k))
+        })
+        .collect();
     let ge = || query.iter().map(|&(c, k)| dev_ge(c, k)).collect::<Option<Vec<_>>>().map(and_of);
     let all_colors = |f: &dyn Fn(usize, u8) -> Option<PlaneExpr>| {
         (0..COLOR_PLANES)
@@ -244,9 +239,12 @@ fn compile_devotion(op: CmpOp, pips: &std::collections::HashMap<String, u8>) -> 
 /// (Ge/Gt past the boundary): clamp each queried count to 3. Every real match
 /// has count >= k >= 3 per queried color, so it lands in the saturated bucket
 /// — a loose candidate set for the driver to verify (~0.5% of cards/color).
-pub(crate) fn compile_devotion_superset(pips: &std::collections::HashMap<String, u8>) -> Option<PlaneExpr> {
-    pips.iter()
-        .map(|(sym, &k)| devotion_color(sym).and_then(|c| dev_ge(c, k.min(3))))
+pub(crate) fn compile_devotion_superset(pips: u64) -> Option<PlaneExpr> {
+    (0..COLOR_PLANES)
+        .filter_map(|c| {
+            let k = lane_get(pips, c);
+            (k > 0).then(|| dev_ge(c, k.min(3)))
+        })
         .collect::<Option<Vec<_>>>()
         .map(and_of)
 }
@@ -291,7 +289,7 @@ pub(crate) fn compile_plane(filter: &FilterExpr) -> Option<PlaneExpr> {
         }
         // Devotion is card-level and two-valued (tri_bool always), so its
         // bit-sliced planes compile exactly within the saturation boundary.
-        FilterExpr::Devotion { op, pips } => compile_devotion(*op, pips),
+        FilterExpr::Devotion { op, pips } => compile_devotion(*op, *pips),
         _ => None,
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2539,6 +2539,12 @@ fn mana_fixture_store() -> CardData {
         let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
         c.mana_cost = mana_cost_of(pips, &mut mana_vocab);
         c.mana_cost.cmc = cmc;
+        // identity must cover devotion colors (the build tripwire enforces it)
+        for (lane, sym) in ["W", "U", "B", "R", "G"].iter().enumerate() {
+            if super::lane_get(c.mana_cost.devotion, lane) > 0 {
+                c.card_color_identity |= super::color_list_to_mask(&[sym]);
+            }
+        }
         c
     }).collect();
     let mut data = store_of(cards, &[1usize; 7], vocab);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -162,7 +162,7 @@ fn stub_card(oracle_id: u128, card_types: u16, subtypes: &[&str], vocab: &mut Vo
         card_keywords: Vec::new(),
         card_oracle_tags: Vec::new(),
         card_legalities: 0,
-        mana_cost: ManaCost { pips: HashMap::new(), devotion: None, cmc: 0.0 },
+        mana_cost: ManaCost { core: 0, hybrids: Vec::new(), devotion: 0, cmc: 0.0 },
         creature_power_text_id: NONE_STR,
         creature_toughness_text_id: NONE_STR,
     }
@@ -229,6 +229,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
         artist_vocab: vec![],
+        mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
     }
@@ -454,7 +455,7 @@ fn collection_cmp_binds_vocab_ids_and_matches() {
             value: value.to_string(),
             value_id: None,
         };
-        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
         archived.cards.iter().map(|c| f.eval_card(c, &archived.strings) == Tri::True).collect()
     };
 
@@ -484,7 +485,7 @@ fn printing_level_predicates_are_printing_dep_in_card_pass() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
 
     let card = &archived.cards[0];
     // Card pass can't decide an art-tag predicate...
@@ -674,6 +675,7 @@ fn bench_checked_vs_unchecked_access() {
         coll_vocab_sorted: sorted_vocab_ids(&vocab.strings),
         coll_vocab: vocab.strings,
         artist_vocab: vec![],
+        mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
     };
@@ -719,7 +721,7 @@ fn card_pass_extracts_residual_and_matches() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    wolf.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+    wolf.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
 
     // And[t:creature, art:wolf]: the type check is proven at card level and
@@ -747,7 +749,7 @@ fn card_pass_extracts_residual_and_matches() {
         value: "wolf".to_string(),
         value_id: None,
     };
-    wolf2.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+    wolf2.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
     let or = FilterExpr::Or(vec![creature(), wolf2]);
     let t = or.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or);
     assert!(t == Tri::True && residual.is_empty());
@@ -778,7 +780,7 @@ fn artist_predicates_bind_to_vocab_ids_and_narrow() {
         field: super::TextSearchField::ArtistLower,
         word: "rebecca".to_string(),
     };
-    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
     // bind rewrites the contains into an id-set match
     let FilterExpr::ArtistMatch { ref ids } = f else { panic!("expected ArtistMatch after bind") };
     assert_eq!(ids, &vec![rebecca]);
@@ -801,7 +803,7 @@ fn artist_predicates_bind_to_vocab_ids_and_narrow() {
         field: super::TextSearchField::ArtistLower,
         word: "zzz".to_string(),
     };
-    g.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+    g.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
     match narrow_candidates(&g, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert!(v.is_empty()),
         _ => panic!("empty artist match must narrow to the empty set"),
@@ -845,7 +847,7 @@ fn flavor_match_bind_eval_and_narrow() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let bound = |f: &mut FilterExpr| {
-        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.indexes.flavor, &archived.strings);
+        f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
     };
 
     let mut f = FilterExpr::TextContains {
@@ -2021,48 +2023,76 @@ fn broad_tag_postings_scatter_or_decline() {
 /// the planes must reproduce.
 fn devotion_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
-    let costs: &[(&[(&str, u8)], bool)] = &[
-        (&[], false),                       // no cost
-        (&[("U", 1)], false),               // {U}
-        (&[("U", 2)], false),               // {U}{U}
-        (&[("U", 3)], false),               // {U}{U}{U}
-        (&[("U", 5)], false),               // deep: saturates
-        (&[("R/G", 1)], true),              // {R/G}: 1 red AND 1 green
-        (&[("R/G", 2), ("R", 1)], true),    // {R/G}{R/G}{R}: R=3, G=2
-        (&[("W", 1), ("U", 1)], false),     // {W}{U}
-        (&[("C", 2)], false),               // {C}{C}: colorless devotion
+    let costs: &[&[(&str, u8)]] = &[
+        &[],                       // no cost
+        &[("U", 1)],               // {U}
+        &[("U", 2)],               // {U}{U}
+        &[("U", 3)],               // {U}{U}{U}
+        &[("U", 5)],               // deep: saturates
+        &[("R/G", 1)],             // {R/G}: 1 red AND 1 green
+        &[("R/G", 2), ("R", 1)],   // {R/G}{R/G}{R}: R=3, G=2
+        &[("W", 1), ("U", 1)],     // {W}{U}
+        &[("C", 2)],               // {C}{C}: colorless devotion
     ];
-    let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &(pips, hybrid))| {
+    let mut mana_vocab: Vec<String> = Vec::new();
+    let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &pips)| {
         let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
-        let pip_map: HashMap<String, u8> = pips.iter().map(|&(s, n)| (s.to_string(), n)).collect();
-        let devotion = if hybrid {
-            let mut d: HashMap<String, u8> = HashMap::new();
-            for (sym, &n) in &pip_map {
-                if sym.contains('/') {
-                    for part in sym.split('/') {
-                        *d.entry(part.to_string()).or_insert(0) += n;
-                    }
-                } else {
-                    *d.entry(sym.clone()).or_insert(0) += n;
-                }
-            }
-            Some(d)
-        } else {
-            None
-        };
+        c.mana_cost = mana_cost_of(pips, &mut mana_vocab);
         // identity must cover devotion colors (the build tripwire enforces it)
         let mut ident = 0u8;
-        for sym in ["W", "U", "B", "R", "G"] {
-            let m = devotion.as_ref().unwrap_or(&pip_map);
-            if m.get(sym).copied().unwrap_or(0) > 0 {
+        for (lane, sym) in ["W", "U", "B", "R", "G"].iter().enumerate() {
+            if super::lane_get(c.mana_cost.devotion, lane) > 0 {
                 ident |= super::color_list_to_mask(&[sym]);
             }
         }
         c.card_color_identity = ident;
-        c.mana_cost = ManaCost { pips: pip_map, devotion, cmc: 0.0 };
         c
     }).collect();
-    store_of(cards, &[1usize; 9], vocab)
+    let mut data = store_of(cards, &[1usize; 9], vocab);
+    data.mana_vocab = mana_vocab;
+    data
+}
+
+/// Build a ManaCost from (symbol, count) pairs the way the loader does:
+/// lane symbols pack into core, hybrids expand into devotion and intern into
+/// `mana_vocab` (the store's table, shared across cards).
+fn mana_cost_of(pips: &[(&str, u8)], mana_vocab: &mut Vec<String>) -> ManaCost {
+    let mut core = 0u64;
+    let mut devotion = 0u64;
+    let mut hybrids: Vec<(u8, u8)> = Vec::new();
+    for &(sym, n) in pips {
+        match super::mana_lane(sym) {
+            Some(lane) => {
+                core = super::lane_add(core, lane, n);
+                if lane < 6 {
+                    devotion = super::lane_add(devotion, lane, n);
+                }
+            }
+            None => {
+                let id = mana_vocab.iter().position(|v| v == sym).unwrap_or_else(|| {
+                    mana_vocab.push(sym.to_string());
+                    mana_vocab.len() - 1
+                });
+                hybrids.push((id as u8, n));
+                for part in sym.split('/') {
+                    if let Some(lane) = super::mana_lane(part).filter(|&l| l < 6) {
+                        devotion = super::lane_add(devotion, lane, n);
+                    }
+                }
+            }
+        }
+    }
+    hybrids.sort_unstable();
+    ManaCost { core, hybrids, devotion, cmc: 0.0 }
+}
+
+/// Pack WUBRGC (symbol, count) pairs into devotion lanes for query pips.
+fn packed_pips(pips: &[(&str, u8)]) -> u64 {
+    let mut p = 0u64;
+    for &(sym, n) in pips {
+        p = super::lane_add(p, super::mana_lane(sym).expect("lane symbol"), n);
+    }
+    p
 }
 
 // Every devotion op agrees with tri() through the planes, at every saturation
@@ -2072,10 +2102,7 @@ fn devotion_plane_parity_and_boundaries() {
     let data = devotion_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let dev = |op, pips: &[(&str, u8)]| FilterExpr::Devotion {
-        op,
-        pips: pips.iter().map(|&(s, n)| (s.to_string(), n)).collect(),
-    };
+    let dev = |op, pips: &[(&str, u8)]| FilterExpr::Devotion { op, pips: packed_pips(pips) };
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check_exact = |f: &FilterExpr| {
         let pe = compile_plane(f).expect("must compile exactly");
@@ -2118,10 +2145,7 @@ fn hybrid_pip_counts_toward_both_colors() {
     let data = devotion_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let dev = |sym: &str, k: u8| FilterExpr::Devotion {
-        op: CmpOp::Ge,
-        pips: std::iter::once((sym.to_string(), k)).collect(),
-    };
+    let dev = |sym: &str, k: u8| FilterExpr::Devotion { op: CmpOp::Ge, pips: packed_pips(&[(sym, k)]) };
     let mut bitmap: Vec<u64> = Vec::new();
     let rg_card = 5; // {R/G}
     for (f, want) in [(dev("R", 1), true), (dev("G", 1), true), (dev("R", 2), false), (dev("U", 1), false)] {
@@ -2286,12 +2310,12 @@ fn regex_tier_classifies_pattern_shapes() {
     assert_eq!(regex_tier("dragon$"), 1);
     assert_eq!(regex_tier("(?i)^\\{t\\}: add"), 1, "escaped punctuation is literal");
     assert_eq!(regex_tier("^gob"), 1);
-    assert_eq!(regex_tier("(?i)flying"), 3, "unanchored literal = contains cost");
-    assert_eq!(regex_tier("draw .* cards?"), 4);
-    assert_eq!(regex_tier("^[aeiou]"), 4);
-    assert_eq!(regex_tier("(?i)^\\d+$"), 4, "class escapes are machinery");
-    assert_eq!(regex_tier("a|b"), 4);
-    assert_eq!(regex_tier("ends with backslash\\"), 4, "dangling escape: not literal");
+    assert_eq!(regex_tier("(?i)flying"), 2, "unanchored literal = contains cost");
+    assert_eq!(regex_tier("draw .* cards?"), 3);
+    assert_eq!(regex_tier("^[aeiou]"), 3);
+    assert_eq!(regex_tier("(?i)^\\d+$"), 3, "class escapes are machinery");
+    assert_eq!(regex_tier("a|b"), 3);
+    assert_eq!(regex_tier("ends with backslash\\"), 3, "dangling escape: not literal");
 }
 
 // And children reorder cheapest-tier-first regardless of written order, and
@@ -2356,7 +2380,7 @@ fn verify_order_or_sorts_by_bucket_only() {
 // devotion:bbb` 1.2× when measured).
 #[test]
 fn verify_order_or_keeps_scan_cost_band_in_written_order() {
-    let devotion = || FilterExpr::Devotion { op: CmpOp::Ge, pips: HashMap::from([("B".to_string(), 3u8)]) };
+    let devotion = || FilterExpr::Devotion { op: CmpOp::Ge, pips: packed_pips(&[("B", 3)]) };
     let mut f = FilterExpr::Or(vec![contains_scan(), devotion()]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
@@ -2491,4 +2515,130 @@ fn verify_order_spellings_agree_end_to_end() {
     let or_a = FilterExpr::Or(vec![machinery_regex(), type_mask()]);
     let or_b = FilterExpr::Or(vec![type_mask(), machinery_regex()]);
     assert_eq!(run(or_a), run(or_b));
+}
+
+// ─── Packed mana pips: ManaCostCmp semantics ─────────────────────────────────
+
+/// Store with a spread of cost shapes: plain, multi-pip, hybrid, X, snow,
+/// empty — enough to exercise every ManaCostCmp op against the packed lanes,
+/// the hybrid overflow vec, and the bind path.
+fn mana_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let mut mana_vocab: Vec<String> = Vec::new();
+    // (pips, cmc): oracle ids 1..=7 in this order
+    let costs: &[(&[(&str, u8)], f32)] = &[
+        (&[("W", 1)], 1.0),               // 1: {W}
+        (&[("W", 2)], 2.0),               // 2: {W}{W}
+        (&[("W", 1), ("U", 1)], 2.0),     // 3: {W}{U}
+        (&[("R/G", 1)], 1.0),             // 4: {R/G}
+        (&[("X", 1), ("R", 1)], 1.0),     // 5: {X}{R}
+        (&[("S", 1), ("G", 1)], 2.0),     // 6: {S}{G}
+        (&[], 0.0),                       // 7: no cost
+    ];
+    let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &(pips, cmc))| {
+        let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+        c.mana_cost = mana_cost_of(pips, &mut mana_vocab);
+        c.mana_cost.cmc = cmc;
+        c
+    }).collect();
+    let mut data = store_of(cards, &[1usize; 7], vocab);
+    data.mana_vocab = mana_vocab;
+    data
+}
+
+/// Build a bound ManaCostCmp the way build_binary + bind would: lane symbols
+/// pack into core, hybrid symbols resolve against the store's vocab (or the
+/// reserved unknown id when absent).
+fn mana_cmp_of(op: CmpOp, pips: &[(&str, u8)], cmc: f32, mana_vocab: &[String]) -> FilterExpr {
+    let mut core = 0u64;
+    let mut hybrids: Vec<(String, u8)> = Vec::new();
+    let mut hybrid_ids: Vec<(u8, u8)> = Vec::new();
+    let mut unknown = 0u8;
+    for &(sym, n) in pips {
+        match super::mana_lane(sym) {
+            Some(lane) => core = super::lane_add(core, lane, n),
+            None => {
+                hybrids.push((sym.to_string(), n));
+                match mana_vocab.iter().position(|v| v == sym) {
+                    Some(i) => hybrid_ids.push((i as u8, n)),
+                    None => unknown = unknown.saturating_add(n),
+                }
+            }
+        }
+    }
+    hybrids.sort_unstable();
+    hybrid_ids.sort_unstable();
+    if unknown > 0 {
+        hybrid_ids.push((super::MANA_SYM_UNKNOWN, unknown));
+    }
+    FilterExpr::ManaCostCmp { op, core, hybrids, hybrid_ids, cmc }
+}
+
+// Containment, exactness, and their strict/negated variants over the packed
+// representation, matching the jsonb multiset semantics they replace: `=`
+// needs the same distinct symbols with the same counts (a zero lane IS an
+// absent key), hybrids are their own symbols (never lane-expanded for
+// mana=), and X on a card blocks exactness against an X-less query.
+#[test]
+fn mana_cost_cmp_packed_semantics() {
+    let data = mana_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let matches = |f: &FilterExpr| -> Vec<u128> {
+        archived.cards.iter()
+            .filter(|c| f.eval_card(c, &archived.strings) == Tri::True)
+            .map(|c| u128::from(c.oracle_id))
+            .collect()
+    };
+    let mv: Vec<String> = archived.mana_vocab.iter().map(|s| s.to_string()).collect();
+
+    // Ge = query ⊆ card (and cmc >=): every white cost with cmc >= 1.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("W", 1)], 1.0, &mv)), [1, 2, 3]);
+    // Eq: same symbols, same counts, same cmc — {W} only, not {W}{W} or {W}{U}.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("W", 1)], 1.0, &mv)), [1]);
+    // Le = card ⊆ query: {W}, {W}{W}, and the empty cost.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Le, &[("W", 2)], 2.0, &mv)), [1, 2, 7]);
+    // Strict variants exclude the exact cost.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Gt, &[("W", 1)], 1.0, &mv)), [2, 3]);
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Lt, &[("W", 2)], 2.0, &mv)), [1, 7]);
+    // Hybrid pips are distinct symbols: {R/G} matches only through the vocab.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("R/G", 1)], 1.0, &mv)), [4]);
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("R/G", 1)], 1.0, &mv)), [4]);
+    // ...and {R} does not contain {R/G}, nor does the {X}{R} card equal {R}.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("R", 1)], 1.0, &mv)), [5]);
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("R", 1)], 1.0, &mv)), Vec::<u128>::new());
+    // Snow is a lane like any other.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("S", 1)], 1.0, &mv)), [6]);
+    // A symbol no card carries: containment and exactness fail everywhere;
+    // card ⊆ query still holds for the empty cost (query-only symbols never
+    // constrain the subset direction — same as the HashMap semantics).
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("Q/Z", 1)], 1.0, &mv)), Vec::<u128>::new());
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("Q/Z", 1)], 1.0, &mv)), Vec::<u128>::new());
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Le, &[("Q/Z", 1)], 2.0, &mv)), [7]);
+    // Ne is not-exactly-equal.
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ne, &[("W", 1)], 1.0, &mv)), [2, 3, 4, 5, 6, 7]);
+}
+
+// The SWAR lane comparison agrees with the scalar per-lane loop across the
+// value spectrum, including the saturation cap that keeps it sound.
+#[test]
+fn lanes_ge_matches_scalar_compare() {
+    let vals = [0u8, 1, 2, 3, 5, 126, 127];
+    for &a0 in &vals {
+        for &b0 in &vals {
+            for &a5 in &vals {
+                for &b5 in &vals {
+                    let a = super::lane_add(super::lane_add(0, 0, a0), 5, a5);
+                    let b = super::lane_add(super::lane_add(0, 0, b0), 5, b5);
+                    let want = a0 >= b0 && a5 >= b5;
+                    assert_eq!(super::lanes_ge(a, b, super::LANES6_HI), want, "a0={a0} b0={b0} a5={a5} b5={b5}");
+                }
+            }
+        }
+    }
+    // lane_add saturates below the lane's high bit, so borrows can't escape.
+    let big = super::lane_add(super::lane_add(0, 2, 120), 2, 120);
+    assert_eq!(super::lane_get(big, 2), 127);
+    assert_eq!(super::lane_get(big, 1), 0);
+    assert_eq!(super::lane_get(big, 3), 0);
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     build_artwork_group_counts, build_bit_planes, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
-    range_too_broad_to_narrow, run_query, trigram_candidates, int_range_candidates, PrintingRangeIndex, NARROW_FLOOR,
+    range_too_broad_to_narrow, run_query, trigram_candidates, PrintingRangeIndex, NARROW_FLOOR,
     bitmap_contains, compile_plane, eval_planes, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,

--- a/docs/changelog/2026-07-09-packed-mana-pips.md
+++ b/docs/changelog/2026-07-09-packed-mana-pips.md
@@ -1,0 +1,23 @@
+# Mana pip counts pack into u64 lanes
+
+`ManaCost` stored pip counts as `HashMap<String, u8>` — a shape chosen
+because it made the Postgres jsonb query easy to write, not because the
+engine needed it. Devotion and `mana=` comparisons paid string hashing and
+map iteration per candidate (~21 ns and ~6–10 ns respectively).
+
+Pips now pack into 8-bit lanes of a `u64` (WUBRGC + snow + X; generic
+numbers were already dropped on both sides), with the ~29 hybrid `/` symbols
+in a small sorted `(vocab id, count)` overflow vec that is empty on ~97% of
+cards. Devotion is an always-materialized 6-lane `u64`. Per-lane containment
+is a three-op SWAR compare and pip-set equality is integer equality, so a
+zero lane and an absent key are the same thing — `mana=`'s distinct-key
+semantics fall out for free.
+
+Measured on the real 31,508-card cost distribution
+(`cargo test --release bench_mana -- --ignored --nocapture`, parity asserted
+on every card × query × op): devotion 21.4 → 0.7 ns/card (~30×), mana
+containment 6–10 → 1.7–2.1 ns/card (~4–5×), equality unchanged (~1 ns).
+Both filters move to verifier cost tier 1.
+
+Archive format version bumped (ManaCost layout change). Design discussion:
+issue #650.


### PR DESCRIPTION
# Pack Mana Pip Counts Into u64 Lanes, Replacing the Pip HashMaps

Closes #650. Stacked on #648 (it adjusts the verifier cost tiers that PR introduced).

## What this does

`ManaCost` stored pip counts as `HashMap<String, u8>` plus an `Option<HashMap>` for devotion — a shape chosen because it mirrored `mana_cost_jsonb` and made the Postgres query easy to write, not because the engine needed it. Every devotion or `mana=` verification paid string hashing, map iteration, and (for devotion) a per-eval `is_devotion_sym` key filter.

Both maps are gone:

- **`core: u64`** — the eight single-symbol keys mana_cost_jsonb can hold (WUBRGC + snow + X; generic numbers are already dropped on both the import and query sides) pack into 8-bit lanes. Per-lane `>=` is a three-op branchless SWAR borrow compare (`((a | HI) - b) & HI == HI`, sound because lanes saturate at 127), and pip-set equality is **integer equality** — a zero lane and an absent key are the same thing, which is what makes `mana=`'s distinct-key-set semantics fall out for free instead of needing the old `len()` bookkeeping.
- **`hybrids: Vec<(u8, u8)>`** — the ~29 hybrid `/` symbols overflow to a sorted (vocab id, count) vec, **empty on ~97% of cards**, interned into a new `CardData.mana_vocab` at load and resolved per query by `bind()` exactly like the collection vocab. Query symbols no card carries merge into a reserved id that can never match — same convention as `CollectionCmp`'s unbound `value_id`.
- **`devotion: u64`** — always materialized at load (WUBRGC lanes, hybrids expanded), retiring the `Option<HashMap>` + raw-pips fallback and the `is_devotion_sym` filtering in the filter arm and the plane builder.

Issue #650 proposed `[u8; 6]` + overflow; this lands the packed-integer refinement from review discussion: masks/lanes instead of arrays (equality and containment become single integer ops), X and S get lanes rather than overflow slots, and the overflow vec is genuinely rare.

## Measured — kernels timed directly, no query machinery

Per the review discussion, the benchmark is a micro-benchmark of the compares themselves (`card_engine/src/bench_mana.rs`, `cargo test --release bench_mana -- --ignored --nocapture`): the real per-oracle-card cost distribution (31,508 rows exported from the corpus to `benchmarks/mana/mana_costs.tsv`), all contenders built from the same strings in one process — no subprocess layout artifacts, no query-path noise. The old evaluation loops are lifted verbatim; a sorted-vec contender is included to show the choice was measured, not assumed. **Every contender is asserted result-identical on every (card, query, op) pair before timing**, so the run doubles as a parity suite over the full real-data distribution.

| query | hashmap (old) | sortvec | packed (new) | speedup |
|---|---|---|---|---|
| `devotion ge B=1` | 21.51 ns/card | — | **0.78 ns/card** | **27×** |
| `devotion ge G=2` | 21.30 | — | **0.65** | **33×** |
| `devotion ge U=3` | 21.33 | — | **0.76** | **28×** |
| `devotion eq W=1` | 21.44 | — | **0.65** | **33×** |
| `devotion le R=1` | 21.44 | — | **0.65** | **33×** |
| `mana ge {B}{B}` | 8.96 | 3.14 | **1.82** | **4.9×** |
| `mana ge {W}` | 9.91 | 2.43 | **2.03** | **4.9×** |
| `mana ge {R/G}` | 6.04 | 2.85 | **1.67** | **3.6×** |
| `mana le {2}{W}{W}` | 9.23 | 2.29 | **2.09** | **4.4×** |
| `mana eq {W}{U}` | 0.97 | 1.33 | 1.14 | ~1× |
| `mana ne {G}` | 1.09 | 1.33 | **0.95** | ~1× |

Devotion's ~30× is the headline: the old path walked `keys().filter(is_devotion_sym).count()` plus per-color hashmap gets on every candidate. Equality was already cheap (the `len()` check rejects most cards before any hashing), and stays so. Packed beats the sorted-vec contender on every containment shape, which is why it ships.

Both filters drop from verifier cost tier 2 to tier 1 (#648's model): ~1–2 ns/card is binary-search territory. Devotion at 0.65 ns is arguably tier 0, but tier 1 keeps it out of the Or acceptance-gamble bucket that #648 measured as a trap.

## Semantics preserved exactly

- Multiset containment/equality over jsonb keys is reproduced lane-for-lane and entry-for-entry; the new `mana_cost_cmp_packed_semantics` test pins all six ops including: hybrids as distinct symbols (`{R}` does not contain `{R/G}`), X-on-card blocking exactness against an X-less query (jsonb keeps X on cards; the query parser drops it — preexisting asymmetry, unchanged), snow as an ordinary lane, and unknown query symbols failing containment/exactness while never constraining the subset direction.
- `lanes_ge_matches_scalar_compare` verifies the SWAR trick against the scalar loop across the value spectrum including the saturation cap.
- The devotion plane fixtures (`devotion_plane_parity_and_boundaries`, `hybrid_pip_counts_toward_both_colors`) pass unchanged against the packed builder.
- The bench's parity sweep covers the entire real corpus distribution for all three representations.

## Notes

- `ARCHIVE_FORMAT_VERSION` bumped: `ManaCost` is part of the rkyv blob, so stale archives rebuild rather than being mapped with the old layout.
- The archive also shrinks: two heap HashMaps per card become 16 bytes + a usually-empty vec.
- Python surface unchanged (`mana_cost` text field untouched); `mana_cost_jsonb` is consumed at import only.
- Lane counts saturate at 127. Real costs peak around 16 pips; a query like `devotion:` with >127 repeated symbols saturates to 127 on both sides, which changes nothing observable (no card exceeds 16).

## Tests

`cargo test`: 64 passed — the new semantics/SWAR tests plus the full existing suite (devotion planes, verifier ordering, narrowing, streaming parity). Python: 3 differential-oracle property tests, 467 api unit tests, 1,347 parser tests pass against the rebuilt wheel. Micro-bench parity: 31,508 cards × 11 queries × 3 representations, zero divergences.

## End-to-end: where the kernel speedup does and doesn't reach queries

Follow-up two-build A/B (old = #648 tip, new = this branch; same corpus, same harness, 3 reps each, totals identical on all 11 shapes):

| query | total | old | new | |
|---|---|---|---|---|
| `devotion:bb` | 1,561 | 0.063 ms | 0.064 ms | 0.98× |
| `devotion:bbb` | 179 | 0.058 ms | 0.059 ms | 0.99× |
| `devotion<={w}{w}` | 8,819 | 0.108 ms | 0.109 ms | 0.99× |
| `devotion:bbbb` | 26 | 0.025 ms | **0.020 ms** | 1.26× |
| `oracle:vigilance or devotion:bbb` | 1,219 | 0.115 ms | 0.110 ms | 1.05× |
| `mana:{b}{b}` | 1,440 | 0.414 ms | **0.204 ms** | **2.02×** |
| `mana:{2}{w}{w}` | 811 | 0.457 ms | **0.239 ms** | **1.92×** |
| `o:/sacrifice a creature/ mana:{b}{b}` | 61 | 0.537 ms | **0.355 ms** | **1.52×** |
| `mana={r/g}` | 6 | 0.188 ms | 0.204 ms | 0.92× |
| `c:g` (control) | 6,407 | 0.084 ms | 0.084 ms | 1.00× |

Exactly what the architecture predicts: shallow devotion (counts ≤ 3, any op within the exactness boundary) is answered **entirely by the #643 bit-sliced planes** — the Devotion kernel never runs per card, so those queries can't get faster (and don't). The kernel speedup reaches queries wherever verification actually runs: `mana:`/`mana=` containment has no index of any kind and full-scan-verifies every card (**~2×** end-to-end), mana conjuncts inherit the cheaper rejector (1.5×), and past-saturation devotion verifies its superset candidates (1.26× on an already-fast query). `mana={r/g}` is ~16 µs slower, consistent with the micro-bench: old equality was already ~1 ns/card because the `len()` check rejects without hashing, and packed equality pays a float compare first — bounded by the scan floor either way. The devotion win therefore remains what the micro-bench shows (per-candidate cost in verified contexts), plus the structural wins: no `Option<HashMap>` in the archive and no hash tables to walk when devotion *does* reach the verifier.
