### PR TITLE
Speed Up Numeric Comparisons via eval() Inlining and a Direct Printing-to-Card Lookup Array

### DIFF
--- a/card_engine/src/bench_card_dedup.rs
+++ b/card_engine/src/bench_card_dedup.rs
@@ -1,0 +1,172 @@
+//! Micro-benchmark, split into two purposes:
+//!
+//! 1. Regression guard for `cards_of_printings`' direct-array projection
+//!    (`printing_to_card`, shipped — see
+//!    docs/issues/local-engine-direct-projection-arrays.md), benchmarked here
+//!    against synthetic offsets at real corpus scale.
+//! 2. Still-open exploration of `groups_of_printings`/`printing_to_global_group`
+//!    for crossover axis 4 of docs/issues/local-engine-broad-range-fastpath.md
+//!    — deferred, not shipped; kept here as the recorded evidence for that
+//!    future decision.
+//!
+//! Synthetic offsets at real scale (31,508 cards / 97,206 printings, ~3.09 printings/card
+//! average) rather than corpus-derived — this is about the cost *shape* at realistic scale, not
+//! validating one exact query, same reasoning as bench_posting_intersect.rs.
+//!
+//!     cargo test --release bench_card_dedup -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::RngExt;
+use rkyv::{rancor::Error, Archived};
+
+use super::{build_printing_to_card, cards_of_printings, scatter_bits, AOffsets};
+
+const N_CARDS: usize = 31_508;
+const ITERS: usize = 50;
+
+/// Prototype for the still-open question in crossover axis 4: would a
+/// groups_of_printings, mirroring cards_of_printings but deduping by (card, local
+/// artwork_group_id) instead of by card alone, close artwork mode's gap toward card
+/// mode's? Unlike cards_of_printings' small-k path, adjacent-compare-after-sort
+/// doesn't work here even for small k: printings within one card's range can visit
+/// local group ids in any order (0, 1, 0, 2, ...), so equal groups from the same
+/// card aren't necessarily adjacent in a printing-index-sorted walk the way card ids
+/// are (cards own contiguous ranges; groups don't have that property within a
+/// card's range). Always bitmap-scatter here rather than replicate that assumption
+/// incorrectly.
+fn groups_of_printings(offsets: &AOffsets, group_offsets: &[u32], local_group_ids: &[u16], printing_ids: &[u32], n_groups: usize) -> usize {
+    let global_ids = printing_ids.iter().map(|&p| {
+        let card = offsets.partition_point(|o| u32::from(*o) <= p) as u32 - 1;
+        group_offsets[card as usize] + u32::from(local_group_ids[p as usize])
+    });
+    let bits = scatter_bits(global_ids, n_groups);
+    bits.iter().map(|w| w.count_ones() as usize).sum()
+}
+
+/// Direct `printing_id -> global_group_id` lookup, precomputed once -- the same
+/// mechanism as `build_printing_to_card`, but deferred (not shipped) since nothing
+/// in the current codebase would consume it. See "Finding" in
+/// docs/issues/local-engine-direct-projection-arrays.md for why: `unique=artwork`'s
+/// real implementation dedupes per-card locally, not via a global projection.
+fn printing_to_global_group(offsets: &[u32], group_offsets: &[u32], local_group_ids: &[u16]) -> Vec<u32> {
+    let mut out = vec![0u32; local_group_ids.len()];
+    for (card, w) in offsets.windows(2).enumerate() {
+        for p in w[0]..w[1] {
+            out[p as usize] = group_offsets[card] + u32::from(local_group_ids[p as usize]);
+        }
+    }
+    out
+}
+
+fn groups_of_printings_direct(printing_to_group: &[u32], printing_ids: &[u32], n_groups: usize) -> usize {
+    let bits = scatter_bits(printing_ids.iter().map(|&p| printing_to_group[p as usize]), n_groups);
+    bits.iter().map(|w| w.count_ones() as usize).sum()
+}
+
+fn time_ns(mut kernel: impl FnMut() -> usize) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+/// Real per-card printing-count shape is heavily right-skewed (most cards 1-4 printings, a
+/// long tail to ~385 for basic lands) -- approximated here with a mostly-small-count
+/// distribution plus an occasional large one, landing on the real total printing count.
+fn synthetic_offsets(rng: &mut rand::rngs::SmallRng) -> (Vec<u32>, usize) {
+    let mut offsets = Vec::with_capacity(N_CARDS + 1);
+    offsets.push(0u32);
+    let mut total = 0u32;
+    for i in 0..N_CARDS {
+        let n = if i % 500 == 0 { rng.random_range(50..120) } else { rng.random_range(1..=6) };
+        total += n;
+        offsets.push(total);
+    }
+    (offsets, total as usize)
+}
+
+fn archive_u32_vec(v: &[u32]) -> Vec<u8> {
+    rkyv::to_bytes::<Error>(&v.to_vec()).expect("serialize").to_vec()
+}
+
+/// Real corpus shape (benchmarks/bitplanes/corpus.jsonl): 46,112 distinct illustrations over
+/// 31,508 cards / 97,206 printings -- 1.46 groups/card average, i.e. n_groups sits much closer
+/// to n_cards (1.46x) than to n_printings (47.4%). Approximated per-card here the same way
+/// printing counts are: mostly 1-2 groups, occasional larger (a card with several distinct
+/// arts), scaled to land near the real n_groups/n_printings ratio.
+fn synthetic_groups(rng: &mut rand::rngs::SmallRng, offsets: &[u32]) -> (Vec<u32>, Vec<u16>, usize) {
+    let mut group_offsets = Vec::with_capacity(N_CARDS + 1);
+    group_offsets.push(0u32);
+    let mut local_group_ids = vec![0u16; *offsets.last().unwrap() as usize];
+    let mut total_groups = 0u32;
+    for w in offsets.windows(2) {
+        let n_printings_this_card = (w[1] - w[0]) as usize;
+        let n_groups_this_card = rng.random_range(1..=n_printings_this_card.min(3)).max(1) as u16;
+        for (i, slot) in local_group_ids[w[0] as usize..w[1] as usize].iter_mut().enumerate() {
+            *slot = (i % n_groups_this_card as usize) as u16;
+        }
+        total_groups += u32::from(n_groups_this_card);
+        group_offsets.push(total_groups);
+    }
+    (group_offsets, local_group_ids, total_groups as usize)
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic data at real corpus scale"]
+fn bench_card_dedup_broad_vs_selective() {
+    let mut rng: rand::rngs::SmallRng = rand::make_rng();
+    let (offsets_vec, n_printings) = synthetic_offsets(&mut rng);
+    let offsets_bytes = archive_u32_vec(&offsets_vec);
+    let offsets: &AOffsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
+    let printing_to_card_vec = build_printing_to_card(&offsets_vec);
+    let printing_to_card_bytes = archive_u32_vec(&printing_to_card_vec);
+    let printing_to_card: &AOffsets = rkyv::access::<Archived<Vec<u32>>, Error>(&printing_to_card_bytes).expect("access printing_to_card");
+    let (group_offsets, local_group_ids, n_groups) = synthetic_groups(&mut rng, &offsets_vec);
+    let group_lookup = printing_to_global_group(&offsets_vec, &group_offsets, &local_group_ids);
+
+    println!("\nN_CARDS={N_CARDS}, n_printings={n_printings}, n_groups={n_groups}, ITERS={ITERS} (best-of), all times in ns");
+    println!(
+        "{:>10} {:>10}  {:>10} {:>10}  {:>10} {:>10}  {:>10} {:>10}",
+        "k", "match_pct", "cards (shipped)", "ns/match", "groups (bsearch)", "ns/match", "groups_dir (deferred)", "ns/match"
+    );
+
+    // Real k values from the actual corpus at each usd<X threshold in the selectivity sweep
+    // (benchmarks/bitplanes/corpus.jsonl, 97,206 real printings): 0.1, 0.5, 1, 5, 10, 25, 50.
+    // Scaled to this synthetic offsets' n_printings so the *fraction* matches the real sweep.
+    let real_fracs = [6114.0 / 97206.0, 50614.0 / 97206.0, 57854.0 / 97206.0, 71308.0 / 97206.0, 75738.0 / 97206.0, 79158.0 / 97206.0, 80527.0 / 97206.0];
+    for &frac in &real_fracs {
+        let k = (n_printings as f64 * frac) as usize;
+        let k = k.min(n_printings);
+        let mut printing_ids: Vec<u32> = {
+            let mut set = std::collections::HashSet::with_capacity(k);
+            while set.len() < k {
+                set.insert(rng.random_range(0..n_printings as u32));
+            }
+            set.into_iter().collect()
+        };
+        printing_ids.sort_unstable();
+
+        let t_cards = time_ns(|| cards_of_printings(offsets, printing_to_card, &printing_ids).len());
+        let t_groups = time_ns(|| groups_of_printings(offsets, &group_offsets, &local_group_ids, &printing_ids, n_groups));
+        let t_groups_dir = time_ns(|| groups_of_printings_direct(&group_lookup, &printing_ids, n_groups));
+        let pct = 100.0 * k as f64 / n_printings as f64;
+        println!(
+            "{:>10} {:>9.1}%  {:>15.0} {:>10.2}  {:>16.0} {:>10.2}  {:>21.0} {:>10.2}",
+            k,
+            pct,
+            t_cards,
+            t_cards / k as f64,
+            t_groups,
+            t_groups / k as f64,
+            t_groups_dir,
+            t_groups_dir / k as f64
+        );
+    }
+}

--- a/card_engine/src/bench_verify_cost.rs
+++ b/card_engine/src/bench_verify_cost.rs
@@ -162,3 +162,46 @@ fn bench_verify_cost_clusters() {
     println!("  regex machinery (literal prefix) : {machinery_ns:.3}");
     println!("  regex machinery (no prefix)      : {machinery_noprefix_ns:.3}");
 }
+
+/// Pins the per-card `NumericCmp` cost for usd/collector_number/year --
+/// exactly the fields whose bind-time-cents rewrite (usd) and eval/eval_arith
+/// split (all three) this file's own module docs point at as the thing
+/// being measured. `cmc` above already covers the generic Field<op>Const
+/// leaf; this adds the specific fields the interleaved A/B benchmarks (see
+/// commit history) reported real per-printing wins for, so a future
+/// regression in either optimization shows up here as a real ns/card
+/// number, not just a percentage in a PR description that can't be re-run.
+/// usd goes through `bind()` (same as a real query) rather than a
+/// hand-converted cents `Const`, so this also exercises the bind rewrite
+/// itself, not just field_num's read side.
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_price_and_range_verify_cost() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n = data.cards.len();
+    println!("\n{n} oracle cards from {STORE_PATH}");
+
+    let pairs: Vec<(usize, usize)> = (0..n).map(|cid| (cid, u32::from(data.offsets[cid]) as usize)).collect();
+    let run = |name: &str, f: &FilterExpr| -> f64 {
+        time_kernel(name, n, || pairs.iter().filter(|&&(cid, pid)| f.matches(&data.cards[cid], &data.printings[pid], &data.strings)).count() as u32)
+    };
+
+    println!("\n-- price / range NumericCmp (mask/field compare tier) --");
+    let mut usd = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    usd.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
+    run("NumericCmp (usd<50)", &usd);
+    run(
+        "NumericCmp (cn<100)",
+        &FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op: CmpOp::Lt, rhs: NumExpr::Const(100.0) },
+    );
+    run("YearCmp (year>2020)", &FilterExpr::YearCmp { op: CmpOp::Gt, year: 2020 });
+}

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -125,26 +125,42 @@ pub(crate) enum NumExpr {
 }
 
 impl NumExpr {
+    // #[inline(always)] alone doesn't reach the goal here: LLVM's
+    // always-inliner refuses to inline ANY self-recursive function at ANY
+    // call site, not just the recursive edge -- confirmed in the release
+    // disassembly, where a first attempt at just adding the attribute to a
+    // still-self-recursive eval() left both `bl NumExpr::eval` calls in
+    // FilterExpr::tri's NumericCmp arm untouched. Splitting the Arith case
+    // into its own (separately named, not force-inlined) function makes
+    // eval() itself non-recursive, so the attribute now actually applies:
+    // for the common Const/Field leaf case (e.g. `usd<50`, no arithmetic),
+    // eval()'s whole body -- including field_num, already small enough to
+    // inline on its own -- folds directly into tri(), eliminating both
+    // calls' prologue/epilogue/jump-table tax. Arith (`cmc+1<power`) is
+    // colder and still recurses through eval_arith, unaffected either way.
+    #[inline(always)]
     fn eval(&self, card: &AOracleCard, printing: Option<&APrinting>) -> NumVal {
         match self {
             NumExpr::Const(v) => NumVal::Known(*v),
             NumExpr::Field(f) => field_num(card, printing, *f),
-            NumExpr::Arith(lhs, op, rhs) => {
-                // Null dominates PDep: Null op anything is Null for every
-                // printing, so the card-level result is already exact.
-                match (lhs.eval(card, printing), rhs.eval(card, printing)) {
-                    (NumVal::Null, _) | (_, NumVal::Null) => NumVal::Null,
-                    (NumVal::PDep, _) | (_, NumVal::PDep) => NumVal::PDep,
-                    (NumVal::Known(l), NumVal::Known(r)) => match op {
-                        ArithOp::Add => NumVal::Known(l + r),
-                        ArithOp::Sub => NumVal::Known(l - r),
-                        ArithOp::Mul => NumVal::Known(l * r),
-                        ArithOp::Div => {
-                            if r == 0.0 { NumVal::Null } else { NumVal::Known(l / r) }
-                        }
-                    },
+            NumExpr::Arith(lhs, op, rhs) => Self::eval_arith(lhs, *op, rhs, card, printing),
+        }
+    }
+
+    fn eval_arith(lhs: &NumExpr, op: ArithOp, rhs: &NumExpr, card: &AOracleCard, printing: Option<&APrinting>) -> NumVal {
+        // Null dominates PDep: Null op anything is Null for every
+        // printing, so the card-level result is already exact.
+        match (lhs.eval(card, printing), rhs.eval(card, printing)) {
+            (NumVal::Null, _) | (_, NumVal::Null) => NumVal::Null,
+            (NumVal::PDep, _) | (_, NumVal::PDep) => NumVal::PDep,
+            (NumVal::Known(l), NumVal::Known(r)) => match op {
+                ArithOp::Add => NumVal::Known(l + r),
+                ArithOp::Sub => NumVal::Known(l - r),
+                ArithOp::Mul => NumVal::Known(l * r),
+                ArithOp::Div => {
+                    if r == 0.0 { NumVal::Null } else { NumVal::Known(l / r) }
                 }
-            }
+            },
         }
     }
 }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -89,15 +89,19 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
     fn known(v: Option<f32>) -> NumVal {
         v.map_or(NumVal::Null, |x| NumVal::Known(x as f64))
     }
-    // Cents -> dollars via exact f64 division, not through f32 -- 722.0 / 100.0 and a
-    // directly-parsed query constant "7.22" round to the identical nearest f64 (both are
-    // single, non-lossy roundings of the same rational number), so this and NumExpr::Const
-    // (untouched) always agree exactly. The old `v as f32 as f64` path widened an
-    // already-lossy f32 approximation, which essentially never matched a full-precision query
-    // constant even at the exact boundary it was supposed to represent -- see
+    // Raw cents, no dollars conversion: `FilterExpr::bind` rewrites a price
+    // NumericCmp's Const from dollars to cents once per query
+    // (`price_dollars_to_cents`), so this per-printing evaluation -- run
+    // once per candidate printing, the actual hot path -- never needs to
+    // divide. Comparing raw cents against a cents-scale Const is exact for
+    // the identical reason the old dollars-vs-dollars comparison was: both
+    // sides are single, non-lossy f64 values derived from the same
+    // rational number, just scaled by 100 instead of by 1. The old `v as
+    // f32 as f64` path (pre-#688) widened an already-lossy f32
+    // approximation, which is a separate, already-fixed bug -- see
     // docs/issues/local-engine-broad-range-fastpath.md.
     fn known_cents(v: Option<u32>) -> NumVal {
-        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents) / 100.0))
+        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents)))
     }
     match f {
         NumField::Cmc                => known(card.cmc.as_ref().map(|v| u8::from(*v) as f32)),
@@ -716,6 +720,25 @@ impl FilterExpr {
                 }
             }
             FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, mana_vocab, flavor, strings),
