### PR TITLE
Cardinality Estimator With Fuzz-Validated Sound Bounds (#702)

### DIFF
--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -1,0 +1,452 @@
+//! Standalone, SOUND, cheap cardinality estimator (PR1 of #702 — see
+//! docs/issues/00702-engine-plan-selection-layer.md). NOT wired into query
+//! routing; validated only through the `fuzz_row_identity_matches_reference`
+//! harness, which asserts the mode="card" reference count always lands inside
+//! `[lo, hi]` for every query the corpus throws.
+//!
+//! Composition happens entirely in card-space (universe N = n_cards) with a
+//! printing-varying gate on the AND lower bound and NOT (see
+//! `has_printing_varying_leaf` and `estimate_rec`). Printing-space leaf counts
+//! (ranges, printing-space tag postings, artist/flavor CSR widths) are
+//! projected to card-space per-leaf via `project`.
+//!
+//! SOUNDNESS is the hard invariant; tightness/cheapness are secondary. When a
+//! leaf can't be bounded cheaply we return the trivially-sound "unknown"
+//! `{lo:0, est:N/2, hi:N}`.
+
+use super::*;
+
+/// Card-space cardinality facts for plan selection. `lo`/`hi` are SOUND bounds
+/// (mode="card" truth always lands inside); `est` is the point estimate.
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub(crate) struct Cardinality {
+    pub lo: u32,
+    pub est: u32,
+    pub hi: u32,
+}
+
+/// The trivially-sound "I don't know" answer over a universe of size `n`.
+fn unknown(n: u32) -> Cardinality {
+    Cardinality { lo: 0, est: n / 2, hi: n }
+}
+
+/// An exact card count: bounds collapse onto the point.
+fn exact(c: u32) -> Cardinality {
+    Cardinality { lo: c, est: c, hi: c }
+}
+
+/// Clamp a `(lo, est, hi)` triple into `[0, n]`, enforce `lo <= hi`, and pin
+/// `est` into `[lo, hi]`. The final `est` clamp is a safety rail — if it ever
+/// changes `est` materially that signals a composition bug.
+fn finalize(lo: u32, est: u32, hi: u32, n: u32) -> Cardinality {
+    let hi = hi.min(n);
+    let lo = lo.min(hi);
+    let est = est.clamp(lo, hi);
+    Cardinality { lo, est, hi }
+}
+
+/// Project a printing-space count `k` into card-space (PR1 tier: free
+/// global-ratio point estimate). Bounds for a projected varying leaf:
+/// `lo = (k>0)?1:0`, `hi = min(k, N)`; `est = round(k * N / n_printings)`
+/// clamped into `[1, hi]` when `k>0`, else 0.
+///
+/// TODO(#702): the doc's sampled (map `s` sampled ids) and exact-below-`K`
+/// (transition-count on sorted ids) projection tiers are a documented
+/// follow-up; PR1 deliberately ships only the free tier.
+fn project(k: u32, n_cards: u32, n_printings: u32) -> Cardinality {
+    if k == 0 || n_cards == 0 {
+        return Cardinality { lo: 0, est: 0, hi: 0 };
+    }
+    let hi = k.min(n_cards);
+    let est = if n_printings == 0 {
+        1
+    } else {
+        let raw = (u64::from(k) * u64::from(n_cards) + u64::from(n_printings) / 2) / u64::from(n_printings);
+        (raw as u32).clamp(1, hi)
+    };
+    Cardinality { lo: 1, est, hi }
+}
+
+/// ANY-composition printing-varying classifier: true if ANY leaf in the tree
+/// is printing-varying. Deliberately NOT `filter::printing_dependent` (that is
+/// an ALL-composition for verifier ordering). Leaf classification copies the
+/// field lists from `printing_dependent`'s leaf arms but composes with `.any`.
+///
+/// `Legality` is treated as varying here (conservative): divergent reprints
+/// genuinely vary per-printing (#667), even though `printing_dependent` ranks
+/// it invariant for its own (common-case) reason.
+pub(crate) fn has_printing_varying_leaf(f: &FilterExpr) -> bool {
+    fn num_varying(e: &NumExpr) -> bool {
+        match e {
+            NumExpr::Const(_) => false,
+            NumExpr::Field(field) => matches!(
+                field,
+                NumField::RarityInt
+                    | NumField::CollectorNumberInt
+                    | NumField::PriceUsd
+                    | NumField::PriceEur
+                    | NumField::PriceTix
+                    | NumField::PreferScore
+            ),
+            NumExpr::Arith(lhs, _, rhs) => num_varying(lhs) || num_varying(rhs),
+        }
+    }
+    match f {
+        FilterExpr::NumericCmp { lhs, rhs, .. } => num_varying(lhs) || num_varying(rhs),
+        FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => true,
+        FilterExpr::ArtistMatch { .. } | FilterExpr::FlavorMatch { .. } => true,
+        FilterExpr::TextContains { field, .. } => matches!(field, TextSearchField::FlavorTextLower),
+        FilterExpr::TextExact { field, .. } | FilterExpr::TextRegex { field, .. } => matches!(
+            field,
+            TextField::FlavorTextLower | TextField::SetCode | TextField::Border | TextField::Watermark | TextField::CollectorNumber
+        ),
+        FilterExpr::CollectionCmp { field, .. } => {
+            matches!(field, CollField::ArtTags | CollField::IsTags | CollField::FrameData)
+        }
+        FilterExpr::Legality { .. } => true,
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().any(has_printing_varying_leaf),
+        FilterExpr::Not(inner) => has_printing_varying_leaf(inner),
+        // Exhaustive, not `_ => false`: a new variant must get a considered
+        // answer here rather than silently inheriting "invariant".
+        FilterExpr::True
+        | FilterExpr::ExactName(_)
+        | FilterExpr::NameMatch { .. }
+        | FilterExpr::OracleMatch { .. }
+        | FilterExpr::ColorCmp { .. }
+        | FilterExpr::TypeCmp { .. }
+        | FilterExpr::ManaCostCmp { .. }
+        | FilterExpr::Devotion { .. } => false,
+    }
+}
+
+/// Whether `f` is a TOTAL two-valued, card-invariant predicate: its card-level
+/// `tri` is always True/False, never Null and never PrintingDep. Only then is
+/// the complement clean (`|NOT P| = N - |P|` exactly), because a Null card
+/// satisfies NEITHER `P` nor `NOT P` under three-valued logic — so a nullable
+/// inner's `N - |P|` OVER-counts `NOT P` by the Null cards, and using
+/// `N - inner.hi` as a NOT lower bound would be UNSOUND (found by the fuzz
+/// harness on `NOT(toughness>3)`: toughness is Null for non-creatures).
+///
+/// Base cases are exactly the leaves whose `tri` is unconditional `tri_bool`
+/// (filter.rs): `True`, `ColorCmp` (colors always present — colorless is mask
+/// 0, not Null), `TypeCmp` (type line always present). And/Or/Not of total
+/// children stay total (no child can introduce a Null), and all three bases are
+/// card-invariant, so totality implies card-invariance.
+fn is_total_two_valued(f: &FilterExpr) -> bool {
+    match f {
+        FilterExpr::True | FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => true,
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(is_total_two_valued),
+        FilterExpr::Not(inner) => is_total_two_valued(inner),
+        _ => false,
+    }
+}
+
+/// Entry point. Derives `n_cards`/`n_printings` from `offsets` (mirrors
+/// lib.rs's `narrow_candidates_exact` / `narrow_rec`) and recurses.
+#[allow(dead_code)]
+pub(crate) fn estimate_cardinality(f: &FilterExpr, indexes: &Archived<CardIndexes>, offsets: &AOffsets) -> Cardinality {
+    let n_cards = offsets.len().saturating_sub(1);
+    let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
+    estimate_rec(f, indexes, n_cards as u32, n_printings as u32)
+}
+
+fn estimate_rec(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, n_printings: u32) -> Cardinality {
+    let n = n_cards;
+    match f {
+        FilterExpr::And(children) => compose_and(children, indexes, n_cards, n_printings),
+        FilterExpr::Or(children) => compose_or(children, indexes, n_cards, n_printings),
+        FilterExpr::Not(inner) => {
+            let c = estimate_rec(inner, indexes, n_cards, n_printings);
+            if is_total_two_valued(inner) {
+                // Total two-valued, card-invariant inner: no Null cards, so the
+                // complement is clean — `|NOT P| = N - |P|` — and bounds invert.
+                finalize(n.saturating_sub(c.hi), n.saturating_sub(c.est), n.saturating_sub(c.lo), n)
+            } else if has_printing_varying_leaf(inner) {
+                // Printing-varying inner: the NOT card-set is "some printing does
+                // NOT satisfy inner", which is neither the complement of inner's
+                // card-projection (a card can have one satisfying and one not) nor
+                // bounded below cheaply once Nulls are possible. Only `truth <= N`
+                // is sound; `lo = 0`.
+                finalize(0, n.saturating_sub(c.est), n, n)
+            } else {
+                // Card-invariant but possibly-Null inner: `P` and `NOT P` are
+                // disjoint (a card is True, False, or Null for the invariant
+                // predicate), so `|NOT P| <= N - |P| <= N - inner.lo` (sound
+                // upper bound). Null cards are in NEITHER set, so `N - inner.hi`
+                // is NOT a sound lower bound — use `lo = 0`.
+                finalize(0, n.saturating_sub(c.est), n.saturating_sub(c.lo), n)
+            }
+        }
+        _ => estimate_leaf(f, indexes, n_cards, n_printings),
+    }
+}
+
+fn compose_and(children: &[FilterExpr], indexes: &Archived<CardIndexes>, n_cards: u32, n_printings: u32) -> Cardinality {
+    let n = n_cards;
+    if children.is_empty() {
+        return exact(n);
+    }
+    let cs: Vec<Cardinality> = children.iter().map(|c| estimate_rec(c, indexes, n_cards, n_printings)).collect();
+    let k = children.len() as u64;
+
+    // Upper bound: always min(child.hi).
+    let hi = cs.iter().map(|c| c.hi).min().unwrap_or(n);
+
+    // Point estimate: independence, N * Π(est_i / N).
+    let est = if n == 0 {
+        0
+    } else {
+        let mut prod = 1.0f64;
+        for c in &cs {
+            prod *= f64::from(c.est) / f64::from(n);
+        }
+        (prod * f64::from(n)).round() as u32
+    };
+
+    // Lower bound: Bonferroni ONLY when at most one child is printing-varying
+    // (otherwise a card can be in each child's card-projection via DIFFERENT
+    // printings while no single printing satisfies all — the AND set is then
+    // NOT the intersection of the projections and Bonferroni is unsound).
+    let varying = children.iter().filter(|c| has_printing_varying_leaf(c)).count();
+    let lo = if varying <= 1 {
+        let sum: u64 = cs.iter().map(|c| u64::from(c.lo)).sum();
+        sum.saturating_sub((k - 1) * u64::from(n)).min(u64::from(n)) as u32
+    } else {
+        0
+    };
+
+    finalize(lo, est, hi, n)
+}
+
+fn compose_or(children: &[FilterExpr], indexes: &Archived<CardIndexes>, n_cards: u32, n_printings: u32) -> Cardinality {
+    let n = n_cards;
+    if children.is_empty() {
+        return Cardinality { lo: 0, est: 0, hi: 0 };
+    }
+    let cs: Vec<Cardinality> = children.iter().map(|c| estimate_rec(c, indexes, n_cards, n_printings)).collect();
+
+    // OR card-set = union of the children's card-projections (a card matches
+    // the OR iff some printing satisfies some child), so these are sound with
+    // no varying gate: lo = max(child.lo), hi = min(N, Σ child.hi).
+    let lo = cs.iter().map(|c| c.lo).max().unwrap_or(0);
+    let hi = cs.iter().map(|c| u64::from(c.hi)).sum::<u64>().min(u64::from(n)) as u32;
+
+    let est = if n == 0 {
+        0
+    } else {
+        let mut prod = 1.0f64;
+        for c in &cs {
+            prod *= 1.0 - f64::from(c.est) / f64::from(n);
+        }
+        ((1.0 - prod) * f64::from(n)).round() as u32
+    };
+
+    finalize(lo, est, hi, n)
+}
+
+/// Plane popcount for a plane-expressible leaf. Returns `(count, existential)`
+/// where `existential` marks an existence-projection plane (legality / rarity /
+/// border) whose popcount is a card-space superset — see
+/// `planes::plane_expr_is_existential`. Guards on plane availability exactly
+/// like `narrow_rec`'s plane path.
+fn plane_popcount(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32) -> Option<(u32, bool)> {
+    if n_cards == 0 || u32::from(indexes.planes.n_cards) != n_cards {
+        return None;
+    }
+    let pe = compile_plane(f, &indexes.planes, &indexes.oracle_trigram.words)?;
+    let mut bits: Vec<u64> = Vec::new();
+    eval_planes(&pe, &indexes.planes, &mut bits);
+    let c: u32 = bits.iter().map(|w| w.count_ones()).sum();
+    Some((c, plane_expr_is_existential(&pe)))
+}
+
+/// A plane-backed leaf. `force_loose` forces the superset treatment
+/// (`{lo:0, est:c, hi:c}`) even for a non-existential plane — used for
+/// Devotion, whose plane popcount is a documented superset.
+fn plane_card(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, force_loose: bool) -> Cardinality {
+    match plane_popcount(f, indexes, n_cards) {
+        Some((c, existential)) => {
+            if existential || force_loose {
+                Cardinality { lo: 0, est: c, hi: c }
+            } else {
+                exact(c)
+            }
+        }
+        None => unknown(n_cards),
+    }
+}
+
+/// Card count `end - start` from the numeric index's partition_point bounds,
+/// WITHOUT materializing the id vec (mirrors `numeric_candidates`). None for
+/// Ne (not selective).
+fn numeric_count(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Option<u32> {
+    let (start, end) = match op {
+        CmpOp::Ne => return None,
+        CmpOp::Eq => {
+            if val.fract() != 0.0 {
+                return Some(0);
+            }
+            let s = idx.partition_point(|p| (i16::from(p.0) as f64) < val);
+            let e = idx.partition_point(|p| (i16::from(p.0) as f64) <= val);
+            (s, e)
+        }
+        CmpOp::Lt => (0, idx.partition_point(|p| (i16::from(p.0) as f64) < val)),
+        CmpOp::Le => (0, idx.partition_point(|p| (i16::from(p.0) as f64) <= val)),
+        CmpOp::Gt => (idx.partition_point(|p| (i16::from(p.0) as f64) <= val), idx.len()),
+        CmpOp::Ge => (idx.partition_point(|p| (i16::from(p.0) as f64) < val), idx.len()),
+    };
+    Some((end - start) as u32)
+}
+
+/// Printing count `e - s` for a `[lo, hi)` window over a printing range index,
+/// WITHOUT materializing (mirrors `range_narrowed`'s `k = e - s`).
+fn range_count(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32) -> u32 {
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    (e - s) as u32
+}
+
+fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, n_printings: u32) -> Cardinality {
+    let n = n_cards;
+    match f {
+        FilterExpr::True => exact(n),
+
+        // ExactName's exact card count is the name-range width, which needs the
+        // `cards` slice (lib.rs:2831-2833) — not in this entry point's
+        // signature — so PR1 returns the sound "unknown" for it. (Not exercised
+        // by the fuzz corpus, which emits TextExact{NameLower}, not ExactName.)
+        FilterExpr::ExactName(_) => unknown(n),
+
+        FilterExpr::NumericCmp { lhs, op, rhs } => {
+            // Only the simple `Field(f) op Const(c)` / `Const op Field(f)`
+            // shapes; Arith and Field-vs-Field bail to unknown.
+            let (field, op, c) = match (lhs, rhs) {
+                (NumExpr::Field(fld), NumExpr::Const(c)) => (*fld, *op, *c),
+                (NumExpr::Const(c), NumExpr::Field(fld)) => (*fld, flip_op(*op), *c),
+                _ => return unknown(n),
+            };
+            match field {
+                NumField::Cmc => numeric_count(&indexes.cmc, op, c).map_or_else(|| unknown(n), exact),
+                NumField::Power => numeric_count(&indexes.power, op, c).map_or_else(|| unknown(n), exact),
+                NumField::Toughness => numeric_count(&indexes.toughness, op, c).map_or_else(|| unknown(n), exact),
+                // Card-space "any-printing-at-rarity" count = the mode=card
+                // some-match count for a single rarity leaf. narrow_rarity's
+                // set is loose (for Not), but its POPCOUNT is exact here.
+                NumField::RarityInt => {
+                    narrow_rarity(indexes, n_cards as usize, op, c).map_or_else(|| unknown(n), |nar| exact(nar.set.len() as u32))
+                }
+                // Printing-space integer-cent range → project (varying).
+                NumField::PriceUsd => match int_range_bounds(op, snap_to_nearest_cent(c * PRICE_CENTS_PER_DOLLAR)) {
+                    None => unknown(n),
+                    Some(None) => project(0, n_cards, n_printings),
+                    Some(Some((lo, hi))) => project(range_count(&indexes.price_usd, lo, hi), n_cards, n_printings),
+                },
+                // Printing-space integer range → project (varying).
+                NumField::CollectorNumberInt => match int_range_bounds(op, c) {
+                    None => unknown(n),
+                    Some(None) => project(0, n_cards, n_printings),
+                    Some(Some((lo, hi))) => project(range_count(&indexes.collector_number, lo, hi), n_cards, n_printings),
+                },
+                // No index (price_eur/price_tix are not indexed) or unindexed
+                // fields (loyalty/edhrec/prefer_score) → sound unknown.
+                NumField::PriceEur | NumField::PriceTix | NumField::Loyalty | NumField::EdhrEc | NumField::PreferScore => unknown(n),
+            }
+        }
+
+        // Card-invariant exact plane popcount.
+        FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => plane_card(f, indexes, n_cards, false),
+
+        // Existence-projection plane → superset {0, c, c}.
+        FilterExpr::Legality { .. } => plane_card(f, indexes, n_cards, true),
+
+        // Devotion Ge/Gt: saturated-bucket plane superset {0, c, c}; other ops
+        // are not plane-narrowable → unknown.
+        FilterExpr::Devotion { op: CmpOp::Ge | CmpOp::Gt, .. } => plane_card(f, indexes, n_cards, true),
+        FilterExpr::Devotion { .. } => unknown(n),
+
+        FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } => {
+            // Mirror narrow_rec's field dispatch (lib.rs:3040-3047).
+            let (idx, card_space, complete) = match field {
+                CollField::Subtypes => (&indexes.subtypes, true, true),
+                CollField::Keywords => (&indexes.keywords, true, true),
+                CollField::OracleTags => (&indexes.oracle_tags, true, true),
+                CollField::ArtTags => (&indexes.art_tags, false, true),
+                CollField::IsTags => (&indexes.is_tags, false, true),
+                CollField::FrameData => (&indexes.frame_data, false, false),
+            };
+            match idx.get(value.as_str()) {
+                Some(v) => {
+                    let cnt = v.len() as u32;
+                    if card_space {
+                        exact(cnt)
+                    } else {
+                        project(cnt, n_cards, n_printings)
+                    }
+                }
+                None if complete => {
+                    // Absent from a complete index ⇒ matches nothing.
+                    if card_space {
+                        exact(0)
+                    } else {
+                        project(0, n_cards, n_printings)
+                    }
+                }
+                // frame_data drops dense values at build (#628), so absence
+                // proves nothing → unknown.
+                None => unknown(n),
+            }
+        }
+        FilterExpr::CollectionCmp { .. } => unknown(n),
+
+        // Printing-space CSR width sums → project (varying).
+        FilterExpr::ArtistMatch { ids } => {
+            let k: usize = ids
+                .iter()
+                .map(|&a| (u32::from(indexes.artists.offsets[a as usize + 1]) - u32::from(indexes.artists.offsets[a as usize])) as usize)
+                .sum();
+            project(k as u32, n_cards, n_printings)
+        }
+        FilterExpr::FlavorMatch { dense_ids, .. } => {
+            let flavor = &indexes.flavor;
+            let k: usize = dense_ids
+                .iter()
+                .map(|&d| (u32::from(flavor.offsets[d as usize + 1]) - u32::from(flavor.offsets[d as usize])) as usize)
+                .sum();
+            project(k as u32, n_cards, n_printings)
+        }
+
+        // Memoize-produced card-space id sets (never emitted by bind(), so not
+        // seen in the fuzz corpus). NameMatch keys on card_name_id — names are
+        // unique per oracle card, so ids.len() is the exact card count.
+        // OracleMatch keys on oracle_text_lower_id; see the soundness caveat in
+        // the module report (shared oracle-text ids could in principle make
+        // gids.len() an undercount; not exercised here).
+        FilterExpr::NameMatch { ids } => exact(ids.len() as u32),
+        FilterExpr::OracleMatch { gids } => exact(gids.len() as u32),
+
+        FilterExpr::DateCmp { op, value } => match date_range_bounds(*op, *value) {
+            None => unknown(n),
+            Some((lo, hi)) => project(range_count(&indexes.released_at, lo, hi), n_cards, n_printings),
+        },
+        FilterExpr::YearCmp { op, year } => match year_range_bounds(*op, *year) {
+            None => unknown(n),
+            Some((lo, hi)) => project(range_count(&indexes.released_at, lo, hi), n_cards, n_printings),
+        },
+
+        // set:X postings → project (varying); every other TextExact/TextRegex
+        // and all TextContains/ManaCostCmp are unindexed here → unknown.
+        FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
+            let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
+            project(k as u32, n_cards, n_printings)
+        }
+
+        FilterExpr::TextExact { .. }
+        | FilterExpr::TextRegex { .. }
+        | FilterExpr::TextContains { .. }
+        | FilterExpr::ManaCostCmp { .. } => unknown(n),
+
+        // Composites are handled in estimate_rec; reaching here is a bug.
+        FilterExpr::And(_) | FilterExpr::Or(_) | FilterExpr::Not(_) => unknown(n),
+    }
+}

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -790,6 +790,7 @@ mod filter;
 use filter::*;
 mod planes;
 use planes::*;
