### PR TITLE
Add Card-Level Narrowing Planes for border: (black/borderless/white)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1191,6 +1191,65 @@ fn build_name_bigram_index(cards: &[OracleCard]) -> NameBigramIndex {
     idx
 }
 
+// ─── Border planes (#664: loose card-level narrowing for border:) ──────────
+// card_border_id is a *printing*-level interned string (a card can have both a
+// black and a borderless printing), unlike everything BitPlanes/compile_plane
+// already handle (colors/types/devotion are card-invariant — identical across
+// every printing). unique=card semantics require one printing to satisfy the
+// *whole* filter, not each predicate independently satisfied by some
+// (possibly different) printing, so an AND of two independent per-card "has
+// X border" bits can false-positive: `border:black border:borderless` has no
+// shared witness and must return zero, but two independently-true bits would
+// wrongly say every card with one of each qualifies. These planes are
+// therefore *always* `Narrowed::loose` — real candidates, never fed through
+// `compile_plane`'s exact/tight machinery, which is safe only because nothing
+// else it touches varies per printing. Loose narrowing only shrinks which
+// cards' printings the residual per-printing walk bothers checking at all;
+// the real answer always comes from that walk, same as today.
+// See docs/issues/engine-border-planes.md for the full rationale, including
+// why `-border:x` (Not, which narrows only through tight children) and the
+// rare gold/yellow values are both deliberately left on the existing full
+// scan rather than chasing exactness this representation can't safely give.
+//
+// Real corpus (benchmarks/bitplanes/corpus.jsonl): black 98.92% of cards
+// (declines via the existing broadness guard, no special-casing needed),
+// borderless 10.73%, white 6.53% — gold/yellow (2.02% combined) get no plane.
+const BORDER_BLACK: usize = 0;
+const BORDER_BORDERLESS: usize = 1;
+const BORDER_WHITE: usize = 2;
+const BORDER_PLANE_COUNT: usize = 3;
+
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct BorderPlanes {
+    n_cards: u32,
+    /// BORDER_PLANE_COUNT × words_per_plane(n_cards), flattened plane-major —
+    /// the same layout convention as BitPlanes.words, just not fed through
+    /// compile_plane (see the module doc above for why).
+    words: Vec<u64>,
+}
+
+fn build_border_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32], strings: &[String]) -> BorderPlanes {
+    let n_cards = cards.len();
+    let wpp = words_per_plane(n_cards);
+    let mut words = vec![0u64; BORDER_PLANE_COUNT * wpp];
+    for card in 0..n_cards {
+        let range = offsets[card] as usize..offsets[card + 1] as usize;
+        for p in &printings[range] {
+            if p.card_border_id == NONE_STR {
+                continue;
+            }
+            let plane = match strings[p.card_border_id as usize].as_str() {
+                "black" => BORDER_BLACK,
+                "borderless" => BORDER_BORDERLESS,
+                "white" => BORDER_WHITE,
+                _ => continue,
+            };
+            words[plane * wpp + (card >> 6)] |= 1u64 << (card & 63);
+        }
+    }
+    BorderPlanes { n_cards: n_cards as u32, words }
+}
+
 // Named lifetime (not elided/HRTB) so get_text may return text borrowed from the
 // string table rather than from the card itself.
 fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str) -> SortedTrigramIndex {
@@ -2081,6 +2140,7 @@ struct CardIndexes {
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
+    border_planes:  BorderPlanes,              // card space: loose narrowing only for border: (#664), never compile_plane-consumable — see BorderPlanes' doc
 }
 
 impl Default for CardIndexes {
@@ -2109,6 +2169,7 @@ impl Default for CardIndexes {
             planes:         BitPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
+            border_planes:  BorderPlanes::default(),
         }
     }
 }
@@ -2861,6 +2922,27 @@ fn narrow_rec(
             Narrowed::tight(Candidates::Printings(
                 indexes.set_codes.get(value.as_str()).map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(*x)).collect()),
             ))
