### PR TITLE
Fix Devotion + Mana-Pip Parsing Bugs, Close 5 Mana/Devotion Coverage Gaps

### DIFF
--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -22,6 +22,14 @@ def extract_image_location_uuid(card: dict[str, Any]) -> str:
     raise AssertionError(msg)
 
 
+# Card types that can exist as a permanent on the battlefield. Devotion (MTG
+# comprehensive rules) is defined only over permanents' mana costs, confirmed
+# against the real Scryfall API (devotion: never matches a pure Instant/Sorcery,
+# e.g. the real Lightning Bolt), so calculate_devotion()'s result is discarded
+# for any card with no type in this set. Title-cased to match parse_type_line().
+PERMANENT_CARD_TYPES = {"Artifact", "Battle", "Creature", "Enchantment", "Land", "Planeswalker"}
+
+
 def parse_type_line(type_line: str) -> tuple[list[str], list[str]]:
     """Parse the type line of a card."""
     card_types, _, card_subtypes = (x.strip().split() for x in type_line.title().partition("\u2014"))
@@ -214,7 +222,10 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
 
     mana_cost_text = card.get("mana_cost", "")
     card["mana_cost_jsonb"] = mana_cost_str_to_dict(mana_cost_text)
-    card["devotion"] = calculate_devotion(mana_cost_text)
+    # Nonpermanents (Instant/Sorcery) never contribute devotion, regardless of
+    # their mana cost - see PERMANENT_CARD_TYPES.
+    is_permanent = bool(PERMANENT_CARD_TYPES & set(card_types))
+    card["devotion"] = calculate_devotion(mana_cost_text) if is_permanent else {}
 
     # Map field names to match database column names for jsonb_populate_record
     # Don't overwrite card_name if already set (for DFCs, it's set before processing faces)

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -379,6 +379,8 @@ def mana_cost_str_to_dict(mana_cost_str: str) -> dict:
     """Convert a mana cost string to a dictionary of colored symbols and their counts.
 
     Supports both braced format ({W}{U}), unbraced format (WU or wu), and mixed format (R{G}).
+    X is a real pip symbol here (its cmc contribution of 0 is handled separately
+    by calculate_cmc), not a hybrid — {X} and bare X both produce an "X" key.
     """
     colored_symbol_counts = {}
     mana_cost_upper = mana_cost_str.upper()
@@ -397,8 +399,10 @@ def mana_cost_str_to_dict(mana_cost_str: str) -> dict:
     # We don't care about digits here, only colored symbols
     unbraced_part = re.sub(r"{[^}]*}", " ", mana_cost_upper)
     for char in unbraced_part:
-        # Only count color characters (W, U, B, R, G, C)
-        if char in "WUBRGC":
+        # Color characters (W, U, B, R, G, C) plus X, its own pip symbol —
+        # confirmed against the real Scryfall API: mana:x behaves identically
+        # to mana:{x}. calculate_cmc() already excludes X from cmc separately.
+        if char in "WUBRGCX":
             colored_symbol_counts[char] = colored_symbol_counts.get(char, 0) + 1
 
     as_dict = {}

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -161,6 +161,20 @@ def test_full_sql_translation(parse_query, input_query: str, expected_sql: str, 
             r"(%(p_dict_eydHJzogWzFdfQ)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s AND card.mana_cost_jsonb <> %(p_dict_eydHJzogWzFdfQ)s)",
             {"p_dict_eydHJzogWzFdfQ": {"G": [1]}, "p_int_MQ": 1},
         ),
+        # X is its own pip symbol, not a hybrid, and contributes 0 to cmc
+        # (mana_cost_jsonb keeps the X key; cmc excludes it) — braced and bare
+        # forms must produce identical SQL, since mana_cost_str_to_dict()
+        # treats them the same.
+        (
+            "mana:{X}{R}",
+            r"(%(p_dict_eydYJzogWzFdLCAnUic6IFsxXX0)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s)",
+            {"p_dict_eydYJzogWzFdLCAnUic6IFsxXX0": {"X": [1], "R": [1]}, "p_int_MQ": 1},
+        ),
+        (
+            "mana:xr",
+            r"(%(p_dict_eydYJzogWzFdLCAnUic6IFsxXX0)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s)",
+            {"p_dict_eydYJzogWzFdLCAnUic6IFsxXX0": {"X": [1], "R": [1]}, "p_int_MQ": 1},
+        ),
     ],
 )
 def test_full_sql_translation_jsonb_colors(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -128,6 +128,39 @@ def test_full_sql_translation(parse_query, input_query: str, expected_sql: str, 
             r"(card.devotion @> %(p_dict_eydSJzogWzFdLCAnRyc6IFsxXX0)s)",
             {"p_dict_eydSJzogWzFdLCAnRyc6IFsxXX0": {"G": [1], "R": [1]}},
         ),
+        # mana: tests — unlike devotion, every op ANDs in a cmc compare
+        # alongside jsonb containment/equality (see
+        # _handle_mana_cost_approximate_comparison), and ":" normalizes to ">=".
+        (
+            "mana:{g}",
+            r"(%(p_dict_eydHJzogWzFdfQ)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}, "p_int_MQ": 1},
+        ),
+        (
+            "mana={g}",
+            r"(card.mana_cost_jsonb = %(p_dict_eydHJzogWzFdfQ)s AND card.cmc = %(p_int_MQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}, "p_int_MQ": 1},
+        ),
+        (
+            "mana<={g}",
+            r"(card.mana_cost_jsonb <@ %(p_dict_eydHJzogWzFdfQ)s AND card.cmc <= %(p_int_MQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}, "p_int_MQ": 1},
+        ),
+        (
+            "mana<{g}",
+            r"(card.mana_cost_jsonb <@ %(p_dict_eydHJzogWzFdfQ)s AND card.cmc <= %(p_int_MQ)s AND card.mana_cost_jsonb <> %(p_dict_eydHJzogWzFdfQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}, "p_int_MQ": 1},
+        ),
+        (
+            "mana>={g}{r}",
+            r"(%(p_dict_eydHJzogWzFdLCAnUic6IFsxXX0)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_Mg)s)",
+            {"p_dict_eydHJzogWzFdLCAnUic6IFsxXX0": {"G": [1], "R": [1]}, "p_int_Mg": 2},
+        ),
+        (
+            "mana>{g}",
+            r"(%(p_dict_eydHJzogWzFdfQ)s <@ card.mana_cost_jsonb AND card.cmc >= %(p_int_MQ)s AND card.mana_cost_jsonb <> %(p_dict_eydHJzogWzFdfQ)s)",
+            {"p_dict_eydHJzogWzFdfQ": {"G": [1]}, "p_int_MQ": 1},
+        ),
     ],
 )
 def test_full_sql_translation_jsonb_colors(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:

--- a/api/tests/fixtures/engine_cards.json
+++ b/api/tests/fixtures/engine_cards.json
@@ -7296,5 +7296,176 @@
     "type_line": "Sorcery",
     "prefer_score": 170.64348,
     "cubecobra_score": 9.339396
+  },
+  {
+    "scryfall_id": "0c9eeced-6464-41f0-bbea-05b3af4cc005",
+    "oracle_id": "325b88e1-ec7f-4d22-887c-a7f18a868bb0",
+    "illustration_id": "325b88e1-ec7f-4d22-887c-a7f18a868bb0",
+    "card_artist": "Forrest Imel",
+    "card_border": "black",
+    "card_color_identity": {
+      "R": true,
+      "U": true,
+      "W": true
+    },
+    "card_colors": {
+      "R": true,
+      "U": true,
+      "W": true
+    },
+    "card_frame_data": {},
+    "card_is_tags": {},
+    "card_keywords": {},
+    "card_layout": "normal",
+    "card_legalities": {
+      "tlr": "not_legal",
+      "duel": "legal",
+      "brawl": "legal",
+      "penny": "not_legal",
+      "predh": "not_legal",
+      "future": "legal",
+      "legacy": "legal",
+      "modern": "legal",
+      "pauper": "legal",
+      "alchemy": "legal",
+      "pioneer": "legal",
+      "vintage": "legal",
+      "historic": "legal",
+      "standard": "legal",
+      "timeless": "legal",
+      "commander": "legal",
+      "gladiator": "legal",
+      "oldschool": "not_legal",
+      "premodern": "not_legal",
+      "oathbreaker": "legal",
+      "standardbrawl": "legal",
+      "paupercommander": "legal"
+    },
+    "card_name": "Monastery Messenger",
+    "card_oracle_tags": {},
+    "card_rarity_int": 0,
+    "card_set_code": "tdm",
+    "card_subtypes": [
+      "Bird",
+      "Scout"
+    ],
+    "card_types": [
+      "Creature"
+    ],
+    "card_watermark": null,
+    "cmc": 6,
+    "collector_number": "208",
+    "collector_number_int": 208,
+    "creature_power": 2,
+    "creature_toughness": 3,
+    "edhrec_rank": null,
+    "flavor_text": null,
+    "mana_cost_jsonb": {
+      "2/U": [
+        1
+      ],
+      "2/R": [
+        1
+      ],
+      "2/W": [
+        1
+      ]
+    },
+    "mana_cost_text": "{2/U}{2/R}{2/W}",
+    "oracle_text": "Flying",
+    "planeswalker_loyalty": null,
+    "price_eur": null,
+    "price_tix": null,
+    "price_usd": null,
+    "produced_mana": {},
+    "released_at": "2025-04-11",
+    "creature_power_text": "2",
+    "creature_toughness_text": "3",
+    "set_name": "Tarkir: Dragonstorm",
+    "type_line": "Creature \u2014 Bird Scout",
+    "prefer_score": 0.0,
+    "cubecobra_score": 0.0
+  },
+  {
+    "scryfall_id": "07592731-68be-4218-bb2c-c2523c5a27f1",
+    "oracle_id": "0297eeb2-47ec-4f9a-b1ad-4e7286994f00",
+    "illustration_id": "0297eeb2-47ec-4f9a-b1ad-4e7286994f00",
+    "card_artist": "Nils Hamm",
+    "card_border": "black",
+    "card_color_identity": {
+      "W": true
+    },
+    "card_colors": {
+      "W": true
+    },
+    "card_frame_data": {},
+    "card_is_tags": {},
+    "card_keywords": {
+      "Defender": true
+    },
+    "card_layout": "normal",
+    "card_legalities": {
+      "tlr": "not_legal",
+      "duel": "legal",
+      "brawl": "not_legal",
+      "penny": "not_legal",
+      "predh": "not_legal",
+      "future": "not_legal",
+      "legacy": "legal",
+      "modern": "legal",
+      "pauper": "not_legal",
+      "alchemy": "not_legal",
+      "pioneer": "not_legal",
+      "vintage": "legal",
+      "historic": "not_legal",
+      "standard": "not_legal",
+      "timeless": "not_legal",
+      "commander": "legal",
+      "gladiator": "not_legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "oathbreaker": "legal",
+      "standardbrawl": "not_legal",
+      "paupercommander": "not_legal"
+    },
+    "card_name": "Cathedral Membrane",
+    "card_oracle_tags": {},
+    "card_rarity_int": 0,
+    "card_set_code": "nph",
+    "card_subtypes": [
+      "Phyrexian",
+      "Wall"
+    ],
+    "card_types": [
+      "Artifact",
+      "Creature"
+    ],
+    "card_watermark": "phyrexian",
+    "cmc": 2,
+    "collector_number": "5",
+    "collector_number_int": 5,
+    "creature_power": 0,
+    "creature_toughness": 3,
+    "edhrec_rank": null,
+    "flavor_text": null,
+    "mana_cost_jsonb": {
+      "W/P": [
+        1
+      ]
+    },
+    "mana_cost_text": "{1}{W/P}",
+    "oracle_text": "({W/P} can be paid with either {W} or 2 life.)\nDefender",
+    "planeswalker_loyalty": null,
+    "price_eur": null,
+    "price_tix": null,
+    "price_usd": null,
+    "produced_mana": {},
+    "released_at": "2011-05-13",
+    "creature_power_text": "0",
+    "creature_toughness_text": "3",
+    "set_name": "New Phyrexia",
+    "type_line": "Artifact Creature \u2014 Phyrexian Wall",
+    "prefer_score": 0.0,
+    "cubecobra_score": 0.0
   }
 ]

