### PR TITLE
Force-Plan Seam: Make the Four Physical Plans Individually Executable (#702)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3974,67 +3974,118 @@ fn printing_range_fastpath<'a>(
     Some((k, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
 }
 
-fn run_query<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
+/// The four physical plans `run_query` can dispatch to (#702 step 2, the
+/// force-plan seam). Each has an applicability predicate (its correctness
+/// preconditions — the future `choose_plan` eligibility gates) and a callable
+/// executor. `run_query`'s default routing is unchanged: it still picks among
+/// these in exactly the same order, on exactly the same conditions; this enum
+/// only makes each plan *individually addressable* via `run_query_with_plan`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)] // variants only referenced through the (test-facing) force entry point
+enum PhysicalPlan {
+    /// #695 bare-broad-range fast path under `unique=printing` (executor:
+    /// `printing_range_fastpath`).
+    PrintingRangeScan,
+    /// #634 Step 2 plane-bitmap popcount-skip order phase (`run_query_streamed_popcount`).
+    PlanePopcountOrder,
+    /// Streamed selection over the sort permutation (`run_query_streamed`).
+    StreamedSelect,
+    /// The universal fallback: the gathered per-card loop + `select_page`.
+    GatheredScan,
+}
+
+/// The shared P3/P4 preparation product (see `prepare_candidates`): the
+/// materialized candidate card list (or `None` = scan the whole store) and the
+/// #634-Step-1 exactness bit. `existential_plane` is *not* bundled — it is
+/// recomputed cheaply per executor from `(mode, plane, indexes)` via
+/// `existential_plane_for`, keeping this struct free of borrows.
+struct PreparedCandidates {
+    candidate_cards: Option<Vec<u32>>,
+    all_match_known: bool,
+}
+
+/// Row selection (docs/issues/00667-engine-legality-divergent-carveout.md "Row
+/// selection for unique=card"): only Mode::Card can have folded a legality leaf
+/// into `plane` at all (unique_is_card declines the fold otherwise), and only
+/// then does all_match's "the card matches" stop implying "any printing will
+/// do" for picking which one to show. Cheap to recompute, so the executors do
+/// so rather than threading it through `PreparedCandidates`.
+fn existential_plane_for<'a>(
+    mode: Mode,
+    plane: Option<&'a PlaneExpr>,
+    indexes: &'a Archived<CardIndexes>,
+) -> Option<(&'a PlaneExpr, &'a Archived<BitPlanes>)> {
+    match (mode, plane) {
+        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe) => Some((pe, &indexes.planes)),
+        _ => None,
+    }
+}
+
+// ─── Applicability predicates ───────────────────────────────────────────────
+// Each captures a plan's *correctness* preconditions (not its perf gate). These
+// are the future `choose_plan` eligibility gates — real, named, reusable.
+
+/// `GatheredScan` can execute any query.
+#[allow(dead_code)] // trivially true; referenced through the force entry point
+fn gathered_scan_applicable() -> bool {
+    true
+}
+
+/// `StreamedSelect` needs a precomputed sort permutation for `(sort_col,
+/// descending)` whose length matches the card count, over a non-empty store.
+/// `maybe_broad` is deliberately excluded — that is a routing/perf choice, not a
+/// correctness constraint; StreamedSelect returns correct rows at any breadth.
+fn streamed_select_applicable(
+    cards: &[AOracleCard],
+    sort_col: SortCol,
+    descending: bool,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    !cards.is_empty() && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+}
+
+/// `PlanePopcountOrder` needs the filter fully consumed to `True`, `Mode::Card`,
+/// a plane component, and both the forward (length-matched) and inverse sort
+/// permutations. Mirrors the #634 Step 2 branch's guard exactly.
+fn plane_popcount_order_applicable(
+    filter: &FilterExpr,
+    mode: Mode,
+    cards: &[AOracleCard],
+    plane: Option<&PlaneExpr>,
+    sort_col: SortCol,
+    descending: bool,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    matches!(filter, FilterExpr::True)
+        && matches!(mode, Mode::Card)
+        && !cards.is_empty()
+        && plane.is_some()
+        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
+}
+
+/// `PrintingRangeScan` structural eligibility only — whether it actually runs is
+/// decided by `printing_range_fastpath` returning `Some` (it declines with
+/// `None` for anything it doesn't own).
+fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: &[AOracleCard]) -> bool {
+    *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
+}
+
+// ─── Shared P3/P4 candidate preparation ─────────────────────────────────────
+
+/// The candidate materialization + filter rewriting shared by `StreamedSelect`
+/// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
+/// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
+/// `!all_match_known` / `*VERIFY_ORDER` guards and in the same order as before.
+fn prepare_candidates(
+    cards: &[AOracleCard],
     offsets: &AOffsets,
     strings: &AStrings,
     filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
-    unique: &str,
-    prefer: &str,
-    orderby: &str,
-    direction: &str,
-    limit: usize,
-    page_offset: usize,
+    mode: Mode,
     indexes: &Archived<CardIndexes>,
-) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    let sort_col   = orderby_to_col(orderby);
-    let descending = direction == "desc";
-    let prefer     = prefer_from_str(prefer);
-
-    let mode = match unique {
-        "artwork"  => Mode::Artwork,
-        "printing" => Mode::Printing,
-        _          => Mode::Card,
-    };
-
-    // PR 1 (docs/issues/local-engine-sorted-range-fastpath.md): a bare, broad range predicate
-    // under unique=printing gets its total from the range index's binary search and its page from
-    // an early-stopping permutation walk, skipping the O(n) count pass the general path pays.
-    // Requires no plane component (else the plane's own predicate must also hold, which this
-    // ignores); everything unrecognized returns None and falls through unchanged.
-    if *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
-        && let Some(result) =
-            printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
-    {
-        return result;
-    }
-
-    // #634 Step 2: when the filter fully consumed to True (split_planes ate
-    // the whole thing), the plane bitmap IS the exact match set at any
-    // selectivity — no candidate materialization, no card_pass, needed at
-    // all. Scoped to unique=card for now (see run_query_streamed_popcount);
-    // other modes/residuals fall through to the existing path below, which
-    // already handles them correctly (Step 1 already removes the redundant
-    // card_pass there, just not the O(candidates) counts-buffer fill).
-    if matches!(filter, FilterExpr::True) && matches!(mode, Mode::Card) && !cards.is_empty()
-        && let (Some(expr), Some(perm), Some(inv_perm)) =
-            (plane, indexes.sort_perms.get(sort_col, descending), indexes.sort_perms.get_inv(sort_col, descending))
-        && perm.len() == cards.len()
-    {
-        thread_local! {
-            static PLANE_BITMAP_POPCOUNT: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
-        }
-        return PLANE_BITMAP_POPCOUNT.with(|cell| {
-            let mut bitmap = cell.borrow_mut();
-            eval_planes(expr, &indexes.planes, &mut bitmap);
-            run_query_streamed_popcount(
-                cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap, expr, &indexes.planes, strings,
-            )
-        });
-    }
-
+) -> PreparedCandidates {
     // Candidates in either space project to card ids for the walk; the walk's
     // per-printing verification restores exactness for printing-space losses.
     // A list covering nearly the whole corpus narrows nothing — the walk would
@@ -4131,35 +4182,101 @@ fn run_query<'a>(
             filter.order_children_by_verify_cost();
         }
     }
