### PR TITLE
Add Bitplanes for produces: (Produced Mana)

### DIFF
--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -30,7 +30,14 @@ const COLOR_PLANES: usize = 6;
 const TYPE_PLANES: usize = 14;
 const PLANE_COLORS: usize = 0;
 const PLANE_IDENTITY: usize = COLOR_PLANES;
-const PLANE_TYPES: usize = 2 * COLOR_PLANES;
+/// Produced mana (docs/issues/engine-produces-planes.md): a plain per-color
+/// bitmask on OracleCard, built with the same jsonb_color_to_bits helper and
+/// evaluated through the same ColorCmp code path as Colors/ColorIdentity —
+/// structurally identical in every way that matters for plane-exactness
+/// (card-level, never Null/PrintingDep). Was deliberately left unplaned in
+/// #630 phase 1; this closes that gap the same way, no new machinery needed.
+const PLANE_PRODUCED_MANA: usize = PLANE_IDENTITY + COLOR_PLANES;
+const PLANE_TYPES: usize = PLANE_PRODUCED_MANA + COLOR_PLANES;
 /// Devotion is bit-sliced: two saturating bits per color (count clamped to
 /// 0..=3), so `devotion:uu` is one plane read and `devotion:uuu` is exactly
 /// the saturated bucket. Counts come from the same hybrid-expanded map the
@@ -162,6 +169,9 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
             }
             if card.card_color_identity & (1 << b) != 0 {
                 set(PLANE_IDENTITY + b);
+            }
+            if card.produced_mana & (1 << b) != 0 {
+                set(PLANE_PRODUCED_MANA + b);
             }
         }
         let mut bits = card.card_types;
@@ -653,8 +663,7 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
             let base = match field {
                 ColorField::Colors => PLANE_COLORS,
                 ColorField::ColorIdentity => PLANE_IDENTITY,
-                // Deliberately unplaned for now (#630): produces: stays residual.
-                ColorField::ProducedMana => return None,
+                ColorField::ProducedMana => PLANE_PRODUCED_MANA,
             };
             // color_to_bit only sets bits 0..6; anything else would make the
             // plane complement unsound, so refuse rather than assume.

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1676,26 +1676,32 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
 const FALLAJI_CID: usize = 5;
 fn plane_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
