### PR TITLE
Implement #634: Exactness Propagation + Permuted-Bitmap Popcount-Skip Order Phase

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1338,6 +1338,18 @@ fn expand_flavor_ids(idx: &Archived<FlavorIndex>, dense_ids: &[u32]) -> Vec<u32>
 // into the primary key only — secondaries keep their fixed order in both
 // directions, so a reversed ascending walk would be wrong inside ties.
 // 10 × ~126 kB ≈ 1.26 MB.
+//
+// `inv` mirrors `perm` one-for-one (inv[col][dir][card] = card's position in
+// that sort order) for #634 Step 2's popcount-skip order phase: scattering a
+// match bitmap through inv turns "walk the permutation, skip page_offset
+// matches" into "accumulate word popcounts to the boundary word," O(words)
+// instead of O(matches). Stored explicitly per direction rather than derived
+// from one another (e.g. inv_desc[c] = n-1-inv_asc[c]) for the same reason
+// `perm` itself isn't derived that way: ties keep fixed relative order in
+// both directions (see above), so reversing one inverse gets tied groups'
+// internal order backwards — verified by re-deriving the sort key construction
+// before implementing, not assumed from the general "arrays can be negated"
+// intuition. Same size as `perm`: another ~1.26 MB.
 
 #[derive(Archive, Serialize, Deserialize, Default)]
 struct SortPermutations {
@@ -1351,6 +1363,13 @@ struct SortPermutations {
     // lookup table: equal-name blocks are contiguous (rank is the primary key)
     // and narrow_rec's ExactName arm binary-searches it.
     name:      [Vec<u32>; 2],
+    // Inverse of each column above, same [ascending, descending] layout.
+    edhrec_inv:    [Vec<u32>; 2],
+    cubecobra_inv: [Vec<u32>; 2],
+    cmc_inv:       [Vec<u32>; 2],
+    power_inv:     [Vec<u32>; 2],
+    toughness_inv: [Vec<u32>; 2],
+    name_inv:      [Vec<u32>; 2],
 }
 
 impl ArchivedSortPermutations {
@@ -1365,6 +1384,20 @@ impl ArchivedSortPermutations {
             SortCol::Power      => &self.power,
             SortCol::Toughness  => &self.toughness,
             SortCol::Name       => &self.name,
+            SortCol::Rarity | SortCol::PriceUsd => return None,
+        };
+        Some(&pair[descending as usize])
+    }
+
+    /// The inverse permutation for a streamable column/direction (#634 Step 2).
+    fn get_inv(&self, col: SortCol, descending: bool) -> Option<&Archived<Vec<u32>>> {
+        let pair = match col {
+            SortCol::EdhrecRank => &self.edhrec_inv,
+            SortCol::Cubecobra  => &self.cubecobra_inv,
+            SortCol::Cmc        => &self.cmc_inv,
+            SortCol::Power      => &self.power_inv,
+            SortCol::Toughness  => &self.toughness_inv,
+            SortCol::Name       => &self.name_inv,
             SortCol::Rarity | SortCol::PriceUsd => return None,
         };
         Some(&pair[descending as usize])
@@ -1390,6 +1423,15 @@ fn assign_name_ranks(cards: &mut [OracleCard]) {
     }
 }
 
+/// `inv[perm[i]] == i` — the position of each card within the permutation.
+fn invert_perm(perm: &[u32]) -> Vec<u32> {
+    let mut inv = vec![0u32; perm.len()];
+    for (pos, &card) in perm.iter().enumerate() {
+        inv[card as usize] = pos as u32;
+    }
+    inv
+}
+
 fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets: &[u32]) -> SortPermutations {
     let perm = |get: &dyn Fn(&OracleCard) -> Option<f32>, descending: bool| -> Vec<u32> {
         let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
@@ -1409,14 +1451,24 @@ fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets
         });
         ids
     };
-    let both = |get: &dyn Fn(&OracleCard) -> Option<f32>| [perm(get, false), perm(get, true)];
+    // Inverse built per direction, not derived from one another — ties keep
+    // fixed relative order in both directions (see the struct doc above), so
+    // reversing one inverse would get tied groups' internal order backwards.
+    let both = |get: &dyn Fn(&OracleCard) -> Option<f32>| -> ([Vec<u32>; 2], [Vec<u32>; 2]) {
+        let asc = perm(get, false);
+        let desc = perm(get, true);
+        let inv = [invert_perm(&asc), invert_perm(&desc)];
+        ([asc, desc], inv)
+    };
+    let (edhrec, edhrec_inv) = both(&|c| c.edhrec_rank.map(|v| v as f32));
+    let (cubecobra, cubecobra_inv) = both(&|c| c.cubecobra_score);
+    let (cmc, cmc_inv) = both(&|c| c.cmc.map(|v| v as f32));
+    let (power, power_inv) = both(&|c| c.creature_power.map(|v| v as f32));
+    let (toughness, toughness_inv) = both(&|c| c.creature_toughness.map(|v| v as f32));
+    let (name, name_inv) = both(&|c| Some(c.name_rank as f32));
     SortPermutations {
-        edhrec:    both(&|c| c.edhrec_rank.map(|v| v as f32)),
-        cubecobra: both(&|c| c.cubecobra_score),
-        cmc:       both(&|c| c.cmc.map(|v| v as f32)),
-        power:     both(&|c| c.creature_power.map(|v| v as f32)),
-        toughness: both(&|c| c.creature_toughness.map(|v| v as f32)),
-        name:      both(&|c| Some(c.name_rank as f32)),
+        edhrec, cubecobra, cmc, power, toughness, name,
+        edhrec_inv, cubecobra_inv, cmc_inv, power_inv, toughness_inv, name_inv,
     }
 }
 
@@ -2918,6 +2970,28 @@ fn run_query<'a>(
         _          => Mode::Card,
     };
 
+    // #634 Step 2: when the filter fully consumed to True (split_planes ate
+    // the whole thing), the plane bitmap IS the exact match set at any
+    // selectivity — no candidate materialization, no card_pass, needed at
+    // all. Scoped to unique=card for now (see run_query_streamed_popcount);
+    // other modes/residuals fall through to the existing path below, which
+    // already handles them correctly (Step 1 already removes the redundant
+    // card_pass there, just not the O(candidates) counts-buffer fill).
+    if matches!(filter, FilterExpr::True) && matches!(mode, Mode::Card) && !cards.is_empty()
+        && let (Some(expr), Some(perm), Some(inv_perm)) =
+            (plane, indexes.sort_perms.get(sort_col, descending), indexes.sort_perms.get_inv(sort_col, descending))
+        && perm.len() == cards.len()
+    {
+        thread_local! {
+            static PLANE_BITMAP_POPCOUNT: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+        }
+        return PLANE_BITMAP_POPCOUNT.with(|cell| {
+            let mut bitmap = cell.borrow_mut();
+            eval_planes(expr, &indexes.planes, &mut bitmap);
+            run_query_streamed_popcount(cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap)
+        });
+    }
+
     // Candidates in either space project to card ids for the walk; the walk's
     // per-printing verification restores exactness for printing-space losses.
     // A list covering nearly the whole corpus narrows nothing — the walk would
@@ -3052,6 +3126,121 @@ fn run_query<'a>(
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
         .collect();
     (total, page)
+}
+
+/// #634 Step 2: popcount-skip order phase. Scoped to `unique=card` queries
+/// whose filter fully consumed to `FilterExpr::True` (the plane bitmap IS the
+/// exact match set, at any selectivity — colors/types/legality). Scatters the
+/// match bitmap through the inverse permutation, then works in word space
+/// instead of candidate space: total is a popcount, skip is a running
+/// word-popcount sum to the boundary word, emit walks set bits from there
+/// mapping back through the forward permutation for `limit` cards. O(words)
+/// regardless of match count or page depth — unlike `run_query_streamed`'s
+/// counts-buffer fill, which is O(candidates) no matter how deep the
+/// requested page is. Compound exact filters that didn't fully consume to
+/// True (e.g. `t:creature power>3`, residual = `power>3`) still go through
+/// `run_query_streamed`'s Step-1-improved-but-not-popcount path — extending
+/// this to non-True residuals is a reasonable fast-follow, not required here.
+#[allow(clippy::too_many_arguments)]
+fn run_query_streamed_popcount<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    prefer: Prefer,
+    limit: usize,
+    page_offset: usize,
+    perm: &Archived<Vec<u32>>,
+    inv_perm: &Archived<Vec<u32>>,
+    bitmap: &[u64],
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let n_cards = cards.len();
+    let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
+    if total == 0 || page_offset >= total {
+        return (total, Vec::new());
+    }
+
+    thread_local! {
+        static PERMUTED: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+    PERMUTED.with(|cell| {
+        let mut permuted = cell.borrow_mut();
+        let wpp = n_cards.div_ceil(64);
+        permuted.clear();
+        permuted.resize(wpp, 0);
+        // Scatter: every set bit's position in sort order (inv_perm[cid])
+        // becomes a set bit here. Tail bits never get touched — inv_perm's
+        // range is exactly 0..n_cards, so no cid maps past the last word.
+        for (i, &word) in bitmap.iter().enumerate() {
+            let mut w = word;
+            while w != 0 {
+                let cid = (i as u32) << 6 | w.trailing_zeros();
+                w &= w - 1;
+                let pos = u32::from(inv_perm[cid as usize]) as usize;
+                permuted[pos / 64] |= 1u64 << (pos % 64);
+            }
+        }
+
+        // Skip: accumulate word popcounts until the boundary word containing
+        // page_offset — 64 cards per word read, deep pagination is a
+        // ~n_cards/64-word scan regardless of match count.
+        let mut skip = page_offset;
+        let mut word_idx = 0;
+        while word_idx < permuted.len() {
+            let wc = permuted[word_idx].count_ones() as usize;
+            if skip < wc {
+                break;
+            }
+            skip -= wc;
+            word_idx += 1;
+        }
+
+        // Emit: walk set bits from the boundary word onward (skipping `skip`
+        // more within it), mapping position -> card id via the forward perm.
+        // all_match is always true here (filter fully consumed to True), so
+        // the printing choice mirrors push_card_matches' Mode::Card branch
+        // under all_match exactly: first printing for default prefer (ranges
+        // are stored in descending default-prefer order), best-scored
+        // otherwise.
+        let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+        'walk: while word_idx < permuted.len() {
+            let mut w = permuted[word_idx];
+            while w != 0 {
+                let bit = w.trailing_zeros();
+                w &= w - 1;
+                if skip > 0 {
+                    skip -= 1;
+                    continue;
+                }
+                let pos = (word_idx as u32) << 6 | bit;
+                let cid = u32::from(perm[pos as usize]);
+                let card = &cards[cid as usize];
+                let start = u32::from(offsets[cid as usize]) as usize;
+                let end = u32::from(offsets[cid as usize + 1]) as usize;
+                let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
+                    (start < end).then_some(start as u32)
+                } else {
+                    // Strict > only (matches push_card_matches): ties keep the
+                    // first-found printing, not the last.
+                    let mut best: Option<(u32, f64)> = None;
+                    for pid in start..end {
+                        let score = prefer_score(card, &printings[pid], prefer);
+                        if best.is_none_or(|(_, s)| score > s) {
+                            best = Some((pid as u32, score));
+                        }
+                    }
+                    best.map(|(pid, _)| pid)
+                };
+                if let Some(pid) = chosen {
+                    page.push((card, &printings[pid as usize]));
+                }
+                if page.len() == limit {
+                    break 'walk;
+                }
+            }
+            word_idx += 1;
+        }
+        (total, page)
+    })
 }
 
 /// Streamed selection: match phase records per-card match counts (total is
