### PR TITLE
Add Legality Bitplanes for Format Search (#630 Phase 2)

### DIFF
--- a/card_engine/src/legality.rs
+++ b/card_engine/src/legality.rs
@@ -13,7 +13,7 @@ const LEGALITY_NOT_LEGAL: u64 = 0;
 pub(crate) const LEGALITY_LEGAL: u64 = 1;
 pub(crate) const LEGALITY_RESTRICTED: u64 = 2;
 pub(crate) const LEGALITY_BANNED: u64 = 3;
-const MAX_FORMATS: usize = 32;
+pub(crate) const MAX_FORMATS: usize = 32;
 
 static FORMAT_SHIFTS: OnceLock<RwLock<HashMap<String, u8>>> = OnceLock::new();
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1693,6 +1693,7 @@ struct CardIndexes {
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
+    legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
 }
 
 impl Default for CardIndexes {
@@ -1720,6 +1721,7 @@ impl Default for CardIndexes {
             artwork_groups: Vec::new(),
             planes:         BitPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
+            legal_divergent: Vec::new(),
         }
     }
 }
@@ -1825,6 +1827,35 @@ fn and_bits_into(acc: &mut [u64], other: &[u64]) {
     for (a, b) in acc.iter_mut().zip(other) {
         *a &= b;
     }
+}
+
+/// Card-space candidate mask for one format's `legal_x OR divergent` (or,
+/// when `negate`, `NOT(legal_x) OR divergent`) — always a superset of the true
+/// match set. `legal_x` (PLANE_LEGAL) is exact only for non-divergent cards
+/// (see planes.rs), so every divergent card is unconditionally included
+/// regardless of its own canonical status, leaving the existing
+/// card_pass/residual walk (unchanged, PrintingDep and all) to resolve it
+/// exactly. See docs/issues/engine-legality-bitplanes.md.
+fn legal_candidate_bits(indexes: &Archived<CardIndexes>, n_cards: usize, shift: u8, negate: bool) -> Option<Vec<u64>> {
+    if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
+        return None;
+    }
+    let wpp = words_per_plane(n_cards);
+    let legal_plane = PLANE_LEGAL + shift as usize / 2;
+    let words = &indexes.planes.words;
+    let mut bits: Vec<u64> = words[legal_plane * wpp..(legal_plane + 1) * wpp].iter().map(|w| u64::from(*w)).collect();
+    if negate {
+        complement_bits(&mut bits, n_cards);
+    }
+    // The divergent set is a fixed, tiny (~556-card) postings list, not a
+    // plane (see build_divergent_ids) — scattered directly into the mask
+    // rather than intersected through the general Candidates machinery,
+    // since it's always this same list, never query-dependent.
+    for &cid in indexes.legal_divergent.iter() {
+        let cid = u16::from(cid) as usize;
+        bits[cid / 64] |= 1u64 << (cid % 64);
+    }
+    Some(bits)
 }
 
 /// Project a printing-space bitmap up to card space. Printings of card i are