+            // usd/eur/tix<op>threshold: rewrite the query-side dollar Const to
+            // the exact cents value once per query (super::price_dollars_to_cents,
+            // shared with narrow_rec/compile_price_range so all three paths derive
+            // the identical cents value), so field_num's per-printing evaluation
+            // -- run once per candidate printing, not once per query -- can
+            // compare raw cents directly with no division. Only the Const
+            // side is rewritten; NumExpr::Field/Arith are left alone (an
+            // arithmetic expression mixing a price field with something
+            // else, e.g. `usd+1<power`, isn't a shape this rewrite covers).
+            // Unlike every other rewrite in this match (TextContains ->
+            // ArtistMatch/FlavorMatch), this one does NOT change the node's
+            // shape, so it is NOT idempotent -- calling bind twice on the
+            // same node would rescale the Const a second time. Callers must
+            // bind each filter exactly once, same as today's single
+            // `filter_expr.bind(...)` call site.
+            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), rhs: NumExpr::Const(v), .. }
+            | FilterExpr::NumericCmp { lhs: NumExpr::Const(v), rhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), .. } => {
+                *v = super::price_dollars_to_cents(*v);
+            }
             FilterExpr::ManaCostCmp { hybrids, hybrid_ids, .. } if !hybrids.is_empty() => {
                 *hybrid_ids = bind_mana_hybrids(hybrids, mana_vocab);
             }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -89,19 +89,17 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
     fn known(v: Option<f32>) -> NumVal {
         v.map_or(NumVal::Null, |x| NumVal::Known(x as f64))
     }
-    // Raw cents, no dollars conversion: `FilterExpr::bind` rewrites a price
-    // NumericCmp's Const from dollars to cents once per query
-    // (`price_dollars_to_cents`), so this per-printing evaluation -- run
-    // once per candidate printing, the actual hot path -- never needs to
-    // divide. Comparing raw cents against a cents-scale Const is exact for
-    // the identical reason the old dollars-vs-dollars comparison was: both
-    // sides are single, non-lossy f64 values derived from the same
-    // rational number, just scaled by 100 instead of by 1. The old `v as
-    // f32 as f64` path (pre-#688) widened an already-lossy f32
-    // approximation, which is a separate, already-fixed bug -- see
-    // docs/issues/local-engine-broad-range-fastpath.md.
+    // Cents -> dollars via exact f64 division, not through f32 -- 722.0 / 100.0 and a
+    // directly-parsed query constant "7.22" round to the identical nearest f64 (both are
+    // single, non-lossy roundings of the same rational number), so this and NumExpr::Const
+    // (untouched) always agree exactly. Unconditional, regardless of comparison shape
+    // (Arith, Field-vs-Field, bare Field-vs-Const, ...): a bind-time fast path that
+    // special-cased only the bare shape shipped two silent correctness bugs
+    // (`usd+1<power`, `usd<cmc` -- see docs/issues/local-engine-broad-range-fastpath.md)
+    // for a ~2-3% win on the one shape it covered, not worth the ongoing risk of a
+    // representation that's easy to bypass by rephrasing a logically identical query.
     fn known_cents(v: Option<u32>) -> NumVal {
-        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents)))
+        v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents) / 100.0))
     }
     match f {
         NumField::Cmc                => known(card.cmc.as_ref().map(|v| u8::from(*v) as f32)),
@@ -736,25 +734,6 @@ impl FilterExpr {
                 }
             }
             FilterExpr::Not(inner) => inner.bind(vocab, sorted_ids, artist_vocab, mana_vocab, flavor, strings),
-            // usd/eur/tix<op>threshold: rewrite the query-side dollar Const to
-            // the exact cents value once per query (super::price_dollars_to_cents,
-            // shared with narrow_rec/compile_price_range so all three paths derive
-            // the identical cents value), so field_num's per-printing evaluation
-            // -- run once per candidate printing, not once per query -- can
-            // compare raw cents directly with no division. Only the Const
-            // side is rewritten; NumExpr::Field/Arith are left alone (an
-            // arithmetic expression mixing a price field with something
-            // else, e.g. `usd+1<power`, isn't a shape this rewrite covers).
-            // Unlike every other rewrite in this match (TextContains ->
-            // ArtistMatch/FlavorMatch), this one does NOT change the node's
-            // shape, so it is NOT idempotent -- calling bind twice on the
-            // same node would rescale the Const a second time. Callers must
-            // bind each filter exactly once, same as today's single
-            // `filter_expr.bind(...)` call site.
-            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), rhs: NumExpr::Const(v), .. }
-            | FilterExpr::NumericCmp { lhs: NumExpr::Const(v), rhs: NumExpr::Field(NumField::PriceUsd | NumField::PriceEur | NumField::PriceTix), .. } => {
-                *v = super::price_dollars_to_cents(*v);
-            }
             FilterExpr::ManaCostCmp { hybrids, hybrid_ids, .. } if !hybrids.is_empty() => {
                 *hybrid_ids = bind_mana_hybrids(hybrids, mana_vocab);
             }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1969,6 +1969,17 @@ fn snap_to_nearest_cent(cents: f64) -> f64 {
     if (cents - rounded).abs() < 1e-6 { rounded } else { cents }
 }
 
+/// Convert a query-side dollar amount to the exact cents value price fields
+/// compare against -- shared by `FilterExpr::bind`'s one-time Const rewrite
+/// (real queries) and by tests constructing a price comparison directly
+/// (bypassing `bind`), so both derive the identical cents value from the
+/// identical dollar input. Two independent encodings of "how many cents is
+/// this dollar amount" quietly disagreeing is exactly Bug B's shape --
+/// this exists so there's only ever the one.
+pub(crate) fn price_dollars_to_cents(dollars: f64) -> f64 {
+    snap_to_nearest_cent(dollars * PRICE_CENTS_PER_DOLLAR)
+}
+
 /// Half-open [lo, hi) bounds for indexes over plain integers (collector
 /// number). Query values are f64 and may be fractional or out of range; bounds
 /// are chosen so the range is exact for every op — `cn<100.5` means
@@ -2888,10 +2899,13 @@ fn narrow_rec(
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
-            // Same shape as `cn` below now that price is integer cents, not lossy f32 dollars --
-            // the only price-specific step is snapping the *PRICE_CENTS_PER_DOLLAR conversion
-            // against its own floating-point noise before delegating to int_range_bounds.
-            let price = |op, v: &f64| match int_range_bounds(op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))? {
+            // `v` is already cents, not dollars: `FilterExpr::bind` rewrites a
+            // price `NumericCmp`'s query-side dollar `Const` to cents once
+            // per query (`price_dollars_to_cents`), so this -- called once
+            // per query, not once per printing -- no longer does its own
+            // dollars-to-cents multiplication. `snap_to_nearest_cent` stays
+            // as a defensive re-snap for any caller that skips `bind`.
+            let price = |op, v: &f64| match int_range_bounds(op, snap_to_nearest_cent(*v))? {
                 None => Narrowed::tight(Candidates::Printings(Vec::new())),
                 Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true),
             };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1880,6 +1880,23 @@ fn assign_artwork_groups(printings: &mut [Printing], offsets: &[u32]) -> Vec<u16
     counts
 }
 
