### PR TITLE
Measure the Verifier Cost Tiers, Replace Ordinal Ranks With ns Constants

### DIFF
--- a/card_engine/src/bench_verify_cost.rs
+++ b/card_engine/src/bench_verify_cost.rs
@@ -1,0 +1,164 @@
+//! Micro-benchmark for the verifier cost model (docs/issues/done/
+//! engine-verifier-cost-ordering.md, follow-up to #651).
+//!
+//! `verify_cost_tier()`/`regex_tier()` group FilterExpr variants into cost
+//! clusters used to sort And/Or children cheapest-first before the tri walk.
+//! Only Devotion/ManaCostCmp have ever been measured (bench_mana.rs, #651);
+//! every other cluster was assigned by judgment. This times the real
+//! `FilterExpr::matches()` path — no reimplemented kernels, nothing to
+//! compare — against the real corpus archive, so every cluster in the model
+//! ends up backed by a number.
+//!
+//! Nodes are built the same way the query driver builds them: hand-written
+//! pre-bind FilterExpr literals, then run through the crate's own bind() /
+//! memoize_text_predicates() against the loaded archive, so id-set sizes
+//! (ArtistMatch/FlavorMatch/NameMatch/OracleMatch) are real production sizes.
+//!
+//!     cargo test --release bench_verify_cost -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (rebuild after any AOracleCard/
+//! APrinting layout change — the header's size-of check will reject a stale
+//! file):
+//!
+//!     rm -f benchmarks/verify-order/real.store
+//!     .venv/bin/python -c "
+//!     import pathlib, sys; sys.path.insert(0, '.')
+//!     from scripts.bench_bitplanes import load_engine
+//!     load_engine(pathlib.Path('benchmarks/bitplanes/corpus.jsonl'),
+//!                 pathlib.Path('benchmarks/verify-order/real.store'))
+//!     "
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use regex::Regex;
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, CardData, CmpOp, ColorField, CollField, FilterExpr, Mmap, NumExpr, NumField, TextField,
+    TextSearchField, TYPE_CREATURE, ARCHIVE_HEADER_LEN,
+};
+
+const ITERS: usize = 50;
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn time_kernel(name: &str, n: usize, mut kernel: impl FnMut() -> u32) -> f64 {
+    let mut best = u128::MAX;
+    let mut matches = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        matches = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    let ns_per = best as f64 / n as f64;
+    println!("  {name:<28} {ns_per:>8.3} ns/card  ({matches} matches)");
+    ns_per
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_verify_cost_clusters() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as get_mmap() in lib.rs — the file is written by
+    // rkyv::to_bytes and replaced atomically; we re-validate the header below
+    // before treating the payload as a trusted archive.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+
+    let n = data.cards.len();
+    println!("\n{n} oracle cards from {STORE_PATH}");
+
+    // One (card, printing) pair per oracle card: the default-preferred
+    // printing, same indexing sample_preferred() uses (lib.rs).
+    let pairs: Vec<(usize, usize)> = (0..n).map(|cid| (cid, u32::from(data.offsets[cid]) as usize)).collect();
+
+    let run = |name: &str, f: &FilterExpr| -> f64 {
+        time_kernel(name, n, || pairs.iter().filter(|&&(cid, pid)| f.matches(&data.cards[cid], &data.printings[pid], &data.strings)).count() as u32)
+    };
+
+    // ─── Cluster: mask / field compare (current tier 0) ──────────────────────
+    println!("\n-- mask/field compare --");
+    let mask_ns: Vec<f64> = vec![
+        run("TypeCmp", &FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }),
+        run("ColorCmp", &FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 0b0000_0100 }),
+        run(
+            "NumericCmp",
+            &FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) },
+        ),
+        run("ExactName", &FilterExpr::ExactName("lightning bolt".to_string())),
+        run(
+            "TextExact",
+            &FilterExpr::TextExact { field: TextField::NameLower, op: CmpOp::Eq, value: "island".to_string() },
+        ),
+        run("Legality", &FilterExpr::Legality { shift: Some(0), expected: 0b11 }),
+        run("DateCmp", &FilterExpr::DateCmp { op: CmpOp::Lt, value: 20_200_101 }),
+        run("YearCmp", &FilterExpr::YearCmp { op: CmpOp::Lt, year: 2020 }),
+    ];
+
+    // ─── Cluster: memoized-set binary search (current tier 1) ────────────────
+    println!("\n-- memoized-set binary search --");
+    let mut set_ns: Vec<f64> = Vec::new();
+
+    let mut artist = FilterExpr::TextContains { field: TextSearchField::ArtistLower, word: "guay".to_string() };
+    artist.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
+    assert!(matches!(artist, FilterExpr::ArtistMatch { .. }), "bind() didn't rewrite to ArtistMatch");
+    set_ns.push(run("ArtistMatch", &artist));
+
+    let mut flavor = FilterExpr::TextContains { field: TextSearchField::FlavorTextLower, word: "dragon".to_string() };
+    flavor.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
+    assert!(matches!(flavor, FilterExpr::FlavorMatch { .. }), "bind() didn't rewrite to FlavorMatch");
+    set_ns.push(run("FlavorMatch", &flavor));
+
+    let mut name = FilterExpr::TextContains { field: TextSearchField::NameLower, word: "storm".to_string() };
+    name.memoize_text_predicates(&data.cards, &data.strings, &data.indexes.name_trigram, &data.indexes.name_bigrams, &data.indexes.oracle_trigram, n);
+    assert!(matches!(name, FilterExpr::NameMatch { .. }), "memoize didn't rewrite to NameMatch (needle too common/rare?)");
+    set_ns.push(run("NameMatch", &name));
+
+    let mut oracle = FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
+    oracle.memoize_text_predicates(&data.cards, &data.strings, &data.indexes.name_trigram, &data.indexes.name_bigrams, &data.indexes.oracle_trigram, n);
+    assert!(matches!(oracle, FilterExpr::OracleMatch { .. }), "memoize didn't rewrite to OracleMatch (needle too common/rare?)");
+    set_ns.push(run("OracleMatch", &oracle));
+
+    let mut coll = FilterExpr::CollectionCmp { field: CollField::Keywords, op: CmpOp::Ge, value: "Flying".to_string(), value_id: None };
+    coll.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
+    set_ns.push(run("CollectionCmp", &coll));
+
+    // ─── Cluster: text scan (current tier 2) ─────────────────────────────────
+    println!("\n-- text scan (unmemoized TextContains) --");
+    let scan_ns = run("TextContains", &FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() });
+
+    // ─── Cluster: regex shapes (regex_tier 1 / 2 / 3) ────────────────────────
+    println!("\n-- regex shapes --");
+    let anchored_ns = run(
+        "TextRegex (anchored literal)",
+        &FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: Regex::new("(?i)^flying$").unwrap() },
+    );
+    let bare_ns = run(
+        "TextRegex (bare literal)",
+        &FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: Regex::new("(?i)flying").unwrap() },
+    );
+    let machinery_ns = run(
+        "TextRegex (machinery, literal prefix)",
+        &FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: Regex::new("(?i)draw .* cards?").unwrap() },
+    );
+    let machinery_noprefix_ns = run(
+        "TextRegex (machinery, no prefix)",
+        &FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: Regex::new("(?i)^[aeiou]").unwrap() },
+    );
+
+    println!("\n-- cluster summary (ns/card) --");
+    println!("  mask/field compare : {mask_ns:.3?}");
+    println!("  set lookup         : {set_ns:.3?}");
+    println!("  text scan          : {scan_ns:.3}");
+    println!("  regex anchored     : {anchored_ns:.3}");
+    println!("  regex bare literal : {bare_ns:.3}");
+    println!("  regex machinery (literal prefix) : {machinery_ns:.3}");
+    println!("  regex machinery (no prefix)      : {machinery_noprefix_ns:.3}");
+}

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -393,40 +393,63 @@ pub(crate) enum FilterExpr {
     },
 }
 
