### PR TITLE
Generalize Existential Planes to Rarity and Border

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1191,65 +1191,6 @@ fn build_name_bigram_index(cards: &[OracleCard]) -> NameBigramIndex {
     idx
 }
 
-// ─── Border planes (#664: loose card-level narrowing for border:) ──────────
-// card_border_id is a *printing*-level interned string (a card can have both a
-// black and a borderless printing), unlike everything BitPlanes/compile_plane
-// already handle (colors/types/devotion are card-invariant — identical across
-// every printing). unique=card semantics require one printing to satisfy the
-// *whole* filter, not each predicate independently satisfied by some
-// (possibly different) printing, so an AND of two independent per-card "has
-// X border" bits can false-positive: `border:black border:borderless` has no
-// shared witness and must return zero, but two independently-true bits would
-// wrongly say every card with one of each qualifies. These planes are
-// therefore *always* `Narrowed::loose` — real candidates, never fed through
-// `compile_plane`'s exact/tight machinery, which is safe only because nothing
-// else it touches varies per printing. Loose narrowing only shrinks which
-// cards' printings the residual per-printing walk bothers checking at all;
-// the real answer always comes from that walk, same as today.
-// See docs/issues/engine-border-planes.md for the full rationale, including
-// why `-border:x` (Not, which narrows only through tight children) and the
-// rare gold/yellow values are both deliberately left on the existing full
-// scan rather than chasing exactness this representation can't safely give.
-//
-// Real corpus (benchmarks/bitplanes/corpus.jsonl): black 98.92% of cards
-// (declines via the existing broadness guard, no special-casing needed),
-// borderless 10.73%, white 6.53% — gold/yellow (2.02% combined) get no plane.
-const BORDER_BLACK: usize = 0;
-const BORDER_BORDERLESS: usize = 1;
-const BORDER_WHITE: usize = 2;
-const BORDER_PLANE_COUNT: usize = 3;
-
-#[derive(Archive, Serialize, Deserialize, Default)]
-struct BorderPlanes {
-    n_cards: u32,
-    /// BORDER_PLANE_COUNT × words_per_plane(n_cards), flattened plane-major —
-    /// the same layout convention as BitPlanes.words, just not fed through
-    /// compile_plane (see the module doc above for why).
-    words: Vec<u64>,
-}
-
-fn build_border_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32], strings: &[String]) -> BorderPlanes {
-    let n_cards = cards.len();
-    let wpp = words_per_plane(n_cards);
-    let mut words = vec![0u64; BORDER_PLANE_COUNT * wpp];
-    for card in 0..n_cards {
-        let range = offsets[card] as usize..offsets[card + 1] as usize;
-        for p in &printings[range] {
-            if p.card_border_id == NONE_STR {
-                continue;
-            }
-            let plane = match strings[p.card_border_id as usize].as_str() {
-                "black" => BORDER_BLACK,
-                "borderless" => BORDER_BORDERLESS,
-                "white" => BORDER_WHITE,
-                _ => continue,
-            };
-            words[plane * wpp + (card >> 6)] |= 1u64 << (card & 63);
-        }
-    }
-    BorderPlanes { n_cards: n_cards as u32, words }
-}
-
 // Named lifetime (not elided/HRTB) so get_text may return text borrowed from the
 // string table rather than from the card itself.
 fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str) -> SortedTrigramIndex {
@@ -2128,20 +2069,23 @@ fn rarity_candidates(idx: &Archived<RarityIndex>, op: CmpOp, val: f64) -> Option
     Some(result)
 }
 
