### PR TITLE
Add unique=printing Fast Path for Broad Sorted-Range Predicates

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3956,6 +3956,16 @@ fn printing_range_fastpath<'a>(
         return is_price_leaf(filter)
             .then(|| (k, aligned_page(idx, s, e, cards, printings, &indexes.printing_to_card, descending, page_offset, limit)));
     }
+    // The walk reproduces run_query_streamed's *stream* emission (per-card-contiguous), which the
+    // general path only uses above STREAM_MIN_MATCHES; at or below it, run_query_streamed gathers
+    // and sorts globally, ordering full-sort-key ties across cards by pid instead. Bail there so
+    // the fastpath never claims a range the general path would gather. The band is narrow
+    // (NARROW_FLOOR < k <= STREAM_MIN_MATCHES, i.e. 1000 < k <= 1024) and only reachable on a tiny
+    // index (broad needs k > index_len/4, so index_len < ~4096) -- never in production, where broad
+    // means tens of thousands. aligned_page above matches the gathered path directly, so it's exempt.
+    if k <= *STREAM_MIN_MATCHES {
+        return None;
+    }
     let perm = indexes.sort_perms.get(sort_col, descending)?;
     if perm.len() != cards.len() {
         return None;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2004,6 +2004,38 @@ fn int_range_bounds(op: CmpOp, value: f64) -> Option<Option<(u32, u32)>> {
     Some(Some((lo as u32, hi as u32)))
 }
 
+/// Half-open [lo, hi) bounds over the packed released-at integer for a date
+/// comparison. None = Ne (never narrows). Shared by narrow_rec's `DateCmp` arm
+/// and the printing-range fastpath so the two never drift (see [`bare_range_bounds`]).
+fn date_range_bounds(op: CmpOp, value: u32) -> Option<(u32, u32)> {
+    Some(match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => (value, value.saturating_add(1)),
+        CmpOp::Lt => (0, value),
+        CmpOp::Le => (0, value.saturating_add(1)),
+        CmpOp::Gt => (value.saturating_add(1), u32::MAX),
+        CmpOp::Ge => (value, u32::MAX),
+    })
+}
+
+/// Half-open [lo, hi) bounds over the packed released-at integer for a year
+/// comparison (`released_at` packs as `year*10000 + ...`). None = Ne or an
+/// out-of-range year (never narrows). Shared like [`date_range_bounds`].
+fn year_range_bounds(op: CmpOp, year: i32) -> Option<(u32, u32)> {
+    if !(0..=9999).contains(&year) {
+        return None;
+    }
+    let y = year as u32;
+    Some(match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => (y * 10_000, (y + 1) * 10_000),
+        CmpOp::Lt => (0, y * 10_000),
+        CmpOp::Le => (0, (y + 1) * 10_000),
+        CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
+        CmpOp::Ge => (y * 10_000, u32::MAX),
+    })
+}
+
 /// Sorted printing ids with an indexed value in [lo, hi), or None for ranges
 /// too broad to be worth narrowing (see MAX_NARROW_FRACTION). Test-only
 /// reference for the sparse path range_narrowed() shares.
@@ -3099,30 +3131,12 @@ fn narrow_rec(
         }
 
         FilterExpr::DateCmp { op, value } => {
-            let (lo, hi) = match op {
-                CmpOp::Ne => return None,
-                CmpOp::Eq => (*value, value.saturating_add(1)),
-                CmpOp::Lt => (0, *value),
-                CmpOp::Le => (0, value.saturating_add(1)),
-                CmpOp::Gt => (value.saturating_add(1), u32::MAX),
-                CmpOp::Ge => (*value, u32::MAX),
-            };
+            let (lo, hi) = date_range_bounds(*op, *value)?;
             range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
         }
 
         FilterExpr::YearCmp { op, year } => {
-            if *year < 0 || *year > 9999 {
-                return None;
-            }
-            let y = *year as u32;
-            let (lo, hi) = match op {
-                CmpOp::Ne => return None,
-                CmpOp::Eq => (y * 10_000, (y + 1) * 10_000),
-                CmpOp::Lt => (0, y * 10_000),
-                CmpOp::Le => (0, (y + 1) * 10_000),
-                CmpOp::Gt => ((y + 1) * 10_000, u32::MAX),
-                CmpOp::Ge => (y * 10_000, u32::MAX),
-            };
+            let (lo, hi) = year_range_bounds(*op, *year)?;
             range_narrowed(&indexes.released_at, lo, hi, n_printings, broad_ok, true)
         }
 
@@ -3717,6 +3731,238 @@ static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_EN
 /// position exists for benchmarking written-order sensitivity.
 static VERIFY_ORDER: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_VERIFY_ORDER", 1));
 