--- a/api/tests/fixtures/engine_cards.json
+++ b/api/tests/fixtures/engine_cards.json
@@ -7467,5 +7467,84 @@
     "type_line": "Artifact Creature \u2014 Phyrexian Wall",
     "prefer_score": 0.0,
     "cubecobra_score": 0.0
+  },
+  {
+    "scryfall_id": "df45a43e-a5b7-4fd4-873b-7b3c021be198",
+    "oracle_id": "aa7714b0-2bfb-458a-8ebf-37ec2c53383e",
+    "illustration_id": "aa7714b0-2bfb-458a-8ebf-37ec2c53383e",
+    "card_artist": "Xavier Ribeiro",
+    "card_border": "black",
+    "card_color_identity": {
+      "R": true
+    },
+    "card_colors": {
+      "R": true
+    },
+    "card_frame_data": {},
+    "card_is_tags": {},
+    "card_keywords": {},
+    "card_layout": "normal",
+    "card_legalities": {
+      "tlr": "not_legal",
+      "duel": "legal",
+      "brawl": "not_legal",
+      "penny": "legal",
+      "predh": "legal",
+      "future": "not_legal",
+      "legacy": "legal",
+      "modern": "legal",
+      "pauper": "not_legal",
+      "alchemy": "not_legal",
+      "pioneer": "legal",
+      "vintage": "legal",
+      "historic": "legal",
+      "standard": "not_legal",
+      "timeless": "legal",
+      "commander": "legal",
+      "gladiator": "legal",
+      "oldschool": "not_legal",
+      "premodern": "legal",
+      "oathbreaker": "legal",
+      "standardbrawl": "not_legal",
+      "paupercommander": "not_legal"
+    },
+    "card_name": "Fireball",
+    "card_oracle_tags": {},
+    "card_rarity_int": 1,
+    "card_set_code": "clb",
+    "card_subtypes": [],
+    "card_types": [
+      "Sorcery"
+    ],
+    "card_watermark": null,
+    "cmc": 1,
+    "collector_number": "175",
+    "collector_number_int": 175,
+    "creature_power": null,
+    "creature_toughness": null,
+    "edhrec_rank": null,
+    "flavor_text": null,
+    "mana_cost_jsonb": {
+      "X": [
+        1
+      ],
+      "R": [
+        1
+      ]
+    },
+    "mana_cost_text": "{X}{R}",
+    "oracle_text": "This spell costs {1} more to cast for each target it has beyond the first.\nFireball deals X damage divided as you choose among any number of targets.",
+    "planeswalker_loyalty": null,
+    "price_eur": null,
+    "price_tix": null,
+    "price_usd": null,
+    "produced_mana": {},
+    "released_at": "2022-06-10",
+    "creature_power_text": null,
+    "creature_toughness_text": null,
+    "set_name": "Commander Legends: Battle for Baldur's Gate",
+    "type_line": "Sorcery",
+    "prefer_score": 0.0,
+    "cubecobra_score": 0.0
   }
 ]

--- a/api/tests/fixtures/test_data.sql
+++ b/api/tests/fixtures/test_data.sql
@@ -1,8 +1,15 @@
 -- Minimal test data for integration tests