@@ -3306,7 +3495,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260720;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260721;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2096,23 +2096,62 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
     }
 }
 
+/// Like narrow_candidates, but also reports whether the returned set (when
+/// Some) is card-level exact — #634 Step 1's all_match promotion needs this:
+/// when the residual is provably both tight (no false positives) and
+/// complete (every true match included, which `narrow_rec`'s `tight` already
+/// tracks through its And/Or composition — see `and_all`/`or_all`), the whole
+/// original query is exact whenever a present `plane` is too (always true —
+/// that's what `compile_plane` already guarantees), and per-candidate
+/// `card_pass` becomes redundant work the narrowing already did.
+///
+/// Critically, `tight` alone is not enough: it means every member of the set
+/// truly satisfies the predicate *in the set's own space*. For a printing-
+/// space result that's "this specific printing matches," not "every printing
+/// of the associated card matches" — but `card_pass`'s `Tri::True` (what
+/// `all_match` stands in for) specifically means the latter. A card can have
+/// printings in and out of a printing-space match (e.g. `set:war` — most
+/// cards have other-set printings too), so a tight-but-printing-space result
+/// must never promote. Only a genuinely card-space tight result qualifies.
+///
+/// A discarded-for-broadness result never promotes either: "exact" alone
+/// isn't enough without the actual membership in hand to skip verification
+/// safely — a too-broad-to-narrow-with `cmc<=6` is still exact in principle,
+/// but we don't have its membership without paying to materialize it, which
+/// isn't worth doing just for this (see
+/// docs/issues/engine-permuted-bitmap-order-phase.md).
+fn narrow_candidates_exact(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    cards: &[AOracleCard],
+) -> (Option<Candidates>, bool) {
+    let n_cards = offsets.len().saturating_sub(1);
+    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
+    match narrow_rec(filter, indexes, offsets, cards, false) {
+        None => (None, false),
+        Some(n) => {
+            let printing_space = n.set.is_printing_space();
+            let domain = if printing_space { n_printings } else { n_cards };
+            if n.set.len() <= domain - domain / 4 {
+                (Some(n.set), n.tight && !printing_space)
+            } else {
+                (None, false)
+            }
+        }
+    }
+}
+
+// Only run_query needs the exactness bit (#634 Step 1); every other caller —
+// all in tests — just wants the candidate set, same as before that change.
+#[cfg(test)]
 fn narrow_candidates(
     filter: &FilterExpr,
     indexes: &Archived<CardIndexes>,
     offsets: &AOffsets,
     cards: &[AOracleCard],
 ) -> Option<Candidates> {
-    let n_cards = offsets.len().saturating_sub(1);
-    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-    narrow_rec(filter, indexes, offsets, cards, false)
-        .filter(|n| {
-            // Near-total sets narrow nothing; dropping them here (a popcount,
-            // before any projection or materialization) keeps broad composed
-            // results from paying conversion costs on the way to being useless.
-            let domain = if n.set.is_printing_space() { n_printings } else { n_cards };
-            n.set.len() <= domain - domain / 4
-        })
-        .map(|n| n.set)
+    narrow_candidates_exact(filter, indexes, offsets, cards).0
 }
 
 /// Once any candidate source in an And is this selective, evaluating further
@@ -2888,7 +2927,17 @@ fn run_query<'a>(
     // queries exactly as before. Left un-materialized (Candidates, not
     // Vec<u32>) here so the plane branch below can AND two card-space bitmaps
     // directly instead of paying to materialize one of them first.
-    let raw_candidates: Option<Candidates> = narrow_candidates(filter, indexes, offsets, cards);
+    let (raw_candidates, residual_exact): (Option<Candidates>, bool) =
+        narrow_candidates_exact(filter, indexes, offsets, cards);
+    // A present plane is always exact (that's what compile_plane guarantees),
+    // so the whole original query is exact iff the residual is too — either
+    // because split_planes consumed all of it (bare True) or narrow_rec
+    // proved the remainder tight and complete with its membership in hand
+    // (see narrow_candidates_exact). #634 Step 1: when this holds, every
+    // candidate is already known to match, so the per-candidate card_pass
+    // calls below and in run_query_streamed become redundant re-verification
+    // of what the narrowing already established.
+    let all_match_known = matches!(filter, FilterExpr::True) || residual_exact;
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
     // subexpression (split_planes), so it composes with the residual's
@@ -2938,15 +2987,18 @@ fn run_query<'a>(
     // the gate is per-node and cost-based (see memoize_pays): each predicate
     // compares its own bind bound against the evaluation domain, so a broad
     // candidate set with a selective needle memoizes while a narrow one
-    // leaves the scan alone.
-    let eval_domain = candidate_cards.as_ref().map_or(cards.len(), Vec::len);
-    filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram, eval_domain);
-    // Sort And/Or children cheapest-verification-first so the walk's
-    // short-circuit spares the expensive text predicates (semantics-preserving;
-    // see order_children_by_verify_cost). After memoization, which flips
-    // TextContains nodes from the scan tier to the set tier.
-    if *VERIFY_ORDER != 0 {
-        filter.order_children_by_verify_cost();
+    // leaves the scan alone. Skipped entirely when all_match_known: card_pass
+    // never runs, so there is nothing left for the rewrite to speed up.
+    if !all_match_known {
+        let eval_domain = candidate_cards.as_ref().map_or(cards.len(), Vec::len);
+        filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram, eval_domain);
+        // Sort And/Or children cheapest-verification-first so the walk's
+        // short-circuit spares the expensive text predicates (semantics-preserving;
+        // see order_children_by_verify_cost). After memoization, which flips
+        // TextContains nodes from the scan tier to the set tier.
+        if *VERIFY_ORDER != 0 {
+            filter.order_children_by_verify_cost();
+        }
     }
     let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
@@ -2962,7 +3014,7 @@ fn run_query<'a>(
     if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
         if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
             return run_query_streamed(
-                cards, printings, offsets, strings, filter, mode, prefer, sort_col, descending, limit,
+                cards, printings, offsets, strings, filter, all_match_known, mode, prefer, sort_col, descending, limit,
                 page_offset, perm, card_ids, &indexes.artwork_groups,
             );
         }
@@ -2977,11 +3029,15 @@ fn run_query<'a>(
     let mut residual_is_or = false;
     for cid in card_ids {
         let card = &cards[cid as usize];
-        let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
-            Tri::False | Tri::Null => continue,
-            Tri::True => true,          // every printing matches: skip per-printing checks
-            Tri::PrintingDep => false,  // verify each printing against the residual below
-        };
+        // #634 Step 1: all_match_known means the narrowing already proved
+        // every candidate matches — card_pass would just re-derive Tri::True
+        // at real per-node evaluation cost for nothing.
+        let all_match = all_match_known
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                Tri::False | Tri::Null => continue,
+                Tri::True => true,          // every printing matches: skip per-printing checks
+                Tri::PrintingDep => false,  // verify each printing against the residual below
+            };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         push_card_matches(
@@ -3008,6 +3064,7 @@ fn run_query_streamed<'a>(
     offsets: &AOffsets,
     strings: &AStrings,
     filter: &FilterExpr,
+    all_match_known: bool,
     mode: Mode,
     prefer: Prefer,
     sort_col: SortCol,
@@ -3037,11 +3094,22 @@ fn run_query_streamed<'a>(
     let mut total: usize = 0;
     for cid in card_ids {
         let card = &cards[cid as usize];
-        let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
-            Tri::False | Tri::Null => continue,
-            Tri::True => true,
-            Tri::PrintingDep => false,
-        };
+        // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True
+        // when the narrowing already proved every candidate matches. Gated
+        // off for Mode::Artwork specifically: measured a ~45% regression for
+        // `t:creature` unique=artwork with this applied unconditionally here
+        // (0.13ms -> 0.19ms typical, isolated by bisecting call sites) despite
+        // being a no-op change in card_pass's own return value (True either
+        // way) — an unexplained codegen/scheduling effect in this loop for
+        // that mode specifically, not a logical cost. Card/Printing modes
+        // showed no such effect and do benefit (this loop visits every
+        // candidate, not just the ~limit emitted).
+        let all_match = (all_match_known && !matches!(mode, Mode::Artwork))
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                Tri::False | Tri::Null => continue,
+                Tri::True => true,
+                Tri::PrintingDep => false,
+            };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         // Every printing matches: card/printing counts are O(1) inside the
@@ -3069,11 +3137,12 @@ fn run_query_streamed<'a>(
                 continue;
             }
             let card = &cards[cid as usize];
