### PR TITLE
Add a Word-Level Inverted Index for Oracle Text Search

### DIFF
--- a/card_engine/Cargo.lock
+++ b/card_engine/Cargo.lock
@@ -51,6 +51,7 @@ name = "card_engine"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "memchr",
  "memmap2",
  "pyo3",
  "rand",

--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -18,6 +18,7 @@ alloc-counter = []
 # plain `cargo test` can still link against libpython for Rust unit tests.
 pyo3 = { version = "0.29.0", features = ["uuid"] }
 regex = "1"
+memchr = "2"
 serde_json = "1"
 rkyv = "0.8"
 memmap2 = "0.9"

--- a/card_engine/src/bench_iter_dispatch.rs
+++ b/card_engine/src/bench_iter_dispatch.rs
@@ -1,0 +1,126 @@
+//! Micro-benchmark for `run_query`'s match-phase loop shape: `card_ids` is
+//! typed `Box<dyn Iterator<Item = u32>>` (to unify the `Some(candidates)` vs
+//! `None` (full-range) cases into one type), meaning every `.next()` call in
+//! the hottest loop in the query goes through a vtable — surfaced while
+//! investigating `oracle:token`'s cost, where the match-phase loop measured
+//! ~2x what raw string-search alone should cost.
+//!
+//! Two comparisons, both over the real corpus's card count:
+//! - `bare`: trivial per-iteration work (a black_box sum) — isolates the
+//!   dispatch overhead alone, nothing else.
+//! - `realistic`: the actual TextContains predicate evaluated per card (the
+//!   real `oracle:token` per-candidate cost) — shows what fraction of the
+//!   *real* workload the dispatch overhead actually is.
+//!
+//! Both compare a `Box<dyn Iterator<Item = u32>>` (today's shape) against a
+//! concrete, monomorphizable iterator type over the identical id sequence.
+//!
+//!     cargo test --release bench_iter_dispatch -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same archive bench_verify_cost
+//! uses — see that module's doc comment for the one-time build command).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rkyv::Archived;
+
+use super::{archive_header, archive_payload, CardData, FilterExpr, Mmap, Tri, ARCHIVE_HEADER_LEN};
+
+const ITERS: usize = 200;
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_iter_dispatch_cost() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as get_mmap() in lib.rs — re-validated below.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n = data.cards.len();
+    println!("\n{n} oracle cards from {STORE_PATH}");
+
+    // A realistic candidate list: every 8th card id, ~n/8 entries — comparable
+    // in size to oracle:token's 3,993-of-31,508 narrowed candidate set.
+    let ids: Vec<u32> = (0..n as u32).step_by(8).collect();
+    println!("candidate set size: {}", ids.len());
+
+    // ─── bare: trivial per-iteration work, isolates dispatch alone ───
+    let boxed_bare = time_ns(|| {
+        let it: Box<dyn Iterator<Item = u32>> = Box::new(ids.iter().copied());
+        let mut acc = 0u32;
+        for cid in it {
+            acc = acc.wrapping_add(black_box(cid));
+        }
+        acc
+    });
+    let concrete_bare = time_ns(|| {
+        let it = ids.iter().copied();
+        let mut acc = 0u32;
+        for cid in it {
+            acc = acc.wrapping_add(black_box(cid));
+        }
+        acc
+    });
+    println!(
+        "\nbare (trivial body):       boxed={boxed_bare:>10.0} ns   concrete={concrete_bare:>10.0} ns   ratio={:.2}x",
+        boxed_bare / concrete_bare
+    );
+
+    // ─── realistic: the real oracle:token per-card predicate, via the exact
+    // card_pass() call the real match-phase loop makes (same residual/
+    // residual_is_or plumbing) ───
+    let filter = FilterExpr::TextContains { field: super::TextSearchField::OracleTextLower, word: "token".to_string() };
+    let strings = &data.strings;
+
+    let boxed_real = time_ns(|| {
+        let it: Box<dyn Iterator<Item = u32>> = Box::new(ids.iter().copied());
+        let mut residual: Vec<&FilterExpr> = Vec::new();
+        let mut residual_is_or = false;
+        let mut n_match = 0u32;
+        for cid in it {
+            let card = &data.cards[black_box(cid) as usize];
+            if matches!(filter.card_pass(card, strings, &mut residual, &mut residual_is_or), Tri::True) {
+                n_match += 1;
+            }
+        }
+        n_match
+    });
+    let concrete_real = time_ns(|| {
+        let it = ids.iter().copied();
+        let mut residual: Vec<&FilterExpr> = Vec::new();
+        let mut residual_is_or = false;
+        let mut n_match = 0u32;
+        for cid in it {
+            let card = &data.cards[black_box(cid) as usize];
+            if matches!(filter.card_pass(card, strings, &mut residual, &mut residual_is_or), Tri::True) {
+                n_match += 1;
+            }
+        }
+        n_match
+    });
+    println!(
+        "realistic (oracle:token):  boxed={boxed_real:>10.0} ns   concrete={concrete_real:>10.0} ns   ratio={:.2}x   (dispatch overhead ~{:.0} ns/iter)",
+        boxed_real / concrete_real,
+        (boxed_real - concrete_real) / ids.len() as f64,
+    );
+}