+mod estimator;
 
 // ─── Trigram index ────────────────────────────────────────────────────────────
 

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2343,6 +2343,18 @@ fn fuzz_check_case(archived: &Archived<CardData>, spec: &FuzzSpec, ctx: &str, or
         let expected = fuzz_reference_total(archived, &ref_filter, mode);
         let unique_is_card = mode == "card";
 
+        // #702 PR1: the standalone cardinality estimator's SOUND bounds must
+        // bracket the mode="card" reference count for every query. `ref_filter`
+        // is the full bound filter (no plane split — matches fuzz_reference_total).
+        if mode == "card" {
+            let c = super::estimator::estimate_cardinality(&ref_filter, &archived.indexes, &archived.offsets);
+            assert!(
+                (c.lo as usize) <= expected && expected <= (c.hi as usize),
+                "estimator bounds unsound: mode=card expected={expected} bounds=[{},{}] est={} ({ctx})",
+                c.lo, c.hi, c.est,
+            );
+        }
+
         // Full page (offset 0): total + every row satisfies. Unplaned = raw filter, plane = None;
         // plane path = split_planes + the promoted plane (unique_is_card matches the real caller).
         let mut plain = fuzz_bound_filter(spec, archived);
@@ -2523,6 +2535,77 @@ fn fuzz_row_identity_matches_reference() {
         let ctx = format!("corpus-rowid, filter={}", fuzz_describe(&spec));
         fuzz_check_row_identity(archived, &spec, &ctx, orderby, direction, mode, 100, offset);
     }
+}
+
+/// #702 PR1 estimator accuracy report (NOT an assertion — a reporting tool).
+/// Runs a spread of fuzz queries against a corpus store, comparing the point
+/// estimate and bounds to the mode="card" reference count, and prints the
+/// error distribution. Run with:
+///   cargo test --release estimator_accuracy -- --ignored --nocapture
+#[test]
+#[ignore = "estimator accuracy report; cargo test estimator_accuracy -- --ignored --nocapture"]
+fn estimator_accuracy() {
+    use rand::SeedableRng;
+    const CORPUS_CARDS: usize = 6_000;
+    const QUERIES: usize = 5_000;
+    const MAX_DEPTH: u8 = 3;
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(4_242);
+    let data = fuzz_store_n(&mut rng, CORPUS_CARDS);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_cards = archived.cards.len();
+
+    let (mut exact, mut within_2x, mut worse) = (0u32, 0u32, 0u32);
+    let mut tight_bounds = 0u32; // bounds narrower than half the universe
+    let mut collapsed_bounds = 0u32; // lo == hi (a fully-pinned answer)
+    let mut unsound = 0u32; // must stay 0
+    let mut total = 0u32;
+
+    for _ in 0..QUERIES {
+        let spec = fuzz_gen(&mut rng, MAX_DEPTH);
+        let f = fuzz_bound_filter(&spec, archived);
+        let truth = fuzz_reference_total(archived, &f, "card");
+        let c = super::estimator::estimate_cardinality(&f, &archived.indexes, &archived.offsets);
+        total += 1;
+
+        if (c.lo as usize) > truth || truth > (c.hi as usize) {
+            unsound += 1;
+            eprintln!("UNSOUND: truth={truth} bounds=[{},{}] filter={}", c.lo, c.hi, fuzz_describe(&spec));
+        }
+
+        // Point-estimate accuracy vs truth.
+        let est = c.est as usize;
+        if est == truth {
+            exact += 1;
+        } else {
+            let (a, b) = (est.max(1), truth.max(1));
+            if a <= 2 * b && b <= 2 * a {
+                within_2x += 1;
+            } else {
+                worse += 1;
+            }
+        }
+
+        // Bounds tightness.
+        let width = (c.hi - c.lo) as usize;
+        if width * 2 < n_cards {
+            tight_bounds += 1;
+        }
+        if c.lo == c.hi {
+            collapsed_bounds += 1;
+        }
+    }
+
+    let pct = |x: u32| 100.0 * f64::from(x) / f64::from(total);
+    eprintln!("\n=== #702 estimator accuracy ({total} queries, {n_cards} cards) ===");
+    eprintln!("unsound bounds violations : {unsound} (MUST be 0)");
+    eprintln!("point est == truth        : {exact} ({:.1}%)", pct(exact));
+    eprintln!("point est within 2x       : {within_2x} ({:.1}%)", pct(within_2x));
+    eprintln!("point est worse than 2x   : {worse} ({:.1}%)", pct(worse));
+    eprintln!("bounds width < N/2        : {tight_bounds} ({:.1}%)", pct(tight_bounds));
+    eprintln!("bounds collapsed (lo==hi) : {collapsed_bounds} ({:.1}%)", pct(collapsed_bounds));
+    assert_eq!(unsound, 0, "estimator produced unsound bounds — see stderr");
 }
 
 /// format:A AND format:B (two distinct formats) can't be answered by ANDing