+        }
+
+        // border: (#664) — loose, card-level only. Only Eq on the three tracked
+        // values narrows at all; every other op/value (Ne, Lt/Le/Gt/Ge, gold,
+        // yellow, anything unrecognized) declines to the existing full scan,
+        // same as today. See BorderPlanes' doc for why this can never be tight.
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
+            let idx = &indexes.border_planes;
+            if u32::from(idx.n_cards) as usize != n_cards {
+                return None; // archive without border planes for this store
+            }
+            let plane = match value.as_str() {
+                "black" => BORDER_BLACK,
+                "borderless" => BORDER_BORDERLESS,
+                "white" => BORDER_WHITE,
+                _ => return None,
+            };
+            let wpp = words_per_plane(n_cards);
+            let start = plane * wpp;
+            let bits: Vec<u64> = idx.words[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
+            Narrowed::loose(Candidates::CardBits(bits))
         }
 
         FilterExpr::DateCmp { op, value } => {
@@ -4287,6 +4369,7 @@ impl QueryEngine {
             planes:         build_bit_planes(&cards),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
+            border_planes:  build_border_planes(&cards, &printings, &offsets, &strings),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    build_artwork_group_counts, build_bit_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
+    build_artwork_group_counts, build_bit_planes, build_border_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
@@ -847,6 +847,7 @@ fn bench_checked_vs_unchecked_access() {
         planes:         build_bit_planes(&cards),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
+        border_planes:  build_border_planes(&cards, &printings, &offsets, &strings),
     };
     let data = CardData {
         cards,
@@ -2483,6 +2484,163 @@ fn trigram_dense_sparse_dispatch_parity() {
     // with no posting to seed from at all.
     let ops = vec![super::lookup_trigram(archived, *b"aaa").unwrap(), super::lookup_trigram(archived, *b"bbb").unwrap()];
     assert_eq!(super::intersect_operands(ops), vec![1, 2, 3, 4, 5, 6], "plane x plane AND path, no posting seed available");
+}
+
+// ─── Border planes (docs/issues/engine-border-planes.md, #664) ─────────────
+
+/// 8 cards with varied printing-level border colors. Card 3 independently has
+/// a black printing *and* a separate borderless printing — the shared-witness
+/// correctness canary subject: `border:black border:borderless` must find no
+/// single printing satisfying both, even though the card "has" each color.
+fn border_planes_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let specs: &[&[Option<&str>]] = &[
+        &[Some("black")],                                     // 0: pure black
+        &[Some("black"), Some("black")],                       // 1: pure black, 2 printings
+        &[Some("borderless")],                                 // 2: pure borderless
+        &[Some("black"), Some("borderless")],                  // 3: shared-witness subject
+        &[Some("white")],                                       // 4: pure white
+        &[Some("gold")],                                        // 5: untracked value only
+        &[None],                                                 // 6: missing border
+        &[Some("black"), Some("white"), Some("borderless")],   // 7: all three tracked
+    ];
+    let cards: Vec<OracleCard> = specs.iter().enumerate().map(|(i, _)| stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab)).collect();
+    let printing_counts: Vec<usize> = specs.iter().map(|s| s.len()).collect();
+    let mut data = store_of(cards, &printing_counts, vocab);
+    let mut idx = 0;
+    for borders in specs {
+        for border in borders.iter() {
+            data.printings[idx].card_border_id = border.map_or(NONE_STR, |b| interner.intern(b.to_string()));
+            idx += 1;
+        }
+    }
+    data.strings = interner.strings;
+    data.indexes.border_planes = build_border_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
+    data
+}
+
+/// Brute-force `border:<value>` over every card, for differential comparison:
+/// does any printing of this card carry the given border color.
+fn brute_force_has_border(archived: &Archived<CardData>, border: &str) -> Vec<u32> {
+    (0..archived.cards.len() as u32)
+        .filter(|&cid| {
+            let start = u32::from(archived.offsets[cid as usize]);
+            let end = u32::from(archived.offsets[cid as usize + 1]);
+            (start..end).any(|p| {
+                let bid = u32::from(archived.printings[p as usize].card_border_id);
+                bid != NONE_STR && archived.strings[bid as usize].as_str() == border
+            })
+        })
+        .collect()
+}
+
+// The narrowed set must match the brute-force existential exactly (a solo
+// leaf's per-card existential really is exact), but must never be marked
+// tight -- these planes are never safe to feed through compile_plane or
+// complement via Not, regardless of how correct they happen to be in
+// isolation. See BorderPlanes' doc for why.
+#[test]
+fn border_planes_exact_union_parity() {
+    let data = border_planes_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
+    let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
+
+    for value in ["borderless", "white"] {
+        let expected = brute_force_has_border(archived, value);
+        let n = rec(&border(value)).unwrap_or_else(|| panic!("border:{value} must narrow"));
+        assert!(!n.tight, "border planes must always narrow loose, never tight");
+        assert_eq!(n.set.into_cards(&archived.offsets), expected, "border:{value} narrowed set must match brute force");
+    }
+}
+
+// The regression test this design exists to guarantee: two independent
+// per-card "has X border" bits, ANDed, would wrongly include card 3 (which
+// has a black printing and a separate borderless printing, independently
+// satisfying both) -- but no single printing is both, so the real answer
+// (found by the residual per-printing walk the loose narrowing never
+// bypasses) must be zero matches.
+#[test]
+fn border_shared_witness_correctness() {
+    let data = border_planes_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
+
+    let mut f = FilterExpr::And(vec![border("black"), border("borderless")]);
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no printing is both black and borderless: must be zero matches, not a false positive from independent narrowing");
+}
+
+// Untracked values (gold/yellow) and non-Eq ops must decline to narrow at all
+// -- but the evaluated result (via the untouched residual path) must still be
+// correct end to end, since narrowing declining is advisory, not a
+// correctness concern.
+#[test]
+fn border_planes_decline_shapes() {
+    let data = border_planes_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
+    let border_eq = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
+
+    assert!(rec(&border_eq("gold")).is_none(), "untracked border value must decline to narrow");
+    assert!(rec(&border_eq("yellow")).is_none());
+
+    let border_ne = FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Ne, value: "black".to_string() };
+    assert!(rec(&border_ne).is_none(), "Ne must decline: these planes are never tight, so Not/Ne can't invert them");
+
+    let mut f = border_eq("gold");
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 1, "exactly card 5 has a gold printing");
+}
+
+/// 7 of 8 cards have a black printing (87.5%, past narrow_candidates_exact's
+/// keep-if-<=75%-of-domain broadness guard, `domain - domain/4` with integer
+/// division); the 8th has a borderless printing (12.5%).
+fn border_broadness_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let mut interner = Interner::new();
+    let specs: &[&str] = &["black", "black", "black", "black", "black", "black", "black", "borderless"];
+    let cards: Vec<OracleCard> = specs.iter().enumerate().map(|(i, _)| stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab)).collect();
+    let mut data = store_of(cards, &[1usize; 8], vocab);
+    for (i, border) in specs.iter().enumerate() {
+        data.printings[i].card_border_id = interner.intern(border.to_string());
+    }
+    data.strings = interner.strings;
+    data.indexes.border_planes = build_border_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
+    data
+}
+
+// The dedicated arm always narrows (that's its whole job), but
+// narrow_candidates_exact's existing broadness guard -- unrelated to this
+// PR, already exercised elsewhere -- must still decline an overly-broad
+// result at the root, exactly as it would for any other narrowing source.
+// No special-casing needed for border:black: this is the guard doing its
+// job, not a gap this design has to plug itself.
+#[test]
+fn border_black_declines_via_broadness_guard() {
+    let data = border_broadness_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
+
+    let n = super::narrow_rec(&border("black"), &archived.indexes, &archived.offsets, &archived.cards, true).expect("the dedicated arm itself always narrows");
+    assert_eq!(n.set.into_cards(&archived.offsets).len(), 7);
+
+    assert!(
+        narrow_candidates(&border("black"), &archived.indexes, &archived.offsets, &archived.cards).is_none(),
+        "border:black alone must decline: 87.5% exceeds narrow_candidates_exact's 75% broadness cutoff"
+    );
+    assert!(narrow_candidates(&border("borderless"), &archived.indexes, &archived.offsets, &archived.cards).is_some());
 }
 
 // ─── Adaptive candidate sets (#636) ───────────────────────────────────────────