--- a/card_engine/src/bench_posting_intersect.rs
+++ b/card_engine/src/bench_posting_intersect.rs
@@ -1,0 +1,158 @@
+//! Micro-benchmark comparing posting-list intersection strategies around the
+//! sparse/dense storage crossover — surfaced while designing
+//! docs/issues/engine-oracle-word-index.md's posting/bitmap crossover
+//! section. Question: for lists *below* the ~6.25% memory-parity crossover
+//! (stored sparse), is there still a case for treating them as bitmaps
+//! purely for intersection speed, and does the shortest-first sequential
+//! filter (today's `intersect_sorted`) want merge or galloping search at
+//! each step?
+//!
+//! Four primitives, all counting-only (no candidate materialization, to
+//! isolate the comparison cost itself):
+//! - `merge_intersect`: classic two-pointer sorted merge, O(a+b).
+//! - `gallop_intersect`: binary-search each element of the shorter list into
+//!   the longer one, O(a log b).
+//! - `bitmap_and_count`: both operands already dense bitmaps, O(n/64) flat,
+//!   independent of density.
+//! - `probe_into_bitmap`: one operand sparse, one already a dense bitmap —
+//!   O(a) with O(1) per probe, no conversion cost paid at all.
+//!
+//! Synthetic sorted id lists (uniform random, no clustering) over a universe
+//! of N=29,088 — this codebase's real oracle-text-corpus scale (distinct
+//! texts by content, matching `oracle.gids.len()`) — swept across sizes and
+//! ratios that bracket the design doc's crossover (1,818 ids, 6.25%).
+//! Synthetic rather than corpus-derived deliberately: this is about mapping
+//! out a cost *curve* across sizes/ratios, not validating one specific query.
+//!
+//!     cargo test --release bench_posting_intersect -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::RngExt;
+
+const N: usize = 29_088;
+const ITERS: usize = 300;
+
+fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+fn random_sorted_list(rng: &mut rand::rngs::SmallRng, universe: usize, size: usize) -> Vec<u32> {
+    let mut set = std::collections::HashSet::with_capacity(size);
+    while set.len() < size {
+        set.insert((rng.random::<u64>() as usize % universe) as u32);
+    }
+    let mut v: Vec<u32> = set.into_iter().collect();
+    v.sort_unstable();
+    v
+}
+
+fn to_bitmap(list: &[u32], universe: usize) -> Vec<u64> {
+    let mut bits = vec![0u64; universe.div_ceil(64)];
+    for &id in list {
+        bits[id as usize / 64] |= 1u64 << (id as usize % 64);
+    }
+    bits
+}
+
+fn merge_intersect(a: &[u32], b: &[u32]) -> u32 {
+    let (mut i, mut j) = (0usize, 0usize);
+    let mut count = 0u32;
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => {
+                count += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    count
+}
+
+fn gallop_intersect(short: &[u32], long: &[u32]) -> u32 {
+    let mut count = 0u32;
+    for &v in short {
+        if long.binary_search(&v).is_ok() {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn bitmap_and_count(a: &[u64], b: &[u64]) -> u32 {
+    a.iter().zip(b.iter()).map(|(&x, &y)| (x & y).count_ones()).sum()
+}
+
+fn probe_into_bitmap(sparse: &[u32], bitmap: &[u64]) -> u32 {
+    let mut count = 0u32;
+    for &id in sparse {
+        let word = bitmap[id as usize / 64];
+        if word & (1u64 << (id as usize % 64)) != 0 {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic data, no external deps"]
+fn bench_posting_intersect_crossover() {
+    let mut rng: rand::rngs::SmallRng = rand::make_rng();
+
+    // (size_a, size_b) pairs bracketing the ~1,818-id (6.25%) crossover:
+    // close-to-crossover/close ratio, close-to-crossover/large ratio, and a
+    // couple of smaller sizes for contrast.
+    let configs: &[(usize, usize)] = &[
+        (200, 200),
+        (200, 1_000),
+        (200, 5_000),
+        (200, 15_000),
+        (1_000, 1_000),
+        (1_000, 2_000),
+        (1_000, 10_000),
+        (1_818, 1_818),
+        (1_818, 3_600),
+        (1_818, 10_000),
+        (1_818, 22_000),
+    ];
+
+    println!("\nN={N}, ITERS={ITERS} (best-of), all times in ns");
+    println!(
+        "{:>6} {:>6}  {:>10} {:>10} {:>10} {:>10}   {:>7}",
+        "a", "b", "merge", "gallop", "bitmap_and", "probe->bm", "winner"
+    );
+
+    for &(a_size, b_size) in configs {
+        let a = random_sorted_list(&mut rng, N, a_size);
+        let b = random_sorted_list(&mut rng, N, b_size);
+        let bitmap_a = to_bitmap(&a, N);
+        let bitmap_b = to_bitmap(&b, N);
+        let (short, long_bitmap) = if a.len() <= b.len() { (&a, &bitmap_b) } else { (&b, &bitmap_a) };
+        let (short_g, long_g) = if a.len() <= b.len() { (a.as_slice(), b.as_slice()) } else { (b.as_slice(), a.as_slice()) };
+
+        let t_merge = time_ns(|| merge_intersect(&a, &b));
+        let t_gallop = time_ns(|| gallop_intersect(short_g, long_g));
+        let t_bitmap = time_ns(|| bitmap_and_count(&bitmap_a, &bitmap_b));
+        let t_probe = time_ns(|| probe_into_bitmap(short, long_bitmap));
+
+        let times = [("merge", t_merge), ("gallop", t_gallop), ("bitmap_and", t_bitmap), ("probe->bm", t_probe)];
+        let winner = times.iter().min_by(|x, y| x.1.partial_cmp(&y.1).unwrap()).unwrap().0;
+
+        println!(
+            "{:>6} {:>6}  {:>10.0} {:>10.0} {:>10.0} {:>10.0}   {:>7}",
+            a_size, b_size, t_merge, t_gallop, t_bitmap, t_probe, winner
+        );
+    }
+}

--- a/card_engine/src/bench_text_search.rs
+++ b/card_engine/src/bench_text_search.rs
@@ -1,0 +1,94 @@
+//! Micro-benchmark for oracle-text substring search: std `str::contains` vs
+//! `memchr::memmem`, one-shot and Finder-reuse, over the real distinct
+//! oracle texts (issue: accelerating `oracle:`/`name:`/`artist:`/`flavor:`
+//! substring search — surfaced while investigating `oracle:token`'s cost).
+//!
+//! Every contender is asserted result-identical against every distinct text
+//! before anything is timed, so the run doubles as a parity check over the
+//! full real-data distribution.
+//!
+//!     cargo test --release bench_text_search -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same archive bench_verify_cost
+//! uses — see that module's doc comment for the one-time build command).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use memchr::memmem;
+use rkyv::Archived;
+
+use super::{archive_header, archive_payload, str_at, CardData, Mmap, ARCHIVE_HEADER_LEN};
+
+const ITERS: usize = 50;
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_text_search_contenders() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as get_mmap() in lib.rs — re-validated below.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+
+    // Distinct oracle texts, first-seen order — same dedup shape the real
+    // oracle trigram index and memoize_text_predicates operate over.
+    let mut seen = std::collections::HashSet::new();
+    let mut texts: Vec<&str> = Vec::new();
+    for card in data.cards.iter() {
+        let gid = u32::from(card.oracle_text_lower_id);
+        if seen.insert(gid) {
+            if let Some(s) = str_at(&data.strings, gid) {
+                texts.push(s);
+            }
+        }
+    }
+    println!("\n{} distinct oracle texts from {STORE_PATH}", texts.len());
+
+    // Needles spanning the range of trigram-selectivity behavior seen in
+    // practice: "token" (declines memoization — its trigrams are nearly as
+    // common as the intersection), a short common word, a longer phrase.
+    let needles = ["token", "draw", "haste", "destroy", "sacrifice a creature"];
+
+    for needle in needles {
+        // Parity check first: all three contenders must agree on every text.
+        let finder = memmem::Finder::new(needle.as_bytes());
+        for &t in &texts {
+            let std_r = t.contains(needle);
+            let oneshot_r = memmem::find(t.as_bytes(), needle.as_bytes()).is_some();
+            let finder_r = finder.find(t.as_bytes()).is_some();
+            assert_eq!(std_r, oneshot_r, "mismatch (one-shot) on {needle:?} vs {t:?}");
+            assert_eq!(std_r, finder_r, "mismatch (finder) on {needle:?} vs {t:?}");
+        }
+
+        let n_std = time_ns(|| texts.iter().filter(|t| t.contains(needle)).count() as u32);
+        let n_oneshot = time_ns(|| texts.iter().filter(|t| memmem::find(t.as_bytes(), needle.as_bytes()).is_some()).count() as u32);
+        let finder = memmem::Finder::new(needle.as_bytes());
+        let n_finder = time_ns(|| texts.iter().filter(|t| finder.find(t.as_bytes()).is_some()).count() as u32);
+
+        println!(
+            "{needle:<24} std={n_std:>10.0} ns  memmem_oneshot={n_oneshot:>10.0} ns ({:.2}x)  memmem_finder={n_finder:>10.0} ns ({:.2}x)",
+            n_std / n_oneshot,
+            n_std / n_finder,
+        );
+    }
+}

--- a/card_engine/src/bench_word_dict_scan.rs
+++ b/card_engine/src/bench_word_dict_scan.rs
@@ -1,0 +1,128 @@
+//! Micro-benchmark for the oracle word dictionary's sparse-tier scan
+//! (docs/issues/engine-oracle-word-index.md): std `str::match_indices` over
+//! the concatenated `sparse_blob` vs. `memchr::memmem::Finder::find_iter`
+//! over the same blob.
+//!
+//! Context: the naive per-word `.contains()` loop (one call per ~6,300
+//! sparse dictionary words) measured as a genuine broad-survey regression —
+//! `.contains()` redoes needle preprocessing on every call, so calling it
+//! thousands of times per query was the actual bottleneck. Concatenating the
+//! dictionary into one NUL-delimited blob and scanning it once with
+//! `match_indices` fixed that (see lib.rs's `scan_oracle_words`). This asks
+//! the next question: does `memchr::memmem` (SIMD first-byte scan + a
+//! Sunday-style skip table) do even better than the standard library's
+//! Two-Way search over that same single long blob — the opposite shape from
+//! `bench_text_search.rs`'s prior finding (memmem lost there, but that
+//! compared many *separate short-haystack* calls, not one long scan).
+//!
+//! Every contender is asserted result-identical (same word indices) before
+//! anything is timed.
+//!
+//!     cargo test --release bench_word_dict_scan -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same archive bench_verify_cost
+//! uses — see that module's doc comment for the one-time build command; note
+//! its layout changed with the oracle word index, so it needs rebuilding on
+//! this branch if it predates that change).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use memchr::memmem;
+use rkyv::Archived;
+
+use super::{archive_header, archive_payload, CardData, Mmap, ARCHIVE_HEADER_LEN};
+
+const ITERS: usize = 50;
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+/// Word indices (deduped, ascending) that contain `needle`, via std
+/// `match_indices` over the blob — the same logic as lib.rs's
+/// `scan_oracle_words`, reimplemented locally so this file has no
+/// dependency on that function's exact form.
+fn matches_std(blob: &str, starts: &[u32], needle: &str) -> Vec<u32> {
+    let mut out = Vec::new();
+    for (pos, _) in blob.match_indices(needle) {
+        let idx = (starts.partition_point(|&s| (s as usize) <= pos) - 1) as u32;
+        if out.last() != Some(&idx) {
+            out.push(idx);
+        }
+    }
+    out
+}
+
+fn matches_memmem(finder: &memmem::Finder, blob: &[u8], starts: &[u32], needle_len: usize) -> Vec<u32> {
+    let mut out = Vec::new();
+    for pos in finder.find_iter(blob) {
+        let _ = needle_len;
+        let idx = (starts.partition_point(|&s| (s as usize) <= pos) - 1) as u32;
+        if out.last() != Some(&idx) {
+            out.push(idx);
+        }
+    }
+    out
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_word_dict_scan_contenders() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as get_mmap() in lib.rs — re-validated below.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let words = &data.indexes.oracle_trigram.words;
+    let blob: &str = words.sparse_blob.as_str();
+    let starts: Vec<u32> = words.sparse_word_starts.iter().map(|s| u32::from(*s)).collect();
+    println!(
+        "\n{} sparse dictionary words, {} byte blob, from {STORE_PATH}",
+        words.sparse_words.len(),
+        blob.len()
+    );
+
+    // Needles spanning the real distribution: a word right at the sparse/dense
+    // crossover boundary ("sacrifice" — common but still sparse), a handful of
+    // ordinary sparse words, and one absent from the dictionary entirely (the
+    // decline path — no allocation should even matter here, but worth timing).
+    let needles = ["sacrifice", "hexproof", "planeswalker", "counter", "zzzznotfound"];
+
+    for needle in needles {
+        let finder = memmem::Finder::new(needle.as_bytes());
+        let std_r = matches_std(blob, &starts, needle);
+        let memmem_r = matches_memmem(&finder, blob.as_bytes(), &starts, needle.len());
+        assert_eq!(std_r, memmem_r, "mismatch on {needle:?}: std={std_r:?} memmem={memmem_r:?}");
+
+        let n_std = time_ns(|| matches_std(blob, &starts, needle).len() as u32);
+        let finder = memmem::Finder::new(needle.as_bytes());
+        let n_memmem = time_ns(|| matches_memmem(&finder, blob.as_bytes(), &starts, needle.len()).len() as u32);
+        let n_memmem_with_setup = time_ns(|| {
+            let f = memmem::Finder::new(needle.as_bytes());
+            matches_memmem(&f, blob.as_bytes(), &starts, needle.len()).len() as u32
+        });
+
+        println!(
+            "{needle:<14} hits={:>4}  std={n_std:>9.0} ns  memmem(reused finder)={n_memmem:>9.0} ns ({:.2}x)  memmem(+setup)={n_memmem_with_setup:>9.0} ns ({:.2}x)",
+            std_r.len(),
+            n_std / n_memmem,
+            n_std / n_memmem_with_setup,
+        );
+    }
+}

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 use serde_json::Value;
-use super::{AOracleCard, APrinting, AStrings, str_at, mana_lane, lane_add, lanes_ge, LANES6_HI, LANES8_HI, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, NameBigramIndex, OracleTextIndex, TrigramIndex, flavor_fingerprint, flavor_match_sets};
+use super::{AOracleCard, APrinting, AStrings, str_at, mana_lane, lane_add, lanes_ge, LANES6_HI, LANES8_HI, mana_pip_counts, mana_cmc, color_list_to_mask, card_type_str_to_bit, trigram_candidates, trigram_min_posting, ARTIST_NONE, NONE_STR, FlavorIndex, NameBigramIndex, OracleTextIndex, SortedTrigramIndex, flavor_fingerprint, flavor_match_sets};
 use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, format_shift};
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
@@ -797,7 +797,7 @@ impl FilterExpr {
         &mut self,
         cards: &[AOracleCard],
         strings: &AStrings,
-        name_trigram: &rkyv::Archived<TrigramIndex>,
+        name_trigram: &rkyv::Archived<SortedTrigramIndex>,
         name_bigrams: &rkyv::Archived<NameBigramIndex>,
         oracle: &rkyv::Archived<OracleTextIndex>,
         eval_domain: usize,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1269,6 +1269,13 @@ fn intersect_operands(ops: Vec<TriOperand>) -> Vec<u32> {
         }
     }
     if postings.is_empty() {
+        // No sparse operand to seed a working set from — every trigram window
+        // landed in the dense tier. Two different shapes get here: a 3-byte
+        // needle (a single window, ordinary whenever that one trigram is
+        // common enough to be dense) and a longer multi-window needle where
+        // every window happens to be a hot trigram (uncommon — a longer
+        // needle usually has at least one rarer window, which is what lets
+        // the sparse-seeded path below narrow well).
         let mut acc = planes.swap_remove(0);
         for p in &planes {
             for (a, b) in acc.iter_mut().zip(p) {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDate, PyDateAccess, PyDict, PyList, PyTuple};
 use rkyv::{Archive, Archived, Deserialize, Serialize};
 use memmap2::Mmap;
+use memchr::memmem;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::io::Write as IoWrite;
@@ -769,7 +770,186 @@ use planes::*;
 
 // ─── Trigram index ────────────────────────────────────────────────────────────
 
-type TrigramIndex = HashMap<[u8; 3], Vec<u32>>;
+/// Two-tier trigram → posting-list index, generic over the id domain it posts
+/// (card ids for `name_trigram`, dense oracle-text ids for
+/// `OracleTextIndex.trigrams`) — `domain` records which, both for the
+/// dense-plane word count and as a build/read compatibility check.
+///
+/// Same #639 crossover this reuses everywhere else: past `words_per_plane(domain)*8`
+/// bytes a plane is smaller *and* faster to probe than a posting list, so build
+/// time buckets each trigram into whichever tier it's cheaper in — never both,
+/// no discriminant per entry (see `NameBigramIndex` for the same split with a
+/// worked rationale). Keys are sorted ascending within each tier so query time
+/// binary-searches instead of hashing; this is also what makes the structure
+/// zero-copy archivable with rkyv, unlike the `HashMap` it replaces.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct SortedTrigramIndex {
+    /// Card id (name index) or dense text id (oracle index) count the
+    /// postings/planes below range over.
+    domain: u32,
+    /// Sorted ascending; parallel to `dense_bits` (each entry is
+    /// `words_per_plane(domain)` words) and `dense_counts`.
+    dense_keys: Vec<[u8; 3]>,
+    /// Match count per dense entry, parallel to `dense_keys` — avoids a
+    /// popcount just to answer trigram_min_posting's size query.
+    dense_counts: Vec<u32>,
+    dense_bits: Vec<u64>,
+    /// Sorted ascending; CSR row `sparse_postings[sparse_offsets[i]..sparse_offsets[i+1]]`.
+    sparse_keys: Vec<[u8; 3]>,
+    sparse_offsets: Vec<u32>,
+    /// u16: both domains (card ids, dense text ids) fit comfortably at this
+    /// corpus size — half the bytes of a u32 posting. `finalize_trigram_index`
+    /// forces every entry dense if `domain` ever doesn't fit, so this never
+    /// silently truncates.
+    sparse_postings: Vec<u16>,
+}
+
+/// Bucket a trigram→postings map into `SortedTrigramIndex`'s two tiers.
+/// `domain` is the id space the postings range over (card count for the name
+/// index, distinct-text count for the oracle index) — both the crossover math
+/// and the u16-fits check key off it.
+fn finalize_trigram_index(map: HashMap<[u8; 3], Vec<u32>>, domain: usize) -> SortedTrigramIndex {
+    let wpp = words_per_plane(domain);
+    let plane_bytes = wpp * 8;
+    let u16_ok = domain <= u16::MAX as usize + 1;
+    let mut entries: Vec<([u8; 3], Vec<u32>)> = map.into_iter().collect();
+    entries.sort_unstable_by_key(|(k, _)| *k);
+
+    let mut idx = SortedTrigramIndex { domain: domain as u32, ..Default::default() };
+    idx.sparse_offsets.push(0);
+    for (key, ids) in entries {
+        if u16_ok && ids.len() * 2 <= plane_bytes {
+            idx.sparse_keys.push(key);
+            idx.sparse_postings.extend(ids.iter().map(|&i| i as u16));
+            idx.sparse_offsets.push(idx.sparse_postings.len() as u32);
+        } else {
+            idx.dense_keys.push(key);
+            idx.dense_counts.push(ids.len() as u32);
+            let base = idx.dense_bits.len();
+            idx.dense_bits.resize(base + wpp, 0);
+            for id in ids {
+                idx.dense_bits[base + (id as usize >> 6)] |= 1u64 << (id & 63);
+            }
+        }
+    }
+    idx
+}
+
+/// Word dictionary + inverted index over distinct oracle texts, for needles
+/// longer than 3 characters that are a single tokenized fragment (no
+/// whitespace/punctuation) — see docs/issues/engine-oracle-word-index.md.
+/// Tokenization boundaries are exactly the characters absent from such a
+/// needle, so any occurrence of the needle lies entirely inside one
+/// tokenized word: scanning the dictionary for words containing it and
+/// unioning their postings is the exact match set, no verification pass.
+///
+/// Needles of length <= 3 don't need an entry here at all: a 3-character
+/// needle IS a trigram, and the existing trigram index's posting list is
+/// already the exact answer for it (no intersection, no ambiguity) — see the
+/// design doc's "3-character case is already solved" section. So this
+/// dictionary only holds words longer than 3 characters.
+///
+/// Two tiers, split by #639's crossover (reused with domain = n_texts, the
+/// same distinct-text count `SortedTrigramIndex`'s oracle instance uses):
+/// - `sparse_*`: below the crossover, postings are ascending dense *text*
+///   ids (like the trigram index) — expanded to cards via the shared CSR at
+///   query time.
+/// - `dense_*`: at/above the crossover, stored as **card-space** bitmaps,
+///   already expanded through the CSR at build time. This is deliberately a
+///   different domain than the sparse tier: the dense tier exists so
+///   `compile_plane` can AND it directly against other card planes with zero
+///   further expansion, and the query-time answer is card space either way,
+///   so there's no reason to also materialize a text-id-space bitmap only to
+///   immediately re-expand it.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct OracleWordIndex {
+    /// Card count the dense tier's bitmaps are sized to — a build/read
+    /// compatibility check, same convention as `NameBigramIndex.n_cards`.
+    n_cards: u32,
+    /// Sorted ascending (for determinism — query-time lookup goes through
+    /// `sparse_blob` below, not this list directly; a word containing the
+    /// needle can land anywhere lexicographically, so it isn't
+    /// binary-searchable on its own).
+    sparse_words: Vec<String>,
+    /// CSR row boundaries into `sparse_postings`, length sparse_words.len()+1.
+    sparse_offsets: Vec<u32>,
+    /// Ascending dense text ids per row. u16: n_texts fits comfortably at
+    /// this corpus size (build forces every word dense if it doesn't).
+    sparse_postings: Vec<u16>,
+    /// `sparse_words` concatenated in order, each preceded by a `\0` byte —
+    /// a byte no tokenized word or eligible query needle ever contains (see
+    /// `oracle_word_eligible`), so a needle match can never straddle two
+    /// words. Query time scans this ONE buffer with `memchr::memmem`
+    /// instead of calling `.contains()` once per dictionary word: calling
+    /// `.contains()` ~6,300 times (once per sparse word, measured against
+    /// the real corpus) redoes substring-search setup on every call — the
+    /// actual bottleneck the naive per-word loop pays — where concatenating
+    /// and scanning once amortizes that setup, and memmem's SIMD scan beats
+    /// std's `match_indices` by 5-6x on this same blob for real dictionary
+    /// sizes (bench_word_dict_scan.rs) — the reverse of the per-card-haystack
+    /// finding in bench_text_search.rs, because this is one long contiguous
+    /// scan rather than many short separate ones. `sparse_word_starts` maps
+    /// a match's byte offset back to a word index by binary search.
+    sparse_blob: String,
+    /// Byte offset of `sparse_words[i]`'s leading `\0` in `sparse_blob`,
+    /// ascending, length sparse_words.len(). A match at position p belongs
+    /// to word `partition_point(|&s| s <= p) - 1`.
+    sparse_word_starts: Vec<u32>,
+    /// Sorted ascending, parallel to a `dense_bits` slice of
+    /// `words_per_plane(n_cards)` words each. Not blobbed: at ~56 entries
+    /// (per the design doc's corpus measurement) a plain loop is already far
+    /// cheaper than the sparse tier's scan ever was.
+    dense_words: Vec<String>,
+    dense_bits: Vec<u64>,
+}
+
+/// Byte that never appears in a tokenized dictionary word or an eligible
+/// query needle (see `oracle_word_eligible`'s `[a-z0-9']` charset) — safe as
+/// a `sparse_blob` word separator with no escaping needed.
+const WORD_BLOB_DELIM: u8 = 0;
+
+/// True for needles the word index can answer exactly: longer than 3 bytes
+/// (see `OracleWordIndex`'s doc) and composed only of tokenizer word bytes
+/// (`[a-z0-9']`) — i.e. a single fragment that can't itself straddle a
+/// tokenization boundary. Multi-word phrases and anything shorter falls
+/// through to the trigram path unchanged.
+fn oracle_word_eligible(word: &str) -> bool {
+    word.len() > 3 && word.bytes().all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'\'')
+}
+
+/// Which dictionary words (by index into their tier) contain `needle` as a
+/// substring — the whole query-time cost of the word index.
+pub(crate) struct OracleWordScan {
+    pub(crate) dense: Vec<u32>,
+    pub(crate) sparse: Vec<u32>,
+}
+
+pub(crate) fn scan_oracle_words(idx: &Archived<OracleWordIndex>, needle: &str) -> OracleWordScan {
+    // Dense tier is tiny (~56 entries in production): a plain per-word loop
+    // costs nothing next to the sparse tier's scan below.
+    let dense = idx.dense_words.iter().enumerate().filter(|(_, w)| w.as_str().contains(needle)).map(|(i, _)| i as u32).collect();
+
+    // Sparse tier: one memchr::memmem pass over the whole concatenated blob
+    // instead of ~6,300 separate `.contains()` calls — see `sparse_blob`'s
+    // doc. memmem measured 5-6x faster here than std `match_indices`
+    // (bench_word_dict_scan.rs, real dictionary blob) — the reverse of
+    // bench_text_search.rs's earlier finding, because this is one long
+    // contiguous scan rather than many separate short-haystack calls (where
+    // memmem's setup cost dominated instead). Matches never straddle a word
+    // (the delimiter can't appear in `needle`), so each hit maps to exactly
+    // one word via a binary search on its start offset; consecutive hits
+    // within the same word (a needle can occur more than once in one word)
+    // collapse to a single push.
+    let mut sparse: Vec<u32> = Vec::new();
+    let blob = idx.sparse_blob.as_str().as_bytes();
+    for pos in memmem::find_iter(blob, needle.as_bytes()) {
+        let word_idx = (idx.sparse_word_starts.partition_point(|s| (u32::from(*s) as usize) <= pos) - 1) as u32;
+        if sparse.last() != Some(&word_idx) {
+            sparse.push(word_idx);
+        }
+    }
+    OracleWordScan { dense, sparse }
+}
 
 /// Oracle-text trigram index, deduplicated by distinct text.
 ///
@@ -783,7 +963,7 @@ type TrigramIndex = HashMap<[u8; 3], Vec<u32>>;
 #[derive(Archive, Serialize, Deserialize, Default)]
 struct OracleTextIndex {
     /// trigram → ascending list of dense text ids whose text contains it.
-    trigrams: TrigramIndex,
+    trigrams: SortedTrigramIndex,
     /// Dense text id → global string id (CardData.strings) of the distinct
     /// lowercase oracle text, in first-seen card order — same shape as
     /// FlavorIndex.gids. Length n_texts.
@@ -794,6 +974,34 @@ struct OracleTextIndex {
     /// All card indices, grouped by text id; every card appears exactly once
     /// (its text interned to exactly one id), so expansion can never duplicate.
     card_indices: Vec<u32>,
+    /// Word dictionary + inverted index, built in the same pass as the
+    /// trigrams above (docs/issues/engine-oracle-word-index.md).
+    words: OracleWordIndex,
+}
+
+/// Emit each maximal run of `[a-z0-9']` bytes at least 4 long in `text`.
+/// Byte-indexed slicing is safe here: every boundary sits on an ASCII byte
+/// (word bytes are all < 0x80, and any non-word byte — including every
+/// continuation/lead byte of a multi-byte UTF-8 sequence, all >= 0x80 —
+/// immediately ends the run), so slice bounds always land on char boundaries.
+fn tokenize_words_ge4(text: &str, mut emit: impl FnMut(&str)) {
+    let is_word_byte = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'\'';
+    let bytes = text.as_bytes();
+    let mut start: Option<usize> = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if is_word_byte(b) {
+            start.get_or_insert(i);
+        } else if let Some(s) = start.take() {
+            if i - s >= 4 {
+                emit(&text[s..i]);
+            }
+        }
+    }
+    if let Some(s) = start {
+        if bytes.len() - s >= 4 {
+            emit(&text[s..]);
+        }
+    }
 }
 
 fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTextIndex {
@@ -815,22 +1023,30 @@ fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTe
         global_of_dense[d as usize] = global;
     }
 
-    // Trigram postings over distinct texts only — the window-sliding loop runs once
-    // per text instead of once per printing. Visiting texts in ascending dense-id
-    // order appends ids in ascending order, giving the sorted posting lists that
-    // intersect_sorted() requires, with no per-list sort.
-    let mut trigrams: TrigramIndex = HashMap::new();
+    // Trigram postings and the word dictionary's postings, over distinct texts
+    // only, in the same window-sliding/tokenizing pass per text (one pass
+    // instead of one for each of trigrams/words). Visiting texts in ascending
+    // dense-id order appends ids in ascending order for both, giving sorted
+    // posting lists with no per-list sort needed.
+    let mut trigrams: HashMap<[u8; 3], Vec<u32>> = HashMap::new();
+    let mut words: HashMap<String, Vec<u32>> = HashMap::new();
     for (d, &global) in global_of_dense.iter().enumerate() {
-        let bytes = strings[global as usize].as_bytes();
-        if bytes.len() < 3 {
-            continue;
+        let text = strings[global as usize].as_str();
+        let bytes = text.as_bytes();
+        if bytes.len() >= 3 {
+            for w in bytes.windows(3) {
+                let list = trigrams.entry([w[0], w[1], w[2]]).or_default();
+                if list.last() != Some(&(d as u32)) {
+                    list.push(d as u32);
+                }
+            }
         }
-        for w in bytes.windows(3) {
-            let list = trigrams.entry([w[0], w[1], w[2]]).or_default();
+        tokenize_words_ge4(text, |word| {
+            let list = words.entry(word.to_string()).or_default();
             if list.last() != Some(&(d as u32)) {
                 list.push(d as u32);
             }
-        }
+        });
     }
 
     // CSR expansion table via counting sort: count cards per text, prefix-sum
@@ -850,7 +1066,49 @@ fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTe
         cursor[t as usize] += 1;
     }
 
-    OracleTextIndex { trigrams, gids: global_of_dense, offsets, card_indices }
+    // Word dictionary split: #639's crossover, reused verbatim with domain =
+    // n_texts (matching SortedTrigramIndex's oracle instance) to decide
+    // sparse-vs-dense, but a promoted word's *stored* bitmap is expanded
+    // through the CSR just built above to card space — see OracleWordIndex's
+    // doc for why.
+    let n_cards = cards.len();
+    let wpp_cards = words_per_plane(n_cards);
+    let wpp_texts = words_per_plane(n_texts);
+    let text_u16_ok = n_texts <= u16::MAX as usize + 1;
+    let mut word_entries: Vec<(String, Vec<u32>)> = words.into_iter().collect();
+    word_entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+    let mut oracle_words = OracleWordIndex { n_cards: n_cards as u32, ..Default::default() };
+    oracle_words.sparse_offsets.push(0);
+    for (word, text_ids) in word_entries {
+        if text_u16_ok && text_ids.len() * 2 <= wpp_texts * 8 {
+            oracle_words.sparse_word_starts.push(oracle_words.sparse_blob.len() as u32);
+            oracle_words.sparse_blob.push(WORD_BLOB_DELIM as char);
+            oracle_words.sparse_blob.push_str(&word);
+            oracle_words.sparse_words.push(word);
+            oracle_words.sparse_postings.extend(text_ids.iter().map(|&t| t as u16));
+            oracle_words.sparse_offsets.push(oracle_words.sparse_postings.len() as u32);
+        } else {
+            let base = oracle_words.dense_bits.len();
+            oracle_words.dense_bits.resize(base + wpp_cards, 0);
+            for t in text_ids {
+                let start = offsets[t as usize] as usize;
+                let end = offsets[t as usize + 1] as usize;
+                for &cid in &card_indices[start..end] {
+                    oracle_words.dense_bits[base + (cid as usize >> 6)] |= 1u64 << (cid & 63);
+                }
+            }
+            oracle_words.dense_words.push(word);
+        }
+    }
+
+    OracleTextIndex {
+        trigrams: finalize_trigram_index(trigrams, n_texts),
+        gids: global_of_dense,
+        offsets,
+        card_indices,
+        words: oracle_words,
+    }
 }
 
 /// Expand surviving dense text ids to card indices via the CSR table.
@@ -935,8 +1193,8 @@ fn build_name_bigram_index(cards: &[OracleCard]) -> NameBigramIndex {
 
 // Named lifetime (not elided/HRTB) so get_text may return text borrowed from the
 // string table rather than from the card itself.
-fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str) -> TrigramIndex {
-    let mut idx: TrigramIndex = HashMap::new();
+fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str) -> SortedTrigramIndex {
+    let mut idx: HashMap<[u8; 3], Vec<u32>> = HashMap::new();
     for (i, card) in rows.iter().enumerate() {
         let text  = get_text(card);
         let bytes = text.as_bytes();
@@ -949,7 +1207,7 @@ fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str
             }
         }
     }
-    idx
+    finalize_trigram_index(idx, rows.len())
 }
 
 // Generic over the second operand's element type so it can walk archived
@@ -969,45 +1227,115 @@ where
     out
 }
 