-    let card_ids: Box<dyn Iterator<Item = u32>> = match &candidate_cards {
+
+    PreparedCandidates { candidate_cards, all_match_known }
+}
+
+// ─── Plan executors ─────────────────────────────────────────────────────────
+
+/// P2 executor: evaluate the plane into the popcount thread-local and run the
+/// #634 Step 2 popcount-skip order phase. Caller guarantees applicability
+/// (`plane_popcount_order_applicable`).
+#[allow(clippy::too_many_arguments)]
+fn exec_plane_popcount_order<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    plane_expr: &PlaneExpr,
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
+    let inv_perm =
+        indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
+    thread_local! {
+        static PLANE_BITMAP_POPCOUNT: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+    PLANE_BITMAP_POPCOUNT.with(|cell| {
+        let mut bitmap = cell.borrow_mut();
+        eval_planes(plane_expr, &indexes.planes, &mut bitmap);
+        run_query_streamed_popcount(
+            cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap, plane_expr, &indexes.planes, strings,
+        )
+    })
+}
+
+/// P3 executor: streamed selection over the sort permutation. Caller guarantees
+/// applicability (`streamed_select_applicable`) and has run `prepare_candidates`.
+#[allow(clippy::too_many_arguments)]
+fn exec_streamed_select<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    prep: &PreparedCandidates,
+    plane: Option<&PlaneExpr>,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let perm = indexes.sort_perms.get(sort_col, descending).expect("StreamedSelect applicability guarantees a permutation");
+    let existential_plane = existential_plane_for(mode, plane, indexes);
+    let card_ids: Box<dyn Iterator<Item = u32>> = match &prep.candidate_cards {
         Some(v) => Box::new(v.iter().copied()),
         None    => Box::new(0..cards.len() as u32),
     };
