### PR TITLE
Post-#690 Docs Cleanup: Rename Direct-Projection-Arrays Doc, Update Cross-References

### DIFF
--- a/card_engine/src/bench_card_dedup.rs
+++ b/card_engine/src/bench_card_dedup.rs
@@ -2,7 +2,7 @@
 //!
 //! 1. Regression guard for `cards_of_printings`' direct-array projection
 //!    (`printing_to_card`, shipped — see
-//!    docs/issues/local-engine-direct-projection-arrays.md), benchmarked here
+//!    docs/issues/00690-engine-direct-projection-arrays.md), benchmarked here
 //!    against synthetic offsets at real corpus scale.
 //! 2. Still-open exploration of `groups_of_printings`/`printing_to_global_group`
 //!    for crossover axis 4 of docs/issues/local-engine-broad-range-fastpath.md
@@ -48,7 +48,7 @@ fn groups_of_printings(offsets: &AOffsets, group_offsets: &[u32], local_group_id
 /// Direct `printing_id -> global_group_id` lookup, precomputed once -- the same
 /// mechanism as `build_printing_to_card`, but deferred (not shipped) since nothing
 /// in the current codebase would consume it. See "Finding" in
-/// docs/issues/local-engine-direct-projection-arrays.md for why: `unique=artwork`'s
+/// docs/issues/00690-engine-direct-projection-arrays.md for why: `unique=artwork`'s
 /// real implementation dedupes per-card locally, not via a global projection.
 fn printing_to_global_group(offsets: &[u32], group_offsets: &[u32], local_group_ids: &[u16]) -> Vec<u32> {
     let mut out = vec![0u32; local_group_ids.len()];

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1885,7 +1885,7 @@ fn assign_artwork_groups(printings: &mut [Printing], offsets: &[u32]) -> Vec<u16
 /// scatter-into-printing-bitmap-then-monotone-cursor path `cards_of_printings`
 /// otherwise pays past 1024 matches, and unconditionally cheaper than the
 /// small-k `partition_point` binary search too — see
-/// docs/issues/local-engine-direct-projection-arrays.md.
+/// docs/issues/00690-engine-direct-projection-arrays.md.
 fn build_printing_to_card(offsets: &[u32]) -> Vec<u32> {
     let n_printings = offsets.last().copied().unwrap_or(0) as usize;
     let mut out = vec![0u32; n_printings];
@@ -2218,7 +2218,7 @@ struct CardIndexes {
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     // printing space: printing_id -> card_id, direct lookup. Replaces a
     // partition_point search on `offsets` in cards_of_printings' hot paths —
-    // see docs/issues/local-engine-direct-projection-arrays.md.
+    // see docs/issues/00690-engine-direct-projection-arrays.md.
     printing_to_card: Vec<u32>,
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
@@ -2413,7 +2413,7 @@ fn printing_bits_to_card_bits(pbits: &[u64], offsets: &AOffsets, n_cards: usize)
 /// bits is cheaper than repeated pushes (same reasoning as `scatter_bits`
 /// elsewhere). Both branches use the direct array now — benchmarked
 /// unconditionally cheaper than a `partition_point` search on `offsets` at
-/// every k tested, see docs/issues/local-engine-direct-projection-arrays.md.
+/// every k tested, see docs/issues/00690-engine-direct-projection-arrays.md.
 fn cards_of_printings(offsets: &AOffsets, printing_to_card: &AOffsets, printing_ids: &[u32]) -> Vec<u32> {
     if printing_ids.len() > 1024 {
         let n_cards = offsets.len().saturating_sub(1);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -708,7 +708,7 @@ fn cards_of_printings_maps_and_dedups() {
 }
 
 /// Differential test for the direct-array projection
-/// (docs/issues/local-engine-direct-projection-arrays.md): `cards_of_printings`
+/// (docs/issues/00690-engine-direct-projection-arrays.md): `cards_of_printings`
 /// must agree with an independent reference oracle (a `partition_point` search on
 /// `offsets`, applied uniformly regardless of size -- the mechanism the small-k
 /// path itself used before this change) at every k, spanning both the small-k

--- a/docs/issues/00690-engine-direct-projection-arrays.md
+++ b/docs/issues/00690-engine-direct-projection-arrays.md
@@ -1,6 +1,6 @@
 # Engine: direct printing→card / printing→group projection arrays
 
-Status: **`printing_to_card` shipped** 2026-07-14, no GitHub issue yet. Surfaced investigating
+Status: **`printing_to_card` shipped**, merged via [#690](https://github.com/jbylund/sylvan_librarian/pull/690). Surfaced investigating
 [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md)'s crossover axis 4
 (does `unique=card`'s exact `total` cost too much to make its fast-path win moot?) — turned into a
 standalone win independent of that project, landed first since it changed the baseline costs that

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -131,6 +131,24 @@ composition-safety question (does the `Not`-arm's complement correctly exclude N
 printings, which are simply absent from the index?) deferred to the fastpath work below, not a
 side effect of this fix.
 
+### Tried and reverted: skipping `field_num`'s division by binding price to cents
+
+`field_num` still divides cents to dollars (`/100.0`) on every printing evaluated, since the
+query-side `Const` stays in dollars. Tried removing that division by having `FilterExpr::bind`
+rewrite a bare `usd`/`eur`/`tix` `Field`-vs-`Const` comparison's `Const` to cents once per query,
+so `field_num` could compare raw cents directly. Measured win was small (~2-3%) and narrow (only
+that one exact shape). Shipped, then reverted after code review found a real correctness bug:
+the rewrite only recognized that one shape, so `usd+1<power` (price inside `NumExpr::Arith`) and
+`usd<cmc` (price compared directly against another `Field`, no `Const` at all) left the
+query-side operand in dollars while a modified `field_num` returned cents unconditionally —
+silently off by 100x. A type-level fix was possible (a distinct `NumExpr::PriceCents` variant,
+constructed only for the verified-safe shape) but made two logically identical queries
+(`usd<5.00` vs. `usd+0.01<5.01`) take inconsistently optimized paths depending on phrasing — the
+same shape-dependent fragility that caused the bug, and worth avoiding rather than papering over.
+Not worth re-attempting without a fundamentally different approach (e.g. a real compile-time
+unit-checked representation, not a bind-time rewrite keyed on syntactic shape). Full history in
+[#690](https://github.com/jbylund/sylvan_librarian/pull/690).
+
 ## Problem
 
 `usd<50` matches 80,527 of 97,206 printings (83%) — genuinely broad, same shape as the
@@ -190,12 +208,13 @@ and test each candidate for set membership inline, stopping once `limit` matches
   id and test-and-set a bit (new bit set → a newly-counted distinct card; already set → skip).
   That per-printing card lookup can't use `cards_of_printings`' own broad-k trick
   (`printing_bits_to_card_bits`'s monotone cursor needs ascending printing-id order, which a
-  permutation walk doesn't provide) — it needs the direct-array lookup instead, see
-  [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md), which is
-  worth landing before committing to idea 1 for this reason specifically, not just its narrower
-  standalone win. Still an open, measurement-shaped question (kernel benchmark, not end-to-end
-  timing) whether this incremental floor is cheap enough to make `unique=card` competitive with
-  `unique=printing` — landing the direct array first is what makes that measurement fair.
+  permutation walk doesn't provide) — it needs the direct-array lookup instead. **Landed** (see
+  [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md), merged via
+  [#690](https://github.com/jbylund/sylvan_librarian/pull/690)), so idea 1's incremental per-match
+  card lookup can use `printing_to_card` directly. Still an open, measurement-shaped question
+  (kernel benchmark, not end-to-end timing) whether this incremental floor is cheap enough to make
+  `unique=card` competitive with `unique=printing` — the direct array being on `main` now is what
+  makes that measurement fair.
 
 ## Idea 2: scatter the exact narrowed set into a bitmap, feed the existing popcount-skip path
 
@@ -280,10 +299,11 @@ fifth (tight/loose) axis to worry about — every field behaves identically ther
 
 - [x] Ship the price exactness fix standalone (see Prerequisite above) — landed as the
       integer-cents migration in [#688](https://github.com/jbylund/sylvan_librarian/pull/688).
-- [ ] Ship `printing_to_card` standalone first (see
-      [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md)) —
-      load-bearing for idea 1's incremental per-match card check, neutral to idea 2, changes this
-      doc's crossover-axis-4 baseline numbers.
+- [x] Ship `printing_to_card` standalone first (see
+      [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md)) —
+      load-bearing for idea 1's incremental per-match card check, neutral to idea 2. Landed via
+      [#690](https://github.com/jbylund/sylvan_librarian/pull/690); this doc's crossover-axis-4
+      baseline numbers (not yet measured) should be taken against `main` post-#690.
 - [ ] Prove the fast-path mechanism on `unique=printing` for a tight field first (`released_at`
       or `collector_number`) — this is the case that genuinely isolates the crossover question
       from row-selection (no picking-a-printing problem at all when each printing is its own
@@ -317,7 +337,7 @@ fifth (tight/loose) axis to worry about — every field behaves identically ther
 
 ## Related
 
-- [local-engine-direct-projection-arrays.md](local-engine-direct-projection-arrays.md) —
+- [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —
   prerequisite `printing_to_card` array, load-bearing for idea 1's per-match card check.
 - [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
   analogous fix for `cmc`/`power`/`toughness`; doesn't transfer (card-invariant, not existential).


### PR DESCRIPTION
## Summary

Docs-only follow-up to #690 (merged).

- Renamed `local-engine-direct-projection-arrays.md` → `00690-engine-direct-projection-arrays.md`
  now that it shipped via a real merged PR, per `docs/issues`' naming convention. Updated its own
  status line and every cross-reference (1 other doc + 3 Rust source comments in `lib.rs`,
  `bench_card_dedup.rs`, `tests.rs` — comment-only, no code changes).
- `local-engine-broad-range-fastpath.md`: checked off the `printing_to_card` Plan item and updated
  the Idea 1 discussion now that it's landed on `main`, and added a "Tried and reverted" note
  documenting the bind-time price-cents optimization (implemented, benchmarked, found to have a
  correctness bug, reverted in #690) so a future reader doesn't re-attempt the same
  shape-dependent fast path without knowing why it was abandoned.

## Test plan

- [x] `cargo build --release --tests` clean (Rust changes are comment-only)
- [x] Checked every remaining reference to the renamed file across the repo