--- a/docs/issues/00702-engine-plan-selection-layer.md
+++ b/docs/issues/00702-engine-plan-selection-layer.md
@@ -5,10 +5,10 @@
 The engine already makes cost-based execution decisions — it just makes them
 in a growing decision tree scattered through `run_query` (lib.rs ~3976),
 each branch gated on a conjunction of preconditions. This issue proposes
-folding that tree into one explicit plan-selection layer: enumerate the
-applicable physical plans, cost each with the constants we already measure,
-pick the cheapest. Structurally a planner; deliberately **not** a
-Selinger-style cost-based optimizer (see Non-goals).
+folding that tree into one explicit plan-selection layer driven by **cheap
+cardinality estimates**: estimate how many rows each candidate plan would
+touch, cost each, pick the cheapest. Structurally a planner; deliberately
+**not** a Selinger-style optimizer (see Non-goals).
 
 ## Why now
 
@@ -34,8 +34,8 @@ Each precondition set is hand-maintained and pairwise-disjoint *by
 construction*, not by any checked invariant. Two concrete smells:
 
 - The 7/8 cutoff in (3) is the one place we *guess* a selectivity threshold
-  instead of reading an exact size — it's a plan choice masquerading as a
-  filter step.
+  instead of reading a size — it's a plan choice masquerading as a filter
+  step.
 - (2) and (4) both want "a sort permutation exists" but diverge on the
   filter shape; (1) and (4) both handle broad range predicates but in
   different modes. The preconditions already brush against each other.
