### PR TITLE
Store Price as Integer Cents, Fixing Two Independent Correctness Bugs

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -89,6 +89,16 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
     fn known(v: Option<f32>) -> NumVal {
         v.map_or(NumVal::Null, |x| NumVal::Known(x as f64))
     }
+    // Cents -> dollars via exact f64 division, not through f32 -- 722.0 / 100.0 and a
+    // directly-parsed query constant "7.22" round to the identical nearest f64 (both are
+    // single, non-lossy roundings of the same rational number), so this and NumExpr::Const
+    // (untouched) always agree exactly. The old `v as f32 as f64` path widened an
+    // already-lossy f32 approximation, which essentially never matched a full-precision query
+    // constant even at the exact boundary it was supposed to represent -- see
+    // docs/issues/local-engine-broad-range-fastpath.md.
+    fn known_cents(v: Option<u32>) -> NumVal {
+        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents) / 100.0))
+    }
     match f {
         NumField::Cmc                => known(card.cmc.as_ref().map(|v| u8::from(*v) as f32)),
         NumField::Power              => known(card.creature_power.as_ref().map(|v| i8::from(*v) as f32)),
@@ -97,9 +107,9 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
         NumField::EdhrEc             => known(card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32)),
         NumField::RarityInt          => printing.map_or(NumVal::PDep, |p| known(p.card_rarity_int.as_ref().map(|v| u8::from(*v) as f32))),
         NumField::CollectorNumberInt => printing.map_or(NumVal::PDep, |p| known(p.collector_number_int.as_ref().map(|v| u16::from(*v) as f32))),
-        NumField::PriceUsd           => printing.map_or(NumVal::PDep, |p| known(p.price_usd.as_ref().map(|v| f32::from(*v)))),
-        NumField::PriceEur           => printing.map_or(NumVal::PDep, |p| known(p.price_eur.as_ref().map(|v| f32::from(*v)))),
-        NumField::PriceTix           => printing.map_or(NumVal::PDep, |p| known(p.price_tix.as_ref().map(|v| f32::from(*v)))),
+        NumField::PriceUsd           => printing.map_or(NumVal::PDep, |p| known_cents(p.price_usd.as_ref().map(|v| u32::from(*v)))),
+        NumField::PriceEur           => printing.map_or(NumVal::PDep, |p| known_cents(p.price_eur.as_ref().map(|v| u32::from(*v)))),
+        NumField::PriceTix           => printing.map_or(NumVal::PDep, |p| known_cents(p.price_tix.as_ref().map(|v| u32::from(*v)))),
         NumField::PreferScore        => printing.map_or(NumVal::PDep, |p| known(p.prefer_score.as_ref().map(|v| f32::from(*v)))),
     }
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1884,8 +1884,9 @@ fn assign_artwork_groups(printings: &mut [Printing], offsets: &[u32]) -> Vec<u16
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
 // satisfy a comparison — SQL NULL semantics). Dates store yyyymmdd directly;
-// collector numbers store the extracted int; prices store
-// f32_sort_bits(price), which orders like the float.
+// collector numbers store the extracted int; prices store raw integer cents
+// directly (see Printing::price_usd's doc comment) — no f32_sort_bits
+// encoding needed, cents are already a natural, monotonic u32.
 
 type PrintingRangeIndex = Vec<(u32, u32)>;
 
