### PR TITLE
Make price_bounds Exact Instead of Widened-and-Deferred

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1918,17 +1918,33 @@ fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u
     idx
 }
 
+/// Every stored price is exactly cent-precise (checked against the corpus: 0 of 81,540 priced
+/// printings differ from their rounded-to-cent value by more than 0.001) and the real max price
+/// ($5,142.02) is far below where f32 loses cent resolution (ULP ~$0.0006 there, 16x finer than
+/// a cent) — verified collision-free for every adjacent cent pair up to $50,000, 10x the real
+/// max (`f32_sort_bits_distinguishes_every_cent_up_to_50k` in tests.rs). So snapping to the
+/// cents grid via floor/ceil before computing bounds — the same technique `int_range_bounds`
+/// uses for `collector_number`'s integer domain — gives an exact bound for any threshold,
+/// on-grid or not (`price_bounds_matches_direct_comparison_on_and_off_grid`), with no need to
+/// defer to a downstream verify pass.
+const PRICE_CENTS_PER_DOLLAR: f64 = 100.0;
+
 /// Half-open [lo, hi) sort-bits bounds for `price op value`, or None for Ne.
-/// Query values are f64 while prices are f32, so bounds are widened by one
-/// position where rounding could otherwise exclude a real match — narrowing
-/// must stay a superset; the walk verifies exactly.
 fn price_bounds(op: CmpOp, value: f64) -> Option<(u32, u32)> {
-    let b = f32_sort_bits(value as f32);
+    let cent_to_bits = |c: f64| f32_sort_bits((c / PRICE_CENTS_PER_DOLLAR) as f32);
     match op {
         CmpOp::Ne => None,
-        CmpOp::Eq => Some((b, b.saturating_add(1))),
-        CmpOp::Lt | CmpOp::Le => Some((0, b.saturating_add(1))),
-        CmpOp::Gt | CmpOp::Ge => Some((b, u32::MAX)),
+        // Eq's single-bit-pattern bound has no strict/non-strict ambiguity to resolve, so it
+        // doesn't need cents-snapping: an off-grid value (no real price could ever equal it)
+        // correctly narrows to nothing, exactly as it does today.
+        CmpOp::Eq => {
+            let b = f32_sort_bits(value as f32);
+            Some((b, b.saturating_add(1)))
+        }
+        CmpOp::Lt => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()))),
+        CmpOp::Le => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0))),
+        CmpOp::Gt => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0), u32::MAX)),
+        CmpOp::Ge => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()), u32::MAX)),
     }
 }
 
@@ -2557,8 +2573,11 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
         FilterExpr::NumericCmp { lhs, rhs, .. } => {
             let f = |e: &NumExpr| match e {
                 NumExpr::Field(NumField::Cmc | NumField::Power | NumField::Toughness) => Some(false),
-                // Price is absent deliberately: its bounds are widened
-                // supersets (see range_narrowed), never tight.
+                // Price is absent deliberately, even though price_bounds now produces exact
+                // (not widened) bounds: this classifier gates the Not arm's complement-safety
+                // check, which is a separate question from range_narrowed's own exactness —
+                // deferred to local-engine-broad-range-fastpath.md's fastpath work, not yet
+                // reviewed for composition safety here.
                 NumExpr::Field(NumField::CollectorNumberInt) => Some(true),
                 NumExpr::Const(_) => None,
                 _ => None,
@@ -2837,7 +2856,7 @@ fn narrow_rec(
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
             let price = |op, v: &f64| {
-                price_bounds(op, *v).and_then(|(lo, hi)| range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, false))
+                price_bounds(op, *v).and_then(|(lo, hi)| range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true))
             };
             let cn = |op, v: &f64| match int_range_bounds(op, *v)? {
                 None => Narrowed::tight(Candidates::Printings(Vec::new())),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1929,6 +1929,22 @@ fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u
 /// defer to a downstream verify pass.
 const PRICE_CENTS_PER_DOLLAR: f64 = 100.0;
 
+/// `value * PRICE_CENTS_PER_DOLLAR` is itself a new floating-point operation, not a lossless
+/// relabeling — for roughly a quarter of two-decimal dollar amounts it lands just off the
+/// intended integer (`0.28_f64 * 100.0 == 28.000000000000004`, `0.57_f64 * 100.0 ==
+/// 56.99999999999999`), which silently shifts floor/ceil's result by a whole cent and produces a
+/// real false negative at that exact boundary (caught in review: `Ge(0.28)` against a printing
+/// priced at exactly $0.28). Snap back to the intended integer first — the error from the
+/// multiplication is on the order of 1e-10 to 1e-15 (`5142.02_f64 * 100.0 ==
+/// 514202.00000000006`), so 1e-6 has enormous margin over the noise while staying far below the
+/// smallest gap we'd ever want to preserve between a genuinely off-grid threshold and its
+/// nearest real cent value (>= 0.005 in every case checked in
+/// `price_bounds_matches_direct_comparison_on_and_off_grid`).
+fn snap_to_nearest_cent(cents: f64) -> f64 {
+    let rounded = cents.round();
+    if (cents - rounded).abs() < 1e-6 { rounded } else { cents }
+}
+
 /// Half-open [lo, hi) sort-bits bounds for `price op value`, or None for Ne.
 fn price_bounds(op: CmpOp, value: f64) -> Option<(u32, u32)> {
     let cent_to_bits = |c: f64| f32_sort_bits((c / PRICE_CENTS_PER_DOLLAR) as f32);
@@ -1941,10 +1957,10 @@ fn price_bounds(op: CmpOp, value: f64) -> Option<(u32, u32)> {
             let b = f32_sort_bits(value as f32);
             Some((b, b.saturating_add(1)))
         }
-        CmpOp::Lt => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()))),
-        CmpOp::Le => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0))),
-        CmpOp::Gt => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0), u32::MAX)),
-        CmpOp::Ge => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()), u32::MAX)),
+        CmpOp::Lt => Some((0, cent_to_bits(snap_to_nearest_cent(value * PRICE_CENTS_PER_DOLLAR).ceil()))),
+        CmpOp::Le => Some((0, cent_to_bits(snap_to_nearest_cent(value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0))),
+        CmpOp::Gt => Some((cent_to_bits(snap_to_nearest_cent(value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0), u32::MAX)),
+        CmpOp::Ge => Some((cent_to_bits(snap_to_nearest_cent(value * PRICE_CENTS_PER_DOLLAR).ceil()), u32::MAX)),
     }
 }
 

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -95,7 +95,7 @@ pub(crate) const PLANE_RESTRICTED_ABSENT: usize = PLANE_RESTRICTED_EXISTS + MAX_
 /// just another plane, no different from "power==5" — which is what lets a
 /// sparse tail (power has 2 cards at -1) get absorbed automatically instead
 /// of needing a side table or a live re-query. See
