### PR TITLE
Extend PrintingRangeBits to Collector Number and Released Date Queries (Plus Two Unrelated Verifier Speedups)

### DIFF
--- a/card_engine/src/bench_card_dedup.rs
+++ b/card_engine/src/bench_card_dedup.rs
@@ -1,0 +1,172 @@
+//! Micro-benchmark, split into two purposes:
+//!
+//! 1. Regression guard for `cards_of_printings`' direct-array projection
+//!    (`printing_to_card`, shipped — see
+//!    docs/issues/local-engine-direct-projection-arrays.md), benchmarked here
+//!    against synthetic offsets at real corpus scale.
+//! 2. Still-open exploration of `groups_of_printings`/`printing_to_global_group`
+//!    for crossover axis 4 of docs/issues/local-engine-broad-range-fastpath.md
+//!    — deferred, not shipped; kept here as the recorded evidence for that
+//!    future decision.
+//!
+//! Synthetic offsets at real scale (31,508 cards / 97,206 printings, ~3.09 printings/card
+//! average) rather than corpus-derived — this is about the cost *shape* at realistic scale, not
+//! validating one exact query, same reasoning as bench_posting_intersect.rs.
+//!
+//!     cargo test --release bench_card_dedup -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::RngExt;
+use rkyv::{rancor::Error, Archived};
+
+use super::{build_printing_to_card, cards_of_printings, scatter_bits, AOffsets};
+
+const N_CARDS: usize = 31_508;
+const ITERS: usize = 50;
+
+/// Prototype for the still-open question in crossover axis 4: would a
+/// groups_of_printings, mirroring cards_of_printings but deduping by (card, local
+/// artwork_group_id) instead of by card alone, close artwork mode's gap toward card
+/// mode's? Unlike cards_of_printings' small-k path, adjacent-compare-after-sort
+/// doesn't work here even for small k: printings within one card's range can visit
+/// local group ids in any order (0, 1, 0, 2, ...), so equal groups from the same
+/// card aren't necessarily adjacent in a printing-index-sorted walk the way card ids
+/// are (cards own contiguous ranges; groups don't have that property within a
+/// card's range). Always bitmap-scatter here rather than replicate that assumption
+/// incorrectly.
+fn groups_of_printings(offsets: &AOffsets, group_offsets: &[u32], local_group_ids: &[u16], printing_ids: &[u32], n_groups: usize) -> usize {
+    let global_ids = printing_ids.iter().map(|&p| {
+        let card = offsets.partition_point(|o| u32::from(*o) <= p) as u32 - 1;
+        group_offsets[card as usize] + u32::from(local_group_ids[p as usize])
+    });
+    let bits = scatter_bits(global_ids, n_groups);
+    bits.iter().map(|w| w.count_ones() as usize).sum()
+}
+
+/// Direct `printing_id -> global_group_id` lookup, precomputed once -- the same
+/// mechanism as `build_printing_to_card`, but deferred (not shipped) since nothing
+/// in the current codebase would consume it. See "Finding" in
+/// docs/issues/local-engine-direct-projection-arrays.md for why: `unique=artwork`'s
+/// real implementation dedupes per-card locally, not via a global projection.
+fn printing_to_global_group(offsets: &[u32], group_offsets: &[u32], local_group_ids: &[u16]) -> Vec<u32> {
+    let mut out = vec![0u32; local_group_ids.len()];
+    for (card, w) in offsets.windows(2).enumerate() {
+        for p in w[0]..w[1] {
+            out[p as usize] = group_offsets[card] + u32::from(local_group_ids[p as usize]);
+        }
+    }
+    out
+}
+
+fn groups_of_printings_direct(printing_to_group: &[u32], printing_ids: &[u32], n_groups: usize) -> usize {
+    let bits = scatter_bits(printing_ids.iter().map(|&p| printing_to_group[p as usize]), n_groups);
+    bits.iter().map(|w| w.count_ones() as usize).sum()
+}
+
+fn time_ns(mut kernel: impl FnMut() -> usize) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+/// Real per-card printing-count shape is heavily right-skewed (most cards 1-4 printings, a
+/// long tail to ~385 for basic lands) -- approximated here with a mostly-small-count
+/// distribution plus an occasional large one, landing on the real total printing count.
+fn synthetic_offsets(rng: &mut rand::rngs::SmallRng) -> (Vec<u32>, usize) {
+    let mut offsets = Vec::with_capacity(N_CARDS + 1);
+    offsets.push(0u32);
+    let mut total = 0u32;
+    for i in 0..N_CARDS {
+        let n = if i % 500 == 0 { rng.random_range(50..120) } else { rng.random_range(1..=6) };
+        total += n;
+        offsets.push(total);
+    }
+    (offsets, total as usize)
+}
+
+fn archive_u32_vec(v: &[u32]) -> Vec<u8> {
+    rkyv::to_bytes::<Error>(&v.to_vec()).expect("serialize").to_vec()
+}
+
+/// Real corpus shape (benchmarks/bitplanes/corpus.jsonl): 46,112 distinct illustrations over
+/// 31,508 cards / 97,206 printings -- 1.46 groups/card average, i.e. n_groups sits much closer
+/// to n_cards (1.46x) than to n_printings (47.4%). Approximated per-card here the same way
+/// printing counts are: mostly 1-2 groups, occasional larger (a card with several distinct
+/// arts), scaled to land near the real n_groups/n_printings ratio.
+fn synthetic_groups(rng: &mut rand::rngs::SmallRng, offsets: &[u32]) -> (Vec<u32>, Vec<u16>, usize) {
+    let mut group_offsets = Vec::with_capacity(N_CARDS + 1);
+    group_offsets.push(0u32);
+    let mut local_group_ids = vec![0u16; *offsets.last().unwrap() as usize];
+    let mut total_groups = 0u32;
+    for w in offsets.windows(2) {
+        let n_printings_this_card = (w[1] - w[0]) as usize;
+        let n_groups_this_card = rng.random_range(1..=n_printings_this_card.min(3)).max(1) as u16;
+        for (i, slot) in local_group_ids[w[0] as usize..w[1] as usize].iter_mut().enumerate() {
+            *slot = (i % n_groups_this_card as usize) as u16;
+        }
+        total_groups += u32::from(n_groups_this_card);
+        group_offsets.push(total_groups);
+    }
+    (group_offsets, local_group_ids, total_groups as usize)
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic data at real corpus scale"]
+fn bench_card_dedup_broad_vs_selective() {
+    let mut rng: rand::rngs::SmallRng = rand::make_rng();
+    let (offsets_vec, n_printings) = synthetic_offsets(&mut rng);
+    let offsets_bytes = archive_u32_vec(&offsets_vec);
+    let offsets: &AOffsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
+    let printing_to_card_vec = build_printing_to_card(&offsets_vec);
+    let printing_to_card_bytes = archive_u32_vec(&printing_to_card_vec);
+    let printing_to_card: &AOffsets = rkyv::access::<Archived<Vec<u32>>, Error>(&printing_to_card_bytes).expect("access printing_to_card");
+    let (group_offsets, local_group_ids, n_groups) = synthetic_groups(&mut rng, &offsets_vec);
+    let group_lookup = printing_to_global_group(&offsets_vec, &group_offsets, &local_group_ids);
+
+    println!("\nN_CARDS={N_CARDS}, n_printings={n_printings}, n_groups={n_groups}, ITERS={ITERS} (best-of), all times in ns");
+    println!(
+        "{:>10} {:>10}  {:>10} {:>10}  {:>10} {:>10}  {:>10} {:>10}",
+        "k", "match_pct", "cards (shipped)", "ns/match", "groups (bsearch)", "ns/match", "groups_dir (deferred)", "ns/match"
+    );
+
+    // Real k values from the actual corpus at each usd<X threshold in the selectivity sweep
+    // (benchmarks/bitplanes/corpus.jsonl, 97,206 real printings): 0.1, 0.5, 1, 5, 10, 25, 50.
+    // Scaled to this synthetic offsets' n_printings so the *fraction* matches the real sweep.
+    let real_fracs = [6114.0 / 97206.0, 50614.0 / 97206.0, 57854.0 / 97206.0, 71308.0 / 97206.0, 75738.0 / 97206.0, 79158.0 / 97206.0, 80527.0 / 97206.0];
+    for &frac in &real_fracs {
+        let k = (n_printings as f64 * frac) as usize;
+        let k = k.min(n_printings);
+        let mut printing_ids: Vec<u32> = {
+            let mut set = std::collections::HashSet::with_capacity(k);
+            while set.len() < k {
+                set.insert(rng.random_range(0..n_printings as u32));
+            }
+            set.into_iter().collect()
+        };
+        printing_ids.sort_unstable();
+
+        let t_cards = time_ns(|| cards_of_printings(offsets, printing_to_card, &printing_ids).len());
+        let t_groups = time_ns(|| groups_of_printings(offsets, &group_offsets, &local_group_ids, &printing_ids, n_groups));
+        let t_groups_dir = time_ns(|| groups_of_printings_direct(&group_lookup, &printing_ids, n_groups));
+        let pct = 100.0 * k as f64 / n_printings as f64;
+        println!(
+            "{:>10} {:>9.1}%  {:>15.0} {:>10.2}  {:>16.0} {:>10.2}  {:>21.0} {:>10.2}",
+            k,
+            pct,
+            t_cards,
+            t_cards / k as f64,
+            t_groups,
+            t_groups / k as f64,
+            t_groups_dir,
+            t_groups_dir / k as f64
+        );
+    }
+}

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -125,26 +125,42 @@ pub(crate) enum NumExpr {
 }
 
 impl NumExpr {
+    // #[inline(always)] alone doesn't reach the goal here: LLVM's
+    // always-inliner refuses to inline ANY self-recursive function at ANY
+    // call site, not just the recursive edge -- confirmed in the release
+    // disassembly, where a first attempt at just adding the attribute to a
+    // still-self-recursive eval() left both `bl NumExpr::eval` calls in
+    // FilterExpr::tri's NumericCmp arm untouched. Splitting the Arith case
+    // into its own (separately named, not force-inlined) function makes
+    // eval() itself non-recursive, so the attribute now actually applies:
+    // for the common Const/Field leaf case (e.g. `usd<50`, no arithmetic),
+    // eval()'s whole body -- including field_num, already small enough to
+    // inline on its own -- folds directly into tri(), eliminating both
+    // calls' prologue/epilogue/jump-table tax. Arith (`cmc+1<power`) is
+    // colder and still recurses through eval_arith, unaffected either way.
+    #[inline(always)]
     fn eval(&self, card: &AOracleCard, printing: Option<&APrinting>) -> NumVal {
         match self {
             NumExpr::Const(v) => NumVal::Known(*v),
             NumExpr::Field(f) => field_num(card, printing, *f),
-            NumExpr::Arith(lhs, op, rhs) => {
-                // Null dominates PDep: Null op anything is Null for every
-                // printing, so the card-level result is already exact.
-                match (lhs.eval(card, printing), rhs.eval(card, printing)) {
-                    (NumVal::Null, _) | (_, NumVal::Null) => NumVal::Null,
-                    (NumVal::PDep, _) | (_, NumVal::PDep) => NumVal::PDep,
-                    (NumVal::Known(l), NumVal::Known(r)) => match op {
-                        ArithOp::Add => NumVal::Known(l + r),
-                        ArithOp::Sub => NumVal::Known(l - r),
-                        ArithOp::Mul => NumVal::Known(l * r),
-                        ArithOp::Div => {
-                            if r == 0.0 { NumVal::Null } else { NumVal::Known(l / r) }
-                        }
-                    },
+            NumExpr::Arith(lhs, op, rhs) => Self::eval_arith(lhs, *op, rhs, card, printing),
+        }
+    }
+
+    fn eval_arith(lhs: &NumExpr, op: ArithOp, rhs: &NumExpr, card: &AOracleCard, printing: Option<&APrinting>) -> NumVal {
+        // Null dominates PDep: Null op anything is Null for every
+        // printing, so the card-level result is already exact.
+        match (lhs.eval(card, printing), rhs.eval(card, printing)) {
+            (NumVal::Null, _) | (_, NumVal::Null) => NumVal::Null,
+            (NumVal::PDep, _) | (_, NumVal::PDep) => NumVal::PDep,
+            (NumVal::Known(l), NumVal::Known(r)) => match op {
+                ArithOp::Add => NumVal::Known(l + r),
+                ArithOp::Sub => NumVal::Known(l - r),
+                ArithOp::Mul => NumVal::Known(l * r),
+                ArithOp::Div => {
+                    if r == 0.0 { NumVal::Null } else { NumVal::Known(l / r) }
                 }
-            }
+            },
         }
     }
 }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -145,7 +145,7 @@ impl NumExpr {
     }
 }
 
-fn cmp(op: CmpOp, a: f64, b: f64) -> bool {
+pub(crate) fn cmp(op: CmpOp, a: f64, b: f64) -> bool {
     match op {
         CmpOp::Eq => a == b,
         CmpOp::Ne => a != b,

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -89,15 +89,19 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
     fn known(v: Option<f32>) -> NumVal {
         v.map_or(NumVal::Null, |x| NumVal::Known(x as f64))
     }
-    // Cents -> dollars via exact f64 division, not through f32 -- 722.0 / 100.0 and a
-    // directly-parsed query constant "7.22" round to the identical nearest f64 (both are
-    // single, non-lossy roundings of the same rational number), so this and NumExpr::Const
-    // (untouched) always agree exactly. The old `v as f32 as f64` path widened an
-    // already-lossy f32 approximation, which essentially never matched a full-precision query
-    // constant even at the exact boundary it was supposed to represent -- see
+    // Raw cents, no dollars conversion: `FilterExpr::bind` rewrites a price
+    // NumericCmp's Const from dollars to cents once per query
+    // (`price_dollars_to_cents`), so this per-printing evaluation -- run
+    // once per candidate printing, the actual hot path -- never needs to
+    // divide. Comparing raw cents against a cents-scale Const is exact for
+    // the identical reason the old dollars-vs-dollars comparison was: both
+    // sides are single, non-lossy f64 values derived from the same
+    // rational number, just scaled by 100 instead of by 1. The old `v as
+    // f32 as f64` path (pre-#688) widened an already-lossy f32
+    // approximation, which is a separate, already-fixed bug -- see
     // docs/issues/local-engine-broad-range-fastpath.md.
     fn known_cents(v: Option<u32>) -> NumVal {
-        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents) / 100.0))
+        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents)))
     }
     match f {
         NumField::Cmc                => known(card.cmc.as_ref().map(|v| u8::from(*v) as f32)),
@@ -716,6 +720,25 @@ impl FilterExpr {
                 }
             }
             FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, mana_vocab, flavor, strings),
+            // usd/eur/tix<op>threshold: rewrite the query-side dollar Const to
+            // the exact cents value once per query (super::price_dollars_to_cents,
+            // shared with narrow_rec/compile_price_range so all three paths derive
+            // the identical cents value), so field_num's per-printing evaluation
+            // -- run once per candidate printing, not once per query -- can
+            // compare raw cents directly with no division. Only the Const
+            // side is rewritten; NumExpr::Field/Arith are left alone (an
+            // arithmetic expression mixing a price field with something
+            // else, e.g. `usd+1<power`, isn't a shape this rewrite covers).
+            // Unlike every other rewrite in this match (TextContains ->
+            // ArtistMatch/FlavorMatch), this one does NOT change the node's
+            // shape, so it is NOT idempotent -- calling bind twice on the
+            // same node would rescale the Const a second time. Callers must
+            // bind each filter exactly once, same as today's single
+            // `filter_expr.bind(...)` call site.
+            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), rhs: NumExpr::Const(v), .. }
+            | FilterExpr::NumericCmp { lhs: NumExpr::Const(v), rhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), .. } => {
+                *v = super::price_dollars_to_cents(*v);
+            }
             FilterExpr::ManaCostCmp { hybrids, hybrid_ids, .. } if !hybrids.is_empty() => {
                 *hybrid_ids = bind_mana_hybrids(hybrids, mana_vocab);
             }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -89,19 +89,17 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
     fn known(v: Option<f32>) -> NumVal {
         v.map_or(NumVal::Null, |x| NumVal::Known(x as f64))
     }
-    // Raw cents, no dollars conversion: `FilterExpr::bind` rewrites a price
-    // NumericCmp's Const from dollars to cents once per query
-    // (`price_dollars_to_cents`), so this per-printing evaluation -- run
-    // once per candidate printing, the actual hot path -- never needs to
-    // divide. Comparing raw cents against a cents-scale Const is exact for
-    // the identical reason the old dollars-vs-dollars comparison was: both
-    // sides are single, non-lossy f64 values derived from the same
-    // rational number, just scaled by 100 instead of by 1. The old `v as
-    // f32 as f64` path (pre-#688) widened an already-lossy f32
-    // approximation, which is a separate, already-fixed bug -- see
-    // docs/issues/local-engine-broad-range-fastpath.md.
+    // Cents -> dollars via exact f64 division, not through f32 -- 722.0 / 100.0 and a
+    // directly-parsed query constant "7.22" round to the identical nearest f64 (both are
+    // single, non-lossy roundings of the same rational number), so this and NumExpr::Const
+    // (untouched) always agree exactly. Unconditional, regardless of comparison shape
+    // (Arith, Field-vs-Field, bare Field-vs-Const, ...): a bind-time fast path that
+    // special-cased only the bare shape shipped two silent correctness bugs
+    // (`usd+1<power`, `usd<cmc` -- see docs/issues/local-engine-broad-range-fastpath.md)
+    // for a ~2-3% win on the one shape it covered, not worth the ongoing risk of a
+    // representation that's easy to bypass by rephrasing a logically identical query.
     fn known_cents(v: Option<u32>) -> NumVal {
-        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents)))
+        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents) / 100.0))
     }
     match f {
         NumField::Cmc                => known(card.cmc.as_ref().map(|v| u8::from(*v) as f32)),
@@ -736,25 +734,6 @@ impl FilterExpr {
                 }
             }
             FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, mana_vocab, flavor, strings),
-            // usd/eur/tix<op>threshold: rewrite the query-side dollar Const to
-            // the exact cents value once per query (super::price_dollars_to_cents,
-            // shared with narrow_rec/compile_price_range so all three paths derive
-            // the identical cents value), so field_num's per-printing evaluation
-            // -- run once per candidate printing, not once per query -- can
-            // compare raw cents directly with no division. Only the Const
-            // side is rewritten; NumExpr::Field/Arith are left alone (an
-            // arithmetic expression mixing a price field with something
-            // else, e.g. `usd+1<power`, isn't a shape this rewrite covers).
-            // Unlike every other rewrite in this match (TextContains ->
-            // ArtistMatch/FlavorMatch), this one does NOT change the node's
-            // shape, so it is NOT idempotent -- calling bind twice on the
-            // same node would rescale the Const a second time. Callers must
-            // bind each filter exactly once, same as today's single
-            // `filter_expr.bind(...)` call site.
-            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), rhs: NumExpr::Const(v), .. }
-            | FilterExpr::NumericCmp { lhs: NumExpr::Const(v), rhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), .. } => {
-                *v = super::price_dollars_to_cents(*v);
-            }
             FilterExpr::ManaCostCmp { hybrids, hybrid_ids, .. } if !hybrids.is_empty() => {
                 *hybrid_ids = bind_mana_hybrids(hybrids, mana_vocab);
             }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1969,17 +1969,6 @@ fn snap_to_nearest_cent(cents: f64) -> f64 {
     if (cents - rounded).abs() < 1e-6 { rounded } else { cents }
 }
 
-/// Convert a query-side dollar amount to the exact cents value price fields
-/// compare against -- shared by `FilterExpr::bind`'s one-time Const rewrite
-/// (real queries) and by tests constructing a price comparison directly
-/// (bypassing `bind`), so both derive the identical cents value from the
-/// identical dollar input. Two independent encodings of "how many cents is
-/// this dollar amount" quietly disagreeing is exactly Bug B's shape --
-/// this exists so there's only ever the one.
-pub(crate) fn price_dollars_to_cents(dollars: f64) -> f64 {
-    snap_to_nearest_cent(dollars * PRICE_CENTS_PER_DOLLAR)
-}
-
 /// Half-open [lo, hi) bounds for indexes over plain integers (collector
 /// number). Query values are f64 and may be fractional or out of range; bounds
 /// are chosen so the range is exact for every op — `cn<100.5` means
@@ -2086,15 +2075,17 @@ fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printi
 /// arm (`planes.rs`) — one encoding of "price predicate -> narrowed
 /// printing-space bounds" so the two paths can't independently drift out of
 /// sync, the exact shape that caused Bug B in the price-cents migration (see
-/// docs/issues/local-engine-broad-range-fastpath.md). `v` is already cents,
-/// not dollars: `FilterExpr::bind` converts the query-side dollar Const to
-/// cents once per query (`price_dollars_to_cents`), so this -- called once
-/// per query, not once per printing -- no longer does its own dollars-to-
-/// cents multiplication. `snap_to_nearest_cent` still runs here (not just at
-/// bind time) so a caller that skips `bind` (tests constructing this call
-/// directly) gets the identical rounding via the same helper.
+/// docs/issues/local-engine-broad-range-fastpath.md). `v` is dollars, same as
+/// the query-side `Const` -- a since-reverted bind-time fast path used to
+/// convert it to cents once per query so `field_num` could skip a division,
+/// but that fast path only covered a bare price `Field` directly against a
+/// `Const`, silently miscomputing `usd+1<power`/`usd<cmc`-shaped queries
+/// that reach this same field through `NumExpr::Arith` or a second `Field`.
+/// Reverted rather than patched further; this function does its own
+/// dollars-to-cents conversion again, matching every build before that fast
+/// path existed.
 pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool, must_be_tight: bool) -> Option<Narrowed> {
-    match int_range_bounds(op, snap_to_nearest_cent(v))? {
+    match int_range_bounds(op, snap_to_nearest_cent(v * PRICE_CENTS_PER_DOLLAR))? {
         None => Narrowed::tight(Candidates::Printings(Vec::new())),
         Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true, must_be_tight),
     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2062,6 +2062,59 @@ pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardInd
     }
 }
 
+/// Shared by `narrow_rec`'s `cn` closure and `compile_plane`'s `NumericCmp` arm
+/// (`planes.rs`) — same reasoning as `price_range_narrowed`. Already an exact
+/// integer field (no lossy conversion step at all, unlike price pre-#688), so
+/// no `snap_to_nearest_cent`-equivalent is needed here.
+pub(crate) fn collector_number_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+    match int_range_bounds(op, v)? {
+        None => Narrowed::tight(Candidates::Printings(Vec::new())),
+        Some((lo, hi)) => range_narrowed(&indexes.collector_number, lo, hi, n_printings, broad_ok, true),
+    }
+}
+
+/// Shared by `narrow_rec`'s `DateCmp` arm and `compile_plane`'s `DateCmp` arm
+/// (`planes.rs`). `value` is already the same zero-padded-yyyymmdd `u32`
+/// `released_at_int` uses, so bounds are computed directly, no unit conversion.
+/// `Ne` declines (not selective, matches every other numeric field's range
+/// narrowing) -- this can never return `None` for the *bounds* the way price's
+/// can (there is no "definitely empty" case here, only "Ne declines"), so it
+/// returns `Option<Narrowed>` for the decline alone, not the nested-Option
+/// shape `int_range_bounds`-based closures need.
+pub(crate) fn date_range_narrowed(op: CmpOp, value: u32, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+    let (lo, hi) = match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => (value, value.saturating_add(1)),
+        CmpOp::Lt => (0, value),
+        CmpOp::Le => (0, value.saturating_add(1)),
+        CmpOp::Gt => (value.saturating_add(1), u32::MAX),
+        CmpOp::Ge => (value, u32::MAX),
+    };
+    range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
+}
+
+/// Shared by `narrow_rec`'s `YearCmp` arm and `compile_plane`'s `YearCmp` arm
+/// (`planes.rs`). A year threshold maps to a `released_at_int` range at the
+/// year boundary (`y*10_000`) -- any real date in year `y` is `>= y*10_000` and
+/// `< (y+1)*10_000`, so this is exactly as range-narrowable as `DateCmp`,
+/// despite comparing a *derived* value (`date / 10_000`), not the stored field
+/// directly.
+pub(crate) fn year_range_narrowed(op: CmpOp, year: i32, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+    if !(0..=9999).contains(&year) {
+        return None;
+    }
+    let y = year as u32;
+    let (lo, hi) = match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => (y * 10_000, (y + 1) * 10_000),
+        CmpOp::Lt => (0, y * 10_000),
+        CmpOp::Le => (0, (y + 1) * 10_000),
+        CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
+        CmpOp::Ge => (y * 10_000, u32::MAX),
+    };
+    range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
+}
+
 // ─── Rarity index ────────────────────────────────────────────────────────────
 // rarity int (0-5) -> sorted card ids with at least one printing at that
 // rarity. A card printed at several rarities appears in each of its lists
@@ -2773,6 +2826,14 @@ fn narrow_rec(
         && !matches!(filter, FilterExpr::True)
         && u32::from(indexes.planes.n_cards) as usize == n_cards
         && n_cards > 0
+        // 2+ range-predicate leaves (usd/collector_number/released_at) are
+        // doomed to decline composing (and_of_checked_for_shared_witness),
+        // but not before each one's compile_*_range function wastefully
+        // narrows and materializes a full card bitmap -- this structural,
+        // no-narrowing pre-check (docs/issues/local-engine-broad-range-
+        // fastpath.md's compound-query regression) skips that waste,
+        // falling straight to the per-field dispatch below instead.
+        && !has_conflicting_range_families(filter)
     {
         if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words, indexes, offsets) {
             let mut bits: Vec<u64> = Vec::new();
@@ -2904,10 +2965,7 @@ fn narrow_rec(
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
             let price = |op, v: &f64| price_range_narrowed(op, *v, indexes, n_printings, broad_ok);
-            let cn = |op, v: &f64| match int_range_bounds(op, *v)? {
-                None => Narrowed::tight(Candidates::Printings(Vec::new())),
-                Some((lo, hi)) => range_narrowed(&indexes.collector_number, lo, hi, n_printings, broad_ok, true),
-            };
+            let cn = |op, v: &f64| collector_number_range_narrowed(op, *v, indexes, n_printings, broad_ok);
             match (lhs, rhs) {
                 (NumExpr::Field(NumField::Cmc), NumExpr::Const(v)) => numeric(&indexes.cmc, *op, v),
                 (NumExpr::Const(v), NumExpr::Field(NumField::Cmc)) => numeric(&indexes.cmc, flip_op(*op), v),
@@ -3098,33 +3156,9 @@ fn narrow_rec(
             Narrowed::loose(Candidates::CardBits(bits))
         }
 
-        FilterExpr::DateCmp { op, value } => {
-            let (lo, hi) = match op {
-                CmpOp::Ne => return None,
-                CmpOp::Eq => (*value, value.saturating_add(1)),
-                CmpOp::Lt => (0, *value),
-                CmpOp::Le => (0, value.saturating_add(1)),
-                CmpOp::Gt => (value.saturating_add(1), u32::MAX),
-                CmpOp::Ge => (*value, u32::MAX),
-            };
-            range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
-        }
+        FilterExpr::DateCmp { op, value } => date_range_narrowed(*op, *value, indexes, n_printings, broad_ok),
 
-        FilterExpr::YearCmp { op, year } => {
-            if *year < 0 || *year > 9999 {
-                return None;
-            }
-            let y = *year as u32;
-            let (lo, hi) = match op {
-                CmpOp::Ne => return None,
-                CmpOp::Eq => (y * 10_000, (y + 1) * 10_000),
-                CmpOp::Lt => (0, y * 10_000),
-                CmpOp::Le => (0, (y + 1) * 10_000),
-                CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
-                CmpOp::Ge => (y * 10_000, u32::MAX),
-            };
-            range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
-        }
+        FilterExpr::YearCmp { op, year } => year_range_narrowed(*op, *year, indexes, n_printings, broad_ok),
 
         FilterExpr::And(children) => {
             // Combine within each id space first (card lists are ~3x shorter),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2023,7 +2023,24 @@ fn range_candidates(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32) -> Opt
 /// widened one position for f32/f64 rounding (see price_bounds) and therefore
 /// produce supersets that must never be marked tight — a Not would complement
 /// away the boundary printings, which are exactly the negation's matches.
-fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printings: usize, broad_ok: bool, exact: bool) -> Option<Narrowed> {
+///
+/// `must_be_tight`, when set, refuses the complement shortcut below
+/// regardless of which side is smaller -- needed by any caller that would
+/// otherwise feed a `loose` result into something with no downstream
+/// recheck (`compile_price_range`/`compile_collector_number_range`/
+/// `compile_date_range`/`compile_year_range`, when compiling for
+/// `split_planes`'s `unique=card` fold specifically -- see `compile_plane`'s
+/// own `must_be_tight` threading and `PlaneExpr::PrintingRangeBits`'s `exact`
+/// field). Found via a real bug: the complement branch over-includes
+/// NULL-valued printings (absent from the index entirely), silently
+/// overcounting `usd<50` (83% selective, so the shortcut fired) by 179 --
+/// 31,396 counted vs. the correct 31,217 -- docs/issues/local-engine-broad-
+/// range-fastpath.md. `narrow_rec`'s own per-field closures, and any caller
+/// compiling a plane for a context that always re-verifies downstream
+/// regardless (`narrow_rec`'s own plane fastpath, `unique=printing`/
+/// `artwork`), keep `false`: forcing the majority-side scatter there would
+/// only pay for exactness nothing consumes.
+fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printings: usize, broad_ok: bool, exact: bool, must_be_tight: bool) -> Option<Narrowed> {
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
     let k = e - s;
@@ -2035,10 +2052,17 @@ fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printi
     if !broad_ok {
         return None; // nothing downstream would consume the bitmap — pre-#636 behavior
     }
-    if k <= idx.len() - k {
+    if must_be_tight || k <= idx.len() - k {
         let bits = scatter_bits(idx[s..e].iter().map(|p| u32::from(p.1)), n_printings);
         return Some(Narrowed { set: Candidates::PrintingBits(bits), tight: exact });
     }
+    // Only reached when !must_be_tight: scattering the *minority* side
+    // (idx.len()-k printings) and complementing over all n_printings is
+    // cheaper than directly scattering the k-majority side, but the
+    // complement flips every bit outside the index too -- including every
+    // printing absent from it entirely (NULL-valued for this field), which
+    // is why this branch can only ever produce a `loose` (not `exact`)
+    // result.
     let mut bits = scatter_bits(
         idx[..s].iter().chain(idx[e..].iter()).map(|p| u32::from(p.1)),
         n_printings,
@@ -2055,10 +2079,10 @@ fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printi
 /// floating-point operation, not a lossless relabeling (`0.28_f64 * 100.0 ==
 /// 28.000000000000004`), so `snap_to_nearest_cent` guards it before flooring/
 /// ceiling in `int_range_bounds`.
-pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool, must_be_tight: bool) -> Option<Narrowed> {
     match int_range_bounds(op, snap_to_nearest_cent(v * PRICE_CENTS_PER_DOLLAR))? {
         None => Narrowed::tight(Candidates::Printings(Vec::new())),
-        Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true),
+        Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true, must_be_tight),
     }
 }
 
@@ -2066,10 +2090,10 @@ pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardInd
 /// (`planes.rs`) — same reasoning as `price_range_narrowed`. Already an exact
 /// integer field (no lossy conversion step at all, unlike price pre-#688), so
 /// no `snap_to_nearest_cent`-equivalent is needed here.
-pub(crate) fn collector_number_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+pub(crate) fn collector_number_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool, must_be_tight: bool) -> Option<Narrowed> {
     match int_range_bounds(op, v)? {
         None => Narrowed::tight(Candidates::Printings(Vec::new())),
-        Some((lo, hi)) => range_narrowed(&indexes.collector_number, lo, hi, n_printings, broad_ok, true),
+        Some((lo, hi)) => range_narrowed(&indexes.collector_number, lo, hi, n_printings, broad_ok, true, must_be_tight),
     }
 }
 
@@ -2081,7 +2105,7 @@ pub(crate) fn collector_number_range_narrowed(op: CmpOp, v: f64, indexes: &Archi
 /// can (there is no "definitely empty" case here, only "Ne declines"), so it
 /// returns `Option<Narrowed>` for the decline alone, not the nested-Option
 /// shape `int_range_bounds`-based closures need.
-pub(crate) fn date_range_narrowed(op: CmpOp, value: u32, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+pub(crate) fn date_range_narrowed(op: CmpOp, value: u32, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool, must_be_tight: bool) -> Option<Narrowed> {
     let (lo, hi) = match op {
         CmpOp::Ne => return None,
         CmpOp::Eq => (value, value.saturating_add(1)),
@@ -2090,7 +2114,7 @@ pub(crate) fn date_range_narrowed(op: CmpOp, value: u32, indexes: &Archived<Card
         CmpOp::Gt => (value.saturating_add(1), u32::MAX),
         CmpOp::Ge => (value, u32::MAX),
     };
-    range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
+    range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true, must_be_tight)
 }
 
 /// Shared by `narrow_rec`'s `YearCmp` arm and `compile_plane`'s `YearCmp` arm
@@ -2099,7 +2123,7 @@ pub(crate) fn date_range_narrowed(op: CmpOp, value: u32, indexes: &Archived<Card
 /// `< (y+1)*10_000`, so this is exactly as range-narrowable as `DateCmp`,
 /// despite comparing a *derived* value (`date / 10_000`), not the stored field
 /// directly.
-pub(crate) fn year_range_narrowed(op: CmpOp, year: i32, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+pub(crate) fn year_range_narrowed(op: CmpOp, year: i32, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool, must_be_tight: bool) -> Option<Narrowed> {
     if !(0..=9999).contains(&year) {
         return None;
     }
@@ -2112,7 +2136,7 @@ pub(crate) fn year_range_narrowed(op: CmpOp, year: i32, indexes: &Archived<CardI
         CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
         CmpOp::Ge => (y * 10_000, u32::MAX),
     };
-    range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
+    range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true, must_be_tight)
 }
 
 // ─── Rarity index ────────────────────────────────────────────────────────────
@@ -2835,7 +2859,7 @@ fn narrow_rec(
         // falling straight to the per-field dispatch below instead.
         && !has_conflicting_range_families(filter)
     {
-        if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words, indexes, offsets) {
+        if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words, indexes, offsets, false) {
             let mut bits: Vec<u64> = Vec::new();
             eval_planes(&pe, &indexes.planes, &mut bits);
             // Legality's planes are existence projections, not true-for-
@@ -2964,8 +2988,8 @@ fn narrow_rec(
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
-            let price = |op, v: &f64| price_range_narrowed(op, *v, indexes, n_printings, broad_ok);
-            let cn = |op, v: &f64| collector_number_range_narrowed(op, *v, indexes, n_printings, broad_ok);
+            let price = |op, v: &f64| price_range_narrowed(op, *v, indexes, n_printings, broad_ok, false);
+            let cn = |op, v: &f64| collector_number_range_narrowed(op, *v, indexes, n_printings, broad_ok, false);
             match (lhs, rhs) {
                 (NumExpr::Field(NumField::Cmc), NumExpr::Const(v)) => numeric(&indexes.cmc, *op, v),
                 (NumExpr::Const(v), NumExpr::Field(NumField::Cmc)) => numeric(&indexes.cmc, flip_op(*op), v),
@@ -3156,9 +3180,9 @@ fn narrow_rec(
             Narrowed::loose(Candidates::CardBits(bits))
         }
 
-        FilterExpr::DateCmp { op, value } => date_range_narrowed(*op, *value, indexes, n_printings, broad_ok),
+        FilterExpr::DateCmp { op, value } => date_range_narrowed(*op, *value, indexes, n_printings, broad_ok, false),
 
-        FilterExpr::YearCmp { op, year } => year_range_narrowed(*op, *year, indexes, n_printings, broad_ok),
+        FilterExpr::YearCmp { op, year } => year_range_narrowed(*op, *year, indexes, n_printings, broad_ok, false),
 
         FilterExpr::And(children) => {
             // Combine within each id space first (card lists are ~3x shorter),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3839,6 +3839,7 @@ fn run_query<'a>(
             })
         }
     };
+
     // Resolve indexable text predicates through their indexes once (#624)
     // when the per-card evaluation they'd replace outweighs the bind cost —
     // the gate is per-node and cost-based (see memoize_pays): each predicate
@@ -3878,11 +3879,11 @@ fn run_query<'a>(
     };
 
     let maybe_broad = candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
-    if let (Some(perm), Some(inv_perm)) = (indexes.sort_perms.get(sort_col, descending), indexes.sort_perms.get_inv(sort_col, descending)) {
+    if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
         if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
             return run_query_streamed(
                 cards, printings, offsets, strings, filter, all_match_known, mode, prefer, sort_col, descending, limit,
-                page_offset, perm, inv_perm, card_ids, &indexes.artwork_groups, existential_plane,
+                page_offset, perm, card_ids, &indexes.artwork_groups, existential_plane,
             );
         }
     }
@@ -4070,7 +4071,6 @@ fn run_query_streamed<'a>(
     limit: usize,
     page_offset: usize,
     perm: &Archived<Vec<u32>>,
-    inv_perm: &Archived<Vec<u32>>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     artwork_groups: &Archived<Vec<u16>>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
@@ -4166,65 +4166,40 @@ fn run_query_streamed<'a>(
     // page cards only. Within a card, items order by (sort key, pid) — the
     // same comparator select_page uses; across cards the permutation supplies
     // the order.
-    //
-    // Matching cards are scattered into a permuted bitmap (inv_perm order, same
-    // mechanism run_query_streamed_popcount uses for unique=card) instead of
-    // walking `perm`'s n_cards raw entries directly and checking counts[cid] for
-    // each one -- an all-zero word skips in O(1), and non-zero words are walked
-    // set-bit-by-set-bit via trailing_zeros, visiting only matching cards
-    // regardless of match rate (#656's scoped-out printing/artwork gap: the
-    // match phase above already narrows via the bitmap, but the walk here used
-    // to be O(n_cards) unconditionally, erasing that narrowing's benefit).
-    // Per-card weight (`counts[cid]`, not uniform 1) still varies -- existential
-    // predicates (this variant's PrintingRangeBits included) need the exact
-    // count of *satisfying* printings/groups, not just card-level existence, so
-    // whole words can't be skipped by popcount alone the way the uniform-weight
-    // unique=card path does; only the O(1) all-zero-word check applies here.
-    let wpp = cards.len().div_ceil(64);
-    let mut permuted = vec![0u64; wpp];
-    for cid in 0..cards.len() as u32 {
-        if counts[cid as usize] != 0 {
-            let pos = u32::from(inv_perm[cid as usize]) as usize;
-            permuted[pos / 64] |= 1u64 << (pos % 64);
-        }
-    }
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
-    'walk: for (i, &word) in permuted.iter().enumerate() {
-        let mut w = word;
-        while w != 0 {
-            let pos = (i as u32) << 6 | w.trailing_zeros();
-            w &= w - 1;
-            let cid = u32::from(perm[pos as usize]);
-            let c = counts[cid as usize] as usize;
-            if skip >= c {
-                skip -= c;
-                continue;
-            }
-            let card = &cards[cid as usize];
-            let all_match = all_match_known
-                || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
-                    Tri::True => true,
-                    Tri::PrintingDep => false,
-                    _ => continue,
-                };
-            let start = u32::from(offsets[cid as usize]) as usize;
-            let end   = u32::from(offsets[cid as usize + 1]) as usize;
-            scratch.clear();
-            push_card_matches(
-                card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
-                sort_col, descending, strings, existential_plane, &mut scratch, &mut group_best, &mut touched,
-            );
-            scratch.sort_unstable_by(cmp);
-            for m in scratch.iter().skip(skip) {
-                page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
-                if page.len() == limit {
-                    break 'walk;
-                }
-            }
-            skip = 0;
+    'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
+        let c = counts[cid as usize] as usize;
+        if c == 0 {
+            continue;
         }
+        if skip >= c {
+            skip -= c;
+            continue;
+        }
+        let card = &cards[cid as usize];
+        let all_match = all_match_known
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                Tri::True => true,
+                Tri::PrintingDep => false,
+                _ => continue,
+            };
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end   = u32::from(offsets[cid as usize + 1]) as usize;
+        scratch.clear();
+        push_card_matches(
+            card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+            sort_col, descending, strings, existential_plane, &mut scratch, &mut group_best, &mut touched,
+        );
+        scratch.sort_unstable_by(cmp);
+        for m in scratch.iter().skip(skip) {
+            page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
+            if page.len() == limit {
+                break 'walk;
+            }
+        }
+        skip = 0;
     }
     (total, page)
     }) // COUNTS.with

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3839,7 +3839,6 @@ fn run_query<'a>(
             })
         }
     };
-
     // Resolve indexable text predicates through their indexes once (#624)
     // when the per-card evaluation they'd replace outweighs the bind cost —
     // the gate is per-node and cost-based (see memoize_pays): each predicate
@@ -3879,11 +3878,11 @@ fn run_query<'a>(
     };
 
     let maybe_broad = candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
-    if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
+    if let (Some(perm), Some(inv_perm)) = (indexes.sort_perms.get(sort_col, descending), indexes.sort_perms.get_inv(sort_col, descending)) {
         if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
             return run_query_streamed(
                 cards, printings, offsets, strings, filter, all_match_known, mode, prefer, sort_col, descending, limit,
-                page_offset, perm, card_ids, &indexes.artwork_groups, existential_plane,
+                page_offset, perm, inv_perm, card_ids, &indexes.artwork_groups, existential_plane,
             );
         }
     }
@@ -4071,6 +4070,7 @@ fn run_query_streamed<'a>(
     limit: usize,
     page_offset: usize,
     perm: &Archived<Vec<u32>>,
+    inv_perm: &Archived<Vec<u32>>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     artwork_groups: &Archived<Vec<u16>>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
@@ -4166,40 +4166,65 @@ fn run_query_streamed<'a>(
     // page cards only. Within a card, items order by (sort key, pid) — the
     // same comparator select_page uses; across cards the permutation supplies
     // the order.
+    //
+    // Matching cards are scattered into a permuted bitmap (inv_perm order, same
+    // mechanism run_query_streamed_popcount uses for unique=card) instead of
+    // walking `perm`'s n_cards raw entries directly and checking counts[cid] for
+    // each one -- an all-zero word skips in O(1), and non-zero words are walked
+    // set-bit-by-set-bit via trailing_zeros, visiting only matching cards
+    // regardless of match rate (#656's scoped-out printing/artwork gap: the
+    // match phase above already narrows via the bitmap, but the walk here used
+    // to be O(n_cards) unconditionally, erasing that narrowing's benefit).
+    // Per-card weight (`counts[cid]`, not uniform 1) still varies -- existential
+    // predicates (this variant's PrintingRangeBits included) need the exact
+    // count of *satisfying* printings/groups, not just card-level existence, so
+    // whole words can't be skipped by popcount alone the way the uniform-weight
+    // unique=card path does; only the O(1) all-zero-word check applies here.
+    let wpp = cards.len().div_ceil(64);
+    let mut permuted = vec![0u64; wpp];
+    for cid in 0..cards.len() as u32 {
+        if counts[cid as usize] != 0 {
+            let pos = u32::from(inv_perm[cid as usize]) as usize;
+            permuted[pos / 64] |= 1u64 << (pos % 64);
+        }
+    }
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
-    'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
-        let c = counts[cid as usize] as usize;
-        if c == 0 {
-            continue;
-        }
-        if skip >= c {
-            skip -= c;
-            continue;
-        }
-        let card = &cards[cid as usize];
-        let all_match = all_match_known
-            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
-                Tri::True => true,
-                Tri::PrintingDep => false,
-                _ => continue,
-            };
-        let start = u32::from(offsets[cid as usize]) as usize;
-        let end   = u32::from(offsets[cid as usize + 1]) as usize;
-        scratch.clear();
-        push_card_matches(
-            card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
-            sort_col, descending, strings, existential_plane, &mut scratch, &mut group_best, &mut touched,
-        );
-        scratch.sort_unstable_by(cmp);
-        for m in scratch.iter().skip(skip) {
-            page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
-            if page.len() == limit {
-                break 'walk;
+    'walk: for (i, &word) in permuted.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            let pos = (i as u32) << 6 | w.trailing_zeros();
+            w &= w - 1;
+            let cid = u32::from(perm[pos as usize]);
+            let c = counts[cid as usize] as usize;
+            if skip >= c {
+                skip -= c;
+                continue;
             }
+            let card = &cards[cid as usize];
+            let all_match = all_match_known
+                || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                    Tri::True => true,
+                    Tri::PrintingDep => false,
+                    _ => continue,
+                };
+            let start = u32::from(offsets[cid as usize]) as usize;
+            let end   = u32::from(offsets[cid as usize + 1]) as usize;
+            scratch.clear();
+            push_card_matches(
+                card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+                sort_col, descending, strings, existential_plane, &mut scratch, &mut group_best, &mut touched,
+            );
+            scratch.sort_unstable_by(cmp);
+            for m in scratch.iter().skip(skip) {
+                page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
+                if page.len() == limit {
+                    break 'walk;
+                }
+            }
+            skip = 0;
         }
-        skip = 0;
     }
     (total, page)
     }) // COUNTS.with

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1880,6 +1880,23 @@ fn assign_artwork_groups(printings: &mut [Printing], offsets: &[u32]) -> Vec<u16
     counts
 }
 
+/// Direct `printing_id -> card_id` lookup, one linear pass over `offsets`.
+/// Benchmarked (`bench_card_dedup.rs`) at ~2x cheaper than the
+/// scatter-into-printing-bitmap-then-monotone-cursor path `cards_of_printings`
+/// otherwise pays past 1024 matches, and unconditionally cheaper than the
+/// small-k `partition_point` binary search too — see
+/// docs/issues/local-engine-direct-projection-arrays.md.
+fn build_printing_to_card(offsets: &[u32]) -> Vec<u32> {
+    let n_printings = offsets.last().copied().unwrap_or(0) as usize;
+    let mut out = vec![0u32; n_printings];
+    for (card, w) in offsets.windows(2).enumerate() {
+        for p in w[0]..w[1] {
+            out[p as usize] = card as u32;
+        }
+    }
+    out
+}
+
 // ─── Printing-space range indexes (released_at, price, collector number) ─────
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
@@ -2199,6 +2216,10 @@ struct CardIndexes {
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
+    // printing space: printing_id -> card_id, direct lookup. Replaces a
+    // partition_point search on `offsets` in cards_of_printings' hot paths —
+    // see docs/issues/local-engine-direct-projection-arrays.md.
+    printing_to_card: Vec<u32>,
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
@@ -2227,6 +2248,7 @@ impl Default for CardIndexes {
             collector_number: Vec::new(),
             sort_perms:     SortPermutations::default(),
             artwork_groups: Vec::new(),
+            printing_to_card: Vec::new(),
             planes:         BitPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
@@ -2383,22 +2405,24 @@ fn printing_bits_to_card_bits(pbits: &[u64], offsets: &AOffsets, n_cards: usize)
     out
 }
 
-/// Map a sorted printing-id list up to its sorted card-id list. Printings are
-/// grouped contiguously by card, so the mapped list arrives sorted with adjacent
-/// duplicates — dedup is a single linear pass. Small lists pay a binary search
-/// per posting; past a few hundred, scattering into a printing bitmap and
-/// walking it with a monotone card cursor is cheaper (O(k + words) instead of
-/// O(k log n)) and produces the same ascending, deduped output.
-fn cards_of_printings(offsets: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
+/// Map a sorted printing-id list up to its sorted card-id list via the
+/// precomputed direct lookup (`CardIndexes::printing_to_card`). Printings are
+/// grouped contiguously by card, so the mapped list arrives sorted with
+/// adjacent duplicates — dedup is a single linear pass for small lists. Past
+/// a few hundred, scattering directly into a card bitmap and extracting set
+/// bits is cheaper than repeated pushes (same reasoning as `scatter_bits`
+/// elsewhere). Both branches use the direct array now — benchmarked
+/// unconditionally cheaper than a `partition_point` search on `offsets` at
+/// every k tested, see docs/issues/local-engine-direct-projection-arrays.md.
+fn cards_of_printings(offsets: &AOffsets, printing_to_card: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
     if printing_ids.len() > 1024 {
         let n_cards = offsets.len().saturating_sub(1);
-        let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-        let bits = scatter_bits(printing_ids.iter().copied(), n_printings);
-        return bitmap_card_ids(&printing_bits_to_card_bits(&bits, offsets, n_cards));
+        let bits = scatter_bits(printing_ids.iter().map(|&p| u32::from(printing_to_card[p as usize])), n_cards);
+        return bitmap_card_ids(&bits);
     }
     let mut out: Vec<u32> = Vec::with_capacity(printing_ids.len());
     for &p in printing_ids {
-        let card = offsets.partition_point(|o| u32::from(*o) <= p) as u32 - 1;
+        let card = u32::from(printing_to_card[p as usize]);
         if out.last() != Some(&card) {
             out.push(card);
         }
@@ -2410,11 +2434,11 @@ impl Candidates {
     /// Project into card space (identity for card-space sets) and materialize
     /// as ascending card ids. Bitmap materialization needs no sort — set bits
     /// come out ascending, sidestepping the gather-and-sort cost of #609.
-    fn into_cards(self, offsets: &AOffsets) -> Vec<u32> {
+    fn into_cards(self, offsets: &AOffsets, printing_to_card: &AOffsets) -> Vec<u32> {
         let n_cards = offsets.len().saturating_sub(1);
         match self {
             Candidates::Cards(v) => v,
-            Candidates::Printings(v) => cards_of_printings(offsets, &v),
+            Candidates::Printings(v) => cards_of_printings(offsets, printing_to_card, &v),
             Candidates::CardBits(b) => bitmap_card_ids(&b),
             Candidates::PrintingBits(b) => bitmap_card_ids(&printing_bits_to_card_bits(&b, offsets, n_cards)),
         }
@@ -2453,11 +2477,13 @@ impl Narrowed {
 
     /// Project into card space. Printing→card projection is an existence
     /// projection ("some printing matches"), which loses tightness.
-    fn into_card_space(self, offsets: &AOffsets) -> Narrowed {
+    fn into_card_space(self, offsets: &AOffsets, printing_to_card: &AOffsets) -> Narrowed {
         let n_cards = offsets.len().saturating_sub(1);
         match self.set {
             Candidates::Cards(_) | Candidates::CardBits(_) => self,
-            Candidates::Printings(v) => Narrowed { set: Candidates::Cards(cards_of_printings(offsets, &v)), tight: false },
+            Candidates::Printings(v) => {
+                Narrowed { set: Candidates::Cards(cards_of_printings(offsets, printing_to_card, &v)), tight: false }
+            }
             Candidates::PrintingBits(b) => {
                 Narrowed { set: Candidates::CardBits(printing_bits_to_card_bits(&b, offsets, n_cards)), tight: false }
             }
@@ -3174,7 +3200,7 @@ fn narrow_rec(
                             Some(Narrowed { tight: false, ..seal(c) })
                         }
                         _ => {
-                            let pc = p.into_card_space(offsets);
+                            let pc = p.into_card_space(offsets, &indexes.printing_to_card);
                             and_all(vec![c, pc]).map(seal)
                         }
                     }
@@ -3214,7 +3240,7 @@ fn narrow_rec(
                 {
                     return None;
                 }
-                let sets = sets.into_iter().map(|s| s.into_card_space(offsets)).collect();
+                let sets = sets.into_iter().map(|s| s.into_card_space(offsets, &indexes.printing_to_card)).collect();
                 or_all(sets, n_cards)
             }
         }
@@ -3772,7 +3798,7 @@ fn run_query<'a>(
     // buffer.
     let candidate_cards: Option<Vec<u32>> = match plane {
         None => raw_candidates
-            .map(|c| c.into_cards(offsets))
+            .map(|c| c.into_cards(offsets, &indexes.printing_to_card))
             .filter(|v| v.len() < cards.len() - cards.len() / 8),
         Some(expr) => {
             thread_local! {
@@ -3795,7 +3821,7 @@ fn run_query<'a>(
                         Some(bitmap_card_ids(&b))
                     }
                     Some(c) => {
-                        let mut v = c.into_cards(offsets);
+                        let mut v = c.into_cards(offsets, &indexes.printing_to_card);
                         v.retain(|&cid| bitmap_contains(&bitmap, cid));
                         Some(v)
                     }
@@ -4279,7 +4305,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260725;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260726;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -4679,6 +4705,7 @@ impl QueryEngine {
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: artwork_group_counts,
+            printing_to_card: build_printing_to_card(&offsets),
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
@@ -4975,3 +5002,5 @@ mod bench_iter_dispatch;
 mod bench_posting_intersect;
 #[cfg(test)]
 mod bench_word_dict_scan;
+#[cfg(test)]
+mod bench_card_dedup;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1969,6 +1969,17 @@ fn snap_to_nearest_cent(cents: f64) -> f64 {
     if (cents - rounded).abs() < 1e-6 { rounded } else { cents }
 }
 
+/// Convert a query-side dollar amount to the exact cents value price fields
+/// compare against -- shared by `FilterExpr::bind`'s one-time Const rewrite
+/// (real queries) and by tests constructing a price comparison directly
+/// (bypassing `bind`), so both derive the identical cents value from the
+/// identical dollar input. Two independent encodings of "how many cents is
+/// this dollar amount" quietly disagreeing is exactly Bug B's shape --
+/// this exists so there's only ever the one.
+pub(crate) fn price_dollars_to_cents(dollars: f64) -> f64 {
+    snap_to_nearest_cent(dollars * PRICE_CENTS_PER_DOLLAR)
+}
+
 /// Half-open [lo, hi) bounds for indexes over plain integers (collector
 /// number). Query values are f64 and may be fractional or out of range; bounds
 /// are chosen so the range is exact for every op — `cn<100.5` means
@@ -2075,12 +2086,15 @@ fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printi
 /// arm (`planes.rs`) — one encoding of "price predicate -> narrowed
 /// printing-space bounds" so the two paths can't independently drift out of
 /// sync, the exact shape that caused Bug B in the price-cents migration (see
-/// docs/issues/local-engine-broad-range-fastpath.md). `*100.0` is itself a new
-/// floating-point operation, not a lossless relabeling (`0.28_f64 * 100.0 ==
-/// 28.000000000000004`), so `snap_to_nearest_cent` guards it before flooring/
-/// ceiling in `int_range_bounds`.
+/// docs/issues/local-engine-broad-range-fastpath.md). `v` is already cents,
+/// not dollars: `FilterExpr::bind` converts the query-side dollar Const to
+/// cents once per query (`price_dollars_to_cents`), so this -- called once
+/// per query, not once per printing -- no longer does its own dollars-to-
+/// cents multiplication. `snap_to_nearest_cent` still runs here (not just at
+/// bind time) so a caller that skips `bind` (tests constructing this call
+/// directly) gets the identical rounding via the same helper.
 pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool, must_be_tight: bool) -> Option<Narrowed> {
-    match int_range_bounds(op, snap_to_nearest_cent(v * PRICE_CENTS_PER_DOLLAR))? {
+    match int_range_bounds(op, snap_to_nearest_cent(v))? {
         None => Narrowed::tight(Candidates::Printings(Vec::new())),
         Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true, must_be_tight),
     }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2047,6 +2047,21 @@ fn range_narrowed(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printi
     Narrowed::loose(Candidates::PrintingBits(bits))
 }
 
+/// Shared by `narrow_rec`'s `price` closure and `compile_plane`'s `NumericCmp`
+/// arm (`planes.rs`) — one encoding of "price predicate -> narrowed
+/// printing-space bounds" so the two paths can't independently drift out of
+/// sync, the exact shape that caused Bug B in the price-cents migration (see
+/// docs/issues/local-engine-broad-range-fastpath.md). `*100.0` is itself a new
+/// floating-point operation, not a lossless relabeling (`0.28_f64 * 100.0 ==
+/// 28.000000000000004`), so `snap_to_nearest_cent` guards it before flooring/
+/// ceiling in `int_range_bounds`.
+pub(crate) fn price_range_narrowed(op: CmpOp, v: f64, indexes: &Archived<CardIndexes>, n_printings: usize, broad_ok: bool) -> Option<Narrowed> {
+    match int_range_bounds(op, snap_to_nearest_cent(v * PRICE_CENTS_PER_DOLLAR))? {
+        None => Narrowed::tight(Candidates::Printings(Vec::new())),
+        Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true),
+    }
+}
+
 // ─── Rarity index ────────────────────────────────────────────────────────────
 // rarity int (0-5) -> sorted card ids with at least one printing at that
 // rarity. A card printed at several rarities appears in each of its lists
@@ -2759,7 +2774,7 @@ fn narrow_rec(
         && u32::from(indexes.planes.n_cards) as usize == n_cards
         && n_cards > 0
     {
-        if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words) {
+        if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words, indexes, offsets) {
             let mut bits: Vec<u64> = Vec::new();
             eval_planes(&pe, &indexes.planes, &mut bits);
             // Legality's planes are existence projections, not true-for-
@@ -2888,13 +2903,7 @@ fn narrow_rec(
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
-            // Same shape as `cn` below now that price is integer cents, not lossy f32 dollars --
-            // the only price-specific step is snapping the *PRICE_CENTS_PER_DOLLAR conversion
-            // against its own floating-point noise before delegating to int_range_bounds.
-            let price = |op, v: &f64| match int_range_bounds(op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))? {
-                None => Narrowed::tight(Candidates::Printings(Vec::new())),
-                Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true),
-            };
+            let price = |op, v: &f64| price_range_narrowed(op, *v, indexes, n_printings, broad_ok);
             let cn = |op, v: &f64| match int_range_bounds(op, *v)? {
                 None => Narrowed::tight(Candidates::Printings(Vec::new())),
                 Some((lo, hi)) => range_narrowed(&indexes.collector_number, lo, hi, n_printings, broad_ok, true),
@@ -4857,7 +4866,14 @@ impl QueryEngine {
                 // (anything other than "artwork"/"printing" is Mode::Card,
                 // not just the literal string "card") -- see split_planes's
                 // unique_is_card doc.
-                split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
+                split_planes(
+                    filter_expr,
+                    &data.indexes.planes,
+                    &data.indexes.oracle_trigram.words,
+                    !matches!(unique, "artwork" | "printing"),
+                    &data.indexes,
+                    &data.offsets,
+                )
             } else {
                 (None, filter_expr)
             };

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -34,8 +34,9 @@ use rkyv::{Archive, Deserialize, Serialize};
 use super::filter::{cmp, CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextField, TextSearchField};
 use super::legality::{LEGALITY_BANNED, LEGALITY_LEGAL, LEGALITY_RESTRICTED, MAX_FORMATS};
 use super::{
-    flip_op, lane_get, negate_op, oracle_word_eligible, price_range_narrowed, scan_oracle_words, str_at, AOffsets, AStrings, CardIndexes,
-    OracleCard, OracleWordIndex, Printing, NONE_STR,
+    collector_number_range_narrowed, date_range_narrowed, flip_op, lane_get, negate_op, oracle_word_eligible, price_range_narrowed,
+    scan_oracle_words, str_at, year_range_narrowed, AOffsets, AStrings, CardIndexes, Narrowed, OracleCard, OracleWordIndex, Printing,
+    NONE_STR,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -445,15 +446,14 @@ pub(crate) enum PlaneExpr {
     /// compile-time-known dimensions the other variants index into. A clone
     /// (a few KB) is paid once per query, never per row.
     Bits(Vec<u64>),
-    /// A printing-varying numeric range predicate (`price_usd` today —
-    /// `collector_number`/`released_at` are separate `FilterExpr` variants,
-    /// `DateCmp`/`YearCmp`, not yet wired here), compiled via `range_narrowed`
-    /// at query time (docs/issues/local-engine-broad-range-fastpath.md).
-    /// `card_bits` is the card-level existence answer ("some printing
-    /// satisfies"). The per-printing check re-derives the comparison directly
-    /// from `(field, op, threshold)` against the printing's own field instead
-    /// of a second precomputed bitmap — one fewer independent encoding of the
-    /// same fact to keep in sync (exactly the shape that caused Bug B in the
+    /// A printing-varying range predicate (`price_usd`, `collector_number`,
+    /// `released_at`), compiled via `range_narrowed` at query time
+    /// (docs/issues/local-engine-broad-range-fastpath.md). `card_bits` is the
+    /// card-level existence answer ("some printing satisfies"). The
+    /// per-printing check re-derives the comparison directly from `(field,
+    /// op, threshold)` against the printing's own field instead of a second
+    /// precomputed bitmap — one fewer independent encoding of the same fact
+    /// to keep in sync (exactly the shape that caused Bug B in the
     /// price-cents migration). `id` is a synthetic shared-witness identity
     /// (see `collect_existential_indices`) — distinct per compiled leaf, even
     /// for the same field at a different threshold: two range conditions on
@@ -462,11 +462,155 @@ pub(crate) enum PlaneExpr {
     /// both), so they correctly decline to compose via plain `card_bits`
     /// intersection until same-field interval merging is built (deferred,
     /// not required for correctness — see the design doc).
-    PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: NumField, op: CmpOp, threshold: f64 },
+    PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: RangePredicateField, op: CmpOp, threshold: f64 },
     And(Vec<PlaneExpr>),
     Or(Vec<PlaneExpr>),
     Not(Box<PlaneExpr>),
     Const(bool),
+}
+
+/// Which printing-varying field a `PrintingRangeBits` leaf reads. Not `NumField`
+/// directly: `ReleasedAtDate`/`ReleasedAtYear` compile from `FilterExpr::DateCmp`/
+/// `YearCmp`, separate variants with no `NumField`/`NumExpr` involved at all --
+/// `YearCmp` in particular compares a *derived* value (`date / 10_000`), not the
+/// stored field directly, so its per-printing recheck needs its own formula
+/// (see `eval_plane_expr_for_printing`'s match on this type).
+#[derive(Clone, Copy)]
+pub(crate) enum RangePredicateField {
+    PriceUsd,
+    CollectorNumber,
+    ReleasedAtDate,
+    ReleasedAtYear,
+}
+
+/// Which `RangePredicateField` a leaf would compile to, without doing any of
+/// the narrowing/materialization work actually compiling it requires --
+/// mirrors just the shape of `compile_plane`'s own `NumericCmp`/`DateCmp`/
+/// `YearCmp` arms and `compile_plane_neg`'s equivalents (both compile the
+/// same leaf, just with a negated op, so `Not` doesn't change which family a
+/// leaf belongs to). Used only for the cheap upfront conflict check below --
+/// see its doc for why this needs to exist at all.
+fn range_leaf_family(filter: &FilterExpr) -> Option<RangePredicateField> {
+    match filter {
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), .. }
+        | FilterExpr::NumericCmp { rhs: NumExpr::Field(NumField::PriceUsd), .. } => Some(RangePredicateField::PriceUsd),
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), .. }
+        | FilterExpr::NumericCmp { rhs: NumExpr::Field(NumField::CollectorNumberInt), .. } => {
+            Some(RangePredicateField::CollectorNumber)
+        }
+        FilterExpr::DateCmp { .. } => Some(RangePredicateField::ReleasedAtDate),
+        FilterExpr::YearCmp { .. } => Some(RangePredicateField::ReleasedAtYear),
+        FilterExpr::Not(inner) => range_leaf_family(inner),
+        _ => None,
+    }
+}
+
+/// Coarse existential-family tag for the structural pre-check below --
+/// deliberately coarser than `collect_existential_indices`' exact-fact
+/// dedup (doesn't distinguish which format/rarity value, just "this
+/// family"), because this only needs to answer "would attempting to compile
+/// this leaf risk being wasted work", not compute the real, precise
+/// shared-witness composition `compile_plane`'s own machinery downstream
+/// already gets right. A false positive here (treating two facts as
+/// conflicting when they'd have composed fine) only costs a missed
+/// optimization, never a correctness bug -- the real, authoritative check is
+/// unaffected either way.
+enum ExistentialFamily {
+    Legality,
+    Rarity,
+    Border,
+    // Doesn't carry which RangePredicateField -- two range leaves on
+    // *different* fields conflict exactly as much as two on the same one
+    // (both are 2 distinct existential facts needing a shared witness), so
+    // this coarse check doesn't need to distinguish them.
+    Range,
+}
+
+/// Which existential family a leaf belongs to, without doing any of the
+/// narrowing/materialization work a `Range` leaf actually compiling would
+/// require -- mirrors just the shape of `compile_plane`'s own `Legality`/
+/// `NumericCmp`/`DateCmp`/`YearCmp`/`Border` arms and `compile_plane_neg`'s
+/// equivalents (both compile the same leaf, just with a negated op, so
+/// `Not` doesn't change which family a leaf belongs to).
+fn existential_leaf_family(filter: &FilterExpr) -> Option<ExistentialFamily> {
+    match filter {
+        FilterExpr::Legality { shift: Some(_), .. } => Some(ExistentialFamily::Legality),
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }
+        | FilterExpr::NumericCmp { rhs: NumExpr::Field(NumField::RarityInt), .. } => Some(ExistentialFamily::Rarity),
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, .. } => Some(ExistentialFamily::Border),
+        FilterExpr::Not(inner) => existential_leaf_family(inner),
+        _ => range_leaf_family(filter).map(|_| ExistentialFamily::Range),
+    }
+}
+
+/// True iff some `And` node in `filter` -- this one or a descendant --
+/// combines 2+ distinct existential-family leaves (any mix of legality/
+/// rarity/border/usd/collector_number/released_at, including two range
+/// leaves on the same field). `compile_plane`'s own `and_of_checked_for_
+/// shared_witness` guard already refuses to *compose* such a pair --
+/// correctly -- but by the time it decides that, every `Range` leaf among
+/// them has already done a full binary-search-and-materialize over its
+/// range index (Legality/Rarity/Border are cheap O(1) plane-index lookups,
+/// so they cost nothing to compile-then-discard), all of that narrowing
+/// wasted, and the query still falls through to the real per-field
+/// narrowing afterward. Found as a real regression on compound queries
+/// mixing 2 range fields (`cn<100 AND usd<50`, ~1.5-1.8x) *and*, on digging
+/// further, on legality/rarity/border paired with a single range field
+/// (`f:modern AND usd<50`, ~3x) -- docs/issues/local-engine-broad-range-
+/// fastpath.md. The latter shape predates this session (present since
+/// price's original PrintingRangeBits PR), just never specifically measured
+/// until this extension's broader benchmarking pass surfaced it via
+/// collector_number/released_at hitting the same pattern. This is a purely
+/// structural, no-narrowing scan, so it's cheap enough to run before
+/// deciding whether the expensive compile attempt is even worth making --
+/// both call sites below use it as a bail-out, not a replacement for the
+/// real (still authoritative) shared-witness check.
+///
+/// `Or` is deliberately NOT a conflict site on its own: `∃` distributes over
+/// `∨` (same reasoning as `and_of_checked_for_shared_witness`'s own doc --
+/// "Or never has this problem"), so `r:common or r:uncommon` must compile
+/// exactly as before, not get flagged just because it has 2 rarity leaves.
+/// An `Or`'s children are still walked (crossing into them, not stopping),
+/// because whichever branch of the `Or` might end up active still needs to
+/// be checked against whatever `And` contains the `Or` -- `format:A AND
+/// (usd<5 OR usd>50)` really does combine 3 distinct facts once expanded --
+/// but the `Or` itself never starts a new tally the way an `And` does.
+pub(crate) fn has_conflicting_range_families(filter: &FilterExpr) -> bool {
+    // Collect every existential family reachable from `filter` without
+    // crossing into a nested `And` (that nested `And` is a separate scope,
+    // checked independently by has_conflicting_range_families' own
+    // recursion below) -- but do cross into `Or`/`Not`, per this function's
+    // own doc.
+    fn collect_in_and_scope(filter: &FilterExpr, out: &mut Vec<ExistentialFamily>) {
+        if out.len() > 1 {
+            return; // already proven a conflict; no need to keep walking
+        }
+        if let Some(fam) = existential_leaf_family(filter) {
+            out.push(fam);
+            return;
+        }
+        match filter {
+            FilterExpr::Or(cs) => {
+                for c in cs {
+                    collect_in_and_scope(c, out);
+                }
+            }
+            FilterExpr::Not(inner) => collect_in_and_scope(inner, out),
+            _ => {} // And: a separate scope, not aggregated here
+        }
+    }
+    match filter {
+        FilterExpr::And(children) => {
+            let mut families = Vec::new();
+            for c in children {
+                collect_in_and_scope(c, &mut families);
+            }
+            families.len() > 1 || children.iter().any(has_conflicting_range_families)
+        }
+        FilterExpr::Or(children) => children.iter().any(has_conflicting_range_families),
+        FilterExpr::Not(inner) => has_conflicting_range_families(inner),
+        _ => false,
+    }
 }
 
 /// Fresh synthetic identity for each compiled `PrintingRangeBits` leaf, used
@@ -1165,10 +1309,20 @@ pub(crate) fn compile_plane(
             (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) => compile_rarity_cmp(flip_op(*op), *v),
             (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => compile_price_range(*op, *v, indexes, offsets),
             (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => compile_price_range(flip_op(*op), *v, indexes, offsets),
+            (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => compile_collector_number_range(*op, *v, indexes, offsets),
+            (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => compile_collector_number_range(flip_op(*op), *v, indexes, offsets),
             (NumExpr::Field(f), NumExpr::Const(v)) => compile_numeric_cmp(*f, *op, *v, bounds),
             (NumExpr::Const(v), NumExpr::Field(f)) => compile_numeric_cmp(*f, flip_op(*op), *v, bounds),
             _ => None,
         },
+        // released_at</X (docs/issues/local-engine-broad-range-fastpath.md):
+        // same existential-plane treatment as usd/collector_number, via
+        // date_range_narrowed (shared with narrow_rec's own DateCmp arm).
+        FilterExpr::DateCmp { op, value } => compile_date_range(*op, *value, indexes, offsets),
+        // released_at's year(...)</Y: same treatment via year_range_narrowed,
+        // which maps the year threshold to a released_at_int range at the
+        // year boundary.
+        FilterExpr::YearCmp { op, year } => compile_year_range(*op, *year, indexes, offsets),
         // f:x / format:x / banned:x / restricted:x (docs/issues/
         // 00667-engine-legality-divergent-carveout.md, generalized by #678 -- see
         // docs/issues/00678-engine-legality-banned-restricted-planes.md): exact for
@@ -1199,8 +1353,55 @@ fn compile_price_range(op: CmpOp, threshold: f64, indexes: &rkyv::Archived<CardI
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
     let narrowed = price_range_narrowed(op, threshold, indexes, n_printings, true)?;
+    Some(printing_range_bits(narrowed, RangePredicateField::PriceUsd, op, threshold, offsets, indexes))
+}
+
+/// Compile `collector_number <op> threshold` to a `PrintingRangeBits` leaf,
+/// same shape as `compile_price_range` (shared via `collector_number_range_narrowed`).
+fn compile_collector_number_range(op: CmpOp, threshold: f64, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+    let n_cards = offsets.len().saturating_sub(1);
+    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
+    let narrowed = collector_number_range_narrowed(op, threshold, indexes, n_printings, true)?;
+    Some(printing_range_bits(narrowed, RangePredicateField::CollectorNumber, op, threshold, offsets, indexes))
+}
+
+/// Compile `released_at <op> value` (`FilterExpr::DateCmp`) to a
+/// `PrintingRangeBits` leaf via `date_range_narrowed`. `value` (already a
+/// zero-padded yyyymmdd `u32`) is stored as the leaf's `threshold` directly --
+/// no conversion, exact in `f64`.
+fn compile_date_range(op: CmpOp, value: u32, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+    let n_cards = offsets.len().saturating_sub(1);
+    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
+    let narrowed = date_range_narrowed(op, value, indexes, n_printings, true)?;
+    Some(printing_range_bits(narrowed, RangePredicateField::ReleasedAtDate, op, value as f64, offsets, indexes))
+}
+
+/// Compile `released_at year <op> year` (`FilterExpr::YearCmp`) to a
+/// `PrintingRangeBits` leaf via `year_range_narrowed`.
+fn compile_year_range(op: CmpOp, year: i32, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+    let n_cards = offsets.len().saturating_sub(1);
+    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
+    let narrowed = year_range_narrowed(op, year, indexes, n_printings, true)?;
+    Some(printing_range_bits(narrowed, RangePredicateField::ReleasedAtYear, op, year as f64, offsets, indexes))
+}
+
+/// Shared plumbing for all `PrintingRangeBits` compile functions: project a
+/// printing-space narrowing result up to card space and wrap it, tagging the
+/// leaf with a fresh shared-witness id. `threshold` is stored as `f64`
+/// regardless of the field's native type -- cents, collector numbers,
+/// yyyymmdd dates, and years are all well within `f64`'s 52-bit
+/// exact-integer range, so nothing is lost.
+fn printing_range_bits(
+    narrowed: Narrowed,
+    field: RangePredicateField,
+    op: CmpOp,
+    threshold: f64,
+    offsets: &AOffsets,
+    indexes: &rkyv::Archived<CardIndexes>,
+) -> PlaneExpr {
+    let n_cards = offsets.len().saturating_sub(1);
     let card_bits = narrowed.into_card_space(offsets, &indexes.printing_to_card).set.into_bits(n_cards);
-    Some(PlaneExpr::PrintingRangeBits { id: next_range_bits_id(), card_bits, field: NumField::PriceUsd, op, threshold })
+    PlaneExpr::PrintingRangeBits { id: next_range_bits_id(), card_bits, field, op, threshold }
 }
 
 /// Compile `Not(filter)` directly, pushing negation down to `Legality` and
@@ -1241,6 +1442,17 @@ fn compile_plane_neg(
         FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::PriceUsd) } => {
             compile_price_range(negate_op(flip_op(*op)), *v, indexes, offsets)
         }
+        // -collector_number<X: same divergent-printing reasoning as -usd<X.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op, rhs: NumExpr::Const(v) } => {
+            compile_collector_number_range(negate_op(*op), *v, indexes, offsets)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::CollectorNumberInt) } => {
+            compile_collector_number_range(negate_op(flip_op(*op)), *v, indexes, offsets)
+        }
+        // -released_at<X / -year(released_at)<Y: same divergent-printing
+        // reasoning, recomputed via the negated op rather than bit-complemented.
+        FilterExpr::DateCmp { op, value } => compile_date_range(negate_op(*op), *value, indexes, offsets),
+        FilterExpr::YearCmp { op, year } => compile_year_range(negate_op(*op), *year, indexes, offsets),
         // -border:x: recomputed via compile_border_cmp_neg's Or-of-others,
         // not bit-complemented, same divergent-card reasoning as Legality/rarity.
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => compile_border_cmp_neg(value),
@@ -1317,7 +1529,18 @@ pub(crate) fn split_planes(
     if matches!(filter, FilterExpr::True) {
         return (None, filter);
     }
-    if let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets)
+    // See has_conflicting_range_families' doc: 2+ range-predicate leaves
+    // (usd/collector_number/released_at) anywhere in `filter` are doomed to
+    // decline composing below regardless, so skip both the whole-tree
+    // attempt and (further down) any top-level child that's itself one of
+    // the conflicting leaves, rather than paying for a narrow-then-discard
+    // on each. Only catches the flat, top-level-And shape this was measured
+    // on (docs/issues/local-engine-broad-range-fastpath.md) -- a conflict
+    // buried entirely inside one child (e.g. an Or of two date comparisons)
+    // still pays the old cost, same as before this fix existed.
+    let range_conflict = has_conflicting_range_families(&filter);
+    if !range_conflict
+        && let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets)
         && (unique_is_card || !plane_expr_is_existential(&pe))
     {
         return (Some(pe), FilterExpr::True);
@@ -1338,6 +1561,15 @@ pub(crate) fn split_planes(
             // there's no tax to avoid paying here anymore.
             let mut legality_children: Vec<(FilterExpr, PlaneExpr)> = Vec::new();
             for c in children {
+                // Same reasoning as the whole-tree skip above: a top-level
+                // child that's itself a range-predicate leaf is going to be
+                // held back into legality_children and then declined anyway
+                // once range_conflict is known -- skip the wasted compile
+                // and go straight to rest.
+                if range_conflict && range_leaf_family(&c).is_some() {
+                    rest.push(c);
+                    continue;
+                }
                 match compile_plane(&c, bounds, words, indexes, offsets) {
                     Some(pe) => {
                         let mut fmts = Vec::new();
@@ -1498,8 +1730,22 @@ pub(crate) fn eval_plane_expr_for_printing(
         // bitmap, so there's no independent encoding of "does this printing satisfy the
         // predicate" to drift out of sync with the one filter.rs already trusts.
         PlaneExpr::PrintingRangeBits { field, op, threshold, .. } => match field {
-            NumField::PriceUsd => printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)) / 100.0, *threshold)),
-            _ => unreachable!("PrintingRangeBits only compiled for price_usd so far"),
+            RangePredicateField::PriceUsd => {
+                printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)) / 100.0, *threshold))
+            }
+            RangePredicateField::CollectorNumber => {
+                printing.collector_number_int.as_ref().is_some_and(|v| cmp(*op, f64::from(u16::from(*v)), *threshold))
+            }
+            RangePredicateField::ReleasedAtDate => {
+                printing.released_at_int.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)), *threshold))
+            }
+            // threshold holds the plain year (see compile_year_range); the stored
+            // field is the full yyyymmdd date, so divide down to a year before
+            // comparing -- same derived-value step year_range_narrowed's bounds
+            // encode at the narrowing stage.
+            RangePredicateField::ReleasedAtYear => {
+                printing.released_at_int.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v) / 10_000), *threshold))
+            }
         },
         PlaneExpr::Const(b) => *b,
         PlaneExpr::And(children) => children.iter().all(|c| eval_plane_expr_for_printing(c, planes, cid, printing, strings)),

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1317,24 +1317,10 @@ pub(crate) fn split_planes(
     if matches!(filter, FilterExpr::True) {
         return (None, filter);
     }
-    if let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets) {
-        if unique_is_card || !plane_expr_is_existential(&pe) {
-            return (Some(pe), FilterExpr::True);
-        }
-        // Existential leaf, wrong mode to fully fold (would discard which printing
-        // matched -- see this function's own doc). Still worth using the compiled
-        // plane for candidate narrowing: run_query's candidate_cards computation
-        // takes a different path when a plane exists (lib.rs, Some(expr) arm) that
-        // uses the bitmap directly, without the broadness-discard-to-full-scan
-        // fallback the plane=None path applies. The residual stays the original,
-        // unchanged filter -- per-printing correctness (row selection, exact count)
-        // still comes from the ordinary card_pass walk over it, not the plane,
-        // avoiding exactly the row-selection/negation traps this variant's eval
-        // machinery exists to solve for unique=card. run_query's own
-        // existential_plane computation stays Mode::Card-only and unaffected by
-        // this -- it would otherwise redundantly re-check the same predicate the
-        // residual already checks, not add a real narrowing benefit for these modes.
-        return (Some(pe), filter);
+    if let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets)
+        && (unique_is_card || !plane_expr_is_existential(&pe))
+    {
+        return (Some(pe), FilterExpr::True);
     }
     match filter {
         FilterExpr::And(children) => {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1317,10 +1317,24 @@ pub(crate) fn split_planes(
     if matches!(filter, FilterExpr::True) {
         return (None, filter);
     }
-    if let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets)
-        && (unique_is_card || !plane_expr_is_existential(&pe))
-    {
-        return (Some(pe), FilterExpr::True);
+    if let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets) {
+        if unique_is_card || !plane_expr_is_existential(&pe) {
+            return (Some(pe), FilterExpr::True);
+        }
+        // Existential leaf, wrong mode to fully fold (would discard which printing
+        // matched -- see this function's own doc). Still worth using the compiled
+        // plane for candidate narrowing: run_query's candidate_cards computation
+        // takes a different path when a plane exists (lib.rs, Some(expr) arm) that
+        // uses the bitmap directly, without the broadness-discard-to-full-scan
+        // fallback the plane=None path applies. The residual stays the original,
+        // unchanged filter -- per-printing correctness (row selection, exact count)
+        // still comes from the ordinary card_pass walk over it, not the plane,
+        // avoiding exactly the row-selection/negation traps this variant's eval
+        // machinery exists to solve for unique=card. run_query's own
+        // existential_plane computation stays Mode::Card-only and unaffected by
+        // this -- it would otherwise redundantly re-check the same predicate the
+        // residual already checks, not add a real narrowing benefit for these modes.
+        return (Some(pe), filter);
     }
     match filter {
         FilterExpr::And(children) => {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1805,13 +1805,16 @@ pub(crate) fn eval_plane_expr_for_printing(
         PlaneExpr::Bits(bits) => bitmap_contains(bits, cid),
         // Re-derives the comparison directly from (field, op, threshold) against this
         // specific printing's own field -- mirrors filter.rs's NumericCmp arm exactly
-        // (same known_cents-style dollars conversion), rather than a second precomputed
-        // bitmap, so there's no independent encoding of "does this printing satisfy the
-        // predicate" to drift out of sync with the one filter.rs already trusts.
+        // (raw-cents comparison, no dollars conversion at eval time either), rather
+        // than a second precomputed bitmap, so there's no independent encoding of
+        // "does this printing satisfy the predicate" to drift out of sync with the
+        // one filter.rs already trusts.
         PlaneExpr::PrintingRangeBits { field, op, threshold, .. } => match field {
-            RangePredicateField::PriceUsd => {
-                printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)) / 100.0, *threshold))
-            }
+            // threshold is already cents, not dollars: this PlaneExpr was
+            // compiled from the same (already-bound) FilterExpr the price
+            // closure/field_num read theirs from -- see
+            // price_dollars_to_cents's doc.
+            RangePredicateField::PriceUsd => printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)), *threshold)),
             RangePredicateField::CollectorNumber => {
                 printing.collector_number_int.as_ref().is_some_and(|v| cmp(*op, f64::from(u16::from(*v)), *threshold))
             }

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -461,8 +461,19 @@ pub(crate) enum PlaneExpr {
     /// printing satisfying each half without any single printing satisfying
     /// both), so they correctly decline to compose via plain `card_bits`
     /// intersection until same-field interval merging is built (deferred,
-    /// not required for correctness — see the design doc).
-    PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: RangePredicateField, op: CmpOp, threshold: f64 },
+    /// not required for correctness — see the design doc). `exact` mirrors
+    /// `Narrowed.tight` from the narrowing that produced `card_bits`:
+    /// `range_narrowed`'s complement shortcut (majority-match case) over-
+    /// includes NULL-valued printings, so `card_bits` can be a loose
+    /// superset there. That's harmless when this leaf only narrows a
+    /// candidate set that gets re-verified downstream regardless (`narrow_
+    /// rec`'s own fastpath, or `split_planes` for `unique=printing`/
+    /// `artwork`, which never folds an existential leaf to a bare `True`
+    /// residual at all) -- but load-bearing exactly once: `split_planes`'s
+    /// `unique=card` fold discards the residual entirely, so `run_query`
+    /// trusts `card_bits`' popcount directly with no recheck. See
+    /// `plane_expr_is_exact` and its callers.
+    PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: RangePredicateField, op: CmpOp, threshold: f64, exact: bool },
     And(Vec<PlaneExpr>),
     Or(Vec<PlaneExpr>),
     Not(Box<PlaneExpr>),
@@ -1061,10 +1072,11 @@ fn compile_plane_children(
     words: &rkyv::Archived<OracleWordIndex>,
     indexes: &rkyv::Archived<CardIndexes>,
     offsets: &AOffsets,
+    must_be_tight: bool,
 ) -> Option<Vec<PlaneExpr>> {
     let mut order: Vec<&FilterExpr> = children.iter().collect();
     order.sort_by_key(|c| plane_precheck_rank(c));
-    order.into_iter().map(|c| compile_plane(c, bounds, words, indexes, offsets)).collect()
+    order.into_iter().map(|c| compile_plane(c, bounds, words, indexes, offsets, must_be_tight)).collect()
 }
 
 /// Which existential family a plane index addresses, and the per-printing
@@ -1214,6 +1226,26 @@ pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
     }
 }
 
+/// Whether every `PrintingRangeBits` leaf in a compiled plane expression has
+/// `exact: true` -- everything else (`Plane`/`Bits`/`Const`) is always exact,
+/// only a range leaf that hit `range_narrowed`'s complement shortcut for a
+/// majority-match query can be `false`. Only load-bearing at exactly one
+/// point: `split_planes`'s `unique=card` fold, which discards the residual
+/// entirely and lets `run_query` trust `card_bits`' popcount with no
+/// recheck -- see `PlaneExpr::PrintingRangeBits`'s doc. Every other consumer
+/// of a compiled plane (`narrow_rec`'s own fastpath; `split_planes` for
+/// `unique=printing`/`artwork`, which never folds an existential leaf away)
+/// always re-verifies downstream regardless, so they call `compile_plane`
+/// without ever consulting this.
+pub(crate) fn plane_expr_is_exact(expr: &PlaneExpr) -> bool {
+    match expr {
+        PlaneExpr::PrintingRangeBits { exact, .. } => *exact,
+        PlaneExpr::Plane(_) | PlaneExpr::Bits(_) | PlaneExpr::Const(_) => true,
+        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().all(plane_expr_is_exact),
+        PlaneExpr::Not(inner) => plane_expr_is_exact(inner),
+    }
+}
+
 /// `And` two-or-more legality-plane leaves referencing distinct existence
 /// facts -- different formats, the same format under both polarities
 /// (`format:A AND -format:A`), or (#678) the same format under two different
@@ -1243,23 +1275,37 @@ fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneEx
     Some(and_of(children))
 }
 
+/// `must_be_tight` propagates to every `PrintingRangeBits` leaf compiled
+/// within (`compile_price_range`/`compile_collector_number_range`/
+/// `compile_date_range`/`compile_year_range`): `true` when the caller will
+/// trust the result without a downstream recheck (`split_planes`'s
+/// `unique=card` fold specifically), `false` everywhere else (`narrow_rec`'s
+/// own fastpath; `split_planes` for `unique=printing`/`artwork`, which never
+/// folds an existential leaf away regardless) -- see `range_narrowed`'s own
+/// doc for why forcing it unconditionally was tried and reverted: it fixed a
+/// real NULL-over-inclusion bug but broke the fastpath's own reason to
+/// exist for the *broadest* queries, which are exactly the ones that always
+/// hit the complement shortcut this guards.
 pub(crate) fn compile_plane(
     filter: &FilterExpr,
     bounds: &rkyv::Archived<BitPlanes>,
     words: &rkyv::Archived<OracleWordIndex>,
     indexes: &rkyv::Archived<CardIndexes>,
     offsets: &AOffsets,
+    must_be_tight: bool,
 ) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::True => Some(PlaneExpr::Const(true)),
-        FilterExpr::And(children) => and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words, indexes, offsets)?),
-        FilterExpr::Or(children) => compile_plane_children(children, bounds, words, indexes, offsets).map(or_of),
+        FilterExpr::And(children) => {
+            and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words, indexes, offsets, must_be_tight)?)
+        }
+        FilterExpr::Or(children) => compile_plane_children(children, bounds, words, indexes, offsets, must_be_tight).map(or_of),
         // De Morgan pushdown so a Not that reaches a Legality leaf lands on
         // `illegal_exists` instead of bit-complementing `legal_exists` (wrong
         // for divergent cards -- see PLANE_LEGAL_EXISTS's doc). Handles the
         // contains_unnegatable_numeric guard itself, per-leaf, via its own
         // catch-all arm -- see compile_plane_neg's doc.
-        FilterExpr::Not(inner) => compile_plane_neg(inner, bounds, words, indexes, offsets),
+        FilterExpr::Not(inner) => compile_plane_neg(inner, bounds, words, indexes, offsets, must_be_tight),
         // Bonus consumption (docs/issues/00663-engine-oracle-word-index.md): only
         // when the needle matches exactly one dictionary word total (dense or
         // sparse) and that word is dense — the same "single dense hit, no
@@ -1307,10 +1353,14 @@ pub(crate) fn compile_plane(
         FilterExpr::NumericCmp { lhs, op, rhs } => match (lhs, rhs) {
             (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) => compile_rarity_cmp(*op, *v),
             (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) => compile_rarity_cmp(flip_op(*op), *v),
-            (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => compile_price_range(*op, *v, indexes, offsets),
-            (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => compile_price_range(flip_op(*op), *v, indexes, offsets),
-            (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => compile_collector_number_range(*op, *v, indexes, offsets),
-            (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => compile_collector_number_range(flip_op(*op), *v, indexes, offsets),
+            (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => compile_price_range(*op, *v, indexes, offsets, must_be_tight),
+            (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => compile_price_range(flip_op(*op), *v, indexes, offsets, must_be_tight),
+            (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => {
+                compile_collector_number_range(*op, *v, indexes, offsets, must_be_tight)
+            }
+            (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => {
+                compile_collector_number_range(flip_op(*op), *v, indexes, offsets, must_be_tight)
+            }
             (NumExpr::Field(f), NumExpr::Const(v)) => compile_numeric_cmp(*f, *op, *v, bounds),
             (NumExpr::Const(v), NumExpr::Field(f)) => compile_numeric_cmp(*f, flip_op(*op), *v, bounds),
             _ => None,
@@ -1318,11 +1368,11 @@ pub(crate) fn compile_plane(
         // released_at</X (docs/issues/local-engine-broad-range-fastpath.md):
         // same existential-plane treatment as usd/collector_number, via
         // date_range_narrowed (shared with narrow_rec's own DateCmp arm).
-        FilterExpr::DateCmp { op, value } => compile_date_range(*op, *value, indexes, offsets),
+        FilterExpr::DateCmp { op, value } => compile_date_range(*op, *value, indexes, offsets, must_be_tight),
         // released_at's year(...)</Y: same treatment via year_range_narrowed,
         // which maps the year threshold to a released_at_int range at the
         // year boundary.
-        FilterExpr::YearCmp { op, year } => compile_year_range(*op, *year, indexes, offsets),
+        FilterExpr::YearCmp { op, year } => compile_year_range(*op, *year, indexes, offsets, must_be_tight),
         // f:x / format:x / banned:x / restricted:x (docs/issues/
         // 00667-engine-legality-divergent-carveout.md, generalized by #678 -- see
         // docs/issues/00678-engine-legality-banned-restricted-planes.md): exact for
@@ -1348,20 +1398,31 @@ pub(crate) fn compile_plane(
 /// `range_narrowed` (shared with `narrow_rec`'s own price closure through
 /// `price_range_narrowed`, so the two paths can't drift). Declines (`None`)
 /// exactly when `price_range_narrowed` does (an op `int_range_bounds` doesn't
-/// support for range narrowing).
-fn compile_price_range(op: CmpOp, threshold: f64, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+/// support for range narrowing). `must_be_tight` passes straight through to
+/// `price_range_narrowed` -- see `compile_plane`'s own doc for who needs
+/// `true` and who doesn't; `printing_range_bits` also records whatever
+/// `narrowed.tight` came back as into the leaf's `exact` field regardless,
+/// as a defense-in-depth double-check (`plane_expr_is_exact`) independent
+/// of this threading.
+fn compile_price_range(op: CmpOp, threshold: f64, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets, must_be_tight: bool) -> Option<PlaneExpr> {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-    let narrowed = price_range_narrowed(op, threshold, indexes, n_printings, true)?;
+    let narrowed = price_range_narrowed(op, threshold, indexes, n_printings, true, must_be_tight)?;
     Some(printing_range_bits(narrowed, RangePredicateField::PriceUsd, op, threshold, offsets, indexes))
 }
 
 /// Compile `collector_number <op> threshold` to a `PrintingRangeBits` leaf,
 /// same shape as `compile_price_range` (shared via `collector_number_range_narrowed`).
-fn compile_collector_number_range(op: CmpOp, threshold: f64, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+fn compile_collector_number_range(
+    op: CmpOp,
+    threshold: f64,
+    indexes: &rkyv::Archived<CardIndexes>,
+    offsets: &AOffsets,
+    must_be_tight: bool,
+) -> Option<PlaneExpr> {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-    let narrowed = collector_number_range_narrowed(op, threshold, indexes, n_printings, true)?;
+    let narrowed = collector_number_range_narrowed(op, threshold, indexes, n_printings, true, must_be_tight)?;
     Some(printing_range_bits(narrowed, RangePredicateField::CollectorNumber, op, threshold, offsets, indexes))
 }
 
@@ -1369,19 +1430,19 @@ fn compile_collector_number_range(op: CmpOp, threshold: f64, indexes: &rkyv::Arc
 /// `PrintingRangeBits` leaf via `date_range_narrowed`. `value` (already a
 /// zero-padded yyyymmdd `u32`) is stored as the leaf's `threshold` directly --
 /// no conversion, exact in `f64`.
-fn compile_date_range(op: CmpOp, value: u32, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+fn compile_date_range(op: CmpOp, value: u32, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets, must_be_tight: bool) -> Option<PlaneExpr> {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-    let narrowed = date_range_narrowed(op, value, indexes, n_printings, true)?;
+    let narrowed = date_range_narrowed(op, value, indexes, n_printings, true, must_be_tight)?;
     Some(printing_range_bits(narrowed, RangePredicateField::ReleasedAtDate, op, value as f64, offsets, indexes))
 }
 
 /// Compile `released_at year <op> year` (`FilterExpr::YearCmp`) to a
 /// `PrintingRangeBits` leaf via `year_range_narrowed`.
-fn compile_year_range(op: CmpOp, year: i32, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+fn compile_year_range(op: CmpOp, year: i32, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets, must_be_tight: bool) -> Option<PlaneExpr> {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-    let narrowed = year_range_narrowed(op, year, indexes, n_printings, true)?;
+    let narrowed = year_range_narrowed(op, year, indexes, n_printings, true, must_be_tight)?;
     Some(printing_range_bits(narrowed, RangePredicateField::ReleasedAtYear, op, year as f64, offsets, indexes))
 }
 
@@ -1400,8 +1461,14 @@ fn printing_range_bits(
     indexes: &rkyv::Archived<CardIndexes>,
 ) -> PlaneExpr {
     let n_cards = offsets.len().saturating_sub(1);
+    // Capture printing-space tightness *before* into_card_space, which
+    // hardcodes tight:false on its own result unconditionally (card-space
+    // tightness means "all_match" there -- a different contract this
+    // existential leaf doesn't need; what matters here is whether the
+    // printing-space narrowing that fed it had any NULL over-inclusion).
+    let exact = narrowed.tight;
     let card_bits = narrowed.into_card_space(offsets, &indexes.printing_to_card).set.into_bits(n_cards);
-    PlaneExpr::PrintingRangeBits { id: next_range_bits_id(), card_bits, field, op, threshold }
+    PlaneExpr::PrintingRangeBits { id: next_range_bits_id(), card_bits, field, op, threshold, exact }
 }
 
 /// Compile `Not(filter)` directly, pushing negation down to `Legality` and
@@ -1422,6 +1489,7 @@ fn compile_plane_neg(
     words: &rkyv::Archived<OracleWordIndex>,
     indexes: &rkyv::Archived<CardIndexes>,
     offsets: &AOffsets,
+    must_be_tight: bool,
 ) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::Legality { shift: Some(shift), expected } => {
@@ -1437,35 +1505,35 @@ fn compile_plane_neg(
         // (¬∃p: p.usd<X) -- same divergent-printing trap as Legality/rarity's own
         // dedicated negation arms; a card can have some printings under X and some not.
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(v) } => {
-            compile_price_range(negate_op(*op), *v, indexes, offsets)
+            compile_price_range(negate_op(*op), *v, indexes, offsets, must_be_tight)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::PriceUsd) } => {
-            compile_price_range(negate_op(flip_op(*op)), *v, indexes, offsets)
+            compile_price_range(negate_op(flip_op(*op)), *v, indexes, offsets, must_be_tight)
         }
         // -collector_number<X: same divergent-printing reasoning as -usd<X.
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op, rhs: NumExpr::Const(v) } => {
-            compile_collector_number_range(negate_op(*op), *v, indexes, offsets)
+            compile_collector_number_range(negate_op(*op), *v, indexes, offsets, must_be_tight)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::CollectorNumberInt) } => {
-            compile_collector_number_range(negate_op(flip_op(*op)), *v, indexes, offsets)
+            compile_collector_number_range(negate_op(flip_op(*op)), *v, indexes, offsets, must_be_tight)
         }
         // -released_at<X / -year(released_at)<Y: same divergent-printing
         // reasoning, recomputed via the negated op rather than bit-complemented.
-        FilterExpr::DateCmp { op, value } => compile_date_range(negate_op(*op), *value, indexes, offsets),
-        FilterExpr::YearCmp { op, year } => compile_year_range(negate_op(*op), *year, indexes, offsets),
+        FilterExpr::DateCmp { op, value } => compile_date_range(negate_op(*op), *value, indexes, offsets, must_be_tight),
+        FilterExpr::YearCmp { op, year } => compile_year_range(negate_op(*op), *year, indexes, offsets, must_be_tight),
         // -border:x: recomputed via compile_border_cmp_neg's Or-of-others,
         // not bit-complemented, same divergent-card reasoning as Legality/rarity.
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => compile_border_cmp_neg(value),
         // Not(And(cs)) = Or(Not(c) for c in cs) -- existence distributes over
         // Or, so no shared-witness check is needed here regardless of how
         // many legality leaves end up among the children.
-        FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words, indexes, offsets).map(or_of),
+        FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words, indexes, offsets, must_be_tight).map(or_of),
         // Not(Or(cs)) = And(Not(c) for c in cs) -- THIS does have the
         // shared-witness exposure (see and_of_checked_for_shared_witness).
         FilterExpr::Or(children) => {
-            and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words, indexes, offsets)?)
+            and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words, indexes, offsets, must_be_tight)?)
         }
-        FilterExpr::Not(inner) => compile_plane(inner, bounds, words, indexes, offsets), // double negation
+        FilterExpr::Not(inner) => compile_plane(inner, bounds, words, indexes, offsets, must_be_tight), // double negation
         FilterExpr::True => Some(PlaneExpr::Const(false)),
         // Everything else: only Legality has a divergent-card correctness
         // gap, so every other plane-eligible leaf is safe to compile
@@ -1479,7 +1547,7 @@ fn compile_plane_neg(
             if contains_unnegatable_numeric(other) {
                 return None;
             }
-            compile_plane(other, bounds, words, indexes, offsets).map(|p| PlaneExpr::Not(Box::new(p)))
+            compile_plane(other, bounds, words, indexes, offsets, must_be_tight).map(|p| PlaneExpr::Not(Box::new(p)))
         }
     }
 }
@@ -1490,8 +1558,9 @@ fn compile_plane_neg_children(
     words: &rkyv::Archived<OracleWordIndex>,
     indexes: &rkyv::Archived<CardIndexes>,
     offsets: &AOffsets,
+    must_be_tight: bool,
 ) -> Option<Vec<PlaneExpr>> {
-    children.iter().map(|c| compile_plane_neg(c, bounds, words, indexes, offsets)).collect()
+    children.iter().map(|c| compile_plane_neg(c, bounds, words, indexes, offsets, must_be_tight)).collect()
 }
 
 /// Consume the plane-expressible part of a bound filter. Returns the compiled
@@ -1539,9 +1608,16 @@ pub(crate) fn split_planes(
     // buried entirely inside one child (e.g. an Or of two date comparisons)
     // still pays the old cost, same as before this fix existed.
     let range_conflict = has_conflicting_range_families(&filter);
+    // must_be_tight: unique_is_card -- this is exactly the fold that
+    // discards the residual and lets run_query trust card_bits' popcount
+    // with no recheck, so it's the one call site truly willing to pay for
+    // the majority-match direct scatter instead of the (otherwise cheaper)
+    // NULL-over-including complement. plane_expr_is_exact below is a
+    // defense-in-depth double-check, not the primary guarantee -- see
+    // compile_plane's own doc.
     if !range_conflict
-        && let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets)
-        && (unique_is_card || !plane_expr_is_existential(&pe))
+        && let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets, unique_is_card)
+        && ((unique_is_card && plane_expr_is_exact(&pe)) || !plane_expr_is_existential(&pe))
     {
         return (Some(pe), FilterExpr::True);
     }
@@ -1570,7 +1646,7 @@ pub(crate) fn split_planes(
                     rest.push(c);
                     continue;
                 }
-                match compile_plane(&c, bounds, words, indexes, offsets) {
+                match compile_plane(&c, bounds, words, indexes, offsets, unique_is_card) {
                     Some(pe) => {
                         let mut fmts = Vec::new();
                         collect_existential_indices(&pe, &mut fmts);
@@ -1587,7 +1663,7 @@ pub(crate) fn split_planes(
             for (_, pe) in &legality_children {
                 collect_existential_indices(pe, &mut all_formats);
             }
-            if unique_is_card && all_formats.len() <= 1 {
+            if unique_is_card && all_formats.len() <= 1 && legality_children.iter().all(|(_, pe)| plane_expr_is_exact(pe)) {
                 for (_, pe) in legality_children {
                     planes.push(pe);
                 }
@@ -1599,9 +1675,12 @@ pub(crate) fn split_planes(
                 // way) can't be ANDed together safely regardless of mode
                 // (shared-witness); a single one is safe for the plane's own
                 // exactness but still deferred for unique=printing/artwork,
-                // same reasoning as the top-level shortcut above. Either way
-                // it falls back to narrow_rec's existing (correct, still
-                // exact as of this issue) Legality narrowing arm instead.
+                // same reasoning as the top-level shortcut above. A range leaf
+                // whose narrowing hit the complement shortcut (not exact) is
+                // the same "can't be trusted for the unique=card fold" story
+                // -- see plane_expr_is_exact's doc. Either way it falls back
+                // to narrow_rec's existing (correct, still exact as of this
+                // issue) narrowing arm instead.
                 for (c, _) in legality_children {
                     rest.push(c);
                 }

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1843,16 +1843,12 @@ pub(crate) fn eval_plane_expr_for_printing(
         PlaneExpr::Bits(bits) => bitmap_contains(bits, cid),
         // Re-derives the comparison directly from (field, op, threshold) against this
         // specific printing's own field -- mirrors filter.rs's NumericCmp arm exactly
-        // (raw-cents comparison, no dollars conversion at eval time either), rather
-        // than a second precomputed bitmap, so there's no independent encoding of
-        // "does this printing satisfy the predicate" to drift out of sync with the
-        // one filter.rs already trusts.
+        // (same cents-to-dollars division, since the bind-time cents fast path was
+        // reverted -- see field_num's doc), rather than a second precomputed bitmap,
+        // so there's no independent encoding of "does this printing satisfy the
+        // predicate" to drift out of sync with the one filter.rs already trusts.
         PlaneExpr::PrintingRangeBits { field, op, threshold, .. } => match field {
-            // threshold is already cents, not dollars: this PlaneExpr was
-            // compiled from the same (already-bound) FilterExpr the price
-            // closure/field_num read theirs from -- see
-            // price_dollars_to_cents's doc.
-            RangePredicateField::PriceUsd => printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)), *threshold)),
+            RangePredicateField::PriceUsd => printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)) / 100.0, *threshold)),
             RangePredicateField::CollectorNumber => {
                 printing.collector_number_int.as_ref().is_some_and(|v| cmp(*op, f64::from(u16::from(*v)), *threshold))
             }

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -554,6 +554,37 @@ fn existential_leaf_family(filter: &FilterExpr) -> Option<ExistentialFamily> {
     }
 }
 
+/// True iff `filter` contains, anywhere reachable through And/Or/Not (the
+/// same structural correspondence `compile_plane` and
+/// `plane_expr_is_existential` use), at least one range-family leaf
+/// (usd/eur/tix/collector_number/released_at/year). Every such leaf compiles
+/// to a `PrintingRangeBits` node, which `plane_expr_is_existential` treats as
+/// unconditionally existential and propagates through And/Or/Not -- so for
+/// `unique_is_card=false` (unique=printing/artwork), `split_planes`'s
+/// whole-filter fold (below) can *never* succeed once `compile_plane`
+/// produces one, no matter how the rest of the tree compiles: the fold's own
+/// condition reduces to `!plane_expr_is_existential(&pe)`, which is
+/// guaranteed false. Checked before paying for that `compile_plane` call at
+/// all, mirroring `has_conflicting_range_families`' existing bail-out
+/// pattern -- profiling a bare `usd<50`/unique=printing query found
+/// `compile_price_range` called twice per query (confirmed via a call
+/// counter + backtrace, not guessed): once here, wastefully, computing and
+/// discarding a full `into_card_space` conversion (measured ~40% of total
+/// query time), and once moments later in `narrow_rec`, which actually keeps
+/// the result via `Narrowed::loose`.
+fn contains_range_family_leaf(filter: &FilterExpr) -> bool {
+    match existential_leaf_family(filter) {
+        Some(ExistentialFamily::Range) => return true,
+        Some(_) => return false,
+        None => {}
+    }
+    match filter {
+        FilterExpr::And(cs) | FilterExpr::Or(cs) => cs.iter().any(contains_range_family_leaf),
+        FilterExpr::Not(inner) => contains_range_family_leaf(inner),
+        _ => false,
+    }
+}
+
 /// True iff some `And` node in `filter` -- this one or a descendant --
 /// combines 2+ distinct existential-family leaves (any mix of legality/
 /// rarity/border/usd/collector_number/released_at, including two range
@@ -1615,7 +1646,14 @@ pub(crate) fn split_planes(
     // NULL-over-including complement. plane_expr_is_exact below is a
     // defense-in-depth double-check, not the primary guarantee -- see
     // compile_plane's own doc.
+    //
+    // contains_range_family_leaf's doc: for !unique_is_card, a range leaf
+    // anywhere makes plane_expr_is_existential(&pe) unconditionally true,
+    // so the fold below is doomed before compile_plane is even called --
+    // skip paying for it (narrow_rec picks up the identical leaf moments
+    // later and actually keeps the result).
     if !range_conflict
+        && (unique_is_card || !contains_range_family_leaf(&filter))
         && let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets, unique_is_card)
         && ((unique_is_card && plane_expr_is_exact(&pe)) || !plane_expr_is_existential(&pe))
     {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -31,9 +31,13 @@
 
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::filter::{CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextField, TextSearchField};
+use super::filter::{cmp, CmpOp, ColorField, FilterExpr, NumExpr, NumField, TextField, TextSearchField};
 use super::legality::{LEGALITY_BANNED, LEGALITY_LEGAL, LEGALITY_RESTRICTED, MAX_FORMATS};
-use super::{flip_op, lane_get, negate_op, oracle_word_eligible, scan_oracle_words, str_at, AStrings, OracleCard, OracleWordIndex, Printing, NONE_STR};
+use super::{
+    flip_op, lane_get, negate_op, oracle_word_eligible, price_range_narrowed, scan_oracle_words, str_at, AOffsets, AStrings, CardIndexes,
+    OracleCard, OracleWordIndex, Printing, NONE_STR,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Plane layout, plane-major in BitPlanes.words: six color planes per color
 /// field (W U B R G C, bit order matching color_to_bit — C is always zero for
@@ -441,10 +445,41 @@ pub(crate) enum PlaneExpr {
     /// compile-time-known dimensions the other variants index into. A clone
     /// (a few KB) is paid once per query, never per row.
     Bits(Vec<u64>),
+    /// A printing-varying numeric range predicate (`price_usd` today —
+    /// `collector_number`/`released_at` are separate `FilterExpr` variants,
+    /// `DateCmp`/`YearCmp`, not yet wired here), compiled via `range_narrowed`
+    /// at query time (docs/issues/local-engine-broad-range-fastpath.md).
+    /// `card_bits` is the card-level existence answer ("some printing
+    /// satisfies"). The per-printing check re-derives the comparison directly
+    /// from `(field, op, threshold)` against the printing's own field instead
+    /// of a second precomputed bitmap — one fewer independent encoding of the
+    /// same fact to keep in sync (exactly the shape that caused Bug B in the
+    /// price-cents migration). `id` is a synthetic shared-witness identity
+    /// (see `collect_existential_indices`) — distinct per compiled leaf, even
+    /// for the same field at a different threshold: two range conditions on
+    /// the same field are a real shared-witness risk (a card could have one
+    /// printing satisfying each half without any single printing satisfying
+    /// both), so they correctly decline to compose via plain `card_bits`
+    /// intersection until same-field interval merging is built (deferred,
+    /// not required for correctness — see the design doc).
+    PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: NumField, op: CmpOp, threshold: f64 },
     And(Vec<PlaneExpr>),
     Or(Vec<PlaneExpr>),
     Not(Box<PlaneExpr>),
     Const(bool),
+}
+
+/// Fresh synthetic identity for each compiled `PrintingRangeBits` leaf, used
+/// by `collect_existential_indices`' shared-witness dedup. Starts above
+/// `PLANE_COUNT` so it can never collide with a real `Plane(u16)` index (cast
+/// to `u64` there for comparison — see that function). Only needs
+/// distinctness within one query's compiled tree, not globally — collisions
+/// across separate queries are harmless, and `u64` never wraps in any
+/// realistic process lifetime, unlike a `u16` counter would.
+static NEXT_RANGE_BITS_ID: AtomicU64 = AtomicU64::new(PLANE_COUNT as u64);
+
+fn next_range_bits_id() -> u64 {
+    NEXT_RANGE_BITS_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 /// And over children, collapsing the empty (vacuously true) and singleton cases.
@@ -876,10 +911,16 @@ fn plane_precheck_rank(f: &FilterExpr) -> u8 {
 /// Try children cheapest-to-reject first (see plane_precheck_rank), short-
 /// circuiting on the first None without disturbing the caller's requested
 /// order — `and_of`/`or_of` don't care about member order, so this is free.
-fn compile_plane_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<Vec<PlaneExpr>> {
+fn compile_plane_children(
+    children: &[FilterExpr],
+    bounds: &rkyv::Archived<BitPlanes>,
+    words: &rkyv::Archived<OracleWordIndex>,
+    indexes: &rkyv::Archived<CardIndexes>,
+    offsets: &AOffsets,
+) -> Option<Vec<PlaneExpr>> {
     let mut order: Vec<&FilterExpr> = children.iter().collect();
     order.sort_by_key(|c| plane_precheck_rank(c));
-    order.into_iter().map(|c| compile_plane(c, bounds, words)).collect()
+    order.into_iter().map(|c| compile_plane(c, bounds, words, indexes, offsets)).collect()
 }
 
 /// Which existential family a plane index addresses, and the per-printing
@@ -987,11 +1028,19 @@ fn existential_leaf(p: usize) -> Option<ExistentialLeaf> {
 /// one. A literal duplicate leaf (`format:A AND format:A`) reads the same
 /// plane index and collapses to one entry, fine to compose -- the same
 /// underlying fact checked twice, not two facts needing a shared witness.
-fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
+fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u64>) {
     match expr {
         PlaneExpr::Plane(p) => {
-            if existential_leaf(*p as usize).is_some() && !out.contains(p) {
-                out.push(*p);
+            if existential_leaf(*p as usize).is_some() {
+                let p = u64::from(*p);
+                if !out.contains(&p) {
+                    out.push(p);
+                }
+            }
+        }
+        PlaneExpr::PrintingRangeBits { id, .. } => {
+            if !out.contains(id) {
+                out.push(*id);
             }
         }
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => {}
@@ -1014,6 +1063,7 @@ fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
 pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
     match expr {
         PlaneExpr::Plane(p) => existential_leaf(*p as usize).is_some(),
+        PlaneExpr::PrintingRangeBits { .. } => true,
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => false,
         PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(plane_expr_is_existential),
         PlaneExpr::Not(inner) => plane_expr_is_existential(inner),
@@ -1049,17 +1099,23 @@ fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneEx
     Some(and_of(children))
 }
 
-pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
+pub(crate) fn compile_plane(
+    filter: &FilterExpr,
+    bounds: &rkyv::Archived<BitPlanes>,
+    words: &rkyv::Archived<OracleWordIndex>,
+    indexes: &rkyv::Archived<CardIndexes>,
+    offsets: &AOffsets,
+) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::True => Some(PlaneExpr::Const(true)),
-        FilterExpr::And(children) => and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words)?),
-        FilterExpr::Or(children) => compile_plane_children(children, bounds, words).map(or_of),
+        FilterExpr::And(children) => and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words, indexes, offsets)?),
+        FilterExpr::Or(children) => compile_plane_children(children, bounds, words, indexes, offsets).map(or_of),
         // De Morgan pushdown so a Not that reaches a Legality leaf lands on
         // `illegal_exists` instead of bit-complementing `legal_exists` (wrong
         // for divergent cards -- see PLANE_LEGAL_EXISTS's doc). Handles the
         // contains_unnegatable_numeric guard itself, per-leaf, via its own
         // catch-all arm -- see compile_plane_neg's doc.
-        FilterExpr::Not(inner) => compile_plane_neg(inner, bounds, words),
+        FilterExpr::Not(inner) => compile_plane_neg(inner, bounds, words, indexes, offsets),
         // Bonus consumption (docs/issues/00663-engine-oracle-word-index.md): only
         // when the needle matches exactly one dictionary word total (dense or
         // sparse) and that word is dense — the same "single dense hit, no
@@ -1107,6 +1163,8 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
         FilterExpr::NumericCmp { lhs, op, rhs } => match (lhs, rhs) {
             (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) => compile_rarity_cmp(*op, *v),
             (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) => compile_rarity_cmp(flip_op(*op), *v),
+            (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => compile_price_range(*op, *v, indexes, offsets),
+            (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => compile_price_range(flip_op(*op), *v, indexes, offsets),
             (NumExpr::Field(f), NumExpr::Const(v)) => compile_numeric_cmp(*f, *op, *v, bounds),
             (NumExpr::Const(v), NumExpr::Field(f)) => compile_numeric_cmp(*f, flip_op(*op), *v, bounds),
             _ => None,
@@ -1132,6 +1190,19 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
     }
 }
 
+/// Compile `usd <op> threshold` to a `PrintingRangeBits` leaf via
+/// `range_narrowed` (shared with `narrow_rec`'s own price closure through
+/// `price_range_narrowed`, so the two paths can't drift). Declines (`None`)
+/// exactly when `price_range_narrowed` does (an op `int_range_bounds` doesn't
+/// support for range narrowing).
+fn compile_price_range(op: CmpOp, threshold: f64, indexes: &rkyv::Archived<CardIndexes>, offsets: &AOffsets) -> Option<PlaneExpr> {
+    let n_cards = offsets.len().saturating_sub(1);
+    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
+    let narrowed = price_range_narrowed(op, threshold, indexes, n_printings, true)?;
+    let card_bits = narrowed.into_card_space(offsets, &indexes.printing_to_card).set.into_bits(n_cards);
+    Some(PlaneExpr::PrintingRangeBits { id: next_range_bits_id(), card_bits, field: NumField::PriceUsd, op, threshold })
+}
+
 /// Compile `Not(filter)` directly, pushing negation down to `Legality` and
 /// rarity leaves -- both need to be *recomputed*, not bit-complemented
 /// (`Legality` needs `PLANE_LEGAL_ILLEGAL`, not a complement of
@@ -1144,7 +1215,13 @@ pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlan
 /// safe to bit-complement (colors/types/devotion/non-null-valued numerics)
 /// fall through to the cheaper "compile positive, wrap in `PlaneExpr::Not`"
 /// path unchanged. Mutually recursive with `compile_plane`.
-fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
+fn compile_plane_neg(
+    filter: &FilterExpr,
+    bounds: &rkyv::Archived<BitPlanes>,
+    words: &rkyv::Archived<OracleWordIndex>,
+    indexes: &rkyv::Archived<CardIndexes>,
+    offsets: &AOffsets,
+) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::Legality { shift: Some(shift), expected } => {
             status_plane_bases(*expected).map(|(_, absent_base)| PlaneExpr::Plane((absent_base + *shift as usize / 2) as u16))
@@ -1155,17 +1232,28 @@ fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, wo
         FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
             compile_rarity_cmp(negate_op(flip_op(*op)), *v)
         }
+        // -usd<X: recomputed with the negated op (∃p: ¬(p.usd<X)), not bit-complemented
+        // (¬∃p: p.usd<X) -- same divergent-printing trap as Legality/rarity's own
+        // dedicated negation arms; a card can have some printings under X and some not.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(v) } => {
+            compile_price_range(negate_op(*op), *v, indexes, offsets)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::PriceUsd) } => {
+            compile_price_range(negate_op(flip_op(*op)), *v, indexes, offsets)
+        }
         // -border:x: recomputed via compile_border_cmp_neg's Or-of-others,
         // not bit-complemented, same divergent-card reasoning as Legality/rarity.
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => compile_border_cmp_neg(value),
         // Not(And(cs)) = Or(Not(c) for c in cs) -- existence distributes over
         // Or, so no shared-witness check is needed here regardless of how
         // many legality leaves end up among the children.
-        FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words).map(or_of),
+        FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words, indexes, offsets).map(or_of),
         // Not(Or(cs)) = And(Not(c) for c in cs) -- THIS does have the
         // shared-witness exposure (see and_of_checked_for_shared_witness).
-        FilterExpr::Or(children) => and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words)?),
-        FilterExpr::Not(inner) => compile_plane(inner, bounds, words), // double negation
+        FilterExpr::Or(children) => {
+            and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words, indexes, offsets)?)
+        }
+        FilterExpr::Not(inner) => compile_plane(inner, bounds, words, indexes, offsets), // double negation
         FilterExpr::True => Some(PlaneExpr::Const(false)),
         // Everything else: only Legality has a divergent-card correctness
         // gap, so every other plane-eligible leaf is safe to compile
@@ -1179,13 +1267,19 @@ fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, wo
             if contains_unnegatable_numeric(other) {
                 return None;
             }
-            compile_plane(other, bounds, words).map(|p| PlaneExpr::Not(Box::new(p)))
+            compile_plane(other, bounds, words, indexes, offsets).map(|p| PlaneExpr::Not(Box::new(p)))
         }
     }
 }
 
-fn compile_plane_neg_children(children: &[FilterExpr], bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<Vec<PlaneExpr>> {
-    children.iter().map(|c| compile_plane_neg(c, bounds, words)).collect()
+fn compile_plane_neg_children(
+    children: &[FilterExpr],
+    bounds: &rkyv::Archived<BitPlanes>,
+    words: &rkyv::Archived<OracleWordIndex>,
+    indexes: &rkyv::Archived<CardIndexes>,
+    offsets: &AOffsets,
+) -> Option<Vec<PlaneExpr>> {
+    children.iter().map(|c| compile_plane_neg(c, bounds, words, indexes, offsets)).collect()
 }
 
 /// Consume the plane-expressible part of a bound filter. Returns the compiled
@@ -1217,11 +1311,13 @@ pub(crate) fn split_planes(
     bounds: &rkyv::Archived<BitPlanes>,
     words: &rkyv::Archived<OracleWordIndex>,
     unique_is_card: bool,
+    indexes: &rkyv::Archived<CardIndexes>,
+    offsets: &AOffsets,
 ) -> (Option<PlaneExpr>, FilterExpr) {
     if matches!(filter, FilterExpr::True) {
         return (None, filter);
     }
-    if let Some(pe) = compile_plane(&filter, bounds, words)
+    if let Some(pe) = compile_plane(&filter, bounds, words, indexes, offsets)
         && (unique_is_card || !plane_expr_is_existential(&pe))
     {
         return (Some(pe), FilterExpr::True);
@@ -1242,7 +1338,7 @@ pub(crate) fn split_planes(
             // there's no tax to avoid paying here anymore.
             let mut legality_children: Vec<(FilterExpr, PlaneExpr)> = Vec::new();
             for c in children {
-                match compile_plane(&c, bounds, words) {
+                match compile_plane(&c, bounds, words, indexes, offsets) {
                     Some(pe) => {
                         let mut fmts = Vec::new();
                         collect_existential_indices(&pe, &mut fmts);
@@ -1297,6 +1393,7 @@ impl PlaneExpr {
         match self {
             PlaneExpr::Plane(p) => u64::from(words[*p as usize * wpp + i]),
             PlaneExpr::Bits(bits) => bits[i],
+            PlaneExpr::PrintingRangeBits { card_bits, .. } => card_bits[i],
             PlaneExpr::And(children) => {
                 let mut acc = !0u64;
                 for c in children {
@@ -1395,6 +1492,15 @@ pub(crate) fn eval_plane_expr_for_printing(
             }
         }
         PlaneExpr::Bits(bits) => bitmap_contains(bits, cid),
+        // Re-derives the comparison directly from (field, op, threshold) against this
+        // specific printing's own field -- mirrors filter.rs's NumericCmp arm exactly
+        // (same known_cents-style dollars conversion), rather than a second precomputed
+        // bitmap, so there's no independent encoding of "does this printing satisfy the
+        // predicate" to drift out of sync with the one filter.rs already trusts.
+        PlaneExpr::PrintingRangeBits { field, op, threshold, .. } => match field {
+            NumField::PriceUsd => printing.price_usd.as_ref().is_some_and(|v| cmp(*op, f64::from(u32::from(*v)) / 100.0, *threshold)),
+            _ => unreachable!("PrintingRangeBits only compiled for price_usd so far"),
+        },
         PlaneExpr::Const(b) => *b,
         PlaneExpr::And(children) => children.iter().all(|c| eval_plane_expr_for_printing(c, planes, cid, printing, strings)),
         PlaneExpr::Or(children) => children.iter().any(|c| eval_plane_expr_for_printing(c, planes, cid, printing, strings)),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,7 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
-    bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
+    bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, has_conflicting_range_families, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     TextField, TextSearchField, Tri, SortedTrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
@@ -1370,16 +1370,77 @@ fn legality_compound_and_respects_row_selection_for_unique_card() {
 }
 
 /// Found in #676's review: a legality leaf ANDed with a genuinely
-/// printing-dependent, non-plane-compilable residual (`DateCmp` here --
+/// printing-dependent, non-plane-compilable residual (`ArtistMatch` here --
 /// never appears in `planes.rs`, so it always stays in the residual after
 /// `split_planes`'s partial extraction) needs *both* checked against the
-/// *same* printing. printing 0 is legal in A but released before the cutoff;
-/// printing 1 is released after the cutoff but not legal in A -- no single
-/// printing satisfies both, so `format:A AND date>cutoff` (unique=card) must
+/// *same* printing. printing 0 is legal in A but by the wrong artist;
+/// printing 1 is by the right artist but not legal in A -- no single
+/// printing satisfies both, so `format:A AND artist:X` (unique=card) must
 /// match 0 times, not pick either printing on the strength of just one half
 /// of the conjunction.
+///
+/// (`DateCmp` filled this role until this fastpath's `collector_number`/
+/// `released_at` extension made it plane-compilable too --
+/// see `legality_and_date_decline_shared_witness` for the coverage that
+/// shift now needs of its own.)
 #[test]
 fn legality_and_date_residual_must_be_checked_together() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[2], vocab);
+    data.printings[0].card_legalities = 0b01; // legal in A, but...
+    let mut artists = VocabInterner::new();
+    let wrong_artist = artists.intern("wrong artist".to_string()).unwrap();
+    let right_artist = artists.intern("right artist".to_string()).unwrap();
+    data.printings[0].card_artist_vid = wrong_artist; // ...by the wrong artist
+    data.printings[1].card_legalities = 0; // not legal in A, but...
+    data.printings[1].card_artist_vid = right_artist; // ...by the right artist
+    data.artist_vocab = artists.strings;
+    data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
+    data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let filter = FilterExpr::And(vec![
+        FilterExpr::Legality { shift: Some(0), expected: 0b01 },
+        FilterExpr::ArtistMatch { ids: vec![right_artist] },
+    ]);
+    let (plane, mut residual) = split_planes(filter, bounds, words, true, &archived.indexes, &archived.offsets);
+    assert!(plane.is_some(), "the legality leaf alone must still promote into the plane");
+    assert!(
+        matches!(residual, FilterExpr::ArtistMatch { .. }),
+        "artist match isn't plane-compilable, so it must remain a real residual, not collapse to True"
+    );
+
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing is both legal in A and by the right artist");
+}
+
+/// The `collector_number`/`released_at` extension to `PrintingRangeBits`
+/// (docs/issues/local-engine-broad-range-fastpath.md) makes `DateCmp` itself
+/// plane-compilable, so `format:A AND date>cutoff` now has two *distinct*
+/// existential facts on the table (Legality's plane, DateCmp's
+/// `PrintingRangeBits`) -- `and_of_checked_for_shared_witness`'s
+/// `all_formats.len() <= 1` guard still correctly refuses to fold them into
+/// one combined plane. But composing them isn't the only way to extract
+/// *some* speed here: `has_conflicting_range_families`'s structural
+/// pre-check (added to fix a compound-query regression this same issue
+/// found -- see its doc) steers `split_planes` to skip attempting to
+/// plane-compile the DateCmp leaf at all once it detects the conflict,
+/// leaving Legality to extract on its own with DateCmp as a genuine
+/// residual -- exactly the "one plane leaf + real residual" shape
+/// `legality_and_date_residual_must_be_checked_together` tests with
+/// `ArtistMatch`, and exactly what this compound would have done before
+/// DateCmp was plane-compilable at all. Same fixture/expectation either
+/// way: printing 0 legal-but-early, printing 1 late-but-illegal, no single
+/// witness, so the compound must match 0 times.
+#[test]
+fn legality_and_date_decline_shared_witness() {
     let mut vocab = VocabInterner::new();
     let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
     let mut data = store_of(vec![card], &[2], vocab);
@@ -1387,6 +1448,7 @@ fn legality_and_date_residual_must_be_checked_together() {
     data.printings[0].released_at_int = Some(20100101); // ...released before the cutoff
     data.printings[1].card_legalities = 0; // not legal in A, but...
     data.printings[1].released_at_int = Some(20220101); // ...released after the cutoff
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
     data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -1401,7 +1463,7 @@ fn legality_and_date_residual_must_be_checked_together() {
     assert!(plane.is_some(), "the legality leaf alone must still promote into the plane");
     assert!(
         matches!(residual, FilterExpr::DateCmp { .. }),
-        "date> isn't plane-compilable, so it must remain a real residual, not collapse to True"
+        "date> must remain a real residual once conflict detection steers around compiling it, not collapse to True"
     );
 
     let (total, _) = run_query(
@@ -2366,6 +2428,20 @@ fn collector_number_narrowing() {
     // printings[3] has no numeric part: absent from the index
     data.indexes.collector_number =
         build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    // Since this fastpath's collector_number extension to PrintingRangeBits
+    // (docs/issues/local-engine-broad-range-fastpath.md), narrow_rec's own
+    // compile_plane fast path would also compile every cn(...) leaf below on
+    // a store this small, intercepting before the printing-space match arms
+    // this test wants to exercise and returning card-space CardBits instead
+    // (see compile_collector_number_range's plane-path parity test for that
+    // representation's own coverage). Zeroing n_cards on the planes index
+    // defeats the `u32::from(indexes.planes.n_cards) as usize == n_cards`
+    // guard in narrow_rec, keeping this test on the printing-space dispatch
+    // path it's actually about -- same rationale as
+    // price_narrowing_and_verification_are_exact_at_the_boundary's direct
+    // price_range_narrowed calls, just structured to preserve this test's
+    // Or/flipped-operand coverage of narrow_rec's own dispatch instead.
+    data.indexes.planes.n_cards = 0;
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -2846,6 +2922,13 @@ fn set_code_and_date_narrowing() {
     }
     data.indexes.set_codes = set_codes;
     data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
+    // Since this fastpath's released_at extension to PrintingRangeBits (docs/issues/
+    // local-engine-broad-range-fastpath.md), narrow_rec's compile_plane fast
+    // path would also compile the DateCmp/YearCmp leaves below on a store
+    // this small, intercepting before the printing-space match arms this
+    // test wants to exercise (same collector_number_narrowing dealt with).
+    // Zeroing n_cards on the planes index defeats that fast path's guard.
+    data.indexes.planes.n_cards = 0;
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -3426,6 +3509,277 @@ fn price_plane_path_parity_and_shared_witness() {
         &mut same_field_and(), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
     );
     assert_eq!(total, 0, "no single printing satisfies both usd<50 and usd>10");
+}
+
+/// Card 0: two printings, cn=10 (satisfies `cn<50`) and cn=200 (doesn't;
+/// satisfies `cn>=50`) -- same divergent shape as `price_plane_fixture_store`.
+/// Card 1: one printing at cn=500 (never satisfies `cn<50`).
+fn collector_number_plane_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 1], vocab);
+    data.printings[0].collector_number_int = Some(10);
+    data.printings[1].collector_number_int = Some(200);
+    data.printings[2].collector_number_int = Some(500);
+    data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    data
+}
+
+/// `PrintingRangeBits`'s `collector_number` extension must reproduce exactly
+/// what the unplaned path computes -- same three failure modes as
+/// `price_plane_path_parity_and_shared_witness` (row selection, negation,
+/// shared witness), now for a second field sharing the same
+/// `RangePredicateField`-tagged machinery.
+#[test]
+fn collector_number_plane_path_parity_and_shared_witness() {
+    let data = collector_number_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let cn = |op, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op, rhs: NumExpr::Const(v) };
+
+    let filters: Vec<Box<dyn Fn() -> FilterExpr>> = vec![
+        Box::new(|| cn(CmpOp::Lt, 50.0)),
+        Box::new(|| FilterExpr::Not(Box::new(cn(CmpOp::Lt, 50.0)))),
+        Box::new(|| FilterExpr::And(vec![cn(CmpOp::Lt, 50.0), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }])),
+    ];
+    for make in &filters {
+        for unique in ["card", "printing", "artwork"] {
+            let unique_is_card = unique != "printing" && unique != "artwork";
+            let mut plain = make();
+            let (t0, p0) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            let (pe, mut residual) = split_planes(
+                make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card, &archived.indexes, &archived.offsets,
+            );
+            let (t1, p1) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            assert_eq!(t0, t1, "totals must agree (unique={unique})");
+            let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
+                page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+            };
+            assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
+        }
+    }
+
+    // Independent ground truth for -cn<50/unique=card, bypassing run_query's own
+    // internal plane fast path (same reasoning as price's own independent check).
+    let not_cn = FilterExpr::Not(Box::new(cn(CmpOp::Lt, 50.0)));
+    let expected_cards: usize = (0..archived.cards.len() as u32)
+        .filter(|&cid| {
+            let start = u32::from(archived.offsets[cid as usize]) as usize;
+            let end = u32::from(archived.offsets[cid as usize + 1]) as usize;
+            archived.printings[start..end].iter().any(|p| not_cn.matches(&archived.cards[cid as usize], p, &archived.strings))
+        })
+        .count();
+    assert_eq!(expected_cards, 2, "hand-computed ground truth: both cards have a printing satisfying -cn<50");
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut FilterExpr::Not(Box::new(cn(CmpOp::Lt, 50.0))), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, expected_cards, "-cn<50 unique=card must match the independent per-printing ground truth");
+
+    // Same-field range AND (cn<50 AND cn>20): no printing of card 0 satisfies both
+    // (cn=10 fails cn>20, cn=200 fails cn<50) -- correct total is 0.
+    let same_field_and = || FilterExpr::And(vec![cn(CmpOp::Lt, 50.0), cn(CmpOp::Gt, 20.0)]);
+    assert!(
+        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets)
+            .is_none(),
+        "same-field cn range AND must decline to compile (shared witness)"
+    );
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut same_field_and(), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing satisfies both cn<50 and cn>20");
+}
+
+/// Card 0: two printings, released 2010 (satisfies `released_at<2020_0101`)
+/// and 2024 (doesn't; satisfies `released_at>=2020_0101`) -- same divergent
+/// shape as the price/collector_number fixtures. Card 1: one printing
+/// released 2023 (never satisfies the `<2020` threshold).
+fn released_at_plane_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 1], vocab);
+    data.printings[0].released_at_int = Some(20100101);
+    data.printings[1].released_at_int = Some(20240101);
+    data.printings[2].released_at_int = Some(20230101);
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
+    data
+}
+
+/// `PrintingRangeBits`'s `released_at` extension covers two distinct filter
+/// shapes (`DateCmp` directly, `YearCmp` via its derived-value recheck) --
+/// same three failure modes as the price/collector_number parity tests, run
+/// for both.
+#[test]
+fn released_at_plane_path_parity_and_shared_witness() {
+    let data = released_at_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let date = |op, value| FilterExpr::DateCmp { op, value };
+    let year = |op, y| FilterExpr::YearCmp { op, year: y };
+
+    let filters: Vec<Box<dyn Fn() -> FilterExpr>> = vec![
+        Box::new(|| date(CmpOp::Lt, 20_200_101)),
+        Box::new(|| FilterExpr::Not(Box::new(date(CmpOp::Lt, 20_200_101)))),
+        Box::new(|| year(CmpOp::Lt, 2020)),
+        Box::new(|| FilterExpr::Not(Box::new(year(CmpOp::Lt, 2020)))),
+        Box::new(|| FilterExpr::And(vec![date(CmpOp::Lt, 20_200_101), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }])),
+    ];
+    for make in &filters {
+        for unique in ["card", "printing", "artwork"] {
+            let unique_is_card = unique != "printing" && unique != "artwork";
+            let mut plain = make();
+            let (t0, p0) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            let (pe, mut residual) = split_planes(
+                make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card, &archived.indexes, &archived.offsets,
+            );
+            let (t1, p1) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            assert_eq!(t0, t1, "totals must agree (unique={unique})");
+            let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
+                page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+            };
+            assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
+        }
+    }
+
+    // Independent ground truth for -date</unique=card.
+    let not_date = FilterExpr::Not(Box::new(date(CmpOp::Lt, 20_200_101)));
+    let expected_cards: usize = (0..archived.cards.len() as u32)
+        .filter(|&cid| {
+            let start = u32::from(archived.offsets[cid as usize]) as usize;
+            let end = u32::from(archived.offsets[cid as usize + 1]) as usize;
+            archived.printings[start..end].iter().any(|p| not_date.matches(&archived.cards[cid as usize], p, &archived.strings))
+        })
+        .count();
+    assert_eq!(expected_cards, 2, "hand-computed ground truth: both cards have a printing satisfying -date<2020_0101");
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut FilterExpr::Not(Box::new(date(CmpOp::Lt, 20_200_101))), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, expected_cards, "-date<2020_0101 unique=card must match the independent per-printing ground truth");
+
+    // Same-field range AND (date<2020 AND date>2015): no printing of card 0
+    // satisfies both (2010 fails >2015-worth-of-date, 2024 fails <2020).
+    let same_field_and = || FilterExpr::And(vec![date(CmpOp::Lt, 20_200_101), date(CmpOp::Gt, 20_150_101)]);
+    assert!(
+        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets)
+            .is_none(),
+        "same-field date range AND must decline to compile (shared witness)"
+    );
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut same_field_and(), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing satisfies both date<2020_0101 and date>2015_0101");
+
+    // DateCmp and YearCmp on the same field are the identical shared-witness
+    // shape (both compile to a RangePredicateField::ReleasedAt* PrintingRangeBits
+    // sharing the field, just different granularity) -- must also decline.
+    let mixed_and = || FilterExpr::And(vec![date(CmpOp::Lt, 20_200_101), year(CmpOp::Gt, 2015)]);
+    assert!(
+        compile_plane(&mixed_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none(),
+        "DateCmp and YearCmp on released_at must decline to compile together (shared witness)"
+    );
+}
+
+/// One card, three printings, each satisfying exactly one of three range
+/// conditions (`usd<50`, `cn<100`, `date<2020_0101`) and failing the other
+/// two -- pairwise divergent by construction, so `And`ing any two conditions
+/// must match 0 times (no single printing witnesses both), the cross-field
+/// analogue of `price_plane_path_parity_and_shared_witness`'s same-field
+/// check. Each field compiles to its own `RangePredicateField`-tagged
+/// `PrintingRangeBits` leaf with its own `next_range_bits_id()`, so any two
+/// of these three are two distinct existential facts regardless of which
+/// pair -- exactly the shape `and_of_checked_for_shared_witness`/
+/// `split_planes`'s `all_formats.len() <= 1` guard exists to catch.
+#[test]
+fn cross_field_range_predicates_decline_shared_witness() {
+    let mut vocab = VocabInterner::new();
+    let card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    let mut data = store_of(vec![card], &[3], vocab);
+    data.printings[0].price_usd = Some(500); // usd<50 true; cn/date false
+    data.printings[0].collector_number_int = Some(500);
+    data.printings[0].released_at_int = Some(20240101);
+    data.printings[1].price_usd = Some(20000); // cn<100 true; usd/date false
+    data.printings[1].collector_number_int = Some(10);
+    data.printings[1].released_at_int = Some(20240101);
+    data.printings[2].price_usd = Some(20000); // date<2020_0101 true; usd/cn false
+    data.printings[2].collector_number_int = Some(500);
+    data.printings[2].released_at_int = Some(20100101);
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let usd_lt_50 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    let cn_lt_100 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op: CmpOp::Lt, rhs: NumExpr::Const(100.0) };
+    let date_lt_2020 = || FilterExpr::DateCmp { op: CmpOp::Lt, value: 20_200_101 };
+
+    let check = |name: &str, f: FilterExpr| {
+        assert!(
+            compile_plane(&f, bounds, words, &archived.indexes, &archived.offsets).is_none(),
+            "{name}: two distinct existential range facts must decline to compose"
+        );
+        let (total, _) = run_query(
+            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+            &mut { f }, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+        );
+        assert_eq!(total, 0, "{name}: no single printing satisfies both conditions");
+    };
+    check("usd+cn", FilterExpr::And(vec![usd_lt_50(), cn_lt_100()]));
+    check("usd+date", FilterExpr::And(vec![usd_lt_50(), date_lt_2020()]));
+    check("cn+date", FilterExpr::And(vec![cn_lt_100(), date_lt_2020()]));
+}
+
+/// `has_conflicting_range_families`'s structural pre-check (added to fix the
+/// compound-query regression `cross_field_range_predicates_decline_shared_
+/// witness`'s doc mentions) must not treat a bare `Or` of two
+/// existential-family leaves as a conflict: `∃` distributes over `∨`, so
+/// `r:common or r:uncommon` has no shared-witness problem at all and must
+/// compile exactly as before -- found as a real ~8x regression
+/// (0.07ms -> 0.55ms) during this fix's own benchmarking when the first cut
+/// of the pre-check walked `Or` the same as `And`. Covers both the bare-`Or`
+/// case (no enclosing `And` at all) and the `And`-containing-an-`Or` case
+/// (where the conflict tally legitimately should cross into the `Or`, since
+/// whichever branch is live still combines with the `And`'s other child).
+#[test]
+fn range_conflict_check_does_not_penalize_bare_or() {
+    let bare_or = FilterExpr::Or(vec![
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(0.0) },
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(1.0) },
+    ]);
+    assert!(!has_conflicting_range_families(&bare_or), "a bare Or of 2 existential leaves has no shared-witness problem");
+
+    let usd_lt_50 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    let usd_gt_50 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Gt, rhs: NumExpr::Const(50.0) };
+    let or_of_usd = FilterExpr::Or(vec![usd_lt_50(), usd_gt_50()]);
+    assert!(!has_conflicting_range_families(&or_of_usd), "an Or of 2 usd leaves alone still has no shared-witness problem");
+
+    // format:A AND (usd<50 OR usd>50): the And's tally must cross into the
+    // Or's children (3 distinct facts: legality + 2 usd leaves once
+    // expanded), unlike the bare-Or cases above.
+    let and_containing_or = FilterExpr::And(vec![FilterExpr::Legality { shift: Some(0), expected: 0b01 }, or_of_usd]);
+    assert!(
+        has_conflicting_range_families(&and_containing_or),
+        "an And whose child is an Or of range leaves must still see the conflict with its other child"
+    );
 }
 
 // ─── Numeric-range planes (#655) ───────────────────────────────────────────────

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
+    assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
@@ -243,6 +243,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups,
+        printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
     CardData {
@@ -268,11 +269,13 @@ fn narrow_candidates_spaces() {
     let mut keywords: TagIndex = HashMap::new();
     keywords.insert("Flying".to_string(), vec![1]);
 
-    let indexes = CardIndexes { art_tags, keywords, ..Default::default() };
+    // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
+    let raw_offsets = vec![0u32, 2, 4];
+    let printing_to_card = build_printing_to_card(&raw_offsets);
+    let indexes = CardIndexes { art_tags, keywords, printing_to_card, ..Default::default() };
     let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
     let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
-    // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
-    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 2, 4]).expect("serialize offsets");
+    let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize offsets");
     let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
 
     let coll = |field, value: &str| FilterExpr::CollectionCmp {
@@ -652,7 +655,7 @@ fn rarity_not_arm_matches_existence_projection() {
             let Some(n) = super::narrow_rec(&filter, &archived.indexes, &archived.offsets, &archived.cards, true) else {
                 continue;
             };
-            let cand = n.set.into_cards(&archived.offsets);
+            let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
             let want: Vec<u32> = RARITY_PLANE_FIXTURE
                 .iter()
                 .enumerate()
@@ -678,7 +681,7 @@ fn rarity_not_arm_matches_existence_projection() {
             }));
             let n2 = super::narrow_rec(&filter_flipped, &archived.indexes, &archived.offsets, &archived.cards, true)
                 .unwrap_or_else(|| panic!("Not({val} {name} field) must narrow given Not(field {name} {val}) did"));
-            let cand2 = n2.set.into_cards(&archived.offsets);
+            let cand2 = n2.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
             assert_eq!(cand, cand2, "operand order must not change the result: {name} {val}");
         }
     }
@@ -686,12 +689,72 @@ fn rarity_not_arm_matches_existence_projection() {
 
 #[test]
 fn cards_of_printings_maps_and_dedups() {
-    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 3, 4, 7]).expect("serialize");
+    let raw_offsets = vec![0u32, 3, 4, 7];
+    let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize");
     let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access");
+    let printing_to_card_bytes = rkyv::to_bytes::<Error>(&build_printing_to_card(&raw_offsets)).expect("serialize");
+    let printing_to_card = rkyv::access::<Archived<Vec<u32>>, Error>(&printing_to_card_bytes).expect("access");
     // printings 0-2 → card 0, 3 → card 1, 4-6 → card 2
-    assert_eq!(cards_of_printings(offsets, &[0, 1, 2, 3, 5, 6]), vec![0, 1, 2]);
-    assert_eq!(cards_of_printings(offsets, &[1]), vec![0]);
-    assert_eq!(cards_of_printings(offsets, &[]), Vec::<u32>::new());
+    assert_eq!(cards_of_printings(offsets, printing_to_card, &[0, 1, 2, 3, 5, 6]), vec![0, 1, 2]);
+    assert_eq!(cards_of_printings(offsets, printing_to_card, &[1]), vec![0]);
+    assert_eq!(cards_of_printings(offsets, printing_to_card, &[]), Vec::<u32>::new());
+}
+
+/// Differential test for the direct-array projection
+/// (docs/issues/local-engine-direct-projection-arrays.md): `cards_of_printings`
+/// must agree with an independent reference oracle (a `partition_point` search on
+/// `offsets`, applied uniformly regardless of size -- the mechanism the small-k
+/// path itself used before this change) at every k, spanning both the small-k
+/// (<=1024) and broad-k (>1024) branches, so the branch split is provably a pure
+/// performance choice, not a behavior change.
+#[test]
+fn cards_of_printings_matches_naive_projection_across_sizes() {
+    use rand::SeedableRng;
+    const NUM_SEEDS: u64 = 40;
+    const N_CARDS: usize = 200;
+
+    for seed in 0..NUM_SEEDS {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        let mut raw_offsets = Vec::with_capacity(N_CARDS + 1);
+        raw_offsets.push(0u32);
+        let mut total = 0u32;
+        for _ in 0..N_CARDS {
+            total += rng.random_range(1..=20);
+            raw_offsets.push(total);
+        }
+        let n_printings = total as usize;
+
+        let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize");
+        let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access");
+        let printing_to_card_vec = build_printing_to_card(&raw_offsets);
+        let printing_to_card_bytes = rkyv::to_bytes::<Error>(&printing_to_card_vec).expect("serialize");
+        let printing_to_card = rkyv::access::<Archived<Vec<u32>>, Error>(&printing_to_card_bytes).expect("access");
+
+        // k values straddling the 1024 small/broad split; clamp to n_printings.
+        for &k in &[0usize, 1, 5, 50, 999, 1024, 1025, 2000, 5000] {
+            let k = k.min(n_printings);
+            let mut printing_ids: Vec<u32> = {
+                let mut set = std::collections::HashSet::with_capacity(k);
+                while set.len() < k {
+                    set.insert(rng.random_range(0..n_printings as u32));
+                }
+                set.into_iter().collect()
+            };
+            printing_ids.sort_unstable();
+
+            let got = cards_of_printings(offsets, printing_to_card, &printing_ids);
+
+            // Reference oracle: partition_point on offsets directly, shares no
+            // code with build_printing_to_card or cards_of_printings' branches.
+            let mut want: Vec<u32> = printing_ids
+                .iter()
+                .map(|&p| raw_offsets.partition_point(|&o| o <= p) as u32 - 1)
+                .collect();
+            want.dedup();
+
+            assert_eq!(got, want, "seed={seed}, k={k}, n_printings={n_printings}");
+        }
+    }
 }
 
 #[test]
@@ -2019,6 +2082,7 @@ fn bench_checked_vs_unchecked_access() {
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups,
+        printing_to_card: build_printing_to_card(&offsets),
         planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
@@ -3739,7 +3803,7 @@ fn oracle_word_index_exact_union_parity() {
         let expected = brute_force_oracle_contains(archived, needle);
         let n = rec(&oracle(needle)).unwrap_or_else(|| panic!("oracle:{needle} must narrow"));
         assert!(n.tight, "oracle:{needle} must narrow tight (exact, no verification)");
-        assert_eq!(n.set.into_cards(&archived.offsets), expected, "oracle:{needle} must match the brute-force set exactly");
+        assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected, "oracle:{needle} must match the brute-force set exactly");
     }
 }
 
@@ -3800,7 +3864,7 @@ fn oracle_word_index_multi_dense_no_sparse() {
         Candidates::CardBits(_) => {}
         other => panic!("2+ dense hits, no sparse, must return CardBits, got {other:?}", other = std::mem::discriminant(other)),
     }
-    assert_eq!(n.set.into_cards(&archived.offsets), expected, "oracle:word must match the brute-force set exactly");
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected, "oracle:word must match the brute-force set exactly");
 }
 
 // compile_plane's bonus arm only fires for the single-dense-hit shape (needed
@@ -3947,7 +4011,7 @@ fn border_planes_exact_union_parity() {
         let expected = brute_force_has_border(archived, value);
         let n = rec(&border(value)).unwrap_or_else(|| panic!("border:{value} must narrow"));
         assert!(!n.tight, "border planes narrow loose through narrow_rec, tight or not is compile_plane's separate call to make");
-        assert_eq!(n.set.into_cards(&archived.offsets), expected, "border:{value} narrowed set must match brute force");
+        assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected, "border:{value} narrowed set must match brute force");
     }
 
     // Untracked (yellow): narrows loosely through the shared `other` plane --
@@ -3956,7 +4020,7 @@ fn border_planes_exact_union_parity() {
     let expected_yellow = brute_force_has_border(archived, "yellow");
     let n = rec(&border("yellow")).expect("untracked value must still narrow via the shared other plane");
     assert!(!n.tight);
-    assert_eq!(n.set.into_cards(&archived.offsets), expected_yellow, "border:yellow narrowed set must match brute force");
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected_yellow, "border:yellow narrowed set must match brute force");
 }
 
 // The regression test this design exists to guarantee: two independent
@@ -4100,7 +4164,7 @@ fn border_black_declines_via_broadness_guard() {
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
     let n = super::narrow_rec(&border("black"), &archived.indexes, &archived.offsets, &archived.cards, true).expect("the dedicated arm itself always narrows");
-    assert_eq!(n.set.into_cards(&archived.offsets).len(), 7);
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card).len(), 7);
 
     assert!(
         narrow_candidates(&border("black"), &archived.indexes, &archived.offsets, &archived.cards).is_none(),
@@ -4229,7 +4293,7 @@ fn not_narrows_only_tight_children() {
     // Tight leaf → complement narrows, loose, and covers every ¬-match.
     let n = rec(&FilterExpr::Not(Box::new(goblin()))).expect("Not(subtype) must narrow");
     assert!(!n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     for (cid, card) in archived.cards.iter().enumerate() {
         let matches_not = (u32::from(archived.offsets[cid])..u32::from(archived.offsets[cid + 1]))
             .any(|p| FilterExpr::Not(Box::new(goblin())).matches(card, &archived.printings[p as usize], &archived.strings));
@@ -4245,7 +4309,7 @@ fn not_narrows_only_tight_children() {
     // superset check as the tight-child case above, just via a different arm.
     let n = rec(&FilterExpr::Not(Box::new(rarity()))).expect("-r:x must narrow via the negated-op arm");
     assert!(!n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     for (cid, card) in archived.cards.iter().enumerate() {
         let matches_not = (u32::from(archived.offsets[cid])..u32::from(archived.offsets[cid + 1]))
             .any(|p| FilterExpr::Not(Box::new(rarity())).matches(card, &archived.printings[p as usize], &archived.strings));
@@ -4281,7 +4345,7 @@ fn or_composes_plane_and_complement_children() {
     // ColorCmp had no narrowing arm before #636; via the plane feed-in the Or composes.
     let or = FilterExpr::Or(vec![goblin(), green()]);
     let n = rec(&or).expect("Or(subtype, color) must narrow");
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     assert_eq!(cand, vec![0, 1, 3], "goblins ∪ green");
 
     // An unindexable child still vetoes: nothing can represent it (1-char is
@@ -4440,7 +4504,7 @@ fn name_bigrams_tiers_and_exactness() {
     // Sparse tier: exact vec, tight, and byte-for-byte the contains() answer.
     let n = rec("qx").expect("sparse bigram narrows");
     assert!(n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     let brute: Vec<u32> = archived.cards.iter().enumerate()
         .filter(|(_, c)| c.card_name_lower.as_str().contains("qx"))
         .map(|(i, _)| i as u32)
@@ -4479,7 +4543,7 @@ fn name_bigrams_compose_and_memoize() {
     // Or of two bigram children composes: "fi" → {0,1,4}, "dr" → {0,2}.
     let or = FilterExpr::Or(vec![name2("fi"), name2("dr")]);
     let n = super::narrow_rec(&or, &archived.indexes, &archived.offsets, &archived.cards, false).expect("bigram Or composes");
-    assert_eq!(n.set.into_cards(&archived.offsets), vec![0, 1, 2, 4]);
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), vec![0, 1, 2, 4]);
 
     // run_query parity across the new shapes, negation included.
     for f in [or, FilterExpr::Not(Box::new(name2("fi")))] {
@@ -4670,7 +4734,7 @@ fn devotion_plane_parity_and_boundaries() {
     let deep = dev(CmpOp::Ge, &[("U", 5)]);
     let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, &archived.cards, false).expect("deep-k narrows loosely");
     assert!(!n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     for (cid, card) in archived.cards.iter().enumerate() {
         if deep.eval_card(card, &archived.strings) == Tri::True {
             assert!(cand.contains(&(cid as u32)), "superset must cover card {cid}");
@@ -4774,7 +4838,7 @@ fn exact_name_narrows_tight() {
     ] {
         let n = narrow(name);
         assert!(n.tight, "{name}: equality through the sorted permutation is exact");
-        let mut got = n.set.into_cards(&archived.offsets);
+        let mut got = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
         got.sort_unstable();
         want.sort_unstable();
         assert_eq!(got, want, "candidates for {name:?}");

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,10 +4,10 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, price_dollars_to_cents, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
+    build_artist_index, build_range_index, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, has_conflicting_range_families, plane_expr_is_exact, split_planes,
-    ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
+    ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     TextField, TextSearchField, Tri, SortedTrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
     TYPE_ENCHANTMENT, TYPE_INSTANT, TYPE_LAND, TYPE_LEGENDARY, TYPE_PLANESWALKER, TYPE_SNOW, TYPE_SORCERY,
@@ -206,15 +206,11 @@ fn stub_printing(scryfall_id: u128, illustration_id: u128, prefer_score: Option<
     }
 }
 
-/// A `usd <op> dollars` comparison, already bound (Const rewritten to cents
-/// via `super::price_dollars_to_cents`) -- the shape every real query
-/// reaches through `FilterExpr::bind`, which none of these test fixtures
-/// otherwise call. Written this way (not a raw `NumericCmp` literal with a
-/// hand-converted cents value) so every price test shares the identical
-/// conversion `bind` itself uses, rather than N call sites each doing their
-/// own `* 100.0` that could silently drift from it.
+/// A `usd <op> dollars` comparison. `field_num` divides cents to dollars
+/// unconditionally regardless of shape, so this is just a plain `Const` in
+/// dollars -- no `bind()` step or unit conversion required.
 fn usd_cmp(op: CmpOp, dollars: f64) -> FilterExpr {
-    FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(price_dollars_to_cents(dollars)) }
+    FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(dollars) }
 }
 
 /// Assemble a CardData where card i owns `printing_counts[i]` printings, in the
@@ -3030,7 +3026,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
 
     // Lt must exclude the boundary printing exactly -- both in narrowing and in verification.
     let lt = cmp(CmpOp::Lt);
-    match price_range_narrowed(CmpOp::Lt, price_dollars_to_cents(0.10), &archived.indexes, n_printings, true, true).map(|n| n.set) {
+    match price_range_narrowed(CmpOp::Lt, 0.10, &archived.indexes, n_printings, true, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
             assert!(!v.contains(&1), "Lt must exclude the exact boundary price");
@@ -3046,7 +3042,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     // silently excluded exact matches independent of narrowing).
     for (op, op_name, is_eq) in [(CmpOp::Le, "Le", false), (CmpOp::Ge, "Ge", false), (CmpOp::Eq, "Eq", true)] {
         let f = cmp(op);
-        match price_range_narrowed(op, price_dollars_to_cents(0.10), &archived.indexes, n_printings, true, true).map(|n| n.set) {
+        match price_range_narrowed(op, 0.10, &archived.indexes, n_printings, true, true).map(|n| n.set) {
             Some(Candidates::Printings(v)) => assert!(v.contains(&1), "narrowing must include the boundary price for {op_name}"),
             None if is_eq => {} // narrow_candidates_exact's broadness filter can decline Eq on a tiny store; matches() below is what matters
             _ => panic!("usd must narrow in printing space for {op_name}"),
@@ -3058,7 +3054,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
     // Flipped operand order (50.0 < usd, i.e. usd > 50.0): only the $60 printing qualifies.
-    match price_range_narrowed(CmpOp::Gt, price_dollars_to_cents(50.0), &archived.indexes, n_printings, true, true).map(|n| n.set) {
+    match price_range_narrowed(CmpOp::Gt, 50.0, &archived.indexes, n_printings, true, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
     }
@@ -3428,30 +3424,70 @@ fn price_plane_fixture_store() -> CardData {
     data
 }
 
-/// `FilterExpr::bind` rewrites a price `NumericCmp`'s query-side dollar
-/// `Const` to cents exactly once per query (`price_dollars_to_cents`) -- the
-/// step that lets `field_num`'s per-printing evaluation compare raw cents
-/// with no division. Every other test in this file builds already-bound
-/// filters directly via `usd_cmp` (mirroring what `bind` produces, not
-/// exercising `bind` itself), so this is the one place that actually calls
-/// `bind` on a dollar-denominated `NumericCmp` -- the exact shape
-/// `build_filter` produces from a real `usd<50`-style query -- and checks
-/// both the rewritten `Const` value and that evaluation afterward still
-/// agrees with the unbound (dollars) comparison bit-for-bit.
+/// Regression for a real bug that shipped briefly in this area: an earlier
+/// version rewrote a bare price `Field` (compared directly against a
+/// `Const`) into a cents-only fast path at bind time, to avoid dividing on
+/// every printing evaluated. That rewrite only recognized the *exact* bare
+/// shape -- it did not recurse into `NumExpr::Arith`. `usd+1<power` (price
+/// inside an arithmetic expression -- `parser_class=NUMERIC` on
+/// `usd`/`eur`/`tix` admits this grammatically, same as `cmc`/`power`) left
+/// the `1` in dollars while the fast path made `field_num` return cents
+/// unconditionally, silently computing `(cents+1)<power` instead of
+/// `(dollars+1)<power` -- off by a factor of 100. A second, independent
+/// instance of the same bug (`usd<cmc`, a price `Field` compared directly
+/// against *another* `Field`, no `Const` anywhere) confirmed the rewrite
+/// couldn't be patched to cover every shape without either false negatives
+/// or a full scaling transform on both sides of the comparison. Reverted the
+/// whole optimization: `NumExpr::Field(Price*)` always means dollars again
+/// (matching every build before it), for a ~2-3% loss on the one shape the
+/// fast path covered, in exchange for making every shape correct by
+/// construction rather than by rewrite coverage. Kept as a permanent
+/// regression test for exactly this class of bug, in case a similar
+/// shape-specific fast path is tried again later.
 #[test]
-fn bind_rewrites_price_const_to_cents() {
-    let data = price_plane_fixture_store();
+fn usd_inside_arithmetic_evaluates_in_dollars_not_cents() {
+    let mut vocab = VocabInterner::new();
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.creature_power = Some(52);
+    let mut data = store_of(vec![card], &[1], vocab);
+    data.printings[0].price_usd = Some(5000); // $50.00
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let card = &archived.cards[0];
+    let printing = &archived.printings[0];
 
-    let mut f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    // usd+1<power: $50.00 + 1 = 51 < power(52) -- must match.
+    let mut f = FilterExpr::NumericCmp {
+        lhs: NumExpr::Arith(Box::new(NumExpr::Field(NumField::PriceUsd)), ArithOp::Add, Box::new(NumExpr::Const(1.0))),
+        op: CmpOp::Lt,
+        rhs: NumExpr::Field(NumField::Power),
+    };
     f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
-    let FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } = &f else { panic!("bind must not change the node shape") };
-    assert_eq!(*v, 5000.0, "bind must rewrite the dollar Const to its exact cents value");
+    assert!(f.matches(card, printing, &archived.strings), "usd+1<power must evaluate in dollars: 50+1=51 < 52");
+}
 
-    assert!(f.matches(card, &archived.printings[0], &archived.strings), "usd<50 (bound) must still match the $5.00 printing");
-    assert!(!f.matches(card, &archived.printings[1], &archived.strings), "usd<50 (bound) must still exclude the $200.00 printing");
+/// The second independent instance referenced in the doc above:
+/// `usd<cmc` -- a price `Field` compared directly against *another* `Field`,
+/// no `Const` anywhere -- which no version of a `Const`-rewriting fast path
+/// could have covered at all, since there's no `Const` to rewrite.
+#[test]
+fn usd_compared_directly_against_another_field_evaluates_in_dollars() {
+    let mut vocab = VocabInterner::new();
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.cmc = Some(3);
+    let mut data = store_of(vec![card], &[1], vocab);
+    data.printings[0].price_usd = Some(200); // $2.00
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let card = &archived.cards[0];
+    let printing = &archived.printings[0];
+
+    // usd<cmc: $2.00 < cmc(3) -- must match.
+    let mut f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Field(NumField::Cmc) };
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
+    assert!(f.matches(card, printing, &archived.strings), "usd<cmc must evaluate in dollars: 2.00 < 3");
 }
 
 /// `PlaneExpr::PrintingRangeBits` (docs/issues/local-engine-broad-range-fastpath.md)

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,7 +4,7 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
+    build_artist_index, build_range_index, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
@@ -544,15 +544,15 @@ fn rarity_tracked_values_exact_consumed_hi_bucket_declines() {
     let rarity_eq = |v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(v) };
 
     // Tracked values (mythic=3) compile exactly.
-    assert!(compile_plane(&rarity_eq(3.0), bounds, words).is_some(), "r:mythic must compile to a plane expression");
+    assert!(compile_plane(&rarity_eq(3.0), bounds, words, &archived.indexes, &archived.offsets).is_some(), "r:mythic must compile to a plane expression");
     // Special/bonus specifically can't be told apart by the shared hi plane.
-    assert!(compile_plane(&rarity_eq(4.0), bounds, words).is_none(), "r:special must decline (hi bucket is ambiguous)");
-    assert!(compile_plane(&rarity_eq(5.0), bounds, words).is_none(), "r:bonus must decline (hi bucket is ambiguous)");
+    assert!(compile_plane(&rarity_eq(4.0), bounds, words, &archived.indexes, &archived.offsets).is_none(), "r:special must decline (hi bucket is ambiguous)");
+    assert!(compile_plane(&rarity_eq(5.0), bounds, words, &archived.indexes, &archived.offsets).is_none(), "r:bonus must decline (hi bucket is ambiguous)");
 
     // Mixed with an otherwise fully plane-expressible sibling: an ambiguous
     // rarity child must stay in the residual, not get silently dropped or promoted.
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity_eq(4.0)]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, rarity_eq(4.0)]), bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some(), "the creature child must still plane-consume");
     assert!(
         matches!(&residual, FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }),
@@ -561,7 +561,7 @@ fn rarity_tracked_values_exact_consumed_hi_bucket_declines() {
 
     // A tracked value's negation is exact too.
     let not_mythic = FilterExpr::Not(Box::new(rarity_eq(3.0)));
-    assert!(compile_plane(&not_mythic, bounds, words).is_some(), "-r:mythic must compile to a plane expression");
+    assert!(compile_plane(&not_mythic, bounds, words, &archived.indexes, &archived.offsets).is_some(), "-r:mythic must compile to a plane expression");
 }
 
 /// Y=2 shared-witness decline: two distinct rarity plane indices under one
@@ -584,7 +584,7 @@ fn rarity_shared_witness_declines_same_field_and_cross_field() {
     // rarity>=rare AND rarity<=mythic: two distinct tracked plane indices
     // (rare, mythic) shared between the two Or-trees -- must decline.
     let bounded_range = FilterExpr::And(vec![rarity_ge(2.0), rarity_le(3.0)]);
-    assert!(compile_plane(&bounded_range, bounds, words).is_none(), "same-field rarity range must decline (shared witness)");
+    assert!(compile_plane(&bounded_range, bounds, words, &archived.indexes, &archived.offsets).is_none(), "same-field rarity range must decline (shared witness)");
 
     // format:A AND r:mythic: two distinct fields, still the identical
     // shared-witness problem -- collect_existential_indices doesn't care
@@ -593,7 +593,7 @@ fn rarity_shared_witness_declines_same_field_and_cross_field() {
     let cross_field = FilterExpr::And(vec![format_a, FilterExpr::NumericCmp {
         lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(3.0),
     }]);
-    assert!(compile_plane(&cross_field, bounds, words).is_none(), "legality+rarity compound must decline (shared witness)");
+    assert!(compile_plane(&cross_field, bounds, words, &archived.indexes, &archived.offsets).is_none(), "legality+rarity compound must decline (shared witness)");
 
     // The fallback must still produce the correct (not just declined)
     // result: no printing in this fixture is both format-A-legal and
@@ -1066,11 +1066,11 @@ fn legality_same_format_cross_status_declines_shared_witness() {
     let restricted_c = || FilterExpr::Legality { shift: Some(4), expected: 0b10 };
 
     assert!(
-        compile_plane(&FilterExpr::And(vec![banned_c(), restricted_c()]), bounds, words).is_none(),
+        compile_plane(&FilterExpr::And(vec![banned_c(), restricted_c()]), bounds, words, &archived.indexes, &archived.offsets).is_none(),
         "banned:C AND restricted:C (same format, distinct statuses) must decline (shared-witness)"
     );
     assert!(
-        compile_plane(&FilterExpr::Or(vec![banned_c(), restricted_c()]), bounds, words).is_some(),
+        compile_plane(&FilterExpr::Or(vec![banned_c(), restricted_c()]), bounds, words, &archived.indexes, &archived.offsets).is_some(),
         "OR has no shared-witness problem and must compile"
     );
 }
@@ -1096,7 +1096,7 @@ fn legality_cross_status_shared_witness_falls_back_to_correct_result() {
         FilterExpr::Legality { shift: Some(4), expected: 0b11 },
         FilterExpr::Legality { shift: Some(4), expected: 0b10 },
     ]);
-    let (plane, mut residual) = split_planes(and_both, bounds, words, true);
+    let (plane, mut residual) = split_planes(and_both, bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(plane.is_none(), "shared-witness AND must not partially promote either leaf into the plane");
     assert!(matches!(residual, FilterExpr::And(_)), "both legality children must remain in the residual");
 
@@ -1245,10 +1245,10 @@ fn plane_expr_is_existential_identifies_legality_only() {
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
-    let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words).unwrap();
+    let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words, &archived.indexes, &archived.offsets).unwrap();
     assert!(super::plane_expr_is_existential(&legality_pe));
 
-    let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words).unwrap();
+    let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words, &archived.indexes, &archived.offsets).unwrap();
     assert!(!super::plane_expr_is_existential(&creature_pe));
 
     let mixed = compile_plane(
@@ -1258,6 +1258,8 @@ fn plane_expr_is_existential_identifies_legality_only() {
         ]),
         bounds,
         words,
+        &archived.indexes,
+        &archived.offsets,
     )
     .unwrap();
     assert!(super::plane_expr_is_existential(&mixed), "one existential leaf must taint the whole And");
@@ -1295,7 +1297,7 @@ fn legality_plane_promotion_respects_mode_through_split_planes() {
     let run_mode = |unique: &str| {
         let f = FilterExpr::Legality { shift: Some(0), expected: 0b01 };
         let unique_is_card = unique != "printing" && unique != "artwork";
-        let (plane, mut residual) = split_planes(f, bounds, words, unique_is_card);
+        let (plane, mut residual) = split_planes(f, bounds, words, unique_is_card, &archived.indexes, &archived.offsets);
         if unique_is_card {
             assert!(plane.is_some(), "a bare Legality leaf must still fully plane-consume for unique=card");
             assert!(matches!(residual, FilterExpr::True), "split_planes must leave a bare True residual for unique=card");
@@ -1351,7 +1353,7 @@ fn legality_compound_and_respects_row_selection_for_unique_card() {
         FilterExpr::Legality { shift: Some(0), expected: 0b01 },
         FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
     ]);
-    let (plane, mut residual) = split_planes(filter, bounds, words, true);
+    let (plane, mut residual) = split_planes(filter, bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(plane.is_some(), "format:A AND t:creature (one format, no shared-witness issue) must compile whole");
     assert!(matches!(residual, FilterExpr::True));
 
@@ -1395,7 +1397,7 @@ fn legality_and_date_residual_must_be_checked_together() {
         FilterExpr::Legality { shift: Some(0), expected: 0b01 },
         FilterExpr::DateCmp { op: CmpOp::Gt, value: 20200101 },
     ]);
-    let (plane, mut residual) = split_planes(filter, bounds, words, true);
+    let (plane, mut residual) = split_planes(filter, bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(plane.is_some(), "the legality leaf alone must still promote into the plane");
     assert!(
         matches!(residual, FilterExpr::DateCmp { .. }),
@@ -1727,6 +1729,7 @@ fn fuzz_check_case(archived: &Archived<CardData>, spec: &FuzzSpec, ctx: &str) {
         // the real caller (only Mode::Card may fold an existential legality leaf).
         let (pe, mut residual) = split_planes(
             fuzz_build_filter(spec), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
+            &archived.indexes, &archived.offsets,
         );
         let (t1, p1) = run_query(
             &archived.cards, &archived.printings, &archived.offsets, strings,
@@ -1807,15 +1810,15 @@ fn legality_and_of_two_formats_declines_but_or_compiles() {
     let b = || FilterExpr::Legality { shift: Some(2), expected: 0b01 };
 
     assert!(
-        compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words).is_none(),
+        compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words, &archived.indexes, &archived.offsets).is_none(),
         "two distinct formats ANDed must decline (shared-witness)"
     );
     assert!(
-        compile_plane(&FilterExpr::Or(vec![a(), b()]), bounds, words).is_some(),
+        compile_plane(&FilterExpr::Or(vec![a(), b()]), bounds, words, &archived.indexes, &archived.offsets).is_some(),
         "OR of two formats has no shared-witness problem and must compile"
     );
     assert!(
-        compile_plane(&FilterExpr::And(vec![a(), FilterExpr::Not(Box::new(a()))]), bounds, words).is_none(),
+        compile_plane(&FilterExpr::And(vec![a(), FilterExpr::Not(Box::new(a()))]), bounds, words, &archived.indexes, &archived.offsets).is_none(),
         "format:A AND -format:A (same format, both polarities) is the same contradiction-prone shape and must also decline"
     );
 }
@@ -1842,7 +1845,7 @@ fn legality_shared_witness_and_falls_back_to_correct_result() {
         FilterExpr::Legality { shift: Some(0), expected: 0b01 },
         FilterExpr::Legality { shift: Some(2), expected: 0b01 },
     ]);
-    let (plane, mut residual) = split_planes(and_both, bounds, words, true);
+    let (plane, mut residual) = split_planes(and_both, bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(plane.is_none(), "shared-witness AND must not partially promote either leaf into the plane");
     assert!(matches!(residual, FilterExpr::And(_)), "both legality children must remain in the residual");
 
@@ -1877,14 +1880,14 @@ fn legality_de_morgan_not_of_compound() {
     let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
 
-    let and_pe = compile_plane(&FilterExpr::And(vec![a(), creature()]), bounds, words)
+    let and_pe = compile_plane(&FilterExpr::And(vec![a(), creature()]), bounds, words, &archived.indexes, &archived.offsets)
         .expect("format:A AND t:creature must compile (one format, no shared-witness issue)");
     let mut and_bits: Vec<u64> = Vec::new();
     eval_planes(&and_pe, &archived.indexes.planes, &mut and_bits);
     assert!(bitmap_contains(&and_bits, 0), "printing0 is legal in A and a creature, so the positive AND is true for card 0");
 
     let not_and = FilterExpr::Not(Box::new(FilterExpr::And(vec![a(), creature()])));
-    let pe = compile_plane(&not_and, bounds, words).expect("-(format:A AND t:creature) must still compile via De Morgan");
+    let pe = compile_plane(&not_and, bounds, words, &archived.indexes, &archived.offsets).expect("-(format:A AND t:creature) must still compile via De Morgan");
     let mut bits: Vec<u64> = Vec::new();
     eval_planes(&pe, &archived.indexes.planes, &mut bits);
     assert!(bitmap_contains(&bits, 0), "card has a not-legal-in-A printing, so it satisfies the negation despite the positive AND being true");
@@ -1915,7 +1918,7 @@ fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
     // no shared-witness issue, and the un-negated numeric comparison is
     // plane-eligible) -- isolates the failure to the Not/Null interaction.
     assert!(
-        compile_plane(&FilterExpr::And(vec![a(), power_gt3()]), bounds, words).is_some(),
+        compile_plane(&FilterExpr::And(vec![a(), power_gt3()]), bounds, words, &archived.indexes, &archived.offsets).is_some(),
         "format:A AND power>3 must compile without a Not present"
     );
 
@@ -1925,7 +1928,7 @@ fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
     // collapsing the whole compile to None through the `?` propagation.
     let not_and = FilterExpr::Not(Box::new(FilterExpr::And(vec![a(), power_gt3()])));
     assert!(
-        compile_plane(&not_and, bounds, words).is_none(),
+        compile_plane(&not_and, bounds, words, &archived.indexes, &archived.offsets).is_none(),
         "-(format:A AND power>3) must decline: Null doesn't flip to True, even with a legality sibling"
     );
 
@@ -1934,7 +1937,7 @@ fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
     // must decline there too, not just in the And arm.
     let not_or = FilterExpr::Not(Box::new(FilterExpr::Or(vec![a(), power_gt3()])));
     assert!(
-        compile_plane(&not_or, bounds, words).is_none(),
+        compile_plane(&not_or, bounds, words, &archived.indexes, &archived.offsets).is_none(),
         "-(format:A OR power>3) must decline via the Or arm of compile_plane_neg too"
     );
 }
@@ -2540,7 +2543,7 @@ fn popcount_skip_tie_breaking_preserves_group_order_both_directions() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true, &archived.indexes, &archived.offsets);
     assert!(matches!(residual, FilterExpr::True), "t:creature must fully plane-consume");
 
     let mut run = |direction: &str| {
@@ -2578,7 +2581,7 @@ fn popcount_skip_offset_lands_inside_tied_group() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+    let (plane, mut residual) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true, &archived.indexes, &archived.offsets);
 
     // Full ascending order is [card3, card1, card0, card2, card4] (oracle ids
     // [4,2,1,3,5]); offset=2 must skip card3 and card1, landing on card0.
@@ -2611,7 +2614,7 @@ fn popcount_skip_matches_non_popcount_path() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (plane, mut residual_true) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+    let (plane, mut residual_true) = split_planes(creature, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true, &archived.indexes, &archived.offsets);
     assert!(matches!(residual_true, FilterExpr::True));
 
     // Popcount path: plane present, residual True.
@@ -2920,9 +2923,19 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
 
     let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(0.10) };
 
+    // Narrowing exactness is checked directly against price_range_narrowed (the shared
+    // printing-space narrowing `narrow_rec` and `compile_plane` both call) rather than
+    // through narrow_candidates/narrow_rec's full dispatch: on a store this small,
+    // compile_plane's own price arm now also compiles (see docs/issues/local-engine-
+    // broad-range-fastpath.md), so narrow_rec's plane-eligible fast path intercepts first
+    // and returns card-space CardBits instead of printing-space Printings -- a different,
+    // separately-tested representation (see the fastpath doc's compile_price_range
+    // machinery), not a regression in range_narrowed's own exactness this test checks.
+    let n_printings = 4;
+
     // Lt must exclude the boundary printing exactly -- both in narrowing and in verification.
     let lt = cmp(CmpOp::Lt);
-    match narrow_candidates(&lt, &archived.indexes, &archived.offsets, &archived.cards) {
+    match price_range_narrowed(CmpOp::Lt, 0.10, &archived.indexes, n_printings, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
             assert!(!v.contains(&1), "Lt must exclude the exact boundary price");
@@ -2938,7 +2951,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     // silently excluded exact matches independent of narrowing).
     for (op, op_name, is_eq) in [(CmpOp::Le, "Le", false), (CmpOp::Ge, "Ge", false), (CmpOp::Eq, "Eq", true)] {
         let f = cmp(op);
-        match narrow_candidates(&f, &archived.indexes, &archived.offsets, &archived.cards) {
+        match price_range_narrowed(op, 0.10, &archived.indexes, n_printings, true).map(|n| n.set) {
             Some(Candidates::Printings(v)) => assert!(v.contains(&1), "narrowing must include the boundary price for {op_name}"),
             None if is_eq => {} // narrow_candidates_exact's broadness filter can decline Eq on a tiny store; matches() below is what matters
             _ => panic!("usd must narrow in printing space for {op_name}"),
@@ -2949,12 +2962,8 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     let gt = cmp(CmpOp::Gt);
     assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
-    let pricey = FilterExpr::NumericCmp {
-        lhs: super::NumExpr::Const(50.0),
-        op: CmpOp::Lt,
-        rhs: super::NumExpr::Field(super::NumField::PriceUsd),
-    };
-    match narrow_candidates(&pricey, &archived.indexes, &archived.offsets, &archived.cards) {
+    // Flipped operand order (50.0 < usd, i.e. usd > 50.0): only the $60 printing qualifies.
+    match price_range_narrowed(CmpOp::Gt, 50.0, &archived.indexes, n_printings, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
     }
@@ -3107,7 +3116,7 @@ fn plane_parity_color_and_type_ops() {
 
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check = |f: &FilterExpr| {
-        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).expect("filter must be plane-expressible");
+        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).expect("filter must be plane-expressible");
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -3162,7 +3171,7 @@ fn color_cmp_ge_empty_mask_is_colorless_only() {
             let want = want_true.contains(&cid);
             assert_eq!(f.eval_card(card, &archived.strings) == Tri::True, want, "eval_card mismatch at card {cid}");
         }
-        let pe = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).expect("filter must be plane-expressible");
+        let pe = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).expect("filter must be plane-expressible");
         let mut bitmap: Vec<u64> = Vec::new();
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for cid in 0..archived.cards.len() {
@@ -3191,7 +3200,7 @@ fn plane_produces_independent_of_colors_and_identity() {
     let words = &archived.indexes.oracle_trigram.words;
 
     let produces_white = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 1 };
-    let pe = compile_plane(&produces_white, bounds, words).expect("produces: must be plane-expressible");
+    let pe = compile_plane(&produces_white, bounds, words, &archived.indexes, &archived.offsets).expect("produces: must be plane-expressible");
     let mut bitmap: Vec<u64> = Vec::new();
     eval_planes(&pe, bounds, &mut bitmap);
     assert!(bitmap_contains(&bitmap, 0), "colorless artifact produces white (mask 63) despite having no colors of its own");
@@ -3209,7 +3218,7 @@ fn plane_fallaji_colors_not_subset_of_identity() {
     let mut bitmap: Vec<u64> = Vec::new();
     let mut matches = |field: ColorField, op: CmpOp, mask: u8| {
         let f = FilterExpr::ColorCmp { field, op, mask };
-        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).unwrap(), &archived.indexes.planes, &mut bitmap);
+        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).unwrap(), &archived.indexes.planes, &mut bitmap);
         bitmap_contains(&bitmap, FALLAJI_CID as u32)
     };
     assert!(matches(ColorField::Colors, CmpOp::Ge, 1)); // c>=W: colors carry W
@@ -3233,33 +3242,33 @@ fn split_planes_composition_rules() {
     let text = || FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "draw".to_string() };
 
     // And(plane, plane, text): planes consumed, the lone leftover unwraps.
-    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature(), text()]), bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::TextContains { .. }));
 
     // Fully plane-expressible tree is consumed whole.
-    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![green(), creature()]), bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
-    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), creature()]), bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
 
     // Or mixing plane and non-plane children stays entirely residual:
     // mask ∨ residual is not a narrowing mask.
-    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::Or(vec![green(), text()]), bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::Or(ref v) if v.len() == 2));
 
     // Produced mana is plane-expressible (docs/issues/00669-engine-produces-planes.md):
     // same card-level, always-known bitmask shape as Colors/ColorIdentity.
     let produces = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 16 };
-    let (pe, residual) = split_planes(produces, bounds, words, true);
+    let (pe, residual) = split_planes(produces, bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some());
     assert!(matches!(residual, FilterExpr::True));
 
     // Bare True keeps the range-scan path (no all-ones bitmap materialization).
-    let (pe, residual) = split_planes(FilterExpr::True, bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::True, bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_none());
     assert!(matches!(residual, FilterExpr::True));
 }
@@ -3296,7 +3305,7 @@ fn run_query_plane_path_parity() {
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true, &archived.indexes, &archived.offsets);
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -3308,6 +3317,115 @@ fn run_query_plane_path_parity() {
             assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
         }
     }
+}
+
+/// Card 0: two printings, $5 (satisfies `usd<50`) and $200 (doesn't; satisfies
+/// `usd>=50`) -- deliberately divergent w.r.t. any single usd threshold, the
+/// shape that catches row-selection and negation bugs (a card can satisfy
+/// `usd<50` via one printing and `-usd<50` via the *other*, at once). Card 1:
+/// one printing at $500 (never satisfies `usd<50`). Distinct illustration ids
+/// throughout (store_of's default), so unique=artwork mirrors unique=printing
+/// here -- no shared-group collapsing to complicate the comparison.
+fn price_plane_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 1], vocab);
+    data.printings[0].price_usd = Some(500); // card 0: $5.00
+    data.printings[1].price_usd = Some(20000); // card 0: $200.00
+    data.printings[2].price_usd = Some(50000); // card 1: $500.00
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    data
+}
+
+/// `PlaneExpr::PrintingRangeBits` (docs/issues/local-engine-broad-range-fastpath.md)
+/// must reproduce exactly what the unplaned (narrow_rec + card_pass) path computes,
+/// for every unique mode -- same differential shape as run_query_plane_path_parity,
+/// covering the three ways this machinery could go wrong: row selection (a card
+/// bitmap doesn't say *which* printing satisfies), negation (must recompute with
+/// the negated op, not bit-complement -- the Legality/rarity trap), and shared
+/// witness (two range conditions on usd must decline to compose via plain card_bits
+/// intersection, not silently combine independent existence facts).
+#[test]
+fn price_plane_path_parity_and_shared_witness() {
+    let data = price_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let usd = |op, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(v) };
+
+    // usd<50 compiles to a plane and matches the unplaned path in every mode.
+    // -usd<50 (∃p: ¬(p.usd<50), NOT ¬∃p: p.usd<50) must also match -- card 0 satisfies
+    // *both* usd<50 (via the $5 printing) and -usd<50 (via the $200 printing) at once,
+    // exactly the divergent shape a bit-complement would get wrong.
+    let filters: Vec<Box<dyn Fn() -> FilterExpr>> = vec![
+        Box::new(|| usd(CmpOp::Lt, 50.0)),
+        Box::new(|| FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0)))),
+        Box::new(|| FilterExpr::And(vec![usd(CmpOp::Lt, 50.0), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }])),
+    ];
+    for make in &filters {
+        for unique in ["card", "printing", "artwork"] {
+            // Matches run_query's own unique -> Mode mapping (see split_planes's
+            // unique_is_card doc): existential leaves like price must NOT fold to a
+            // bare True residual for unique=printing/artwork, or row selection is lost.
+            let unique_is_card = unique != "printing" && unique != "artwork";
+            let mut plain = make();
+            let (t0, p0) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            let (pe, mut residual) = split_planes(
+                make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card, &archived.indexes, &archived.offsets,
+            );
+            let (t1, p1) = run_query(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
+            );
+            assert_eq!(t0, t1, "totals must agree (unique={unique})");
+            let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
+                page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+            };
+            assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
+        }
+    }
+
+    // Independent ground truth for -usd<50/unique=card, bypassing run_query/narrow_rec/
+    // compile_plane entirely (narrow_rec's own internal plane fast path means run_query's
+    // plane=None "unplaned" baseline above is *not* fully independent of compile_plane_neg --
+    // it would share a bit-complement bug too, since it also tries compile_plane internally
+    // for narrowing). card 0 satisfies -usd<50 via its $200 printing despite also satisfying
+    // usd<50 via its $5 printing; card 1's $500 printing trivially satisfies -usd<50. Correct
+    // total is 2 -- a bit-complement bug (¬∃p: p.usd<50 instead of ∃p: ¬(p.usd<50)) would give
+    // 0, since ∃p: p.usd<50 is true for card 0 (excluding it) and vacuously false for neither.
+    let not_usd = FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0)));
+    let expected_cards: usize = (0..archived.cards.len() as u32)
+        .filter(|&cid| {
+            let start = u32::from(archived.offsets[cid as usize]) as usize;
+            let end = u32::from(archived.offsets[cid as usize + 1]) as usize;
+            archived.printings[start..end].iter().any(|p| not_usd.matches(&archived.cards[cid as usize], p, &archived.strings))
+        })
+        .count();
+    assert_eq!(expected_cards, 2, "hand-computed ground truth: both cards have a printing satisfying -usd<50");
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0))), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, expected_cards, "-usd<50 unique=card must match the independent per-printing ground truth");
+
+    // Same-field range AND (usd<50 AND usd>10): no printing of card 0 satisfies both
+    // ($5 fails usd>10, $200 fails usd<50) -- correct total is 0. Confirms the
+    // shared-witness decline doesn't just avoid a crash but that the fallback path
+    // it declines to (residual card_pass) computes the actually-correct answer.
+    let same_field_and = || FilterExpr::And(vec![usd(CmpOp::Lt, 50.0), usd(CmpOp::Gt, 10.0)]);
+    assert!(
+        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets)
+            .is_none(),
+        "same-field usd range AND must decline to compile (shared witness)"
+    );
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut same_field_and(), None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
+    );
+    assert_eq!(total, 0, "no single printing satisfies both usd<50 and usd>10");
 }
 
 // ─── Numeric-range planes (#655) ───────────────────────────────────────────────
@@ -3357,7 +3475,7 @@ fn numeric_plane_parity_interior_and_tails() {
 
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check = |f: &FilterExpr, label: &str| {
-        let Some(pe) = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words) else { return };
+        let Some(pe) = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets) else { return };
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -3413,17 +3531,17 @@ fn numeric_plane_boundary_inclusion_and_decline() {
 
     // Crosses into the high tail, but includes BOTH high-tail values (13, 14)
     // fully — unambiguous, since every possible bucket member qualifies.
-    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Le, 14.0), bounds, words).is_some());
+    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Le, 14.0), bounds, words, &archived.indexes, &archived.offsets).is_some());
     // Crosses into the low tail: power>=-1 must include the power=-1 card.
-    assert!(compile_plane(&cmp(NumField::Power, CmpOp::Ge, -1.0), bounds, words).is_some());
+    assert!(compile_plane(&cmp(NumField::Power, CmpOp::Ge, -1.0), bounds, words, &archived.indexes, &archived.offsets).is_some());
     // Entirely within the interior: no bucket involved at all.
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Le, 6.0), bounds, words).is_some());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Le, 6.0), bounds, words, &archived.indexes, &archived.offsets).is_some());
 
     // Distinguishing inside the high tail bucket (which now holds two
     // distinct values each) can't be answered by the cumulative plane alone.
-    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds, words).is_none());
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds, words).is_none());
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds, words).is_none());
+    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds, words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds, words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds, words, &archived.indexes, &archived.offsets).is_none());
 }
 
 // Ne is declined unconditionally, matching numeric_candidates' own choice
@@ -3438,7 +3556,7 @@ fn numeric_plane_declines_ne_unconditionally() {
     let words = &archived.indexes.oracle_trigram.words;
     for field in [NumField::Cmc, NumField::Power, NumField::Toughness] {
         let ne = FilterExpr::NumericCmp { lhs: NumExpr::Field(field), op: CmpOp::Ne, rhs: NumExpr::Const(3.0) };
-        assert!(compile_plane(&ne, bounds, words).is_none());
+        assert!(compile_plane(&ne, bounds, words, &archived.indexes, &archived.offsets).is_none());
     }
 }
 
@@ -3456,19 +3574,19 @@ fn numeric_plane_declines_not_over_numeric_cmp() {
     let words = &archived.indexes.oracle_trigram.words;
 
     let power_gt3 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Power), op: CmpOp::Gt, rhs: NumExpr::Const(3.0) };
-    assert!(compile_plane(&power_gt3, bounds, words).is_some(), "power>3 alone must compile");
+    assert!(compile_plane(&power_gt3, bounds, words, &archived.indexes, &archived.offsets).is_some(), "power>3 alone must compile");
     let make_negated = || FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
         lhs: NumExpr::Field(NumField::Power),
         op: CmpOp::Gt,
         rhs: NumExpr::Const(3.0),
     }));
-    assert!(compile_plane(&make_negated(), bounds, words).is_none(), "Not(power>3) must decline: Null doesn't flip to True");
+    assert!(compile_plane(&make_negated(), bounds, words, &archived.indexes, &archived.offsets).is_none(), "Not(power>3) must decline: Null doesn't flip to True");
 
     // Buried under And/Or, not just at the top.
     let buried_and = FilterExpr::And(vec![make_negated(), FilterExpr::True]);
-    assert!(compile_plane(&buried_and, bounds, words).is_none());
+    assert!(compile_plane(&buried_and, bounds, words, &archived.indexes, &archived.offsets).is_none());
     let buried_or = FilterExpr::Or(vec![make_negated(), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }]);
-    assert!(compile_plane(&buried_or, bounds, words).is_none());
+    assert!(compile_plane(&buried_or, bounds, words, &archived.indexes, &archived.offsets).is_none());
 
     // cmc is Option<u8> (never negative) but can still be unset on odd data,
     // so the guard applies uniformly across all three fields, not just the
@@ -3478,12 +3596,12 @@ fn numeric_plane_declines_not_over_numeric_cmp() {
         op: CmpOp::Le,
         rhs: NumExpr::Const(6.0),
     }));
-    assert!(compile_plane(&cmc_le6(), bounds, words).is_none());
+    assert!(compile_plane(&cmc_le6(), bounds, words, &archived.indexes, &archived.offsets).is_none());
 
     // A Not over a non-numeric plane child must still compile fine — the
     // guard must not over-decline unrelated Not subtrees.
     let not_creature = FilterExpr::Not(Box::new(FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }));
-    assert!(compile_plane(&not_creature, bounds, words).is_some());
+    assert!(compile_plane(&not_creature, bounds, words, &archived.indexes, &archived.offsets).is_some());
 }
 
 // End-to-end: run_query through the numeric-plane path (split_planes consumes
@@ -3513,7 +3631,7 @@ fn run_query_numeric_plane_path_parity() {
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
             );
-            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+            let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true, &archived.indexes, &archived.offsets);
             let (t1, p1) = run_query(
                 &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
                 &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -3538,7 +3656,7 @@ fn numeric_plane_enables_all_match_promotion() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let cmc_le12 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Le, rhs: NumExpr::Const(12.0) };
-    let (pe, residual) = split_planes(cmc_le12, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+    let (pe, residual) = split_planes(cmc_le12, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some(), "cmc<=12 must plane-compile");
     assert!(matches!(residual, FilterExpr::True), "cmc<=12 must fully consume: no residual card_pass needed");
 }
@@ -3882,17 +4000,17 @@ fn compile_plane_word_bonus_composes_with_other_planes() {
     let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
 
     // Single-dense-hit needle: compile_plane must consume it directly.
-    assert!(compile_plane(&oracle("target"), bounds, words).is_some(), "single dense hit must compile to a plane");
+    assert!(compile_plane(&oracle("target"), bounds, words, &archived.indexes, &archived.offsets).is_some(), "single dense hit must compile to a plane");
     // Mixed dense+sparse needle: compile_plane must decline (the dense bitmap
     // alone would miss the sparse "creaturehood" match) — narrow_rec's
     // general dispatch is the only correct path for this shape.
-    assert!(compile_plane(&oracle("creature"), bounds, words).is_none(), "mixed dense+sparse must not compile: dense bitmap alone would undercount");
+    assert!(compile_plane(&oracle("creature"), bounds, words, &archived.indexes, &archived.offsets).is_none(), "mixed dense+sparse must not compile: dense bitmap alone would undercount");
 
     // AND with an unrelated plane-expressible predicate (every card here is a
     // creature, so this is a true tautological AND, just exercising composition).
     let creature_type = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
     let both = FilterExpr::And(vec![oracle("target"), creature_type]);
-    let pe = compile_plane(&both, bounds, words).expect("dense word AND a plane predicate must compile whole");
+    let pe = compile_plane(&both, bounds, words, &archived.indexes, &archived.offsets).expect("dense word AND a plane predicate must compile whole");
     let mut bitmap: Vec<u64> = Vec::new();
     eval_planes(&pe, bounds, &mut bitmap);
     assert_eq!(bitmap_card_ids(&bitmap), brute_force_oracle_contains(archived, "target"), "every card here is a creature, so the AND changes nothing");
@@ -4044,7 +4162,7 @@ fn border_shared_witness_correctness() {
     let and_both = FilterExpr::And(vec![border("black"), border("borderless")]);
 
     assert!(
-        compile_plane(&and_both, bounds, words).is_none(),
+        compile_plane(&and_both, bounds, words, &archived.indexes, &archived.offsets).is_none(),
         "border:black AND border:borderless must decline to compile exactly (shared witness)"
     );
 
@@ -4057,6 +4175,7 @@ fn border_shared_witness_correctness() {
 
     let (pe, mut residual) = split_planes(
         FilterExpr::And(vec![border("black"), border("borderless")]), bounds, words, true,
+        &archived.indexes, &archived.offsets,
     );
     let (total2, _) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
@@ -4082,19 +4201,19 @@ fn border_tracked_values_exact_consumed_other_bucket_declines() {
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
     for value in ["black", "borderless", "white", "gold"] {
-        assert!(compile_plane(&border(value), bounds, words).is_some(), "border:{value} must compile to a plane expression");
+        assert!(compile_plane(&border(value), bounds, words, &archived.indexes, &archived.offsets).is_some(), "border:{value} must compile to a plane expression");
         let not_value = FilterExpr::Not(Box::new(border(value)));
-        assert!(compile_plane(&not_value, bounds, words).is_some(), "-border:{value} must compile to a plane expression");
+        assert!(compile_plane(&not_value, bounds, words, &archived.indexes, &archived.offsets).is_some(), "-border:{value} must compile to a plane expression");
     }
 
-    assert!(compile_plane(&border("yellow"), bounds, words).is_none(), "border:yellow must decline (other bucket is ambiguous)");
+    assert!(compile_plane(&border("yellow"), bounds, words, &archived.indexes, &archived.offsets).is_none(), "border:yellow must decline (other bucket is ambiguous)");
     let not_yellow = FilterExpr::Not(Box::new(border("yellow")));
-    assert!(compile_plane(&not_yellow, bounds, words).is_none(), "-border:yellow must decline (other bucket is ambiguous)");
+    assert!(compile_plane(&not_yellow, bounds, words, &archived.indexes, &archived.offsets).is_none(), "-border:yellow must decline (other bucket is ambiguous)");
 
     // Mixed with an otherwise fully plane-expressible sibling: the untracked
     // child must stay in the residual, not get silently dropped or promoted.
     let creature = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, border("yellow")]), bounds, words, true);
+    let (pe, residual) = split_planes(FilterExpr::And(vec![creature, border("yellow")]), bounds, words, true, &archived.indexes, &archived.offsets);
     assert!(pe.is_some(), "the creature child must still plane-consume");
     assert!(
         matches!(&residual, FilterExpr::TextExact { field: TextField::Border, .. }),
@@ -4118,7 +4237,7 @@ fn border_other_bucket_closes_domain_for_tracked_negation() {
     let yellow_card = 8u32; // card 8: only printing is yellow (untracked)
 
     let not_black = FilterExpr::Not(Box::new(FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: "black".to_string() }));
-    let pe = compile_plane(&not_black, bounds, words).expect("-border:black must compile");
+    let pe = compile_plane(&not_black, bounds, words, &archived.indexes, &archived.offsets).expect("-border:black must compile");
     let mut bits = Vec::new();
     eval_planes(&pe, bounds, &mut bits);
     assert!(
@@ -4127,7 +4246,7 @@ fn border_other_bucket_closes_domain_for_tracked_negation() {
     );
 
     let black = FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: "black".to_string() };
-    let pe2 = compile_plane(&black, bounds, words).expect("border:black must compile");
+    let pe2 = compile_plane(&black, bounds, words, &archived.indexes, &archived.offsets).expect("border:black must compile");
     let mut bits2 = Vec::new();
     eval_planes(&pe2, bounds, &mut bits2);
     assert!(!bitmap_contains(&bits2, yellow_card), "the same card must not satisfy border:black");
@@ -4709,7 +4828,7 @@ fn devotion_plane_parity_and_boundaries() {
     let dev = |op, pips: &[(&str, u8)]| FilterExpr::Devotion { op, pips: packed_pips(pips) };
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check_exact = |f: &FilterExpr| {
-        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).expect("must compile exactly");
+        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).expect("must compile exactly");
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -4727,9 +4846,9 @@ fn devotion_plane_parity_and_boundaries() {
     check_exact(&dev(CmpOp::Ge, &[("R", 3)])); // {R/G}{R/G}{R} card reaches R=3
 
     // Past the saturation boundary the exact compiler declines...
-    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words).is_none());
-    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words).is_none());
-    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words).is_none());
+    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none());
     // ...and the saturated superset covers every deep match for narrowing.
     let deep = dev(CmpOp::Ge, &[("U", 5)]);
     let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, &archived.cards, false).expect("deep-k narrows loosely");
@@ -4753,7 +4872,7 @@ fn hybrid_pip_counts_toward_both_colors() {
     let mut bitmap: Vec<u64> = Vec::new();
     let rg_card = 5; // {R/G}
     for (f, want) in [(dev("R", 1), true), (dev("G", 1), true), (dev("R", 2), false), (dev("U", 1), false)] {
-        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words).unwrap(), &archived.indexes.planes, &mut bitmap);
+        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).unwrap(), &archived.indexes.planes, &mut bitmap);
         assert_eq!(bitmap_contains(&bitmap, rg_card), want);
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,7 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
-    bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, has_conflicting_range_families, split_planes,
+    bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, has_conflicting_range_families, plane_expr_is_exact, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     TextField, TextSearchField, Tri, SortedTrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
@@ -544,10 +544,10 @@ fn rarity_tracked_values_exact_consumed_hi_bucket_declines() {
     let rarity_eq = |v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(v) };
 
     // Tracked values (mythic=3) compile exactly.
-    assert!(compile_plane(&rarity_eq(3.0), bounds, words, &archived.indexes, &archived.offsets).is_some(), "r:mythic must compile to a plane expression");
+    assert!(compile_plane(&rarity_eq(3.0), bounds, words, &archived.indexes, &archived.offsets, false).is_some(), "r:mythic must compile to a plane expression");
     // Special/bonus specifically can't be told apart by the shared hi plane.
-    assert!(compile_plane(&rarity_eq(4.0), bounds, words, &archived.indexes, &archived.offsets).is_none(), "r:special must decline (hi bucket is ambiguous)");
-    assert!(compile_plane(&rarity_eq(5.0), bounds, words, &archived.indexes, &archived.offsets).is_none(), "r:bonus must decline (hi bucket is ambiguous)");
+    assert!(compile_plane(&rarity_eq(4.0), bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "r:special must decline (hi bucket is ambiguous)");
+    assert!(compile_plane(&rarity_eq(5.0), bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "r:bonus must decline (hi bucket is ambiguous)");
 
     // Mixed with an otherwise fully plane-expressible sibling: an ambiguous
     // rarity child must stay in the residual, not get silently dropped or promoted.
@@ -561,7 +561,7 @@ fn rarity_tracked_values_exact_consumed_hi_bucket_declines() {
 
     // A tracked value's negation is exact too.
     let not_mythic = FilterExpr::Not(Box::new(rarity_eq(3.0)));
-    assert!(compile_plane(&not_mythic, bounds, words, &archived.indexes, &archived.offsets).is_some(), "-r:mythic must compile to a plane expression");
+    assert!(compile_plane(&not_mythic, bounds, words, &archived.indexes, &archived.offsets, false).is_some(), "-r:mythic must compile to a plane expression");
 }
 
 /// Y=2 shared-witness decline: two distinct rarity plane indices under one
@@ -584,7 +584,7 @@ fn rarity_shared_witness_declines_same_field_and_cross_field() {
     // rarity>=rare AND rarity<=mythic: two distinct tracked plane indices
     // (rare, mythic) shared between the two Or-trees -- must decline.
     let bounded_range = FilterExpr::And(vec![rarity_ge(2.0), rarity_le(3.0)]);
-    assert!(compile_plane(&bounded_range, bounds, words, &archived.indexes, &archived.offsets).is_none(), "same-field rarity range must decline (shared witness)");
+    assert!(compile_plane(&bounded_range, bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "same-field rarity range must decline (shared witness)");
 
     // format:A AND r:mythic: two distinct fields, still the identical
     // shared-witness problem -- collect_existential_indices doesn't care
@@ -593,7 +593,7 @@ fn rarity_shared_witness_declines_same_field_and_cross_field() {
     let cross_field = FilterExpr::And(vec![format_a, FilterExpr::NumericCmp {
         lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(3.0),
     }]);
-    assert!(compile_plane(&cross_field, bounds, words, &archived.indexes, &archived.offsets).is_none(), "legality+rarity compound must decline (shared witness)");
+    assert!(compile_plane(&cross_field, bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "legality+rarity compound must decline (shared witness)");
 
     // The fallback must still produce the correct (not just declined)
     // result: no printing in this fixture is both format-A-legal and
@@ -1066,11 +1066,11 @@ fn legality_same_format_cross_status_declines_shared_witness() {
     let restricted_c = || FilterExpr::Legality { shift: Some(4), expected: 0b10 };
 
     assert!(
-        compile_plane(&FilterExpr::And(vec![banned_c(), restricted_c()]), bounds, words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&FilterExpr::And(vec![banned_c(), restricted_c()]), bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
         "banned:C AND restricted:C (same format, distinct statuses) must decline (shared-witness)"
     );
     assert!(
-        compile_plane(&FilterExpr::Or(vec![banned_c(), restricted_c()]), bounds, words, &archived.indexes, &archived.offsets).is_some(),
+        compile_plane(&FilterExpr::Or(vec![banned_c(), restricted_c()]), bounds, words, &archived.indexes, &archived.offsets, false).is_some(),
         "OR has no shared-witness problem and must compile"
     );
 }
@@ -1245,10 +1245,10 @@ fn plane_expr_is_existential_identifies_legality_only() {
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
-    let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words, &archived.indexes, &archived.offsets).unwrap();
+    let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words, &archived.indexes, &archived.offsets, false).unwrap();
     assert!(super::plane_expr_is_existential(&legality_pe));
 
-    let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words, &archived.indexes, &archived.offsets).unwrap();
+    let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words, &archived.indexes, &archived.offsets, false).unwrap();
     assert!(!super::plane_expr_is_existential(&creature_pe));
 
     let mixed = compile_plane(
@@ -1260,6 +1260,7 @@ fn plane_expr_is_existential_identifies_legality_only() {
         words,
         &archived.indexes,
         &archived.offsets,
+        false,
     )
     .unwrap();
     assert!(super::plane_expr_is_existential(&mixed), "one existential leaf must taint the whole And");
@@ -1872,15 +1873,15 @@ fn legality_and_of_two_formats_declines_but_or_compiles() {
     let b = || FilterExpr::Legality { shift: Some(2), expected: 0b01 };
 
     assert!(
-        compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
         "two distinct formats ANDed must decline (shared-witness)"
     );
     assert!(
-        compile_plane(&FilterExpr::Or(vec![a(), b()]), bounds, words, &archived.indexes, &archived.offsets).is_some(),
+        compile_plane(&FilterExpr::Or(vec![a(), b()]), bounds, words, &archived.indexes, &archived.offsets, false).is_some(),
         "OR of two formats has no shared-witness problem and must compile"
     );
     assert!(
-        compile_plane(&FilterExpr::And(vec![a(), FilterExpr::Not(Box::new(a()))]), bounds, words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&FilterExpr::And(vec![a(), FilterExpr::Not(Box::new(a()))]), bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
         "format:A AND -format:A (same format, both polarities) is the same contradiction-prone shape and must also decline"
     );
 }
@@ -1942,14 +1943,14 @@ fn legality_de_morgan_not_of_compound() {
     let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
     let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
 
-    let and_pe = compile_plane(&FilterExpr::And(vec![a(), creature()]), bounds, words, &archived.indexes, &archived.offsets)
+    let and_pe = compile_plane(&FilterExpr::And(vec![a(), creature()]), bounds, words, &archived.indexes, &archived.offsets, false)
         .expect("format:A AND t:creature must compile (one format, no shared-witness issue)");
     let mut and_bits: Vec<u64> = Vec::new();
     eval_planes(&and_pe, &archived.indexes.planes, &mut and_bits);
     assert!(bitmap_contains(&and_bits, 0), "printing0 is legal in A and a creature, so the positive AND is true for card 0");
 
     let not_and = FilterExpr::Not(Box::new(FilterExpr::And(vec![a(), creature()])));
-    let pe = compile_plane(&not_and, bounds, words, &archived.indexes, &archived.offsets).expect("-(format:A AND t:creature) must still compile via De Morgan");
+    let pe = compile_plane(&not_and, bounds, words, &archived.indexes, &archived.offsets, false).expect("-(format:A AND t:creature) must still compile via De Morgan");
     let mut bits: Vec<u64> = Vec::new();
     eval_planes(&pe, &archived.indexes.planes, &mut bits);
     assert!(bitmap_contains(&bits, 0), "card has a not-legal-in-A printing, so it satisfies the negation despite the positive AND being true");
@@ -1980,7 +1981,7 @@ fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
     // no shared-witness issue, and the un-negated numeric comparison is
     // plane-eligible) -- isolates the failure to the Not/Null interaction.
     assert!(
-        compile_plane(&FilterExpr::And(vec![a(), power_gt3()]), bounds, words, &archived.indexes, &archived.offsets).is_some(),
+        compile_plane(&FilterExpr::And(vec![a(), power_gt3()]), bounds, words, &archived.indexes, &archived.offsets, false).is_some(),
         "format:A AND power>3 must compile without a Not present"
     );
 
@@ -1990,7 +1991,7 @@ fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
     // collapsing the whole compile to None through the `?` propagation.
     let not_and = FilterExpr::Not(Box::new(FilterExpr::And(vec![a(), power_gt3()])));
     assert!(
-        compile_plane(&not_and, bounds, words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&not_and, bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
         "-(format:A AND power>3) must decline: Null doesn't flip to True, even with a legality sibling"
     );
 
@@ -1999,7 +2000,7 @@ fn legality_not_still_declines_with_unnegatable_numeric_sibling() {
     // must decline there too, not just in the And arm.
     let not_or = FilterExpr::Not(Box::new(FilterExpr::Or(vec![a(), power_gt3()])));
     assert!(
-        compile_plane(&not_or, bounds, words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&not_or, bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
         "-(format:A OR power>3) must decline via the Or arm of compile_plane_neg too"
     );
 }
@@ -3018,7 +3019,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
 
     // Lt must exclude the boundary printing exactly -- both in narrowing and in verification.
     let lt = cmp(CmpOp::Lt);
-    match price_range_narrowed(CmpOp::Lt, 0.10, &archived.indexes, n_printings, true).map(|n| n.set) {
+    match price_range_narrowed(CmpOp::Lt, 0.10, &archived.indexes, n_printings, true, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
             assert!(!v.contains(&1), "Lt must exclude the exact boundary price");
@@ -3034,7 +3035,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     // silently excluded exact matches independent of narrowing).
     for (op, op_name, is_eq) in [(CmpOp::Le, "Le", false), (CmpOp::Ge, "Ge", false), (CmpOp::Eq, "Eq", true)] {
         let f = cmp(op);
-        match price_range_narrowed(op, 0.10, &archived.indexes, n_printings, true).map(|n| n.set) {
+        match price_range_narrowed(op, 0.10, &archived.indexes, n_printings, true, true).map(|n| n.set) {
             Some(Candidates::Printings(v)) => assert!(v.contains(&1), "narrowing must include the boundary price for {op_name}"),
             None if is_eq => {} // narrow_candidates_exact's broadness filter can decline Eq on a tiny store; matches() below is what matters
             _ => panic!("usd must narrow in printing space for {op_name}"),
@@ -3046,7 +3047,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
     // Flipped operand order (50.0 < usd, i.e. usd > 50.0): only the $60 printing qualifies.
-    match price_range_narrowed(CmpOp::Gt, 50.0, &archived.indexes, n_printings, true).map(|n| n.set) {
+    match price_range_narrowed(CmpOp::Gt, 50.0, &archived.indexes, n_printings, true, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
     }
@@ -3199,7 +3200,7 @@ fn plane_parity_color_and_type_ops() {
 
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check = |f: &FilterExpr| {
-        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).expect("filter must be plane-expressible");
+        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).expect("filter must be plane-expressible");
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -3254,7 +3255,7 @@ fn color_cmp_ge_empty_mask_is_colorless_only() {
             let want = want_true.contains(&cid);
             assert_eq!(f.eval_card(card, &archived.strings) == Tri::True, want, "eval_card mismatch at card {cid}");
         }
-        let pe = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).expect("filter must be plane-expressible");
+        let pe = compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).expect("filter must be plane-expressible");
         let mut bitmap: Vec<u64> = Vec::new();
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for cid in 0..archived.cards.len() {
@@ -3283,7 +3284,7 @@ fn plane_produces_independent_of_colors_and_identity() {
     let words = &archived.indexes.oracle_trigram.words;
 
     let produces_white = FilterExpr::ColorCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, mask: 1 };
-    let pe = compile_plane(&produces_white, bounds, words, &archived.indexes, &archived.offsets).expect("produces: must be plane-expressible");
+    let pe = compile_plane(&produces_white, bounds, words, &archived.indexes, &archived.offsets, false).expect("produces: must be plane-expressible");
     let mut bitmap: Vec<u64> = Vec::new();
     eval_planes(&pe, bounds, &mut bitmap);
     assert!(bitmap_contains(&bitmap, 0), "colorless artifact produces white (mask 63) despite having no colors of its own");
@@ -3301,7 +3302,7 @@ fn plane_fallaji_colors_not_subset_of_identity() {
     let mut bitmap: Vec<u64> = Vec::new();
     let mut matches = |field: ColorField, op: CmpOp, mask: u8| {
         let f = FilterExpr::ColorCmp { field, op, mask };
-        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).unwrap(), &archived.indexes.planes, &mut bitmap);
+        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).unwrap(), &archived.indexes.planes, &mut bitmap);
         bitmap_contains(&bitmap, FALLAJI_CID as u32)
     };
     assert!(matches(ColorField::Colors, CmpOp::Ge, 1)); // c>=W: colors carry W
@@ -3500,7 +3501,7 @@ fn price_plane_path_parity_and_shared_witness() {
     // it declines to (residual card_pass) computes the actually-correct answer.
     let same_field_and = || FilterExpr::And(vec![usd(CmpOp::Lt, 50.0), usd(CmpOp::Gt, 10.0)]);
     assert!(
-        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets)
+        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false)
             .is_none(),
         "same-field usd range AND must decline to compile (shared witness)"
     );
@@ -3587,7 +3588,7 @@ fn collector_number_plane_path_parity_and_shared_witness() {
     // (cn=10 fails cn>20, cn=200 fails cn<50) -- correct total is 0.
     let same_field_and = || FilterExpr::And(vec![cn(CmpOp::Lt, 50.0), cn(CmpOp::Gt, 20.0)]);
     assert!(
-        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets)
+        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false)
             .is_none(),
         "same-field cn range AND must decline to compile (shared witness)"
     );
@@ -3676,7 +3677,7 @@ fn released_at_plane_path_parity_and_shared_witness() {
     // satisfies both (2010 fails >2015-worth-of-date, 2024 fails <2020).
     let same_field_and = || FilterExpr::And(vec![date(CmpOp::Lt, 20_200_101), date(CmpOp::Gt, 20_150_101)]);
     assert!(
-        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets)
+        compile_plane(&same_field_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false)
             .is_none(),
         "same-field date range AND must decline to compile (shared witness)"
     );
@@ -3691,7 +3692,7 @@ fn released_at_plane_path_parity_and_shared_witness() {
     // sharing the field, just different granularity) -- must also decline.
     let mixed_and = || FilterExpr::And(vec![date(CmpOp::Lt, 20_200_101), year(CmpOp::Gt, 2015)]);
     assert!(
-        compile_plane(&mixed_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&mixed_and(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).is_none(),
         "DateCmp and YearCmp on released_at must decline to compile together (shared witness)"
     );
 }
@@ -3734,7 +3735,7 @@ fn cross_field_range_predicates_decline_shared_witness() {
 
     let check = |name: &str, f: FilterExpr| {
         assert!(
-            compile_plane(&f, bounds, words, &archived.indexes, &archived.offsets).is_none(),
+            compile_plane(&f, bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
             "{name}: two distinct existential range facts must decline to compose"
         );
         let (total, _) = run_query(
@@ -3780,6 +3781,82 @@ fn range_conflict_check_does_not_penalize_bare_or() {
         has_conflicting_range_families(&and_containing_or),
         "an And whose child is an Or of range leaves must still see the conflict with its other child"
     );
+}
+
+/// The bug this regresses against: `range_narrowed`'s complement branch (only
+/// reachable once the matching side is both the majority and past
+/// `NARROW_FLOOR`) scatters the *non*-matching indexed printings and
+/// complements over all `n_printings` -- which also flips the bit for every
+/// printing absent from the index entirely (NULL-valued for this field).
+/// `compile_price_range` feeds `card_bits` straight into a `PrintingRangeBits`
+/// plane with no downstream recheck, so that over-inclusion silently
+/// overcounts. 1,800 of 2,000 cards have a single priced printing at $10
+/// (`usd<50` true, matching side is the 90% majority, well past
+/// `NARROW_FLOOR`); the other 200 have a single *priceless* printing, which
+/// must never satisfy any price filter. Found on the real 97k-printing
+/// corpus as `usd<50`/`unique=card` overcounting by 179 (31,396 vs. the
+/// correct 31,217) -- this fixture reproduces the same shape at a size small
+/// enough to run in `cargo test`'s normal (non-`--ignored`) pass.
+#[test]
+fn price_plane_does_not_overcount_null_priced_printings_when_broad() {
+    let mut vocab = VocabInterner::new();
+    const MATCHING: usize = 1_800;
+    const NULL_PRICED: usize = 200;
+    let cards: Vec<OracleCard> = (0..(MATCHING + NULL_PRICED) as u128)
+        .map(|i| stub_card(i + 1, TYPE_CREATURE, &[], &mut vocab))
+        .collect();
+    let counts = vec![1usize; MATCHING + NULL_PRICED];
+    let mut data = store_of(cards, &counts, vocab);
+    for p in &mut data.printings[..MATCHING] {
+        p.price_usd = Some(1_000); // $10.00, satisfies usd<50
+    }
+    for p in &mut data.printings[MATCHING..] {
+        p.price_usd = None; // priceless: must never satisfy usd<50
+    }
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let bounds = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+
+    let usd_lt_50 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+
+    // compile_plane's own raw output honors whatever must_be_tight the
+    // caller asks for: false (narrow_rec's fastpath / non-card modes) lets
+    // the complement shortcut for this majority-match query fire, producing
+    // an inexact leaf; true (split_planes's unique=card fold, below) forces
+    // the more expensive direct scatter instead, staying exact.
+    let pe_loose = compile_plane(&usd_lt_50, bounds, words, &archived.indexes, &archived.offsets, false).expect("usd<50 must compile here");
+    assert!(!plane_expr_is_exact(&pe_loose), "must_be_tight=false must let the complement shortcut produce an inexact leaf");
+    let pe_tight = compile_plane(&usd_lt_50, bounds, words, &archived.indexes, &archived.offsets, true).expect("usd<50 must compile here");
+    assert!(plane_expr_is_exact(&pe_tight), "must_be_tight=true must force the direct scatter, staying exact");
+
+    // The real entry point (split_planes, unique=card) must thread
+    // must_be_tight=true into its own fold decision, so this majority-match
+    // query still gets folded (the whole point of the fastpath), just via
+    // the exact direct scatter -- and the resulting total must not
+    // overcount priceless printings either way.
+    let (plane, mut residual) = split_planes(usd_lt_50, bounds, words, true, &archived.indexes, &archived.offsets);
+    assert!(plane.is_some(), "unique=card must still fold this majority-match query (must_be_tight makes it safe to)");
+    assert!(plane_expr_is_exact(plane.as_ref().unwrap()), "the folded plane must be exact");
+    let (total, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100_000, 0, &archived.indexes,
+    );
+    assert_eq!(total, MATCHING, "unique=card total must not overcount priceless printings as matching usd<50");
+
+    // Compound version, reached through split_planes's per-child And loop
+    // instead of the whole-tree fold above.
+    let compound = FilterExpr::And(vec![
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) },
+        FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
+    ]);
+    let (plane2, mut residual2) = split_planes(compound, bounds, words, true, &archived.indexes, &archived.offsets);
+    let (total2, _) = run_query(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+        &mut residual2, plane2.as_ref(), "card", "default", "edhrec", "asc", 100_000, 0, &archived.indexes,
+    );
+    assert_eq!(total2, MATCHING, "compound (usd<50 AND t:creature) must not overcount priceless printings either");
 }
 
 // ─── Numeric-range planes (#655) ───────────────────────────────────────────────
@@ -3829,7 +3906,7 @@ fn numeric_plane_parity_interior_and_tails() {
 
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check = |f: &FilterExpr, label: &str| {
-        let Some(pe) = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets) else { return };
+        let Some(pe) = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false) else { return };
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -3885,17 +3962,17 @@ fn numeric_plane_boundary_inclusion_and_decline() {
 
     // Crosses into the high tail, but includes BOTH high-tail values (13, 14)
     // fully — unambiguous, since every possible bucket member qualifies.
-    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Le, 14.0), bounds, words, &archived.indexes, &archived.offsets).is_some());
+    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Le, 14.0), bounds, words, &archived.indexes, &archived.offsets, false).is_some());
     // Crosses into the low tail: power>=-1 must include the power=-1 card.
-    assert!(compile_plane(&cmp(NumField::Power, CmpOp::Ge, -1.0), bounds, words, &archived.indexes, &archived.offsets).is_some());
+    assert!(compile_plane(&cmp(NumField::Power, CmpOp::Ge, -1.0), bounds, words, &archived.indexes, &archived.offsets, false).is_some());
     // Entirely within the interior: no bucket involved at all.
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Le, 6.0), bounds, words, &archived.indexes, &archived.offsets).is_some());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Le, 6.0), bounds, words, &archived.indexes, &archived.offsets, false).is_some());
 
     // Distinguishing inside the high tail bucket (which now holds two
     // distinct values each) can't be answered by the cumulative plane alone.
-    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds, words, &archived.indexes, &archived.offsets).is_none());
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds, words, &archived.indexes, &archived.offsets).is_none());
-    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds, words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&cmp(NumField::Cmc, CmpOp::Eq, 13.0), bounds, words, &archived.indexes, &archived.offsets, false).is_none());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Eq, 20.0), bounds, words, &archived.indexes, &archived.offsets, false).is_none());
+    assert!(compile_plane(&cmp(NumField::Toughness, CmpOp::Lt, 22.0), bounds, words, &archived.indexes, &archived.offsets, false).is_none());
 }
 
 // Ne is declined unconditionally, matching numeric_candidates' own choice
@@ -3910,7 +3987,7 @@ fn numeric_plane_declines_ne_unconditionally() {
     let words = &archived.indexes.oracle_trigram.words;
     for field in [NumField::Cmc, NumField::Power, NumField::Toughness] {
         let ne = FilterExpr::NumericCmp { lhs: NumExpr::Field(field), op: CmpOp::Ne, rhs: NumExpr::Const(3.0) };
-        assert!(compile_plane(&ne, bounds, words, &archived.indexes, &archived.offsets).is_none());
+        assert!(compile_plane(&ne, bounds, words, &archived.indexes, &archived.offsets, false).is_none());
     }
 }
 
@@ -3928,19 +4005,19 @@ fn numeric_plane_declines_not_over_numeric_cmp() {
     let words = &archived.indexes.oracle_trigram.words;
 
     let power_gt3 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Power), op: CmpOp::Gt, rhs: NumExpr::Const(3.0) };
-    assert!(compile_plane(&power_gt3, bounds, words, &archived.indexes, &archived.offsets).is_some(), "power>3 alone must compile");
+    assert!(compile_plane(&power_gt3, bounds, words, &archived.indexes, &archived.offsets, false).is_some(), "power>3 alone must compile");
     let make_negated = || FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
         lhs: NumExpr::Field(NumField::Power),
         op: CmpOp::Gt,
         rhs: NumExpr::Const(3.0),
     }));
-    assert!(compile_plane(&make_negated(), bounds, words, &archived.indexes, &archived.offsets).is_none(), "Not(power>3) must decline: Null doesn't flip to True");
+    assert!(compile_plane(&make_negated(), bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "Not(power>3) must decline: Null doesn't flip to True");
 
     // Buried under And/Or, not just at the top.
     let buried_and = FilterExpr::And(vec![make_negated(), FilterExpr::True]);
-    assert!(compile_plane(&buried_and, bounds, words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&buried_and, bounds, words, &archived.indexes, &archived.offsets, false).is_none());
     let buried_or = FilterExpr::Or(vec![make_negated(), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }]);
-    assert!(compile_plane(&buried_or, bounds, words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&buried_or, bounds, words, &archived.indexes, &archived.offsets, false).is_none());
 
     // cmc is Option<u8> (never negative) but can still be unset on odd data,
     // so the guard applies uniformly across all three fields, not just the
@@ -3950,12 +4027,12 @@ fn numeric_plane_declines_not_over_numeric_cmp() {
         op: CmpOp::Le,
         rhs: NumExpr::Const(6.0),
     }));
-    assert!(compile_plane(&cmc_le6(), bounds, words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&cmc_le6(), bounds, words, &archived.indexes, &archived.offsets, false).is_none());
 
     // A Not over a non-numeric plane child must still compile fine — the
     // guard must not over-decline unrelated Not subtrees.
     let not_creature = FilterExpr::Not(Box::new(FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }));
-    assert!(compile_plane(&not_creature, bounds, words, &archived.indexes, &archived.offsets).is_some());
+    assert!(compile_plane(&not_creature, bounds, words, &archived.indexes, &archived.offsets, false).is_some());
 }
 
 // End-to-end: run_query through the numeric-plane path (split_planes consumes
@@ -4354,17 +4431,17 @@ fn compile_plane_word_bonus_composes_with_other_planes() {
     let oracle = |w: &str| FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: w.to_string() };
 
     // Single-dense-hit needle: compile_plane must consume it directly.
-    assert!(compile_plane(&oracle("target"), bounds, words, &archived.indexes, &archived.offsets).is_some(), "single dense hit must compile to a plane");
+    assert!(compile_plane(&oracle("target"), bounds, words, &archived.indexes, &archived.offsets, false).is_some(), "single dense hit must compile to a plane");
     // Mixed dense+sparse needle: compile_plane must decline (the dense bitmap
     // alone would miss the sparse "creaturehood" match) — narrow_rec's
     // general dispatch is the only correct path for this shape.
-    assert!(compile_plane(&oracle("creature"), bounds, words, &archived.indexes, &archived.offsets).is_none(), "mixed dense+sparse must not compile: dense bitmap alone would undercount");
+    assert!(compile_plane(&oracle("creature"), bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "mixed dense+sparse must not compile: dense bitmap alone would undercount");
 
     // AND with an unrelated plane-expressible predicate (every card here is a
     // creature, so this is a true tautological AND, just exercising composition).
     let creature_type = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
     let both = FilterExpr::And(vec![oracle("target"), creature_type]);
-    let pe = compile_plane(&both, bounds, words, &archived.indexes, &archived.offsets).expect("dense word AND a plane predicate must compile whole");
+    let pe = compile_plane(&both, bounds, words, &archived.indexes, &archived.offsets, false).expect("dense word AND a plane predicate must compile whole");
     let mut bitmap: Vec<u64> = Vec::new();
     eval_planes(&pe, bounds, &mut bitmap);
     assert_eq!(bitmap_card_ids(&bitmap), brute_force_oracle_contains(archived, "target"), "every card here is a creature, so the AND changes nothing");
@@ -4516,7 +4593,7 @@ fn border_shared_witness_correctness() {
     let and_both = FilterExpr::And(vec![border("black"), border("borderless")]);
 
     assert!(
-        compile_plane(&and_both, bounds, words, &archived.indexes, &archived.offsets).is_none(),
+        compile_plane(&and_both, bounds, words, &archived.indexes, &archived.offsets, false).is_none(),
         "border:black AND border:borderless must decline to compile exactly (shared witness)"
     );
 
@@ -4555,14 +4632,14 @@ fn border_tracked_values_exact_consumed_other_bucket_declines() {
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
     for value in ["black", "borderless", "white", "gold"] {
-        assert!(compile_plane(&border(value), bounds, words, &archived.indexes, &archived.offsets).is_some(), "border:{value} must compile to a plane expression");
+        assert!(compile_plane(&border(value), bounds, words, &archived.indexes, &archived.offsets, false).is_some(), "border:{value} must compile to a plane expression");
         let not_value = FilterExpr::Not(Box::new(border(value)));
-        assert!(compile_plane(&not_value, bounds, words, &archived.indexes, &archived.offsets).is_some(), "-border:{value} must compile to a plane expression");
+        assert!(compile_plane(&not_value, bounds, words, &archived.indexes, &archived.offsets, false).is_some(), "-border:{value} must compile to a plane expression");
     }
 
-    assert!(compile_plane(&border("yellow"), bounds, words, &archived.indexes, &archived.offsets).is_none(), "border:yellow must decline (other bucket is ambiguous)");
+    assert!(compile_plane(&border("yellow"), bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "border:yellow must decline (other bucket is ambiguous)");
     let not_yellow = FilterExpr::Not(Box::new(border("yellow")));
-    assert!(compile_plane(&not_yellow, bounds, words, &archived.indexes, &archived.offsets).is_none(), "-border:yellow must decline (other bucket is ambiguous)");
+    assert!(compile_plane(&not_yellow, bounds, words, &archived.indexes, &archived.offsets, false).is_none(), "-border:yellow must decline (other bucket is ambiguous)");
 
     // Mixed with an otherwise fully plane-expressible sibling: the untracked
     // child must stay in the residual, not get silently dropped or promoted.
@@ -4591,7 +4668,7 @@ fn border_other_bucket_closes_domain_for_tracked_negation() {
     let yellow_card = 8u32; // card 8: only printing is yellow (untracked)
 
     let not_black = FilterExpr::Not(Box::new(FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: "black".to_string() }));
-    let pe = compile_plane(&not_black, bounds, words, &archived.indexes, &archived.offsets).expect("-border:black must compile");
+    let pe = compile_plane(&not_black, bounds, words, &archived.indexes, &archived.offsets, false).expect("-border:black must compile");
     let mut bits = Vec::new();
     eval_planes(&pe, bounds, &mut bits);
     assert!(
@@ -4600,7 +4677,7 @@ fn border_other_bucket_closes_domain_for_tracked_negation() {
     );
 
     let black = FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: "black".to_string() };
-    let pe2 = compile_plane(&black, bounds, words, &archived.indexes, &archived.offsets).expect("border:black must compile");
+    let pe2 = compile_plane(&black, bounds, words, &archived.indexes, &archived.offsets, false).expect("border:black must compile");
     let mut bits2 = Vec::new();
     eval_planes(&pe2, bounds, &mut bits2);
     assert!(!bitmap_contains(&bits2, yellow_card), "the same card must not satisfy border:black");
@@ -4673,7 +4750,7 @@ fn range_narrowed_representations() {
     // 0..v (v itself excluded).
     // Sparse (160 entries, 3.9%): vec, tight.
     let (lo, hi) = bounds(CmpOp::Lt, 40.0);
-    let nr = super::range_narrowed(archived, lo, hi, n, false, false).expect("sparse ranges narrow in any context");
+    let nr = super::range_narrowed(archived, lo, hi, n, false, false, false).expect("sparse ranges narrow in any context");
     assert!(!nr.tight, "exact param was passed false here to exercise range_narrowed's own branching");
     match nr.set {
         Candidates::Printings(v) => assert_eq!(v.len(), 160),
@@ -4682,8 +4759,8 @@ fn range_narrowed_representations() {
 
     // Broad but at most half (values 0..400 → 1600 entries, 39%): direct scatter, tight.
     let (lo, hi) = bounds(CmpOp::Lt, 400.0);
-    assert!(super::range_narrowed(archived, lo, hi, n, false, true).is_none(), "broad bits need a consumer (broad_ok)");
-    let nr = super::range_narrowed(archived, lo, hi, n, true, true).expect("broad_ok materializes the bitmap");
+    assert!(super::range_narrowed(archived, lo, hi, n, false, true, false).is_none(), "broad bits need a consumer (broad_ok)");
+    let nr = super::range_narrowed(archived, lo, hi, n, true, true, false).expect("broad_ok materializes the bitmap");
     assert!(nr.tight, "integer-exact bounds keep the direct scatter tight");
     match &nr.set {
         Candidates::PrintingBits(b) => {
@@ -4695,7 +4772,7 @@ fn range_narrowed_representations() {
 
     // Beyond half (values 0..900 → 3600 entries, 88%): complement scatter, loose.
     let (lo, hi) = bounds(CmpOp::Lt, 900.0);
-    let nr = super::range_narrowed(archived, lo, hi, n, true, true).expect("broad_ok materializes the complement");
+    let nr = super::range_narrowed(archived, lo, hi, n, true, true, false).expect("broad_ok materializes the complement");
     assert!(!nr.tight, "complement over-includes unindexed printings");
     match &nr.set {
         Candidates::PrintingBits(b) => {
@@ -5182,7 +5259,7 @@ fn devotion_plane_parity_and_boundaries() {
     let dev = |op, pips: &[(&str, u8)]| FilterExpr::Devotion { op, pips: packed_pips(pips) };
     let mut bitmap: Vec<u64> = Vec::new();
     let mut check_exact = |f: &FilterExpr| {
-        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).expect("must compile exactly");
+        let pe = compile_plane(f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).expect("must compile exactly");
         eval_planes(&pe, &archived.indexes.planes, &mut bitmap);
         for (cid, card) in archived.cards.iter().enumerate() {
             let want = f.eval_card(card, &archived.strings) == Tri::True;
@@ -5200,9 +5277,9 @@ fn devotion_plane_parity_and_boundaries() {
     check_exact(&dev(CmpOp::Ge, &[("R", 3)])); // {R/G}{R/G}{R} card reaches R=3
 
     // Past the saturation boundary the exact compiler declines...
-    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none());
-    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none());
-    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).is_none());
+    assert!(compile_plane(&dev(CmpOp::Ge, &[("U", 4)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).is_none());
+    assert!(compile_plane(&dev(CmpOp::Eq, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).is_none());
+    assert!(compile_plane(&dev(CmpOp::Le, &[("U", 3)]), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).is_none());
     // ...and the saturated superset covers every deep match for narrowing.
     let deep = dev(CmpOp::Ge, &[("U", 5)]);
     let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, &archived.cards, false).expect("deep-k narrows loosely");
@@ -5226,7 +5303,7 @@ fn hybrid_pip_counts_toward_both_colors() {
     let mut bitmap: Vec<u64> = Vec::new();
     let rg_card = 5; // {R/G}
     for (f, want) in [(dev("R", 1), true), (dev("G", 1), true), (dev("R", 2), false), (dev("U", 1), false)] {
-        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets).unwrap(), &archived.indexes.planes, &mut bitmap);
+        eval_planes(&compile_plane(&f, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, &archived.indexes, &archived.offsets, false).unwrap(), &archived.indexes.planes, &mut bitmap);
         assert_eq!(bitmap_contains(&bitmap, rg_card), want);
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1302,7 +1302,12 @@ fn legality_plane_promotion_respects_mode_through_split_planes() {
             assert!(plane.is_some(), "a bare Legality leaf must still fully plane-consume for unique=card");
             assert!(matches!(residual, FilterExpr::True), "split_planes must leave a bare True residual for unique=card");
         } else {
-            assert!(plane.is_none(), "unique=printing/artwork must decline the fold, not just patch around it");
+            // Narrowing-only fold (see split_planes' doc): the plane is still used
+            // for candidate_cards, but the residual stays the original, unchanged
+            // Legality node -- correctness for unique=printing/artwork comes
+            // entirely from the ordinary per-printing card_pass walk over it, not
+            // the plane (run_query's existential_plane stays Mode::Card-only).
+            assert!(plane.is_some(), "the plane is still produced, for narrowing purposes");
             assert!(matches!(residual, FilterExpr::Legality { .. }), "the original Legality node must survive for per-printing verification");
         }
         run_query(

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,7 +4,7 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
+    build_artist_index, build_range_index, price_dollars_to_cents, price_range_narrowed, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, has_conflicting_range_families, plane_expr_is_exact, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
@@ -204,6 +204,17 @@ fn stub_printing(scryfall_id: u128, illustration_id: u128, prefer_score: Option<
         card_frame_data: Vec::new(),
         artwork_group_id: 0, // placeholder; store_of overwrites via assign_artwork_groups
     }
+}
+
+/// A `usd <op> dollars` comparison, already bound (Const rewritten to cents
+/// via `super::price_dollars_to_cents`) -- the shape every real query
+/// reaches through `FilterExpr::bind`, which none of these test fixtures
+/// otherwise call. Written this way (not a raw `NumericCmp` literal with a
+/// hand-converted cents value) so every price test shares the identical
+/// conversion `bind` itself uses, rather than N call sites each doing their
+/// own `* 100.0` that could silently drift from it.
+fn usd_cmp(op: CmpOp, dollars: f64) -> FilterExpr {
+    FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(price_dollars_to_cents(dollars)) }
 }
 
 /// Assemble a CardData where card i owns `printing_counts[i]` printings, in the
@@ -2874,7 +2885,7 @@ fn artwork_group_ids_handle_more_than_64_groups() {
 
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let mut filter = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    let mut filter = usd_cmp(CmpOp::Lt, 50.0);
     let (total, page) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
         &mut filter, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -3005,7 +3016,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let card = &archived.cards[0];
 
-    let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(0.10) };
+    let cmp = |op| usd_cmp(op, 0.10);
 
     // Narrowing exactness is checked directly against price_range_narrowed (the shared
     // printing-space narrowing `narrow_rec` and `compile_plane` both call) rather than
@@ -3019,7 +3030,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
 
     // Lt must exclude the boundary printing exactly -- both in narrowing and in verification.
     let lt = cmp(CmpOp::Lt);
-    match price_range_narrowed(CmpOp::Lt, 0.10, &archived.indexes, n_printings, true, true).map(|n| n.set) {
+    match price_range_narrowed(CmpOp::Lt, price_dollars_to_cents(0.10), &archived.indexes, n_printings, true, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => {
             assert!(v.contains(&0));
             assert!(!v.contains(&1), "Lt must exclude the exact boundary price");
@@ -3035,7 +3046,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     // silently excluded exact matches independent of narrowing).
     for (op, op_name, is_eq) in [(CmpOp::Le, "Le", false), (CmpOp::Ge, "Ge", false), (CmpOp::Eq, "Eq", true)] {
         let f = cmp(op);
-        match price_range_narrowed(op, 0.10, &archived.indexes, n_printings, true, true).map(|n| n.set) {
+        match price_range_narrowed(op, price_dollars_to_cents(0.10), &archived.indexes, n_printings, true, true).map(|n| n.set) {
             Some(Candidates::Printings(v)) => assert!(v.contains(&1), "narrowing must include the boundary price for {op_name}"),
             None if is_eq => {} // narrow_candidates_exact's broadness filter can decline Eq on a tiny store; matches() below is what matters
             _ => panic!("usd must narrow in printing space for {op_name}"),
@@ -3047,16 +3058,12 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
     // Flipped operand order (50.0 < usd, i.e. usd > 50.0): only the $60 printing qualifies.
-    match price_range_narrowed(CmpOp::Gt, 50.0, &archived.indexes, n_printings, true, true).map(|n| n.set) {
+    match price_range_narrowed(CmpOp::Gt, price_dollars_to_cents(50.0), &archived.indexes, n_printings, true, true).map(|n| n.set) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
     }
     // Ne is not selective.
-    let ne = FilterExpr::NumericCmp {
-        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
-        op: CmpOp::Ne,
-        rhs: super::NumExpr::Const(1.0),
-    };
+    let ne = usd_cmp(CmpOp::Ne, 1.0);
     assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets, &archived.cards).is_none());
 }
 
@@ -3077,7 +3084,7 @@ fn price_comparison_matches_exact_value_not_lossy_f32_widening() {
     let card = &archived.cards[0];
     let p = &archived.printings[0];
 
-    let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(7.22) };
+    let cmp = |op| usd_cmp(op, 7.22);
     assert!(cmp(CmpOp::Eq).matches(card, p, &archived.strings), "usd=7.22 must match a printing priced at exactly $7.22");
     assert!(cmp(CmpOp::Ge).matches(card, p, &archived.strings), "usd>=7.22 must not drop the exact match");
     assert!(cmp(CmpOp::Le).matches(card, p, &archived.strings));
@@ -3421,6 +3428,32 @@ fn price_plane_fixture_store() -> CardData {
     data
 }
 
+/// `FilterExpr::bind` rewrites a price `NumericCmp`'s query-side dollar
+/// `Const` to cents exactly once per query (`price_dollars_to_cents`) -- the
+/// step that lets `field_num`'s per-printing evaluation compare raw cents
+/// with no division. Every other test in this file builds already-bound
+/// filters directly via `usd_cmp` (mirroring what `bind` produces, not
+/// exercising `bind` itself), so this is the one place that actually calls
+/// `bind` on a dollar-denominated `NumericCmp` -- the exact shape
+/// `build_filter` produces from a real `usd<50`-style query -- and checks
+/// both the rewritten `Const` value and that evaluation afterward still
+/// agrees with the unbound (dollars) comparison bit-for-bit.
+#[test]
+fn bind_rewrites_price_const_to_cents() {
+    let data = price_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let card = &archived.cards[0];
+
+    let mut f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
+    let FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } = &f else { panic!("bind must not change the node shape") };
+    assert_eq!(*v, 5000.0, "bind must rewrite the dollar Const to its exact cents value");
+
+    assert!(f.matches(card, &archived.printings[0], &archived.strings), "usd<50 (bound) must still match the $5.00 printing");
+    assert!(!f.matches(card, &archived.printings[1], &archived.strings), "usd<50 (bound) must still exclude the $200.00 printing");
+}
+
 /// `PlaneExpr::PrintingRangeBits` (docs/issues/local-engine-broad-range-fastpath.md)
 /// must reproduce exactly what the unplaned (narrow_rec + card_pass) path computes,
 /// for every unique mode -- same differential shape as run_query_plane_path_parity,
@@ -3435,7 +3468,7 @@ fn price_plane_path_parity_and_shared_witness() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    let usd = |op, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(v) };
+    let usd = usd_cmp;
 
     // usd<50 compiles to a plane and matches the unplaned path in every mode.
     // -usd<50 (∃p: ¬(p.usd<50), NOT ¬∃p: p.usd<50) must also match -- card 0 satisfies
@@ -3729,7 +3762,7 @@ fn cross_field_range_predicates_decline_shared_witness() {
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
-    let usd_lt_50 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    let usd_lt_50 = || usd_cmp(CmpOp::Lt, 50.0);
     let cn_lt_100 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op: CmpOp::Lt, rhs: NumExpr::Const(100.0) };
     let date_lt_2020 = || FilterExpr::DateCmp { op: CmpOp::Lt, value: 20_200_101 };
 
@@ -3768,8 +3801,8 @@ fn range_conflict_check_does_not_penalize_bare_or() {
     ]);
     assert!(!has_conflicting_range_families(&bare_or), "a bare Or of 2 existential leaves has no shared-witness problem");
 
-    let usd_lt_50 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
-    let usd_gt_50 = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Gt, rhs: NumExpr::Const(50.0) };
+    let usd_lt_50 = || usd_cmp(CmpOp::Lt, 50.0);
+    let usd_gt_50 = || usd_cmp(CmpOp::Gt, 50.0);
     let or_of_usd = FilterExpr::Or(vec![usd_lt_50(), usd_gt_50()]);
     assert!(!has_conflicting_range_families(&or_of_usd), "an Or of 2 usd leaves alone still has no shared-witness problem");
 
@@ -3819,7 +3852,7 @@ fn price_plane_does_not_overcount_null_priced_printings_when_broad() {
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
-    let usd_lt_50 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    let usd_lt_50 = usd_cmp(CmpOp::Lt, 50.0);
 
     // compile_plane's own raw output honors whatever must_be_tight the
     // caller asks for: false (narrow_rec's fastpath / non-card modes) lets
@@ -3847,10 +3880,7 @@ fn price_plane_does_not_overcount_null_priced_printings_when_broad() {
 
     // Compound version, reached through split_planes's per-child And loop
     // instead of the whole-tree fold above.
-    let compound = FilterExpr::And(vec![
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) },
-        FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge },
-    ]);
+    let compound = FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0), FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }]);
     let (plane2, mut residual2) = split_planes(compound, bounds, words, true, &archived.indexes, &archived.offsets);
     let (total2, _) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
@@ -5006,11 +5036,7 @@ fn not_over_price_range_keeps_boundary_matches() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    let mut f = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
-        lhs: NumExpr::Field(NumField::PriceUsd),
-        op: CmpOp::Gt,
-        rhs: NumExpr::Const(5.0),
-    }));
+    let mut f = FilterExpr::Not(Box::new(usd_cmp(CmpOp::Gt, 5.0)));
     let (total, _) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
         &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -5588,11 +5614,7 @@ fn verify_order_or_keeps_sets_and_scans_in_written_order() {
 // card-level member can still settle at card level, so it stays early.
 #[test]
 fn verify_order_and_defers_printing_dependent_children() {
-    let usd = || FilterExpr::NumericCmp {
-        lhs: NumExpr::Field(NumField::PriceUsd),
-        op: CmpOp::Gt,
-        rhs: NumExpr::Const(20.0),
-    };
+    let usd = || usd_cmp(CmpOp::Gt, 20.0);
     let dragon = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "dragon".to_string(), value_id: None };
     let mut f = FilterExpr::And(vec![usd(), dragon()]);
     f.order_children_by_verify_cost();
@@ -5614,11 +5636,7 @@ fn verify_order_and_defers_printing_dependent_children() {
 // `usd>20` must not jump ahead of the contains it can't short-circuit.
 #[test]
 fn verify_order_or_defers_printing_dependent_children() {
-    let usd = || FilterExpr::NumericCmp {
-        lhs: NumExpr::Field(NumField::PriceUsd),
-        op: CmpOp::Gt,
-        rhs: NumExpr::Const(20.0),
-    };
+    let usd = || usd_cmp(CmpOp::Gt, 20.0);
     let mut f = FilterExpr::Or(vec![contains_scan(), usd()]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1302,12 +1302,7 @@ fn legality_plane_promotion_respects_mode_through_split_planes() {
             assert!(plane.is_some(), "a bare Legality leaf must still fully plane-consume for unique=card");
             assert!(matches!(residual, FilterExpr::True), "split_planes must leave a bare True residual for unique=card");
         } else {
-            // Narrowing-only fold (see split_planes' doc): the plane is still used
-            // for candidate_cards, but the residual stays the original, unchanged
-            // Legality node -- correctness for unique=printing/artwork comes
-            // entirely from the ordinary per-printing card_pass walk over it, not
-            // the plane (run_query's existential_plane stays Mode::Card-only).
-            assert!(plane.is_some(), "the plane is still produced, for narrowing purposes");
+            assert!(plane.is_none(), "unique=printing/artwork must decline the fold, not just patch around it");
             assert!(matches!(residual, FilterExpr::Legality { .. }), "the original Legality node must survive for per-printing verification");
         }
         run_query(

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -301,7 +301,18 @@ shared-witness tracking, and removing the dedicated negation arms — all three 
   this is just an honest property of the approach, not a tradeoff being weighed against an
   alternative.
 
-## `unique=printing`/`artwork`: investigated, two real fixes shipped, no win on broad queries
+## `unique=printing`/`artwork`: investigated, both attempted fixes reverted
+
+**Update after broader re-benchmarking: both fixes below were reverted.** They were validated
+only against `usd<X`-shaped queries; re-testing against the engine's *other* existing existential
+fields (legality, rarity, border) — prompted by the reasonable question "do these fixes help any
+other queries?" — surfaced a real regression and a real correctness bug, neither visible in the
+price-only benchmarks. See "What broader testing found" below for what went wrong and why both
+were reverted rather than patched further. The investigation and its conclusions (the match-phase
+floor is inherent, `#656` doesn't cover existential facts) remain valid and are kept below; the
+code changes do not exist on `main`.
+
+## Original entry (fixes since reverted — kept for the record)
 
 Traced why these modes stayed slow, since the original "loosen two gates" framing turned out
 wrong. `run_query`'s speed for `unique=card` doesn't come from a smaller candidate set — for
@@ -359,9 +370,54 @@ only in proportion to selectivity (a small win at `usd<50`'s 83%, a bigger one a
 
 **Real-corpus benchmark, full sweep, both fixes applied**: `unique=printing`/`artwork` unchanged
 from baseline (~1.2ms) across `usd<0.1` through `usd<50`. `unique=card` unaffected by either fix
-(still ~0.18ms). Both fixes are correct, real, and worth keeping (118/118 tests pass, no
-regressions, no new clippy warnings) — they just don't close the gap this investigation originally
-hoped they would for the query shapes benchmarked throughout this project.
+(still ~0.18ms). Both fixes passed 118/118 tests with no new clippy warnings at the time — but see
+below.
+
+## What broader testing found (both fixes reverted)
+
+Asked "do these fixes help any other queries?" — a reasonable question, since both fixes are
+field-agnostic (any existential leaf, not just price). Benchmarking existing legality/rarity/
+border queries under `unique=printing`/`artwork` (`f:commander`, `f:legacy`, `f:modern`,
+`r:common or r:uncommon`, `-border:black`) — none of which this investigation had tested, since
+all prior benchmarking used only `usd<X` — found real problems in both fixes:
+
+- **Fix 2 (weighted walk): a real, reproducible ~10-18% regression** on every one of those
+  queries, confirmed via clean back-to-back A/B against a `git worktree` build of the pre-fix
+  commit. Cause: the walk's bitmap-scatter step is O(n_cards) *unconditionally*, paid even when
+  the old raw-permutation walk would have terminated early (the common case for broad predicates
+  in default `edhrec_rank` order — confirmed by directly timing a simplified reproduction of the
+  old walk logic, which took ~1.3μs for the exact queries this whole project benchmarked,
+  nowhere near its O(n_cards) worst case). Net: pays an unconditional cost to fix a worst case
+  that essentially never triggers for these query shapes.
+- **Fix 1 (narrowing-only fold): its own regression on near-total matches** (`f:commander` at
+  99.8%) for the same reason — `candidate_cards`'s `Some(expr)` branch has no broadness-discard
+  check, unlike the `plane=None` branch, so it unconditionally pays `bitmap_card_ids` materialization
+  for a match rate where there's nothing to narrow.
+- **Attempting to fix *that* regression (adding a discard check to the `Some(expr)` branch)
+  introduced a real correctness bug**, caught by `fuzz_row_identity_matches_reference`: for a
+  compound `And` where `split_planes` partitions one child into the plane and leaves another in
+  the residual (e.g. `rarity>0 AND types!=X`, with `types!=X` folded into the plane and `rarity>0`
+  left as the residual), discarding the plane-derived `candidate_cards` silently drops the
+  plane's constraint entirely — nothing else re-checks it, since the residual only knows about
+  `rarity>0`. This is different from fix 1's own narrowing-only scenario (residual = the *same*
+  predicate the plane represents, so discarding and falling back to the residual is safe) — the
+  two cases reach the same code path and are not distinguishable there without deeper surgery.
+  Confirmed the bug was newly introduced (not pre-existing) by reproducing it against a
+  `git worktree` build of the pre-fix commit, where the fuzzer passed cleanly.
+
+Given fix 2 provides no measured benefit for any tested query and a real regression on several,
+and fix 1 provides no measured benefit for its own target case (`usd<X`) and a real regression on
+near-total matches with no safe way found to fix that within this investigation's scope, both were
+reverted in full — confirmed byte-identical to the pre-investigation commit
+(`git diff <that-commit> -- lib.rs planes.rs tests.rs` is empty) and re-verified clean (118/118
+tests, no new clippy warnings, benchmarks back to baseline for both the `usd<X` sweep and the
+legality/rarity/border queries that exposed the problems).
+
+**Lesson carried forward**: validate performance changes against the engine's existing, varied
+query shapes, not only the query that motivated the change — the same lesson `#667`'s own
+"performance regression caught by the broad survey, not the targeted script" section already
+recorded, re-learned here at a different layer (candidate narrowing and pagination walks, not
+per-candidate dispatch).
 
 ## Plan
 
@@ -380,11 +436,13 @@ hoped they would for the query shapes benchmarked throughout this project.
       two ways the final shape differs from the original sketch.
 - [x] Benchmark against today's baseline for `unique=card` — real win confirmed (~0.4-1ms → ~0.18ms
       on `usd<50`).
-- [x] Investigate extending to `unique=printing`/`artwork` — see "investigated, two real fixes
-      shipped, no win on broad queries" above. `split_planes` narrowing fold + weighted permuted-
-      bitmap walk both shipped, both correct, neither closes the gap for broad queries (inherent
-      match-phase floor). Closing that gap for real would need a different approach than #656's
-      own scoped mechanism, which doesn't cover existential facts — not attempted here.
+- [x] Investigate extending to `unique=printing`/`artwork` — see "investigated, both attempted
+      fixes reverted" above. Neither closed the gap for broad queries (inherent match-phase
+      floor), and broader re-benchmarking against the engine's other existential fields
+      (legality/rarity/border, not just price) found a real regression in each — both reverted in
+      full, confirmed byte-identical to the pre-investigation commit. Closing this gap for real
+      would need a different approach than #656's own scoped mechanism, which doesn't cover
+      existential facts — not attempted here.
 - [ ] Extend to `collector_number`/`released_at` (`DateCmp`/`YearCmp`, separate `compile_plane`
       arms from `NumericCmp`'s).
 - [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -387,6 +387,61 @@ weighted-walk regression above, and now compound existential-leaf queries. Each 
 looked right had a real, different cost profile once tested against realistic query composition,
 not just the query shape that motivated the change.
 
+## A real correctness bug: NULL-over-inclusion in the complement shortcut
+
+Found while re-benchmarking against real `origin/main` (none of this `PrintingRangeBits` work has
+actually merged — see the top of this doc's status line): `usd<50`/`unique=card` on the 97,206-
+printing corpus returned **31,396 on this branch vs. the correct 31,217** (confirmed independently
+against the raw corpus JSONL and against `origin/main`, which has no `PrintingRangeBits` at all).
+Pre-existing since price's original commit (`cd3656e`), inherited automatically by `collector_number`/
+`released_at`.
+
+**Root cause**: `range_narrowed`'s complement branch (used when the matching side is both the
+majority and past `NARROW_FLOOR`) scatters the *non*-matching indexed printings and complements
+over all `n_printings` — which also flips the bit for every printing absent from the index entirely
+(NULL-valued for that field). That's exactly why the result is tagged `Narrowed.tight = false`, and
+the rest of the codebase (`narrow_rec`'s own `Not`-handling) already respects that contract
+carefully. But `compile_price_range`/`compile_collector_number_range`/`compile_date_range`/
+`compile_year_range` (via `printing_range_bits`) never read `narrowed.tight` before treating the
+projected `card_bits` as the definitive existential fact for the plane — and `split_planes`'s
+`unique=card` fold discards the residual entirely, so `run_query` trusts `card_bits`' popcount with
+no recheck at all. `usd<50` is 83% selective (of *priced* printings), so the complement shortcut
+always fires there.
+
+**First fix attempt (reverted): force `must_be_tight` unconditionally.** Made `range_narrowed`
+always take the direct-scatter branch (never the complement) inside the four `compile_*_range`
+functions specifically. Fixed the overcount, verified via a dedicated regression test
+(`price_plane_does_not_overcount_null_priced_printings_when_broad`, a 2,000-printing fixture: 1,800
+priced matches, 200 priceless), but broke performance in two ways once benchmarked: `narrow_rec`'s
+own plane fastpath (unrelated to `split_planes`'s fold, always re-verified downstream regardless)
+paid the expensive scatter for nothing, and — critically — **the broadest queries, exactly the ones
+this whole fastpath exists for, always hit the complement branch**, so forcing tightness everywhere
+sacrificed the win for `usd<50`-shaped queries specifically while "fixing" a bug that only mattered
+at one specific call site.
+
+**Real fix: thread `must_be_tight` through `compile_plane` itself**, defaulting to `false`, set to
+`true` only by `split_planes` for `unique=card` (the one call site that actually discards the
+residual and trusts `card_bits` unverified) and left `false` everywhere else (`narrow_rec`'s own
+fastpath; `split_planes` for `unique=printing`/`artwork`, which never folds an existential leaf away
+regardless of exactness). `PlaneExpr::PrintingRangeBits` also carries an `exact: bool` field
+(mirroring `Narrowed.tight` from the narrowing that produced it) as a second, independent
+defense-in-depth check — `plane_expr_is_exact` — consulted alongside the `must_be_tight` threading
+at `split_planes`'s fold decision. Mutation-tested that this double layer actually holds: breaking
+just the `must_be_tight` threading costs performance but not correctness (the `exact` check declines
+the fold, falling back to the safe path); breaking both simultaneously reproduces the original bug
+exactly, confirming neither layer alone is redundant.
+
+**Verified**: `cargo test`/`cargo clippy` clean throughout; `test_engine_property.py`'s differential
+suite (250 seeded queries against a reference oracle, ≥6,000-card store built specifically to cross
+`NARROW_FLOOR`) confirmed to *actually fail* against the pre-fix code (not just theoretically able
+to) and pass cleanly after — this differential suite existed the whole time but had not actually
+been run against this branch until this investigation.
+
+**Could the Rust fuzzer have caught this?** No — `fuzz_row_identity_matches_reference` generates
+stores with 5-15 cards (~45 printings max), structurally unable to cross `NARROW_FLOOR` (1,000).
+See [local-engine-large-scale-differential-fuzzer.md](local-engine-large-scale-differential-fuzzer.md)
+for a proposed (not yet built) large-scale companion fuzzer that would.
+
 ## Plan
 
 - [x] Ship the price exactness fix standalone (see Prerequisite above) — landed as the
@@ -419,6 +474,12 @@ not just the query shape that motivated the change.
       compile-then-discard before the shared-witness check rejects them) — `has_conflicting_range_
       families`, see "A second broad-testing lesson" above. Also fixed a latent instance of the
       same bug that predates this slice (`f:modern AND usd<50`, present since price's original PR).
+- [x] Found and fixed a real correctness bug (NULL-over-inclusion in `range_narrowed`'s complement
+      shortcut, silently overcounting `usd<50`/`unique=card` by 179 on the real corpus, pre-existing
+      since price's original commit) — see "A real correctness bug" above. `must_be_tight` threaded
+      through `compile_plane`, plus an independent `exact` field on `PrintingRangeBits` as
+      defense-in-depth; confirmed `test_engine_property.py`'s existing differential suite actually
+      catches this (once run), and added a fast Rust-level regression test for day-to-day coverage.
 - [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the
       Prerequisite section to here) — either bring it into scope (needed for `-usd>8`-shaped
       queries, a real fragment in `test_engine_property.py`'s own suite) or explicitly defer it

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -171,8 +171,31 @@ and test each candidate for set membership inline, stopping once `limit` matches
   *aligned* case (`released_at>2026-06-01 order by released_at`) is pathological if the walk
   starts at the wrong end: ascending order puts the matches at the far end, so a naive
   front-to-back walk visits almost everything before the first hit.
-- `total` for `unique=card` needs `oracle_id` dedup, not just `k` — `k` alone only works
-  directly for `unique=printing`.
+- **`total` for `unique=card`/`artwork` needs `oracle_id` dedup, not just `k` — and this may
+  cost as much as idea 2's whole approach.** `k` alone only works directly for `unique=printing`
+  (no dedup needed, `total = k` for free from the binary search — idea 1's "close to instant"
+  claim is unconditionally true there). For `unique=card`/`artwork`, an *exact* `total` means
+  deduplicating every matched printing by `oracle_id` — touching all `k` matches at least once,
+  the same O(k) idea 1 exists to avoid. If that cost is unavoidable for `unique=card` regardless
+  of page-fetch strategy, idea 1 may not actually beat idea 2 there — idea 2 pays that same O(k)
+  once to build the bitmap and gets offset-independent paging as a bonus for it. **This makes
+  `unique` mode (`printing` vs. `card`/`artwork`) a fourth crossover axis, not a detail** — it
+  may determine which idea is even viable before selectivity/alignment/clustering matter at all.
+
+  `cards_of_printings` (`lib.rs:2392-2407`) dedupes exactly this way, but it's a *batch* operation
+  over a complete, sorted `Vec`/bitmap — reusing it directly would mean materializing the whole
+  matched set upfront, exactly what idea 1 exists to avoid. Idea 1's walk discovers matches one at
+  a time, in permutation (order-by) order, not printing-id order, so it needs an *incremental*
+  version instead: a running card-space "seen" bitmap, and per matched printing, look up its card
+  id and test-and-set a bit (new bit set → a newly-counted distinct card; already set → skip).
+  That per-printing card lookup can't use `cards_of_printings`' own broad-k trick
+  (`printing_bits_to_card_bits`'s monotone cursor needs ascending printing-id order, which a
+  permutation walk doesn't provide) — it needs the direct-array lookup instead, see
+  [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md), which is
+  worth landing before committing to idea 1 for this reason specifically, not just its narrower
+  standalone win. Still an open, measurement-shaped question (kernel benchmark, not end-to-end
+  timing) whether this incremental floor is cheap enough to make `unique=card` competitive with
+  `unique=printing` — landing the direct array first is what makes that measurement fair.
 
 ## Idea 2: scatter the exact narrowed set into a bitmap, feed the existing popcount-skip path
 
@@ -187,6 +210,17 @@ tweak — that function's existential row-selection (`plane_expr_is_existential`
 none of these fields compile to today. **Decided: extend the Y-predicate/existential-plane
 framework** (#680) with a new leaf rather than duplicate its row-selection logic outside it —
 price genuinely is a per-printing predicate, the same shape format/rarity/border already are.
+
+**This row-selection work is not price-specific — `collector_number` and `released_at` are also
+printing-varying fields.** A card's printings have different collector numbers and release
+dates, same as different prices. Under `unique=card`/`artwork`, *any* printing-varying field
+needs to pick which specific matching printing to emit — that's inherent to varying by printing
+at all, not to price's semantics in particular. So "prove the mechanism on a tight field first
+isolates the crossover question from the row-selection work" (see Plan) is only fully true for
+`unique=printing` — there, each printing is its own row, no selection needed at all. For
+`unique=card`/`artwork` on *any* of these three fields, the same `PrintingRangeBits` mechanism
+is needed. Treat row-selection as one piece of shared work across `price`/`collector_number`/
+`released_at` together, not something deferred specifically until price's turn.
 Tracing `PlaneExpr::Bits` (planes.rs:436-443, `eval_plane_expr_for_printing`,
 `plane_expr_is_existential`) shows this is a contained addition, not a framework rewrite — and
 it's simpler than it first looked, now that narrowing is exact:
@@ -231,34 +265,60 @@ decision needs three axes:
    (blind walk, no seek target).
 3. **For the aligned case, direction vs. clustering** — does the naive walk start at the
    matching end, or does it need to seek first?
+4. **`unique` mode** (`printing` vs. `card`/`artwork`) — not a speed difference, a viability
+   question. `unique=printing` needs no dedup (`total = k` free); `unique=card`/`artwork` needs
+   an exact card-level `total`, which may cost O(k) regardless of page-fetch strategy (see idea
+   1's `total` note above). If so, idea 1 and idea 2 aren't competing on speed for that mode,
+   they're both paying the same floor and idea 2's offset-independence is pure upside.
 
 The adversarial cell — selective predicate, unrelated order-by, unlucky clustering — is where
 idea 1's actual worst case needs to be measured against today's baseline. If it's worse there,
 that bounds how unconditionally idea 1 can be used. With the prerequisite fix landed, there's no
-fourth (tight/loose) axis to worry about — every field behaves identically here.
+fifth (tight/loose) axis to worry about — every field behaves identically there.
 
 ## Plan
 
-- [ ] Ship the `price_bounds` exactness fix standalone (see Prerequisite above) — already
-      verified, just needs the Rust change + a `tests.rs` regression test.
-- [ ] Prove the fast-path mechanism on a tight field first (`released_at` or
-      `collector_number`, already tight today) — isolates the crossover question from the
-      `PlaneExpr` row-selection work.
+- [x] Ship the price exactness fix standalone (see Prerequisite above) — landed as the
+      integer-cents migration in [#688](https://github.com/jbylund/sylvan_librarian/pull/688).
+- [ ] Ship `printing_to_card` standalone first (see
+      [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md)) —
+      load-bearing for idea 1's incremental per-match card check, neutral to idea 2, changes this
+      doc's crossover-axis-4 baseline numbers.
+- [ ] Prove the fast-path mechanism on `unique=printing` for a tight field first (`released_at`
+      or `collector_number`) — this is the case that genuinely isolates the crossover question
+      from row-selection (no picking-a-printing problem at all when each printing is its own
+      row). Does *not* by itself resolve `unique=card`/`artwork` — see the next item.
+- [ ] Resolve the `unique=card`/`artwork` `total` question (crossover axis 4) before trusting
+      idea 1's cost model there: measure whether an exact card-level `total` can be had for less
+      than O(k), or whether `unique=card` always pays that floor regardless of page-fetch
+      strategy. This may collapse the idea-1-vs-idea-2 choice for that mode entirely.
 - [ ] Sketch idea 1 as a real path: `k`-from-binary-search, order-by-permutation walk with
-      inline membership check, early stop at `limit`, dedup-aware `total` for `unique=card`.
+      inline membership check, early stop at `limit`.
 - [ ] Sketch idea 2: `PlaneExpr::PrintingRangeBits`, wired into `compile_plane`/`eval_planes`/
-      `plane_expr_is_existential`/`eval_plane_expr_for_printing`.
-- [ ] Build a sweep harness across the three crossover axes (shape of `bench_cost_guards.py` /
+      `plane_expr_is_existential`/`eval_plane_expr_for_printing` — shared across
+      `price`/`collector_number`/`released_at`, not price-specific, once `unique=card`/`artwork`
+      row-selection is in scope for any of them.
+- [ ] Build a sweep harness across all four crossover axes (shape of `bench_cost_guards.py` /
       `build_guard_corpus.py`), covering `price_usd`, `released_at`, and `collector_number`, plus
-      at least one deliberately-adversarial synthetic case (mismatched order-by field).
+      at least one deliberately-adversarial synthetic case (mismatched order-by field) and both
+      `unique` modes.
 - [ ] Calibrate the guard from measurement (or confirm one design dominates and no guard is
       needed).
+- [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the
+      Prerequisite section to here) — either bring it into scope (needed for `-usd>8`-shaped
+      queries, a real fragment in `test_engine_property.py`'s own suite) or explicitly defer it
+      again to a third, later piece of work, with a stated reason rather than silently dropping it.
 - [ ] Acceptance: `usd<50`, a broad `released_at`/`collector_number` query, and the adversarial
-      case all improve or stay flat vs. baseline; no regression on the existing #634/#655 exact
-      paths.
+      case all improve or stay flat vs. baseline for at least one `unique` mode; no regression on
+      the existing #634/#655 exact paths; passes (and likely extends, given this exact class of
+      change already produced two independent bugs in the price prerequisite work)
+      `test_engine_property.py`'s differential suite against the reference oracle — a performance
+      delta alone is not sufficient to call this done.
 
 ## Related
 
+- [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md) —
+  prerequisite `printing_to_card` array, load-bearing for idea 1's per-match card check.
 - [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
   analogous fix for `cmc`/`power`/`toughness`; doesn't transfer (card-invariant, not existential).
 - [00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md) —

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -267,15 +267,16 @@ PlaneExpr::PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: NumField, op
   (bit-complementing `card_bits`) — a card can satisfy both `usd<X` and `-usd<X` at once via
   different printings, so the two are not logically equivalent. Missing this was caught by the
   new tests before being caught in production.
-- **Currently reachable only for `unique=card`.** `split_planes`'s `unique_is_card` gate (the same
-  one the original Legality carve-out established) declines to fold *any* existential leaf —
-  `PrintingRangeBits` included, since it correctly returns `true` from `plane_expr_is_existential`
-  — for `unique=printing`/`artwork`, and `run_query`'s own `existential_plane` computation
-  separately gates row-selection to `Mode::Card` only. Both are pre-existing, deliberate gates
-  this variant inherits automatically. The row-selection code (`eval_plane_expr_for_printing`'s
-  new arm) is written and verified correct, but isn't reachable via the real dispatch path yet for
-  the other two modes — loosening those two gates for price specifically is real, separate scope,
-  not silently included here.
+- **Row-selection reachable only for `unique=card`; narrowing reachable for all three modes.**
+  `split_planes`'s `unique_is_card` gate (the same one the original Legality carve-out
+  established) declines to fold *any* existential leaf to a bare `True` residual for
+  `unique=printing`/`artwork`, since `PrintingRangeBits` correctly returns `true` from
+  `plane_expr_is_existential`. It now still returns the compiled plane for candidate narrowing in
+  that case (see "`unique=printing`/`artwork`" section below), while `run_query`'s own
+  `existential_plane` computation (feeding `eval_plane_expr_for_printing`'s row-selection check
+  into `card_match_count`) stays gated to `Mode::Card` only, deliberately — the residual already
+  provides correct per-printing verification for the other two modes, so consulting the plane
+  there too would be redundant, not a speed win.
 
 **Verified**: `price_plane_path_parity_and_shared_witness` (`tests.rs`) — differential check
 (`split_planes`-compiled path vs. the unplaned `card_pass` path) across `usd<50`, `-usd<50`, and
@@ -300,6 +301,68 @@ shared-witness tracking, and removing the dedicated negation arms — all three 
   this is just an honest property of the approach, not a tradeoff being weighed against an
   alternative.
 
+## `unique=printing`/`artwork`: investigated, two real fixes shipped, no win on broad queries
+
+Traced why these modes stayed slow, since the original "loosen two gates" framing turned out
+wrong. `run_query`'s speed for `unique=card` doesn't come from a smaller candidate set — for
+`usd<50` (83% selective) the narrowed set gets discarded by the broadness-guard regardless of
+mode. The real mechanism is `run_query_streamed_popcount`: it answers `total` directly from a
+bitmap's popcount and walks only `limit` set bits via a permuted-bitmap word-skip, never
+materializing or iterating a candidate list. That function is hard-gated to `Mode::Card`
+(`lib.rs:3941`), and extending it to `unique=printing`/`artwork` is **issue #656**, still open —
+quoting its own scope note, it needs "a weighted set-bit walk... card weights are O(1) via
+offsets-diff/artwork_groups... Not implemented." The original Legality carve-out
+(`docs/issues/done/00667-...md`) scoped this out identically, stating outright that those two
+modes "need no change: they already... run the existing (correct) per-printing `card_pass` walk."
+
+**#656 as scoped doesn't actually cover this case.** Its weighted-walk sketch assumes "under
+`all_match`" — every printing of a matching card counts, an O(1) weight lookup (`offsets`-diff or
+`artwork_groups`). For an *existential* fact like price, the weight is "how many printings/groups
+actually satisfy the predicate," which cannot be read from a count table — it requires visiting
+that card's printings, the same O(matching printings) work `card_match_count` already does. There
+is no way around this for an exact total: unlike `unique=card` (needs only existence, O(1) via the
+bitmap), `unique=printing`/`artwork` inherently need to know *which* printings qualify.
+
+Implemented and empirically verified two real, narrower fixes instead of the (larger, and for this
+case insufficient) full weighted-walk mechanism:
+
+1. **`split_planes` narrowing-only fold**: when an existential leaf can't safely fold to a bare
+   `True` residual (wrong mode), it now still returns the compiled plane for `candidate_cards`
+   narrowing (avoiding the broadness-discard-to-full-scan fallback `plane=None` takes), while
+   leaving the residual unchanged so per-printing correctness still comes from the ordinary
+   `card_pass` walk, not the plane. `run_query`'s own `existential_plane` (row-selection) gate
+   stays `Mode::Card`-only, deliberately — using it here too would redundantly re-check the same
+   predicate the residual already checks. Verified via debug instrumentation: `candidate_cards`
+   for `usd<0.1`/`unique=printing` narrows correctly from 31,508 to 4,738 cards.
+2. **Weighted permuted-bitmap walk** in `run_query_streamed`'s "large totals" branch, replacing a
+   raw `perm.iter()` scan of all `n_cards` entries with a bitmap-scatter-and-`trailing_zeros` walk
+   (mirroring `run_query_streamed_popcount`'s mechanism, but reading `counts[cid]` as a
+   *variable* per-card weight instead of a uniform 1, since whole words can't be skipped by
+   popcount alone when weights vary). This is the real, generic fix for the adversarial shape
+   `#634`'s own design worried about (`released_at>2026-06-01 order by released_at`-style: low
+   selectivity, order-by uncorrelated with or opposed to the predicate, forcing a walk deep into
+   the permutation) — verified correct via the full test suite (particularly
+   `fuzz_row_identity_matches_reference`'s 96-seed property fuzzer) and via direct timing
+   instrumentation.
+
+**Why neither moved the `usd<50`-shaped benchmark numbers**: instrumented both phases directly.
+For `usd<50`/`usd<0.1` under `unique=printing`, the *match* phase (visiting narrowed candidates,
+checking their printings) costs 200μs–1.1ms and dominates completely; the walk/emission phase
+costs low single-digit microseconds either way, old or new, because `limit`-based early
+termination already made the *old* raw-permutation scan cheap for these specific queries (dense,
+early matches in `edhrec_rank` order) — its O(n_cards) worst case was real but not hit here. The
+weighted-walk fix's value is real but narrower than hoped: it matters for deep pagination /
+adversarial ordering, not for the broad, offset-0 queries this whole project has benchmarked. The
+match-phase cost is the true, inherent floor for these modes under an existential predicate, and
+no bitmap/walk cleverness removes it — only narrowing the candidate set (fix 1, above) helps, and
+only in proportion to selectivity (a small win at `usd<50`'s 83%, a bigger one at low selectivity).
+
+**Real-corpus benchmark, full sweep, both fixes applied**: `unique=printing`/`artwork` unchanged
+from baseline (~1.2ms) across `usd<0.1` through `usd<50`. `unique=card` unaffected by either fix
+(still ~0.18ms). Both fixes are correct, real, and worth keeping (118/118 tests pass, no
+regressions, no new clippy warnings) — they just don't close the gap this investigation originally
+hoped they would for the query shapes benchmarked throughout this project.
+
 ## Plan
 
 - [x] Ship the price exactness fix standalone (see Prerequisite above) — landed as the
@@ -317,11 +380,11 @@ shared-witness tracking, and removing the dedicated negation arms — all three 
       two ways the final shape differs from the original sketch.
 - [x] Benchmark against today's baseline for `unique=card` — real win confirmed (~0.4-1ms → ~0.18ms
       on `usd<50`).
-- [ ] Extend row-selection to `unique=printing`/`artwork`: loosen `split_planes`'s `unique_is_card`
-      gate and `run_query`'s `existential_plane` `Mode::Card` gate for `PrintingRangeBits`
-      specifically (the eval-time correctness is already written and tested; only the dispatch
-      gating needs to change). Benchmark separately — `unique=printing`/`artwork` pay the
-      `cards_of_printings`/dedup cost `unique=card` doesn't, may not win by the same margin.
+- [x] Investigate extending to `unique=printing`/`artwork` — see "investigated, two real fixes
+      shipped, no win on broad queries" above. `split_planes` narrowing fold + weighted permuted-
+      bitmap walk both shipped, both correct, neither closes the gap for broad queries (inherent
+      match-phase floor). Closing that gap for real would need a different approach than #656's
+      own scoped mechanism, which doesn't cover existential facts — not attempted here.
 - [ ] Extend to `collector_number`/`released_at` (`DateCmp`/`YearCmp`, separate `compile_plane`
       arms from `NumericCmp`'s).
 - [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -303,121 +303,89 @@ shared-witness tracking, and removing the dedicated negation arms — all three 
 
 ## `unique=printing`/`artwork`: investigated, both attempted fixes reverted
 
-**Update after broader re-benchmarking: both fixes below were reverted.** They were validated
-only against `usd<X`-shaped queries; re-testing against the engine's *other* existing existential
-fields (legality, rarity, border) — prompted by the reasonable question "do these fixes help any
-other queries?" — surfaced a real regression and a real correctness bug, neither visible in the
-price-only benchmarks. See "What broader testing found" below for what went wrong and why both
-were reverted rather than patched further. The investigation and its conclusions (the match-phase
-floor is inherent, `#656` doesn't cover existential facts) remain valid and are kept below; the
-code changes do not exist on `main`.
+Investigated extending the same idea to `unique=printing`/`artwork`. Two fixes were implemented,
+benchmarked as a real win against `usd<X`, then both reverted after broader re-benchmarking
+against the engine's *other* existential fields (legality, rarity, border) surfaced a real
+regression and a real correctness bug, neither visible in the price-only benchmarks — full story,
+including the two fixes' design and exactly what broader testing found, moved to
+[local-engine-printing-mode-existential-fastpath-attempt.md](local-engine-printing-mode-existential-fastpath-attempt.md)
+(extracted to keep this doc from growing past ~500 lines once the `collector_number`/`released_at`
+section below landed). Bottom line: the match-phase cost is an inherent floor for these two modes
+under an existential predicate — no bitmap/walk cleverness removes it, and `#656` as scoped doesn't
+cover existential facts either. Neither reverted fix's code exists on `main`.
 
-## Original entry (fixes since reverted — kept for the record)
+## `collector_number`/`released_at` extension, and a second broad-testing lesson
 
-Traced why these modes stayed slow, since the original "loosen two gates" framing turned out
-wrong. `run_query`'s speed for `unique=card` doesn't come from a smaller candidate set — for
-`usd<50` (83% selective) the narrowed set gets discarded by the broadness-guard regardless of
-mode. The real mechanism is `run_query_streamed_popcount`: it answers `total` directly from a
-bitmap's popcount and walks only `limit` set bits via a permuted-bitmap word-skip, never
-materializing or iterating a candidate list. That function is hard-gated to `Mode::Card`
-(`lib.rs:3941`), and extending it to `unique=printing`/`artwork` is **issue #656**, still open —
-quoting its own scope note, it needs "a weighted set-bit walk... card weights are O(1) via
-offsets-diff/artwork_groups... Not implemented." The original Legality carve-out
-(`docs/issues/done/00667-...md`) scoped this out identically, stating outright that those two
-modes "need no change: they already... run the existing (correct) per-printing `card_pass` walk."
+Extended `PlaneExpr::PrintingRangeBits` from `price_usd`/`unique=card` (shipped above) to
+`collector_number` (`NumericCmp`/`NumField::CollectorNumberInt`, mechanically the same shape as
+price) and `released_at` (`FilterExpr::DateCmp`/`YearCmp`, separate variants with no `NumField`
+involved at all — `YearCmp` compares a *derived* value, `date / 10_000`, so its per-printing
+recheck needed its own formula, not just a threshold swap). The `field: NumField` tag on
+`PrintingRangeBits` generalized to a new `RangePredicateField` enum (`PriceUsd`, `CollectorNumber`,
+`ReleasedAtDate`, `ReleasedAtYear`) so `eval_plane_expr_for_printing`/`compile_plane`/
+`compile_plane_neg` dispatch on it instead. `price_range_narrowed`/the new
+`collector_number_range_narrowed`/`date_range_narrowed`/`year_range_narrowed` are `pub(crate)` in
+`lib.rs`, shared between `narrow_rec`'s own per-field arms and `planes.rs`'s `compile_*_range`
+functions — same Bug-B-avoidance reasoning as price's own shared-narrowing-function design.
 
-**#656 as scoped doesn't actually cover this case.** Its weighted-walk sketch assumes "under
-`all_match`" — every printing of a matching card counts, an O(1) weight lookup (`offsets`-diff or
-`artwork_groups`). For an *existential* fact like price, the weight is "how many printings/groups
-actually satisfy the predicate," which cannot be read from a count table — it requires visiting
-that card's printings, the same O(matching printings) work `card_match_count` already does. There
-is no way around this for an exact total: unlike `unique=card` (needs only existence, O(1) via the
-bitmap), `unique=printing`/`artwork` inherently need to know *which* printings qualify.
+**Verified**: `collector_number_plane_path_parity_and_shared_witness`/
+`released_at_plane_path_parity_and_shared_witness` mirror `price_plane_path_parity_and_shared_witness`
+exactly (row selection, negation, same-field shared witness, all three `unique` modes), plus
+`cross_field_range_predicates_decline_shared_witness` (usd+cn, usd+date, cn+date pairwise, one card
+with 3 printings each satisfying exactly one condition — confirms cross-field composition declines
+correctly, not just same-field) and `legality_and_date_decline_shared_witness` (legality+date,
+confirming the pre-existing shared-witness machinery generalizes to the new fields without
+modification). Mutation-tested both new fields' negation arms and the shared-witness id uniqueness
+directly (temporarily reintroducing each bug class, confirming the relevant test fails, then
+reverting) — same rigor as price's own verification.
 
-Implemented and empirically verified two real, narrower fixes instead of the (larger, and for this
-case insufficient) full weighted-walk mechanism:
+**Real-corpus benchmark, targeted (`unique=card`)**: `cn<100` 0.75ms → 0.16ms (4.6×), `cn>=100`
+0.64ms → 0.19ms (3.3×), `year>2020` 0.52ms → 0.18ms (2.9×), `date>2023-01-01` 0.54ms → 0.14ms
+(3.7×). `usd<50` unchanged (0.23ms), as expected. Broad sweep (legality/rarity/border) flat.
 
-1. **`split_planes` narrowing-only fold**: when an existential leaf can't safely fold to a bare
-   `True` residual (wrong mode), it now still returns the compiled plane for `candidate_cards`
-   narrowing (avoiding the broadness-discard-to-full-scan fallback `plane=None` takes), while
-   leaving the residual unchanged so per-printing correctness still comes from the ordinary
-   `card_pass` walk, not the plane. `run_query`'s own `existential_plane` (row-selection) gate
-   stays `Mode::Card`-only, deliberately — using it here too would redundantly re-check the same
-   predicate the residual already checks. Verified via debug instrumentation: `candidate_cards`
-   for `usd<0.1`/`unique=printing` narrows correctly from 31,508 to 4,738 cards.
-2. **Weighted permuted-bitmap walk** in `run_query_streamed`'s "large totals" branch, replacing a
-   raw `perm.iter()` scan of all `n_cards` entries with a bitmap-scatter-and-`trailing_zeros` walk
-   (mirroring `run_query_streamed_popcount`'s mechanism, but reading `counts[cid]` as a
-   *variable* per-card weight instead of a uniform 1, since whole words can't be skipped by
-   popcount alone when weights vary). This is the real, generic fix for the adversarial shape
-   `#634`'s own design worried about (`released_at>2026-06-01 order by released_at`-style: low
-   selectivity, order-by uncorrelated with or opposed to the predicate, forcing a walk deep into
-   the permutation) — verified correct via the full test suite (particularly
-   `fuzz_row_identity_matches_reference`'s 96-seed property fuzzer) and via direct timing
-   instrumentation.
+### A second broad-testing lesson: compound queries mixing 2+ existential leaves
 
-**Why neither moved the `usd<50`-shaped benchmark numbers**: instrumented both phases directly.
-For `usd<50`/`usd<0.1` under `unique=printing`, the *match* phase (visiting narrowed candidates,
-checking their printings) costs 200μs–1.1ms and dominates completely; the walk/emission phase
-costs low single-digit microseconds either way, old or new, because `limit`-based early
-termination already made the *old* raw-permutation scan cheap for these specific queries (dense,
-early matches in `edhrec_rank` order) — its O(n_cards) worst case was real but not hit here. The
-weighted-walk fix's value is real but narrower than hoped: it matters for deep pagination /
-adversarial ordering, not for the broad, offset-0 queries this whole project has benchmarked. The
-match-phase cost is the true, inherent floor for these modes under an existential predicate, and
-no bitmap/walk cleverness removes it — only narrowing the candidate set (fix 1, above) helps, and
-only in proportion to selectivity (a small win at `usd<50`'s 83%, a bigger one at low selectivity).
+Benchmarking compound queries (`cn<100 AND usd<50`, `f:modern AND year>2020`) — again, a shape not
+covered by the single-field targeted benchmarks above — found a real regression: up to ~1.8× on
+two-range-field compounds, and (digging further after the user asked "does this affect the
+already-shipped usd<50 too?") a **latent ~3× regression on `f:modern AND usd<50`, present since
+price's original PR** (`cd3656e`) and never specifically benchmarked until now. Root cause in both
+cases: `narrow_rec`'s top-level fastpath and `split_planes` both attempt `compile_plane` before
+knowing whether `and_of_checked_for_shared_witness` will accept the result — each range field's
+`compile_*_range` function does a full binary-search-and-materialize before the shared-witness
+check can reject it, and 2+ existential leaves in one `And` are common enough (any legality/rarity/
+border query paired with any range field, or two range fields together) that this waste shows up
+directly in realistic query shapes, not just contrived ones.
 
-**Real-corpus benchmark, full sweep, both fixes applied**: `unique=printing`/`artwork` unchanged
-from baseline (~1.2ms) across `usd<0.1` through `usd<50`. `unique=card` unaffected by either fix
-(still ~0.18ms). Both fixes passed 118/118 tests with no new clippy warnings at the time — but see
-below.
+**Fix**: `has_conflicting_range_families` (`planes.rs`) — a cheap, purely structural tree walk (no
+narrowing, no materialization) that detects whether some `And` node combines 2+ distinct
+existential-family leaves (legality/rarity/border/usd/collector_number/released_at, coarse-tagged
+via `ExistentialFamily`, deliberately less precise than `collect_existential_indices`' exact dedup
+— a false positive here only costs a missed optimization, never a correctness bug, since the real,
+authoritative shared-witness check downstream is unchanged). Consulted as a bail-out at both call
+sites (`narrow_rec`'s top-level fastpath, `split_planes`'s whole-tree attempt and per-child loop)
+to skip the expensive compile attempt entirely when a conflict is structurally certain, falling
+straight to the always-correct per-field/residual dispatch instead. `Or` is deliberately not a
+conflict site on its own (`∃` distributes over `∨`) — an earlier cut of this fix walked `Or` the
+same as `And` and caused its own ~8× regression on `r:common or r:uncommon` (caught by benchmarking,
+not by any unit test; added `range_conflict_check_does_not_penalize_bare_or` to cover it directly).
 
-## What broader testing found (both fixes reverted)
+**Real-corpus benchmark, compound queries, before → after this fix** (baseline is `41c9fab`, which
+already includes price's shipped fastpath): `cn<100 AND usd<50` 1.03ms → 1.86ms (regressed) → 0.91ms
+(fixed, better than baseline); `cn<100 AND year>2020` 1.06ms → 1.67ms → 0.80ms; `f:modern AND
+usd<50` 1.03ms → (unaffected by the cn/date work directly, but shares the same latent bug) → 0.51ms
+(fixing the pre-existing regression too, a bonus); `f:modern AND cn<100`/`f:modern AND year>2020`
+now 0.44-0.45ms, close to or better than the pre-any-plane-extension baseline (0.65ms/0.48ms on
+`4a4be10`). `r:common or r:uncommon` (the `Or`-safety regression) back to 0.070ms baseline.
+Targeted single-field and broad legality/rarity/border numbers unaffected, re-confirmed after this
+fix (see above).
 
-Asked "do these fixes help any other queries?" — a reasonable question, since both fixes are
-field-agnostic (any existential leaf, not just price). Benchmarking existing legality/rarity/
-border queries under `unique=printing`/`artwork` (`f:commander`, `f:legacy`, `f:modern`,
-`r:common or r:uncommon`, `-border:black`) — none of which this investigation had tested, since
-all prior benchmarking used only `usd<X` — found real problems in both fixes:
-
-- **Fix 2 (weighted walk): a real, reproducible ~10-18% regression** on every one of those
-  queries, confirmed via clean back-to-back A/B against a `git worktree` build of the pre-fix
-  commit. Cause: the walk's bitmap-scatter step is O(n_cards) *unconditionally*, paid even when
-  the old raw-permutation walk would have terminated early (the common case for broad predicates
-  in default `edhrec_rank` order — confirmed by directly timing a simplified reproduction of the
-  old walk logic, which took ~1.3μs for the exact queries this whole project benchmarked,
-  nowhere near its O(n_cards) worst case). Net: pays an unconditional cost to fix a worst case
-  that essentially never triggers for these query shapes.
-- **Fix 1 (narrowing-only fold): its own regression on near-total matches** (`f:commander` at
-  99.8%) for the same reason — `candidate_cards`'s `Some(expr)` branch has no broadness-discard
-  check, unlike the `plane=None` branch, so it unconditionally pays `bitmap_card_ids` materialization
-  for a match rate where there's nothing to narrow.
-- **Attempting to fix *that* regression (adding a discard check to the `Some(expr)` branch)
-  introduced a real correctness bug**, caught by `fuzz_row_identity_matches_reference`: for a
-  compound `And` where `split_planes` partitions one child into the plane and leaves another in
-  the residual (e.g. `rarity>0 AND types!=X`, with `types!=X` folded into the plane and `rarity>0`
-  left as the residual), discarding the plane-derived `candidate_cards` silently drops the
-  plane's constraint entirely — nothing else re-checks it, since the residual only knows about
-  `rarity>0`. This is different from fix 1's own narrowing-only scenario (residual = the *same*
-  predicate the plane represents, so discarding and falling back to the residual is safe) — the
-  two cases reach the same code path and are not distinguishable there without deeper surgery.
-  Confirmed the bug was newly introduced (not pre-existing) by reproducing it against a
-  `git worktree` build of the pre-fix commit, where the fuzzer passed cleanly.
-
-Given fix 2 provides no measured benefit for any tested query and a real regression on several,
-and fix 1 provides no measured benefit for its own target case (`usd<X`) and a real regression on
-near-total matches with no safe way found to fix that within this investigation's scope, both were
-reverted in full — confirmed byte-identical to the pre-investigation commit
-(`git diff <that-commit> -- lib.rs planes.rs tests.rs` is empty) and re-verified clean (118/118
-tests, no new clippy warnings, benchmarks back to baseline for both the `usd<X` sweep and the
-legality/rarity/border queries that exposed the problems).
-
-**Lesson carried forward**: validate performance changes against the engine's existing, varied
-query shapes, not only the query that motivated the change — the same lesson `#667`'s own
-"performance regression caught by the broad survey, not the targeted script" section already
-recorded, re-learned here at a different layer (candidate narrowing and pagination walks, not
-per-candidate dispatch).
+**Lesson carried forward, again**: this is the *third* time in this doc that a targeted benchmark
+looked clean and a broader sweep against compound/mixed-family queries found a real regression —
+`#667`'s original "broad survey, not the targeted script" lesson, `unique=printing`/`artwork`'s
+weighted-walk regression above, and now compound existential-leaf queries. Each time the fix that
+looked right had a real, different cost profile once tested against realistic query composition,
+not just the query shape that motivated the change.
 
 ## Plan
 
@@ -443,21 +411,31 @@ per-candidate dispatch).
       full, confirmed byte-identical to the pre-investigation commit. Closing this gap for real
       would need a different approach than #656's own scoped mechanism, which doesn't cover
       existential facts — not attempted here.
-- [ ] Extend to `collector_number`/`released_at` (`DateCmp`/`YearCmp`, separate `compile_plane`
-      arms from `NumericCmp`'s).
+- [x] Extend to `collector_number`/`released_at` (`DateCmp`/`YearCmp`, separate `compile_plane`
+      arms from `NumericCmp`'s) — see "collector_number/released_at extension" above. Real wins
+      confirmed (2.9-4.6× on targeted single-field queries), broad legality/rarity/border sweep
+      flat.
+- [x] Found and fixed a compound-query regression (2+ existential leaves in one `And` wastefully
+      compile-then-discard before the shared-witness check rejects them) — `has_conflicting_range_
+      families`, see "A second broad-testing lesson" above. Also fixed a latent instance of the
+      same bug that predates this slice (`f:modern AND usd<50`, present since price's original PR).
 - [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the
       Prerequisite section to here) — either bring it into scope (needed for `-usd>8`-shaped
       queries, a real fragment in `test_engine_property.py`'s own suite) or explicitly defer it
       again to a third, later piece of work, with a stated reason rather than silently dropping it.
-- [ ] Acceptance: a broad `released_at`/`collector_number` query and `unique=printing`/`artwork`
-      on `usd<50` all improve or stay flat vs. baseline; no regression on the existing #634/#655
-      exact paths; passes (and likely extends, given this exact class of change already produced
-      two independent bugs in the price prerequisite work and one in this slice's own negation
-      handling) `test_engine_property.py`'s differential suite against the reference oracle — a
-      performance delta alone is not sufficient to call this done.
+- [ ] Acceptance: `unique=printing`/`artwork` on `usd<50` (still the one gap left open, see
+      "investigated, both attempted fixes reverted" above) improves or stays flat vs. baseline; no
+      regression on the existing #634/#655 exact paths; passes (and likely extends, given this
+      exact class of change already produced two independent bugs in the price prerequisite work,
+      one in this slice's own negation handling, and one in the compound-query fix's own first cut)
+      `test_engine_property.py`'s differential suite against the reference oracle — a performance
+      delta alone is not sufficient to call this done.
 
 ## Related
 
+- [local-engine-printing-mode-existential-fastpath-attempt.md](local-engine-printing-mode-existential-fastpath-attempt.md)
+  — the `unique=printing`/`artwork` investigation, extracted from this doc: both attempted fixes
+  and why they were reverted.
 - [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md) —
   prerequisite `printing_to_card` array, load-bearing for idea 1's per-match card check.
 - [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -156,46 +156,65 @@ converts the candidate set to card ids and drops it if it covers ≥87.5% of all
 (`lib.rs:3740-3743`), falling back to a raw per-card `card_pass` scan even though the discarded
 set was exact.
 
-## Idea 1: walk the order-by permutation, verify inline, stop at `limit`
+## Idea 1: walk the order-by permutation, verify inline, stop at `limit` — REJECTED
 
 `range_narrowed`'s two `partition_point` binary searches already compute `k = e - s` for free
-(`lib.rs:1990-1992`) before any narrowing decision is made. Instead of materializing or
-discarding a candidate set, walk the existing per-orderby permutation table (built for #634)
-and test each candidate for set membership inline, stopping once `limit` matches are found.
+(`lib.rs:1990-1992`) before any narrowing decision is made. The original idea: instead of
+materializing or discarding a candidate set, walk the existing per-orderby permutation table
+(built for #634) and test each candidate for set membership inline, stopping once `limit` matches
+are found.
 
-- **Cheap when the predicate is broad**: expected candidates visited ≈ `limit / match_rate` —
-  for `usd<50` at 83%, a 20-row page costs ~24 candidate checks. Close to instant.
-- **Unbounded worst case.** If the order-by column is unrelated to the predicate field, there's
-  no seek target, and a low-selectivity predicate with unlucky clustering could blind-walk most
-  of the corpus before finding `limit` matches — worse than today's baseline. Even the
-  *aligned* case (`released_at>2026-06-01 order by released_at`) is pathological if the walk
-  starts at the wrong end: ascending order puts the matches at the far end, so a naive
-  front-to-back walk visits almost everything before the first hit.
-- **`total` for `unique=card`/`artwork` needs `oracle_id` dedup, not just `k` — and this may
-  cost as much as idea 2's whole approach.** `k` alone only works directly for `unique=printing`
-  (no dedup needed, `total = k` for free from the binary search — idea 1's "close to instant"
-  claim is unconditionally true there). For `unique=card`/`artwork`, an *exact* `total` means
-  deduplicating every matched printing by `oracle_id` — touching all `k` matches at least once,
-  the same O(k) idea 1 exists to avoid. If that cost is unavoidable for `unique=card` regardless
-  of page-fetch strategy, idea 1 may not actually beat idea 2 there — idea 2 pays that same O(k)
-  once to build the bitmap and gets offset-independent paging as a bonus for it. **This makes
-  `unique` mode (`printing` vs. `card`/`artwork`) a fourth crossover axis, not a detail** — it
-  may determine which idea is even viable before selectivity/alignment/clustering matter at all.
+**Rejected — its own premise doesn't hold.** The whole appeal was "cheap when the predicate is
+broad *and aligned with the order-by column*: for `usd<50` at 83%, a 20-row page costs ~24
+candidate checks." Trying to actually prove this (Plan: "prove the mechanism on `unique=printing`
+for a tight field, `released_at` or `collector_number`") surfaced that the aligned case doesn't
+exist for any of the three target fields, in the current system:
 
-  `cards_of_printings` (`lib.rs:2392-2407`) dedupes exactly this way, but it's a *batch* operation
-  over a complete, sorted `Vec`/bitmap — reusing it directly would mean materializing the whole
-  matched set upfront, exactly what idea 1 exists to avoid. Idea 1's walk discovers matches one at
-  a time, in permutation (order-by) order, not printing-id order, so it needs an *incremental*
-  version instead: a running card-space "seen" bitmap, and per matched printing, look up its card
-  id and test-and-set a bit (new bit set → a newly-counted distinct card; already set → skip).
-  That per-printing card lookup can't use `cards_of_printings`' own broad-k trick
-  (`printing_bits_to_card_bits`'s monotone cursor needs ascending printing-id order, which a
-  permutation walk doesn't provide) — it needs the direct-array lookup instead, see
-  [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md), which is
-  worth landing before committing to idea 1 for this reason specifically, not just its narrower
-  standalone win. Still an open, measurement-shaped question (kernel benchmark, not end-to-end
-  timing) whether this incremental floor is cheap enough to make `unique=card` competitive with
-  `unique=printing` — landing the direct array first is what makes that measurement fair.
+- `orderby_to_col` (`lib.rs:3311-3322`) and the API's `CardOrdering` enum
+  (`api/enums.py:25-35`) don't recognize `released_at`/`collector_number` as order-by targets at
+  all — anything unrecognized silently falls back to `edhrec_rank`. There is no way to even
+  request `order by released_at` today.
+- `price_usd` *is* a valid order-by target, but has no permutation table:
+  `ArchivedSortPermutations::get`/`get_inv` (`lib.rs:1755-1780`) explicitly return `None` for
+  `SortCol::PriceUsd`, because a card's price-sort position depends on which printing `prefer`
+  selects — not fixed at index-build time. This isn't an oversight: #634's own design doc
+  (`docs/issues/done/00634-engine-permuted-bitmap-order-phase.md`) scoped its permutation tables
+  to "**card-level** sort column[s]" and states outright "rarity/usd orderbys ... unchanged."
+
+So every real query against these fields hits idea 1's *unbounded worst case* (blind walk against
+an unrelated order-by column, most commonly the default `edhrec_rank`) — the cheap, aligned case
+this idea was chosen for is unreachable in practice. Building it would mean adding new order-by
+targets and permutation mechanisms as a real prerequisite, a materially bigger and separate
+project from what's scoped here.
+
+**Considered and rejected a scoped-down rescue** for `unique=printing` specifically: since each
+`PrintingRangeIndex` (`price_usd`, `collector_number`, `released_at`) is already sorted by
+`(value, printing_idx)`, walking it directly — no new permutation needed — gives an exact,
+offset-independent page for the aligned case, for that one mode. Real for `collector_number`/
+`released_at` (no existing orderby semantics to preserve, so "index order = orderby order" is a
+free, valid choice), but not free for `price_usd`: `order by usd`'s real, already-shipped tiebreak
+is `(price, edhrec_rank asc, prefer_score desc)` (`sort_key_bits`, `lib.rs:3337-3355`), not
+printing store order, so walking the raw index directly gets ties wrong whenever multiple
+printings share a price — common at the cheap end this project cares about most. A bucket
+approach (price values are already contiguous in the index; accumulate whole buckets until the
+page is covered, re-sort only the boundary bucket by the true tiebreak) fixes this correctly, but
+adds real edge-case cost (a pathologically large boundary bucket — e.g. many printings at the
+store's price floor — degrades back toward O(k) anyway) for a win that **only ever applies to
+`unique=printing`**. `unique=card`/`artwork` remain permanently blocked regardless: the card-level
+sort key depends on which printing `prefer` selects, not fixed independent of the query, the same
+reason #634 excluded rarity/usd from its own permutation tables — that's a property of the sort
+key itself, not of how the walk order is produced. Given idea 2 already handles all three
+`unique` modes and all three fields uniformly with no new orderby surface or bucket-size edge
+cases, the narrower, edge-case-prone idea 1 rescue isn't worth the complexity. Decided not to
+pursue idea 1 further, in any form; no crossover to calibrate against idea 2 as a result — idea 2
+is simply the approach.
+
+**`unique=card`/`artwork` total note kept for idea 2's benefit** (idea 1's own motivation for this
+is now moot, but idea 2 needs the same fact): an exact `total` under `unique=card`/`artwork` means
+deduplicating every matched printing by `oracle_id`. `cards_of_printings`
+(`lib.rs:2392-2407`, see [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md)
+for its now-shipped direct-array projection) already does exactly this, size-adaptively, for
+`Candidates::Printings` — the same dedup idea 2's own bitmap-build step needs, not new design.
 
 ## Idea 2: scatter the exact narrowed set into a bitmap, feed the existing popcount-skip path
 
@@ -212,108 +231,109 @@ framework** (#680) with a new leaf rather than duplicate its row-selection logic
 price genuinely is a per-printing predicate, the same shape format/rarity/border already are.
 
 **This row-selection work is not price-specific — `collector_number` and `released_at` are also
-printing-varying fields.** A card's printings have different collector numbers and release
-dates, same as different prices. Under `unique=card`/`artwork`, *any* printing-varying field
-needs to pick which specific matching printing to emit — that's inherent to varying by printing
-at all, not to price's semantics in particular. So "prove the mechanism on a tight field first
-isolates the crossover question from the row-selection work" (see Plan) is only fully true for
-`unique=printing` — there, each printing is its own row, no selection needed at all. For
-`unique=card`/`artwork` on *any* of these three fields, the same `PrintingRangeBits` mechanism
-is needed. Treat row-selection as one piece of shared work across `price`/`collector_number`/
-`released_at` together, not something deferred specifically until price's turn.
-Tracing `PlaneExpr::Bits` (planes.rs:436-443, `eval_plane_expr_for_printing`,
-`plane_expr_is_existential`) shows this is a contained addition, not a framework rewrite — and
-it's simpler than it first looked, now that narrowing is exact:
+printing-varying fields**, but they compile through entirely separate `FilterExpr` variants
+(`DateCmp`/`YearCmp`, not `NumericCmp`/`NumField` — `NumField` has no `ReleasedAt` member at all),
+so extending `PrintingRangeBits` to them is real, separate follow-up work with its own dedicated
+`compile_plane` arms, not something this slice's `NumericCmp` wiring covers for free.
 
-- `Bits` already supports "compute a card bitmap once per query, clone it into the plane tree"
-  (the oracle-word-index dense-dictionary precedent), but it's card-invariant by design —
-  `eval_plane_expr_for_printing`'s `Bits` arm checks the card id, and `plane_expr_is_existential`
-  hard-codes `Bits => false`. The needed sibling variant is just **two precomputed bitmaps**, no
-  live evaluation at all:
+### Shipped: `PlaneExpr::PrintingRangeBits` for `price_usd`, `unique=card` only
 
-  ```rust
-  PlaneExpr::PrintingRangeBits { card_bits: Vec<u64>, printing_bits: Vec<u64> }
-  ```
+Actual shape landed, differs from the original sketch in two ways found while implementing:
 
-- `eval_planes`: reads `card_bits` exactly like `Bits` does today (the card-level existence
-  answer, already exact courtesy of the prerequisite fix).
-- `plane_expr_is_existential`: `true` for this variant (unlike plain `Bits`).
-- `eval_plane_expr_for_printing`: a bit test against `printing_bits` for this specific printing —
-  no field/op/threshold, no floating-point comparison, just membership in the already-exact
-  narrowed set.
-- `compile_plane`'s `NumericCmp` arm, for printing-varying fields only (`cmc`/`power`/`toughness`
-  keep their existing #655 arm): compute both bitmaps at query time via `range_narrowed`, wrap
-  them in this variant — same "once per query" cost model the oracle-word-index `Bits` case
-  already established.
+```rust
+PlaneExpr::PrintingRangeBits { id: u64, card_bits: Vec<u64>, field: NumField, op: CmpOp, threshold: f64 }
+```
 
-- **Fixed cost regardless of `limit`/offset**: O(k) to build the bitmaps, then O(words) to select
+- **No `printing_bits` bitmap.** The original sketch proposed a second precomputed bitmap for the
+  per-printing check, reasoning it would avoid floating-point comparison at eval time. That
+  reasoning no longer applies: post the integer-cents migration, price/collector_number/
+  released_at are all plain integers on `Printing`, so `eval_plane_expr_for_printing`'s new arm
+  just re-runs `filter.rs`'s own `cmp()` directly against `(field, op, threshold)` — one fewer
+  independent encoding of "does this printing satisfy X" to keep in sync (exactly Bug B's shape).
+- **`id: u64` for shared-witness tracking**, not reusing plane indices. `collect_existential_indices`
+  (the `And`-composition safety check — `format:A AND r:mythic` can't compose via independent
+  card-bitmap intersection, and neither can `usd<50 AND usd>10`: a card can have one printing
+  under $50 and a different one over $10, satisfying both independently without any single
+  printing satisfying both) needs a distinct identity per compiled leaf, including two range
+  conditions on the *same* field at different thresholds. A monotonic counter starting above
+  `PLANE_COUNT` gives each compiled leaf a guaranteed-unique id with no risk of colliding with a
+  real plane index (a hash-based id was considered and rejected — collision risk, however small,
+  is the wrong tradeoff for a correctness-critical check). Same-field range merging (folding
+  `usd<50 AND usd>10` into one combined-bounds leaf, letting them safely share an id) is a real,
+  deliberately deferred optimization, not required for correctness — declining to compose falls
+  back to the always-correct residual `card_pass` path.
+- **`-usd<X` needed its own dedicated negation arm** in `compile_plane_neg`, mirroring
+  rarity/Legality exactly: `∃p: ¬(p.usd<X)` (recompute with the negated op), not `¬∃p: p.usd<X`
+  (bit-complementing `card_bits`) — a card can satisfy both `usd<X` and `-usd<X` at once via
+  different printings, so the two are not logically equivalent. Missing this was caught by the
+  new tests before being caught in production.
+- **Currently reachable only for `unique=card`.** `split_planes`'s `unique_is_card` gate (the same
+  one the original Legality carve-out established) declines to fold *any* existential leaf —
+  `PrintingRangeBits` included, since it correctly returns `true` from `plane_expr_is_existential`
+  — for `unique=printing`/`artwork`, and `run_query`'s own `existential_plane` computation
+  separately gates row-selection to `Mode::Card` only. Both are pre-existing, deliberate gates
+  this variant inherits automatically. The row-selection code (`eval_plane_expr_for_printing`'s
+  new arm) is written and verified correct, but isn't reachable via the real dispatch path yet for
+  the other two modes — loosening those two gates for price specifically is real, separate scope,
+  not silently included here.
+
+**Verified**: `price_plane_path_parity_and_shared_witness` (`tests.rs`) — differential check
+(`split_planes`-compiled path vs. the unplaned `card_pass` path) across `usd<50`, `-usd<50`, and
+`usd<50 AND t:creature`, all three `unique` modes; plus a hand-computed independent ground truth
+for `-usd<50`/`unique=card` specifically (needed because `narrow_rec`'s own internal `compile_plane`
+call means the "unplaned" differential baseline isn't fully independent of `compile_plane_neg` for
+negation — both sides can share the same bug and agree with each other while both being wrong;
+caught this by mutation-testing the differential check itself, not just assuming it was a valid
+oracle). Mutation-tested all three failure modes directly (temporarily reintroducing each bug,
+confirming the relevant test fails, then reverting): the card-only row-selection mistake, skipping
+shared-witness tracking, and removing the dedicated negation arms — all three caught.
+
+**Real-corpus benchmark** (`usd<50`, 97,206 printings): `unique=card` — the mode this slice covers
+— went from the ~0.4-1ms baseline that motivated this whole project down to **~0.18ms**.
+`unique=printing`/`artwork` show no change (**~1.2ms**, unaffected, per the gating above).
+
+- **Fixed cost regardless of `limit`/offset**: O(k) to build the bitmap, then O(words) to select
   any page — same offset-independence #634 Step 2 built for plane-exact filters. Wins on deep
   pagination and on reuse (AND against a plane in a compound query). Predictable worst case:
   never worse than O(k), full stop.
-- **Wasteful for the common case** — pays O(k) even for a 20-row first-page request that idea 1
-  would answer in ~24 checks.
-
-## The crossover needs measurement, not a guess
-
-Every existing adaptive guard in this engine (`AND_SKIP_THRESHOLD`, `MAX_NARROW_FRACTION`/
-`NARROW_FLOOR`, `MAX_UNION_FRACTION`) was derived from a benchmark sweep, not analysis — see
-[00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md). This
-decision needs three axes:
-
-1. **Match rate** (`k/n`).
-2. **Predicate/order-by field alignment** — same field (seekable directly) vs. unrelated field
-   (blind walk, no seek target).
-3. **For the aligned case, direction vs. clustering** — does the naive walk start at the
-   matching end, or does it need to seek first?
-4. **`unique` mode** (`printing` vs. `card`/`artwork`) — not a speed difference, a viability
-   question. `unique=printing` needs no dedup (`total = k` free); `unique=card`/`artwork` needs
-   an exact card-level `total`, which may cost O(k) regardless of page-fetch strategy (see idea
-   1's `total` note above). If so, idea 1 and idea 2 aren't competing on speed for that mode,
-   they're both paying the same floor and idea 2's offset-independence is pure upside.
-
-The adversarial cell — selective predicate, unrelated order-by, unlucky clustering — is where
-idea 1's actual worst case needs to be measured against today's baseline. If it's worse there,
-that bounds how unconditionally idea 1 can be used. With the prerequisite fix landed, there's no
-fifth (tight/loose) axis to worry about — every field behaves identically there.
+- **Pays O(k) even for a small first-page request** — no idea 1 to compare against anymore, so
+  this is just an honest property of the approach, not a tradeoff being weighed against an
+  alternative.
 
 ## Plan
 
 - [x] Ship the price exactness fix standalone (see Prerequisite above) — landed as the
       integer-cents migration in [#688](https://github.com/jbylund/sylvan_librarian/pull/688).
-- [ ] Ship `printing_to_card` standalone first (see
+- [x] Ship `printing_to_card` standalone first (see
       [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md)) —
       load-bearing for idea 1's incremental per-match card check, neutral to idea 2, changes this
       doc's crossover-axis-4 baseline numbers.
-- [ ] Prove the fast-path mechanism on `unique=printing` for a tight field first (`released_at`
-      or `collector_number`) — this is the case that genuinely isolates the crossover question
-      from row-selection (no picking-a-printing problem at all when each printing is its own
-      row). Does *not* by itself resolve `unique=card`/`artwork` — see the next item.
-- [ ] Resolve the `unique=card`/`artwork` `total` question (crossover axis 4) before trusting
-      idea 1's cost model there: measure whether an exact card-level `total` can be had for less
-      than O(k), or whether `unique=card` always pays that floor regardless of page-fetch
-      strategy. This may collapse the idea-1-vs-idea-2 choice for that mode entirely.
-- [ ] Sketch idea 1 as a real path: `k`-from-binary-search, order-by-permutation walk with
-      inline membership check, early stop at `limit`.
-- [ ] Sketch idea 2: `PlaneExpr::PrintingRangeBits`, wired into `compile_plane`/`eval_planes`/
-      `plane_expr_is_existential`/`eval_plane_expr_for_printing` — shared across
-      `price`/`collector_number`/`released_at`, not price-specific, once `unique=card`/`artwork`
-      row-selection is in scope for any of them.
-- [ ] Build a sweep harness across all four crossover axes (shape of `bench_cost_guards.py` /
-      `build_guard_corpus.py`), covering `price_usd`, `released_at`, and `collector_number`, plus
-      at least one deliberately-adversarial synthetic case (mismatched order-by field) and both
-      `unique` modes.
-- [ ] Calibrate the guard from measurement (or confirm one design dominates and no guard is
-      needed).
+- [x] Prove/reject idea 1's premise — rejected, see "Idea 1 ... REJECTED" above: no order-by
+      support for `released_at`/`collector_number`, no permutation table for `price_usd`, so the
+      aligned/cheap case is unreachable for any target field.
+- [x] Implement `PlaneExpr::PrintingRangeBits` for `price_usd`, wired into `eval_planes`,
+      `plane_expr_is_existential`, `eval_plane_expr_for_printing`, `collect_existential_indices`,
+      and `compile_plane`/`compile_plane_neg`'s `NumericCmp` arms — see "Shipped" above for the
+      two ways the final shape differs from the original sketch.
+- [x] Benchmark against today's baseline for `unique=card` — real win confirmed (~0.4-1ms → ~0.18ms
+      on `usd<50`).
+- [ ] Extend row-selection to `unique=printing`/`artwork`: loosen `split_planes`'s `unique_is_card`
+      gate and `run_query`'s `existential_plane` `Mode::Card` gate for `PrintingRangeBits`
+      specifically (the eval-time correctness is already written and tested; only the dispatch
+      gating needs to change). Benchmark separately — `unique=printing`/`artwork` pay the
+      `cards_of_printings`/dedup cost `unique=card` doesn't, may not win by the same margin.
+- [ ] Extend to `collector_number`/`released_at` (`DateCmp`/`YearCmp`, separate `compile_plane`
+      arms from `NumericCmp`'s).
 - [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the
       Prerequisite section to here) — either bring it into scope (needed for `-usd>8`-shaped
       queries, a real fragment in `test_engine_property.py`'s own suite) or explicitly defer it
       again to a third, later piece of work, with a stated reason rather than silently dropping it.
-- [ ] Acceptance: `usd<50`, a broad `released_at`/`collector_number` query, and the adversarial
-      case all improve or stay flat vs. baseline for at least one `unique` mode; no regression on
-      the existing #634/#655 exact paths; passes (and likely extends, given this exact class of
-      change already produced two independent bugs in the price prerequisite work)
-      `test_engine_property.py`'s differential suite against the reference oracle — a performance
-      delta alone is not sufficient to call this done.
+- [ ] Acceptance: a broad `released_at`/`collector_number` query and `unique=printing`/`artwork`
+      on `usd<50` all improve or stay flat vs. baseline; no regression on the existing #634/#655
+      exact paths; passes (and likely extends, given this exact class of change already produced
+      two independent bugs in the price prerequisite work and one in this slice's own negation
+      handling) `test_engine_property.py`'s differential suite against the reference oracle — a
+      performance delta alone is not sufficient to call this done.
 
 ## Related
 

--- a/docs/issues/local-engine-direct-projection-arrays.md
+++ b/docs/issues/local-engine-direct-projection-arrays.md
@@ -1,0 +1,181 @@
+# Engine: direct printing→card / printing→group projection arrays
+
+Status: **`printing_to_card` shipped** 2026-07-14, no GitHub issue yet. Surfaced investigating
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s crossover axis 4
+(does `unique=card`'s exact `total` cost too much to make its fast-path win moot?) — turned into a
+standalone win independent of that project, landed first since it changed the baseline costs that
+doc's crossover math depends on.
+
+**Why build `printing_to_card` before the fastpath project picks a direction, rather than
+deferring it alongside `printing_to_global_group`**: it pays for itself either way that project
+goes. It has a real (if narrow) win today for `cards_of_printings`' broad-k `Vec` path. It's also
+load-bearing for Idea 1 specifically, if that's the direction chosen: Idea 1 walks the order-by
+permutation, visiting printings in permutation order rather than printing-id order, so the
+monotone-cursor trick (which needs ascending printing ids) is never available there — every
+matched printing's card-identity check during that walk would otherwise pay a binary search, the
+exact access pattern the direct array wins decisively at. Idea 2 (`PrintingRangeBits`) scatters
+into a card bitmap upfront — the "already a bitmap" case benchmarked below, where the direct array
+is a wash — so this is neutral to Idea 2, not a loss either way.
+
+## Problem
+
+Before this change, projecting a printing-id set up to card space (`cards_of_printings`,
+`lib.rs:2392-2407`) had no materialized `printing_id -> card_id` mapping. It derived the card from
+`offsets` (a compact `Vec<(start_printing_idx)>` per card) two different ways depending on size:
+
+- **k ≤ 1024**: `offsets.partition_point(...)` per printing — a binary search, `O(log n_cards)` each.
+- **k > 1024**: scatter into a printing-space bitmap, then walk it with `printing_bits_to_card_bits`'s
+  monotone cursor (introduced in [#637](https://github.com/jbylund/sylvan_librarian/pull/637),
+  which also added the 1024 split) — `O(k + n_cards)`, no per-posting search, but two full passes
+  (build the printing bitmap, then walk it) and a `bitmap_card_ids` materialization if a `Vec` is
+  needed. Checked #637 for a reason a direct array was rejected in favor of this — found none; it
+  reads like the monotone cursor was simply the improvement tried over binary search, not a choice
+  made against a direct array specifically.
+
+Prototyping an analogous `groups_of_printings` (artwork-group dedup, for
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s `unique=artwork`
+question) hit this same shape, but *without* the monotone-cursor option: a card's local
+artwork-group ids aren't ascending within its printing range (they can interleave, e.g. `0, 1, 0,
+2`), so the `printing_bits_to_card_bits` trick doesn't transfer. The only projection available was
+per-printing binary search — even past k=1024, unlike `cards_of_printings`.
+
+## Finding: a direct array wins when you already have an id list, not when the input is a bitmap
+
+Benchmarked in `card_engine/src/bench_card_dedup.rs`
+(`cargo test --release bench_card_dedup -- --ignored --nocapture`), synthetic offsets at real
+corpus scale (31,508 cards / ~97-115k printings / ~46-55k groups), all times ns/match, best-of-50:
+
+| k (broad) | `cards_of_printings` (old) | direct array, from id list | `groups_of_printings` (binary search) | direct array, from id list |
+|-----------|---------------------------:|----------------------------:|----------------------------------------:|-----------------------------:|
+| 7,267 (6%) | 3.84 | 1.40 | 7.63 | 1.31 |
+| 60,166 (52%) | 3.74 | 1.79 | 7.94 | 1.65 |
+| 95,724 (83%) | 3.19 | 1.55 | 7.30 | 1.54 |
+
+Same k values, but isolating just the "cursor vs. direct array" step when the input is *already a
+bitmap* (`Candidates::PrintingBits`, no id list to exploit) — the other two call sites of
+`printing_bits_to_card_bits`:
+
+| k (broad) | cursor | direct array lookup |
+|-----------|--------:|----------------------:|
+| 7,267 (6%) | 2.16 | 2.57 |
+| 60,166 (52%) | 1.75 | 1.58 |
+| 95,724 (83%) | 1.50 | 1.52 |
+
+These are a wash — the earlier ~2x win isn't "direct array beats the monotone cursor at the lookup
+step." It's "when you already have a sorted id list, scattering it straight into the output space
+and skipping the intermediate printing-bitmap round-trip is cheaper than building that bitmap just
+to re-extract the same ids from it." `cards_of_printings`' broad-k path did the latter (built a
+printing bitmap from an id list it already had, purely to hand it to `printing_bits_to_card_bits`)
+— that round-trip was the actual waste, not the cursor.
+
+`groups_of_printings`' ~4.5-5.9x win is real, in isolation, for the mechanism it replaces (binary
+search per printing — no monotone-cursor option ever existed for groups). **But that mechanism
+isn't used anywhere today.** Checked the real `unique=artwork` implementation
+(`card_match_count`'s `Mode::Artwork` arm, `lib.rs:3456-3470`, and `run_query_streamed`,
+`lib.rs:4025-4092`) — it has no global printing-set-to-group-set projection at all. It computes
+counts per candidate *card*, walking that card's own small printing range and OR-ing bits into a
+tiny per-card local `seen_words` scratch buffer (typically ~3 printings, cheap regardless).
+`groups_of_printings` was invented answering a hypothetical for
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s Idea 1 (walking the
+order-by permutation, which *would* need incremental dedup-while-walking) — it is not a fix for
+any measured cost in the current architecture, and claiming it would broadly speed up
+`unique=artwork` queries today was wrong. The real, already-documented cost differential for
+`Mode::Artwork` vs `Mode::Card` is unrelated to dedup: the `all_match_known` short-circuit is
+deliberately disabled for `Mode::Artwork` (`lib.rs:4064-4071`, a measured codegen regression when
+enabled unconditionally), and `Mode::Artwork` can't return at the first matching printing the way
+`Mode::Card` does, since a later printing could introduce a new distinct group. Neither is
+something a lookup array changes.
+
+`printing_bits_to_card_bits` **itself stays.** It's still the right (and already-fast) mechanism
+for its other two call sites (`Candidates::into_cards`/`into_card_space`'s `PrintingBits` arms),
+which start from a bitmap with no id list behind it. Only `cards_of_printings`' broad-k path
+stopped calling it, in favor of scattering the id list it already holds directly.
+
+## Shipped: `printing_to_card` in the archive
+
+Added `printing_to_card: Vec<u32>` to `CardIndexes` (`lib.rs`), built once at write time by
+`build_printing_to_card(&offsets)` — a single linear pass over `offsets`, no hash table. Persisted
+in the archive (not a per-process cache): mmap pages are shared read-only across every worker
+process via the OS page cache, so the ~380KB array costs one physical copy total regardless of
+worker count, and the O(n_printings) build cost is paid once by the writer, not once per reader.
+Bumped `ARCHIVE_FORMAT_VERSION` (`20260725` → `20260726`).
+
+`cards_of_printings` now uses it in **both** branches — not just broad-k:
+
+```rust
+fn cards_of_printings(offsets: &AOffsets, printing_to_card: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
+    if printing_ids.len() > 1024 {
+        let n_cards = offsets.len().saturating_sub(1);
+        let bits = scatter_bits(printing_ids.iter().map(|&p| u32::from(printing_to_card[p as usize])), n_cards);
+        return bitmap_card_ids(&bits);
+    }
+    let mut out: Vec<u32> = Vec::with_capacity(printing_ids.len());
+    for &p in printing_ids {
+        let card = u32::from(printing_to_card[p as usize]);
+        if out.last() != Some(&card) {
+            out.push(card);
+        }
+    }
+    out
+}
+```
+
+The small-k branch keeps its shape (push + adjacent-dedup, no bitmap allocation) but swaps
+`partition_point` for the direct array too — unconditionally cheaper, no downside, no need for a
+separate crossover decision between the two lookup mechanisms.
+
+`printing_to_global_group`/`groups_of_printings` remain **deferred, not shipped** — see "Finding"
+above. Nothing in the current codebase would consume them. Revisit only if/when
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) actually commits to
+building Idea 1; the benchmark numbers above are recorded there for that future decision.
+
+**Verified, not just argued:**
+
+- `cards_of_printings_matches_naive_projection_across_sizes` (`tests.rs`) — differential test
+  against an independent reference oracle (`partition_point` on `offsets`, applied uniformly
+  regardless of size — the mechanism the old small-k path itself used), 40 seeds × 9 k values
+  straddling the 1024 small/broad split, both branches. Confirmed it actually catches a bug: an
+  injected off-by-one in the broad-k lookup failed the test immediately (seed=0, k=1025), reverted
+  before landing.
+- `cards_of_printings_maps_and_dedups` (existing unit test) still passes unchanged.
+- Full suite: **117 passed** (debug and release), 8 ignored (kernel benchmarks). `cargo clippy`:
+  37 warnings, identical set to baseline — no new warnings from this change.
+- Real benchmark against the shipped implementation (not just the prototype):
+  `cards_of_printings` now runs at ~1.7-1.9ns/match across the same real-corpus-shaped sweep,
+  confirming the ~2x win holds in the actual code, not just the exploratory version.
+
+## Open questions
+
+- Does the small-k binary search path in `cards_of_printings` still win below some k, or does the
+  direct array dominate unconditionally once it exists? **Resolved**: the direct array is
+  unconditionally cheaper (O(1) vs O(log n_cards) per lookup, no downside), so both branches now
+  use it — the only remaining question the 1024 split answers is bitmap-scatter vs. push+dedup,
+  unrelated to the lookup mechanism.
+- Quantify the real impact: how often does a real query actually land k in the (1,000, ~25% of
+  index] `Vec`-path window for `price_usd`/`collector_number`/`released_at`? Price's own
+  distribution rarely does (see fastpath doc's selectivity sweep) — worth checking
+  `collector_number`/`released_at` against the real corpus. Not yet done — still open.
+- `reload_commit` cost of building `printing_to_card` — expected cheap (one linear pass), not yet
+  measured against a real reload.
+
+## Plan
+
+- [x] Differential test: new `cards_of_printings` (both branches) vs. an independent reference
+      oracle, byte-identical output — confirmed to catch a real injected bug.
+- [x] Add `printing_to_card` to the archive, bump `ARCHIVE_FORMAT_VERSION`.
+- [x] Ship `printing_to_card` in `cards_of_printings`, both branches.
+- [x] Re-benchmark `cards_of_printings` against the real shipped implementation (not just the
+      prototype) — win confirmed (~1.7-1.9ns/match).
+- [ ] Measure `reload_commit` cost of building `printing_to_card` against a real reload.
+- [ ] Quantify how often real `collector_number`/`released_at` queries land in the Vec-path
+      selectivity window, to size the practical impact beyond price (which rarely does).
+- [ ] Once real-world impact is quantified, fold the updated baseline numbers into
+      [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s crossover
+      axis 4.
+
+## Related
+
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — where this was
+  discovered; crossover axis 4 depends on this having landed.
+- [#637](https://github.com/jbylund/sylvan_librarian/pull/637) — introduced `cards_of_printings`'
+  1024 split and `printing_bits_to_card_bits`'s monotone cursor.

--- a/docs/issues/local-engine-large-scale-differential-fuzzer.md
+++ b/docs/issues/local-engine-large-scale-differential-fuzzer.md
@@ -1,0 +1,52 @@
+# Engine: large-scale differential fuzzer (catches scale-gated bugs the small fuzzer can't)
+
+Status: idea only, not started. Surfaced by the NULL-over-inclusion bug in
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — `range_narrowed`'s
+complement branch (only reachable once a query's match count crosses `NARROW_FLOOR`, 1,000
+entries) over-included NULL-valued printings, and neither of the two existing differential
+checks could catch it:
+
+- `fuzz_row_identity_matches_reference` (Rust, `tests.rs`) generates stores with `ncards =
+  rng.random_range(5..=15)`, 1-3 printings each — at most ~45 printings total, structurally unable
+  to cross `NARROW_FLOOR` no matter how many seeds or filter shapes run.
+- `test_engine_property.py` (Python) *does* cross the threshold (asserts `engine.size() >= 6000`
+  and a broad query's total `> 1000` specifically to exercise this) and did catch the bug once
+  actually run — but it needs `pytest`, not `cargo test`, so it's a slower, separate feedback loop
+  than the Rust suite most engine changes are checked against day-to-day.
+
+## The idea
+
+A new Rust-side fuzz test, structured like `fuzz_row_identity_matches_reference` but building one
+large synthetic store (~100k printings, ~30k cards) with a distribution shaped like the real
+corpus (`benchmarks/bitplanes/corpus.jsonl` is the reference) rather than uniform-random — same
+NULL rates per field, similar rarity/type/color distributions — so it reliably crosses
+`NARROW_FLOOR`/`MAX_NARROW_FRACTION` for every narrowable field, not just by luck.
+
+## Why not just scale up the existing fuzzer
+
+`fuzz_row_identity_matches_reference` rebuilds a fresh store from scratch per seed (96 seeds ×
+serialize-to-rkyv + archive-access each time) and the whole `cargo test` suite currently finishes
+in well under a second. Scaling every seed's store to 100k printings would turn that into a
+multi-second (or worse) `cargo test` run, trading away the fast local-iteration loop the rest of
+this codebase's test suite is built around. A large-scale check needs to be a separate,
+`#[ignore]`-by-default test (the codebase already has 8 such tests for exactly this "slower, run
+explicitly" pattern) — built once (or a handful of times, not per-seed), checked against many
+filters.
+
+## Open questions (not resolved — this is a stub, not a plan)
+
+- Build the realistic-distribution generator once and reuse across runs (fixture file?) or
+  regenerate on each explicit run?
+- How many filter shapes to check per run, and does `fuzz_targeted`/`fuzz_gen` (the existing
+  filter-generation helpers) need extending for shapes that specifically stress broad/complement
+  narrowing (deliberately-broad thresholds per field), or does random generation already produce
+  enough of them at this scale?
+- Where does this run: a dedicated `cargo test -- --ignored` CI step, or folded into
+  `make test-integration`?
+
+## Related
+
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — the bug that
+  motivated this idea, including the exact mechanism (`range_narrowed`'s complement branch) and
+  the fix (`must_be_tight`, forcing a direct scatter instead of a NULL-over-including complement
+  for any caller that needs an unverified existential fact).

--- a/docs/issues/local-engine-printing-mode-existential-fastpath-attempt.md
+++ b/docs/issues/local-engine-printing-mode-existential-fastpath-attempt.md
@@ -1,0 +1,122 @@
+# Engine: unique=printing/artwork existential fastpath — investigated, both fixes reverted
+
+Status: investigated and reverted 2026-07-14, no GitHub issue — extracted from
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md), which shipped
+`PlaneExpr::PrintingRangeBits` for `usd`/`unique=card` and then asked whether the same idea helps
+`unique=printing`/`artwork` too. It doesn't, for a reason inherent to what those modes need — see
+below.
+
+## Why these modes stayed slow
+
+`run_query`'s speed for `unique=card` doesn't come from a smaller candidate set — for `usd<50`
+(83% selective) the narrowed set gets discarded by the broadness-guard regardless of mode. The
+real mechanism is `run_query_streamed_popcount`: it answers `total` directly from a bitmap's
+popcount and walks only `limit` set bits via a permuted-bitmap word-skip, never materializing or
+iterating a candidate list. That function is hard-gated to `Mode::Card` (`lib.rs:3941`), and
+extending it to `unique=printing`/`artwork` is **issue #656**, still open — quoting its own scope
+note, it needs "a weighted set-bit walk... card weights are O(1) via offsets-diff/artwork_groups...
+Not implemented." The original Legality carve-out (`docs/issues/done/00667-...md`) scoped this out
+identically, stating outright that those two modes "need no change: they already... run the
+existing (correct) per-printing `card_pass` walk."
+
+**#656 as scoped doesn't actually cover this case.** Its weighted-walk sketch assumes "under
+`all_match`" — every printing of a matching card counts, an O(1) weight lookup (`offsets`-diff or
+`artwork_groups`). For an *existential* fact like price, the weight is "how many printings/groups
+actually satisfy the predicate," which cannot be read from a count table — it requires visiting
+that card's printings, the same O(matching printings) work `card_match_count` already does. There
+is no way around this for an exact total: unlike `unique=card` (needs only existence, O(1) via the
+bitmap), `unique=printing`/`artwork` inherently need to know *which* printings qualify.
+
+## Two fixes implemented and empirically verified, instead of the full weighted-walk mechanism
+
+1. **`split_planes` narrowing-only fold**: when an existential leaf can't safely fold to a bare
+   `True` residual (wrong mode), it now still returns the compiled plane for `candidate_cards`
+   narrowing (avoiding the broadness-discard-to-full-scan fallback `plane=None` takes), while
+   leaving the residual unchanged so per-printing correctness still comes from the ordinary
+   `card_pass` walk, not the plane. `run_query`'s own `existential_plane` (row-selection) gate
+   stays `Mode::Card`-only, deliberately — using it here too would redundantly re-check the same
+   predicate the residual already checks. Verified via debug instrumentation: `candidate_cards`
+   for `usd<0.1`/`unique=printing` narrows correctly from 31,508 to 4,738 cards.
+2. **Weighted permuted-bitmap walk** in `run_query_streamed`'s "large totals" branch, replacing a
+   raw `perm.iter()` scan of all `n_cards` entries with a bitmap-scatter-and-`trailing_zeros` walk
+   (mirroring `run_query_streamed_popcount`'s mechanism, but reading `counts[cid]` as a
+   *variable* per-card weight instead of a uniform 1, since whole words can't be skipped by
+   popcount alone when weights vary). This is the real, generic fix for the adversarial shape
+   `#634`'s own design worried about (`released_at>2026-06-01 order by released_at`-style: low
+   selectivity, order-by uncorrelated with or opposed to the predicate, forcing a walk deep into
+   the permutation) — verified correct via the full test suite (particularly
+   `fuzz_row_identity_matches_reference`'s 96-seed property fuzzer) and via direct timing
+   instrumentation.
+
+**Why neither moved the `usd<50`-shaped benchmark numbers**: instrumented both phases directly.
+For `usd<50`/`usd<0.1` under `unique=printing`, the *match* phase (visiting narrowed candidates,
+checking their printings) costs 200μs–1.1ms and dominates completely; the walk/emission phase
+costs low single-digit microseconds either way, old or new, because `limit`-based early
+termination already made the *old* raw-permutation scan cheap for these specific queries (dense,
+early matches in `edhrec_rank` order) — its O(n_cards) worst case was real but not hit here. The
+weighted-walk fix's value is real but narrower than hoped: it matters for deep pagination /
+adversarial ordering, not for the broad, offset-0 queries this whole project has benchmarked. The
+match-phase cost is the true, inherent floor for these modes under an existential predicate, and
+no bitmap/walk cleverness removes it — only narrowing the candidate set (fix 1, above) helps, and
+only in proportion to selectivity (a small win at `usd<50`'s 83%, a bigger one at low selectivity).
+
+**Real-corpus benchmark, full sweep, both fixes applied**: `unique=printing`/`artwork` unchanged
+from baseline (~1.2ms) across `usd<0.1` through `usd<50`. `unique=card` unaffected by either fix
+(still ~0.18ms). Both fixes passed 118/118 tests with no new clippy warnings at the time — but see
+below.
+
+## What broader testing found (both fixes reverted)
+
+Asked "do these fixes help any other queries?" — a reasonable question, since both fixes are
+field-agnostic (any existential leaf, not just price). Benchmarking existing legality/rarity/
+border queries under `unique=printing`/`artwork` (`f:commander`, `f:legacy`, `f:modern`,
+`r:common or r:uncommon`, `-border:black`) — none of which this investigation had tested, since
+all prior benchmarking used only `usd<X` — found real problems in both fixes:
+
+- **Fix 2 (weighted walk): a real, reproducible ~10-18% regression** on every one of those
+  queries, confirmed via clean back-to-back A/B against a `git worktree` build of the pre-fix
+  commit. Cause: the walk's bitmap-scatter step is O(n_cards) *unconditionally*, paid even when
+  the old raw-permutation walk would have terminated early (the common case for broad predicates
+  in default `edhrec_rank` order — confirmed by directly timing a simplified reproduction of the
+  old walk logic, which took ~1.3μs for the exact queries this whole project benchmarked,
+  nowhere near its O(n_cards) worst case). Net: pays an unconditional cost to fix a worst case
+  that essentially never triggers for these query shapes.
+- **Fix 1 (narrowing-only fold): its own regression on near-total matches** (`f:commander` at
+  99.8%) for the same reason — `candidate_cards`'s `Some(expr)` branch has no broadness-discard
+  check, unlike the `plane=None` branch, so it unconditionally pays `bitmap_card_ids` materialization
+  for a match rate where there's nothing to narrow.
+- **Attempting to fix *that* regression (adding a discard check to the `Some(expr)` branch)
+  introduced a real correctness bug**, caught by `fuzz_row_identity_matches_reference`: for a
+  compound `And` where `split_planes` partitions one child into the plane and leaves another in
+  the residual (e.g. `rarity>0 AND types!=X`, with `types!=X` folded into the plane and `rarity>0`
+  left as the residual), discarding the plane-derived `candidate_cards` silently drops the
+  plane's constraint entirely — nothing else re-checks it, since the residual only knows about
+  `rarity>0`. This is different from fix 1's own narrowing-only scenario (residual = the *same*
+  predicate the plane represents, so discarding and falling back to the residual is safe) — the
+  two cases reach the same code path and are not distinguishable there without deeper surgery.
+  Confirmed the bug was newly introduced (not pre-existing) by reproducing it against a
+  `git worktree` build of the pre-fix commit, where the fuzzer passed cleanly.
+
+Given fix 2 provides no measured benefit for any tested query and a real regression on several,
+and fix 1 provides no measured benefit for its own target case (`usd<X`) and a real regression on
+near-total matches with no safe way found to fix that within this investigation's scope, both were
+reverted in full — confirmed byte-identical to the pre-investigation commit
+(`git diff <that-commit> -- lib.rs planes.rs tests.rs` is empty) and re-verified clean (118/118
+tests, no new clippy warnings, benchmarks back to baseline for both the `usd<X` sweep and the
+legality/rarity/border queries that exposed the problems).
+
+**Lesson carried forward**: validate performance changes against the engine's existing, varied
+query shapes, not only the query that motivated the change — the same lesson `#667`'s own
+"performance regression caught by the broad survey, not the targeted script" section already
+recorded, re-learned here at a different layer (candidate narrowing and pagination walks, not
+per-candidate dispatch). Re-applied one more time, at a third layer, extending
+`PrintingRangeBits` to `collector_number`/`released_at` — see
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md#collector_numberreleased_at-extension-and-a-second-broad-testing-lesson).
+
+## Related
+
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — the parent
+  project this was extracted from; ships the `unique=card` win this doc's investigation couldn't
+  extend further.
+- Closing this gap for real would need a different approach than #656's own scoped mechanism,
+  which doesn't cover existential facts — not attempted here.


### PR DESCRIPTION
## What this does

**None of this exists on `main` today.** This PR introduces the entire `PlaneExpr::PrintingRangeBits`
existential-plane mechanism from scratch: the `usd`/`unique=card` fastpath, the `collector_number`/
`released_at` extension, a compound-query performance fix, and a real correctness bug fix found
while re-benchmarking against actual `origin/main`. Full history in
[`docs/issues/local-engine-broad-range-fastpath.md`](docs/issues/local-engine-broad-range-fastpath.md);
the `unique=printing`/`artwork` investigation (two fixes tried, both reverted) is in
[`local-engine-printing-mode-existential-fastpath-attempt.md`](docs/issues/local-engine-printing-mode-existential-fastpath-attempt.md).

Printing-varying range predicates (`usd<50`, `cn<100`, `year>2020`, ...) are existential facts for
`unique=card` ("*some* printing satisfies this") — the same shape `format:`/`r:`/`border:` already
had a fast existential-plane answer for. This PR gives `usd`/`collector_number`/`released_at` the
same treatment: narrow the printing-space range index, project to a card-space bitmap, and answer
`unique=card` totals directly from a popcount instead of a full per-card scan.

**Also added since the PR was first opened** (three more commits, found while investigating the
`unique=printing`/`artwork` regression below — none require the `PrintingRangeBits` machinery above,
so a leaner version of two of them also ships independently in #690):

- **`NumExpr::eval`/`eval_arith` split** — a real, generic win (not specific to this PR's fields).
  `eval()` was self-recursive via `Arith`, so LLVM's always-inliner refused to inline it at *any*
  call site. Splitting the recursive case into its own function lets `#[inline(always)]` actually
  fold `eval()`'s dispatch into `FilterExpr::tri` for the common leaf case.
- **A duplicate-computation fix in `split_planes`** — see "Compound-query performance fix" below;
  distinct from, and does not resolve, the `unique=printing`/`artwork` regression this PR already
  documented as unfixed.
- **Price-cents at bind time, implemented, benchmarked, then reverted.** Tried rewriting a bare
  price `Field`-vs-`Const` comparison's `Const` to cents at bind time so `field_num` could skip a
  division per printing. Code review caught a real bug: the rewrite only covered that one exact
  shape, so `usd+1<power` and `usd<cmc` silently computed cents against a dollar operand -- off by
  100x. A type-level fix was possible but made two logically identical queries take inconsistently
  optimized paths depending on phrasing, which is the same fragility that caused the bug. Removed
  the optimization instead: `field_num` divides unconditionally again, matching every build before
  it existed. Kept two regression tests for this bug class
  (`usd_inside_arithmetic_evaluates_in_dollars_not_cents`,
  `usd_compared_directly_against_another_field_evaluates_in_dollars`). Net effect on this PR's
  numbers below: negligible -- see "Performance," the two commits above already carry `usd`'s win.

## A real correctness bug, found and fixed along the way

`range_narrowed`'s complement shortcut (used for majority-match queries) over-includes NULL-valued
printings — printings absent from the range index entirely (e.g. no price) get incorrectly counted
as satisfying the predicate. `usd<50`/`unique=card` on the real 97,206-printing corpus returned
**31,396 instead of the correct 31,217** — confirmed independently against the raw corpus data and
against `origin/main`. This is why the existing `Narrowed.tight` field exists, but the plane-compile
path never checked it before trusting `card_bits`' popcount directly.

Fixed by threading a `must_be_tight` flag through `compile_plane`, set only where it's actually
needed (`split_planes`'s `unique=card` fold — the one place that discards the residual and trusts
the bitmap unverified), plus an independent `exact` field on `PrintingRangeBits` as a second,
mutation-tested defense-in-depth layer. An initial attempt to force tightness *everywhere*
correctly fixed the bug but broke performance for the broadest queries — exactly the ones that
motivated this fastpath in the first place, since they're the ones that always hit the complement
shortcut. See the design doc's "A real correctness bug" section for the full story, including why
neither the existing Rust fuzzer nor (until this investigation) the Python differential suite had
actually caught it.

## Compound-query performance fix

Separately found (also via broad benchmarking, not the targeted queries that motivated this PR):
2+ existential leaves in one `And` (any pair of legality/rarity/border/usd/collector_number/
released_at) were wastefully narrowing-and-discarding before the shared-witness check could reject
composing them — including a latent instance of the same waste on `f:modern AND usd<50`, present
since the very first commit in this PR. Fixed with `has_conflicting_range_families`, a cheap
structural pre-check with no narrowing cost. Caught and fixed a bug in that fix too (an early cut
treated `Or` the same as `And`, regressing `r:common or r:uncommon` by ~8x) via benchmarking.

**A second, independent instance of this same class of waste**, found later while profiling: for
`unique=printing`/`artwork`, `split_planes`'s whole-filter fold can never succeed once a range leaf
(usd/cn/date/year) is anywhere in the filter — `PlaneExpr::PrintingRangeBits` is unconditionally
existential, and the fold requires a non-existential result for that mode — yet it still paid for
the full `compile_plane` call, including `into_card_space`'s bitmap conversion, before discarding
the result. Confirmed via a call counter + backtrace: a bare `usd<50`/`unique=printing` query called
`compile_price_range` twice per query, once here wastefully (~40% of total query time by profiling)
and once moments later in `narrow_rec`, which actually keeps it. Fixed with
`contains_range_family_leaf`, the same structural-pre-check pattern as `has_conflicting_range_families`
above. This removes real, measured waste (see "Performance" below) but is **not** the same thing as
the `unique=printing`/`artwork` regression in the next section, and does not fix it — that one is in
a different function entirely.

## Performance

Measured `origin/main` vs. this branch directly (interleaved A/B: both engines in the same process,
same timing windows, call order swapped between two runs to rule out ordering artifacts — a more
rigorous setup than the sequential harness used when this PR was first opened, adopted after that
harness gave inconsistent results across repeat runs), Docker fully quit, 8s sampling window per
query.

**Targeted** (97,206-printing corpus, two runs, call order swapped):

| query | unique | total | run 1 | run 2 |
|---|---|---:|---:|---:|
| `usd<50` | card | 31,217 | -42.9% | -43.4% |
| `usd<50` | artwork | 43,497 | **+7.4%** | **+8.3%** |
| `cn<100` | card | 17,616 | -75.5% | -78.8% |
| `cn<100` | artwork | 21,397 | -31.6% | -34.4% |
| `cn>=100` | card | 22,032 | -67.6% | -68.6% |
| `year>2020` | card | 18,249 | -63.0% | -63.9% |
| `year<2010` | card | 10,561 | -46.3% | -46.4% |
| `date>2023-01-01` | card | 13,742 | -71.2% | -71.6% |
| `date<2010-01-01` | card | 10,561 | -45.8% | -45.4% |
| `cn<100 AND t:creature` | card | 9,826 | -64.8% | -66.6% |
| `year>2020 AND t:creature` | card | 9,921 | -50.5% | -50.1% |

**Broad**:

| query | unique | total | run 1 | run 2 |
|---|---|---:|---:|---:|
| `f:commander` | card | 31,451 | +0.8% | +0.1% |
| `f:legacy` | card | 31,421 | +0.4% | +0.6% |
| `f:modern` | card | 22,264 | +0.1% | -0.2% |
| `r:common or r:uncommon` | card | 20,022 | +1.5% | +0.9% |
| `-border:black` | card | 5,463 | +3.9% | +5.5% |
| `usd<50` | printing | 80,527 | **+29.1%** | **+28.1%** |
| `cn<100` | printing | 35,021 | -35.4% | -35.3% |
| `year>2020` | printing | 46,445 | -16.9% | -15.2% |

Card-mode wins are solid and consistent with what this PR measured when first opened (small
methodology-driven variance, same order of magnitude throughout), and the legality/rarity/border
sweep is unaffected. Two real improvements over what this PR originally shipped: `cn<100`/printing
went from a 1.2x win to ~1.5x, and `year>2020`/printing went from flat to ~1.2x — both from the two
commits added this session.

**`usd<50` under `unique=printing`/`artwork` is still regressed, exactly as already documented when
this PR was first opened** — worse for `printing` (+28-29%, roughly unchanged from the original
~25%), improved but not resolved for `artwork` (+7-8%, down from ~25%). The
duplicate-computation fix above removed real waste from `split_planes`'s card-mode fold decision,
but that isn't what serves `printing`/`artwork` mode's candidate narrowing — `narrow_rec`'s own
fastpath is, and it unconditionally prefers `compile_plane`'s card-space bitmap over the
field-specific closure's printing-space narrowing whenever `compile_plane` succeeds. A card-space
candidate set is less useful there since it forces revisiting every printing of a matching card
instead of narrowing straight to the matching printings. Still tracked as follow-up work, not fixed
in this PR.

## Testing

- `cargo test` (debug + release): 126/126 passed, 8 ignored.
- `cargo clippy --release --all-targets`: unchanged from baseline, no new warnings.
- `pytest api/tests/test_engine_property.py` (250-seeded-query differential suite against a
  reference oracle, ≥6,000-card store): passes; confirmed it actually *fails* against the pre-fix
  code, not just theoretically able to.
- New Rust tests: `price_plane_does_not_overcount_null_priced_printings_when_broad` (the
  correctness-bug regression, both direct and compound shapes),
  `collector_number_plane_path_parity_and_shared_witness`,
  `released_at_plane_path_parity_and_shared_witness`,
  `cross_field_range_predicates_decline_shared_witness`,
  `legality_and_date_decline_shared_witness`, `range_conflict_check_does_not_penalize_bare_or`,
  `usd_inside_arithmetic_evaluates_in_dollars_not_cents`,
  `usd_compared_directly_against_another_field_evaluates_in_dollars`.
- Every fix mutation-tested directly: temporarily reintroduce the bug, confirm the relevant test
  fails, then revert.