-/// Card-space candidate mask for `rarity <op> val` using the 4 planed rarity
-/// values (common/uncommon/rare/mythic, buckets 0-3 — PLANE_RARITY,
-/// docs/issues/engine-rarity-planes.md), OR'd together directly from the
-/// plane words; buckets 4-5 (special/bonus) have no plane, so whenever the
-/// comparison also selects one of those two, their RarityIndex postings are
-/// scattered directly into the same mask (same shape as legality_candidate_bits's
-/// divergent-set scatter, just op-dependent instead of a fixed list). Loose,
-/// same as rarity_candidates: rarity is PrintingDep at card level, so this
-/// only narrows candidates — card_pass/printing-level residual eval still
-/// verifies which printings actually match. Unlike rarity_candidates, Ne
-/// doesn't need to decline: with 4 of 6 buckets plane-backed, "not equal" is
-/// mostly a cheap plane-OR plus a tiny tail scatter, not a near-total postings
-/// union. No bucket_verdict/ambiguity logic needed either — every bucket here
-/// is a single fully-known value, not an open-ended numeric range.
+/// Card-space candidate mask for `rarity <op> val` using the 4 tracked
+/// one-hot rarity planes (common/uncommon/rare/mythic, buckets 0-3 —
+/// PLANE_RARITY, docs/issues/engine-rarity-planes.md) plus the shared "above
+/// mythic" plane (PLANE_RARITY_HI, special/bonus combined —
+/// docs/issues/engine-existential-plane-generalization.md, #680), mirroring
+/// `compile_rarity_cmp`'s exact-plane construction but producing a raw
+/// bitmap instead of a `PlaneExpr`. `rarity_hi_verdict` decides the hi
+/// plane's fate the same way it does there: `Ambiguous` (the query needs to
+/// distinguish special from bonus specifically) declines the whole plane
+/// path, falling through to `rarity_candidates`'s postings, which already
+/// answer those two values exactly at the same cost measured before this
+/// change (docs/issues/engine-existential-plane-generalization.md's
+/// "Measured problem" -- their cost tracks candidate count, not narrowing
+/// representation, so nothing is lost by keeping them there). Loose, same as
+/// rarity_candidates: rarity is PrintingDep at card level, so this only
+/// narrows candidates — card_pass/printing-level residual eval still
+/// verifies which printings actually match.
 fn rarity_plane_candidates(indexes: &Archived<CardIndexes>, n_cards: usize, op: CmpOp, val: f64) -> Option<Vec<u64>> {
     if u32::from(indexes.planes.n_cards) as usize != n_cards || n_cards == 0 {
         return None;
@@ -2156,7 +2100,7 @@ fn rarity_plane_candidates(indexes: &Archived<CardIndexes>, n_cards: usize, op: 
     };
     let wpp = words_per_plane(n_cards);
     let mut bits = vec![0u64; wpp];
-    for b in 0..RARITY_PLANES {
+    for b in 0..RARITY_INTERIOR {
         if keep(b as f64) {
             let plane = PLANE_RARITY + b;
             for (a, w) in bits.iter_mut().zip(&indexes.planes.words[plane * wpp..(plane + 1) * wpp]) {
@@ -2164,13 +2108,14 @@ fn rarity_plane_candidates(indexes: &Archived<CardIndexes>, n_cards: usize, op: 
             }
         }
     }
-    for r in RARITY_PLANES..indexes.rarity.len() {
-        if keep(r as f64) {
-            for &cid in indexes.rarity[r].iter() {
-                let cid = u32::from(cid) as usize;
-                bits[cid / 64] |= 1u64 << (cid % 64);
+    match rarity_hi_verdict(op, val) {
+        BucketVerdict::FullyIncluded => {
+            for (a, w) in bits.iter_mut().zip(&indexes.planes.words[PLANE_RARITY_HI * wpp..(PLANE_RARITY_HI + 1) * wpp]) {
+                *a |= u64::from(*w);
             }
         }
+        BucketVerdict::FullyExcluded => {}
+        BucketVerdict::Ambiguous => return None,
     }
     Some(bits)
 }
@@ -2217,7 +2162,6 @@ struct CardIndexes {
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
-    border_planes:  BorderPlanes,              // card space: loose narrowing only for border: (#664), never compile_plane-consumable — see BorderPlanes' doc
 }
 
 impl Default for CardIndexes {
@@ -2246,7 +2190,6 @@ impl Default for CardIndexes {
             planes:         BitPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
-            border_planes:  BorderPlanes::default(),
         }
     }
 }
@@ -3048,24 +2991,25 @@ fn narrow_rec(
             ))
         }
 
-        // border: (#664) — loose, card-level only. Only Eq on the three tracked
-        // values narrows at all; every other op/value (Ne, Lt/Le/Gt/Ge, gold,
-        // yellow, anything unrecognized) declines to the existing full scan,
-        // same as today. See BorderPlanes' doc for why this can never be tight.
+        // border: (#664, promoted to an existential field reaching
+        // compile_plane/all_match for tracked values by #680 -- see
+        // PLANE_BORDER's doc) — loose, card-level narrowing here regardless
+        // of tracked/untracked: a tracked value (black/borderless/white/gold)
+        // reads its own one-hot plane; any other Known value (currently just
+        // yellow) reads the shared `other` plane -- narrower than a full
+        // scan even though the residual walk still has to confirm which
+        // specific value it is. Only Eq is handled (compile_plane's arm
+        // handles the exact tracked-value/all_match path; Not is handled by
+        // narrow_rec's generic complement machinery declining, same as ever,
+        // since this is loose).
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
-            let idx = &indexes.border_planes;
-            if u32::from(idx.n_cards) as usize != n_cards {
-                return None; // archive without border planes for this store
+            if u32::from(indexes.planes.n_cards) as usize != n_cards {
+                return None; // archive without these planes for this store
             }
-            let plane = match value.as_str() {
-                "black" => BORDER_BLACK,
-                "borderless" => BORDER_BORDERLESS,
-                "white" => BORDER_WHITE,
-                _ => return None,
-            };
+            let plane = BORDER_TRACKED_VALUES.iter().position(|&v| v == value.as_str()).map_or(PLANE_BORDER_OTHER, |idx| PLANE_BORDER + idx);
             let wpp = words_per_plane(n_cards);
             let start = plane * wpp;
-            let bits: Vec<u64> = idx.words[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
+            let bits: Vec<u64> = indexes.planes.words[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
             Narrowed::loose(Candidates::CardBits(bits))
         }
 
@@ -3470,7 +3414,7 @@ fn card_match_count(
     // doc): the blind all_match shortcut never applies, and both the
     // residual and the plane must hold for the same printing.
     let satisfies =
-        |pid: usize| eval_plane_expr_for_printing(pe, planes, cid, &printings[pid])
+        |pid: usize| eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
             && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or));
     match mode {
         Mode::Card => {
@@ -3560,7 +3504,7 @@ fn push_card_matches(
             // `card_match_count` is split this way — see its doc.
             let chosen: Option<u32> = if let Some((pe, planes)) = existential_plane {
                 let satisfies = |pid: usize| {
-                    eval_plane_expr_for_printing(pe, planes, cid, &printings[pid])
+                    eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
                         && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
                 };
                 if matches!(prefer, Prefer::Default) {
@@ -3703,7 +3647,7 @@ fn run_query<'a>(
             let mut bitmap = cell.borrow_mut();
             eval_planes(expr, &indexes.planes, &mut bitmap);
             run_query_streamed_popcount(
-                cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap, expr, &indexes.planes,
+                cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap, expr, &indexes.planes, strings,
             )
         });
     }
@@ -3894,6 +3838,7 @@ fn run_query_streamed_popcount<'a>(
     bitmap: &[u64],
     plane: &PlaneExpr,
     planes: &Archived<BitPlanes>,
+    strings: &AStrings,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
@@ -3965,7 +3910,7 @@ fn run_query_streamed_popcount<'a>(
                 let card = &cards[cid as usize];
                 let start = u32::from(offsets[cid as usize]) as usize;
                 let end = u32::from(offsets[cid as usize + 1]) as usize;
-                let satisfies = |pid: usize| !existential || eval_plane_expr_for_printing(plane, planes, cid, &printings[pid]);
+                let satisfies = |pid: usize| !existential || eval_plane_expr_for_printing(plane, planes, cid, &printings[pid], strings);
                 let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
                     (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
                 } else {
@@ -4252,7 +4197,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260722;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260723;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -4647,10 +4592,9 @@ impl QueryEngine {
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: build_artwork_group_counts(&printings, &offsets),
-            planes:         build_bit_planes(&cards, &printings, &offsets),
+            planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
-            border_planes:  build_border_planes(&cards, &printings, &offsets, &strings),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -14,19 +14,26 @@
 //! reproduces the filter's card-level truth exactly.
 //! Legality (docs/issues/engine-legality-divergent-carveout.md, generalized
 //! to banned/restricted by docs/issues/engine-legality-banned-restricted-
-//! planes.md, #678) is exact via two planes per (format, status) -- an
-//! `_EXISTS` plane ("some printing has this status") and an `_ABSENT`/
+//! planes.md, #678) and rarity (docs/issues/engine-rarity-planes.md,
+//! promoted from narrowing-only to existential by docs/issues/engine-
+//! existential-plane-generalization.md, #680) are *existential*, not
+//! card-invariant: a card-level True only means "some printing has this
+//! fact," not "every printing does," so `compile_plane`/`all_match`
+//! promotion for these is gated to `unique=card` and needs a per-printing
+//! recheck at row-selection time (`eval_plane_expr_for_printing`) -- see
+//! `ExistentialLeaf`. Legality is exact via two planes per (format, status)
+//! -- an `_EXISTS` plane ("some printing has this status") and an `_ABSENT`/
 //! `_ILLEGAL` plane ("some printing doesn't"), both computed directly from
 //! printings so they're correct for every card including ones whose
-//! printings disagree, unlike a single card-level bit. Rarity (the 4 most
-//! common values; docs/issues/engine-rarity-planes.md) is narrowing-only, for
-//! the PrintingDep reason legality used to have -- see PLANE_RARITY.
+//! printings disagree, unlike a single card-level bit. Rarity is one-hot for
+//! the 4 tracked values (common/uncommon/rare/mythic) plus one shared
+//! "above mythic" plane for special/bonus -- see `PLANE_RARITY_HI`.
 
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextSearchField};
+use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextField, TextSearchField};
 use super::legality::{LEGALITY_BANNED, LEGALITY_LEGAL, LEGALITY_RESTRICTED, MAX_FORMATS};
-use super::{flip_op, lane_get, oracle_word_eligible, scan_oracle_words, OracleCard, OracleWordIndex, Printing};
+use super::{flip_op, lane_get, negate_op, oracle_word_eligible, scan_oracle_words, str_at, AStrings, OracleCard, OracleWordIndex, Printing, NONE_STR};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
 /// field (W U B R G C, bit order matching color_to_bit — C is always zero for
@@ -100,18 +107,65 @@ pub(crate) const PLANE_POWER_HI: usize = PLANE_POWER + NUM_INTERIOR_WIDTH;
 pub(crate) const PLANE_TOUGHNESS_LO: usize = PLANE_POWER_HI + 1;
 pub(crate) const PLANE_TOUGHNESS: usize = PLANE_TOUGHNESS_LO + 1;
 pub(crate) const PLANE_TOUGHNESS_HI: usize = PLANE_TOUGHNESS + NUM_INTERIOR_WIDTH;
-/// One-hot planes for rarity (docs/issues/engine-rarity-planes.md), covering only the
-/// 4 most common values -- common=0, uncommon=1, rare=2, mythic=3, matching
-/// `magic.rarity_text_to_int`'s numbering directly (no offset needed). special=4/
-/// bonus=5 are far too sparse in production (1.17%/0.00% of cards) to be worth a
-/// fixed-cost plane each; they stay on the existing `RarityIndex` postings path
-/// (`lib.rs`'s `rarity_candidates`). Unlike cmc/power/toughness, there's no interior/
-/// overflow-bucket split: the planed range is the entire domain of interest, not a
-/// window into an unbounded numeric range, so no `BucketBounds` tracking is needed
-/// either -- a plain one-hot block, same shape as `PLANE_TYPES`.
-pub(crate) const RARITY_PLANES: usize = 4;
+/// Rarity planes (docs/issues/engine-rarity-planes.md, promoted to an
+/// existential field reaching `compile_plane`/`all_match` by
+/// docs/issues/engine-existential-plane-generalization.md, #680): one-hot
+/// planes for the 4 most common values -- common=0, uncommon=1, rare=2,
+/// mythic=3, matching `magic.rarity_text_to_int`'s numbering directly (no
+/// offset needed) -- plus one shared "above mythic" plane covering
+/// special=4/bonus=5 together. This is the *same shape* as `PLANE_CMC_HI`/
+/// `PLANE_POWER_HI`/`PLANE_TOUGHNESS_HI` (an interior one-hot range plus one
+/// tail bucket for everything past it), not an unordered "unrecognized value"
+/// catch-all the way border's will be -- rarity is ordinal, so "above
+/// mythic" is exactly what the 5th plane means, no vaguer than that. Unlike
+/// those numeric fields' tail buckets, this one needs no live `BucketBounds`
+/// tracking: `{special, bonus}` is a closed, schema-fixed pair (`magic.
+/// valid_rarities` has exactly 6 rows), not an open-ended observed range, so
+/// `rarity_hi_verdict` compares directly against the two known values instead
+/// of a live [min,max]. `!=val` on any of the 4 tracked values is still exact
+/// (Or of the other 3 tracked planes plus the hi plane -- see
+/// `compile_rarity_cmp`), but a query needing to distinguish special from
+/// bonus specifically (`r:special`, `r:bonus`, `-r:special`, ...) can't be
+/// answered from the hi plane alone and declines, falling back to
+/// `RarityIndex`/`rarity_candidates` (`lib.rs`) exactly as today -- unaffected,
+/// still the fastest path for those two rarely-queried, very sparse values.
+pub(crate) const RARITY_INTERIOR: usize = 4;
 pub(crate) const PLANE_RARITY: usize = PLANE_TOUGHNESS_HI + 1;
-pub(crate) const PLANE_COUNT: usize = PLANE_RARITY + RARITY_PLANES;
+pub(crate) const PLANE_RARITY_HI: usize = PLANE_RARITY + RARITY_INTERIOR;
+
+/// Border planes (docs/issues/done/engine-border-planes.md, #664, promoted
+/// from loose-narrowing-only to an existential field reaching
+/// `compile_plane`/`all_match` by docs/issues/engine-existential-plane-
+/// generalization.md, #680): one-hot planes for the 4 tracked values --
+/// black, borderless, white, gold (`BORDER_TRACKED_VALUES`, in plane-index
+/// order) -- plus one shared "other" plane for any Known-but-untracked value
+/// (currently just `yellow`, all from set `dft`/Aetherdrift; real, current
+/// data, not an ingestion artifact -- checked against the live DB, not
+/// assumed). Unlike rarity's hi bucket, this is NOT an ordinal tail --
+/// border has no ordering at all (`TextExact` only ever compiles `Eq`) -- so
+/// "other" really is an unordered catch-all, and unlike rarity's `{special,
+/// bonus}` it isn't schema-closed either: `card_border` is free text (only
+/// `check_card_border_lowercase` constrains it, no FK/enum the way `magic.
+/// valid_rarities` gives rarity), so a brand new Scryfall border color
+/// someday would fall into `other` rather than silently vanishing from every
+/// plane the way an unenumerated value would with no catch-all at all. `Or`
+/// of the other 3 tracked planes plus `other` is still exact for `!=val` on
+/// a tracked value (see `compile_border_cmp_neg`) for the identical reason
+/// rarity's is: `{black, borderless, white, gold, other, null}` is
+/// exhaustive by construction, whatever a printing's real border turns out
+/// to be. A query naming an untracked value specifically (`border:yellow`)
+/// can't be told apart from any other untracked value by the shared bucket,
+/// so it declines to compile exactly (same shape as `r:special`/`r:bonus`)
+/// but still narrows loosely through `other` in `narrow_rec` -- strictly
+/// better than today's unindexed full scan for those values, even without
+/// reaching Y=1 exactness.
+pub(crate) const BORDER_TRACKED_VALUES: [&str; 4] = ["black", "borderless", "white", "gold"];
+pub(crate) const BORDER_TRACKED: usize = BORDER_TRACKED_VALUES.len();
+pub(crate) const BORDER_PLANES: usize = BORDER_TRACKED + 1;
+pub(crate) const PLANE_BORDER: usize = PLANE_RARITY_HI + 1;
+pub(crate) const PLANE_BORDER_OTHER: usize = PLANE_BORDER + BORDER_TRACKED;
+
+pub(crate) const PLANE_COUNT: usize = PLANE_BORDER + BORDER_PLANES;
 
 /// The observed [min,max] of whatever cards landed in one bucket plane,
 /// recomputed on every build/reload (never hardcoded from a one-time data
@@ -212,7 +266,7 @@ fn set_numeric_plane(
     }
 }
 
-pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32]) -> BitPlanes {
+pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32], strings: &[String]) -> BitPlanes {
     let wpp = words_per_plane(cards.len());
     let mut words = vec![0u64; PLANE_COUNT * wpp];
     let mut cmc_hi = BucketBounds::default();
@@ -224,10 +278,12 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
         let mut set = |plane: usize| words[plane * wpp + i / 64] |= 1u64 << (i % 64);
         // Rarity (docs/issues/engine-rarity-planes.md): "any printing at this
         // rarity" existence projection, same aggregation build_rarity_index
-        // does over the same range, just OR'd into planes instead of postings
-        // for the 4 most common values. Missing rarity (None) contributes no
-        // bit, same as build_rarity_index -- a card whose printings are all
-        // null-rarity correctly sets nothing here.
+        // does over the same range, just OR'd into planes instead of
+        // postings for the 4 tracked values. Missing rarity (None)
+        // contributes no bit, same as build_rarity_index -- a card whose
+        // printings are all null-rarity correctly sets nothing here. Bits 4/5
+        // (special/bonus) fold into the single "above mythic" plane rather
+        // than getting their own -- see PLANE_RARITY_HI's doc.
         let range = offsets[i] as usize..offsets[i + 1] as usize;
         let mut rarity_mask: u8 = 0;
         for p in &printings[range.clone()] {
@@ -235,9 +291,26 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
                 rarity_mask |= 1 << r;
             }
         }
-        for b in 0..RARITY_PLANES {
+        for b in 0..RARITY_INTERIOR {
             if rarity_mask & (1 << b) != 0 {
                 set(PLANE_RARITY + b);
+            }
+        }
+        if rarity_mask >> RARITY_INTERIOR != 0 {
+            set(PLANE_RARITY_HI);
+        }
+        // Border (docs/issues/done/engine-border-planes.md, #664; promoted to
+        // an existential field by #680 -- see PLANE_BORDER's doc): each
+        // printing's border, if known, sets its tracked one-hot plane or the
+        // shared "other" plane.
+        for p in &printings[range.clone()] {
+            if p.card_border_id == NONE_STR {
+                continue;
+            }
+            let s = strings[p.card_border_id as usize].as_str();
+            match BORDER_TRACKED_VALUES.iter().position(|&v| v == s) {
+                Some(idx) => set(PLANE_BORDER + idx),
+                None => set(PLANE_BORDER_OTHER),
             }
         }
         for b in 0..COLOR_PLANES {
@@ -577,7 +650,7 @@ fn matches_op(op: CmpOp, v: f64, threshold: f64) -> bool {
     }
 }
 
-enum BucketVerdict {
+pub(crate) enum BucketVerdict {
     /// Every possible value in the bucket satisfies the comparison.
     FullyIncluded,
     /// No possible value in the bucket satisfies it (including: bucket empty).
@@ -685,6 +758,81 @@ fn compile_numeric_cmp(field: NumField, op: CmpOp, threshold: f64, bounds: &rkyv
     Some(or_of(included))
 }
 
+/// The "above mythic" plane's verdict for `rarity <op> threshold` --
+/// `special`(4)/`bonus`(5) are a closed, schema-fixed pair (`magic.
+/// valid_rarities` has exactly 6 rows), not a live-observed range, so this
+/// compares directly against those two known values rather than reusing
+/// `bucket_verdict`'s `BucketBounds`-based machinery. Deliberately doesn't
+/// reuse `bucket_verdict` itself either: that function's `Ne` arm is
+/// `unreachable!` by contract (every existing caller declines `Ne` before
+/// calling it), whereas rarity's `!=val` on a tracked value genuinely needs
+/// this verdict to resolve `Ne` (see `compile_rarity_cmp`) -- `matches_op`
+/// already implements `Ne` correctly, so comparing both known values
+/// directly through it needs no special-casing at all.
+pub(crate) fn rarity_hi_verdict(op: CmpOp, threshold: f64) -> BucketVerdict {
+    match (matches_op(op, 4.0, threshold), matches_op(op, 5.0, threshold)) {
+        (true, true) => BucketVerdict::FullyIncluded,
+        (false, false) => BucketVerdict::FullyExcluded,
+        _ => BucketVerdict::Ambiguous,
+    }
+}
+
+/// Compile `rarity <op> threshold` to `Or` of the qualifying planes: the 4
+/// tracked one-hot values (never ambiguous -- a one-hot plane is a single
+/// point) plus the shared "above mythic" plane when `rarity_hi_verdict` says
+/// it's fully included. Unlike `compile_numeric_cmp`, `Ne` is not declined
+/// up front: with the domain closed at `{0..=3, hi}` (see `PLANE_RARITY_HI`'s
+/// doc), `!=val` for a tracked `val` is exactly `Or` of the other 3 tracked
+/// planes plus `hi` (safe for the same reason legality's absent-plane
+/// negation is safe -- whatever a printing's real rarity is, it lands in
+/// exactly one of these buckets or is null, so a `True` witness anywhere in
+/// the `Or` really does mean "some printing has a different rarity").
+/// Declines (returns `None`) exactly when the query needs to distinguish
+/// special from bonus specifically (`r:special`, `r:bonus`, `-r:special`,
+/// `-r:bonus`, `rarity>=bonus`, ...) -- the shared plane can't tell them
+/// apart, so those fall back to `RarityIndex` postings (`lib.rs`), unaffected
+/// by this change.
+fn compile_rarity_cmp(op: CmpOp, threshold: f64) -> Option<PlaneExpr> {
+    let mut included: Vec<PlaneExpr> = (0..RARITY_INTERIOR)
+        .filter(|&v| matches_op(op, v as f64, threshold))
+        .map(|v| PlaneExpr::Plane((PLANE_RARITY + v) as u16))
+        .collect();
+    match rarity_hi_verdict(op, threshold) {
+        BucketVerdict::FullyIncluded => included.push(PlaneExpr::Plane(PLANE_RARITY_HI as u16)),
+        BucketVerdict::FullyExcluded => {}
+        BucketVerdict::Ambiguous => return None,
+    }
+    Some(or_of(included))
+}
+
+/// Compile `border == value` to its tracked one-hot plane, or decline for an
+/// untracked value (`other` can't tell which untracked value a printing has --
+/// see `PLANE_BORDER_OTHER`'s doc). `border:gold` and the other 3 tracked
+/// values compile exactly; `border:yellow` (or any future value) declines
+/// here and falls back to `narrow_rec`'s loose narrowing through `other`
+/// instead.
+fn compile_border_cmp(value: &str) -> Option<PlaneExpr> {
+    BORDER_TRACKED_VALUES.iter().position(|&v| v == value).map(|idx| PlaneExpr::Plane((PLANE_BORDER + idx) as u16))
+}
+
+/// Compile `Not(border == value)` for a *tracked* value: `Or` of the other 3
+/// tracked planes plus `other` -- exact for the identical reason
+/// `compile_rarity_cmp`'s `!=val` is: `{black, borderless, white, gold,
+/// other, null}` is exhaustive by construction, so a `True` witness anywhere
+/// in the `Or` really does mean "some printing has a different border."
+/// Declines for an untracked value (`-border:yellow`) -- `other` can't tell
+/// yellow apart from any other untracked value either, same as
+/// `-r:special`/`-r:bonus`.
+fn compile_border_cmp_neg(value: &str) -> Option<PlaneExpr> {
+    let tracked_idx = BORDER_TRACKED_VALUES.iter().position(|&v| v == value)?;
+    let included: Vec<PlaneExpr> = (0..BORDER_TRACKED)
+        .filter(|&i| i != tracked_idx)
+        .map(|i| PlaneExpr::Plane((PLANE_BORDER + i) as u16))
+        .chain(std::iter::once(PlaneExpr::Plane(PLANE_BORDER_OTHER as u16)))
+        .collect();
+    Some(or_of(included))
+}
+
 /// True if `filter` (recursively through And/Or/Not) contains a NumericCmp
 /// on a plane-backed field (cmc/power/toughness). These are NOT safe to
 /// blindly complement via `PlaneExpr::Not`, unlike ColorCmp/TypeCmp/Devotion:
@@ -734,57 +882,103 @@ fn compile_plane_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPl
     order.into_iter().map(|c| compile_plane(c, bounds, words)).collect()
 }
 
-/// Whether plane index `p` falls in any legality existence-projection block
-/// (`LEGALITY_STATUS_TABLE`), regardless of which status/polarity it is.
-fn is_legality_plane(p: usize) -> bool {
-    legality_plane_shift(p).is_some()
+/// Which existential family a plane index addresses, and the per-printing
+/// fact it stands for -- one source of truth consulted by
+/// `plane_expr_is_existential` (mode gating), `collect_existential_indices`
+/// (shared-witness dedup, across every family at once), and
+/// `eval_plane_expr_for_printing` (per-printing row-selection check).
+/// Generalizes what was legality-only (docs/issues/engine-legality-divergent-
+/// carveout.md) to any field whose plane is an existence projection over
+/// printing-varying data, not a card-invariant fact
+/// (docs/issues/engine-existential-plane-generalization.md, #680): a
+/// card-level True here does not imply every printing of the card
+/// individually satisfies the query, unlike colors/types/devotion/numeric
+/// buckets.
+enum ExistentialLeaf {
+    Legality { shift: u8, expected: u64, is_illegal: bool },
+    /// One of the 4 tracked one-hot rarity values (common/uncommon/rare/mythic).
+    RarityTracked(u8),
+    /// The shared "above mythic" plane (special or bonus, indistinguishable
+    /// from each other here -- see `PLANE_RARITY_HI`'s doc).
+    RarityHi,
+    /// One of the 4 tracked one-hot border values (`BORDER_TRACKED_VALUES`).
+    BorderTracked(u8),
+    /// The shared "other" plane (any Known-but-untracked border value,
+    /// indistinguishable from each other here -- see `PLANE_BORDER_OTHER`'s doc).
+    BorderOther,
 }
 
-/// Collect distinct legality plane indices referenced by legality-plane
-/// leaves within `expr`, appending into `out` (deduplicated). Each specific
-/// plane index already identifies one (format, status, polarity) existence
-/// fact, so deduping on the raw index is exactly the right granularity --
-/// simpler than (and a superset of) the old `(format, polarity)` tuple key,
-/// which only had to consider `LEGAL`. Every distinct fact referenced inside
-/// an `And` is shared-witness-prone: `format:A AND -format:A` (same format,
-/// two polarities), `banned:A AND restricted:A` (same format, two statuses),
-/// and `format:A AND format:B` (two formats) are all the identical problem --
-/// a divergent card can satisfy two existence facts via two *different*
-/// witnessing printings, even though no single printing can satisfy both at
-/// once (see `and_of_checked_for_shared_witness`'s doc). A literal duplicate
-/// leaf (`format:A AND format:A`) reads the same plane index and collapses to
-/// one entry, fine to compose -- the same underlying fact checked twice, not
-/// two facts needing a shared witness.
-fn collect_legality_formats(expr: &PlaneExpr, out: &mut Vec<u16>) {
+/// Plane index `p`'s existential family and fact, or `None` for a
+/// card-invariant plane. Derived from `LEGALITY_STATUS_TABLE`, `PLANE_RARITY`'s
+/// range, and `PLANE_BORDER`'s range -- the same single sources of truth
+/// `status_plane_bases`/`compile_rarity_cmp`/`compile_border_cmp` read -- so a
+/// new indexed status or field can never drift out of sync with what this
+/// recognizes.
+fn existential_leaf(p: usize) -> Option<ExistentialLeaf> {
+    for &(expected, exists_base, absent_base) in &LEGALITY_STATUS_TABLE {
+        if (exists_base..exists_base + MAX_FORMATS).contains(&p) {
+            return Some(ExistentialLeaf::Legality { shift: ((p - exists_base) * 2) as u8, expected, is_illegal: false });
+        }
+        if (absent_base..absent_base + MAX_FORMATS).contains(&p) {
+            return Some(ExistentialLeaf::Legality { shift: ((p - absent_base) * 2) as u8, expected, is_illegal: true });
+        }
+    }
+    if (PLANE_RARITY..PLANE_RARITY_HI).contains(&p) {
+        return Some(ExistentialLeaf::RarityTracked((p - PLANE_RARITY) as u8));
+    }
+    if p == PLANE_RARITY_HI {
+        return Some(ExistentialLeaf::RarityHi);
+    }
+    if (PLANE_BORDER..PLANE_BORDER_OTHER).contains(&p) {
+        return Some(ExistentialLeaf::BorderTracked((p - PLANE_BORDER) as u8));
+    }
+    if p == PLANE_BORDER_OTHER {
+        return Some(ExistentialLeaf::BorderOther);
+    }
+    None
+}
+
+/// Collect distinct existential plane indices referenced anywhere within
+/// `expr`, appending into `out` (deduplicated), regardless of which family
+/// (legality, rarity, ...) each belongs to. Each specific plane index already
+/// identifies one existence fact (one format/status/polarity, or one rarity
+/// value), so deduping on the raw index is exactly the right granularity, and
+/// counting across families is deliberate: `format:A AND r:mythic` is the
+/// identical shared-witness problem as `format:A AND format:B` -- a divergent
+/// card can satisfy two existence facts via two *different* witnessing
+/// printings, even though no single printing can satisfy both at once (see
+/// `and_of_checked_for_shared_witness`'s doc), and that's just as true when
+/// the two facts come from different fields as when they come from the same
+/// one. A literal duplicate leaf (`format:A AND format:A`) reads the same
+/// plane index and collapses to one entry, fine to compose -- the same
+/// underlying fact checked twice, not two facts needing a shared witness.
+fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
     match expr {
         PlaneExpr::Plane(p) => {
-            if is_legality_plane(*p as usize) && !out.contains(p) {
+            if existential_leaf(*p as usize).is_some() && !out.contains(p) {
                 out.push(*p);
             }
         }
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => {}
         PlaneExpr::And(cs) | PlaneExpr::Or(cs) => {
             for c in cs {
-                collect_legality_formats(c, out);
+                collect_existential_indices(c, out);
             }
         }
-        PlaneExpr::Not(inner) => collect_legality_formats(inner, out),
+        PlaneExpr::Not(inner) => collect_existential_indices(inner, out),
     }
 }
 
-/// Whether any leaf of a compiled plane expression reads a legality plane
-/// (any status/polarity in `LEGALITY_STATUS_TABLE`). These are existence projections over
-/// per-printing-varying data ("*some* printing has this status") -- unlike
-/// every other plane (colors, types, numeric buckets, devotion, border, all
-/// card-invariant), a card-level True here does not imply every printing of
-/// the card individually satisfies the query. Used to gate the #634 Step 1
-/// `all_match_known` fast path to `unique=card`, where existence is exactly
-/// the semantics needed (docs/issues/engine-legality-divergent-carveout.md;
-/// Step 2's popcount path is already `Mode::Card`-only for unrelated reasons,
-/// see `run_query`).
+/// Whether any leaf of a compiled plane expression reads an existential plane
+/// (any family -- legality's status/polarity blocks, rarity's one-hot
+/// values). Used to gate the #634 Step 1 `all_match_known` fast path to
+/// `unique=card`, where existence is exactly the semantics needed
+/// (docs/issues/engine-legality-divergent-carveout.md,
+/// docs/issues/engine-existential-plane-generalization.md; Step 2's popcount
+/// path is already `Mode::Card`-only for unrelated reasons, see `run_query`).
 pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
     match expr {
-        PlaneExpr::Plane(p) => is_legality_plane(*p as usize),
+        PlaneExpr::Plane(p) => existential_leaf(*p as usize).is_some(),
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => false,
         PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(plane_expr_is_existential),
         PlaneExpr::Not(inner) => plane_expr_is_existential(inner),
@@ -812,7 +1006,7 @@ pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
 fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneExpr> {
     let mut formats = Vec::new();
     for c in &children {
-        collect_legality_formats(c, &mut formats);
+        collect_existential_indices(c, &mut formats);
     }
     if formats.len() > 1 {
         return None;
@@ -876,6 +1070,8 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
         // bit-sliced planes compile exactly within the saturation boundary.
         FilterExpr::Devotion { op, pips } => compile_devotion(*op, *pips),
         FilterExpr::NumericCmp { lhs, op, rhs } => match (lhs, rhs) {
+            (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) => compile_rarity_cmp(*op, *v),
+            (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) => compile_rarity_cmp(flip_op(*op), *v),
             (NumExpr::Field(f), NumExpr::Const(v)) => compile_numeric_cmp(*f, *op, *v, bounds),
             (NumExpr::Const(v), NumExpr::Field(f)) => compile_numeric_cmp(*f, flip_op(*op), *v, bounds),
             _ => None,
@@ -890,21 +1086,43 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
         FilterExpr::Legality { shift: Some(shift), expected } => {
             status_plane_bases(*expected).map(|(exists_base, _)| PlaneExpr::Plane((exists_base + *shift as usize / 2) as u16))
         }
+        // border:x (docs/issues/done/engine-border-planes.md, #664,
+        // promoted by #680 -- see PLANE_BORDER's doc): exact for the 4
+        // tracked values via their one-hot plane. An untracked value
+        // (`border:yellow`) declines here and falls back to narrow_rec's
+        // loose narrowing through `other`; `Not` is handled by
+        // compile_plane_neg, not here.
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => compile_border_cmp(value),
         _ => None,
     }
 }
 
-/// Compile `Not(filter)` directly, pushing negation down to `Legality` leaves
-/// (which need `PLANE_LEGAL_ILLEGAL`, not a bit-complement of
-/// `PLANE_LEGAL_EXISTS`) via De Morgan, while leaves that are safe to
-/// bit-complement (colors/types/devotion/non-null-valued numerics) fall
-/// through to the cheaper "compile positive, wrap in `PlaneExpr::Not`" path
-/// unchanged. Mutually recursive with `compile_plane`.
+/// Compile `Not(filter)` directly, pushing negation down to `Legality` and
+/// rarity leaves -- both need to be *recomputed*, not bit-complemented
+/// (`Legality` needs `PLANE_LEGAL_ILLEGAL`, not a complement of
+/// `PLANE_LEGAL_EXISTS`; rarity needs `compile_rarity_cmp` re-run with
+/// `negate_op` applied, not a complement of the positive Or -- a bit-
+/// complement of `Or(exists-planes)` would wrongly compute "no printing has
+/// this value" (`∀p: r(p)≠val`) instead of the existential `∃p: r(p)≠val`
+/// `compile_rarity_cmp(negate_op(op), val)` already gets right, same
+/// divergent-card trap as Legality's) -- via De Morgan, while leaves that are
+/// safe to bit-complement (colors/types/devotion/non-null-valued numerics)
+/// fall through to the cheaper "compile positive, wrap in `PlaneExpr::Not`"
+/// path unchanged. Mutually recursive with `compile_plane`.
 fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::Legality { shift: Some(shift), expected } => {
             status_plane_bases(*expected).map(|(_, absent_base)| PlaneExpr::Plane((absent_base + *shift as usize / 2) as u16))
         }
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(v) } => {
+            compile_rarity_cmp(negate_op(*op), *v)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            compile_rarity_cmp(negate_op(flip_op(*op)), *v)
+        }
+        // -border:x: recomputed via compile_border_cmp_neg's Or-of-others,
+        // not bit-complemented, same divergent-card reasoning as Legality/rarity.
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => compile_border_cmp_neg(value),
         // Not(And(cs)) = Or(Not(c) for c in cs) -- existence distributes over
         // Or, so no shared-witness check is needed here regardless of how
         // many legality leaves end up among the children.
@@ -992,7 +1210,7 @@ pub(crate) fn split_planes(
                 match compile_plane(&c, bounds, words) {
                     Some(pe) => {
                         let mut fmts = Vec::new();
-                        collect_legality_formats(&pe, &mut fmts);
+                        collect_existential_indices(&pe, &mut fmts);
                         if fmts.is_empty() {
                             planes.push(pe);
                         } else {
@@ -1004,7 +1222,7 @@ pub(crate) fn split_planes(
             }
             let mut all_formats = Vec::new();
             for (_, pe) in &legality_children {
-                collect_legality_formats(pe, &mut all_formats);
+                collect_existential_indices(pe, &mut all_formats);
             }
             if unique_is_card && all_formats.len() <= 1 {
                 for (_, pe) in legality_children {
@@ -1013,7 +1231,7 @@ pub(crate) fn split_planes(
             } else {
                 // 2+ distinct legality existence facts (different formats,
                 // different statuses of the same format, or the same format
-                // under both polarities -- collect_legality_formats dedupes
+                // under both polarities -- collect_existential_indices dedupes
                 // by raw plane index, so all three shapes count the same
                 // way) can't be ANDed together safely regardless of mode
                 // (shared-witness); a single one is safe for the plane's own
@@ -1092,63 +1310,60 @@ pub(crate) fn eval_planes(expr: &PlaneExpr, planes: &rkyv::Archived<BitPlanes>, 
     }
 }
 
-/// If plane `p` is one of legality's existence planes, the (shift, expected,
-/// is_illegal) it addresses -- `shift` matches `FilterExpr::Legality`'s own
-/// field, `expected` is the status the block was built for (`LEGAL`/`BANNED`/
-/// `RESTRICTED`), and `is_illegal` distinguishes an `_ABSENT`/`_ILLEGAL`
-/// (negated-check) plane from its `_EXISTS` counterpart. `None` for every
-/// other (card-invariant) plane. Derived from `LEGALITY_STATUS_TABLE`, the
-/// same single source of truth `status_plane_bases` reads.
-fn legality_plane_shift(p: usize) -> Option<(u8, u64, bool)> {
-    for &(expected, exists_base, absent_base) in &LEGALITY_STATUS_TABLE {
-        if (exists_base..exists_base + MAX_FORMATS).contains(&p) {
-            return Some((((p - exists_base) * 2) as u8, expected, false));
-        }
-        if (absent_base..absent_base + MAX_FORMATS).contains(&p) {
-            return Some((((p - absent_base) * 2) as u8, expected, true));
-        }
-    }
-    None
-}
-
 /// Evaluate a compiled plane expression against one specific printing, rather
 /// than a card's already-known aggregate truth -- needed wherever row
 /// emission picks/verifies a printing for a card whose card-level match came
-/// through a legality leaf (docs/issues/engine-legality-divergent-carveout.md
-/// "Row selection for unique=card"): `legal_exists`/`illegal_exists` only
-/// guarantee *some* printing satisfies the expression, not this one. Every
-/// other (card-invariant) leaf reads the same card-level bit `eval_planes`
-/// would have used -- identical for every printing of the card by
-/// construction -- so this only actually diverges from the card-level answer
-/// at a legality leaf, which consults `printing` directly instead, mirroring
-/// `tri()`'s own per-printing check (`filter.rs`'s `Legality` arm). Callers
-/// only need this for the bounded set of printings being emitted, never the
-/// whole candidate set -- see the design doc for why that scoping is what
-/// makes this cheap instead of repeating the abandoned first design's
-/// performance mistake.
+/// through an existential leaf (docs/issues/engine-legality-divergent-
+/// carveout.md "Row selection for unique=card",
+/// docs/issues/engine-existential-plane-generalization.md): an existence
+/// plane only guarantees *some* printing satisfies the expression, not this
+/// one. Every other (card-invariant) leaf reads the same card-level bit
+/// `eval_planes` would have used -- identical for every printing of the card
+/// by construction -- so this only actually diverges from the card-level
+/// answer at an existential leaf, which consults `printing` directly instead,
+/// mirroring `tri()`'s own per-printing check (`filter.rs`'s `Legality` and
+/// `NumericCmp` arms). Callers only need this for the bounded set of
+/// printings being emitted, never the whole candidate set -- see the design
+/// doc for why that scoping is what makes this cheap instead of repeating the
+/// abandoned first design's performance mistake.
 pub(crate) fn eval_plane_expr_for_printing(
     expr: &PlaneExpr,
     planes: &rkyv::Archived<BitPlanes>,
     cid: u32,
     printing: &rkyv::Archived<Printing>,
+    strings: &AStrings,
 ) -> bool {
     match expr {
         PlaneExpr::Plane(p) => {
             let p = *p as usize;
-            if let Some((shift, expected, is_illegal)) = legality_plane_shift(p) {
-                let status = (u64::from(printing.card_legalities) >> shift) & 0b11;
-                if is_illegal { status != expected } else { status == expected }
-            } else {
-                let wpp = words_per_plane(u32::from(planes.n_cards) as usize);
-                let word = u64::from(planes.words[p * wpp + cid as usize / 64]);
-                (word >> (cid % 64)) & 1 == 1
+            match existential_leaf(p) {
+                Some(ExistentialLeaf::Legality { shift, expected, is_illegal }) => {
+                    let status = (u64::from(printing.card_legalities) >> shift) & 0b11;
+                    if is_illegal { status != expected } else { status == expected }
+                }
+                Some(ExistentialLeaf::RarityTracked(value)) => {
+                    printing.card_rarity_int.as_ref().is_some_and(|v| *v == value)
+                }
+                Some(ExistentialLeaf::RarityHi) => {
+                    printing.card_rarity_int.as_ref().is_some_and(|v| *v >= RARITY_INTERIOR as u8)
+                }
+                Some(ExistentialLeaf::BorderTracked(idx)) => {
+                    str_at(strings, u32::from(printing.card_border_id)) == Some(BORDER_TRACKED_VALUES[idx as usize])
+                }
+                Some(ExistentialLeaf::BorderOther) => str_at(strings, u32::from(printing.card_border_id))
+                    .is_some_and(|s| !BORDER_TRACKED_VALUES.contains(&s)),
+                None => {
+                    let wpp = words_per_plane(u32::from(planes.n_cards) as usize);
+                    let word = u64::from(planes.words[p * wpp + cid as usize / 64]);
+                    (word >> (cid % 64)) & 1 == 1
+                }
             }
         }
         PlaneExpr::Bits(bits) => bitmap_contains(bits, cid),
         PlaneExpr::Const(b) => *b,
-        PlaneExpr::And(children) => children.iter().all(|c| eval_plane_expr_for_printing(c, planes, cid, printing)),
-        PlaneExpr::Or(children) => children.iter().any(|c| eval_plane_expr_for_printing(c, planes, cid, printing)),
-        PlaneExpr::Not(inner) => !eval_plane_expr_for_printing(inner, planes, cid, printing),
+        PlaneExpr::And(children) => children.iter().all(|c| eval_plane_expr_for_printing(c, planes, cid, printing, strings)),
+        PlaneExpr::Or(children) => children.iter().any(|c| eval_plane_expr_for_printing(c, planes, cid, printing, strings)),
+        PlaneExpr::Not(inner) => !eval_plane_expr_for_printing(inner, planes, cid, printing, strings),
     }
 }
 

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -908,32 +908,67 @@ enum ExistentialLeaf {
     BorderOther,
 }
 
+/// How to turn an in-block offset into the specific fact a block's plane
+/// index addresses. Blocks vary in what "the fact" even is (a legality
+/// shift/status pair, a one-hot tracked value, or a single no-payload shared
+/// bucket) -- unifying *that* isn't attempted, only which range of plane
+/// indices belongs to which field, which genuinely is uniform (see
+/// `PLANE_BLOCKS`).
+#[derive(Clone, Copy)]
+enum BlockKind {
+    Legality { expected: u64, is_illegal: bool },
+    RarityTracked,
+    RarityHi,
+    BorderTracked,
+    BorderOther,
+}
+
+struct PlaneBlock {
+    base: usize,
+    len: usize,
+    kind: BlockKind,
+}
+
+/// Single source of truth for every existential field's plane layout: one
+/// entry per contiguous `[base, base+len)` range and what it means. Adding a
+/// field's block here (plus an `ExistentialLeaf` variant and one arm in
+/// `existential_leaf`'s match below) is now the only place that needs to
+/// know its plane layout, instead of a hand-written range check per block --
+/// the range-recognition part really is uniform across fields, unlike the
+/// leaf-construction part (see `BlockKind`'s doc). Legality's 3 statuses ×
+/// 2 polarities become 6 flat entries here, still reading `LEGALITY_STATUS_TABLE`
+/// as their single source of truth so a new indexed status can't drift out
+/// of sync with what this recognizes.
+const PLANE_BLOCKS: [PlaneBlock; 10] = [
+    PlaneBlock { base: LEGALITY_STATUS_TABLE[0].1, len: MAX_FORMATS, kind: BlockKind::Legality { expected: LEGALITY_STATUS_TABLE[0].0, is_illegal: false } },
+    PlaneBlock { base: LEGALITY_STATUS_TABLE[0].2, len: MAX_FORMATS, kind: BlockKind::Legality { expected: LEGALITY_STATUS_TABLE[0].0, is_illegal: true } },
+    PlaneBlock { base: LEGALITY_STATUS_TABLE[1].1, len: MAX_FORMATS, kind: BlockKind::Legality { expected: LEGALITY_STATUS_TABLE[1].0, is_illegal: false } },
+    PlaneBlock { base: LEGALITY_STATUS_TABLE[1].2, len: MAX_FORMATS, kind: BlockKind::Legality { expected: LEGALITY_STATUS_TABLE[1].0, is_illegal: true } },
+    PlaneBlock { base: LEGALITY_STATUS_TABLE[2].1, len: MAX_FORMATS, kind: BlockKind::Legality { expected: LEGALITY_STATUS_TABLE[2].0, is_illegal: false } },
+    PlaneBlock { base: LEGALITY_STATUS_TABLE[2].2, len: MAX_FORMATS, kind: BlockKind::Legality { expected: LEGALITY_STATUS_TABLE[2].0, is_illegal: true } },
+    PlaneBlock { base: PLANE_RARITY, len: RARITY_INTERIOR, kind: BlockKind::RarityTracked },
+    PlaneBlock { base: PLANE_RARITY_HI, len: 1, kind: BlockKind::RarityHi },
+    PlaneBlock { base: PLANE_BORDER, len: BORDER_TRACKED, kind: BlockKind::BorderTracked },
+    PlaneBlock { base: PLANE_BORDER_OTHER, len: 1, kind: BlockKind::BorderOther },
+];
+
 /// Plane index `p`'s existential family and fact, or `None` for a
-/// card-invariant plane. Derived from `LEGALITY_STATUS_TABLE`, `PLANE_RARITY`'s
-/// range, and `PLANE_BORDER`'s range -- the same single sources of truth
-/// `status_plane_bases`/`compile_rarity_cmp`/`compile_border_cmp` read -- so a
-/// new indexed status or field can never drift out of sync with what this
-/// recognizes.
+/// card-invariant plane. Walks `PLANE_BLOCKS` once; which block `p` falls in
+/// (if any) says both which field it belongs to and, via the in-block
+/// offset, which specific fact.
 fn existential_leaf(p: usize) -> Option<ExistentialLeaf> {
-    for &(expected, exists_base, absent_base) in &LEGALITY_STATUS_TABLE {
-        if (exists_base..exists_base + MAX_FORMATS).contains(&p) {
-            return Some(ExistentialLeaf::Legality { shift: ((p - exists_base) * 2) as u8, expected, is_illegal: false });
+    for block in &PLANE_BLOCKS {
+        if !(block.base..block.base + block.len).contains(&p) {
+            continue;
         }
-        if (absent_base..absent_base + MAX_FORMATS).contains(&p) {
-            return Some(ExistentialLeaf::Legality { shift: ((p - absent_base) * 2) as u8, expected, is_illegal: true });
-        }
-    }
-    if (PLANE_RARITY..PLANE_RARITY_HI).contains(&p) {
-        return Some(ExistentialLeaf::RarityTracked((p - PLANE_RARITY) as u8));
-    }
-    if p == PLANE_RARITY_HI {
-        return Some(ExistentialLeaf::RarityHi);
-    }
-    if (PLANE_BORDER..PLANE_BORDER_OTHER).contains(&p) {
-        return Some(ExistentialLeaf::BorderTracked((p - PLANE_BORDER) as u8));
-    }
-    if p == PLANE_BORDER_OTHER {
-        return Some(ExistentialLeaf::BorderOther);
+        let offset = (p - block.base) as u8;
+        return Some(match block.kind {
+            BlockKind::Legality { expected, is_illegal } => ExistentialLeaf::Legality { shift: offset * 2, expected, is_illegal },
+            BlockKind::RarityTracked => ExistentialLeaf::RarityTracked(offset),
+            BlockKind::RarityHi => ExistentialLeaf::RarityHi,
+            BlockKind::BorderTracked => ExistentialLeaf::BorderTracked(offset),
+            BlockKind::BorderOther => ExistentialLeaf::BorderOther,
+        });
     }
     None
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    build_artwork_group_counts, build_bit_planes, build_border_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
+    build_artwork_group_counts, build_bit_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
@@ -227,7 +227,11 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
     // Real planes and bigrams so narrowing tests see the same store shape
     // reload_commit builds (type narrowing goes through the planes since #637).
     let indexes = CardIndexes {
-        planes: build_bit_planes(&cards, &printings, &offsets),
+        // No printing sets card_border_id away from NONE_STR at this point (any
+        // border values a fixture wants get set after store_of returns, same as
+        // border_planes_fixture_store already does), so an empty string table is
+        // safe here -- the border-scatter loop skips every printing regardless.
+        planes: build_bit_planes(&cards, &printings, &offsets, &[]),
         name_bigrams: build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards, &printings, &offsets),
@@ -412,13 +416,26 @@ fn rarity_plane_fixture_store() -> CardData {
         }
     }
     data.indexes.rarity = build_rarity_index(&data.printings, &data.offsets);
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data
+}
+
+/// True for the (op, val) pairs where the shared "above mythic" plane can't
+/// resolve the comparison exactly -- val is 4 (special) or 5 (bonus)
+/// specifically, and the op needs to tell them apart (docs/issues/
+/// engine-existential-plane-generalization.md, #680's "K exact + 1 shared
+/// hi bucket" design, following the same tail-bucket shape as
+/// cmc/power/toughness's PLANE_*_HI, just fixed at [4,5] instead of
+/// live-observed). Every other (op, val) combination is unambiguous because
+/// 4 and 5 always agree on which side of any *other* threshold they fall.
+fn rarity_hi_ambiguous(op: CmpOp, val: f64) -> bool {
+    matches!((val, op), (4.0, CmpOp::Eq | CmpOp::Ne | CmpOp::Le | CmpOp::Gt) | (5.0, CmpOp::Eq | CmpOp::Ne | CmpOp::Lt | CmpOp::Ge))
 }
 
 /// The plane-aware narrowing function must reproduce the true existence
 /// projection ("does any printing of this card satisfy op(rarity, val)") for
-/// every op, across the full 0-5 domain and an impossible threshold — the
+/// every op, across the full 0-5 domain and an impossible threshold, in
+/// every case it doesn't legitimately decline (`rarity_hi_ambiguous`) — the
 /// reference here is brute force over RARITY_PLANE_FIXTURE directly, not
 /// rarity_candidates (which declines for Ne and over-ceiling unions, so it
 /// can't serve as the reference for every op the way the plane path must
@@ -445,19 +462,24 @@ fn rarity_plane_candidates_matches_existence_projection() {
     ];
     for (name, op) in ops {
         for val in [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 2.5, -1.0, 6.0] {
-            let bits = super::rarity_plane_candidates(&archived.indexes, n_cards, op, val).expect("plane path must not decline");
-            let want: Vec<u32> = RARITY_PLANE_FIXTURE
-                .iter()
-                .enumerate()
-                .filter(|(_, rarities)| rarities.iter().any(|r| r.is_some_and(|r| keep(op, f64::from(r), val))))
-                .map(|(cid, _)| cid as u32)
-                .collect();
-            for cid in 0..n_cards as u32 {
-                assert_eq!(
-                    bitmap_contains(&bits, cid),
-                    want.contains(&cid),
-                    "op {name} val {val}: card {cid} membership mismatch"
-                );
+            match super::rarity_plane_candidates(&archived.indexes, n_cards, op, val) {
+                None => assert!(rarity_hi_ambiguous(op, val), "op {name} val {val}: plane path declined unexpectedly"),
+                Some(bits) => {
+                    assert!(!rarity_hi_ambiguous(op, val), "op {name} val {val}: plane path should have declined but didn't");
+                    let want: Vec<u32> = RARITY_PLANE_FIXTURE
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, rarities)| rarities.iter().any(|r| r.is_some_and(|r| keep(op, f64::from(r), val))))
+                        .map(|(cid, _)| cid as u32)
+                        .collect();
+                    for cid in 0..n_cards as u32 {
+                        assert_eq!(
+                            bitmap_contains(&bits, cid),
+                            want.contains(&cid),
+                            "op {name} val {val}: card {cid} membership mismatch"
+                        );
+                    }
+                }
             }
         }
     }
@@ -482,38 +504,96 @@ fn rarity_plane_null_rarity_card_matches_nothing() {
     ];
     for (name, op) in ops {
         for val in [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] {
-            let bits = super::rarity_plane_candidates(&archived.indexes, n_cards, op, val).expect("plane path must not decline");
+            let Some(bits) = super::rarity_plane_candidates(&archived.indexes, n_cards, op, val) else {
+                assert!(rarity_hi_ambiguous(op, val), "op {name} val {val}: plane path declined unexpectedly");
+                continue;
+            };
             assert!(!bitmap_contains(&bits, null_card), "op {name} val {val}: null-rarity card must never match");
         }
     }
 }
 
-/// Rarity is PrintingDep (a card can have printings at multiple rarities), so
-/// it must never be exact-consumed via compile_plane/split_planes -- only the
-/// loose narrowing path (tested above) is sound. This is the correctness
-/// property the whole design depends on: routing rarity through compile_plane
-/// would silently promote it to all_match, skipping the per-printing
-/// verification that resolves mixed-rarity cards correctly.
+/// Rarity is now an existential-plane field (docs/issues/engine-existential-
+/// plane-generalization.md, #680), promoted the same way legality is
+/// (docs/issues/engine-legality-divergent-carveout.md): the 4 tracked values
+/// exact-consume via compile_plane, `!=val` on a tracked value is exact too
+/// (Or of the other tracked planes plus the shared hi plane), but a query
+/// needing to distinguish special from bonus specifically still declines to
+/// compile — the plane can't tell them apart (see `PLANE_RARITY_HI`'s doc) --
+/// and correctly falls back to the (unaffected) narrow_rec/RarityIndex path,
+/// not a silently wrong all_match.
 #[test]
-fn rarity_never_exact_consumed() {
+fn rarity_tracked_values_exact_consumed_hi_bucket_declines() {
     let data = plane_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
-    let rarity = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(3.0) };
-    assert!(compile_plane(&rarity, bounds, words).is_none(), "rarity must never compile to a plane expression");
+    let rarity_eq = |v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(v) };
 
-    // Mixed with an otherwise fully plane-expressible sibling: the rarity
-    // child must stay in the residual, not get silently dropped or promoted.
+    // Tracked values (mythic=3) compile exactly.
+    assert!(compile_plane(&rarity_eq(3.0), bounds, words).is_some(), "r:mythic must compile to a plane expression");
+    // Special/bonus specifically can't be told apart by the shared hi plane.
+    assert!(compile_plane(&rarity_eq(4.0), bounds, words).is_none(), "r:special must decline (hi bucket is ambiguous)");
+    assert!(compile_plane(&rarity_eq(5.0), bounds, words).is_none(), "r:bonus must decline (hi bucket is ambiguous)");
+
+    // Mixed with an otherwise fully plane-expressible sibling: an ambiguous
+    // rarity child must stay in the residual, not get silently dropped or promoted.
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity_eq(4.0)]), bounds, words, true);
     assert!(pe.is_some(), "the creature child must still plane-consume");
     assert!(
         matches!(&residual, FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }),
-        "rarity must remain in the residual, not be consumed to True"
+        "r:special must remain in the residual, not be consumed to True"
     );
+
+    // A tracked value's negation is exact too.
+    let not_mythic = FilterExpr::Not(Box::new(rarity_eq(3.0)));
+    assert!(compile_plane(&not_mythic, bounds, words).is_some(), "-r:mythic must compile to a plane expression");
+}
+
+/// Y=2 shared-witness decline: two distinct rarity plane indices under one
+/// And (whether from the same field, like a bounded range, or a different
+/// field entirely, like legality) can't be answered from independent
+/// existence planes -- the same argument as two distinct legality facts
+/// (docs/issues/engine-existential-plane-generalization.md point 1's hand
+/// verification), now exercised with rarity's own indices in scope.
+#[test]
+fn rarity_shared_witness_declines_same_field_and_cross_field() {
+    let data = legal_plane_fixture();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let rarity_ge = |v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Ge, rhs: NumExpr::Const(v) };
+    let rarity_le = |v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Le, rhs: NumExpr::Const(v) };
+
+    // rarity>=rare AND rarity<=mythic: two distinct tracked plane indices
+    // (rare, mythic) shared between the two Or-trees -- must decline.
+    let bounded_range = FilterExpr::And(vec![rarity_ge(2.0), rarity_le(3.0)]);
+    assert!(compile_plane(&bounded_range, bounds, words).is_none(), "same-field rarity range must decline (shared witness)");
+
+    // format:A AND r:mythic: two distinct fields, still the identical
+    // shared-witness problem -- collect_existential_indices doesn't care
+    // which family a plane index came from.
+    let format_a = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let cross_field = FilterExpr::And(vec![format_a, FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(3.0),
+    }]);
+    assert!(compile_plane(&cross_field, bounds, words).is_none(), "legality+rarity compound must decline (shared witness)");
+
+    // The fallback must still produce the correct (not just declined)
+    // result: no printing in this fixture is both format-A-legal and
+    // mythic, so it must be zero, not a false positive from independently
+    // narrowing each fact.
+    let mut residual_check = cross_field;
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual_check, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no card in this fixture is both format-A-legal and mythic");
 }
 
 /// -rarity:x / rarity:x negation, exercised through narrow_rec end-to-end
@@ -545,14 +625,25 @@ fn rarity_not_arm_matches_existence_projection() {
     ];
     for (name, op) in ops {
         for val in [0.0, 1.0, 2.0, 3.0, 4.0, 5.0] {
-            // Not(field op val).
+            // A tracked value narrows exactly via the plane. Special/bonus
+            // specifically (val 4 or 5, hi-bucket-ambiguous op) may decline
+            // the plane and fall to RarityIndex postings instead -- which can
+            // itself decline for its own, pre-existing, unrelated reason (the
+            // MAX_UNION_FRACTION broadness guard, when the negated op selects
+            // most of the corpus). Either decline is a correct answer (a full
+            // residual scan is always correct, just unnarrowed), so this test
+            // only checks correctness when narrowing *does* happen -- the
+            // plane's own decline boundary is pinned down precisely by
+            // rarity_hi_ambiguous elsewhere, which doesn't depend on corpus
+            // shape the way the postings guard does.
             let filter = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
                 lhs: NumExpr::Field(NumField::RarityInt),
                 op,
                 rhs: NumExpr::Const(val),
             }));
-            let n = super::narrow_rec(&filter, &archived.indexes, &archived.offsets, &archived.cards, true)
-                .unwrap_or_else(|| panic!("Not(rarity {name} {val}) must narrow"));
+            let Some(n) = super::narrow_rec(&filter, &archived.indexes, &archived.offsets, &archived.cards, true) else {
+                continue;
+            };
             let cand = n.set.into_cards(&archived.offsets);
             let want: Vec<u32> = RARITY_PLANE_FIXTURE
                 .iter()
@@ -578,7 +669,7 @@ fn rarity_not_arm_matches_existence_projection() {
                 rhs: NumExpr::Field(NumField::RarityInt),
             }));
             let n2 = super::narrow_rec(&filter_flipped, &archived.indexes, &archived.offsets, &archived.cards, true)
-                .unwrap_or_else(|| panic!("Not({val} {name} field) must narrow"));
+                .unwrap_or_else(|| panic!("Not({val} {name} field) must narrow given Not(field {name} {val}) did"));
             let cand2 = n2.set.into_cards(&archived.offsets);
             assert_eq!(cand, cand2, "operand order must not change the result: {name} {val}");
         }
@@ -772,7 +863,7 @@ fn legal_plane_fixture() -> CardData {
     data.printings[1].card_legalities = (0b01 << 2) | (0b10 << 4); // card1: legal in B, restricted in C
     data.printings[2].card_legalities = 0b01 | (0b11 << 4); // card2 printing 1: legal in A, banned in C
     data.printings[3].card_legalities = 0b01 << 4; // card2 printing 2: not legal in A, legal (not banned) in C
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     data
 }
@@ -924,7 +1015,7 @@ fn legality_cross_status_shared_witness_falls_back_to_correct_result() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0b11 << 4; // banned in C only
     data.printings[1].card_legalities = 0b10 << 4; // restricted in C only
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
@@ -960,7 +1051,7 @@ fn banned_plane_row_selection_preserves_divergent_printing_correctness() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0b01 << 4; // preferred: legal (not banned) in C
     data.printings[1].card_legalities = 0b11 << 4; // non-preferred: banned in C
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -1009,7 +1100,7 @@ fn legal_plane_narrowing_preserves_divergent_printing_correctness() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0; // preferred: not legal
     data.printings[1].card_legalities = 0b01; // non-preferred: legal
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -1054,7 +1145,7 @@ fn legal_plane_narrows_correctly_across_word_boundary() {
     for i in 0..n {
         data.printings[i].card_legalities = if i % 2 == 0 { 0b01 << 2 } else { 0 };
     }
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -1123,7 +1214,7 @@ fn legality_plane_promotion_respects_mode_through_split_planes() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0; // preferred: not legal
     data.printings[1].card_legalities = 0b01; // non-preferred: legal
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -1178,7 +1269,7 @@ fn legality_compound_and_respects_row_selection_for_unique_card() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0; // preferred: not legal in A
     data.printings[1].card_legalities = 0b01; // non-preferred: legal in A
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -1223,7 +1314,7 @@ fn legality_and_date_residual_must_be_checked_together() {
     data.printings[0].released_at_int = Some(20100101); // ...released before the cutoff
     data.printings[1].card_legalities = 0; // not legal in A, but...
     data.printings[1].released_at_int = Some(20220101); // ...released after the cutoff
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
@@ -1311,10 +1402,11 @@ fn fuzz_leaf_rarity(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
     FuzzSpec::Leaf(FuzzLeaf::Rarity { op: fuzz_op(rng), val: rng.random_range(0..=4u8) as f64 })
 }
 fn fuzz_leaf_border(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
-    // "gold" is deliberately untracked by the border planes (they only cover
-    // black/white/borderless) — a decline-to-narrow case that must still be
+    // "yellow" is deliberately untracked by the border planes (#680 tracks
+    // black/white/borderless/gold, folding anything else into the shared
+    // `other` plane) — a decline-to-compile-exactly case that must still be
     // evaluated correctly via the residual path.
-    const BORDERS: [&str; 4] = ["black", "white", "borderless", "gold"];
+    const BORDERS: [&str; 5] = ["black", "white", "borderless", "gold", "yellow"];
     FuzzSpec::Leaf(FuzzLeaf::Border { value: BORDERS[rng.random_range(0..BORDERS.len())].to_string() })
 }
 fn fuzz_leaf_legality(rng: &mut rand::rngs::SmallRng) -> FuzzSpec {
@@ -1430,7 +1522,7 @@ fn fuzz_store(rng: &mut rand::rngs::SmallRng) -> CardData {
     fn rand_word(rng: &mut rand::rngs::SmallRng) -> u64 {
         FUZZ_SHIFTS.iter().fold(0u64, |w, &s| w | (rng.random_range(0..4u64) << s))
     }
-    const BORDERS: [Option<&str>; 5] = [Some("black"), Some("white"), Some("borderless"), Some("gold"), None];
+    const BORDERS: [Option<&str>; 6] = [Some("black"), Some("white"), Some("borderless"), Some("gold"), Some("yellow"), None];
 
     let ncards = rng.random_range(5..=15usize);
     let mut vocab = VocabInterner::new();
@@ -1491,9 +1583,8 @@ fn fuzz_store(rng: &mut rand::rngs::SmallRng) -> CardData {
     // store_of built indexes from the placeholder printings; rebuild every index
     // that depends on the fields mutated above.
     data.indexes.rarity = build_rarity_index(&data.printings, &data.offsets);
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
-    data.indexes.border_planes = build_border_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
     data
 }
@@ -1670,7 +1761,7 @@ fn legality_shared_witness_and_falls_back_to_correct_result() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0b01; // legal in A (shift 0) only
     data.printings[1].card_legalities = 0b01 << 2; // legal in B (shift 2) only
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
@@ -1706,7 +1797,7 @@ fn legality_de_morgan_not_of_compound() {
     let mut data = store_of(vec![card], &[2], vocab);
     data.printings[0].card_legalities = 0b01; // legal in A
     data.printings[1].card_legalities = 0; // not legal in A
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let bounds = &archived.indexes.planes;
@@ -1916,10 +2007,9 @@ fn bench_checked_vs_unchecked_access() {
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups: build_artwork_group_counts(&printings, &offsets),
-        planes:         build_bit_planes(&cards, &printings, &offsets),
+        planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
-        border_planes:  build_border_planes(&cards, &printings, &offsets, &strings),
     };
     let data = CardData {
         cards,
@@ -3621,12 +3711,18 @@ fn trigram_dense_sparse_dispatch_parity() {
     assert_eq!(super::intersect_operands(ops), vec![1, 2, 3, 4, 5, 6], "plane x plane AND path, no posting seed available");
 }
 
-// ─── Border planes (docs/issues/engine-border-planes.md, #664) ─────────────
+// ─── Border planes (docs/issues/done/engine-border-planes.md, #664; promoted
+// to an existential field reaching compile_plane/all_match for the 4 tracked
+// values by docs/issues/engine-existential-plane-generalization.md, #680) ──
 
-/// 8 cards with varied printing-level border colors. Card 3 independently has
+/// 9 cards with varied printing-level border colors. Card 3 independently has
 /// a black printing *and* a separate borderless printing — the shared-witness
 /// correctness canary subject: `border:black border:borderless` must find no
 /// single printing satisfying both, even though the card "has" each color.
+/// Card 5 (gold) is now a *tracked* value, unlike before #680; card 8
+/// (yellow) is the genuinely-untracked subject exercising the shared `other`
+/// plane -- real Scryfall data (all yellow-border cards are from Aetherdrift/
+/// `dft`), not a synthetic placeholder.
 fn border_planes_fixture_store() -> CardData {
     let mut vocab = VocabInterner::new();
     let mut interner = Interner::new();
@@ -3636,9 +3732,10 @@ fn border_planes_fixture_store() -> CardData {
         &[Some("borderless")],                                 // 2: pure borderless
         &[Some("black"), Some("borderless")],                  // 3: shared-witness subject
         &[Some("white")],                                       // 4: pure white
-        &[Some("gold")],                                        // 5: untracked value only
+        &[Some("gold")],                                        // 5: tracked (4th value)
         &[None],                                                 // 6: missing border
-        &[Some("black"), Some("white"), Some("borderless")],   // 7: all three tracked
+        &[Some("black"), Some("white"), Some("borderless")],   // 7: all tracked values at once
+        &[Some("yellow")],                                       // 8: untracked -- the shared `other` plane's subject
     ];
     let cards: Vec<OracleCard> = specs.iter().enumerate().map(|(i, _)| stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab)).collect();
     let printing_counts: Vec<usize> = specs.iter().map(|s| s.len()).collect();
@@ -3651,7 +3748,7 @@ fn border_planes_fixture_store() -> CardData {
         }
     }
     data.strings = interner.strings;
-    data.indexes.border_planes = build_border_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data
 }
 
@@ -3670,11 +3767,11 @@ fn brute_force_has_border(archived: &Archived<CardData>, border: &str) -> Vec<u3
         .collect()
 }
 
-// The narrowed set must match the brute-force existential exactly (a solo
-// leaf's per-card existential really is exact), but must never be marked
-// tight -- these planes are never safe to feed through compile_plane or
-// complement via Not, regardless of how correct they happen to be in
-// isolation. See BorderPlanes' doc for why.
+// narrow_rec's border arm must reproduce the brute-force existential exactly
+// for every tracked value (a solo leaf's per-card existential really is
+// exact), but never mark it tight -- narrow_rec's loose narrowing feeds the
+// residual per-printing walk regardless of what compile_plane can separately
+// do with the same leaf (tested below).
 #[test]
 fn border_planes_exact_union_parity() {
     let data = border_planes_fixture_store();
@@ -3683,12 +3780,20 @@ fn border_planes_exact_union_parity() {
     let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
-    for value in ["borderless", "white"] {
+    for value in ["borderless", "white", "gold"] {
         let expected = brute_force_has_border(archived, value);
         let n = rec(&border(value)).unwrap_or_else(|| panic!("border:{value} must narrow"));
-        assert!(!n.tight, "border planes must always narrow loose, never tight");
+        assert!(!n.tight, "border planes narrow loose through narrow_rec, tight or not is compile_plane's separate call to make");
         assert_eq!(n.set.into_cards(&archived.offsets), expected, "border:{value} narrowed set must match brute force");
     }
+
+    // Untracked (yellow): narrows loosely through the shared `other` plane --
+    // strictly better than declining outright, even though it can't tell
+    // yellow apart from a hypothetical second untracked value.
+    let expected_yellow = brute_force_has_border(archived, "yellow");
+    let n = rec(&border("yellow")).expect("untracked value must still narrow via the shared other plane");
+    assert!(!n.tight);
+    assert_eq!(n.set.into_cards(&archived.offsets), expected_yellow, "border:yellow narrowed set must match brute force");
 }
 
 // The regression test this design exists to guarantee: two independent
@@ -3696,46 +3801,109 @@ fn border_planes_exact_union_parity() {
 // has a black printing and a separate borderless printing, independently
 // satisfying both) -- but no single printing is both, so the real answer
 // (found by the residual per-printing walk the loose narrowing never
-// bypasses) must be zero matches.
+// bypasses) must be zero matches. Checked through both the unplaned path
+// (plane: None, exercising narrow_rec + card_pass alone) and the real planed
+// path (split_planes, exercising compile_plane's new shared-witness decline
+// for border -- see and_of_checked_for_shared_witness's generalization).
 #[test]
 fn border_shared_witness_correctness() {
     let data = border_planes_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
-    let mut f = FilterExpr::And(vec![border("black"), border("borderless")]);
+    let and_both = FilterExpr::And(vec![border("black"), border("borderless")]);
+
+    assert!(
+        compile_plane(&and_both, bounds, words).is_none(),
+        "border:black AND border:borderless must decline to compile exactly (shared witness)"
+    );
+
+    let mut f = and_both;
     let (total, _) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
         &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
-    assert_eq!(total, 0, "no printing is both black and borderless: must be zero matches, not a false positive from independent narrowing");
+    assert_eq!(total, 0, "unplaned: no printing is both black and borderless");
+
+    let (pe, mut residual) = split_planes(
+        FilterExpr::And(vec![border("black"), border("borderless")]), bounds, words, true,
+    );
+    let (total2, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, pe.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total2, 0, "planed: falls back to the same correct zero result, not a false positive from independent narrowing");
 }
 
-// Untracked values (gold/yellow) and non-Eq ops must decline to narrow at all
-// -- but the evaluated result (via the untouched residual path) must still be
-// correct end to end, since narrowing declining is advisory, not a
-// correctness concern.
+/// Tracked values (black/borderless/white/gold) now exact-consume via
+/// compile_plane, mirroring rarity/legality; an untracked value
+/// (`border:yellow`) can't be told apart from any other untracked value by
+/// the shared `other` plane, so it declines to compile exactly -- same shape
+/// as `r:special`/`r:bonus` -- while still narrowing loosely (tested above).
+/// Negation on a tracked value is exact too (Or of the other 3 tracked planes
+/// plus `other`).
 #[test]
-fn border_planes_decline_shapes() {
+fn border_tracked_values_exact_consumed_other_bucket_declines() {
     let data = border_planes_fixture_store();
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
-    let border_eq = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+    let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
-    assert!(rec(&border_eq("gold")).is_none(), "untracked border value must decline to narrow");
-    assert!(rec(&border_eq("yellow")).is_none());
+    for value in ["black", "borderless", "white", "gold"] {
+        assert!(compile_plane(&border(value), bounds, words).is_some(), "border:{value} must compile to a plane expression");
+        let not_value = FilterExpr::Not(Box::new(border(value)));
+        assert!(compile_plane(&not_value, bounds, words).is_some(), "-border:{value} must compile to a plane expression");
+    }
 
-    let border_ne = FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Ne, value: "black".to_string() };
-    assert!(rec(&border_ne).is_none(), "Ne must decline: these planes are never tight, so Not/Ne can't invert them");
+    assert!(compile_plane(&border("yellow"), bounds, words).is_none(), "border:yellow must decline (other bucket is ambiguous)");
+    let not_yellow = FilterExpr::Not(Box::new(border("yellow")));
+    assert!(compile_plane(&not_yellow, bounds, words).is_none(), "-border:yellow must decline (other bucket is ambiguous)");
 
-    let mut f = border_eq("gold");
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    // Mixed with an otherwise fully plane-expressible sibling: the untracked
+    // child must stay in the residual, not get silently dropped or promoted.
+    let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, border("yellow")]), bounds, words, true);
+    assert!(pe.is_some(), "the creature child must still plane-consume");
+    assert!(
+        matches!(&residual, FilterExpr::TextExact { field: TextField::Border, .. }),
+        "border:yellow must remain in the residual, not be consumed to True"
     );
-    assert_eq!(total, 1, "exactly card 5 has a gold printing");
+}
+
+/// The `other` bucket's exact-negation safety net, specifically: a card whose
+/// *only* printing carries an untracked border must still evaluate correctly
+/// (via `Or(..., other)`) for both a positive and a negated query on a
+/// tracked value -- proving the shared bucket really does close the domain by
+/// construction the way the design doc argues, not just for the cards this
+/// fixture happens to include incidentally.
+#[test]
+fn border_other_bucket_closes_domain_for_tracked_negation() {
+    let data = border_planes_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+    let yellow_card = 8u32; // card 8: only printing is yellow (untracked)
+
+    let not_black = FilterExpr::Not(Box::new(FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: "black".to_string() }));
+    let pe = compile_plane(&not_black, bounds, words).expect("-border:black must compile");
+    let mut bits = Vec::new();
+    eval_planes(&pe, bounds, &mut bits);
+    assert!(
+        bitmap_contains(&bits, yellow_card),
+        "a card whose only printing is untracked must satisfy -border:black (it has no black printing)"
+    );
+
+    let black = FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: "black".to_string() };
+    let pe2 = compile_plane(&black, bounds, words).expect("border:black must compile");
+    let mut bits2 = Vec::new();
+    eval_planes(&pe2, bounds, &mut bits2);
+    assert!(!bitmap_contains(&bits2, yellow_card), "the same card must not satisfy border:black");
 }
 
 /// 7 of 8 cards have a black printing (87.5%, past narrow_candidates_exact's
@@ -3751,7 +3919,7 @@ fn border_broadness_fixture_store() -> CardData {
         data.printings[i].card_border_id = interner.intern(border.to_string());
     }
     data.strings = interner.strings;
-    data.indexes.border_planes = build_border_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data
 }
 
@@ -3864,7 +4032,7 @@ fn narrow_fixture_store() -> CardData {
     // rebuilt here too -- build_bit_planes already ran once inside store_of
     // before card_rarity_int was overwritten above, leaving stale (all-zero)
     // rarity plane bits otherwise.
-    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets);
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let mut set_codes: TagIndex = HashMap::new();
     for (i, p) in data.printings.iter().enumerate() {
         set_codes.entry(p.card_set_code.as_str().to_string()).or_default().push(i as u32);

--- a/docs/issues/engine-existential-plane-generalization.md
+++ b/docs/issues/engine-existential-plane-generalization.md
@@ -1,0 +1,206 @@
+# Engine: generalize existential planes beyond legality (Y-predicate framework)
+
+Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+GitHub: #680. Status: proposed, not started. Grew out of investigating #678's rarity follow-on
+(two rejected attempts, see "Measured problem"). Scope widened in discussion to also cover
+`border:` (previously #664/`docs/issues/done/engine-border-planes.md`, which deliberately stopped at
+loose narrowing) — folded in here rather than filed separately, since it's the same registry
+mechanism and strengthens the case that this is a general framework, not a legality-specific or
+even a two-field trick.
+
+## The general shape
+
+Every query is `X` card-invariant predicates AND `Y` printing-varying predicates, ANDed with
+whatever `Or`/`Not` structure the parser produced. `Y` — not which specific field a printing-
+varying predicate belongs to — determines what's achievable:
+
+- **Y=0**: today's fully-tight path. `compile_plane`, `all_match`, Step 2's popcount-skip walk,
+  zero residual verification. Unaffected by anything below.
+- **Y=1**: exactly one printing-varying predicate (any number of card-invariant siblings, which
+  factor straight through the existential: `∃p: g(p) ∧ f_card` = `f_card ∧ ∃p: g(p)`). Total is
+  exact from that predicate's own existence plane — zero scan. Row selection is bounded by the
+  *emitted page* (≤ `limit`), not the candidate set: walk each returned card's printings for the
+  first one satisfying the predicate, conjoined with any genuinely-residual sibling
+  (`eval_plane_expr_for_printing(...) && (all_match || residual_matches(...))`).
+- **Y≥2**: two distinct printing-varying facts can't be answered from independent existence planes
+  — `∃p: f(p) ∧ g(p)` needs one printing to satisfy both at once, which `(∃p: f(p)) ∧ (∃p: g(p))`
+  doesn't guarantee (a card can satisfy each via a *different* printing). No free count; each
+  predicate's own plane can still loosely narrow the candidate set, but membership requires
+  walking every surviving candidate's printings and evaluating all Y predicates jointly against
+  one printing at a time.
+
+This is already exactly what #667 built for legality — `format:A AND format:B` declining is a Y=2
+instance, not a legality-specific rule. It only *looks* field-specific today because legality is
+the only field with existence planes, so "two distinct facts" currently can only mean "two
+distinct formats." The mechanism (`plane_expr_is_existential`, `collect_legality_formats`'s
+shared-witness dedup, `eval_plane_expr_for_printing`) is written generically against raw plane
+indices already — recursing through `Or` (safe: `∃` distributes over `∨`) and declining on 2+
+distinct indices under an `And`. It needs its *range checks* widened to span fields, not its logic
+rewritten.
+
+## Measured problem
+
+Two narrow_rec-level attempts at rarity's `special`/`bonus` values (sparse, currently
+postings-backed while common/uncommon/rare/mythic are planes) both measured as no-ops, isolating
+exactly why a field-local fix can't reach the win:
+
+1. **Promote special/bonus to planes too** (widen `RARITY_PLANES` 4→6): net negative on wide
+   comparisons. `rarity_plane_candidates` already unconditionally builds a `words_per_plane`
+   bitmap for *every* rarity query; this just replaced a cheap ~370-entry postings scatter with
+   two more full-width word-OR passes. `-r:mythic` went 488-579μs → 511-630μs.
+2. **Skip the bitmap, return the postings union directly as `Candidates::Cards`**: no measurable
+   change either. `r:special` stayed at ~74μs, `r:bonus` at ~3-4μs, isolated by comparing the two
+   directly (0 vs. 370 candidates, same code path) — the ~70μs delta tracks candidate *count*, not
+   narrowing *representation*. Because rarity's narrowing is `loose` (never `tight` — it's
+   `PrintingDep` at the card level), the driver still walks and re-verifies every narrowed
+   candidate against the real filter before it can sort/emit. That per-candidate residual pass,
+   not the gather step either attempt touched, is the actual cost.
+
+Both attempts stayed inside `narrow_rec` (today's ceiling for anything not legality). Reaching the
+Y=1 win requires the same three pieces legality has: an exact existence plane reaching
+`compile_plane`, `all_match`-eligibility gated by mode, and a per-page row-selection walk — i.e.
+promoting rarity all the way to where legality already lives, not a cheaper `narrow_rec` trick.
+
+## Where the cost is
+
+`compile_plane`/`split_planes`/`plane_expr_is_existential`/`collect_legality_formats`/
+`eval_plane_expr_for_printing` (all `card_engine/src/planes.rs`) are today hardcoded to legality's
+plane ranges specifically. Rarity's planes (`PLANE_RARITY`) exist but only feed `narrow_rec`,
+always `loose`, always paying full residual verification over the whole candidate set — never
+reaching the code that would let Y=1 skip the scan.
+
+Border is a third instance of the same gap, with an extra wrinkle: `build_border_planes`
+(`card_engine/src/lib.rs:1231-1251`) hardcodes a 3-value match (`"black"`, `"borderless"`,
+`"white"` → a plane index; `_ => continue`), so any other border value — currently `gold` (1,238
+printings) and `yellow` (90 printings, all from set `dft`/Aetherdrift, released 2025-02-14 —
+confirmed real current data, not an ingestion artifact) — contributes to *no* plane at all.
+Unlike rarity, this isn't just an unplaned tail of otherwise-enumerable values: `card_border` has no
+DB-level enum/FK (`check_card_border_lowercase` only constrains case), so there's no schema
+guarantee the domain is closed the way `valid_rarities` guarantees rarity's is. Any exact-plane
+design for border has to construct that closure itself rather than lean on the DB for it.
+
+## Proposed approach
+
+**1. Generalize the existential-plane infrastructure to be field-agnostic.** Replace the
+legality-specific range checks with a small registry of `(field, exists_base, absent_base_or_none,
+per_printing_accessor)` entries that `plane_expr_is_existential`, the shared-witness dedup, and the
+per-printing walk all consult, instead of only knowing about `LEGALITY_STATUS_TABLE`. The
+shared-witness decline logic itself (dedupe distinct plane indices reachable under an `And`,
+recursing safely through `Or`) needs no algorithm change — verified by hand against the
+range-comparison case: `r>=rare AND r<=mythic` compiles each side to an `Or` of several rarity
+plane indices (safe alone — `Or` distributes over `∃`), but the `And` of the two `Or`-trees
+reaches 6 distinct plane indices total (rare/mythic double-counted, common/uncommon/special/bonus
+added), correctly exceeding 1 and declining exactly like two distinct legality facts would. The
+existing index-counting approach already covers this; it just needs rarity's indices in scope.
+
+**2. Give rarity its own existence planes, wired into `compile_plane`, not just `narrow_rec`.**
+`NumericCmp{field: RarityInt, op, val}` compiles to `Or` of the qualifying buckets' existence
+planes — the same construction `rarity_plane_candidates` already does, just moved earlier so it
+can reach `all_match`. One simplification specific to rarity: unlike legality (only 3 of 4 possible
+status values are ever directly queried, so a dedicated `_ABSENT` plane per value is simpler than
+building an unused 4th exists-plane), rarity's domain is fully enumerable *and* every value would
+be planed here — so `!=val` needs no dedicated absent-plane at all, it's just `Or` of the other 5
+values' exists-planes (`∃p: r(p)≠val` ⟺ `∃p: r(p)=v₀ ∨ ... ∨ r(p)=v₅` excluding `val`, since
+exactly one value holds per printing). Simpler than legality's two-plane-per-value shape.
+
+**Confirmed** (traced through code + schema, not just assumed): `card_rarity_int` is `Option<u8>`
+(`NumVal::Null` short-circuits both `Eq` and `Ne` to `Tri::Null` — filter.rs's `NumericCmp` arm — so
+a null-rarity printing never contributes `True` to either side of the equivalence, symmetrically). An
+"unrecognized rarity" value outside the 6 buckets (`rarity_text_to_int` maps unmapped strings to
+`-1`, not `None`) would break it, but the DB forecloses that: `fk_cards_rarity` FKs `card_rarity_int`
+to `magic.valid_rarities`, which contains exactly rows 0-5 — a `-1` fails to load rather than
+persisting. Domain really is exhaustive over `{null, 0..5}`; still worth a differential test at
+implementation time as a regression guard, but the design itself needs no absent-plane fallback.
+
+**3. Mode-gate and wire row selection**, reusing legality's exact shape: `plane_expr_is_existential`
+gates `unique=card`-only promotion (`unique=printing`/`artwork` keep the full per-printing scan,
+unaffected); `eval_plane_expr_for_printing` gets a rarity accessor (`printing.card_rarity_int`,
+already exists) alongside legality's; the conjunction fix
+(`eval_plane_expr_for_printing(...) && (all_match || residual_matches(...))`) applies unchanged in
+shape to whichever field the existential leaf came from.
+
+**4. Give border four exact planes (black/borderless/white/gold) plus one shared loose "other"
+plane**, closing its domain by construction instead of relying on a schema guarantee. `gold` gets
+promoted to a real exists-plane alongside the existing three (cheap: a 5th 3.9KB-class plane is
+noise against the archive). `yellow` — and any future Scryfall border value, since nothing stops
+one from appearing — folds into a single `has_other_border_printing` plane: *∃ a printing whose
+border is Known but isn't one of the 4 tracked values*. This is the piece rarity gets for free from
+`valid_rarities` and border doesn't: with `other` in place, `{black, borderless, white, gold, other,
+null}` is exhaustive by construction, so `!=val`/`Not(border:val)` on any of the 4 tracked values is
+`Or` of the other 3 tracked planes plus `other` — safe for the same reason rarity's Or-of-others is
+safe (whatever a printing's real border is, it lands in exactly one of these buckets or is null).
+
+This is a genuine widening of point 1's registry, not just more data in the same shape: rarity's (and
+legality's) bucket lists are *all* exact/existential-eligible, but border needs the registry to
+distinguish "K exact, existential-eligible buckets" from "1 shared loose bucket, valid as an
+Or-of-others disjunct and for candidate narrowing, never itself promoted through `compile_plane`/
+`all_match`." A query naming a value that isn't one of the 4 tracked ones (`border:yellow`, or a
+hypothetical future color) can't be answered from `other` alone — it's a disjunction over
+unspecified values, not a specific one — so it narrows candidates via `other` (strictly better than
+today's zero narrowing for such values) and still falls through to a full residual walk to confirm
+the actual value, the same fallback shape rarity's pre-generalization special/bonus already used.
+Shared-witness Y≥2 decline needs no new logic: `border:black AND border:borderless` already
+declines correctly today via loose narrowing + residual (#664's `border_shared_witness_correctness`
+test) — the exact-plane version must reproduce the same decline via index-counting (2 distinct
+tracked indices under an `And`), which is exactly what point 1's mechanism already does. Row
+selection needs a `printing.card_border_id` accessor in `eval_plane_expr_for_printing` alongside
+legality's and rarity's, same conjunction-fix shape.
+
+**5. Y≥2 stays declined, not solved.** The joint per-printing evaluator
+(`docs/issues/engine-printing-varying-plane-repair-pattern.md`'s `eval_plane_expr_for_divergent_card`
+design, prototyped for legality and never shipped) is *not* part of this issue. Once rarity and
+border are second and third fields, `r:special AND f:modern` and `border:gold AND r:mythic` become
+real, plausible Y=2 query shapes — more plausible than `format:A AND format:B` ever was — worth
+remeasuring after this ships to see if they show up enough in the broad survey to justify building
+the joint evaluator later. Building it speculatively
+now is exactly the kind of unrequested complexity to avoid; the existing decline-and-fall-back
+behavior (loose per-field narrowing + full residual verification) is correct today for any Y≥2
+shape and stays correct after this generalization, just reachable via more field combinations.
+
+## Acceptance
+
+1. Baseline (targeted rarity script `scripts/bench_rarity_planes.py`, targeted border script
+   `scripts/bench_border_planes.py`, broad survey, memory) on `main`, same corpus/seed convention as
+   #678/#664.
+2. Targeted: `r:special`/`r:bonus` solo and negated should approach the few-microsecond floor
+   legality's sparsest values hit (`banned:alchemy` at 5μs); compound with card-invariant siblings
+   (`r:special t:creature`); the Y=2 declines (`r:special AND f:modern`, `r>=rare AND r<=mythic`)
+   verified both to decline *and* to still produce correct results via the fallback (not just a
+   decline check — mirror `legality_shared_witness_and_falls_back_to_correct_result`); `unique=
+   printing`/`artwork` unaffected; controls unaffected.
+3. Targeted, border: `border:black`/`borderless`/`white`/`gold` solo and negated (expect the same
+   few-microsecond floor for the three non-declining ones — `border:black` alone still declines via
+   the existing broadness guard, unchanged from #664); compound with a card-invariant sibling
+   (`border:gold type:creature`); `border:yellow` (expect improved-but-not-zero-scan — narrowed via
+   `other`, verified via residual, strictly faster than today's unindexed full scan but not the Y=1
+   floor); a fixture with a synthetic 6th/unenumerated border value exercising `other`'s safety-net
+   role specifically (proving a future Scryfall value can't silently reopen the domain-completeness
+   gap); `border:black AND border:borderless` (must still return zero matches — the #664 correctness
+   canary, now re-verified at the exact-plane level, not just loose narrowing); `unique=printing`/
+   `artwork` unaffected; controls unaffected.
+4. Correctness review at the same rigor #667 needed — it found three separate holes
+   (mode-aware `all_match`, row-selection picking the wrong printing, the conjunction fix) across
+   multiple review rounds despite careful design up front, and a fourth (a ~15% regression the
+   targeted script couldn't see, only the broad survey could). Expect the same here: broad survey
+   is not optional, and the row-selection/conjunction tests need to check the actual returned
+   `scryfall_id` on a fixture where the preferred printing is deliberately the non-matching one, not
+   just totals. For border specifically, also re-verify the `other`-bucket safety net directly: a
+   store where a card's only printings carry an unenumerated border value must still evaluate
+   correctly (via residual fallback) for both positive and negated queries on the tracked values.
+5. Total-row-count parity on every config, every run.
+6. Re-measure and iterate; open PR.
+
+## Related
+
+- `docs/issues/engine-legality-divergent-carveout.md` (#667/#676) — the concrete Y=1 instance this
+  generalizes; every correctness hole found there is a hole to specifically re-check here
+- `docs/issues/engine-legality-banned-restricted-planes.md` (#678) — where the rarity follow-on
+  (and the two rejected narrow_rec-level attempts motivating this doc) came from
+- `docs/issues/engine-rarity-planes.md` — the existing `narrow_rec`-only rarity planes this
+  extends
+- `docs/issues/done/engine-border-planes.md` (#664) — the existing loose-only, 3-value border
+  planes this extends to 4 exact + 1 loose catch-all; its shared-witness correctness test
+  (`border_shared_witness_correctness`) is the regression this issue's exact-plane version must
+  keep passing, not just the loose-narrowing version
+- `docs/issues/engine-printing-varying-plane-repair-pattern.md` — the joint per-printing evaluator
+  this issue deliberately does not build (Y≥2 stays declined)

--- a/docs/issues/engine-existential-plane-generalization.md
+++ b/docs/issues/engine-existential-plane-generalization.md
@@ -1,7 +1,8 @@
 # Engine: generalize existential planes beyond legality (Y-predicate framework)
 
 Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
-GitHub: #680. Status: proposed, not started. Grew out of investigating #678's rarity follow-on
+GitHub: #680. Status: implemented (rarity + border), benchmarked, pending PR merge. Grew out of
+investigating #678's rarity follow-on
 (two rejected attempts, see "Measured problem"). Scope widened in discussion to also cover
 `border:` (previously #664/`docs/issues/done/engine-border-planes.md`, which deliberately stopped at
 loose narrowing) — folded in here rather than filed separately, since it's the same registry
@@ -189,6 +190,54 @@ shape and stays correct after this generalization, just reachable via more field
    correctly (via residual fallback) for both positive and negated queries on the tracked values.
 5. Total-row-count parity on every config, every run.
 6. Re-measure and iterate; open PR.
+
+## Results
+
+Implemented in two commits: the field generalization itself (rarity's 4 tracked + 1 ordinal hi
+bucket, border's 4 tracked + 1 unordered `other` bucket, both reaching `compile_plane`/`all_match`),
+then a follow-up extracting `existential_leaf`'s plane-index-range recognition into a single static
+`PLANE_BLOCKS` table walked in a loop (replacing a hand-written if-chain per field) — kept separate
+since it's a distinct, lower-risk change than the field work itself, done as a self-review pass
+after the fact rather than folded in. Both commits: 113 tests passing (debug + release), clippy
+output identical to `main` (verified via a temporary worktree diff, not just eyeballed), zero total-
+count mismatches across every benchmark run.
+
+Targeted (`scripts/bench_rarity_planes.py` / `scripts/bench_border_planes.py`,
+`benchmarks/bitplanes/corpus.jsonl`, 97,206 printings):
+
+| config | before | after | change |
+|---|---|---|---|
+| `r:common`/`uncommon`/`rare`/`mythic` (solo) | 0.12-0.25ms | 0.058-0.062ms | 2.1-4.1x |
+| `rarity<=mythic`, `rarity>=uncommon` | 0.35-0.39ms | 0.074-0.075ms | 4.7-5.4x |
+| `r!=mythic`, `r!=common` | 0.35-0.46ms | 0.074-0.075ms | 4.6-6.3x |
+| `r>=rare`, `-r:common` | 0.28-0.42ms | 0.074-0.076ms | 3.8-5.6x |
+| `-r:mythic` | 0.55ms | 0.075ms | 7.4x |
+| `t:creature r:mythic` | 0.094ms | 0.066ms | 1.4x |
+| `r:special`/`r:bonus` (unaffected control) | 0.075ms / 3.4μs | 0.074ms / 3.3μs | ~1.0x |
+| `f:modern r:mythic` (Y=2, unaffected) | 0.123ms | 0.118ms | ~1.0x |
+| `r:mythic` (`unique=printing`/`artwork`, unaffected) | 0.18-0.21ms | 0.17-0.19ms | ~1.0-1.1x |
+| `border:borderless`/`white` (solo) | 0.17-0.21ms | 0.062-0.063ms | 2.7-3.4x |
+| `border:black` (was decline-via-broadness) | 0.43ms | 0.072ms | 5.9x |
+| `border:gold` (now tracked, was unindexed) | 0.91ms | 0.060ms | 15.0x |
+| `border:yellow` (untracked, now via `other`) | 0.93ms | 0.062ms | 14.9x |
+| `-border:black`, `-border:white` | 0.49-1.17ms | 0.074-0.099ms | 6.6-11.8x |
+| `border:black AND border:borderless` (=0, Y=2 canary) | 0.33ms | 0.31ms | ~1.05x |
+| controls (both scripts) | — | — | flat |
+
+**Geometric mean:** rarity 2.24x (21 configs), border 2.38x (17 configs)
+**Test corpus:** `benchmarks/bitplanes/corpus.jsonl`, 97,206 printings / 31,508 cards
+
+Broad survey (`scripts/survey_queries.py`, 400 generated + 120 wild, seed 42, 520 queries):
+**0 total-count mismatches** across every query, both stages. Overall geomean 1.02x (most queries
+don't touch rarity/border at all, as expected); border-tagged geomean 1.03x over 7 queries drawn by
+this seed (rarity-tagged: 0 queries drawn — `client/query_runner.py` has no rarity dimension at all,
+so this seed's wild slice carries no rarity coverage; the targeted script is doing the real
+verification work there, matching the plan in Acceptance item 1).
+
+Memory: `+11.8KB` archive growth (69,015,816 → 69,027,636 bytes), matching the plane-count math
+exactly (net +3 planes after removing the old standalone `BorderPlanes` struct: rarity's `+1` hi
+bucket, border's `+5` unified planes, `-3` for the removed struct, at ~3.9KB/plane).
+`reload_peak` unchanged.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Extends the legality divergent-card existential-plane machinery (#667/#676/#678) to rarity and border. common/uncommon/rare/mythic and black/borderless/white/gold each get exact one-hot planes reaching `compile_plane`/`all_match`; a shared bucket (rarity's ordinal "above mythic", border's unordered "other") covers the untracked tail so `!=val` stays exact via Or-of-others without every value needing its own plane. Y≥2 shared-witness decline (same-field ranges, or cross-field like `format:A AND r:mythic`) needed zero new logic — just widening which plane indices the existing dedup mechanism recognizes.

Border's old standalone `BorderPlanes` struct is removed entirely, folded into the unified `BitPlanes` alongside legality/rarity.

Design doc: [docs/issues/engine-existential-plane-generalization.md](../blob/existential-planes-rarity-border-680/docs/issues/engine-existential-plane-generalization.md)

## Changes

- Generalize `plane_expr_is_existential`/shared-witness dedup/row-selection check (`planes.rs`) from legality-only into a field-agnostic `ExistentialLeaf` dispatch, now covering legality, rarity, and border.
- Rarity: common/uncommon/rare/mythic get exact planes; special+bonus share one ordinal "above mythic" plane (same shape as the existing `PLANE_CMC_HI`-style tail buckets, just closed-range instead of live-observed). `r:special`/`r:bonus` specifically decline to compile exactly and fall back to the existing `RarityIndex` postings, unaffected.
- Border: black/borderless/white/gold get exact planes; any other Known value (yellow, or a future Scryfall color) folds into a shared unordered `other` plane.
- `build_bit_planes`/`eval_plane_expr_for_printing` both gained a `strings` parameter (border's per-printing check needs the interned string table); propagated through all call sites.
- Bumped `ARCHIVE_FORMAT_VERSION` (archive layout changed — `BitPlanes` grew, `CardIndexes` lost the `border_planes` field).
- Follow-up commit: extracted `existential_leaf`'s plane-index-range recognition into a single static `PLANE_BLOCKS` table walked in a loop, replacing a hand-written if-chain per field. The `BlockKind` match it introduces has no wildcard arm, so adding a block kind without wiring up its construction is now a compile error — same deliberate exhaustive-match convention `FilterExpr`'s `verify_cost_tier`/`printing_dependent` already use.
- Extended tests: rarity's hi-bucket ambiguity boundary, border's other-bucket domain-closure safety net (a synthetic unenumerated value), same-field and cross-field Y≥2 shared-witness declines with real fixtures, all with real fixtures rather than assertions on totals alone. The #677 row-identity fuzzer (which already randomizes rarity/border leaves) passed clean throughout, including through the border struct migration.

## Related issues

Closes #680

---

## Performance

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `r:common`/`uncommon`/`rare`/`mythic` (solo) | 0.12-0.25ms | 0.058-0.062ms | 2.1-4.1x |
| `rarity<=mythic`, `rarity>=uncommon` | 0.35-0.39ms | 0.074-0.075ms | 4.7-5.4x |
| `r!=mythic`, `r!=common` | 0.35-0.46ms | 0.074-0.075ms | 4.6-6.3x |
| `-r:mythic` | 0.55ms | 0.075ms | 7.4x |
| `r:special`/`r:bonus` (unaffected control) | 0.075ms / 3.4μs | 0.074ms / 3.3μs | ~1.0x |
| `f:modern r:mythic` (Y=2, unaffected) | 0.123ms | 0.118ms | ~1.0x |
| `border:borderless`/`white` (solo) | 0.17-0.21ms | 0.062-0.063ms | 2.7-3.4x |
| `border:black` (was decline-via-broadness) | 0.43ms | 0.072ms | 5.9x |
| `border:gold` (now tracked, was unindexed) | 0.91ms | 0.060ms | 15.0x |
| `border:yellow` (untracked, now via `other`) | 0.93ms | 0.062ms | 14.9x |
| `-border:black`, `-border:white` | 0.49-1.17ms | 0.074-0.099ms | 6.6-11.8x |
| `border:black AND border:borderless` (=0, Y=2 canary) | 0.33ms | 0.31ms | ~1.05x |
| controls (both scripts) | — | — | flat |

**Geometric mean:** rarity 2.24x (21 configs), border 2.38x (17 configs)
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl`, 97,206 printings / 31,508 cards