+/// Direct `printing_id -> card_id` lookup, one linear pass over `offsets`.
+/// Benchmarked (`bench_card_dedup.rs`) at ~2x cheaper than the
+/// scatter-into-printing-bitmap-then-monotone-cursor path `cards_of_printings`
+/// otherwise pays past 1024 matches, and unconditionally cheaper than the
+/// small-k `partition_point` binary search too — see
+/// docs/issues/local-engine-direct-projection-arrays.md.
+fn build_printing_to_card(offsets: &[u32]) -> Vec<u32> {
+    let n_printings = offsets.last().copied().unwrap_or(0) as usize;
+    let mut out = vec![0u32; n_printings];
+    for (card, w) in offsets.windows(2).enumerate() {
+        for p in w[0]..w[1] {
+            out[p as usize] = card as u32;
+        }
+    }
+    out
+}
+
 // ─── Printing-space range indexes (released_at, price, collector number) ─────
 // Sorted (value, printing idx); binary-searched ranges answer range filters in
 // printing space. Printings without the value are absent (they can never
@@ -2199,6 +2216,10 @@ struct CardIndexes {
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
+    // printing space: printing_id -> card_id, direct lookup. Replaces a
+    // partition_point search on `offsets` in cards_of_printings' hot paths —
+    // see docs/issues/local-engine-direct-projection-arrays.md.
+    printing_to_card: Vec<u32>,
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
@@ -2227,6 +2248,7 @@ impl Default for CardIndexes {
             collector_number: Vec::new(),
             sort_perms:     SortPermutations::default(),
             artwork_groups: Vec::new(),
+            printing_to_card: Vec::new(),
             planes:         BitPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
@@ -2383,22 +2405,24 @@ fn printing_bits_to_card_bits(pbits: &[u64], offsets: &AOffsets, n_cards: usize)
     out
 }
 
-/// Map a sorted printing-id list up to its sorted card-id list. Printings are
-/// grouped contiguously by card, so the mapped list arrives sorted with adjacent
-/// duplicates — dedup is a single linear pass. Small lists pay a binary search
-/// per posting; past a few hundred, scattering into a printing bitmap and
-/// walking it with a monotone card cursor is cheaper (O(k + words) instead of
-/// O(k log n)) and produces the same ascending, deduped output.
-fn cards_of_printings(offsets: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
+/// Map a sorted printing-id list up to its sorted card-id list via the
+/// precomputed direct lookup (`CardIndexes::printing_to_card`). Printings are
+/// grouped contiguously by card, so the mapped list arrives sorted with
+/// adjacent duplicates — dedup is a single linear pass for small lists. Past
+/// a few hundred, scattering directly into a card bitmap and extracting set
+/// bits is cheaper than repeated pushes (same reasoning as `scatter_bits`
+/// elsewhere). Both branches use the direct array now — benchmarked
+/// unconditionally cheaper than a `partition_point` search on `offsets` at
+/// every k tested, see docs/issues/local-engine-direct-projection-arrays.md.
+fn cards_of_printings(offsets: &AOffsets, printing_to_card: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
     if printing_ids.len() > 1024 {
         let n_cards = offsets.len().saturating_sub(1);
-        let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
-        let bits = scatter_bits(printing_ids.iter().copied(), n_printings);
-        return bitmap_card_ids(&printing_bits_to_card_bits(&bits, offsets, n_cards));
+        let bits = scatter_bits(printing_ids.iter().map(|&p| u32::from(printing_to_card[p as usize])), n_cards);
+        return bitmap_card_ids(&bits);
     }
     let mut out: Vec<u32> = Vec::with_capacity(printing_ids.len());
     for &p in printing_ids {
-        let card = offsets.partition_point(|o| u32::from(*o) <= p) as u32 - 1;
+        let card = u32::from(printing_to_card[p as usize]);
         if out.last() != Some(&card) {
             out.push(card);
         }
@@ -2410,11 +2434,11 @@ impl Candidates {
     /// Project into card space (identity for card-space sets) and materialize
     /// as ascending card ids. Bitmap materialization needs no sort — set bits
     /// come out ascending, sidestepping the gather-and-sort cost of #609.
-    fn into_cards(self, offsets: &AOffsets) -> Vec<u32> {
+    fn into_cards(self, offsets: &AOffsets, printing_to_card: &AOffsets) -> Vec<u32> {
         let n_cards = offsets.len().saturating_sub(1);
         match self {
             Candidates::Cards(v) => v,
-            Candidates::Printings(v) => cards_of_printings(offsets, &v),
+            Candidates::Printings(v) => cards_of_printings(offsets, printing_to_card, &v),
             Candidates::CardBits(b) => bitmap_card_ids(&b),
             Candidates::PrintingBits(b) => bitmap_card_ids(&printing_bits_to_card_bits(&b, offsets, n_cards)),
         }
@@ -2453,11 +2477,13 @@ impl Narrowed {
 
     /// Project into card space. Printing→card projection is an existence
     /// projection ("some printing matches"), which loses tightness.
-    fn into_card_space(self, offsets: &AOffsets) -> Narrowed {
+    fn into_card_space(self, offsets: &AOffsets, printing_to_card: &AOffsets) -> Narrowed {
         let n_cards = offsets.len().saturating_sub(1);
         match self.set {
             Candidates::Cards(_) | Candidates::CardBits(_) => self,
-            Candidates::Printings(v) => Narrowed { set: Candidates::Cards(cards_of_printings(offsets, &v)), tight: false },
+            Candidates::Printings(v) => {
+                Narrowed { set: Candidates::Cards(cards_of_printings(offsets, printing_to_card, &v)), tight: false }
+            }
             Candidates::PrintingBits(b) => {
                 Narrowed { set: Candidates::CardBits(printing_bits_to_card_bits(&b, offsets, n_cards)), tight: false }
             }
@@ -3174,7 +3200,7 @@ fn narrow_rec(
                             Some(Narrowed { tight: false, ..seal(c) })
                         }
                         _ => {
-                            let pc = p.into_card_space(offsets);
+                            let pc = p.into_card_space(offsets, &indexes.printing_to_card);
                             and_all(vec![c, pc]).map(seal)
                         }
                     }
@@ -3214,7 +3240,7 @@ fn narrow_rec(
                 {
                     return None;
                 }
-                let sets = sets.into_iter().map(|s| s.into_card_space(offsets)).collect();
+                let sets = sets.into_iter().map(|s| s.into_card_space(offsets, &indexes.printing_to_card)).collect();
                 or_all(sets, n_cards)
             }
         }
@@ -3772,7 +3798,7 @@ fn run_query<'a>(
     // buffer.
     let candidate_cards: Option<Vec<u32>> = match plane {
         None => raw_candidates
-            .map(|c| c.into_cards(offsets))
+            .map(|c| c.into_cards(offsets, &indexes.printing_to_card))
             .filter(|v| v.len() < cards.len() - cards.len() / 8),
         Some(expr) => {
             thread_local! {
@@ -3795,7 +3821,7 @@ fn run_query<'a>(
                         Some(bitmap_card_ids(&b))
                     }
                     Some(c) => {
-                        let mut v = c.into_cards(offsets);
+                        let mut v = c.into_cards(offsets, &indexes.printing_to_card);
                         v.retain(|&cid| bitmap_contains(&bitmap, cid));
                         Some(v)
                     }
@@ -4279,7 +4305,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260725;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260726;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -4679,6 +4705,7 @@ impl QueryEngine {
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: artwork_group_counts,
+            printing_to_card: build_printing_to_card(&offsets),
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
@@ -4975,3 +5002,5 @@ mod bench_iter_dispatch;
 mod bench_posting_intersect;
 #[cfg(test)]
 mod bench_word_dict_scan;
+#[cfg(test)]
+mod bench_card_dedup;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1969,17 +1969,6 @@ fn snap_to_nearest_cent(cents: f64) -> f64 {
     if (cents - rounded).abs() < 1e-6 { rounded } else { cents }
 }
 
-/// Convert a query-side dollar amount to the exact cents value price fields
-/// compare against -- shared by `FilterExpr::bind`'s one-time Const rewrite
-/// (real queries) and by tests constructing a price comparison directly
-/// (bypassing `bind`), so both derive the identical cents value from the
-/// identical dollar input. Two independent encodings of "how many cents is
-/// this dollar amount" quietly disagreeing is exactly Bug B's shape --
-/// this exists so there's only ever the one.
-pub(crate) fn price_dollars_to_cents(dollars: f64) -> f64 {
-    snap_to_nearest_cent(dollars * PRICE_CENTS_PER_DOLLAR)
-}
-
 /// Half-open [lo, hi) bounds for indexes over plain integers (collector
 /// number). Query values are f64 and may be fractional or out of range; bounds
 /// are chosen so the range is exact for every op — `cn<100.5` means
@@ -2899,13 +2888,10 @@ fn narrow_rec(
             // complement would wrongly exclude cards `-rarity:x` matches.
             let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
-            // `v` is already cents, not dollars: `FilterExpr::bind` rewrites a
-            // price `NumericCmp`'s query-side dollar `Const` to cents once
-            // per query (`price_dollars_to_cents`), so this -- called once
-            // per query, not once per printing -- no longer does its own
-            // dollars-to-cents multiplication. `snap_to_nearest_cent` stays
-            // as a defensive re-snap for any caller that skips `bind`.
-            let price = |op, v: &f64| match int_range_bounds(op, snap_to_nearest_cent(*v))? {
+            // Same shape as `cn` below now that price is integer cents, not lossy f32 dollars --
+            // the only price-specific step is snapping the *PRICE_CENTS_PER_DOLLAR conversion
+            // against its own floating-point noise before delegating to int_range_bounds.
+            let price = |op, v: &f64| match int_range_bounds(op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))? {
                 None => Narrowed::tight(Candidates::Printings(Vec::new())),
                 Some((lo, hi)) => range_narrowed(&indexes.price_usd, lo, hi, n_printings, broad_ok, true),
             };

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, flavor_fingerprint, flavor_match_sets,
+    assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
@@ -243,6 +243,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups,
+        printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
     CardData {
@@ -268,11 +269,13 @@ fn narrow_candidates_spaces() {
     let mut keywords: TagIndex = HashMap::new();
     keywords.insert("Flying".to_string(), vec![1]);
 
-    let indexes = CardIndexes { art_tags, keywords, ..Default::default() };
+    // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
+    let raw_offsets = vec![0u32, 2, 4];
+    let printing_to_card = build_printing_to_card(&raw_offsets);
+    let indexes = CardIndexes { art_tags, keywords, printing_to_card, ..Default::default() };
     let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
     let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
-    // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
-    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 2, 4]).expect("serialize offsets");
+    let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize offsets");
     let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
 
     let coll = |field, value: &str| FilterExpr::CollectionCmp {
@@ -652,7 +655,7 @@ fn rarity_not_arm_matches_existence_projection() {
             let Some(n) = super::narrow_rec(&filter, &archived.indexes, &archived.offsets, &archived.cards, true) else {
                 continue;
             };
-            let cand = n.set.into_cards(&archived.offsets);
+            let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
             let want: Vec<u32> = RARITY_PLANE_FIXTURE
                 .iter()
                 .enumerate()
@@ -678,7 +681,7 @@ fn rarity_not_arm_matches_existence_projection() {
             }));
             let n2 = super::narrow_rec(&filter_flipped, &archived.indexes, &archived.offsets, &archived.cards, true)
                 .unwrap_or_else(|| panic!("Not({val} {name} field) must narrow given Not(field {name} {val}) did"));
-            let cand2 = n2.set.into_cards(&archived.offsets);
+            let cand2 = n2.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
             assert_eq!(cand, cand2, "operand order must not change the result: {name} {val}");
         }
     }
@@ -686,12 +689,72 @@ fn rarity_not_arm_matches_existence_projection() {
 
 #[test]
 fn cards_of_printings_maps_and_dedups() {
-    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 3, 4, 7]).expect("serialize");
+    let raw_offsets = vec![0u32, 3, 4, 7];
+    let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize");
     let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access");
+    let printing_to_card_bytes = rkyv::to_bytes::<Error>(&build_printing_to_card(&raw_offsets)).expect("serialize");
+    let printing_to_card = rkyv::access::<Archived<Vec<u32>>, Error>(&printing_to_card_bytes).expect("access");
     // printings 0-2 → card 0, 3 → card 1, 4-6 → card 2
-    assert_eq!(cards_of_printings(offsets, &[0, 1, 2, 3, 5, 6]), vec![0, 1, 2]);
-    assert_eq!(cards_of_printings(offsets, &[1]), vec![0]);
-    assert_eq!(cards_of_printings(offsets, &[]), Vec::<u32>::new());
+    assert_eq!(cards_of_printings(offsets, printing_to_card, &[0, 1, 2, 3, 5, 6]), vec![0, 1, 2]);
+    assert_eq!(cards_of_printings(offsets, printing_to_card, &[1]), vec![0]);
+    assert_eq!(cards_of_printings(offsets, printing_to_card, &[]), Vec::<u32>::new());
+}
+
+/// Differential test for the direct-array projection
+/// (docs/issues/local-engine-direct-projection-arrays.md): `cards_of_printings`
+/// must agree with an independent reference oracle (a `partition_point` search on
+/// `offsets`, applied uniformly regardless of size -- the mechanism the small-k
+/// path itself used before this change) at every k, spanning both the small-k
+/// (<=1024) and broad-k (>1024) branches, so the branch split is provably a pure
+/// performance choice, not a behavior change.
+#[test]
+fn cards_of_printings_matches_naive_projection_across_sizes() {
+    use rand::SeedableRng;
+    const NUM_SEEDS: u64 = 40;
+    const N_CARDS: usize = 200;
+
+    for seed in 0..NUM_SEEDS {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        let mut raw_offsets = Vec::with_capacity(N_CARDS + 1);
+        raw_offsets.push(0u32);
+        let mut total = 0u32;
+        for _ in 0..N_CARDS {
+            total += rng.random_range(1..=20);
+            raw_offsets.push(total);
+        }
+        let n_printings = total as usize;
+
+        let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize");
+        let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access");
+        let printing_to_card_vec = build_printing_to_card(&raw_offsets);
+        let printing_to_card_bytes = rkyv::to_bytes::<Error>(&printing_to_card_vec).expect("serialize");
+        let printing_to_card = rkyv::access::<Archived<Vec<u32>>, Error>(&printing_to_card_bytes).expect("access");
+
+        // k values straddling the 1024 small/broad split; clamp to n_printings.
+        for &k in &[0usize, 1, 5, 50, 999, 1024, 1025, 2000, 5000] {
+            let k = k.min(n_printings);
+            let mut printing_ids: Vec<u32> = {
+                let mut set = std::collections::HashSet::with_capacity(k);
+                while set.len() < k {
+                    set.insert(rng.random_range(0..n_printings as u32));
+                }
+                set.into_iter().collect()
+            };
+            printing_ids.sort_unstable();
+
+            let got = cards_of_printings(offsets, printing_to_card, &printing_ids);
+
+            // Reference oracle: partition_point on offsets directly, shares no
+            // code with build_printing_to_card or cards_of_printings' branches.
+            let mut want: Vec<u32> = printing_ids
+                .iter()
+                .map(|&p| raw_offsets.partition_point(|&o| o <= p) as u32 - 1)
+                .collect();
+            want.dedup();
+
+            assert_eq!(got, want, "seed={seed}, k={k}, n_printings={n_printings}");
+        }
+    }
 }
 
 #[test]
@@ -2019,6 +2082,7 @@ fn bench_checked_vs_unchecked_access() {
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups,
+        printing_to_card: build_printing_to_card(&offsets),
         planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
@@ -3739,7 +3803,7 @@ fn oracle_word_index_exact_union_parity() {
         let expected = brute_force_oracle_contains(archived, needle);
         let n = rec(&oracle(needle)).unwrap_or_else(|| panic!("oracle:{needle} must narrow"));
         assert!(n.tight, "oracle:{needle} must narrow tight (exact, no verification)");
-        assert_eq!(n.set.into_cards(&archived.offsets), expected, "oracle:{needle} must match the brute-force set exactly");
+        assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected, "oracle:{needle} must match the brute-force set exactly");
     }
 }
 
@@ -3800,7 +3864,7 @@ fn oracle_word_index_multi_dense_no_sparse() {
         Candidates::CardBits(_) => {}
         other => panic!("2+ dense hits, no sparse, must return CardBits, got {other:?}", other = std::mem::discriminant(other)),
     }
-    assert_eq!(n.set.into_cards(&archived.offsets), expected, "oracle:word must match the brute-force set exactly");
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected, "oracle:word must match the brute-force set exactly");
 }
 
 // compile_plane's bonus arm only fires for the single-dense-hit shape (needed
@@ -3947,7 +4011,7 @@ fn border_planes_exact_union_parity() {
         let expected = brute_force_has_border(archived, value);
         let n = rec(&border(value)).unwrap_or_else(|| panic!("border:{value} must narrow"));
         assert!(!n.tight, "border planes narrow loose through narrow_rec, tight or not is compile_plane's separate call to make");
-        assert_eq!(n.set.into_cards(&archived.offsets), expected, "border:{value} narrowed set must match brute force");
+        assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected, "border:{value} narrowed set must match brute force");
     }
 
     // Untracked (yellow): narrows loosely through the shared `other` plane --
@@ -3956,7 +4020,7 @@ fn border_planes_exact_union_parity() {
     let expected_yellow = brute_force_has_border(archived, "yellow");
     let n = rec(&border("yellow")).expect("untracked value must still narrow via the shared other plane");
     assert!(!n.tight);
-    assert_eq!(n.set.into_cards(&archived.offsets), expected_yellow, "border:yellow narrowed set must match brute force");
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), expected_yellow, "border:yellow narrowed set must match brute force");
 }
 
 // The regression test this design exists to guarantee: two independent
@@ -4100,7 +4164,7 @@ fn border_black_declines_via_broadness_guard() {
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
 
     let n = super::narrow_rec(&border("black"), &archived.indexes, &archived.offsets, &archived.cards, true).expect("the dedicated arm itself always narrows");
-    assert_eq!(n.set.into_cards(&archived.offsets).len(), 7);
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card).len(), 7);
 
     assert!(
         narrow_candidates(&border("black"), &archived.indexes, &archived.offsets, &archived.cards).is_none(),
@@ -4229,7 +4293,7 @@ fn not_narrows_only_tight_children() {
     // Tight leaf → complement narrows, loose, and covers every ¬-match.
     let n = rec(&FilterExpr::Not(Box::new(goblin()))).expect("Not(subtype) must narrow");
     assert!(!n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     for (cid, card) in archived.cards.iter().enumerate() {
         let matches_not = (u32::from(archived.offsets[cid])..u32::from(archived.offsets[cid + 1]))
             .any(|p| FilterExpr::Not(Box::new(goblin())).matches(card, &archived.printings[p as usize], &archived.strings));
@@ -4245,7 +4309,7 @@ fn not_narrows_only_tight_children() {
     // superset check as the tight-child case above, just via a different arm.
     let n = rec(&FilterExpr::Not(Box::new(rarity()))).expect("-r:x must narrow via the negated-op arm");
     assert!(!n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     for (cid, card) in archived.cards.iter().enumerate() {
         let matches_not = (u32::from(archived.offsets[cid])..u32::from(archived.offsets[cid + 1]))
             .any(|p| FilterExpr::Not(Box::new(rarity())).matches(card, &archived.printings[p as usize], &archived.strings));
@@ -4281,7 +4345,7 @@ fn or_composes_plane_and_complement_children() {
     // ColorCmp had no narrowing arm before #636; via the plane feed-in the Or composes.
     let or = FilterExpr::Or(vec![goblin(), green()]);
     let n = rec(&or).expect("Or(subtype, color) must narrow");
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     assert_eq!(cand, vec![0, 1, 3], "goblins ∪ green");
 
     // An unindexable child still vetoes: nothing can represent it (1-char is
@@ -4440,7 +4504,7 @@ fn name_bigrams_tiers_and_exactness() {
     // Sparse tier: exact vec, tight, and byte-for-byte the contains() answer.
     let n = rec("qx").expect("sparse bigram narrows");
     assert!(n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     let brute: Vec<u32> = archived.cards.iter().enumerate()
         .filter(|(_, c)| c.card_name_lower.as_str().contains("qx"))
         .map(|(i, _)| i as u32)
@@ -4479,7 +4543,7 @@ fn name_bigrams_compose_and_memoize() {
     // Or of two bigram children composes: "fi" → {0,1,4}, "dr" → {0,2}.
     let or = FilterExpr::Or(vec![name2("fi"), name2("dr")]);
     let n = super::narrow_rec(&or, &archived.indexes, &archived.offsets, &archived.cards, false).expect("bigram Or composes");
-    assert_eq!(n.set.into_cards(&archived.offsets), vec![0, 1, 2, 4]);
+    assert_eq!(n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card), vec![0, 1, 2, 4]);
 
     // run_query parity across the new shapes, negation included.
     for f in [or, FilterExpr::Not(Box::new(name2("fi")))] {
@@ -4670,7 +4734,7 @@ fn devotion_plane_parity_and_boundaries() {
     let deep = dev(CmpOp::Ge, &[("U", 5)]);
     let n = super::narrow_rec(&deep, &archived.indexes, &archived.offsets, &archived.cards, false).expect("deep-k narrows loosely");
     assert!(!n.tight);
-    let cand = n.set.into_cards(&archived.offsets);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     for (cid, card) in archived.cards.iter().enumerate() {
         if deep.eval_card(card, &archived.strings) == Tri::True {
             assert!(cand.contains(&(cid as u32)), "superset must cover card {cid}");
@@ -4774,7 +4838,7 @@ fn exact_name_narrows_tight() {
     ] {
         let n = narrow(name);
         assert!(n.tight, "{name}: equality through the sorted permutation is exact");
-        let mut got = n.set.into_cards(&archived.offsets);
+        let mut got = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
         got.sort_unstable();
         want.sort_unstable();
         assert_eq!(got, want, "candidates for {name:?}");

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,7 +4,7 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
+    build_artist_index, build_range_index, price_dollars_to_cents, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
@@ -204,6 +204,17 @@ fn stub_printing(scryfall_id: u128, illustration_id: u128, prefer_score: Option<
         card_frame_data: Vec::new(),
         artwork_group_id: 0, // placeholder; store_of overwrites via assign_artwork_groups
     }
+}
+
+/// A `usd <op> dollars` comparison, already bound (Const rewritten to cents
+/// via `super::price_dollars_to_cents`) -- the shape every real query
+/// reaches through `FilterExpr::bind`, which none of these test fixtures
+/// otherwise call. Written this way (not a raw `NumericCmp` literal with a
+/// hand-converted cents value) so every price test shares the identical
+/// conversion `bind` itself uses, rather than N call sites each doing their
+/// own `* 100.0` that could silently drift from it.
+fn usd_cmp(op: CmpOp, dollars: f64) -> FilterExpr {
+    FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(price_dollars_to_cents(dollars)) }
 }
 
 /// Assemble a CardData where card i owns `printing_counts[i]` printings, in the
@@ -2794,7 +2805,7 @@ fn artwork_group_ids_handle_more_than_64_groups() {
 
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let mut filter = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    let mut filter = usd_cmp(CmpOp::Lt, 50.0);
     let (total, page) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
         &mut filter, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -2918,7 +2929,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let card = &archived.cards[0];
 
-    let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(0.10) };
+    let cmp = |op| usd_cmp(op, 0.10);
 
     // Lt must exclude the boundary printing exactly -- both in narrowing and in verification.
     let lt = cmp(CmpOp::Lt);
@@ -2949,21 +2960,18 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     let gt = cmp(CmpOp::Gt);
     assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
+    // Flipped operand order (50.0 < usd, i.e. usd > 50.0): only the $60 printing qualifies.
     let pricey = FilterExpr::NumericCmp {
-        lhs: super::NumExpr::Const(50.0),
+        lhs: NumExpr::Const(price_dollars_to_cents(50.0)),
         op: CmpOp::Lt,
-        rhs: super::NumExpr::Field(super::NumField::PriceUsd),
+        rhs: NumExpr::Field(NumField::PriceUsd),
     };
     match narrow_candidates(&pricey, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
     }
     // Ne is not selective.
-    let ne = FilterExpr::NumericCmp {
-        lhs: super::NumExpr::Field(super::NumField::PriceUsd),
-        op: CmpOp::Ne,
-        rhs: super::NumExpr::Const(1.0),
-    };
+    let ne = usd_cmp(CmpOp::Ne, 1.0);
     assert!(narrow_candidates(&ne, &archived.indexes, &archived.offsets, &archived.cards).is_none());
 }
 
@@ -2984,7 +2992,7 @@ fn price_comparison_matches_exact_value_not_lossy_f32_widening() {
     let card = &archived.cards[0];
     let p = &archived.printings[0];
 
-    let cmp = |op| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(7.22) };
+    let cmp = |op| usd_cmp(op, 7.22);
     assert!(cmp(CmpOp::Eq).matches(card, p, &archived.strings), "usd=7.22 must match a printing priced at exactly $7.22");
     assert!(cmp(CmpOp::Ge).matches(card, p, &archived.strings), "usd>=7.22 must not drop the exact match");
     assert!(cmp(CmpOp::Le).matches(card, p, &archived.strings));
@@ -3308,6 +3316,50 @@ fn run_query_plane_path_parity() {
             assert_eq!(ids(&p0), ids(&p1), "pages must agree (unique={unique})");
         }
     }
+}
+
+/// Card 0: two printings, $5 (satisfies `usd<50`) and $200 (doesn't; satisfies
+/// `usd>=50`) -- deliberately divergent w.r.t. any single usd threshold, the
+/// shape that catches row-selection and negation bugs (a card can satisfy
+/// `usd<50` via one printing and `-usd<50` via the *other*, at once). Card 1:
+/// one printing at $500 (never satisfies `usd<50`). Distinct illustration ids
+/// throughout (store_of's default), so unique=artwork mirrors unique=printing
+/// here -- no shared-group collapsing to complicate the comparison.
+fn price_plane_fixture_store() -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 1], vocab);
+    data.printings[0].price_usd = Some(500); // card 0: $5.00
+    data.printings[1].price_usd = Some(20000); // card 0: $200.00
+    data.printings[2].price_usd = Some(50000); // card 1: $500.00
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    data
+}
+
+/// `FilterExpr::bind` rewrites a price `NumericCmp`'s query-side dollar
+/// `Const` to cents exactly once per query (`price_dollars_to_cents`) -- the
+/// step that lets `field_num`'s per-printing evaluation compare raw cents
+/// with no division. Every other test in this file builds already-bound
+/// filters directly via `usd_cmp` (mirroring what `bind` produces, not
+/// exercising `bind` itself), so this is the one place that actually calls
+/// `bind` on a dollar-denominated `NumericCmp` -- the exact shape
+/// `build_filter` produces from a real `usd<50`-style query -- and checks
+/// both the rewritten `Const` value and that evaluation afterward still
+/// agrees with the unbound (dollars) comparison bit-for-bit.
+#[test]
+fn bind_rewrites_price_const_to_cents() {
+    let data = price_plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let card = &archived.cards[0];
+
+    let mut f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
+    let FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } = &f else { panic!("bind must not change the node shape") };
+    assert_eq!(*v, 5000.0, "bind must rewrite the dollar Const to its exact cents value");
+
+    assert!(f.matches(card, &archived.printings[0], &archived.strings), "usd<50 (bound) must still match the $5.00 printing");
+    assert!(!f.matches(card, &archived.printings[1], &archived.strings), "usd<50 (bound) must still exclude the $200.00 printing");
 }
 
 // ─── Numeric-range planes (#655) ───────────────────────────────────────────────
@@ -4456,11 +4508,7 @@ fn not_over_price_range_keeps_boundary_matches() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
-    let mut f = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
-        lhs: NumExpr::Field(NumField::PriceUsd),
-        op: CmpOp::Gt,
-        rhs: NumExpr::Const(5.0),
-    }));
+    let mut f = FilterExpr::Not(Box::new(usd_cmp(CmpOp::Gt, 5.0)));
     let (total, _) = run_query(
         &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
         &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
@@ -5038,11 +5086,7 @@ fn verify_order_or_keeps_sets_and_scans_in_written_order() {
 // card-level member can still settle at card level, so it stays early.
 #[test]
 fn verify_order_and_defers_printing_dependent_children() {
-    let usd = || FilterExpr::NumericCmp {
-        lhs: NumExpr::Field(NumField::PriceUsd),
-        op: CmpOp::Gt,
-        rhs: NumExpr::Const(20.0),
-    };
+    let usd = || usd_cmp(CmpOp::Gt, 20.0);
     let dragon = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "dragon".to_string(), value_id: None };
     let mut f = FilterExpr::And(vec![usd(), dragon()]);
     f.order_children_by_verify_cost();
@@ -5064,11 +5108,7 @@ fn verify_order_and_defers_printing_dependent_children() {
 // `usd>20` must not jump ahead of the contains it can't short-circuit.
 #[test]
 fn verify_order_or_defers_printing_dependent_children() {
-    let usd = || FilterExpr::NumericCmp {
-        lhs: NumExpr::Field(NumField::PriceUsd),
-        op: CmpOp::Gt,
-        rhs: NumExpr::Const(20.0),
-    };
+    let usd = || usd_cmp(CmpOp::Gt, 20.0);
     let mut f = FilterExpr::Or(vec![contains_scan(), usd()]);
     f.order_children_by_verify_cost();
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,10 +4,10 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, price_dollars_to_cents, range_candidates, narrow_candidates, rarity_candidates,
+    build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
-    ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
+    ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
     TextField, TextSearchField, Tri, SortedTrigramIndex, VocabInterner, ARTIST_NONE, NONE_STR, TYPE_ARTIFACT, TYPE_CREATURE,
     TYPE_ENCHANTMENT, TYPE_INSTANT, TYPE_LAND, TYPE_LEGENDARY, TYPE_PLANESWALKER, TYPE_SNOW, TYPE_SORCERY,
@@ -206,15 +206,11 @@ fn stub_printing(scryfall_id: u128, illustration_id: u128, prefer_score: Option<
     }
 }
 
-/// A `usd <op> dollars` comparison, already bound (Const rewritten to cents
-/// via `super::price_dollars_to_cents`) -- the shape every real query
-/// reaches through `FilterExpr::bind`, which none of these test fixtures
-/// otherwise call. Written this way (not a raw `NumericCmp` literal with a
-/// hand-converted cents value) so every price test shares the identical
-/// conversion `bind` itself uses, rather than N call sites each doing their
-/// own `* 100.0` that could silently drift from it.
+/// A `usd <op> dollars` comparison. `field_num` divides cents to dollars
+/// unconditionally regardless of shape, so this is just a plain `Const` in
+/// dollars -- no `bind()` step or unit conversion required.
 fn usd_cmp(op: CmpOp, dollars: f64) -> FilterExpr {
-    FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(price_dollars_to_cents(dollars)) }
+    FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(dollars) }
 }
 
 /// Assemble a CardData where card i owns `printing_counts[i]` printings, in the
@@ -2961,11 +2957,7 @@ fn price_narrowing_and_verification_are_exact_at_the_boundary() {
     assert!(!gt.matches(card, &archived.printings[1], &archived.strings));
 
     // Flipped operand order (50.0 < usd, i.e. usd > 50.0): only the $60 printing qualifies.
-    let pricey = FilterExpr::NumericCmp {
-        lhs: NumExpr::Const(price_dollars_to_cents(50.0)),
-        op: CmpOp::Lt,
-        rhs: NumExpr::Field(NumField::PriceUsd),
-    };
+    let pricey = FilterExpr::NumericCmp { lhs: NumExpr::Const(50.0), op: CmpOp::Lt, rhs: NumExpr::Field(NumField::PriceUsd) };
     match narrow_candidates(&pricey, &archived.indexes, &archived.offsets, &archived.cards) {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![2]),
         _ => panic!("flipped usd comparison must narrow"),
@@ -3318,48 +3310,70 @@ fn run_query_plane_path_parity() {
     }
 }
 
-/// Card 0: two printings, $5 (satisfies `usd<50`) and $200 (doesn't; satisfies
-/// `usd>=50`) -- deliberately divergent w.r.t. any single usd threshold, the
-/// shape that catches row-selection and negation bugs (a card can satisfy
-/// `usd<50` via one printing and `-usd<50` via the *other*, at once). Card 1:
-/// one printing at $500 (never satisfies `usd<50`). Distinct illustration ids
-/// throughout (store_of's default), so unique=artwork mirrors unique=printing
-/// here -- no shared-group collapsing to complicate the comparison.
-fn price_plane_fixture_store() -> CardData {
-    let mut vocab = VocabInterner::new();
-    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
-    let mut data = store_of(cards, &[2, 1], vocab);
-    data.printings[0].price_usd = Some(500); // card 0: $5.00
-    data.printings[1].price_usd = Some(20000); // card 0: $200.00
-    data.printings[2].price_usd = Some(50000); // card 1: $500.00
-    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
-    data
-}
-
-/// `FilterExpr::bind` rewrites a price `NumericCmp`'s query-side dollar
-/// `Const` to cents exactly once per query (`price_dollars_to_cents`) -- the
-/// step that lets `field_num`'s per-printing evaluation compare raw cents
-/// with no division. Every other test in this file builds already-bound
-/// filters directly via `usd_cmp` (mirroring what `bind` produces, not
-/// exercising `bind` itself), so this is the one place that actually calls
-/// `bind` on a dollar-denominated `NumericCmp` -- the exact shape
-/// `build_filter` produces from a real `usd<50`-style query -- and checks
-/// both the rewritten `Const` value and that evaluation afterward still
-/// agrees with the unbound (dollars) comparison bit-for-bit.
+/// Regression for a real bug that shipped briefly in this area: an earlier
+/// version rewrote a bare price `Field` (compared directly against a
+/// `Const`) into a cents-only fast path at bind time, to avoid dividing on
+/// every printing evaluated. That rewrite only recognized the *exact* bare
+/// shape -- it did not recurse into `NumExpr::Arith`. `usd+1<power` (price
+/// inside an arithmetic expression -- `parser_class=NUMERIC` on
+/// `usd`/`eur`/`tix` admits this grammatically, same as `cmc`/`power`) left
+/// the `1` in dollars while the fast path made `field_num` return cents
+/// unconditionally, silently computing `(cents+1)<power` instead of
+/// `(dollars+1)<power` -- off by a factor of 100. A second, independent
+/// instance of the same bug (`usd<cmc`, a price `Field` compared directly
+/// against *another* `Field`, no `Const` anywhere) confirmed the rewrite
+/// couldn't be patched to cover every shape without either false negatives
+/// or a full scaling transform on both sides of the comparison. Reverted the
+/// whole optimization: `NumExpr::Field(Price*)` always means dollars again
+/// (matching every build before it), for a ~2-3% loss on the one shape the
+/// fast path covered, in exchange for making every shape correct by
+/// construction rather than by rewrite coverage. Kept as a permanent
+/// regression test for exactly this class of bug, in case a similar
+/// shape-specific fast path is tried again later.
 #[test]
-fn bind_rewrites_price_const_to_cents() {
-    let data = price_plane_fixture_store();
+fn usd_inside_arithmetic_evaluates_in_dollars_not_cents() {
+    let mut vocab = VocabInterner::new();
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.creature_power = Some(52);
+    let mut data = store_of(vec![card], &[1], vocab);
+    data.printings[0].price_usd = Some(5000); // $50.00
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let card = &archived.cards[0];
+    let printing = &archived.printings[0];
 
-    let mut f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(50.0) };
+    // usd+1<power: $50.00 + 1 = 51 < power(52) -- must match.
+    let mut f = FilterExpr::NumericCmp {
+        lhs: NumExpr::Arith(Box::new(NumExpr::Field(NumField::PriceUsd)), ArithOp::Add, Box::new(NumExpr::Const(1.0))),
+        op: CmpOp::Lt,
+        rhs: NumExpr::Field(NumField::Power),
+    };
     f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
-    let FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } = &f else { panic!("bind must not change the node shape") };
-    assert_eq!(*v, 5000.0, "bind must rewrite the dollar Const to its exact cents value");
+    assert!(f.matches(card, printing, &archived.strings), "usd+1<power must evaluate in dollars: 50+1=51 < 52");
+}
 
-    assert!(f.matches(card, &archived.printings[0], &archived.strings), "usd<50 (bound) must still match the $5.00 printing");
-    assert!(!f.matches(card, &archived.printings[1], &archived.strings), "usd<50 (bound) must still exclude the $200.00 printing");
+/// The second independent instance referenced in the doc above:
+/// `usd<cmc` -- a price `Field` compared directly against *another* `Field`,
+/// no `Const` anywhere -- which no version of a `Const`-rewriting fast path
+/// could have covered at all, since there's no `Const` to rewrite.
+#[test]
+fn usd_compared_directly_against_another_field_evaluates_in_dollars() {
+    let mut vocab = VocabInterner::new();
+    let mut card = stub_card(1, TYPE_CREATURE, &[], &mut vocab);
+    card.cmc = Some(3);
+    let mut data = store_of(vec![card], &[1], vocab);
+    data.printings[0].price_usd = Some(200); // $2.00
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let card = &archived.cards[0];
+    let printing = &archived.printings[0];
+
+    // usd<cmc: $2.00 < cmc(3) -- must match.
+    let mut f = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Field(NumField::Cmc) };
+    f.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
+    assert!(f.matches(card, printing, &archived.strings), "usd<cmc must evaluate in dollars: 2.00 < 3");
 }
 
 // ─── Numeric-range planes (#655) ───────────────────────────────────────────────

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -171,8 +171,31 @@ and test each candidate for set membership inline, stopping once `limit` matches
   *aligned* case (`released_at>2026-06-01 order by released_at`) is pathological if the walk
   starts at the wrong end: ascending order puts the matches at the far end, so a naive
   front-to-back walk visits almost everything before the first hit.
-- `total` for `unique=card` needs `oracle_id` dedup, not just `k` — `k` alone only works
-  directly for `unique=printing`.
+- **`total` for `unique=card`/`artwork` needs `oracle_id` dedup, not just `k` — and this may
+  cost as much as idea 2's whole approach.** `k` alone only works directly for `unique=printing`
+  (no dedup needed, `total = k` for free from the binary search — idea 1's "close to instant"
+  claim is unconditionally true there). For `unique=card`/`artwork`, an *exact* `total` means
+  deduplicating every matched printing by `oracle_id` — touching all `k` matches at least once,
+  the same O(k) idea 1 exists to avoid. If that cost is unavoidable for `unique=card` regardless
+  of page-fetch strategy, idea 1 may not actually beat idea 2 there — idea 2 pays that same O(k)
+  once to build the bitmap and gets offset-independent paging as a bonus for it. **This makes
+  `unique` mode (`printing` vs. `card`/`artwork`) a fourth crossover axis, not a detail** — it
+  may determine which idea is even viable before selectivity/alignment/clustering matter at all.
+
+  `cards_of_printings` (`lib.rs:2392-2407`) dedupes exactly this way, but it's a *batch* operation
+  over a complete, sorted `Vec`/bitmap — reusing it directly would mean materializing the whole
+  matched set upfront, exactly what idea 1 exists to avoid. Idea 1's walk discovers matches one at
+  a time, in permutation (order-by) order, not printing-id order, so it needs an *incremental*
+  version instead: a running card-space "seen" bitmap, and per matched printing, look up its card
+  id and test-and-set a bit (new bit set → a newly-counted distinct card; already set → skip).
+  That per-printing card lookup can't use `cards_of_printings`' own broad-k trick
+  (`printing_bits_to_card_bits`'s monotone cursor needs ascending printing-id order, which a
+  permutation walk doesn't provide) — it needs the direct-array lookup instead, see
+  [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md), which is
+  worth landing before committing to idea 1 for this reason specifically, not just its narrower
+  standalone win. Still an open, measurement-shaped question (kernel benchmark, not end-to-end
+  timing) whether this incremental floor is cheap enough to make `unique=card` competitive with
+  `unique=printing` — landing the direct array first is what makes that measurement fair.
 
 ## Idea 2: scatter the exact narrowed set into a bitmap, feed the existing popcount-skip path
 
@@ -187,6 +210,17 @@ tweak — that function's existential row-selection (`plane_expr_is_existential`
 none of these fields compile to today. **Decided: extend the Y-predicate/existential-plane
 framework** (#680) with a new leaf rather than duplicate its row-selection logic outside it —
 price genuinely is a per-printing predicate, the same shape format/rarity/border already are.
+
+**This row-selection work is not price-specific — `collector_number` and `released_at` are also
+printing-varying fields.** A card's printings have different collector numbers and release
+dates, same as different prices. Under `unique=card`/`artwork`, *any* printing-varying field
+needs to pick which specific matching printing to emit — that's inherent to varying by printing
+at all, not to price's semantics in particular. So "prove the mechanism on a tight field first
+isolates the crossover question from the row-selection work" (see Plan) is only fully true for
+`unique=printing` — there, each printing is its own row, no selection needed at all. For
+`unique=card`/`artwork` on *any* of these three fields, the same `PrintingRangeBits` mechanism
+is needed. Treat row-selection as one piece of shared work across `price`/`collector_number`/
+`released_at` together, not something deferred specifically until price's turn.
 Tracing `PlaneExpr::Bits` (planes.rs:436-443, `eval_plane_expr_for_printing`,
 `plane_expr_is_existential`) shows this is a contained addition, not a framework rewrite — and
 it's simpler than it first looked, now that narrowing is exact:
@@ -231,34 +265,60 @@ decision needs three axes:
    (blind walk, no seek target).
 3. **For the aligned case, direction vs. clustering** — does the naive walk start at the
    matching end, or does it need to seek first?
+4. **`unique` mode** (`printing` vs. `card`/`artwork`) — not a speed difference, a viability
+   question. `unique=printing` needs no dedup (`total = k` free); `unique=card`/`artwork` needs
+   an exact card-level `total`, which may cost O(k) regardless of page-fetch strategy (see idea
+   1's `total` note above). If so, idea 1 and idea 2 aren't competing on speed for that mode,
+   they're both paying the same floor and idea 2's offset-independence is pure upside.
 
 The adversarial cell — selective predicate, unrelated order-by, unlucky clustering — is where
 idea 1's actual worst case needs to be measured against today's baseline. If it's worse there,
 that bounds how unconditionally idea 1 can be used. With the prerequisite fix landed, there's no
-fourth (tight/loose) axis to worry about — every field behaves identically here.
+fifth (tight/loose) axis to worry about — every field behaves identically there.
 
 ## Plan
 
-- [ ] Ship the `price_bounds` exactness fix standalone (see Prerequisite above) — already
-      verified, just needs the Rust change + a `tests.rs` regression test.
-- [ ] Prove the fast-path mechanism on a tight field first (`released_at` or
-      `collector_number`, already tight today) — isolates the crossover question from the
-      `PlaneExpr` row-selection work.
+- [x] Ship the price exactness fix standalone (see Prerequisite above) — landed as the
+      integer-cents migration in [#688](https://github.com/jbylund/sylvan_librarian/pull/688).
+- [ ] Ship `printing_to_card` standalone first (see
+      [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md)) —
+      load-bearing for idea 1's incremental per-match card check, neutral to idea 2, changes this
+      doc's crossover-axis-4 baseline numbers.
+- [ ] Prove the fast-path mechanism on `unique=printing` for a tight field first (`released_at`
+      or `collector_number`) — this is the case that genuinely isolates the crossover question
+      from row-selection (no picking-a-printing problem at all when each printing is its own
+      row). Does *not* by itself resolve `unique=card`/`artwork` — see the next item.
+- [ ] Resolve the `unique=card`/`artwork` `total` question (crossover axis 4) before trusting
+      idea 1's cost model there: measure whether an exact card-level `total` can be had for less
+      than O(k), or whether `unique=card` always pays that floor regardless of page-fetch
+      strategy. This may collapse the idea-1-vs-idea-2 choice for that mode entirely.
 - [ ] Sketch idea 1 as a real path: `k`-from-binary-search, order-by-permutation walk with
-      inline membership check, early stop at `limit`, dedup-aware `total` for `unique=card`.
+      inline membership check, early stop at `limit`.
 - [ ] Sketch idea 2: `PlaneExpr::PrintingRangeBits`, wired into `compile_plane`/`eval_planes`/
-      `plane_expr_is_existential`/`eval_plane_expr_for_printing`.
-- [ ] Build a sweep harness across the three crossover axes (shape of `bench_cost_guards.py` /
+      `plane_expr_is_existential`/`eval_plane_expr_for_printing` — shared across
+      `price`/`collector_number`/`released_at`, not price-specific, once `unique=card`/`artwork`
+      row-selection is in scope for any of them.
+- [ ] Build a sweep harness across all four crossover axes (shape of `bench_cost_guards.py` /
       `build_guard_corpus.py`), covering `price_usd`, `released_at`, and `collector_number`, plus
-      at least one deliberately-adversarial synthetic case (mismatched order-by field).
+      at least one deliberately-adversarial synthetic case (mismatched order-by field) and both
+      `unique` modes.
 - [ ] Calibrate the guard from measurement (or confirm one design dominates and no guard is
       needed).
+- [ ] Decide the `Not`-arm/`tight_narrow_space` composition-safety question (deferred from the
+      Prerequisite section to here) — either bring it into scope (needed for `-usd>8`-shaped
+      queries, a real fragment in `test_engine_property.py`'s own suite) or explicitly defer it
+      again to a third, later piece of work, with a stated reason rather than silently dropping it.
 - [ ] Acceptance: `usd<50`, a broad `released_at`/`collector_number` query, and the adversarial
-      case all improve or stay flat vs. baseline; no regression on the existing #634/#655 exact
-      paths.
+      case all improve or stay flat vs. baseline for at least one `unique` mode; no regression on
+      the existing #634/#655 exact paths; passes (and likely extends, given this exact class of
+      change already produced two independent bugs in the price prerequisite work)
+      `test_engine_property.py`'s differential suite against the reference oracle — a performance
+      delta alone is not sufficient to call this done.
 
 ## Related
 
+- [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md) —
+  prerequisite `printing_to_card` array, load-bearing for idea 1's per-match card check.
 - [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
   analogous fix for `cmc`/`power`/`toughness`; doesn't transfer (card-invariant, not existential).
 - [00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md) —

--- a/docs/issues/local-engine-direct-projection-arrays.md
+++ b/docs/issues/local-engine-direct-projection-arrays.md
@@ -1,0 +1,181 @@
+# Engine: direct printing→card / printing→group projection arrays
+
+Status: **`printing_to_card` shipped** 2026-07-14, no GitHub issue yet. Surfaced investigating
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s crossover axis 4
+(does `unique=card`'s exact `total` cost too much to make its fast-path win moot?) — turned into a
+standalone win independent of that project, landed first since it changed the baseline costs that
+doc's crossover math depends on.
+
+**Why build `printing_to_card` before the fastpath project picks a direction, rather than
+deferring it alongside `printing_to_global_group`**: it pays for itself either way that project
+goes. It has a real (if narrow) win today for `cards_of_printings`' broad-k `Vec` path. It's also
+load-bearing for Idea 1 specifically, if that's the direction chosen: Idea 1 walks the order-by
+permutation, visiting printings in permutation order rather than printing-id order, so the
+monotone-cursor trick (which needs ascending printing ids) is never available there — every
+matched printing's card-identity check during that walk would otherwise pay a binary search, the
+exact access pattern the direct array wins decisively at. Idea 2 (`PrintingRangeBits`) scatters
+into a card bitmap upfront — the "already a bitmap" case benchmarked below, where the direct array
+is a wash — so this is neutral to Idea 2, not a loss either way.
+
+## Problem
+
+Before this change, projecting a printing-id set up to card space (`cards_of_printings`,
+`lib.rs:2392-2407`) had no materialized `printing_id -> card_id` mapping. It derived the card from
+`offsets` (a compact `Vec<(start_printing_idx)>` per card) two different ways depending on size:
+
+- **k ≤ 1024**: `offsets.partition_point(...)` per printing — a binary search, `O(log n_cards)` each.
+- **k > 1024**: scatter into a printing-space bitmap, then walk it with `printing_bits_to_card_bits`'s
+  monotone cursor (introduced in [#637](https://github.com/jbylund/sylvan_librarian/pull/637),
+  which also added the 1024 split) — `O(k + n_cards)`, no per-posting search, but two full passes
+  (build the printing bitmap, then walk it) and a `bitmap_card_ids` materialization if a `Vec` is
+  needed. Checked #637 for a reason a direct array was rejected in favor of this — found none; it
+  reads like the monotone cursor was simply the improvement tried over binary search, not a choice
+  made against a direct array specifically.
+
+Prototyping an analogous `groups_of_printings` (artwork-group dedup, for
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s `unique=artwork`
+question) hit this same shape, but *without* the monotone-cursor option: a card's local
+artwork-group ids aren't ascending within its printing range (they can interleave, e.g. `0, 1, 0,
+2`), so the `printing_bits_to_card_bits` trick doesn't transfer. The only projection available was
+per-printing binary search — even past k=1024, unlike `cards_of_printings`.
+
+## Finding: a direct array wins when you already have an id list, not when the input is a bitmap
+
+Benchmarked in `card_engine/src/bench_card_dedup.rs`
+(`cargo test --release bench_card_dedup -- --ignored --nocapture`), synthetic offsets at real
+corpus scale (31,508 cards / ~97-115k printings / ~46-55k groups), all times ns/match, best-of-50:
+
+| k (broad) | `cards_of_printings` (old) | direct array, from id list | `groups_of_printings` (binary search) | direct array, from id list |
+|-----------|---------------------------:|----------------------------:|----------------------------------------:|-----------------------------:|
+| 7,267 (6%) | 3.84 | 1.40 | 7.63 | 1.31 |
+| 60,166 (52%) | 3.74 | 1.79 | 7.94 | 1.65 |
+| 95,724 (83%) | 3.19 | 1.55 | 7.30 | 1.54 |
+
+Same k values, but isolating just the "cursor vs. direct array" step when the input is *already a
+bitmap* (`Candidates::PrintingBits`, no id list to exploit) — the other two call sites of
+`printing_bits_to_card_bits`:
+
+| k (broad) | cursor | direct array lookup |
+|-----------|--------:|----------------------:|
+| 7,267 (6%) | 2.16 | 2.57 |
+| 60,166 (52%) | 1.75 | 1.58 |
+| 95,724 (83%) | 1.50 | 1.52 |
+
+These are a wash — the earlier ~2x win isn't "direct array beats the monotone cursor at the lookup
+step." It's "when you already have a sorted id list, scattering it straight into the output space
+and skipping the intermediate printing-bitmap round-trip is cheaper than building that bitmap just
+to re-extract the same ids from it." `cards_of_printings`' broad-k path did the latter (built a
+printing bitmap from an id list it already had, purely to hand it to `printing_bits_to_card_bits`)
+— that round-trip was the actual waste, not the cursor.
+
+`groups_of_printings`' ~4.5-5.9x win is real, in isolation, for the mechanism it replaces (binary
+search per printing — no monotone-cursor option ever existed for groups). **But that mechanism
+isn't used anywhere today.** Checked the real `unique=artwork` implementation
+(`card_match_count`'s `Mode::Artwork` arm, `lib.rs:3456-3470`, and `run_query_streamed`,
+`lib.rs:4025-4092`) — it has no global printing-set-to-group-set projection at all. It computes
+counts per candidate *card*, walking that card's own small printing range and OR-ing bits into a
+tiny per-card local `seen_words` scratch buffer (typically ~3 printings, cheap regardless).
+`groups_of_printings` was invented answering a hypothetical for
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s Idea 1 (walking the
+order-by permutation, which *would* need incremental dedup-while-walking) — it is not a fix for
+any measured cost in the current architecture, and claiming it would broadly speed up
+`unique=artwork` queries today was wrong. The real, already-documented cost differential for
+`Mode::Artwork` vs `Mode::Card` is unrelated to dedup: the `all_match_known` short-circuit is
+deliberately disabled for `Mode::Artwork` (`lib.rs:4064-4071`, a measured codegen regression when
+enabled unconditionally), and `Mode::Artwork` can't return at the first matching printing the way
+`Mode::Card` does, since a later printing could introduce a new distinct group. Neither is
+something a lookup array changes.
+
+`printing_bits_to_card_bits` **itself stays.** It's still the right (and already-fast) mechanism
+for its other two call sites (`Candidates::into_cards`/`into_card_space`'s `PrintingBits` arms),
+which start from a bitmap with no id list behind it. Only `cards_of_printings`' broad-k path
+stopped calling it, in favor of scattering the id list it already holds directly.
+
+## Shipped: `printing_to_card` in the archive
+
+Added `printing_to_card: Vec<u32>` to `CardIndexes` (`lib.rs`), built once at write time by
+`build_printing_to_card(&offsets)` — a single linear pass over `offsets`, no hash table. Persisted
+in the archive (not a per-process cache): mmap pages are shared read-only across every worker
+process via the OS page cache, so the ~380KB array costs one physical copy total regardless of
+worker count, and the O(n_printings) build cost is paid once by the writer, not once per reader.
+Bumped `ARCHIVE_FORMAT_VERSION` (`20260725` → `20260726`).
+
+`cards_of_printings` now uses it in **both** branches — not just broad-k:
+
+```rust
+fn cards_of_printings(offsets: &AOffsets, printing_to_card: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
+    if printing_ids.len() > 1024 {
+        let n_cards = offsets.len().saturating_sub(1);
+        let bits = scatter_bits(printing_ids.iter().map(|&p| u32::from(printing_to_card[p as usize])), n_cards);
+        return bitmap_card_ids(&bits);
+    }
+    let mut out: Vec<u32> = Vec::with_capacity(printing_ids.len());
+    for &p in printing_ids {
+        let card = u32::from(printing_to_card[p as usize]);
+        if out.last() != Some(&card) {
+            out.push(card);
+        }
+    }
+    out
+}
+```
+
+The small-k branch keeps its shape (push + adjacent-dedup, no bitmap allocation) but swaps
+`partition_point` for the direct array too — unconditionally cheaper, no downside, no need for a
+separate crossover decision between the two lookup mechanisms.
+
+`printing_to_global_group`/`groups_of_printings` remain **deferred, not shipped** — see "Finding"
+above. Nothing in the current codebase would consume them. Revisit only if/when
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) actually commits to
+building Idea 1; the benchmark numbers above are recorded there for that future decision.
+
+**Verified, not just argued:**
+
+- `cards_of_printings_matches_naive_projection_across_sizes` (`tests.rs`) — differential test
+  against an independent reference oracle (`partition_point` on `offsets`, applied uniformly
+  regardless of size — the mechanism the old small-k path itself used), 40 seeds × 9 k values
+  straddling the 1024 small/broad split, both branches. Confirmed it actually catches a bug: an
+  injected off-by-one in the broad-k lookup failed the test immediately (seed=0, k=1025), reverted
+  before landing.
+- `cards_of_printings_maps_and_dedups` (existing unit test) still passes unchanged.
+- Full suite: **117 passed** (debug and release), 8 ignored (kernel benchmarks). `cargo clippy`:
+  37 warnings, identical set to baseline — no new warnings from this change.
+- Real benchmark against the shipped implementation (not just the prototype):
+  `cards_of_printings` now runs at ~1.7-1.9ns/match across the same real-corpus-shaped sweep,
+  confirming the ~2x win holds in the actual code, not just the exploratory version.
+
+## Open questions
+
+- Does the small-k binary search path in `cards_of_printings` still win below some k, or does the
+  direct array dominate unconditionally once it exists? **Resolved**: the direct array is
+  unconditionally cheaper (O(1) vs O(log n_cards) per lookup, no downside), so both branches now
+  use it — the only remaining question the 1024 split answers is bitmap-scatter vs. push+dedup,
+  unrelated to the lookup mechanism.
+- Quantify the real impact: how often does a real query actually land k in the (1,000, ~25% of
+  index] `Vec`-path window for `price_usd`/`collector_number`/`released_at`? Price's own
+  distribution rarely does (see fastpath doc's selectivity sweep) — worth checking
+  `collector_number`/`released_at` against the real corpus. Not yet done — still open.
+- `reload_commit` cost of building `printing_to_card` — expected cheap (one linear pass), not yet
+  measured against a real reload.
+
+## Plan
+
+- [x] Differential test: new `cards_of_printings` (both branches) vs. an independent reference
+      oracle, byte-identical output — confirmed to catch a real injected bug.
+- [x] Add `printing_to_card` to the archive, bump `ARCHIVE_FORMAT_VERSION`.
+- [x] Ship `printing_to_card` in `cards_of_printings`, both branches.
+- [x] Re-benchmark `cards_of_printings` against the real shipped implementation (not just the
+      prototype) — win confirmed (~1.7-1.9ns/match).
+- [ ] Measure `reload_commit` cost of building `printing_to_card` against a real reload.
+- [ ] Quantify how often real `collector_number`/`released_at` queries land in the Vec-path
+      selectivity window, to size the practical impact beyond price (which rarely does).
+- [ ] Once real-world impact is quantified, fold the updated baseline numbers into
+      [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s crossover
+      axis 4.
+
+## Related
+
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — where this was
+  discovered; crossover axis 4 depends on this having landed.
+- [#637](https://github.com/jbylund/sylvan_librarian/pull/637) — introduced `cards_of_printings`'
+  1024 split and `printing_bits_to_card_bits`'s monotone cursor.

--- a/scripts/bench_price_range_targeted.py
+++ b/scripts/bench_price_range_targeted.py
@@ -22,7 +22,7 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import load_engine, bench_one  # noqa: E402
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # usd/cn/year/date across card/printing/artwork are what the two commits in this PR target.

--- a/scripts/bench_price_range_targeted.py
+++ b/scripts/bench_price_range_targeted.py
@@ -1,0 +1,91 @@
+"""Targeted benchmark for PR #690 (price-cents bind-time conversion + NumExpr::eval inlining).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export, so the same
+script run on two builds (main baseline vs. this branch) produces directly comparable CSVs.
+Follows scripts/bench_bitplanes.py's pattern.
+
+    .venv/bin/python scripts/bench_price_range_targeted.py \
+        --out benchmarks/pr690/baseline-main.csv
+
+The `total` column doubles as a parity check: it must be identical across builds for every
+config, or the comparison is void.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import load_engine, bench_one  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+# usd/cn/year/date across card/printing/artwork are what the two commits in this PR target.
+# "control" rows are unaffected by either change (no NumericCmp/YearCmp/price at all) and
+# must not regress.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    ("usd", "usd<50", "card", "edhrec", "default"),
+    ("usd", "usd<50", "printing", "edhrec", "default"),
+    ("usd", "usd<50", "artwork", "edhrec", "default"),
+    ("usd", "usd>=50", "printing", "edhrec", "default"),
+    ("cn", "cn<100", "card", "edhrec", "default"),
+    ("cn", "cn<100", "printing", "edhrec", "default"),
+    ("cn", "cn<100", "artwork", "edhrec", "default"),
+    ("cn", "cn>=100", "card", "edhrec", "default"),
+    ("year", "year>2020", "card", "edhrec", "default"),
+    ("year", "year>2020", "printing", "edhrec", "default"),
+    ("year", "year<2010", "card", "edhrec", "default"),
+    ("date", "date>2023-01-01", "card", "edhrec", "default"),
+    ("date", "date<2010-01-01", "card", "edhrec", "default"),
+    ("compound", "cn<100 t:creature", "card", "edhrec", "default"),
+    ("compound", "year>2020 t:creature", "card", "edhrec", "default"),
+    ("compound", "usd<50 t:creature", "printing", "edhrec", "default"),
+    ("compound", "f:modern usd<50", "card", "edhrec", "default"),
+    ("compound", "cn<100 usd<50", "printing", "edhrec", "default"),
+    ("control", "f:commander", "card", "edhrec", "default"),
+    ("control", "f:legacy", "card", "edhrec", "default"),
+    ("control", "f:modern", "card", "edhrec", "default"),
+    ("control", "r:common or r:uncommon", "card", "edhrec", "default"),
+    ("control", "-border:black", "card", "edhrec", "default"),
+    ("control", "t:creature", "printing", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=8.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<9} {'query':<26} {'unique':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<9} {query:<26} {unique:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this does

Two commits with real, verified wins, neither depending on #689's `PrintingRangeBits` work —
bundled here so they can be measured and merged independently of that larger, still-in-progress
branch. (A third optimization, converting price comparisons to cents at bind time, was implemented,
benchmarked, reviewed, found to have a real correctness bug, and reverted — see "A fast path we
tried and removed" below. Its diff is gone; mentioning it here because the commit history isn't.)

1. **Direct printing→card lookup array** (`cd4239e` here — a cherry-pick of `4a4be10` from #689's
   branch, identical diff, different hash since the parent differs; not new work from this
   investigation, just a pre-existing commit that isn't on `origin/main` yet, picked here as this
   branch's base since it's a prerequisite-free, standalone win). Adds `printing_to_card:
   Vec<u32>` to `CardIndexes`, built once at write time (a single linear pass over `offsets`), so
   `cards_of_printings` maps a printing-id list to card ids via O(1) array lookup instead of a
   binary search (small-k path) or a monotone-cursor scan through `offsets` (broad-k path). Full
   rationale, alternatives considered, and benchmarks in
   [`local-engine-direct-projection-arrays.md`](docs/issues/local-engine-direct-projection-arrays.md) —
   turns out to be broader-reaching than that doc describes; see below.

2. **`NumExpr::eval` / `eval_arith` split.** `eval()` was self-recursive via its `Arith` case, so
   LLVM's always-inliner refused to inline it at *any* call site, not just the recursive edge —
   confirmed in the release disassembly, which showed `FilterExpr::tri`'s `NumericCmp` arm making
   two separate `bl NumExpr::eval` calls (lhs, rhs), each paying a full prologue/epilogue, for what a
   bare `Field<op>Const` comparison needs to be a single load and compare. Moving the recursive
   `Arith` case into its own `eval_arith` function leaves `eval()` itself non-recursive, so
   `#[inline(always)]` now actually folds its whole dispatch into `tri()` for the common leaf case.
   Generic to every numeric field (`cmc`, `power`, `usd`, `collector_number`, ...), not price-specific.

## A fast path we tried and removed

Also implemented: `FilterExpr::bind` rewriting a bare price `Field`-vs-`Const` comparison's `Const`
to cents once per query, so `field_num`'s per-printing evaluation could skip a division. Code review
caught a real bug: `field_num` returned cents unconditionally, but the rewrite only recognized that
one exact shape. `usd+1<power` (price inside `NumExpr::Arith`) and `usd<cmc` (price compared
directly against another `Field`, no `Const` anywhere) both left the query-side operand in dollars
while `field_num` returned cents — silently computing `(cents+1)<power` and `cents<cmc` instead of
the dollar-denominated comparison the query asked for, off by 100x. Both are reachable: `usd`/`eur`/
`tix` are `parser_class=ParserClass.NUMERIC` in `api/parsing/db_info.py`, the same class as `cmc`/
`power`, and the arithmetic grammar admits any `NUMERIC`-class field as an operand.

Tried a type-level fix (a distinct `NumExpr::PriceCents` variant, constructed only by `bind()` for
the one shape verified safe), but this surfaced a worse problem: two logically identical queries
(`usd<5.00` vs `usd+0.01<5.01`) would take entirely different, inconsistently-optimized code paths
depending on superficial phrasing — exactly the kind of shape-dependent fragility that produced the
bug, and easy to reintroduce with the next well-intentioned tweak. Removed the optimization instead:
`field_num` divides cents to dollars unconditionally again, matching every build before this fast
path existed. Costs ~2-3% on the one shape it covered (see "Benchmark results" below — this cost
turned out to be smaller than expected, because the two commits that remain in this PR already carry
most of `usd`'s win). Kept two regression tests
(`usd_inside_arithmetic_evaluates_in_dollars_not_cents`,
`usd_compared_directly_against_another_field_evaluates_in_dollars`) as a permanent tripwire for this
bug class, in case a similar fast path is tried again later.

## Benchmark results

Following [`docs/workflows/performance-pr-workflow.md`](docs/workflows/performance-pr-workflow.md):
broad screen via `scripts/survey_queries.py`, targeted set via a fixed `CONFIGS` list scoped to this
PR's feature area (`scripts/bench_price_range_targeted.py`, new script, committed). Both run against
`origin/main` (`b267453`) and this branch sequentially — same corpus, same seed, Docker fully quit.

**Broad screen** (520 queries: 400 generated + 120 from real `scryfall.com/search` traffic,
`--seed 42`):

|  | main | branch |
|---|---:|---:|
| p50 | 0.061ms | 0.059ms |
| p75 | 0.098ms | 0.094ms |
| p90 | 0.200ms | 0.189ms |
| p95 | 0.295ms | 0.276ms |
| p99 | 0.799ms | 0.777ms |
| max | 1.218ms | 1.157ms |

**Geometric mean: 1.1382x faster overall.** As with the earlier version of this PR, that headline
number is inflated by the fastest ~46% of queries (below 0.05ms/50µs — the whole distribution is
sub-millisecond here, this corpus is small and the engine is in-memory, so "fast" means tens of µs):

| subset | n | geomean |
|---|---:|---:|
| queries ≥0.05ms | 282 | **1.06x** |
| queries <0.05ms | 238 | 1.24x |

Every one of the 520 `total` counts matched exactly (correctness parity). 5 of 520 queries regressed
>5% (0 did before this optimization was removed) — checked each one: only `id:g -(format:legacy or
usd>1)` (-5.1%) actually touches price at all, and that's the honest, expected cost of the revert on
a shape close to what the fast path covered. The other four
(`id:gw -(color:gw or set:mom)` -5.5%, `(name:an or id:u) (watermark:set or oracle:counter)` -8.5%,
`-oracle:haste id:rg` -12.6%, `a:"Iwamoto05"` -5.7%, the last one down in the noise-dominated
sub-0.05ms tail) touch no price field at all and aren't plausibly caused by anything in this PR —
consistent with the sequential single-run noise this PR's benchmark methodology already documented
elsewhere (a single generated query in a 400-query seeded set gets exactly one sample; ±5-12% on an
unrelated shape is within what's already been observed for controls in this exact harness).

**Targeted set** (24 configs: usd/cn/year/date across card/printing/artwork, plus 6 unrelated
`control` queries that must not move), `min_ms` reported rather than `avg_ms` for the same reason as
the earlier version of this PR (`avg_ms` put unrelated controls at up to 0.75x in a sequential run —
noise-dominated at this timescale; `min_ms` held controls flat):

**Geometric mean (excluding controls): 1.1127x faster** — essentially unchanged from 1.1101x with
the price-cents fast path still in place. `usd<50` itself still improves 1.11-1.13x across all three
unique modes on the strength of the two remaining commits alone; removing the fast path barely
moved the aggregate, because it was never carrying much of `usd`'s win in the first place. Every
`total` count matched exactly; controls stayed at 1.00-1.04x (the noise floor for this harness).

**Bisecting the win, and where it actually comes from:** initially assumed the >2x swings on some
sub-50µs wild-corpus queries were measurement noise. That was wrong — a resampling check (500-sample
batches drawn repeatedly from one build's own long-run distribution) shows only ~2.5% spread,
nowhere near enough to produce a 2x swing from sampling noise alone, so two sequential runs really
were sampling different distributions. Bisected with worktrees built at individual commits —
`cd4239e`/`4a4be10` alone reproduces the effect; neither of the other two commits contributes to it —
then traced through the code to find the mechanism, rather than leaving it at "plausibly":

`narrow_rec`'s `And` handling ([lib.rs](card_engine/src/lib.rs), the `FilterExpr::And` arm) buckets
each child's narrowed result into `card_sets` or `printing_sets` by which space it narrowed in, then
combines them. When both are non-empty and the printing side isn't a broad bitmap, it does exactly
this:
```rust
let pc = p.into_card_space(offsets, &indexes.printing_to_card);
and_all(vec![c, pc]).map(seal)
```
`into_card_space` calls `cards_of_printings` for `Candidates::Printings` — precisely the function
`cd4239e`/`4a4be10` sped up (binary search over `offsets` → O(1) direct array lookup). So *any*
`And` of a card-level narrower (`t:`, `c:`, `!"name"`, a color/type/rarity/border plane, ...) with a
printing-level one (`set:`, `cn:`, `usd:`, `released:`, ...) crosses this exact projection, not just
exact-name queries specifically. Measured three points along that shape, 5s/900k-sample windows,
`main` vs. `cd4239e`:

| query | total | main | `cd4239e` | speedup |
|---|---:|---:|---:|---:|
| `!"Delver of Secrets//Insectile Aberration" set:INR` | 0 (rejects) | 12.0µs | 5.2µs | 2.4x |
| `set:m11 !"lightning bolt"` | 1 | 8.15µs | 6.06µs | 1.35x |
| `t:creature set:m11` | 116 | 68.06µs | 62.48µs | 1.09x |

The magnitude tracks how much of each query's total cost *is* that one projection: for the first two
(a handful of candidate printings, almost the entire query), the win is large; for the third (116
matching cards, most of the cost is elsewhere — plane evaluation, result-row construction), the same
optimization is still real but a smaller slice of a bigger pie. `4a4be10`'s own doc describes this as
a narrow, `cards_of_printings`-specific win — it's broader than that in practice, and worth folding
back into that doc as a follow-up.

**Cross-checked with a second, independent methodology** (from the earlier version of this PR, with
the price-cents fast path still active): an interleaved A/B harness (both builds in the same process,
same timing windows, call order swapped between runs) gave consistent 10-29% wins on the same query
shapes, with one exception — `usd<50`/`unique=printing` flipped sign across repeated runs there
(both with Docker running and with it quit), while every other query was consistently faster across
every run of both methodologies. That exception predates this revert and isn't specific to it.

## New regression test

`bench_price_and_range_verify_cost` (`bench_verify_cost.rs`) pins the per-card `NumericCmp` cost for
`usd`/`collector_number`/`year` against the real corpus. Current numbers, post-revert:

```
NumericCmp (usd<50)             3.731 ns/card  (30702 matches)
NumericCmp (cn<100)             3.827 ns/card  (12732 matches)
YearCmp (year>2020)             2.897 ns/card  (14819 matches)
```

(`usd<50` was 3.478 ns/card with the price-cents fast path active — the ~7% difference here is that
fast path's actual, honest cost at this micro-benchmark's scale, separate from the broad/targeted
numbers above which also include `cd4239e`'s and the eval-inlining commit's wins.)

## Testing

- `cargo test` (debug + release): 119/119 passed, 9 ignored.
- `cargo clippy --release --all-targets`: unchanged from baseline, no new warnings.
- Cherry-picked from #689's branch onto plain `origin/main`: `cd4239e`/`4a4be10` and the eval-inlining
  commit applied cleanly.
- All live-repro queries (`usd+1<power`, `usd<cmc`, `usd+power<100`) and known-good corpus counts
  (`usd<50` across all three unique modes, `cn<100 AND usd<50`) reverified against a live engine
  after the revert.