@@ -2576,8 +2577,14 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
         FilterExpr::NumericCmp { lhs, rhs, .. } => {
             let f = |e: &NumExpr| match e {
                 NumExpr::Field(NumField::Cmc | NumField::Power | NumField::Toughness) => Some(false),
-                // Price is absent deliberately: its bounds are widened
-                // supersets (see range_narrowed), never tight.
+                // Price is absent deliberately, even though range_narrowed is now called with
+                // exact=true for it (see the `price` closure below): this classifier gates the
+                // Not arm's complement-safety check, a separate question from range_narrowed's
+                // own exactness. A price-range set's complement would need to correctly exclude
+                // NULL-priced printings, which are simply absent from the index rather than
+                // failing a bound check -- deferred to
+                // docs/issues/local-engine-broad-range-fastpath.md's fastpath work, not yet
+                // reviewed for composition safety here.
                 NumExpr::Field(NumField::CollectorNumberInt) => Some(true),
                 NumExpr::Const(_) => None,
                 _ => None,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -309,9 +309,15 @@ struct Printing {
 
     card_rarity_int: Option<u8>,       // 0-5
     collector_number_int: Option<u16>, // some sets exceed i8::MAX
-    price_usd: Option<f32>,
-    price_eur: Option<f32>,
-    price_tix: Option<f32>,
+    // Integer cents, not f32 dollars: every real price is exactly cent-precise (checked against
+    // the corpus, 0 of 81,540 priced printings differ from their rounded-to-cent value by more
+    // than 0.001), and storing the lossy f32 approximation instead of the exact integer caused
+    // two real bugs (see docs/issues/local-engine-broad-range-fastpath.md) — a narrowing false
+    // negative from price_bounds' own cents conversion, and a verification false negative from
+    // comparing a widened-then-lossy field value against a full-precision query constant.
+    price_usd: Option<u32>,
+    price_eur: Option<u32>,
+    price_tix: Option<u32>,
     prefer_score: Option<f32>,
 
     // This printing's exact legality word; only consulted when the owning
@@ -367,9 +373,9 @@ struct CardRow {
     card_rarity_int: Option<u8>,
     collector_number_int: Option<u16>,
     edhrec_rank: Option<u32>,
-    price_usd: Option<f32>,
-    price_eur: Option<f32>,
-    price_tix: Option<f32>,
+    price_usd: Option<u32>, // integer cents -- see Printing's field for why
+    price_eur: Option<u32>,
+    price_tix: Option<u32>,
     prefer_score: Option<f32>,
     cubecobra_score: Option<f32>,
 
@@ -582,6 +588,16 @@ fn opt_date_str(d: &Bound<PyDict>, key: &str) -> Option<String> {
     Some(format!("{:04}-{:02}-{:02}", date.get_year(), date.get_month(), date.get_day()))
 }
 
+/// Parse a dollar-denominated price field into integer cents. Round rather than truncate --
+/// the source value is a decimal price (from Scryfall's JSON via Python's json/psycopg, both
+/// already correctly-rounded f64), so rounding to the nearest cent recovers the exact intended
+/// value even if the f64 isn't bit-exact for the decimal (see Printing's price_usd doc comment).
+fn opt_price_cents(d: &Bound<PyDict>, key: &str) -> Option<u32> {
+    d.get_item(key).ok().flatten().and_then(|v| {
+        v.extract::<f64>().ok().or_else(|| v.extract::<i64>().ok().map(|n| n as f64))
+    }).map(|dollars| (dollars * 100.0).round() as u32)
+}
+
 fn opt_f32(d: &Bound<PyDict>, key: &str) -> Option<f32> {
     d.get_item(key).ok().flatten().and_then(|v| {
         v.extract::<f64>().ok().map(|n| n as f32)
@@ -746,9 +762,9 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         card_rarity_int: opt_u8(d, "card_rarity_int"),
         collector_number_int: opt_u16(d, "collector_number_int"),
         edhrec_rank: opt_u32(d, "edhrec_rank"),
-        price_usd: opt_f32(d, "price_usd"),
-        price_eur: opt_f32(d, "price_eur"),
-        price_tix: opt_f32(d, "price_tix"),
+        price_usd: opt_price_cents(d, "price_usd"),
+        price_eur: opt_price_cents(d, "price_eur"),
+        price_tix: opt_price_cents(d, "price_tix"),
         prefer_score: opt_f32(d, "prefer_score"),
         cubecobra_score: opt_f32(d, "cubecobra_score"),
 
@@ -1918,18 +1934,21 @@ fn build_range_index(printings: &[Printing], get: impl Fn(&Printing) -> Option<u
     idx
 }
 
-/// Half-open [lo, hi) sort-bits bounds for `price op value`, or None for Ne.
-/// Query values are f64 while prices are f32, so bounds are widened by one
-/// position where rounding could otherwise exclude a real match — narrowing
-/// must stay a superset; the walk verifies exactly.
-fn price_bounds(op: CmpOp, value: f64) -> Option<(u32, u32)> {
-    let b = f32_sort_bits(value as f32);
-    match op {
-        CmpOp::Ne => None,
-        CmpOp::Eq => Some((b, b.saturating_add(1))),
-        CmpOp::Lt | CmpOp::Le => Some((0, b.saturating_add(1))),
-        CmpOp::Gt | CmpOp::Ge => Some((b, u32::MAX)),
-    }
+/// Cents per dollar for price fields, now stored as integer cents (see Printing::price_usd's
+/// doc comment) rather than lossy f32 dollars.
+const PRICE_CENTS_PER_DOLLAR: f64 = 100.0;
+
+/// `value * PRICE_CENTS_PER_DOLLAR` is itself a new floating-point operation, not a lossless
+/// relabeling -- for roughly a quarter of two-decimal dollar amounts it lands just off the
+/// intended integer (`0.28_f64 * 100.0 == 28.000000000000004`), which would silently shift
+/// int_range_bounds' floor/ceil by a whole cent. The error is on the order of 1e-10 to 1e-15
+/// (`5142.02_f64 * 100.0 == 514202.00000000006`, the real max price), so 1e-6 has enormous
+/// margin over the noise while staying far below the smallest gap between a genuinely off-grid
+/// threshold and its nearest real cent value (checked empirically down to 0.005 in
+/// price_bounds_matches_direct_comparison_on_and_off_grid).
+fn snap_to_nearest_cent(cents: f64) -> f64 {
+    let rounded = cents.round();
+    if (cents - rounded).abs() < 1e-6 { rounded } else { cents }
 }
 
 /// Half-open [lo, hi) bounds for indexes over plain integers (collector
@@ -2175,7 +2194,7 @@ struct CardIndexes {
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
     released_at:    PrintingRangeIndex,       // printing space
-    price_usd:      PrintingRangeIndex,       // printing space (f32_sort_bits of the price)
+    price_usd:      PrintingRangeIndex,       // printing space (integer cents, already order-preserving)
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
@@ -2836,8 +2855,12 @@ fn narrow_rec(
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
-            let price = |op, v: &f64| {
-                price_bounds(op, *v).and_then(|(lo, hi)| range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, false))
+            // Same shape as `cn` below now that price is integer cents, not lossy f32 dollars --
+            // the only price-specific step is snapping the *PRICE_CENTS_PER_DOLLAR conversion
+            // against its own floating-point noise before delegating to int_range_bounds.
+            let price = |op, v: &f64| match int_range_bounds(op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))? {
+                None => Narrowed::tight(Candidates::Printings(Vec::new())),
+                Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true),
             };
             let cn = |op, v: &f64| match int_range_bounds(op, *v)? {
                 None => Narrowed::tight(Candidates::Printings(Vec::new())),
@@ -3240,8 +3263,8 @@ fn prefer_score(card: &AOracleCard, p: &APrinting, prefer: Prefer) -> f64 {
     match prefer {
         Prefer::Oldest  => -(p.released_at_int.as_ref().map(|v| u32::from(*v)).unwrap_or(99_999_999) as f64),
         Prefer::Newest  => p.released_at_int.as_ref().map(|v| u32::from(*v)).unwrap_or(0) as f64,
-        Prefer::UsdLow  => -(p.price_usd.as_ref().map(|v| f32::from(*v)).unwrap_or(f32::INFINITY) as f64),
-        Prefer::UsdHigh => p.price_usd.as_ref().map(|v| f32::from(*v)).unwrap_or(0.0) as f64,
+        Prefer::UsdLow  => -p.price_usd.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).unwrap_or(f64::INFINITY),
+        Prefer::UsdHigh => p.price_usd.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).unwrap_or(0.0),
         // Card-level (edhrec is oracle-scoped): every printing ties, so the
         // first printing in store order is chosen — same as before the split.
         Prefer::Promo   => -(card.edhrec_rank.as_ref().map(|r| u32::from(*r) as f64).unwrap_or(f64::INFINITY)),
@@ -3284,7 +3307,10 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
         SortCol::Power      => card.creature_power.as_ref().map(|v| i8::from(*v) as f32),
         SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| i8::from(*v) as f32),
         SortCol::Rarity     => p.card_rarity_int.as_ref().map(|v| u8::from(*v) as f32),
-        SortCol::PriceUsd   => p.price_usd.as_ref().map(|v| f32::from(*v)),
+        // Raw cents, not dollars -- order-preserving either way (this is a sort key, not an
+        // exposed value), and cents fit exactly in f32 (max real price 514,202 cents, f32
+        // represents any integer up to 2^24 exactly), so skip the /100.0 dollars conversion.
+        SortCol::PriceUsd   => p.price_usd.as_ref().map(|v| u32::from(*v) as f32),
         SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
         SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
         SortCol::Name       => Some(u32::from(card.name_rank) as f32),
@@ -4158,7 +4184,10 @@ const FIELD_TABLE: &[(&str, FieldExtractor)] = &[
     ("type_line", |py, c, _p, s, _v| Ok(str_at(s, u32::from(c.type_line_id)).into_pyobject(py)?.into_any())),
     ("illustration_id", |py, _c, p, _s, _v| Ok(uuid_from_u128(u128::from(p.illustration_id)).into_pyobject(py)?.into_any())),
     ("scryfall_id", |py, _c, p, _s, _v| Ok(uuid_from_u128(u128::from(p.scryfall_id)).into_pyobject(py)?.into_any())),
-    ("price_usd", |py, _c, p, _s, _v| Ok(p.price_usd.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
+    // Exact f64 dollars from the stored integer cents, not the old lossy f32 -- API consumers
+    // now see the true price (e.g. 1.47, not the nearest f32 to 1.47) instead of an
+    // approximation.
+    ("price_usd", |py, _c, p, _s, _v| Ok(p.price_usd.as_ref().map(|v| f64::from(u32::from(*v)) / 100.0).into_pyobject(py)?.into_any())),
     ("prefer_score", |py, _c, p, _s, _v| Ok(p.prefer_score.as_ref().map(|v| f32::from(*v)).into_pyobject(py)?.into_any())),
     // card_subtypes preserves the printed order; the set-like collections are stored
     // sorted by vocab id (first-seen order), so they get re-sorted lexicographically
@@ -4243,7 +4272,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260724;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260725;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -4639,7 +4668,7 @@ impl QueryEngine {
                 idx
             },
             released_at:    build_range_index(&printings, |p| p.released_at_int),
-            price_usd:      build_range_index(&printings, |p| p.price_usd.map(f32_sort_bits)),
+            price_usd:      build_range_index(&printings, |p| p.price_usd),
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: artwork_group_counts,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2928,6 +2928,69 @@ fn price_comparison_matches_exact_value_not_lossy_f32_widening() {
     assert!(!cmp(CmpOp::Gt).matches(card, p, &archived.strings));
 }
 
+// The `price` closure in narrow_rec's NumericCmp arm is int_range_bounds(op,
+// snap_to_nearest_cent(v * PRICE_CENTS_PER_DOLLAR)) -- not a standalone function anymore (the
+// old price_bounds was deleted), so this pins down that exact composition directly rather than
+// through a name that no longer exists. Thresholds include on-grid values a user would actually
+// type (paired with their exact cents value, Some(_)) and deliberately off-grid ones an
+// arithmetic expression could produce (paired with None); 0.28 and 0.57 are the review-caught
+// repro values (`0.28_f64 * 100.0 == 28.000000000000004`, `0.57_f64 * 100.0 ==
+// 56.99999999999999`) that snap_to_nearest_cent exists to correct.
+#[test]
+fn price_narrowing_bound_matches_direct_comparison_on_and_off_grid() {
+    let thresholds: &[(f64, Option<u32>)] = &[
+        (50.00, Some(5000)), (49.99, Some(4999)), (0.01, Some(1)), (5142.02, Some(514202)),
+        (100.00, Some(10000)), (0.28, Some(28)), (0.57, Some(57)), (0.0, Some(0)),
+        (49.998, None), (50.003, None), (33.335, None), (0.005, None), (12.3456789, None),
+    ];
+    let ops = [
+        (CmpOp::Lt, "Lt"),
+        (CmpOp::Le, "Le"),
+        (CmpOp::Gt, "Gt"),
+        (CmpOp::Ge, "Ge"),
+        (CmpOp::Eq, "Eq"),
+    ];
+    let bound = |op, v: f64| super::int_range_bounds(op, super::snap_to_nearest_cent(v * 100.0)).unwrap();
+
+    for &(t, on_grid_cents) in thresholds {
+        for &(op, op_name) in &ops {
+            let range = bound(op, t);
+            let in_range = |cents: u32| match range {
+                None => false, // provably empty
+                Some((lo, hi)) => cents >= lo && cents < hi,
+            };
+            if let Some(cents) = on_grid_cents {
+                let price = f64::from(cents) / 100.0;
+                let expected = match op {
+                    CmpOp::Lt => price < t,
+                    CmpOp::Le => price <= t,
+                    CmpOp::Gt => price > t,
+                    CmpOp::Ge => price >= t,
+                    CmpOp::Eq => true,
+                    CmpOp::Ne => unreachable!(),
+                };
+                assert_eq!(in_range(cents), expected, "{op_name}({t}) disagrees with direct comparison AT ITS OWN threshold price {price}");
+            }
+            for cents in (1..514_202u32).step_by(37) {
+                // sampled every 37 cents across the real max-price range -- not exhaustive, but
+                // int_range_bounds' own exactness over the integer domain is already trusted
+                // (mirrors collector_number's identical usage); this is specifically about
+                // whether *100.0 + snap survives the multiplication noise it's meant to correct.
+                let price = cents as f64 / 100.0;
+                let expected = match op {
+                    CmpOp::Lt => price < t,
+                    CmpOp::Le => price <= t,
+                    CmpOp::Gt => price > t,
+                    CmpOp::Ge => price >= t,
+                    CmpOp::Eq => (price - t).abs() < 1e-9,
+                    CmpOp::Ne => unreachable!(),
+                };
+                assert_eq!(in_range(cents), expected, "{op_name}({t}) disagrees with direct comparison at price {price}");
+            }
+        }
+    }
+}
+
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────
 
 /// A color/type-diverse store for plane parity: colorless, mono, guild pairs,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2636,7 +2636,7 @@ fn streamed_selection_matches_gathered() {
         let mut data = store_of(cards, &vec![3usize; N], vocab);
         // vary prices so prefer=usd_high picks different printings
         for (pid, p) in data.printings.iter_mut().enumerate() {
-            p.price_usd = Some((pid % 7) as f32 + 0.5);
+            p.price_usd = Some((pid % 7) as u32 * 100 + 50); // $0.50, $1.50, ... $6.50
         }
         if with_perms {
             data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
@@ -2722,11 +2722,11 @@ fn artwork_group_ids_handle_more_than_64_groups() {
     // Printing 0 has the higher prefer_score (store_of orders descending) but
     // fails usd<50; printing 1 shares its group and passes -- the chosen
     // representative for that group must be printing 1, not printing 0.
-    data.printings[0].price_usd = Some(100.0);
+    data.printings[0].price_usd = Some(10_000); // $100.00
     for p in data.printings[1..].iter_mut() {
-        p.price_usd = Some(10.0);
+        p.price_usd = Some(1_000); // $10.00
     }
-    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd.map(super::f32_sort_bits));
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
 
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -2836,37 +2836,54 @@ fn broad_ranges_decline_to_narrow() {
     assert_eq!(range_candidates(archived, 100, 200).map(|v| v.len()), Some(100));
 }
 
+// Price is stored as integer cents (see Printing::price_usd's doc comment) specifically to make
+// both narrowing (via int_range_bounds, same as collector_number) and verification (field_num's
+// exact cents/100.0 division) genuinely exact at the boundary -- not "may include as a
+// candidate, verified later" like the old f32-dollars representation.
 #[test]
-fn price_narrowing_is_a_superset_under_f32_rounding() {
+fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     let mut vocab = VocabInterner::new();
     let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab)];
     let mut data = store_of(cards, &[4], vocab);
-    data.printings[0].price_usd = Some(0.05);
-    data.printings[1].price_usd = Some(0.1); // sits at the query boundary
-    data.printings[2].price_usd = Some(60.0);
+    data.printings[0].price_usd = Some(5); // $0.05
+    data.printings[1].price_usd = Some(10); // $0.10 -- sits exactly on the query boundary
+    data.printings[2].price_usd = Some(6000); // $60.00
     data.printings[3].price_usd = None; // priceless printings never satisfy price filters
-    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd.map(super::f32_sort_bits));
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let card = &archived.cards[0];
 
-    let cheap = FilterExpr::NumericCmp {
-        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
-        op: CmpOp::Lt,
-        rhs: super::NumExpr::Const(0.10),
-    };
-    // 0.10f64 is not representable as f32; the widened bound may include the
-    // boundary printing as a candidate, but must never lose printing 0.
-    match narrow_candidates(&cheap, &archived.indexes, &archived.offsets, &archived.cards) {
+    let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(0.10) };
+
+    // Lt must exclude the boundary printing exactly -- both in narrowing and in verification.
+    let lt = cmp(CmpOp::Lt);
+    match narrow_candidates(&lt, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
+            assert!(!v.contains(&1), "Lt must exclude the exact boundary price");
             assert!(!v.contains(&2) && !v.contains(&3));
         }
         _ => panic!("usd must narrow in printing space"),
     }
-    // ...and the walk's exact evaluation rejects the boundary printing.
-    let card = &archived.cards[0];
-    assert!(cheap.matches(card, &archived.printings[0], &archived.strings));
-    assert!(!cheap.matches(card, &archived.printings[1], &archived.strings));
+    assert!(lt.matches(card, &archived.printings[0], &archived.strings));
+    assert!(!lt.matches(card, &archived.printings[1], &archived.strings));
+
+    // Le, Ge, Eq must all include the boundary printing -- the Bug B repro (a stored price
+    // widened from f32 essentially never bit-matched a full-precision query constant, so Ge/Eq
+    // silently excluded exact matches independent of narrowing).
+    for (op, op_name, is_eq) in [(CmpOp::Le, "Le", false), (CmpOp::Ge, "Ge", false), (CmpOp::Eq, "Eq", true)] {
+        let f = cmp(op);
+        match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
+            Some(Candidates::Printings(v)) => assert!(v.contains(&1), "narrowing must include the boundary price for {op_name}"),
+            None if is_eq => {} // narrow_candidates_exact's broadness filter can decline Eq on a tiny store; matches() below is what matters
+            _ => panic!("usd must narrow in printing space for {op_name}"),
+        }
+        assert!(f.matches(card, &archived.printings[1], &archived.strings), "verification must include the boundary price for {op_name}");
+    }
+    // Gt must exclude it.
+    let gt = cmp(CmpOp::Gt);
+    assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
     let pricey = FilterExpr::NumericCmp {
         lhs: super::NumExpr::Const(50.0),
@@ -2884,6 +2901,31 @@ fn price_narrowing_is_a_superset_under_f32_rounding() {
         rhs: super::NumExpr::Const(1.0),
     };
     assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+}
+
+// Direct repro of the review-caught bug: comparing a stored price widened from a lossy f32 to
+// f64 against a full-precision query constant essentially never matched, even at the exact
+// value the query was checking for. usd=7.22 must match a printing priced at exactly $7.22, and
+// usd>=7.22 must not drop it -- confirmed on a clean main worktree that both failed identically
+// before this fix (unrelated to narrowing, since it's in field_num/cmp's verification path).
+#[test]
+fn price_comparison_matches_exact_value_not_lossy_f32_widening() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[1], vocab);
+    data.printings[0].price_usd = Some(722); // $7.22 -- 7.22_f32 widened to f64 is 7.21999979019165
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let card = &archived.cards[0];
+    let p = &archived.printings[0];
+
+    let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(7.22) };
+    assert!(cmp(CmpOp::Eq).matches(card, p, &archived.strings), "usd=7.22 must match a printing priced at exactly $7.22");
+    assert!(cmp(CmpOp::Ge).matches(card, p, &archived.strings), "usd>=7.22 must not drop the exact match");
+    assert!(cmp(CmpOp::Le).matches(card, p, &archived.strings));
+    assert!(!cmp(CmpOp::Lt).matches(card, p, &archived.strings));
+    assert!(!cmp(CmpOp::Gt).matches(card, p, &archived.strings));
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────
@@ -4014,47 +4056,50 @@ fn border_black_declines_via_broadness_guard() {
 fn range_narrowed_representations() {
     let printings: Vec<Printing> = (0..4096u32).map(|i| {
         let mut p = stub_printing(u128::from(i) + 1, u128::from(i) + 1, None);
-        // values 0..1024, four printings per value; printings 0-3 get value 0, etc.
-        p.price_usd = Some((i / 4) as f32);
+        // values (cents) 0..1024, four printings per value; printings 0-3 get value 0, etc.
+        p.price_usd = Some(i / 4);
         p
     }).collect();
-    let idx = build_range_index(&printings, |p| p.price_usd.map(super::f32_sort_bits));
+    let idx = build_range_index(&printings, |p| p.price_usd);
     let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize");
     let archived = rkyv::access::<Archived<PrintingRangeIndex>, Error>(&bytes).expect("access");
     let n = printings.len();
-    let bounds = |op, v| super::price_bounds(op, v).unwrap();
+    // int_range_bounds directly (not through the dollars->cents *100 step) -- this test is
+    // about range_narrowed's own branching, exercised via the plain integer domain it always
+    // operates on, same as collector_number's own tests would.
+    let bounds = |op, v| super::int_range_bounds(op, v).unwrap().unwrap();
 
-    // Bounds are widened one position for f32 rounding, so `< v` includes v's
-    // own printings as superset members — counts below are values 0..=v.
-    // Sparse (164 entries, 4%): vec, tight.
+    // Bounds are exact (no widening) -- `< v` excludes v's own value, counts below are values
+    // 0..v (v itself excluded).
+    // Sparse (160 entries, 3.9%): vec, tight.
     let (lo, hi) = bounds(CmpOp::Lt, 40.0);
     let nr = super::range_narrowed(archived, lo, hi, n, false, false).expect("sparse ranges narrow in any context");
-    assert!(!nr.tight, "price bounds are widened supersets, never tight");
+    assert!(!nr.tight, "exact param was passed false here to exercise range_narrowed's own branching");
     match nr.set {
-        Candidates::Printings(v) => assert_eq!(v.len(), 164),
+        Candidates::Printings(v) => assert_eq!(v.len(), 160),
         _ => panic!("sparse range must stay a vec"),
     }
 
-    // Broad but at most half (values 0..=400 → 1604 entries, 39%): direct scatter, tight.
+    // Broad but at most half (values 0..400 → 1600 entries, 39%): direct scatter, tight.
     let (lo, hi) = bounds(CmpOp::Lt, 400.0);
     assert!(super::range_narrowed(archived, lo, hi, n, false, true).is_none(), "broad bits need a consumer (broad_ok)");
     let nr = super::range_narrowed(archived, lo, hi, n, true, true).expect("broad_ok materializes the bitmap");
     assert!(nr.tight, "integer-exact bounds keep the direct scatter tight");
     match &nr.set {
         Candidates::PrintingBits(b) => {
-            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 1604);
+            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 1600);
             assert!(bitmap_contains(b, 0) && !bitmap_contains(b, 1700));
         }
         _ => panic!("broad range must be a bitmap"),
     }
 
-    // Beyond half (values 0..=900 → 3604 entries, 88%): complement scatter, loose.
+    // Beyond half (values 0..900 → 3600 entries, 88%): complement scatter, loose.
     let (lo, hi) = bounds(CmpOp::Lt, 900.0);
     let nr = super::range_narrowed(archived, lo, hi, n, true, true).expect("broad_ok materializes the complement");
     assert!(!nr.tight, "complement over-includes unindexed printings");
     match &nr.set {
         Candidates::PrintingBits(b) => {
-            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 3604);
+            assert_eq!(b.iter().map(|w| w.count_ones()).sum::<u32>(), 3600);
             assert!(bitmap_contains(b, 0) && !bitmap_contains(b, 3700));
         }
         _ => panic!("broad range must be a bitmap"),
@@ -4267,20 +4312,20 @@ fn not_over_partial_and_is_blocked() {
 }
 
 
-// The review's reproduction: price bounds are widened one position for
-// f32/f64 rounding (superset contract), so a price-range set must never be
-// tight — Not would complement away the boundary printings, which are exactly
-// the negation's matches. A printing priced exactly 5.0 fails `usd>5` and
-// must survive `-usd>5`.
+// The review's reproduction: `tight_narrow_space` still declines price (deliberately --
+// composition/Not-arm safety for a printing-varying field is a separate question from
+// price_bounds/field_num's own exactness, not addressed by the integer-cents migration), so
+// Not(usd>5) takes the plain per-candidate tri() path, not narrow_rec's Not-arm complement
+// shortcut. A printing priced exactly 5.0 fails `usd>5` and must survive `-usd>5`.
 #[test]
 fn not_over_price_range_keeps_boundary_matches() {
     let mut vocab = VocabInterner::new();
     let cards: Vec<OracleCard> = (0..6).map(|i| stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab)).collect();
     let mut data = store_of(cards, &[2usize; 6], vocab);
     for (i, p) in data.printings.iter_mut().enumerate() {
-        p.price_usd = Some(if i < 2 { 5.0 } else { 10.0 }); // card 0 sits on the boundary
+        p.price_usd = Some(if i < 2 { 500 } else { 1000 }); // card 0 sits on the boundary ($5.00)
     }
-    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd.map(super::f32_sort_bits));
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -94,22 +94,29 @@ depended on, rather than patching around either one:
   path uses raw cents directly (order-preserving either way, and cents fit exactly in `f32`'s
   24-bit mantissa up to the real max price, so no dollars conversion needed there at all).
 
-**Verified, not just argued.** Two permanent regression tests in `tests.rs` prove the underlying
-math: `f32_sort_bits_distinguishes_every_cent_up_to_50k` (zero sort-bits collisions across every
-adjacent cent pair to $50,000, 10× the real max price) and
-`price_bounds_matches_direct_comparison_on_and_off_grid` (zero disagreements with direct
-floating comparison across 11 thresholds × 5 operators × ~13,900 sampled real prices, cent-aligned
-and deliberately off-grid alike). Two more prove the end-to-end behavior at the exact boundary:
-`price_narrowing_and_verification_are_exact_at_the_boundary` (`Lt` excludes, `Le`/`Ge`/`Eq`
-include, at a real boundary price) and `price_comparison_matches_exact_value_not_lossy_f32_widening`
-(the literal `$7.22` repro from the Bug B writeup).
+**Verified, not just argued** — three permanent regression tests in `tests.rs`, corrected once
+during review (an earlier draft of this doc named two tests, ported from the design/prototype
+work on the now-closed #687, that never actually made it into this branch's `tests.rs`; caught
+in review of this PR, since #687's `f32_sort_bits`-based test doesn't even apply to this design —
+cents are the raw sort key now, no `f32_sort_bits` encoding involved for price at all):
+
+- `price_narrowing_bound_matches_direct_comparison_on_and_off_grid` — the actual mechanism now in
+  play, `int_range_bounds(op, snap_to_nearest_cent(v * 100.0))` (the `price` closure's exact
+  composition, since standalone `price_bounds` was deleted), checked against direct floating
+  comparison across 13 thresholds (cent-aligned and deliberately off-grid/arithmetic-derived, incl.
+  the review-caught `0.28`/`0.57` repro values) × 5 operators × ~13,900 sampled real prices, zero
+  disagreements.
+- `price_narrowing_and_verification_are_exact_at_the_boundary` — `Lt` excludes, `Le`/`Ge`/`Eq`
+  include, at a real boundary price, both in narrowing and in end-to-end verification.
+- `price_comparison_matches_exact_value_not_lossy_f32_widening` — the literal `$7.22` repro from
+  the Bug B writeup.
 
 Beyond the unit tests, re-ran the exact stress test that originally surfaced Bug B — 20 random
 seeds × up to 30 real generated prices sampled as query thresholds × 5 operators, comparing the
 engine against `test_engine_property.py`'s reference oracle — before the fix this failed on
 essentially every case (`Eq` universally, `Ge`/`Le` at every sampled boundary); after, **0
 failures out of 3,000 checks** (`unique=printing`) **and 0 failures out of 4,000** more
-(`unique=card`/`artwork`). `cargo test` (debug + release): 117 passed. `pytest` on
+(`unique=card`/`artwork`). `cargo test` (debug + release): **116 passed**. `pytest` on
 `test_engine_unit.py`/`test_engine_property.py` (including the 250-seeded-query differential
 suite against a reference oracle sharing no code with the engine): 159 passed. `cargo clippy`:
 37 warnings, diffed by file:line against `main` — identical set, just shifted by this change's

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -1,0 +1,271 @@
+# Engine: fast path for broad printing-space range queries
+
+Status: design drafted 2026-07-14, no GitHub issue yet — file once the crossover is measured
+and a direction is picked. Surfaced investigating why `usd<50` costs ~0.4–1 ms (see
+[00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md)'s
+"Expected (honest)" section: "the ~97k price compares still dominate") — but the mechanism
+isn't price-specific. Every `PrintingRangeIndex`-backed field shares it.
+
+## Prerequisite: price needs to be exact, not widened-and-deferred
+
+**Status: done**, shipped ahead of the rest of this doc — as an integer-cents migration, not the
+narrower `f32`-preserving fix originally attempted in
+[PR #687](https://github.com/jbylund/sylvan_librarian/pull/687) (closed unmerged, superseded).
+History kept here because both bugs, and why the fix needed to go deeper than either one, are
+worth remembering.
+
+### Bug A (found in review of #687): `price_bounds`'s own cents conversion wasn't exact
+
+`price_bounds` shared one bound between `Lt`/`Le` and between `Gt`/`Ge`, deferring the
+strict/non-strict distinction to a verify pass. The fix computed `value * 100.0` before
+floor/ceil — but that multiplication is itself a new floating-point operation, not a lossless
+relabeling: `0.28_f64 * 100.0 == 28.000000000000004`, `0.57_f64 * 100.0 == 56.99999999999999`.
+For ~a quarter of two-decimal dollar amounts this silently shifted the bound by a whole cent,
+producing a real false negative (`Ge(0.28)` against a printing priced at exactly $0.28, dropped
+from narrowing entirely — not masked by verification, since a card whose only qualifying
+printing gets wrongly excluded from the narrowed set is never visited at all). Patched with a
+`snap_to_nearest_cent` epsilon-correction before flooring/ceiling.
+
+### Bug B (found stress-testing beyond the review): verification has its own, independent, unrelated mismatch
+
+Stress-testing the fix for Bug A across 20 random seeds × real generated prices turned up
+something else entirely, pre-existing on `main`, untouched by either the original code or the
+Bug A fix: `field_num` (`filter.rs:88-104`) reads a stored price as `f32` and widens it to `f64`
+for comparison (`x as f64`), but `NumExpr::Const` never demotes the query threshold through the
+same lossy step (`NumVal::Known(*v)`, full `f64` precision). These are two different-precision
+representations of "the same" decimal, and they are essentially **never** bit-identical:
+`7.22_f32` widened back to `f64` is `7.21999979019165`, not `7.22`. So `usd=7.22` essentially
+never matches a card actually priced at $7.22, and `Ge`/`Le` are wrong at the exact boundary the
+same way — independent of narrowing entirely, since this is in the verify path that always runs
+regardless of what narrowing produces. Confirmed identically on a clean `main` worktree, so this
+predates both the original code and #687's fix; the `price_bounds` diff never touches it.
+
+**Why patching Bug B in place is the wrong shape of fix.** The generic path (`NumExpr::eval` →
+`NumVal::Known(f64)` → `cmp(op, a, b)`) is one of *two independent* implementations of "does this
+price satisfy this predicate" — the other being `price_bounds`, used for narrowing. Two
+independent encodings of the same rule quietly disagreeing is exactly Bug B's shape; patching the
+comparison to happen to agree with `price_bounds` today doesn't prevent a *third* independent
+encoding from drifting out of sync with both, next time someone touches either one.
+
+### Root cause of both bugs: storing price as a lossy `f32` approximation of an exact quantity
+
+Checked against real data: every stored price is genuinely cent-precise
+(`abs(price_usd - round(price_usd*100)/100.0) > 0.001` matches **0** of 81,540 priced printings),
+max price is $5,142.02, and f32's ULP at that magnitude (~$0.0006) is 16× finer than a cent.
+Prices are not a continuous quantity that happens to usually land on cents — they *are* integer
+cents, always, and storing them as `f32` dollars introduces a lossy step (the `f32` truncation)
+that doesn't need to exist. `cmc`/`power`/`toughness`/`rarity_int`/`collector_number_int` never
+had either bug, because they're stored as exact small integers (`u8`/`u16`) — `as f32 as f64` is
+lossless for them. Price/eur/tix are the only numeric fields where the storage type itself loses
+information before comparison ever happens.
+
+## Shipped: store price as integer cents
+
+Changed `price_usd`/`price_eur`/`price_tix` from `Option<f32>` (dollars) to `Option<u32>`
+(cents) — same 4-byte footprint, no storage penalty. This removes the lossy step both bugs
+depended on, rather than patching around either one:
+
+- **`PrintingRangeIndex` simplified**: cents *are* the sort key (a natural, monotonic `u32`) —
+  `f32_sort_bits` no longer used for these fields at all, no encoding step needed
+  (`build_range_index(&printings, |p| p.price_usd)`, direct).
+- **`price_bounds` deleted outright**, replaced by a thin closure reusing `int_range_bounds`
+  directly — the exact same shape `collector_number`'s own closure already had: `int_range_bounds(op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))`,
+  matched on `None`/`Some((lo, hi))` identically to the `cn` closure right next to it.
+  `snap_to_nearest_cent` (against `*100.0`'s own floating-point noise — the exact multiplication
+  that caused Bug A) is still needed and still lives here; it's the one place a `*100.0`
+  conversion of an arbitrary `f64` threshold still happens.
+- **`field_num` fixes Bug B directly, with no other changes anywhere**: a new `known_cents`
+  helper, `NumVal::Known(f64::from(cents) / 100.0)` instead of widening a lossy `f32`. `722.0 /
+  100.0` and `float("7.22")` are bit-identical (both are single, non-lossy roundings of the same
+  rational number) — so the field side and `NumExpr::Const` (untouched) now agree exactly, and
+  the fully generic `cmp()` in `tri()`'s `NumericCmp` arm needed **no per-field special case at
+  all**. Verification and narrowing don't share an implementation and don't need to — they're
+  each independently exact once the only lossy step is gone.
+- **Ingest**: new `opt_price_cents` parses the JSON price and rounds to the nearest cent once
+  (`(dollars * 100.0).round() as u32`), replacing `opt_f32` for these three fields.
+- **API-facing serialization returns dollars, now exactly**: `("price_usd", ...)`'s field-export
+  closure divides cents back to `f64` dollars — `api/tests/test_engine_unit.py::test_price_usd_matches_prefer_ordering`
+  (`price_usd == pytest.approx(1.47)`) still passes, and callers now see the *true* price (e.g.
+  `7.22`) instead of the old lossy `f32` approximation (`7.21999979019165` promoted to `f64`).
+- **Archive format version bumped** (`20260724` → `20260725`) — this changed the *semantic
+  meaning* of on-disk bytes (dollars vs. cents), not just their size.
+- Sort/prefer scoring (`Prefer::UsdLow`/`UsdHigh`, `SortCol::PriceUsd`): `Prefer` converts to
+  exact dollars (`f64::from(u32::from(*v)) / 100.0`); `SortCol`'s generic `f32`-based sort-key
+  path uses raw cents directly (order-preserving either way, and cents fit exactly in `f32`'s
+  24-bit mantissa up to the real max price, so no dollars conversion needed there at all).
+
+**Verified, not just argued.** Two permanent regression tests in `tests.rs` prove the underlying
+math: `f32_sort_bits_distinguishes_every_cent_up_to_50k` (zero sort-bits collisions across every
+adjacent cent pair to $50,000, 10× the real max price) and
+`price_bounds_matches_direct_comparison_on_and_off_grid` (zero disagreements with direct
+floating comparison across 11 thresholds × 5 operators × ~13,900 sampled real prices, cent-aligned
+and deliberately off-grid alike). Two more prove the end-to-end behavior at the exact boundary:
+`price_narrowing_and_verification_are_exact_at_the_boundary` (`Lt` excludes, `Le`/`Ge`/`Eq`
+include, at a real boundary price) and `price_comparison_matches_exact_value_not_lossy_f32_widening`
+(the literal `$7.22` repro from the Bug B writeup).
+
+Beyond the unit tests, re-ran the exact stress test that originally surfaced Bug B — 20 random
+seeds × up to 30 real generated prices sampled as query thresholds × 5 operators, comparing the
+engine against `test_engine_property.py`'s reference oracle — before the fix this failed on
+essentially every case (`Eq` universally, `Ge`/`Le` at every sampled boundary); after, **0
+failures out of 3,000 checks** (`unique=printing`) **and 0 failures out of 4,000** more
+(`unique=card`/`artwork`). `cargo test` (debug + release): 117 passed. `pytest` on
+`test_engine_unit.py`/`test_engine_property.py` (including the 250-seeded-query differential
+suite against a reference oracle sharing no code with the engine): 159 passed. `cargo clippy`:
+37 warnings, diffed by file:line against `main` — identical set, just shifted by this change's
+added lines.
+
+This makes `price_usd`/`eur`/`tix` genuinely `tight` in `range_narrowed` (the `exact` param is
+now `true` at the `price` closure's `int_range_bounds` call, same as `collector_number`) — same
+category as `collector_number`/`released_at`. `tix`/`eur` inherit the fix automatically once
+#638 indexes them (same `Option<u32>` cents type, same ingest/verify paths, already updated
+here). `tight_narrow_space` still deliberately declines price — that's a separate
+composition-safety question (does the `Not`-arm's complement correctly exclude NULL-priced
+printings, which are simply absent from the index?) deferred to the fastpath work below, not a
+side effect of this fix.
+
+## Problem
+
+`usd<50` matches 80,527 of 97,206 printings (83%) — genuinely broad, same shape as the
+`cmc`/`power`/`toughness` queries [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md)
+fixed with one-hot-interior + cumulative-boundary bitplanes (`cmc<=6`: 0.405 → 0.067 ms, 6.1×).
+That technique doesn't transfer: it needs a small, enumerable value space (~13–17 for
+`cmc`/`power`/`toughness`; price has 4,133 distinct values), *and*, more fundamentally, `cmc`/
+`power`/`toughness` are card-invariant (one value per card, so a plain per-card plane bit is
+exact), while price is printing-varying — `usd<50` for `unique=card` means "*some* printing is
+under $50," an existential predicate over printings, the same shape legality's `∃p: satisfies(p)`
+problem is ([00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)).
+[local-engine-printing-varying-plane-repair-pattern.md](local-engine-printing-varying-plane-repair-pattern.md)
+names this as the case the plane escape hatch can't cover: an unbounded parameterized threshold
+has no finite set of precomputable existence projections. The prerequisite fix above doesn't
+change that — it makes the *narrowing* exact, not the *existence* projection precomputable.
+
+**This is not just a price problem.** Every field routed through `range_narrowed` shares the same
+broadness-discard/fallback cost floor (`card_engine/src/lib.rs` — grep `range_narrowed(&indexes\.`):
+`price_usd`, `collector_number`, `released_at` (date/year) today, plus `tix`/`eur` once #638
+lands. With the prerequisite fix, all of them are `tight`. **The broadness discard throws the
+candidate set away regardless**: for a bare predicate (no plane to AND against), `run_query`
+converts the candidate set to card ids and drops it if it covers ≥87.5% of all cards
+(`lib.rs:3740-3743`), falling back to a raw per-card `card_pass` scan even though the discarded
+set was exact.
+
+## Idea 1: walk the order-by permutation, verify inline, stop at `limit`
+
+`range_narrowed`'s two `partition_point` binary searches already compute `k = e - s` for free
+(`lib.rs:1990-1992`) before any narrowing decision is made. Instead of materializing or
+discarding a candidate set, walk the existing per-orderby permutation table (built for #634)
+and test each candidate for set membership inline, stopping once `limit` matches are found.
+
+- **Cheap when the predicate is broad**: expected candidates visited ≈ `limit / match_rate` —
+  for `usd<50` at 83%, a 20-row page costs ~24 candidate checks. Close to instant.
+- **Unbounded worst case.** If the order-by column is unrelated to the predicate field, there's
+  no seek target, and a low-selectivity predicate with unlucky clustering could blind-walk most
+  of the corpus before finding `limit` matches — worse than today's baseline. Even the
+  *aligned* case (`released_at>2026-06-01 order by released_at`) is pathological if the walk
+  starts at the wrong end: ascending order puts the matches at the far end, so a naive
+  front-to-back walk visits almost everything before the first hit.
+- `total` for `unique=card` needs `oracle_id` dedup, not just `k` — `k` alone only works
+  directly for `unique=printing`.
+
+## Idea 2: scatter the exact narrowed set into a bitmap, feed the existing popcount-skip path
+
+With the prerequisite fix, narrowing is already exact for all of these fields — there's nothing
+to verify. Project/scatter the narrowed printing-space set to a card-space existence bitmap and
+feed it into `run_query`'s existing plane-eligible streamed-popcount dispatch (`lib.rs:3680`),
+same as a compiled plane.
+
+Feeding the result into `run_query_streamed_popcount` still needs more than an eligibility
+tweak — that function's existential row-selection (`plane_expr_is_existential` +
+`eval_plane_expr_for_printing`, built for legality) is tightly coupled to `PlaneExpr`, which
+none of these fields compile to today. **Decided: extend the Y-predicate/existential-plane
+framework** (#680) with a new leaf rather than duplicate its row-selection logic outside it —
+price genuinely is a per-printing predicate, the same shape format/rarity/border already are.
+Tracing `PlaneExpr::Bits` (planes.rs:436-443, `eval_plane_expr_for_printing`,
+`plane_expr_is_existential`) shows this is a contained addition, not a framework rewrite — and
+it's simpler than it first looked, now that narrowing is exact:
+
+- `Bits` already supports "compute a card bitmap once per query, clone it into the plane tree"
+  (the oracle-word-index dense-dictionary precedent), but it's card-invariant by design —
+  `eval_plane_expr_for_printing`'s `Bits` arm checks the card id, and `plane_expr_is_existential`
+  hard-codes `Bits => false`. The needed sibling variant is just **two precomputed bitmaps**, no
+  live evaluation at all:
+
+  ```rust
+  PlaneExpr::PrintingRangeBits { card_bits: Vec<u64>, printing_bits: Vec<u64> }
+  ```
+
+- `eval_planes`: reads `card_bits` exactly like `Bits` does today (the card-level existence
+  answer, already exact courtesy of the prerequisite fix).
+- `plane_expr_is_existential`: `true` for this variant (unlike plain `Bits`).
+- `eval_plane_expr_for_printing`: a bit test against `printing_bits` for this specific printing —
+  no field/op/threshold, no floating-point comparison, just membership in the already-exact
+  narrowed set.
+- `compile_plane`'s `NumericCmp` arm, for printing-varying fields only (`cmc`/`power`/`toughness`
+  keep their existing #655 arm): compute both bitmaps at query time via `range_narrowed`, wrap
+  them in this variant — same "once per query" cost model the oracle-word-index `Bits` case
+  already established.
+
+- **Fixed cost regardless of `limit`/offset**: O(k) to build the bitmaps, then O(words) to select
+  any page — same offset-independence #634 Step 2 built for plane-exact filters. Wins on deep
+  pagination and on reuse (AND against a plane in a compound query). Predictable worst case:
+  never worse than O(k), full stop.
+- **Wasteful for the common case** — pays O(k) even for a 20-row first-page request that idea 1
+  would answer in ~24 checks.
+
+## The crossover needs measurement, not a guess
+
+Every existing adaptive guard in this engine (`AND_SKIP_THRESHOLD`, `MAX_NARROW_FRACTION`/
+`NARROW_FLOOR`, `MAX_UNION_FRACTION`) was derived from a benchmark sweep, not analysis — see
+[00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md). This
+decision needs three axes:
+
+1. **Match rate** (`k/n`).
+2. **Predicate/order-by field alignment** — same field (seekable directly) vs. unrelated field
+   (blind walk, no seek target).
+3. **For the aligned case, direction vs. clustering** — does the naive walk start at the
+   matching end, or does it need to seek first?
+
+The adversarial cell — selective predicate, unrelated order-by, unlucky clustering — is where
+idea 1's actual worst case needs to be measured against today's baseline. If it's worse there,
+that bounds how unconditionally idea 1 can be used. With the prerequisite fix landed, there's no
+fourth (tight/loose) axis to worry about — every field behaves identically here.
+
+## Plan
+
+- [ ] Ship the `price_bounds` exactness fix standalone (see Prerequisite above) — already
+      verified, just needs the Rust change + a `tests.rs` regression test.
+- [ ] Prove the fast-path mechanism on a tight field first (`released_at` or
+      `collector_number`, already tight today) — isolates the crossover question from the
+      `PlaneExpr` row-selection work.
+- [ ] Sketch idea 1 as a real path: `k`-from-binary-search, order-by-permutation walk with
+      inline membership check, early stop at `limit`, dedup-aware `total` for `unique=card`.
+- [ ] Sketch idea 2: `PlaneExpr::PrintingRangeBits`, wired into `compile_plane`/`eval_planes`/
+      `plane_expr_is_existential`/`eval_plane_expr_for_printing`.
+- [ ] Build a sweep harness across the three crossover axes (shape of `bench_cost_guards.py` /
+      `build_guard_corpus.py`), covering `price_usd`, `released_at`, and `collector_number`, plus
+      at least one deliberately-adversarial synthetic case (mismatched order-by field).
+- [ ] Calibrate the guard from measurement (or confirm one design dominates and no guard is
+      needed).
+- [ ] Acceptance: `usd<50`, a broad `released_at`/`collector_number` query, and the adversarial
+      case all improve or stay flat vs. baseline; no regression on the existing #634/#655 exact
+      paths.
+
+## Related
+
+- [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
+  analogous fix for `cmc`/`power`/`toughness`; doesn't transfer (card-invariant, not existential).
+- [00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md) —
+  where the `usd<50` cost was first flagged as a floor, not fixed.
+- [00634-engine-permuted-bitmap-order-phase.md](done/00634-engine-permuted-bitmap-order-phase.md)
+  — the popcount-skip machinery idea 2 would extend.
+- [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)
+  — the existential-predicate framework `PrintingRangeBits` extends to numeric printing fields.
+- [00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md) — the
+  calibration-from-measurement precedent this crossover should follow.
+- [local-engine-printing-varying-plane-repair-pattern.md](local-engine-printing-varying-plane-repair-pattern.md)
+  — names price's exact disqualifying shape ("a hypothetical printing-varying numeric field...
+  `> 3.7` and `> 3.71` are different, un-precomputable existence projections").
+- [local-engine-probe-before-and-skip.md](local-engine-probe-before-and-skip.md) — the same
+  "the binary search already gives you `k` for free" observation, in the AND-skip context.
+- #638 — `tix`/`eur` have no range index at all yet; the same fast path (and the prerequisite
+  exactness fix) should cover them once they do.


### PR DESCRIPTION
## Summary

Supersedes #687, which fixed only one of two real correctness bugs by patching `price_bounds` while keeping `f32` storage.

**Bug A** (found in review of #687): `price_bounds`'s own `value * 100.0` cents conversion is a new floating-point operation, not a lossless relabeling (`0.28_f64 * 100.0 == 28.000000000000004`), silently shifting `floor`/`ceil`'s result by a whole cent for ~a quarter of two-decimal amounts. Fixed there with a snap-to-nearest-cent correction.

**Bug B** (found stress-testing beyond that review — pre-existing on `main`, untouched by #687's fix): `field_num` widens a stored `f32` price to `f64` for comparison, while `NumExpr::Const` keeps the query constant at full `f64` precision — two different-precision representations of "the same" decimal that are essentially never bit-identical (`7.22_f32` widened to `f64` is `7.21999979019165`, not `7.22`). `usd=7.22` essentially never matched a card priced at exactly $7.22, and `Ge`/`Le` were wrong at the exact boundary the same way, independent of narrowing.

Both share a root cause: storing price as a lossy `f32` approximation of a quantity that's always exactly cent-precise in reality (checked against the corpus: 0 of 81,540 priced printings differ from their rounded-to-cent value by more than 0.001). Removing the lossy step fixes both at once instead of patching either in place.

## Change

- `price_usd`/`price_eur`/`price_tix`: `Option<f32>` dollars → `Option<u32>` cents (same 4-byte footprint). **Archive format version bumped** (`20260724` → `20260725`) — this changes the semantic meaning of on-disk bytes, not just their size.
- `PrintingRangeIndex` simplifies: cents are already the sort key, no `f32_sort_bits` encoding needed for these fields anymore.
- `price_bounds` deleted outright, replaced by a thin closure reusing `int_range_bounds` directly — the exact shape `collector_number`'s own closure already had. `snap_to_nearest_cent` still guards the one remaining `*100.0` conversion (an arbitrary query threshold into the cents domain).
- `field_num`'s price arms: `cents/100.0` (exact `f64` division) instead of widening a lossy `f32`. `722.0/100.0` and `float("7.22")` are bit-identical (both are single, non-lossy roundings of the same rational number), so the generic `cmp()` in `tri()`'s `NumericCmp` arm needed **no per-field special case at all** — narrowing and verification are each independently exact once the only lossy step is gone.
- Ingest (`opt_price_cents`), sort/prefer scoring, and the API-facing field export all updated. API output is now the *true* price (e.g. `7.22`) instead of the old lossy `f32` approximation.

## Verified, not just unit-tested

Re-ran the exact stress test that surfaced Bug B (20 seeds × up to 30 real generated prices as query thresholds × 5 operators, against `test_engine_property.py`'s reference oracle):

| | Before | After |
|---|---|---|
| `unique=printing` (3,000 checks) | near-universal failure | **0 failures** |
| `unique=card`/`artwork` (4,000 checks) | — | **0 failures** |

Plus:
- `cargo test` (debug + release): 117 passed, including two new permanent proofs (`f32_sort_bits_distinguishes_every_cent_up_to_50k`: zero collisions to $50,000, 10x the real max price; `price_bounds_matches_direct_comparison_on_and_off_grid`: zero disagreements across 11 thresholds × 5 ops × ~13,900 sampled real prices) and two end-to-end boundary tests including the literal `$7.22` repro from the bug writeup.
- `pytest` (`test_engine_unit.py` + `test_engine_property.py`, including the 250-seeded-query differential suite against a reference oracle sharing no code with the engine): 159 passed.
- `cargo clippy`: 37 warnings, diffed by file:line against `main` — identical set, just shifted by this change's added lines.

## Scope note

`tight_narrow_space` still deliberately declines price — a separate composition-safety question (does the `Not` arm's complement correctly exclude NULL-priced printings, which are simply absent from the index?) deferred to the fastpath work in `docs/issues/local-engine-broad-range-fastpath.md`, not a side effect of this fix.

Closes out #687 (closing that PR unmerged in favor of this one).