-fn trigram_candidates(idx: &Archived<TrigramIndex>, word: &str) -> Option<Vec<u32>> {
+/// One trigram's resolved posting, either tier. trigram_min_posting answers
+/// its size bound straight from the index (dense_counts / offsets), without
+/// going through this at all, so there's no reason to carry a count here too.
+enum TriOperand {
+    Posting(Vec<u32>),
+    Plane(Vec<u64>),
+}
+
+fn lookup_trigram(idx: &Archived<SortedTrigramIndex>, key: [u8; 3]) -> Option<TriOperand> {
+    if let Ok(pos) = idx.dense_keys.binary_search(&key) {
+        let wpp = words_per_plane(u32::from(idx.domain) as usize);
+        let start = pos * wpp;
+        let bits = idx.dense_bits[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
+        return Some(TriOperand::Plane(bits));
+    }
+    if let Ok(pos) = idx.sparse_keys.binary_search(&key) {
+        let start = u32::from(idx.sparse_offsets[pos]) as usize;
+        let end = u32::from(idx.sparse_offsets[pos + 1]) as usize;
+        let ids = idx.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))).collect();
+        return Some(TriOperand::Posting(ids));
+    }
+    None
+}
+
+/// Posting-vs-plane dispatch (docs/issues/engine-oracle-word-index.md's
+/// crossover table): posting×posting merges, posting×plane probes the
+/// posting's ids into the plane directly, plane×plane bitmap-ANDs. The
+/// smallest posting seeds the working set (as before this index had a dense
+/// tier at all); every plane operand filters that seed before any remaining
+/// posting merges, since a plane never loses to probing/merging a posting
+/// against it. If every operand is dense (no posting to seed from), AND the
+/// planes together first and bit-scan the result.
+fn intersect_operands(ops: Vec<TriOperand>) -> Vec<u32> {
+    let mut planes: Vec<Vec<u64>> = Vec::new();
+    let mut postings: Vec<Vec<u32>> = Vec::new();
+    for op in ops {
+        match op {
+            TriOperand::Plane(bits) => planes.push(bits),
+            TriOperand::Posting(ids) => postings.push(ids),
+        }
+    }
+    if postings.is_empty() {
+        let mut acc = planes.swap_remove(0);
+        for p in &planes {
+            for (a, b) in acc.iter_mut().zip(p) {
+                *a &= *b;
+            }
+        }
+        return bitmap_card_ids(&acc);
+    }
+    postings.sort_by_key(Vec::len);
+    let mut result = postings.swap_remove(0);
+    for p in &planes {
+        result.retain(|&id| (p[(id >> 6) as usize] >> (id & 63)) & 1 != 0);
+    }
+    for p in &postings {
+        if result.is_empty() {
+            break;
+        }
+        result = intersect_sorted(&result, p.as_slice());
+    }
+    result
+}
+
+fn trigram_candidates(idx: &Archived<SortedTrigramIndex>, word: &str) -> Option<Vec<u32>> {
     let bytes = word.as_bytes();
     if bytes.len() < 3 { return None; }
 
-    let mut lists: Vec<&Archived<Vec<u32>>> = Vec::with_capacity(bytes.len() - 2);
+    let mut seen: Vec<[u8; 3]> = Vec::with_capacity(bytes.len() - 2);
+    let mut ops: Vec<TriOperand> = Vec::with_capacity(bytes.len() - 2);
     for w in bytes.windows(3) {
-        match idx.get(&[w[0], w[1], w[2]]) {
-            Some(list) => lists.push(list),
+        let key = [w[0], w[1], w[2]];
+        // Repeated trigrams (e.g. "aaaa") would otherwise intersect the same
+        // operand against itself for no benefit.
+        if seen.contains(&key) {
+            continue;
+        }
+        seen.push(key);
+        match lookup_trigram(idx, key) {
+            Some(op) => ops.push(op),
             // A trigram absent from the index appears in no card: nothing can match.
             None => return Some(Vec::new()),
         }
     }
-    lists.sort_unstable_by_key(|l| l.len());
-    // Repeated trigrams (e.g. "aaaa") resolve to the same archived entry — drop
-    // the pointer-equal duplicates instead of intersecting them again.
-    lists.dedup_by(|a, b| std::ptr::eq(*a, *b));
-
-    // Posting lists are built sorted (build_trigram_index and the oracle CSR
-    // both append ids in ascending order), so intersection runs directly over
-    // the archived lists; only the shortest one is materialized as the
-    // working set.
-    let mut result: Vec<u32> = lists[0].iter().map(|x| u32::from(*x)).collect();
-    for list in &lists[1..] {
-        if result.is_empty() { break; }
-        result = intersect_sorted(&result, list.as_slice());
-    }
-    Some(result)
+    Some(intersect_operands(ops))
 }
 
-/// Length of the needle's shortest trigram posting list — an upper bound on
+/// Length of the needle's shortest trigram posting/plane — an upper bound on
 /// trigram_candidates()' result size, available without materializing or
 /// intersecting anything. None: needle under 3 bytes (no trigrams).
 /// Some(0): a trigram is absent from the index, so nothing can match.
-fn trigram_min_posting(idx: &Archived<TrigramIndex>, word: &str) -> Option<usize> {
+fn trigram_min_posting(idx: &Archived<SortedTrigramIndex>, word: &str) -> Option<usize> {
     let bytes = word.as_bytes();
     if bytes.len() < 3 {
         return None;
     }
-    bytes.windows(3).map(|w| idx.get(&[w[0], w[1], w[2]]).map_or(0, |l| l.len())).min()
+    bytes
+        .windows(3)
+        .map(|w| {
+            let key = [w[0], w[1], w[2]];
+            if let Ok(pos) = idx.dense_keys.binary_search(&key) {
+                u32::from(idx.dense_counts[pos]) as usize
+            } else if let Ok(pos) = idx.sparse_keys.binary_search(&key) {
+                (u32::from(idx.sparse_offsets[pos + 1]) - u32::from(idx.sparse_offsets[pos])) as usize
+            } else {
+                0
+            }
+        })
+        .min()
 }
 
 fn union_sorted(a: Vec<u32>, b: Vec<u32>) -> Vec<u32> {
@@ -1723,7 +2051,7 @@ fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option
 // carry their space (see Candidates) and convert at combine points.
 #[derive(Archive, Serialize, Deserialize)]
 struct CardIndexes {
-    name_trigram:   TrigramIndex,    // card space
+    name_trigram:   SortedTrigramIndex, // card space
     oracle_trigram: OracleTextIndex, // card space (via dense text ids)
     cmc:            NumericIndex,    // card space
     power:          NumericIndex,    // card space
@@ -1751,7 +2079,7 @@ struct CardIndexes {
 impl Default for CardIndexes {
     fn default() -> Self {
         CardIndexes {
-            name_trigram:   HashMap::new(),
+            name_trigram:   SortedTrigramIndex::default(),
             oracle_trigram: OracleTextIndex::default(),
             cmc:            Vec::new(),
             power:          Vec::new(),
@@ -2258,12 +2586,24 @@ fn narrow_rec(
     // filters were already consumed by split_planes; this catches the ones
     // left inside mixed contexts, where they previously could not narrow at
     // all (an Or with a color child was a guaranteed full scan). True is
-    // excluded: its all-ones bitmap narrows nothing.
-    if !matches!(filter, FilterExpr::True)
+    // excluded: its all-ones bitmap narrows nothing. A lone oracle-word leaf
+    // is excluded too: compile_plane's bonus arm for it is a strict subset of
+    // the dedicated TextContains arm below (same dictionary scan, just also
+    // requiring "no sparse hit" to return a PlaneExpr instead of a Narrowed),
+    // so speculatively trying it here only pays for a second full dictionary
+    // scan on every shape the dedicated arm below was going to handle anyway
+    // — measured (scripts/bench_oracle_word_index.py) as a genuine 2x
+    // regression on `o:token`-shaped queries before this exclusion.
+    let lone_oracle_word_leaf = matches!(
+        filter,
+        FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word } if oracle_word_eligible(word)
+    );
+    if !lone_oracle_word_leaf
+        && !matches!(filter, FilterExpr::True)
         && u32::from(indexes.planes.n_cards) as usize == n_cards
         && n_cards > 0
     {
-        if let Some(pe) = compile_plane(filter, &indexes.planes) {
+        if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words) {
             let mut bits: Vec<u64> = Vec::new();
             eval_planes(&pe, &indexes.planes, &mut bits);
             return Narrowed::tight(Candidates::CardBits(bits));
@@ -2308,6 +2648,53 @@ fn narrow_rec(
                 .get(&bg)
                 .map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(u16::from(*x))).collect());
             Narrowed::tight(Candidates::Cards(ids))
+        }
+
+        FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word }
+            if oracle_word_eligible(word) && u32::from(indexes.oracle_trigram.words.n_cards) as usize == n_cards =>
+        {
+            // Exact, not a superset: every occurrence of `word` lies entirely
+            // inside one tokenized dictionary word (see OracleWordIndex's
+            // doc), so the union of postings for every dictionary word
+            // containing it is precisely the match set — no verification.
+            let words = &indexes.oracle_trigram.words;
+            let scan = scan_oracle_words(words, word);
+            let wpp = words_per_plane(n_cards);
+            let sparse_text_ids = |sparse: &[u32]| -> Vec<u32> {
+                let mut ids: Vec<u32> = Vec::new();
+                for &s in sparse {
+                    let start = u32::from(words.sparse_offsets[s as usize]) as usize;
+                    let end = u32::from(words.sparse_offsets[s as usize + 1]) as usize;
+                    let row: Vec<u32> = words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))).collect();
+                    ids = union_sorted(ids, row);
+                }
+                ids
+            };
+            match (scan.dense.as_slice(), scan.sparse.as_slice()) {
+                ([], []) => Narrowed::tight(Candidates::Cards(Vec::new())),
+                ([], sparse) => {
+                    let text_ids = sparse_text_ids(sparse);
+                    Narrowed::tight(Candidates::Cards(expand_text_ids(&indexes.oracle_trigram, &text_ids)))
+                }
+                ([d], []) => {
+                    let start = *d as usize * wpp;
+                    let bits: Vec<u64> = words.dense_bits[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
+                    Narrowed::tight(Candidates::CardBits(bits))
+                }
+                (dense, sparse) => {
+                    let mut acc = vec![0u64; wpp];
+                    for &d in dense {
+                        let start = d as usize * wpp;
+                        for (a, w) in acc.iter_mut().zip(&words.dense_bits[start..start + wpp]) {
+                            *a |= u64::from(*w);
+                        }
+                    }
+                    for cid in expand_text_ids(&indexes.oracle_trigram, &sparse_text_ids(sparse)) {
+                        acc[(cid >> 6) as usize] |= 1u64 << (cid & 63);
+                    }
+                    Narrowed::tight(Candidates::CardBits(acc))
+                }
+            }
         }
 
         FilterExpr::TextContains { field, word }
@@ -4037,7 +4424,7 @@ impl QueryEngine {
         // rejects pre-plane archives, this is defense in depth.
         let (plane_expr, mut filter_expr) =
             if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
-                split_planes(filter_expr, &data.indexes.planes)
+                split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words)
             } else {
                 (None, filter_expr)
             };
@@ -4174,3 +4561,11 @@ mod tests;
 mod bench_mana;
 #[cfg(test)]
 mod bench_verify_cost;
+#[cfg(test)]
+mod bench_text_search;
+#[cfg(test)]
+mod bench_iter_dispatch;
+#[cfg(test)]
+mod bench_posting_intersect;
+#[cfg(test)]
+mod bench_word_dict_scan;

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -18,9 +18,9 @@
 
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField};
+use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextSearchField};
 use super::legality::{LEGALITY_LEGAL, MAX_FORMATS};
-use super::{flip_op, lane_get, OracleCard};
+use super::{flip_op, lane_get, oracle_word_eligible, scan_oracle_words, OracleCard, OracleWordIndex};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
 /// field (W U B R G C, bit order matching color_to_bit — C is always zero for
@@ -250,6 +250,13 @@ pub(crate) fn build_divergent_ids(cards: &[OracleCard]) -> Vec<u16> {
 /// temporaries.
 pub(crate) enum PlaneExpr {
     Plane(u16),
+    /// An externally-precomputed card bitmap, cloned in whole at compile
+    /// time (docs/issues/engine-oracle-word-index.md's dense word dictionary — see
+    /// compile_plane's TextContains arm). Not part of BitPlanes' fixed
+    /// layout: which words promote to a bitmap is data-dependent, unlike the
+    /// compile-time-known dimensions the other variants index into. A clone
+    /// (a few KB) is paid once per query, never per row.
+    Bits(Vec<u64>),
     And(Vec<PlaneExpr>),
     Or(Vec<PlaneExpr>),
     Not(Box<PlaneExpr>),
@@ -586,24 +593,61 @@ fn contains_unnegatable_numeric(filter: &FilterExpr) -> bool {
 /// PrintingDep, which holds for ColorCmp and TypeCmp by their tri() arms —
 /// and, for NumericCmp on cmc/power/toughness, only when the subtree being
 /// negated doesn't contain one at all (see `contains_unnegatable_numeric`).
-pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>) -> Option<PlaneExpr> {
+/// Sort key for trying And/Or children in compile_plane: oracle-word leaves
+/// (the only shape that pays a real cost — a dictionary scan — just to find
+/// out whether it declines) sort last, so a cheap-to-reject sibling (e.g. a
+/// NumericCmp field compile_numeric_cmp doesn't handle) fails the whole
+/// `.collect::<Option<Vec<_>>>()` before the scan ever runs. Both And and Or
+/// are order-independent once compiled, so reordering only for this internal
+/// short-circuit check never changes the result.
+fn plane_precheck_rank(f: &FilterExpr) -> u8 {
+    match f {
+        FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word } if oracle_word_eligible(word) => 1,
+        _ => 0,
+    }
+}
+
+/// Try children cheapest-to-reject first (see plane_precheck_rank), short-
+/// circuiting on the first None without disturbing the caller's requested
+/// order — `and_of`/`or_of` don't care about member order, so this is free.
+fn compile_plane_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<Vec<PlaneExpr>> {
+    let mut order: Vec<&FilterExpr> = children.iter().collect();
+    order.sort_by_key(|c| plane_precheck_rank(c));
+    order.into_iter().map(|c| compile_plane(c, bounds, words)).collect()
+}
+
+pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::True => Some(PlaneExpr::Const(true)),
-        FilterExpr::And(children) => children
-            .iter()
-            .map(|c| compile_plane(c, bounds))
-            .collect::<Option<Vec<_>>>()
-            .map(and_of),
-        FilterExpr::Or(children) => children
-            .iter()
-            .map(|c| compile_plane(c, bounds))
-            .collect::<Option<Vec<_>>>()
-            .map(or_of),
+        FilterExpr::And(children) => compile_plane_children(children, bounds, words).map(and_of),
+        FilterExpr::Or(children) => compile_plane_children(children, bounds, words).map(or_of),
         FilterExpr::Not(inner) => {
             if contains_unnegatable_numeric(inner) {
                 return None;
             }
-            compile_plane(inner, bounds).map(|p| PlaneExpr::Not(Box::new(p)))
+            compile_plane(inner, bounds, words).map(|p| PlaneExpr::Not(Box::new(p)))
+        }
+        // Bonus consumption (docs/issues/engine-oracle-word-index.md): only
+        // when the needle matches exactly one dictionary word total (dense or
+        // sparse) and that word is dense — the same "single dense hit, no
+        // sparse hits" case narrow_rec's general dispatch handles, just
+        // reached here first so it composes with other planes via And/Or
+        // instead of forcing the whole subtree residual. Any other shape
+        // (multiple hits, or a sparse hit at all) declines: unioning would be
+        // needed, which this bonus arm intentionally doesn't attempt — the
+        // general path in narrow_rec already covers it correctly.
+        FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word }
+            if oracle_word_eligible(word) && u32::from(words.n_cards) == u32::from(bounds.n_cards) =>
+        {
+            let scan = scan_oracle_words(words, word);
+            match (scan.dense.as_slice(), scan.sparse.as_slice()) {
+                ([d], []) => {
+                    let wpp = words_per_plane(u32::from(words.n_cards) as usize);
+                    let start = *d as usize * wpp;
+                    Some(PlaneExpr::Bits(words.dense_bits[start..start + wpp].iter().map(|w| u64::from(*w)).collect()))
+                }
+                _ => None,
+            }
         }
         FilterExpr::ColorCmp { field, op, mask } => {
             let base = match field {
@@ -648,11 +692,11 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
 /// narrowing mask, so a partially compilable Or stays entirely residual.
 /// A bare True is left alone — the full-range scan beats materializing an
 /// all-ones bitmap into a candidate list.
-pub(crate) fn split_planes(filter: FilterExpr, bounds: &rkyv::Archived<BitPlanes>) -> (Option<PlaneExpr>, FilterExpr) {
+pub(crate) fn split_planes(filter: FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> (Option<PlaneExpr>, FilterExpr) {
     if matches!(filter, FilterExpr::True) {
         return (None, filter);
     }
-    if let Some(pe) = compile_plane(&filter, bounds) {
+    if let Some(pe) = compile_plane(&filter, bounds, words) {
         return (Some(pe), FilterExpr::True);
     }
     match filter {
@@ -660,7 +704,7 @@ pub(crate) fn split_planes(filter: FilterExpr, bounds: &rkyv::Archived<BitPlanes
             let mut planes: Vec<PlaneExpr> = Vec::new();
             let mut rest: Vec<FilterExpr> = Vec::new();
             for c in children {
-                match compile_plane(&c, bounds) {
+                match compile_plane(&c, bounds, words) {
                     Some(pe) => planes.push(pe),
                     None => rest.push(c),
                 }
@@ -685,6 +729,7 @@ impl PlaneExpr {
     fn eval_word(&self, words: &rkyv::Archived<Vec<u64>>, wpp: usize, i: usize) -> u64 {
         match self {
             PlaneExpr::Plane(p) => u64::from(words[*p as usize * wpp + i]),
+            PlaneExpr::Bits(bits) => bits[i],
             PlaneExpr::And(children) => {
                 let mut acc = !0u64;
                 for c in children {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,11 +5,11 @@ use super::{
     build_artwork_group_counts, build_bit_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
-    range_too_broad_to_narrow, run_query, trigram_candidates, PrintingRangeIndex, NARROW_FLOOR,
-    bitmap_contains, compile_plane, eval_planes, split_planes,
+    range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
+    bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
-    TextField, TextSearchField, Tri, TrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
+    TextField, TextSearchField, Tri, SortedTrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
     TYPE_ENCHANTMENT, TYPE_INSTANT, TYPE_LAND, TYPE_LEGENDARY, TYPE_PLANESWALKER, TYPE_SNOW, TYPE_SORCERY,
 };
 use rkyv::{rancor::Error, Archived};
@@ -31,9 +31,16 @@ fn vocab_ids(vocab: &mut VocabInterner, items: &[&str]) -> Vec<u16> {
     ids
 }
 
-/// Build a TrigramIndex mapping each word's trigrams to the given card ids.
-fn index_of(words: &[(&str, &[u32])]) -> TrigramIndex {
-    let mut idx: TrigramIndex = HashMap::new();
+/// Build a SortedTrigramIndex mapping each word's trigrams to the given card
+/// ids. Domain is a large fixed constant so tiny test posting lists never
+/// cross into the dense tier by accident — tests that specifically want the
+/// dense/plane path use `index_of_domain` with a small domain instead.
+fn index_of(words: &[(&str, &[u32])]) -> SortedTrigramIndex {
+    index_of_domain(words, 100_000)
+}
+
+fn index_of_domain(words: &[(&str, &[u32])], domain: usize) -> SortedTrigramIndex {
+    let mut idx: HashMap<[u8; 3], Vec<u32>> = HashMap::new();
     for (word, cards) in words {
         for w in word.as_bytes().windows(3) {
             let entry = idx.entry([w[0], w[1], w[2]]).or_default();
@@ -43,13 +50,13 @@ fn index_of(words: &[(&str, &[u32])]) -> TrigramIndex {
             entry.sort_unstable();
         }
     }
-    idx
+    finalize_trigram_index(idx, domain)
 }
 
 /// Archive the index and query it, matching how the engine reads the shared snapshot.
-fn candidates(idx: &TrigramIndex, word: &str) -> Option<Vec<u32>> {
+fn candidates(idx: &SortedTrigramIndex, word: &str) -> Option<Vec<u32>> {
     let bytes = rkyv::to_bytes::<Error>(idx).expect("serialize trigram index");
-    let archived = rkyv::access::<Archived<TrigramIndex>, Error>(&bytes).expect("access trigram index");
+    let archived = rkyv::access::<Archived<SortedTrigramIndex>, Error>(&bytes).expect("access trigram index");
     trigram_candidates(archived, word)
 }
 
@@ -1294,7 +1301,7 @@ fn popcount_skip_tie_breaking_preserves_group_order_both_directions() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes);
+    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
     assert!(matches!(residual, FilterExpr::True), "t:creature must fully plane-consume");
 
     let mut run = |direction: &str| {
@@ -1332,7 +1339,7 @@ fn popcount_skip_offset_lands_inside_tied_group() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes);
+    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
 
     // Full ascending order is [card3, card1, card0, card2, card4] (oracle ids
     // [4,2,1,3,5]); offset=2 must skip card3 and card1, landing on card0.
@@ -1365,7 +1372,7 @@ fn popcount_skip_matches_non_popcount_path() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual_true) = split_planes(creature, &archived.indexes.planes);
+    let (plane, mut residual_true) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
     assert!(matches!(residual_true, FilterExpr::True));
 
     // Popcount path: plane present, residual True.
@@ -1704,7 +1711,7 @@ fn plane_parity_color_and_type_ops() {
 
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check = |f: &FilterExpr| {
-        let pe = compile_plane(f, &archived.indexes.planes).expect("filter must be plane-expressible");
+        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).expect("filter must be plane-expressible");
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -1750,7 +1757,7 @@ fn plane_fallaji_colors_not_subset_of_identity() {
     let mut bitmap: Vec<u64> = Vec::new();
     let mut matches = |field: ColorField, op: CmpOp, mask: u8| {
         let f = FilterExpr::ColorCmp { field, op, mask };
-        eval_planes(&compile_plane(&f, &archived.indexes.planes).unwrap(), &archived.indexes.planes, &mut bitmap);
+        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).unwrap(), &archived.indexes.planes, &mut bitmap);
         bitmap_contains(&bitmap, FALLAJI_CID as u32)
     };
     assert!(matches(ColorField::Colors, CmpOp::Ge, 1)); // c>=W: colors carry W
@@ -1767,38 +1774,39 @@ fn split_planes_composition_rules() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
 
     let green = || FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 16 };
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
     let text = || FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
 
     // And(plane, plane, text): planes consumed, the lone leftover unwraps.
-    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]), bounds);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]), bounds, words);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::TextContains { .. }));
 
     // Fully plane-expressible tree is consumed whole.
-    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]), bounds);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]), bounds, words);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
-    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]), bounds);
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]), bounds, words);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
 
     // Or mixing plane and non-plane children stays entirely residual:
     // mask ∨ residual is not a narrowing mask.
