### PR TITLE
Add Card-Level Rarity Bitplanes for common/uncommon/rare/mythic

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2110,6 +2110,53 @@ fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option
     Some(result)
 }
 
+/// Card-space candidate mask for `rarity <op> val` using the 4 planed rarity
+/// values (common/uncommon/rare/mythic, buckets 0-3 — PLANE_RARITY,
+/// docs/issues/engine-rarity-planes.md), OR'd together directly from the
+/// plane words; buckets 4-5 (special/bonus) have no plane, so whenever the
+/// comparison also selects one of those two, their RarityIndex postings are
+/// scattered directly into the same mask (same shape as legal_candidate_bits's
+/// divergent-set scatter, just op-dependent instead of a fixed list). Loose,
+/// same as rarity_candidates: rarity is PrintingDep at card level, so this
+/// only narrows candidates — card_pass/printing-level residual eval still
+/// verifies which printings actually match. Unlike rarity_candidates, Ne
+/// doesn't need to decline: with 4 of 6 buckets plane-backed, "not equal" is
+/// mostly a cheap plane-OR plus a tiny tail scatter, not a near-total postings
+/// union. No bucket_verdict/ambiguity logic needed either — every bucket here
+/// is a single fully-known value, not an open-ended numeric range.
+fn rarity_plane_candidates(indexes: &Archived<CardIndexes>, n_cards: usize, op: CmpOp, val: f64) -> Option<Vec<u64>> {
+    if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
+        return None;
+    }
+    let keep = |r: f64| match op {
+        CmpOp::Eq => r == val,
+        CmpOp::Lt => r < val,
+        CmpOp::Le => r <= val,
+        CmpOp::Gt => r > val,
+        CmpOp::Ge => r >= val,
+        CmpOp::Ne => r != val,
+    };
+    let wpp = words_per_plane(n_cards);
+    let mut bits = vec![0u64; wpp];
+    for b in 0..RARITY_PLANES {
+        if keep(b as f64) {
+            let plane = PLANE_RARITY + b;
+            for (a, w) in bits.iter_mut().zip(&indexes.planes.words[plane * wpp..(plane + 1) * wpp]) {
+                *a |= u64::from(*w);
+            }
+        }
+    }
+    for r in RARITY_PLANES..indexes.rarity.len() {
+        if keep(r as f64) {
+            for &cid in indexes.rarity[r].iter() {
+                let cid = u32::from(cid) as usize;
+                bits[cid / 64] |= 1u64 << (cid % 64);
+            }
+        }
+    }
+    Some(bits)
+}
+
 // ─── Combined indexes ────────────────────────────────────────────────────────
 
 // Postings live in two id spaces: card-level indexes post OracleCard indices
@@ -2789,7 +2836,17 @@ fn narrow_rec(
             // other printings that do NOT satisfy the comparison, so the
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
-            let rarity = |op, v: &f64| rarity_candidates(&indexes.rarity, op, *v).and_then(|c| Narrowed::loose(Candidates::Cards(c)));
+            // Plane path first (docs/issues/engine-rarity-planes.md): almost
+            // always available (the guard only declines on a mismatched/empty
+            // archive, mirroring legal_candidate_bits), and unlike the postings
+            // path never declines on selectivity -- a plane-OR is O(words)
+            // regardless of how broad the comparison is.
+            let rarity = |op, v: &f64| {
+                if let Some(bits) = rarity_plane_candidates(indexes, n_cards, op, *v) {
+                    return Narrowed::loose(Candidates::CardBits(bits));
+                }
+                rarity_candidates(&indexes.rarity, op, *v).and_then(|c| Narrowed::loose(Candidates::Cards(c)))
+            };
             let price = |op, v: &f64| {
                 price_bounds(op, *v).and_then(|(lo, hi)| range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, false))
             };
@@ -4366,7 +4423,7 @@ impl QueryEngine {
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: build_artwork_group_counts(&printings, &offsets),
-            planes:         build_bit_planes(&cards),
+            planes:         build_bit_planes(&cards, &printings, &offsets),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
             border_planes:  build_border_planes(&cards, &printings, &offsets, &strings),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1447,6 +1447,24 @@ fn flip_op(op: CmpOp) -> CmpOp {
     }
 }
 
+/// Logical negation of a comparison operator (NOT(a op b) == a negate_op(op) b),
+/// as opposed to flip_op's operand-order swap. Verified against filter.rs's
+/// actual tri() implementation, not just boolean-logic intuition: NumericCmp's
+/// NumVal::Null branch short-circuits to Tri::Null before the op-specific
+/// comparison ever runs, for every op including Ne, and Not(Null) stays Null
+/// (never flips to True) -- so Not(Eq(v)) and Ne(v) agree on null-valued
+/// printings too, not just known ones.
+fn negate_op(op: CmpOp) -> CmpOp {
+    match op {
+        CmpOp::Eq => CmpOp::Ne,
+        CmpOp::Ne => CmpOp::Eq,
+        CmpOp::Lt => CmpOp::Ge,
+        CmpOp::Ge => CmpOp::Lt,
+        CmpOp::Le => CmpOp::Gt,
+        CmpOp::Gt => CmpOp::Le,
+    }
+}
+
 /// Return sorted card indices satisfying `field op val` using the numeric index.
 /// Returns None for Ne (not selective) and Some(empty) when no cards can match.
 /// Card-space narrowing needs no selectivity guard (unlike MAX_NARROW_FRACTION
@@ -2157,6 +2175,18 @@ fn rarity_plane_candidates(indexes: &Archived<CardIndexes>, n_cards: usize, op: 
     Some(bits)
 }
 
+/// Narrow `rarity <op> val`: plane path first, postings fallback otherwise
+/// (see rarity_plane_candidates's doc). Standalone rather than a narrow_rec-
+/// local closure so both the direct NumericCmp arm and -rarity:x's dedicated
+/// Not arm can share it -- the latter calls this with negate_op(op), not a
+/// bitmap complement (see that arm's comment for why the distinction matters).
+fn narrow_rarity(indexes: &Archived<CardIndexes>, n_cards: usize, op: CmpOp, val: f64) -> Option<Narrowed> {
+    if let Some(bits) = rarity_plane_candidates(indexes, n_cards, op, val) {
+        return Narrowed::loose(Candidates::CardBits(bits));
+    }
+    rarity_candidates(&indexes.rarity, op, val).and_then(|c| Narrowed::loose(Candidates::Cards(c)))
+}
+
 // ─── Combined indexes ────────────────────────────────────────────────────────
 
 // Postings live in two id spaces: card-level indexes post OracleCard indices
@@ -2836,17 +2866,7 @@ fn narrow_rec(
             // other printings that do NOT satisfy the comparison, so the
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
-            // Plane path first (docs/issues/engine-rarity-planes.md): almost
-            // always available (the guard only declines on a mismatched/empty
-            // archive, mirroring legal_candidate_bits), and unlike the postings
-            // path never declines on selectivity -- a plane-OR is O(words)
-            // regardless of how broad the comparison is.
-            let rarity = |op, v: &f64| {
-                if let Some(bits) = rarity_plane_candidates(indexes, n_cards, op, *v) {
-                    return Narrowed::loose(Candidates::CardBits(bits));
-                }
-                rarity_candidates(&indexes.rarity, op, *v).and_then(|c| Narrowed::loose(Candidates::Cards(c)))
-            };
+            let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
             let price = |op, v: &f64| {
                 price_bounds(op, *v).and_then(|(lo, hi)| range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, false))
             };
