### PR TITLE
Add Legality Planes for banned:/restricted: (#678)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2133,7 +2133,7 @@ fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option
 /// docs/issues/engine-rarity-planes.md), OR'd together directly from the
 /// plane words; buckets 4-5 (special/bonus) have no plane, so whenever the
 /// comparison also selects one of those two, their RarityIndex postings are
-/// scattered directly into the same mask (same shape as legal_candidate_bits's
+/// scattered directly into the same mask (same shape as legality_candidate_bits's
 /// divergent-set scatter, just op-dependent instead of a fixed list). Loose,
 /// same as rarity_candidates: rarity is PrintingDep at card level, so this
 /// only narrows candidates — card_pass/printing-level residual eval still
@@ -2354,24 +2354,26 @@ fn and_bits_into(acc: &mut [u64], other: &[u64]) {
     }
 }
 
-/// Card-space candidate mask for one format's legality check --
-/// (docs/issues/engine-legality-divergent-carveout.md) exact for every card,
-/// including divergent ones: reads `PLANE_LEGAL_EXISTS` directly for the
-/// positive case or `PLANE_LEGAL_ILLEGAL` for the negated case, never a
-/// bit-complement of the other (that would compute `∀p: ¬legal(p)`, wrong --
-/// a divergent card can satisfy both `∃p: legal(p)` and `∃p: ¬legal(p)` at
-/// once). Exact as a *narrowing* set (no divergent-postings OR needed
-/// anymore -- `legal_divergent` is unchanged and still used by `filter.rs`'s
-/// per-printing `Legality` evaluation, just not here), but callers still
-/// report `Narrowed::loose`: existence-for-some-printing isn't the
-/// true-for-every-printing fact `tight` requires (see `narrow_rec`'s
-/// `Legality` arms and `Narrowed`'s doc).
-fn legal_candidate_bits(indexes: &Archived<CardIndexes>, n_cards: usize, shift: u8, negate: bool) -> Option<Vec<u64>> {
+/// Card-space candidate mask for one (format, status) legality check --
+/// (docs/issues/engine-legality-divergent-carveout.md, generalized to
+/// banned/restricted by #678, see docs/issues/engine-legality-banned-
+/// restricted-planes.md) exact for every card, including divergent ones:
+/// reads the status's `_EXISTS` plane directly for the positive case or its
+/// `_ABSENT`/`_ILLEGAL` plane for the negated case, never a bit-complement of
+/// the other (that would compute `∀p: ¬status(p)`, wrong -- a divergent card
+/// can satisfy both `∃p: status(p)` and `∃p: ¬status(p)` at once). Exact as a
+/// *narrowing* set (no divergent-postings OR needed anymore -- `legal_divergent`
+/// is unchanged and still used by `filter.rs`'s per-printing `Legality`
+/// evaluation, just not here), but callers still report `Narrowed::loose`:
+/// existence-for-some-printing isn't the true-for-every-printing fact `tight`
+/// requires (see `narrow_rec`'s `Legality` arms and `Narrowed`'s doc).
+fn legality_candidate_bits(indexes: &Archived<CardIndexes>, n_cards: usize, shift: u8, expected: u64, negate: bool) -> Option<Vec<u64>> {
     if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
         return None;
     }
+    let (exists_base, absent_base) = status_plane_bases(expected)?;
     let wpp = words_per_plane(n_cards);
-    let base = if negate { PLANE_LEGAL_ILLEGAL } else { PLANE_LEGAL_EXISTS };
+    let base = if negate { absent_base } else { exists_base };
     let legal_plane = base + shift as usize / 2;
     let words = &indexes.planes.words;
     Some(words[legal_plane * wpp..(legal_plane + 1) * wpp].iter().map(|w| u64::from(*w)).collect())
@@ -2909,37 +2911,40 @@ fn narrow_rec(
             Narrowed::loose(Candidates::CardBits(bits))
         }
 
-        // f:x / format:x (docs/issues/engine-legality-divergent-carveout.md):
-        // legal_candidate_bits reads PLANE_LEGAL_EXISTS directly, so this is
-        // exact card-space narrowing -- but still reported `loose`, not
-        // `tight`: `tight` means true for *every* printing (see the Narrowed
-        // struct's doc), and legality genuinely varies printing-to-printing,
-        // so "the card has some legal printing" doesn't satisfy that
-        // contract, same reason -r:x below is loose despite rarity's plane
-        // also being exact. compile_plane separately exact-consumes this
-        // shape for unique=card (see planes.rs, plane_expr_is_existential);
-        // this arm still matters for mixed filters compile_plane declines
-        // (the shared-witness 2+-distinct-format case) and for unique=printing/
-        // artwork, where the residual card_pass verification this `loose`
-        // narrowing feeds into is required for correctness. banned:/
-        // restricted: (expected != LEGALITY_LEGAL) and formats absent from
-        // loaded data (shift: None) fall through unindexed, unchanged.
-        FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
-            Narrowed::loose(Candidates::CardBits(legal_candidate_bits(indexes, n_cards, *shift, false)?))
+        // f:x / format:x / banned:x / restricted:x (docs/issues/
+        // engine-legality-divergent-carveout.md, generalized by #678 -- see
+        // docs/issues/engine-legality-banned-restricted-planes.md):
+        // legality_candidate_bits reads the status's `_EXISTS` plane
+        // directly, so this is exact card-space narrowing -- but still
+        // reported `loose`, not `tight`: `tight` means true for *every*
+        // printing (see the Narrowed struct's doc), and legality genuinely
+        // varies printing-to-printing, so "the card has some printing with
+        // this status" doesn't satisfy that contract, same reason -r:x below
+        // is loose despite rarity's plane also being exact. compile_plane
+        // separately exact-consumes this shape for unique=card (see
+        // planes.rs, plane_expr_is_existential); this arm still matters for
+        // mixed filters compile_plane declines (the shared-witness
+        // 2+-distinct-fact case) and for unique=printing/artwork, where the
+        // residual card_pass verification this `loose` narrowing feeds into
+        // is required for correctness. Formats absent from loaded data
+        // (shift: None) fall through unindexed, unchanged.
+        FilterExpr::Legality { shift: Some(shift), expected } if status_plane_bases(*expected).is_some() => {
+            Narrowed::loose(Candidates::CardBits(legality_candidate_bits(indexes, n_cards, *shift, *expected, false)?))
         }
 
-        // -f:x — matched as its own leaf shape rather than falling through to
-        // the generic Not-complement below (which requires a `tight` child
-        // and wouldn't apply here regardless): bit-complementing the positive
-        // plane would compute `∀p: ¬legal(p)` (wrong for a divergent card,
-        // which can satisfy both `∃p: legal(p)` and `∃p: ¬legal(p)` at once)
-        // instead of reading PLANE_LEGAL_ILLEGAL directly, which is what this
-        // arm does.
+        // -f:x / -banned:x / -restricted:x — matched as its own leaf shape
+        // rather than falling through to the generic Not-complement below
+        // (which requires a `tight` child and wouldn't apply here
+        // regardless): bit-complementing the positive plane would compute
+        // `∀p: ¬status(p)` (wrong for a divergent card, which can satisfy
+        // both `∃p: status(p)` and `∃p: ¬status(p)` at once) instead of
+        // reading the status's `_ABSENT`/`_ILLEGAL` plane directly, which is
+        // what this arm does.
         FilterExpr::Not(inner)
-            if matches!(inner.as_ref(), FilterExpr::Legality { shift: Some(_), expected } if *expected == LEGALITY_LEGAL) =>
+            if matches!(inner.as_ref(), FilterExpr::Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some()) =>
         {
-            let FilterExpr::Legality { shift: Some(shift), .. } = inner.as_ref() else { unreachable!() };
-            Narrowed::loose(Candidates::CardBits(legal_candidate_bits(indexes, n_cards, *shift, true)?))
+            let FilterExpr::Legality { shift: Some(shift), expected } = inner.as_ref() else { unreachable!() };
+            Narrowed::loose(Candidates::CardBits(legality_candidate_bits(indexes, n_cards, *shift, *expected, true)?))
         }
 
         // -r:x / -rarity:x — same reason as -f:x above: rarity's narrowing is

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -12,10 +12,12 @@
 //! are card-level and two-valued (their tri() never returns Null or
 //! PrintingDep), so plane algebra — including complement for Not —
 //! reproduces the filter's card-level truth exactly.
-//! Legality (docs/issues/engine-legality-divergent-carveout.md) is exact via
-//! two planes per format -- PLANE_LEGAL_EXISTS ("some printing is legal") and
-//! PLANE_LEGAL_ILLEGAL ("some printing is not legal"), both computed directly
-//! from printings so they're correct for every card including ones whose
+//! Legality (docs/issues/engine-legality-divergent-carveout.md, generalized
+//! to banned/restricted by docs/issues/engine-legality-banned-restricted-
+//! planes.md, #678) is exact via two planes per (format, status) -- an
+//! `_EXISTS` plane ("some printing has this status") and an `_ABSENT`/
+//! `_ILLEGAL` plane ("some printing doesn't"), both computed directly from
+//! printings so they're correct for every card including ones whose
 //! printings disagree, unlike a single card-level bit. Rarity (the 4 most
 //! common values; docs/issues/engine-rarity-planes.md) is narrowing-only, for
 //! the PrintingDep reason legality used to have -- see PLANE_RARITY.
@@ -23,7 +25,7 @@
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextSearchField};
-use super::legality::{LEGALITY_LEGAL, MAX_FORMATS};
+use super::legality::{LEGALITY_BANNED, LEGALITY_LEGAL, LEGALITY_RESTRICTED, MAX_FORMATS};
 use super::{flip_op, lane_get, oracle_word_eligible, scan_oracle_words, OracleCard, OracleWordIndex, Printing};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