-    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]), bounds);
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]), bounds, words);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::Or(ref v) if v.len() == 2));
 
     // Produced mana is deliberately unplaned in phase 1.
     let produces = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 16 };
-    let (pe, residual) = split_planes(produces, bounds);
+    let (pe, residual) = split_planes(produces, bounds, words);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::ColorCmp { field: ColorField::ProducedMana, .. }));
 
     // Bare True keeps the range-scan path (no all-ones bitmap materialization).
-    let (pe, residual) = split_planes(FilterExpr::True, bounds);
+    let (pe, residual) = split_planes(FilterExpr::True, bounds, words);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::True));
 }
@@ -1835,7 +1843,7 @@ fn run_query_plane_path_parity() {
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes);
+            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -1896,7 +1904,7 @@ fn numeric_plane_parity_interior_and_tails() {
 
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check = |f: &FilterExpr, label: &str| {
-        let Some(pe) = compile_plane(f, &archived.indexes.planes) else { return };
+        let Some(pe) = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words) else { return };
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -1946,22 +1954,23 @@ fn numeric_plane_boundary_inclusion_and_decline() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
 
     let cmp = |field, op, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(field), op, rhs: NumExpr::Const(v) };
 
     // Crosses into the high tail, but includes BOTH high-tail values (13, 14)
     // fully — unambiguous, since every possible bucket member qualifies.