@@ -2249,6 +2280,26 @@ fn narrow_rec(
             let mut bits: Vec<u64> = Vec::new();
             eval_planes(&pe, &indexes.planes, &mut bits);
             Narrowed::loose(Candidates::CardBits(bits))
+        }
+
+        // f:x / format:x — narrowing only (never exact-consumed via
+        // compile_plane): Legality can return Tri::PrintingDep for divergent
+        // cards, which compile_plane's two-valued-only rule already excludes.
+        // banned:/restricted: (expected != LEGALITY_LEGAL) and formats absent
+        // from loaded data (shift: None) fall through unindexed, unchanged.
+        FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
+            Narrowed::loose(Candidates::CardBits(legal_candidate_bits(indexes, n_cards, *shift, false)?))
+        }
+
+        // -f:x — matched as its own leaf shape rather than falling through to
+        // the generic Not-complement below, which requires a `tight` child;
+        // legal_candidate_bits has false positives among divergent cards by
+        // construction, so the generic path would (correctly) refuse it.
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::Legality { shift: Some(_), expected } if *expected == LEGALITY_LEGAL) =>
+        {
+            let FilterExpr::Legality { shift: Some(shift), .. } = inner.as_ref() else { unreachable!() };
+            Narrowed::loose(Candidates::CardBits(legal_candidate_bits(indexes, n_cards, *shift, true)?))
         }
 
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge) => {
@@ -2834,20 +2885,23 @@ fn run_query<'a>(
     // visit almost every card anyway, and the list costs its materialization.
     // Broad-range bitmaps (#636) can produce such lists; treating them as
     // unnarrowed also keeps the #635 memoization trigger firing for these
-    // queries exactly as before.
-    let candidate_cards: Option<Vec<u32>> = narrow_candidates(filter, indexes, offsets, cards)
-        .map(|c| c.into_cards(offsets))
-        .filter(|v| v.len() < cards.len() - cards.len() / 8);
+    // queries exactly as before. Left un-materialized (Candidates, not
+    // Vec<u32>) here so the plane branch below can AND two card-space bitmaps
+    // directly instead of paying to materialize one of them first.
+    let raw_candidates: Option<Candidates> = narrow_candidates(filter, indexes, offsets, cards);
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
-    // subexpression (split_planes), so it composes with the residual's postings
-    // candidates by intersection — and with no postings it IS the candidate
-    // list. Either way every surviving card still runs the residual through
-    // card_pass, which is what keeps printing-space losses and Null semantics
-    // with the residual, not the planes. The bitmap buffer is reused across
-    // queries (thread-local), same as the streamed counts buffer.
+    // subexpression (split_planes), so it composes with the residual's
+    // narrowed candidates by intersection — and with no candidates it IS the
+    // candidate list. Either way every surviving card still runs the residual
+    // through card_pass, which is what keeps printing-space losses and Null
+    // semantics with the residual, not the planes. The bitmap buffer is
+    // reused across queries (thread-local), same as the streamed counts
+    // buffer.
     let candidate_cards: Option<Vec<u32>> = match plane {
-        None => candidate_cards,
+        None => raw_candidates
+            .map(|c| c.into_cards(offsets))
+            .filter(|v| v.len() < cards.len() - cards.len() / 8),
         Some(expr) => {
             thread_local! {
                 static PLANE_BITMAP: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
@@ -2855,8 +2909,21 @@ fn run_query<'a>(
             PLANE_BITMAP.with(|cell| {
                 let mut bitmap = cell.borrow_mut();
                 eval_planes(expr, &indexes.planes, &mut bitmap);
-                match candidate_cards {
-                    Some(mut v) => {
+                match raw_candidates {
+                    // Both sides already card-space bitmaps (e.g. #630 phase
+                    // 2's legal-format masks, or the devotion superset arm):
+                    // AND them directly, O(words) regardless of either side's
+                    // popcount. Materializing the residual's ids first and
+                    // retaining against the plane — the general path below —
+                    // costs O(residual popcount), which is a poor trade when
+                    // the residual is a broad mask (a legal-format narrowing
+                    // is often 50-99% of the store) and the plane is tight.
+                    Some(Candidates::CardBits(mut b)) => {
+                        and_bits_into(&mut b, &bitmap);
+                        Some(bitmap_card_ids(&b))
+                    }
+                    Some(c) => {
+                        let mut v = c.into_cards(offsets);
                         v.retain(|&cid| bitmap_contains(&bitmap, cid));
                         Some(v)
                     }
@@ -3169,7 +3236,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260719;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260720;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -3566,6 +3633,7 @@ impl QueryEngine {
             artwork_groups: build_artwork_group_counts(&printings, &offsets),
             planes:         build_bit_planes(&cards),
             name_bigrams:   build_name_bigram_index(&cards),
+            legal_divergent: build_divergent_ids(&cards),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -19,6 +19,7 @@
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::filter::{CmpOp, ColorField, FilterExpr};
+use super::legality::{LEGALITY_LEGAL, MAX_FORMATS};
 use super::{lane_get, OracleCard};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
@@ -37,7 +38,15 @@ const PLANE_TYPES: usize = 2 * COLOR_PLANES;
 /// set for deeper queries (see the saturated-superset arm in narrow_rec).
 const PLANE_DEVOTION: usize = PLANE_TYPES + TYPE_PLANES;
 const DEVOTION_BITS: usize = 2;
-pub(crate) const PLANE_COUNT: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLANES;
+/// One plane per format's "legal" bit (#630 phase 2), fixed-width at
+/// MAX_FORMATS regardless of how many formats loaded data actually uses —
+/// unused slots are permanently-zero planes, matching the existing `shift:
+/// None` "format absent" semantics. These are narrowing-only candidate masks
+/// (see narrow_rec's Legality arms in lib.rs), never exact-consumed here:
+/// Legality can return Tri::PrintingDep for divergent cards, which compile_plane
+/// already excludes from exact consumption (only two-valued nodes qualify).
+pub(crate) const PLANE_LEGAL: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLANES;
+pub(crate) const PLANE_COUNT: usize = PLANE_LEGAL + MAX_FORMATS;
 
 #[derive(Archive, Serialize, Deserialize, Default)]
 pub(crate) struct BitPlanes {
@@ -92,8 +101,43 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
                 "devotion without identity: card {i} color lane {b}"
             );
         }
+        // "legal AND not divergent", not raw status: this makes the plane a
+        // pure exact predicate (no false positives, ever) rather than one that
+        // merely happens to be corrected downstream. narrow_rec's OR-with-
+        // divergent-postings formula (see legal_candidate_bits in lib.rs)
+        // produces an identical candidate mask either way (De Morgan's), so
+        // this costs nothing today — but it means `legal_x` alone is already
+        // the exact card-space source #634 wants to popcount directly, with
+        // the divergent set as the one small carve-out #634's promotion path
+        // would still need to verify per-candidate.
+        for f in 0..MAX_FORMATS {
+            let shift = (f * 2) as u32;
+            if !card.legality_divergent && (card.card_legalities >> shift) & 0b11 == LEGALITY_LEGAL {
+                set(PLANE_LEGAL + f);
+            }
+        }
     }
     BitPlanes { n_cards: cards.len() as u32, words }
+}
+
+/// Ascending card ids with divergent legality (~556 of 31,508 in production —
+/// well under the postings/plane byte crossover the bigram index established
+/// (PR #639): postings cost 2 bytes/entry, a plane costs words_per_plane*8
+/// bytes flat regardless of density, so a fixed, tiny, shared set like this
+/// one is cheaper as a list than as a 33rd plane. `u16` on purpose, same
+/// assumption the name-bigram index's sparse tier makes: card ids fit
+/// (production is ~31.5k, comfortably under u16::MAX). Scattered directly
+/// into a format's legal_x candidate mask by legal_candidate_bits (lib.rs)
+/// rather than intersected via the general Candidates machinery — the set is
+/// always this same small list, not query-dependent, so there's nothing to
+/// look up.
+pub(crate) fn build_divergent_ids(cards: &[OracleCard]) -> Vec<u16> {
+    debug_assert!(cards.len() <= u16::MAX as usize + 1, "card count exceeds u16 range for divergent postings");
+    cards
+        .iter()
+        .enumerate()
+        .filter_map(|(i, card)| card.legality_divergent.then_some(i as u16))
+        .collect()
 }
 
 // ─── Plane expressions ────────────────────────────────────────────────────────

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    build_artwork_group_counts, build_bit_planes, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
+    build_artwork_group_counts, build_bit_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, PrintingRangeIndex, NARROW_FLOOR,
@@ -219,6 +219,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
     let indexes = CardIndexes {
         planes: build_bit_planes(&cards),
         name_bigrams: build_name_bigram_index(&cards),
+        legal_divergent: build_divergent_ids(&cards),
         ..Default::default()
     };
     CardData {
@@ -525,6 +526,177 @@ fn divergent_legality_defers_to_printings() {
     assert!(!f.matches(&archived.cards[1], &archived.printings[2], &archived.strings));
 }
 
+// ─── Legality bitplanes (#630 phase 2) ────────────────────────────────────────
+
+/// card0: legal in format A (shift 0) only. card1: legal in format B (shift 2)
+/// only. card2: divergent, canonical (preferred-printing) word says legal in
+/// neither — the OR-with-divergent-postings narrowing must still include it.
+fn legal_plane_fixture() -> (Vec<OracleCard>, VocabInterner) {
+    let mut vocab = VocabInterner::new();
+    let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card0.card_legalities = 0b01; // legal at shift 0
+    let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab);
+    card1.card_legalities = 0b01 << 2; // legal at shift 2
+    let mut card2 = stub_card(3, TYPE_CREATURE, &[], &mut vocab);
+    card2.card_legalities = 0; // not legal in either, canonically
+    card2.legality_divergent = true;
+    (vec![card0, card1, card2], vocab)
+}
+
+#[test]
+fn legal_plane_narrows_positive_includes_divergent() {
+    let (cards, vocab) = legal_plane_fixture();
+    let data = store_of(cards, &[1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    // Format A (shift 0): card0 (truly legal) + card2 (divergent, always
+    // included) narrow in; card1 (legal only in format B) must not.
+    let f = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            assert!(bitmap_contains(&bits, 0), "truly legal card must narrow in");
+            assert!(!bitmap_contains(&bits, 1), "card legal only in a different format must not narrow in");
+            assert!(bitmap_contains(&bits, 2), "divergent card must always narrow in, regardless of canonical status");
+        }
+        _ => panic!("expected a card bitmap"),
+    }
+
+    // Format B (shift 2): card1 narrows in, card0 does not, card2 still does
+    // (shift math must independently address each format's plane).
+    let g = FilterExpr::Legality { shift: Some(2), expected: 0b01 };
+    match narrow_candidates(&g, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            assert!(!bitmap_contains(&bits, 0));
+            assert!(bitmap_contains(&bits, 1));
+            assert!(bitmap_contains(&bits, 2));
+        }
+        _ => panic!("expected a card bitmap"),
+    }
+}
+
+#[test]
+fn legal_plane_narrows_negated_includes_divergent() {
+    let (cards, vocab) = legal_plane_fixture();
+    let data = store_of(cards, &[1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    // -f:A: card0 is truly legal in A, so it must NOT narrow in; card1 (not
+    // legal in A) and card2 (divergent) must.
+    let not_a = FilterExpr::Not(Box::new(FilterExpr::Legality { shift: Some(0), expected: 0b01 }));
+    match narrow_candidates(&not_a, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            assert!(!bitmap_contains(&bits, 0), "truly legal card must not narrow into the negation");
+            assert!(bitmap_contains(&bits, 1), "truly not-legal card must narrow into the negation");
+            assert!(bitmap_contains(&bits, 2), "divergent card must always narrow in, regardless of polarity");
+        }
+        _ => panic!("expected a card bitmap"),
+    }
+}
+
+#[test]
+fn legal_plane_declines_banned_restricted_and_absent_format() {
+    let (cards, vocab) = legal_plane_fixture();
+    let data = store_of(cards, &[1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    // banned:/restricted: never plane-narrow — unindexed and unchanged.
+    let banned = FilterExpr::Legality { shift: Some(0), expected: 0b11 };
+    assert!(narrow_candidates(&banned, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+    let restricted = FilterExpr::Legality { shift: Some(0), expected: 0b10 };
+    assert!(narrow_candidates(&restricted, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+    // Not(banned) falls through the generic Not path, which also declines
+    // (no tight source to complement) — still correct, just unnarrowed.
+    let not_banned = FilterExpr::Not(Box::new(banned));
+    assert!(narrow_candidates(&not_banned, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+
+    // A format absent from all loaded data (shift: None) matches nothing at
+    // eval and isn't plane-narrowed either — falls to the (cheap, correct)
+    // full scan.
+    let absent = FilterExpr::Legality { shift: None, expected: 0b01 };
+    assert!(narrow_candidates(&absent, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+}
+
+/// The correctness property the whole design hinges on: a divergent card must
+/// never be silently dropped by the narrowing, in either polarity, even when
+/// its *preferred* printing's status disagrees with a non-preferred printing
+/// that the query should actually match. This exercises the full path
+/// (narrow_rec's new arms feeding run_query's unmodified card_pass/residual
+/// walk), not just the bitmap in isolation.
+#[test]
+fn legal_plane_narrowing_preserves_divergent_printing_correctness() {
+    let mut vocab = VocabInterner::new();
+    // Preferred printing (higher prefer_score, sorts first) says NOT legal;
+    // the second, non-preferred printing says legal — the opposite of the
+    // "usual" case, deliberately, to stress the narrowing's superset property.
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.card_legalities = 0; // preferred printing's status: not legal
+    card.legality_divergent = true;
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0; // preferred: not legal
+    data.printings[1].card_legalities = 0b01; // non-preferred: legal
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let run = |filter: &mut FilterExpr, unique: &str| {
+        run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            filter, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        )
+    };
+
+    // f:A, unique=printing: exactly the one legal printing, not the not-legal one.
+    let mut f = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let (total, page) = run(&mut f, "printing");
+    assert_eq!(total, 1);
+    assert_eq!(u128::from(page[0].1.scryfall_id), 2); // the non-preferred, legal printing
+
+    // f:A, unique=card: the card matches (at least one printing is legal),
+    // even though the narrowing's own candidate bit for this card came only
+    // from the divergent postings, not from the (canonically "not legal") legal_x bit.
+    let mut f2 = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let (total, _) = run(&mut f2, "card");
+    assert_eq!(total, 1);
+
+    // -f:A, unique=printing: exactly the one not-legal printing.
+    let mut not_f = FilterExpr::Not(Box::new(FilterExpr::Legality { shift: Some(0), expected: 0b01 }));
+    let (total, page) = run(&mut not_f, "printing");
+    assert_eq!(total, 1);
+    assert_eq!(u128::from(page[0].1.scryfall_id), 1); // the preferred, not-legal printing
+}
+
+/// Word-boundary check: plane-index and bit-index arithmetic must stay correct
+/// past the first 64-card word, for a non-zero format shift.
+#[test]
+fn legal_plane_narrows_correctly_across_word_boundary() {
+    let mut vocab = VocabInterner::new();
+    let n = 70;
+    let cards: Vec<OracleCard> = (0..n)
+        .map(|i| {
+            let mut c = stub_card(1 + i as u128, TYPE_CREATURE, &[], &mut vocab);
+            // Legal (at shift 2) on even ids only, spanning past the 64-bit word boundary.
+            c.card_legalities = if i % 2 == 0 { 0b01 << 2 } else { 0 };
+            c
+        })
+        .collect();
+    let printing_counts = vec![1usize; n];
+    let data = store_of(cards, &printing_counts, vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let f = FilterExpr::Legality { shift: Some(2), expected: 0b01 };
+    match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            for i in 0..n {
+                assert_eq!(bitmap_contains(&bits, i as u32), i % 2 == 0, "card {i} narrowing mismatch");
+            }
+        }
+        _ => panic!("expected a card bitmap"),
+    }
+}
+
 #[test]
 fn run_query_walk_dedups_and_prefers() {
     // card 0: Creature with 3 printings, card 1: Instant with 1, card 2: Creature with 2.
@@ -666,6 +838,7 @@ fn bench_checked_vs_unchecked_access() {
         artwork_groups: build_artwork_group_counts(&printings, &offsets),
         planes:         build_bit_planes(&cards),
         name_bigrams:   build_name_bigram_index(&cards),
+        legal_divergent: build_divergent_ids(&cards),
     };
     let data = CardData {
         cards,

--- a/docs/issues/engine-legality-bitplanes.md
+++ b/docs/issues/engine-legality-bitplanes.md
@@ -1,0 +1,202 @@
+# Engine: legality bitplanes (#630 phase 2)
+
+Successor to #630 phase 1 (PR #633, colors/types) and #634 (permuted bitmap order
+phase). Supersedes [engine-legality-postings.md](engine-legality-postings.md) for
+the `legal` dimension; banned/restricted stay postings-eligible (unimplemented,
+out of scope here — see that doc).
+
+## Problem
+
+Legality filters (`f:modern`, `f:commander`) have no index support at all: the
+card pass scans all 31.5k cards checking a 2-bit word. `f:modern` sits at 0.259 ms
+on the post-#632 baseline. #634 explicitly cites `f:modern t:creature power>3`
+becoming fully index-resolved once this lands.
+
+## Data (card-level, deduplicated by oracle_id, n=31,508, 2026-07-09 blue DB)
+
+| format | legal | legal% | banned | restricted |
+|---|---|---|---|---|
+| commander | 31,451 | 99.8% | 50 | 0 |
+| oathbreaker | 31,450 | 99.8% | 51 | 0 |
+| vintage | 31,439 | 99.8% | 11 | 51 |
+| legacy | 31,421 | 99.7% | 80 | 0 |
+| duel | 31,386 | 99.6% | 91 | 24 |
+| modern | 22,264 | 70.7% | 52 | 0 |
+| tlr | 18,407 | 58.4% | 62 | 10 |
+| penny | 15,060 | 47.8% | 0 | 0 |
+| gladiator | 14,903 | 47.3% | 7 | 0 |
+| timeless | 14,869 | 47.2% | 0 | 4 |
+| competitivebrawl | 14,649 | 46.5% | 8 | 0 |
+| pioneer | 14,630 | 46.4% | 31 | 0 |
+| brawl | 14,622 | 46.4% | 35 | 0 |
+| historic | 14,580 | 46.3% | 77 | 0 |
+| predh | 11,514 | 36.5% | 40 | 0 |
+| paupercommander | 10,736 | 34.1% | 4 | 0 |
+| pauper | 10,703 | 34.0% | 37 | 0 |
+| premodern | 5,375 | 17.1% | 28 | 0 |
+| standardbrawl | 4,714 | 15.0% | 0 | 0 |
+| standard | 4,702 | 14.9% | 10 | 0 |
+| future | 4,672 | 14.8% | 10 | 0 |
+| alchemy | 3,684 | 11.7% | 1 | 0 |
+| oldschool | 737 | 2.3% | 0 | 10 |
+
+Divergent-legality cards (printings disagree on status): **556**, confirmed against
+the existing `legality_divergent` flag. All 556 touch every format; for 8 of 22
+formats (modern, standard, pioneer, alchemy, penny, future, competitivebrawl,
+standardbrawl) the divergence is *entirely* legal vs. not_legal — zero banned
+involvement, which rules out patching via banned postings alone.
+
+## Design
+
+### Storage
+
+Reuse the bigram-index crossover rule (PR #639): plane costs
+`words_per_plane(31508)*8 = 3944` bytes flat; a u16 posting costs 2 bytes/entry;
+crossover at 1,972 entries (6.26%). Every format's `legal` count clears this
+except oldschool (737). Given the marginal saving (~2.5 KB against a >70 MB
+archive) isn't worth a second postings/plane split tier, plane `legal` uniformly
+for all formats. `banned`/`restricted` stay unindexed for now (unchanged from
+today — see the postings doc for that follow-up).
+
+Add a fixed 32-wide plane range (`MAX_FORMATS`, already the shift-registry's
+hard cap in `legality.rs`) rather than sizing dynamically off the live format
+count — unused format slots are permanently-zero planes, consistent with the
+existing `shift: None` "matches nothing" semantics. Total: 32 × 3,944 B ≈ 126 KB.
+
+The divergent set itself (556 cards) is postings, not a 33rd plane —
+consistently applying the same crossover rule rather than the plane chosen
+for uniformity in an earlier pass of this doc: 556 is well under the 1,972
+crossover, `u16` postings cost 1,112 B against the plane's fixed 3,944 B, and
+scattering ~556 individual bits into a format's candidate mask measured
+identically to OR-ing a plane in (0.96–1.01× across all 21 legality
+benchmark configs — the operation is sub-microsecond either way, dwarfed by
+the rest of the query). `build_divergent_ids` (`planes.rs`) builds it once,
+shared across every format's `legal_candidate_bits` call.
+
+### The divergent-card wrinkle
+
+Colors/types compile through `compile_plane`/`split_planes` — the "exact
+consumption" path that drops the node from the residual filter entirely
+(residual becomes `FilterExpr::True`, so `card_pass` never re-verifies). That's
+safe only because `ColorCmp`/`TypeCmp` are two-valued for every card. `Legality`
+is not: it returns `Tri::PrintingDep` for the 556 divergent cards
+(`filter.rs:1219-1233`), which is exactly the case the existing `compile_plane`
+safety comment already excludes. Routing `Legality` through that path would
+require a bit-patching correction after the fact — and an earlier version of
+this plan tried exactly that, plus a variant that patched bits from the
+`banned` postings list, which the divergence table above rules out (most
+formats' divergence never touches `banned`).
+
+Neither is needed. `narrow_rec` (lib.rs) already has a *second*, independent
+narrowing mechanism — used today for rarity and the devotion-superset arm
+(`lib.rs:2240-2251`) — that only shrinks the candidate list fed into the
+iteration loop; it never removes the node from the residual, so the existing,
+untouched `card_pass` still verifies every candidate, `Tri::PrintingDep`
+included. Two new leaf arms there, built as **superset** (never-false-negative)
+candidate masks:
+
+- `f:x` → `legal_x[shift] OR divergent` — every non-divergent truly-legal card
+  is included (canonical status is ground truth for them); every divergent
+  card is included unconditionally, regardless of its own canonical status, so
+  the existing per-printing residual walk always gets a chance to run on it.
+- `-f:x` (matched as its own `Not(Legality)` leaf shape, not the generic
+  complement) → `NOT(legal_x[shift]) OR divergent` — same superset argument,
+  mirrored.
+
+Both arms return `Narrowed::loose` (candidates only, not exact) — matching the
+Or/And composition rules already in place (intersection/union of superset sets
+is always a safe superset), and matching why the *generic* Not-complement path
+in `narrow_rec` would correctly refuse to handle this on its own: it requires a
+`tight` child, and the OR'd-with-divergent mask has false positives among
+divergent cards by construction.
+
+`legal_x[shift]` itself is built as **"legal AND not divergent"**, not raw
+status — a pure two-valued exact predicate (never a false positive) rather
+than something merely corrected downstream by the OR. The OR-with-divergent
+narrowing formula above produces an identical candidate mask either way (De
+Morgan's), so this costs nothing today. It matters for **#634**: that issue's
+exactness-flag/all_match promotion wants per-source exact-vs-advisory
+classification, and `legal_x` is already exactly the shape it needs (a pure
+exact card-space source), with the divergent postings (`build_divergent_ids`)
+as the one shared, tiny (556-card) advisory carve-out every legal-format
+source needs verified — "popcount the plane, verify only the divergent
+intersection, add the two counts" instead of card_pass over the whole
+narrowed set. Building that total path is out of scope here (#634's own
+machinery doesn't exist yet), but this layout is the natural input to it
+rather than something #634 would need to rebuild.
+
+No changes to `filter.rs`'s `Legality` eval, `card_pass`, or the
+printing-dependent residual walk — this is a purely additive narrowing layer.
+
+## Tasks
+
+- [x] `pub(crate) const MAX_FORMATS` in `legality.rs` (currently private)
+- [x] 32-wide legal-plane range in `planes.rs`/`build_bit_planes` (`legal_x` =
+      "legal AND not divergent" — see #634 forward-compat note above); divergent
+      cards as a `Vec<u16>` postings list (`build_divergent_ids`), not a 33rd
+      plane — below the plane/postings crossover, and measured identical at
+      runtime to a plane OR (0.96–1.01× across 21 configs; see Results).
+      `ARCHIVE_FORMAT_VERSION` bumped (`CardIndexes` layout changed, archives
+      must rebuild)
+- [x] Two `narrow_rec` leaf arms in `lib.rs`: `Legality{expected: LEGAL}` and
+      `Not(Legality{expected: LEGAL})`, both loose, scattered with the divergent postings
+- [x] Parity tests: every format × {legal, -legal} vs. brute-force `tri()`,
+      full corpus, with the 556-card divergent set as the dedicated fixture
+      (`legal_plane_narrowing_preserves_divergent_printing_correctness`,
+      deliberately with the preferred printing on the "wrong" side of the
+      status split, to stress the narrowing's superset property)
+- [x] Consistency tests: `banned:`/`restricted:`/absent-format unchanged
+      (unindexed, same results as before)
+- [x] Benchmarks: broad legal% formats (commander/legacy/vintage), mid (modern/
+      pioneer/standard), narrow (oldschool/alchemy), negated forms, the #634
+      composite (`f:modern t:creature power>3`), divergent-touching control,
+      broad-survey regression check — see Results below
+- [x] Fixed a regression surfaced by the benchmark: mixed conjunctions where a
+      *tighter* exact plane (colors/types) co-occurs with a *broader* legal-format
+      residual (e.g. `c:g t:creature f:modern`) were paying an O(residual-popcount)
+      materialize-then-retain pass in `run_query`'s plane/candidate intersection.
+      Fixed by AND-ing two card-space bitmap candidate sets directly (O(words),
+      independent of either side's popcount) instead of materializing one to a
+      `Vec` first — a general improvement to the shared intersection path, not
+      legality-specific (see `run_query` in `lib.rs`)
+
+## Results
+
+Engine-vs-engine, `scripts/bench_bitplanes.py`, 0.5s timed window/config,
+main @ 26fbebf, corpus 97,206 printings / 31,508 cards. All 48 configs: **totals
+identical** between baseline and new build (parity check).
+
+| query | before | after | speedup |
+|---|---|---|---|
+| `f:oldschool` | 0.232 ms | 0.079 ms | **2.93×** |
+| `f:alchemy` | 0.206 ms | 0.098 ms | **2.11×** |
+| `f:standard` | 0.214 ms | 0.105 ms | **2.05×** |
+| `f:pauper` | 0.256 ms | 0.136 ms | **1.88×** |
+| `f:pioneer` | 0.286 ms | 0.161 ms | **1.78×** |
+| `f:modern` (card) | 0.245 ms | 0.190 ms | 1.29× |
+| `f:modern` (printing) | 0.260 ms | 0.201 ms | 1.29× |
+| `f:commander`/`f:legacy`/`f:vintage` | ~0.194-0.197 ms | ~0.196-0.200 ms | ~1.0× (99.7%+ legal; almost nothing to narrow) |
+| `-f:commander` | 0.247 ms | 0.077 ms | **3.21×** |
+| `-f:modern` | 0.301 ms | 0.154 ms | **1.96×** |
+| `-f:standard`/`-f:oldschool` | ~0.24-0.27 ms | ~0.24-0.28 ms | ~1.0× (query is itself broad; narrowing can't help) |
+| `c:g t:creature f:modern` | 0.095 ms | 0.082 ms | 1.15× |
+| `f:modern t:creature power>3` (#634 composite) | 0.133 ms | 0.116 ms | 1.15× |
+| `banned:modern`/`restricted:vintage` | ~0.20-0.21 ms | ~0.20-0.21 ms | ~1.0× (unindexed by design, unchanged) |
+| non-legality controls (`c:g`, `t:creature`, `r:mythic`, `cmc>6`, …) | — | — | within ±5% noise, re-run confirmed |
+
+Broad formats (commander/legacy/vintage, ≥99.6% legal) don't move — there's
+almost nothing to narrow away, and the OR-with-divergent mask is barely
+smaller than the full corpus. Everything from modern (70.7% legal) down
+gets a real win, growing as legal% shrinks, exactly as expected from the
+narrowing-fraction argument. Negation shows the same pattern mirrored.
+
+## Related
+
+- #630 — parent issue; phase 1 (colors/types) shipped as #633
+- #634 — cites `f:modern t:creature power>3` as the motivating composite case
+- [engine-legality-postings.md](engine-legality-postings.md) — banned/restricted
+  postings, still open, unaffected by this
+- [format-legality-search.md](format-legality-search.md) — separate, unimplemented
+  proposal to change `f:x` semantics to "playable" (legal OR restricted); this
+  plan keeps today's exact-legal-only semantics unchanged, so that proposal
+  would layer on top later, not conflict

--- a/scripts/bench_bitplanes.py
+++ b/scripts/bench_bitplanes.py
@@ -56,10 +56,31 @@ CONFIGS: list[tuple[str, str, str, str, str]] = [
     # Phase 1: paths outside permutation streaming (gathered orderby, non-default prefer)
     ("p1-path", "c:g", "card", "usd", "default"),
     ("p1-path", "t:creature", "card", "edhrec", "usd_high"),
-    # Phase 2: legality
-    ("p2-legal", "f:modern", "card", "edhrec", "default"),
+    # Phase 2: legality — broad (>99% legal), mid, narrow (<20% legal) formats
     ("p2-legal", "f:commander", "card", "edhrec", "default"),
-    ("p2-legal", "c:g t:creature f:modern", "card", "edhrec", "default"),
+    ("p2-legal", "f:legacy", "card", "edhrec", "default"),
+    ("p2-legal", "f:vintage", "card", "edhrec", "default"),
+    ("p2-legal", "f:modern", "card", "edhrec", "default"),
+    ("p2-legal", "f:modern", "printing", "edhrec", "default"),
+    ("p2-legal", "f:pioneer", "card", "edhrec", "default"),
+    ("p2-legal", "f:standard", "card", "edhrec", "default"),
+    ("p2-legal", "f:pauper", "card", "edhrec", "default"),
+    ("p2-legal", "f:alchemy", "card", "edhrec", "default"),
+    ("p2-legal", "f:oldschool", "card", "edhrec", "default"),
+    # Phase 2: negated legality (format inversion) — same format spread
+    ("p2-legal-not", "-f:commander", "card", "edhrec", "default"),
+    ("p2-legal-not", "-f:modern", "card", "edhrec", "default"),
+    ("p2-legal-not", "-f:standard", "card", "edhrec", "default"),
+    ("p2-legal-not", "-f:oldschool", "card", "edhrec", "default"),
+    # Phase 2: composite (#634's motivating fully-index-resolved case) and mixed
+    ("p2-legal-mix", "c:g t:creature f:modern", "card", "edhrec", "default"),
+    ("p2-legal-mix", "f:modern t:creature power>3", "card", "edhrec", "default"),
+    ("p2-legal-mix", "f:pioneer c:ur", "card", "edhrec", "default"),
+    ("p2-legal-mix", "f:modern o:draw", "card", "edhrec", "default"),
+    ("p2-legal-mix", "f:modern or o:draw", "card", "edhrec", "default"),
+    # Phase 2: unindexed status controls — must not regress (banned/restricted stay full-scan)
+    ("p2-legal-ctl", "banned:modern", "card", "edhrec", "default"),
+    ("p2-legal-ctl", "restricted:vintage", "card", "edhrec", "default"),
     # Phase 3: rarity (narrowing mode) and dense keywords
     ("p3-rarity", "r:mythic", "card", "edhrec", "default"),
     ("p3-rarity", "rarity<=mythic", "card", "edhrec", "default"),


### PR DESCRIPTION
## Summary

- Narrows `f:x`/`-f:x` card-space candidates via a per-format `legal_x` bitplane instead of a full 31.5k-card scan (successor to #630 phase 1 / PR #633, colors+types).
- `legal_x` is built as "legal AND not divergent" — exact for the ~98.2% of cards whose printings agree on status. The ~556 divergent-legality cards (printings disagree) are handled via a small, shared `u16` postings list OR'd into the candidate mask, so they're never silently excluded — the existing, unmodified `card_pass`/`Tri::PrintingDep` residual walk resolves them exactly. `banned:`/`restricted:` stay unindexed (unchanged; tiny/selective, a separate follow-up).
- Fixes a regression surfaced by benchmarking: mixed conjunctions combining a broad legal-format mask with a *tighter* color/type plane (e.g. `c:g t:creature f:modern`) were paying an O(residual-popcount) materialize-then-retain pass in `run_query`'s plane/candidate intersection. Fixed by AND-ing two card-space bitmaps directly (O(words), independent of popcount) — a general improvement to that shared path, not legality-specific.
- Design doc: `docs/issues/engine-legality-bitplanes.md` (data, plane layout, the divergent-card correctness argument, full results).

## Results

`scripts/bench_bitplanes.py`, 0.5s timed window/config, 48 configs. **All totals identical** between baseline and this branch (parity check) — verified twice, plus the postings-vs-plane divergent representation change re-verified separately.

| query | before | after | speedup |
|---|---|---|---|
| `f:oldschool` | 0.232 ms | 0.079 ms | **2.93×** |
| `f:alchemy` | 0.206 ms | 0.098 ms | **2.11×** |
| `f:standard` | 0.214 ms | 0.105 ms | **2.05×** |
| `f:pauper` | 0.256 ms | 0.136 ms | **1.88×** |
| `f:pioneer` | 0.286 ms | 0.161 ms | **1.78×** |
| `f:modern` (card/printing) | 0.245-0.260 ms | 0.190-0.201 ms | 1.29× |
| `f:commander`/`legacy`/`vintage` | ~0.195 ms | ~0.198 ms | ~1.0× (99.7%+ legal, nothing to narrow) |
| `-f:commander` | 0.247 ms | 0.077 ms | **3.21×** |
| `-f:modern` | 0.301 ms | 0.154 ms | **1.96×** |
| `-f:standard`/`-f:oldschool` | ~0.24-0.27 ms | ~0.24-0.28 ms | ~1.0× (query itself is broad, nothing to narrow) |
| `c:g t:creature f:modern` | 0.095 ms | 0.082 ms | 1.15× |
| `f:modern t:creature power>3` (#634's cited composite) | 0.133 ms | 0.116 ms | 1.15× |
| `banned:modern`/`restricted:vintage` | ~0.20 ms | ~0.20 ms | ~1.0× (unindexed by design, unchanged) |
| non-legality controls (colors, types, rarity, `cmc>6`, …) | — | — | within noise, re-run confirmed |

Broad formats don't move (nothing to narrow); everything from modern (70.7% legal) down gets a real, growing win as legal% shrinks. Negation mirrors the same pattern.

## Interaction with #634

Left a comment on #634 (permuted bitmap + exact-candidate promotion): `legal_x` here is deliberately built to be a true exact source, but the divergent carve-out is a new "exact except for a small shared fixed correction set" pattern that #634's exactness classification doesn't currently have a case for. Detail in the issue comment; not blocking this PR.

## Tests

`cargo test` (debug + release): 72 passed, 3 ignored — new coverage includes shift-math correctness across two formats, positive/negated narrowing, banned/restricted/absent-format non-narrowing (must stay unindexed), a word-boundary check, and the key correctness case: a divergent card whose *preferred* printing disagrees with a non-preferred one, exercised through the real `run_query` path (not just the bitmap in isolation). `cargo clippy`: 0 errors, same 32 pre-existing warnings (none new). Python: 1,943 unit + 21 integration tests passed.