@@ -61,6 +63,21 @@ const DEVOTION_BITS: usize = 2;
 /// bit-complement of the first (which would compute `∀p: ¬legal(p)`, wrong).
 pub(crate) const PLANE_LEGAL_EXISTS: usize = PLANE_DEVOTION + DEVOTION_BITS * COLOR_PLANES;
 pub(crate) const PLANE_LEGAL_ILLEGAL: usize = PLANE_LEGAL_EXISTS + MAX_FORMATS;
+/// Same escape hatch, generalized to `banned`/`restricted`
+/// (docs/issues/engine-legality-banned-restricted-planes.md, #678): the query
+/// space (`expected` against a fixed format list) is exactly as finite and
+/// build-time-precomputable for these two values as it was for `LEGAL`, so
+/// the identical two-exact-planes construction applies, just with more
+/// blocks. `restricted` genuinely diverges per printing for `oldschool`
+/// (30th Anniversary Edition / Vintage Championship promo prints, the same
+/// divergent-printing pattern `LEGAL` already has) -- `build_bit_planes`
+/// reads printings directly here too, so it's exact regardless. `banned`
+/// never diverges in the real corpus, but gets the same treatment for
+/// uniformity rather than a third, special-cased mechanism.
+pub(crate) const PLANE_BANNED_EXISTS: usize = PLANE_LEGAL_ILLEGAL + MAX_FORMATS;
+pub(crate) const PLANE_BANNED_ABSENT: usize = PLANE_BANNED_EXISTS + MAX_FORMATS;
+pub(crate) const PLANE_RESTRICTED_EXISTS: usize = PLANE_BANNED_ABSENT + MAX_FORMATS;
+pub(crate) const PLANE_RESTRICTED_ABSENT: usize = PLANE_RESTRICTED_EXISTS + MAX_FORMATS;
 /// One-hot planes for cmc/power/toughness (#655), covering the interior
 /// range [0,12] — hundreds-to-thousands of cards per value — plus a shared
 /// "13+" high-tail bucket per field (all three have a genuine spread of rare
@@ -75,7 +92,7 @@ pub(crate) const PLANE_LEGAL_ILLEGAL: usize = PLANE_LEGAL_EXISTS + MAX_FORMATS;
 const NUM_INTERIOR_LO: i32 = 0;
 const NUM_INTERIOR_HI: i32 = 12;
 const NUM_INTERIOR_WIDTH: usize = (NUM_INTERIOR_HI - NUM_INTERIOR_LO + 1) as usize;
-pub(crate) const PLANE_CMC: usize = PLANE_LEGAL_ILLEGAL + MAX_FORMATS;
+pub(crate) const PLANE_CMC: usize = PLANE_RESTRICTED_ABSENT + MAX_FORMATS;
 pub(crate) const PLANE_CMC_HI: usize = PLANE_CMC + NUM_INTERIOR_WIDTH;
 pub(crate) const PLANE_POWER_LO: usize = PLANE_CMC_HI + 1;
 pub(crate) const PLANE_POWER: usize = PLANE_POWER_LO + 1;