-/// docs/issues/local-engine-numeric-range-planes.md for the design history.
+/// docs/issues/00655-engine-numeric-range-planes.md for the design history.
 const NUM_INTERIOR_LO: i32 = 0;
 const NUM_INTERIOR_HI: i32 = 12;
 const NUM_INTERIOR_WIDTH: usize = (NUM_INTERIOR_HI - NUM_INTERIOR_LO + 1) as usize;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2897,6 +2897,59 @@ fn price_narrowing_is_exact_at_the_boundary() {
     assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets, &archived.cards).is_none());
 }
 
+// Caught in review: `value * PRICE_CENTS_PER_DOLLAR` is a real floating-point operation, not a
+// lossless relabeling -- `0.28_f64 * 100.0 == 28.000000000000004`, so ceil() rounded up to 29
+// cents instead of 28, silently excluding a printing priced at exactly the Ge threshold from
+// narrowing. Unlike the 0.10 boundary above (`0.10 * 100.0 == 10.0` exactly, no noise), 0.28 and
+// 0.57 actually exercise the multiplication's rounding error -- deliberately chosen because they
+// don't round-trip cleanly, not because they're otherwise special.
+#[test]
+fn price_narrowing_survives_cents_multiplication_noise() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[3], vocab);
+    data.printings[0].price_usd = Some(0.27);
+    data.printings[1].price_usd = Some(0.28); // exactly the Ge/Le threshold below
+    data.printings[2].price_usd = Some(0.29);
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd.map(super::f32_sort_bits));
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let ge = FilterExpr::NumericCmp {
+        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
+        op: CmpOp::Ge,
+        rhs: super::NumExpr::Const(0.28),
+    };
+    match narrow_candidates(&ge, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(v)) => {
+            assert!(v.contains(&1), "Ge(0.28) must not drop the printing priced at exactly 0.28");
+            assert!(v.contains(&2) && !v.contains(&0));
+        }
+        _ => panic!("usd must narrow in printing space"),
+    }
+
+    let le = FilterExpr::NumericCmp {
+        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
+        op: CmpOp::Le,
+        rhs: super::NumExpr::Const(0.57),
+    };
+    let mut vocab2 = VocabInterner::new();
+    let cards2 = vec![stub_card(2, TYPE_CREATURE, &[], &mut vocab2)];
+    let mut data2 = store_of(cards2, &[2], vocab2);
+    data2.printings[0].price_usd = Some(0.57); // exactly the Le threshold
+    data2.printings[1].price_usd = Some(0.58);
+    data2.indexes.price_usd = build_range_index(&data2.printings, |p| p.price_usd.map(super::f32_sort_bits));
+    let bytes2 = rkyv::to_bytes::<Error>(&data2).expect("serialize");
+    let archived2 = rkyv::access::<Archived<CardData>, Error>(&bytes2).expect("access");
+    match narrow_candidates(&le, &archived2.indexes, &archived2.offsets, &archived2.cards) {
+        Some(Candidates::Printings(v)) => {
+            assert!(v.contains(&0), "Le(0.57) must not drop the printing priced at exactly 0.57");
+            assert!(!v.contains(&1));
+        }
+        _ => panic!("usd must narrow in printing space"),
+    }
+}
+
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────
 
 /// A color/type-diverse store for plane parity: colorless, mono, guild pairs,