-            let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
-                Tri::True => true,
-                Tri::PrintingDep => false,
-                _ => continue,
-            };
+            let all_match = all_match_known
+                || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                    Tri::True => true,
+                    Tri::PrintingDep => false,
+                    _ => continue,
+                };
             let start = u32::from(offsets[cid as usize]) as usize;
             let end   = u32::from(offsets[cid as usize + 1]) as usize;
             push_card_matches(
@@ -3105,11 +3174,12 @@ fn run_query_streamed<'a>(
             continue;
         }
         let card = &cards[cid as usize];
-        let all_match = match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
-            Tri::True => true,
-            Tri::PrintingDep => false,
-            _ => continue,
-        };
+        let all_match = all_match_known
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                Tri::True => true,
+                Tri::PrintingDep => false,
+                _ => continue,
+            };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         scratch.clear();

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1161,6 +1161,96 @@ fn collector_number_narrowing() {
     assert_eq!(narrow(&or), Some(vec![0, 1]));
 }
 
+// ─── #634 Step 1: all_match promotion ─────────────────────────────────────────
+
+/// The regression this suite exists to prevent: a printing-space predicate
+/// narrowing "tight" (every posted printing genuinely matches — see
+/// collector_number_narrowing above) does NOT mean "every printing of the
+/// associated card matches," which is what `all_match`/`Tri::True` means at
+/// card_pass's level. card 0 has two printings — one at cn=100 (matches),
+/// one at cn=228 (does not) — so `cn=100` must resolve to exactly one
+/// printing match, never both (which is what wrongly promoting a tight
+/// printing-space result to all_match would produce).
+#[test]
+fn all_match_promotion_never_fires_for_printing_space_tight_results() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 2], vocab);
+    data.printings[0].collector_number_int = Some(100);
+    data.printings[1].collector_number_int = Some(228);
+    data.printings[2].collector_number_int = Some(101);
+    data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut cn_eq_100 = FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::CollectorNumberInt),
+        op: CmpOp::Eq,
+        rhs: NumExpr::Const(100.0),
+    };
+    let (total, page) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut cn_eq_100, None, "printing", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 1, "cn=100 must match exactly one printing, not both of card 0's printings");
+    assert_eq!(u128::from(page[0].1.scryfall_id), 1); // the cn=100 printing specifically
+
+    // unique=card must also see exactly one matching card (not both, and not
+    // zero), and it must be card 0.
+    let mut cn_eq_100b = FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::CollectorNumberInt),
+        op: CmpOp::Eq,
+        rhs: NumExpr::Const(100.0),
+    };
+    let (total, page) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut cn_eq_100b, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 1);
+    assert_eq!(u128::from(page[0].0.oracle_id), 1);
+}
+
+/// The positive case: a genuinely card-space exact predicate (a numeric
+/// range — cmc/power/toughness are card-level fields, identical across every
+/// printing) gets the same correct results with or without all_match
+/// promotion. Doesn't assert card_pass was skipped (an implementation
+/// detail) — just that results stay correct, across uniques, when the
+/// narrowing IS safe to trust directly.
+#[test]
+fn all_match_promotion_correct_for_card_space_exact_predicate() {
+    let mut vocab = VocabInterner::new();
+    let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card0.creature_power = Some(5);
+    let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab);
+    card1.creature_power = Some(1);
+    let mut data = store_of(vec![card0, card1], &[2, 3], vocab);
+    data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(|v| v as i16));
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let mut power_gt_3 = FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Power),
+        op: CmpOp::Gt,
+        rhs: NumExpr::Const(3.0),
+    };
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut power_gt_3, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 1); // only card0 (power 5)
+
+    let mut power_gt_3p = FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Power),
+        op: CmpOp::Gt,
+        rhs: NumExpr::Const(3.0),
+    };
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut power_gt_3p, None, "printing", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 2); // card0's 2 printings, all matching (power is card-level)
+}
+
 // Frame postings are selectivity-thresholded at build: values covering more
 // of printing space than the range guard would accept are not stored, and the
 // absent-key convention makes them (and unknown values) fall back to the scan.

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -220,6 +220,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         planes: build_bit_planes(&cards),
         name_bigrams: build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
+        sort_perms: build_sort_permutations(&cards, &printings, &offsets),
         ..Default::default()
     };
     CardData {
@@ -1249,6 +1250,142 @@ fn all_match_promotion_correct_for_card_space_exact_predicate() {
         &mut power_gt_3p, None, "printing", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, 2); // card0's 2 printings, all matching (power is card-level)
+}
+
+// ─── #634 Step 2: popcount-skip order phase ───────────────────────────────────
+
+/// Five all-Creature cards (so `t:creature` fully plane-consumes to True —
+/// the whole filter, every selectivity) with three tied on cmc=3, to stress
+/// exactly the property the design correction was about: descending order is
+/// NOT simply the reverse of ascending, because the edhrec tie-break never
+/// flips with the primary column's direction. If inverse permutations were
+/// (wrongly) derived via `n-1-pos` instead of stored per-direction, the tied
+/// group's internal order would come out reversed in one direction.
+fn tie_break_fixture() -> (Vec<OracleCard>, VocabInterner) {
+    let mut vocab = VocabInterner::new();
+    let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab); // cmc=3, edhrec=10
+    card0.cmc = Some(3);
+    card0.edhrec_rank = Some(10);
+    let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab); // cmc=3, edhrec=5 (lowest in the tie)
+    card1.cmc = Some(3);
+    card1.edhrec_rank = Some(5);
+    let mut card2 = stub_card(3, TYPE_CREATURE, &[], &mut vocab); // cmc=3, edhrec=20 (highest in the tie)
+    card2.cmc = Some(3);
+    card2.edhrec_rank = Some(20);
+    let mut card3 = stub_card(4, TYPE_CREATURE, &[], &mut vocab); // cmc=1
+    card3.cmc = Some(1);
+    card3.edhrec_rank = Some(1);
+    let mut card4 = stub_card(5, TYPE_CREATURE, &[], &mut vocab); // cmc=5
+    card4.cmc = Some(5);
+    card4.edhrec_rank = Some(1);
+    (vec![card0, card1, card2, card3, card4], vocab)
+}
+
+/// Expected order, by oracle_id: ascending is [card3(1), card1(3,e5),
+/// card0(3,e10), card2(3,e20), card4(5)]; descending is [card4(5), card1,
+/// card0, card2, card3(1)] — the tied trio (card1,card0,card2) keeps the
+/// SAME internal order in both directions, only the untied cards (card3,
+/// card4) swap ends.
+#[test]
+fn popcount_skip_tie_breaking_preserves_group_order_both_directions() {
+    let (cards, vocab) = tie_break_fixture();
+    let data = store_of(cards, &[1, 1, 1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let (plane, mut residual) = split_planes(creature);
+    assert!(matches!(residual, FilterExpr::True), "t:creature must fully plane-consume");
+
+    let mut run = |direction: &str| {
+        run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut residual, plane.as_ref(), "card", "default", "cmc", direction, 100, 0, &archived.indexes,
+        )
+    };
+
+    let (total, page) = run("asc");
+    assert_eq!(total, 5);
+    let order: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
+    assert_eq!(order, vec![4, 2, 1, 3, 5], "ascending: tied trio in edhrec-ascending order");
+
+    let (total, page) = run("desc");
+    assert_eq!(total, 5);
+    let order: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
+    assert_eq!(
+        order,
+        vec![5, 2, 1, 3, 4],
+        "descending: only the untied ends (card3/card4) swap — the tied trio's \
+         internal order (card1,card0,card2) must stay identical to ascending, \
+         not reverse"
+    );
+}
+
+/// Offset landing mid-tied-group: skipping the first 2 (ascending) must land
+/// exactly on the third-ranked card, not off-by-one from a word/bit
+/// miscount.
+#[test]
+fn popcount_skip_offset_lands_inside_tied_group() {
+    let (cards, vocab) = tie_break_fixture();
+    let data = store_of(cards, &[1, 1, 1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let (plane, mut residual) = split_planes(creature);
+
+    // Full ascending order is [card3, card1, card0, card2, card4] (oracle ids
+    // [4,2,1,3,5]); offset=2 must skip card3 and card1, landing on card0.
+    let (total, page) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "cmc", "asc", 100, 2, &archived.indexes,
+    );
+    assert_eq!(total, 5);
+    let order: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
+    assert_eq!(order, vec![1, 3, 5]);
+
+    // offset at exactly total must yield an empty page, not panic.
+    let (total, page) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "cmc", "asc", 100, 5, &archived.indexes,
+    );
+    assert_eq!(total, 5);
+    assert!(page.is_empty());
+}
+
+/// The popcount-skip path must produce byte-identical results to the
+/// existing (non-popcount) path for the same query — cross-checked directly
+/// against run_query_streamed's counts-buffer path by disabling the plane
+/// (forcing the old path) and comparing.
+#[test]
+fn popcount_skip_matches_non_popcount_path() {
+    let (cards, vocab) = tie_break_fixture();
+    let data = store_of(cards, &[1, 1, 1, 1, 1], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let (plane, mut residual_true) = split_planes(creature);
+    assert!(matches!(residual_true, FilterExpr::True));
+
+    // Popcount path: plane present, residual True.
+    let (total_pc, page_pc) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual_true, plane.as_ref(), "card", "default", "cmc", "desc", 100, 1, &archived.indexes,
+    );
+
+    // Non-popcount path: same logical filter, but passed as a real predicate
+    // (not pre-consumed to True) with no plane, forcing the counts-buffer path.
+    let mut creature_raw = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let (total_old, page_old) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut creature_raw, None, "card", "default", "cmc", "desc", 100, 1, &archived.indexes,
+    );
+
+    assert_eq!(total_pc, total_old);
+    let ids_pc: Vec<u128> = page_pc.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
+    let ids_old: Vec<u128> = page_old.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
+    assert_eq!(ids_pc, ids_old);
 }
 
 // Frame postings are selectivity-thresholded at build: values covering more