-    // (card_colors, card_color_identity, card_types); color bits W=1 U=2 B=4 R=8 G=16 C=32
-    let specs: &[(u8, u8, u16)] = &[
-        (0, 0, TYPE_ARTIFACT),                     // colorless artifact
-        (16, 16, TYPE_CREATURE),                   // mono G creature
-        (1, 1, TYPE_CREATURE | TYPE_LEGENDARY),    // mono W legendary creature
-        (3, 3, TYPE_INSTANT),                      // WU instant
-        (0, 24, TYPE_LAND),                        // land: no colors, RG identity (Taiga)
-        (31, 16, TYPE_CREATURE),                   // Fallaji Wayfarer (see FALLAJI_CID)
-        (2, 3, TYPE_SORCERY),                      // U sorcery with WU identity
-        (24, 31, TYPE_CREATURE | TYPE_ARTIFACT),   // RG artifact creature, WUBRG identity
-        (4, 4, TYPE_ENCHANTMENT | TYPE_SNOW),      // mono B snow enchantment
-        (0, 32, TYPE_LAND),                        // C-bit identity, exercising the C plane
+    // (card_colors, card_color_identity, card_types, produced_mana); color bits W=1 U=2 B=4 R=8 G=16 C=32.
+    // produced_mana is deliberately independent of colors/identity on several
+    // rows (card 0: colorless artifact that produces all five + C, like a
+    // mana rock; card 5: Fallaji Wayfarer produces only C, matching neither
+    // its own colors (31) nor its identity (16)) to prove the plane is its
+    // own independent transposition, not derived from the other two.
+    let specs: &[(u8, u8, u16, u8)] = &[
+        (0, 0, TYPE_ARTIFACT, 63),                   // colorless artifact, produces everything
+        (16, 16, TYPE_CREATURE, 0),                  // mono G creature, produces nothing
+        (1, 1, TYPE_CREATURE | TYPE_LEGENDARY, 0),   // mono W legendary creature
+        (3, 3, TYPE_INSTANT, 0),                      // WU instant
+        (0, 24, TYPE_LAND, 24),                       // land: no colors, RG identity (Taiga), produces RG
+        (31, 16, TYPE_CREATURE, 32),                  // Fallaji Wayfarer (see FALLAJI_CID), produces only C
+        (2, 3, TYPE_SORCERY, 0),                       // U sorcery with WU identity
+        (24, 31, TYPE_CREATURE | TYPE_ARTIFACT, 8),   // RG artifact creature, WUBRG identity, produces only R
+        (4, 4, TYPE_ENCHANTMENT | TYPE_SNOW, 0),      // mono B snow enchantment
+        (0, 32, TYPE_LAND, 32),                        // C-bit identity, exercising the C plane, produces C
     ];
     let cards = specs
         .iter()
         .enumerate()
-        .map(|(i, &(colors, identity, types))| {
+        .map(|(i, &(colors, identity, types, produced))| {
             let mut c = stub_card(i as u128 + 1, types, &[], &mut vocab);
             c.card_colors = colors;
             c.card_color_identity = identity;
+            c.produced_mana = produced;
             c
         })
         .collect();
@@ -1734,6 +1740,7 @@ fn plane_parity_color_and_type_ops() {
         for mask in color_masks {
             check(&FilterExpr::ColorCmp { field: ColorField::Colors, op, mask });
             check(&FilterExpr::ColorCmp { field: ColorField::ColorIdentity, op, mask });
+            check(&FilterExpr::ColorCmp { field: ColorField::ProducedMana, op, mask });
         }
         for mask in type_masks {
             check(&FilterExpr::TypeCmp { mask, op });
@@ -1742,9 +1749,32 @@ fn plane_parity_color_and_type_ops() {
 
     let green = || FilterExpr::ColorCmp { field: ColorField::Colors, op: CmpOp::Ge, mask: 16 };
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let produces_red = || FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 8 };
     check(&FilterExpr::And(vec![green(), creature()]));
     check(&FilterExpr::Or(vec![green(), creature()]));
     check(&FilterExpr::Not(Box::new(FilterExpr::Or(vec![green(), creature()]))));
+    check(&FilterExpr::And(vec![produces_red(), creature()]));
+    check(&FilterExpr::Not(Box::new(produces_red())));
+}
+
+// produced_mana must be its own independent transposition, not derived from
+// colors or identity: card 0 (colorless, produces everything) and card 5
+// (Fallaji Wayfarer, colors=WUBR/identity=G, produces only C) both have
+// produced_mana disjoint from their own colors/identity bits.
+#[test]
+fn plane_produces_independent_of_colors_and_identity() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let produces_white = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 1 };
+    let pe = compile_plane(&produces_white, bounds, words).expect("produces: must be plane-expressible");
+    let mut bitmap: Vec<u64> = Vec::new();
+    eval_planes(&pe, bounds, &mut bitmap);
+    assert!(bitmap_contains(&bitmap, 0), "colorless artifact produces white (mask 63) despite having no colors of its own");
+    assert!(!bitmap_contains(&bitmap, 5), "Fallaji Wayfarer (colors WUBR) produces only C, not white");
 }
 
 // The Fallaji shape specifically: color planes and identity planes must be
@@ -1800,11 +1830,12 @@ fn split_planes_composition_rules() {
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::Or(ref v) if v.len() == 2));
 
-    // Produced mana is deliberately unplaned in phase 1.
+    // Produced mana is plane-expressible (docs/issues/engine-produces-planes.md):
+    // same card-level, always-known bitmask shape as Colors/ColorIdentity.
     let produces = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 16 };
     let (pe, residual) = split_planes(produces, bounds, words);
