### PR TITLE
Add Dual Exact Bitplanes for Legality Divergent-Card Carve-Out (#667)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3437,6 +3437,17 @@ fn card_match_count(
 
 /// Emit this card's matches as (sort key, cid, pid) tuples — the per-card body
 /// of the gathered path, shared by the streamed path for page cards.
+///
+/// `existential_plane`: `Some((plane, planes))` iff `mode` is `Card` and the
+/// plane driving `all_match` touched a legality leaf
+/// (docs/issues/engine-legality-divergent-carveout.md "Row selection for
+/// unique=card") — `all_match` there only proves *some* printing matches, not
+/// whichever one prefer-order would pick, so the chosen printing must be
+/// verified against the plane directly instead of trusted blindly. `None`
+/// (the overwhelmingly common case) keeps today's behavior exactly: `Mode`s
+/// other than `Card` never hit this (their planes are never folded this way,
+/// see `unique_is_card`), and a card-invariant `all_match` needs no check
+/// (every printing already agrees).
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn push_card_matches(
@@ -3453,6 +3464,7 @@ fn push_card_matches(
     sort_col: SortCol,
     descending: bool,
     strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     out: &mut Vec<Match>,
     groups: &mut Vec<(u128, u32, f64)>,
 ) {
@@ -3461,21 +3473,19 @@ fn push_card_matches(
             // Printings are stored in descending default-prefer order, so
             // for the default prefer the first matching printing IS the
             // chosen one — O(1) when the card pass already said True.
+            let satisfies = |pid: usize| match existential_plane {
+                Some((pe, planes)) => eval_plane_expr_for_printing(pe, planes, cid, &printings[pid]),
+                None => all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or),
+            };
             let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
-                let mut found: Option<u32> = None;
-                for pid in start..end {
-                    if all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
-                        found = Some(pid as u32);
-                        break;
-                    }
-                }
-                found
+                (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
             } else {
                 let mut chosen: Option<(u32, f64)> = None;
                 for pid in start..end {
-                    let p = &printings[pid];
-                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
-                    let score = prefer_score(card, p, prefer);
+                    if !satisfies(pid) {
+                        continue;
+                    }
+                    let score = prefer_score(card, &printings[pid], prefer);
                     if chosen.is_none_or(|(_, s)| score > s) {
                         chosen = Some((pid as u32, score));
                     }
@@ -3583,7 +3593,9 @@ fn run_query<'a>(
         return PLANE_BITMAP_POPCOUNT.with(|cell| {
             let mut bitmap = cell.borrow_mut();
             eval_planes(expr, &indexes.planes, &mut bitmap);
-            run_query_streamed_popcount(cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap)
+            run_query_streamed_popcount(
+                cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap, expr, &indexes.planes,
+            )
         });
     }
 
@@ -3693,12 +3705,22 @@ fn run_query<'a>(
     // candidate list at or below the gather threshold can't produce more
     // matches than that, so the fused path is already microseconds and the
     // match phase would be pure overhead.
+    // Row selection (docs/issues/engine-legality-divergent-carveout.md "Row
+    // selection for unique=card"): only Mode::Card can have folded a legality
+    // leaf into `plane` at all (unique_is_card declines the fold otherwise),
+    // and only then does all_match's "the card matches" stop implying "any
+    // printing will do" for picking which one to show.
+    let existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = match (mode, plane) {
+        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe) => Some((pe, &indexes.planes)),
+        _ => None,
+    };
+
     let maybe_broad = candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
     if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
         if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
             return run_query_streamed(
                 cards, printings, offsets, strings, filter, all_match_known, mode, prefer, sort_col, descending, limit,
-                page_offset, perm, card_ids, &indexes.artwork_groups,
+                page_offset, perm, card_ids, &indexes.artwork_groups, existential_plane,
             );
         }
     }
@@ -3725,7 +3747,7 @@ fn run_query<'a>(
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         push_card_matches(
             card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
-            sort_col, descending, strings, &mut best, &mut groups,
+            sort_col, descending, strings, existential_plane, &mut best, &mut groups,
         );
     }
 
@@ -3751,6 +3773,7 @@ fn run_query<'a>(
 /// `run_query_streamed`'s Step-1-improved-but-not-popcount path — extending
 /// this to non-True residuals is a reasonable fast-follow, not required here.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn run_query_streamed_popcount<'a>(
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
@@ -3761,6 +3784,8 @@ fn run_query_streamed_popcount<'a>(
     perm: &Archived<Vec<u32>>,
     inv_perm: &Archived<Vec<u32>>,
     bitmap: &[u64],
+    plane: &PlaneExpr,
+    planes: &Archived<BitPlanes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
@@ -3807,9 +3832,16 @@ fn run_query_streamed_popcount<'a>(
         // more within it), mapping position -> card id via the forward perm.
         // all_match is always true here (filter fully consumed to True), so
         // the printing choice mirrors push_card_matches' Mode::Card branch
-        // under all_match exactly: first printing for default prefer (ranges
-        // are stored in descending default-prefer order), best-scored
-        // otherwise.
+        // under all_match: first printing for default prefer (ranges are
+        // stored in descending default-prefer order), best-scored otherwise
+        // -- *unless* the plane touched a legality leaf
+        // (docs/issues/engine-legality-divergent-carveout.md "Row selection
+        // for unique=card"), in which case card-level truth only proves
+        // *some* printing matches, not whichever one prefer-order would pick
+        // blindly -- verify against `eval_plane_expr_for_printing` too. Cheap
+        // even then: bounded by `limit` emitted cards, not the candidate set,
+        // and only pays the extra check at all for legality-touching planes.
+        let existential = plane_expr_is_existential(plane);
         let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
         'walk: while word_idx < permuted.len() {
             let mut w = permuted[word_idx];
@@ -3825,13 +3857,17 @@ fn run_query_streamed_popcount<'a>(
                 let card = &cards[cid as usize];
                 let start = u32::from(offsets[cid as usize]) as usize;
                 let end = u32::from(offsets[cid as usize + 1]) as usize;
+                let satisfies = |pid: usize| !existential || eval_plane_expr_for_printing(plane, planes, cid, &printings[pid]);
                 let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
-                    (start < end).then_some(start as u32)
+                    (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
                 } else {
                     // Strict > only (matches push_card_matches): ties keep the
                     // first-found printing, not the last.
                     let mut best: Option<(u32, f64)> = None;
                     for pid in start..end {
+                        if !satisfies(pid) {
+                            continue;
+                        }
                         let score = prefer_score(card, &printings[pid], prefer);
                         if best.is_none_or(|(_, s)| score > s) {
                             best = Some((pid as u32, score));
@@ -3872,6 +3908,7 @@ fn run_query_streamed<'a>(
     perm: &Archived<Vec<u32>>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     artwork_groups: &Archived<Vec<u16>>,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
@@ -3945,7 +3982,7 @@ fn run_query_streamed<'a>(
             let end   = u32::from(offsets[cid as usize + 1]) as usize;
             push_card_matches(
                 card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
-                sort_col, descending, strings, &mut best, &mut groups,
+                sort_col, descending, strings, existential_plane, &mut best, &mut groups,
             );
         }
         let page = select_page(best, page_offset, limit)
@@ -3983,7 +4020,7 @@ fn run_query_streamed<'a>(
         scratch.clear();
         push_card_matches(
             card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
-            sort_col, descending, strings, &mut scratch, &mut groups,
+            sort_col, descending, strings, existential_plane, &mut scratch, &mut groups,
         );
         scratch.sort_unstable_by(cmp);
         for m in scratch.iter().skip(skip) {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2354,33 +2354,27 @@ fn and_bits_into(acc: &mut [u64], other: &[u64]) {
     }
 }
 
-/// Card-space candidate mask for one format's `legal_x OR divergent` (or,
-/// when `negate`, `NOT(legal_x) OR divergent`) — always a superset of the true
-/// match set. `legal_x` (PLANE_LEGAL) is exact only for non-divergent cards
-/// (see planes.rs), so every divergent card is unconditionally included
-/// regardless of its own canonical status, leaving the existing
-/// card_pass/residual walk (unchanged, PrintingDep and all) to resolve it
-/// exactly. See docs/issues/engine-legality-bitplanes.md.
+/// Card-space candidate mask for one format's legality check --
+/// (docs/issues/engine-legality-divergent-carveout.md) exact for every card,
+/// including divergent ones: reads `PLANE_LEGAL_EXISTS` directly for the
+/// positive case or `PLANE_LEGAL_ILLEGAL` for the negated case, never a
+/// bit-complement of the other (that would compute `∀p: ¬legal(p)`, wrong --
+/// a divergent card can satisfy both `∃p: legal(p)` and `∃p: ¬legal(p)` at
+/// once). Exact as a *narrowing* set (no divergent-postings OR needed
+/// anymore -- `legal_divergent` is unchanged and still used by `filter.rs`'s
+/// per-printing `Legality` evaluation, just not here), but callers still
+/// report `Narrowed::loose`: existence-for-some-printing isn't the
+/// true-for-every-printing fact `tight` requires (see `narrow_rec`'s
+/// `Legality` arms and `Narrowed`'s doc).
 fn legal_candidate_bits(indexes: &Archived<CardIndexes>, n_cards: usize, shift: u8, negate: bool) -> Option<Vec<u64>> {
     if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
         return None;
     }
     let wpp = words_per_plane(n_cards);
-    let legal_plane = PLANE_LEGAL + shift as usize / 2;
+    let base = if negate { PLANE_LEGAL_ILLEGAL } else { PLANE_LEGAL_EXISTS };
+    let legal_plane = base + shift as usize / 2;
     let words = &indexes.planes.words;
-    let mut bits: Vec<u64> = words[legal_plane * wpp..(legal_plane + 1) * wpp].iter().map(|w| u64::from(*w)).collect();
-    if negate {
-        complement_bits(&mut bits, n_cards);
-    }
-    // The divergent set is a fixed, tiny (~556-card) postings list, not a
-    // plane (see build_divergent_ids) — scattered directly into the mask
-    // rather than intersected through the general Candidates machinery,
-    // since it's always this same list, never query-dependent.
-    for &cid in indexes.legal_divergent.iter() {
-        let cid = u16::from(cid) as usize;
-        bits[cid / 64] |= 1u64 << (cid % 64);
-    }
-    Some(bits)
+    Some(words[legal_plane * wpp..(legal_plane + 1) * wpp].iter().map(|w| u64::from(*w)).collect())
 }
 
 /// Project a printing-space bitmap up to card space. Printings of card i are
@@ -2751,7 +2745,17 @@ fn narrow_rec(
         if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words) {
             let mut bits: Vec<u64> = Vec::new();
             eval_planes(&pe, &indexes.planes, &mut bits);
-            return Narrowed::tight(Candidates::CardBits(bits));
+            // Legality's planes are existence projections, not true-for-
+            // every-printing facts (docs/issues/engine-legality-divergent-
+            // carveout.md) -- `tight`'s contract needs the latter (see
+            // `Narrowed`'s doc and the dedicated `Legality` arms below), so a
+            // compiled expression touching them can only narrow loosely here,
+            // same as if it had fallen through to those arms directly.
+            return if plane_expr_is_existential(&pe) {
+                Narrowed::loose(Candidates::CardBits(bits))
+            } else {
+                Narrowed::tight(Candidates::CardBits(bits))
+            };
         }
     }
 
@@ -2905,19 +2909,32 @@ fn narrow_rec(
             Narrowed::loose(Candidates::CardBits(bits))
         }
 
-        // f:x / format:x — narrowing only (never exact-consumed via
-        // compile_plane): Legality can return Tri::PrintingDep for divergent
-        // cards, which compile_plane's two-valued-only rule already excludes.
-        // banned:/restricted: (expected != LEGALITY_LEGAL) and formats absent
-        // from loaded data (shift: None) fall through unindexed, unchanged.
+        // f:x / format:x (docs/issues/engine-legality-divergent-carveout.md):
+        // legal_candidate_bits reads PLANE_LEGAL_EXISTS directly, so this is
+        // exact card-space narrowing -- but still reported `loose`, not
+        // `tight`: `tight` means true for *every* printing (see the Narrowed
+        // struct's doc), and legality genuinely varies printing-to-printing,
+        // so "the card has some legal printing" doesn't satisfy that
+        // contract, same reason -r:x below is loose despite rarity's plane
+        // also being exact. compile_plane separately exact-consumes this
+        // shape for unique=card (see planes.rs, plane_expr_is_existential);
+        // this arm still matters for mixed filters compile_plane declines
+        // (the shared-witness 2+-distinct-format case) and for unique=printing/
+        // artwork, where the residual card_pass verification this `loose`
+        // narrowing feeds into is required for correctness. banned:/
+        // restricted: (expected != LEGALITY_LEGAL) and formats absent from
+        // loaded data (shift: None) fall through unindexed, unchanged.
         FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
             Narrowed::loose(Candidates::CardBits(legal_candidate_bits(indexes, n_cards, *shift, false)?))
         }
 
         // -f:x — matched as its own leaf shape rather than falling through to
-        // the generic Not-complement below, which requires a `tight` child;
-        // legal_candidate_bits has false positives among divergent cards by
-        // construction, so the generic path would (correctly) refuse it.
+        // the generic Not-complement below (which requires a `tight` child
+        // and wouldn't apply here regardless): bit-complementing the positive
+        // plane would compute `∀p: ¬legal(p)` (wrong for a divergent card,
+        // which can satisfy both `∃p: legal(p)` and `∃p: ¬legal(p)` at once)
+        // instead of reading PLANE_LEGAL_ILLEGAL directly, which is what this
+        // arm does.
         FilterExpr::Not(inner)
             if matches!(inner.as_ref(), FilterExpr::Legality { shift: Some(_), expected } if *expected == LEGALITY_LEGAL) =>
         {
@@ -3589,7 +3606,21 @@ fn run_query<'a>(
     // candidate is already known to match, so the per-candidate card_pass
     // calls below and in run_query_streamed become redundant re-verification
     // of what the narrowing already established.
-    let all_match_known = matches!(filter, FilterExpr::True) || residual_exact;
+    //
+    // A plane-driven True residual needs one more check first: legality's
+    // planes (docs/issues/engine-legality-divergent-carveout.md) are
+    // existence projections ("*some* printing matches"), unlike every other
+    // plane (card-invariant fields, true or false alike for every printing
+    // of a card). For unique=card that's exactly the semantics wanted --
+    // Mode::Card only needs *a* matching printing to exist, same as Step 2
+    // above. But Mode::Printing/Artwork enumerate individual printings, and
+    // "the card has some legal printing" does not mean "this printing is
+    // legal" -- card_pass must still run per printing there whenever the
+    // plane touched legality, so this only trusts a True residual for those
+    // modes when the plane is existential-free (plane_expr_is_existential).
+    let plane_true_for_mode =
+        plane.is_none_or(|expr| matches!(mode, Mode::Card) || !plane_expr_is_existential(expr));
+    let all_match_known = (matches!(filter, FilterExpr::True) && plane_true_for_mode) || residual_exact;
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
     // subexpression (split_planes), so it composes with the residual's
@@ -4616,7 +4647,11 @@ impl QueryEngine {
         // rejects pre-plane archives, this is defense in depth.
         let (plane_expr, mut filter_expr) =
             if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
-                split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words)
+                // Matches run_query's own unique -> Mode mapping exactly
+                // (anything other than "artwork"/"printing" is Mode::Card,
+                // not just the literal string "card") -- see split_planes's
+                // unique_is_card doc.
+                split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
             } else {
                 (None, filter_expr)
             };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3381,10 +3381,22 @@ enum Mode { Card, Artwork, Printing }
 /// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
 /// passing printings for Printing mode, distinct illustrations with a passing
 /// printing for Artwork mode. `ills` is a reused scratch buffer.