--- a/docs/issues/engine-numeric-range-planes.md
+++ b/docs/issues/engine-numeric-range-planes.md
@@ -1,0 +1,79 @@
+# Engine: numeric-range bitplanes for cmc/power/toughness
+
+Follow-on to #630 (phases 1/2 shipped as PR #633, #654). Not in scope for
+#634 (permuted bitmap / exactness promotion, `engine-permuted-bitmap-order-
+phase.md`) — filed separately, surfaced while benchmarking that work. Status:
+proposed, not designed in detail yet.
+
+## Problem
+
+#630 phase 1's original survey rejected numeric ranges ("already served by
+card-space range indexes that never lose"), which is true in isolation — the
+sorted-index binary search (`numeric_candidates`) is exact and cheap for
+selective queries. But it materializes every qualifying id from the sorted
+index, so cost scales with match count. For a **broad** range this is real:
+`cmc<=6` (30,164 of 31,508 cards, 96%) costs 0.436 ms today, dominated by
+materializing that Vec — not by anything downstream.
+
+## Why this isn't devotion's bit-slicing scheme
+
+Devotion's 2-bit-per-color scheme works because queries are always about a
+small, fixed set of thresholds (pip count 0/1/2/3+) — 2 bits exactly cover
+every comparison shape that can occur. CMC/power/toughness queries use
+arbitrary thresholds (`cmc<=4`, `cmc<=6`, `cmc=3`, ...), so a coarse
+bucket scheme only answers exactly when a query happens to land on a bucket
+boundary. The mechanism that actually generalizes is closer to colors/types:
+**one plane per distinct value**, OR'd together for a range comparison —
+`cmc<=6` becomes 7 planes ORed (~7×wpp word ops), cost independent of match
+count. This is why it helps broad ranges specifically and does nothing for
+selective ones (`cmc=9`, 101 cards — already cheap).
+
+## Data (card-level, deduplicated by oracle_id, n=31,508, 2026-07-09 blue DB)
+
+```
+cmc:        0→1190  1→3055  2→6654  3→7602  4→5952  5→3762  6→1949
+            7→853  8→297  9→101  10→52  11→18  12→16  13-16→7 (total)
+power:      -1→2  0→767  1→3274  2→5181  3→3718  4→2130  5→1125  6→623
+            7→265  8→115  9→47  10→40  11→9  12→13  13+→11 (total)
+toughness:  -1→1  0→257  1→3434  2→4284  3→3954  4→2839  5→1395  6→689
+            7→272  8→122  9→45  10→42  11→13  12→13  13+→9 (total)
+```
+
+All three are heavily right-skewed: cmc<=6 alone is 96% of the corpus.
+One-hot planes for 0..12 (13 planes) plus a saturated "13+" bucket cover
+99.98%+ of cmc values; similar for power/toughness.
+
+## Design sketch
+
+- One-hot plane per value 0..M (M≈12), plus one saturated "M+" plane (like
+  devotion's top bucket): `field<=K`/`field>=K`/`field=K` compile exactly via
+  mask OR whenever the comparison stays within 0..M, or crosses cleanly into
+  "M+" without needing to distinguish values inside it (`field>=K` for K<=M
+  is exact: OR planes K..M plus the M+ plane; `field=15` specifically is not
+  — decline, fall back to today's exact index for that ~6-11-card sliver).
+- No postings-repair / divergent-carve-out needed, unlike legality — these
+  are pure card-level fields, never `Tri::PrintingDep`, never ambiguous. The
+  tail simply declines to plane-compile and falls back to the existing exact
+  numeric index, which is already cheap at that size.
+- **Asymmetry to resolve before implementing:** cmc has no negative values
+  (min 0), but power/toughness do (`-1` on 1-2 cards each, presumably `*`-power
+  cards encoded oddly). cmc only needs saturation at the top; power/toughness
+  need it at both ends, or a range like `power<=2` would silently exclude
+  those 1-2 cards. Check what `-1` actually represents in the source data
+  before committing to a bidirectional scheme.
+
+## Expected
+
+Should compound with #634: a plane-compiled `cmc<=6` becomes exact by
+construction, feeding directly into #634 Part B's all_match promotion — no
+separate exactness-classification work needed for this dimension once both
+land.
+
+## Related
+
+- #630 — parent issue; phase 1 (colors/types, PR #633) explicitly considered
+  and rejected numeric ranges with the reasoning this doc revisits
+- [engine-permuted-bitmap-order-phase.md](engine-permuted-bitmap-order-phase.md)
+  — #634, where this was surfaced; not bundled into that work
+- [engine-legality-bitplanes.md](engine-legality-bitplanes.md) — the
+  divergent-carve-out pattern that does *not* apply here, and why

--- a/docs/issues/engine-numeric-range-planes.md
+++ b/docs/issues/engine-numeric-range-planes.md
@@ -43,31 +43,65 @@ All three are heavily right-skewed: cmc<=6 alone is 96% of the corpus.
 One-hot planes for 0..12 (13 planes) plus a saturated "13+" bucket cover
 99.98%+ of cmc values; similar for power/toughness.
 
-## Design sketch
+## Design (revised — the original sketch below was wrong, kept for context)
 
-- One-hot plane per value 0..M (M≈12), plus one saturated "M+" plane (like
-  devotion's top bucket): `field<=K`/`field>=K`/`field=K` compile exactly via
-  mask OR whenever the comparison stays within 0..M, or crosses cleanly into
-  "M+" without needing to distinguish values inside it (`field>=K` for K<=M
-  is exact: OR planes K..M plus the M+ plane; `field=15` specifically is not
-  — decline, fall back to today's exact index for that ~6-11-card sliver).
-- No postings-repair / divergent-carve-out needed, unlike legality — these
-  are pure card-level fields, never `Tri::PrintingDep`, never ambiguous. The
-  tail simply declines to plane-compile and falls back to the existing exact
-  numeric index, which is already cheap at that size.
-- **Asymmetry to resolve before implementing:** cmc has no negative values
-  (min 0), but power/toughness do (`-1` on 1-2 cards each, presumably `*`-power
-  cards encoded oddly). cmc only needs saturation at the top; power/toughness
-  need it at both ends, or a range like `power<=2` would silently exclude
-  those 1-2 cards. Check what `-1` actually represents in the source data
-  before committing to a bidirectional scheme.
+**Planes for the common range** (roughly 0 through 10-12, hundreds-to-
+thousands of cards each): one-hot plane per distinct value, OR'd together
+for a range comparison — `cmc<=6` = 7 planes ORed, exact, O(words)
+regardless of match count.
+
+**A compile-time-resolved correction for sparse/outlier values** — power's
+2 cards at `power=-1`, toughness's 1 card at `toughness=-1`, and cmc's high
+tail (13→1, 14→1, 15→4, 16→1) — instead of either a saturating bucket
+(declines to compile exactly whenever a query needs to distinguish *within*
+the bucket, e.g. `cmc=15`) or a dedicated plane per rare value (an entire
+3,944-byte plane, plus one more word-OR on *every* query touching that
+dimension forever, to encode 1-4 cards' membership — wasteful).
+
+The key realization, initially missed: unlike legality's divergent-card
+correction (#654), which has to happen **per candidate at query time**
+because a divergent card's true status depends on which printing you're
+looking at (unknowable until `card_pass` runs), a card's numeric value is
+fixed and known at *build* time — there's no ambiguity to defer. So the
+correction can happen **once per query, at compile time**: for each sparse
+tail value (a tiny precomputed `value -> card_ids` side table), check
+whether `value <op> threshold` holds — a single scalar comparison — and if
+so, scatter that value's few known card ids directly into the result
+bitmap. Not "always include and let something re-verify" (legality's
+pattern) but "resolve statically, include only when actually true" —
+strictly exact, O(1) per query plus O(tail size) to scatter, no
+decline/fallback case anywhere. This also removes the high-tail
+saturating-bucket problem: `cmc=15` becomes exactly resolvable (check
+13/14/15/16 against `=15`, scatter in the 4 matching ids) instead of
+falling back to the old scan.
+
+**Implementation note:** `compile_plane` currently returns just
+`Option<PlaneExpr>`. Folding in "a few extra known ids to OR into the
+result" needs a small side-channel out of that function — not a new
+`PlaneExpr` tree node, just a few extra ids scattered into the evaluated
+bitmap once after the tree evaluates (the same way `legal_candidate_bits`
+scatters legality's divergent postings today). Empty/unused for every
+existing caller (colors/types/devotion), populated only for numeric-range
+tail values.
+
+### Original sketch (superseded)
+
+The first pass proposed a saturating "M+" bucket (declining to compile
+`field=15` exactly, falling back to the old scan) and treated power/
+toughness's negative tail as an open question ("check what -1 means before
+committing to a bidirectional scheme"). Superseded by the compile-time
+resolution above, which handles both ends of both tails exactly with less
+storage than either a bucket or dedicated planes, and needs no fallback path
+at all.
 
 ## Expected
 
 Should compound with #634: a plane-compiled `cmc<=6` becomes exact by
-construction, feeding directly into #634 Part B's all_match promotion — no
-separate exactness-classification work needed for this dimension once both
-land.
+construction, feeding directly into #634's all_match promotion and
+popcount-skip order phase — no separate exactness-classification work
+needed for this dimension once both land. Because every value (common or
+sparse) resolves exactly, there's no residual/fallback path to test for
+these three fields at all.
 
 ## Related
 

--- a/docs/issues/engine-numeric-range-planes.md
+++ b/docs/issues/engine-numeric-range-planes.md
@@ -43,56 +43,72 @@ All three are heavily right-skewed: cmc<=6 alone is 96% of the corpus.
 One-hot planes for 0..12 (13 planes) plus a saturated "13+" bucket cover
 99.98%+ of cmc values; similar for power/toughness.
 
-## Design (revised — the original sketch below was wrong, kept for context)
+## Design (final — one-hot interior planes + two cumulative boundary planes)
 
-**Planes for the common range** (roughly 0 through 10-12, hundreds-to-
-thousands of cards each): one-hot plane per distinct value, OR'd together
-for a range comparison — `cmc<=6` = 7 planes ORed, exact, O(words)
-regardless of match count.
+This went through three passes before landing here; see below for what
+didn't work and why.
 
-**A compile-time-resolved correction for sparse/outlier values** — power's
-2 cards at `power=-1`, toughness's 1 card at `toughness=-1`, and cmc's high
-tail (13→1, 14→1, 15→4, 16→1) — instead of either a saturating bucket
-(declines to compile exactly whenever a query needs to distinguish *within*
-the bucket, e.g. `cmc=15`) or a dedicated plane per rare value (an entire
-3,944-byte plane, plus one more word-OR on *every* query touching that
-dimension forever, to encode 1-4 cards' membership — wasteful).
+**One-hot planes for the well-populated interior** (roughly 1 through
+9-10, hundreds-to-thousands of cards each): `field=K` for the interior
+compiles directly to a plane read; ranges OR the relevant interior planes
+together, same as colors/types.
 
-The key realization, initially missed: unlike legality's divergent-card
-correction (#654), which has to happen **per candidate at query time**
-because a divergent card's true status depends on which printing you're
-looking at (unknowable until `card_pass` runs), a card's numeric value is
-fixed and known at *build* time — there's no ambiguity to defer. So the
-correction can happen **once per query, at compile time**: for each sparse
-tail value (a tiny precomputed `value -> card_ids` side table), check
-whether `value <op> threshold` holds — a single scalar comparison — and if
-so, scatter that value's few known card ids directly into the result
-bitmap. Not "always include and let something re-verify" (legality's
-pattern) but "resolve statically, include only when actually true" —
-strictly exact, O(1) per query plus O(tail size) to scatter, no
-decline/fallback case anywhere. This also removes the high-tail
-saturating-bucket problem: `cmc=15` becomes exactly resolvable (check
-13/14/15/16 against `=15`, scatter in the 4 matching ids) instead of
-falling back to the old scan.
+**Two *cumulative* boundary planes per dimension, not one-hot per boundary
+value:** `field<=L` (e.g. `power<=0`) and `field>=H` (e.g. `power>=10`),
+built with the exact same plane machinery as everything else — a card's
+bit is set if its value satisfies the threshold, full stop. This is the
+key simplification:
 
-**Implementation note:** `compile_plane` currently returns just
-`Option<PlaneExpr>`. Folding in "a few extra known ids to OR into the
-result" needs a small side-channel out of that function — not a new
-`PlaneExpr` tree node, just a few extra ids scattered into the evaluated
-bitmap once after the tree evaluates (the same way `legal_candidate_bits`
-scatters legality's divergent postings today). Empty/unused for every
-existing caller (colors/types/devotion), populated only for numeric-range
-tail values.
+- The low boundary plane (`<=0`) automatically absorbs whatever sparse
+  negative values exist (power's 2 cards at -1, toughness's 1 card at -1)
+  purely because that's what "value <= 0" already means — no separate
+  handling of the negative tail, no side table, no live re-query needed.
+- The high boundary plane (`>=10`, or wherever the interior stops)
+  automatically absorbs the sparse high tail (cmc's 13-16, power/
+  toughness's 13+) the same way.
+- Any query of the shape `field<=K` or `field>=K` for **any** K — interior
+  or landing on/beyond a boundary — compiles exactly as an OR of {relevant
+  interior one-hot planes, the relevant boundary plane}. Zero new data
+  structures, zero index queries at compile time — just more entries in
+  the same `PlaneExpr::Or`, evaluated by the existing `eval_planes`.
 
-### Original sketch (superseded)
+**What still declines, and why that's fine:** queries that need to
+distinguish *inside* a boundary bucket — `power=-1` specifically, or
+`power<-1` (strictly tighter than what the `<=0` plane alone resolves) —
+`compile_plane` simply returns `None` for these, exactly its existing
+contract for anything outside a plane's scope, falling back to today's
+`numeric_candidates` path unchanged. Not a compromise: these are
+inherently selective queries (2 cards, 4 cards), and #630's original
+verdict on numeric ranges only broke down for *broad* queries, which the
+boundary planes now fully cover. No side-channel out of `compile_plane`,
+no new `PlaneExpr` variant, no live re-query mechanism needed anywhere —
+the exactness-boundary logic per operator (`Le`/`Lt`/`Ge`/`Gt`/`Eq`/`Ne`
+against interior-range-plus-two-boundaries) mirrors `compile_devotion`'s
+existing boundary tracking almost exactly, just with two saturation edges
+instead of one.
 
-The first pass proposed a saturating "M+" bucket (declining to compile
-`field=15` exactly, falling back to the old scan) and treated power/
-toughness's negative tail as an open question ("check what -1 means before
-committing to a bidirectional scheme"). Superseded by the compile-time
-resolution above, which handles both ends of both tails exactly with less
-storage than either a bucket or dedicated planes, and needs no fallback path
-at all.
+### Earlier passes (superseded, kept for context on why they lost)
+
+1. **Saturating "M+" bucket only, decline on the low tail as an open
+   question.** Original sketch — left power/toughness's negative values
+   unresolved ("check what -1 means before committing to a bidirectional
+   scheme") and declined `field=15`-style queries entirely.
+2. **A precomputed `value -> card_ids` side table for sparse values,
+   resolved once per query at compile time.** Better — exact, no decline
+   case — but needed a new side-channel out of `compile_plane` (it
+   currently returns just `Option<PlaneExpr>`) to carry "a few extra ids
+   to OR in" back to the caller, plus a new small build-time structure to
+   maintain.
+3. **Skip the side table, re-query the existing `numeric_candidates`
+   index live at compile time** for whatever falls outside the one-hot
+   range. No new storage, but still needed the same `compile_plane`
+   side-channel, just fed by a live lookup instead of a precomputed table.
+
+The final design above needs neither: making the boundaries themselves
+*planes* (cumulative, not one-hot) means the sparse tails are absorbed
+automatically by a mechanism that already exists, and the only "new"
+behavior is `compile_plane` declining for the rare within-bucket case —
+which is just its existing contract, unchanged.
 
 ## Expected
 

--- a/docs/issues/engine-permuted-bitmap-order-phase.md
+++ b/docs/issues/engine-permuted-bitmap-order-phase.md
@@ -1,0 +1,240 @@
+# Engine: permuted match bitmaps + exact-candidate promotion
+
+Status: filed 2026-07-08, successor to #630 phase 1 (PR #633). GitHub: #634.
+
+## Problem
+
+Planes made the filter free; the bitmap's *delivery* is the new ~5 ns/match
+floor (candidate vec materialization, card_pass(True) dispatch, 126 kB counts
+fill, 31.5k-entry perm walk with random counts reads). This is why
+`t:creature` didn't move in #633 — identical downstream work either way:
+t:instant 3.6k → 0.072 ms, c:g 6.4k → 0.089, t:creature 17.3k → 0.149.
+
+## Design
+
+**A. Permuted bitmap.** Inverse permutation per card-level sort column
+(~630 kB total; desc = n-1-pos). Scatter set bits through inv_perm into a
+second 4 kB thread-local buffer. unique=card: total = popcount, skip =
+word-popcount accumulation (64 cards/word — deep pagination ≈ 492 words),
+emit = bit-select + map back via forward perm, per-card work for ~limit
+cards only. printing/artwork under all_match: weights are O(1)
+(offsets diff / artwork_groups) — trailing_zeros walk over set bits only.
+Mixed filters scatter after residual eval; counts read at set bits only.
+rarity/usd orderbys and STREAM_MIN_MATCHES gate unchanged.
+
+**B. Exactness flag.** narrow_candidates sources classified exact
+(planes, card-space numeric ranges, TypeCmp Ge postings) vs advisory
+(trigrams, printing-space projections). And-intersection exact iff every
+child consumed exactly; exact whole-filter → all_match promotion → no
+residual eval, counts from offsets/groups, path A applies.
+`f:modern t:creature power>3` (post phase 2) → zero per-card predicate work.
+
+## Expected
+
+t:creature 0.149 → ~0.03–0.06 ms; c:g 0.089 → ~0.03–0.05; deep pagination
+O(words); advisory residuals (o:draw, regex, arithmetic) keep the
+set-bit-iteration floor by design.
+
+## Related
+
+- [engine-card-bitplanes.md](engine-card-bitplanes.md) — #630; phase 2
+  legality planes widen the exact-composed class
+- [engine-bitmap-streaming-select.md](engine-bitmap-streaming-select.md) —
+  #632 forward perms + counts buffer this partially retires
+- [engine-legality-bitplanes.md](engine-legality-bitplanes.md) — #630 phase 2
+  (PR #654), base branch for this work; flagged on #634 as a source shape
+  ("exact + shared advisory carve-out") the exactness classification below
+  doesn't yet have a case for — Step 3 candidate, not in scope here
+
+## Grounded implementation plan (2026-07-09, branched off PR #654)
+
+### Baseline (`scripts/bench_permuted_order.py`, new — adds an `offset` axis
+`bench_bitplanes.py` never exercised, 0.5s/config)
+
+| group | query | unique | offset | total | avg ms |
+|---|---|---|---|---|---|
+| exact-single | `t:creature` | card | 0 | 17,317 | 0.139 |
+| exact-single | `cmc<=6` | card | 0 | 30,164 | 0.436 |
+| exact-single | `!"Lightning Bolt"` | card | 0 | 1 | 0.003 |
+| exact-compound | `t:creature power>3` | card | 0 | 4,239 | 0.109 |
+| exact-compound | `c:g t:creature cmc<=4` | card | 0 | 2,931 | **0.237** |
+| exact-compound | `t:creature` | printing | 0 | 45,976 | 0.131 |
+| exact-compound | `t:creature` | artwork | 0 | 22,510 | 0.127 |
+| deep-offset | `t:creature` | card | 5,000 | 17,317 | 0.146 |
+| deep-offset | `t:creature` | card | 15,000 | 17,317 | 0.159 |
+| deep-offset | `t:creature power>3` | card | 5,000 | 4,239 | 0.056 |
+| deep-offset | `cmc<=6` | card | 500 | 30,164 | 0.449 |
+| advisory-single | `f:modern` | card | 0 | 22,264 | 0.188 |
+| advisory-mixed | `f:modern t:creature power>3` | card | 0 | 3,046 | 0.113 |
+
+`exact-*`/`deep-*` rows are the queries Part A/B target. `advisory-*` rows are
+the correctness tripwire — must never get promoted, must not regress.
+
+### Key finding: Part B's classification mostly already exists
+
+Tracing the actual code rather than re-deriving from the design above:
+`Narrowed { set: Candidates, tight: bool }` in `narrow_rec` already tracks
+"exact" — set by numeric ranges, `ExactName`, complete-index `CollectionCmp::Ge`,
+and the compile_plane-consumed check. `and_all`/`or_all` (the And/Or
+composition already used by `narrow_rec`) already propagate it correctly:
+"Tight iff every input is tight," and the And arm's `every_child_included`
+guard already turns it false whenever a child got skipped for cost reasons
+(`AND_SKIP_THRESHOLD`) — exactly the "don't promote unless provably complete"
+rule this design calls for. Grep confirms `.tight` is read in exactly 4
+places, all inside `narrow_rec`'s own recursion — it never escapes to a
+caller today. So Part B isn't a new classification system from scratch; it's:
+
+1. `narrow_candidates()` (the public wrapper `run_query` calls) needs to
+   expose `tight` instead of discarding it (returns `Option<Candidates>`
+   today, throwing the flag away).
+2. Nothing yet combines the residual's `tight` with the `plane`'s exactness
+   (always exact when present — that's what `compile_plane` already
+   guarantees) into one "is the whole original filter exact" signal at the
+   `query()`/`run_query` boundary.
+3. Nothing uses that signal to skip `card_pass` — confirmed by reading
+   `run_query`'s match loop and `run_query_streamed`'s two call sites:
+   `card_pass` runs per candidate unconditionally today, even for a
+   provably-tight numeric range, redoing real `tri()` evaluation for no
+   reason. `card_match_count`/`push_card_matches` already accept an
+   `all_match: bool` and already have the O(1) fast-path branches for it
+   (built for the per-card case where `card_pass` itself said `Tri::True`) —
+   Part B just needs to supply that bool structurally instead of per-card.
+
+### Secondary finding, bundle into Step 1
+
+`c:g t:creature cmc<=4` (0.237 ms) is anomalously slow for a 2,931-row result
+(compare `t:creature power>3`, 4,239 rows, 0.109 ms). After `split_planes`
+consumes `c:g`/`t:creature` into `plane` (popcount ~4,166), the residual
+`cmc<=4` narrows via `numeric_candidates`, which returns a **materialized
+`Vec<u32>`** — likely 20,000+ entries (`cmc<=6` alone is 30,164, 96% of the
+corpus). `run_query` retains that large Vec against the small plane bitmap:
+the same "materialize the broad side, retain against the tight side" shape as
+the legality regression fixed in PR #654 — except numeric ranges return
+`Candidates::Cards`, not `CardBits`, so that fix's direct bitmap-AND doesn't
+apply here. Not fully free to fix (`numeric_candidates` has to materialize
+*something* from the sorted index), but scattering the Vec into a bitmap
+before intersecting — rather than retaining element-by-element — turns an
+O(popcount) retain plus an O(wpp) plane read into one O(wpp) AND. Worth
+bundling into Step 1 since that work already touches this exact code path.
+
+### Phased plan
+
+**Step 1 (Part B: exactness propagation + all_match promotion) — done**
+- Expose `tight` from `narrow_candidates` (new `narrow_candidates_exact`,
+  `narrow_candidates` kept as a `#[cfg(test)]`-only thin wrapper); combine
+  with plane exactness at the `run_query` boundary: `all_match_known =
+  matches!(filter, FilterExpr::True) || residual_exact`.
+- Skip `card_pass` per candidate when `all_match_known`; feed the existing
+  `all_match: bool` fast paths directly, in `run_query`'s gathered loop and
+  `run_query_streamed`'s two emission loops (small-gather, main walk).
+- Does **not** touch the permutation walk, counts buffer, or pagination —
+  removes redundant per-candidate evaluation, keeps today's O(candidates)
+  materialization. That's Step 2. The bundled "scatter-before-intersect" idea
+  from the original plan was dropped: `c:g t:creature cmc<=4`'s slowness
+  turned out to be `numeric_candidates`'s internal re-sort (value-order index
+  slice re-sorted to id-order), paid before any plane interaction — a
+  numeric-index-specific cost the plane-intersection swap wouldn't have
+  touched. Left as a possible `numeric_candidates` optimization, not pursued
+  here (out of scope for this issue; see confirmed-flat benchmark row below).
+
+  **Two real bugs found and fixed during implementation** (both caught by the
+  differential property test suite and/or targeted regression tests before
+  reaching benchmarking):
+  1. **Printing-space tight ≠ card-level all_match.** `narrow_rec`'s `tight`
+     means "every member of *this* set satisfies the predicate" — for a
+     printing-space result (`set:`, `artist:`, `frame:`, `year:`/`date:`,
+     `number:`) that's "this specific printing," not "every printing of the
+     card," which is what `card_pass`'s `Tri::True` means. A card can have
+     printings in and out of a printing-space match (`s:lea` — most cards
+     have other-set printings too). Fix: `narrow_candidates_exact` only
+     reports exact when the result is card-space. Regression test:
+     `all_match_promotion_never_fires_for_printing_space_tight_results`.
+  2. **Mode::Artwork match-phase regression.** Applying `all_match_known` in
+     `run_query_streamed`'s match phase (which visits every candidate, not
+     just the emitted page) measured a ~45% slowdown for `t:creature`
+     unique=artwork specifically (isolated by bisecting call sites) — an
+     unexplained codegen/scheduling effect in that loop for that mode, not a
+     logical cost (card_pass's own return value is identical either way).
+     Card/Printing modes showed no such effect and do benefit. Fix: gate that
+     one call site on `!matches!(mode, Mode::Artwork)`; the two emission
+     loops (which only touch ~`limit` candidates) are unaffected either way.
+- Risk: shared, hot, correctness-critical path. `advisory-*` benchmark rows
+  are the regression tripwire — a wrongly-promoted advisory filter would
+  silently return wrong results, not just run slow. Parity tests non-negotiable
+  before benchmarking — both bugs above were caught this way, not by the
+  benchmark.
+
+**Step 1 results** (`scripts/bench_permuted_order.py`, 1.0s/config, machine
+quiesced — Docker Desktop's VM was consuming ~32% CPU continuously and
+contaminated earlier measurement attempts; min_ms shown, more robust to
+system noise than avg_ms):
+
+| query | before | after | speedup |
+|---|---|---|---|
+| `t:creature` (card) | 0.127 ms | 0.099 ms | **1.29×** |
+| `t:creature` (printing) | 0.119 ms | 0.092 ms | **1.29×** |
+| `c:g` | 0.076 ms | 0.068 ms | 1.12× |
+| `power>4` | 0.080 ms | 0.072 ms | 1.11× |
+| `t:creature power>3` | 0.101 ms | 0.087 ms | 1.16× |
+| `t:creature` deep offset (5000) | 0.133 ms | 0.105 ms | **1.27×** |
+| `t:creature` deep offset (15000) | 0.143 ms | 0.114 ms | **1.25×** |
+| `t:creature power>3` deep offset (5000) | 0.053 ms | 0.037 ms | **1.42×** |
+| `t:creature` (artwork) | 0.117 ms | 0.118 ms | 0.99× (mode-gated, by design) |
+| `cmc<=6` (broad, discarded-for-broadness) | 0.406 ms | 0.411 ms | ~1.0× (no membership in hand, correctly declines) |
+| `c:g t:creature cmc<=4` | 0.224 ms | 0.226 ms | ~1.0× (numeric_candidates sort dominates, see above) |
+| `f:modern` / `o:draw` / `r:mythic` (advisory) | — | — | ~1.0×, unaffected |
+| mixed exact+advisory (must never promote) | — | — | ~1.0×, unaffected |
+
+All totals verified identical across every config. Real, consistent wins for
+genuinely exact queries (single and compound predicates, card and printing
+modes, and biggest at deep pagination offsets); correctly flat for broad/
+advisory/mixed cases that must not promote.
+
+**Step 2 (Part A: permuted bitmap + popcount-skip order phase)**
+- Inverse permutations for the four numeric/rank sort columns already in
+  `SortPermutations` (`cmc`, `power`, `toughness`, `edhrec`/`cubecobra`);
+  `name` deferred (added to `SortPermutations` after this issue was filed —
+  revisit once Step 1/2 are stable). Archive version bump.
+- Scatter matched bits (plane ∧ Step-1-exact residual) through the inverse
+  permutation into a fresh permuted-order bitmap.
+- `unique=card`: total = popcount; skip = accumulate word popcounts to the
+  boundary word; emit = walk set bits from there, map back through the
+  forward permutation for `limit` cards.
+- `unique=printing`/`artwork` under all_match: O(1) card weights (offsets
+  diff / `artwork_groups`) via a `trailing_zeros` walk over set bits.
+- Unchanged: `rarity`/`usd` orderbys (no permutation, gathered path already),
+  `STREAM_MIN_MATCHES` gate, emission/tiebreak semantics.
+- Target: `deep-offset` rows, where today's forward-perm walk already hides
+  most of the offset cost, but the O(candidates) counts-buffer fill remains
+  regardless of depth — collapsing that to O(words) is the actual win.
+
+### Step 1.5 (proposed, not yet designed): per-child exact-node elision
+
+Current Step 1 is all-or-nothing: `power>3 AND o:draw` gets zero benefit even
+though `power>3` alone is exact, because the residual as a whole isn't (one
+non-exact child taints it). A more general version: instead of a single
+whole-residual exactness bool, have the And-composition (which already
+tracks `every_child_included` per child) identify *which* children are
+individually card-space-exact, and rebuild a reduced `FilterExpr` with those
+children replaced/dropped — mirroring what `split_planes` already does for
+`compile_plane`-able children, generalized to numeric ranges/`ExactName`/
+complete-index lookups. `card_pass` then only evaluates the genuinely
+advisory remainder. Real, separate tree-surgery work (narrow_rec today only
+computes candidate sets, never touches the `FilterExpr` tree) — sequence
+after Step 1 lands and is validated, not bundled in.
+
+### Tasks
+
+- [ ] Step 1: expose `tight`, combine with plane exactness, skip `card_pass`
+      when `all_match` is structurally known
+- [ ] Step 1 bundled: scatter-before-intersect for broad Vec residuals
+- [ ] Step 1 tests: parity vs brute force for every exact/advisory shape;
+      explicit test that mixed exact+advisory never promotes and still
+      verifies the advisory part per candidate
+- [ ] Step 1 benchmark + regression check, iterate
+- [ ] Step 2: inverse permutations, archive version bump, scatter pass,
+      popcount-skip walk, weighted set-bit walk for printing/artwork
+- [ ] Step 2 equivalence tests vs the counts-buffer path (uniques × orderbys
+      × directions × offsets, deep offsets, tie blocks)
+- [ ] Step 2 benchmark + regression check, iterate
+- [ ] Final report