@@ -2903,6 +2923,31 @@ fn narrow_rec(
         {
             let FilterExpr::Legality { shift: Some(shift), .. } = inner.as_ref() else { unreachable!() };
             Narrowed::loose(Candidates::CardBits(legal_candidate_bits(indexes, n_cards, *shift, true)?))
+        }
+
+        // -r:x / -rarity:x — same reason as -f:x above: rarity's narrowing is
+        // loose (docs/issues/engine-rarity-planes.md), so the generic
+        // Not-complement below would (correctly) refuse it -- a posted/planed
+        // card can have other printings that don't satisfy the comparison, so
+        // bit-complementing the existing candidate set would wrongly drop
+        // real -r:x matches (see the comment on the NumericCmp arm above).
+        // This is NOT a complement: it recomputes narrowing from scratch with
+        // the logically-negated operator (Not(Eq(v)) == Ne(v), verified
+        // against tri()'s actual Null handling in negate_op's doc comment),
+        // which is a different and correct operation.
+        FilterExpr::Not(inner)
+            if matches!(
+                inner.as_ref(),
+                FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), rhs: NumExpr::Const(_), .. }
+                    | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), rhs: NumExpr::Field(NumField::RarityInt), .. }
+            ) =>
+        {
+            let FilterExpr::NumericCmp { lhs, op, rhs } = inner.as_ref() else { unreachable!() };
+            match (lhs, rhs) {
+                (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) => narrow_rarity(indexes, n_cards, negate_op(*op), *v),
+                (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) => narrow_rarity(indexes, n_cards, negate_op(flip_op(*op)), *v),
+                _ => unreachable!(),
+            }
         }
 
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge) => {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -12,15 +12,15 @@
 //! are card-level and two-valued (their tri() never returns Null or
 //! PrintingDep), so plane algebra — including complement for Not —
 //! reproduces the filter's card-level truth exactly.
-//! Produced mana is deliberately left out for now; `produces:` queries stay on
-//! the residual path. Rarity and legality need the narrowing/divergence
-//! machinery from later phases (see the issue).
+//! Legality is narrowing-only (see PLANE_LEGAL). Rarity (the 4 most common
+//! values; docs/issues/engine-rarity-planes.md) is narrowing-only too, for
+//! the same PrintingDep reason -- see PLANE_RARITY.
 
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextSearchField};
 use super::legality::{LEGALITY_LEGAL, MAX_FORMATS};
-use super::{flip_op, lane_get, oracle_word_eligible, scan_oracle_words, OracleCard, OracleWordIndex};
+use super::{flip_op, lane_get, oracle_word_eligible, scan_oracle_words, OracleCard, OracleWordIndex, Printing};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
 /// field (W U B R G C, bit order matching color_to_bit — C is always zero for
@@ -75,7 +75,18 @@ pub(crate) const PLANE_POWER_HI: usize = PLANE_POWER + NUM_INTERIOR_WIDTH;
 pub(crate) const PLANE_TOUGHNESS_LO: usize = PLANE_POWER_HI + 1;
 pub(crate) const PLANE_TOUGHNESS: usize = PLANE_TOUGHNESS_LO + 1;
 pub(crate) const PLANE_TOUGHNESS_HI: usize = PLANE_TOUGHNESS + NUM_INTERIOR_WIDTH;
-pub(crate) const PLANE_COUNT: usize = PLANE_TOUGHNESS_HI + 1;
+/// One-hot planes for rarity (docs/issues/engine-rarity-planes.md), covering only the
+/// 4 most common values -- common=0, uncommon=1, rare=2, mythic=3, matching
+/// `magic.rarity_text_to_int`'s numbering directly (no offset needed). special=4/
+/// bonus=5 are far too sparse in production (1.17%/0.00% of cards) to be worth a
+/// fixed-cost plane each; they stay on the existing `RarityIndex` postings path
+/// (`lib.rs`'s `rarity_candidates`). Unlike cmc/power/toughness, there's no interior/
+/// overflow-bucket split: the planed range is the entire domain of interest, not a
+/// window into an unbounded numeric range, so no `BucketBounds` tracking is needed
+/// either -- a plain one-hot block, same shape as `PLANE_TYPES`.
+pub(crate) const RARITY_PLANES: usize = 4;
+pub(crate) const PLANE_RARITY: usize = PLANE_TOUGHNESS_HI + 1;
+pub(crate) const PLANE_COUNT: usize = PLANE_RARITY + RARITY_PLANES;
 
 /// The observed [min,max] of whatever cards landed in one bucket plane,
 /// recomputed on every build/reload (never hardcoded from a one-time data
@@ -153,7 +164,7 @@ fn set_numeric_plane(
     }
 }
 
-pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
+pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32]) -> BitPlanes {
     let wpp = words_per_plane(cards.len());
     let mut words = vec![0u64; PLANE_COUNT * wpp];
     let mut cmc_hi = BucketBounds::default();
@@ -163,6 +174,24 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard]) -> BitPlanes {
     let mut toughness_hi = BucketBounds::default();
     for (i, card) in cards.iter().enumerate() {
         let mut set = |plane: usize| words[plane * wpp + i / 64] |= 1u64 << (i % 64);
+        // Rarity (docs/issues/engine-rarity-planes.md): "any printing at this
+        // rarity" existence projection, same aggregation build_rarity_index
+        // does over the same range, just OR'd into planes instead of postings
+        // for the 4 most common values. Missing rarity (None) contributes no
+        // bit, same as build_rarity_index -- a card whose printings are all
+        // null-rarity correctly sets nothing here.
+        let range = offsets[i] as usize..offsets[i + 1] as usize;
+        let mut rarity_mask: u8 = 0;
+        for p in &printings[range] {
+            if let Some(r) = p.card_rarity_int {
+                rarity_mask |= 1 << r;
+            }
+        }
+        for b in 0..RARITY_PLANES {
+            if rarity_mask & (1 << b) != 0 {
+                set(PLANE_RARITY + b);
+            }
+        }
         for b in 0..COLOR_PLANES {
             if card.card_colors & (1 << b) != 0 {
                 set(PLANE_COLORS + b);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -513,6 +513,75 @@ fn rarity_never_exact_consumed() {
     );
 }
 
+/// -rarity:x / rarity:x negation, exercised through narrow_rec end-to-end
+/// (not just narrow_rarity directly), through the dedicated Not arm --
+/// recomputes with negate_op(op) rather than complementing the existing
+/// candidate set. Covers both operand orders (Field/Const and Const/Field,
+/// the latter needing negate_op(flip_op(op))) and confirms the negated form
+/// agrees with the same brute-force existence projection used for the
+/// non-negated ops above.
+#[test]
+fn rarity_not_arm_matches_existence_projection() {
+    let data = rarity_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_cards = RARITY_PLANE_FIXTURE.len();
+
+    let keep = |op: CmpOp, r: f64, val: f64| match op {
+        CmpOp::Eq => r == val,
+        CmpOp::Lt => r < val,
+        CmpOp::Le => r <= val,
+        CmpOp::Gt => r > val,
+        CmpOp::Ge => r >= val,
+        CmpOp::Ne => r != val,
+    };
+
+    let ops = [
+        ("Eq", CmpOp::Eq), ("Ne", CmpOp::Ne), ("Lt", CmpOp::Lt),
+        ("Le", CmpOp::Le), ("Gt", CmpOp::Gt), ("Ge", CmpOp::Ge),
+    ];
+    for (name, op) in ops {
+        for val in [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] {
+            // Not(field op val).
+            let filter = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
+                lhs: NumExpr::Field(NumField::RarityInt),
+                op,
+                rhs: NumExpr::Const(val),
+            }));
+            let n = super::narrow_rec(&filter, &archived.indexes, &archived.offsets, &archived.cards, true)
+                .unwrap_or_else(|| panic!("Not(rarity {name} {val}) must narrow"));
+            let cand = n.set.into_cards(&archived.offsets);
+            let want: Vec<u32> = RARITY_PLANE_FIXTURE
+                .iter()
+                .enumerate()
+                .filter(|(_, rarities)| rarities.iter().any(|r| r.is_some_and(|r| !keep(op, f64::from(r), val))))
+                .map(|(cid, _)| cid as u32)
+                .collect();
+            for cid in 0..n_cards as u32 {
+                assert_eq!(
+                    cand.contains(&cid),
+                    want.contains(&cid),
+                    "Not(field {name} {val}): card {cid} membership mismatch"
+                );
+            }
+
+            // Not(val flip_op(op) field) -- the flipped operand order
+            // expressing the SAME predicate as `field op val` (e.g. `field <
+            // val` is `val > field`, not `val < field` -- same op on both
+            // sides would be a different comparison entirely).
+            let filter_flipped = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
+                lhs: NumExpr::Const(val),
+                op: super::flip_op(op),
+                rhs: NumExpr::Field(NumField::RarityInt),
+            }));
+            let n2 = super::narrow_rec(&filter_flipped, &archived.indexes, &archived.offsets, &archived.cards, true)
+                .unwrap_or_else(|| panic!("Not({val} {name} field) must narrow"));
+            let cand2 = n2.set.into_cards(&archived.offsets);
+            assert_eq!(cand, cand2, "operand order must not change the result: {name} {val}");
+        }
+    }
+}
+
 #[test]
 fn cards_of_printings_maps_and_dedups() {
     let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 3, 4, 7]).expect("serialize");
@@ -2967,8 +3036,23 @@ fn not_narrows_only_tight_children() {
         }
     }
 
