### PR TITLE
Enforce 2-Key Ordering Parity Across Plans (#702)

### DIFF
--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,7 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
-    walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, SortCol, STREAM_MIN_MATCHES,
+    walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
     CollField, CmpOp, FilterExpr, InlineStr, Interner, ManaCost, OracleCard, Printing, TagIndex,
@@ -2543,18 +2543,21 @@ fn fuzz_row_identity_matches_reference() {
 /// four individually-callable executors (`run_query_with_plan`) agree, so
 /// swapping which plan runs a query is a pure performance decision.
 ///
-/// For each fuzz query × unique mode × sort: compute the `GatheredScan` result
-/// (always `Some`) as the reference, then for every other plan call
-/// `run_query_with_plan`; if it returns `Some` (it was applicable), assert its
-/// `(total, page-of-scryfall-ids)` equals the reference. The page is the full
-/// result at offset 0 (`full_limit`, offset 0). Row identity is compared as a
-/// sorted multiset of scryfall_ids: the plans provably return the same *rows*,
-/// but their tie-break order can legitimately differ (the sort permutation's
-/// tertiary key is the first printing's prefer score, while the gathered
-/// comparator ties by pid), so comparing the exact sequence would flag benign
-/// ordering differences rather than a missing/extra row. Total equality plus
-/// multiset equality is the row-identity check (per-path ordering is already
-/// self-checked by `fuzz_row_identity_matches_reference`'s pagination slices).
+/// For each fuzz query × prefer × unique mode × sort: compute the `GatheredScan`
+/// result (always `Some`) as the reference, then for every other plan call
+/// `run_query_with_plan`; if it returns `Some` (it was applicable), assert
+/// against the reference on three axes at the full offset-0 page:
+///   - `total` equality,
+///   - `scryfall_id` multiset equality — same *rows*,
+///   - **2-key ordering** equality — the `(primary, edhrec_rank)` value
+///     sequence (top 64 bits of `sort_key_bits`).
+/// The 2-key value sequence is the ordering-parity contract (#702): plans agree
+/// on the two SQL-defined keys they're guaranteed to, and diverge only past
+/// them (key 3, prefer_score, and below — see the `PREFERS` comment below and
+/// docs/issues/00702). Comparing the 2-key *value* sequence, not the row
+/// sequence, is what tolerates that key-3 slop while still catching any real
+/// mis-ordering: tied rows share their (key1, key2) value, so the sequence is
+/// identical even when they interleave.
 ///
 /// Hand-built specs guarantee P1 (`PrintingRangeScan`) and P2
 /// (`PlanePopcountOrder`) coverage — the random generator rarely emits a bare
@@ -2610,53 +2613,80 @@ fn force_plan_differential_agreement() {
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
     let strings = &archived.strings;
-    // Sorted multiset of scryfall_ids — row identity independent of tie-break order.
+    // Same rows regardless of tie order.
     let id_multiset = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
         let mut v: Vec<u128> = page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
         v.sort_unstable();
         v
     };
 
+    // Ordering-parity contract (#702): plans agree on the SQL-defined keys 1-2
+    // (primary sort column, then edhrec_rank) — the top 64 bits of
+    // sort_key_bits. Key 3 (prefer_score) and beyond are unspecified across
+    // plans: the permutation bakes in the *default* representative's
+    // prefer_score, so under a non-default prefer the perm-based plans can order
+    // a key-3 tie differently from the gathered path (a known, pre-existing
+    // divergence — see docs/issues/00702-engine-plan-selection-layer.md).
+    // Comparing the 2-key VALUE sequence is stable across that: tied rows share
+    // their (key1, key2) value, so the sequence is identical even when they
+    // interleave. Exercised under a default AND a non-default prefer — 2-key
+    // parity holds at both (3-key would not, at non-default prefer).
+    const PREFERS: [&str; 2] = ["default", "usd_low"];
+
     for (spec, orderby, direction) in &cases {
-        for &mode in &modes {
-            let unique_is_card = mode == "card";
+        let sort_col = orderby_to_col(orderby);
+        let descending = *direction == "desc";
+        // (key1, key2) = the top 64 bits of sort_key_bits; drop the low 32 (key 3).
+        let key2_seq = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
+            page.iter().map(|&(c, p)| sort_key_bits(c, p, sort_col, descending) >> 32).collect()
+        };
+        for &prefer in &PREFERS {
+            for &mode in &modes {
+                let unique_is_card = mode == "card";
 
-            // Reference: GatheredScan is always applicable. A fresh bound + split
-            // filter per plan call because prepare_candidates mutates the filter.
-            let (ref_pe, mut ref_res) = split_planes(
-                fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
-            );
-            let (ref_total, ref_page) = run_query_with_plan(
-                PhysicalPlan::GatheredScan, &archived.cards, &archived.printings, &archived.offsets, strings,
-                &mut ref_res, ref_pe.as_ref(), mode, "default", orderby, direction, full_limit, 0, &archived.indexes,
-            )
-            .expect("GatheredScan is always applicable");
-            ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
-            let ref_ids = id_multiset(&ref_page);
-
-            for &plan in &all_plans {
-                if plan == PhysicalPlan::GatheredScan {
-                    continue;
-                }
-                let (pe, mut res) = split_planes(
+                // Reference: GatheredScan is always applicable. A fresh bound + split
+                // filter per plan call because prepare_candidates mutates the filter.
+                let (ref_pe, mut ref_res) = split_planes(
                     fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
                 );
-                let out = run_query_with_plan(
-                    plan, &archived.cards, &archived.printings, &archived.offsets, strings,
-                    &mut res, pe.as_ref(), mode, "default", orderby, direction, full_limit, 0, &archived.indexes,
-                );
-                let Some((total, page)) = out else { continue };
-                ran[plan_idx(plan)] += 1;
-                assert_eq!(
-                    total, ref_total,
-                    "{plan:?} total disagrees with GatheredScan (mode={mode}, orderby={orderby}, dir={direction}, filter={})",
-                    fuzz_describe(spec),
-                );
-                assert_eq!(
-                    id_multiset(&page), ref_ids,
-                    "{plan:?} rows disagree with GatheredScan (mode={mode}, orderby={orderby}, dir={direction}, filter={})",
-                    fuzz_describe(spec),
-                );
+                let (ref_total, ref_page) = run_query_with_plan(
+                    PhysicalPlan::GatheredScan, &archived.cards, &archived.printings, &archived.offsets, strings,
+                    &mut ref_res, ref_pe.as_ref(), mode, prefer, orderby, direction, full_limit, 0, &archived.indexes,
+                )
+                .expect("GatheredScan is always applicable");
+                ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
+                let ref_ids = id_multiset(&ref_page);
+                let ref_key2 = key2_seq(&ref_page);
+
+                for &plan in &all_plans {
+                    if plan == PhysicalPlan::GatheredScan {
+                        continue;
+                    }
+                    let (pe, mut res) = split_planes(
+                        fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
+                    );
+                    let out = run_query_with_plan(
+                        plan, &archived.cards, &archived.printings, &archived.offsets, strings,
+                        &mut res, pe.as_ref(), mode, prefer, orderby, direction, full_limit, 0, &archived.indexes,
+                    );
+                    let Some((total, page)) = out else { continue };
+                    ran[plan_idx(plan)] += 1;
+                    assert_eq!(
+                        total, ref_total,
+                        "{plan:?} total disagrees with GatheredScan (mode={mode}, prefer={prefer}, orderby={orderby}, dir={direction}, filter={})",
+                        fuzz_describe(spec),
+                    );
+                    assert_eq!(
+                        id_multiset(&page), ref_ids,
+                        "{plan:?} rows disagree with GatheredScan (mode={mode}, prefer={prefer}, orderby={orderby}, dir={direction}, filter={})",
+                        fuzz_describe(spec),
+                    );
+                    assert_eq!(
+                        key2_seq(&page), ref_key2,
+                        "{plan:?} 2-key order disagrees with GatheredScan (mode={mode}, prefer={prefer}, orderby={orderby}, dir={direction}, filter={})",
+                        fuzz_describe(spec),
+                    );
+                }
             }
         }
     }

--- a/docs/issues/00702-engine-plan-selection-layer.md
+++ b/docs/issues/00702-engine-plan-selection-layer.md
@@ -238,6 +238,29 @@ how they stay honest. This reuses the discipline the engine already applies to
   regret report; a risen tail means the constants need refitting or the formula
   *shape* is wrong (structured residuals), not just the coefficients.
 
+## Ordering parity across plans
+
+Swapping which plan runs a query must not change the *rows* — and it doesn't
+change the *order* over the keys the product actually defines. SQL's `ORDER BY`
+is three terms — `[sort column] → edhrec_rank → prefer_score` — then arbitrary
+(no unique final key), so there is nothing to be parity-with past key 3. The
+contract we enforce is therefore **2-key parity**: all plans agree on keys 1–2
+(primary sort column, then `edhrec_rank`), both of which are card-level values
+read identically by every plan (the top 64 bits of `sort_key_bits`).
+
+- **Key 3 (`prefer_score`) is deliberately *not* enforced across plans.** The
+  precomputed sort permutation bakes in the *default* representative's
+  prefer_score; under a non-default prefer the perm-based plans can order a
+  key-3 tie differently from the gathered path (and from SQL). Fixing it would
+  cost the streaming fast-path on non-default-prefer broad queries for a tie
+  that is vanishingly rare (`edhrec_rank` is ~unique per card), so it is a
+  known, accepted, pre-existing divergence — not fixed here.
+- **Enforced by** `force_plan_differential_agreement`: every applicable plan's
+  2-key value sequence + scryfall_id multiset must match `GatheredScan`, across
+  modes and a default *and* non-default prefer. (This is Rust plan-vs-plan; a
+  Rust-vs-SQL order check is separate and rides the existing engine/SQL parity
+  suite.)
+
 ## Measurement
 
 Hook the estimator into the `fuzz_row_identity_matches_reference` harness and

--- a/docs/issues/00707-engine-3key-ordering-parity.md
+++ b/docs/issues/00707-engine-3key-ordering-parity.md
@@ -1,0 +1,57 @@
+# 3-Key Ordering Parity Across Plans
+
+[#707](https://github.com/jbylund/sylvan_librarian/issues/707) — deferred from
+[#706](https://github.com/jbylund/sylvan_librarian/pull/706) /
+[00702](./00702-engine-plan-selection-layer.md).
+
+The plan-selection layer enforces **2-key** ordering parity (primary sort
+column → `edhrec_rank`). Key 3 (`prefer_score`) is deliberately not enforced
+across plans. This is the note for if/when we decide to close that gap.
+
+## The divergence
+
+`build_sort_permutations` (lib.rs) bakes the **default** representative
+printing's `prefer_score` into the permutation's 3rd sort key (the perm comment
+says as much: "the first (store-preferred) printing's default prefer score").
+Under a **non-default prefer** the query-chosen representative differs, so:
+
+- **gathered path** (`sort_key_bits`) reads the *chosen* printing's
+  `prefer_score` — matches SQL, whose `DISTINCT ON` representative supplies it;
+- **perm-based plans** (StreamedSelect / PlanePopcountOrder / PrintingRangeScan)
+  inherit the *default* representative's — so a key-3 tie can order differently.
+
+Pre-existing; the force-plan differential test surfaced it. SQL's `ORDER BY` is
+only three terms then arbitrary, so parity past key 3 is undefined regardless.
+
+## Why deferred
+
+Manifests only under *all* of: non-default prefer ∧ card-level sort column ∧ a
+`(primary, edhrec_rank)` tie (edhrec is ~unique per card → rare) ∧ a
+broad/streamed query. Vanishingly rare, never observed in results.
+
+## Options (measure before choosing)
+
+**Step 0 — quantify.** Instrument how often the divergence actually occurs:
+non-default-prefer broad queries landing on a keys-1-2 tie. If ~never, leave as
+wontfix.
+
+**(A) Gate perm-based plans on default prefer.** Non-default prefer routes to
+the gathered path (correct key 3). Cheap: one applicability condition. Cost: the
+streaming / popcount / range fast-paths are lost for *all* non-default-prefer
+broad queries — a real perf hit on that slice to fix a rarely-visible tie.
+
+**(F) Prefer-independent key 3.** Define the 3rd sort key as the card's
+canonical/default `prefer_score`, regardless of the query's prefer, in both
+`sort_key_bits` and SQL's `ORDER BY`. Perf-neutral — keeps the perm and every
+fast-path. Cost: a cross-cutting SQL + Rust change, plus a product-semantics
+decision — card order becomes stable regardless of which printing `prefer`
+surfaces (arguably cleaner than order shifting with prefer, but a behavior
+change to confirm).
+
+## Closing it out
+
+Whichever option, the differential test (`force_plan_differential_agreement`)
+upgrades from 2-key to 3-key value-sequence comparison (drop the `>> 32` /
+compare the low 32 bits too), exercised under non-default prefer — which is
+exactly the assertion that currently would fail and is why 3-key isn't enforced
+today.


### PR DESCRIPTION
Pins down the cross-plan ordering contract before the calibration harness (step 3) leans on it. Test-and-docs only — **no sort-code or SQL change**.

## Contract: 2-key parity

Swapping which physical plan runs a query must not change the rows, and doesn't change the order over the keys the product actually defines. SQL's `ORDER BY` is three terms — `[sort column] → edhrec_rank → prefer_score` — then arbitrary (no unique final key), so there's nothing to be parity-with past key 3. We enforce **keys 1–2** (primary sort column, then `edhrec_rank`) — both card-level values read identically by every plan (the top 64 bits of `sort_key_bits`).

`force_plan_differential_agreement` now asserts, for every applicable plan vs `GatheredScan`: `total` + `scryfall_id` multiset (same rows) **+ the 2-key value sequence** (same order over keys 1–2). Comparing the 2-key *value* sequence tolerates key-3 slop while still catching any real mis-ordering — tied rows share their (key1, key2) value, so the sequence is identical even when they interleave. Now also exercised under a **non-default prefer**, not just default.

## Key 3 deliberately not enforced

The sort permutation bakes in the **default** representative's `prefer_score`, so under a non-default prefer the perm-based plans can order a key-3 tie differently from the gathered path (and from SQL). That tie is vanishingly rare (`edhrec_rank` is ~unique per card), and fixing it would cost the streaming fast-path on non-default-prefer broad queries — so it's a **known, accepted, pre-existing divergence**, documented in `docs/issues/00702`, not fixed here.

Empirically confirmed: the strengthened test passes across the corpus in all three modes, both prefers, debug + release. (Cross-plan; a Rust-vs-SQL order check rides the existing engine/SQL parity suite separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)