--- a/docs/issues/engine-permuted-bitmap-order-phase.md
+++ b/docs/issues/engine-permuted-bitmap-order-phase.md
@@ -190,23 +190,62 @@ genuinely exact queries (single and compound predicates, card and printing
 modes, and biggest at deep pagination offsets); correctly flat for broad/
 advisory/mixed cases that must not promote.
 
-**Step 2 (Part A: permuted bitmap + popcount-skip order phase)**
-- Inverse permutations for the four numeric/rank sort columns already in
-  `SortPermutations` (`cmc`, `power`, `toughness`, `edhrec`/`cubecobra`);
-  `name` deferred (added to `SortPermutations` after this issue was filed —
-  revisit once Step 1/2 are stable). Archive version bump.
-- Scatter matched bits (plane ∧ Step-1-exact residual) through the inverse
-  permutation into a fresh permuted-order bitmap.
-- `unique=card`: total = popcount; skip = accumulate word popcounts to the
-  boundary word; emit = walk set bits from there, map back through the
-  forward permutation for `limit` cards.
-- `unique=printing`/`artwork` under all_match: O(1) card weights (offsets
-  diff / `artwork_groups`) via a `trailing_zeros` walk over set bits.
+**Step 2 (Part A: permuted bitmap + popcount-skip order phase) — done**
+- Inverse permutations for all six `SortPermutations` columns (`cmc`, `power`,
+  `toughness`, `edhrec`, `cubecobra`, `name` — no reason to defer `name`,
+  same mechanism). **Correction to the original issue's design** (caught
+  before writing any code, by re-deriving the sort-key construction rather
+  than trusting the "desc = n-1-pos, no second table" shortcut): this
+  codebase's tie-breakers (`edhrec_rank`, then `prefer_score`) never flip sign
+  with the primary column's direction (`build_sort_permutations`'s `perm`
+  closure negates only the primary key for `descending`), so cards tied on
+  the primary value keep *identical* relative order in both the ascending and
+  descending permutations. Reversing the ascending inverse (`n-1-pos`) would
+  also reverse that internal tied-group order, which is wrong whenever the
+  sort column has ties — the common case, not the exception (`cmc=3` alone is
+  7,602 of 31,508 cards). Storing both inverse permutations explicitly, same
+  as the forward tables already do, costs another ~1.26 MB (matching the
+  forward tables' own size) — trivial against a >70 MB archive, and correct
+  regardless of tie clustering. Archive version bump.
+- New `run_query_streamed_popcount`: scatters the plane bitmap through the
+  inverse permutation, then works in word space — total = popcount, skip =
+  running word-popcount sum to the boundary word, emit = walk set bits from
+  there mapping back through the forward permutation.
+- **Scope, deliberately narrower than the original plan**: engages only when
+  `unique=card` and the filter fully consumed to `FilterExpr::True` (plane
+  bitmap IS the exact match set — colors/types/legality, any selectivity).
+  Compound exact filters that didn't fully consume (`t:creature power>3`,
+  residual = `power>3`) and `unique=printing`/`artwork` still use Step 1's
+  path unchanged — extending to those is a reasonable fast-follow, not
+  required to deliver the core win. Also: `cmc<=6` alone does **not** speed up
+  under Step 2 either, for the same reason noted under Step 1 — `cmc` has no
+  bitmap representation without the separate numeric-range-planes work, so
+  there's nothing to scatter without first paying the O(match count) cost
+  Step 2 exists to eliminate.
 - Unchanged: `rarity`/`usd` orderbys (no permutation, gathered path already),