-    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Le, 14.0), bounds).is_some());
+    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Le, 14.0), bounds, words).is_some());
     // Crosses into the low tail: power>=-1 must include the power=-1 card.
-    assert!(compile_plane(&cmp(NumField::Power, CmpOp::Ge, -1.0), bounds).is_some());
+    assert!(compile_plane(&cmp(NumField::Power, CmpOp::Ge, -1.0), bounds, words).is_some());
     // Entirely within the interior: no bucket involved at all.
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Le, 6.0), bounds).is_some());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Le, 6.0), bounds, words).is_some());
 
     // Distinguishing inside the high tail bucket (which now holds two
     // distinct values each) can't be answered by the cumulative plane alone.
-    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds).is_none());
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds).is_none());
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds).is_none());
+    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds, words).is_none());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds, words).is_none());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds, words).is_none());
 }
 
 // Ne is declined unconditionally, matching numeric_candidates' own choice
@@ -1973,9 +1982,10 @@ fn numeric_plane_declines_ne_unconditionally() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
     for field in [NumField::Cmc, NumField::Power, NumField::Toughness] {
         let ne = FilterExpr::NumericCmp { lhs: NumExpr::Field(field), op: CmpOp::Ne, rhs: NumExpr::Const(3.0) };
-        assert!(compile_plane(&ne, bounds).is_none());
+        assert!(compile_plane(&ne, bounds, words).is_none());
     }
 }
 