+// #676 review: a legality leaf promoted into `plane` alongside a genuinely
+// printing-dependent residual (DateCmp, ArtistMatch, ...) needs *both*
+// checked against the *same* printing -- `all_match`/`residual_matches` alone
+// only proves the residual holds for some printing, `existential_plane` alone
+// only proves the plane's existential leaf holds for some (possibly
+// different) printing. Neither implies a single printing satisfies both, so
+// `format:A AND date>X` (unique=card) must not count/match unless some
+// printing is *both* legal-in-A and past the cutoff. `existential_plane` is
+// only ever `Some` for `Mode::Card` (see its computation in `run_query`), so
+// `Mode::Printing`/`Artwork` below are unaffected -- their planes, if any,
+// were never folded to begin with when existential (`unique_is_card`).
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn card_match_count(
     card: &AOracleCard,
+    cid: u32,
     printings: &[APrinting],
     start: usize,
     end: usize,
@@ -3393,27 +3405,38 @@ fn card_match_count(
     residual_is_or: bool,
     mode: Mode,
     strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     ills: &mut Vec<u128>,
 ) -> u32 {
+    let satisfies = |pid: usize| {
+        let residual_ok = all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or);
+        match existential_plane {
+            Some((pe, planes)) => residual_ok && eval_plane_expr_for_printing(pe, planes, cid, &printings[pid]),
+            None => residual_ok,
+        }
+    };
+    // The blind "every printing matches" shortcut only holds when there's no
+    // existential plane to re-verify per printing -- see this function's doc.
+    let blind_all_match = all_match && existential_plane.is_none();
     match mode {
         Mode::Card => {
-            if all_match {
+            if blind_all_match {
                 return u32::from(start < end);
             }
             for pid in start..end {
-                if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                if satisfies(pid) {
                     return 1;
                 }
             }
             0
         }
         Mode::Printing => {
-            if all_match {
+            if blind_all_match {
                 return (end - start) as u32;
             }
             let mut n = 0u32;
             for pid in start..end {
-                if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                if satisfies(pid) {
                     n += 1;
                 }
             }
@@ -3422,7 +3445,7 @@ fn card_match_count(
         Mode::Artwork => {
             ills.clear();
             for pid in start..end {
-                if !all_match && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                if !satisfies(pid) {
                     continue;
                 }
                 let ill = u128::from(printings[pid].illustration_id);
@@ -3441,13 +3464,16 @@ fn card_match_count(
 /// `existential_plane`: `Some((plane, planes))` iff `mode` is `Card` and the
 /// plane driving `all_match` touched a legality leaf
 /// (docs/issues/engine-legality-divergent-carveout.md "Row selection for
-/// unique=card") — `all_match` there only proves *some* printing matches, not
-/// whichever one prefer-order would pick, so the chosen printing must be
-/// verified against the plane directly instead of trusted blindly. `None`
-/// (the overwhelmingly common case) keeps today's behavior exactly: `Mode`s
-/// other than `Card` never hit this (their planes are never folded this way,
-/// see `unique_is_card`), and a card-invariant `all_match` needs no check
-/// (every printing already agrees).
+/// unique=card") — `all_match`/`residual` there only prove *some* printing
+/// satisfies the residual, not that it's the same printing the plane's
+/// existential leaf is true for, so the chosen printing must satisfy *both*
+/// checked against each other, not either one alone (a legality leaf ANDed
+/// with a genuinely printing-dependent residual like `DateCmp` needs one
+/// printing past the cutoff *and* legal at once — checking only the plane
+/// missed this, caught in #676's review). `None` (the overwhelmingly common
+/// case) keeps today's behavior exactly: `Mode`s other than `Card` never hit
+/// this (their planes are never folded this way, see `unique_is_card`), and a
+/// card-invariant `all_match` needs no check (every printing already agrees).
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn push_card_matches(
@@ -3473,9 +3499,20 @@ fn push_card_matches(
             // Printings are stored in descending default-prefer order, so
             // for the default prefer the first matching printing IS the
             // chosen one — O(1) when the card pass already said True.
-            let satisfies = |pid: usize| match existential_plane {
-                Some((pe, planes)) => eval_plane_expr_for_printing(pe, planes, cid, &printings[pid]),
-                None => all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or),
+            //
+            // #676 review: when `existential_plane` is `Some`, the residual
+            // check is still required, not replaced -- a legality leaf folded
+            // into `plane` alongside a genuinely printing-dependent residual
+            // (DateCmp, ArtistMatch, ...) needs a printing satisfying *both*
+            // at once (docs/issues/engine-legality-divergent-carveout.md "Row
+            // selection for unique=card"); checking only the plane could pick
+            // a printing that's legal but fails the residual, or vice versa.
+            let satisfies = |pid: usize| {
+                let residual_ok = all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or);
+                match existential_plane {
+                    Some((pe, planes)) => residual_ok && eval_plane_expr_for_printing(pe, planes, cid, &printings[pid]),
+                    None => residual_ok,
+                }
             };
             let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
                 (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
@@ -3773,7 +3810,6 @@ fn run_query<'a>(
 /// `run_query_streamed`'s Step-1-improved-but-not-popcount path — extending
 /// this to non-True residuals is a reasonable fast-follow, not required here.
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 fn run_query_streamed_popcount<'a>(
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
@@ -3952,7 +3988,10 @@ fn run_query_streamed<'a>(
         let c = if all_match && matches!(mode, Mode::Artwork) && have_group_counts {
             u32::from(u16::from(artwork_groups[cid as usize]))
         } else {
-            card_match_count(card, printings, start, end, all_match, &residual, residual_is_or, mode, strings, &mut ills)
+            card_match_count(
+                card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, strings, existential_plane,
+                &mut ills,
+            )
         };
         counts[cid as usize] = c;
         total += c as usize;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3408,21 +3408,67 @@ fn card_match_count(
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     ills: &mut Vec<u128>,
 ) -> u32 {
-    let satisfies = |pid: usize| {
-        let residual_ok = all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or);
-        match existential_plane {
-            Some((pe, planes)) => residual_ok && eval_plane_expr_for_printing(pe, planes, cid, &printings[pid]),
-            None => residual_ok,
-        }
+    // No existential plane: identical code shape to before #676's
+    // existential_plane parameter existed at all -- no closure, no extra
+    // branch inside the hot loop. This is the overwhelmingly common case
+    // (every query without a promoted legality leaf), and it's called once
+    // per *candidate*, not once per emitted row, so its cost is on the
+    // critical path for every non-Step-2 query. A prior version of this
+    // function routed both cases through one closure-based `satisfies`
+    // helper regardless of `existential_plane`; measured as a real (~15%)
+    // regression on `banned:modern`/`restricted:vintage` (full-candidate-set
+    // scans, unaffected by `existential_plane` in outcome but paying its
+    // indirection anyway) via the broad survey, not the targeted benchmark --
+    // isolating the fast path here restores it.
+    let Some((pe, planes)) = existential_plane else {
+        return match mode {
+            Mode::Card => {
+                if all_match {
+                    return u32::from(start < end);
+                }
+                for pid in start..end {
+                    if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                        return 1;
+                    }
+                }
+                0
+            }
+            Mode::Printing => {
+                if all_match {
+                    return (end - start) as u32;
+                }
+                let mut n = 0u32;
+                for pid in start..end {
+                    if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                        n += 1;
+                    }
+                }
+                n
+            }
+            Mode::Artwork => {
+                ills.clear();
+                for pid in start..end {
+                    if !all_match && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                        continue;
+                    }
+                    let ill = u128::from(printings[pid].illustration_id);
+                    if !ills.contains(&ill) {
+                        ills.push(ill);
+                    }
+                }
+                ills.len() as u32
+            }
+        };
     };
-    // The blind "every printing matches" shortcut only holds when there's no
-    // existential plane to re-verify per printing -- see this function's doc.
-    let blind_all_match = all_match && existential_plane.is_none();
+
+    // Existential plane present (Mode::Card only -- see this function's
+    // doc): the blind all_match shortcut never applies, and both the
+    // residual and the plane must hold for the same printing.
+    let satisfies =
+        |pid: usize| eval_plane_expr_for_printing(pe, planes, cid, &printings[pid])
+            && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or));
     match mode {
         Mode::Card => {
-            if blind_all_match {
-                return u32::from(start < end);
-            }
             for pid in start..end {
                 if satisfies(pid) {
                     return 1;
@@ -3431,9 +3477,6 @@ fn card_match_count(
             0
         }
         Mode::Printing => {
-            if blind_all_match {
-                return (end - start) as u32;
-            }
             let mut n = 0u32;
             for pid in start..end {
                 if satisfies(pid) {
@@ -3507,22 +3550,46 @@ fn push_card_matches(
             // at once (docs/issues/engine-legality-divergent-carveout.md "Row
             // selection for unique=card"); checking only the plane could pick
             // a printing that's legal but fails the residual, or vice versa.
-            let satisfies = |pid: usize| {
-                let residual_ok = all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or);
-                match existential_plane {
-                    Some((pe, planes)) => residual_ok && eval_plane_expr_for_printing(pe, planes, cid, &printings[pid]),
-                    None => residual_ok,
+            // Kept as two separate closures (not one closure branching on
+            // `existential_plane` every call) for the same reason
+            // `card_match_count` is split this way — see its doc.
+            let chosen: Option<u32> = if let Some((pe, planes)) = existential_plane {
+                let satisfies = |pid: usize| {
+                    eval_plane_expr_for_printing(pe, planes, cid, &printings[pid])
+                        && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
+                };
+                if matches!(prefer, Prefer::Default) {
+                    (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
+                } else {
+                    let mut chosen: Option<(u32, f64)> = None;
+                    for pid in start..end {
+                        if !satisfies(pid) {
+                            continue;
+                        }
+                        let score = prefer_score(card, &printings[pid], prefer);
+                        if chosen.is_none_or(|(_, s)| score > s) {
+                            chosen = Some((pid as u32, score));
+                        }
+                    }
+                    chosen.map(|(pid, _)| pid)
                 }
-            };
-            let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
-                (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
+            } else if matches!(prefer, Prefer::Default) {
+                let mut found: Option<u32> = None;
+                for pid in start..end {
+                    if all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                        found = Some(pid as u32);
+                        break;
+                    }
+                }
+                found
             } else {
                 let mut chosen: Option<(u32, f64)> = None;
                 for pid in start..end {
-                    if !satisfies(pid) {
+                    let p = &printings[pid];
+                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
                         continue;
                     }
-                    let score = prefer_score(card, &printings[pid], prefer);
+                    let score = prefer_score(card, p, prefer);
                     if chosen.is_none_or(|(_, s)| score > s) {
                         chosen = Some((pid as u32, score));
                     }

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -12,9 +12,13 @@
 //! are card-level and two-valued (their tri() never returns Null or
 //! PrintingDep), so plane algebra — including complement for Not —
 //! reproduces the filter's card-level truth exactly.
-//! Legality is narrowing-only (see PLANE_LEGAL). Rarity (the 4 most common
-//! values; docs/issues/engine-rarity-planes.md) is narrowing-only too, for
-//! the same PrintingDep reason -- see PLANE_RARITY.
+//! Legality (docs/issues/engine-legality-divergent-carveout.md) is exact via
+//! two planes per format -- PLANE_LEGAL_EXISTS ("some printing is legal") and
+//! PLANE_LEGAL_ILLEGAL ("some printing is not legal"), both computed directly
+//! from printings so they're correct for every card including ones whose
+//! printings disagree, unlike a single card-level bit. Rarity (the 4 most
+//! common values; docs/issues/engine-rarity-planes.md) is narrowing-only, for
+//! the PrintingDep reason legality used to have -- see PLANE_RARITY.
 
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -45,14 +49,18 @@ const PLANE_TYPES: usize = PLANE_PRODUCED_MANA + COLOR_PLANES;
 /// set for deeper queries (see the saturated-superset arm in narrow_rec).
 const PLANE_DEVOTION: usize = PLANE_TYPES + TYPE_PLANES;
 const DEVOTION_BITS: usize = 2;
-/// One plane per format's "legal" bit (#630 phase 2), fixed-width at
-/// MAX_FORMATS regardless of how many formats loaded data actually uses —
-/// unused slots are permanently-zero planes, matching the existing `shift:
-/// None` "format absent" semantics. These are narrowing-only candidate masks
-/// (see narrow_rec's Legality arms in lib.rs), never exact-consumed here:
-/// Legality can return Tri::PrintingDep for divergent cards, which compile_plane
-/// already excludes from exact consumption (only two-valued nodes qualify).
-pub(crate) const PLANE_LEGAL: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLANES;
+/// Two planes per format (docs/issues/engine-legality-divergent-carveout.md),
+/// fixed-width at MAX_FORMATS each regardless of how many formats loaded data
+/// actually uses -- unused slots are permanently-zero planes, matching the
+/// existing `shift: None` "format absent" semantics. Both are computed
+/// directly from printings (`build_bit_planes`), not the card-level canonical
+/// word, so both are exact -- including divergent cards, which is what makes
+/// `compile_plane` able to consume `Legality` at all: `∃p: legal(p)` and
+/// `∃p: ¬legal(p)` are genuinely different facts for a divergent card (both
+/// can be true at once), so `-format:X` needs its own plane rather than a
+/// bit-complement of the first (which would compute `∀p: ¬legal(p)`, wrong).
+pub(crate) const PLANE_LEGAL_EXISTS: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLANES;
+pub(crate) const PLANE_LEGAL_ILLEGAL: usize = PLANE_LEGAL_EXISTS + MAX_FORMATS;
 /// One-hot planes for cmc/power/toughness (#655), covering the interior
 /// range [0,12] — hundreds-to-thousands of cards per value — plus a shared
 /// "13+" high-tail bucket per field (all three have a genuine spread of rare
@@ -67,7 +75,7 @@ pub(crate) const PLANE_LEGAL: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLA
 const NUM_INTERIOR_LO: i32 = 0;
 const NUM_INTERIOR_HI: i32 = 12;
 const NUM_INTERIOR_WIDTH: usize = (NUM_INTERIOR_HI - NUM_INTERIOR_LO + 1) as usize;
-pub(crate) const PLANE_CMC: usize = PLANE_LEGAL + MAX_FORMATS;
+pub(crate) const PLANE_CMC: usize = PLANE_LEGAL_ILLEGAL + MAX_FORMATS;
 pub(crate) const PLANE_CMC_HI: usize = PLANE_CMC + NUM_INTERIOR_WIDTH;
 pub(crate) const PLANE_POWER_LO: usize = PLANE_CMC_HI + 1;
 pub(crate) const PLANE_POWER: usize = PLANE_POWER_LO + 1;
@@ -182,7 +190,7 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
         // null-rarity correctly sets nothing here.
         let range = offsets[i] as usize..offsets[i + 1] as usize;
         let mut rarity_mask: u8 = 0;
-        for p in &printings[range] {
+        for p in &printings[range.clone()] {
             if let Some(r) = p.card_rarity_int {
                 rarity_mask |= 1 << r;
             }
@@ -225,19 +233,32 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
                 "devotion without identity: card {i} color lane {b}"
             );
         }
-        // "legal AND not divergent", not raw status: this makes the plane a
-        // pure exact predicate (no false positives, ever) rather than one that
-        // merely happens to be corrected downstream. narrow_rec's OR-with-
-        // divergent-postings formula (see legal_candidate_bits in lib.rs)
-        // produces an identical candidate mask either way (De Morgan's), so
-        // this costs nothing today — but it means `legal_x` alone is already
-        // the exact card-space source #634 wants to popcount directly, with
-        // the divergent set as the one small carve-out #634's promotion path
-        // would still need to verify per-candidate.
+        // Legality (docs/issues/engine-legality-divergent-carveout.md): two
+        // existence projections per format, computed directly from this
+        // card's own printings (the `range` rarity already sliced above) --
+        // legal_exists = some printing legal, illegal_exists = some printing
+        // not legal. Both exact for every card, including ones whose
+        // printings disagree, since neither depends on a single canonical
+        // card-level word or a divergence flag. MAX_FORMATS (32) fits a u64
+        // mask with room to spare.
+        let mut legal_mask: u64 = 0;
+        let mut illegal_mask: u64 = 0;
+        for p in &printings[range] {
+            for f in 0..MAX_FORMATS {
+                let shift = (f * 2) as u32;
+                if (p.card_legalities >> shift) & 0b11 == LEGALITY_LEGAL {
+                    legal_mask |= 1 << f;
+                } else {
+                    illegal_mask |= 1 << f;
+                }
+            }
+        }
         for f in 0..MAX_FORMATS {
-            let shift = (f * 2) as u32;
-            if !card.legality_divergent && (card.card_legalities >> shift) & 0b11 == LEGALITY_LEGAL {
-                set(PLANE_LEGAL + f);
+            if legal_mask & (1 << f) != 0 {
+                set(PLANE_LEGAL_EXISTS + f);
+            }
+            if illegal_mask & (1 << f) != 0 {
+                set(PLANE_LEGAL_ILLEGAL + f);
             }
         }
         // #655: cmc is Option<u8>, type-guaranteed non-negative, so it has no
@@ -662,17 +683,105 @@ fn compile_plane_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPl
     order.into_iter().map(|c| compile_plane(c, bounds, words)).collect()
 }
 
+/// Collect distinct (format, polarity) pairs referenced by legality-plane
+/// leaves within `expr`, appending into `out` (deduplicated). Polarity is
+/// part of the key, not folded away: `format:A` and `-format:A` read
+/// different planes (`legal_exists`/`illegal_exists`) backing different,
+/// independently-true-or-false existence facts about the same format, so
+/// `format:A AND -format:A` is exactly as shared-witness-prone as
+/// `format:A AND format:B` -- a divergent-on-A card satisfies both
+/// `legal_exists(A)` and `illegal_exists(A)` at once, even though no single
+/// printing can be both legal and not-legal in A simultaneously (see
+/// `and_of_checked_for_shared_witness`'s doc). A literal duplicate leaf
+/// (`format:A AND format:A`) collapses to one entry and is fine to compose --
+/// it's the same underlying fact checked twice, not two facts needing a
+/// shared witness.
+fn collect_legality_formats(expr: &PlaneExpr, out: &mut Vec<(usize, bool)>) {
+    match expr {
+        PlaneExpr::Plane(p) => {
+            let p = *p as usize;
+            let fmt = if (PLANE_LEGAL_EXISTS..PLANE_LEGAL_EXISTS + MAX_FORMATS).contains(&p) {
+                Some((p - PLANE_LEGAL_EXISTS, false))
+            } else if (PLANE_LEGAL_ILLEGAL..PLANE_LEGAL_ILLEGAL + MAX_FORMATS).contains(&p) {
+                Some((p - PLANE_LEGAL_ILLEGAL, true))
+            } else {
+                None
+            };
+            if let Some(entry) = fmt
+                && !out.contains(&entry)
+            {
+                out.push(entry);
+            }
+        }
+        PlaneExpr::Bits(_) | PlaneExpr::Const(_) => {}
+        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => {
+            for c in cs {
+                collect_legality_formats(c, out);
+            }
+        }
+        PlaneExpr::Not(inner) => collect_legality_formats(inner, out),
+    }
+}
+
+/// Whether any leaf of a compiled plane expression reads a legality plane
+/// (`PLANE_LEGAL_EXISTS`/`PLANE_LEGAL_ILLEGAL`). These are existence
+/// projections over per-printing-varying data ("*some* printing is/isn't
+/// legal") -- unlike every other plane (colors, types, numeric buckets,
+/// devotion, border, all card-invariant), a card-level True here does not
+/// imply every printing of the card individually satisfies the query. Used
+/// to gate the #634 Step 1 `all_match_known` fast path to `unique=card`,
+/// where existence is exactly the semantics needed (docs/issues/
+/// engine-legality-divergent-carveout.md; Step 2's popcount path is already
+/// `Mode::Card`-only for unrelated reasons, see `run_query`).
+pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
+    match expr {
+        PlaneExpr::Plane(p) => {
+            let p = *p as usize;
+            (PLANE_LEGAL_EXISTS..PLANE_LEGAL_EXISTS + MAX_FORMATS).contains(&p)
+                || (PLANE_LEGAL_ILLEGAL..PLANE_LEGAL_ILLEGAL + MAX_FORMATS).contains(&p)
+        }
+        PlaneExpr::Bits(_) | PlaneExpr::Const(_) => false,
+        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(plane_expr_is_existential),
+        PlaneExpr::Not(inner) => plane_expr_is_existential(inner),
+    }
+}
+
+/// `And` two-or-more legality-plane leaves referencing *different* formats
+/// (or the same format under both polarities -- `format:A AND -format:A`)
+/// can't be answered by ANDing independent existence projections: `∃p:
+/// legal_A(p) ∧ legal_B(p)` requires one printing to satisfy both at once,
+/// which isn't the same as `(∃p: legal_A(p)) ∧ (∃p: legal_B(p))` (a false
+/// positive the moment different printings would be the witness for each).
+/// `Or` never has this problem (`∃` distributes over `∨`), so this is only
+/// called where an `And` is about to be assembled -- both the direct case
+/// and the De-Morgan'd `Not(Or(...))` case in `compile_plane_neg`. Declining
+/// (falling back to `narrow_rec`'s existing, correct `Legality` narrowing) is
+/// deliberately simpler than building a shared-witness-safe joint check for a
+/// shape nobody realistically writes --
+/// docs/issues/engine-printing-varying-plane-repair-pattern.md has the joint
+/// per-printing evaluation this would need if it ever mattered enough to build.
+fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneExpr> {
+    let mut formats = Vec::new();
+    for c in &children {
+        collect_legality_formats(c, &mut formats);
+    }
+    if formats.len() > 1 {
+        return None;
+    }
+    Some(and_of(children))
+}
+
 pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::True => Some(PlaneExpr::Const(true)),
-        FilterExpr::And(children) => compile_plane_children(children, bounds, words).map(and_of),
+        FilterExpr::And(children) => and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words)?),
         FilterExpr::Or(children) => compile_plane_children(children, bounds, words).map(or_of),
-        FilterExpr::Not(inner) => {
-            if contains_unnegatable_numeric(inner) {
-                return None;
-            }
-            compile_plane(inner, bounds, words).map(|p| PlaneExpr::Not(Box::new(p)))
-        }
+        // De Morgan pushdown so a Not that reaches a Legality leaf lands on
+        // `illegal_exists` instead of bit-complementing `legal_exists` (wrong
+        // for divergent cards -- see PLANE_LEGAL_EXISTS's doc). Handles the
+        // contains_unnegatable_numeric guard itself, per-leaf, via its own
+        // catch-all arm -- see compile_plane_neg's doc.
+        FilterExpr::Not(inner) => compile_plane_neg(inner, bounds, words),
         // Bonus consumption (docs/issues/engine-oracle-word-index.md): only
         // when the needle matches exactly one dictionary word total (dense or
         // sparse) and that word is dense — the same "single dense hit, no
@@ -722,8 +831,58 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
             (NumExpr::Const(v), NumExpr::Field(f)) => compile_numeric_cmp(*f, flip_op(*op), *v, bounds),
             _ => None,
         },
+        // f:x / format:x (docs/issues/engine-legality-divergent-carveout.md):
+        // exact for every card via PLANE_LEGAL_EXISTS -- no divergent-card
+        // caveat, unlike the single-plane design this replaced. banned:/
+        // restricted: (expected != LEGALITY_LEGAL) and absent formats
+        // (shift: None) stay unindexed, matching narrow_rec's existing
+        // restriction; `Not` is handled by compile_plane_neg, not here.
+        FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
+            Some(PlaneExpr::Plane((PLANE_LEGAL_EXISTS + *shift as usize / 2) as u16))
+        }
         _ => None,
     }
+}
+
+/// Compile `Not(filter)` directly, pushing negation down to `Legality` leaves
+/// (which need `PLANE_LEGAL_ILLEGAL`, not a bit-complement of
+/// `PLANE_LEGAL_EXISTS`) via De Morgan, while leaves that are safe to
+/// bit-complement (colors/types/devotion/non-null-valued numerics) fall
+/// through to the cheaper "compile positive, wrap in `PlaneExpr::Not`" path
+/// unchanged. Mutually recursive with `compile_plane`.
+fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
+    match filter {
+        FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
+            Some(PlaneExpr::Plane((PLANE_LEGAL_ILLEGAL + *shift as usize / 2) as u16))
+        }
+        // Not(And(cs)) = Or(Not(c) for c in cs) -- existence distributes over
+        // Or, so no shared-witness check is needed here regardless of how
+        // many legality leaves end up among the children.
+        FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words).map(or_of),
+        // Not(Or(cs)) = And(Not(c) for c in cs) -- THIS does have the
+        // shared-witness exposure (see and_of_checked_for_shared_witness).
+        FilterExpr::Or(children) => and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words)?),
+        FilterExpr::Not(inner) => compile_plane(inner, bounds, words), // double negation
+        FilterExpr::True => Some(PlaneExpr::Const(false)),
+        // Everything else: only Legality has a divergent-card correctness
+        // gap, so every other plane-eligible leaf is safe to compile
+        // positive and wrap -- contains_unnegatable_numeric still guards
+        // cmc/power/toughness's Null-vs-missing-value issue exactly as
+        // before, just checked per-leaf here instead of once upfront (this
+        // function's own And/Or recursion propagates a declined leaf's None
+        // through .collect::<Option<_>>() the same way the old upfront check
+        // did for the whole subtree).
+        other => {
+            if contains_unnegatable_numeric(other) {
+                return None;
+            }
+            compile_plane(other, bounds, words).map(|p| PlaneExpr::Not(Box::new(p)))
+        }
+    }
+}
+
+fn compile_plane_neg_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<Vec<PlaneExpr>> {
+    children.iter().map(|c| compile_plane_neg(c, bounds, words)).collect()
 }
 
 /// Consume the plane-expressible part of a bound filter. Returns the compiled
@@ -737,28 +896,85 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
 /// narrowing mask, so a partially compilable Or stays entirely residual.
 /// A bare True is left alone — the full-range scan beats materializing an
 /// all-ones bitmap into a candidate list.
-pub(crate) fn split_planes(filter: FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> (Option<PlaneExpr>, FilterExpr) {
+///
+/// `unique_is_card` gates legality specifically: its planes are existence
+/// projections ("*some* printing matches"), so consuming a leaf touching them
+/// to a bare `True` residual (docs/issues/engine-legality-divergent-
+/// carveout.md) is only sound for `unique=card`, where existence is the
+/// semantics wanted. For `unique=printing`/`artwork`, doing so would discard
+/// the only thing that can re-derive *which* printing actually matches --
+/// there's no information left in a `True` residual to recover it from, so
+/// this must decline the fold at the source rather than try to patch it up
+/// after (`plane_expr_is_existential` in `run_query` is kept anyway, as a
+/// defense-in-depth check for any other caller of `split_planes`/`run_query`
+/// that doesn't route through here). Every other plane (card-invariant
+/// fields) has no such exposure and ignores this flag entirely.
+pub(crate) fn split_planes(
+    filter: FilterExpr,
+    bounds: &rkyv::Archived<BitPlanes>,
+    words: &rkyv::Archived<OracleWordIndex>,
+    unique_is_card: bool,
+) -> (Option<PlaneExpr>, FilterExpr) {
     if matches!(filter, FilterExpr::True) {
         return (None, filter);
     }
-    if let Some(pe) = compile_plane(&filter, bounds, words) {
+    if let Some(pe) = compile_plane(&filter, bounds, words)
+        && (unique_is_card || !plane_expr_is_existential(&pe))
+    {
         return (Some(pe), FilterExpr::True);
     }
     match filter {
         FilterExpr::And(children) => {
             let mut planes: Vec<PlaneExpr> = Vec::new();
             let mut rest: Vec<FilterExpr> = Vec::new();
+            // Legality-touching children are held back until every child has
+            // been tried, so the shared-witness check (see
+            // and_of_checked_for_shared_witness) sees the full picture --
+            // this loop calls compile_plane per child directly (not the
+            // whole-And path above, which already failed), so it needs its
+            // own version of that same guard. Non-legality children
+            // (colors/types) have no shared-witness exposure and are always
+            // safe to extract immediately, whether or not the rest resolves
+            // -- unlike the first (repair-based) design for this issue,
+            // there's no tax to avoid paying here anymore.
+            let mut legality_children: Vec<(FilterExpr, PlaneExpr)> = Vec::new();
             for c in children {
                 match compile_plane(&c, bounds, words) {
-                    Some(pe) => planes.push(pe),
+                    Some(pe) => {
+                        let mut fmts = Vec::new();
+                        collect_legality_formats(&pe, &mut fmts);
+                        if fmts.is_empty() {
+                            planes.push(pe);
+                        } else {
+                            legality_children.push((c, pe));
+                        }
+                    }
                     None => rest.push(c),
+                }
+            }
+            let mut all_formats = Vec::new();
+            for (_, pe) in &legality_children {
+                collect_legality_formats(pe, &mut all_formats);
+            }
+            if unique_is_card && all_formats.len() <= 1 {
+                for (_, pe) in legality_children {
+                    planes.push(pe);
+                }
+            } else {
+                // 2+ distinct (format, polarity) pairs can't be ANDed
+                // together safely regardless of mode (shared-witness); a
+                // single one is safe for the plane's own exactness but still
+                // deferred for unique=printing/artwork, same reasoning as the
+                // top-level shortcut above. Either way it falls back to
+                // narrow_rec's existing (correct, still exact as of this
+                // issue) Legality narrowing arm instead.
+                for (c, _) in legality_children {
+                    rest.push(c);
                 }
             }
             if planes.is_empty() {
                 return (None, FilterExpr::And(rest));
             }
-            // rest is nonempty here: had every child compiled, the whole-tree
-            // compile above would have consumed the And.
             let residual = if rest.len() == 1 { rest.pop().unwrap() } else { FilterExpr::And(rest) };
             (Some(and_of(planes)), residual)
         }

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1039,6 +1039,61 @@ pub(crate) fn eval_planes(expr: &PlaneExpr, planes: &rkyv::Archived<BitPlanes>, 
     }
 }
 
+/// If plane `p` is one of legality's existence planes, the (shift, is_illegal)
+/// it addresses -- `shift` matches `FilterExpr::Legality`'s own field, and
+/// `is_illegal` distinguishes `PLANE_LEGAL_ILLEGAL` (the negated-check plane)
+/// from `PLANE_LEGAL_EXISTS`. `None` for every other (card-invariant) plane.
+fn legality_plane_shift(p: usize) -> Option<(u8, bool)> {
+    if (PLANE_LEGAL_EXISTS..PLANE_LEGAL_EXISTS + MAX_FORMATS).contains(&p) {
+        Some((((p - PLANE_LEGAL_EXISTS) * 2) as u8, false))
+    } else if (PLANE_LEGAL_ILLEGAL..PLANE_LEGAL_ILLEGAL + MAX_FORMATS).contains(&p) {
+        Some((((p - PLANE_LEGAL_ILLEGAL) * 2) as u8, true))
+    } else {
+        None
+    }
+}
+
+/// Evaluate a compiled plane expression against one specific printing, rather
+/// than a card's already-known aggregate truth -- needed wherever row
+/// emission picks/verifies a printing for a card whose card-level match came
+/// through a legality leaf (docs/issues/engine-legality-divergent-carveout.md
+/// "Row selection for unique=card"): `legal_exists`/`illegal_exists` only
+/// guarantee *some* printing satisfies the expression, not this one. Every
+/// other (card-invariant) leaf reads the same card-level bit `eval_planes`
+/// would have used -- identical for every printing of the card by
+/// construction -- so this only actually diverges from the card-level answer
+/// at a legality leaf, which consults `printing` directly instead, mirroring
+/// `tri()`'s own per-printing check (`filter.rs`'s `Legality` arm). Callers
+/// only need this for the bounded set of printings being emitted, never the
+/// whole candidate set -- see the design doc for why that scoping is what
+/// makes this cheap instead of repeating the abandoned first design's
+/// performance mistake.
+pub(crate) fn eval_plane_expr_for_printing(
+    expr: &PlaneExpr,
+    planes: &rkyv::Archived<BitPlanes>,
+    cid: u32,
+    printing: &rkyv::Archived<Printing>,
+) -> bool {
+    match expr {
+        PlaneExpr::Plane(p) => {
+            let p = *p as usize;
+            if let Some((shift, is_illegal)) = legality_plane_shift(p) {
+                let status = (u64::from(printing.card_legalities) >> shift) & 0b11;
+                if is_illegal { status != LEGALITY_LEGAL } else { status == LEGALITY_LEGAL }
+            } else {
+                let wpp = words_per_plane(u32::from(planes.n_cards) as usize);
+                let word = u64::from(planes.words[p * wpp + cid as usize / 64]);
+                (word >> (cid % 64)) & 1 == 1
+            }
+        }
+        PlaneExpr::Bits(bits) => bitmap_contains(bits, cid),
+        PlaneExpr::Const(b) => *b,
+        PlaneExpr::And(children) => children.iter().all(|c| eval_plane_expr_for_printing(c, planes, cid, printing)),
+        PlaneExpr::Or(children) => children.iter().any(|c| eval_plane_expr_for_printing(c, planes, cid, printing)),
+        PlaneExpr::Not(inner) => !eval_plane_expr_for_printing(inner, planes, cid, printing),
+    }
+}
+
 /// True iff card `cid`'s bit is set in the bitmap.
 pub(crate) fn bitmap_contains(bitmap: &[u64], cid: u32) -> bool {
     bitmap[(cid >> 6) as usize] >> (cid & 63) & 1 != 0

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1003,8 +1003,58 @@ fn legality_plane_promotion_respects_mode_through_split_planes() {
     assert_eq!(total, 1, "only the one legal printing may match, even though the plane says the card matches");
     assert_eq!(u128::from(page[0].1.scryfall_id), 2);
 
-    let (total, _) = run_mode("card");
+    // unique=card: the count is right via existence alone, but the *returned
+    // printing* must still be the legal one, not just the card's normal
+    // default-preferred printing (docs/issues/engine-legality-divergent-
+    // carveout.md "Row selection for unique=card") -- this is exactly the
+    // case a prior version of this test missed, by discarding `page` here.
+    let (total, page) = run_mode("card");
     assert_eq!(total, 1, "unique=card only needs the existence fact the plane already proves");
+    assert_eq!(
+        u128::from(page[0].1.scryfall_id),
+        2,
+        "unique=card must return the legal printing, not the preferred-but-not-legal one"
+    );
+}
+
+/// The same row-selection bug, but reached via a compound filter (the shape
+/// this issue's own motivating query has: `format:X` ANDed with a
+/// card-invariant sibling) rather than a bare Legality leaf -- exercises
+/// `existential_plane` detection on a composed `PlaneExpr::And`, not just a
+/// single `PlaneExpr::Plane`.
+#[test]
+fn legality_compound_and_respects_row_selection_for_unique_card() {
+    let mut vocab = VocabInterner::new();
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.legality_divergent = true;
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0; // preferred: not legal in A
+    data.printings[1].card_legalities = 0b01; // non-preferred: legal in A
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.legal_divergent = build_divergent_ids(&data.cards);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Legality { shift: Some(0), expected: 0b01 },
+        FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
+    ]);
+    let (plane, mut residual) = split_planes(filter, bounds, words, true);
+    assert!(plane.is_some(), "format:A AND t:creature (one format, no shared-witness issue) must compile whole");
+    assert!(matches!(residual, FilterExpr::True));
+
+    let (total, page) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 1);
+    assert_eq!(
+        u128::from(page[0].1.scryfall_id),
+        2,
+        "the compound's card-invariant sibling must not mask the legality leaf's row-selection requirement"
+    );
 }
 
 /// format:A AND format:B (two distinct formats) can't be answered by ANDing

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -505,7 +505,7 @@ fn rarity_never_exact_consumed() {
     // Mixed with an otherwise fully plane-expressible sibling: the rarity
     // child must stay in the residual, not get silently dropped or promoted.
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity]), bounds, words);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity]), bounds, words, true);
     assert!(pe.is_some(), "the creature child must still plane-consume");
     assert!(
         matches!(&residual, FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }),
@@ -738,50 +738,63 @@ fn divergent_legality_defers_to_printings() {
     assert!(!f.matches(&archived.cards[1], &archived.printings[2], &archived.strings));
 }
 
-// ─── Legality bitplanes (#630 phase 2) ────────────────────────────────────────
+// ─── Legality bitplanes (#630 phase 2 / #667 dual-exact-plane redesign) ───────
 
-/// card0: legal in format A (shift 0) only. card1: legal in format B (shift 2)
-/// only. card2: divergent, canonical (preferred-printing) word says legal in
-/// neither — the OR-with-divergent-postings narrowing must still include it.
-fn legal_plane_fixture() -> (Vec<OracleCard>, VocabInterner) {
+/// card0: legal in format A (shift 0) only, single printing. card1: legal in
+/// format B (shift 2) only, single printing. card2: genuinely divergent for
+/// format A — two printings, one legal and one not — so both
+/// `legal_exists(A)` and `illegal_exists(A)` are true for it at once
+/// (docs/issues/engine-legality-divergent-carveout.md).
+fn legal_plane_fixture() -> CardData {
     let mut vocab = VocabInterner::new();
     let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
     card0.card_legalities = 0b01; // legal at shift 0
     let mut card1 = stub_card(2, TYPE_CREATURE, &[], &mut vocab);
     card1.card_legalities = 0b01 << 2; // legal at shift 2
     let mut card2 = stub_card(3, TYPE_CREATURE, &[], &mut vocab);
-    card2.card_legalities = 0; // not legal in either, canonically
     card2.legality_divergent = true;
-    (vec![card0, card1, card2], vocab)
+    let mut data = store_of(vec![card0, card1, card2], &[1, 1, 2], vocab);
+    // build_bit_planes reads printing-level card_legalities, not the
+    // OracleCard-level field set above -- store_of's stub printings all
+    // default to 0, so every printing needs its own legality set here before
+    // the planes are rebuilt below. card2's two printings deliberately
+    // disagree on format A: one legal, one not.
+    data.printings[0].card_legalities = 0b01; // card0: legal in A
+    data.printings[1].card_legalities = 0b01 << 2; // card1: legal in B
+    data.printings[2].card_legalities = 0b01; // card2 printing 1: legal in A
+    data.printings[3].card_legalities = 0; // card2 printing 2: not legal in A
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.legal_divergent = build_divergent_ids(&data.cards);
+    data
 }
 
 #[test]
 fn legal_plane_narrows_positive_includes_divergent() {
-    let (cards, vocab) = legal_plane_fixture();
-    let data = store_of(cards, &[1, 1, 1], vocab);
+    let data = legal_plane_fixture();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    // Format A (shift 0): card0 (truly legal) + card2 (divergent, always
-    // included) narrow in; card1 (legal only in format B) must not.
+    // Format A (shift 0): card0 (truly legal) + card2 (divergent, has a legal
+    // printing) narrow in; card1 (legal only in format B) must not.
     let f = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
     match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::CardBits(bits)) => {
             assert!(bitmap_contains(&bits, 0), "truly legal card must narrow in");
             assert!(!bitmap_contains(&bits, 1), "card legal only in a different format must not narrow in");
-            assert!(bitmap_contains(&bits, 2), "divergent card must always narrow in, regardless of canonical status");
+            assert!(bitmap_contains(&bits, 2), "divergent card with a legal printing must narrow in");
         }
         _ => panic!("expected a card bitmap"),
     }
 
-    // Format B (shift 2): card1 narrows in, card0 does not, card2 still does
-    // (shift math must independently address each format's plane).
+    // Format B (shift 2): card1 narrows in, card0 does not, card2 does not
+    // (its printings only vary on format A; shift math must independently
+    // address each format's plane).
     let g = FilterExpr::Legality { shift: Some(2), expected: 0b01 };
     match narrow_candidates(&g, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::CardBits(bits)) => {
             assert!(!bitmap_contains(&bits, 0));
             assert!(bitmap_contains(&bits, 1));
-            assert!(bitmap_contains(&bits, 2));
+            assert!(!bitmap_contains(&bits, 2));
         }
         _ => panic!("expected a card bitmap"),
     }
@@ -789,19 +802,19 @@ fn legal_plane_narrows_positive_includes_divergent() {
 
 #[test]
 fn legal_plane_narrows_negated_includes_divergent() {
-    let (cards, vocab) = legal_plane_fixture();
-    let data = store_of(cards, &[1, 1, 1], vocab);
+    let data = legal_plane_fixture();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    // -f:A: card0 is truly legal in A, so it must NOT narrow in; card1 (not
-    // legal in A) and card2 (divergent) must.
+    // -f:A: card0 is truly legal in A (no illegal printing), so it must NOT
+    // narrow in; card1 (not legal in A) and card2 (divergent, has a
+    // not-legal printing too) must.
     let not_a = FilterExpr::Not(Box::new(FilterExpr::Legality { shift: Some(0), expected: 0b01 }));
     match narrow_candidates(&not_a, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::CardBits(bits)) => {
             assert!(!bitmap_contains(&bits, 0), "truly legal card must not narrow into the negation");
             assert!(bitmap_contains(&bits, 1), "truly not-legal card must narrow into the negation");
-            assert!(bitmap_contains(&bits, 2), "divergent card must always narrow in, regardless of polarity");
+            assert!(bitmap_contains(&bits, 2), "divergent card with a not-legal printing must narrow into the negation");
         }
         _ => panic!("expected a card bitmap"),
     }
@@ -809,8 +822,7 @@ fn legal_plane_narrows_negated_includes_divergent() {
 
 #[test]
 fn legal_plane_declines_banned_restricted_and_absent_format() {
-    let (cards, vocab) = legal_plane_fixture();
-    let data = store_of(cards, &[1, 1, 1], vocab);
+    let data = legal_plane_fixture();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -835,20 +847,22 @@ fn legal_plane_declines_banned_restricted_and_absent_format() {
 /// never be silently dropped by the narrowing, in either polarity, even when
 /// its *preferred* printing's status disagrees with a non-preferred printing
 /// that the query should actually match. This exercises the full path
-/// (narrow_rec's new arms feeding run_query's unmodified card_pass/residual
+/// (narrow_rec's plane arms feeding run_query's unmodified card_pass/residual
 /// walk), not just the bitmap in isolation.
 #[test]
 fn legal_plane_narrowing_preserves_divergent_printing_correctness() {
     let mut vocab = VocabInterner::new();
     // Preferred printing (higher prefer_score, sorts first) says NOT legal;
     // the second, non-preferred printing says legal — the opposite of the
-    // "usual" case, deliberately, to stress the narrowing's superset property.
+    // "usual" case, deliberately, to stress that narrowing is built from
+    // per-printing truth, not just the preferred printing's status.
     let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
-    card.card_legalities = 0; // preferred printing's status: not legal
     card.legality_divergent = true;
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0; // preferred: not legal
     data.printings[1].card_legalities = 0b01; // non-preferred: legal
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -866,8 +880,7 @@ fn legal_plane_narrowing_preserves_divergent_printing_correctness() {
     assert_eq!(u128::from(page[0].1.scryfall_id), 2); // the non-preferred, legal printing
 
     // f:A, unique=card: the card matches (at least one printing is legal),
-    // even though the narrowing's own candidate bit for this card came only
-    // from the divergent postings, not from the (canonically "not legal") legal_x bit.
+    // read straight from the exact legal_exists(A) plane bit.
     let mut f2 = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
     let (total, _) = run(&mut f2, "card");
     assert_eq!(total, 1);
@@ -885,16 +898,15 @@ fn legal_plane_narrowing_preserves_divergent_printing_correctness() {
 fn legal_plane_narrows_correctly_across_word_boundary() {
     let mut vocab = VocabInterner::new();
     let n = 70;
-    let cards: Vec<OracleCard> = (0..n)
-        .map(|i| {
-            let mut c = stub_card(1 + i as u128, TYPE_CREATURE, &[], &mut vocab);
-            // Legal (at shift 2) on even ids only, spanning past the 64-bit word boundary.
-            c.card_legalities = if i % 2 == 0 { 0b01 << 2 } else { 0 };
-            c
-        })
-        .collect();
+    let cards: Vec<OracleCard> = (0..n).map(|i| stub_card(1 + i as u128, TYPE_CREATURE, &[], &mut vocab)).collect();
     let printing_counts = vec![1usize; n];
-    let data = store_of(cards, &printing_counts, vocab);
+    let mut data = store_of(cards, &printing_counts, vocab);
+    // Legal (at shift 2) on even ids only, spanning past the 64-bit word
+    // boundary; printing_counts is all 1s so printing i belongs to card i.
+    for i in 0..n {
+        data.printings[i].card_legalities = if i % 2 == 0 { 0b01 << 2 } else { 0 };
+    }
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -907,6 +919,193 @@ fn legal_plane_narrows_correctly_across_word_boundary() {
         }
         _ => panic!("expected a card bitmap"),
     }
+}
+
+/// `plane_expr_is_existential` is the whole mode-aware-all_match fix's load-
+/// bearing check: it must flag any compiled expression touching a legality
+/// plane (docs/issues/engine-legality-divergent-carveout.md) and only those
+/// -- card-invariant fields (types here) must never be flagged, and an And
+/// mixing the two must still be flagged (any existential leaf taints the
+/// whole composed expression).
+#[test]
+fn plane_expr_is_existential_identifies_legality_only() {
+    let data = legal_plane_fixture();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words).unwrap();
+    assert!(super::plane_expr_is_existential(&legality_pe));
+
+    let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words).unwrap();
+    assert!(!super::plane_expr_is_existential(&creature_pe));
+
+    let mixed = compile_plane(
+        &FilterExpr::And(vec![
+            FilterExpr::Legality { shift: Some(0), expected: 0b01 },
+            FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
+        ]),
+        bounds,
+        words,
+    )
+    .unwrap();
+    assert!(super::plane_expr_is_existential(&mixed), "one existential leaf must taint the whole And");
+}
+
+/// Regression for the mode-aware all_match bug found while building this
+/// design: `format:A` run through the *real* pipeline (split_planes, not a
+/// direct narrow_candidates/run_query call with plane=None) must not let
+/// unique=printing see every printing of a matching card just because the
+/// card-level existence fact is true. A bare Legality leaf fully consumed to
+/// `FilterExpr::True` regardless of mode would discard the only thing that
+/// could re-derive *which* printing matches, so split_planes now declines the
+/// fold itself for unique=printing/artwork (`unique_is_card=false`), leaving
+/// the original Legality node in the residual for the normal per-printing
+/// card_pass walk. unique=card is unaffected: existence is exactly what it
+/// needs, so it still takes the fully-consumed fast path.
+#[test]
+fn legality_plane_promotion_respects_mode_through_split_planes() {
+    let mut vocab = VocabInterner::new();
+    // Preferred printing not legal, non-preferred printing legal -- same
+    // deliberately-inverted shape as the narrow_rec-level correctness test
+    // above, but exercised through split_planes this time.
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.legality_divergent = true;
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0; // preferred: not legal
+    data.printings[1].card_legalities = 0b01; // non-preferred: legal
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.legal_divergent = build_divergent_ids(&data.cards);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let run_mode = |unique: &str| {
+        let f = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+        let unique_is_card = unique != "printing" && unique != "artwork";
+        let (plane, mut residual) = split_planes(f, bounds, words, unique_is_card);
+        if unique_is_card {
+            assert!(plane.is_some(), "a bare Legality leaf must still fully plane-consume for unique=card");
+            assert!(matches!(residual, FilterExpr::True), "split_planes must leave a bare True residual for unique=card");
+        } else {
+            assert!(plane.is_none(), "unique=printing/artwork must decline the fold, not just patch around it");
+            assert!(matches!(residual, FilterExpr::Legality { .. }), "the original Legality node must survive for per-printing verification");
+        }
+        run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut residual, plane.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        )
+    };
+
+    let (total, page) = run_mode("printing");
+    assert_eq!(total, 1, "only the one legal printing may match, even though the plane says the card matches");
+    assert_eq!(u128::from(page[0].1.scryfall_id), 2);
+
+    let (total, _) = run_mode("card");
+    assert_eq!(total, 1, "unique=card only needs the existence fact the plane already proves");
+}
+
+/// format:A AND format:B (two distinct formats) can't be answered by ANDing
+/// independent existence-projection planes -- ∃p: legal_A(p) ∧ legal_B(p) is
+/// not the same as (∃p: legal_A(p)) ∧ (∃p: legal_B(p)); a card can have
+/// different witness printings for each side. compile_plane must decline this
+/// shape and shared-format-both-polarities alike, while Or of two distinct
+/// formats has no such problem and does compile (∃ distributes over ∨).
+#[test]
+fn legality_and_of_two_formats_declines_but_or_compiles() {
+    let data = legal_plane_fixture();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let b = || FilterExpr::Legality { shift: Some(2), expected: 0b01 };
+
+    assert!(
+        compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words).is_none(),
+        "two distinct formats ANDed must decline (shared-witness)"
+    );
+    assert!(
+        compile_plane(&FilterExpr::Or(vec![a(), b()]), bounds, words).is_some(),
+        "OR of two formats has no shared-witness problem and must compile"
+    );
+    assert!(
+        compile_plane(&FilterExpr::And(vec![a(), FilterExpr::Not(Box::new(a()))]), bounds, words).is_none(),
+        "format:A AND -format:A (same format, both polarities) is the same contradiction-prone shape and must also decline"
+    );
+}
+
+/// The shared-witness decline's fallback must still be *correct*, not just
+/// declined: a card legal in A via one printing and legal in B via a
+/// different printing (no single printing satisfies both) is the trap in
+/// action -- legal_exists(A) AND legal_exists(B) would wrongly say true.
+/// Routed through the real split_planes + run_query pipeline.
+#[test]
+fn legality_shared_witness_and_falls_back_to_correct_result() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0b01; // legal in A (shift 0) only
+    data.printings[1].card_legalities = 0b01 << 2; // legal in B (shift 2) only
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let and_both = FilterExpr::And(vec![
+        FilterExpr::Legality { shift: Some(0), expected: 0b01 },
+        FilterExpr::Legality { shift: Some(2), expected: 0b01 },
+    ]);
+    let (plane, mut residual) = split_planes(and_both, bounds, words, true);
+    assert!(plane.is_none(), "shared-witness AND must not partially promote either leaf into the plane");
+    assert!(matches!(residual, FilterExpr::And(_)), "both legality children must remain in the residual");
+
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing is legal in both A and B at once");
+}
+
+/// -(format:A AND t:creature): Not wrapping a compound needs De Morgan pushed
+/// to compile time so the Not lands on the Legality leaf directly (swapping
+/// to illegal_exists), never as a bit-complement of the AND's compiled plane.
+/// Demonstrated against a card divergent in A: the positive AND is true for
+/// it (its legal-in-A printing is also a creature), so a naive complement
+/// would wrongly exclude it -- but the card's *other*, not-legal-in-A
+/// printing separately satisfies the negation, so the correct answer
+/// includes it.
+#[test]
+fn legality_de_morgan_not_of_compound() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0b01; // legal in A
+    data.printings[1].card_legalities = 0; // not legal in A
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+
+    let and_pe = compile_plane(&FilterExpr::And(vec![a(), creature()]), bounds, words)
+        .expect("format:A AND t:creature must compile (one format, no shared-witness issue)");
+    let mut and_bits: Vec<u64> = Vec::new();
+    eval_planes(&and_pe, &archived.indexes.planes, &mut and_bits);
+    assert!(bitmap_contains(&and_bits, 0), "printing0 is legal in A and a creature, so the positive AND is true for card 0");
+
+    let not_and = FilterExpr::Not(Box::new(FilterExpr::And(vec![a(), creature()])));
+    let pe = compile_plane(&not_and, bounds, words).expect("-(format:A AND t:creature) must still compile via De Morgan");
+    let mut bits: Vec<u64> = Vec::new();
+    eval_planes(&pe, &archived.indexes.planes, &mut bits);
+    assert!(bitmap_contains(&bits, 0), "card has a not-legal-in-A printing, so it satisfies the negation despite the positive AND being true");
 }
 
 #[test]
@@ -1506,7 +1705,7 @@ fn popcount_skip_tie_breaking_preserves_group_order_both_directions() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
+    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
     assert!(matches!(residual, FilterExpr::True), "t:creature must fully plane-consume");
 
     let mut run = |direction: &str| {
@@ -1544,7 +1743,7 @@ fn popcount_skip_offset_lands_inside_tied_group() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
+    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
 
     // Full ascending order is [card3, card1, card0, card2, card4] (oracle ids
     // [4,2,1,3,5]); offset=2 must skip card3 and card1, landing on card0.
@@ -1577,7 +1776,7 @@ fn popcount_skip_matches_non_popcount_path() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual_true) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
+    let (plane, mut residual_true) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
     assert!(matches!(residual_true, FilterExpr::True));
 
     // Popcount path: plane present, residual True.
@@ -2048,33 +2247,33 @@ fn split_planes_composition_rules() {
     let text = || FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
 
     // And(plane, plane, text): planes consumed, the lone leftover unwraps.
-    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]), bounds, words);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]), bounds, words, true);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::TextContains { .. }));
 
     // Fully plane-expressible tree is consumed whole.
