### PR TITLE
Normalize Missing flavor_text to Empty String

### DIFF
--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -156,6 +156,13 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
     card.setdefault("face_name", card.get("name"))
     card.setdefault("face_idx", 1)
 
+    # Scryfall omits flavor_text entirely when a printing has none (unlike oracle_text, which it
+    # always sends, empty string included, even for vanilla cards). Normalize to '' so negated
+    # flavor-text filters treat "no flavor text" as empty, matching Scryfall's own search behavior
+    # (confirmed empirically: -flavor:<impossible> includes flavorless prints on scryfall.com) and
+    # the engine's existing unwrap_or_default() handling.
+    card["flavor_text"] = card.get("flavor_text") or ""
+
     # Store the original card data before modifications for raw_card_blob
     raw_card_data = copy.deepcopy(card)
     card["raw_card_blob"] = raw_card_data

--- a/api/db/2026-07-14-01-flavor-text-null-backfill.sql
+++ b/api/db/2026-07-14-01-flavor-text-null-backfill.sql
@@ -1,0 +1,3 @@
+UPDATE magic.cards SET flavor_text = '' WHERE flavor_text IS NULL;
+ALTER TABLE magic.cards ALTER COLUMN flavor_text SET NOT NULL;
+ALTER TABLE magic.cards ALTER COLUMN flavor_text SET DEFAULT '';

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -344,6 +344,31 @@ class TestCardProcessing:
         assert result["price_eur"] is None
         assert result["price_tix"] is None
 
+    def test_preprocess_card_defaults_missing_flavor_text_to_empty_string(self) -> None:
+        """Scryfall omits flavor_text entirely when a printing has none; we normalize to ''."""
+        card = create_test_card()
+        assert "flavor_text" not in card
+
+        result = preprocess_card(card)
+
+        assert result[0]["flavor_text"] == ""
+
+    def test_preprocess_card_defaults_null_flavor_text_to_empty_string(self) -> None:
+        """An explicit null flavor_text (not just an absent key) also normalizes to ''."""
+        card = create_test_card(flavor_text=None)
+
+        result = preprocess_card(card)
+
+        assert result[0]["flavor_text"] == ""
+
+    def test_preprocess_card_preserves_present_flavor_text(self) -> None:
+        """A real flavor_text value passes through unchanged."""
+        card = create_test_card(flavor_text="A flavor line.")
+
+        result = preprocess_card(card)
+
+        assert result[0]["flavor_text"] == "A flavor line."
+
     def test_preprocess_card_handles_non_numeric_power_toughness(self) -> None:
         """Test preprocess_card handles non-numeric power/toughness values."""
         card = create_test_card(


### PR DESCRIPTION
## Summary

Scryfall omits the `flavor_text` key entirely for printings with none, but always sends `oracle_text` (empty string included, even for vanilla creatures). Because of that asymmetry, negated text filters diverged between the engine and SQL:

- `-o:draw` already agrees between engine and SQL — `oracle_text` is never NULL in the DB (Scryfall always sends it), and the engine's `unwrap_or_default()` matches.
- `-flavor:draw` did **not** agree — 45,015 of 97,206 printings have `flavor_text IS NULL`, so SQL's `NOT (NULL LIKE ...)` → NULL → excluded, while the engine (same `unwrap_or_default()` treatment) already includes them.

## Which behavior is right?

Checked scryfall.com's live search directly rather than guessing:

| Query (`game:paper unique:prints -is:funny`) | `total_cards` |
|---|---|
| baseline | 95,042 |
| `-o:zzzzznonsenseword` | 95,042 |
| `-flavor:zzzzznonsenseword` | 95,042 |
| `has:flavor` | 51,559 |
| `-has:flavor` | 43,483 (sums exactly to baseline) |

Both negated searches for an impossible needle return the full baseline count, and `has:flavor`/`-has:flavor` partition the corpus exactly with no third "unknown, excluded either way" bucket. Scryfall treats missing text as empty, not as SQL NULL — so the engine's existing behavior is the one to standardize on.

## Change

- `preprocess_card`: default missing/null `flavor_text` to `''` at ingest (mirrors the existing `creature_power_text`/`creature_toughness_text` explicit-default pattern).
- New migration: backfill existing NULL rows to `''`, then `ALTER COLUMN flavor_text SET NOT NULL, SET DEFAULT ''`.
- No engine change needed — `unwrap_or_default()` already does the right thing.

Closes the local `engine-null-vs-empty-text-parity` tracking doc.

## Test plan

- [x] `api/tests/test_card_processing.py` — 3 new tests (missing key, explicit `null`, real value passes through unchanged); full file passes (25/25)
- [x] `api/tests/test_upsert_cards.py`, `api/tests/test_import_card_by_name.py` pass (29/29)
- [x] Migration dry-run against blue DB in a rolled-back transaction: 45,015 rows backfilled, `ALTER TABLE` succeeds, `information_schema.columns` confirms `NOT NULL` + `DEFAULT ''`
- [x] `ruff check` clean