@@ -1990,21 +2000,22 @@ fn numeric_plane_declines_not_over_numeric_cmp() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
 
     let power_gt3 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Power), op: CmpOp::Gt, rhs: NumExpr::Const(3.0) };
-    assert!(compile_plane(&power_gt3, bounds).is_some(), "power>3 alone must compile");
+    assert!(compile_plane(&power_gt3, bounds, words).is_some(), "power>3 alone must compile");
     let make_negated = || FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
         lhs: NumExpr::Field(NumField::Power),
         op: CmpOp::Gt,
         rhs: NumExpr::Const(3.0),
     }));
-    assert!(compile_plane(&make_negated(), bounds).is_none(), "Not(power>3) must decline: Null doesn't flip to True");
+    assert!(compile_plane(&make_negated(), bounds, words).is_none(), "Not(power>3) must decline: Null doesn't flip to True");
 
     // Buried under And/Or, not just at the top.
     let buried_and = FilterExpr::And(vec![make_negated(), FilterExpr::True]);
-    assert!(compile_plane(&buried_and, bounds).is_none());
+    assert!(compile_plane(&buried_and, bounds, words).is_none());
     let buried_or = FilterExpr::Or(vec![make_negated(), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }]);
-    assert!(compile_plane(&buried_or, bounds).is_none());
+    assert!(compile_plane(&buried_or, bounds, words).is_none());
 
     // cmc is Option<u8> (never negative) but can still be unset on odd data,
     // so the guard applies uniformly across all three fields, not just the
@@ -2014,12 +2025,12 @@ fn numeric_plane_declines_not_over_numeric_cmp() {
         op: CmpOp::Le,
         rhs: NumExpr::Const(6.0),
     }));
-    assert!(compile_plane(&cmc_le6(), bounds).is_none());
+    assert!(compile_plane(&cmc_le6(), bounds, words).is_none());
 
     // A Not over a non-numeric plane child must still compile fine — the
     // guard must not over-decline unrelated Not subtrees.
     let not_creature = FilterExpr::Not(Box::new(FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }));
-    assert!(compile_plane(&not_creature, bounds).is_some());
+    assert!(compile_plane(&not_creature, bounds, words).is_some());
 }
 
 // End-to-end: run_query through the numeric-plane path (split_planes consumes
@@ -2049,7 +2060,7 @@ fn run_query_numeric_plane_path_parity() {
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes);
+            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -2074,7 +2085,7 @@ fn numeric_plane_enables_all_match_promotion() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let cmc_le12 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Le, rhs: NumExpr::Const(12.0) };
-    let (pe, residual) = split_planes(cmc_le12, &archived.indexes.planes);
+    let (pe, residual) = split_planes(cmc_le12, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
     assert!(pe.is_some(), "cmc<=12 must plane-compile");
     assert!(matches!(residual, FilterExpr::True), "cmc<=12 must fully consume: no residual card_pass needed");
 }