+/// Kill-switch for the printing-mode bare-range fastpath (`printing_range_fastpath`). Default on;
+/// set to 0 to force every such query back onto the general path (used to A/B correctness and
+/// timing). A binary switch, not a calibrated threshold.
+static PRINTING_RANGE_FASTPATH: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_PRINTING_RANGE_FASTPATH", 1));
+
+/// The range index and half-open `[lo, hi)` a *bare* range-predicate leaf selects, or None for
+/// anything else (compound, `Ne`, a non-range numeric field). Provably-empty predicates return a
+/// zero-width `[v, v)` so the fastpath's `k` resolves to 0. Reuses the exact bound derivations the
+/// narrowing path uses (`int_range_bounds`, [`date_range_bounds`], [`year_range_bounds`]) so the
+/// fastpath and `narrow_rec` can never disagree on which printings a predicate covers.
+fn bare_range_bounds<'i>(
+    filter: &FilterExpr,
+    indexes: &'i Archived<CardIndexes>,
+) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
+    match filter {
+        FilterExpr::NumericCmp { lhs, op, rhs } => {
+            // Only price/collector-number are printing-range-indexed; cmc/power/toughness/rarity are
+            // card-space and belong to other paths. Value snapping matches narrow_rec's `price` closure.
+            let (idx, op, value) = match (lhs, rhs) {
+                (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => (&indexes.price_usd, *op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
+                (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => (&indexes.price_usd, flip_op(*op), snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
+                (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => (&indexes.collector_number, *op, *v),
+                (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => (&indexes.collector_number, flip_op(*op), *v),
+                _ => return None,
+            };
+            match int_range_bounds(op, value)? {
+                None => Some((idx, 0, 0)),
+                Some((lo, hi)) => Some((idx, lo, hi)),
+            }
+        }
+        FilterExpr::DateCmp { op, value } => {
+            let (lo, hi) = date_range_bounds(*op, *value)?;
+            Some((&indexes.released_at, lo, hi))
+        }
+        FilterExpr::YearCmp { op, year } => {
+            let (lo, hi) = year_range_bounds(*op, *year)?;
+            Some((&indexes.released_at, lo, hi))
+        }
+        _ => None,
+    }
+}
+
+/// Page for a `unique=printing` bare-range query ordered by a *card-level* key: walk that key's
+/// precomputed card permutation, emit each card's matching printings, stop once the page is full.
+/// A card-level sort key is shared by all of a card's printings, so card order is printing order;
+/// within a card, printings order by `sort_key_bits` then pid — byte-identical to the streamed
+/// path's emission (`run_query_streamed`), just without the O(n) count pass, since the caller
+/// already has the exact `total` from the index.
+#[allow(clippy::too_many_arguments)]
+fn walk_printing_page<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    leaf: &FilterExpr,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    perm: &Archived<Vec<u32>>,
+) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    let residual: [&FilterExpr; 1] = [leaf];
+    let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
+    let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+    let mut scratch: Vec<Match> = Vec::new();
+    let mut skip = page_offset;
+    for cid in perm.iter().map(|x| u32::from(*x)) {
+        let card = &cards[cid as usize];
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end   = u32::from(offsets[cid as usize + 1]) as usize;
+        scratch.clear();
+        for pid in start..end {
+            let p = &printings[pid];
+            if FilterExpr::residual_matches(card, p, strings, &residual, false) {
+                scratch.push((sort_key_bits(card, p, sort_col, descending), cid, pid as u32));
+            }
+        }
+        if scratch.is_empty() {
+            continue;
+        }
+        if skip >= scratch.len() {
+            skip -= scratch.len();
+            continue;
+        }
+        scratch.sort_unstable_by(cmp);
+        for m in scratch.iter().skip(skip) {
+            page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
+            if page.len() == limit {
+                return page;
+            }
+        }
+        skip = 0;
+    }
+    page
+}
+
+/// Whether `filter` is a bare price comparison (either operand order) — the only range field that
+/// is also a sort column, so the only one an `order by usd` page can be served aligned.
+fn is_price_leaf(filter: &FilterExpr) -> bool {
+    matches!(
+        filter,
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), .. }
+            | FilterExpr::NumericCmp { rhs: NumExpr::Field(NumField::PriceUsd), .. }
+    )
+}
+
+/// Page for a `unique=printing` price query ordered by `usd` (the aligned case). The price index's
+/// `[s, e)` slice is already value-sorted, so the page's value-buckets are found by count without
+/// touching most of the slice; only the bucket(s) the page overlaps are canonically re-sorted
+/// (their within-value order in the index is by pid, but the sort key ties on
+/// `(edhrec, prefer_score, pid)`, and price ties are large). The tiebreak does not flip with
+/// direction, so `descending` only reverses which buckets are walked first; the same
+/// `sort_key_bits`/`select_page` comparator orders the collected set, so the result is identical to
+/// the gathered path it replaces.
+#[allow(clippy::too_many_arguments)]
+fn aligned_page<'a>(
+    idx: &Archived<PrintingRangeIndex>,
+    s: usize,
+    e: usize,
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    printing_to_card: &AOffsets,
+    descending: bool,
+    page_offset: usize,
+    limit: usize,
+) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    // Walk value-buckets lazily *from the page's starting end* — `s` forward for ascending, `e`
+    // backward for descending — forming only the buckets the page touches and stopping once
+    // offset+limit items are covered. Whole buckets before the page are skipped by count without
+    // collecting them; the untouched remainder of the slice is never scanned at all (so the cost
+    // is O(touched buckets), not O(distinct values in the slice)).
+    let want = page_offset + limit;
+    let mut collected: Vec<u32> = Vec::new();
+    let mut cum = 0usize;
+    let mut first_touched_cum = 0usize;
+    let mut started = false;
+    let (mut lo, mut hi) = (s, e);
+    while lo < hi {
+        // The next value-bucket in page order (a maximal run of equal value).
+        let (bs, be) = if descending {
+            let v = u32::from(idx[hi - 1].0);
+            let mut b = hi - 1;
+            while b > lo && u32::from(idx[b - 1].0) == v {
+                b -= 1;
+            }
+            (b, hi)
+        } else {
+            let v = u32::from(idx[lo].0);
+            let mut b = lo + 1;
+            while b < hi && u32::from(idx[b].0) == v {
+                b += 1;
+            }
+            (lo, b)
+        };
+        if descending { hi = bs } else { lo = be }
+        let sz = be - bs;
+        if !started && cum + sz <= page_offset {
+            cum += sz;
+            continue;
+        }
+        if !started {
+            started = true;
+            first_touched_cum = cum;
+        }
+        collected.extend((bs..be).map(|t| u32::from(idx[t].1)));
+        cum += sz;
+        if cum >= want {
+            break;
+        }
+    }
+    // Canonically sort the collected touched-bucket printings (small: ~one or two buckets) and
+    // window the page — same comparator select_page uses, so ordering matches the gathered path.
+    let mut matches: Vec<Match> = collected
+        .iter()
+        .map(|&pid| {
+            let cid = u32::from(printing_to_card[pid as usize]);
+            (sort_key_bits(&cards[cid as usize], &printings[pid as usize], SortCol::PriceUsd, descending), cid, pid)
+        })
+        .collect();
+    matches.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
+    let start = page_offset - first_touched_cum;
+    let end = (start + limit).min(matches.len());
+    matches[start..end].iter().map(|m| (&cards[m.1 as usize], &printings[m.2 as usize])).collect()
+}
+
+/// Fast path for a *bare, broad* range predicate under `unique=printing`
+/// (docs/issues/local-engine-sorted-range-fastpath.md, PR 1). `total` is `k` from the range
+/// index's binary search — no full per-printing count pass — and the page is produced in order
+/// without materializing all `k` matches. Returns None (fall through to the general path) for
+/// anything it doesn't own: non-printing modes, a plane component, a non-bare/non-range filter, a
+/// selective range (the existing narrowing already wins, and restricting the walk to dense
+/// predicates keeps its worst case bounded), or an order-by without a card permutation (e.g. the
+/// range field itself — deferred).
+#[allow(clippy::too_many_arguments)]
+fn printing_range_fastpath<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    let (idx, lo, hi) = bare_range_bounds(filter, indexes)?;
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    let k = e - s;
+    if !range_too_broad_to_narrow(k, idx.len()) {
+        return None; // selective: the existing narrowing path narrows tightly and wins
+    }
+    // total = matching printings = k (each priced printing in [lo, hi) is one row; NULL-valued
+    // printings are absent from the index and don't match). Same value the count pass would sum.
+    if k == 0 || page_offset >= k {
+        return Some((k, Vec::new()));
+    }
+    // Aligned: order by the range field itself. `usd` is the only range field that is also a sort
+    // column, and only a price predicate makes `idx` the value-sorted permutation for that sort;
+    // a non-price predicate ordered by usd has no aligned mapping (and no permutation) — bail.
+    if matches!(sort_col, SortCol::PriceUsd) {
+        return is_price_leaf(filter)
+            .then(|| (k, aligned_page(idx, s, e, cards, printings, &indexes.printing_to_card, descending, page_offset, limit)));
+    }
+    let perm = indexes.sort_perms.get(sort_col, descending)?;
+    if perm.len() != cards.len() {
+        return None;
+    }
+    Some((k, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
+}
+
 fn run_query<'a>(
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
@@ -3741,6 +3987,18 @@ fn run_query<'a>(
         "printing" => Mode::Printing,
         _          => Mode::Card,
     };