-/// Per-candidate verification cost of a node in the tri walk, grouped into
-/// tiers wide enough that the ranking is safe without measurement:
+/// Verifier per-candidate cost estimates, in hundredths of a nanosecond
+/// (ns * 100 — e.g. 1.83 ns -> 183) so sub-nanosecond gaps between measured
+/// ops stay representable as plain integers, and adding or recalibrating one
+/// op is a one-line constant edit instead of a renumbering of its neighbors
+/// (#651 forced exactly that churn on the previous 0..4 ordinal scheme).
 ///
-///   0 — field loads and integer/float/mask compares (numerics, dates,
-///       colors, types, legality words, exact string equality)
-///   1 — bounded lookups: a binary search over a bind/memoize-resolved id set
-///       (ArtistMatch/FlavorMatch/NameMatch/OracleMatch) or a card collection
-///       (CollectionCmp), anchored-literal regexes (a memcmp at a known
-///       position — see regex_tier), and the packed-lane pip compares of
-///       Devotion / ManaCostCmp (SWAR plus a usually-empty hybrid walk)
-///   2 — per-candidate text scans: TextContains (substring search; artist /
-///       flavor contains were rewritten to tier 1 at bind) and
-///       unanchored-literal regexes, whose prefilter costs the same scan
-///   3 — TextRegex with real regex machinery — the single worst
-///       per-candidate cost the engine has
+/// Measured on the real corpus (`bench_verify_cost.rs`, `cargo test --release
+/// bench_verify_cost -- --ignored --nocapture`, 31,508 oracle cards, min-of-50
+/// per kernel, 3 repeated runs — see that file for the per-op numbers):
 ///