@@ -138,6 +155,29 @@ pub(crate) struct BitPlanes {
 
 pub(crate) fn words_per_plane(n_cards: usize) -> usize {
     n_cards.div_ceil(64)
+}
+
+/// Single source of truth for every indexed legality status: `(expected,
+/// exists_base, absent_base)`. Every other legality-plane helper
+/// (`status_plane_bases`, `legality_plane_shift`, `is_legality_plane`,
+/// `build_bit_planes`'s scatter loop) derives from this one table instead of
+/// each maintaining its own parallel copy -- adding a 4th indexed status is a
+/// one-line change here, nowhere else
+/// (docs/issues/engine-legality-banned-restricted-planes.md, #678).
+/// `LEGALITY_NOT_LEGAL` has no row: the parser never emits a bare `Legality`
+/// leaf with that `expected` (`-format:X` is
+/// `Not(Legality{expected: LEGALITY_LEGAL})`, not a literal `NOT_LEGAL` leaf).
+const LEGALITY_STATUS_TABLE: [(u64, usize, usize); 3] = [
+    (LEGALITY_LEGAL, PLANE_LEGAL_EXISTS, PLANE_LEGAL_ILLEGAL),
+    (LEGALITY_BANNED, PLANE_BANNED_EXISTS, PLANE_BANNED_ABSENT),
+    (LEGALITY_RESTRICTED, PLANE_RESTRICTED_EXISTS, PLANE_RESTRICTED_ABSENT),
+];
+
+/// The (exists_base, absent_base) plane block pair for one `Legality::expected`
+/// value, or `None` for a value with no indexed plane. Used by every place
+/// that used to hardcode `expected == LEGALITY_LEGAL`.
+pub(crate) fn status_plane_bases(expected: u64) -> Option<(usize, usize)> {
+    LEGALITY_STATUS_TABLE.iter().find(|&&(e, ..)| e == expected).map(|&(_, exists_base, absent_base)| (exists_base, absent_base))
 }
 
 /// A card's effective devotion count for one color lane, saturated to 0..=3
@@ -233,32 +273,43 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
                 "devotion without identity: card {i} color lane {b}"
             );
         }
-        // Legality (docs/issues/engine-legality-divergent-carveout.md): two
-        // existence projections per format, computed directly from this
-        // card's own printings (the `range` rarity already sliced above) --
-        // legal_exists = some printing legal, illegal_exists = some printing
-        // not legal. Both exact for every card, including ones whose
+        // Legality (docs/issues/engine-legality-divergent-carveout.md,
+        // generalized to banned/restricted by #678 -- see
+        // docs/issues/engine-legality-banned-restricted-planes.md): two
+        // existence projections per (format, status), computed directly from
+        // this card's own printings (the `range` rarity already sliced
+        // above) -- exists = some printing has this status, absent = some
+        // printing doesn't. Both exact for every card, including ones whose
         // printings disagree, since neither depends on a single canonical
         // card-level word or a divergence flag. MAX_FORMATS (32) fits a u64
         // mask with room to spare.