-  `STREAM_MIN_MATCHES` gate, emission/tiebreak semantics.
-- Target: `deep-offset` rows, where today's forward-perm walk already hides
-  most of the offset cost, but the O(candidates) counts-buffer fill remains
-  regardless of depth — collapsing that to O(words) is the actual win.
+  `STREAM_MIN_MATCHES` gate, emission/tiebreak semantics — verified via a
+  direct equivalence test against the non-popcount path, not just inspection.
+
+**Step 2 results** (same protocol as Step 1, `min_ms`, machine quiesced):
+
+| query | Step 1 | Step 2 | speedup (Step 2 alone) | cumulative vs. pre-#634 |
+|---|---|---|---|---|
+| `t:creature` (offset 0) | 0.096 ms | 0.060 ms | **1.59×** | **2.09×** (0.126 ms baseline) |
+| `t:creature` (offset 5,000) | 0.104 ms | 0.062 ms | **1.67×** | **2.16×** (0.134 ms baseline) |
+| `t:creature` (offset 15,000) | 0.113 ms | 0.060 ms | **1.89×** | **2.38×** (0.143 ms baseline) |
+| `c:g` (offset 0) | 0.065 ms | 0.053 ms | 1.23× | — |
+| `c:g` (offset 3,000) | 0.074 ms | 0.054 ms | **1.37×** | — |
+| `t:instant` | 0.056 ms | 0.049 ms | 1.16× | — |
+| `t:creature power>3` (compound, out of scope) | 0.087 ms | 0.088 ms | ~1.0× (expected) | — |
+| `t:creature` printing/artwork (out of scope) | 0.090/0.117 ms | 0.093/0.118 ms | ~1.0× (expected) | — |
+| `cmc<=6`, advisory/mixed/control | — | — | ~1.0× (expected, no bitmap available) | — |
+
+The headline result: at pre-#634 baseline, `t:creature` cost **grew with page
+depth** (0.126 → 0.134 → 0.143 ms across offset 0/5,000/15,000 — a ~13%
+increase). Under Step 2 it's **flat** (0.060 → 0.062 → 0.060 ms) — the exact
+"deep pagination becomes O(words)" property Step 2 was built for, and not
+plausibly noise given the specific shape (flat, not just lower). All totals
+verified identical across every config throughout.
 
 ### Step 1.5 (proposed, not yet designed): per-child exact-node elision
 