-/// Composites take the max of their children: their short-circuit may have to
-/// evaluate every child, so the most expensive child bounds the cost.
-fn verify_cost_tier(f: &FilterExpr) -> u8 {
+/// - field loads and integer/float/mask compares (TypeCmp, ColorCmp,
+///   NumericCmp, ExactName, TextExact, Legality, DateCmp, YearCmp): 1.8-5.6 ns
+///   measured; NumericCmp is the priciest member (NumExpr::eval() indirection
+///   on both sides costs more than a direct field load), so the constant sits
+///   above it.
+pub(crate) const MASK_COMPARE_NS100: u32 = 600;
+/// - bounded lookups: a binary search over a bind/memoize-resolved id set
+///   (ArtistMatch/FlavorMatch/NameMatch/OracleMatch), a card collection
+///   (CollectionCmp), and anchored-literal regexes (a memcmp at a known
+///   position — see regex_tier): 1.8-8.1 ns measured. Devotion/ManaCostCmp
+///   (#651, bench_mana.rs) measure below this range (0.65-2 ns) but share the
+///   constant deliberately — see their arm below.
+pub(crate) const SET_LOOKUP_NS100: u32 = 900;
+/// - per-candidate text scans: unmemoized TextContains: 21.6-22.7 ns measured.
+pub(crate) const TEXT_SCAN_NS100: u32 = 2_300;
+/// - regex without a usable anchor: bare literal and general machinery
+///   measured statistically identical (~44-49 ns) once compared on equal
+///   footing (both carrying the (?i) every query regex has) — the regex
+///   crate's literal-prefix optimization doesn't meaningfully beat a full
+///   scan for an *unanchored* pattern. This corrects the previous assumption
+///   that bare-literal costs the same as TextContains (it measures ~2x more).
+///   An anchored non-literal pattern (e.g. `^[aeiou]`) measured far cheaper
+///   (~17.7 ns, anchoring bounds the scan regardless of what's being tested)
+///   but regex_tier() doesn't distinguish that case from general machinery —
+///   left as a known conservative overestimate, not fixed here (would need a
+///   regex_tier() classification change, not just a constant recalibration).
+pub(crate) const REGEX_MACHINERY_NS100: u32 = 5_000;
+
+/// Per-candidate verification cost of a node in the tri walk. Composites take
+/// the max of their children: their short-circuit may have to evaluate every
+/// child, so the most expensive child bounds the cost.
+fn verify_cost_tier(f: &FilterExpr) -> u32 {
     match f {
         FilterExpr::TextRegex { regex, .. } => regex_tier(regex.as_str()),
-        FilterExpr::TextContains { .. } => 2,
-        FilterExpr::Devotion { .. } | FilterExpr::ManaCostCmp { .. } => 1,
+        FilterExpr::TextContains { .. } => TEXT_SCAN_NS100,
+        FilterExpr::Devotion { .. } | FilterExpr::ManaCostCmp { .. } => SET_LOOKUP_NS100,
         FilterExpr::ArtistMatch { .. }
         | FilterExpr::FlavorMatch { .. }
         | FilterExpr::NameMatch { .. }
         | FilterExpr::OracleMatch { .. }
-        | FilterExpr::CollectionCmp { .. } => 1,
+        | FilterExpr::CollectionCmp { .. } => SET_LOOKUP_NS100,
         FilterExpr::And(children) | FilterExpr::Or(children) => {
             children.iter().map(verify_cost_tier).max().unwrap_or(0)
         }
         FilterExpr::Not(inner) => verify_cost_tier(inner),
-        // Exhaustive, not `_ => 0`: a new variant must get a considered tier
-        // here rather than silently inheriting tier 0 (cheapest).
+        // Exhaustive, not `_ => MASK_COMPARE_NS100`: a new variant must get a
+        // considered cost here rather than silently inheriting the cheapest.
         FilterExpr::True
         | FilterExpr::ExactName(_)
         | FilterExpr::NumericCmp { .. }
@@ -435,7 +458,7 @@ fn verify_cost_tier(f: &FilterExpr) -> u8 {
         | FilterExpr::TypeCmp { .. }
         | FilterExpr::Legality { .. }
         | FilterExpr::DateCmp { .. }
-        | FilterExpr::YearCmp { .. } => 0,
+        | FilterExpr::YearCmp { .. } => MASK_COMPARE_NS100,
     }
 }
 
@@ -447,10 +470,12 @@ fn verify_cost_tier(f: &FilterExpr) -> u8 {
 /// as one. Ranking them as general regexes inverted real costs and made
 /// `o:/^flying$/ oracle:sacrifice` 2.4× slower, so:
 ///
-///   1 — literal with a ^ or $ anchor (starts_with/ends_with/equality)
-///   2 — bare literal (substring search, same tier as TextContains)
-///   3 — anything with live regex metacharacters
-pub(crate) fn regex_tier(pattern: &str) -> u8 {
+///   SET_LOOKUP_NS100    — literal with a ^ or $ anchor (starts_with/
+///                         ends_with/equality; memcmp at a known position)
+///   REGEX_MACHINERY_NS100 — everything else: bare literal (measured the
+///                         same cost as live metacharacters, not the same as
+///                         TextContains — see REGEX_MACHINERY_NS100's doc)
+pub(crate) fn regex_tier(pattern: &str) -> u32 {
     let mut p = pattern.strip_prefix("(?i)").unwrap_or(pattern);
     let anchored_start = p.starts_with('^');
     if anchored_start {
@@ -465,17 +490,17 @@ pub(crate) fn regex_tier(pattern: &str) -> u8 {
             // alphanumeric escape (\d \w \b \p…) is a class — real machinery.
             b'\\' => match bytes.get(i + 1) {
                 Some(c) if !c.is_ascii_alphanumeric() => i += 2,
-                _ => return 3,
+                _ => return REGEX_MACHINERY_NS100,
             },
             b'$' if i == bytes.len() - 1 => {
                 anchored_end = true;
                 i += 1;
             }
-            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return 3,
+            b'.' | b'*' | b'+' | b'?' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'$' => return REGEX_MACHINERY_NS100,
             _ => i += 1,
         }
     }
-    if anchored_start || anchored_end { 1 } else { 2 }
+    if anchored_start || anchored_end { SET_LOOKUP_NS100 } else { REGEX_MACHINERY_NS100 }
 }
 
 /// Whether a node can NEVER settle the card-level pass — it compares only
@@ -566,9 +591,9 @@ fn printing_dependent(f: &FilterExpr) -> bool {
 fn or_child_key(f: &FilterExpr) -> (u8, bool) {
     let tier = verify_cost_tier(f);
     let pdep = printing_dependent(f);
-    let bucket = if tier >= 3 {
+    let bucket = if tier >= REGEX_MACHINERY_NS100 {
         2
-    } else if tier == 0 && !pdep {
+    } else if tier == MASK_COMPARE_NS100 && !pdep {
         0
     } else {
         1

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3821,3 +3821,5 @@ mod card_engine {
 mod tests;
 #[cfg(test)]
 mod bench_mana;
+#[cfg(test)]
+mod bench_verify_cost;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2301,21 +2301,23 @@ fn machinery_regex() -> FilterExpr {
     FilterExpr::TextRegex { field: TextField::OracleTextLower, regex: regex::Regex::new("draw .* cards?").unwrap() }
 }
 
-// Pattern-shape cost classification: anchored literals are memcmp-cheap,
-// bare literals cost a substring scan, real machinery gets the top tier.
+// Pattern-shape cost classification: anchored literals are memcmp-cheap
+// (SET_LOOKUP_NS100); everything else — bare literals included, measured the
+// same cost as real machinery, not a text scan (bench_verify_cost.rs) —
+// shares REGEX_MACHINERY_NS100.
 #[test]
 fn regex_tier_classifies_pattern_shapes() {
-    use super::regex_tier;
-    assert_eq!(regex_tier("(?i)^flying$"), 1);
-    assert_eq!(regex_tier("dragon$"), 1);
-    assert_eq!(regex_tier("(?i)^\\{t\\}: add"), 1, "escaped punctuation is literal");
-    assert_eq!(regex_tier("^gob"), 1);
-    assert_eq!(regex_tier("(?i)flying"), 2, "unanchored literal = contains cost");
-    assert_eq!(regex_tier("draw .* cards?"), 3);
-    assert_eq!(regex_tier("^[aeiou]"), 3);
-    assert_eq!(regex_tier("(?i)^\\d+$"), 3, "class escapes are machinery");
-    assert_eq!(regex_tier("a|b"), 3);
-    assert_eq!(regex_tier("ends with backslash\\"), 3, "dangling escape: not literal");
+    use super::{regex_tier, REGEX_MACHINERY_NS100, SET_LOOKUP_NS100};
+    assert_eq!(regex_tier("(?i)^flying$"), SET_LOOKUP_NS100);
+    assert_eq!(regex_tier("dragon$"), SET_LOOKUP_NS100);
+    assert_eq!(regex_tier("(?i)^\\{t\\}: add"), SET_LOOKUP_NS100, "escaped punctuation is literal");
+    assert_eq!(regex_tier("^gob"), SET_LOOKUP_NS100);
+    assert_eq!(regex_tier("(?i)flying"), REGEX_MACHINERY_NS100, "unanchored literal measures the same as machinery");
+    assert_eq!(regex_tier("draw .* cards?"), REGEX_MACHINERY_NS100);
+    assert_eq!(regex_tier("^[aeiou]"), REGEX_MACHINERY_NS100);
+    assert_eq!(regex_tier("(?i)^\\d+$"), REGEX_MACHINERY_NS100, "class escapes are machinery");
+    assert_eq!(regex_tier("a|b"), REGEX_MACHINERY_NS100);
+    assert_eq!(regex_tier("ends with backslash\\"), REGEX_MACHINERY_NS100, "dangling escape: not literal");
 }
 
 // And children reorder cheapest-tier-first regardless of written order, and

--- a/docs/changelog/2026-07-09-measured-verify-cost-tiers.md
+++ b/docs/changelog/2026-07-09-measured-verify-cost-tiers.md
@@ -1,0 +1,54 @@
+# Verifier cost tiers are measured, not guessed
+
+`verify_cost_tier()`/`regex_tier()` (#648, refined in #651) ranked FilterExpr
+nodes into small ordinal tiers (0-3 / 1-3) assigned by judgment — only
+Devotion/ManaCostCmp had ever been measured against an absolute cost
+(`bench_mana.rs`, #651). Renumbering already caused churn once: #651's
+reclassification forced a tier compaction across the whole function.
+
+Both functions now return `u32` costs in hundredths of a nanosecond
+(`ns * 100`) instead of ordinal ranks, via named constants
+(`MASK_COMPARE_NS100`, `SET_LOOKUP_NS100`, `TEXT_SCAN_NS100`,
+`REGEX_MACHINERY_NS100`) — recalibrating or inserting one op is now a
+one-line constant edit, never a renumbering of its neighbors. Every constant
+is backed by a new kernel bench, `bench_verify_cost.rs`, which times the real
+`FilterExpr::matches()` path (no reimplemented kernels — there's nothing to
+compare, just the current cost of the current code) against the real corpus
+archive (31,508 oracle cards, min-of-50 per kernel, 3 repeated runs):
+
+| cluster | measured | constant |
+|---|---|---|
+| mask/field compare (TypeCmp, ColorCmp, NumericCmp, ExactName, TextExact, Legality, DateCmp, YearCmp) | 1.8-5.6 ns | `MASK_COMPARE_NS100` = 600 |
+| memoized-set binary search (ArtistMatch, FlavorMatch, NameMatch, OracleMatch, CollectionCmp) + anchored-literal regex | 1.8-8.1 ns | `SET_LOOKUP_NS100` = 900 |
+| unmemoized TextContains | 21.6-22.7 ns | `TEXT_SCAN_NS100` = 2300 |
+| regex without a usable anchor (bare literal *and* general machinery) | 44-49 ns | `REGEX_MACHINERY_NS100` = 5000 |
+
+One correction fell out of the measurement: bare-literal regex (`(?i)flying`)
+was assumed to cost the same as `TextContains` (both "a scan"). Measured on
+equal footing (both carrying the `(?i)` every query regex has), it costs the
+same as full regex machinery instead — ~2x a `TextContains` scan, not the
+same. `regex_tier()` now folds the bare-literal case into
+`REGEX_MACHINERY_NS100`.
+
+Devotion/ManaCostCmp (#651) measure below `SET_LOOKUP_NS100`'s range
+(0.65-2 ns) but keep sharing the constant deliberately, per #651's own
+reasoning: tier 1 keeps them out of the Or acceptance-gamble bucket that
+tier 0 would expose them to.
+
+Re-ran the `bench_verify_order.py` A/B suite after recalibrating: parity
+holds (554/554 queries, totals identical old vs new — this is a pure speed
+dial), and the enrichment-family geomean improved from 1.16x to 1.21x, with
+`o:/sacrifice a creature/ mana:{b}{b}` now hitting 4.78x (up from 3.15x
+originally measured in #648, before #651's pip repacking and this
+recalibration).
+
+## Known gap, not fixed here
+
+`bench_verify_cost.rs` also measured an *anchored non-literal* pattern
+(`^[aeiou]`, no exploitable literal prefix): ~17.7 ns — far cheaper than
+either bare-literal or machinery (~45 ns), because anchoring bounds the scan
+to one position regardless of what's being tested there, not just for pure
+literals. `regex_tier()` doesn't currently detect this — any pattern with
+live metacharacters after the anchor still falls to `REGEX_MACHINERY_NS100`,
+a safe but measurably conservative overestimate for this shape. See
+`docs/issues/engine-regex-anchor-detection.md`.


### PR DESCRIPTION
# Measure the Verifier Cost Tiers, Replace Ordinal Ranks With ns Constants

Stacked on #651 (recalibrates the tier constants that PR introduced).

## What this does

`verify_cost_tier()`/`regex_tier()` (#648, refined in #651) ranked FilterExpr
nodes into small ordinal tiers (0-3 / 1-3) assigned by judgment — only
Devotion/ManaCostCmp had ever been measured against an absolute cost
(`bench_mana.rs`, #651). Renumbering already caused churn once: #651's
reclassification forced a tier compaction across the whole function and a
matching rename in `tests.rs`.

Both functions now return `u32` costs in hundredths of a nanosecond
(`ns * 100`, e.g. 1.83 ns -> 183) instead of ordinal ranks, via named
constants (`MASK_COMPARE_NS100`, `SET_LOOKUP_NS100`, `TEXT_SCAN_NS100`,
`REGEX_MACHINERY_NS100`). Recalibrating or inserting one op is now a one-line
constant edit, never a renumbering of its neighbors.

## The bench

Every constant is backed by a new kernel bench, `bench_verify_cost.rs`, which
times the real `FilterExpr::matches()` path — no reimplemented kernels,
nothing to compare, just the current cost of the current code — against the
real corpus archive (mmap + the same rkyv-access pattern the production
`QueryEngine` uses), 31,508 oracle cards, min-of-50 per kernel, 3 repeated
runs:

| cluster | measured | constant |
|---|---|---|
| mask/field compare (TypeCmp, ColorCmp, NumericCmp, ExactName, TextExact, Legality, DateCmp, YearCmp) | 1.8-5.9 ns | `MASK_COMPARE_NS100` = 600 |
| memoized-set binary search (ArtistMatch, FlavorMatch, NameMatch, OracleMatch, CollectionCmp) + anchored-literal regex | 1.8-8.1 ns | `SET_LOOKUP_NS100` = 900 |
| unmemoized TextContains | 21.6-23.0 ns | `TEXT_SCAN_NS100` = 2300 |
| regex without a usable anchor (bare literal *and* general machinery) | 44-49 ns | `REGEX_MACHINERY_NS100` = 5000 |

Nodes are built the same way the query driver builds them: pre-bind
`FilterExpr` literals run through the crate's own `bind()` /
`memoize_text_predicates()` against the loaded archive, so id-set sizes
(ArtistMatch/FlavorMatch/NameMatch/OracleMatch) are real production sizes,
not hand-picked.

## One correction

Bare-literal regex (`(?i)flying`) was assumed to cost the same as
`TextContains` — both "a scan." Measured on equal footing (both carrying the
`(?i)` every query regex has — my first pass compared these unfairly and the
inconsistency showed up immediately as a 2x flip), it costs the same as full
regex machinery instead (~2x a `TextContains` scan, not the same).
`regex_tier()` now folds the bare-literal case into `REGEX_MACHINERY_NS100`.

Devotion/ManaCostCmp (#651) measure below `SET_LOOKUP_NS100`'s range
(0.65-2 ns) but keep sharing the constant deliberately, per #651's own
reasoning: tier 1 keeps them out of the Or acceptance-gamble bucket that
tier 0 would expose them to.

## Verified after recalibrating

- `cargo test` (debug): 64 passed.
- `bench_verify_order.py` A/B suite re-run: parity holds (554/554 queries,
  totals identical old vs new — this is a pure speed dial), and the
  enrichment-family geomean improved from 1.16x to 1.21x, with
  `o:/sacrifice a creature/ mana:{b}{b}` now hitting 4.78x (up from 3.15x
  originally measured in #648, before #651's pip repacking and this
  recalibration).
- `cargo clippy --all-targets`: no new warnings.

## Known gap, flagged not fixed

The bench also measured an anchored *non-literal* pattern (`^[aeiou]`, no
exploitable literal prefix): ~17.7 ns — cheaper than both bare-literal and
machinery (~45 ns each), because anchoring bounds the scan to one position
regardless of what's being tested there, not just for pure literals.
`regex_tier()` doesn't detect this today (any metacharacter after an anchor
still falls to `REGEX_MACHINERY_NS100`) — a safe but measurably conservative
overestimate for that shape. Filed as
`docs/issues/engine-regex-anchor-detection.md` rather than folded in here:
it's a classification-logic change needing its own measurement matrix, not a
constant recalibration.