-    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]), bounds, words);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]), bounds, words, true);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
-    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]), bounds, words);
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]), bounds, words, true);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
 
     // Or mixing plane and non-plane children stays entirely residual:
     // mask ∨ residual is not a narrowing mask.
-    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]), bounds, words);
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]), bounds, words, true);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::Or(ref v) if v.len() == 2));
 
     // Produced mana is plane-expressible (docs/issues/engine-produces-planes.md):
     // same card-level, always-known bitmask shape as Colors/ColorIdentity.
     let produces = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 16 };
-    let (pe, residual) = split_planes(produces, bounds, words);
+    let (pe, residual) = split_planes(produces, bounds, words, true);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
 
     // Bare True keeps the range-scan path (no all-ones bitmap materialization).
-    let (pe, residual) = split_planes(FilterExpr::True, bounds, words);
+    let (pe, residual) = split_planes(FilterExpr::True, bounds, words, true);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::True));
 }
@@ -2111,7 +2310,7 @@ fn run_query_plane_path_parity() {
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
+            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -2328,7 +2527,7 @@ fn run_query_numeric_plane_path_parity() {
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
+            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -2353,7 +2552,7 @@ fn numeric_plane_enables_all_match_promotion() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let cmc_le12 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Le, rhs: NumExpr::Const(12.0) };
-    let (pe, residual) = split_planes(cmc_le12, &archived.indexes.planes, &archived.indexes.oracle_trigram.words);
+    let (pe, residual) = split_planes(cmc_le12, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
     assert!(pe.is_some(), "cmc<=12 must plane-compile");
     assert!(matches!(residual, FilterExpr::True), "cmc<=12 must fully consume: no residual card_pass needed");
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1200,6 +1200,55 @@ fn legality_de_morgan_not_of_compound() {
     assert!(bitmap_contains(&bits, 0), "card has a not-legal-in-A printing, so it satisfies the negation despite the positive AND being true");
 }
 
+/// Regression closing a gap this design doc's own Acceptance section left
+/// open (and a second reviewer flagged): `contains_unnegatable_numeric`'s
+/// pre-existing guard (declining `Not` entirely when a null-valued numeric
+/// field like power/toughness is anywhere inside, since `Tri::Null` never
+/// flips to `True`) must still fire correctly now that `compile_plane_neg`
+/// has a Legality-aware `And`/`Or` arm alongside it -- composing a legality
+/// leaf with an unnegatable numeric leaf under `Not` must decline exactly
+/// like composing it with any other card-invariant leaf already did
+/// (`numeric_plane_declines_not_over_numeric_cmp` covers the pre-existing,
+/// Legality-free shapes; this covers the new interaction specifically).
+#[test]
+fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
+    let data = legal_plane_fixture();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let power_gt3 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Power), op: CmpOp::Gt, rhs: NumExpr::Const(3.0) };
+
+    // Sanity: the positive compound compiles fine on its own (one format,
+    // no shared-witness issue, and the un-negated numeric comparison is
+    // plane-eligible) -- isolates the failure to the Not/Null interaction.
+    assert!(
+        compile_plane(&FilterExpr::And(vec![a(), power_gt3()]), bounds, words).is_some(),
+        "format:A AND power>3 must compile without a Not present"
+    );
+
+    // Not(And(legality, unnegatable numeric)): the And arm of compile_plane_neg
+    // recurses per child (De Morgan into an Or) -- the numeric child must
+    // still decline via contains_unnegatable_numeric's catch-all check,
+    // collapsing the whole compile to None through the `?` propagation.
+    let not_and = FilterExpr::Not(Box::new(FilterExpr::And(vec![a(), power_gt3()])));
+    assert!(
+        compile_plane(&not_and, bounds, words).is_none(),
+        "-(format:A AND power>3) must decline: Null doesn't flip to True, even with a legality sibling"
+    );
+
+    // Not(Or(legality, unnegatable numeric)): the Or arm goes through
+    // and_of_checked_for_shared_witness, a different code path than And's --
+    // must decline there too, not just in the And arm.
+    let not_or = FilterExpr::Not(Box::new(FilterExpr::Or(vec![a(), power_gt3()])));
+    assert!(
+        compile_plane(&not_or, bounds, words).is_none(),
+        "-(format:A OR power>3) must decline via the Or arm of compile_plane_neg too"
+    );
+}
+
 #[test]
 fn run_query_walk_dedups_and_prefers() {
     // card 0: Creature with 3 printings, card 1: Instant with 1, card 2: Creature with 2.

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1057,6 +1057,48 @@ fn legality_compound_and_respects_row_selection_for_unique_card() {
     );
 }
 