+--
+-- mana_cost_jsonb/devotion are dict[symbol, list[int]] (array length = pip
+-- count) — NOT plain integers — matching mana_cost_str_to_dict()/
+-- calculate_devotion() in api/parsing/card_query_nodes.py. devotion is only
+-- nonempty for permanents (Creature/Artifact/etc, never Instant/Sorcery) —
+-- confirmed against the real Scryfall API, where devotion: never matches a
+-- pure Instant (e.g. the real Lightning Bolt).
 
 -- Insert some test cards
 INSERT INTO magic.cards (
-    scryfall_id, oracle_id, card_name, cmc, mana_cost_text, mana_cost_jsonb, raw_card_blob,
+    scryfall_id, oracle_id, card_name, cmc, mana_cost_text, mana_cost_jsonb, devotion, raw_card_blob,
     card_types, card_subtypes, card_colors, card_color_identity, card_keywords,
     oracle_text, creature_power, creature_toughness, card_oracle_tags, collector_number, collector_number_int,
     released_at
@@ -13,7 +20,8 @@ INSERT INTO magic.cards (
     'Lightning Bolt',
     1,
     '{R}',
-    '{"R": 1}',
+    '{"R": [1]}',
+    '{}', -- Instant: nonpermanent, so devotion is empty despite the {R} cost
     '{"name": "Lightning Bolt", "type": "Instant", "collector_number": "123"}',
     '["Instant"]',
     '[]',
@@ -34,7 +42,8 @@ INSERT INTO magic.cards (
     'Serra Angel',
     5,
     '{3}{W}{W}',
-    '{"3": 3, "W": 2}',
+    '{"W": [1, 2]}', -- pure-generic braces like {3} are dropped, never a key
+    '{"W": [1, 2]}', -- Creature: a permanent, so this is the positive devotion control
     '{"name": "Serra Angel", "type": "Creature", "collector_number": "45a"}',
     '["Creature"]',
     '["Angel"]',
@@ -56,6 +65,7 @@ INSERT INTO magic.cards (
     0,
     '{0}',
     '{}',
+    '{}',
     '{"name": "Black Lotus", "type": "Artifact", "collector_number": "1"}',
     '["Artifact"]',
     '[]',
@@ -69,6 +79,56 @@ INSERT INTO magic.cards (
     '1',
     1,
     '2024-02-23'
+),
+(
+    -- Boggart Ram-Gang {R/G}{R/G}{R/G} (real card, shm #203): a hybrid
+    -- permanent — mana:{R} must NOT match it (opaque hybrid key), but
+    -- devotion:{R} and devotion:{G} both do (hybrid symbols split for devotion).
+    '00000000-0000-0000-0000-000000000004',
+    '30d2437a-87c9-4f88-8fb8-b686d6522677',
+    'Boggart Ram-Gang',
+    3,
+    '{R/G}{R/G}{R/G}',
+    '{"R/G": [1, 2, 3]}',
+    '{"R": [1, 2, 3], "G": [1, 2, 3]}',
+    '{"name": "Boggart Ram-Gang", "type": "Creature", "collector_number": "203"}',
+    '["Creature"]',
+    '["Goblin", "Warrior"]',
+    '{"R": true, "G": true}',
+    '{"R": true, "G": true}',
+    '{}',
+    'Whenever Boggart Ram-Gang attacks, you may sacrifice another creature. If you do, target creature gets +2/+0 until end of turn.',
+    3,
+    3,
+    '{}',
+    '203',
+    203,
+    '2008-05-02'
+),
+(
+    -- Cathedral Membrane {1}{W/P} (real card, nph #5): a Phyrexian permanent —
+    -- mana:{W} must NOT match it (opaque hybrid key, same as any other
+    -- hybrid), but devotion:{W} does (P isn't a tracked devotion letter).
+    '00000000-0000-0000-0000-000000000005',
+    '0297eeb2-47ec-4f9a-b1ad-4e7286994f00',
+    'Cathedral Membrane',
+    2,
+    '{1}{W/P}',
+    '{"W/P": [1]}',
+    '{"W": [1]}',
+    '{"name": "Cathedral Membrane", "type": "Artifact Creature", "collector_number": "5"}',
+    '["Artifact", "Creature"]',
+    '["Phyrexian", "Wall"]',
+    '{"W": true}',
+    '{"W": true}',
+    '{}',
+    '({W/P} can be paid with either {W} or 2 life.)\nDefender',
+    0,
+    3,
+    '{}',
+    '5',
+    5,
+    '2011-05-13'
 ) ON CONFLICT (scryfall_id) DO NOTHING;
 
 -- Insert test tags

--- a/api/tests/fixtures/test_data.sql
+++ b/api/tests/fixtures/test_data.sql
@@ -129,6 +129,32 @@ INSERT INTO magic.cards (
     '5',
     5,
     '2011-05-13'
+),
+(
+    -- Fireball {X}{R} (real card, clb #175): X is its own pip symbol (not a
+    -- hybrid) and contributes 0 to cmc — mana:{X} and bare mana:x must both
+    -- match it, and mana:{X}{R}{R} (implied cmc 2) must not (cmc is 1).
+    -- Sorcery: nonpermanent, so devotion is empty despite the {R} pip.
+    '00000000-0000-0000-0000-000000000006',
+    'aa7714b0-2bfb-458a-8ebf-37ec2c53383e',
+    'Fireball',
+    1,
+    '{X}{R}',
+    '{"X": [1], "R": [1]}',
+    '{}',
+    '{"name": "Fireball", "type": "Sorcery", "collector_number": "175"}',
+    '["Sorcery"]',
+    '[]',
+    '{"R": true}',
+    '{"R": true}',
+    '{}',
+    'This spell costs {1} more to cast for each target it has beyond the first.\nFireball deals X damage divided as you choose among any number of targets.',
+    NULL,
+    NULL,
+    '{}',
+    '175',
+    175,
+    '2022-06-10'
 ) ON CONFLICT (scryfall_id) DO NOTHING;
 
 -- Insert test tags

--- a/api/tests/test_engine_property.py
+++ b/api/tests/test_engine_property.py
@@ -36,6 +36,12 @@ SETS = ["lea", "m21", "znr", "neo", "mom", "ltr", "woe", "mkm"]
 COLORS = "wubrg"
 N_CARDS = 3000
 
+# Devotion (MTG comprehensive rules) is defined only over permanents' mana
+# costs, confirmed against the real Scryfall API (devotion: never matches a
+# pure Instant/Sorcery). Mirrors PERMANENT_TYPES in card_processing.py /
+# PERMANENT_TYPES in lib.rs.
+PERMANENT_TYPES = {"Artifact", "Battle", "Creature", "Enchantment", "Land", "Planeswalker"}
+
 FRAGMENTS = [
     # colors / identity across ops (":" on id is subset; on c it is contains)
     "c:g",
@@ -97,6 +103,12 @@ FRAGMENTS = [
     "devotion:uuuu",
     "devotion=gg",
     "-devotion:rr",
+    # mana: pip containment + cmc (unlike devotion, no hybrid splitting and
+    # every op ANDs in a cmc compare), Eq, and negation
+    "mana:u",
+    "mana:uu",
+    "mana=gg",
+    "-mana:rr",
 ]
 
 
@@ -125,7 +137,11 @@ def _make_cards(rng: random.Random) -> list[dict[str, Any]]:
             for c in colors:
                 pips[c] = rng.choice([1, 1, 2, 2, 3, 4])
             if rng.random() < 0.1 and len(colors) >= 1:
-                other = rng.choice([x for x in "WUBRG" if x != colors[0]] or ["C"])
+                # ~30% of hybrid pips are Phyrexian ({W/P}) rather than
+                # color/color or generic/color, so devotion:/mana: get fuzzed
+                # against Phyrexian symbols too (a plain color letter, "P",
+                # never a devotion-tracked letter).
+                other = "P" if rng.random() < 0.3 else rng.choice([x for x in "WUBRG" if x != colors[0]] or ["C"])
                 pips[f"{colors[0]}/{other}"] = rng.choice([1, 2])
         pos = 1
         mana_cost_jsonb: dict[str, list[int]] = {}
@@ -209,10 +225,14 @@ def _ref_leaf(frag: str, card: dict[str, Any]) -> bool | None:  # noqa: PLR0911,
     if frag.startswith(("devotion:", "devotion=")):
         op = frag[len("devotion")]
         counts: dict[str, int] = {}
-        for sym, positions in card["mana_cost_jsonb"].items():
-            for part in sym.split("/"):
-                if part in "WUBRGC":
-                    counts[part] = counts.get(part, 0) + len(positions)
+        # Devotion only counts permanents' mana costs (MTG comprehensive
+        # rules; confirmed against the real Scryfall API) — a nonpermanent's
+        # pips never contribute, regardless of the operator.
+        if PERMANENT_TYPES & set(card["card_types"]):
+            for sym, positions in card["mana_cost_jsonb"].items():
+                for part in sym.split("/"):
+                    if part in "WUBRGC":
+                        counts[part] = counts.get(part, 0) + len(positions)
         want: dict[str, int] = {}
         for ch in frag[len("devotion") + 1 :]:
             want[ch.upper()] = want.get(ch.upper(), 0) + 1
@@ -221,6 +241,24 @@ def _ref_leaf(frag: str, card: dict[str, Any]) -> bool | None:  # noqa: PLR0911,
             return ge
         # "=": exact per-color counts AND no devotion outside the queried colors
         return all(counts.get(c, 0) == k for c, k in want.items()) and all(c in want for c, n in counts.items() if n > 0)
+    if frag.startswith(("mana:", "mana=")):
+        op = frag[len("mana")]
+        want_pips: dict[str, int] = {}
+        for ch in frag[len("mana") + 1 :]:
+            want_pips[ch.upper()] = want_pips.get(ch.upper(), 0) + 1
+        want_cmc = sum(want_pips.values())
+        # Unlike devotion, mana: never splits hybrid symbols (they're opaque
+        # keys) and every op ANDs in a cmc compare alongside pip containment.
+        have_pips = {sym: len(positions) for sym, positions in card["mana_cost_jsonb"].items()}
+        cmc = card["cmc"]
+        if op == ":":
+            if not all(have_pips.get(sym, 0) >= n for sym, n in want_pips.items()):
+                return False
+            return None if cmc is None else cmc >= want_cmc
+        # "=": the exact same distinct symbols with the same counts, and the same cmc.
+        if have_pips != want_pips:
+            return False
+        return None if cmc is None else cmc == want_cmc
     if frag.startswith('!"'):
         return card["card_name"].lower() == frag[2:-1].lower()
     if field == "name":

--- a/api/tests/test_engine_property.py
+++ b/api/tests/test_engine_property.py
@@ -109,6 +109,11 @@ FRAGMENTS = [
     "mana:uu",
     "mana=gg",
     "-mana:rr",
+    # X: its own pip symbol (not a hybrid, 0 cmc contribution), bare (no
+    # braces) — real Scryfall treats bare mana:x identically to mana:{x}.
+    "mana:x",
+    "mana:xr",
+    "-mana:x",
 ]
 
 
@@ -143,6 +148,11 @@ def _make_cards(rng: random.Random) -> list[dict[str, Any]]:
                 # never a devotion-tracked letter).
                 other = "P" if rng.random() < 0.3 else rng.choice([x for x in "WUBRG" if x != colors[0]] or ["C"])
                 pips[f"{colors[0]}/{other}"] = rng.choice([1, 2])
+            if rng.random() < 0.08:
+                # X is its own pip symbol (mana:{X} matches Fireball-style
+                # cards on real Scryfall), not a hybrid, and contributes 0 to
+                # cmc — independent of the color pips above.
+                pips["X"] = rng.choice([1, 2])
         pos = 1
         mana_cost_jsonb: dict[str, list[int]] = {}
         for sym, n in pips.items():
@@ -246,7 +256,9 @@ def _ref_leaf(frag: str, card: dict[str, Any]) -> bool | None:  # noqa: PLR0911,
         want_pips: dict[str, int] = {}
         for ch in frag[len("mana") + 1 :]:
             want_pips[ch.upper()] = want_pips.get(ch.upper(), 0) + 1
-        want_cmc = sum(want_pips.values())
+        # X contributes 0 to cmc (confirmed on real Scryfall: Fireball {X}{R}
+        # has cmc 1.0, not 2.0) — every other symbol contributes 1.
+        want_cmc = sum(n for sym, n in want_pips.items() if sym != "X")
         # Unlike devotion, mana: never splits hybrid symbols (they're opaque
         # keys) and every op ANDs in a cmc compare alongside pip containment.
         have_pips = {sym: len(positions) for sym, positions in card["mana_cost_jsonb"].items()}

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -2,18 +2,21 @@
 """Unit tests for the Rust QueryEngine — filters, dedup, prefer, and sort.
 
 Fixture: api/tests/fixtures/engine_cards.json
-  87 real card printings across 13 oracle IDs and 32+ illustration IDs.
+  90 real card printings across 16 oracle IDs and 40+ illustration IDs.
   Chosen to exercise shared artworks, null prices, multi-color, hybrid mana,
-  and varied CMC / type / rarity distributions.
+  Phyrexian mana, X costs, and varied CMC / type / rarity distributions.
 
 Card summary (name → printings):
   Black Lotus       5p   colorless artifact        cmc=0
   Boggart Ram-Gang  4p   RG creature {R/G}{R/G}{R/G}  cmc=3
+  Cathedral Membrane 1p  W artifact creature {1}{W/P} cmc=2
   Counterspell      6p   blue instant              cmc=2
   Dark Ritual       5p   black instant             cmc=1
+  Fireball          1p   red sorcery {X}{R}         cmc=1
   Jace, the Mind Sculptor 10p  blue planeswalker   cmc=4
   Kitchen Finks     6p   GW creature {1}{G/W}{G/W} cmc=3
   Lightning Bolt   10p   red instant               cmc=1
+  Monastery Messenger 1p RUW creature {2/U}{2/R}{2/W} cmc=6
   Nicol Bolas, Planeswalker 7p  UBR planeswalker   cmc=8
   Serra Angel       7p   white creature 4/4        cmc=5
   Shivan Dragon     5p   red creature 5/5          cmc=6
@@ -102,8 +105,8 @@ def _names(cards: list[dict]) -> list[str]:
 class TestFilters:
     def test_match_all(self, engine: QueryEngine) -> None:
         total, cards = _run(engine)
-        assert total == 89
-        assert len(cards) == 89
+        assert total == 90
+        assert len(cards) == 90
 
     def test_name_exact(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, 'name="Lightning Bolt"')
@@ -182,9 +185,9 @@ class TestFilters:
 
     def test_color_red(self, engine: QueryEngine) -> None:
         # Lightning Bolt (10) + Shivan Dragon (5) + Nicol Bolas (7) + Boggart
-        # Ram-Gang (4) + Monastery Messenger (1, R/U/W)
+        # Ram-Gang (4) + Monastery Messenger (1, R/U/W) + Fireball (1)
         total, _ = _run(engine, "c:r")
-        assert total == 27
+        assert total == 28
 
     def test_color_white(self, engine: QueryEngine) -> None:
         # Serra Angel (7) + Kitchen Finks (6) + Spectral Procession (6) +
@@ -218,9 +221,10 @@ class TestFilters:
         assert all(c["name"] == "Black Lotus" for c in cards)
 
     def test_cmc_equals_one(self, engine: QueryEngine) -> None:
-        # Lightning Bolt (10) + Dark Ritual (5) + Sol Ring (5)
+        # Lightning Bolt (10) + Dark Ritual (5) + Sol Ring (5) + Fireball (1,
+        # {X}{R} has cmc 1 since X contributes 0)
         total, _ = _run(engine, "cmc=1")
-        assert total == 20
+        assert total == 21
 
     def test_cmc_gte_four(self, engine: QueryEngine) -> None:
         # Jace (cmc=4, 10) + Serra Angel (cmc=5, 7) + Shivan Dragon (cmc=6, 5)
@@ -353,9 +357,9 @@ class TestCollectionOperators:
         assert total == 0
 
     def test_type_ne_not_exactly(self, engine: QueryEngine) -> None:
-        # Everything except the 34 exactly-{Creature} printings.
+        # Everything except the 34 exactly-{Creature} printings (90 - 34).
         total, _ = _run(engine, "t!=creature")
-        assert total == 55
+        assert total == 56
 
     def test_keyword_eq_exact(self, engine: QueryEngine) -> None:
         # Shivan Dragon has exactly {Flying}; Serra Angel has {Flying, Vigilance}.
@@ -409,7 +413,7 @@ class TestStagedReload:
         one_shot = fresh_engine()
         one_shot.reload(cards)
 
-        assert staged.size() == one_shot.size() == 89
+        assert staged.size() == one_shot.size() == 90
         for q in ("t:creature", "name:bolt", "devotion:{R}", "cmc>=4"):
             t_staged, c_staged = _run(staged, q, orderby="cmc")
             t_one, c_one = _run(one_shot, q, orderby="cmc")
@@ -434,7 +438,7 @@ class TestStagedReload:
         assert e.reload_begin() is True
         e.add_batch(cards[:5])
         e.reload_abort()
-        assert e.size() == 89
+        assert e.size() == 90
         # And the lock must have been released: a fresh cycle works
         e.reload(cards[:5])
         assert e.size() == 5
@@ -478,17 +482,17 @@ class TestUnique:
 
     def test_unique_printing_returns_all(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, unique="printing")
-        assert total == 89
+        assert total == 90
 
     def test_unique_card_deduplicates_by_oracle_id(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, unique="card")
-        assert total == 15
-        assert len({c["name"] for c in cards}) == 15
+        assert total == 16
+        assert len({c["name"] for c in cards}) == 16
 
     def test_unique_artwork_deduplicates_by_illustration(self, engine: QueryEngine) -> None:
-        # 40 distinct illustration_ids across the 89 fixture printings
+        # 41 distinct illustration_ids across the 90 fixture printings
         total, _ = _run(engine, unique="artwork")
-        assert total == 40
+        assert total == 41
 
     def test_unique_card_single_result_per_name(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, 'name="Lightning Bolt"', unique="card")
@@ -531,8 +535,8 @@ class TestPrefer:
 
     def test_prefer_default_returns_one_per_oracle(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, unique="card", prefer="default")
-        assert total == 15
-        assert len({c["name"] for c in cards}) == 15
+        assert total == 16
+        assert len({c["name"] for c in cards}) == 16
 
 
 class TestSort:
@@ -554,7 +558,7 @@ class TestSort:
 
     def test_limit_caps_returned_cards(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, limit=5)
-        assert total == 89  # total reflects full match count
+        assert total == 90  # total reflects full match count
         assert len(cards) == 5
 
     def test_sort_direction_desc_reverses_order(self, engine: QueryEngine) -> None:
@@ -755,6 +759,32 @@ class TestManaCost:
         total, _ = _run(engine, 'mana:{W} name="Cathedral Membrane"')
         assert total == 0
 
+    def test_mana_x_is_its_own_symbol(self, engine: QueryEngine) -> None:
+        # Fireball costs {X}{R}. X is a real pip symbol (its own lane), not a
+        # hybrid — mana:{X} matches it and must not match a card with no X.
+        total_fireball, _ = _run(engine, 'mana:{X} name="Fireball"')
+        total_bolt, _ = _run(engine, 'mana:{X} name="Lightning Bolt"')
+        assert total_fireball == 1
+        assert total_bolt == 0
+
+    def test_mana_x_bare_same_as_braced(self, engine: QueryEngine) -> None:
+        # Bare (unbraced) x must behave identically to braced {X} — confirmed
+        # against the real Scryfall API (mana:x == mana:{x}). This regresses
+        # a real bug: the query-string parser used to silently drop X, braced
+        # or not.
+        total_braced, _ = _run(engine, 'mana:{X} name="Fireball"')
+        total_bare, _ = _run(engine, 'mana:x name="Fireball"')
+        assert total_braced == total_bare == 1
+
+    def test_mana_x_excluded_from_cmc(self, engine: QueryEngine) -> None:
+        # X contributes 0 to cmc (real Scryfall: Fireball {X}{R} has cmc 1.0,
+        # not 2.0) — mana:{X}{R} (implied cmc 1) matches; mana:{X}{R}{R}
+        # (implied cmc 2) must not, since Fireball's actual cmc is 1.
+        total_cmc1, _ = _run(engine, 'mana:{X}{R} name="Fireball"')
+        total_cmc2, _ = _run(engine, 'mana:{X}{R}{R} name="Fireball"')
+        assert total_cmc1 == 1
+        assert total_cmc2 == 0
+
 
 class TestColorIdentity:
     def test_identity_subset_green(self, engine: QueryEngine) -> None:
@@ -771,7 +801,7 @@ class TestColorIdentity:
     def test_identity_superset_matches_all(self, engine: QueryEngine) -> None:
         # Every card fits in a 5-color deck
         total, _ = _run(engine, "id:wubrg")
-        assert total == 89
+        assert total == 90
 
     def test_identity_differs_from_color(self, engine: QueryEngine) -> None:
         # Nicol Bolas (UBR) has c:r but only cards with identity ⊆ {R} fit in a mono-red deck
@@ -859,16 +889,17 @@ class TestKeywordsAndSubtypes:
         # Cards with no subtypes should match t<="Dragon" on both paths.
         total_le, _ = _run(engine, 't<="Dragon"')
         total_dragon, _ = _run(engine, "t:dragon")
-        # LE includes Dragon-only cards plus all cards with no subtypes (37 in fixture)
-        assert total_le == total_dragon + 37
+        # LE includes Dragon-only cards plus all cards with no subtypes (38 in
+        # fixture; Fireball has no subtypes)
+        assert total_le == total_dragon + 38
 
 
 class TestLegalityAndFormats:
     def test_legal_in_legacy(self, engine: QueryEngine) -> None:
-        # Black Lotus is banned in legacy — 79 cards are legal (both Monastery
-        # Messenger and Cathedral Membrane are legacy-legal)
+        # Black Lotus is banned in legacy — 80 cards are legal (Monastery
+        # Messenger, Cathedral Membrane, and Fireball are all legacy-legal)
         total, _ = _run(engine, "f:legacy")
-        assert total == 79
+        assert total == 80
 
     def test_legal_in_pauper(self, engine: QueryEngine) -> None:
         # Only commons are legal in pauper; Monastery Messenger is pauper-legal,
@@ -890,9 +921,9 @@ class TestLegalityAndFormats:
 
 class TestCardProperties:
     def test_border_black(self, engine: QueryEngine) -> None:
-        # +2: Monastery Messenger and Cathedral Membrane are both black-bordered
+        # +3: Monastery Messenger, Cathedral Membrane, and Fireball are all black-bordered
         total, _ = _run(engine, "border:black")
-        assert total == 72
+        assert total == 73
 
     def test_border_borderless(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, "border:borderless")
@@ -901,7 +932,7 @@ class TestCardProperties:
     def test_layout_normal(self, engine: QueryEngine) -> None:
         # All fixture cards are normal layout
         total, _ = _run(engine, "layout:normal")
-        assert total == 89
+        assert total == 90
 
     def test_frame_2015(self, engine: QueryEngine) -> None:
         total_2015, _ = _run(engine, "frame:2015")
@@ -1094,16 +1125,17 @@ class TestCommonCardTypes:
 
     def test_type_counts(self, engine: QueryEngine) -> None:
         result = engine.common_card_types()
-        # 15 oracle groups: 3 artifacts, 7 creatures, 3 instants, 2 legendary
-        # planeswalkers, 1 sorcery. Jace and Nicol Bolas are both
+        # 16 oracle groups: 3 artifacts, 7 creatures, 3 instants, 2 legendary
+        # planeswalkers, 2 sorceries. Jace and Nicol Bolas are both
         # Legendary+Planeswalker; Cathedral Membrane is Artifact+Creature
-        # (counts toward both); Monastery Messenger is a plain Creature.
+        # (counts toward both); Monastery Messenger is a plain Creature;
+        # Fireball is a plain Sorcery (alongside Spectral Procession).
         assert result["Artifact"] == 3
         assert result["Creature"] == 7
         assert result["Instant"] == 3
         assert result["Legendary"] == 2
         assert result["Planeswalker"] == 2
-        assert result["Sorcery"] == 1
+        assert result["Sorcery"] == 2
 
     def test_subtype_counts(self, engine: QueryEngine) -> None:
         result = engine.common_card_types()

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -102,8 +102,8 @@ def _names(cards: list[dict]) -> list[str]:
 class TestFilters:
     def test_match_all(self, engine: QueryEngine) -> None:
         total, cards = _run(engine)
-        assert total == 87
-        assert len(cards) == 87
+        assert total == 89
+        assert len(cards) == 89
 
     def test_name_exact(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, 'name="Lightning Bolt"')
@@ -181,19 +181,21 @@ class TestFilters:
         assert t_lower == t_proper
 
     def test_color_red(self, engine: QueryEngine) -> None:
-        # Lightning Bolt (10) + Shivan Dragon (5) + Nicol Bolas (7) + Boggart Ram-Gang (4)
+        # Lightning Bolt (10) + Shivan Dragon (5) + Nicol Bolas (7) + Boggart
+        # Ram-Gang (4) + Monastery Messenger (1, R/U/W)
         total, _ = _run(engine, "c:r")
-        assert total == 26
+        assert total == 27
 
     def test_color_white(self, engine: QueryEngine) -> None:
-        # Serra Angel (7) + Kitchen Finks (6) + Spectral Procession (6)
+        # Serra Angel (7) + Kitchen Finks (6) + Spectral Procession (6) +
+        # Monastery Messenger (1, R/U/W) + Cathedral Membrane (1, W)
         total, _ = _run(engine, "c:w")
-        assert total == 19
+        assert total == 21
 
     def test_color_blue(self, engine: QueryEngine) -> None:
-        # Counterspell (6) + Jace (10) + Nicol Bolas (7)
+        # Counterspell (6) + Jace (10) + Nicol Bolas (7) + Monastery Messenger (1, R/U/W)
         total, _ = _run(engine, "c:u")
-        assert total == 23
+        assert total == 24
 
     def test_color_black(self, engine: QueryEngine) -> None:
         # Dark Ritual (5) + Nicol Bolas (7)
@@ -222,9 +224,10 @@ class TestFilters:
 
     def test_cmc_gte_four(self, engine: QueryEngine) -> None:
         # Jace (cmc=4, 10) + Serra Angel (cmc=5, 7) + Shivan Dragon (cmc=6, 5)
-        # + Spectral Procession (cmc=6, 6) + Nicol Bolas (cmc=8, 7)
+        # + Spectral Procession (cmc=6, 6) + Nicol Bolas (cmc=8, 7) +
+        # Monastery Messenger (cmc=6, 1)
         total, _ = _run(engine, "cmc>=4")
-        assert total == 35
+        assert total == 36
 
     def test_type_instant(self, engine: QueryEngine) -> None:
         # Lightning Bolt (10) + Counterspell (6) + Dark Ritual (5)
@@ -232,9 +235,11 @@ class TestFilters:
         assert total == 21
 
     def test_type_creature(self, engine: QueryEngine) -> None:
-        # Serra Angel (7) + Tarmogoyf (11) + Shivan Dragon (5) + Boggart Ram-Gang (4) + Kitchen Finks (6)
+        # Serra Angel (7) + Tarmogoyf (11) + Shivan Dragon (5) + Boggart
+        # Ram-Gang (4) + Kitchen Finks (6) + Monastery Messenger (1) +
+        # Cathedral Membrane (1, Artifact Creature)
         total, _ = _run(engine, "t:creature")
-        assert total == 33
+        assert total == 35
 
     def test_type_planeswalker(self, engine: QueryEngine) -> None:
         # Jace (10) + Nicol Bolas (7)
@@ -242,9 +247,9 @@ class TestFilters:
         assert total == 17
 
     def test_type_artifact(self, engine: QueryEngine) -> None:
-        # Black Lotus (5) + Sol Ring (5)
+        # Black Lotus (5) + Sol Ring (5) + Cathedral Membrane (1, Artifact Creature)
         total, _ = _run(engine, "t:artifact")
-        assert total == 10
+        assert total == 11
 
     def test_power_eq(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, "pow=4")
@@ -257,9 +262,10 @@ class TestFilters:
         assert all(c["name"] == "Serra Angel" for c in cards)
 
     def test_oracle_text_contains_flying(self, engine: QueryEngine) -> None:
-        # Serra Angel (7) + Shivan Dragon (5) + Spectral Procession (6, creates flying tokens)
+        # Serra Angel (7) + Shivan Dragon (5) + Spectral Procession (6, creates
+        # flying tokens) + Monastery Messenger (1, oracle text is "Flying")
         total, _ = _run(engine, "o:flying")
-        assert total == 18
+        assert total == 19
 
     def test_set_filter(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, "s:lea")
@@ -288,7 +294,9 @@ class TestFilters:
     def test_not_filter(self, engine: QueryEngine) -> None:
         # All creatures except Serra Angel
         total, cards = _run(engine, "t:creature -name:serra")
-        assert total == 26  # Tarmogoyf (11) + Shivan Dragon (5) + Boggart Ram-Gang (4) + Kitchen Finks (6)
+        # Tarmogoyf (11) + Shivan Dragon (5) + Boggart Ram-Gang (4) + Kitchen
+        # Finks (6) + Monastery Messenger (1) + Cathedral Membrane (1)
+        assert total == 28
         assert all(c["name"] != "Serra Angel" for c in cards)
 
 
@@ -306,9 +314,10 @@ class TestArithmetic:
         assert {c["name"] for c in cards} == {"Shivan Dragon"}
 
     def test_cmc_plus_constant_gt_power(self, engine: QueryEngine) -> None:
-        # All 4 creature types: cmc+1 > power for all of them
+        # All creature types: cmc+1 > power for all of them, Monastery
+        # Messenger (6+1>2) and Cathedral Membrane (2+1>0) included
         total, _ = _run(engine, "cmc+1>power")
-        assert total == 22
+        assert total == 24
 
 
 class TestCollectionOperators:
@@ -321,18 +330,21 @@ class TestCollectionOperators:
 
     def test_type_gt_contains_plus_more(self, engine: QueryEngine) -> None:
         # Jace (10) + Nicol Bolas (7) are {Legendary, Planeswalker} ⊋ {Planeswalker};
-        # every fixture creature is exactly {Creature}, so t>creature matches nothing.
+        # Cathedral Membrane is {Artifact, Creature} ⊋ {Creature} — every other
+        # fixture creature is exactly {Creature}.
         total_pw, _ = _run(engine, "t>planeswalker")
         total_creature, _ = _run(engine, "t>creature")
         assert total_pw == 17
-        assert total_creature == 0
+        assert total_creature == 1
 
     def test_type_eq_exact(self, engine: QueryEngine) -> None:
-        # All 33 creature printings are exactly {Creature}; both planeswalkers
-        # carry Legendary too, so t=planeswalker matches nothing.
+        # 34 creature printings are exactly {Creature} (the 33 pre-existing
+        # ones plus Monastery Messenger); Cathedral Membrane is {Artifact,
+        # Creature}, not exactly {Creature}. Both planeswalkers carry
+        # Legendary too, so t=planeswalker matches nothing.
         total_creature, _ = _run(engine, "t=creature")
         total_pw, _ = _run(engine, "t=planeswalker")
-        assert total_creature == 33
+        assert total_creature == 34
         assert total_pw == 0
 
     def test_type_lt_matches_nothing(self, engine: QueryEngine) -> None:
@@ -341,9 +353,9 @@ class TestCollectionOperators:
         assert total == 0
 
     def test_type_ne_not_exactly(self, engine: QueryEngine) -> None:
-        # Everything except the 33 exactly-{Creature} printings.
+        # Everything except the 34 exactly-{Creature} printings.
         total, _ = _run(engine, "t!=creature")
-        assert total == 54
+        assert total == 55
 
     def test_keyword_eq_exact(self, engine: QueryEngine) -> None:
         # Shivan Dragon has exactly {Flying}; Serra Angel has {Flying, Vigilance}.
@@ -397,7 +409,7 @@ class TestStagedReload:
         one_shot = fresh_engine()
         one_shot.reload(cards)
 
-        assert staged.size() == one_shot.size() == 87
+        assert staged.size() == one_shot.size() == 89
         for q in ("t:creature", "name:bolt", "devotion:{R}", "cmc>=4"):
             t_staged, c_staged = _run(staged, q, orderby="cmc")
             t_one, c_one = _run(one_shot, q, orderby="cmc")
@@ -422,7 +434,7 @@ class TestStagedReload:
         assert e.reload_begin() is True
         e.add_batch(cards[:5])
         e.reload_abort()
-        assert e.size() == 87
+        assert e.size() == 89
         # And the lock must have been released: a fresh cycle works
         e.reload(cards[:5])
         assert e.size() == 5
@@ -466,17 +478,17 @@ class TestUnique:
 
     def test_unique_printing_returns_all(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, unique="printing")
-        assert total == 87
+        assert total == 89
 
     def test_unique_card_deduplicates_by_oracle_id(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, unique="card")
-        assert total == 13
-        assert len({c["name"] for c in cards}) == 13
+        assert total == 15
+        assert len({c["name"] for c in cards}) == 15
 
     def test_unique_artwork_deduplicates_by_illustration(self, engine: QueryEngine) -> None:
-        # 38 distinct illustration_ids across the 87 fixture printings
+        # 40 distinct illustration_ids across the 89 fixture printings
         total, _ = _run(engine, unique="artwork")
-        assert total == 38
+        assert total == 40
 
     def test_unique_card_single_result_per_name(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, 'name="Lightning Bolt"', unique="card")
@@ -519,8 +531,8 @@ class TestPrefer:
 
     def test_prefer_default_returns_one_per_oracle(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, unique="card", prefer="default")
-        assert total == 13
-        assert len({c["name"] for c in cards}) == 13
+        assert total == 15
+        assert len({c["name"] for c in cards}) == 15
 
 
 class TestSort:
@@ -542,7 +554,7 @@ class TestSort:
 
     def test_limit_caps_returned_cards(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, limit=5)
-        assert total == 87  # total reflects full match count
+        assert total == 89  # total reflects full match count
         assert len(cards) == 5
 
     def test_sort_direction_desc_reverses_order(self, engine: QueryEngine) -> None:
@@ -558,12 +570,35 @@ class TestDevotion:
     Hybrid symbols like {R/G} must contribute to BOTH R and G devotion,
     matching calculate_devotion() in the SQL path. Previously the engine
     kept {R/G} as a single key and missed pure-color devotion queries.
+
+    Devotion only counts permanents' mana costs (MTG comprehensive rules;
+    confirmed against the real Scryfall API — devotion: never matches a pure
+    Instant/Sorcery). Test subjects here are deliberately permanents
+    (Tarmogoyf, Shivan Dragon, Boggart Ram-Gang, Kitchen Finks, Monastery
+    Messenger) — see test_devotion_nonpermanent_never_counts for the
+    nonpermanent case.
     """
 
     def test_devotion_pure_color(self, engine: QueryEngine) -> None:
-        # Lightning Bolt {R}: each printing has 1 R pip, so devotion:{R} should match all 10
-        total, _ = _run(engine, 'devotion:{R} name="Lightning Bolt"')
-        assert total == 10
+        # Tarmogoyf {G}: each printing has 1 G pip, so devotion:{G} should match all 11.
+        # Tarmogoyf (Creature), not Lightning Bolt (Instant): devotion only counts
+        # permanents' mana costs (see test_devotion_nonpermanent_never_counts).
+        total, _ = _run(engine, 'devotion:{G} name="Tarmogoyf"')
+        assert total == 11
+
+    def test_devotion_nonpermanent_never_counts(self, engine: QueryEngine) -> None:
+        # Devotion (MTG comprehensive rules) is defined only over permanents'
+        # mana costs — confirmed against the real Scryfall API, where devotion:r
+        # never matches the real Lightning Bolt (an Instant). Sylvan Librarian
+        # mirrors that: a nonpermanent's colored pips never count, no matter the
+        # operator — a positive devotion query never matches, and <= (subset)
+        # always matches since its devotion is the empty set.
+        total_ge, _ = _run(engine, 'devotion:{R} name="Lightning Bolt"')
+        total_le, _ = _run(engine, 'devotion<={R} name="Lightning Bolt"')
+        total_sorcery, _ = _run(engine, 'devotion:{W} name="Spectral Procession"')
+        assert total_ge == 0
+        assert total_le == 10
+        assert total_sorcery == 0
 
     def test_devotion_hybrid_rg_counts_as_red(self, engine: QueryEngine) -> None:
         # Boggart Ram-Gang {R/G}{R/G}{R/G}: each {R/G} counts as 1 R pip
@@ -587,10 +622,12 @@ class TestDevotion:
         assert total == 6
 
     def test_devotion_2w_hybrid_counts_as_white(self, engine: QueryEngine) -> None:
-        # Spectral Procession {2/W}{2/W}{2/W}: the W in each {2/W} counts as 1 W pip
-        # devotion:{W} (at least 1 W) should match all 6 printings
-        total, _cards = _run(engine, 'devotion:{W} name="Spectral Procession"')
-        assert total == 6
+        # Monastery Messenger {2/U}{2/R}{2/W}: the W in {2/W} counts as 1 W pip.
+        # Must be a permanent (Creature) — Spectral Procession is a Sorcery, so
+        # it no longer counts for devotion at all (see
+        # test_devotion_nonpermanent_never_counts).
+        total, _cards = _run(engine, 'devotion:{W} name="Monastery Messenger"')
+        assert total == 1
 
     def test_devotion_threshold_hybrid(self, engine: QueryEngine) -> None:
         # Boggart Ram-Gang has 3 R pips and 3 G pips from {R/G}{R/G}{R/G}
@@ -604,9 +641,11 @@ class TestDevotion:
     # column: = is exact, <= is subset (<@), > is containment-but-not-equal, etc.
 
     def test_devotion_eq_exact_match(self, engine: QueryEngine) -> None:
-        # Lightning Bolt {R} has devotion exactly {R: 1}
-        total, _ = _run(engine, 'devotion={R} name="Lightning Bolt"')
-        assert total == 10
+        # Tarmogoyf {G} has devotion exactly {G: 1} (a permanent — see
+        # test_devotion_nonpermanent_never_counts for why this can't be
+        # Lightning Bolt, whose devotion is now the empty set).
+        total, _ = _run(engine, 'devotion={G} name="Tarmogoyf"')
+        assert total == 11
 
     def test_devotion_eq_rejects_higher_count(self, engine: QueryEngine) -> None:
         # Shivan Dragon {4}{R}{R} has devotion {R: 2}, not exactly {R: 1}
@@ -635,18 +674,29 @@ class TestDevotion:
         assert total == 5
 
     def test_devotion_gt_strict(self, engine: QueryEngine) -> None:
-        # > means contains-but-not-equal: Boggart {R: 3, G: 3} > {R}; Bolt {R: 1} is not > {R}
+        # > means contains-but-not-equal: Boggart {R: 3, G: 3} > {R}; Bolt's
+        # devotion is the empty set (Instant, not a permanent), which can't
+        # satisfy any positive devotion query, > included.
         total_boggart, _ = _run(engine, 'devotion>{R} name="Boggart Ram-Gang"')
         total_bolt, _ = _run(engine, 'devotion>{R} name="Lightning Bolt"')
         assert total_boggart == 4
         assert total_bolt == 0
 
     def test_devotion_ne(self, engine: QueryEngine) -> None:
-        # != is not-exactly-equal: Bolt {R: 1} is exactly {R: 1}; Shivan {R: 2} is not
+        # != is not-exactly-equal: Bolt's devotion is the empty set (Instant),
+        # which is never exactly {R: 1}, so != matches all 10 printings; Shivan
+        # {R: 2} is a permanent whose devotion isn't exactly {R: 1} either.
         total_bolt, _ = _run(engine, 'devotion!={R} name="Lightning Bolt"')
         total_shivan, _ = _run(engine, 'devotion!={R} name="Shivan Dragon"')
-        assert total_bolt == 0
+        assert total_bolt == 10
         assert total_shivan == 5
+
+    def test_devotion_phyrexian_counts_as_color(self, engine: QueryEngine) -> None:
+        # Cathedral Membrane {1}{W/P}: the W in {W/P} counts as 1 W pip, same
+        # as any other hybrid — Phyrexian's "or 2 life" alternate cost doesn't
+        # change how the color letter counts toward devotion.
+        total, _ = _run(engine, 'devotion:{W} name="Cathedral Membrane"')
+        assert total == 1
 
 
 class TestManaCost:
@@ -693,6 +743,18 @@ class TestManaCost:
         total, _ = _run(engine, 'mana:{W} name="Spectral Procession"')
         assert total == 0
 
+    def test_mana_contains_phyrexian_symbol(self, engine: QueryEngine) -> None:
+        # Cathedral Membrane costs {1}{W/P}; mana:{W/P} matches. Like any
+        # other hybrid, {W/P} is an opaque key for mana: (no color/devotion
+        # splitting — see test_mana_phyrexian_does_not_match_pure_white).
+        total, _ = _run(engine, 'mana:{W/P} name="Cathedral Membrane"')
+        assert total == 1
+
+    def test_mana_phyrexian_does_not_match_pure_white(self, engine: QueryEngine) -> None:
+        # Cathedral Membrane has no pure {W} pips — only {W/P}.
+        total, _ = _run(engine, 'mana:{W} name="Cathedral Membrane"')
+        assert total == 0
+
 
 class TestColorIdentity:
     def test_identity_subset_green(self, engine: QueryEngine) -> None:
@@ -709,7 +771,7 @@ class TestColorIdentity:
     def test_identity_superset_matches_all(self, engine: QueryEngine) -> None:
         # Every card fits in a 5-color deck
         total, _ = _run(engine, "id:wubrg")
-        assert total == 87
+        assert total == 89
 
     def test_identity_differs_from_color(self, engine: QueryEngine) -> None:
         # Nicol Bolas (UBR) has c:r but only cards with identity ⊆ {R} fit in a mono-red deck
@@ -721,8 +783,9 @@ class TestColorIdentity:
 
 class TestRarityAndLoyalty:
     def test_rarity_common(self, engine: QueryEngine) -> None:
+        # +2: Monastery Messenger and Cathedral Membrane are both common
         total, _ = _run(engine, "r=common")
-        assert total == 15
+        assert total == 17
 
     def test_rarity_rare(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, "r=rare")
@@ -802,14 +865,16 @@ class TestKeywordsAndSubtypes:
 
 class TestLegalityAndFormats:
     def test_legal_in_legacy(self, engine: QueryEngine) -> None:
-        # Black Lotus is banned in legacy — 77 cards are legal
+        # Black Lotus is banned in legacy — 79 cards are legal (both Monastery
+        # Messenger and Cathedral Membrane are legacy-legal)
         total, _ = _run(engine, "f:legacy")
-        assert total == 77
+        assert total == 79
 
     def test_legal_in_pauper(self, engine: QueryEngine) -> None:
-        # Only commons are legal in pauper
+        # Only commons are legal in pauper; Monastery Messenger is pauper-legal,
+        # Cathedral Membrane is not
         total, _ = _run(engine, "f:pauper")
-        assert total == 21
+        assert total == 22
 
     def test_banned_in_commander(self, engine: QueryEngine) -> None:
         # Black Lotus (5 printings) is banned in commander
@@ -825,8 +890,9 @@ class TestLegalityAndFormats:
 
 class TestCardProperties:
     def test_border_black(self, engine: QueryEngine) -> None:
+        # +2: Monastery Messenger and Cathedral Membrane are both black-bordered
         total, _ = _run(engine, "border:black")
-        assert total == 70
+        assert total == 72
 
     def test_border_borderless(self, engine: QueryEngine) -> None:
         total, _ = _run(engine, "border:borderless")
@@ -835,7 +901,7 @@ class TestCardProperties:
     def test_layout_normal(self, engine: QueryEngine) -> None:
         # All fixture cards are normal layout
         total, _ = _run(engine, "layout:normal")
-        assert total == 87
+        assert total == 89
 
     def test_frame_2015(self, engine: QueryEngine) -> None:
         total_2015, _ = _run(engine, "frame:2015")
@@ -934,8 +1000,9 @@ class TestCardProperties:
         assert cards[0]["name"] == "Black Lotus"
 
     def test_collector_number_lte(self, engine: QueryEngine) -> None:
+        # +1: Cathedral Membrane is cn 5 (Monastery Messenger is cn 208, excluded)
         total, _ = _run(engine, "cn<=10")
-        assert total == 6
+        assert total == 7
 
     def test_flavor_text_contains(self, engine: QueryEngine) -> None:
         # Shivan Dragon flavor text mentions "dragon"
@@ -1027,10 +1094,12 @@ class TestCommonCardTypes:
 
     def test_type_counts(self, engine: QueryEngine) -> None:
         result = engine.common_card_types()
-        # 13 oracle groups: 2 artifacts, 5 creatures, 3 instants, 2 legendary
-        # planeswalkers, 1 sorcery. Jace and Nicol Bolas are both Legendary+Planeswalker.
-        assert result["Artifact"] == 2
-        assert result["Creature"] == 5
+        # 15 oracle groups: 3 artifacts, 7 creatures, 3 instants, 2 legendary
+        # planeswalkers, 1 sorcery. Jace and Nicol Bolas are both
+        # Legendary+Planeswalker; Cathedral Membrane is Artifact+Creature
+        # (counts toward both); Monastery Messenger is a plain Creature.
+        assert result["Artifact"] == 3
+        assert result["Creature"] == 7
         assert result["Instant"] == 3
         assert result["Legendary"] == 2
         assert result["Planeswalker"] == 2

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -172,10 +172,10 @@ class TestContainerIntegration:
         assert isinstance(result, dict)
         assert "cards" in result
 
-        # Should find every red card (Lightning Bolt, and Boggart Ram-Gang
-        # which is R/G)
+        # Should find every red card (Lightning Bolt, Boggart Ram-Gang which
+        # is R/G, and Fireball which is {X}{R})
         cards = result["cards"]
-        assert {c["name"] for c in cards} == {"Lightning Bolt", "Boggart Ram-Gang"}
+        assert {c["name"] for c in cards} == {"Lightning Bolt", "Boggart Ram-Gang", "Fireball"}
 
     def test_cmc_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by converted mana cost."""
@@ -204,9 +204,20 @@ class TestContainerIntegration:
     def test_mana_cost_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """mana: is exact-symbol containment (plus cmc) — hybrid keys don't split."""
         result = api_resource._search_sql(**search_kwargs("mana:{R}", limit=10))
-        # Lightning Bolt has a pure {R} pip; Boggart Ram-Gang only has {R/G} —
+        # Lightning Bolt has a pure {R} pip, as does Fireball ({X}{R}, and X
+        # doesn't block containment on R); Boggart Ram-Gang only has {R/G} —
         # an opaque hybrid key that mana:{R} must not match.
-        assert {c["name"] for c in result["cards"]} == {"Lightning Bolt"}
+        assert {c["name"] for c in result["cards"]} == {"Lightning Bolt", "Fireball"}
+
+    def test_mana_cost_x_symbol(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """X is its own pip symbol (not a hybrid); bare x behaves like braced {X}."""
+        braced = api_resource._search_sql(**search_kwargs("mana:{X}", limit=10))
+        bare = api_resource._search_sql(**search_kwargs("mana:x", limit=10))
+        assert {c["name"] for c in braced["cards"]} == {c["name"] for c in bare["cards"]} == {"Fireball"}
+        # X contributes 0 to cmc: mana:{X}{R}{R} implies cmc 2, but Fireball's
+        # actual cmc is 1 — must not match.
+        too_high = api_resource._search_sql(**search_kwargs("mana:{X}{R}{R}", limit=10))
+        assert too_high["cards"] == []
 
     def test_mana_cost_exact_match(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """mana= requires the exact same distinct symbols, counts, and cmc."""
@@ -272,9 +283,9 @@ class TestContainerIntegration:
 
         # Should only have our test cards
         cards = result["cards"]
-        assert len(cards) == 5
+        assert len(cards) == 6
         card_names = {card["name"] for card in cards}
-        expected_names = {"Lightning Bolt", "Serra Angel", "Black Lotus", "Boggart Ram-Gang", "Cathedral Membrane"}
+        expected_names = {"Lightning Bolt", "Serra Angel", "Black Lotus", "Boggart Ram-Gang", "Cathedral Membrane", "Fireball"}
         assert card_names == expected_names
 
     def test_random_search_shape_matches_search(self: TestContainerIntegration, api_resource: APIResource) -> None:

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -147,10 +147,10 @@ class TestContainerIntegration:
         assert isinstance(result, dict)
         assert "cards" in result
 
-        # Should find Serra Angel (the only creature in test data)
+        # Should find every creature in test data (Serra Angel, Boggart
+        # Ram-Gang, and the Artifact Creature Cathedral Membrane)
         cards = result["cards"]
-        assert len(cards) == 1
-        assert cards[0]["name"] == "Serra Angel"
+        assert {c["name"] for c in cards} == {"Serra Angel", "Boggart Ram-Gang", "Cathedral Membrane"}
 
     def test_card_search_by_name(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by name."""
@@ -172,10 +172,10 @@ class TestContainerIntegration:
         assert isinstance(result, dict)
         assert "cards" in result
 
-        # Should find Lightning Bolt (red card)
+        # Should find every red card (Lightning Bolt, and Boggart Ram-Gang
+        # which is R/G)
         cards = result["cards"]
-        assert len(cards) == 1
-        assert cards[0]["name"] == "Lightning Bolt"
+        assert {c["name"] for c in cards} == {"Lightning Bolt", "Boggart Ram-Gang"}
 
     def test_cmc_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by converted mana cost."""
@@ -200,6 +200,41 @@ class TestContainerIntegration:
         cards = result["cards"]
         assert len(cards) == 1
         assert cards[0]["name"] == "Serra Angel"
+
+    def test_mana_cost_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """mana: is exact-symbol containment (plus cmc) — hybrid keys don't split."""
+        result = api_resource._search_sql(**search_kwargs("mana:{R}", limit=10))
+        # Lightning Bolt has a pure {R} pip; Boggart Ram-Gang only has {R/G} —
+        # an opaque hybrid key that mana:{R} must not match.
+        assert {c["name"] for c in result["cards"]} == {"Lightning Bolt"}
+
+    def test_mana_cost_exact_match(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """mana= requires the exact same distinct symbols, counts, and cmc."""
+        result = api_resource._search_sql(**search_kwargs('mana="{R}"', limit=10))
+        assert {c["name"] for c in result["cards"]} == {"Lightning Bolt"}
+
+    def test_devotion_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """devotion: counts a permanent's colored pips, hybrids (incl. Phyrexian) split."""
+        result = api_resource._search_sql(**search_kwargs("devotion:{W}", limit=10))
+        # Serra Angel {W}{W} and Cathedral Membrane {1}{W/P} (Phyrexian W
+        # counts toward W devotion, same as a plain hybrid would)
+        assert {c["name"] for c in result["cards"]} == {"Serra Angel", "Cathedral Membrane"}
+
+    def test_devotion_hybrid_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """A color/color hybrid contributes to BOTH colors' devotion."""
+        red = api_resource._search_sql(**search_kwargs("devotion:{R}", limit=10))
+        green = api_resource._search_sql(**search_kwargs("devotion:{G}", limit=10))
+        assert {c["name"] for c in red["cards"]} == {"Boggart Ram-Gang"}
+        assert {c["name"] for c in green["cards"]} == {"Boggart Ram-Gang"}
+
+    def test_devotion_permanent_only(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """Devotion only counts permanents — an Instant's colored pips never count.
+
+        Confirmed against the real Scryfall API: devotion:r never matches the
+        real Lightning Bolt, despite its {R} mana cost.
+        """
+        result = api_resource._search_sql(**search_kwargs("devotion:{R}", limit=10))
+        assert "Lightning Bolt" not in {c["name"] for c in result["cards"]}
 
     def test_search_sql_default_fields(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Omitting fields= keeps the historical 9-key shape."""
@@ -237,9 +272,9 @@ class TestContainerIntegration:
 
         # Should only have our test cards
         cards = result["cards"]
-        assert len(cards) == 3
+        assert len(cards) == 5
         card_names = {card["name"] for card in cards}
-        expected_names = {"Lightning Bolt", "Serra Angel", "Black Lotus"}
+        expected_names = {"Lightning Bolt", "Serra Angel", "Black Lotus", "Boggart Ram-Gang", "Cathedral Membrane"}
         assert card_names == expected_names
 
     def test_random_search_shape_matches_search(self: TestContainerIntegration, api_resource: APIResource) -> None:

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -160,13 +160,20 @@ pub(crate) fn mana_pip_counts(s: &str) -> HashMap<String, u8> {
         match c {
             '{' => { in_brace = true; sym.clear(); }
             '}' => {
-                if in_brace && sym.parse::<u32>().is_err() && sym != "X" {
+                // X is a real pip symbol (its own lane, see MANA_LANE_SYMS) —
+                // only its cmc contribution is 0, handled separately by
+                // mana_cmc. Confirmed against the real Scryfall API:
+                // mana:{X} matches Fireball ({X}{R}) and excludes cards with
+                // no X pip, which this exclusion broke.
+                if in_brace && sym.parse::<u32>().is_err() {
                     *pips.entry(sym.clone()).or_insert(0) += 1;
                 }
                 in_brace = false;
             }
             _ if in_brace => sym.push(c),
-            _ if "WUBRGC".contains(c) => { *pips.entry(c.to_string()).or_insert(0) += 1; }
+            // Bare (unbraced) X is a real pip symbol too — confirmed against
+            // the real Scryfall API: mana:x behaves identically to mana:{x}.
+            _ if "WUBRGCX".contains(c) => { *pips.entry(c.to_string()).or_insert(0) += 1; }
             _ => {}
         }
     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -51,6 +51,17 @@ const TYPE_SNOW:         u16 = 1 << 11;
 const TYPE_SORCERY:      u16 = 1 << 12;
 const TYPE_WORLD:        u16 = 1 << 13;
 
+/// Card types that can exist as a permanent on the battlefield. Devotion
+/// (MTG comprehensive rules) is defined only over permanents' mana costs —
+/// confirmed against the real Scryfall API (`devotion:` never matches a pure
+/// Instant/Sorcery, e.g. the real Lightning Bolt) — so `mana_cost.devotion` is
+/// zeroed at load for any card with no bit in this mask. `TYPE_INSTANT` and
+/// `TYPE_SORCERY` are the only nonpermanent primary types; every other bit
+/// (BASIC, CONSPIRACY, KINDRED, LEGENDARY, SNOW, WORLD) is a supertype that
+/// always co-occurs with a permanent or nonpermanent primary type, never
+/// determines it alone.
+const PERMANENT_TYPES: u16 = TYPE_ARTIFACT | TYPE_BATTLE | TYPE_CREATURE | TYPE_ENCHANTMENT | TYPE_LAND | TYPE_PLANESWALKER;
+
 pub(crate) fn card_type_str_to_bit(s: &str) -> u16 {
     match s {
         "Artifact"     => TYPE_ARTIFACT,
@@ -635,7 +646,7 @@ fn jsonb_obj_to_ids(d: &Bound<PyDict>, key: &str, vocab: &mut VocabInterner) -> 
 mod legality;
 use legality::*;
 
-fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>, mana_vocab: &mut ManaVocabInterner) -> PyResult<ManaCost> {
+fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>, mana_vocab: &mut ManaVocabInterner, card_types: u16) -> PyResult<ManaCost> {
     let mut core = 0u64;
     let mut devotion = 0u64;
     let mut hybrids: Vec<(u8, u8)> = Vec::new();
@@ -663,6 +674,11 @@ fn mana_cost_from_pydict(d: &Bound<PyDict>, cmc_val: Option<f32>, mana_vocab: &m
         }
     }
     hybrids.sort_unstable();
+    // Nonpermanents (Instant/Sorcery) never contribute devotion, regardless of
+    // their mana cost — see PERMANENT_TYPES.
+    if card_types & PERMANENT_TYPES == 0 {
+        devotion = 0;
+    }
     Ok(ManaCost { core, hybrids, devotion, cmc: cmc_val.unwrap_or(0.0) })
 }
 
@@ -680,6 +696,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         Some(a) => artists.intern(a.to_lowercase())?,
         None => ARTIST_NONE,
     };
+    let card_types = card_types_list_to_bits(&str_list(d, "card_types"));
 
     Ok(CardRow {
         scryfall_id: opt_uuid(d, "scryfall_id"),
@@ -720,7 +737,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         prefer_score: opt_f32(d, "prefer_score"),
         cubecobra_score: opt_f32(d, "cubecobra_score"),
 
-        card_types: card_types_list_to_bits(&str_list(d, "card_types")),
+        card_types,
         card_subtypes: str_list_to_ids(d, "card_subtypes", vocab)?,
         card_keywords: jsonb_obj_to_ids(d, "card_keywords", vocab)?,
         card_legalities: jsonb_obj_to_legality_bits(d, "card_legalities"),
@@ -729,7 +746,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         card_is_tags: jsonb_obj_to_ids(d, "card_is_tags", vocab)?,
         card_frame_data: jsonb_obj_to_ids(d, "card_frame_data", vocab)?,
 
-        mana_cost: mana_cost_from_pydict(d, opt_f32(d, "cmc"), mana)?,
+        mana_cost: mana_cost_from_pydict(d, opt_f32(d, "cmc"), mana, card_types)?,
 
         creature_power_text_id: it.intern_opt(opt_str(d, "creature_power_text")),
         creature_toughness_text_id: it.intern_opt(opt_str(d, "creature_toughness_text")),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2540,6 +2540,40 @@ fn verify_order_spellings_agree_end_to_end() {
     assert_eq!(run(or_a), run(or_b));
 }
 
+// ─── Query-string mana parsing: mana_pip_counts / mana_cmc ───────────────────
+
+// X is its own pip symbol (its own lane, see MANA_LANE_SYMS), not a hybrid and
+// not excluded — only its cmc contribution is 0, handled by mana_cmc
+// separately. Confirmed against the real Scryfall API: mana:{X} matches
+// Fireball ({X}{R}) and mana:x behaves identically to mana:{x}. This parser
+// (used only for query-time mana:/devotion: values — see build_binary's
+// attr == "mana_cost_jsonb"/"devotion" arms) once dropped X entirely, braced
+// or not, silently degrading `mana:{X}{R}` into `mana:{R}` and matching cards
+// with no X pip at all (e.g. Shivan Dragon, {4}{R}{R}).
+#[test]
+fn mana_pip_counts_treats_x_as_a_real_symbol() {
+    use super::mana_pip_counts;
+    let braced = mana_pip_counts("{X}{R}");
+    assert_eq!(braced.get("X"), Some(&1), "braced X must not be dropped");
+    assert_eq!(braced.get("R"), Some(&1));
+    let bare = mana_pip_counts("XR");
+    assert_eq!(bare.get("X"), Some(&1), "bare X must be recognized, same as braced");
+    assert_eq!(bare.get("R"), Some(&1));
+    let doubled = mana_pip_counts("{X}{X}{R}");
+    assert_eq!(doubled.get("X"), Some(&2), "repeated X pips must accumulate");
+}
+
+// mana_cmc's X-exclusion was already correct (X contributes 0 whether braced
+// or bare) — pinned here so a future refactor of mana_pip_counts can't
+// accidentally couple the two functions' X handling back together.
+#[test]
+fn mana_cmc_excludes_x_braced_and_bare() {
+    use super::mana_cmc;
+    assert_eq!(mana_cmc("{X}{R}"), 1.0);
+    assert_eq!(mana_cmc("XR"), 1.0);
+    assert_eq!(mana_cmc("{X}{X}{2}{R}"), 3.0, "two generic + one R; both Xs contribute 0");
+}
+
 // ─── Packed mana pips: ManaCostCmp semantics ─────────────────────────────────
 
 /// Store with a spread of cost shapes: plain, multi-pip, hybrid, X, snow,
@@ -2646,6 +2680,13 @@ fn mana_cost_cmp_packed_semantics() {
     assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("W/P", 1)], 1.0, &mv)), [8]);
     // Snow is a lane like any other.
     assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("S", 1)], 1.0, &mv)), [6]);
+    // X is a lane like any other too, not a hybrid — only card 5 carries it.
+    // (This exercises the FilterExpr evaluator's already-correct lane
+    // handling; the query-string parser's X-dropping bug is pinned directly
+    // in mana_pip_counts_treats_x_as_a_real_symbol above, since mana_cmp_of
+    // builds the FilterExpr from typed pips and bypasses string parsing.)
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("X", 1)], 0.0, &mv)), [5]);
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("X", 1), ("R", 1)], 1.0, &mv)), [5]);
     // A symbol no card carries: containment and exactness fail everywhere;
     // card ⊆ query still holds for the empty cost (query-only symbols never
     // constrain the subset direction — same as the HashMap semantics).

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2023,21 +2023,27 @@ fn broad_tag_postings_scatter_or_decline() {
 /// the planes must reproduce.
 fn devotion_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
-    let costs: &[&[(&str, u8)]] = &[
-        &[],                       // no cost
-        &[("U", 1)],               // {U}
-        &[("U", 2)],               // {U}{U}
-        &[("U", 3)],               // {U}{U}{U}
-        &[("U", 5)],               // deep: saturates
-        &[("R/G", 1)],             // {R/G}: 1 red AND 1 green
-        &[("R/G", 2), ("R", 1)],   // {R/G}{R/G}{R}: R=3, G=2
-        &[("W", 1), ("U", 1)],     // {W}{U}
-        &[("C", 2)],               // {C}{C}: colorless devotion
+    let costs: &[(&[(&str, u8)], u16)] = &[
+        (&[], TYPE_CREATURE),                     // no cost
+        (&[("U", 1)], TYPE_CREATURE),              // {U}
+        (&[("U", 2)], TYPE_CREATURE),              // {U}{U}
+        (&[("U", 3)], TYPE_CREATURE),              // {U}{U}{U}
+        (&[("U", 5)], TYPE_CREATURE),              // deep: saturates
+        (&[("R/G", 1)], TYPE_CREATURE),            // {R/G}: 1 red AND 1 green
+        (&[("R/G", 2), ("R", 1)], TYPE_CREATURE),  // {R/G}{R/G}{R}: R=3, G=2
+        (&[("W", 1), ("U", 1)], TYPE_CREATURE),    // {W}{U}
+        (&[("C", 2)], TYPE_CREATURE),               // {C}{C}: colorless devotion
+        (&[("R", 1)], TYPE_INSTANT),                // {R} on an Instant: never counts (see devotion_ignores_nonpermanent_pips)
     ];
     let mut mana_vocab: Vec<String> = Vec::new();
-    let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &pips)| {
-        let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+    let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &(pips, card_types))| {
+        let mut c = stub_card(i as u128 + 1, card_types, &[], &mut vocab);
         c.mana_cost = mana_cost_of(pips, &mut mana_vocab);
+        // Mirrors mana_cost_from_pydict()'s PERMANENT_TYPES gate (lib.rs):
+        // devotion only exists for permanents, regardless of the raw pips.
+        if card_types & super::PERMANENT_TYPES == 0 {
+            c.mana_cost.devotion = 0;
+        }
         // identity must cover devotion colors (the build tripwire enforces it)
         let mut ident = 0u8;
         for (lane, sym) in ["W", "U", "B", "R", "G"].iter().enumerate() {
@@ -2048,7 +2054,7 @@ fn devotion_fixture_store() -> CardData {
         c.card_color_identity = ident;
         c
     }).collect();
-    let mut data = store_of(cards, &[1usize; 9], vocab);
+    let mut data = store_of(cards, &[1usize; 10], vocab);
     data.mana_vocab = mana_vocab;
     data
 }
@@ -2152,6 +2158,23 @@ fn hybrid_pip_counts_toward_both_colors() {
         eval_planes(&compile_plane(&f).unwrap(), &archived.indexes.planes, &mut bitmap);
         assert_eq!(bitmap_contains(&bitmap, rg_card), want);
     }
+}
+
+// Devotion (MTG comprehensive rules) is defined only over permanents' mana
+// costs, confirmed against the real Scryfall API (devotion: never matches a
+// pure Instant/Sorcery, e.g. the real Lightning Bolt). A colored pip on a
+// nonpermanent must contribute zero devotion, no matter the operator.
+#[test]
+fn devotion_ignores_nonpermanent_pips() {
+    let data = devotion_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let instant_card = &archived.cards[9]; // {R} on TYPE_INSTANT
+    assert_eq!(u64::from(instant_card.mana_cost.devotion), 0, "an Instant's devotion must be zeroed at load, regardless of its pips");
+    let ge_r = FilterExpr::Devotion { op: CmpOp::Ge, pips: packed_pips(&[("R", 1)]) };
+    let le_r = FilterExpr::Devotion { op: CmpOp::Le, pips: packed_pips(&[("R", 1)]) };
+    assert!(ge_r.eval_card(instant_card, &archived.strings) != Tri::True, "a nonpermanent's {{R}} must not satisfy devotion:{{R}}");
+    assert!(le_r.eval_card(instant_card, &archived.strings) == Tri::True, "empty devotion is a subset of any query");
 }
 
 // ─── Sorted name index: order:name + exact-name narrowing ────────────────────
@@ -2525,7 +2548,7 @@ fn verify_order_spellings_agree_end_to_end() {
 fn mana_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
     let mut mana_vocab: Vec<String> = Vec::new();
-    // (pips, cmc): oracle ids 1..=7 in this order
+    // (pips, cmc): oracle ids 1..=8 in this order
     let costs: &[(&[(&str, u8)], f32)] = &[
         (&[("W", 1)], 1.0),               // 1: {W}
         (&[("W", 2)], 2.0),               // 2: {W}{W}
@@ -2534,6 +2557,7 @@ fn mana_fixture_store() -> CardData {
         (&[("X", 1), ("R", 1)], 1.0),     // 5: {X}{R}
         (&[("S", 1), ("G", 1)], 2.0),     // 6: {S}{G}
         (&[], 0.0),                       // 7: no cost
+        (&[("W/P", 1)], 1.0),             // 8: {W/P} (Phyrexian — an opaque hybrid key, same as {R/G})
     ];
     let cards: Vec<OracleCard> = costs.iter().enumerate().map(|(i, &(pips, cmc))| {
         let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
@@ -2547,7 +2571,7 @@ fn mana_fixture_store() -> CardData {
         }
         c
     }).collect();
-    let mut data = store_of(cards, &[1usize; 7], vocab);
+    let mut data = store_of(cards, &[1usize; 8], vocab);
     data.mana_vocab = mana_vocab;
     data
 }
@@ -2613,6 +2637,13 @@ fn mana_cost_cmp_packed_semantics() {
     // ...and {R} does not contain {R/G}, nor does the {X}{R} card equal {R}.
     assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("R", 1)], 1.0, &mv)), [5]);
     assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("R", 1)], 1.0, &mv)), Vec::<u128>::new());
+    // Phyrexian mana is just another opaque hybrid symbol for mana: — {W/P}
+    // matches only through the vocab, and {W} does not contain it (mirrors
+    // {R/G} above; the "Phyrexian still counts toward W devotion" invariant
+    // is pinned in api/tests/test_engine_unit.py and test_data.sql instead,
+    // since this fixture only exercises ManaCostCmp, not Devotion).
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("W/P", 1)], 1.0, &mv)), [8]);
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("W/P", 1)], 1.0, &mv)), [8]);
     // Snow is a lane like any other.
     assert_eq!(matches(&mana_cmp_of(CmpOp::Ge, &[("S", 1)], 1.0, &mv)), [6]);
     // A symbol no card carries: containment and exactness fail everywhere;
@@ -2622,7 +2653,7 @@ fn mana_cost_cmp_packed_semantics() {
     assert_eq!(matches(&mana_cmp_of(CmpOp::Eq, &[("Q/Z", 1)], 1.0, &mv)), Vec::<u128>::new());
     assert_eq!(matches(&mana_cmp_of(CmpOp::Le, &[("Q/Z", 1)], 2.0, &mv)), [7]);
     // Ne is not-exactly-equal.
-    assert_eq!(matches(&mana_cmp_of(CmpOp::Ne, &[("W", 1)], 1.0, &mv)), [2, 3, 4, 5, 6, 7]);
+    assert_eq!(matches(&mana_cmp_of(CmpOp::Ne, &[("W", 1)], 1.0, &mv)), [2, 3, 4, 5, 6, 7, 8]);
 }
 
 // The SWAR lane comparison agrees with the scalar per-lane loop across the


### PR DESCRIPTION
# Fix Devotion + Mana-Pip Parsing Bugs, Close 5 Mana/Devotion Coverage Gaps

Stacked on #651.

This PR grew in two passes, both triggered by the same discipline: verify
against the real Scryfall API instead of trusting the existing code or
writing tests that just characterize current behavior.

## Bug 1: devotion: ignored permanent type

Auditing mana/devotion test coverage (fuzz suite, SQL-gen, integration,
Phyrexian symbols) surfaced a real correctness bug, not just a coverage gap:
**`devotion:` only counts colored mana symbols on permanents**, per MTG
comprehensive rules. Confirmed live against `api.scryfall.com`:

- The real classic Lightning Bolt (`{R}`, Instant) does not match `devotion:r`.
- `type:instant devotion:r` returns 18 results — every one an Adventure/split
  card whose *other face* is a creature. No pure instant ever matches.
- A plain green permanent (Nyxbloom Ancient) matches `devotion:g` normally.

Sylvan Librarian's `devotion:` did no such filtering on either backend. Worse:
the *existing, already-shipped* test suite baked in the wrong behavior —
`TestDevotion` used Lightning Bolt (Instant) and Spectral Procession (Sorcery)
as positive-match subjects for several assertions.

**Fix**: both backends now zero a card's devotion at load if it has no
permanent-type bit (`lib.rs`'s `mana_cost_from_pydict` gated on `PERMANENT_TYPES`;
`card_processing.py`'s `PERMANENT_CARD_TYPES` gate on `calculate_devotion()`).
Existing wrong assertions re-derived from the corrected semantics (not blindly
flipped), plus a dedicated `test_devotion_nonpermanent_never_counts` pin and a
new nonpermanent fixture card in the Rust `devotion_fixture_store`.

## Bug 2: mana: silently dropped X pips

While adding coverage for X-cost cards (`{X}{R}`) — which had **zero** test
coverage anywhere, only ever appearing as incidental fixture filler — the same
"verify against real Scryfall" check surfaced a second, independent bug:

- The Rust engine's query-time mana parser (`lib.rs`'s `mana_pip_counts`)
  explicitly excluded `"X"` **even when braced**. `mana:{X}{R}` silently
  degraded to `mana:{R}` — live-confirmed matching **Shivan Dragon**
  (`{4}{R}{R}`, zero X pips).
- Both backends' unbraced-symbol scanners only recognized `WUBRGC`, silently
  dropping bare `x` as a pip — confirmed on real Scryfall that bare `mana:x`
  behaves identically to `mana:{x}`.

`calculate_cmc`/`mana_cmc`'s X-exclusion (X contributes 0 to cmc) was already
correct in both languages — only the pip-*counting* side had the two bugs, now
fixed with minimal, isolated changes.

Also clarified for my own understanding (and worth noting): unlike most query
fields, which Python fully resolves before serializing to JSON for Rust,
`mana:`/`devotion:` are an explicit, commented exception —
`card_query_nodes.py`'s `_rhs_to_json` passes the *raw mana-cost string*
through, and Rust does its own parsing (`mana_pip_counts`/`mana_cmc`). That's
exactly why these two independent implementations could drift apart on the X
detail.

## The 5 coverage gaps closed

Each verified against independently-understood ground truth, not copied
behavior:

1. **`test_engine_property.py`** (differential fuzzer): `mana:` added to the
   reference oracle (reimplemented independently from `mana_cost_jsonb`,
   matching `_handle_mana_cost_approximate_comparison`); the devotion oracle
   fixed for the same permanent-type bug, since the synthetic corpus assigns
   colored pips to Instants/Sorceries too; X pip generation added to the
   corpus, plus bare `mana:x`/`mana:xr`/`-mana:x` fragments. Sabotaged the
   oracle twice (once for the mana: hybrid-splitting logic, once for the X-cmc
   computation) and confirmed the suite actually fails before restoring it.
2. **`test_sql_gen.py`**: 6 `mana:` cases covering every operator, plus 2 more
   proving braced `{X}{R}` and bare `xr` produce identical SQL.
3. **`test_integration_testcontainers.py`**: new `mana:`/`devotion:` tests
   against real Postgres, which required fixing a third, independent bug this
   same discipline caught — **`test_data.sql`'s `mana_cost_jsonb` had the
   wrong shape** (plain integers, a bogus generic-mana key) instead of the
   real `dict[symbol, list[int]]` shape.
4. **Phyrexian mana (`{W/P}`)**: untested anywhere before this. Added real,
   Scryfall-verified permanents (Monastery Messenger, Cathedral Membrane,
   Boggart Ram-Gang) pinning that Phyrexian symbols are opaque hybrid keys for
   `mana:` but still split for `devotion:`.
5. **X costs (`{X}{R}`)**: untested anywhere before this either. Added the
   real Fireball (`{X}{R}`, clb #175) across the Rust fixture, `engine_cards.json`,
   and `test_data.sql`, with dedicated unit tests for the parser functions
   themselves (`mana_pip_counts_treats_x_as_a_real_symbol`,
   `mana_cmc_excludes_x_braced_and_bare`) since the existing `ManaCostCmp`
   tests build `FilterExpr` from typed pips and bypass string parsing
   entirely — they could never have caught this bug.

## Known ripple, handled

Adding real cards to `engine_cards.json` across two passes shifted this file's
aggregate fixture-wide counts twice (87→89→90 printings, 13→15→16 oracle
groups). Every affected assertion is corrected with the exact delta computed
from the new cards' real, Scryfall-verified fields — not regenerated by
running the suite once and copying whatever came out.

## Verification

- `cargo test`: 67 passed.
- Full `pytest` suite: 1964 passed, including live Docker/Postgres integration
  tests.
- `ruff check` / `cargo clippy --all-targets`: clean.
- Sabotaged three different oracle/parser pieces mid-review (devotion
  permanent-check, mana: hybrid-splitting, X-cmc computation) and confirmed
  each failure is actually caught before restoring the fix.
- Re-checked against live `api.scryfall.com` after each fix.