-    // Loose children block the Not arm entirely.
-    assert!(rec(&FilterExpr::Not(Box::new(rarity()))).is_none(), "rarity existence sets are not complement-safe");
+    // -r:x narrows via its own dedicated Not(NumericCmp{RarityInt}) arm --
+    // recomputing with the negated op (Not(Eq) -> Ne), not complementing the
+    // existing loose rarity candidate set (which would be unsafe: a posted
+    // card can have other printings that don't satisfy the comparison). Same
+    // superset check as the tight-child case above, just via a different arm.
+    let n = rec(&FilterExpr::Not(Box::new(rarity()))).expect("-r:x must narrow via the negated-op arm");
+    assert!(!n.tight);
+    let cand = n.set.into_cards(&archived.offsets);
+    for (cid, card) in archived.cards.iter().enumerate() {
+        let matches_not = (u32::from(archived.offsets[cid])..u32::from(archived.offsets[cid + 1]))
+            .any(|p| FilterExpr::Not(Box::new(rarity())).matches(card, &archived.printings[p as usize], &archived.strings));
+        if matches_not {
+            assert!(cand.contains(&(cid as u32)), "-r:x narrowing must not drop card {cid}");
+        }
+    }
+
+    // Genuinely loose children with no dedicated Not arm still block it.
     assert!(rec(&FilterExpr::Not(Box::new(name1()))).is_none(), "sub-bigram text cannot narrow at all");
     let double_not = FilterExpr::Not(Box::new(FilterExpr::Not(Box::new(goblin()))));
     assert!(rec(&double_not).is_none(), "complements are loose, so double negation stops narrowing");

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -224,7 +224,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
     // Real planes and bigrams so narrowing tests see the same store shape
     // reload_commit builds (type narrowing goes through the planes since #637).
     let indexes = CardIndexes {
-        planes: build_bit_planes(&cards),
+        planes: build_bit_planes(&cards, &printings, &offsets),
         name_bigrams: build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards, &printings, &offsets),
@@ -376,6 +376,141 @@ fn narrow_candidates_rarity_card_space() {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("flipped rarity must narrow in card space"),
     }
+}
+
+/// Card i's printing rarities (docs/issues/engine-rarity-planes.md): one value
+/// per printing, None for no-rarity. Covers all 6 buckets, cards spanning two
+/// buckets at once (mixed within the planed range, and mixed across the
+/// plane/postings-tail boundary), and a card with no rarity anywhere.
+const RARITY_PLANE_FIXTURE: &[&[Option<u8>]] = &[
+    &[Some(0)],         // card 0: common only
+    &[Some(1)],         // card 1: uncommon only
+    &[Some(2)],         // card 2: rare only
+    &[Some(3)],         // card 3: mythic only
+    &[Some(4)],         // card 4: special only
+    &[Some(5)],         // card 5: bonus only
+    &[Some(0), Some(3)], // card 6: common + mythic (mixed, both planed)
+    &[Some(2), Some(4)], // card 7: rare + special (mixed, spans plane/tail)
+    &[None],             // card 8: no rarity anywhere
+];
+
+fn rarity_plane_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = (0..RARITY_PLANE_FIXTURE.len())
+        .map(|i| stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab))
+        .collect();
+    let counts: Vec<usize> = RARITY_PLANE_FIXTURE.iter().map(|r| r.len()).collect();
+    let mut data = store_of(cards, &counts, vocab);
+    let mut p_idx = 0;
+    for rarities in RARITY_PLANE_FIXTURE {
+        for &r in *rarities {
+            data.printings[p_idx].card_rarity_int = r;
+            p_idx += 1;
+        }
+    }
+    data.indexes.rarity = build_rarity_index(&data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data
+}
+
+/// The plane-aware narrowing function must reproduce the true existence
+/// projection ("does any printing of this card satisfy op(rarity, val)") for
+/// every op, across the full 0-5 domain and an impossible threshold — the
+/// reference here is brute force over RARITY_PLANE_FIXTURE directly, not
+/// rarity_candidates (which declines for Ne and over-ceiling unions, so it
+/// can't serve as the reference for every op the way the plane path must
+/// still answer).
+#[test]
+fn rarity_plane_candidates_matches_existence_projection() {
+    let data = rarity_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_cards = RARITY_PLANE_FIXTURE.len();
+
+    let keep = |op: CmpOp, r: f64, val: f64| match op {
+        CmpOp::Eq => r == val,
+        CmpOp::Lt => r < val,
+        CmpOp::Le => r <= val,
+        CmpOp::Gt => r > val,
+        CmpOp::Ge => r >= val,
+        CmpOp::Ne => r != val,
+    };
+
+    let ops = [
+        ("Eq", CmpOp::Eq), ("Ne", CmpOp::Ne), ("Lt", CmpOp::Lt),
+        ("Le", CmpOp::Le), ("Gt", CmpOp::Gt), ("Ge", CmpOp::Ge),
+    ];
+    for (name, op) in ops {
+        for val in [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 2.5, -1.0, 6.0] {
+            let bits = super::rarity_plane_candidates(&archived.indexes, n_cards, op, val).expect("plane path must not decline");
+            let want: Vec<u32> = RARITY_PLANE_FIXTURE
+                .iter()
+                .enumerate()
+                .filter(|(_, rarities)| rarities.iter().any(|r| r.is_some_and(|r| keep(op, f64::from(r), val))))
+                .map(|(cid, _)| cid as u32)
+                .collect();
+            for cid in 0..n_cards as u32 {
+                assert_eq!(
+                    bitmap_contains(&bits, cid),
+                    want.contains(&cid),
+                    "op {name} val {val}: card {cid} membership mismatch"
+                );
+            }
+        }
+    }
+}
+
+/// Card 8 (RARITY_PLANE_FIXTURE) has no rarity on any printing -- it must not
+/// appear under any comparison, matching build_rarity_index's own None-skips
+/// silently behavior (this repo's history of Null-semantics bugs elsewhere
+/// makes this worth its own explicit case, not just incidental coverage in
+/// the parity test above).
+#[test]
+fn rarity_plane_null_rarity_card_matches_nothing() {
+    let data = rarity_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_cards = RARITY_PLANE_FIXTURE.len();
+    let null_card = 8u32;
+
+    let ops = [
+        ("Eq", CmpOp::Eq), ("Ne", CmpOp::Ne), ("Lt", CmpOp::Lt),
+        ("Le", CmpOp::Le), ("Gt", CmpOp::Gt), ("Ge", CmpOp::Ge),
+    ];
+    for (name, op) in ops {
+        for val in [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] {
+            let bits = super::rarity_plane_candidates(&archived.indexes, n_cards, op, val).expect("plane path must not decline");
+            assert!(!bitmap_contains(&bits, null_card), "op {name} val {val}: null-rarity card must never match");
+        }
+    }
+}
+
+/// Rarity is PrintingDep (a card can have printings at multiple rarities), so
+/// it must never be exact-consumed via compile_plane/split_planes -- only the
+/// loose narrowing path (tested above) is sound. This is the correctness
+/// property the whole design depends on: routing rarity through compile_plane
+/// would silently promote it to all_match, skipping the per-printing
+/// verification that resolves mixed-rarity cards correctly.
+#[test]
+fn rarity_never_exact_consumed() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let rarity = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(3.0) };
+    assert!(compile_plane(&rarity, bounds, words).is_none(), "rarity must never compile to a plane expression");
+
+    // Mixed with an otherwise fully plane-expressible sibling: the rarity
+    // child must stay in the residual, not get silently dropped or promoted.
+    let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity]), bounds, words);
+    assert!(pe.is_some(), "the creature child must still plane-consume");
+    assert!(
+        matches!(&residual, FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }),
+        "rarity must remain in the residual, not be consumed to True"
+    );
 }
 
 #[test]