@@ -4331,9 +4384,18 @@ fn f32_sort_bits_distinguishes_every_cent_up_to_50k() {
 #[test]
 fn price_bounds_matches_direct_comparison_on_and_off_grid() {
     // Real prices only ever exist at cent granularity; thresholds include on-grid values a user
-    // would actually type, and deliberately off-grid ones an arithmetic expression could produce
-    // (e.g. usd<cmc*7.13) -- price_bounds must be exact for both.
-    let thresholds = [50.00_f64, 49.99, 0.01, 5142.02, 100.00, 49.998, 50.003, 33.335, 0.005, 12.3456789, 0.0];
+    // would actually type (paired with their exact cents value, Some(_)), and deliberately
+    // off-grid ones an arithmetic expression could produce (e.g. usd<cmc*7.13, paired with None)
+    // -- price_bounds must be exact for both. 0.28 and 0.57 are the review-caught repro cases:
+    // `0.28_f64 * 100.0 == 28.000000000000004`, `0.57_f64 * 100.0 == 56.99999999999999` -- a
+    // step-sampled sweep over *other* prices can silently miss a bug that only bites exactly at
+    // a threshold's own value, so every on-grid threshold gets an explicit check against its own
+    // exact price below, not just incidental coverage from the sweep.
+    let thresholds: &[(f64, Option<u32>)] = &[
+        (50.00, Some(5000)), (49.99, Some(4999)), (0.01, Some(1)), (5142.02, Some(514202)),
+        (100.00, Some(10000)), (0.28, Some(28)), (0.57, Some(57)), (0.0, Some(0)),
+        (49.998, None), (50.003, None), (33.335, None), (0.005, None), (12.3456789, None),
+    ];
     let ops = [
         (CmpOp::Lt, "Lt"),
         (CmpOp::Le, "Le"),
@@ -4341,9 +4403,26 @@ fn price_bounds_matches_direct_comparison_on_and_off_grid() {
         (CmpOp::Ge, "Ge"),
         (CmpOp::Eq, "Eq"),
     ];
-    for &t in &thresholds {
+    for &(t, on_grid_cents) in thresholds {
         for &(op, op_name) in &ops {
             let (lo, hi) = super::price_bounds(op, t).expect("price_bounds only returns None for Ne");
+            if let Some(cents) = on_grid_cents {
+                let price = f64::from(cents) / 100.0;
+                let bits = super::f32_sort_bits(price as f32);
+                let expected = match op {
+                    CmpOp::Lt => price < t,
+                    CmpOp::Le => price <= t,
+                    CmpOp::Gt => price > t,
+                    CmpOp::Ge => price >= t,
+                    CmpOp::Eq => true,
+                    CmpOp::Ne => unreachable!(),
+                };
+                let in_range = bits >= lo && bits < hi;
+                assert_eq!(
+                    in_range, expected,
+                    "price_bounds({op_name}, {t}) disagrees with direct comparison AT ITS OWN threshold price {price} (bits {bits}, range [{lo}, {hi}))"
+                );
+            }
             for cents in (1..514_202u32).step_by(37) {
                 // sampled every 37 cents across the real max-price range, not exhaustive --
                 // f32_sort_bits_distinguishes_every_cent_up_to_50k already proves the encoding

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2837,12 +2837,12 @@ fn broad_ranges_decline_to_narrow() {
 }
 
 #[test]
-fn price_narrowing_is_a_superset_under_f32_rounding() {
+fn price_narrowing_is_exact_at_the_boundary() {
     let mut vocab = VocabInterner::new();
     let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab)];
     let mut data = store_of(cards, &[4], vocab);
     data.printings[0].price_usd = Some(0.05);
-    data.printings[1].price_usd = Some(0.1); // sits at the query boundary
+    data.printings[1].price_usd = Some(0.1); // sits exactly on the query boundary
     data.printings[2].price_usd = Some(60.0);
     data.printings[3].price_usd = None; // priceless printings never satisfy price filters
     data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd.map(super::f32_sort_bits));
@@ -2854,16 +2854,27 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
         op: CmpOp::Lt,
         rhs: super::NumExpr::Const(0.10),
     };
-    // 0.10f64 is not representable as f32; the widened bound may include the
-    // boundary printing as a candidate, but must never lose printing 0.
+    // price_bounds now snaps to the cents grid (see its doc comment), so Lt(0.10) excludes the
+    // boundary printing exactly -- not "may include, verify catches it later" like before.
     match narrow_candidates(&cheap, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
+            assert!(!v.contains(&1), "Lt must exclude the exact boundary price now that bounds are exact");
             assert!(!v.contains(&2) && !v.contains(&3));
         }
         _ => panic!("usd must narrow in printing space"),
     }
-    // ...and the walk's exact evaluation rejects the boundary printing.
+    // Le, unlike Lt, must include the same boundary printing.
+    let cheap_le = FilterExpr::NumericCmp {
+        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
+        op: CmpOp::Le,
+        rhs: super::NumExpr::Const(0.10),
+    };
+    match narrow_candidates(&cheap_le, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(v)) => assert!(v.contains(&1), "Le must include the exact boundary price"),
+        _ => panic!("usd must narrow in printing space"),
+    }
+    // ...and the walk's exact evaluation agrees.
     let card = &archived.cards[0];
     assert!(cheap.matches(card, &archived.printings[0], &archived.strings));
     assert!(!cheap.matches(card, &archived.printings[1], &archived.strings));
@@ -4024,37 +4035,38 @@ fn range_narrowed_representations() {
     let n = printings.len();
     let bounds = |op, v| super::price_bounds(op, v).unwrap();
 
-    // Bounds are widened one position for f32 rounding, so `< v` includes v's
-    // own printings as superset members — counts below are values 0..=v.
-    // Sparse (164 entries, 4%): vec, tight.
+    // price_bounds snaps to the cents grid now, so `< v` excludes v's own printings exactly —
+    // counts below are values 0..v (v itself excluded), not 0..=v. exact/broad_ok are passed
+    // directly here to exercise range_narrowed's own branching, independent of price_bounds.
+    // Sparse (160 entries, 3.9%): vec, tight.
     let (lo, hi) = bounds(CmpOp::Lt, 40.0);
     let nr = super::range_narrowed(archived, lo, hi, n, false, false).expect("sparse ranges narrow in any context");
-    assert!(!nr.tight, "price bounds are widened supersets, never tight");
+    assert!(!nr.tight, "exact param was passed false here to exercise range_narrowed's own branching");
     match nr.set {
-        Candidates::Printings(v) => assert_eq!(v.len(), 164),
+        Candidates::Printings(v) => assert_eq!(v.len(), 160),
         _ => panic!("sparse range must stay a vec"),
     }
 
-    // Broad but at most half (values 0..=400 → 1604 entries, 39%): direct scatter, tight.
+    // Broad but at most half (values 0..400 → 1600 entries, 39%): direct scatter, tight.
     let (lo, hi) = bounds(CmpOp::Lt, 400.0);
     assert!(super::range_narrowed(archived, lo, hi, n, false, true).is_none(), "broad bits need a consumer (broad_ok)");
     let nr = super::range_narrowed(archived, lo, hi, n, true, true).expect("broad_ok materializes the bitmap");
     assert!(nr.tight, "integer-exact bounds keep the direct scatter tight");
     match &nr.set {
         Candidates::PrintingBits(b) => {
-            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 1604);
+            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 1600);
             assert!(bitmap_contains(b, 0) && !bitmap_contains(b, 1700));
         }
         _ => panic!("broad range must be a bitmap"),
     }
 
-    // Beyond half (values 0..=900 → 3604 entries, 88%): complement scatter, loose.
+    // Beyond half (values 0..900 → 3600 entries, 88%): complement scatter, loose.
     let (lo, hi) = bounds(CmpOp::Lt, 900.0);
     let nr = super::range_narrowed(archived, lo, hi, n, true, true).expect("broad_ok materializes the complement");
     assert!(!nr.tight, "complement over-includes unindexed printings");
     match &nr.set {
         Candidates::PrintingBits(b) => {
-            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 3604);
+            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 3600);
             assert!(bitmap_contains(b, 0) && !bitmap_contains(b, 3700));
         }
         _ => panic!("broad range must be a bitmap"),
@@ -4267,11 +4279,11 @@ fn not_over_partial_and_is_blocked() {
 }
 
 
-// The review's reproduction: price bounds are widened one position for
-// f32/f64 rounding (superset contract), so a price-range set must never be
-// tight — Not would complement away the boundary printings, which are exactly
-// the negation's matches. A printing priced exactly 5.0 fails `usd>5` and
-// must survive `-usd>5`.
+// The review's reproduction: `tight_narrow_space` still declines price (deliberately —
+// composition/Not-arm safety for a printing-varying field is deferred to
+// local-engine-broad-range-fastpath.md's fastpath work, even though price_bounds itself is now
+// exact), so Not(usd>5) takes the plain per-candidate tri() path, not narrow_rec's Not-arm
+// complement shortcut. A printing priced exactly 5.0 fails `usd>5` and must survive `-usd>5`.
 #[test]
 fn not_over_price_range_keeps_boundary_matches() {
     let mut vocab = VocabInterner::new();
@@ -4294,6 +4306,66 @@ fn not_over_price_range_keeps_boundary_matches() {
         &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, 1, "the boundary-priced card matches -usd>5 and must not be complemented away");
+}
+
+// price_bounds' exactness rests on two facts, both checked here rather than just asserted in a
+// doc comment: every real cent value up to well past the actual max price ($5,142.02) gets a
+// distinct, monotonically increasing sort-bits encoding (no two different prices collide), and
+// the cents-grid floor/ceil bound matches direct floating comparison for every operator, on- and
+// off-grid alike.
+#[test]
+fn f32_sort_bits_distinguishes_every_cent_up_to_50k() {
+    let mut prev: Option<u32> = None;
+    for cents in 1..=5_000_000u32 {
+        // 10x the real max price ($5,142.02) -- comfortably past where f32 could plausibly
+        // start losing cent resolution (estimated crossover ~$84k from f32's ~2^-23 relative
+        // precision).
+        let bits = super::f32_sort_bits(cents as f32 / 100.0);
+        if let Some(p) = prev {
+            assert!(bits > p, "cents {} and {} collided or went non-monotonic: {} vs {}", cents - 1, cents, p, bits);
+        }
+        prev = Some(bits);
+    }
+}
+
+#[test]
+fn price_bounds_matches_direct_comparison_on_and_off_grid() {
+    // Real prices only ever exist at cent granularity; thresholds include on-grid values a user
+    // would actually type, and deliberately off-grid ones an arithmetic expression could produce
+    // (e.g. usd<cmc*7.13) -- price_bounds must be exact for both.
+    let thresholds = [50.00_f64, 49.99, 0.01, 5142.02, 100.00, 49.998, 50.003, 33.335, 0.005, 12.3456789, 0.0];
+    let ops = [
+        (CmpOp::Lt, "Lt"),
+        (CmpOp::Le, "Le"),
+        (CmpOp::Gt, "Gt"),
+        (CmpOp::Ge, "Ge"),
+        (CmpOp::Eq, "Eq"),
+    ];
+    for &t in &thresholds {
+        for &(op, op_name) in &ops {
+            let (lo, hi) = super::price_bounds(op, t).expect("price_bounds only returns None for Ne");
+            for cents in (1..514_202u32).step_by(37) {
+                // sampled every 37 cents across the real max-price range, not exhaustive --
+                // f32_sort_bits_distinguishes_every_cent_up_to_50k already proves the encoding
+                // itself has no gaps to hide a failure in between sample points.
+                let price = cents as f64 / 100.0;
+                let bits = super::f32_sort_bits(price as f32);
+                let expected = match op {
+                    CmpOp::Lt => price < t,
+                    CmpOp::Le => price <= t,
+                    CmpOp::Gt => price > t,
+                    CmpOp::Ge => price >= t,
+                    CmpOp::Eq => (price - t).abs() < 1e-9,
+                    CmpOp::Ne => unreachable!(),
+                };
+                let in_range = bits >= lo && bits < hi;
+                assert_eq!(
+                    in_range, expected,
+                    "price_bounds({op_name}, {t}) disagrees with direct comparison at price {price} (bits {bits}, range [{lo}, {hi}))"
+                );
+            }
+        }
+    }
 }
 
 // ─── Name bigram index (#639) ─────────────────────────────────────────────────

--- a/docs/issues/done/00655-engine-numeric-range-planes.md
+++ b/docs/issues/done/00655-engine-numeric-range-planes.md
@@ -1,9 +1,10 @@
 # Engine: numeric-range bitplanes for cmc/power/toughness
 
-Follow-on to #630 (phases 1/2 shipped as PR #633, #654). Not in scope for
-#634 (permuted bitmap / exactness promotion, `engine-permuted-bitmap-order-
-phase.md`) — filed separately, surfaced while benchmarking that work. Status:
-proposed, not designed in detail yet.
+GitHub: #655. Follow-on to #630 (phases 1/2 shipped as PR #633, #654). Not in
+scope for #634 (permuted bitmap / exactness promotion,
+[00634-engine-permuted-bitmap-order-phase.md](00634-engine-permuted-bitmap-order-phase.md))
+— filed separately, surfaced while benchmarking that work. Status: done — see
+"Results" below.
 
 ## Problem
 

--- a/docs/issues/done/00663-engine-oracle-word-index.md
+++ b/docs/issues/done/00663-engine-oracle-word-index.md
@@ -346,7 +346,7 @@ itself and won't be evidence for this anymore.
   distinct-text CSR idiom this design reuses at word/trigram granularity
 - [00634-engine-permuted-bitmap-order-phase.md](00634-engine-permuted-bitmap-order-phase.md) —
   #634; the all-match/popcount-skip promotion this design can newly reach
-- [local-engine-numeric-range-planes.md](local-engine-numeric-range-planes.md),
+- [00655-engine-numeric-range-planes.md](00655-engine-numeric-range-planes.md),
   [local-engine-legality-postings.md](local-engine-legality-postings.md) — prior
   applications of "threshold and drop to a scan"; this design's contribution
   is replacing "drop" with "represent as a bitmap instead"

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -1,0 +1,195 @@
+# Engine: fast path for broad printing-space range queries
+
+Status: design drafted 2026-07-14, no GitHub issue yet — file once the crossover is measured
+and a direction is picked. Surfaced investigating why `usd<50` costs ~0.4–1 ms (see
+[00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md)'s
+"Expected (honest)" section: "the ~97k price compares still dominate") — but the mechanism
+isn't price-specific. Every `PrintingRangeIndex`-backed field shares it.
+
+## Prerequisite (ships standalone, before any of this): make `price_bounds` exact
+
+**Status: done**, shipped ahead of the rest of this doc.
+
+`price_bounds` (`lib.rs:1933-1949`) used to share one bound between `Lt`/`Le` and between
+`Gt`/`Ge`, deferring the strict/non-strict distinction to a verify pass — its own comment blamed
+this on "f32/f64 rounding," but that's not the real reason. Checked against real data: every
+stored price is genuinely cent-precise (`abs(price_usd - round(price_usd*100)/100.0) > 0.001`
+matches **0** of 81,540 priced printings), max price is $5,142.02, and f32's ULP at that
+magnitude (~$0.0006) is 16× finer than a cent — nowhere near ambiguous.
+
+Fix, shipped: snap to the cents grid via floor/ceil before computing bounds, mirroring
+`int_range_bounds`'s existing exact-integer technique (`lib.rs:1956-1975`) instead of sharing one
+bound and verifying. `Eq` keeps its original single-bit-pattern bound — it has no strict/
+non-strict ambiguity to resolve, so an off-grid `Eq` value still correctly narrows to nothing:
+
+```rust
+let cent_to_bits = |c: f64| f32_sort_bits((c / PRICE_CENTS_PER_DOLLAR) as f32);
+match op {
+    CmpOp::Lt => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()))),
+    CmpOp::Le => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0))),
+    CmpOp::Gt => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0), u32::MAX)),
+    CmpOp::Ge => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()), u32::MAX)),
+    // Eq unchanged — see above.
+}
+```
+
+**Verified, not just argued** — both checks are now permanent regression tests in `tests.rs`:
+`f32_sort_bits_distinguishes_every_cent_up_to_50k` proves zero sort-bits collisions across every
+adjacent cent pair from $0.01 to $50,000 (10× the real max price), and
+`price_bounds_matches_direct_comparison_on_and_off_grid` proves zero disagreements with direct
+floating comparison across 11 thresholds (cent-aligned and deliberately off-grid/
+arithmetic-derived ones like `49.998`, `0.005`, `12.3456789`) × 5 operators × ~13,900 sampled
+real prices. This is provably exact over the entire realistic range, not empirically-probably-fine.
+
+This makes `price_usd` genuinely `tight` (`range_narrowed`'s `exact` param flipped to `true` at
+its one `price_usd` call site) — same category as `collector_number`/`released_at`. Shipped as
+its own tiny, purely-mechanical PR, independent of everything below. `tix`/`eur` should inherit
+the identical fix once #638 indexes them (same cent-granularity argument). `tight_narrow_space`
+still deliberately declines price — that's a separate composition-safety question, deferred to
+the fastpath work below.
+
+## Problem
+
+`usd<50` matches 80,527 of 97,206 printings (83%) — genuinely broad, same shape as the
+`cmc`/`power`/`toughness` queries [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md)
+fixed with one-hot-interior + cumulative-boundary bitplanes (`cmc<=6`: 0.405 → 0.067 ms, 6.1×).
+That technique doesn't transfer: it needs a small, enumerable value space (~13–17 for
+`cmc`/`power`/`toughness`; price has 4,133 distinct values), *and*, more fundamentally, `cmc`/
+`power`/`toughness` are card-invariant (one value per card, so a plain per-card plane bit is
+exact), while price is printing-varying — `usd<50` for `unique=card` means "*some* printing is
+under $50," an existential predicate over printings, the same shape legality's `∃p: satisfies(p)`
+problem is ([00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)).
+[local-engine-printing-varying-plane-repair-pattern.md](local-engine-printing-varying-plane-repair-pattern.md)
+names this as the case the plane escape hatch can't cover: an unbounded parameterized threshold
+has no finite set of precomputable existence projections. The prerequisite fix above doesn't
+change that — it makes the *narrowing* exact, not the *existence* projection precomputable.
+
+**This is not just a price problem.** Every field routed through `range_narrowed` shares the same
+broadness-discard/fallback cost floor (`card_engine/src/lib.rs` — grep `range_narrowed(&indexes\.`):
+`price_usd`, `collector_number`, `released_at` (date/year) today, plus `tix`/`eur` once #638
+lands. With the prerequisite fix, all of them are `tight`. **The broadness discard throws the
+candidate set away regardless**: for a bare predicate (no plane to AND against), `run_query`
+converts the candidate set to card ids and drops it if it covers ≥87.5% of all cards
+(`lib.rs:3740-3743`), falling back to a raw per-card `card_pass` scan even though the discarded
+set was exact.
+
+## Idea 1: walk the order-by permutation, verify inline, stop at `limit`
+
+`range_narrowed`'s two `partition_point` binary searches already compute `k = e - s` for free
+(`lib.rs:1990-1992`) before any narrowing decision is made. Instead of materializing or
+discarding a candidate set, walk the existing per-orderby permutation table (built for #634)
+and test each candidate for set membership inline, stopping once `limit` matches are found.
+
+- **Cheap when the predicate is broad**: expected candidates visited ≈ `limit / match_rate` —
+  for `usd<50` at 83%, a 20-row page costs ~24 candidate checks. Close to instant.
+- **Unbounded worst case.** If the order-by column is unrelated to the predicate field, there's
+  no seek target, and a low-selectivity predicate with unlucky clustering could blind-walk most
+  of the corpus before finding `limit` matches — worse than today's baseline. Even the
+  *aligned* case (`released_at>2026-06-01 order by released_at`) is pathological if the walk
+  starts at the wrong end: ascending order puts the matches at the far end, so a naive
+  front-to-back walk visits almost everything before the first hit.
+- `total` for `unique=card` needs `oracle_id` dedup, not just `k` — `k` alone only works
+  directly for `unique=printing`.
+
+## Idea 2: scatter the exact narrowed set into a bitmap, feed the existing popcount-skip path
+
+With the prerequisite fix, narrowing is already exact for all of these fields — there's nothing
+to verify. Project/scatter the narrowed printing-space set to a card-space existence bitmap and
+feed it into `run_query`'s existing plane-eligible streamed-popcount dispatch (`lib.rs:3680`),
+same as a compiled plane.
+
+Feeding the result into `run_query_streamed_popcount` still needs more than an eligibility
+tweak — that function's existential row-selection (`plane_expr_is_existential` +
+`eval_plane_expr_for_printing`, built for legality) is tightly coupled to `PlaneExpr`, which
+none of these fields compile to today. **Decided: extend the Y-predicate/existential-plane
+framework** (#680) with a new leaf rather than duplicate its row-selection logic outside it —
+price genuinely is a per-printing predicate, the same shape format/rarity/border already are.
+Tracing `PlaneExpr::Bits` (planes.rs:436-443, `eval_plane_expr_for_printing`,
+`plane_expr_is_existential`) shows this is a contained addition, not a framework rewrite — and
+it's simpler than it first looked, now that narrowing is exact:
+
+- `Bits` already supports "compute a card bitmap once per query, clone it into the plane tree"
+  (the oracle-word-index dense-dictionary precedent), but it's card-invariant by design —
+  `eval_plane_expr_for_printing`'s `Bits` arm checks the card id, and `plane_expr_is_existential`
+  hard-codes `Bits => false`. The needed sibling variant is just **two precomputed bitmaps**, no
+  live evaluation at all:
+
+  ```rust
+  PlaneExpr::PrintingRangeBits { card_bits: Vec<u64>, printing_bits: Vec<u64> }
+  ```
+
+- `eval_planes`: reads `card_bits` exactly like `Bits` does today (the card-level existence
+  answer, already exact courtesy of the prerequisite fix).
+- `plane_expr_is_existential`: `true` for this variant (unlike plain `Bits`).
+- `eval_plane_expr_for_printing`: a bit test against `printing_bits` for this specific printing —
+  no field/op/threshold, no floating-point comparison, just membership in the already-exact
+  narrowed set.
+- `compile_plane`'s `NumericCmp` arm, for printing-varying fields only (`cmc`/`power`/`toughness`
+  keep their existing #655 arm): compute both bitmaps at query time via `range_narrowed`, wrap
+  them in this variant — same "once per query" cost model the oracle-word-index `Bits` case
+  already established.
+
+- **Fixed cost regardless of `limit`/offset**: O(k) to build the bitmaps, then O(words) to select
+  any page — same offset-independence #634 Step 2 built for plane-exact filters. Wins on deep
+  pagination and on reuse (AND against a plane in a compound query). Predictable worst case:
+  never worse than O(k), full stop.
+- **Wasteful for the common case** — pays O(k) even for a 20-row first-page request that idea 1
+  would answer in ~24 checks.
+
+## The crossover needs measurement, not a guess
+
+Every existing adaptive guard in this engine (`AND_SKIP_THRESHOLD`, `MAX_NARROW_FRACTION`/
+`NARROW_FLOOR`, `MAX_UNION_FRACTION`) was derived from a benchmark sweep, not analysis — see
+[00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md). This
+decision needs three axes:
+
+1. **Match rate** (`k/n`).
+2. **Predicate/order-by field alignment** — same field (seekable directly) vs. unrelated field
+   (blind walk, no seek target).
+3. **For the aligned case, direction vs. clustering** — does the naive walk start at the
+   matching end, or does it need to seek first?
+
+The adversarial cell — selective predicate, unrelated order-by, unlucky clustering — is where
+idea 1's actual worst case needs to be measured against today's baseline. If it's worse there,
+that bounds how unconditionally idea 1 can be used. With the prerequisite fix landed, there's no
+fourth (tight/loose) axis to worry about — every field behaves identically here.
+
+## Plan
+
+- [ ] Ship the `price_bounds` exactness fix standalone (see Prerequisite above) — already
+      verified, just needs the Rust change + a `tests.rs` regression test.
+- [ ] Prove the fast-path mechanism on a tight field first (`released_at` or
+      `collector_number`, already tight today) — isolates the crossover question from the
+      `PlaneExpr` row-selection work.
+- [ ] Sketch idea 1 as a real path: `k`-from-binary-search, order-by-permutation walk with
+      inline membership check, early stop at `limit`, dedup-aware `total` for `unique=card`.
+- [ ] Sketch idea 2: `PlaneExpr::PrintingRangeBits`, wired into `compile_plane`/`eval_planes`/
+      `plane_expr_is_existential`/`eval_plane_expr_for_printing`.
+- [ ] Build a sweep harness across the three crossover axes (shape of `bench_cost_guards.py` /
+      `build_guard_corpus.py`), covering `price_usd`, `released_at`, and `collector_number`, plus
+      at least one deliberately-adversarial synthetic case (mismatched order-by field).
+- [ ] Calibrate the guard from measurement (or confirm one design dominates and no guard is
+      needed).
+- [ ] Acceptance: `usd<50`, a broad `released_at`/`collector_number` query, and the adversarial
+      case all improve or stay flat vs. baseline; no regression on the existing #634/#655 exact
+      paths.
+
+## Related
+
+- [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
+  analogous fix for `cmc`/`power`/`toughness`; doesn't transfer (card-invariant, not existential).
+- [00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md) —
+  where the `usd<50` cost was first flagged as a floor, not fixed.
+- [00634-engine-permuted-bitmap-order-phase.md](done/00634-engine-permuted-bitmap-order-phase.md)
+  — the popcount-skip machinery idea 2 would extend.
+- [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)
+  — the existential-predicate framework `PrintingRangeBits` extends to numeric printing fields.
+- [00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md) — the
+  calibration-from-measurement precedent this crossover should follow.
+- [local-engine-printing-varying-plane-repair-pattern.md](local-engine-printing-varying-plane-repair-pattern.md)
+  — names price's exact disqualifying shape ("a hypothetical printing-varying numeric field...
+  `> 3.7` and `> 3.71` are different, un-precomputable existence projections").
+- [local-engine-probe-before-and-skip.md](local-engine-probe-before-and-skip.md) — the same
+  "the binary search already gives you `k` for free" observation, in the AND-skip context.
+- #638 — `tix`/`eur` have no range index at all yet; the same fast path (and the prerequisite
+  exactness fix) should cover them once they do.

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -6,32 +6,104 @@ and a direction is picked. Surfaced investigating why `usd<50` costs ~0.4–1 ms
 "Expected (honest)" section: "the ~97k price compares still dominate") — but the mechanism
 isn't price-specific. Every `PrintingRangeIndex`-backed field shares it.
 
-## Prerequisite (ships standalone, before any of this): make `price_bounds` exact
+## Prerequisite: price needs to be exact, not widened-and-deferred
 
-**Status: done**, shipped ahead of the rest of this doc.
+**Status: superseded, redoing from scratch — see "Revised plan: store price as integer cents"
+below.** [PR #687](https://github.com/jbylund/sylvan_librarian/pull/687) shipped a first attempt
+(floor/ceil-in-cents bounds, keeping `f32` storage) that turned out to fix only one of two real
+bugs. History kept here because both bugs, and why the fix needed to go deeper than either one,
+are worth remembering.
 
-`price_bounds` (`lib.rs:1933-1949`) used to share one bound between `Lt`/`Le` and between
-`Gt`/`Ge`, deferring the strict/non-strict distinction to a verify pass — its own comment blamed
-this on "f32/f64 rounding," but that's not the real reason. Checked against real data: every
-stored price is genuinely cent-precise (`abs(price_usd - round(price_usd*100)/100.0) > 0.001`
-matches **0** of 81,540 priced printings), max price is $5,142.02, and f32's ULP at that
-magnitude (~$0.0006) is 16× finer than a cent — nowhere near ambiguous.
+### Bug A (found in review of #687): `price_bounds`'s own cents conversion wasn't exact
 
-Fix, shipped: snap to the cents grid via floor/ceil before computing bounds, mirroring
-`int_range_bounds`'s existing exact-integer technique (`lib.rs:1956-1975`) instead of sharing one
-bound and verifying. `Eq` keeps its original single-bit-pattern bound — it has no strict/
-non-strict ambiguity to resolve, so an off-grid `Eq` value still correctly narrows to nothing:
+`price_bounds` shared one bound between `Lt`/`Le` and between `Gt`/`Ge`, deferring the
+strict/non-strict distinction to a verify pass. The fix computed `value * 100.0` before
+floor/ceil — but that multiplication is itself a new floating-point operation, not a lossless
+relabeling: `0.28_f64 * 100.0 == 28.000000000000004`, `0.57_f64 * 100.0 == 56.99999999999999`.
+For ~a quarter of two-decimal dollar amounts this silently shifted the bound by a whole cent,
+producing a real false negative (`Ge(0.28)` against a printing priced at exactly $0.28, dropped
+from narrowing entirely — not masked by verification, since a card whose only qualifying
+printing gets wrongly excluded from the narrowed set is never visited at all). Patched with a
+`snap_to_nearest_cent` epsilon-correction before flooring/ceiling.
 
-```rust
-let cent_to_bits = |c: f64| f32_sort_bits((c / PRICE_CENTS_PER_DOLLAR) as f32);
-match op {
-    CmpOp::Lt => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()))),
-    CmpOp::Le => Some((0, cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0))),
-    CmpOp::Gt => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).floor() + 1.0), u32::MAX)),
-    CmpOp::Ge => Some((cent_to_bits((value * PRICE_CENTS_PER_DOLLAR).ceil()), u32::MAX)),
-    // Eq unchanged — see above.
-}
-```
+### Bug B (found stress-testing beyond the review): verification has its own, independent, unrelated mismatch
+
+Stress-testing the fix for Bug A across 20 random seeds × real generated prices turned up
+something else entirely, pre-existing on `main`, untouched by either the original code or the
+Bug A fix: `field_num` (`filter.rs:88-104`) reads a stored price as `f32` and widens it to `f64`
+for comparison (`x as f64`), but `NumExpr::Const` never demotes the query threshold through the
+same lossy step (`NumVal::Known(*v)`, full `f64` precision). These are two different-precision
+representations of "the same" decimal, and they are essentially **never** bit-identical:
+`7.22_f32` widened back to `f64` is `7.21999979019165`, not `7.22`. So `usd=7.22` essentially
+never matches a card actually priced at $7.22, and `Ge`/`Le` are wrong at the exact boundary the
+same way — independent of narrowing entirely, since this is in the verify path that always runs
+regardless of what narrowing produces. Confirmed identically on a clean `main` worktree, so this
+predates both the original code and #687's fix; the `price_bounds` diff never touches it.
+
+**Why patching Bug B in place is the wrong shape of fix.** The generic path (`NumExpr::eval` →
+`NumVal::Known(f64)` → `cmp(op, a, b)`) is one of *two independent* implementations of "does this
+price satisfy this predicate" — the other being `price_bounds`, used for narrowing. Two
+independent encodings of the same rule quietly disagreeing is exactly Bug B's shape; patching the
+comparison to happen to agree with `price_bounds` today doesn't prevent a *third* independent
+encoding from drifting out of sync with both, next time someone touches either one.
+
+### Root cause of both bugs: storing price as a lossy `f32` approximation of an exact quantity
+
+Checked against real data: every stored price is genuinely cent-precise
+(`abs(price_usd - round(price_usd*100)/100.0) > 0.001` matches **0** of 81,540 priced printings),
+max price is $5,142.02, and f32's ULP at that magnitude (~$0.0006) is 16× finer than a cent.
+Prices are not a continuous quantity that happens to usually land on cents — they *are* integer
+cents, always, and storing them as `f32` dollars introduces a lossy step (the `f32` truncation)
+that doesn't need to exist. `cmc`/`power`/`toughness`/`rarity_int`/`collector_number_int` never
+had either bug, because they're stored as exact small integers (`u8`/`u16`) — `as f32 as f64` is
+lossless for them. Price/eur/tix are the only numeric fields where the storage type itself loses
+information before comparison ever happens.
+
+## Revised plan: store price as integer cents
+
+Change `price_usd`/`price_eur`/`price_tix` from `Option<f32>` (dollars) to `Option<u32>` (cents)
+— same 4-byte footprint, no storage penalty. This removes the lossy step both bugs depend on,
+rather than patching around either one:
+
+- **`PrintingRangeIndex` simplifies**: cents *are* the sort key already (a natural, monotonic
+  `u32`) — `f32_sort_bits` disappears entirely for these fields, no encoding step needed.
+- **`price_bounds` still needs floor/ceil-in-cents** (narrowing still has to convert a
+  user-typed `f64` dollar threshold into the integer-cents domain to bound a slice of the
+  now-cents-keyed index — that conversion is still a multiplication, still needs the
+  `snap_to_nearest_cent`-style correction), but can likely become a thin wrapper around
+  `int_range_bounds` directly, rather than a bespoke function — `collector_number` already
+  solves exactly this "arbitrary `f64` threshold against an exact small-integer domain" problem.
+- **`field_num` fixes Bug B directly, with no other changes anywhere**: `known(p.price_usd.as_ref().map(|v| u32::from(*v) as f64 / 100.0))`
+  instead of widening a lossy `f32`. `722.0 / 100.0` and `float("7.22")` are already proven
+  bit-identical (both are single, non-lossy roundings of the same rational number) — so the field
+  side and `NumExpr::Const` (untouched) now agree exactly, and the fully generic `cmp()` in
+  `tri()`'s `NumericCmp` arm needs **no per-field special case at all**. Verification and
+  narrowing don't need to share an implementation to stay consistent once the only lossy step is
+  gone — they're each independently exact.
+- **Ingest**: parse the JSON price and round to the nearest cent once (`(v * 100.0).round() as u32`),
+  not per-query.
+- **API-facing serialization must still return dollars**: `api/tests/test_engine_unit.py::test_price_usd_matches_prefer_ordering`
+  asserts `price_usd == pytest.approx(1.47)` — the public contract doesn't change, only the
+  internal representation.
+- **Archive format version bump required** — this changes the *semantic meaning* of on-disk
+  bytes (dollars vs. cents), not just their size; a stale archive would silently misread as
+  wildly wrong prices without it.
+- Sort/prefer scoring (`Prefer::UsdLow`/`UsdHigh`, `SortCol::PriceUsd`): minor conversions:
+  order-preserving either way, so sorting on raw cents directly is also an option, not just a
+  dollars conversion.
+
+### Plan
+
+- [ ] Branch fresh from `main` (not on top of #687 — this supersedes it) and redo the whole
+      thing as the integer-cents migration, informed by everything above.
+- [ ] Struct/ingest/archive-version changes for `price_usd`/`price_eur`/`price_tix`.
+- [ ] `price_bounds` as a thin wrapper (or direct reuse) of `int_range_bounds`-shaped logic.
+- [ ] `field_num`'s price arms switched to exact cents/100.0 division.
+- [ ] Every test touched by #687 re-verified against the new representation, plus new
+      end-to-end tests proving `Eq`/`Ge`/`Le` now agree with narrowing at the exact boundary —
+      not just that narrowing alone is exact.
+- [ ] Decide #687's fate once the new branch is ready: close unmerged, since the new branch's
+      diff against `main` supersedes it entirely.
 
 **Verified, not just argued** — both checks are now permanent regression tests in `tests.rs`:
 `f32_sort_bits_distinguishes_every_cent_up_to_50k` proves zero sort-bits collisions across every


### PR DESCRIPTION
## Summary

`price_bounds` shared one bound between `Lt`/`Le` and between `Gt`/`Ge`, deferring the strict/non-strict distinction to a downstream verify pass — its own comment blamed "f32/f64 rounding," but that's not the real reason. Checked against real data: every stored price is genuinely cent-precise (0 of 81,540 priced printings differ from their rounded-to-cent value by more than 0.001), and the real max price ($5,142.02) is far below where f32 loses cent resolution (ULP ~$0.0006 there, 16x finer than a cent).

Fix: snap to the cents grid via floor/ceil before computing bounds, mirroring `int_range_bounds`'s existing exact-integer technique for `collector_number`. `Eq` is unchanged — its single-bit-pattern bound has no strict/non-strict ambiguity to begin with.

## Verified, not argued

Two new permanent regression tests:
- `f32_sort_bits_distinguishes_every_cent_up_to_50k` — zero sort-bits collisions across every adjacent cent pair from $0.01 to $50,000 (10x the real max price).
- `price_bounds_matches_direct_comparison_on_and_off_grid` — zero disagreements with direct floating comparison across 11 thresholds (cent-aligned and deliberately off-grid/arithmetic-derived, e.g. `49.998`, `0.005`, `12.3456789`) × 5 operators × ~13,900 sampled real prices.

## No behavior or performance change, and here's why

This makes `price_usd` genuinely `tight` (same category as `collector_number`/`released_at`) — a prerequisite for the broad-range fastpath work in `docs/issues/local-engine-broad-range-fastpath.md`. But on its own, nothing today consumes a printing-space `tight` flag in a way that branches differently:

- `narrow_candidates_exact` unconditionally gates exactness off for printing-space results (`n.tight && !printing_space`), so the new `tight=true` for price never reaches the `all_match`/popcount-skip dispatch.
- `tight_narrow_space` still declines price on purpose — that's a separate composition-safety question (the `Not`-arm's complement-soundness gate) deferred to the fastpath PR, not touched here.

Two existing tests (`price_narrowing_is_a_superset_under_f32_rounding` → renamed `price_narrowing_is_exact_at_the_boundary`, and `range_narrowed_representations`) had comments/counts describing the old widened-bound behavior; updated and, in the first case, strengthened to actually assert the new exact boundary exclusion instead of staying silent on it.

## Ride-along

Fixes a `docs/issues` numbering miss from #686 — `local-engine-numeric-range-planes.md` actually has a dedicated GitHub issue (#655) and should never have gotten the `local-` prefix.

## Test plan

- [x] `cargo test` (debug + release): 116 passed, 0 failed
- [x] `python -m pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 159 passed, including the differential property suite (250 seeded queries against a reference oracle sharing no code with the engine)
- [x] `cargo clippy --release`: 37 warnings on both `main` and this branch — diffed by file:line, confirmed the only differences are line-number shifts from this change's added lines, not new warnings