--- a/scripts/bench_border_planes.py
+++ b/scripts/bench_border_planes.py
@@ -1,0 +1,112 @@
+"""Engine-vs-engine benchmark for card-level border: narrowing planes (docs/issues/engine-border-planes.md).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export, so the same script
+run on two builds (main baseline vs. this branch) produces directly comparable CSVs. No SQL side,
+no Docker: build the engine locally (`maturin develop --release -m card_engine/Cargo.toml`) and run:
+
+    .venv/bin/python scripts/bench_border_planes.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/border-planes/baseline-main.csv
+
+Reuses the same corpus JSONL bench_bitplanes.py uses (ENGINE_COLUMNS/schema is unaffected by this
+change, so there's no need to re-export from the blue DB).
+
+The `total` column doubles as a parity check: it must be identical across builds for every config,
+or the comparison is void. `border:black border:borderless` is a correctness canary, not just a
+perf config — total must be 0 on both builds, proving the loose-narrowing-plus-residual-verify
+design doesn't reintroduce the shared-witness false-positive bug the tight/printing-space
+alternative was rejected for (see the design doc).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Selective values: real narrowing win expected (10.73%/6.53% of cards respectively).
+    ("selective", "border:borderless", "card", "edhrec", "default"),
+    ("selective", "border:white", "card", "edhrec", "default"),
+    ("selective", "border:borderless", "printing", "edhrec", "default"),
+    ("selective", "border:white", "artwork", "edhrec", "default"),
+    # And-combos with a card-invariant sibling: narrowing should compose fine.
+    ("and-combo", "border:white type:creature", "card", "edhrec", "default"),
+    ("and-combo", "border:borderless c:g", "card", "edhrec", "default"),
+    # Broad value: expected to decline (98.92% of cards have a black printing) via the existing
+    # broadness guard, not a special case — must not regress vs. today's full scan.
+    ("broad-decline", "border:black", "card", "edhrec", "default"),
+    # Shared-witness correctness canary: two printing-varying border values ANDed can never both
+    # be satisfied by the same printing. total must be 0 on both builds.
+    ("correctness-canary", "border:black border:borderless", "card", "edhrec", "default"),
+    ("correctness-canary", "border:white border:black", "printing", "edhrec", "default"),
+    # Unindexed values: expected to stay fully residual, no change expected either way.
+    ("unindexed-value", "border:gold", "card", "edhrec", "default"),
+    ("unindexed-value", "border:yellow", "card", "edhrec", "default"),
+    # Negation: Not only narrows through tight children, and these bits are deliberately loose —
+    # expected to stay fully residual, not a regression, just not a win for this shape.
+    ("negation", "-border:black", "card", "edhrec", "default"),
+    ("negation", "-border:white", "card", "edhrec", "default"),
+    # Selective controls: unrelated to border:, must not regress.
+    ("control", "name:soldier", "card", "edhrec", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+    ("control", "oracle:creature", "card", "edhrec", "default"),
+    ("control", "t:creature c:g", "card", "edhrec", "default"),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--", "card_engine/src"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        rev += "-dirty"
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    for _, query, _, _, _ in CONFIGS:
+        parse_scryfall_query(query)
+
+    hdr = f"{'group':<20} {'query':<30} {'unique':<9} {'orderby':<8} {'prefer':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<20} {query:<30} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`border:` has no index at all today — every query touching it falls straight to a full per-printing residual scan. Adds three loose, card-level bitplanes (`has_black_printing`/`has_borderless_printing`/`has_white_printing`), each computed as an OR over a card's printing range at build time, covering 98.6% of the real corpus. Deliberately never fed through `compile_plane`: unlike every existing `BitPlanes` dimension (colors, types, devotion), `card_border_id` varies per printing — a card can have both a black and a borderless printing — so treating these bits as exact/tight would reintroduce a shared-witness false positive the moment two printing-varying predicates are ANDed together.

Design doc: `docs/issues/engine-border-planes.md`.

## Changes

- `BorderPlanes`: three fixed card-space bitplanes (`BORDER_BLACK`/`BORDER_BORDERLESS`/`BORDER_WHITE`), built via `build_border_planes` alongside the other per-card indexes (OR over each card's printing range, skipping printings with no border or an untracked value).
- New `narrow_rec` arm for `FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value }`: reads the matching plane directly as `Narrowed::loose(Candidates::CardBits(..))` — deliberately outside `compile_plane`/`PlaneExpr` entirely, so there's no code path through which these bits could ever be treated as tight. Every other op (`Ne`, `Lt`/`Le`/`Gt`/`Ge`) and every untracked value (`gold`, `yellow`, anything else) declines to narrow, falling through to today's unchanged full scan.
- 5 new differential/property tests, including the shared-witness correctness canary (`border:black border:borderless` must stay at 0 matches) and a broadness-guard test confirming `border:black` alone correctly declines to narrow via the *existing* `narrow_candidates_exact` broadness check, with no special-casing added for it.
- `scripts/bench_border_planes.py`: targeted benchmark script following `scripts/bench_oracle_word_index.py`'s pattern.

## Related issues

Closes #664.

---

## Bug (near-miss, caught in design review before any code was written — not shipped)

**Observed:** the natural next idea after "card-level bit narrows well" is to make it *tight* (exact, skip the residual walk) for `unique=card` queries, the same way colors/types already work.
**Expected:** `border:black border:borderless` must return zero matches — no single printing is both.
**Root cause:** `unique=card` semantics require *one* printing to satisfy the *whole* filter, not each predicate independently satisfied by some (possibly different) printing. Two independent per-card "has X" bits, marked tight and ANDed, would each be true for a card with one of each — a false positive, not just a missed optimization. `compile_plane`'s existing exactness guarantee is safe today only because every dimension it touches is card-invariant (identical across every printing); border isn't. There's no local way for `compile_plane`'s bottom-up composition to detect when marking a leaf tight is unsafe — it depends on whether *any other* printing-varying predicate exists anywhere else in the enclosing subtree, a non-local fact.
**Regression test:** `border_shared_witness_correctness` (asserts `border:black border:borderless` returns 0 matches end-to-end) and `border_planes_decline_shapes` (asserts `Ne` and untracked values decline to narrow at all).

## Performance

Targeted (`scripts/bench_border_planes.py`, `benchmarks/bitplanes/corpus.jsonl`, 17 configs, `--window 8.0`; n ranges ~8k-250k iterations/config):

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `border:white type:creature` | 0.5626ms | 0.1014ms | 5.55x |
| `border:white` (unique=artwork) | 0.9386ms | 0.2305ms | 4.07x |
| `border:white` (unique=card) | 0.8636ms | 0.1571ms | 5.50x |
| `border:borderless` (unique=card) | 0.7615ms | 0.1991ms | 3.82x |
| `border:borderless` (unique=printing) | 0.7611ms | 0.2318ms | 3.28x |
| `border:borderless c:g` | 0.2627ms | 0.0881ms | 2.98x |
| `border:black border:borderless` (correctness canary) | 1.3411ms, total=0 | 0.3034ms, total=0 | 4.42x, parity held |
| `border:white border:black` (correctness canary, printing) | 1.0761ms, total=0 | 0.1991ms, total=0 | 5.40x, parity held |
| `border:black` (declines, per design) | 0.4134ms | 0.4031ms | 1.03x |
| `border:gold` / `border:yellow` (unindexed) | 0.8238 / 0.8056ms | 0.8091 / 0.7887ms | 1.02x |
| `-border:black` / `-border:white` (negation) | 1.0220 / 0.4777ms | 1.0255 / 0.4880ms | 1.00x / 0.98x |
| controls (`name:soldier`, `cmc>6`, `oracle:creature`, `t:creature c:g`) | — | — | 0.97-1.01x |

**Geometric mean:** 1.98x faster across all 17 configs. The "must not regress" categories tightened to a 0.97-1.03x spread at this sample size (vs. 0.94-1.11x at a shorter first-pass window), confirming they're genuinely flat.
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl` (97,206 printings, reused from #630/#663 — same schema, no re-export needed)

Broad survey (`scripts/survey_queries.py`, 400 generated + 120 wild, seed 42): overall geomean **1.00x** (flat — most of the 520 queries don't touch `border:`), border-tagged geomean **1.24x faster**.

Memory (`--features alloc-counter`, `QueryEngine.mem_stats()`): **+11.56 KiB** archive growth (+0.017%) — exactly 3 planes × 493 words × 8 bytes for 31,508 cards, matching the design's own sizing. `reload_peak` unchanged.

Total-row-count parity held on every config, every benchmark run, throughout.

---

## Reviewer notes

- The core design decision — loose narrowing only, never `compile_plane`-consumable — is the thing worth focusing review on. `docs/issues/engine-border-planes.md` has the full writeup, including why a naively-tighter design was considered and rejected before any code was written (the shared-witness trap above), and why `-border:x` and `border:gold`/`border:yellow` are explicitly out of scope rather than gaps.
- `border_black_declines_via_broadness_guard` confirms `border:black` alone (98.9% of cards) declines via the *existing* `narrow_candidates_exact` broadness check — no new threshold or special-casing was needed for this.
- Same benchmark protocol as #663 (`docs/workflows/performance-pr-workflow.md`), including the memory-measurement and kernel-benchmark-tier additions that PR made to the workflow doc — no kernel benchmark was needed here since there was no representation-level performance question to isolate, just the narrowing-shape correctness question above.