@@ -844,7 +979,7 @@ fn bench_checked_vs_unchecked_access() {
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups: build_artwork_group_counts(&printings, &offsets),
-        planes:         build_bit_planes(&cards),
+        planes:         build_bit_planes(&cards, &printings, &offsets),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
         border_planes:  build_border_planes(&cards, &printings, &offsets, &strings),
@@ -2788,6 +2923,11 @@ fn narrow_fixture_store() -> CardData {
     }
     data.indexes.subtypes = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
     data.indexes.rarity = build_rarity_index(&data.printings, &data.offsets);
+    // Rarity planes are built from the same printings, so they must be
+    // rebuilt here too -- build_bit_planes already ran once inside store_of
+    // before card_rarity_int was overwritten above, leaving stale (all-zero)
+    // rarity plane bits otherwise.
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
     let mut set_codes: TagIndex = HashMap::new();
     for (i, p) in data.printings.iter().enumerate() {
         set_codes.entry(p.card_set_code.as_str().to_string()).or_default().push(i as u32);

--- a/docs/issues/engine-rarity-planes.md
+++ b/docs/issues/engine-rarity-planes.md
@@ -1,0 +1,265 @@
+# Engine: card-level rarity bitplanes (common/uncommon/rare/mythic)
+
+Status: implemented, PR pending. GitHub: #670. Follows
+[docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+Split out of #630 (bitplanes phase 3) after that issue closed with phases 1/2 shipped.
+Verification-side follow-on tracked separately: #674.
+
+## Measured problem
+
+`card_rarity_int` (`Printing`, `Option<u8>`, `lib.rs:310`) is printing-level: a card can have
+printings at multiple rarities across reprints. Today it's served entirely by `RarityIndex`
+(`lib.rs:2042`, `[Vec<u32>; 6]`) — a card-space "any-printing-at-rarity" postings structure,
+queried via `rarity_candidates()` (`lib.rs:2088`), which unions the qualifying buckets for
+`Eq`/`Lt`/`Le`/`Gt`/`Ge` and declines `Ne` unconditionally ("matches nearly every card, same
+convention as `numeric_candidates`"). A union past `MAX_UNION_FRACTION = 0.70` (`lib.rs:2080`)
+also declines — the code's own comment cites `rarity<=mythic` (99% of entries) and
+`rarity>=uncommon` (69%) as the queries that already sit near or past that ceiling, falling back
+to a full per-card residual scan.
+
+Every rarity query above that 70% coverage ceiling, plus every `Ne` comparison, pays the full
+`narrow_rec` union-materialization cost (the #618 cost #630 phase 1 already retired for
+colors/types) or a full residual scan — regardless of how selective the specific comparison is.
+
+## Where the cost is
+
+Rarity was explicitly deferred out of #630 phase 1/2: it's a `PrintingDep` existence projection at
+card level (never exact-consumable the way colors/types/legality are), so it needed its own design
+pass rather than reusing the exact-consumption machinery verbatim. `compile_plane` has no rarity
+handling today; `NumericLayout`/`numeric_layout` (`planes.rs:428-462`) already has a `_ => None`
+catch-all that a comment at `planes.rs:594` explicitly names rarity under ("Other NumericCmp fields
+(rarity, price, ...) already decline via `compile_plane`'s catch-all") — i.e. the gap is a known,
+named stub, not an oversight to rediscover.
+
+## Proposed approach: 4 of 6 values as planes, extending the existing numeric-range machinery
+
+**Selectivity, measured before committing to scope** (`benchmarks/bitplanes/corpus.jsonl`, 97,206
+printings / 31,508 cards — a printing-level attribute rolling up to card level could in principle
+flatten toward "every card has one of everything," so this was checked rather than assumed):
+
+| rarity | % printings | % cards w/ ≥1 printing |
+|---|---|---|
+| common | 28.31% | 33.74% |
+| uncommon | 24.28% | 32.43% |
+| rare | 37.82% | 34.85% |
+| mythic | 9.18% | **8.15%** |
+| special | 0.40% | 1.17% |
+| bonus | 0.00% | 0.00% |
+
+It doesn't flatten: 91% of cards (28,713/31,508) only ever appear at a single rarity across every
+printing they have, so the card-level existence projection stays close to the printing-level
+distribution — `mythic` in particular stays a genuinely tight 8.15% of cards, comparable to or
+tighter than dimensions already planed (`t:creature` 47% of printings, `f:modern` ~70.7% legal per
+#654). `special`/`bonus` are a different story — 1.17% and effectively 0% of cards, a `bonus` plane
+would be entirely empty in production — not worth a full ~4 KB plane each.
+
+**Design: plane common/uncommon/rare/mythic, leave special/bonus on the existing postings path.**
+`RarityIndex` stays exactly as-is for special/bonus; the 4 planed values are removed from its
+domain (or simply left unqueried by the new plane-aware path — see reconciliation below).
+
+**Do not extend `NumericLayout`/`compile_numeric_cmp` — that machinery is exact-consumption-only,
+and rarity must never be exact-consumed.** Checked against the composition invariants before writing
+any code, per the workflow doc's warning: `compile_numeric_cmp`/`numeric_layout` (`planes.rs:428-585`)
+are called from exactly one place, `compile_plane`'s `FilterExpr::NumericCmp` arm
+(`planes.rs:720-724`) — and `compile_plane`'s own doc comment (`planes.rs:636-641`) restricts it to
+"two-valued card-level nodes... complement (Not) is only sound when the node can never be Null or
+PrintingDep." Rarity is genuinely `PrintingDep`: a card with both a common printing and a mythic
+printing has *both* bits set in the existence-projection plane simultaneously, which is correct for
+narrowing but would be wrong to treat as "this card exactly matches `r:mythic`" the way `compile_plane`
+treats a compiled node. Adding a `NumField::RarityInt` arm to `numeric_layout` would silently route
+rarity into `compile_plane`'s all_match-promotion path — a real correctness bug (skips per-printing
+verification), not just a missed optimization. cmc/power/toughness get away with exact consumption
+despite being `Option`-valued because their `None` is `Tri::Null` (a card-level absolute — no printing
+of a non-creature card has power), which correctly collapses to "excluded" through the plane by
+omission; rarity's multi-valuedness is `PrintingDep` (printings genuinely disagree), which has no
+such collapse.
+
+**The narrowing path needs its own function, not a `compile_plane` extension — and it turns out
+simpler than the numeric-range machinery, not an extension of it.** Rarity's domain is 6
+fully-enumerable values (0-5), not an open-ended numeric range, so there's no need for
+`bucket_verdict`'s fully-included/fully-excluded/ambiguous logic or observed-`[min,max]` bounds
+tracking at all — every "bucket" is a single known value. A new function (in `lib.rs`, alongside
+`rarity_candidates`) reuses `rarity_candidates`'s own bucket-selection (`keep`/`buckets`,
+`lib.rs:2092-2100`) to get the set of matching rarity values for `op`/`threshold`, partitions that
+set into planed (0-3) vs. postings-only (4-5, special/bonus), OR's the plane words for the planed
+subset, and — only when the postings-only subset is non-empty — `scatter_bits`'s (`lib.rs:2249`)
+that subset's postings into a bitmap and OR's it in. Both subsets empty is impossible (the op
+always selects ≥0 values); postings-only empty is the common case and skips `RarityIndex` entirely.
+**This also means `Ne` doesn't need `rarity_candidates`'s unconditional decline carried over**: the
+decline exists there because a pure-postings "not equal" union is usually too large to be worth
+materializing, but with 4 of 6 values plane-backed, `r!=mythic`'s "keep" set is mostly plane-OR
+(cheap) plus a tiny special/bonus scatter — it falls out of the same generic bucket-partition logic
+as every other op, no special-casing needed.
+
+**Feeding the planes: build directly from `printings`/`offsets`, no new field on `OracleCard`.**
+`build_bit_planes` (`planes.rs:156`) takes only `cards: &[OracleCard]` today — every dimension it
+planes (colors/identity/produced_mana/types/legality/cmc/power/toughness) already lives directly on
+`OracleCard`. Rarity doesn't; it's aggregated from `printings`+`offsets` into `RarityIndex`
+separately (`build_rarity_index`, `lib.rs:2044`, called alongside `build_bit_planes` at
+`lib.rs:4345`/`4369`).
+
+The `legality_divergent` precedent doesn't actually transfer here: that field is a genuine *runtime*
+dispatch flag, consulted during `Tri` computation on every query touching legality
+(`filter.rs:1228`, "trust the card-level word or check this printing's own") — that's why it has to
+be a permanent field on `OracleCard`. Rarity has no equivalent runtime need: residual verification
+already evaluates `card_rarity_int` printing-natively (`filter.rs:98`,
+`printing.map_or(NumVal::PDep, |p| known(p.card_rarity_int...))`), never consulting any card-level
+cache. So a card-level rarity summary would only ever be read once, at plane-build time — no reason
+to make it permanent.
+
+Instead: broaden `build_bit_planes` to also accept `printings: &[Printing]`/`offsets: &[u32]`, and
+compute the per-card OR inline in its existing per-card loop (reusing `build_rarity_index`'s
+`mask |= 1 << r`, `lib.rs:2048`, rather than re-deriving it) — decided over the alternative of a
+separate `build_rarity_planes(printings, offsets, wpp) -> Vec<u64>` sibling function, because the
+blast radius is trivial (checked: only 3 call sites — `lib.rs:4369` and two test fixtures at
+`tests.rs:227`/`847` — and all 3 already have `printings`/`offsets` in local scope right next to the
+`build_bit_planes(&cards)` call, since `build_rarity_index` is already called alongside it) and
+because it keeps one function as the single source of truth for the whole plane layout. A sibling
+function would mean a second full pass over all cards plus splicing its output into the middle of
+the same `words` buffer at the right plane offset — two functions independently agreeing on
+`wpp`/plane-index math for one shared buffer, for no benefit given the data's already there. No
+`OracleCard` archive-layout change either way, no permanent extra byte per card, no second copy of
+information `RarityIndex` already encodes.
+
+**Narrowing integration**: `narrow_rec`'s rarity arm (today calling `rarity_candidates`, feeding
+`Candidates::Cards`) gets a plane-based path for comparisons that resolve fully within the 4 planed
+values, falling back to today's postings behavior otherwise (or the reconciliation path above for
+mixed comparisons) — the same `loose`/narrowing-only shape `Legality` already has, not exact
+consumption (rarity is `PrintingDep`, `card_pass`/printing-level residual eval still verifies which
+printings actually match).
+
+**Nullability**: `card_rarity_int` is `Option<u8>` — some printings carry no rarity.
+`build_rarity_index` already skips `None` silently (`lib.rs:2050`); the new `rarity_mask`
+aggregation needs the same behavior (a card whose printings are all null-rarity sets no bits,
+falling through exactly as today's postings do). Explicit parity-test case, given this repo's
+history with Null-semantics bugs in exactly this kind of promotion (#634's implementation caught
+two real ones; see also `docs/issues/engine-null-vs-empty-text-parity.md`).
+
+**Two wins beyond the obvious Eq/Ge/Le narrowing**, worth their own benchmark rows:
+
+- `Ne`, unconditionally declined today (`lib.rs:2089-2090`), becomes just as cheap as any other
+  bucket combination once the 4 common values are planes (OR the other 3 planed buckets, union in
+  special/bonus postings only if involved).
+- `MAX_UNION_FRACTION`'s 0.70 ceiling (`lib.rs:2080`) has no equivalent for planes — a plane-OR is
+  O(words) regardless of selectivity. The comparisons closest to today's cutoff
+  (`rarity<=mythic` at 99%, `rarity>=uncommon` at 69%, both cited in the code comment) are exactly
+  where the plane should show the biggest relative win over today's decline-and-scan behavior.
+
+## Acceptance
+
+1. **Baseline on `main`**: targeted script (new `scripts/bench_rarity_planes.py`, modeled on
+   `scripts/bench_produces_planes.py`) + `scripts/survey_queries.py` (seed 42, same corpus reused
+   from #630/#654/#655/#666/#669 — schema already covers `card_rarity_int`, no re-export needed).
+   Memory baseline too (`--features alloc-counter`): this adds 4 planes (~4 KB × 4 ≈ 16 KB) to the
+   archive; no `OracleCard` growth, since the planes build directly from `printings`/`offsets`.
+2. **Targeted configs**: `r:mythic` / `r:rare` / `r:common` / `r:uncommon` solo, each `CmpOp`
+   (mirroring the existing numeric-range op-coverage tests); `r>=rare`, `r<=uncommon` (mixed
+   plane+postings reconciliation); `r!=mythic` (the newly-cheap `Ne` case); `r:special`/`r:bonus`
+   (must stay on the unchanged postings path — controls, not expected to move); `rarity<=mythic`
+   and `rarity>=uncommon` specifically (today's near-ceiling union-fraction cases, called out above
+   as the expected biggest wins); compound with an already-planed dimension (`t:creature r:mythic`);
+   `-r:common` (negation through the reconciliation path); unrelated controls.
+3. **Differential/parity tests**: op-coverage test for the new narrowing function against every
+   `CmpOp` (mirrors `plane_parity_color_and_type_ops`'s shape, but checked against
+   `rarity_candidates`'s postings result as the reference, not a plane-vs-card-truth comparison —
+   rarity narrows, it never claims card-level truth); a dedicated test for the plane+postings
+   partition (a comparison spanning both, e.g. `r>=rare`, checked against a brute-force reference);
+   a dedicated null-rarity-printing test (mirrors `divergent_legality_defers_to_printings`'s shape —
+   a card whose only printings have no rarity at all must match nothing under any planed
+   comparison, same as today); a test confirming rarity is never routed through `compile_plane`
+   (i.e. `split_planes` never fully consumes a rarity predicate to `FilterExpr::True` — the
+   correctness property this whole design depends on).
+4. **Total-row-count parity** on every benchmark config, every run.
+5. **Queries expected to improve**: any rarity comparison resolvable within the 4 planed values,
+   especially `Ne` and the near-70%-ceiling `Ge`/`Le` cases. `special`/`bonus`-only queries are
+   controls, not expected to move. No regressions expected — no loose/declining case is being
+   removed for the planed values, only added capability.
+6. Re-measure and iterate until no regressions remain; open PR per the workflow's step 6 template,
+   linking #670.
+
+## Results
+
+**Scope turned out narrower than "rarity queries get faster" — worth stating plainly rather than
+overselling.** Solo `Eq` queries on the four planed values (`r:common`/`r:uncommon`/`r:rare`/
+`r:mythic`) show ~1.00x, flat. Traced why before treating it as a problem: the old postings path
+never declined for a single-bucket `Eq` — it degenerates to a copy of one already-sorted bucket
+(`build_rarity_index` builds each bucket in ascending card-id order), so it was already cheap.
+Both old and new paths converge on the identical candidate `Vec<u32>` before `card_pass` anyway
+(`Candidates::CardBits`'s own `into_cards` calls `bitmap_card_ids`, same materialization step
+postings already paid). The dominant, unchanged cost for these queries is `card_pass` itself
+walking each candidate's printings — a genuinely more expensive per-candidate operation than a
+type/color bitmask test, and this PR doesn't touch it. Filed as its own follow-on:
+[#674](https://github.com/jbylund/sylvan_librarian/issues/674) (verification-side short-circuit for
+the 91% of cards with a single distinct rarity), explicitly distinguished from #657 there (#657's
+elision only helps children `narrow_candidates_exact` already proved exact; rarity is never
+exact/tight to begin with, so #657 gives it nothing).
+
+The real, measured wins are exactly the two cases predicted above — where the old path either
+declined outright or was near its decline ceiling:
+
+Targeted (`scripts/bench_rarity_planes.py`, `benchmarks/bitplanes/corpus.jsonl`, 3s window/config,
+`min_ms`, 21 configs):
+
+| group | query | unique | before | after | change |
+|---|---|---|---|---|---|
+| solo | `r:common` | card | 0.168ms | 0.169ms | 0.99x |
+| solo | `r:uncommon` | card | 0.173ms | 0.176ms | 0.98x |
+| solo | `r:rare` | card | 0.224ms | 0.226ms | 1.00x |
+| solo | `r:mythic` | card | 0.112ms | 0.112ms | 1.00x |
+| ceiling | `rarity<=mythic` | card | 0.344ms | 0.351ms | 0.98x |
+| ceiling | `rarity>=uncommon` | card | 0.346ms | 0.311ms | **1.11x** |
+| ne | `r!=mythic` | card | 0.407ms | 0.414ms | 0.98x |
+| ne | `r!=common` | card | 0.554ms | 0.311ms | **1.78x** |
+| mixed-tail | `r>=rare` | card | 0.258ms | 0.246ms | 1.05x |
+| mixed-tail | `-r:common` | card | 0.626ms | 0.632ms | 0.99x |
+| tail-control | `r:special` | card | 0.067ms | 0.068ms | 0.99x |
+| tail-control | `r:bonus` | card | 0.003ms | 0.003ms | 0.93x |
+| negation | `-r:mythic` | card | 0.482ms | 0.483ms | 1.00x |
+| and-combo | `t:creature r:mythic` | card | 0.083ms | 0.081ms | 1.03x |
+| and-combo | `f:modern r:mythic` | card | 0.108ms | 0.107ms | 1.01x |
+| uniques | `r:mythic` (printing) | printing | 0.150ms | 0.149ms | 1.00x |
+| uniques | `r:mythic` (artwork) | artwork | 0.173ms | 0.172ms | 1.00x |
+| control | `name:soldier` | card | 0.029ms | 0.029ms | 1.00x |
+| control | `cmc>6` | card | 0.057ms | 0.056ms | 1.01x |
+| control | `oracle:creature` | card | 0.121ms | 0.120ms | 1.01x |
+| control | `c:g` | card | 0.053ms | 0.051ms | 1.02x |
+
+Geomean 1.03x across all 21 configs, 1.07x restricted to rarity-touching configs. Total-row-count
+parity held on every config, every run.
+
+Broad survey (`scripts/survey_queries.py`, seed 42, 520 queries): overall geomean 1.02x (flat), no
+attributable regressions — the two configs moving >15% (`type:artifact (id:gw or is:modal)`,
+`id:wu oracle:trample frame:showcase`) contain no rarity predicate at all, consistent with
+single-run timing noise on sub-millisecond queries rather than anything this change touched.
+
+Memory (`--features alloc-counter`): `archive_bytes` +15,784 bytes (+0.023%) — matches the
+predicted 4 planes × 493 words × 8 bytes almost exactly. `cards_rkyv_bytes` unchanged, confirming
+no `OracleCard` growth. `reload_peak` unchanged.
+
+One real bug caught during implementation, not by the benchmark: `narrow_fixture_store` (an
+existing test fixture) rebuilt `RarityIndex` after mutating printing rarities but not `BitPlanes`,
+leaving stale (pre-mutation, all-zero) rarity plane bits — caught by
+`adaptive_narrowing_run_query_parity` failing (`total=2` vs brute-force `6`) on first test run.
+Fixed by rebuilding `indexes.planes` alongside `indexes.rarity` in that fixture.
+
+**Decision: land as-is rather than holding for #674.** Same phasing precedent #630 itself already
+established — colors/types bitplanes (#633) didn't move `t:creature` either, until #634 added
+exactness propagation on top; shipping the narrowing substrate before the verification-side win
+lands is this codebase's normal pattern, not a deviation from it. This PR retires part of the #618
+union-materialization cost and closes two real gaps (`Ne` declining, near-ceiling `Ge`/`Le`) on its
+own merits, independent of whether/when #674 lands.
+
+## Related
+
+- #670 — GitHub issue tracking this (Phase 3 remainder of #630)
+- #630 — where rarity was scoped out of phases 1/2 as narrowing-only, `PrintingDep`
+- #618 — the union materialization this retires for the 4 planed values
+- #654 — legality bitplanes; `legality_divergent`'s addition to `OracleCard` is the precedent that
+  was *considered and rejected* here — it's a runtime dispatch flag rarity has no equivalent of
+- #655/#659 — numeric-range bitplanes (`NumericLayout`/`compile_numeric_cmp`); another precedent
+  *considered and rejected* — that machinery is wired exclusively into `compile_plane`'s
+  exact-consumption path (`planes.rs:720-724`), which rarity must never go through given it's
+  `PrintingDep`. Rarity gets its own narrowing-only function instead, feeding `narrow_rec` directly
+- #669 — produced-mana bitplanes; closest recent precedent for "extend existing plane machinery to
+  one more field," though that one needed zero new reconciliation logic (produced mana is fully
+  exact, unlike rarity's partial plane coverage)

--- a/docs/issues/engine-rarity-planes.md
+++ b/docs/issues/engine-rarity-planes.md
@@ -194,51 +194,85 @@ the 91% of cards with a single distinct rarity), explicitly distinguished from #
 elision only helps children `narrow_candidates_exact` already proved exact; rarity is never
 exact/tight to begin with, so #657 gives it nothing).
 
-The real, measured wins are exactly the two cases predicted above — where the old path either
-declined outright or was near its decline ceiling:
+**Second-round finding: the initial `Ne` win didn't reach the way people actually write "not this
+rarity."** `-r:common` parses to `Not(Eq(common))`, not `Ne(common)` directly, and `Not` only
+narrows through *tight* children — rarity's narrowing is always loose, so `-r:common` declined to a
+full scan in both old and new code even after the first round of this change, despite `r!=common`
+(the literal, rarely-typed `!=` operator) already showing a 1.78x win. Fixed by giving `-r:x` its
+own dedicated `Not` arm in `narrow_rec` — the same pattern `-f:x` already established
+(`legal_candidate_bits(..., negate: true)`) — that recomputes narrowing with a logically negated
+operator (`negate_op`: `Eq`↔`Ne`, `Lt`↔`Ge`, `Le`↔`Gt`) rather than complementing the existing
+candidate bitmap, which would be unsound for the same reason the `NumericCmp` arm's own comment
+already flagged (a posted/planed card can have other printings that don't satisfy the comparison,
+so bit-complementing would wrongly drop real matches). The `Not(Eq(v)) == Ne(v)` equivalence this
+relies on was checked against `filter.rs`'s actual `tri()` implementation before writing the code,
+not assumed from boolean-logic intuition alone — `NumericCmp`'s `NumVal::Null` branch short-circuits
+to `Tri::Null` before the op-specific comparison runs, for every op including `Ne`, and `Not`'s own
+`Tri::Null => Tri::Null` line confirms it never flips to a false match — so the two forms agree on
+null-rarity printings too, not just known values.
+
+One test bug caught by this second round, not the benchmark: `not_narrows_only_tight_children` had
+asserted `-r:x` *never* narrows as a correctness guard (true before this fix) — updated to assert
+the new, correct narrowing behavior instead, verified against the same brute-force superset check
+already used for the tight-child case in that test. A test bug of my own also surfaced while
+writing the new parity test for the negation arm: constructing "the same predicate, operands
+flipped" needs `flip_op(op)` on the flipped side (`field < val` is `val > field`, not `val < field`)
+— caught immediately by the new test disagreeing with itself across operand orders, not by manual
+inspection.
+
+The real, measured wins are exactly the two shapes predicted, plus the `-r:x` fix:
 
 Targeted (`scripts/bench_rarity_planes.py`, `benchmarks/bitplanes/corpus.jsonl`, 3s window/config,
 `min_ms`, 21 configs):
 
 | group | query | unique | before | after | change |
 |---|---|---|---|---|---|
-| solo | `r:common` | card | 0.168ms | 0.169ms | 0.99x |
-| solo | `r:uncommon` | card | 0.173ms | 0.176ms | 0.98x |
-| solo | `r:rare` | card | 0.224ms | 0.226ms | 1.00x |
-| solo | `r:mythic` | card | 0.112ms | 0.112ms | 1.00x |
-| ceiling | `rarity<=mythic` | card | 0.344ms | 0.351ms | 0.98x |
-| ceiling | `rarity>=uncommon` | card | 0.346ms | 0.311ms | **1.11x** |
-| ne | `r!=mythic` | card | 0.407ms | 0.414ms | 0.98x |
-| ne | `r!=common` | card | 0.554ms | 0.311ms | **1.78x** |
-| mixed-tail | `r>=rare` | card | 0.258ms | 0.246ms | 1.05x |
-| mixed-tail | `-r:common` | card | 0.626ms | 0.632ms | 0.99x |
-| tail-control | `r:special` | card | 0.067ms | 0.068ms | 0.99x |
+| solo | `r:common` | card | 0.168ms | 0.171ms | 0.98x |
+| solo | `r:uncommon` | card | 0.173ms | 0.177ms | 0.97x |
+| solo | `r:rare` | card | 0.224ms | 0.230ms | 0.98x |
+| solo | `r:mythic` | card | 0.112ms | 0.113ms | 0.99x |
+| ceiling | `rarity<=mythic` | card | 0.344ms | 0.349ms | 0.99x |
+| ceiling | `rarity>=uncommon` | card | 0.346ms | 0.312ms | **1.11x** |
+| ne | `r!=mythic` | card | 0.407ms | 0.411ms | 0.99x |
+| ne | `r!=common` | card | 0.554ms | 0.312ms | **1.78x** |
+| mixed-tail | `r>=rare` | card | 0.258ms | 0.249ms | 1.04x |
+| mixed-tail | `-r:common` | card | 0.626ms | 0.364ms | **1.72x** |
+| tail-control | `r:special` | card | 0.067ms | 0.069ms | 0.98x |
 | tail-control | `r:bonus` | card | 0.003ms | 0.003ms | 0.93x |
-| negation | `-r:mythic` | card | 0.482ms | 0.483ms | 1.00x |
-| and-combo | `t:creature r:mythic` | card | 0.083ms | 0.081ms | 1.03x |
-| and-combo | `f:modern r:mythic` | card | 0.108ms | 0.107ms | 1.01x |
-| uniques | `r:mythic` (printing) | printing | 0.150ms | 0.149ms | 1.00x |
-| uniques | `r:mythic` (artwork) | artwork | 0.173ms | 0.172ms | 1.00x |
-| control | `name:soldier` | card | 0.029ms | 0.029ms | 1.00x |
-| control | `cmc>6` | card | 0.057ms | 0.056ms | 1.01x |
-| control | `oracle:creature` | card | 0.121ms | 0.120ms | 1.01x |
-| control | `c:g` | card | 0.053ms | 0.051ms | 1.02x |
+| negation | `-r:mythic` | card | 0.482ms | 0.487ms | 0.99x |
+| and-combo | `t:creature r:mythic` | card | 0.083ms | 0.084ms | 0.99x |
+| and-combo | `f:modern r:mythic` | card | 0.108ms | 0.109ms | 0.98x |
+| uniques | `r:mythic` (printing) | printing | 0.150ms | 0.154ms | 0.98x |
+| uniques | `r:mythic` (artwork) | artwork | 0.173ms | 0.177ms | 0.98x |
+| control | `name:soldier` | card | 0.029ms | 0.030ms | 0.97x |
+| control | `cmc>6` | card | 0.057ms | 0.058ms | 0.97x |
+| control | `oracle:creature` | card | 0.121ms | 0.123ms | 0.99x |
+| control | `c:g` | card | 0.053ms | 0.053ms | 0.99x |
 
-Geomean 1.03x across all 21 configs, 1.07x restricted to rarity-touching configs. Total-row-count
-parity held on every config, every run.
+Geomean 1.04x across all 21 configs. Total-row-count parity held on every config, every run.
+`-r:common` (1.72x) now matches `r!=common` (1.78x) closely, as expected — verified-identical
+predicates. `-r:mythic`/`r!=mythic` both stay flat: "not mythic" narrows to only ~94% of the corpus
+(mythic is the rarest planed value at 8.15% of cards, so almost every card has *some* non-mythic
+printing), leaving little for narrowing to exclude before `card_pass` regardless — same underlying
+"narrowing only pays off when the exclusion is substantial" dynamic as the solo-`Eq` finding above,
+not a new phenomenon. The small (1-3%) dips across otherwise-unrelated `control`/`and-combo`/
+`uniques` rows are within this corpus's normal run-to-run noise band for sub-millisecond queries,
+not attributable to a code path those queries don't exercise (none of them touch `Not`).
 
-Broad survey (`scripts/survey_queries.py`, seed 42, 520 queries): overall geomean 1.02x (flat), no
-attributable regressions — the two configs moving >15% (`type:artifact (id:gw or is:modal)`,
-`id:wu oracle:trample frame:showcase`) contain no rarity predicate at all, consistent with
-single-run timing noise on sub-millisecond queries rather than anything this change touched.
+Broad survey (`scripts/survey_queries.py`, seed 42, 520 queries): geomean 1.01x (flat), zero
+regressions >15%. No rarity-predicate queries happened to land in this particular random sample
+(the generator doesn't appear to weight `r:`/`rarity:` filters at all — only `orderby=rarity` sorts
+showed up under that tag), so this run serves as a pure regression safety net rather than
+demonstrating the win, which the targeted benchmark above covers directly.
 
 Memory (`--features alloc-counter`): `archive_bytes` +15,784 bytes (+0.023%) — matches the
-predicted 4 planes × 493 words × 8 bytes almost exactly. `cards_rkyv_bytes` unchanged, confirming
-no `OracleCard` growth. `reload_peak` unchanged.
+predicted 4 planes × 493 words × 8 bytes almost exactly, unchanged by the `-r:x` fix (pure logic,
+no new data). `cards_rkyv_bytes` unchanged, confirming no `OracleCard` growth. `reload_peak`
+unchanged.
 
-One real bug caught during implementation, not by the benchmark: `narrow_fixture_store` (an
-existing test fixture) rebuilt `RarityIndex` after mutating printing rarities but not `BitPlanes`,
-leaving stale (pre-mutation, all-zero) rarity plane bits — caught by
+One real bug caught during the first implementation round, not by the benchmark:
+`narrow_fixture_store` (an existing test fixture) rebuilt `RarityIndex` after mutating printing
+rarities but not `BitPlanes`, leaving stale (pre-mutation, all-zero) rarity plane bits — caught by
 `adaptive_narrowing_run_query_parity` failing (`total=2` vs brute-force `6`) on first test run.
 Fixed by rebuilding `indexes.planes` alongside `indexes.rarity` in that fixture.
 
@@ -246,8 +280,9 @@ Fixed by rebuilding `indexes.planes` alongside `indexes.rarity` in that fixture.
 established — colors/types bitplanes (#633) didn't move `t:creature` either, until #634 added
 exactness propagation on top; shipping the narrowing substrate before the verification-side win
 lands is this codebase's normal pattern, not a deviation from it. This PR retires part of the #618
-union-materialization cost and closes two real gaps (`Ne` declining, near-ceiling `Ge`/`Le`) on its
-own merits, independent of whether/when #674 lands.
+union-materialization cost and closes three real gaps (`Ne` declining, `-r:x` declining via the
+tight-only `Not` rule, near-ceiling `Ge`/`Le`) on its own merits, independent of whether/when #674
+lands.
 
 ## Related
 

--- a/scripts/bench_rarity_planes.py
+++ b/scripts/bench_rarity_planes.py
@@ -1,0 +1,116 @@
+"""Engine-vs-engine benchmark for rarity bitplanes (docs/issues/engine-rarity-planes.md).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export, so the same script
+run on two builds (main baseline vs. this branch) produces directly comparable CSVs. No SQL side,
+no Docker: build the engine locally (`maturin develop --release -m card_engine/Cargo.toml`) and run:
+
+    .venv/bin/python scripts/bench_rarity_planes.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/rarity-planes/baseline-main.csv
+
+Reuses the same corpus JSONL bench_bitplanes.py uses (ENGINE_COLUMNS/schema is unaffected by this
+change, so there's no need to re-export from the blue DB).
+
+The `total` column doubles as a parity check: it must be identical across builds for every config,
+or the comparison is void.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Solo predicates on the 4 planed values (common/uncommon/rare/mythic).
+    ("solo", "r:common", "card", "edhrec", "default"),
+    ("solo", "r:uncommon", "card", "edhrec", "default"),
+    ("solo", "r:rare", "card", "edhrec", "default"),
+    ("solo", "r:mythic", "card", "edhrec", "default"),
+    # Near today's MAX_UNION_FRACTION=0.70 ceiling (lib.rs:2080) -- exactly where the
+    # postings union already declines to a full scan, so the plane should win biggest here.
+    ("ceiling", "rarity<=mythic", "card", "edhrec", "default"),
+    ("ceiling", "rarity>=uncommon", "card", "edhrec", "default"),
+    # Ne is unconditionally declined by rarity_candidates today (lib.rs:2089-2090) --
+    # becomes just as cheap as Eq/Ge/Le once the 4 common values are planes.
+    ("ne", "r!=mythic", "card", "edhrec", "default"),
+    ("ne", "r!=common", "card", "edhrec", "default"),
+    # Mixed plane+postings reconciliation: match set spans a planed value (rare/mythic)
+    # and the postings-only tail (special/bonus).
+    ("mixed-tail", "r>=rare", "card", "edhrec", "default"),
+    ("mixed-tail", "-r:common", "card", "edhrec", "default"),
+    # special/bonus stay on the unchanged postings path -- controls, not expected to move.
+    ("tail-control", "r:special", "card", "edhrec", "default"),
+    ("tail-control", "r:bonus", "card", "edhrec", "default"),
+    # Negation on a planed value, no tail involvement (mythic's complement is
+    # common/uncommon/rare, all planed).
+    ("negation", "-r:mythic", "card", "edhrec", "default"),
+    # Compound with an already-planed dimension.
+    ("and-combo", "t:creature r:mythic", "card", "edhrec", "default"),
+    ("and-combo", "f:modern r:mythic", "card", "edhrec", "default"),
+    # printing/artwork uniques -- rarity narrows candidates the same way regardless of mode.
+    ("uniques", "r:mythic", "printing", "edhrec", "default"),
+    ("uniques", "r:mythic", "artwork", "edhrec", "default"),
+    # Controls: unrelated to rarity, must not regress.
+    ("control", "name:soldier", "card", "edhrec", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+    ("control", "oracle:creature", "card", "edhrec", "default"),
+    ("control", "c:g", "card", "edhrec", "default"),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--", "card_engine/src"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        rev += "-dirty"
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    for _, query, _, _, _ in CONFIGS:
+        parse_scryfall_query(query)
+
+    hdr = f"{'group':<13} {'query':<24} {'unique':<9} {'orderby':<8} {'prefer':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<13} {query:<24} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Narrows `rarity`/`r:` comparisons via 4 card-space bitplanes (common/uncommon/rare/mythic) instead of postings-only unions (successor to #630 phase 2 / PR #654, legality). `special`/`bonus` stay on the existing `RarityIndex` postings path — too sparse in production (1.17%/0.00% of cards) to be worth a fixed-cost plane each.
- Narrowing-only, never exact-consumed: rarity is genuinely `PrintingDep` (a card can have printings at multiple rarities), so this never routes through `compile_plane`'s all_match-promotion path — checked against the composition invariants before writing code, per the workflow doc, since `NumericLayout`/`compile_numeric_cmp` (the machinery used for cmc/power/toughness) is wired exclusively into that exact-consumption path and would have been a real correctness bug to extend here.
- New `narrow_rarity`/`rarity_plane_candidates` (not an extension of the numeric-range machinery — see design doc for why) OR's the 4 planed values directly and, only when the comparison also touches special/bonus, scatters `RarityIndex`'s postings for just those two buckets into the same mask.
- `-r:x` gets its own dedicated `Not` arm (mirroring `-f:x`'s existing pattern) that recomputes narrowing with a logically negated operator rather than complementing the candidate bitmap — added in a second round after benchmarking revealed the direct `!=` operator win didn't reach the far more common `-r:x` negation syntax (see Performance below).
- Design doc: `docs/issues/engine-rarity-planes.md` (selectivity data, two rejected precedents — `legality_divergent` on `OracleCard`, and extending `NumericLayout` — the `Not(Eq)==Ne` correctness argument, and full results).

## Changes

- `planes.rs`: `PLANE_RARITY`/`RARITY_PLANES` constants (4 one-hot planes, no interior/overflow-bucket machinery needed — the domain is 6 fully-enumerable values, not an open range); `build_bit_planes` now takes `printings`/`offsets` and populates the rarity planes directly from them (no new `OracleCard` field — rarity's verification never needs a card-level runtime flag, only the plane's build step does).
- `lib.rs`: new `negate_op` (logical negation: `Eq`↔`Ne`, `Lt`↔`Ge`, `Le`↔`Gt` — distinct from `flip_op`'s operand-order swap); `rarity_plane_candidates` + `narrow_rarity` (shared by both the direct `NumericCmp` arm and the new `Not` arm); a new `FilterExpr::Not(inner)` arm for `-r:x`, structurally identical to the existing `-f:x` arm.
- `tests.rs`: 6 new tests — plane-vs-existence-projection parity across every `CmpOp`; the same for the `Not` arm through `narrow_rec` end-to-end, both operand orders; null-rarity-printing card matches nothing; rarity never exact-consumes via `compile_plane`/`split_planes`. Fixed a pre-existing test-fixture bug (`narrow_fixture_store` rebuilt `RarityIndex` after mutating printing rarities but not `BitPlanes`) and updated one existing test (`not_narrows_only_tight_children`) whose assertion encoded the *old* "rarity's Not never narrows" behavior as a correctness guard.
- `scripts/bench_rarity_planes.py`: new targeted benchmark script.

## Related issues

Closes #670. Follow-on filed: #674 (verification-side short-circuit — see Performance below for why it's separate).

---

## Performance

**Scope narrower than "rarity queries get faster" — stated plainly rather than oversold.** Solo `Eq` queries on the 4 planed values (`r:common`/`r:uncommon`/`r:rare`/`r:mythic`) are flat (~0.98-0.99x): the old postings path never declined for a single-bucket `Eq` (it degenerates to a copy of one already-sorted bucket), and both paths converge on the identical candidate `Vec<u32>` before `card_pass` regardless. The unchanged, dominant cost there is `card_pass` itself walking each candidate's printings — filed as #674, distinguished from #657 there (#657's elision only helps children already proven exact; rarity is never exact/tight to begin with).

**Caught during review, fixed in a second round:** the first pass's `Ne` win (`r!=common`, `r!=mythic`) only reached the literal `!=` operator — `-r:common` parses to `Not(Eq(common))`, not `Ne(common)`, and `Not` only narrows through tight children (rarity's narrowing is loose by design), so the far more natural `-r:x` phrasing still declined to a full scan. Added a dedicated `Not(NumericCmp{RarityInt})` arm that recomputes with a logically negated operator instead of complementing the candidate bitmap (unsound for the same reason the direct arm's own comment already flags — a card can have printings that don't satisfy the comparison). The `Not(Eq)==Ne` equivalence was checked against `tri()`'s actual Null-propagation code before writing it, not assumed: `NumVal::Null` short-circuits to `Tri::Null` before any op-specific comparison runs, for every op including `Ne`, so the two forms agree on null-rarity printings too.

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `r!=common` | 0.554ms | 0.312ms | **1.78x** |
| `-r:common` | 0.626ms | 0.364ms | **1.72x** |
| `rarity>=uncommon` (near `MAX_UNION_FRACTION`'s 69% cutoff) | 0.346ms | 0.312ms | **1.11x** |
| `r>=rare` (mixed plane+postings-tail) | 0.258ms | 0.249ms | 1.04x |
| `r:common`/`r:uncommon`/`r:rare`/`r:mythic` (solo, flat by design — see above) | 0.112-0.224ms | 0.113-0.230ms | ~0.98x |
| `r!=mythic`, `-r:mythic` (flat — "not mythic" is ~94% of the corpus; little to exclude) | 0.41-0.48ms | 0.41-0.49ms | ~0.99x |
| `rarity<=mythic`, `r:special`/`r:bonus` (unchanged postings path, controls) | 0.003-0.344ms | 0.003-0.349ms | ~0.98-0.99x |
| `t:creature r:mythic`, `f:modern r:mythic` (compound) | 0.083-0.108ms | 0.084-0.109ms | ~0.98-0.99x |
| `r:mythic` (printing/artwork uniques) | 0.150-0.173ms | 0.154-0.177ms | ~0.98x |
| unrelated controls (`name:soldier`, `cmc>6`, `oracle:creature`, `c:g`) | — | — | ~0.97-0.99x |

**Geometric mean:** 1.04x across all 21 configs. Small (1-3%) dips on unrelated controls/compounds are within this corpus's normal run-to-run noise band — none of those queries touch `Not` at all, so they can't be attributable to this change.
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl` (97,206 printings, reused from #630/#654/#655/#666/#669 — schema unaffected, no re-export needed).

Broad survey (`scripts/survey_queries.py`, seed 42, 520 queries): geomean 1.01x (flat), zero regressions >15%. No rarity-predicate queries happened to land in this particular random sample — it serves as a regression safety net, not a demonstration of the win (the targeted benchmark above covers that).

Memory (`--features alloc-counter`): `archive_bytes` +15,784 bytes (+0.023%) — matches 4 planes × 493 words × 8 bytes almost exactly, unchanged by the `-r:x` fix (pure logic, no new data). `cards_rkyv_bytes` unchanged (no `OracleCard` growth). `reload_peak` unchanged.

Total-row-count parity held on every config, every run, throughout both rounds.

## Tests

`cargo test` (debug + release): 98 passed, 7 ignored (up from 94 on `main` — 6 new tests, one existing test updated to assert the new correct behavior instead of the old one; no new clippy warnings). Python: unaffected paths not re-run (no Python/parsing changes in this PR); `api/parsing` and `make test-unit` are currently blocked in this environment by an unrelated Docker-daemon connectivity issue, not by this change.

## Reviewer notes

Three things worth double-checking:
1. That rarity genuinely never needs `compile_plane` (design doc's "Do not extend `NumericLayout`" section) — a card with printings at both common and mythic sets both plane bits simultaneously, correct for narrowing but wrong to treat as exact card-level truth.
2. The plane+postings reconciliation in `rarity_plane_candidates` (OR the planed buckets, scatter special/bonus postings only when touched) — covered by the parity test.
3. `negate_op`'s correctness for `-r:x` — covered by a dedicated test going through `narrow_rec` end-to-end (not just the underlying function), including both operand orders. Worth noting this test itself had a bug during development (constructing "same predicate, flipped operands" needs `flip_op(op)` on the flipped side, not the same op) — caught immediately by the test disagreeing with itself, not by inspection, which is some evidence the test is doing real work.