+    run_query_streamed(
+        cards, printings, offsets, strings, filter, prep.all_match_known, mode, prefer, sort_col, descending, limit,
+        page_offset, perm, card_ids, &indexes.artwork_groups, existential_plane,
+    )
+}
 
-    // Streamed selection when the orderby has a precomputed permutation — and
-    // the query is broad enough for the match/emit split to pay: a narrowed
-    // candidate list at or below the gather threshold can't produce more
-    // matches than that, so the fused path is already microseconds and the
-    // match phase would be pure overhead.
-    // Row selection (docs/issues/00667-engine-legality-divergent-carveout.md "Row
-    // selection for unique=card"): only Mode::Card can have folded a legality
-    // leaf into `plane` at all (unique_is_card declines the fold otherwise),
-    // and only then does all_match's "the card matches" stop implying "any
-    // printing will do" for picking which one to show.
-    let existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = match (mode, plane) {
-        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe) => Some((pe, &indexes.planes)),
-        _ => None,
+/// P4 executor: the universal gathered per-card loop + `select_page`. Runs any
+/// query (printing-keyed orderbys, stores without permutations, or anything the
+/// other plans decline). Caller has run `prepare_candidates`.
+#[allow(clippy::too_many_arguments)]
+fn exec_gathered_scan<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    prep: &PreparedCandidates,
+    plane: Option<&PlaneExpr>,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let all_match_known = prep.all_match_known;
+    let existential_plane = existential_plane_for(mode, plane, indexes);
+    let card_ids: Box<dyn Iterator<Item = u32>> = match &prep.candidate_cards {
+        Some(v) => Box::new(v.iter().copied()),
+        None    => Box::new(0..cards.len() as u32),
     };
-
-    let maybe_broad = candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
-    if let Some(perm) = indexes.sort_perms.get(sort_col, descending) {
-        if maybe_broad && perm.len() == cards.len() && !cards.is_empty() {
-            return run_query_streamed(
-                cards, printings, offsets, strings, filter, all_match_known, mode, prefer, sort_col, descending, limit,
-                page_offset, perm, card_ids, &indexes.artwork_groups, existential_plane,
-            );
-        }
-    }
 
     // Gathered path (printing-keyed orderbys, or stores without permutations).
     let mut best: Vec<Match> = Vec::new();
@@ -4195,6 +4312,148 @@ fn run_query<'a>(
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
         .collect();
     (total, page)