Broad survey (`scripts/survey_queries.py`, 400 generated + 120 wild, seed 42, 520 queries): **0 total-count mismatches** across every query. Overall geomean 1.02x (most queries don't touch rarity/border), border-tagged geomean 1.03x over 7 queries this seed drew.

Memory: +11.8KB archive growth, matching the plane-count math exactly (net +3 planes after removing the old standalone `BorderPlanes` struct). `reload_peak` unchanged.

---

## Deployment notes

Archive format version bump means any existing on-disk archive gets rebuilt on next load — same as every prior plane-adding PR in this repo's history, no special handling needed beyond that.

## Reviewer notes

Known tradeoffs, surfaced during review of my own diff before opening this:

- The "small registry" the design doc originally imagined (a literal `(field, exists_base, ..., accessor)` data table) didn't fully materialize — `existential_leaf`'s *range recognition* is now genuinely table-driven (`PLANE_BLOCKS`), but `compile_rarity_cmp`/`compile_border_cmp`/the per-printing accessor match in `eval_plane_expr_for_printing` are still field-specific functions/arms, not generic. Legality, rarity, and border are three real, non-identical shapes (symmetric exists/absent pair; ordinal K-tracked+1-hi-bucket; unordered K-tracked+1-catchall) — I didn't think forcing them into one generic closure/trait was worth the indirection on a per-printing hot path without a kernel benchmark backing it, given only 3 fields exist today.
- `RarityIndex`/`rarity_candidates`/`build_rarity_index` (`lib.rs`) are now only reachable for the narrow special-vs-bonus-specific decline case — real, if modest, dead weight left in place rather than removed in this PR. Flagged in a comment as worth a follow-up cleanup.