-    assert!(pe.is_none());
-    assert!(matches!(residual, FilterExpr::ColorCmp { field: ColorField::ProducedMana, .. }));
+    assert!(pe.is_some());
+    assert!(matches!(residual, FilterExpr::True));
 
     // Bare True keeps the range-scan path (no all-ones bitmap materialization).
     let (pe, residual) = split_planes(FilterExpr::True, bounds, words);

--- a/scripts/bench_produces_planes.py
+++ b/scripts/bench_produces_planes.py
@@ -1,0 +1,106 @@
+"""Engine-vs-engine benchmark for produces: bitplanes (docs/issues/engine-produces-planes.md).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export, so the same script
+run on two builds (main baseline vs. this branch) produces directly comparable CSVs. No SQL side,
+no Docker: build the engine locally (`maturin develop --release -m card_engine/Cargo.toml`) and run:
+
+    .venv/bin/python scripts/bench_produces_planes.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/produces-planes/baseline-main.csv
+
+Reuses the same corpus JSONL bench_bitplanes.py uses (ENGINE_COLUMNS/schema is unaffected by this
+change, so there's no need to re-export from the blue DB).
+
+The `total` column doubles as a parity check: it must be identical across builds for every config,
+or the comparison is void.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Solo predicates, across the color spread (3.38%-3.86% of cards individually).
+    # NOTE: deliberately not "produces:c" -- the parser treats the literal "c"/
+    # "colorless" as an empty mask for any color-class field (matches Scryfall's
+    # own color:/identity: convention: no colored pips), which for produces:
+    # means it (incorrectly, pre-existing, out of scope here) matches every
+    # card instead of the ~2% that produce {C}. Filed as a separate follow-up.
+    ("solo", "produces:g", "card", "edhrec", "default"),
+    ("solo", "produces:w", "card", "edhrec", "default"),
+    ("solo", "produces:r", "card", "edhrec", "default"),
+    # Exact slow-tail queries from the broad survey that motivated this (seed 42).
+    ("slow-tail", "oracle:token or produces:b", "card", "edhrec", "default"),
+    ("slow-tail", "set:khm or produces:r", "card", "rarity", "default"),
+    ("slow-tail", "(set:snc color:rg) or (produces:c usd>1)", "printing", "cmc", "default"),
+    # Negation: unlike border:/price_usd, this must narrow fine (card-invariant, exact).
+    ("negation", "-produces:g", "card", "edhrec", "default"),
+    # And-combos: card-invariant sibling (fully plane-compilable) and printing-space sibling
+    # (mixed-space And, exercising the existing Candidates-space-conversion machinery).
+    ("and-combo", "produces:g type:land", "card", "edhrec", "default"),
+    ("and-combo", "produces:r set:war", "printing", "edhrec", "default"),
+    # Controls: unrelated to produces:, must not regress.
+    ("control", "name:soldier", "card", "edhrec", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+    ("control", "oracle:creature", "card", "edhrec", "default"),
+    ("control", "border:white", "card", "edhrec", "default"),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--", "card_engine/src"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        rev += "-dirty"
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    for _, query, _, _, _ in CONFIGS:
+        parse_scryfall_query(query)
+
+    hdr = f"{'group':<12} {'query':<44} {'unique':<9} {'orderby':<8} {'prefer':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<12} {query:<44} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`produces:` was explicitly excluded from `compile_plane` in #630 phase 1 ("deliberately unplaned for now"), so every query touching it — alone or as one branch of an `Or` — fell straight to a full per-card residual scan. `produced_mana` is structurally identical to `card_colors`/`card_color_identity` in every way that matters for plane exactness (same build helper, same bit layout, same evaluation code path, card-level and always known), so this closes that gap the same way those two fields were already planed — no new machinery.

Design doc: `docs/issues/engine-produces-planes.md`.

## Changes

- `PLANE_PRODUCED_MANA`: a third 6-plane block (one per WUBRGC bit), inserted into the existing layout right after `PLANE_IDENTITY` — every downstream `PLANE_*` constant cascades automatically since each is defined relative to its predecessor.
- `build_bit_planes`: sets the new bits in the existing per-card loop, alongside colors/identity.
- `compile_plane`: replaces the `ColorField::ProducedMana => return None` decline with the new plane base — reuses `cmp_expr`/`in_out_planes`'s existing mask-decomposition logic unchanged.
- Tests: flipped `split_planes_composition_rules`'s "produced mana stays residual" assertion to "now plane-expressible, fully consumed"; extended `plane_parity_color_and_type_ops`'s color/type op-coverage loop to include `ProducedMana`; added a dedicated independence test (a card whose `produced_mana` is disjoint from both its own colors and identity — a mana-rock-style colorless artifact that produces every color).
- `scripts/bench_produces_planes.py`: targeted benchmark script.

## Related issues

No design-doc issue filed for this one (surfaced directly from #666's broad-survey slow-tail analysis). Related: #663, #666 (prior PRs in this same benchmark protocol), #630 (where this field was originally left unplaned).

---

## Performance

Targeted (`scripts/bench_produces_planes.py`, `benchmarks/bitplanes/corpus.jsonl`, 13 configs, `--window 5.0`):

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `set:khm or produces:r` | 0.955ms | 0.089ms | 10.73x |
| `oracle:token or produces:b` | 0.577ms | 0.086ms | 6.71x |
| `-produces:g` (negation — fully exact, unlike `border:` from #666) | 0.263ms | 0.072ms | 3.65x |
| `produces:g` / `produces:w` / `produces:r` (solo) | 0.187-0.193ms | 0.053-0.054ms | 3.52-3.57x |
| `produces:g type:land` | 0.103ms | 0.057ms | 1.81x |
| `produces:r set:war` (tiny total=18, floor-limited) | 0.025ms | 0.025ms | ~1.00x |
| `(set:snc color:rg) or (produces:c usd>1)` | 1.647ms | 1.605ms | 1.03x — see note below |
| controls (`name:soldier`, `cmc>6`, `oracle:creature`, `border:white`) | — | — | ~1.00x |

**Geometric mean:** not a single meaningful number here — one config is a flat, explained outlier (below); every other config is a genuine 1.8-10.7x win.
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl` (97,206 printings, reused from #630/#663/#666)

Broad survey (`scripts/survey_queries.py`, seed 42): overall geomean 0.969x (flat), produced_mana-tagged geomean **2.17x faster** across the 8 tagged queries in this sample (7 of 8 improved).

Memory (`--features alloc-counter`): **+23.11 KiB** archive growth (+0.035%) — exactly 6 planes × 493 words × 8 bytes, double `border:`'s footprint (#666) since this is 6 planes instead of 3. `reload_peak` unchanged.

Total-row-count parity held on every config, every run, throughout.

**Note on the one flat config:** `(set:snc color:rg) or (produces:c usd>1)` doesn't speed up — not a limitation of this design. It's downstream of #668 (`color:c`/`produces:c` matching every card due to a pre-existing parser bug, found during this work): that `Or` branch was already unnarrowable before this PR (its own union already covers the whole corpus, since `produces:c` matches everyone regardless of whether it has a plane), so nothing here could have sped it up. Confirmed not a regression either — 23,631 on both builds, identical.

---

## Reviewer notes

- This one's much smaller and lower-risk than #666 — `produced_mana` doesn't vary per printing (unlike `border:`), so there's no shared-witness concern, no tight/loose judgment call, and no new narrowing arm. It's the same "structurally identical to an already-planed field" argument the design doc walks through, and the diff is correspondingly tiny (~12 lines in `planes.rs`).
- #668 (`color:c`/`produces:c` bug) is filed separately and deliberately not touched here — it's a parser-layer semantics issue, unrelated to whether the field has a plane.