@@ -44,88 +44,146 @@ The trigger we're pre-empting: the first fast path whose preconditions
 *overlap* another's and would pick a different (or wrong) plan, or the Nth
 fast path that can't be added without re-reading the prior N−1.
 
-## What the layer is
+## The key realization: routing on cheap estimates, not materialized counts
 
-A thin function — call it `choose_plan` — that runs after binding /
-narrowing has produced the facts the current tree already computes
-(candidate set or its exact size, plane presence/popcount, residual
-shape, whether a sort permutation exists, `all_match_known`) and returns a
-`PhysicalPlan` enum. `run_query` becomes: gather facts → `choose_plan` →
-dispatch. The existing branch bodies become the plan executors, largely
-unchanged.
+The reason today's decisions are staged (fast path 2 must return *before*
+candidate materialization — the general path handles that query correctly
+but pays an O(candidates) counts-buffer fill it skips, lib.rs ~4013) is that
+they key off the **materialized** candidate count. But the *cardinality* of
+most leaf predicates is available far more cheaply than the set itself:
+
+- postings list → `len()`, O(1)
+- range predicate → the two `partition_point` binary searches already
+  compute `k = e − s`, O(log n) — `range_narrowed` discards this today
+- negation → `N − c(P)`, exact given the child
+- plane → popcount, O(words)
+- **un-indexable text `contains`/regex → genuinely unknown, `[0, N]`** — the
+  one gap, and exactly the predicate class that forces a scan anyway
+
+If routing keys off a cheap *estimate* rather than the materialized count,
+every plan decision moves ahead of materialization, materialization becomes
+a *consequence* of the chosen plan, and the staging constraint that
+prevented a single `choose_plan` dissolves. This is safe because **plan
+choice is a pure performance decision** — every plan returns identical rows —
+so a wrong estimate only ever costs latency, never correctness, and every
+wrong guess is bounded by O(N), the query's own cost.
+
+## Cardinality estimation (the routing input)
+
+Compound cardinality from cheap leaf counts, over a universe of size `N`:
 
 ```
-enum PhysicalPlan {
-    PrintingRangeScan { .. },       // fast path 1
-    PlanePopcountOrder { .. },      // fast path 2
-    StreamedSelect { candidates },  // fast path 4, broad
-    GatheredScan { candidates },    // fallback
-}
+AND(c₁..cₖ):  lo = max(0, Σcᵢ − (k−1)·N)   hi = min(cᵢ)   est = N·Π(cᵢ/N)
+OR(c₁..cₖ):   lo = max(cᵢ)                 hi = min(N,Σcᵢ) est = N·(1−Π(1−cᵢ/N))
+NOT(c):       c' = N − c   (bounds invert)
 ```
 