@@ -2231,6 +2242,190 @@ fn oracle_match_none_str_mirrors_text_contains() {
     let plain = FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
     assert!(memoized.eval_card(&archived.cards[0], &archived.strings) == Tri::Null);
     assert!(plain.eval_card(&archived.cards[0], &archived.strings) == Tri::Null);
+}
+
+// ─── Oracle word index (docs/issues/engine-oracle-word-index.md) ────────────
+
+/// 17 distinct oracle texts (n_texts=17, so words_per_plane=1 and the #639
+/// crossover is "dense iff a word's own text count exceeds 4"), deliberately
+/// engineered so a single `oracle:` needle can exercise every cell of the
+/// query-time dispatch:
+/// - "target": word "target" alone contains it (5 texts, dense) and no other
+///   dictionary word does — the single-dense-hit, no-sparse-hit shape.
+/// - "creature": word "creature" (9 texts, dense) plus "creaturehood" (1
+///   text, sparse) both contain it — the mixed dense+sparse shape.
+/// - "cast": "cast"/"recast"/"broadcast" (1 text each, all sparse) all
+///   contain it — the dense-empty, multi-sparse-hit shape.
+/// - "zzzzz": nothing contains it — the both-empty shape.
+fn oracle_word_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let texts: &[&str] = &[
+        "this creature has flying",
+        "this creature has trample",
+        "when this creature enters draw a card",
+        "sacrifice a creature gain 1 life",
+        "target creature gets plus one plus one",
+        "destroy target creature",
+        "return target creature to owner hand",
+        "counter target creature spell",
+        "create a token",
+        "create two tokens",
+        "create a token thats a copy",
+        "exile target artifact or creature",
+        "cast this spell only during combat",
+        "you may recast spells",
+        "broadcast a signal to allies",
+        "vanilla bear with no text",
+        "no true creaturehood exists",
+    ];
+    let cards: Vec<OracleCard> = texts
+        .iter()
+        .enumerate()
+        .map(|(i, text)| {
+            let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+            c.oracle_text_lower_id = interner.intern(text.to_string());
+            c
+        })
+        .collect();
+    let mut data = store_of(cards, &[1usize; 17], vocab);
+    data.strings = interner.strings;
+    data.indexes.oracle_trigram = build_oracle_text_index(&data.cards, &data.strings);
+    data
+}
+
+/// Brute-force `oracle:<needle>` over every card, for differential comparison.
+fn brute_force_oracle_contains(archived: &Archived<CardData>, needle: &str) -> Vec<u32> {
+    (0..archived.cards.len() as u32)
+        .filter(|&cid| archived.strings[u32::from(archived.cards[cid as usize].oracle_text_lower_id) as usize].as_str().contains(needle))
+        .collect()
+}
+
+// Every eligible needle (len > 3, no token-boundary bytes) must narrow to the
+// exact brute-force match set, tight — no verification pass, matching the
+// design doc's exactness argument.
+#[test]
+fn oracle_word_index_exact_union_parity() {
+    let data = oracle_word_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
+    let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
+
+    for needle in ["target", "creature", "cast", "zzzzz"] {
+        let expected = brute_force_oracle_contains(archived, needle);
+        let n = rec(&oracle(needle)).unwrap_or_else(|| panic!("oracle:{needle} must narrow"));
+        assert!(n.tight, "oracle:{needle} must narrow tight (exact, no verification)");
+        assert_eq!(n.set.into_cards(&archived.offsets), expected, "oracle:{needle} must match the brute-force set exactly");
+    }
+}
+
+// Pins the specific representation each needle takes, so a future change that
+// silently falls back to a superset (losing exactness) or picks the wrong
+// tier fails loudly here instead of only in the parity test above.
+#[test]
+fn oracle_word_index_dispatch_shapes() {
+    let data = oracle_word_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
+    let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
+
+    // Single dense hit, no sparse hit: the dense word's bitmap comes back
+    // directly, no allocation-and-scatter round trip.
+    match rec(&oracle("target")).expect("must narrow").set {
+        Candidates::CardBits(_) => {}
+        other => panic!("single dense hit must return CardBits directly, got {other:?}", other = std::mem::discriminant(&other)),
+    }
+    // Dense-empty, sparse hits only: a plain sorted-merge union, no bitmap
+    // touched at all.
+    match rec(&oracle("cast")).expect("must narrow").set {
+        Candidates::Cards(_) => {}
+        other => panic!("sparse-only hits must stay a Cards vec, got {other:?}", other = std::mem::discriminant(&other)),
+    }
+    // Both empty: the empty set is exact (no card can contain a needle no
+    // dictionary word contains), not a decline.
+    match rec(&oracle("zzzzz")).expect("empty is still exact narrowing").set {
+        Candidates::Cards(v) => assert!(v.is_empty()),
+        other => panic!("no-hit shape must be an empty Cards vec, got {other:?}", other = std::mem::discriminant(&other)),
+    }
+    // Mixed dense+sparse: scratch bitmap, OR the dense hit in, scatter the
+    // expanded sparse hit on top.
+    match rec(&oracle("creature")).expect("must narrow").set {
+        Candidates::CardBits(_) => {}
+        other => panic!("mixed dense+sparse must return CardBits, got {other:?}", other = std::mem::discriminant(&other)),
+    }
+}
+
+// compile_plane's bonus arm only fires for the single-dense-hit shape (needed
+// for correctness — a mixed shape's dense bitmap alone would undercount) and,
+// when it does, composes with an unrelated plane predicate via a plain AND —
+// exercising PlaneExpr::Bits directly instead of just the standalone
+// narrow_rec path above.
+#[test]
+fn compile_plane_word_bonus_composes_with_other_planes() {
+    let data = oracle_word_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+    let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
+
+    // Single-dense-hit needle: compile_plane must consume it directly.
+    assert!(compile_plane(&oracle("target"), bounds, words).is_some(), "single dense hit must compile to a plane");
+    // Mixed dense+sparse needle: compile_plane must decline (the dense bitmap
+    // alone would miss the sparse "creaturehood" match) — narrow_rec's
+    // general dispatch is the only correct path for this shape.
+    assert!(compile_plane(&oracle("creature"), bounds, words).is_none(), "mixed dense+sparse must not compile: dense bitmap alone would undercount");
+
+    // AND with an unrelated plane-expressible predicate (every card here is a
+    // creature, so this is a true tautological AND, just exercising composition).
+    let creature_type = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let both = FilterExpr::And(vec![oracle("target"), creature_type]);
+    let pe = compile_plane(&both, bounds, words).expect("dense word AND a plane predicate must compile whole");
+    let mut bitmap: Vec<u64> = Vec::new();
+    eval_planes(&pe, bounds, &mut bitmap);
+    assert_eq!(bitmap_card_ids(&bitmap), brute_force_oracle_contains(archived, "target"), "every card here is a creature, so the AND changes nothing");
+}
+
+// SortedTrigramIndex's posting-vs-plane dispatch (merge/probe/AND), forced
+// through every combination by picking a domain small enough that some
+// trigrams promote to the dense tier and some don't.
+#[test]
+fn trigram_dense_sparse_dispatch_parity() {
+    // Domain 40: words_per_plane(40)=1, plane_bytes=8, dense iff count > 4.
+    let domain = 40usize;
+    // "aaa": 6 ids (dense). "bbb": 6 ids, same 6 ids as "aaa" (dense x dense,
+    // AND path). "ccc": 2 ids, subset of aaa's (sparse x dense, probe path).
+    // "ddd": 2 ids disjoint from "ccc" (sparse x sparse, merge path — already
+    // covered elsewhere, included here for completeness).
+    let mut idx: HashMap<[u8; 3], Vec<u32>> = HashMap::new();
+    idx.insert(*b"aaa", vec![1, 2, 3, 4, 5, 6]);
+    idx.insert(*b"bbb", vec![1, 2, 3, 4, 5, 6]);
+    idx.insert(*b"ccc", vec![2, 4]);
+    idx.insert(*b"ddd", vec![7, 8]);
+    let finalized = super::finalize_trigram_index(idx, domain);
+    let bytes = rkyv::to_bytes::<Error>(&finalized).expect("serialize");
+    let archived = rkyv::access::<Archived<SortedTrigramIndex>, Error>(&bytes).expect("access");
+
+    // "aaabbb": trigrams aaa, aab(absent -> empty), ... — use a needle whose
+    // trigrams are exactly {aaa, bbb} minus the absent middle ones isn't
+    // possible with real sliding windows, so exercise the dispatch directly
+    // through needles built to hit exactly the desired trigram pairs.
+    assert_eq!(trigram_candidates(archived, "aaa").unwrap(), vec![1, 2, 3, 4, 5, 6], "single dense trigram: bitmap bit-scanned back to ids");
+    assert_eq!(super::trigram_min_posting(archived, "aaa"), Some(6));
+    assert_eq!(super::trigram_min_posting(archived, "ccc"), Some(2));
+
+    // ccc's sparse posting [2,4] probed against aaa's dense plane: both 2 and
+    // 4 are set, so the probe keeps everything — same answer as a merge would
+    // give, but taken through the posting-vs-plane path.
+    let ops = vec![super::lookup_trigram(archived, *b"aaa").unwrap(), super::lookup_trigram(archived, *b"ccc").unwrap()];
+    assert_eq!(super::intersect_operands(ops), vec![2, 4], "posting seed probed against a plane operand");
+
+    // aaa AND bbb (both dense, identical bitmaps): plane x plane AND path,
+    // with no posting to seed from at all.
+    let ops = vec![super::lookup_trigram(archived, *b"aaa").unwrap(), super::lookup_trigram(archived, *b"bbb").unwrap()];
+    assert_eq!(super::intersect_operands(ops), vec![1, 2, 3, 4, 5, 6], "plane x plane AND path, no posting seed available");
 }
 
 // ─── Adaptive candidate sets (#636) ───────────────────────────────────────────
@@ -2746,7 +2941,7 @@ fn devotion_plane_parity_and_boundaries() {
     let dev = |op, pips: &[(&str, u8)]| FilterExpr::Devotion { op, pips: packed_pips(pips) };
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check_exact = |f: &FilterExpr| {
-        let pe = compile_plane(f, &archived.indexes.planes).expect("must compile exactly");
+        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).expect("must compile exactly");
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -2764,9 +2959,9 @@ fn devotion_plane_parity_and_boundaries() {
     check_exact(&dev(CmpOp::Ge, &[("R", 3)])); // {R/G}{R/G}{R} card reaches R=3
 
     // Past the saturation boundary the exact compiler declines...
-    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)]), &archived.indexes.planes).is_none());
-    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)]), &archived.indexes.planes).is_none());
-    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)]), &archived.indexes.planes).is_none());
+    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words).is_none());
+    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words).is_none());
+    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words).is_none());
     // ...and the saturated superset covers every deep match for narrowing.
     let deep = dev(CmpOp::Ge, &[("U", 5)]);
     let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, &archived.cards, false).expect("deep-k narrows loosely");
@@ -2790,7 +2985,7 @@ fn hybrid_pip_counts_toward_both_colors() {
     let mut bitmap: Vec<u64> = Vec::new();
     let rg_card = 5; // {R/G}
     for (f, want) in [(dev("R", 1), true), (dev("G", 1), true), (dev("R", 2), false), (dev("U", 1), false)] {
-        eval_planes(&compile_plane(&f, &archived.indexes.planes).unwrap(), &archived.indexes.planes, &mut bitmap);
+        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).unwrap(), &archived.indexes.planes, &mut bitmap);
         assert_eq!(bitmap_contains(&bitmap, rg_card), want);
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2294,6 +2294,40 @@ fn oracle_word_fixture_store() -> CardData {
     data
 }
 
