### PR TITLE
Fix color:/produces: Vacuous Match on Colorless

### DIFF
--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -212,23 +212,31 @@ def _proper_subset_masks(query_mask: int) -> list[int]:
     return [v for v in range(32) if (v & ~query_mask) == 0 and v != query_mask]  # 5 colors => 2^5 possible bitmask values
 
 
-def get_colors_comparison_object(val: str) -> dict[str, bool]:
+def get_colors_comparison_object(val: str, attr: str = "card_colors") -> dict[str, bool]:
     """Convert color string to comparison object for database queries.
 
     Args:
         val: Color string (either color codes like 'WUBRG' or color name like 'red').
+        attr: The DB column this value is being compared against. Colorless means two
+            different things depending on the field: for card_colors/card_color_identity
+            it's the *absence* of any color (Scryfall stores both as `[]`, verified
+            against the live API — e.g. Sol Ring's colors/color_identity are both `[]`),
+            so 'c'/'colorless' maps to an empty dict. For produced_mana, colorless is a
+            genuine producible value (Sol Ring's produced_mana is `["C"]`, not `[]`), so
+            it must map to {"C": True} there instead.
 
     Returns:
         Dictionary mapping color codes to True for matching colors.
-        Returns an empty dict for colorless ('c' or 'colorless'), since colorless
-        cards are stored with an empty color identity in the database.
 
     Raises:
         ValueError: If the color string is invalid.
     """
+    colorless_is_value = attr == "produced_mana"
     # If all chars are color codes
     color_code_set = set(COLOR_CODE_TO_NAME)
     if val and set(val) <= color_code_set:
+        if colorless_is_value:
+            return {c.upper(): True for c in val}
         # Colorless-only queries use an empty dict, matching how colorless cards
         # are stored (card_color_identity = {}) rather than {"C": True}.
         return {c.upper(): True for c in val if c != "c"}
@@ -236,7 +244,7 @@ def get_colors_comparison_object(val: str) -> dict[str, bool]:
     try:
         letter_code = COLOR_NAME_TO_CODE[val]
         if letter_code == "c":
-            return {}
+            return {"C": True} if colorless_is_value else {}
         return {letter_code.upper(): True}
     except KeyError as e:
         msg = f"Invalid color string: {val}"
@@ -559,7 +567,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
                 return _node_to_json(self.rhs)
             val = self.rhs.value.strip()
             if attr in ("card_colors", "card_color_identity", "produced_mana"):
-                return list(get_colors_comparison_object(val.lower()).keys())
+                return list(get_colors_comparison_object(val.lower(), attr).keys())
             if attr == "card_keywords":
                 return list(get_keywords_comparison_object(val).keys())
             if attr == "card_frame_data":
@@ -970,7 +978,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         attr = self.lhs.attribute_name
         is_color_identity = False
         if attr in ("card_colors", "card_color_identity", "produced_mana"):
-            rhs = get_colors_comparison_object(self.rhs.value.strip().lower())
+            rhs = get_colors_comparison_object(self.rhs.value.strip().lower(), attr)
             is_color_identity = attr == "card_color_identity"
             if is_color_identity and self.operator in (":", "<="):
                 subsets = IntArray(_subset_masks(_color_dict_to_mask(rhs)))
@@ -981,6 +989,12 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
                 pmask = context.add(subsets)
                 return f"(magic.color_identity_mask({lhs_sql}) = ANY({pmask}::smallint[]))"
             placeholder = context.add(rhs)
+            # An empty rhs means the query was literally "c"/"colorless", not
+            # "at least zero colors" -- jsonb containment against an empty
+            # object (@>) is vacuously true for every row, so ":"/">=" must
+            # fall back to exact equality when rhs is empty.
+            if not rhs and self.operator in (":", ">="):
+                return f"({lhs_sql} = {placeholder})"
         elif attr == "devotion":
             # Devotion uses mana cost syntax, so we need to convert it to color comparison
             # Extract color codes from mana cost syntax like {G}, {R}{G}, etc.

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -4,7 +4,13 @@ import pytest
 
 from api import parsing
 from api.parsing import QueryContext, generate_sql_query