+/// Found in #676's review: a legality leaf ANDed with a genuinely
+/// printing-dependent, non-plane-compilable residual (`DateCmp` here --
+/// never appears in `planes.rs`, so it always stays in the residual after
+/// `split_planes`'s partial extraction) needs *both* checked against the
+/// *same* printing. printing 0 is legal in A but released before the cutoff;
+/// printing 1 is released after the cutoff but not legal in A -- no single
+/// printing satisfies both, so `format:A AND date>cutoff` (unique=card) must
+/// match 0 times, not pick either printing on the strength of just one half
+/// of the conjunction.
+#[test]
+fn legality_and_date_residual_must_be_checked_together() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0b01; // legal in A, but...
+    data.printings[0].released_at_int = Some(20100101); // ...released before the cutoff
+    data.printings[1].card_legalities = 0; // not legal in A, but...
+    data.printings[1].released_at_int = Some(20220101); // ...released after the cutoff
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Legality { shift: Some(0), expected: 0b01 },
+        FilterExpr::DateCmp { op: CmpOp::Gt, value: 20200101 },
+    ]);
+    let (plane, mut residual) = split_planes(filter, bounds, words, true);
+    assert!(plane.is_some(), "the legality leaf alone must still promote into the plane");
+    assert!(
+        matches!(residual, FilterExpr::DateCmp { .. }),
+        "date> isn't plane-compilable, so it must remain a real residual, not collapse to True"
+    );
+
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing is both legal in A and released after the cutoff");
+}
+
 /// format:A AND format:B (two distinct formats) can't be answered by ANDing
 /// independent existence-projection planes -- ∃p: legal_A(p) ∧ legal_B(p) is
 /// not the same as (∃p: legal_A(p)) ∧ (∃p: legal_B(p)); a card can have

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -371,15 +371,26 @@ given in μs rather than ms:
 
 | config | main | branch | speedup |
 |---|---|---|---|