+}
+
+fn run_query<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &mut FilterExpr,
+    plane: Option<&PlaneExpr>,
+    unique: &str,
+    prefer: &str,
+    orderby: &str,
+    direction: &str,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let sort_col   = orderby_to_col(orderby);
+    let descending = direction == "desc";
+    let prefer     = prefer_from_str(prefer);
+
+    let mode = match unique {
+        "artwork"  => Mode::Artwork,
+        "printing" => Mode::Printing,
+        _          => Mode::Card,
+    };
+
+    // P1 PrintingRangeScan — PR 1 (docs/issues/local-engine-sorted-range-fastpath.md): a bare,
+    // broad range predicate under unique=printing gets its total from the range index's binary
+    // search and its page from an early-stopping permutation walk, skipping the O(n) count pass the
+    // general path pays. Requires no plane component (else the plane's own predicate must also hold,
+    // which this ignores); everything unrecognized returns None and falls through unchanged.
+    if printing_range_scan_applicable(mode, plane, cards)
+        && let Some(result) =
+            printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+    {
+        return result;
+    }
+
+    // P2 PlanePopcountOrder — #634 Step 2: when the filter fully consumed to True (split_planes ate
+    // the whole thing), the plane bitmap IS the exact match set at any selectivity — no candidate
+    // materialization, no card_pass, needed at all. Scoped to unique=card for now (see
+    // run_query_streamed_popcount); other modes/residuals fall through to the existing path below,
+    // which already handles them correctly (Step 1 already removes the redundant card_pass there,
+    // just not the O(candidates) counts-buffer fill).
+    if plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        let plane_expr = plane.expect("PlanePopcountOrder applicability guarantees a plane");
+        return exec_plane_popcount_order(
+            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes,
+        );
+    }
+
+    // Shared P3/P4 candidate preparation (narrowing, plane-∩-candidates composition, and the
+    // memoize/verify-order filter rewrite). Mutates `filter` exactly as before.
+    let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+
+    // P3 StreamedSelect vs P4 GatheredScan. Streamed selection when the orderby has a precomputed
+    // permutation — and the query is broad enough for the match/emit split to pay: a narrowed
+    // candidate list at or below the gather threshold can't produce more matches than that, so the
+    // fused path is already microseconds and the match phase would be pure overhead. `maybe_broad`
+    // is the routing/perf choice (not an applicability condition), so it stays here in `run_query`,
+    // not in the applicability predicate.
+    let maybe_broad = prep.candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
+    if maybe_broad && streamed_select_applicable(cards, sort_col, descending, indexes) {
+        return exec_streamed_select(
+            cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+        );
+    }
+
+    exec_gathered_scan(
+        cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+    )
+}
+
+/// In-process force/dispatch entry point (#702 step 2): run `plan` for this
+/// query if it is applicable, else return `None`. This is the prerequisite for
+/// the calibration harness — it makes each physical plan individually
+/// executable without changing `run_query`'s default routing. Returns `None`
+/// when `plan` fails its applicability predicate (or, for `PrintingRangeScan`,
+/// when `printing_range_fastpath` structurally declines with `None`); `Some`
+/// with the result when it ran. `GatheredScan` is always `Some`.
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)] // force entry point; exercised by force_plan_differential_agreement
+fn run_query_with_plan<'a>(
+    plan: PhysicalPlan,
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &mut FilterExpr,
+    plane: Option<&PlaneExpr>,
+    unique: &str,
+    prefer: &str,
+    orderby: &str,
+    direction: &str,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    let sort_col   = orderby_to_col(orderby);
+    let descending = direction == "desc";
+    let prefer     = prefer_from_str(prefer);
+    let mode = match unique {
+        "artwork"  => Mode::Artwork,
+        "printing" => Mode::Printing,
+        _          => Mode::Card,
+    };
+
+    match plan {
+        PhysicalPlan::PrintingRangeScan => {
+            if !printing_range_scan_applicable(mode, plane, cards) {
+                return None;
+            }
+            // Structural eligibility passed; the fastpath itself decides (None = declined).
+            printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+        }
+        PhysicalPlan::PlanePopcountOrder => {
+            if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+                return None;
+            }
+            let plane_expr = plane.expect("applicability guarantees a plane");
+            Some(exec_plane_popcount_order(
+                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes,
+            ))
+        }
+        PhysicalPlan::StreamedSelect => {
+            if !streamed_select_applicable(cards, sort_col, descending, indexes) {
+                return None;
+            }
+            let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+            Some(exec_streamed_select(
+                cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+            ))
+        }
+        PhysicalPlan::GatheredScan => {
+            debug_assert!(gathered_scan_applicable());
+            let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+            Some(exec_gathered_scan(
+                cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+            ))
+        }
+    }
 }
 
 /// #634 Step 2: popcount-skip order phase. Scoped to `unique=card` queries

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
-    range_too_broad_to_narrow, run_query, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
+    range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, SortCol, STREAM_MIN_MATCHES,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
@@ -2534,6 +2534,138 @@ fn fuzz_row_identity_matches_reference() {
         let offset = if rng.random_bool(0.5) { 0 } else { rng.random_range(0..800) };
         let ctx = format!("corpus-rowid, filter={}", fuzz_describe(&spec));
         fuzz_check_row_identity(archived, &spec, &ctx, orderby, direction, mode, 100, offset);
+    }
+}
+
+/// #702 step 2 (force-plan seam): every physical plan that is *applicable* to a
+/// query must return rows identical to `GatheredScan`, the universal fallback /
+/// reference. This is the correctness guard for the extraction — it proves the
+/// four individually-callable executors (`run_query_with_plan`) agree, so
+/// swapping which plan runs a query is a pure performance decision.
+///
+/// For each fuzz query × unique mode × sort: compute the `GatheredScan` result
+/// (always `Some`) as the reference, then for every other plan call
+/// `run_query_with_plan`; if it returns `Some` (it was applicable), assert its
+/// `(total, page-of-scryfall-ids)` equals the reference. The page is the full
+/// result at offset 0 (`full_limit`, offset 0). Row identity is compared as a
+/// sorted multiset of scryfall_ids: the plans provably return the same *rows*,
+/// but their tie-break order can legitimately differ (the sort permutation's
+/// tertiary key is the first printing's prefer score, while the gathered
+/// comparator ties by pid), so comparing the exact sequence would flag benign
+/// ordering differences rather than a missing/extra row. Total equality plus
+/// multiset equality is the row-identity check (per-path ordering is already
+/// self-checked by `fuzz_row_identity_matches_reference`'s pagination slices).
+///
+/// Hand-built specs guarantee P1 (`PrintingRangeScan`) and P2
+/// (`PlanePopcountOrder`) coverage — the random generator rarely emits a bare
+/// broad range or a fully-True color+type conjunction. A coverage assertion at
+/// the end fails if any of the four plans was never exercised.
+#[test]
+fn force_plan_differential_agreement() {
+    use rand::SeedableRng;
+    const CORPUS_CARDS: usize = 6_000;
+    const MAX_DEPTH: u8 = 3;
+    const RANDOM_QUERIES: usize = 150;
+    const SORTS: [&str; 4] = ["edhrec", "name", "cmc", "usd"];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(70_202);
+    let data = fuzz_store_n(&mut rng, CORPUS_CARDS);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    // (spec, orderby, direction). Hand-built entries pin sorts that guarantee a
+    // plan fires: color+type -> True residual + plane (PlanePopcountOrder needs a
+    // perm sort in card mode); a broad date over a perm sort -> the range
+    // fastpath's walk branch (k > STREAM_MIN); a broad price over usd -> the
+    // fastpath's aligned branch. Random trees then broaden the coverage.
+    let mut cases: Vec<(FuzzSpec, &str, &str)> = vec![
+        (FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]), "edhrec", "asc"),
+        (FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]), "name", "desc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Date { op: CmpOp::Gt, value: 1990_0000 }), "cmc", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Date { op: CmpOp::Gt, value: 1990_0000 }), "edhrec", "desc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "usd", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "usd", "desc"),
+    ];
+    for _ in 0..RANDOM_QUERIES {
+        let orderby = SORTS[rng.random_range(0..SORTS.len())];
+        let direction = if rng.random_bool(0.5) { "desc" } else { "asc" };
+        cases.push((fuzz_gen(&mut rng, MAX_DEPTH), orderby, direction));
+    }
+
+    let modes = ["card", "printing", "artwork"];
+    let all_plans = [
+        PhysicalPlan::PrintingRangeScan,
+        PhysicalPlan::PlanePopcountOrder,
+        PhysicalPlan::StreamedSelect,
+        PhysicalPlan::GatheredScan,
+    ];
+    let plan_idx = |p: PhysicalPlan| match p {
+        PhysicalPlan::PrintingRangeScan => 0,
+        PhysicalPlan::PlanePopcountOrder => 1,
+        PhysicalPlan::StreamedSelect => 2,
+        PhysicalPlan::GatheredScan => 3,
+    };
+    let mut ran = [0u32; 4];
+
+    // >= any possible total, so the offset-0 page is the complete ordered result.
+    let full_limit = archived.printings.len().max(1);
+    let strings = &archived.strings;
+    // Sorted multiset of scryfall_ids — row identity independent of tie-break order.
+    let id_multiset = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
+        let mut v: Vec<u128> = page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
+        v.sort_unstable();
+        v
+    };
+
+    for (spec, orderby, direction) in &cases {
+        for &mode in &modes {
+            let unique_is_card = mode == "card";
+
+            // Reference: GatheredScan is always applicable. A fresh bound + split
+            // filter per plan call because prepare_candidates mutates the filter.
+            let (ref_pe, mut ref_res) = split_planes(
+                fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
+            );
+            let (ref_total, ref_page) = run_query_with_plan(
+                PhysicalPlan::GatheredScan, &archived.cards, &archived.printings, &archived.offsets, strings,
+                &mut ref_res, ref_pe.as_ref(), mode, "default", orderby, direction, full_limit, 0, &archived.indexes,
+            )
+            .expect("GatheredScan is always applicable");
+            ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
+            let ref_ids = id_multiset(&ref_page);
+
+            for &plan in &all_plans {
+                if plan == PhysicalPlan::GatheredScan {
+                    continue;
+                }
+                let (pe, mut res) = split_planes(
+                    fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
+                );
+                let out = run_query_with_plan(
+                    plan, &archived.cards, &archived.printings, &archived.offsets, strings,
+                    &mut res, pe.as_ref(), mode, "default", orderby, direction, full_limit, 0, &archived.indexes,
+                );
+                let Some((total, page)) = out else { continue };
+                ran[plan_idx(plan)] += 1;
+                assert_eq!(
+                    total, ref_total,
+                    "{plan:?} total disagrees with GatheredScan (mode={mode}, orderby={orderby}, dir={direction}, filter={})",
+                    fuzz_describe(spec),
+                );
+                assert_eq!(
+                    id_multiset(&page), ref_ids,
+                    "{plan:?} rows disagree with GatheredScan (mode={mode}, orderby={orderby}, dir={direction}, filter={})",
+                    fuzz_describe(spec),
+                );
+            }
+        }
+    }
+
+    for plan in all_plans {
+        assert!(
+            ran[plan_idx(plan)] > 0,
+            "plan {plan:?} was never exercised by the differential corpus — add coverage",
+        );
     }
 }
 

