### PR TITLE
Replace Artwork-Mode Dedup Scratch Buffer With a Fixed-Size Bitmask

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3406,15 +3406,24 @@ fn select_page(mut v: Vec<Match>, offset: usize, limit: usize) -> Vec<(u32, u32)
 #[derive(Clone, Copy)]
 enum Mode { Card, Artwork, Printing }
 
+/// Upper bound on distinct artwork groups for any one card, sized for
+/// `seen_words`'s fixed-size bitmask (below). Checked against the real corpus:
+/// the max is 385 (Mountain; Island/Plains/Forest/Swamp all in the 365-375
+/// range), so 512 bits (8 u64 words) gives ~33% headroom over today's actual
+/// worst case while staying tiny (64 bytes) -- a stack array, not a heap
+/// allocation, and small enough that a full `fill(0)` every card is cheaper
+/// than the growable Vec's per-printing resize-check it replaces. Revisit if
+/// a future card's reprint count actually approaches this (debug_assert
+/// below catches that during development rather than silently
+/// under-counting in production).
+const ARTWORK_GROUP_WORDS: usize = 8;
+
 /// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
 /// passing printings for Printing mode, distinct illustrations with a passing
 /// printing for Artwork mode. `seen_words` is a reused scratch buffer: a
-/// growable bitmask indexed by each printing's dense `artwork_group_id` (#629),
-/// one bit per group, `word = gid / 64`. Grown on demand (`clear()` keeps the
-/// backing allocation), so the common 1-2-group card never reallocates once
-/// warmed up, and the rare >64-group card (a handful of basic lands in real
-/// data) just grows to a few words -- no separate threshold/fallback path, so
-/// there's no O(k²) tail hiding on exactly the highest-printing-count cards.
+/// fixed-size bitmask indexed by each printing's dense `artwork_group_id`
+/// (#629), one bit per group, `word = gid / 64` -- zeroed in full every card
+/// (cheap: ARTWORK_GROUP_WORDS is tiny), never resized.
 // #676 review: a legality leaf promoted into `plane` alongside a genuinely
 // printing-dependent residual (DateCmp, ArtistMatch, ...) needs *both*
 // checked against the *same* printing -- `all_match`/`residual_matches` alone
@@ -3440,7 +3449,7 @@ fn card_match_count(
     mode: Mode,
     strings: &AStrings,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
-    seen_words: &mut Vec<u64>,
+    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
 ) -> u32 {
     // No existential plane: identical code shape to before #676's
     // existential_plane parameter existed at all -- no closure, no extra
@@ -3480,17 +3489,14 @@ fn card_match_count(
                 n
             }
             Mode::Artwork => {
-                seen_words.clear();
+                seen_words.fill(0);
                 for pid in start..end {
                     if !all_match && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
                         continue;
                     }
                     let gid = u16::from(printings[pid].artwork_group_id) as usize;
-                    let word = gid / 64;
-                    if seen_words.len() <= word {
-                        seen_words.resize(word + 1, 0);
-                    }
-                    seen_words[word] |= 1u64 << (gid % 64);
+                    debug_assert!(gid / 64 < ARTWORK_GROUP_WORDS, "artwork_group_id {gid} exceeds ARTWORK_GROUP_WORDS bound");
+                    seen_words[gid / 64] |= 1u64 << (gid % 64);
                 }
                 seen_words.iter().map(|w| w.count_ones()).sum()
             }
@@ -3522,17 +3528,14 @@ fn card_match_count(
             n
         }
         Mode::Artwork => {
-            seen_words.clear();
+            seen_words.fill(0);
             for pid in start..end {
                 if !satisfies(pid) {
                     continue;
                 }
                 let gid = u16::from(printings[pid].artwork_group_id) as usize;
-                let word = gid / 64;
-                if seen_words.len() <= word {
-                    seen_words.resize(word + 1, 0);
-                }
-                seen_words[word] |= 1u64 << (gid % 64);
+                debug_assert!(gid / 64 < ARTWORK_GROUP_WORDS, "artwork_group_id {gid} exceeds ARTWORK_GROUP_WORDS bound");
+                seen_words[gid / 64] |= 1u64 << (gid % 64);
             }
             seen_words.iter().map(|w| w.count_ones()).sum()
         }
@@ -4068,7 +4071,7 @@ fn run_query_streamed<'a>(
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
-    let mut seen_words: Vec<u64> = Vec::new(); // #629: artwork-mode match-count scratch
+    let mut seen_words = [0u64; ARTWORK_GROUP_WORDS]; // #629: artwork-mode match-count scratch
 
     // Match phase: sequential (candidate-order) evaluation into per-card
     // counts. Exact total = sum of counts, known before emission strategy.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1875,6 +1875,15 @@ fn assign_artwork_groups(printings: &mut [Printing], offsets: &[u32]) -> Vec<u16
             };
             p.artwork_group_id = gid as u16;
         }
+        // Checked once per card at load time, not once per printing per query --
+        // see ARTWORK_GROUP_WORDS' doc for why this bound is expected to hold and
+        // card_match_count's seen_words for the fixed-size bitmask it protects.
+        assert!(
+            ills.len() <= ARTWORK_GROUP_WORDS * 64,
+            "card has {} distinct artwork groups, exceeds ARTWORK_GROUP_WORDS bound ({})",
+            ills.len(),
+            ARTWORK_GROUP_WORDS * 64
+        );
         counts.push(ills.len() as u16);
     }
     counts
@@ -3413,9 +3422,12 @@ enum Mode { Card, Artwork, Printing }
 /// worst case while staying tiny (64 bytes) -- a stack array, not a heap
 /// allocation, and small enough that a full `fill(0)` every card is cheaper
 /// than the growable Vec's per-printing resize-check it replaces. Revisit if