-| `format:modern` | 190μs | 65μs | 2.9x |
-| `format:pioneer` | 159μs | 61μs | 2.6x |
-| `-format:modern` | 154μs | 57μs | 2.7x |
-| `format:modern or format:pioneer` | 207μs | 71μs | 2.9x |
-| `format:modern c:g t:creature` (cited real usage shape) | 83μs | 67μs | 1.2x |
-| `format:modern` @ offset 15000 | 203μs | 68μs | 3.0x (flat with offset — Step 2) |
-| `format:modern t:creature` @ offset 15000 | 85μs | 7μs | 12x |
-| `format:modern t:creature`, `unique=printing`/`artwork` | 140/143μs | 131/135μs | unaffected (correctly not promoted) |
-| `banned:modern`/`restricted:vintage`/`c:g` (controls) | 203/198/58μs | 201/199/60μs | unaffected (re-verified post-conjunction-fix) |
+| `format:modern` | 194μs | 66μs | 2.9x |
+| `format:pioneer` | 164μs | 64μs | 2.6x |
+| `-format:modern` | 158μs | 57μs | 2.8x |
+| `format:modern or format:pioneer` | 210μs | 70μs | 3.0x |
+| `format:modern t:creature` | 142μs | 68μs | 2.1x |
+| `format:modern c:g t:creature` (cited real usage shape) | 84μs | 66μs | 1.3x |
+| `format:modern` @ offset 15000 (total 22264 — genuine deep page) | 208μs | 69μs | 3.0x (flat with offset — Step 2) |
+| `format:modern t:creature` @ offset 10000 (total 12251 — genuine deep page; compare to the plain offset-0 row above: flat both sides) | 158μs | 67μs | 2.4x |
+| `format:modern t:creature` @ offset 15000 (**past** its own total of 12251) | 89μs | 7μs | not comparable to the row above — an offset past the total hits a different, much cheaper code path (empty page, no scatter/skip/emit), not deep pagination |
+| `format:modern t:creature`, `unique=printing`/`artwork` | 143/147μs | 137/136μs | unaffected (correctly not promoted) |
+| `banned:modern`/`restricted:vintage`/`c:g` (controls) | 204/199/60μs | 200/197/59μs | unaffected (re-verified post-conjunction-fix) |
+
+An earlier version of this table compared `format:modern t:creature` at offset 15000 against other
+rows at offset 0 and made the former look implausibly fast (7μs vs the 60-70μs range everywhere else)
+— offset 15000 exceeds that query's own total of 12251, so it was measuring
+`run_query_streamed_popcount`'s early-return-on-empty-page path (`page_offset >= total`), not deep
+pagination. `scripts/bench_legality_divergent.py`'s `deep-offset` configs are now chosen to stay
+within each query's own total (2 of the original 6 rows didn't — a real gap in the benchmark, not the
+engine); the past-total case is kept as its own separately-labeled `offset-beyond-total` group so the
+two shapes are never conflated again.
 
 Total-row-count parity: 0 mismatches across all 24 targeted configs and a 520-query broad survey
 (`scripts/survey_queries.py --seed 667`) run against both builds. Re-measured after the row-selection

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -1,0 +1,239 @@
+# Engine: legality divergent-card carve-out for all_match promotion
+
+Status: implemented and benchmarked (second design, replacing a repair-based first draft), pending PR.
+GitHub: #667.
+Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+Follow-on to #634 (Steps 1/2, shipped in #658), flagged in that issue's own comment thread.
+
+## Measured problem
+
+`FilterExpr::Legality` (`f:`/`format:`) never reaches `all_match` promotion or the #634 Step 2
+popcount-skip order phase, however selective the rest of the filter is. `compile_plane` has no
+`Legality` arm at all — it falls through the `_ => None` catch-all (`planes.rs`) — so `split_planes`
+can never fully consume a filter containing a `Legality` node to `FilterExpr::True`, which is
+Step 2's precondition. Concretely: `format:modern id:g t:creature` — `id:`/`t:` already compile to
+exact planes, but the `format:modern` child alone keeps the whole filter off Step 2, forcing
+per-candidate `card_pass` regardless of how selective `id:g`/`t:creature` already are.
+
+## Why the plane can't just be "legal" today
+
+`legal_x` (#654) is built as "legal AND not divergent": exact for ~98.2% of cards, but the ~556
+divergent-legality cards (their printings disagree on status) are unconditionally excluded from the
+bit regardless of true status, since one card-level bit can't represent per-printing disagreement.
+`compile_plane`'s contract is "two-valued card-level nodes only" (`planes.rs:636-641`), and
+`Legality`'s `tri()` genuinely returns `Tri::PrintingDep` for divergent cards (`filter.rs:1223-1237`)
+— that's why it's excluded today.
+
+## First design (repair-based), tried and abandoned — see the general write-up
+
+A first pass built a repair mechanism: keep the single "legal and not divergent" plane, and for the
+~556 divergent cards specifically, re-derive and overwrite the correct bit on the evaluated bitmap
+before anything reads it. This worked, was fully tested, and its broad-survey regressions were
+tracked down and fixed (a redundant-lookup bug, then a residual-leftover extraction-gate bug) — but
+a much cleaner design was found before landing it: see the analysis below. The repair mechanism, the
+extraction-gate principle, the shared-witness invariant, and the cardinality-guard problem it ran
+into are real, generalizable engineering, captured separately for the next field that doesn't have
+this issue's escape hatch:
+[docs/issues/engine-printing-varying-plane-repair-pattern.md](engine-printing-varying-plane-repair-pattern.md).
+
+## Second design: two exact planes per format, no repair, no runtime tax
+
+**The escape hatch legality has and a hypothetical unbounded field wouldn't**: legality's entire
+query space is finite and known at build time — `expected == LEGALITY_LEGAL`, for one of ~22
+formats. That means *both* existence projections can be precomputed exactly, once, at build time:
+
+- `legal_exists(F)` = `∃p: legal_F(p)` — does this card have any printing legal in format `F`.
+- `illegal_exists(F)` = `∃p: ¬legal_F(p)` — does this card have any printing *not* legal in `F`.
+
+These are genuinely different facts for a divergent card (both can be true at once — that's what
+"the printings disagree" means), so `-format:F` needs its own plane, not a bit-complement of the
+first. Once both exist, `format:F` and `-format:F` are **exact for every card, divergent or not**,
+with **zero runtime cost beyond the existing `eval_planes` word-sweep** — no repair, no divergent
+postings lookup, no cardinality guard, because there's nothing left to correct.
+
+**Storage, checked before assuming it's cheap**: `∃p: legal_F(p)` / `∃p: ¬legal_F(p)` cardinality
+per format, real corpus (`benchmarks/bitplanes/corpus.jsonl`, 31,508 cards):
+
+| format | legal_exists | illegal_exists |
+|---|---|---|
+| commander | 99.8% (31,451) | **0.2% (57)** |
+| legacy | 99.7% (31,421) | 0.3% (87) |
+| vintage | 99.8% (31,439) | 0.2% (69) |
+| modern | 70.7% (22,264) | 29.3% (9,244) |
+| pioneer | 46.4% (14,630) | 53.6% (16,878) |
+| oldschool | **3.1% (961)** | 98.7% (31,083) |
+
+The spread (0.2% to 99.8%) initially suggested a density-thresholded plane-vs-postings choice per
+format/polarity, mirroring #628/#639/#671 — **checked and rejected**: `eval_planes` costs O(words),
+not O(popcount), so a plane for a 57-card sparse set costs exactly the same to evaluate as one for a
+31,451-card dense set. The postings-vs-plane tradeoff only pays off when storage itself is expensive
+(subtypes/keywords: ~1,500 distinct values, a plane per value would be megabytes) or when a
+postings union's materialization cost scales with result size (the exact problem this redesign
+eliminates). Neither applies at 22 formats × 2 polarities × ~3.9KB ≈ 172KB total, trivial against a
+68MB archive. **Simpler design: both planes, unconditionally, every format, no threshold logic.**
+
+### Compiling `Legality` and `Not(Legality)`
+
+- `Legality{shift: Some(s), expected: LEGALITY_LEGAL}` → `PlaneExpr::Plane(legal_exists_plane(s))`.
+- `Not(Legality{shift: Some(s), expected: LEGALITY_LEGAL})` → `PlaneExpr::Plane(illegal_exists_plane(s))`
+  directly — **not** `PlaneExpr::Not(Plane(legal_exists))`, which would compute
+  `¬(∃p: legal(p))` = `∀p: ¬legal(p)` (wrong — a divergent card with both a legal and an illegal
+  printing satisfies `illegal_exists` but not `∀p: ¬legal(p)`).
+- `Not` wrapping something *more complex* than a bare `Legality` leaf (`-(format:X AND t:creature)`)
+  needs De Morgan pushed down at **compile time** so the `Not` lands directly on each leaf: a new
+  `compile_plane_neg` function, mutually recursive with `compile_plane`, implementing
+  `Not(And(cs))` → `Or(compile_plane_neg(c) for c in cs)` and `Not(Or(cs))` → `And(...)` , `Not(Not(x))`
+  → `compile_plane(x)`, `Not(True)` → `Const(false)`, and falling back to "compile positive, wrap in
+  `PlaneExpr::Not`" for leaves that don't need special handling (colors/types/devotion — genuinely
+  two-valued, safe to blindly complement, same as today). `contains_unnegatable_numeric`'s existing
+  guard (declining `Not` entirely when a null-valued numeric field like power/toughness is anywhere
+  inside) is unchanged and checked first — this redesign doesn't touch that, only adds Legality's
+  own case. Cost: a tiny-tree, one-time-per-query bind-time rewrite, not a per-candidate one.
+
+### The shared-witness case that still needs a decline, and why it doesn't need the repair toolkit
+
+`format:A AND format:B` (two *distinct* formats ANDed) still can't be answered by ANDing two
+independent existence-projection planes — `∃p: legal_A(p) ∧ legal_B(p)` isn't
+`(∃p: legal_A(p)) ∧ (∃p: legal_B(p))` regardless of how exactly each side is computed; a card with
+different witness printings for each satisfies the right side without satisfying the left. Same
+issue reached via De Morgan: `¬(format:A OR format:B)` becomes `And(illegal_A, illegal_B)`, which has
+the identical exposure. Even `format:A AND -format:A` (same format, both polarities) is affected — a
+divergent-on-A card satisfies both `legal_exists_A` and `illegal_exists_A` independently, even
+though no single printing can be both legal and not-legal in the same format at once (the true
+answer is always false).
+
+Rather than building the shared-witness-safe per-printing joint-evaluation machinery from the first
+design for this narrow case, **just decline**: before assembling any `PlaneExpr::And` that would
+result from either a direct `And` or a De-Morgan'd `Not(Or(...))`, count how many *distinct*
+`(format, polarity)` pairs are referenced anywhere among the legality-plane leaves being combined. If
+more than one, decline the whole compile (return `None`), falling back to today's
+`legal_candidate_bits`-based narrowing for that shape. `Or` never has this problem (`∃` distributes
+over `∨`), so no check is needed there. This is a real scope cut, not a workaround: nobody
+realistically writes `format:A AND format:B`, and the fallback is exactly as correct (if not as fast)
+as before this issue existed.
+
+Polarity has to be part of the key, not folded away: a first implementation deduplicated by format
+alone, on the theory that "both polarities count as touching that format" — which does correctly
+decline `format:A AND format:B`, but **fails to decline `format:A AND -format:A`**, since that's only
+one *format* even though it's two distinct existence facts (`legal_exists_A` and `illegal_exists_A`,
+independently true for a divergent card, even though no single printing can be both legal and
+not-legal in A at once — the true answer is always false). Caught by a test
+(`legality_and_of_two_formats_declines_but_or_compiles`) that checked this exact shape; fixed by
+keying `collect_legality_formats` on `(format, polarity)` instead of `format` alone. A literal
+duplicate leaf (`format:A AND format:A`) still collapses to one entry and composes fine — same
+underlying fact checked twice, not two facts needing a shared witness.
+
+### Mode-aware `all_match`: the `unique=printing`/`artwork` correctness hole
+
+`compile_plane`'s existing contract — and the `all_match_known` fast path it feeds (#634 Step 1) —
+was built exclusively for **card-invariant** fields (colors, types, cmc, power/toughness, devotion,
+border): the same value on every printing of a card, so "the card matches" trivially implies "every
+printing matches," which is exactly what `all_match=true` tells `push_card_matches`/`card_match_count`
+to assume for `unique=printing`/`artwork` (skip per-printing verification, return every printing in
+range). Legality does not have that property — `legal_exists(F)` is `∃p`, not `∀p` — so naively giving
+it the same treatment is a real correctness bug: a card divergent on modern legality would, under
+`unique=printing`, incorrectly return its *illegal* printings too. Caught by a test
+(`legality_plane_promotion_respects_mode_through_split_planes`) run through the actual
+`split_planes`/`run_query` pipeline, not just direct `narrow_rec` calls — the direct-call tests alone
+did not exercise this, since `#634`'s Step 2 popcount path is already (and remains) hard-gated to
+`Mode::Card` for unrelated reasons, masking the hole from anyone benchmarking Step 2 specifically.
+
+Rarity (#670) has the identical exposure (per-printing-varying, existence-projected) and never ran
+into this because it was deliberately kept **out of** `compile_plane` entirely — narrow_rec-only,
+always `loose`. Legality's escape hatch (finite query space, both projections precomputable) is what
+makes reaching `all_match` possible at all here, but that only helps `unique=card`, where existence is
+exactly the semantics wanted (same as Step 2). The fix has two parts:
+
+- `plane_expr_is_existential(&PlaneExpr)` (`planes.rs`) — walks a compiled plane expression and
+  reports whether any leaf reads a legality plane (`PLANE_LEGAL_EXISTS`/`PLANE_LEGAL_ILLEGAL`).
+- `split_planes` takes a new `unique_is_card: bool` and declines to fold a leaf/child touching
+  legality into the plane-consumed-to-`True` outcome whenever it's false — both at the top-level
+  whole-tree shortcut and in the `And` arm's per-child fold. This has to happen at the *source*
+  (`split_planes`), not by patching `all_match_known` after the fact in `run_query`: once a filter is
+  collapsed to a bare `FilterExpr::True` residual, there is no way to recover *which* printing
+  actually matches — the information is gone, not just mis-flagged. `run_query` additionally keeps a
+  `plane_expr_is_existential`-based check on its own (`plane_true_for_mode`) as defense-in-depth for
+  any caller that builds a `(filter, plane)` pair without going through `split_planes` (tests do this
+  directly). Every other, card-invariant plane ignores `unique_is_card` entirely and reaches
+  `all_match` exactly as before, for every mode.
+
+### A free upgrade to the existing narrowing fallback
+
+`narrow_rec`'s existing `Legality` arm (`legal_candidate_bits`, used whenever a shape declines full
+plane consumption) narrows via `legal_exists`/`illegal_exists` directly now — no more OR-ing in the
+divergent postings as a safe over-approximation, so the *candidate set itself* is exact, not just a
+superset. It still reports `Narrowed::loose`, though, not `tight`: `tight` specifically means true for
+*every* printing (see the `Narrowed` struct's doc), and legality is exactly the kind of per-printing-
+varying fact that can't make that claim, same reasoning as rarity's own narrowing being `loose`
+despite its plane also being exact. (An early version of this arm reported `tight` — caught by the
+same mode-aware-`all_match` hole above, since `narrow_rec`'s own opportunistic `compile_plane`
+fast-path unconditionally treated a successful compile as `tight` too, before it was made to check
+`plane_expr_is_existential` the same way.) `legality_divergent`/`legal_divergent` stay exactly as they
+are for the one thing they're still needed for: `filter.rs`'s per-printing `Legality` `tri()` arm
+(residual `card_pass` verification), which is unrelated to narrowing and unaffected by any of this.
+
+## Acceptance
+
+1. Baseline on `main` (targeted script `scripts/bench_legality_divergent.py` + broad survey
+   `scripts/survey_queries.py`, same corpus/seed as prior work). Memory baseline
+   (`--features alloc-counter`) — expect `archive_bytes` to grow by ~172KB (44 new planes) minus the
+   now-removed single-polarity `PLANE_LEGAL` block's prior ~86KB, net roughly +86KB. Trivial either
+   way, worth confirming the actual delta rather than assuming.
+2. Targeted configs: everything from the first design's benchmark (`format:modern id:g t:creature`,
+   solo `format:X`/`-format:X` across the legal% spread, deep pagination offsets, `unique=printing`/
+   `artwork` unaffected, `banned:`/`restricted:`/absent-format controls) plus the two-format
+   `And`/`Or` shapes (`format:A AND format:B` declines to the fallback; `format:A OR format:B`
+   promotes normally) and `-(format:X AND t:creature)`-shaped De Morgan cases.
+3. **Broad survey is not optional** — the first design's severe regressions were invisible to the
+   targeted script and only surfaced there. Re-run after this design lands and confirm no regressions
+   anywhere, not just on the previously-affected configs — this design has no fixed repair tax to
+   create a narrow-selectivity regression in the first place, so the expectation is a clean win with
+   no residual gap at all (unlike the first design's Part 2 cardinality-guard need).
+4. Parity tests (done, `card_engine/src/tests.rs`): a divergent-card fixture (mixed legal/illegal
+   printings) correct under every polarity/offset/mode reachable; the shared-witness decline for both
+   two-distinct-formats *and* same-format-both-polarities, verified against a fallback that still
+   produces correct results (not just a decline check); `narrow_rec`'s exact-but-still-`loose`
+   `Legality` arms; the mode-aware `all_match` fix exercised through the real `split_planes`/
+   `run_query` pipeline (not just direct `narrow_rec`/`run_query`-with-`plane=None` calls, which would
+   have missed it); the De Morgan `Not`-of-compound case. A regression test that
+   `contains_unnegatable_numeric`'s existing cmc/power/toughness guard is untouched is still open.
+5. Total-row-count parity on every config, every run.
+6. Re-measure (targeted *and* broad survey) and iterate until clean; open PR linking #667.
+
+## Results
+
+Measured on `benchmarks/bitplanes/corpus.jsonl` (97,206 printings), `main` @ `967a6ca` vs. this branch,
+`scripts/bench_legality_divergent.py` (3s window/config):
+
+| config | main | branch | speedup |
+|---|---|---|---|
+| `format:modern` | 0.190ms | 0.065ms | 2.9x |
+| `format:pioneer` | 0.159ms | 0.061ms | 2.6x |
+| `-format:modern` | 0.154ms | 0.057ms | 2.7x |
+| `format:modern or format:pioneer` | 0.207ms | 0.071ms | 2.9x |
+| `format:modern c:g t:creature` (cited real usage shape) | 0.083ms | 0.067ms | 1.2x |
+| `format:modern` @ offset 15000 | 0.203ms | 0.068ms | 3.0x (flat with offset — Step 2) |
+| `format:modern t:creature` @ offset 15000 | 0.085ms | 0.007ms | 12x |
+| `format:modern t:creature`, `unique=printing`/`artwork` | 0.140/0.143ms | 0.131/0.135ms | unaffected (correctly not promoted) |
+| `banned:modern`/`restricted:vintage`/`c:g` (controls) | — | — | unaffected |
+
+Total-row-count parity: 0 mismatches across all 24 targeted configs and a 520-query broad survey
+(`scripts/survey_queries.py --seed 667`) run against both builds.
+
+Memory: archive size grew by 126,208 bytes (123.25 KiB) on this corpus (31,508 cards) — exactly 32 net
+new planes (64 new `legal_exists`/`illegal_exists` planes minus the 32 removed single-polarity
+`PLANE_LEGAL` planes) × 3,944 bytes/plane (`⌈31508/64⌉ × 8`). The original estimate (~86KB, from a
+rougher "44 new planes" guess) undercounted; measuring instead of assuming caught it, same as the
+doc's own acceptance criteria asked for. Trivial regardless, against a ~68MB archive.
+
+## Related
+
+- #667 — GitHub issue tracking this
+- #634 — where the exactness model, `all_match_known`, and the Step 2 popcount-skip walk were built
+- #654 — where the original single-polarity `legal_x` plane and `legal_divergent` postings were
+  built; this issue replaces the plane (two exact planes instead of one approximate one) but keeps
+  the postings list for `filter.rs`'s per-printing evaluation
+- #656 — extends Step 2 to compound residuals and printing/artwork modes; orthogonal to this issue
+- [engine-printing-varying-plane-repair-pattern.md](engine-printing-varying-plane-repair-pattern.md)
+  — the repair-based first design, preserved for a future field that can't use this issue's escape
+  hatch (query space not finite/enumerable at build time)

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -270,7 +270,7 @@ aggregate even though it changes nothing for the common case.
 
 It did: `banned:modern`/`restricted:vintage` — queries with zero code-path overlap with anything in
 this issue (`expected != LEGALITY_LEGAL`, never plane-compilable, always an unindexed full scan, on
-`main` and this branch alike) — went from ~0.20ms to ~0.23ms, a ~15% regression on a control that
+`main` and this branch alike) — went from ~200μs to ~230μs, a ~15% regression on a control that
 should have been provably unaffected. This is exactly the trap `docs/issues/engine-printing-varying-
 plane-repair-pattern.md`'s repair-toolkit history already warned about, and the reason this design
 doc's own Acceptance section insists the broad survey is "not optional": the targeted script