-Costing uses the constants we already have: `verify_cost_tier` per residual
-node × the eval domain (candidate count, known exactly), plus the O(words)
-vs O(popcount) distinction that (2) vs (4) already encode informally. The
-7/8 guess becomes `cost(GatheredScan over candidates)` vs
-`cost(StreamedSelect over full corpus)` — a comparison of two numbers we can
-compute, not a magic ratio.
+- `lo`/`hi` are **sound bounds** (materialized truth always lands inside);
+  `est` is the independence point estimate. The point estimate optimizes the
+  common case; the bounds are the safety rail for decisions where a wrong
+  guess is *expensive* rather than merely suboptimal (most sharply, the
+  idea-1-vs-idea-2 crossover in local-engine-broad-range-fastpath.md: gate
+  idea-1's near-unbounded permutation walk on the *lower bound* of the match
+  count, fall to idea-2's bitmap when the bound can't rule the pathology out).
+- **Independence is the known lie** (`t:creature pow>3`, `c:g` vs `id:g`).
+  The bounds stay valid regardless of correlation, so they cover us; a small
+  table of known structural correlations is a later refinement.
+
+### Two spaces
+
+Postings/ranges are printing-space; planes and the `unique=card` answer are
+card-space. Composition is valid in any *single* universe, but **projection
+does not distribute over AND/OR** — `distinct_cards(A∩B)` is not a function
+of the card counts of `A` and `B`, so you cannot maintain both spaces through
+the recursion. The natural fit for the existing plane/residual split
+(`split_planes` already pulls planes into `plane: Option<&PlaneExpr>`):
+compose the **residual** in printing-space (exact, cheap), project once via
+`printing_to_card` (#690), then combine with the plane's exact card-space
+popcount in card-space at the top.
+
+Card-space projection is `COUNT DISTINCT` (O(k) in general), so it's an
+**adaptive three-tier** thing, sized by `k`:
+
+0. **free** — global-ratio scale `d̂ ≈ k·N_cards/N_printings` (correct on
+   average, wrong under fan-out correlation)
+1. **sampled** — map `s` sampled `[lo,hi)` entries via `printing_to_card`;
+   note linear extrapolation `d_sample/f` is **biased high** (multi-printing
+   cards over-counted), tolerable because plan choice is perf-only
+2. **exact** — below a crossover `K`, project all `k`; `printing_to_card` is
+   monotone, so on sorted ids this is a hash-free transition count
+
+`K` (exact/sample crossover) and `s` (sample size) are calibration knobs,
+same shape as the existing guards, deferred to measurement.
+
+Whether routing ultimately consumes card-space, printing-space, or both is
+still open (see Open questions) — the estimator produces both; which one
+drives each decision is decided when we wire it.
 
 ## Non-goals
 
-This is explicitly **not** a classical cost-based optimizer, because the two
-hardest things a CBO does don't apply:
+Still **not** a classical cost-based optimizer:
 
 - **No join-order search.** Single-table selection + sort + paginate. The
   plan space is shallow and enumerable by hand — a fixed handful of physical
   plans, not a search over trees.
-- **No cardinality *estimation*.** Posting-list lengths and plane popcounts
-  are *exact counts we read*, not statistics we estimate. The layer must
-  preserve that: it costs plans from known sizes. We are not building a
-  statistics/estimator subsystem, and we should resist any plan whose cost
-  depends on a *guessed* selectivity.
-
-The one genuine unknown stays unknown: **acceptance rates** of non-set
-residual predicates (`o:flying`, numeric ranges) — `or_child_key` already
-documents these as "unknowable statically." The layer costs by verify tier ×
-domain size, exactly as the verifier ordering does today; it does not try to
-predict acceptance. If we ever want that, it's a separate build-time
-selectivity table (see Future), not part of this consolidation.
+- **No statistics/sampling subsystem for *acceptance rates*.** Leaf
+  *cardinalities* we estimate cheaply (above); but the acceptance rate of a
+  non-set residual predicate (`o:flying`) mid-walk stays unknown, as
+  `or_child_key` documents. Verifier child ordering still costs by tier ×
+  domain, not by predicted acceptance. A build-time per-field selectivity
+  table is a separate future item, not part of this.
 
 ## Scope / sequencing
 
-Pure refactor first, behavior-preserving: move the four decisions into
-`choose_plan` with the *same* thresholds (including the literal 7/8), gated
-behind a `CARD_ENGINE_PLAN_SELECT` env toggle (same LazyLock pattern as the
-calibrated constants). Prove parity, then — as follow-ups — replace each
-hand-tuned threshold with a computed cost comparison, one at a time, each
-its own A/B. Do not change plan choices and restructure in the same commit.
+Estimator first, so the accuracy is measured before anything reroutes:
 
-Filter trees are tiny, so `choose_plan` cost is noise; it runs once per
-query, not per card.
+1. **Estimator as a standalone, validated component** — leaf counts + bounds
+   algebra + adaptive card projection, *not yet wired into routing*. Pure
+   addition, zero behavior change.
+2. **The `choose_plan` seam** — now genuinely single-layer (routing keys off
+   the estimate, so it precedes materialization). Behavior-preserving where
+   it can be, toggle-gated A/B via `CARD_ENGINE_PLAN_SELECT` (same LazyLock
+   pattern; temporary legacy duplicate of `run_query`, deleted in a
+   follow-up once parity holds).
+3. **Threshold → cost-comparison, one at a time** — the 7/8 cutoff,
+   `STREAM_MIN_MATCHES`, the memoize gate — each its own measured A/B. Do not
+   change plan choices and restructure in the same commit.
+
+Filter trees are tiny, so `choose_plan` and the estimator cost is noise;
+they run once per query, not per card.
 
 ## Measurement
 
-Parity is the whole game for the refactor step: the differential oracle
-(#641 / `fuzz_row_identity_matches_reference`) must show identical row
-identity and totals with the toggle on and off across the fuzz corpus. Any
-divergence is a bug in the move, not an intended plan change. Once each
-threshold is later replaced by a cost comparison, re-run the #647 harness on
-the affected query family and confirm no regression at the geomean and no
-new tail.
+Hook the estimator into the `fuzz_row_identity_matches_reference` harness and
+record `(lo, hi, est, materialized_truth)` per query:
+
+- **Bounds soundness is a hard invariant** — `truth ∈ [lo, hi]` must always
+  hold; a violation is a bug in the algebra, fail the test. (Estimate
+  *accuracy* is a reported distribution, not pass/fail — a bad estimate is
+  only slow.)
+- **Plan-type coverage assertion** — every `PhysicalPlan` variant must be
+  exercised by the corpus; if not, that's a corpus gap to fill (#698/#699
+  just expanded coverage — this makes it *checked*).
+
+For the seam PR, the differential oracle must show identical row identity and
+totals with the toggle on and off; any divergence is either a move bug or a
+*measured, intended* estimate-vs-materialized-count divergence, not a
+surprise. For the threshold PRs, re-run the #647 harness on the affected
+family: no geomean regression, no new tail.
 
 ## Open questions
 
-- Does `choose_plan` return a plan *before* or *after* `memoize_text_predicates`
-  and `order_children_by_verify_cost`? Those currently run mid-`run_query`
-  and depend on the chosen eval domain — likely the layer picks the
-  candidate strategy first, then memoization/ordering run inside the chosen
-  executor.
+- **Which space drives routing** — card, printing, or both per-decision. The
+  estimator produces both; late projection keeps ranges exact longer but
+  complicates the algebra. Deferred to the wiring PR.
+- **Estimator return shape** — recursion composes a single-space
+  `Cardinality { lo, est, hi }`; a both-spaces container (card + printing
+  triples) is assembled only at the *root* for the decision site, never
+  threaded through composition (projection doesn't distribute — above).
 - Is the plane-∩-candidates composition (the `CardBits` direct-AND vs
-  materialize-and-retain choice in fast path 3) a *plan* decision or an
-  executor-internal one? Leaning executor-internal, but it's exactly the
-  kind of buried cost choice this layer is meant to surface.
-- Future, out of scope: a build-time per-field acceptance-rate table would
-  let `or_child_key` / And ordering use real selectivity instead of cost
-  tiers. Tempting, but it's the "statistics" half of a CBO we're otherwise
-  declining — file separately if wild-corpus traffic ever shows verify-order
+  materialize-and-retain choice in fast path 3) a *plan* decision or
+  executor-internal? Leaning executor-internal.
+- Future, out of scope: a build-time per-field acceptance-rate table for
+  verifier ordering — the "statistics" half of a CBO we're otherwise
+  declining. File separately if wild-corpus traffic shows verify-order
   mispredictions costing real latency.

--- a/docs/issues/00702-engine-plan-selection-layer.md
+++ b/docs/issues/00702-engine-plan-selection-layer.md
@@ -133,24 +133,61 @@ Still **not** a classical cost-based optimizer:
   domain, not by predicted acceptance. A build-time per-field selectivity
   table is a separate future item, not part of this.
 
+## Cost model & gold-standard validation
+
+The routing decision is `plan = argmin_plan cost(plan | cardinality)`, not a
+pile of hand-tuned thresholds — the estimator supplies the cardinality, a
+**cost model** turns it into a predicted cost, and the cheapest plan wins.
+This reframes "is the estimate good enough" as a *cost* question, which is
+the right one: a misroute matters only in proportion to the cost gap between
+the plan chosen and the best plan, so a loose estimate is harmless wherever
+the cost curves are flat and only bites where they diverge steeply.
+
+- **Cost model** — `cost(plan | cardinality, N, limit, offset, residual_tier)`
+  in measured per-card units, reusing the `verify_cost_tier` ns/card constants
+  (`bench_verify_cost.rs`) plus a few per-plan terms. Rough shapes:
+  `GatheredScan ≈ C·verify_tier(residual)`; `StreamedSelect ≈ C·match_cost`;
+  `PlanePopcountOrder ≈ (N/64)·word_cost` (flat in match count *and* page
+  depth); `PrintingRangeScan`/idea-1 `≈ (limit/match_rate)·walk_cost` (the one
+  with a bad tail). Each formula consumes the cardinality in its own operating
+  space — which is where the "which space" question (below) gets pinned down.
+- **Gold standard** — `plan_gold = argmin cost(plan | TRUE count)`, the best
+  achievable with perfect cardinality info. **Only legitimate once the model
+  is calibrated against measured runtime** (a cardinality sweep, per the
+  benchmark-artifacts protocol) — otherwise argmin-over-the-model just picks
+  what the model *believes*, and "gold" is circular. This calibration is the
+  load-bearing work.
+- **Estimate regret** — `regret = cost(argmin cost(·|est) | true) −
+  cost(plan_gold | true)`. The regret distribution is the single figure of
+  merit: near-zero → the estimate is good enough to route on as-is; a fat tail
+  → tighten the specific leaf/plan that drives it (the projection tiers).
+  Estimate tightness is thus a *derived* requirement, not a goal — the global
+  "est == truth %" is the wrong target.
+
 ## Scope / sequencing
 
-Estimator first, so the accuracy is measured before anything reroutes:
+Estimator and cost model first, both validated against truth before anything
+reroutes. The estimator (step 1) and the cost model (step 2) are independent —
+the cost model uses TRUE counts, so it branches off `main`, not off the
+estimator PR.
 
-1. **Estimator as a standalone, validated component** — leaf counts + bounds
-   algebra + adaptive card projection, *not yet wired into routing*. Pure
-   addition, zero behavior change.
-2. **The `choose_plan` seam** — now genuinely single-layer (routing keys off
-   the estimate, so it precedes materialization). Behavior-preserving where
-   it can be, toggle-gated A/B via `CARD_ENGINE_PLAN_SELECT` (same LazyLock
-   pattern; temporary legacy duplicate of `run_query`, deleted in a
-   follow-up once parity holds).
-3. **Threshold → cost-comparison, one at a time** — the 7/8 cutoff,
-   `STREAM_MIN_MATCHES`, the memoize gate — each its own measured A/B. Do not
+1. **Estimator** — standalone, sound bounds, fuzz-validated, *unwired*.
+   (Shipped: #704.)
+2. **Cost model + calibration harness** — the per-plan cost formulas plus a
+   cardinality-sweep bench that fits/validates the constants against measured
+   runtime, establishing the true-count gold standard. Independent of #704.
+3. **Estimate-regret report** — feed the estimator into the calibrated model;
+   report the regret distribution. Depends on 1 + 2.
+4. **The `choose_plan` seam** — single-layer, routes on `argmin cost(·|est)`;
+   toggle-gated A/B via `CARD_ENGINE_PLAN_SELECT` (temporary legacy `run_query`
+   duplicate, deleted once parity holds). The toggle's measured runtime
+   confirms the model in production, closing the loop.
+5. **Retire thresholds** — the 7/8 cutoff, `STREAM_MIN_MATCHES`, the memoize
+   gate fall out of the cost comparison, one measured A/B at a time. Do not
    change plan choices and restructure in the same commit.
 
-Filter trees are tiny, so `choose_plan` and the estimator cost is noise;
-they run once per query, not per card.
+Filter trees are tiny, so `choose_plan`, the estimator, and the cost model are
+all per-query noise; they run once per query, not per card.
 
 ## Measurement
 
@@ -173,9 +210,12 @@ family: no geomean regression, no new tail.
 
 ## Open questions
 
-- **Which space drives routing** — card, printing, or both per-decision. The
-  estimator produces both; late projection keeps ranges exact longer but
-  complicates the algebra. Deferred to the wiring PR.
+- **Which space drives routing** — now largely determined by the cost model:
+  each plan's cost formula consumes the cardinality in its own operating space
+  (card-space for card-mode gather/popcount, printing-space for a printing
+  walk), so "which space" is answered per-plan rather than globally. Remaining
+  question is only how tightly the estimator must project between them, which
+  regret (above) decides.
 - **Estimator return shape** — recursion composes a single-space
   `Cardinality { lo, est, hi }`; a both-spaces container (card + printing
   triples) is assembled only at the *root* for the decision site, never


### PR DESCRIPTION
PR1 of the plan-selection layer (#702). Adds a standalone, cheap cardinality estimator over `FilterExpr` and revises the design doc; **not yet wired into query routing** — this is the foundation the `choose_plan` seam will route on.

## What it does

`estimate_cardinality(f, indexes, offsets) -> Cardinality { lo, est, hi }` composes card-space bounds + an independence point estimate from cheap leaf counts (postings `.len()`, `partition_point` widths, plane popcounts — no candidate materialization). Leaves are exact where cheap (True / cmc·power·toughness / colors / types / card-space tags / rarity), loose supersets for existential planes (legality, devotion), projected for printing-space counts, and a sound `[0,N]` for everything unindexed.

## Soundness is the invariant

`lo`/`hi` must bracket the mode=card reference count for **every** query. This is now asserted inside `fuzz_row_identity_matches_reference` (all seeds + the 6k-card corpus, every mode) — a violation fails the test. Key rules:

- **AND** upper = `min(hi)`; lower = Bonferroni **only when ≤1 child is printing-varying**, else 0 — closes the existential trap where a card satisfies two varying leaves via *different* printings (`usd<1 AND usd>100`).
- **OR** = union bounds (`max(lo)`, `min(N, Σhi)`).
- **NOT** = clean complement only for *total two-valued* inner; three-valued NULL cards (e.g. `toughness>3` on a non-creature satisfy neither `P` nor `¬P`) otherwise break `N−|P|`.

The NOT/NULL rule was **found by the assertion firing during development** — the standalone-and-validated-first sequencing catching a bug before anything trusts these bounds for routing.

## Accuracy (informational)

5k queries / 6k cards: est==truth 22.7%, within 2× 42%, bounds collapsed 14%. Loose but sound; the sampled / exact-below-K projection tiers (`TODO(#702)`) are the follow-up that tightens card-space accuracy.

## Not in scope / flagged

- No routing changes, no `PhysicalPlan` yet (PR2).
- `OracleMatch` uses `gids.len()` as an exact card count — potential undercount if oracle-text ids are shared across cards; not exercised by the corpus, verify before PR2 wiring.

Design: `docs/issues/00702-engine-plan-selection-layer.md` (revised in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)