### PR TITLE
Skip tri()'s Call Boundary for Numeric Range Comparisons

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1058,17 +1058,29 @@ impl FilterExpr {
         }
     }
 
-    /// A narrow, byte-identical fast path for the handful of leaf shapes that
-    /// dominate range-query hot loops (NumericCmp/DateCmp/YearCmp -- the cheap
-    /// MASK_COMPARE_NS100 tier, see verify_cost_tier). tri() itself can't be
-    /// force-inlined into these call sites without pulling in the other ~15
-    /// unrelated arms (TextContains, regex, ManaCostCmp, ...) too -- measured
-    /// that directly, made every mode slower (code bloat outweighing the
-    /// saved call). This covers just the cheap arms, small enough to actually
-    /// inline, so the hot per-printing/per-card loops skip tri()'s call
-    /// boundary entirely for the common case, falling back to the exact same
-    /// tri() arm (not a second implementation -- no risk of the two drifting
-    /// apart, unlike the reverted price-cents fast path) for anything else.
+    /// A narrow, byte-identical fast path for the cheap leaf shapes
+    /// (MASK_COMPARE_NS100 tier, see verify_cost_tier) that actually reach
+    /// this code at all. That's the real filter, not raw query frequency:
+    /// compile_plane (planes.rs) already intercepts ColorCmp/TypeCmp/
+    /// Legality/Devotion/rarity-NumericCmp/border-TextExact into a bitmap
+    /// before they ever reach tri() in the common case, so a query like
+    /// `color:g` or `type:creature` alone mostly never calls tri_fast at
+    /// all -- those variants are NOT here despite being high-frequency in
+    /// realistic traffic (client/query_runner.py's weights), because their
+    /// plane path already avoids paying tri()'s cost in the first place.
+    /// NumericCmp (non-rarity fields)/DateCmp/YearCmp have no plane arm --
+    /// every occurrence, however rare, pays the full residual cost, which is
+    /// what justifies them here even though they're a smaller slice of
+    /// real-query volume than color/type. tri() itself can't be
+    /// force-inlined into these call sites without pulling in the other
+    /// ~15 unrelated arms (TextContains, regex, ManaCostCmp, ...) too --
+    /// measured that directly, made every mode slower (code bloat outweighing
+    /// the saved call). This covers just the cheap arms that are also
+    /// un-planed, small enough to actually inline, so the hot
+    /// per-printing/per-card loops skip tri()'s call boundary entirely for
+    /// the common case, falling back to the exact same tri() arm (not a
+    /// second implementation -- no risk of the two drifting apart, unlike
+    /// the reverted price-cents fast path) for anything else.
     #[inline(always)]
     fn tri_fast(&self, card: &AOracleCard, printing: Option<&APrinting>) -> Option<Tri> {
         match self {

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1058,29 +1058,37 @@ impl FilterExpr {
         }
     }
 
-    /// A narrow, byte-identical fast path for the cheap leaf shapes
-    /// (MASK_COMPARE_NS100 tier, see verify_cost_tier) that actually reach
-    /// this code at all. That's the real filter, not raw query frequency:
-    /// compile_plane (planes.rs) already intercepts ColorCmp/TypeCmp/
-    /// Legality/Devotion/rarity-NumericCmp/border-TextExact into a bitmap
-    /// before they ever reach tri() in the common case, so a query like
-    /// `color:g` or `type:creature` alone mostly never calls tri_fast at
-    /// all -- those variants are NOT here despite being high-frequency in
-    /// realistic traffic (client/query_runner.py's weights), because their
-    /// plane path already avoids paying tri()'s cost in the first place.
-    /// NumericCmp (non-rarity fields)/DateCmp/YearCmp have no plane arm --
-    /// every occurrence, however rare, pays the full residual cost, which is
-    /// what justifies them here even though they're a smaller slice of
-    /// real-query volume than color/type. tri() itself can't be
-    /// force-inlined into these call sites without pulling in the other
-    /// ~15 unrelated arms (TextContains, regex, ManaCostCmp, ...) too --
-    /// measured that directly, made every mode slower (code bloat outweighing
-    /// the saved call). This covers just the cheap arms that are also
-    /// un-planed, small enough to actually inline, so the hot
-    /// per-printing/per-card loops skip tri()'s call boundary entirely for
-    /// the common case, falling back to the exact same tri() arm (not a
-    /// second implementation -- no risk of the two drifting apart, unlike
-    /// the reverted price-cents fast path) for anything else.
+    /// A narrow, byte-identical fast path for the one leaf shape that's both
+    /// cheap (MASK_COMPARE_NS100 tier, see verify_cost_tier) and actually
+    /// reaches this code often enough to earn a dedicated arm: numeric range
+    /// compares on non-rarity fields (usd/cn/power/toughness/cmc/...), which
+    /// have no compile_plane arm at all, so every occurrence pays the full
+    /// residual cost -- measured a real ~12-19% win on usd<50 and a compound
+    /// `usd<10 AND year=2024`.
+    ///
+    /// ColorCmp/TypeCmp/Legality/Devotion/rarity-NumericCmp/border-TextExact
+    /// are NOT here despite being high-frequency in realistic traffic
+    /// (client/query_runner.py's weights): compile_plane (planes.rs) already
+    /// intercepts them into a bitmap before they reach tri() in the common
+    /// case -- confirmed directly, profiling a bare `t:creature` shows zero
+    /// samples in tri/card_pass/residual_matches at all. TextExact on
+    /// set_code similarly has its own exact index (indexes.set_codes,
+    /// lib.rs) that narrows before residual, and those queries are already
+    /// ~50us end to end regardless. DateCmp/YearCmp are also NOT here: the
+    /// feature is infrequently used in practice, and narrow date/year
+    /// queries (the common case when it is used, e.g. an exact year) get
+    /// index-narrowed via range_narrowed same as everything else, so the
+    /// residual path for them is rarer still than raw usage would suggest.
+    ///
+    /// tri() itself can't be force-inlined into these call sites without
+    /// pulling in the other ~15 unrelated arms (TextContains, regex,
+    /// ManaCostCmp, ...) too -- measured that directly, made every mode
+    /// slower (code bloat outweighing the saved call). This one arm is
+    /// small enough to actually inline, so the hot per-printing/per-card
+    /// loops skip tri()'s call boundary entirely for the common case,
+    /// falling back to the exact same tri() arm (not a second
+    /// implementation -- no risk of the two drifting apart, unlike the
+    /// reverted price-cents fast path) for anything else.
     #[inline(always)]
     fn tri_fast(&self, card: &AOracleCard, printing: Option<&APrinting>) -> Option<Tri> {
         match self {
@@ -1089,38 +1097,6 @@ impl FilterExpr {
                 (NumVal::PDep, _) | (_, NumVal::PDep) => Tri::PrintingDep,
                 (NumVal::Known(a), NumVal::Known(b)) => tri_bool(cmp(*op, a, b)),
             }),
-            // value is a zero-padded yyyymmdd (see build_binary); zero-padding a
-            // partial date reproduces the old lexicographic-prefix semantics exactly,
-            // since any real day/month (>= 01) compares greater than 00.
-            FilterExpr::DateCmp { op, value } => {
-                let Some(p) = printing else { return Some(Tri::PrintingDep) };
-                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
-                    return Some(Tri::Null); // missing date: SQL NULL
-                };
-                Some(tri_bool(match op {
-                    CmpOp::Eq => date == *value,
-                    CmpOp::Ne => date != *value,
-                    CmpOp::Lt => date < *value,
-                    CmpOp::Le => date <= *value,
-                    CmpOp::Gt => date > *value,
-                    CmpOp::Ge => date >= *value,
-                }))
-            }
-            FilterExpr::YearCmp { op, year } => {
-                let Some(p) = printing else { return Some(Tri::PrintingDep) };
-                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
-                    return Some(Tri::Null); // missing date: SQL NULL
-                };
-                let card_year = (date / 10_000) as i32;
-                Some(tri_bool(match op {
-                    CmpOp::Eq => card_year == *year,
-                    CmpOp::Ne => card_year != *year,
-                    CmpOp::Gt => card_year > *year,
-                    CmpOp::Lt => card_year < *year,
-                    CmpOp::Ge => card_year >= *year,
-                    CmpOp::Le => card_year <= *year,
-                }))
-            }
             _ => None,
         }
     }