@@ -284,8 +284,8 @@ Fixed by splitting `card_match_count` (and, for consistency, `push_card_matches`
 branch) into two code paths instead of one closure branching on `existential_plane` every call: the
 `None` branch is now byte-for-byte the same shape the function had before `existential_plane` existed
 at all, and the `Some` branch (only ever reached for `Mode::Card` with a promoted legality leaf) pays
-the extra conjunction cost. Re-measured: `banned:modern`/`restricted:vintage` back to ~0.20ms,
-matching a freshly-captured `main` baseline; 0 regressions (>15% and >0.01ms) across all 24 targeted
+the extra conjunction cost. Re-measured: `banned:modern`/`restricted:vintage` back to ~200μs,
+matching a freshly-captured `main` baseline; 0 regressions (>15% and >10μs) across all 24 targeted
 configs and the full 520-query survey, re-run back-to-back with a fresh `main` build specifically to
 rule out machine-state drift between runs (this session's first comparison used a `main` baseline
 captured hours earlier, which briefly looked like it might explain some survey deltas until the
@@ -366,19 +366,20 @@ are for the one thing they're still needed for: `filter.rs`'s per-printing `Lega
 ## Results
 
 Measured on `benchmarks/bitplanes/corpus.jsonl` (97,206 printings), `main` @ `967a6ca` vs. this branch,
-`scripts/bench_legality_divergent.py` (3s window/config):
+`scripts/bench_legality_divergent.py` (3s window/config). All timings sub-millisecond throughout,
+given in μs rather than ms:
 
 | config | main | branch | speedup |
 |---|---|---|---|
-| `format:modern` | 0.190ms | 0.065ms | 2.9x |
-| `format:pioneer` | 0.159ms | 0.061ms | 2.6x |
-| `-format:modern` | 0.154ms | 0.057ms | 2.7x |
-| `format:modern or format:pioneer` | 0.207ms | 0.071ms | 2.9x |
-| `format:modern c:g t:creature` (cited real usage shape) | 0.083ms | 0.067ms | 1.2x |
-| `format:modern` @ offset 15000 | 0.203ms | 0.068ms | 3.0x (flat with offset — Step 2) |
-| `format:modern t:creature` @ offset 15000 | 0.085ms | 0.007ms | 12x |
-| `format:modern t:creature`, `unique=printing`/`artwork` | 0.140/0.143ms | 0.131/0.135ms | unaffected (correctly not promoted) |
-| `banned:modern`/`restricted:vintage`/`c:g` (controls) | — | — | unaffected |
+| `format:modern` | 190μs | 65μs | 2.9x |
+| `format:pioneer` | 159μs | 61μs | 2.6x |
+| `-format:modern` | 154μs | 57μs | 2.7x |
+| `format:modern or format:pioneer` | 207μs | 71μs | 2.9x |
+| `format:modern c:g t:creature` (cited real usage shape) | 83μs | 67μs | 1.2x |
+| `format:modern` @ offset 15000 | 203μs | 68μs | 3.0x (flat with offset — Step 2) |
+| `format:modern t:creature` @ offset 15000 | 85μs | 7μs | 12x |
+| `format:modern t:creature`, `unique=printing`/`artwork` | 140/143μs | 131/135μs | unaffected (correctly not promoted) |
+| `banned:modern`/`restricted:vintage`/`c:g` (controls) | 203/198/58μs | 201/199/60μs | unaffected (re-verified post-conjunction-fix) |
 
 Total-row-count parity: 0 mismatches across all 24 targeted configs and a 520-query broad survey
 (`scripts/survey_queries.py --seed 667`) run against both builds. Re-measured after the row-selection

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -329,8 +329,11 @@ are for the one thing they're still needed for: `filter.rs`'s per-printing `Lega
    produces correct results (not just a decline check); `narrow_rec`'s exact-but-still-`loose`
    `Legality` arms; the mode-aware `all_match` fix exercised through the real `split_planes`/
    `run_query` pipeline (not just direct `narrow_rec`/`run_query`-with-`plane=None` calls, which would
-   have missed it); the De Morgan `Not`-of-compound case. A regression test that
-   `contains_unnegatable_numeric`'s existing cmc/power/toughness guard is untouched is still open.
+   have missed it); the De Morgan `Not`-of-compound case; a regression test
+   (`legality_not_still_declines_with_unnegatable_numeric_sibling`, added after a second reviewer
+   flagged this doc's own self-acknowledged gap) that `contains_unnegatable_numeric`'s existing
+   cmc/power/toughness guard still declines correctly when composed with a legality leaf under `Not`,
+   through both `compile_plane_neg`'s `And` and `Or` arms.
    **Gap found in review**: the existing divergent-card test asserted `unique=card`'s *count* but
    discarded the returned page (`let (total, _) = run_mode("card")`) — it never checked *which*
    printing came back, which is exactly where the row-selection bug (below) was hiding. Total-row-count

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -223,6 +223,41 @@ satisfies it.
 the existing (correct) per-printing `card_pass` walk over their full candidate set, which was never
 skipping a per-printing check to begin with.
 
+### A third correctness hole: the plane check and the residual check must be conjoined, not either-or
+
+Found in PR review (not by the test suite — `card_engine/src/tests.rs`'s existing compound test only
+covered a legality leaf ANDed with a *card-invariant* sibling, colors/types, never a genuinely
+printing-dependent one). `split_planes`'s `And` arm can promote a single-format legality leaf into
+`plane` while a real, printing-varying predicate stays behind in the residual — `DateCmp`,
+`ArtistMatch`, `FlavorMatch`, printing-level `CollectionCmp`, and anything else that never appears in
+`planes.rs` and so can never itself be plane-compiled. `format:A AND date>20200101` (`unique=card`) is
+the concrete shape: `format:A` promotes to `legal_exists_A`, `date>20200101` stays as the residual.
+
+The first cut of the row-selection fix checked *only* `eval_plane_expr_for_printing` whenever
+`existential_plane` was `Some`, dropping the residual/`all_match` check entirely — so it would happily
+pick a printing that's legal in A but fails the date filter (or, symmetrically, undercount by ignoring
+that the date-satisfying printing isn't legal). Confirmed with a fixture: printing 0 legal-in-A but
+released before the cutoff, printing 1 released after the cutoff but not legal in A — no single
+printing satisfies both, correct answer is 0 matches, buggy code returned 1. `card_match_count` (the
+counting phase inside `run_query_streamed`, untouched by the first cut of this fix) has the mirror
+gap: it only ever consulted `residual_matches`, with no `existential_plane` awareness at all, so the
+*count* itself — not just which row gets shown — was wrong for this shape.
+
+Fix: both checks must be satisfied by the *same* printing, not either one independently —
+`eval_plane_expr_for_printing(...) && (all_match || residual_matches(...))` in both
+`push_card_matches` and (newly) `card_match_count`, which now also takes `cid` and
+`existential_plane`. This is sound because `eval_plane_expr_for_printing` was already exact per
+printing (it wasn't wrong, just incomplete on its own) — conjoining doesn't change its cost profile,
+still bounded by `limit` in `push_card_matches`'s case, and by the candidate set in
+`card_match_count`'s case (same cost that path already paid for the residual check alone; the extra
+plane check per printing is now the same shape of work already being done for the residual, not a
+new order-of-magnitude).
+
+Verified against the real corpus, not just the fixture: 247 oracle_ids in
+`benchmarks/bitplanes/corpus.jsonl` are genuinely this conflict shape for `oldschool` legality +
+release date (some printing legal, some printing past a cutoff, never the same printing) — 0
+violations post-fix, for both `unique=card` and `unique=printing`.
+
 ### A free upgrade to the existing narrowing fallback
 
 `narrow_rec`'s existing `Legality` arm (`legal_candidate_bits`, used whenever a shape declines full
@@ -279,6 +314,13 @@ are for the one thing they're still needed for: `filter.rs`'s per-printing `Lega
    asserting the returned `scryfall_id` is the legal printing, not the preferred one (mirrors the
    existing `unique=printing` assertion, which already caught this for that mode). Additionally
    verified against the real benchmark corpus, not just hand-built fixtures — see Results.
+8. **Conjunction fix (done)**: found in PR review, see "A third correctness hole" above —
+   `eval_plane_expr_for_printing` and the residual check must both hold for the *same* printing, not
+   either independently; `card_match_count` needed the same `existential_plane` awareness the first
+   cut only gave `push_card_matches`. New unit test: legality leaf ANDed with a genuinely
+   printing-dependent `DateCmp` residual, `unique=card`, asserting 0 matches when no single printing
+   satisfies both. Verified against the real corpus's 247 oracle_ids that are exactly this conflict
+   shape — 0 violations post-fix.
 
 ## Results
 

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -412,6 +412,8 @@ doc's own acceptance criteria asked for. Trivial regardless, against a ~68MB arc
   `border:` out of `compile_plane` for exactly this reason, for every mode
 - #677 — property-based fuzzer for row-selection correctness, split out as follow-on general test
   infrastructure rather than bundled into this PR; the row-selection bug here is its motivating case
+- #678 — indexing `banned:`/`restricted:` (currently unindexed full scan, deliberately out of scope
+  here — this issue's planes only cover `expected == LEGALITY_LEGAL`)
 - [engine-printing-varying-plane-repair-pattern.md](engine-printing-varying-plane-repair-pattern.md)
   — the repair-based first design, preserved for a future field that can't use this issue's escape
   hatch (query space not finite/enumerable at build time)

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -1,7 +1,7 @@
 # Engine: legality divergent-card carve-out for all_match promotion
 
-Status: implemented and benchmarked (second design, replacing a repair-based first draft), pending PR.
-GitHub: #667.
+Status: implemented, including the row-selection fix (see "Row selection for `unique=card`" below),
+benchmarked, pending PR merge. GitHub: #667.
 Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
 Follow-on to #634 (Steps 1/2, shipped in #658), flagged in that issue's own comment thread.
 
@@ -157,6 +157,72 @@ exactly the semantics wanted (same as Step 2). The fix has two parts:
   directly). Every other, card-invariant plane ignores `unique_is_card` entirely and reaches
   `all_match` exactly as before, for every mode.
 
+### Row selection for `unique=card`: a second correctness hole, found in review
+
+Fixing the mode-aware hole above is not the whole fix. Even restricted to `unique=card` (where it's
+legitimate to trust `all_match_known` for the *count*), row emission has its own, separate bug: for a
+divergent card, the code picks the card's normal default-preferred printing to *display* without
+checking that this specific printing is actually legal in the queried format.
+
+`docs/issues/engine-border-planes.md` (#666, already shipped) documents the actual invariant this
+violates, for a different printing-varying field:
+
+> `unique=card` semantics require a *single* printing to satisfy the *whole* filter, not each
+> predicate independently satisfied by *some* (possibly different) printing.
+
+That's exactly why `border:` was kept out of `compile_plane` entirely, for *every* mode, not just
+`unique=printing`/`artwork` — the doc got this right and this issue's second design should have
+re-checked it before assuming existence was enough for row selection too. Confirmed empirically, not
+just by inspection: a fixture with printing 0 (preferred, not legal) and printing 1 (non-preferred,
+legal) returns printing 0 for `f:modern unique=card` — the wrong one. `frame:white f:modern` makes the
+same point concretely: the returned printing for each card must actually have a white frame, not just
+be "the card's usual printing" on a card that happens to have *some* white-framed printing somewhere.
+
+**The two exactness properties this needs are already both in the codebase, just not connected.**
+`Narrowed::tight` already means the stronger, correct thing for row selection — "true for *every*
+printing" (see its own doc comment) — which is exactly why legality's `narrow_rec` arms correctly
+report `loose`, not `tight` (see below). The bug is that `compile_plane`/`split_planes`/
+`all_match_known` has no equivalent second bit: every existing arm (colors, types, cmc, devotion,
+border where it's used at all) happens to be printing-universal, so "compiled successfully" and
+"safe to skip per-printing work when picking a row" were always the same fact — until Legality, which
+is the first plane where they diverge. `plane_expr_is_existential` already *is* the missing bit
+(`existential` = card-exact-only, `!existential` = printing-universal); it was just aimed too
+narrowly, at gating whether `split_planes` attempts the fold per mode, rather than being kept around
+for row emission regardless of mode.
+
+**The count/candidate-membership fast path is unaffected and doesn't need to change.** The number of
+matching *cards* is genuinely mode-independent and existence is genuinely sufficient to compute it —
+Step 2's popcount-skip walk (`run_query_streamed_popcount`) stays exactly as fast as measured. Only
+*row selection* — picking which printing to attribute to a matching card — needs the extra check, and
+only when `plane_expr_is_existential(plane)` is true.
+
+**Proposed fix**: a printing-level evaluator for a compiled `PlaneExpr`, structurally the same idea as
+the abandoned first design's `eval_plane_expr_for_printing` (walk the tree once per printing; a
+`Plane` leaf outside the legality ranges reads the already-known card-level bit — cheap, since
+card-invariant fields don't vary by printing; a `Plane` leaf inside `PLANE_LEGAL_EXISTS`/
+`PLANE_LEGAL_ILLEGAL` reads `printing.card_legalities` directly instead, the same check `tri()`
+already does per printing). The critical difference from the abandoned design, which is what makes
+this cheap rather than a repeat of the earlier performance mistake: that version ran this over *every*
+divergent candidate to repair a bulk bitmap; this only needs to run over the printings of cards in the
+*emitted page* (bounded by `limit`), never the whole candidate set — the count already came from the
+plane without touching this at all. Soundness: whenever the compiled expression is true at the card
+level, at least one printing is guaranteed to satisfy it too (card-invariant leaves hold for every
+printing by construction, and the shared-witness decline already rules out the one composition shape
+where an existentially-true card could lack any single witnessing printing), so the search over a
+card's printings always terminates with a match — it just needs to actually run instead of being
+skipped by `all_match`.
+
+Two call sites need this: `run_query_streamed_popcount`'s emit loop (currently `(start <
+end).then_some(start)` for `Prefer::Default`, unconditionally) and `push_card_matches`'s `Mode::Card`
+branch (same unconditional `all_match || ...` shortcut). Both should fall back to the printing-level
+walk specifically when the plane touched a legality leaf, in preferred-printing order, taking the
+first (or best-`prefer_score`, matching the existing non-default-prefer branch) printing that
+satisfies it.
+
+`unique=printing`/`artwork` need no change: they already decline the fold via `unique_is_card` and run
+the existing (correct) per-printing `card_pass` walk over their full candidate set, which was never
+skipping a per-printing check to begin with.
+
 ### A free upgrade to the existing narrowing fallback
 
 `narrow_rec`'s existing `Legality` arm (`legal_candidate_bits`, used whenever a shape declines full
@@ -197,8 +263,22 @@ are for the one thing they're still needed for: `filter.rs`'s per-printing `Lega
    `run_query` pipeline (not just direct `narrow_rec`/`run_query`-with-`plane=None` calls, which would
    have missed it); the De Morgan `Not`-of-compound case. A regression test that
    `contains_unnegatable_numeric`'s existing cmc/power/toughness guard is untouched is still open.
+   **Gap found in review**: the existing divergent-card test asserted `unique=card`'s *count* but
+   discarded the returned page (`let (total, _) = run_mode("card")`) — it never checked *which*
+   printing came back, which is exactly where the row-selection bug (below) was hiding. Total-row-count
+   parity and the broad survey (both count-only) couldn't have caught this either; it needs an
+   assertion on the actual returned `scryfall_id`, on a fixture where the preferred printing is
+   deliberately the *non-matching* one.
 5. Total-row-count parity on every config, every run.
 6. Re-measure (targeted *and* broad survey) and iterate until clean; open PR linking #667.
+7. **Row-selection fix (done)**: `eval_plane_expr_for_printing` (`planes.rs`), used by
+   `run_query_streamed_popcount`'s emit loop and `push_card_matches`'s `Mode::Card` branch (both the
+   gathered path and both call sites inside `run_query_streamed`) whenever `plane_expr_is_existential`
+   is true for the query's plane, replacing the unconditional "pick the default-preferred printing"
+   shortcut. New unit tests: a bare-leaf and a compound-`And` divergent-card fixture, `unique=card`,
+   asserting the returned `scryfall_id` is the legal printing, not the preferred one (mirrors the
+   existing `unique=printing` assertion, which already caught this for that mode). Additionally
+   verified against the real benchmark corpus, not just hand-built fixtures — see Results.
 
 ## Results
 
@@ -218,7 +298,20 @@ Measured on `benchmarks/bitplanes/corpus.jsonl` (97,206 printings), `main` @ `96
 | `banned:modern`/`restricted:vintage`/`c:g` (controls) | — | — | unaffected |
 
 Total-row-count parity: 0 mismatches across all 24 targeted configs and a 520-query broad survey
-(`scripts/survey_queries.py --seed 667`) run against both builds.
+(`scripts/survey_queries.py --seed 667`) run against both builds. Re-measured after the row-selection
+fix too: identical speedups, no detectable regression from the extra per-emitted-row check (expected —
+it's bounded by `limit`, not the candidate set, and only runs at all for legality-touching queries).
+
+**Row-selection correctness, checked against the real corpus, not just hand-built fixtures** —
+total-row-count parity only proves the *count* is right, which is exactly the blind spot that let the
+row-selection bug through review once already. Cross-referencing every returned `scryfall_id` against
+the corpus's own per-printing `card_legalities`: `oldschool` is this corpus's best real divergent case
+(536 of its 556 divergent oracle_ids, `modern` itself happens to have zero in this specific sample).
+`f:oldschool unique=card` returns 961 cards, 536 of them genuinely divergent-on-`oldschool`, **0**
+returned a printing that isn't actually `oldschool`-legal. Same clean result (0 violations) for
+`-f:oldschool` under both `unique=card` and `unique=printing`, and for the compound
+`f:oldschool t:creature` under both modes — mirroring the shared-witness-safe compound shape this
+issue's own motivating query has.
 
 Memory: archive size grew by 126,208 bytes (123.25 KiB) on this corpus (31,508 cards) — exactly 32 net
 new planes (64 new `legal_exists`/`illegal_exists` planes minus the 32 removed single-polarity
@@ -234,6 +327,9 @@ doc's own acceptance criteria asked for. Trivial regardless, against a ~68MB arc
   built; this issue replaces the plane (two exact planes instead of one approximate one) but keeps
   the postings list for `filter.rs`'s per-printing evaluation
 - #656 — extends Step 2 to compound residuals and printing/artwork modes; orthogonal to this issue
+- #666 — `border:` planes; its design doc already documents the "single printing must satisfy the
+  whole filter" invariant that this issue's row-selection bug violated, and deliberately keeps
+  `border:` out of `compile_plane` for exactly this reason, for every mode
 - [engine-printing-varying-plane-repair-pattern.md](engine-printing-varying-plane-repair-pattern.md)
   — the repair-based first design, preserved for a future field that can't use this issue's escape
   hatch (query space not finite/enumerable at build time)

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -330,6 +330,8 @@ doc's own acceptance criteria asked for. Trivial regardless, against a ~68MB arc
 - #666 — `border:` planes; its design doc already documents the "single printing must satisfy the
   whole filter" invariant that this issue's row-selection bug violated, and deliberately keeps
   `border:` out of `compile_plane` for exactly this reason, for every mode
+- #677 — property-based fuzzer for row-selection correctness, split out as follow-on general test
+  infrastructure rather than bundled into this PR; the row-selection bug here is its motivating case
 - [engine-printing-varying-plane-repair-pattern.md](engine-printing-varying-plane-repair-pattern.md)
   — the repair-based first design, preserved for a future field that can't use this issue's escape
   hatch (query space not finite/enumerable at build time)

--- a/docs/issues/engine-legality-divergent-carveout.md
+++ b/docs/issues/engine-legality-divergent-carveout.md
@@ -258,6 +258,39 @@ Verified against the real corpus, not just the fixture: 247 oracle_ids in
 release date (some printing legal, some printing past a cutoff, never the same printing) — 0
 violations post-fix, for both `unique=card` and `unique=printing`.
 
+### A performance regression, caught by the broad survey, not the targeted script
+
+The first cut of the conjunction fix routed both the "no existential plane" (overwhelmingly common)
+and "existential plane present" cases through one closure-based `satisfies` helper inside
+`card_match_count`. Correct either way, but `card_match_count` runs once per *candidate* — for
+`run_query_streamed`'s counting phase, that's potentially the whole candidate set, not just the
+emitted page — so it's exactly the kind of hot loop where an extra closure indirection and branch,
+paid on *every* call regardless of whether `existential_plane` is ever `Some`, can show up in
+aggregate even though it changes nothing for the common case.
+
+It did: `banned:modern`/`restricted:vintage` — queries with zero code-path overlap with anything in
+this issue (`expected != LEGALITY_LEGAL`, never plane-compilable, always an unindexed full scan, on
+`main` and this branch alike) — went from ~0.20ms to ~0.23ms, a ~15% regression on a control that
+should have been provably unaffected. This is exactly the trap `docs/issues/engine-printing-varying-
+plane-repair-pattern.md`'s repair-toolkit history already warned about, and the reason this design
+doc's own Acceptance section insists the broad survey is "not optional": the targeted script
+(`scripts/bench_legality_divergent.py`) doesn't include a plain unindexed-scan control at the same
+`unique=card` shape being exercised by the change, so it had nothing that would have caught this;
+the 520-query survey did, immediately, once actually re-run after the conjunction fix (worth noting:
+it wasn't re-run automatically — re-running the broad survey after every change in this branch had to
+be a deliberate, repeated step, not a one-time acceptance gate).
+
+Fixed by splitting `card_match_count` (and, for consistency, `push_card_matches`'s `Mode::Card`
+branch) into two code paths instead of one closure branching on `existential_plane` every call: the
+`None` branch is now byte-for-byte the same shape the function had before `existential_plane` existed
+at all, and the `Some` branch (only ever reached for `Mode::Card` with a promoted legality leaf) pays
+the extra conjunction cost. Re-measured: `banned:modern`/`restricted:vintage` back to ~0.20ms,
+matching a freshly-captured `main` baseline; 0 regressions (>15% and >0.01ms) across all 24 targeted
+configs and the full 520-query survey, re-run back-to-back with a fresh `main` build specifically to
+rule out machine-state drift between runs (this session's first comparison used a `main` baseline
+captured hours earlier, which briefly looked like it might explain some survey deltas until the
+provably-untouched controls proved otherwise).
+
 ### A free upgrade to the existing narrowing fallback
 
 `narrow_rec`'s existing `Legality` arm (`legal_candidate_bits`, used whenever a shape declines full
@@ -321,6 +354,11 @@ are for the one thing they're still needed for: `filter.rs`'s per-printing `Lega
    printing-dependent `DateCmp` residual, `unique=card`, asserting 0 matches when no single printing
    satisfies both. Verified against the real corpus's 247 oracle_ids that are exactly this conflict
    shape — 0 violations post-fix.
+9. **Performance regression fix (done)**: see "A performance regression, caught by the broad survey"
+   above — the conjunction fix's first cut cost `banned:modern`/`restricted:vintage` (and likely other
+   `run_query_streamed`-counting-phase queries) ~15%, caught only by re-running the full broad survey
+   after the conjunction fix, not by the targeted script. Fixed by isolating the no-existential-plane
+   path back to its original code shape instead of routing everything through one closure.
 
 ## Results
 