-/// a future card's reprint count actually approaches this (debug_assert
-/// below catches that during development rather than silently
-/// under-counting in production).
+/// a future card's reprint count actually approaches this -- checked once
+/// per card in `assign_artwork_groups` (load time, not the per-query hot
+/// path this bound protects) via a real `assert!`, not `debug_assert!`: the
+/// check is free either way (once per card at load, not once per printing
+/// per query), so there's no reason to let a release build skip it and
+/// silently under-count in production instead of failing loudly on reload.
 const ARTWORK_GROUP_WORDS: usize = 8;
 
 /// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
@@ -3495,7 +3507,6 @@ fn card_match_count(
                         continue;
                     }
                     let gid = u16::from(printings[pid].artwork_group_id) as usize;
-                    debug_assert!(gid / 64 < ARTWORK_GROUP_WORDS, "artwork_group_id {gid} exceeds ARTWORK_GROUP_WORDS bound");
                     seen_words[gid / 64] |= 1u64 << (gid % 64);
                 }
                 seen_words.iter().map(|w| w.count_ones()).sum()
@@ -3534,7 +3545,6 @@ fn card_match_count(
                     continue;
                 }
                 let gid = u16::from(printings[pid].artwork_group_id) as usize;
-                debug_assert!(gid / 64 < ARTWORK_GROUP_WORDS, "artwork_group_id {gid} exceeds ARTWORK_GROUP_WORDS bound");
                 seen_words[gid / 64] |= 1u64 << (gid % 64);
             }
             seen_words.iter().map(|w| w.count_ones()).sum()


### PR DESCRIPTION
## What this does

`Mode::Artwork`'s per-card dedup loop (`card_match_count`, both arms) used a growable `Vec<u64>`
(`seen_words`) indexed by each printing's dense `artwork_group_id`, resized on demand per printing:

```rust
let word = gid / 64;
if seen_words.len() <= word {
    seen_words.resize(word + 1, 0);
}
seen_words[word] |= 1u64 << (gid % 64);
```

Checked the real corpus for how large that ever needs to get: the max distinct artwork groups for
any single card is **385** (Mountain — Island/Plains/Forest/Swamp all in the 365-375 range), well
below the max *printing* count for those same cards (829-851) since many printings share an
illustration. That's a small, stable, checkable bound — `ARTWORK_GROUP_WORDS = 8` (512 bits, 64
bytes) covers it with ~33% headroom, as a stack array that's cheaper to `fill(0)` unconditionally
every card than to resize on demand, and needs no per-printing length check at all.

Bound check lives in `assign_artwork_groups` (load time, once per card) as a real `assert!`, not a
`debug_assert!` in the hot loop: the very first version of this checked `debug_assert!(gid / 64 <
ARTWORK_GROUP_WORDS, ...)` once per printing per query -- exactly the cost this change was trying to
remove, and silently skipped in release builds anyway. Moved to where the bound is actually
knowable (assigning `artwork_group_id` in the first place), where the check is free either way
(once per card at load, not once per printing per query) and fires in every build, so a future card
exceeding it fails loudly on reload instead of silently under-counting in production.

This came out of profiling `usd<50` for #692 (`FilterExpr::tri`'s dispatch cost): part of the
self-time attributed to the misattributed per-candidate loop-harness bucket (`LocalKey::with`, see
that PR's investigation) was this resize check running once per printing.

## A related idea, considered but not pursued here

Also considered pulling `artwork_group_id` out of `Printing` into its own dense
`printing_id -> artwork_group_id` array (`Vec<u16>`, same "direct projection" pattern as
#690's `printing_to_card`), on the theory that `Printing` is a large struct (two u128s, several
`Vec<u16>` fields, `ManaCost`, ...) and a tightly-packed side array would have much better cache
locality when scanning a card's printing range.

Didn't build it: for the queries that actually reach this loop, `all_match` is essentially always
`false` (e.g. `usd<50` — price is inherently printing-dependent, so `card_pass` can never resolve it
to a card-level `True`), which means `FilterExpr::residual_matches(card, &printings[pid], ...)` runs
on the same `pid` immediately before the `artwork_group_id` read — already pulling that printing's
full struct into cache. A separate array wouldn't avoid a cache miss this loop isn't paying for its
dominant real case. It would only help the `all_match == true` case, which the existing card-level
`artwork_groups[cid]` shortcut (`have_group_counts`) mostly bypasses before this loop is even
reached. Not worth the `ARCHIVE_FORMAT_VERSION` bump and added `CardIndexes` field for a case that's
already short-circuited elsewhere.

## Performance

Measured (`min_ms`, 3 repeated 8s-window trials, 97,206-printing corpus, `usd<50`/`unique=artwork` —
the only mode/query combination that touches `seen_words`; card/printing modes are unaffected and
omitted since they never call this code path):

| before | after | speedup |
|---:|---:|---:|
| 821us | ~786us | **1.04x** |

A modest, real win — removing a per-printing branch and resize check from an already fairly cheap
loop. Re-profiled to confirm the mechanism, not just trust the wall-clock number: the misattributed
loop-harness bucket (`LocalKey::with`, see #692) dropped from **37.0%** to **29.2%** of `run_query`'s
self-time for this query.

## Testing

- `cargo test` (debug + release): 119 passed, 9 ignored.
- Verified against the real 97,206-printing corpus: loads cleanly (max is 385, well under the 512
  bound), `usd<50`/artwork totals unchanged.
- `cargo clippy --release --all-targets`: no new warnings vs. baseline.