--- a/docs/issues/00702-engine-plan-selection-layer.md
+++ b/docs/issues/00702-engine-plan-selection-layer.md
@@ -143,14 +143,24 @@ the right one: a misroute matters only in proportion to the cost gap between
 the plan chosen and the best plan, so a loose estimate is harmless wherever
 the cost curves are flat and only bites where they diverge steeply.
 
-- **Cost model** — `cost(plan | cardinality, N, limit, offset, residual_tier)`
-  in measured per-card units, reusing the `verify_cost_tier` ns/card constants
-  (`bench_verify_cost.rs`) plus a few per-plan terms. Rough shapes:
+- **Cost model** — parametric per-plan formulas whose **constants are fit by
+  regression to the measured data** (below), not hand-set. In measured
+  per-card units, reusing the `verify_cost_tier` ns/card *buckets* directly
+  (don't model per-predicate cost — reuse the one calibrated tiering in
+  `bench_verify_cost.rs`, so recalibration updates verifier ordering and
+  planner together). Rough shapes:
   `GatheredScan ≈ C·verify_tier(residual)`; `StreamedSelect ≈ C·match_cost`;
   `PlanePopcountOrder ≈ (N/64)·word_cost` (flat in match count *and* page
   depth); `PrintingRangeScan`/idea-1 `≈ (limit/match_rate)·walk_cost` (the one
   with a bad tail). Each formula consumes the cardinality in its own operating
   space — which is where the "which space" question (below) gets pinned down.