--- a/docs/issues/engine-printing-varying-plane-repair-pattern.md
+++ b/docs/issues/engine-printing-varying-plane-repair-pattern.md
@@ -1,0 +1,101 @@
+# Engine: repairing plane-promoted printing-varying fields (general pattern)
+
+Status: reference only — not an active issue, nothing here is scheduled. Developed while designing
+#667 (legality divergent-card carve-out), then **superseded for legality itself** by a cleaner
+dual-exact-representation design (see
+[docs/issues/engine-legality-divergent-carveout.md](engine-legality-divergent-carveout.md)) that
+needs none of this. Captured here because the reasoning generalizes to a *future* printing-varying
+field that might not have legality's escape hatch available. If nothing ever needs this, that's
+fine — the design work isn't wasted, it's just not costing anything sitting in a doc either.
+
+## The general problem
+
+A card-level plane (`compile_plane`, `all_match` promotion, the #634 popcount-skip walk) requires a
+field to be a genuine two-valued fact *per card* — true for every printing or false for every
+printing, no in-between. Some fields aren't: they vary printing-to-printing within a single card
+(legality, hypothetically `set:`, `frame:`, `border:`, or anything else printing-native), so a naive
+card-level plane bit has to pick *some* answer for a card whose printings disagree, and that answer
+is wrong for whichever direction it didn't pick.
+
+## The escape hatch: when a field doesn't need any of this
+
+If the field's possible query shapes come from a **small, enumerable, known-at-build-time set**
+(legality: ~22 formats × a LEGAL check — nothing else), both existence projections —
+`∃p: satisfies(p)` and `∃p: ¬satisfies(p)` — can be **precomputed exactly at build time**,
+independently, one per format. These are two genuinely different facts (a card can satisfy both at
+once — that's what "the printings disagree" means), so storing both, each in whichever
+representation (plane or postings) is cheap given its own measured density, answers `format:X` and
+`-format:X` **exactly, with zero runtime cost**, for the overwhelming common case: a single such
+field ANDed with any number of card-invariant siblings, since invariant siblings factor straight out
+of the existence quantifier. `Not` wrapping something more complex than a bare leaf (`-(format:X AND
+t:creature)`) needs De Morgan pushed down at compile time so the `Not` lands directly on the leaf
+(swapping to the "other side" plane) rather than bit-complementing a compound — a one-time, tiny-tree,
+bind-time cost, not a per-candidate one.
+
+This escape hatch stops working the moment the field's query space **isn't enumerable ahead of
+time** — a parameterized/unbounded predicate (an arbitrary numeric threshold, an arbitrary string
+match) can't have "both existence projections for every possible value" precomputed, since there are
+infinitely many possible values. That's the actual dividing line: legality qualifies because
+`expected == LEGALITY_LEGAL` against a fixed format list is the *entire* query space for this field;
+a hypothetical printing-varying numeric field would not qualify, because `> 3.7` and `> 3.71` are
+different, un-precomputable existence projections.
+
+## The repair toolkit, for when the escape hatch doesn't apply
+
+If a future field can't use two precomputed exact representations, the following pieces (designed
+and prototyped for legality, unused there once the escape hatch was found, but real and tested code
+at the time) are the shape a repair-based promotion needs:
+
+**1. Best-effort plane + fixed correction set.** Build the plane from *some* choice (e.g. a
+canonical/majority printing's value), and maintain a small, fixed postings list of the cards where
+that choice is wrong for at least one printing (legality's `legal_divergent`, ~556 cards, already
+existed for other reasons and is reusable as-is for a future field with a similarly small
+disagreement rate). Cost is bounded by the *disagreement rate*, not corpus size — only worth it if
+that rate stays small.
+
+**2. Extraction-gate principle.** Promoting the field into the plane only pays for itself when the
+*containing filter* fully resolves to `True` and reaches `all_match`/popcount-skip — a partial
+extraction (some sibling doesn't compile, leaving a residual) gets 100% of the repair's cost and 0%
+of its benefit, since the downstream path was going to do per-candidate verification regardless.
+Concretely: in `split_planes`'s partial-extraction loop, defer any child touching the repair-needing
+field back into the residual *unconditionally* if reached at all — reaching that loop already means
+the whole filter didn't compile as one unit (the prior whole-tree `compile_plane` check would have
+returned otherwise), so there's no scenario where deferring is wrong.
+
+**3. Shared-witness invariant.** Composing *two or more* printing-varying leaves with `And` requires
+one printing to satisfy all of them **at once** — `∃p: f(p) ∧ g(p)`, not `(∃p: f(p)) ∧ (∃p: g(p))`,
+which could be satisfied by two different printings and is a false positive the moment the two
+differ. Card-invariant fields never have this problem (any witness works for all of them
+simultaneously), which is also why the extraction gate only needs to worry about the
+repair-needing field specifically, not every plane-eligible child. The correct implementation
+evaluates the *whole* remaining expression against one printing at a time and only
+existence-quantifies at the end (`eval_plane_expr_for_divergent_card`'s design, in the legality
+doc) — never each leaf's own projection independently combined afterward. Multiple leaves of the
+*same* repair-needing field in one `And` (rare in practice) either need this joint per-printing
+check or can simply be declined from full compile-time promotion, falling back to the field's
+existing (pre-repair) narrowing arm.
+
+**4. Cardinality/selectivity guard.** Even when full resolution *is* achieved, the repair's cost is
+roughly fixed (proportional to the disagreement-set size and leaf count, not to the query's
+selectivity) while the alternative (old narrowing + `card_pass`) cost shrinks with selectivity. For
+a narrow enough compound, paying the fixed repair cost can lose to just not promoting at all, even
+though promotion is *correct* and *usually* faster. This needs actual selectivity information
+(precomputed per-plane popcounts, at minimum) and a calibrated threshold — the same kind of
+benchmark-sweep process this codebase's other guards (`MAX_UNION_FRACTION`, `STREAM_MIN_MATCHES`,
+`AND_SKIP_THRESHOLD`) were derived from, not something to guess analytically.
+
+## Why none of this shipped
+
+Legality turned out to satisfy the escape hatch's condition — a fixed, small, fully-enumerable
+query space (format × LEGAL) — so building two exact, independently-density-thresholded
+representations per format solves the whole problem at build time with no runtime tax and no
+cardinality guard needed at all. The repair toolkit above is real, working, tested code as of this
+writing (the divergent-carve-out PR's first two rounds), just not the shape that landed. Worth
+revisiting this doc, not reinventing it, the next time a printing-varying field's query space turns
+out not to be enumerable ahead of time.
+
+## Related
+
+- [engine-legality-divergent-carveout.md](engine-legality-divergent-carveout.md) — where this was
+  developed, and the dual-representation design that replaced it
+- #667, #634, #654, #656 — same as that doc's Related section

--- a/scripts/bench_legality_divergent.py
+++ b/scripts/bench_legality_divergent.py
@@ -1,0 +1,121 @@
+"""Engine-vs-engine benchmark for the legality divergent-card carve-out (#667).
+
+Same protocol as scripts/bench_permuted_order.py (build locally with
+`maturin develop --release -m card_engine/Cargo.toml`, run against a fixed corpus, compare CSVs
+across builds), reusing its offset-aware bench_one/load_engine directly. Groups:
+
+- `promoted-*` — filters that should reach full plane exactness + popcount-skip once #667 ships:
+  format: alone, and format: compounded with other plane-exact predicates (colors/types). These are
+  the rows this issue is supposed to move -- especially at deep offsets.
+- `deep-*` — the same promoted shapes at large page offsets, where the popcount-skip walk's O(words)
+  behavior (flat with offset) should show up most clearly against the O(candidates) baseline.
+- `advisory-*` — compounds that must NOT be promoted: format: mixed with a genuinely advisory
+  residual (oracle text). Correctness tripwire as much as a performance control.
+- `control-*` — banned:/restricted:/absent-format and unrelated selective queries, must not regress.
+
+    .venv/bin/python scripts/bench_legality_divergent.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/legality-divergent/baseline-main.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_permuted_order import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer, offset) — direction=asc, limit=100 throughout.
+CONFIGS: list[tuple[str, str, str, str, str, int]] = [
+    # format: alone, across the legal% spread -- #654's own targeted rows, now
+    # candidates for all_match + popcount-skip on top of the narrowing they already got.
+    ("promoted-solo", "format:modern", "card", "edhrec", "default", 0),
+    ("promoted-solo", "format:standard", "card", "edhrec", "default", 0),
+    ("promoted-solo", "format:pioneer", "card", "edhrec", "default", 0),
+    ("promoted-solo", "-format:modern", "card", "edhrec", "default", 0),
+    # #667's own cited motivating case, and variants.
+    ("promoted-compound", "format:modern id:g t:creature", "card", "edhrec", "default", 0),
+    ("promoted-compound", "format:modern t:creature", "card", "edhrec", "default", 0),
+    ("promoted-compound", "format:modern c:g", "card", "edhrec", "default", 0),
+    ("promoted-compound", "format:modern or format:pioneer", "card", "edhrec", "default", 0),
+    # format + color (not identity) + type -- the literal shape reported as
+    # the most common real usage pattern for this engine.
+    ("promoted-compound", "format:modern c:g t:creature", "card", "edhrec", "default", 0),
+    # Deep pagination on the promoted shapes -- popcount-skip's specific advantage (#634).
+    ("deep-offset", "format:modern", "card", "edhrec", "default", 5000),
+    ("deep-offset", "format:modern", "card", "edhrec", "default", 15000),
+    ("deep-offset", "format:modern id:g t:creature", "card", "edhrec", "default", 5000),
+    ("deep-offset", "format:modern t:creature", "card", "edhrec", "default", 15000),
+    ("deep-offset", "format:modern c:g t:creature", "card", "edhrec", "default", 5000),
+    ("deep-offset", "format:modern c:g t:creature", "card", "edhrec", "default", 15000),
+    # unique=printing/artwork: Step 2 stays unique=card-only pending #656 -- must be unaffected.
+    ("uniques", "format:modern t:creature", "printing", "edhrec", "default", 0),
+    ("uniques", "format:modern t:creature", "artwork", "edhrec", "default", 0),
+    # Must NOT promote: format: mixed with a genuinely advisory residual.
+    ("advisory-mix", "format:modern o:draw", "card", "edhrec", "default", 0),
+    ("advisory-mix", "format:modern oracle:trample", "card", "edhrec", "default", 0),
+    # Controls: unindexed by design (banned:/restricted:/absent format), must not move.
+    ("control", "banned:modern", "card", "edhrec", "default", 0),
+    ("control", "restricted:vintage", "card", "edhrec", "default", 0),
+    # Controls: unrelated to legality entirely.
+    ("control", "name:soldier", "card", "edhrec", "default", 0),
+    ("control", "cmc>6", "card", "cmc", "default", 0),
+    ("control", "c:g", "card", "edhrec", "default", 0),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--", "card_engine/src"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        rev += "-dirty"
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    for _, query, _, _, _, _ in CONFIGS:
+        parse_scryfall_query(query)
+
+    hdr = f"{'group':<18} {'query':<28} {'unique':<9} {'orderby':<8} {'prefer':<9} {'offset':>7} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.1f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "offset", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer, offset in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer, offset), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, offset, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<18} {query:<28} {unique:<9} {orderby:<8} {prefer:<9} {offset:>7} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}",
+                flush=True,
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_legality_divergent.py
+++ b/scripts/bench_legality_divergent.py
@@ -49,12 +49,27 @@ CONFIGS: list[tuple[str, str, str, str, str, int]] = [
     # the most common real usage pattern for this engine.
     ("promoted-compound", "format:modern c:g t:creature", "card", "edhrec", "default", 0),
     # Deep pagination on the promoted shapes -- popcount-skip's specific advantage (#634).
-    ("deep-offset", "format:modern", "card", "edhrec", "default", 5000),
-    ("deep-offset", "format:modern", "card", "edhrec", "default", 15000),
-    ("deep-offset", "format:modern id:g t:creature", "card", "edhrec", "default", 5000),
-    ("deep-offset", "format:modern t:creature", "card", "edhrec", "default", 15000),
-    ("deep-offset", "format:modern c:g t:creature", "card", "edhrec", "default", 5000),
-    ("deep-offset", "format:modern c:g t:creature", "card", "edhrec", "default", 15000),
+    # Offsets must stay *below* each query's own total or run_query_streamed_popcount's
+    # own "page_offset >= total" early return (an empty page, no scatter/skip/emit at
+    # all) kicks in instead -- a real, correct code path, but a fundamentally different
+    # and much cheaper one than genuine deep pagination, so mixing the two under one
+    # "deep-offset" label is misleading (a prior version of this file did exactly that
+    # for format:modern id:g t:creature/format:modern t:creature/format:modern c:g
+    # t:creature, whose totals -- 2539/12251/2928 -- are all below the 5000/15000
+    # offsets that were being used for them).
+    ("deep-offset", "format:modern", "card", "edhrec", "default", 5000),  # total 22264
+    ("deep-offset", "format:modern", "card", "edhrec", "default", 15000),  # total 22264
+    ("deep-offset", "format:modern id:g t:creature", "card", "edhrec", "default", 2000),  # total 2539
+    ("deep-offset", "format:modern t:creature", "card", "edhrec", "default", 5000),  # total 12251
+    ("deep-offset", "format:modern t:creature", "card", "edhrec", "default", 10000),  # total 12251
+    ("deep-offset", "format:modern c:g t:creature", "card", "edhrec", "default", 2000),  # total 2928
+    ("deep-offset", "format:modern c:g t:creature", "card", "edhrec", "default", 2500),  # total 2928
+    # Offset *past* a query's own total -- the early-return path above, correct and
+    # deliberately cheap, but not "deep pagination stays flat" the way the group above
+    # is. Kept as its own labeled group so the two aren't conflated in results.
+    ("offset-beyond-total", "format:modern id:g t:creature", "card", "edhrec", "default", 5000),  # total 2539
+    ("offset-beyond-total", "format:modern t:creature", "card", "edhrec", "default", 15000),  # total 12251
+    ("offset-beyond-total", "format:modern c:g t:creature", "card", "edhrec", "default", 5000),  # total 2928
     # unique=printing/artwork: Step 2 stays unique=card-only pending #656 -- must be unaffected.
     ("uniques", "format:modern t:creature", "printing", "edhrec", "default", 0),
     ("uniques", "format:modern t:creature", "artwork", "edhrec", "default", 0),


### PR DESCRIPTION
Closes #667

## Summary
- `format:`/`f:` now reaches `all_match` promotion and the #634 popcount-skip walk, via two precomputed exact planes per format (`legal_exists` = ∃p: legal(p), `illegal_exists` = ∃p: ¬legal(p)) instead of the old single "legal and not divergent" plane, which unconditionally excluded the ~556 divergent-legality cards regardless of true status.
- Both planes are exact for every card, including divergent ones, with no runtime repair cost — replaces the first (repair-based) design attempt, which is preserved as a general pattern doc for a future field that can't use legality's escape hatch (finite, enumerable query space).
- `And` of two distinct formats (or the same format under both polarities, e.g. `format:A AND -format:A`) is a shared-witness hazard (`∃p: legal_A(p) ∧ legal_B(p)` ≠ `(∃p: legal_A(p)) ∧ (∃p: legal_B(p))`) and is deliberately declined at compile time, falling back to the existing (still correct, now exact) narrowing.
- Found and fixed a real correctness hole while building this: legality is existence-quantified (unlike every other plane, which is card-invariant), so naively letting it reach `all_match` would make `unique=printing`/`artwork` wrongly return every printing of a matching card, not just the legal ones. Fixed by having `split_planes` decline the fold itself for non-`unique=card` modes (`unique_is_card`), with `run_query` keeping a defense-in-depth check for callers that don't route through `split_planes`.
- Found and fixed a **second** correctness hole in review, before merge: even restricted to `unique=card`, row emission was picking the card's normal default-preferred printing to display without checking it's actually legal in the queried format -- `docs/issues/engine-border-planes.md` (#666) had already documented the real invariant this violated ("a single printing must satisfy the whole filter"). Fixed with `eval_plane_expr_for_printing`, a printing-level evaluator for the compiled plane expression, used only for the bounded emitted page (not the whole candidate set) whenever the plane touched a legality leaf.
- Found and fixed a **third** correctness hole, [flagged by @jbylund in review](https://github.com/jbylund/sylvan_librarian/pull/676#issuecomment-4961579171): the row-selection fix above checked only the plane, dropping the residual check entirely -- a legality leaf ANDed with a genuinely printing-dependent, non-plane-compilable residual (`DateCmp`, `ArtistMatch`, ...) needs *both* satisfied by the same printing. `format:A AND date>X` (`unique=card`) must not match unless some printing is both legal in A and past the cutoff. `card_match_count` (the `run_query_streamed` counting phase) had the mirror gap with zero `existential_plane` awareness at all -- the *count* itself was wrong for this shape, not just row selection. Fixed by conjoining both checks in both places.
- That conjunction fix then introduced its own **performance** regression, caught by re-running the broad survey (not the targeted script): routing both the common and existential-plane cases through one closure inside `card_match_count` (which runs once per *candidate*, not just the emitted page) cost `banned:modern`/`restricted:vintage` ~15% -- queries with zero code-path overlap with anything in this PR. Fixed by splitting into two code paths so the common case is byte-for-byte its pre-#676 shape again; re-verified against a freshly-captured `main` baseline with 0 regressions across all targeted configs and the full survey.

## Results

Measured on `benchmarks/bitplanes/corpus.jsonl` (97,206 printings / 31,508 cards), `main` @ `967a6ca`
vs. this branch, `scripts/bench_legality_divergent.py` (3s window/config, `unique=card` unless noted):

| query | main | branch | speedup |
|---|---|---|---|
| `format:modern` | 194μs | 66μs | 2.9x |
| `format:pioneer` | 164μs | 64μs | 2.6x |
| `-format:modern` | 158μs | 57μs | 2.8x |
| `format:modern or format:pioneer` | 210μs | 70μs | 3.0x |
| `format:modern t:creature` | 142μs | 68μs | 2.1x |
| `format:modern t:creature id:g` | 87μs | 69μs | 1.3x |
| `format:modern t:creature c:g` | 84μs | 66μs | 1.3x |
| `format:modern` @ offset 15000 (total 22264 — genuine deep page) | 208μs | 69μs | 3.0x (flat with offset — Step 2) |
| `format:modern t:creature` @ offset 10000 (total 12251 — genuine deep page, compare to the plain-offset-0 row above: flat both sides) | 158μs | 67μs | 2.4x |
| `format:modern t:creature` @ offset 15000 (**past** its own total of 12251) | 89μs | 7μs | not comparable to the row above — both sides return an empty page here, a different and much cheaper code path than genuine pagination |
| `format:modern t:creature`, `unique=printing`/`artwork` | 143/147μs | 137/136μs | unaffected (correctly not promoted) |
| `banned:modern`/`restricted:vintage`/`c:g` (controls) | 204/199/60μs | 200/197/59μs | unaffected |

`format:modern t:creature id:g`/`c:g` (the compound shape reported as real usage) show a smaller win
than the solo `format:X` cases because `t:creature`/`id:g`/`c:g` already compiled to exact planes
before this change — only the `format:modern` leaf's own contribution is new here. Still a ~30%
latency cut on that shape.

Total-row-count parity: 0 mismatches across all 24 targeted configs and a 520-query broad survey
(`scripts/survey_queries.py --seed 667`) run against both builds.

**Row-selection correctness, checked against the real corpus** (count parity alone doesn't catch
this -- it's exactly the blind spot that let the row-selection bug through once already): `oldschool`
is this corpus's best real divergent case (536 of its 556 divergent oracle_ids -- `modern` itself
happens to have zero divergent cards in this specific sample). `f:oldschool unique=card` returns 961
cards, 536 of them genuinely divergent, **0** returned a printing that isn't actually `oldschool`-legal.
Same clean result for `-f:oldschool` and the compound `f:oldschool t:creature`, both modes.

All timings sub-millisecond throughout, hence μs rather than ms. (An earlier version of this table compared `format:modern t:creature` at offset 15000 against `format:modern t:creature id:g` at offset 0 and made the former look implausibly fast — offset 15000 exceeds that query's own total of 12251, so it was actually measuring `run_query_streamed_popcount`'s early-return-on-empty-page path, not deep pagination. Fixed the benchmark script's offsets to stay within each query's own total, and added an explicitly-labeled row for the past-total case so the two aren't conflated again.)

Memory: archive size +126,208 bytes (123.25 KiB) on this corpus — exactly 32 net new planes (64 new
`legal_exists`/`illegal_exists` planes minus 32 removed single-polarity `PLANE_LEGAL` planes) ×
3,944 bytes/plane. Trivial against a ~68MB archive.

## Test plan
- [x] `cargo test --lib` (debug + release): 105 passed, 0 failed
- [x] `cargo clippy --lib --all-targets`: 46 warnings vs `main`'s 44 -- the +2 are the same pre-existing, already-ignored "loop variable used to index" lint category this file already has many instances of, from necessarily duplicating a loop body to isolate the fast path (see perf-regression fix below); no new lint categories
- [x] Perf regression in the conjunction fix caught and fixed (see Summary) -- re-verified against a **freshly-captured** `main` baseline specifically to rule out machine-state drift between runs, not just the original (by-then-stale) one
- [x] New tests: divergent-card parity under every polarity/mode, shared-witness decline (2 formats + same-format-both-polarities), De Morgan `Not`-of-compound, mode-aware `all_match` through the real `split_planes`/`run_query` pipeline, row-selection correctness for `unique=card` (bare leaf + compound `And`), legality + printing-dependent residual conjunction (`format:A AND date>X`)
- [x] Row-selection and conjunction fixes verified against the real benchmark corpus, not just hand-built fixtures (see Results) -- including confirming the conjunction fixture isn't vacuous (247 real oracle_ids in the corpus are genuinely this conflict shape)
- [x] Targeted + broad-survey benchmarks vs `main` (see Results above)
- [x] Memory measurement vs `main` (see Results above)

Design doc: `docs/issues/engine-legality-divergent-carveout.md`