+/// 6 distinct texts (n_texts=6, words_per_plane=1, dense iff a word's own
+/// text count exceeds 4) engineered so a single needle has TWO dense hits and
+/// ZERO sparse hits: "wordone" and "wordtwo" each appear in 5 of the 6 texts,
+/// and both contain "word" as a substring, with no other dictionary word
+/// containing it. This is the one dispatch shape oracle_word_fixture_store
+/// doesn't produce — "creature" there mixes one dense hit with one sparse hit
+/// ("creaturehood"), never two-or-more dense hits alone — even though both
+/// land in the same catch-all match arm in narrow_rec.
+fn oracle_word_multi_dense_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let texts: &[&str] = &[
+        "wordone wordtwo alpha",
+        "wordone wordtwo beta",
+        "wordone wordtwo gamma",
+        "wordone wordtwo delta",
+        "wordone wordtwo epsilon",
+        "nothing relevant here",
+    ];
+    let cards: Vec<OracleCard> = texts
+        .iter()
+        .enumerate()
+        .map(|(i, text)| {
+            let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+            c.oracle_text_lower_id = interner.intern(text.to_string());
+            c
+        })
+        .collect();
+    let mut data = store_of(cards, &[1usize; 6], vocab);
+    data.strings = interner.strings;
+    data.indexes.oracle_trigram = build_oracle_text_index(&data.cards, &data.strings);
+    data
+}
+
 /// Brute-force `oracle:<needle>` over every card, for differential comparison.
 fn brute_force_oracle_contains(archived: &Archived<CardData>, needle: &str) -> Vec<u32> {
     (0..archived.cards.len() as u32)
@@ -2355,6 +2389,29 @@ fn oracle_word_index_dispatch_shapes() {
         Candidates::CardBits(_) => {}
         other => panic!("mixed dense+sparse must return CardBits, got {other:?}", other = std::mem::discriminant(&other)),
     }
+}
+
+// Two-or-more dense hits with zero sparse hits lands in the same catch-all
+// match arm as "mixed dense+sparse" above, but oracle_word_fixture_store never
+// produces that exact shape (its only multi-hit needle, "creature", always
+// pairs a dense hit with a sparse one) — so this pins it with a dedicated
+// fixture, both for exactness and for the CardBits representation.
+#[test]
+fn oracle_word_index_multi_dense_no_sparse() {
+    let data = oracle_word_multi_dense_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
+    let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
+
+    let expected = brute_force_oracle_contains(archived, "word");
+    let n = rec(&oracle("word")).expect("oracle:word must narrow");
+    assert!(n.tight, "oracle:word must narrow tight (exact, no verification)");
+    match &n.set {
+        Candidates::CardBits(_) => {}
+        other => panic!("2+ dense hits, no sparse, must return CardBits, got {other:?}", other = std::mem::discriminant(other)),
+    }
+    assert_eq!(n.set.into_cards(&archived.offsets), expected, "oracle:word must match the brute-force set exactly");
 }
 
 // compile_plane's bonus arm only fires for the single-dense-hit shape (needed

--- a/scripts/bench_oracle_word_index.py
+++ b/scripts/bench_oracle_word_index.py
@@ -1,0 +1,122 @@
+"""Engine-vs-engine benchmark for the oracle word index (docs/issues/engine-oracle-word-index.md).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export, so the same
+script run on two builds (main baseline vs. this branch) produces directly comparable CSVs.
+No SQL side, no Docker: build the engine locally (`maturin develop --release -m card_engine/Cargo.toml`)
+and run:
+
+    .venv/bin/python scripts/bench_oracle_word_index.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/oracle-word-index/baseline-main.csv
+
+Reuses the same corpus JSONL bench_bitplanes.py uses (ENGINE_COLUMNS/schema is unaffected by
+this change, so there's no need to re-export from the blue DB).
+
+The `total` column doubles as a parity check: it must be identical across builds for every
+config, or the comparison is void.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Motivating single-word needles from the design doc: common enough that
+    # trigram narrowing barely narrows (each constituent trigram 70%+ dense),
+    # so today's engine declines memoization and falls back to a full contains()
+    # scan. The word index should resolve these exactly and cheaply instead.
+    ("single-word", "o:token", "card", "edhrec", "default"),
+    ("single-word", "o:creature", "card", "edhrec", "default"),
+    ("single-word", "o:target", "card", "edhrec", "default"),
+    ("single-word", "o:this", "card", "edhrec", "default"),
+    ("single-word", "o:control", "card", "edhrec", "default"),
+    ("single-word", "o:whenever", "card", "edhrec", "default"),
+    ("single-word", "o:sacrifice", "card", "edhrec", "default"),
+    ("single-word", "o:flying", "card", "edhrec", "default"),
+    # Less common single words: already reasonably narrowed by trigrams today,
+    # must not regress.
+    ("single-word-narrow", "o:hexproof", "card", "edhrec", "default"),
+    ("single-word-narrow", "o:planeswalker", "card", "edhrec", "default"),
+    # Or-combos where an unindexable/broad sibling used to void narrowing for
+    # the whole node (#624's motivating shape) — the oracle child should now
+    # resolve exactly regardless of the sibling.
+    ("or-combo", "o:draw or cn:100", "card", "edhrec", "default"),
+    ("or-combo", "o:token or name:storm", "card", "edhrec", "default"),
+    ("or-combo", "o:creature or frame:showcase", "card", "edhrec", "default"),
+    # And-combos: word-index result composing with other narrowing/plane paths.
+    ("and-combo", "o:creature t:artifact", "card", "edhrec", "default"),
+    ("and-combo", "o:target c:g", "card", "edhrec", "default"),
+    ("and-combo", "o:flying keyword:flying", "card", "edhrec", "default"),
+    # Scope limits that must fall through unchanged: multi-word phrases (span
+    # tokenization boundaries) and needles <=3 chars (trigram-exact already).
+    ("phrase-fallthrough", 'o:"sacrifice a creature"', "card", "edhrec", "default"),
+    ("phrase-fallthrough", 'o:"draw a card"', "card", "edhrec", "default"),
+    ("short-fallthrough", "o:cat", "card", "edhrec", "default"),
+    ("short-fallthrough", "o:fly", "card", "edhrec", "default"),
+    # Selective controls: unrelated to oracle text, must not regress.
+    ("control", "name:soldier", "card", "edhrec", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+    ("control", "power>4", "card", "power", "default"),
+    ("control", "t:creature c:g", "card", "edhrec", "default"),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--", "card_engine/src"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        rev += "-dirty"
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    # parse_scryfall_query is imported to fail fast on a syntax error in a
+    # CONFIGS entry before spending time on the run below.
+    for _, query, _, _, _ in CONFIGS:
+        parse_scryfall_query(query)
+
+    hdr = f"{'group':<20} {'query':<28} {'unique':<9} {'orderby':<8} {'prefer':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<20} {query:<28} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Single-word `oracle:` needles longer than 3 characters (`o:creature`, `o:token`) now resolve exactly through a word dictionary + inverted index instead of trigram narrowing plus a per-candidate `contains()` verification pass: tokenization boundaries are exactly the characters such a needle can't contain, so the union of every dictionary word containing it is provably the full match set — no verification ever needed. Common words (~56 in production) are stored as precomputed card bitmaps and compose directly with `compile_plane`'s existing AND machinery (`oracle:creature type:artifact` ANDs two planes with zero scanning). Also replaces `TrigramIndex`'s `HashMap` with sorted dense/sparse arrays (same #639 crossover, zero-copy archivable with rkyv) and adds the posting-vs-plane dispatch table (merge/probe/AND) `intersect_sorted`'s callers route through.

Design doc: `docs/issues/engine-oracle-word-index.md`.

## Changes

- `OracleWordIndex`: word dictionary + inverted index over distinct oracle texts, built in the same tokenization pass as the existing trigram index. Dense tier (over #639's crossover) stores precomputed card-space bitmaps; sparse tier stores dense-text-id postings, expanded through the existing CSR at query time.
- `narrow_rec`'s new `TextContains{OracleTextLower}` arm: exact 4-way dispatch (both-empty / sparse-only union / single-dense direct / mixed scatter) for any needle >3 chars with no token-boundary characters.
- `SortedTrigramIndex` replaces `TrigramIndex`'s `HashMap<[u8;3], Vec<u32>>` with sorted dense/sparse arrays, binary-searched; used by both `name_trigram` and the oracle trigram fallback (exact-3-char needles, multi-word phrases).
- `PlaneExpr::Bits` + a `compile_plane` bonus arm: a dense word's precomputed bitmap composes with sibling plane predicates via a single AND, when the needle matches exactly one dictionary word (the only case that's safe without a union).
- Dictionary scan performance: sparse-tier words are concatenated into one NUL-delimited blob and scanned once with `memchr::memmem` instead of calling `.contains()` per word (see Bug section below).
- 4 new differential/property tests (`oracle_word_index_exact_union_parity`, `oracle_word_index_dispatch_shapes`, `compile_plane_word_bonus_composes_with_other_planes`, `trigram_dense_sparse_dispatch_parity`) plus a new kernel benchmark (`bench_word_dict_scan.rs`).

## Related issues

none (no GitHub issue filed for the design doc yet)

---

## Bug (found and fixed during this PR's own benchmarking)

**Observed:** the first working version regressed the broad query survey ~9% overall (oracle_text-tagged queries specifically: 42% slower), even though it was a large win on the design doc's own motivating cases.
**Expected:** no regressions on any query shape not touching oracle text, and a net win on oracle text queries broadly, not just the common-word cases.
**Root cause:** the per-word dictionary scan (`.contains()` called once per ~6,300 sparse dictionary words) is O(dictionary size) regardless of the query's own selectivity — unlike a trigram lookup (O(1)-ish exact-key op), it's a fixed tax paid by every eligible predicate. It pays off hugely for common words (the doc's motivating cases) but is close to pure overhead for the majority of real single-word needles, which were already narrow via trigram.
**Regression test:** covered by the benchmark scripts, not a unit test — `scripts/bench_oracle_word_index.py` (targeted) and `scripts/survey_queries.py` (broad) both show the fix's effect directly; see `docs/issues/engine-oracle-word-index-labnotes.md` for the full before/after numbers at each iteration.

---

## Performance

Targeted (`scripts/bench_oracle_word_index.py`, `benchmarks/bitplanes/corpus.jsonl`, 24 configs):

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `o:creature` | 1.356ms | 0.130ms | 10.44x |
| `o:this` | 1.089ms | 0.109ms | 9.99x |
| `o:target` | 0.680ms | 0.094ms | 7.26x |
| `o:whenever` | 0.385ms | 0.060ms | 6.44x |
| `o:control` | 0.602ms | 0.110ms | 5.48x |
| `o:"sacrifice a creature"` (phrase, unchanged path) | 0.422ms | 0.082ms | 5.14x |
| `o:creature t:artifact` | 0.393ms | 0.080ms | 4.94x |
| `o:token` (the doc's opening motivating case) | 0.180ms | 0.080ms | 2.26x |
| controls (`name:soldier`, `cmc>6`, ...) | ~unchanged | ~unchanged | ~1.00x |

**Geometric mean:** 2.34x faster, zero regressions across all 24 configs
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl` (97,206 printings, reused from #630/#639 — same schema, no re-export needed)

Broad survey (`scripts/survey_queries.py`, 400 generated + 120 wild queries, seed 42): overall geomean **1.06x faster** across the whole realistic mix, oracle_text-tagged-query geomean **1.58x faster**, 92 of 117 oracle_text queries improved vs. 6 regressed (all sub-millisecond, within measurement noise). Total-row-count parity held on every config across every benchmark iteration in this PR.

---

## Reviewer notes

- The `compile_plane` bonus arm (`PlaneExpr::Bits`) is deliberately conservative: it only fires when the needle matches **exactly one** dictionary word total (dense, no sparse companion) — see the doc comment above that match arm and the `compile_plane_word_bonus_composes_with_other_planes` test's negative case for why a mixed dense+sparse shape must decline there instead of undercounting.
- `narrow_rec` now skips its own speculative `compile_plane` attempt for a lone eligible oracle leaf, and `compile_plane`'s And/Or children are tried cheapest-to-reject first (`plane_precheck_rank`) — both exist purely to avoid redundant dictionary scans; see the "Bug" section above and the lab notes for the measurement that motivated them.
- `docs/issues/engine-oracle-word-index-labnotes.md` (untracked, not in this diff) has the full blow-by-blow of the regression and fix if useful context during review.
- Two of the four new bench_*.rs files (`bench_iter_dispatch.rs`, `bench_posting_intersect.rs`) predate this PR (prior exploration on this branch, already ruled out / already informing the design doc's crossover table) — included here since their findings are directly cited in code comments this PR adds.