@@ -1336,9 +1312,39 @@ impl FilterExpr {
                 })
             }
 
-            FilterExpr::DateCmp { .. } => self.tri_fast(card, printing).expect("tri_fast always handles DateCmp"),
+            // value is a zero-padded yyyymmdd (see build_binary); zero-padding a
+            // partial date reproduces the old lexicographic-prefix semantics exactly,
+            // since any real day/month (>= 01) compares greater than 00.
+            FilterExpr::DateCmp { op, value } => {
+                let Some(p) = printing else { return Tri::PrintingDep };
+                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
+                    return Tri::Null; // missing date: SQL NULL
+                };
+                tri_bool(match op {
+                    CmpOp::Eq => date == *value,
+                    CmpOp::Ne => date != *value,
+                    CmpOp::Lt => date < *value,
+                    CmpOp::Le => date <= *value,
+                    CmpOp::Gt => date > *value,
+                    CmpOp::Ge => date >= *value,
+                })
+            }
 
-            FilterExpr::YearCmp { .. } => self.tri_fast(card, printing).expect("tri_fast always handles YearCmp"),
+            FilterExpr::YearCmp { op, year } => {
+                let Some(p) = printing else { return Tri::PrintingDep };
+                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
+                    return Tri::Null; // missing date: SQL NULL
+                };
+                let card_year = (date / 10_000) as i32;
+                tri_bool(match op {
+                    CmpOp::Eq => card_year == *year,
+                    CmpOp::Ne => card_year != *year,
+                    CmpOp::Gt => card_year > *year,
+                    CmpOp::Lt => card_year < *year,
+                    CmpOp::Ge => card_year >= *year,
+                    CmpOp::Le => card_year <= *year,
+                })
+            }
         }
     }
 

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -1003,7 +1003,7 @@ impl FilterExpr {
         match self {
             FilterExpr::And(children) => {
                 for c in children {
-                    match c.tri(card, None, strings) {
+                    match c.tri_fast(card, None).unwrap_or_else(|| c.tri(card, None, strings)) {
                         // And(Null, x) is Null or False for every printing —
                         // never True — so the card cannot match.
                         Tri::False | Tri::Null => return Tri::False,
@@ -1016,7 +1016,7 @@ impl FilterExpr {
             FilterExpr::Or(children) => {
                 *residual_is_or = true;
                 for c in children {
-                    match c.tri(card, None, strings) {
+                    match c.tri_fast(card, None).unwrap_or_else(|| c.tri(card, None, strings)) {
                         Tri::True => {
                             residual.clear();
                             return Tri::True;
@@ -1029,7 +1029,7 @@ impl FilterExpr {
                 }
                 if residual.is_empty() { Tri::False } else { Tri::PrintingDep }
             }
-            other => match other.tri(card, None, strings) {
+            other => match other.tri_fast(card, None).unwrap_or_else(|| other.tri(card, None, strings)) {
                 Tri::PrintingDep => {
                     residual.push(self);
                     Tri::PrintingDep
@@ -1050,10 +1050,66 @@ impl FilterExpr {
         residual: &[&FilterExpr],
         residual_is_or: bool,
     ) -> bool {
+        let eval_one = |c: &FilterExpr| c.tri_fast(card, Some(printing)).unwrap_or_else(|| c.tri(card, Some(printing), strings));
         if residual_is_or {
-            residual.iter().any(|c| c.tri(card, Some(printing), strings) == Tri::True)
+            residual.iter().any(|c| eval_one(c) == Tri::True)
         } else {
-            residual.iter().all(|c| c.tri(card, Some(printing), strings) == Tri::True)
+            residual.iter().all(|c| eval_one(c) == Tri::True)
+        }
+    }
+
+    /// A narrow, byte-identical fast path for the handful of leaf shapes that
+    /// dominate range-query hot loops (NumericCmp/DateCmp/YearCmp -- the cheap
+    /// MASK_COMPARE_NS100 tier, see verify_cost_tier). tri() itself can't be
+    /// force-inlined into these call sites without pulling in the other ~15
+    /// unrelated arms (TextContains, regex, ManaCostCmp, ...) too -- measured
+    /// that directly, made every mode slower (code bloat outweighing the
+    /// saved call). This covers just the cheap arms, small enough to actually
+    /// inline, so the hot per-printing/per-card loops skip tri()'s call
+    /// boundary entirely for the common case, falling back to the exact same
+    /// tri() arm (not a second implementation -- no risk of the two drifting
+    /// apart, unlike the reverted price-cents fast path) for anything else.
+    #[inline(always)]
+    fn tri_fast(&self, card: &AOracleCard, printing: Option<&APrinting>) -> Option<Tri> {
+        match self {
+            FilterExpr::NumericCmp { lhs, op, rhs } => Some(match (lhs.eval(card, printing), rhs.eval(card, printing)) {
+                (NumVal::Null, _) | (_, NumVal::Null) => Tri::Null,
+                (NumVal::PDep, _) | (_, NumVal::PDep) => Tri::PrintingDep,
+                (NumVal::Known(a), NumVal::Known(b)) => tri_bool(cmp(*op, a, b)),
+            }),
+            // value is a zero-padded yyyymmdd (see build_binary); zero-padding a
+            // partial date reproduces the old lexicographic-prefix semantics exactly,
+            // since any real day/month (>= 01) compares greater than 00.
+            FilterExpr::DateCmp { op, value } => {
+                let Some(p) = printing else { return Some(Tri::PrintingDep) };
+                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
+                    return Some(Tri::Null); // missing date: SQL NULL
+                };
+                Some(tri_bool(match op {
+                    CmpOp::Eq => date == *value,
+                    CmpOp::Ne => date != *value,
+                    CmpOp::Lt => date < *value,
+                    CmpOp::Le => date <= *value,
+                    CmpOp::Gt => date > *value,
+                    CmpOp::Ge => date >= *value,
+                }))
+            }
+            FilterExpr::YearCmp { op, year } => {
+                let Some(p) = printing else { return Some(Tri::PrintingDep) };
+                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
+                    return Some(Tri::Null); // missing date: SQL NULL
+                };
+                let card_year = (date / 10_000) as i32;
+                Some(tri_bool(match op {
+                    CmpOp::Eq => card_year == *year,
+                    CmpOp::Ne => card_year != *year,
+                    CmpOp::Gt => card_year > *year,
+                    CmpOp::Lt => card_year < *year,
+                    CmpOp::Ge => card_year >= *year,
+                    CmpOp::Le => card_year <= *year,
+                }))
+            }
+            _ => None,
         }
     }
 
@@ -1074,48 +1130,11 @@ impl FilterExpr {
         match self {
             FilterExpr::True => Tri::True,
 
-            FilterExpr::And(children) => {
-                let mut null = false;
-                let mut pdep = false;
-                for c in children {
-                    match c.tri(card, printing, strings) {
-                        Tri::False => return Tri::False,
-                        Tri::Null => null = true,
-                        Tri::PrintingDep => pdep = true,
-                        Tri::True => {}
-                    }
-                }
-                if pdep { Tri::PrintingDep } else if null { Tri::Null } else { Tri::True }
-            }
-            FilterExpr::Or(children) => {
-                let mut null = false;
-                let mut pdep = false;
-                for c in children {
-                    match c.tri(card, printing, strings) {
-                        Tri::True => return Tri::True,
-                        Tri::Null => null = true,
-                        Tri::PrintingDep => pdep = true,
-                        Tri::False => {}
-                    }
-                }
-                if pdep { Tri::PrintingDep } else if null { Tri::Null } else { Tri::False }
-            }
-            FilterExpr::Not(inner) => match inner.tri(card, printing, strings) {
-                Tri::True => Tri::False,
-                Tri::False => Tri::True,
-                Tri::Null => Tri::Null,
-                Tri::PrintingDep => Tri::PrintingDep,
-            },
+            FilterExpr::And(_) | FilterExpr::Or(_) | FilterExpr::Not(_) => self.tri_composite(card, printing, strings),
 
             FilterExpr::ExactName(lower) => tri_bool(card.card_name_lower.as_str() == lower.as_str()),
 
-            FilterExpr::NumericCmp { lhs, op, rhs } => {
-                match (lhs.eval(card, printing), rhs.eval(card, printing)) {
-                    (NumVal::Null, _) | (_, NumVal::Null) => Tri::Null, // missing field: SQL NULL
-                    (NumVal::PDep, _) | (_, NumVal::PDep) => Tri::PrintingDep,
-                    (NumVal::Known(a), NumVal::Known(b)) => tri_bool(cmp(*op, a, b)),
-                }
-            }
+            FilterExpr::NumericCmp { .. } => self.tri_fast(card, printing).expect("tri_fast always handles NumericCmp"),
 
             FilterExpr::TextContains { field, word } => {
                 match text_search_field_value(card, printing, strings, *field) {
@@ -1305,39 +1324,52 @@ impl FilterExpr {
                 })
             }
 
-            FilterExpr::DateCmp { op, value } => {
-                // value is a zero-padded yyyymmdd (see build_binary); zero-padding a
-                // partial date reproduces the old lexicographic-prefix semantics exactly,
-                // since any real day/month (>= 01) compares greater than 00.
-                let Some(p) = printing else { return Tri::PrintingDep };
-                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
-                    return Tri::Null; // missing date: SQL NULL
-                };
-                tri_bool(match op {
-                    CmpOp::Eq => date == *value,
-                    CmpOp::Ne => date != *value,
-                    CmpOp::Lt => date < *value,
-                    CmpOp::Le => date <= *value,
-                    CmpOp::Gt => date > *value,
-                    CmpOp::Ge => date >= *value,
-                })
-            }
+            FilterExpr::DateCmp { .. } => self.tri_fast(card, printing).expect("tri_fast always handles DateCmp"),
 
-            FilterExpr::YearCmp { op, year } => {
-                let Some(p) = printing else { return Tri::PrintingDep };
-                let Some(date) = p.released_at_int.as_ref().map(|v| u32::from(*v)) else {
-                    return Tri::Null; // missing date: SQL NULL
-                };
-                let card_year = (date / 10_000) as i32;
-                tri_bool(match op {
-                    CmpOp::Eq => card_year == *year,
-                    CmpOp::Ne => card_year != *year,
-                    CmpOp::Gt => card_year > *year,
-                    CmpOp::Lt => card_year < *year,
-                    CmpOp::Ge => card_year >= *year,
-                    CmpOp::Le => card_year <= *year,
-                })
+            FilterExpr::YearCmp { .. } => self.tri_fast(card, printing).expect("tri_fast always handles YearCmp"),
+        }
+    }
+
+    /// The self-recursive rest of tri(): boolean composition over children.
+    /// Kept out of tri() itself so tri()'s leaf dispatch can be force-inlined
+    /// (see the comment on tri()) -- this one stays a real call, which is
+    /// fine since a composite node's own cost is dominated by its children,
+    /// not by the one extra call to get here.
+    fn tri_composite(&self, card: &AOracleCard, printing: Option<&APrinting>, strings: &AStrings) -> Tri {
+        match self {
+            FilterExpr::And(children) => {
+                let mut null = false;
+                let mut pdep = false;
+                for c in children {
+                    match c.tri(card, printing, strings) {
+                        Tri::False => return Tri::False,
+                        Tri::Null => null = true,
+                        Tri::PrintingDep => pdep = true,
+                        Tri::True => {}
+                    }
+                }
+                if pdep { Tri::PrintingDep } else if null { Tri::Null } else { Tri::True }
             }
+            FilterExpr::Or(children) => {
+                let mut null = false;
+                let mut pdep = false;
+                for c in children {
+                    match c.tri(card, printing, strings) {
+                        Tri::True => return Tri::True,
+                        Tri::Null => null = true,
+                        Tri::PrintingDep => pdep = true,
+                        Tri::False => {}
+                    }
+                }
+                if pdep { Tri::PrintingDep } else if null { Tri::Null } else { Tri::False }
+            }
+            FilterExpr::Not(inner) => match inner.tri(card, printing, strings) {
+                Tri::True => Tri::False,
+                Tri::False => Tri::True,
+                Tri::Null => Tri::Null,
+                Tri::PrintingDep => Tri::PrintingDep,
+            },
+            _ => unreachable!("tri_composite only called for And/Or/Not"),
         }
     }
 }


### PR DESCRIPTION
## What this does

Profiling `usd<50` across `unique=card`/`printing`/`artwork` (starting from a request to
investigate where per-row comparison time actually goes) found `FilterExpr::tri` as the single
biggest self-time bucket — not because its enum match mispredicts (the same shape repeats every
row, so branch prediction handles it fine), but because `tri()` is too large (~20 arms, including
regex/text-search/mana-cost logic) for LLVM to force-inline at its hot call sites (`card_pass`,
`residual_matches`'s loop) without bloating every caller. Confirmed directly: force-inlining `tri()`
wholesale made every mode 12-18% *slower*, not faster (code bloat outweighing the saved call).

`tri_fast()` pulls just `NumericCmp` — the one leaf shape that's both cheap and has no
`compile_plane`/index narrowing to intercept it first — into its own small, force-inlinable
function. Hot call sites try it first and fall back to the untouched `tri()` for everything else.
`tri()` itself delegates to `tri_fast` for `NumericCmp`, so there's one implementation, not two —
avoids the representation-drift risk that caused the reverted price-cents bind-time optimization's
correctness bugs (#690).

Also split `tri()`'s self-recursive `And`/`Or`/`Not` cases into `tri_composite()` so `tri()` itself
is no longer self-recursive — same fix already applied to `NumExpr::eval` in #690, for the same
LLVM always-inliner limitation.

## Variants considered and rejected (with evidence, not just intuition)

Raw query frequency (`client/query_runner.py`'s realistic traffic weights) turned out to be the
wrong prioritization signal. The real question is "does this shape ever reach `tri()`'s call sites
at all" — several high-frequency shapes never do:

- **ColorCmp / TypeCmp / Legality / Devotion / rarity-NumericCmp / border-TextExact**: all get
  compiled into a bitmap plane (`planes.rs::compile_plane`) before reaching `tri()` in the common
  case. Confirmed by profiling a bare `t:creature` query: zero samples in
  `tri`/`card_pass`/`residual_matches` at all.
- **TextExact on set_code**: has its own exact index (`indexes.set_codes`) that narrows before
  residual, and those queries are already ~50us end to end regardless.
- **DateCmp / YearCmp**: no plane arm, so in principle every occurrence pays full residual cost —
  but the feature is infrequently used, and the common case when it is used (an exact year/date)
  gets index-narrowed via `range_narrowed` same as everything else. Tried keeping them in
  `tri_fast`, reverted per feedback.
- **TextContains**: reaches residual more than the plane-backed shapes above (trigram narrowing is
  loose, not exact — false positives need verification), but its per-call cost is dominated by the
  `.contains()` scan itself (~23-70ns), not dispatch. Measured directly: adding it to `tri_fast`
  made `name:`/`oracle:` queries slightly *slower* than plain `main`, not faster — the extra arm's
  fallback tax on every other shape outweighed its own tiny dispatch savings.
- **ExactName**: a separate, rare bang-quote exact-match node, distinct from the common `name:`
  substring search (that's `TextContains`, addressed above).

## A real, measured cost on the fallback path

Every filter shape that falls through `tri_fast` now pays a small extra "is this `NumericCmp`?"
check before the same `tri()` call it always made. Measured directly (pristine `main` vs. this
branch, pure `TextContains` queries which never hit `tri_fast`): 1.00-1.03x the runtime (i.e. up to
~3% slower) across `name:bolt`/`oracle:draw`/`oracle:flying`, card and printing mode. Real, not free
— the `NumericCmp` win has to outweigh this tax on everything else, which it does by a wide margin
(1.13-1.23x faster vs. up to 1.03x slower), but it's not a costless change.

## Performance

Measured (`min_ms`, repeated 8s-window trials, 97,206-printing corpus, `main` vs. this branch):

| query | unique | before | after | speedup |
|---|---|---:|---:|---:|
| `usd<50` | card | 341us | 282us | **1.21x** |
| `usd<50` | printing | 723us | 621us | **1.16x** |
| `usd<50` | artwork | 807us | 714us | **1.13x** |
| `usd<10 AND year=2024` | card | 311us | 273us | **1.14x** |
| `usd<10 AND year=2024` | printing | 458us | 372us | **1.23x** |
| `usd<10 AND year=2024` | artwork | 478us | 394us | **1.21x** |

Totals unchanged in every case (correctness verified, not just timing).

## Testing

- `cargo test` (debug + release): 119 passed, 9 ignored.
- `cargo clippy --release --all-targets`: no new warnings vs. baseline.
- Re-profiled after the change: `FilterExpr::tri` no longer appears as a separate call at all for
  `NumericCmp`-only queries — its work is now inlined directly into `residual_matches`/`card_pass`.