+
+    // PR 1 (docs/issues/local-engine-sorted-range-fastpath.md): a bare, broad range predicate
+    // under unique=printing gets its total from the range index's binary search and its page from
+    // an early-stopping permutation walk, skipping the O(n) count pass the general path pays.
+    // Requires no plane component (else the plane's own predicate must also hold, which this
+    // ignores); everything unrecognized returns None and falls through unchanged.
+    if *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
+        && let Some(result) =
+            printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+    {
+        return result;
+    }
 
     // #634 Step 2: when the filter fully consumed to True (split_planes ate
     // the whole thing), the plane bitmap IS the exact match set at any

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5499,6 +5499,12 @@ fn printing_range_aligned_page_matches_naive_incl_tie_buckets() {
         let e = idx.partition_point(|p| u32::from(p.0) < 5000);
         let k = e - s;
         assert!(k > 100, "seed {seed}: matching set must be broad with big tie buckets, got {k}");
+        // total = k = the true match count (independent count over all printings). The fastpath
+        // reports total = k, so pinning k == count pins the reported total.
+        let naive_count = (0..archived.printings.len())
+            .filter(|&pid| FilterExpr::residual_matches(&archived.cards[u32::from(archived.indexes.printing_to_card[pid]) as usize], &archived.printings[pid], &archived.strings, &[&leaf], false))
+            .count();
+        assert_eq!(k, naive_count, "seed {seed}: binary-search k must equal the true match count");
         for &desc in &[false, true] {
             // offsets at the start, inside each tie bucket, spanning a boundary, and near the end
             for &off in &[0, k / 5, k / 2, (3 * k) / 4, k.saturating_sub(30)] {
@@ -5549,7 +5555,16 @@ fn printing_range_fastpath_gates_card_walk_at_stream_threshold() {
         let leaf = usd_cmp(CmpOp::Lt, 50.0);
         let ix = &archived.indexes;
         let fp = |sc| printing_range_fastpath(&archived.cards, &archived.printings, &archived.offsets, &archived.strings, &leaf, ix, sc, false, 100, 0);
-        assert_eq!(fp(SortCol::EdhrecRank).is_some(), walk_fires, "card-walk gate at n={n} (STREAM_MIN={stream_min})");
-        assert!(fp(SortCol::PriceUsd).is_some(), "aligned exempt from stream gate at n={n}");
+        // Every printing is priced $1 < $50, so the true match count is n; when the fastpath fires
+        // its reported total must equal it (total == k == match count), end to end.
+        match fp(SortCol::EdhrecRank) {
+            Some((total, _)) => {
+                assert!(walk_fires, "card-walk fired below the gate at n={n} (STREAM_MIN={stream_min})");
+                assert_eq!(total, n, "walk total must equal the true match count at n={n}");
+            }
+            None => assert!(!walk_fires, "card-walk should have fired at n={n} (STREAM_MIN={stream_min})"),
+        }
+        let (aligned_total, _) = fp(SortCol::PriceUsd).expect("aligned exempt from stream gate");
+        assert_eq!(aligned_total, n, "aligned total must equal the true match count at n={n}");
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,7 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
-    walk_printing_page, aligned_page, bare_range_bounds, sort_key_bits, SortCol,
+    walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, SortCol, STREAM_MIN_MATCHES,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
@@ -5512,5 +5512,44 @@ fn printing_range_aligned_page_matches_naive_incl_tie_buckets() {
                 }
             }
         }
+    }
+}
+
+/// `n` cards, one printing each, all priced $1.00 — so `usd<50` matches every printing and k == n,
+/// exactly dialable across the STREAM_MIN_MATCHES boundary. Distinct edhrec ranks, price index built.
+fn all_priced_fixture(n: usize) -> CardData {
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = (0..n)
+        .map(|i| {
+            let mut c = stub_card(i as u128, 0, &[], &mut vocab);
+            c.edhrec_rank = Some(i as u32);
+            c
+        })
+        .collect();
+    let mut data = store_of(cards, &vec![1usize; n], vocab);
+    for p in data.printings.iter_mut() {
+        p.price_usd = Some(100);
+    }
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    data
+}
+
+#[test]
+fn printing_range_fastpath_gates_card_walk_at_stream_threshold() {
+    // The card-level walk reproduces run_query_streamed's per-card-contiguous *stream* emission,
+    // which the general path only uses above STREAM_MIN_MATCHES; at or below it the general path
+    // gathers (global sort), ordering full-key ties across cards differently. So the walk must bail
+    // at/below the threshold and fire above it. Aligned (order by usd) matches the gathered path and
+    // is exempt. k == n in this fixture.
+    let stream_min = *STREAM_MIN_MATCHES;
+    for (n, walk_fires) in [(stream_min, false), (stream_min + 16, true)] {
+        let data = all_priced_fixture(n);
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+        let leaf = usd_cmp(CmpOp::Lt, 50.0);
+        let ix = &archived.indexes;
+        let fp = |sc| printing_range_fastpath(&archived.cards, &archived.printings, &archived.offsets, &archived.strings, &leaf, ix, sc, false, 100, 0);
+        assert_eq!(fp(SortCol::EdhrecRank).is_some(), walk_fires, "card-walk gate at n={n} (STREAM_MIN={stream_min})");
+        assert!(fp(SortCol::PriceUsd).is_some(), "aligned exempt from stream gate at n={n}");
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,6 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
+    walk_printing_page, aligned_page, bare_range_bounds, sort_key_bits, SortCol,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
@@ -5373,4 +5374,143 @@ fn lanes_ge_matches_scalar_compare() {
     assert_eq!(super::lane_get(big, 2), 127);
     assert_eq!(super::lane_get(big, 1), 0);
     assert_eq!(super::lane_get(big, 3), 0);
+}
+
+// ─── Printing-range fastpath (PR 1, docs/issues/local-engine-sorted-range-fastpath.md) ────────
+// The fastpath produces a page for a bare, broad printing-mode range predicate without the O(n)
+// count pass. These differential-test its page production (the card-permutation walk and the
+// aligned boundary-bucket sort) against a naive full-sort reference that shares only the ordering
+// primitive (sort_key_bits) with it, not its bucket/walk selection logic.
+
+/// `n_cards` cards with populated edhrec/cmc sort keys, 1-4 printings each, prices heavily
+/// clustered onto a few hot values (so the price index has large equal-value tie buckets) plus
+/// ~15% NULL, and a real price range index built over them.
+fn printing_range_fixture(seed: u64, n_cards: usize) -> CardData {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+    let mut vocab = VocabInterner::new();
+    // Distinct edhrec ranks (shuffled), as real data has — a rank is unique per card. This keeps
+    // any two cards from sharing a full (primary, edhrec) sort key, so the streamed/walk emission
+    // (per-card-contiguous) and a naive global (key, pid) sort agree; colliding ranks would let
+    // them legitimately differ on cross-card full ties, which never occur in practice.
+    let mut ranks: Vec<u32> = (0..n_cards as u32).collect();
+    for i in (1..n_cards).rev() {
+        ranks.swap(i, rng.random_range(0..=i));
+    }
+    let mut cards = Vec::with_capacity(n_cards);
+    for i in 0..n_cards {
+        let mut c = stub_card(i as u128, 0, &[], &mut vocab);
+        c.edhrec_rank = Some(ranks[i]);
+        c.cmc = Some(rng.random_range(0..8u8));
+        cards.push(c);
+    }
+    let counts: Vec<usize> = (0..n_cards).map(|_| rng.random_range(1..=4)).collect();
+    let mut data = store_of(cards, &counts, vocab);
+    // cents; 5000 == $50.00, which usd<50 excludes (strict). Hot values 15/100 form big buckets.
+    const PRICES: [u32; 6] = [15, 15, 100, 100, 100, 5000];
+    for p in data.printings.iter_mut() {
+        p.price_usd = (rng.random_range(0..100) >= 15).then(|| PRICES[rng.random_range(0..PRICES.len())]);
+    }
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    data
+}
+
+/// Naive reference page for a printing-mode query: filter every printing by `leaf`, sort by
+/// (sort_key_bits, pid) — the exact comparator select_page uses — and window [offset, offset+limit).
+/// Returns the page's scryfall ids in order.
+fn naive_printing_page(
+    archived: &Archived<CardData>, leaf: &FilterExpr, sc: SortCol, desc: bool, offset: usize, limit: usize,
+) -> Vec<u128> {
+    let mut all: Vec<(u128, u32, u32)> = Vec::new();
+    for cid in 0..archived.cards.len() as u32 {
+        let card = &archived.cards[cid as usize];
+        let start = u32::from(archived.offsets[cid as usize]) as usize;
+        let end = u32::from(archived.offsets[cid as usize + 1]) as usize;
+        for pid in start..end {
+            let p = &archived.printings[pid];
+            if FilterExpr::residual_matches(card, p, &archived.strings, &[leaf], false) {
+                all.push((sort_key_bits(card, p, sc, desc), cid, pid as u32));
+            }
+        }
+    }
+    all.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2)));
+    let end = (offset + limit).min(all.len());
+    if offset >= end {
+        return Vec::new();
+    }
+    all[offset..end].iter().map(|&(_, _, pid)| u128::from(archived.printings[pid as usize].scryfall_id)).collect()
+}
+
+fn page_scryfall_ids(page: &[(&Archived<OracleCard>, &Archived<Printing>)]) -> Vec<u128> {
+    page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+}
+
+#[test]
+fn bare_range_bounds_recognizes_leaves_and_rejects_rest() {
+    let data = printing_range_fixture(0, 10);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ix = &archived.indexes;
+    let bounds = |f: &FilterExpr| bare_range_bounds(f, ix).map(|(_, lo, hi)| (lo, hi));
+    // usd<50 -> [0, 5000) cents; cn>=100 -> [100, MAX); year>2020 -> [2021*10000, MAX)
+    assert_eq!(bounds(&usd_cmp(CmpOp::Lt, 50.0)), Some((0, 5000)));
+    let cn_ge = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op: CmpOp::Ge, rhs: NumExpr::Const(100.0) };
+    assert_eq!(bounds(&cn_ge), Some((100, u32::MAX)));
+    assert_eq!(bounds(&FilterExpr::YearCmp { op: CmpOp::Gt, year: 2020 }), Some((2021 * 10_000, u32::MAX)));
+    // rejects: Ne, compound, and a non-range numeric field (cmc is card-space)
+    assert!(bounds(&usd_cmp(CmpOp::Ne, 50.0)).is_none());
+    assert!(bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0)])).is_none());
+    let cmc_lt = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
+    assert!(bounds(&cmc_lt).is_none());
+}
+
+#[test]
+fn printing_range_walk_matches_naive_page() {
+    let leaf = usd_cmp(CmpOp::Lt, 50.0);
+    for seed in 0..16u64 {
+        let data = printing_range_fixture(seed, 200);
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+        for &sc in &[SortCol::EdhrecRank, SortCol::Cmc] {
+            for &desc in &[false, true] {
+                let perm = archived.indexes.sort_perms.get(sc, desc).expect("perm exists");
+                for &(off, lim) in &[(0usize, 10usize), (0, 100), (5, 20), (50, 50), (300, 25)] {
+                    let got = walk_printing_page(
+                        &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &leaf, sc, desc, lim, off, perm,
+                    );
+                    let want = naive_printing_page(&archived, &leaf, sc, desc, off, lim);
+                    assert_eq!(page_scryfall_ids(&got), want, "walk seed {seed} desc {desc} off {off} lim {lim}");
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn printing_range_aligned_page_matches_naive_incl_tie_buckets() {
+    let leaf = usd_cmp(CmpOp::Lt, 50.0);
+    for seed in 0..16u64 {
+        let data = printing_range_fixture(seed, 300);
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+        let idx = &archived.indexes.price_usd;
+        // usd<50 -> cents [0, 5000)
+        let s = idx.partition_point(|p| u32::from(p.0) < 0);
+        let e = idx.partition_point(|p| u32::from(p.0) < 5000);
+        let k = e - s;
+        assert!(k > 100, "seed {seed}: matching set must be broad with big tie buckets, got {k}");
+        for &desc in &[false, true] {
+            // offsets at the start, inside each tie bucket, spanning a boundary, and near the end
+            for &off in &[0, k / 5, k / 2, (3 * k) / 4, k.saturating_sub(30)] {
+                for &lim in &[10usize, 40, 175] {
+                    if off >= k {
+                        continue;
+                    }
+                    let got = aligned_page(idx, s, e, &archived.cards, &archived.printings, &archived.indexes.printing_to_card, desc, off, lim);
+                    let want = naive_printing_page(&archived, &leaf, SortCol::PriceUsd, desc, off, lim);
+                    assert_eq!(page_scryfall_ids(&got), want, "aligned seed {seed} desc {desc} off {off} lim {lim} k {k}");
+                }
+            }
+        }
+    }
 }

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -1,5 +1,12 @@
 # Engine: fast path for broad printing-space range queries
 
+> **Superseded for planning (2026-07-16) by
+> [local-engine-sorted-range-fastpath.md](local-engine-sorted-range-fastpath.md).** That doc
+> carries the current plan (the two mechanisms split cleanly by unique mode; printing mode gets
+> `total = k` free from the sorted index — the win PR #689 wrote off as an "inherent floor"). This
+> doc is kept as the **historical record**: the shipped price-exactness prerequisite (below, still
+> accurate) and the full account of what PR #689 tried and reverted.
+
 Status: design drafted 2026-07-14, no GitHub issue yet — file once the crossover is measured
 and a direction is picked. Surfaced investigating why `usd<50` costs ~0.4–1 ms (see
 [00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md)'s
@@ -356,3 +363,16 @@ fifth (tight/loose) axis to worry about — every field behaves identically ther
   "the binary search already gives you `k` for free" observation, in the AND-skip context.
 - #638 — `tix`/`eur` have no range index at all yet; the same fast path (and the prerequisite
   exactness fix) should cover them once they do.
+
+
+## Notes from Previous PR
+
+For usd<50/unique=printing specifically, the cost splits into two phases with real measured numbers:
+
+narrow_candidates_exact: ~217µs, entirely wasted. narrow_rec's own fastpath calls compile_plane → compile_price_range → a full binary search + scatter + card-space conversion, unconditionally (it hardcodes broad_ok=true regardless of the caller's actual intent). The result comes back raw_candidates_is_some=false — discarded immediately by the very next check, because usd<50 matches 31,217 of 31,508 cards (99.1%), which exceeds the cards.len() - cards.len()/8 (87.5%) broadness-discard threshold at lib.rs:3869. The narrowing is computed and thrown away every single query.
+run_query_streamed: ~805-960µs. The actual per-candidate scan, unavoidable once no useful narrowing survives — it walks essentially all cards checking usd<50 against each printing.
+Compare to cn<100/printing: narrow_candidates_exact costs ~110-150µs but raw_candidates_is_some=true — its card total (17,616, 55.9%) is well under the 87.5% threshold, so the narrowing is kept, and run_query_streamed only costs ~640-680µs by scanning the narrowed set instead of everything.
+
+This fully explains the mixed result from the earlier fix attempt: excluding the fastpath saves the ~217µs waste for usd (which is why that query improved), but for cn/year it throws away narrowing that's genuinely paying for itself (which is why those got worse). The real bug isn't "card-space vs printing-space" — it's that narrow_rec's fastpath doesn't know in advance whether its card-space result will survive the discard check, and pays the full computation cost either way.
+
+The next commit's fix should be narrower and more targeted than my last attempt: something that lets narrow_rec's fastpath cheaply bail before paying for the scatter/conversion specifically when the result is predictably going to be discarded — not a blanket exclusion of range leaves.

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -1,0 +1,413 @@
+# Engine: fast path for broad sorted-range predicates, split by unique mode
+
+Status: plan drafted 2026-07-16; PR 1 (printing-mode slice) is up for review as [#695] (open, not
+merged), gated at the 25% veto boundary. Remaining slices (card/artwork planes, existential-plane
+total) and the crossover guard are unstarted. Supersedes the *planning* half of
+[local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md), which is kept as the
+historical record (the shipped price-exactness prerequisite, and the full account of what PR #689
+tried, muddled, and reverted). This doc restates the plan with what we learned since.
+
+## Problem
+
+Broad range predicates over the `PrintingRangeIndex`-backed fields — `usd<50` (83% of printings),
+`cn<100`, `year>2020`, `date>2023-01-01`, and `tix`/`eur` once [#638] indexes them — cost ~0.4–1 ms.
+On `main` a bare broad range leaf has its narrowing **vetoed** (`broad_ok=false` at the root call
+of `narrow_rec`, [lib.rs:2676](../../card_engine/src/lib.rs#L2676) → `range_narrowed`'s
+`!broad_ok` return, [lib.rs:2044](../../card_engine/src/lib.rs#L2044)), so *all three unique modes*
+fall into the same full scan: `run_query_streamed` walks **every card**, expands each to its
+printings, and evaluates the price predicate per printing to accumulate `total`
+([lib.rs:4099-4131](../../card_engine/src/lib.rs#L4099-L4131)). That whole-corpus predicate scan is
+the cost floor. It is identical across modes — the tell that we're discarding mode-specific
+structure.
+
+## The insight the previous investigation missed
+
+These fields each have a **sorted** `PrintingRangeIndex`. Counting how many printings fall in a
+half-open `[lo, hi)` is therefore two `partition_point`s — **O(log n)**, not O(matching printings).
+
+PR #689's revert reasoned that "an existential predicate needs the exact count of satisfying
+printings, an O(matching printings) cost no walk can remove," and concluded printing mode was an
+inherent floor. That is **false for `usd`/`cn`/`date`**: the sorted index hands you the count in
+O(log n). The PR over-generalized, then tried to serve printing mode by extending the *card-space*
+popcount machinery (`run_query_streamed_popcount` is hard-gated to `Mode::Card`) instead of using
+the count it already had. Wrong tool → looked hard → reverted.
+
+It is also **only partly true for legality / rarity / border**. Those have no sorted index, but
+they *do* have existential plane pairs, which support a cheaper-than-scan printing-mode total — see
+[Existential fields: a second cheap-total mechanism](#existential-fields-a-second-cheap-total-mechanism)
+below. The only genuinely irreducible case is *two broad constraints of different kinds* combined
+(e.g. `usd<50 f:modern`/printing).
+
+Consequence: the printing-mode `total` is cheap for **every** indexed field, just at different
+constants — and the fast path **decomposes by unique mode**, with a printing-mode path the PR
+never built.
+
+## Two mechanisms (doc's original Idea 1 / Idea 2), one per mode family
+
+**Idea 1 — `total = k`, then produce the page in order, stop at `limit`.** For `unique=printing`,
+every matching printing is its own row: `total` is exactly `k` from the binary search, no dedup, no
+card space *ever*. Only the page remains, and how it's produced depends on the order-by:
+
+- **Card-level order (`edhrec`/`name`, the default).** The [#634] sort permutations are *card-space*
+  (`SortCol::PriceUsd`/`Rarity` return `None`, [lib.rs:1763](../../card_engine/src/lib.rs#L1763)) —
+  there is no printing permutation. But a card-level key is shared by all of a card's printings, so
+  card order *is* printing order: walk the existing card permutation in rank order, expand each card
+  to its matching printings, early-stop at `offset + limit`. Cost ≈ `(offset + limit) / match_rate`.
+- **Order by the range field itself (`usd<50 order by usd`).** The range index *is* the printing
+  permutation for that field — its `[s, e)` slice is already value-sorted. But its within-value
+  tiebreak is `pid`, while the canonical key is `(price[dir], edhrec asc, prefer_score asc, pid)`
+  ([`sort_key_bits`](../../card_engine/src/lib.rs#L3355)), and price ties are large (top buckets
+  ~1,600 printings; `order by usd asc` page 1 is chosen entirely from one bucket). So the index
+  serves the *value* order but not the *tie* order. Fix at query time, no new structure: walk
+  value-bucket boundaries by count to find which buckets the page `[offset, offset+limit)` overlaps
+  (skipping whole buckets before/after untouched); take all items from fully-covered buckets (≤
+  `limit` of them); from each boundary bucket `select_nth_unstable` the needed count by tiebreak (n
+  smallest at a leading cut, n largest at a trailing cut; a middle window inside one bucket needs
+  two selects); then sort the combined `limit`-item page once by the full canonical key
+  `(value[dir], edhrec, prefer_score, pid)` — quickselect need only produce the right *set*, the
+  final sort orders it. With `limit`~100 and buckets ~1,600 that's ≤~2 O(bucket) selects + an
+  O(limit log limit) sort (µs) vs. the gathered path's full 80k sort. The tiebreak doesn't flip with
+  direction, so one code path serves both. Result: `total` O(log n), page O(bucket + limit),
+  offset-independent, no archive change.
+- **Order by a *different* printing-varying field** (`usd<50 order by cn`): no aligned permutation;
+  stays on the gathered path — out of PR 1's scope.
+
+**Idea 2 — project the narrowed set to an existence bitmap, feed the popcount-skip pager.** For
+`unique=card`: binary-search → matching printing slice → for each, `printing_to_card[p]`
+([the #690 direct array](00690-engine-direct-projection-arrays.md)) sets that card's bit; `total` =
+**popcount**; page via `run_query_streamed_popcount` ([lib.rs:3945](../../card_engine/src/lib.rs#L3945)).
+No predicate evaluation, only a bit-scatter over the `k` matches. This is `PrintingRangeBits`, the
+core of PR #689. `unique=artwork` is the same shape *once a global artwork id exists*: today the
+group id is per-card-local ([lib.rs:1851](../../card_engine/src/lib.rs#L1851)), so the uniqueness key
+is the pair `(card, artwork_group_id)` and there is no single integer to scatter — which is why
+[#693] needed a per-query dedup bitmask. Assigning each distinct `(card, local_group)` a stable
+**global artwork id** at build time (a `printing_to_artwork` array plus its `artwork_to_card`
+inverse, the direct analogue of [#690]'s `printing_to_card`) makes artwork mode structurally
+identical to card mode: `printing_to_artwork[p]` scatters a bit, `total` is a popcount, and
+`artwork_to_card` resolves each selected artwork back to a card for page emission. This is
+artwork-specific groundwork (see PR 2b in the Plan) — printing mode never dedups and card mode
+already has its array, so it blocks neither PR 1 nor PR 2a.
+
+## Where each wins
+
+| Case | Winner | Why |
+|---|---|---|
+| `unique=printing`, broad, first/shallow page | **Idea 1** | `total = k` free; page is a ~`limit/rate` walk. Idea 2's O(k) scatter is pure overhead here. |
+| `unique=printing`, order-by **aligned** with the field (`usd<50 order by usd`) | **Idea 1** | The range index *is* the value-sorted permutation → direct slice; boundary bucket(s) re-sorted by the canonical tiebreak at query time. Offset-independent, both directions, no new structure. |
+| **compound** `unique=printing`/`artwork`, both broad (`cn<100 usd<50`) | **Idea 2** (printing-space) | No cheap total from either range alone; build+AND+popcount both range bitmaps. Needs the pager extended to printing space ([#656]) — deferred (uncovered gap, ~1.07 ms today). |
+| `unique=card` / `unique=artwork`, broad | **Idea 2** | Exact `total` needs dedup = O(k) regardless; once you pay O(k), the bitmap buys offset-independence + reuse for free. |
+| **Compound** (`usd<50 AND t:creature`) | **Idea 2** | The bitmap intersects other planes in O(words); Idea 1 is a terminal page-producer, can't compose. |
+| **Selective** predicate | *neither* | `main` already narrows these via the sparse-vec path; Idea 1 goes unbounded, Idea 2 is redundant. |
+
+The only cell where they genuinely compete is `unique=printing` + broad + deep-page + unrelated
+order-by. Everywhere else the mode and the compound/offset shape pick the winner unambiguously.
+
+## Existential fields: a second cheap-total mechanism
+
+Legality/rarity/border have no sorted index, so `total = k` doesn't apply — but their **existential
+plane pairs** give a printing-mode total far cheaper than a full scan, without visiting most
+printings. For a queried value `V`, classify every candidate card by two existential planes —
+`has_V` ("∃ printing = V") and `has_notV` ("∃ printing ≠ V"):
+
+```
+total = Σ_{has_V && !has_notV}  pcount(c)         # pure-V card: all printings match, count from offsets, no loop
+      + Σ_{has_V &&  has_notV}  count_matching(c)  # mixed card: loop its printings
+      +  0  for !has_V cards
+```
+
+The plane pairs already exist on `main`: legality has `PLANE_LEGAL_EXISTS` + `PLANE_LEGAL_ILLEGAL`
+directly ([planes.rs:72](../../card_engine/src/planes.rs#L72)); border/rarity are one-hot, so
+`has_notV` is an OR of the other value planes (~5 words per 64 cards). Correctness rests on
+"pure-V ⇒ all printings match V," which holds by construction.
+
+The win is gated on **low intra-card mixing**, which holds: rarity is 91% single-rarity (measured),
+and border/legality mix only via special treatments / the divergent-legality carveout (minorities).
+Mixing is bounded by `min(has_V, has_notV)`, so *whichever* value is queried, the mixed loop is
+short. Magnitude is more modest than the sorted-range case: **O(matching cards) + O(mixed
+printings)** (the pure sum still walks one bit per matching card — `pcount` varies, no popcount
+shortcut), so ~3–5× on the total phase vs. the ~O(log n) sorted-range win.
+
+Two refinements:
+
+- **Bare single-value query** (`border:black`/printing, nothing else): total is a **precomputed
+  per-value printing count** — O(1), no classification. A small build-time table (borders ~6,
+  rarities ~6, legality ~45 format×state). The classification above is the *general* form that also
+  composes with a card-space candidate mask (`border:black AND t:creature`), which the constant can't.
+- **Does not help `usd<50 f:modern`/printing**: combining a range count and an existential count
+  per card needs per-card range counts inside the mixed loop — back to scanning. Two broad
+  constraints of *different kinds* is the one irreducible shape.
+
+### The broadness discard is not the culprit
+
+`border:black`/printing is slow (0.853 ms baseline) because its card-space candidate covers
+≥87.5% of cards and is discarded to a full scan
+([lib.rs:3815](../../card_engine/src/lib.rs#L3815)) — but the discard is *correct*, not a bug to
+undo. Keeping a ~90%-card candidate would iterate ~90% of cards instead of 100% while still
+re-checking `border` per printing (the candidate is a loose card-existence set, so no per-printing
+work is skipped), and the card-id materialization overhead roughly cancels the ~10% iteration
+saved — which is exactly the tradeoff [#647] calibrated the 87.5% threshold to. So un-discarding
+buys ~10% at best. The real cost is counting matching printings with no cheap total, which is what
+the classification above removes (~−75%). Card mode already sidesteps the discard entirely via the
+existential popcount plane (not gated there); printing mode can't (that path is `Mode::Card`-only),
+which is why the slowness is printing-specific. Fix the mechanism (PR 5), not the discard.
+
+## Groundwork (all already on `main`)
+
+- **Exact narrowing**: price is integer cents ([#688]) — `range_narrowed(..., exact=true)` for all
+  three fields; nothing to verify after narrowing.
+- **`printing_to_card` direct array** + `eval` inlining ([#690]) — powers Idea 2's O(k) projection.
+- **`range_narrowed` / `Narrowed.tight` / `broad_ok` / `exact`** plumbing and the binary search
+  that yields `k` for free already exist ([lib.rs:2035](../../card_engine/src/lib.rs#L2035)).
+
+Confirmed absent from `main`: `PrintingRangeBits`, `must_be_tight`, and any range-family check —
+so nothing is half-landed. PR #689's `printing_to_card` and `eval`-split commits were the ones
+extracted and shipped as [#690]; the rest of that branch is unmerged.
+
+## Correctness: the NULL over-inclusion trap (Idea 2 only)
+
+`range_narrowed`'s broad **complement** branch ([lib.rs:2051-2056](../../card_engine/src/lib.rs#L2051))
+over-includes printings absent from the index (NULL value), so it is `loose`, not `tight`. This is
+harmless on `main` (broad lone ranges are vetoed, never reaching a card-space existence answer). It
+becomes a real overcount the moment Idea 2 trusts a card bitmap's popcount directly — PR #689
+measured `usd<50`/card returning 31,396 instead of 31,217. **Idea 2 must gate on `tight` (thread a
+`must_be_tight` flag to the one call site that discards the residual and trusts the bitmap).** Idea
+1 is immune — it re-tests membership per emitted printing. This is *created by* Idea 2, not
+separable from it.
+
+## Baseline (Step 0)
+
+`main` @ 93608a6, 97,206-printing corpus, min ms over an 8 s window (idle machine, Docker down),
+`limit=100`, `orderby=edhrec` unless noted. `total` is the parity check.
+
+| query | card | printing | artwork | total (card / prn) |
+|---|---:|---:|---:|---|
+| `usd<50` | 0.332 | 0.733 | 0.779 | 31,217 / 80,527 |
+| `cn<100` | 0.585 | 0.838 | 0.870 | 17,616 / 35,021 |
+| `year>2020` | 0.472 | 0.704 | 0.755 | 18,249 / 46,445 |
+| `usd<50 order by usd` (printing) | — | **1.036** | — | 80,527 |
+| `usd<50` offset 5000 | 0.345 | 0.746 | — | (vs 0.332 / 0.733 at offset 0) |
+| `border:black` (printing) | — | **0.853** | — | 85,046 |
+| `r:rare` / `f:modern` (printing) | — | 0.358 / 0.180 | — | 36,764 / 73,783 |
+| *ref:* `f:modern` / `t:creature` / `r:rare` (card, kept narrowing) | 0.060 / 0.062 / 0.057 | — | — | — |
+
+**Root cause is uniform:** every slow row is a *broad predicate that loses its narrowing to the
+discard, then pays the full count pass*. The fast reference rows (0.06 ms) are planed or
+narrowing-kept — the target the slow rows should approach. Field type doesn't change the cost;
+broad + printing + no-narrowing = full scan whether the field is sorted-range or existential.
+
+Three findings that shaped the plan:
+
+- **The aligned case (`order by usd`) is the single *worst* config** (1.036 ms, +41% over edhrec
+  order) — it falls off the card permutation to the gathered path. PR 1's boundary-bucket sort
+  turns the worst case into ~the best. Argues for including it *in* PR 1.
+- **Deep offset is flat** — measured at offset 0 vs 5000 for bare (`usd<50`: 0.733→0.746) *and*
+  compound printing/artwork (`cn<100 usd<50`, `usd<50 f:modern`, `usd<50 t:creature`: all deltas
+  ≤0.02 ms). Today's O(n) count pass is offset-independent. This defeats only the
+  *offset-independence* argument for [#656] — **not** its other value (a printing-space popcount
+  total, which would remove the count pass for compound printing/artwork; see below). #656 is
+  deferred for frequency/effort, not because deep-offset is flat.
+- **PR 5's target is *broad* existential printing** (`border:black`), not legality/rarity broadly —
+  the *selective* existential values (`r:rare`, `f:modern`) already narrow and are fast (0.18–0.36
+  ms). Narrows PR 5's scope and its estimate (0.853 → ~0.18 ms).
+
+### Compounds (Step 0)
+
+| compound | printing | artwork | card |
+|---|---:|---:|---:|
+| `usd<50 t:creature` (range + selective) | 0.427 | 0.455 | 0.226 |
+| `usd<50 f:modern` (range + broad plane) | 0.639 | 0.678 | 0.296 |
+| `cn<100 usd<50` (range + range, both broad) | **1.069** | **1.093** | 0.761 |
+| `r:rare border:black` (existential + existential) | 0.587 | 0.597 | 0.296 |
+
+**Compound wins live in card mode** (Idea 2's bitmap composes — PR 2a/3/4). For printing/artwork:
+range+selective is already improved by narrowing (0.43 vs bare 0.73, but not free — a residual
+per-printing check remains); range+broad-plane is the irreducible two-broad shape; range+range is
+the **slowest compound of all (~1.07 ms) and an uncovered gap** — neither range narrows (both
+>25%), so it full-scans with two residuals. A printing-space popcount ([#656], build+AND+popcount
+both range bitmaps) could give range+range printing/artwork ~2×, offset-independent — deferred for
+frequency, not because it's impossible.
+
+So PR 1 (`total=k`) helps **bare** single range predicates only; compound range wins come from
+Idea 2's composable bitmap in **card** mode (PR 2a/3).
+
+## Plan / sequencing
+
+### Step 0 — prep (not a PR)
+
+Establish the interleaved-A/B baseline harness (shape of `bench_cost_guards.py`) across all three
+unique modes for the target queries, and **resolve the PR-1 blocker**: did [#634] build a
+per-sort-column permutation for *printing* mode that Idea 1's walk can ride? This gates the order
+below — if that permutation is absent, PR 1 grows and swaps after PR 2a. Step 0 also sizes the
+Idea-1 guard and confirms whether PR 5 targets a real bottleneck.
+
+### PR order
+
+Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B measurements.
+
+- [x] **PR 1 — Idea 1, `unique=printing`, small & independent.** Implemented, open for review as
+  [#695](https://github.com/jbylund/sylvan_librarian/pull/695) (not yet merged). For a bare broad range leaf, derive
+  `total = k` from the binary search instead of the full count pass, and produce the page without a
+  full sort: for card-level orderings ride the existing card permutation (expand to printings,
+  early-stop); for order-by-the-range-field, slice the range index and re-sort only the boundary
+  bucket(s) by the canonical tiebreak (see [Two mechanisms](#two-mechanisms-docs-original-idea-1--idea-2-one-per-mode-family)).
+  Touches only the printing-mode path; leaves `narrow_rec`/`broad_ok` for card/artwork as `main` has
+  them. No new persisted structure. `CARD_ENGINE_PRINTING_RANGE_FASTPATH=0` is an A/B kill-switch.
+  **Gated at the veto boundary** (`range_too_broad_to_narrow`, ~25% of the index) — the fastpath
+  only claims ranges the general path was already full-scanning, so nothing below 25% changes plan;
+  the card-walk additionally requires `k > STREAM_MIN_MATCHES` so it never reproduces stream
+  ordering where the general path would gather (matters only on tiny indexes; see the crossover
+  guard below). Widening below 25% is the deferred crossover guard.
+  *Measured* (same-build off vs on, 97,206-printing corpus, min ms): `usd<50` 0.75→0.04,
+  `cn<100` 0.87→0.04, `year>2020` 0.74→0.04, aligned `usd<50 order by usd` 1.06→0.05
+  (−90 to −95%); card/artwork/compound/selective controls flat; broad survey unchanged.
+- [ ] **PR 2a — Idea 2, `PrintingRangeBits` for `usd`, `unique=card`.** Project via
+  `printing_to_card` → card existence bitmap → popcount total → streamed-popcount page. Bundles the
+  `must_be_tight` correctness fix (inseparable — the bug is created by this path).
+  *Impacts:* `usd<50`/card, `usd` AND a composable plane (`usd<50 f:modern`), deep-page card.
+  *Magnitude:* −43%. *Depends:* —. *Risk:* med — new plane variant + a bundled correctness fix.
+- [ ] **PR 3 — extend Idea 2 to `collector_number` + `released_at`.** Same machinery as 2a, new
+  `DateCmp`/`YearCmp`/`cn` arms.
+  *Impacts:* `cn`/`year`/`date` under `unique=card` (+ their compounds). *Magnitude:* −46% to −78%.
+  *Depends:* 2a. *Risk:* low.
+- [ ] **PR 4 — compound-query structural pre-checks** (`has_conflicting_range_families`,
+  `contains_range_family_leaf`): skip a `compile_plane` fold that will be discarded, for 2+
+  existential leaves in one `And` and for range leaves under `unique=printing`/`artwork`.
+  *Impacts:* 2+ existential-leaf compounds (`usd<50 f:modern`, `r:rare border:black`); removes
+  narrow-and-discard waste. *Magnitude:* small but broad. *Depends:* 2a's range-family concept.
+  *Risk:* low — pure "skip doomed work."
+- [ ] **PR 2b — global artwork id groundwork + `unique=artwork`.** Land `printing_to_artwork` /
+  `artwork_to_card` (build-time enumeration of `(card, local_group)`, persisted, archive format
+  bump) — the [#690] analogue for artwork — then extend the plane to artwork space (popcount over
+  artwork ids).
+  *Impacts:* `usd`/`cn`/`date` under `unique=artwork` (turns PR #689's +7-8% regression into a
+  win). *Magnitude:* regression → win. *Depends:* 2a (+3 for cn/date). *Risk:* med — new persisted
+  arrays + a format-version bump.
+- [ ] **PR 5 — existential-plane printing-mode total** (legality/rarity/border). Start with the
+  O(1) precomputed per-value count for the bare query; add the `has_V`/`has_notV` classification
+  for the card-mask case if warranted. See
+  [Existential fields](#existential-fields-a-second-cheap-total-mechanism).
+  *Impacts:* bare `r:`/`f:`/`border:` under `unique=printing`. *Magnitude:* ~3× (matches the 3.09
+  printings/card corpus average). *Depends:* Step 0 (gated on it being a real bottleneck).
+  *Risk:* med — independent of the sorted-range PRs.
+
+**Why this order:** PR 1 first keeps the "small, independent, separable" principle — lowest risk,
+printing-only, validates the walk + harness (contingent on Step 0; else swap with 2a). `2a → 3 → 4`
+is the core value block on the default `unique=card` path in dependency order (2a lays the plane, 3
+reuses it, 4 cleans up the compound waste 2a introduces). `2b` follows 3 so the artwork plane
+inherits all three fields at once. `5` last and gated — real but modest, on a combo not yet
+confirmed hot.
+
+### Deferred (explicitly)
+
+- [ ] **Idea-2 printing-space pager** ([#656]) — the mechanism for **compound printing/artwork** (a
+  printing-space popcount total; `cn<100 usd<50`/printing ~1.07 ms is the uncovered gap). Deferred
+  for frequency/effort, *not* deep-offset (measured flat). PR 1 covers bare printing without it.
+  See [#656 assembly](#656-assembly-from-pr-1--pr-2a) — most of its pieces fall out of PR 1 + PR 2a.
+- [ ] **Idea-1 crossover guard** — widen the fastpath below the 25% veto boundary it shipped at
+  ([#695]) into the moderate band, per the [#647] calibrate-from-measurement precedent. The two
+  plans have *opposite* cost curves in `k`: narrow-and-scan rises ~O(k); the fastpath walk falls
+  ~O((offset+limit)·n_cards / k) (denser matches ⇒ shorter walk). Their min-envelope is a **hump**
+  (rise along narrowing, peak at the crossover, fall along the fastpath) — *not* monotonic;
+  calibration lowers and left-shifts the peak, it doesn't remove it. Today's peak sits in the
+  moderate band (`year<2010`, k≈22k, ~0.45 ms) because the gate is stuck at the veto boundary
+  (~20–24k), far above the real first-page crossover **k ≈ √(n_cards · limit) ≈ 1,800**. So the
+  reclaimable band is ~1.8k–20k.
+  **Why it needs a sweep, not a moved constant:** the walk cost carries `offset`, so the crossover
+  is `(k, offset)`-dependent — deep pages flip it (at offset 5,000, k≈1,800 the walk touches
+  ~280k printings, far worse than a scan). A single `k`-threshold would fix page 1 and regress deep
+  pages; the guard must be offset-aware (and ideally order-by-alignment-aware). Strictly additive to
+  [#695]: it only widens where the fastpath applies, never changes the sub-25% plans.
+
+### Crossover guard: sweep design
+
+Goal: replace the walk branch's veto-boundary gate (`range_too_broad_to_narrow && k > STREAM_MIN_MATCHES`)
+with a calibrated `(k, offset)` predicate that picks the cheaper of narrow-and-scan vs. fastpath-walk.
+Follow [#647]'s dialable-`k` method.
+
+Axes to sweep:
+
+- **k (match count)** — the knob. Dial with `usd<X` swept against the corpus price CDF (or a
+  synthetic uniform field for exact control), spanning ~500 → ~40k so it straddles both the
+  first-page crossover (√(n·limit) ≈ 1.8k) and the 25% veto (~20k).
+- **offset (page depth)** — 0, 100, 1,000, 5,000, and ~`k−limit` (last page). This is the axis that
+  bends the guard: the walk carries `offset`, narrowing doesn't.
+- **order-by class** — card-level unrelated (`order by edhrec`, the walk — the offset-sensitive,
+  interesting case) and aligned (`order by usd`, `aligned_page` — offset-independent, a control that
+  should win whenever broad). `limit` fixed at the product page size.
+
+Method: per `(k, offset, order-by)` cell, interleaved A/B of walk vs. narrow via
+`CARD_ENGINE_PRINTING_RANGE_FASTPATH` on/off (off = the narrow+scan the fastpath would replace),
+min ms; the crossover per `(offset, order-by)` slice is the `k` where they cross. Expected fit:
+walk wins when `(offset+limit)·n_cards / k ≲ c·k`, i.e. `k² ≳ (offset+limit)·n_cards / c` — so the
+guard is roughly `k*k > (offset+limit)*n_cards*K` for a measured `K`, offset-aware by construction.
+Aligned keeps its simpler broad gate (offset-independent).
+
+Harness: extend `scripts/bench_printing_range.py` (or a `bench_cost_guards.py`-shaped script) to
+sweep the `(k, offset)` grid with dialable `k` and emit per-slice crossovers. **Acceptance is the
+deep-page floor**: every `(k, deep-offset)` cell must stay ≥ the narrow plan — the guard exists so
+deep pages fall back to narrowing exactly where the walk would lose.
+
+### #656 assembly (from PR 1 + PR 2a)
+
+#656 is not a from-scratch build once PR 1 and PR 2a land — it's mostly assembly. It needs three
+things, and PR 1/PR 2a build all but the glue:
+
+| #656 needs | Built by | Notes |
+|---|---|---|
+| range → **printing** existence bitmap | **PR 2a/3** | `PrintingRangeBits` already carries `printing_bits` (card-mode row selection needs it — `eval_plane_expr_for_printing` tests it), so it's built regardless. |
+| **popcount total** | **PR 2a** | PR 2a popcounts *card* bits; the identical step over printing bits is a trivial transfer. |
+| **printing-space paging** | **PR 1** | PR 1's card-permutation walk (expand to printings, test membership, early-stop) *is* the printing pager — swap the test from "in `[lo, hi)`" to "in the intersected printing bitmap." |
+
+So `#656 ≈ PR 2a's printing bitmaps + PR 1's walk + an AND`. The only net-new work is intersecting
+≥2 printing bitmaps and routing the popcount total into the printing path; the `Mode::Card`-only
+`run_query_streamed_popcount` is *not* reused (PR 1's walk is the printing-mode pager instead).
+**Assembly plan:** (1) intersect the per-leaf `printing_bits` for the compound; (2) `total =
+popcount` of the result; (3) page via PR 1's walk with membership against the intersected bitmap.
+This is the argument for landing *both* PR 1 and PR 2a rather than treating them as either/or —
+together they reduce #656 to a small follow-up, if the range+range gap proves worth closing.
+
+### Acceptance (every PR)
+
+- [ ] Improves or holds flat vs. baseline for its target mode; no regression on the [#634]/[#655]
+  exact paths or the legality/rarity/border sweep.
+- [ ] Passes (and likely extends) `test_engine_property.py`'s differential suite against the
+  reference oracle — a perf delta alone is not "done" (this class already produced two independent
+  bugs in the price prerequisite work).
+
+## Open questions
+
+- **Printing-mode page walk mechanics** — *resolved (Step 0):* #634 permutations are card-space
+  (price/rarity return `None`); PR 1 rides the card permutation for card-level orderings and slices
+  the range index (boundary-bucket re-sort) for order-by-the-range-field. A *different*
+  printing-varying order-by stays on the gathered path.
+- **Global artwork id sizing.** Count of distinct `(card, local_group)` pairs (bounds the
+  `artwork_to_card` array between n_cards and n_printings), and whether the #634 artwork order
+  permutation already keys on a representative printing the global id can align to.
+
+## Related
+
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — history:
+  price-exactness prerequisite (shipped) and the full PR #689 account.
+- [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —
+  `printing_to_card`, load-bearing for Idea 2.
+- [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)
+  — the existential-plane framework Idea 2 extends.
+- [00634-engine-permuted-bitmap-order-phase.md](done/00634-engine-permuted-bitmap-order-phase.md) —
+  the order permutation Idea 1 walks and the popcount pager Idea 2 feeds.
+- [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
+  card-invariant `cmc`/`power`/`toughness` analogue; does not transfer (no existential dimension).
+- [00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md) — the
+  guard-from-measurement precedent for Idea 1's crossover.
+- [#638] `tix`/`eur` range index; [#656] printing-space popcount pager; [#693] artwork dedup bitmask.
+
+[#638]: https://github.com/jbylund/sylvan_librarian/issues/638
+[#647]: https://github.com/jbylund/sylvan_librarian/pull/647
+[#656]: https://github.com/jbylund/sylvan_librarian/issues/656
+[#634]: https://github.com/jbylund/sylvan_librarian/pull/634
+[#655]: https://github.com/jbylund/sylvan_librarian/pull/655
+[#680]: https://github.com/jbylund/sylvan_librarian/pull/680
+[#688]: https://github.com/jbylund/sylvan_librarian/pull/688
+[#689]: https://github.com/jbylund/sylvan_librarian/pull/689
+[#690]: https://github.com/jbylund/sylvan_librarian/pull/690
+[#693]: https://github.com/jbylund/sylvan_librarian/pull/693
+[#695]: https://github.com/jbylund/sylvan_librarian/pull/695

--- a/scripts/bench_printing_range.py
+++ b/scripts/bench_printing_range.py
@@ -1,0 +1,112 @@
+"""Targeted benchmark for the printing-mode sorted-range fastpath (PR 1).
+
+Times engine.query() for a fixed set of configs against a corpus JSONL export, so the same
+script run on two builds (main baseline vs. this branch) produces directly comparable CSVs.
+Follows scripts/bench_bitplanes.py's pattern; see docs/issues/local-engine-sorted-range-fastpath.md.
+
+    .venv/bin/python scripts/bench_printing_range.py --out benchmarks/printing-range/baseline-main.csv
+
+The `total` column doubles as a parity check: it must be identical across builds for every
+config, or the comparison is void.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import WARMUP, load_engine  # noqa: E402
+
+if TYPE_CHECKING:
+    import card_engine
+
+# (group, query, unique, orderby, offset) — direction=asc, limit=100, prefer=default throughout.
+CONFIGS: list[tuple[str, str, str, str, int]] = [
+    # target: bare broad range under unique=printing (total=k + early-stop walk)
+    ("target", "usd<50", "printing", "edhrec", 0),
+    ("target", "cn<100", "printing", "edhrec", 0),
+    ("target", "year>2020", "printing", "edhrec", 0),
+    ("target", "date>2023-01-01", "printing", "edhrec", 0),
+    ("target", "usd>=50", "printing", "edhrec", 0),
+    ("target", "year<2010", "printing", "edhrec", 0),
+    # target: order-by the range field itself (index slice + boundary-bucket sort)
+    ("aligned", "usd<50", "printing", "usd", 0),
+    ("aligned", "usd<50", "printing", "usd", 5000),
+    # target: deep offset (should stay cheap under early-stop)
+    ("deep", "usd<50", "printing", "edhrec", 5000),
+    # control: card/artwork modes unchanged by PR 1 (must not regress)
+    ("control", "usd<50", "card", "edhrec", 0),
+    ("control", "usd<50", "artwork", "edhrec", 0),
+    ("control", "cn<100", "card", "edhrec", 0),
+    # control: non-range queries unaffected (must not regress)
+    ("control", "t:creature", "printing", "edhrec", 0),
+    ("control", "f:modern", "card", "edhrec", 0),
+    ("control", "usd<50 t:creature", "printing", "edhrec", 0),
+]
+
+
+def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str, int], window: float) -> tuple[int, int, float, float]:
+    """(total, n, avg_ms, min_ms) over a fixed timed window; mirrors bench_bitplanes.bench_one."""
+    query, unique, orderby, offset = config
+    kw = {
+        "filters": parse_scryfall_query(query),
+        "unique": unique,
+        "prefer": "default",
+        "orderby": orderby,
+        "direction": "asc",
+        "limit": 100,
+        "offset": offset,
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n, best = 0, float("inf")
+    t_start = now = time.monotonic()
+    deadline = t_start + window
+    while now < deadline:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1000, best * 1000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=8.0, help="timed seconds per config")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    hdr = f"{'group':<8} {'query':<18} {'unique':<9} {'ord':<7} {'off':>5} {'total':>7} {'min ms':>8} {'avg ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s/config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "offset", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, offset in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, offset), args.window)
+            print(
+                f"{group:<8} {query:<18} {unique:<9} {orderby:<7} {offset:>5} {total:>7,} {min_ms:>8.3f} {avg_ms:>8.3f}", flush=True
+            )
+            writer.writerow([rev, group, query, unique, orderby, offset, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -62,8 +62,12 @@ _REGEX_FRAGS = ["name:/^gob/", "o:/draw .* cards?/", "name:/dragon$/", "o:/^flyi
 _ANCHOR_P = 0.5  # chance an arith/regex fragment gets a dimension-fragment anchor
 
 WARMUP = 3
-WINDOW_S = 0.15
-MAX_ITERS = 500
+# Per-query timing budget: stop at whichever of WINDOW_S / MAX_ITERS comes first, reporting the
+# min (best) over that many samples. 0.3s/1000 was chosen to get the per-query min's run-to-run
+# noise floor under a few percent (measured: ~±3% on min_ms) without paying more runtime for a
+# tighter floor than the comparison needs; 0.15s/500 left a noisier tail.
+WINDOW_S = 0.3
+MAX_ITERS = 1000
 
 WILD_CORPUS = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
 # Fraction of the wild sample drawn from bare name lookups. They dominate the


### PR DESCRIPTION
## What

A bare, broad range predicate under `unique=printing` — `usd<50`, `cn<100`, `year>2020`, `date>2023-01-01` — full-scanned. Narrowing is vetoed for broad ranges, so `run_query` walked every card and evaluated the predicate on every printing just to compute `total`, even though the answer is a contiguous slice of a sorted index. `printing_range_fastpath` serves these directly:

- **`total = k`** from the range index's binary search (O(log n)) — no O(n) per-printing count pass.
- **Card-level order-by** (`edhrec`/`name`/…): walk that key's existing card permutation, emit each card's matching printings, stop at `offset+limit`. A card-level key is shared by all of a card's printings, so card order *is* printing order — the emission is byte-identical to `run_query_streamed`, minus the count pass.
- **`order by usd` (aligned)**: the price index *is* the value-sorted printing permutation; find the page's value-buckets by count and canonically re-sort only the bucket(s) the page overlaps (its within-value order is `pid`, but the sort key ties on `edhrec`/`prefer_score`, and price ties are large — top buckets ~1,600). A lazy bucket walk from the page's starting end keeps this O(touched buckets).

Gated to the **broad** case (`range_too_broad_to_narrow`) so selective ranges keep their existing tight narrowing and the walk only runs where matches are dense (bounded worst case — never worse than the count pass it replaces). Date/year bound derivations are extracted into shared helpers so the fastpath and `narrow_rec` can't drift. `CARD_ENGINE_PRINTING_RANGE_FASTPATH=0` forces the general path (A/B kill-switch).

Design: `docs/issues/local-engine-sorted-range-fastpath.md` (PR 1). Card-mode (`PrintingRangeBits`) and artwork are separate follow-ups.

## Performance

97,206-printing corpus, same-build fastpath **off vs on** (isolates this change from build noise), min µs over an 8 s window, Docker down. Speedup = before/after.

| Query (unique=printing) | Before | After | Speedup |
|---|---:|---:|---:|
| `usd<50` | 752 µs | 42 µs | **18×** |
| `cn<100` | 865 µs | 44 µs | 20× |
| `year>2020` | 736 µs | 42 µs | 18× |
| `date>2023-01-01` | 656 µs | 43 µs | 15× |
| `usd<50` order by usd (aligned) | 1,060 µs | 50 µs | 21× |
| `usd<50` offset 5000 (deep page) | 759 µs | 75 µs | 10× |
| `usd>=50` (selective — bails) | 103 µs | 101 µs | ~1× |
| `year<2010` (moderate 23% — bails) | 464 µs | 467 µs | ~1× |
| `usd<50` card / artwork / `usd<50 t:creature` printing (controls) | — | — | ~1× |

Broad regression screen (`survey_queries.py`, 520 queries): no systematic change. The 271 non-printing queries — which this code provably cannot touch (gated on `Mode::Printing`) — serve as a control group; their off-vs-on `min_ms` spread (median −0.7%, worst +2.7%) *is* the harness noise floor, and no query moved beyond it.

## Testing

- **A/B**: 27 configs (broad/selective, every field, various order-by/direction/offset incl. inside large price-tie buckets both directions, mode/compound controls) — fastpath on vs off byte-identical.
- **New Rust tests**: `bare_range_bounds_recognizes_leaves_and_rejects_rest`, `printing_range_walk_matches_naive_page`, `printing_range_aligned_page_matches_naive_incl_tie_buckets` (property-style vs a naive full-sort reference, incl. large tie buckets in both directions).
- `cargo test` debug + release: 122 passed. `cargo clippy --release --all-targets`: no new warnings vs baseline.
- `pytest test_engine_property.py` (differential vs independent oracle, broad `usd<5` printing exercises the fastpath) + `test_engine_unit.py`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