-        let mut legal_mask: u64 = 0;
-        let mut illegal_mask: u64 = 0;
+        // Indexed by position in LEGALITY_STATUS_TABLE -- the same single
+        // source of truth status_plane_bases/legality_plane_shift read, so
+        // this loop can never drift out of sync with which plane block a
+        // status writes into.
+        let mut exists_masks = [0u64; LEGALITY_STATUS_TABLE.len()];
+        let mut absent_masks = [0u64; LEGALITY_STATUS_TABLE.len()];
         for p in &printings[range] {
             for f in 0..MAX_FORMATS {
                 let shift = (f * 2) as u32;
-                if (p.card_legalities >> shift) & 0b11 == LEGALITY_LEGAL {
-                    legal_mask |= 1 << f;
-                } else {
-                    illegal_mask |= 1 << f;
+                let status = (p.card_legalities >> shift) & 0b11;
+                for (i, &(want, ..)) in LEGALITY_STATUS_TABLE.iter().enumerate() {
+                    if status == want {
+                        exists_masks[i] |= 1 << f;
+                    } else {
+                        absent_masks[i] |= 1 << f;
+                    }
                 }
             }
         }
-        for f in 0..MAX_FORMATS {
-            if legal_mask & (1 << f) != 0 {
-                set(PLANE_LEGAL_EXISTS + f);
-            }
-            if illegal_mask & (1 << f) != 0 {
-                set(PLANE_LEGAL_ILLEGAL + f);
+        for (i, &(_, exists_base, absent_base)) in LEGALITY_STATUS_TABLE.iter().enumerate() {
+            for f in 0..MAX_FORMATS {
+                if exists_masks[i] & (1 << f) != 0 {
+                    set(exists_base + f);
+                }
+                if absent_masks[i] & (1 << f) != 0 {
+                    set(absent_base + f);
+                }
             }
         }
         // #655: cmc is Option<u8>, type-guaranteed non-negative, so it has no
@@ -289,11 +340,11 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
 /// bytes flat regardless of density, so a fixed, tiny, shared set like this
 /// one is cheaper as a list than as a 33rd plane. `u16` on purpose, same
 /// assumption the name-bigram index's sparse tier makes: card ids fit
-/// (production is ~31.5k, comfortably under u16::MAX). Scattered directly
-/// into a format's legal_x candidate mask by legal_candidate_bits (lib.rs)
-/// rather than intersected via the general Candidates machinery — the set is
-/// always this same small list, not query-dependent, so there's nothing to
-/// look up.
+/// (production is ~31.5k, comfortably under u16::MAX). No longer scattered
+/// into any candidate mask -- `legality_candidate_bits` (lib.rs) narrows via
+/// the exact `_EXISTS`/`_ABSENT` planes directly (docs/issues/engine-
+/// legality-divergent-carveout.md's "free upgrade"), so this list is now only
+/// consulted by `filter.rs`'s per-printing `Legality` `tri()` residual check.
 pub(crate) fn build_divergent_ids(cards: &[OracleCard]) -> Vec<u16> {
     debug_assert!(cards.len() <= u16::MAX as usize + 1, "card count exceeds u16 range for divergent postings");
     cards
@@ -683,34 +734,32 @@ fn compile_plane_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPl
     order.into_iter().map(|c| compile_plane(c, bounds, words)).collect()
 }
 
-/// Collect distinct (format, polarity) pairs referenced by legality-plane
-/// leaves within `expr`, appending into `out` (deduplicated). Polarity is
-/// part of the key, not folded away: `format:A` and `-format:A` read
-/// different planes (`legal_exists`/`illegal_exists`) backing different,
-/// independently-true-or-false existence facts about the same format, so
-/// `format:A AND -format:A` is exactly as shared-witness-prone as
-/// `format:A AND format:B` -- a divergent-on-A card satisfies both
-/// `legal_exists(A)` and `illegal_exists(A)` at once, even though no single
-/// printing can be both legal and not-legal in A simultaneously (see
-/// `and_of_checked_for_shared_witness`'s doc). A literal duplicate leaf
-/// (`format:A AND format:A`) collapses to one entry and is fine to compose --
-/// it's the same underlying fact checked twice, not two facts needing a
-/// shared witness.
-fn collect_legality_formats(expr: &PlaneExpr, out: &mut Vec<(usize, bool)>) {
+/// Whether plane index `p` falls in any legality existence-projection block
+/// (`LEGALITY_STATUS_TABLE`), regardless of which status/polarity it is.
+fn is_legality_plane(p: usize) -> bool {
+    legality_plane_shift(p).is_some()
+}
+
+/// Collect distinct legality plane indices referenced by legality-plane
+/// leaves within `expr`, appending into `out` (deduplicated). Each specific
+/// plane index already identifies one (format, status, polarity) existence
+/// fact, so deduping on the raw index is exactly the right granularity --
+/// simpler than (and a superset of) the old `(format, polarity)` tuple key,
+/// which only had to consider `LEGAL`. Every distinct fact referenced inside
+/// an `And` is shared-witness-prone: `format:A AND -format:A` (same format,
+/// two polarities), `banned:A AND restricted:A` (same format, two statuses),
+/// and `format:A AND format:B` (two formats) are all the identical problem --
+/// a divergent card can satisfy two existence facts via two *different*
+/// witnessing printings, even though no single printing can satisfy both at
+/// once (see `and_of_checked_for_shared_witness`'s doc). A literal duplicate
+/// leaf (`format:A AND format:A`) reads the same plane index and collapses to
+/// one entry, fine to compose -- the same underlying fact checked twice, not
+/// two facts needing a shared witness.
+fn collect_legality_formats(expr: &PlaneExpr, out: &mut Vec<u16>) {
     match expr {
         PlaneExpr::Plane(p) => {
-            let p = *p as usize;
-            let fmt = if (PLANE_LEGAL_EXISTS..PLANE_LEGAL_EXISTS + MAX_FORMATS).contains(&p) {
-                Some((p - PLANE_LEGAL_EXISTS, false))
-            } else if (PLANE_LEGAL_ILLEGAL..PLANE_LEGAL_ILLEGAL + MAX_FORMATS).contains(&p) {
-                Some((p - PLANE_LEGAL_ILLEGAL, true))
-            } else {
-                None
-            };
-            if let Some(entry) = fmt
-                && !out.contains(&entry)
-            {
-                out.push(entry);
+            if is_legality_plane(*p as usize) && !out.contains(p) {
+                out.push(*p);
             }
         }
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => {}
@@ -724,35 +773,35 @@ fn collect_legality_formats(expr: &PlaneExpr, out: &mut Vec<(usize, bool)>) {
 }
 
 /// Whether any leaf of a compiled plane expression reads a legality plane
-/// (`PLANE_LEGAL_EXISTS`/`PLANE_LEGAL_ILLEGAL`). These are existence
-/// projections over per-printing-varying data ("*some* printing is/isn't
-/// legal") -- unlike every other plane (colors, types, numeric buckets,
-/// devotion, border, all card-invariant), a card-level True here does not
-/// imply every printing of the card individually satisfies the query. Used
-/// to gate the #634 Step 1 `all_match_known` fast path to `unique=card`,
-/// where existence is exactly the semantics needed (docs/issues/
-/// engine-legality-divergent-carveout.md; Step 2's popcount path is already
-/// `Mode::Card`-only for unrelated reasons, see `run_query`).
+/// (any status/polarity in `LEGALITY_STATUS_TABLE`). These are existence projections over
+/// per-printing-varying data ("*some* printing has this status") -- unlike
+/// every other plane (colors, types, numeric buckets, devotion, border, all
+/// card-invariant), a card-level True here does not imply every printing of
+/// the card individually satisfies the query. Used to gate the #634 Step 1
+/// `all_match_known` fast path to `unique=card`, where existence is exactly
+/// the semantics needed (docs/issues/engine-legality-divergent-carveout.md;
+/// Step 2's popcount path is already `Mode::Card`-only for unrelated reasons,
+/// see `run_query`).
 pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
     match expr {
-        PlaneExpr::Plane(p) => {
-            let p = *p as usize;
-            (PLANE_LEGAL_EXISTS..PLANE_LEGAL_EXISTS + MAX_FORMATS).contains(&p)
-                || (PLANE_LEGAL_ILLEGAL..PLANE_LEGAL_ILLEGAL + MAX_FORMATS).contains(&p)
-        }
+        PlaneExpr::Plane(p) => is_legality_plane(*p as usize),
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => false,
         PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(plane_expr_is_existential),
         PlaneExpr::Not(inner) => plane_expr_is_existential(inner),
     }
 }
 
-/// `And` two-or-more legality-plane leaves referencing *different* formats
-/// (or the same format under both polarities -- `format:A AND -format:A`)
-/// can't be answered by ANDing independent existence projections: `∃p:
-/// legal_A(p) ∧ legal_B(p)` requires one printing to satisfy both at once,
-/// which isn't the same as `(∃p: legal_A(p)) ∧ (∃p: legal_B(p))` (a false
-/// positive the moment different printings would be the witness for each).
-/// `Or` never has this problem (`∃` distributes over `∨`), so this is only
+/// `And` two-or-more legality-plane leaves referencing distinct existence
+/// facts -- different formats, the same format under both polarities
+/// (`format:A AND -format:A`), or (#678) the same format under two different
+/// *statuses* (`banned:A AND restricted:A`) -- can't be answered by ANDing
+/// independent existence projections: `∃p: legal_A(p) ∧ legal_B(p)` requires
+/// one printing to satisfy both at once, which isn't the same as `(∃p:
+/// legal_A(p)) ∧ (∃p: legal_B(p))` (a false positive the moment different
+/// printings would be the witness for each) -- the same argument applies
+/// verbatim whichever two distinct facts are involved, since `collect_legality_
+/// formats` dedupes by raw plane index, not by format alone. `Or` never has
+/// this problem (`∃` distributes over `∨`), so this is only
 /// called where an `And` is about to be assembled -- both the direct case
 /// and the De-Morgan'd `Not(Or(...))` case in `compile_plane_neg`. Declining
 /// (falling back to `narrow_rec`'s existing, correct `Legality` narrowing) is
@@ -831,14 +880,15 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
             (NumExpr::Const(v), NumExpr::Field(f)) => compile_numeric_cmp(*f, flip_op(*op), *v, bounds),
             _ => None,
         },
-        // f:x / format:x (docs/issues/engine-legality-divergent-carveout.md):
-        // exact for every card via PLANE_LEGAL_EXISTS -- no divergent-card
-        // caveat, unlike the single-plane design this replaced. banned:/
-        // restricted: (expected != LEGALITY_LEGAL) and absent formats
-        // (shift: None) stay unindexed, matching narrow_rec's existing
-        // restriction; `Not` is handled by compile_plane_neg, not here.
-        FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
-            Some(PlaneExpr::Plane((PLANE_LEGAL_EXISTS + *shift as usize / 2) as u16))
+        // f:x / format:x / banned:x / restricted:x (docs/issues/
+        // engine-legality-divergent-carveout.md, generalized by #678 -- see
+        // docs/issues/engine-legality-banned-restricted-planes.md): exact for
+        // every card via the status's `_EXISTS` plane -- no divergent-card
+        // caveat, same as `LEGAL`. Only a format absent from all loaded data
+        // (shift: None) stays unindexed; `Not` is handled by
+        // compile_plane_neg, not here.
+        FilterExpr::Legality { shift: Some(shift), expected } => {
+            status_plane_bases(*expected).map(|(exists_base, _)| PlaneExpr::Plane((exists_base + *shift as usize / 2) as u16))
         }
         _ => None,
     }
@@ -852,8 +902,8 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
 /// unchanged. Mutually recursive with `compile_plane`.
 fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
     match filter {
-        FilterExpr::Legality { shift: Some(shift), expected } if *expected == LEGALITY_LEGAL => {
-            Some(PlaneExpr::Plane((PLANE_LEGAL_ILLEGAL + *shift as usize / 2) as u16))
+        FilterExpr::Legality { shift: Some(shift), expected } => {
+            status_plane_bases(*expected).map(|(_, absent_base)| PlaneExpr::Plane((absent_base + *shift as usize / 2) as u16))
         }
         // Not(And(cs)) = Or(Not(c) for c in cs) -- existence distributes over
         // Or, so no shared-witness check is needed here regardless of how
@@ -961,13 +1011,16 @@ pub(crate) fn split_planes(
                     planes.push(pe);
                 }
             } else {
-                // 2+ distinct (format, polarity) pairs can't be ANDed
-                // together safely regardless of mode (shared-witness); a
-                // single one is safe for the plane's own exactness but still
-                // deferred for unique=printing/artwork, same reasoning as the
-                // top-level shortcut above. Either way it falls back to
-                // narrow_rec's existing (correct, still exact as of this
-                // issue) Legality narrowing arm instead.
+                // 2+ distinct legality existence facts (different formats,
+                // different statuses of the same format, or the same format
+                // under both polarities -- collect_legality_formats dedupes
+                // by raw plane index, so all three shapes count the same
+                // way) can't be ANDed together safely regardless of mode
+                // (shared-witness); a single one is safe for the plane's own
+                // exactness but still deferred for unique=printing/artwork,
+                // same reasoning as the top-level shortcut above. Either way
+                // it falls back to narrow_rec's existing (correct, still
+                // exact as of this issue) Legality narrowing arm instead.
                 for (c, _) in legality_children {
                     rest.push(c);
                 }
@@ -1039,18 +1092,23 @@ pub(crate) fn eval_planes(expr: &PlaneExpr, planes: &rkyv::Archived<BitPlanes>, 
     }
 }
 
-/// If plane `p` is one of legality's existence planes, the (shift, is_illegal)
-/// it addresses -- `shift` matches `FilterExpr::Legality`'s own field, and
-/// `is_illegal` distinguishes `PLANE_LEGAL_ILLEGAL` (the negated-check plane)
-/// from `PLANE_LEGAL_EXISTS`. `None` for every other (card-invariant) plane.
-fn legality_plane_shift(p: usize) -> Option<(u8, bool)> {
-    if (PLANE_LEGAL_EXISTS..PLANE_LEGAL_EXISTS + MAX_FORMATS).contains(&p) {
-        Some((((p - PLANE_LEGAL_EXISTS) * 2) as u8, false))
-    } else if (PLANE_LEGAL_ILLEGAL..PLANE_LEGAL_ILLEGAL + MAX_FORMATS).contains(&p) {
-        Some((((p - PLANE_LEGAL_ILLEGAL) * 2) as u8, true))
-    } else {
-        None
+/// If plane `p` is one of legality's existence planes, the (shift, expected,
+/// is_illegal) it addresses -- `shift` matches `FilterExpr::Legality`'s own
+/// field, `expected` is the status the block was built for (`LEGAL`/`BANNED`/
+/// `RESTRICTED`), and `is_illegal` distinguishes an `_ABSENT`/`_ILLEGAL`
+/// (negated-check) plane from its `_EXISTS` counterpart. `None` for every
+/// other (card-invariant) plane. Derived from `LEGALITY_STATUS_TABLE`, the
+/// same single source of truth `status_plane_bases` reads.
+fn legality_plane_shift(p: usize) -> Option<(u8, u64, bool)> {
+    for &(expected, exists_base, absent_base) in &LEGALITY_STATUS_TABLE {
+        if (exists_base..exists_base + MAX_FORMATS).contains(&p) {
+            return Some((((p - exists_base) * 2) as u8, expected, false));
+        }
+        if (absent_base..absent_base + MAX_FORMATS).contains(&p) {
+            return Some((((p - absent_base) * 2) as u8, expected, true));
+        }
     }
+    None
 }
 
 /// Evaluate a compiled plane expression against one specific printing, rather
@@ -1077,9 +1135,9 @@ pub(crate) fn eval_plane_expr_for_printing(
     match expr {
         PlaneExpr::Plane(p) => {
             let p = *p as usize;
-            if let Some((shift, is_illegal)) = legality_plane_shift(p) {
+            if let Some((shift, expected, is_illegal)) = legality_plane_shift(p) {
                 let status = (u64::from(printing.card_legalities) >> shift) & 0b11;
-                if is_illegal { status != LEGALITY_LEGAL } else { status == LEGALITY_LEGAL }
+                if is_illegal { status != expected } else { status == expected }
             } else {
                 let wpp = words_per_plane(u32::from(planes.n_cards) as usize);
                 let word = u64::from(planes.words[p * wpp + cid as usize / 64]);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -744,7 +744,13 @@ fn divergent_legality_defers_to_printings() {
 /// format B (shift 2) only, single printing. card2: genuinely divergent for
 /// format A — two printings, one legal and one not — so both
 /// `legal_exists(A)` and `illegal_exists(A)` are true for it at once
-/// (docs/issues/engine-legality-divergent-carveout.md).
+/// (docs/issues/engine-legality-divergent-carveout.md). All three also carry
+/// a format C (shift 4) banned/restricted status, generalized by #678 (see
+/// docs/issues/engine-legality-banned-restricted-planes.md): card0 banned in
+/// C (single printing), card1 restricted in C (single printing), card2
+/// divergent on *banned(C)* too — one printing banned, the other merely
+/// legal (not banned) — mirroring the real `restricted:oldschool` shape
+/// (a 30th-Anniversary-style promo printing disagreeing with the rest).
 fn legal_plane_fixture() -> CardData {
     let mut vocab = VocabInterner::new();
     let mut card0 = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
@@ -759,10 +765,10 @@ fn legal_plane_fixture() -> CardData {
     // default to 0, so every printing needs its own legality set here before
     // the planes are rebuilt below. card2's two printings deliberately
     // disagree on format A: one legal, one not.
-    data.printings[0].card_legalities = 0b01; // card0: legal in A
-    data.printings[1].card_legalities = 0b01 << 2; // card1: legal in B
-    data.printings[2].card_legalities = 0b01; // card2 printing 1: legal in A
-    data.printings[3].card_legalities = 0; // card2 printing 2: not legal in A
+    data.printings[0].card_legalities = 0b01 | (0b11 << 4); // card0: legal in A, banned in C
+    data.printings[1].card_legalities = (0b01 << 2) | (0b10 << 4); // card1: legal in B, restricted in C
+    data.printings[2].card_legalities = 0b01 | (0b11 << 4); // card2 printing 1: legal in A, banned in C
+    data.printings[3].card_legalities = 0b01 << 4; // card2 printing 2: not legal in A, legal (not banned) in C
     data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     data
@@ -820,27 +826,166 @@ fn legal_plane_narrows_negated_includes_divergent() {
     }
 }
 
+/// #678: banned:/restricted: now plane-narrow exactly like format:, including
+/// through a divergent card (card2, banned in C via one printing, merely
+/// legal via the other — see `legal_plane_fixture`'s doc). Only a format
+/// absent from all loaded data (shift: None) still declines.
 #[test]
-fn legal_plane_declines_banned_restricted_and_absent_format() {
+fn banned_restricted_plane_narrows_positive_includes_divergent() {
     let data = legal_plane_fixture();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    // banned:/restricted: never plane-narrow — unindexed and unchanged.
-    let banned = FilterExpr::Legality { shift: Some(0), expected: 0b11 };
-    assert!(narrow_candidates(&banned, &archived.indexes, &archived.offsets, &archived.cards).is_none());
-    let restricted = FilterExpr::Legality { shift: Some(0), expected: 0b10 };
-    assert!(narrow_candidates(&restricted, &archived.indexes, &archived.offsets, &archived.cards).is_none());
-    // Not(banned) falls through the generic Not path, which also declines
-    // (no tight source to complement) — still correct, just unnarrowed.
-    let not_banned = FilterExpr::Not(Box::new(banned));
-    assert!(narrow_candidates(&not_banned, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+    let banned_c = FilterExpr::Legality { shift: Some(4), expected: 0b11 };
+    match narrow_candidates(&banned_c, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            assert!(bitmap_contains(&bits, 0), "card0 truly banned in C must narrow in");
+            assert!(!bitmap_contains(&bits, 1), "card1 is restricted, not banned, in C");
+            assert!(bitmap_contains(&bits, 2), "divergent card2 has a banned-in-C printing");
+        }
+        _ => panic!("expected a card bitmap for banned:C"),
+    }
+
+    let restricted_c = FilterExpr::Legality { shift: Some(4), expected: 0b10 };
+    match narrow_candidates(&restricted_c, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            assert!(!bitmap_contains(&bits, 0), "card0 is banned, not restricted, in C");
+            assert!(bitmap_contains(&bits, 1), "card1 truly restricted in C must narrow in");
+            assert!(!bitmap_contains(&bits, 2), "card2 has no restricted-in-C printing");
+        }
+        _ => panic!("expected a card bitmap for restricted:C"),
+    }
 
     // A format absent from all loaded data (shift: None) matches nothing at
     // eval and isn't plane-narrowed either — falls to the (cheap, correct)
-    // full scan.
-    let absent = FilterExpr::Legality { shift: None, expected: 0b01 };
-    assert!(narrow_candidates(&absent, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+    // full scan, for every indexed status.
+    let absent_banned = FilterExpr::Legality { shift: None, expected: 0b11 };
+    assert!(narrow_candidates(&absent_banned, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+    let absent_restricted = FilterExpr::Legality { shift: None, expected: 0b10 };
+    assert!(narrow_candidates(&absent_restricted, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+}
+
+/// -banned:C: card0 (truly banned) must not narrow in; card1 (restricted, so
+/// not banned) and card2 (divergent, has a not-banned printing) must.
+#[test]
+fn banned_restricted_plane_narrows_negated_includes_divergent() {
+    let data = legal_plane_fixture();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let not_banned_c = FilterExpr::Not(Box::new(FilterExpr::Legality { shift: Some(4), expected: 0b11 }));
+    match narrow_candidates(&not_banned_c, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::CardBits(bits)) => {
+            assert!(!bitmap_contains(&bits, 0), "truly banned-in-C card must not narrow into the negation");
+            assert!(bitmap_contains(&bits, 1), "restricted (not banned) card must narrow into the negation");
+            assert!(bitmap_contains(&bits, 2), "divergent card with a not-banned-in-C printing must narrow in");
+        }
+        _ => panic!("expected a card bitmap"),
+    }
+}
+
+/// banned:C AND restricted:C: two distinct existence facts about the *same*
+/// format — the same shared-witness exposure as two distinct formats or two
+/// polarities of one format, now reachable because `collect_legality_formats`
+/// dedupes by raw plane index (#678) rather than a `(format, polarity)` tuple
+/// that had no way to express "same format, different status."
+#[test]
+fn legality_same_format_cross_status_declines_shared_witness() {
+    let data = legal_plane_fixture();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let banned_c = || FilterExpr::Legality { shift: Some(4), expected: 0b11 };
+    let restricted_c = || FilterExpr::Legality { shift: Some(4), expected: 0b10 };
+
+    assert!(
+        compile_plane(&FilterExpr::And(vec![banned_c(), restricted_c()]), bounds, words).is_none(),
+        "banned:C AND restricted:C (same format, distinct statuses) must decline (shared-witness)"
+    );
+    assert!(
+        compile_plane(&FilterExpr::Or(vec![banned_c(), restricted_c()]), bounds, words).is_some(),
+        "OR has no shared-witness problem and must compile"
+    );
+}
+
+/// The shared-witness decline's fallback must still be *correct*: a card
+/// banned in C via one printing and restricted in C via a different printing
+/// (no single printing is both) is the trap in action — banned_exists(C) AND
+/// restricted_exists(C) would wrongly say true if naively ANDed.
+#[test]
+fn legality_cross_status_shared_witness_falls_back_to_correct_result() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0b11 << 4; // banned in C only
+    data.printings[1].card_legalities = 0b10 << 4; // restricted in C only
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let and_both = FilterExpr::And(vec![
+        FilterExpr::Legality { shift: Some(4), expected: 0b11 },
+        FilterExpr::Legality { shift: Some(4), expected: 0b10 },
+    ]);
+    let (plane, mut residual) = split_planes(and_both, bounds, words, true);
+    assert!(plane.is_none(), "shared-witness AND must not partially promote either leaf into the plane");
+    assert!(matches!(residual, FilterExpr::And(_)), "both legality children must remain in the residual");
+
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing is both banned and restricted in C at once");
+}
+
+/// Row-selection correctness (docs/issues/engine-legality-divergent-carveout.md
+/// "Row selection for unique=card") through the real `run_query` pipeline,
+/// mirroring `legal_plane_narrowing_preserves_divergent_printing_correctness`
+/// but for `banned:` — the preferred printing deliberately says NOT banned,
+/// the non-preferred one says banned, to stress that row emission for
+/// `unique=printing` picks the printing that actually satisfies the query,
+/// not just the card's usual preferred one.
+#[test]
+fn banned_plane_row_selection_preserves_divergent_printing_correctness() {
+    let mut vocab = VocabInterner::new();
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.legality_divergent = true;
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0b01 << 4; // preferred: legal (not banned) in C
+    data.printings[1].card_legalities = 0b11 << 4; // non-preferred: banned in C
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.legal_divergent = build_divergent_ids(&data.cards);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let run = |filter: &mut FilterExpr, unique: &str| {
+        run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            filter, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        )
+    };
+
+    // banned:C, unique=printing: exactly the one banned printing.
+    let mut f = FilterExpr::Legality { shift: Some(4), expected: 0b11 };
+    let (total, page) = run(&mut f, "printing");
+    assert_eq!(total, 1);
+    assert_eq!(u128::from(page[0].1.scryfall_id), 2); // the non-preferred, banned printing
+
+    // banned:C, unique=card: the card matches (at least one printing is
+    // banned), read straight from the exact banned_exists(C) plane bit.
+    let mut f2 = FilterExpr::Legality { shift: Some(4), expected: 0b11 };
+    let (total, _) = run(&mut f2, "card");
+    assert_eq!(total, 1);
+
+    // -banned:C, unique=printing: exactly the one not-banned printing.
+    let mut not_f = FilterExpr::Not(Box::new(FilterExpr::Legality { shift: Some(4), expected: 0b11 }));
+    let (total, page) = run(&mut not_f, "printing");
+    assert_eq!(total, 1);
+    assert_eq!(u128::from(page[0].1.scryfall_id), 1); // the preferred, not-banned printing
 }
 
 /// The correctness property the whole design hinges on: a divergent card must

--- a/scripts/bench_legality_banned_restricted.py
+++ b/scripts/bench_legality_banned_restricted.py
@@ -1,0 +1,121 @@
+"""Engine-vs-engine benchmark for banned:/restricted: legality planes (#678).
+
+Same protocol as scripts/bench_legality_divergent.py (build locally with
+`maturin develop --release -m card_engine/Cargo.toml`, run against a fixed corpus, compare CSVs
+across builds), reusing its offset-aware bench_one/load_engine directly. Groups:
+
+- `promoted-*` — banned:/restricted: filters that should reach exact plane narrowing once #678
+  ships: solo, negated, and compounded with other plane-exact predicates.
+- `same-format-cross-status` / `cross-format` — shapes that must decline the plane path (shared-
+  witness) both before and after this change, falling back to the (still correct) narrow_rec arm.
+- `divergent` — restricted:oldschool, the one printing-varying case found in the real corpus.
+- `uniques` — unique=printing/artwork must be unaffected the same way format: already is.
+- `control` — format:/c:g, already exact via #676, must show zero movement from this change.
+
+    .venv/bin/python scripts/bench_legality_banned_restricted.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/legality-banned-restricted/baseline-main.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_permuted_order import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer, offset) — direction=asc, limit=100 throughout.
+CONFIGS: list[tuple[str, str, str, str, str, int]] = [
+    # Solo banned:/restricted:, across the size spread (card-level counts from
+    # engine-legality-bitplanes.md's table): duel banned=91 (largest banned set),
+    # vintage restricted=51 (largest restricted set), modern banned=52 (the issue's
+    # own cited example), a near-zero set (alchemy banned=1).
+    ("promoted-solo", "banned:duel", "card", "edhrec", "default", 0),
+    ("promoted-solo", "restricted:vintage", "card", "edhrec", "default", 0),
+    ("promoted-solo", "banned:modern", "card", "edhrec", "default", 0),
+    ("promoted-solo", "banned:alchemy", "card", "edhrec", "default", 0),
+    ("promoted-solo", "-banned:duel", "card", "edhrec", "default", 0),
+    ("promoted-solo", "-restricted:vintage", "card", "edhrec", "default", 0),
+    # Compounded with other plane-exact predicates -- must fully resolve to
+    # all_match/popcount-skip, same as format:modern t:creature does today.
+    ("promoted-compound", "banned:modern t:creature", "card", "edhrec", "default", 0),
+    ("promoted-compound", "restricted:vintage c:u", "card", "edhrec", "default", 0),
+    ("promoted-compound", "banned:duel or restricted:vintage", "card", "edhrec", "default", 0),
+    # Same-format, cross-status: two distinct existence facts about one format --
+    # must decline the plane And (shared-witness) exactly like format:A AND -format:A.
+    ("same-format-cross-status", "banned:modern restricted:modern", "card", "edhrec", "default", 0),
+    ("same-format-cross-status", "format:modern banned:modern", "card", "edhrec", "default", 0),
+    # Cross-format: must decline regardless of which statuses are involved.
+    ("cross-format", "banned:modern banned:legacy", "card", "edhrec", "default", 0),
+    ("cross-format", "format:modern banned:legacy", "card", "edhrec", "default", 0),
+    # The one genuinely printing-varying case found in the real corpus (21 card
+    # names, all via 30th Anniversary Edition / Vintage Championship promo prints).
+    ("divergent", "restricted:oldschool", "card", "edhrec", "default", 0),
+    ("divergent", "-restricted:oldschool", "card", "edhrec", "default", 0),
+    # unique=printing/artwork: must stay correct via the existing row-selection
+    # machinery (already status-agnostic), same as format: today.
+    ("uniques", "banned:modern", "printing", "edhrec", "default", 0),
+    ("uniques", "restricted:oldschool", "printing", "edhrec", "default", 0),
+    ("uniques", "banned:modern", "artwork", "edhrec", "default", 0),
+    # Controls: format:/c:g, already plane-exact via #676 -- zero movement expected.
+    ("control", "format:modern", "card", "edhrec", "default", 0),
+    ("control", "c:g", "card", "edhrec", "default", 0),
+    ("control", "name:soldier", "card", "edhrec", "default", 0),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--", "card_engine/src"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    if dirty:
+        rev += "-dirty"
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    for _, query, _, _, _, _ in CONFIGS:
+        parse_scryfall_query(query)
+
+    hdr = f"{'group':<25} {'query':<32} {'unique':<9} {'orderby':<8} {'prefer':<9} {'offset':>7} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.1f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "offset", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer, offset in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer, offset), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, offset, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<25} {query:<32} {unique:<9} {orderby:<8} {prefer:<9} {offset:>7} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}",
+                flush=True,
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`banned:`/`restricted:` legality queries (`FilterExpr::Legality` with `expected != LEGALITY_LEGAL`) had no `compile_plane`/`narrow_rec` arm and always fell through to an unindexed full card-space scan, unlike `format:`/`f:` which got exact bitplanes in #667/#676. This generalizes that same two-exact-plane design (per-(format,status) `_EXISTS`/`_ABSENT` existence projections, computed directly from printings) to `banned:`/`restricted:` instead of building a separate postings mechanism — see the design doc (local, untracked per `docs/workflows/performance-pr-workflow.md`) for the full writeup, including why postings lost the tradeoff once measured.

Checked against the real DB before assuming anything: `banned` never diverges per-printing in any format; `restricted` diverges only for `oldschool` (21 card names, e.g. Ancestral Recall's 30th Anniversary Edition / Vintage Championship promo prints) — the identical divergent-printing pattern `format:`/`f:` already handles via the existing `legality_divergent` flag, reused unchanged here.

## Changes

- `card_engine/src/planes.rs`: 4 new plane blocks (`PLANE_BANNED_EXISTS/ABSENT`, `PLANE_RESTRICTED_EXISTS/ABSENT`); a single `LEGALITY_STATUS_TABLE` source of truth (`(expected, exists_base, absent_base)`) that `status_plane_bases`/`legality_plane_shift`/`build_bit_planes` all derive from; generalized `compile_plane`/`compile_plane_neg`'s `Legality` arms, `collect_legality_formats` (now dedupes shared-witness candidates by raw plane index instead of a `(format, polarity)` tuple, so it also catches the new same-format-cross-status case, e.g. `banned:A AND restricted:A`), and `plane_expr_is_existential`.
- `card_engine/src/lib.rs`: `legal_candidate_bits` → `legality_candidate_bits` (takes `expected`); `narrow_rec`'s two `Legality`/`Not(Legality)` arms generalized from a hardcoded `LEGALITY_LEGAL` guard to `status_plane_bases(*expected).is_some()`.
- `card_engine/src/tests.rs`: extends the existing divergent-card fixture with a format-C banned/restricted case (mirroring the real `oldschool` shape), plus new tests for narrowing (positive/negated), same-format-cross-status shared-witness decline and its correct fallback, and row-selection correctness — flips the old test asserting banned:/restricted: decline narrowing (now they don't).
- `scripts/bench_legality_banned_restricted.py`: new targeted benchmark (same pattern as `bench_legality_divergent.py`), used for the results below.

## Related issues

Fixes #678

---

## Performance

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `banned:duel` (91 matches) | 219μs | 47μs | 4.7x |
| `restricted:vintage` (51) | 200μs | 29μs | 6.9x |
| `banned:modern` (52) | 202μs | 30μs | 6.7x |
| `banned:alchemy` (1 match) | 176μs | 5μs | 35x |
| `banned:modern t:creature` | 129μs | 15μs | 8.6x |
| `restricted:oldschool` (the divergent case) | 186μs | 18μs | 10x |
| `banned:modern`, `unique=printing` | 229μs | 59μs | 3.9x |
| `format:modern`/`c:g` (controls) | 67μs/59μs | 67μs/59μs | unaffected |

**Geometric mean:** ~6x faster across the 20-config targeted set (full table in the design doc); 0 regressions on controls.
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl` (31,508 cards / 97,206 printings, the same corpus #676 used).

Notably, `banned:modern` (30μs) ends up *faster* than the already-shipped `format:modern` (67μs) despite the identical mechanism — the popcount-skip walk (#634/#667) already short-circuits whole-zero words, so cost scales with nonzero words, not a fixed `words_per_plane` count. This is direct evidence against a postings-based alternative: the plane path is already adaptive to sparsity, not a fixed-cost sweep a postings gather could beat.

Broad survey (`scripts/survey_queries.py --seed 678`, 520 queries): 0 systematic regressions — a per-query diff found 9 shifted >10% slower and 7 shifted similarly faster (none touching `banned:`/`restricted:`/`format:`), a symmetric spread consistent with ordinary measurement noise.

Memory: archive grew 504,824 bytes (493 KiB) on the 31,508-card corpus — matches the ~505 KiB estimate (4 new plane blocks × 32 formats × ~3.9 KB/plane) almost exactly. 0.7% of the ~68.5 MB archive.

Total-row-count parity: identical across builds for every targeted config.

## Reviewer notes

Self-reviewed via 8-angle code review before opening; findings and fixes:
- Consolidated 3 independently-maintained legality-status tables (`status_plane_bases`, the old `LEGALITY_PLANE_BLOCKS`, `build_bit_planes`'s local arrays) into one `LEGALITY_STATUS_TABLE` single source of truth, and made `is_legality_plane` delegate to `legality_plane_shift` instead of duplicating its scan.
- Updated two doc comments (`and_of_checked_for_shared_witness`, `split_planes`) that still described the shared-witness trap in terms of format/polarity only, missing the new same-format-cross-status case this PR makes reachable.
- Two minor efficiency notes (a redundant `status_plane_bases` lookup in a match guard, one extra comparison per printing in the row-selection path) were assessed as genuinely negligible (once-per-query, not per-candidate) and left as-is rather than adding match-arm complexity for no measurable benefit — also empirically contradicted by the benchmark numbers above, which show these queries are among the fastest in the suite.

Full property-based differential parity suite (`api/tests/test_engine_property.py`, compares the Rust engine against the reference implementation across randomized query shapes) and the full test suite (1989 tests) pass.