+  Predicate-cost bucketing is cheap here because the term is largely
+  *common-mode* across the plans being compared (gather/stream both pay
+  per-candidate verify ∝ their C; popcount has an empty residual, no verify
+  term), so it mostly cancels in the argmin — cardinality and plan structure
+  do the deciding. `verify_tier(residual)` (already max-over-tree, ignoring
+  short-circuit/acceptance) is the starting per-card term; refine only if
+  regret demands.
 - **Gold standard** — `plan_gold = argmin cost(plan | TRUE count)`, the best
   achievable with perfect cardinality info. **Only legitimate once the model
   is calibrated against measured runtime** (a cardinality sweep, per the
@@ -166,28 +176,67 @@ the cost curves are flat and only bites where they diverge steeply.
 
 ## Scope / sequencing
 
-Estimator and cost model first, both validated against truth before anything
-reroutes. The estimator (step 1) and the cost model (step 2) are independent —
-the cost model uses TRUE counts, so it branches off `main`, not off the
-estimator PR.
+Everything validated against truth before anything reroutes. The force-plan
+seam (step 2) comes *before* calibration because you can't measure a plan's
+cost without being able to execute that specific plan — making plans
+individually addressable is the prerequisite for the run-all-plans harness.
 
 1. **Estimator** — standalone, sound bounds, fuzz-validated, *unwired*.
    (Shipped: #704.)
-2. **Cost model + calibration harness** — the per-plan cost formulas plus a
-   cardinality-sweep bench that fits/validates the constants against measured
-   runtime, establishing the true-count gold standard. Independent of #704.
-3. **Estimate-regret report** — feed the estimator into the calibrated model;
-   report the regret distribution. Depends on 1 + 2.
-4. **The `choose_plan` seam** — single-layer, routes on `argmin cost(·|est)`;
-   toggle-gated A/B via `CARD_ENGINE_PLAN_SELECT` (temporary legacy `run_query`
-   duplicate, deleted once parity holds). The toggle's measured runtime
-   confirms the model in production, closing the loop.
-5. **Retire thresholds** — the 7/8 cutoff, `STREAM_MIN_MATCHES`, the memoize
+2. **Force-plan seam** — extract the four plan bodies into individually
+   callable executors, each with a **applicability predicate** (which plans
+   can correctly run this query; these predicates *are* the future
+   `choose_plan` eligibility gates — not throwaway). Add an in-process
+   force/dispatch entry point. Default routing behavior unchanged; add a
+   differential test that every *applicable* plan returns rows identical to
+   `GatheredScan` (the universal fallback / reference). Branches off `main`,
+   independent of the estimator.
+3. **Cost model + calibration harness** — run each applicable plan n× (min-of-n,
+   quiesced machine — benchmark-artifacts protocol) via the force hook across a
+   cardinality sweep, record `(true counts/features → measured per-plan cost)`,
+   **fit the formula constants** by regression, and establish empirical gold =
+   the plan actually fastest. Uses TRUE counts, so independent of the estimator.
+4. **Estimate-regret report** — feed the estimator into the calibrated model;
+   report the regret distribution (§Cost model). Depends on 1 + 3.
+5. **Route on `argmin cost(·|est)`** — `choose_plan` wires the force/dispatch
+   to the model; toggle-gated A/B via `CARD_ENGINE_PLAN_SELECT` (temporary
+   legacy `run_query` duplicate, deleted once parity holds). The toggle's
+   measured runtime confirms the model in production, closing the loop.
+6. **Retire thresholds** — the 7/8 cutoff, `STREAM_MIN_MATCHES`, the memoize
    gate fall out of the cost comparison, one measured A/B at a time. Do not
    change plan choices and restructure in the same commit.
 
 Filter trees are tiny, so `choose_plan`, the estimator, and the cost model are
 all per-query noise; they run once per query, not per card.
+
+## Keeping costs/plans current as the engine changes
+
+The constants are fit to a point-in-time measurement, so the design has to say
+how they stay honest. This reuses the discipline the engine already applies to
+`verify_cost_tier` and the calibrated guards (#647) — not a new burden:
+
+- **What's robust vs fragile.** Constants are in consistent units (ns/card,
+  ns/word), and `argmin` cares about *ratios* between plans, not absolutes — so
+  a uniform hardware speed change mostly preserves the choice. Recalibration is
+  needed for **non-uniform** changes: a plan reimplemented, a new index shifting
+  a predicate class's cost, a new plan added. Those are code changes, and the
+  process attaches to them.
+- **Adding/changing a plan** is compile-time-forced to be complete, like
+  `FilterExpr` variants force a `verify_cost_tier` arm: a new plan needs an
+  executor + applicability predicate + cost formula + inclusion in the harness.
+  The differential test (all applicable plans agree) then guards correctness
+  automatically.
+- **Recalibration is deliberate and off-CI.** CI machines are too noisy for
+  timing (violates the benchmark-artifacts protocol), so CI runs *correctness*
+  (differential agreement) and at most a coarse **drift tripwire** — assert the
+  model's predicted-cheapest matches empirical-cheapest on a small committed set
+  within tolerance, failing when constants drift enough to *flip* a decision.
+  Re-fitting itself is a manual `--ignored` bench run on a quiesced machine that
+  commits new constants **with provenance** (corpus size, date, machine — the
+  style `verify_cost_tier`'s doc-comments already use).
+- **Regret is the health metric.** After any plan/cost change, re-run the
+  regret report; a risen tail means the constants need refitting or the formula
+  *shape* is wrong (structured residuals), not just the coefficients.
 
 ## Measurement
 


### PR DESCRIPTION
Step 2 of the plan-selection layer (#702). A **pure, behavior-preserving extraction** that makes `run_query`'s four physical plans individually callable — the prerequisite for the run-all-plans calibration harness (step 3): you can't measure a plan you can't execute in isolation.

## What changed

- **`enum PhysicalPlan`** { PrintingRangeScan, PlanePopcountOrder, StreamedSelect, GatheredScan }.
- **`prepare_candidates`** — the shared P3/P4 prep (narrowing, `all_match_known`, plane-∩-candidates composition with its thread-local, and the `memoize_text_predicates` → `order_children_by_verify_cost` rewrite) extracted **verbatim**, same order/guards/thread-locals.
- **Four executors** reusing the existing bodies (`printing_range_fastpath`, popcount, `run_query_streamed`, the gathered loop).
- **Named applicability predicates** — the future `choose_plan` eligibility gates; capture *correctness* preconditions only (e.g. `maybe_broad` stays out of `streamed_select_applicable` — it's a routing/perf choice).
- **`run_query_with_plan(plan, …) -> Option<result>`** — in-process force entry point; `None` when the plan is inapplicable.
- **`run_query` keeps its exact decision tree** (P1/P2 early returns → `prepare_candidates` → `maybe_broad`-gated P3-vs-P4). Not reimplemented as first-applicable.

## Behavior preservation

The default path is unchanged, guarded by **`fuzz_row_identity_matches_reference`** (totals + row identity vs a brute-force reference, 96 seeds + 6k-card corpus, all modes) — passes in debug and release. New **`force_plan_differential_agreement`** asserts every *applicable* forced plan returns rows identical to `GatheredScan` (total + sorted `scryfall_id` multiset), with hand-built cases covering P1/P2 (random trees never produce a bare range or a fully-`True` color+type conjunction) and a coverage assertion that all four fire.

Full suite: 124 passed, 10 ignored, 0 failed (debug + release).

## Known follow-up (not a regression)

Plans agree on *rows* but differ in *within-tie* ordering (permutation tertiary key vs the gathered comparator's pid) — benign today (one plan per query → stable order) but surfaced by the seam. A follow-up PR will give all plans (and the SQL path) a strict total order — `[sort] → edhrec_rank → prefer_score → oracle_id → scryfall_id` — and upgrade this test's comparison from multiset to exact-sequence. That's why this PR compares multiset for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)