--- a/scripts/bench_permuted_order.py
+++ b/scripts/bench_permuted_order.py
@@ -1,0 +1,169 @@
+"""Engine-vs-engine benchmark for the permuted-bitmap order phase / exact-candidate promotion (#634).
+
+Same protocol as scripts/bench_bitplanes.py (build locally with
+`maturin develop --release -m card_engine/Cargo.toml`, run against a fixed
+corpus, compare CSVs across builds) but adds an `offset` axis — #634's Part A
+specifically targets deep pagination, which bench_bitplanes.py never exercises
+(it hardcodes offset=0). Groups:
+
+- `exact-*`  — filters that should be structurally exact today (once #634 Part B
+  ships): pure plane predicates, card-space numeric ranges, ExactName, and
+  compounds of these. These are the rows #634 is supposed to move.
+- `deep-*`   — the same exact shapes at large page offsets, where Part A's
+  popcount-skip should show its biggest win (O(words) instead of O(candidates)).
+- `advisory-*` — filters that must NOT be promoted to all_match: oracle text
+  (trigram-loose), rarity/legality narrowing-mode sources, mixed exact+advisory
+  conjunctions. Included as a correctness/regression tripwire as much as a
+  performance control — a promotion bug here would silently return wrong rows,
+  not just run slow.
+- `control-*` — selective queries unrelated to any of this, must not regress.
+
+    .venv/bin/python scripts/bench_permuted_order.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/permuted-order/baseline-main.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import card_engine  # noqa: E402
+from api.parsing import parse_scryfall_query  # noqa: E402
+
+# (group, query, unique, orderby, prefer, offset) — direction=asc, limit=100 throughout.
+CONFIGS: list[tuple[str, str, str, str, str, int]] = [
+    # Exact today (colors/types via planes, numeric ranges, ExactName) —
+    # #634 Part B should let these skip card_pass entirely.
+    ("exact-single", "t:creature", "card", "edhrec", "default", 0),
+    ("exact-single", "t:instant", "card", "edhrec", "default", 0),
+    ("exact-single", "c:g", "card", "edhrec", "default", 0),
+    ("exact-single", "cmc<=6", "card", "cmc", "default", 0),
+    ("exact-single", "power>4", "card", "power", "default", 0),
+    ("exact-single", '!"Lightning Bolt"', "card", "edhrec", "default", 0),
+    ("exact-compound", "t:creature power>3", "card", "edhrec", "default", 0),
+    ("exact-compound", "c:g t:creature cmc<=4", "card", "edhrec", "default", 0),
+    ("exact-compound", "t:creature", "printing", "edhrec", "default", 0),
+    ("exact-compound", "t:creature", "artwork", "edhrec", "default", 0),
+    # Deep pagination on the same exact shapes — Part A's specific target.
+    ("deep-offset", "t:creature", "card", "edhrec", "default", 5000),
+    ("deep-offset", "t:creature", "card", "edhrec", "default", 15000),
+    ("deep-offset", "c:g", "card", "edhrec", "default", 3000),
+    ("deep-offset", "t:creature power>3", "card", "edhrec", "default", 5000),
+    ("deep-offset", "cmc<=6", "card", "cmc", "default", 500),
+    # Advisory sources that must stay un-promoted: oracle text (trigram-loose),
+    # legality (#630 phase 2's divergent carve-out), rarity (narrowing-mode).
+    # Also the correctness tripwire: mixed exact+advisory must still verify
+    # the advisory part per candidate, never skip it.
+    ("advisory-single", "o:draw", "card", "edhrec", "default", 0),
+    ("advisory-single", "f:modern", "card", "edhrec", "default", 0),
+    ("advisory-single", "r:mythic", "card", "edhrec", "default", 0),
+    ("advisory-mixed", "t:creature o:draw", "card", "edhrec", "default", 0),
+    ("advisory-mixed", "f:modern t:creature power>3", "card", "edhrec", "default", 0),
+    ("advisory-mixed", "c:g r:mythic", "card", "edhrec", "default", 0),
+    # Unrelated selective controls — must not regress.
+    ("control", "name:soldier", "card", "edhrec", "default", 0),
+    ("control", "t:merfolk name:tide", "card", "edhrec", "default", 0),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> card_engine.QueryEngine:
+    """Build a fresh engine store from the corpus JSONL via the staged reload API."""
+    engine = card_engine.QueryEngine(str(shm_path))
+    if not engine.reload_begin():
+        msg = "reload_begin returned False (stale archive published concurrently?)"
+        raise RuntimeError(msg)
+    t0 = time.monotonic()
+    batch: list[dict] = []
+    with corpus.open() as fh:
+        for line in fh:
+            batch.append(json.loads(line))
+            if len(batch) == BATCH_SIZE:
+                engine.add_batch(batch)
+                batch.clear()
+    if batch:
+        engine.add_batch(batch)
+    engine.reload_commit()
+    print(f"Engine loaded: {engine.size():,} printings in {time.monotonic() - t0:.1f}s", flush=True)
+    return engine
+
+
+def bench_one(
+    engine: card_engine.QueryEngine, config: tuple[str, str, str, str, int], window: float
+) -> tuple[int, int, float, float]:
+    """Return (total, n, avg_ms, min_ms) for one (query, unique, orderby, prefer, offset) config."""
+    query, unique, orderby, prefer, offset = config
+    filters = parse_scryfall_query(query)
+    kw = {
+        "filters": filters,
+        "unique": unique,
+        "prefer": prefer,
+        "orderby": orderby,
+        "direction": "asc",
+        "limit": 100,
+        "offset": offset,
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n = 0
+    best = float("inf")
+    t_start = time.monotonic()
+    deadline = t_start + window
+    now = t_start
+    while now < deadline:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1_000, best * 1_000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=0.5, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<16} {'query':<28} {'unique':<9} {'orderby':<8} {'prefer':<9} {'offset':>7} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.1f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "offset", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer, offset in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer, offset), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, offset, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<16} {query:<28} {unique:<9} {orderby:<8} {prefer:<9} {offset:>7} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}",
+                flush=True,
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements #634 in two steps, stacked on #654 (legality bitplanes).

**Step 1 — exactness propagation + all_match promotion.** Exposes `narrow_rec`'s existing `tight` tracking out of `narrow_candidates` (new `narrow_candidates_exact`) and combines it with plane exactness to skip redundant per-candidate `card_pass` calls when the whole filter is structurally proven exact. Turned out to be a much smaller change than #634's own text implies — the classification and And/Or composition rules (`and_all`/`or_all`'s `tight` propagation) already existed; the flag just never escaped `narrow_candidates`'s return value to a caller.

**Step 2 — permuted-bitmap popcount-skip order phase.** Adds inverse permutations (all six `SortPermutations` columns) and a new `run_query_streamed_popcount` for `unique=card` queries whose filter fully consumed to a plane-exact bitmap (colors/types/legality). Scatters the match bitmap through the inverse permutation and works in word space instead of candidate space: total is a popcount, skip is a running word-popcount sum, emit walks set bits mapping back through the forward permutation. Deep pagination goes from O(candidates) to O(words), independent of how deep the page is.

## Two real bugs caught before benchmarking, not after

1. **Printing-space "tight" ≠ card-level "all_match."** `narrow_rec`'s `tight` means "every member of this set satisfies the predicate in its own space" — for a printing-space result (`set:`/`artist:`/`frame:`/`year:`/`number:`) that's "this printing," not "every printing of the card," which is what `card_pass`'s `Tri::True` means. Caught by the Python differential property-test suite (10 failures on first full-suite run). Fixed and permanently guarded with a dedicated regression test.
2. **A design bug in #634's own text, caught before writing code.** The issue proposed deriving descending inverse permutations from ascending via `n-1-pos` ("no second table"). Re-deriving the sort-key construction shows this is wrong for this codebase: tie-breakers (`edhrec_rank`, `prefer_score`) never flip sign with the primary column's direction, so reversing the ascending inverse would scramble tied groups' internal order — confirmed with a dedicated 3-way-tie test (`popcount_skip_tie_breaking_preserves_group_order_both_directions`). Fixed by storing both inverse permutations explicitly, ~1.26 MB extra, matching how the forward tables already work.
3. **A ~45% Mode::Artwork-specific regression**, isolated by bisecting call sites — an unexplained codegen effect for that mode only in `run_query_streamed`'s match-phase loop, not a logical cost. Fixed by gating that one site off for Artwork mode; Card/Printing modes keep the full Step 1 benefit.

## Results

`scripts/bench_permuted_order.py` (new — adds an `offset` axis the existing `bench_bitplanes.py` never exercised), `min_ms`, machine quiesced (a Docker VM was silently consuming ~32% CPU and contaminated earlier measurement attempts — confirmed by isolating and re-measuring with it stopped).

| query | pre-#634 | Step 1 | Step 2 | cumulative |
|---|---|---|---|---|
| `t:creature` (offset 0) | 0.126 ms | 0.096 ms | 0.060 ms | **2.09×** |
| `t:creature` (offset 5,000) | 0.134 ms | 0.104 ms | 0.062 ms | **2.16×** |
| `t:creature` (offset 15,000) | 0.143 ms | 0.113 ms | 0.060 ms | **2.38×** |
| `c:g` (offset 0) | 0.079 ms | 0.065 ms | 0.053 ms | **1.49×** |
| `c:g` (offset 3,000) | 0.085 ms | 0.074 ms | 0.054 ms | **1.58×** |
| `t:instant` | 0.064 ms | 0.056 ms | 0.049 ms | 1.31× |
| `power>4` | — | 0.072 ms | — | — |
| `t:creature power>3` (compound, out of Step-2 scope) | 0.101 ms | 0.087 ms | 0.088 ms | 1.15× (unchanged since Step 1) |
| `t:creature` printing/artwork (out of Step-2 scope) | — | ~1.29×/flat | ~unchanged | — |
| `cmc<=6` (broad, no bitmap available — see #655) | 0.406 ms | 0.411 ms | 0.408 ms | ~1.0× |
| advisory/mixed/control (must never promote) | — | — | — | ~1.0×, unaffected |

Headline: at baseline, `t:creature` got *slower* with page depth (0.126→0.134→0.143 ms across offset 0/5,000/15,000). Under Step 2 it's *flat* (0.060→0.062→0.060 ms) — the "deep pagination becomes O(words)" property this was built for. All totals verified identical across every config throughout, including the printing-space and tie-breaking regression tests.

## Scope, stated honestly

Step 2 only engages for `unique=card` with filters that fully consumed to plane-exact (colors/types/legality). Compound exact residuals (`t:creature power>3`) and `unique=printing`/`artwork` still get Step 1's improvement only — extending further, and adding numeric-range planes so `cmc`/`power`/`toughness` get a bitmap to scatter in the first place, are tracked separately:

- #655 — numeric-range bitplanes for cmc/power/toughness
- #656 — extend popcount-skip to compound residuals and printing/artwork modes
- #657 — per-child exact-node elision for mixed exact/advisory filters (Step 1.5)

## Tests

`cargo test` (debug + release): 77 passed, 3 ignored — new coverage includes the printing-space non-promotion regression, the tie-breaking correctness test (the specific case the design bug would have broken), offset-lands-mid-tied-group, and a direct equivalence test against the non-popcount path. `cargo clippy`: 0 errors, 33 warnings (was 32 before this branch; the one new warning is in an already-precedented lint category with 4 pre-existing instances elsewhere). Python: 1,943 unit + 21 integration tests passed.