-from api.parsing.card_query_nodes import _color_dict_to_mask, _proper_subset_masks, _subset_masks, get_legality_comparison_object
+from api.parsing.card_query_nodes import (
+    _color_dict_to_mask,
+    _proper_subset_masks,
+    _subset_masks,
+    get_colors_comparison_object,
+    get_legality_comparison_object,
+)
 
 
 @pytest.mark.parametrize(
@@ -248,6 +254,69 @@ def test_full_sql_translation_jsonb_colors(parse_query, input_query: str, expect
     ],
 )
 def test_color_identity_sql_translation(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:
+    parsed = parse_query(input_query)
+    observed_params = QueryContext()
+    observed_sql = parsed.to_sql(observed_params)
+    assert (observed_sql, observed_params) == (
+        expected_sql,
+        expected_parameters,
+    ), f"\nExpected: {expected_sql}\t{expected_parameters}\nObserved: {observed_sql}\t{observed_params}"
+
+
+@pytest.mark.parametrize(
+    argnames=("input_query", "expected_sql", "expected_parameters"),
+    argvalues=[
+        (
+            "color=rg",
+            r"(card.card_colors = %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
+            {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
+        ),
+        (
+            "color:rg",
+            r"(card.card_colors @> %(p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ)s)",
+            {"p_dict_eydSJzogVHJ1ZSwgJ0cnOiBUcnVlfQ": {"R": True, "G": True}},
+        ),
+        # Regression for #668: ":"/">=" (Ge) against jsonb containment (@>) is
+        # vacuously true for an empty rhs, so colorless must fall back to "="
+        # instead -- card_colors/card_color_identity store colorless as {}
+        # (verified against the live Scryfall API: Sol Ring's colors is []).
+        (
+            "color:c",
+            r"(card.card_colors = %(p_dict_e30)s)",
+            {"p_dict_e30": {}},
+        ),
+        (
+            "c:c",
+            r"(card.card_colors = %(p_dict_e30)s)",
+            {"p_dict_e30": {}},
+        ),
+        (
+            "color=c",
+            r"(card.card_colors = %(p_dict_e30)s)",
+            {"p_dict_e30": {}},
+        ),
+        # produced_mana is different: Scryfall's produced_mana array can
+        # contain "C" as a genuine value (Sol Ring's produced_mana is ["C"],
+        # not []), so "colorless" here is an ordinary containment query
+        # against {"C": True}, not an empty-set special case.
+        (
+            "produces:c",
+            r"(card.produced_mana @> %(p_dict_eydDJzogVHJ1ZX0)s)",
+            {"p_dict_eydDJzogVHJ1ZX0": {"C": True}},
+        ),
+        (
+            "produces=c",
+            r"(card.produced_mana = %(p_dict_eydDJzogVHJ1ZX0)s)",
+            {"p_dict_eydDJzogVHJ1ZX0": {"C": True}},
+        ),
+        (
+            "produces:colorless",
+            r"(card.produced_mana @> %(p_dict_eydDJzogVHJ1ZX0)s)",
+            {"p_dict_eydDJzogVHJ1ZX0": {"C": True}},
+        ),
+    ],
+)
+def test_color_and_produces_sql_translation(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:
     parsed = parse_query(input_query)
     observed_params = QueryContext()
     observed_sql = parsed.to_sql(observed_params)
@@ -1304,6 +1373,31 @@ def test_empty_query_generates_true(parse_query, query: str | None) -> None:
     sql, params = generate_sql_query(parse_query(query))
     assert sql == "TRUE"
     assert params == {}
+
+
+testcases_colors_comparison_object = {
+    # card_colors/card_color_identity: colorless is the absence of color.
+    "colors_c": {"val": "c", "attr": "card_colors", "expected": {}},
+    "colors_colorless": {"val": "colorless", "attr": "card_colors", "expected": {}},
+    "identity_c": {"val": "c", "attr": "card_color_identity", "expected": {}},
+    "colors_rg": {"val": "rg", "attr": "card_colors", "expected": {"R": True, "G": True}},
+    # produced_mana: colorless ("C") is a genuine producible value, per Scryfall's
+    # own data (Sol Ring's produced_mana is ["C"], not []).
+    "produces_c": {"val": "c", "attr": "produced_mana", "expected": {"C": True}},
+    "produces_colorless": {"val": "colorless", "attr": "produced_mana", "expected": {"C": True}},
+    "produces_wc": {"val": "wc", "attr": "produced_mana", "expected": {"W": True, "C": True}},
+}
+
+
+@pytest.mark.parametrize(
+    argnames=sorted(next(iter(testcases_colors_comparison_object.values()))),
+    argvalues=[
+        [v for k, v in sorted(testcases_colors_comparison_object[t].items())] for t in sorted(testcases_colors_comparison_object)
+    ],
+    ids=sorted(testcases_colors_comparison_object),
+)
+def test_get_colors_comparison_object(val: str, attr: str, expected: dict) -> None:
+    assert get_colors_comparison_object(val, attr) == expected
 
 
 testcases_color_dict_to_mask = {

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -211,9 +211,23 @@ class TestFilters:
         assert total == 21
 
     def test_colorless(self, engine: QueryEngine) -> None:
-        # Black Lotus (5) + Sol Ring (5); use color= (exact) not c: (contains empty set = all cards)
+        # Black Lotus (5) + Sol Ring (5): the only colorless cards in the fixture
         total, _ = _run(engine, "color=c")
         assert total == 10
+
+    def test_colorless_default_operator(self, engine: QueryEngine) -> None:
+        # Regression for #668: c:/color: (the default ":" operator) must match
+        # the same 10 colorless printings as color=c, not every card in the
+        # fixture (":" is Ge, and Ge with an empty mask is vacuously true
+        # unless colorless is special-cased back to equality).
+        total_colon, _ = _run(engine, "c:c")
+        total_eq, _ = _run(engine, "c=c")
+        assert total_colon == total_eq == 10
+
+    def test_produces_colorless(self, engine: QueryEngine) -> None:
+        # Only Sol Ring (5) produces {C}; Black Lotus produces WUBRG, not C.
+        total, _ = _run(engine, "produces:c")
+        assert total == 5
 
     def test_cmc_equals_zero(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, "cmc=0")

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1162,7 +1162,11 @@ impl FilterExpr {
             FilterExpr::ColorCmp { field, op, mask } => {
                 let bits = card_colors(card, *field);
                 tri_bool(match op {
-                    CmpOp::Ge => bits & mask == *mask,
+                    // mask == 0 means the query was literally "c"/"colorless" (see
+                    // get_colors_comparison_object on the Python side), not "at
+                    // least zero colors" -- bits & 0 == 0 is vacuously true for
+                    // every card, so Ge must fall back to exact equality here.
+                    CmpOp::Ge => if *mask == 0 { bits == 0 } else { bits & mask == *mask },
                     CmpOp::Eq => bits == *mask,
                     CmpOp::Le => bits & !mask == 0,
                     CmpOp::Lt => bits & !mask == 0 && bits != *mask,

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -325,6 +325,13 @@ fn cmp_expr(base: usize, width: usize, mask: u16, op: CmpOp, ge_any: bool) -> Pl
         if ge_any { or_of(inp) } else { and_of(inp) }
     };
     match op {
+        // All-of Ge (ColorCmp) with mask 0 means the query was literally
+        // "c"/"colorless": and_of([]) is vacuously true, but the intended
+        // semantics are exact equality (bits == 0), matching the ColorCmp::Ge
+        // special case in filter.rs's eval_card. Gt's own use of ge() below is
+        // deliberately untouched -- Gt's "no colors" case correctly depends on
+        // the vacuous-true shape to reduce to "not equal".
+        CmpOp::Ge if !ge_any && mask == 0 => eq_expr(base, width, mask),
         CmpOp::Ge => ge(),
         CmpOp::Eq => eq_expr(base, width, mask),
         CmpOp::Le => le_expr(base, width, mask),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1757,6 +1757,38 @@ fn plane_parity_color_and_type_ops() {
     check(&FilterExpr::Not(Box::new(produces_red())));
 }
 
+// Regression for #668 (color:c / produces:c matching every card): Ge with an
+// empty mask is the "c"/"colorless" query, and must reduce to bits == 0, not
+// the vacuously-true and_of([])/bits & 0 == 0 shape. Checked against both the
+// row-scan filter and the bitplane compiler, since each has its own Ge arm.
+#[test]
+fn color_cmp_ge_empty_mask_is_colorless_only() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let check = |field: ColorField, want_true: &[usize]| {
+        let f = FilterExpr::ColorCmp { field, op: CmpOp::Ge, mask: 0 };
+        for (cid, card) in archived.cards.iter().enumerate() {
+            let want = want_true.contains(&cid);
+            assert_eq!(f.eval_card(card, &archived.strings) == Tri::True, want, "eval_card mismatch at card {cid}");
+        }
+        let pe = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).expect("filter must be plane-expressible");
+        let mut bitmap: Vec<u64> = Vec::new();
+        eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
+        for cid in 0..archived.cards.len() {
+            assert_eq!(bitmap_contains(&bitmap, cid as u32), want_true.contains(&cid), "plane mismatch at card {cid}");
+        }
+    };
+
+    // card_colors == 0: cards 0, 4, 9 (see plane_fixture_store specs above)
+    check(ColorField::Colors, &[0, 4, 9]);
+    // produced_mana == 0: cards 1, 2, 3, 6, 8
+    check(ColorField::ProducedMana, &[1, 2, 3, 6, 8]);
+    // card_color_identity == 0: only card 0
+    check(ColorField::ColorIdentity, &[0]);
+}
+
 // produced_mana must be its own independent transposition, not derived from
 // colors or identity: card 0 (colorless, produces everything) and card 5
 // (Fallaji Wayfarer, colors=WUBR/identity=G, produces only C) both have


### PR DESCRIPTION
## Summary

Fixes #668. `color:c` / `c:c` / `produces:c` matched every card in the
database instead of just colorless cards / cards producing `{C}` mana.

Two distinct bugs, found in that order:

1. **`Ge` with an empty color mask is vacuously true.** The default
   `:` operator (and `>=`) resolves to `Ge` ("at least these colors").
   For a colorless query the mask is empty, and `bits & 0 == 0` /
   `col @> '{}'` are true for every row. This exists independently in
   three places — the Rust engine's row-scan eval (`filter.rs`), the
   bitplane fast-path compiler (`planes.rs`, a separate implementation
   used by the `produces:` bitplanes work), and the Postgres SQL
   fallback (`card_query_nodes.py`) — all three now special-case an
   empty mask on `Ge` to mean exact equality (`bits == 0`) instead of
   containment. `identity:`/`id:` were already unaffected, since that
   field maps `:` to subset (`Le`) semantics instead of `Ge`.

2. **`produces:` colorless is not the same shape as `color:` colorless
   — verified against the live Scryfall API.** Sol Ring's `colors` and
   `color_identity` are both `[]` (colorless truly means "no color
   pips" there), but its `produced_mana` is `["C"]`, not `[]` — the
   `{C}` mana symbol is a genuine producible value, not an absence.
   `get_colors_comparison_object` collapsed `"c"`/`"colorless"` to `{}`
   for all three color-ish fields uniformly, which would have made fix
   #1 wrong for `produces:` (turning `produces:c` into "produces no
   mana at all" instead of "produces `{C}`"). It's now field-aware:
   `card_colors`/`card_color_identity` still map colorless to `{}`,
   `produced_mana` maps it to `{"C": True}`.

## Test plan

- [x] New Rust regression test `color_cmp_ge_empty_mask_is_colorless_only`
      checks both the row-scan eval and the bitplane compiler against a
      known-colors fixture store
- [x] New Python SQL-generation table (`color:c`, `c:c`, `produces:c`,
      `produces=c`, `produces:colorless`) plus a unit test on
      `get_colors_comparison_object` for the field-aware split
- [x] Updated `test_engine_unit.py`'s `test_colorless` (dropped the
      "use `=` not `:`" workaround comment) and added
      `test_colorless_default_operator` / `test_produces_colorless`
      against the real fixture cards (Black Lotus / Sol Ring)
- [x] `cargo test --lib`: 94 passed, 0 failed
- [x] `python -m pytest`: 1989 passed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)