### PR TITLE
Estimate-Regret Harness + Trigram-Min Text Estimate (#702)

### DIFF
--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -441,9 +441,33 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
             project(k as u32, n_cards, n_printings)
         }
 
+        // Indexable text contains (#702 step 4 fix): the match set ⊆ the cards/
+        // texts carrying the needle's RAREST trigram, so `trigram_min_posting`
+        // (min over the needle's trigrams, no intersection) is a cheap bound.
+        // `None` = needle < 3 bytes (no trigrams) → unknown.
+        FilterExpr::TextContains { field: TextSearchField::NameLower, word } => {
+            // name_trigram postings are CARD ids (one name per card, no dedup),
+            // so the min is a sound card-space upper bound: tight hi AND est.
+            match trigram_min_posting(&indexes.name_trigram, word) {
+                Some(c) => exact((c as u32).min(n)),
+                None => unknown(n),
+            }
+        }
+        FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word } => {
+            // oracle_trigram.trigrams postings count distinct TEXTS, not cards
+            // (texts are deduped; a text can span several cards), so the min is
+            // NOT a sound card upper bound — use it as the point estimate only
+            // (est has no soundness requirement) and keep hi = N. Under-counting
+            // here biases toward P4, the safe fallback, not P3's O(N) floor.
+            match trigram_min_posting(&indexes.oracle_trigram.trigrams, word) {
+                Some(c) => Cardinality { lo: 0, est: (c as u32).min(n), hi: n },
+                None => unknown(n),
+            }
+        }
+
         FilterExpr::TextExact { .. }
         | FilterExpr::TextRegex { .. }
-        | FilterExpr::TextContains { .. }
+        | FilterExpr::TextContains { .. } // flavor/artist contains (bind usually rewrites these)
         | FilterExpr::ManaCostCmp { .. } => unknown(n),
 
         // Composites are handled in estimate_rec; reaching here is a bug.

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,6 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
+    gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, Mode,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
@@ -3250,6 +3251,124 @@ fn plan_regret_report() {
     offenders.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
     println!("worst offenders:");
     for (regret, name) in offenders.iter().take(5) {
+        println!("  {regret:>7.2}x  {name}");
+    }
+}
+
+/// #702 step 4 (breadth): MODELED regret over a large fuzz-generated query set.
+/// No timing, so it scales to thousands of queries where the timed
+/// `plan_regret_report` can't — it catches estimator errors that flip a plan
+/// choice on shapes the hand-picked set doesn't cover. Trustworthy because the
+/// cost model is validated against real timing at 100%
+/// (`plan_cost_model_matches_gold`): for each query we compare the plan the
+/// estimator's `est` would pick against the plan TRUE cardinality would pick,
+/// both scored by the MODELED cost in the true world —
+///
+///     modeled_regret = plan_cost(est_pick | true_feats) / plan_cost(gold_pick | true_feats)  (>= 1.0)
+///
+/// Card mode only (estimator is card-space).
+///
+///     cargo test --release plan_regret_fuzz -- --ignored --nocapture
+///
+/// Needs real.store.
+#[test]
+#[ignore = "modeled-regret fuzz sweep; needs real.store; cargo test --release plan_regret_fuzz -- --ignored --nocapture"]
+fn plan_regret_fuzz() {
+    use rand::SeedableRng;
+    use super::cost::{PlanFeatures, plan_cost};
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const QUERIES: usize = 3_000;
+    const MAX_DEPTH: u8 = 3;
+    const MINOR: f64 = 1.30;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len() as u32;
+    let n_printings = archived.printings.len() as u32;
+    eprintln!("real.store: {n_cards} cards, {n_printings} printings; {QUERIES} fuzz queries, card mode\n");
+
+    let sort_col = orderby_to_col("edhrec");
+    let descending = false;
+    let pages = [(60usize, 0usize), (60usize, 10_000usize)];
+    let all_plans = [
+        PhysicalPlan::PrintingRangeScan,
+        PhysicalPlan::PlanePopcountOrder,
+        PhysicalPlan::StreamedSelect,
+        PhysicalPlan::GatheredScan,
+    ];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(90_210);
+    let (mut n_none, mut n_minor, mut n_real, mut n_configs) = (0usize, 0usize, 0usize, 0usize);
+    let mut log_sum = 0.0f64;
+    let mut worst: Vec<(f64, String)> = Vec::new();
+
+    for _ in 0..QUERIES {
+        let spec = fuzz_gen(&mut rng, MAX_DEPTH);
+        let f = fuzz_bound_filter(&spec, archived);
+        let true_total = fuzz_reference_total(archived, &f, "card") as u32;
+        let est = super::estimator::estimate_cardinality(&f, &archived.indexes, &archived.offsets).est;
+
+        // Actual structure/features (the router knows structure; only cardinality is estimated).
+        let (pe, mut res) = split_planes(
+            fuzz_bound_filter(&spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
+        );
+        let prep = prepare_candidates(
+            &archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), Mode::Card, &archived.indexes,
+        );
+        let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+        let tier = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+
+        // Applicable plans (card mode) via the predicates — no execution needed.
+        let applicable = [
+            printing_range_scan_applicable(Mode::Card, pe.as_ref(), &archived.cards), // false: card mode
+            plane_popcount_order_applicable(&res, Mode::Card, &archived.cards, pe.as_ref(), sort_col, descending, &archived.indexes),
+            streamed_select_applicable(&archived.cards, sort_col, descending, &archived.indexes),
+            gathered_scan_applicable(),
+        ];
+
+        for &(limit, offset) in &pages {
+            let mk = |matches: u32, evd: u32| PlanFeatures {
+                n_cards, n_printings, matches, eval_domain: evd, residual_tier_ns100: tier,
+                limit: limit as u32, offset: offset as u32,
+            };
+            let feats_true = mk(true_total, eval_domain);
+            let feats_est = mk(est, est.min(n_cards));
+            let pick = |feats: &PlanFeatures| {
+                (0..4)
+                    .filter(|&i| applicable[i])
+                    .map(|i| (plan_cost(all_plans[i], feats), i))
+                    .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
+                    .map(|(_, i)| i)
+            };
+            let (Some(gi), Some(ei)) = (pick(&feats_true), pick(&feats_est)) else { continue };
+            // est-pick's cost vs gold-pick's cost, both in the true world (>= 1.0).
+            let regret = plan_cost(all_plans[ei], &feats_true) / plan_cost(all_plans[gi], &feats_true);
+            n_configs += 1;
+            log_sum += regret.ln();
+            if ei == gi {
+                n_none += 1;
+            } else if regret <= MINOR {
+                n_minor += 1;
+            } else {
+                n_real += 1;
+                worst.push((regret, format!("{} [off {offset}] true={true_total} est={est} gold=P{} pick=P{}", fuzz_describe(&spec), gi + 1, ei + 1)));
+            }
+        }
+    }
+
+    let geomean = if n_configs > 0 { (log_sum / n_configs as f64).exp() } else { 1.0 };
+    println!("modeled regret ({n_configs} configs): {n_none} no-regret, {n_minor} minor(<={MINOR}x), {n_real} real(>{MINOR}x)  |  geomean {geomean:.4}x");
+    worst.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+    println!("worst {} real-regret offenders:", worst.len().min(10));
+    for (regret, name) in worst.iter().take(10) {
         println!("  {regret:>7.2}x  {name}");
     }
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2772,6 +2772,55 @@ fn estimator_accuracy() {
     assert_eq!(unsound, 0, "estimator produced unsound bounds — see stderr");
 }
 
+/// The shared 22-query calibration set used by `plan_cost_calibration`,
+/// `plan_cost_model_matches_gold`, and `plan_regret_report`. A spread from
+/// near-whole-corpus down to narrow, covering each plan's applicability
+/// (pure-plane → True residual for P2; bare range for P1; residual predicate for
+/// P3/P4) AND a range of residual verify tiers (plane/numeric cheap → tag
+/// SET_LOOKUP → oracle/name TEXT_SCAN), plus a sparse postings-narrow
+/// (`o:annihilator`, `kw:Flying`) and an OR union. The closures capture nothing,
+/// so they live here rather than being copy-pasted into each bench.
+fn calibration_queries() -> Vec<(&'static str, FuzzSpec)> {
+    // Colors are the low 5 bits (WUBRG); TYPE_CREATURE is 1<<4. Ge (`:`) = contains.
+    let color = |op, mask| FuzzSpec::Leaf(FuzzLeaf::Color { op, mask });
+    let typ   = |op, mask| FuzzSpec::Leaf(FuzzLeaf::Type { op, mask });
+    let cmc   = |op, val| FuzzSpec::Leaf(FuzzLeaf::Cmc { op, val });
+    let power = |op, val| FuzzSpec::Leaf(FuzzLeaf::Power { op, val });
+    let price = |op, val| FuzzSpec::Leaf(FuzzLeaf::Price { op, val });
+    let year   = |op, y: i32| FuzzSpec::Leaf(FuzzLeaf::Year { op, year: y });
+    let otext  = |needle: &str| FuzzSpec::Leaf(FuzzLeaf::TextContains { field: TextSearchField::OracleTextLower, needle: needle.to_string() });
+    let ntext  = |needle: &str| FuzzSpec::Leaf(FuzzLeaf::TextContains { field: TextSearchField::NameLower, needle: needle.to_string() });
+    let rarity = |op, val| FuzzSpec::Leaf(FuzzLeaf::Rarity { op, val });
+    let kw     = |value: &str| FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: value.to_string() });
+
+    vec![
+        ("cmc>=0 (all)",       cmc(CmpOp::Ge, 0.0)),
+        ("t:creature",         typ(CmpOp::Ge, TYPE_CREATURE)),
+        ("color(bit3)",        color(CmpOp::Ge, 1 << 3)),
+        ("color3 t:creature",  FuzzSpec::And(vec![color(CmpOp::Ge, 1 << 3), typ(CmpOp::Ge, TYPE_CREATURE)])),
+        ("t:creature power>3", FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), power(CmpOp::Gt, 3.0)])),
+        ("cmc<=2",             cmc(CmpOp::Le, 2.0)),
+        ("cmc==7",             cmc(CmpOp::Eq, 7.0)),
+        ("usd<5",              price(CmpOp::Lt, 5.0)),
+        ("year>=2020",         year(CmpOp::Ge, 2020)),
+        ("r:mythic(=3)",       rarity(CmpOp::Eq, 3.0)),
+        ("o:flying",           otext("flying")),
+        ("o:sacrifice",        otext("sacrifice")),
+        ("o:annihilator",      otext("annihilator")),
+        ("name:dragon",        ntext("dragon")),
+        ("kw:Flying",          kw("Flying")),
+        ("c:g or c:r",         FuzzSpec::Or(vec![color(CmpOp::Ge, 1 << 3), color(CmpOp::Ge, 1 << 2)])),
+        // Compounds: plane narrows → expensive residual verify on the CANDIDATE
+        // set (not full N); mixed card/printing-space AND; nested And/Or; a Not.
+        ("t:creature o:flying", FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), otext("flying")])),
+        ("t:creature usd<5",   FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), price(CmpOp::Lt, 5.0)])),
+        ("cmc<=3 o:draw",      FuzzSpec::And(vec![cmc(CmpOp::Le, 3.0), otext("draw")])),
+        ("t:cr (c:g or c:r)",  FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), FuzzSpec::Or(vec![color(CmpOp::Ge, 1 << 3), color(CmpOp::Ge, 1 << 2)])])),
+        ("-t:creature",        FuzzSpec::Not(Box::new(typ(CmpOp::Ge, TYPE_CREATURE)))),
+        ("cmc>=15 (narrow)",   cmc(CmpOp::Ge, 15.0)),
+    ]
+}
+
 /// #702 step 3 (cost calibration): time each *applicable* physical plan on the
 /// REAL corpus archive, across a spread of query selectivities × unique modes ×
 /// page depths, so the per-plan cost formulas can be fit to measured runtime and
@@ -2809,49 +2858,7 @@ fn plan_cost_calibration() {
     let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
     eprintln!("real.store: {} cards, {} printings\n", archived.cards.len(), archived.printings.len());
 
-    // Colors are the low 5 bits (WUBRG); TYPE_CREATURE is 1<<4. Ge (`:`) = contains.
-    let color = |op, mask| FuzzSpec::Leaf(FuzzLeaf::Color { op, mask });
-    let typ   = |op, mask| FuzzSpec::Leaf(FuzzLeaf::Type { op, mask });
-    let cmc   = |op, val| FuzzSpec::Leaf(FuzzLeaf::Cmc { op, val });
-    let power = |op, val| FuzzSpec::Leaf(FuzzLeaf::Power { op, val });
-    let price = |op, val| FuzzSpec::Leaf(FuzzLeaf::Price { op, val });
-    let year   = |op, y: i32| FuzzSpec::Leaf(FuzzLeaf::Year { op, year: y });
-    let otext  = |needle: &str| FuzzSpec::Leaf(FuzzLeaf::TextContains { field: TextSearchField::OracleTextLower, needle: needle.to_string() });
-    let ntext  = |needle: &str| FuzzSpec::Leaf(FuzzLeaf::TextContains { field: TextSearchField::NameLower, needle: needle.to_string() });
-    let rarity = |op, val| FuzzSpec::Leaf(FuzzLeaf::Rarity { op, val });
-    let kw     = |value: &str| FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: value.to_string() });
-
-    // A spread from near-whole-corpus down to narrow, covering each plan's
-    // applicability (pure-plane → True residual for P2; bare range for P1;
-    // residual predicate for P3/P4) AND a range of residual verify tiers
-    // (plane/numeric cheap → tag SET_LOOKUP → oracle/name TEXT_SCAN), plus a
-    // sparse postings-narrow (o:annihilator, kw:flying) and an OR union.
-    let queries: Vec<(&str, FuzzSpec)> = vec![
-        ("cmc>=0 (all)",       cmc(CmpOp::Ge, 0.0)),
-        ("t:creature",         typ(CmpOp::Ge, TYPE_CREATURE)),
-        ("color(bit3)",        color(CmpOp::Ge, 1 << 3)),
-        ("color3 t:creature",  FuzzSpec::And(vec![color(CmpOp::Ge, 1 << 3), typ(CmpOp::Ge, TYPE_CREATURE)])),
-        ("t:creature power>3", FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), power(CmpOp::Gt, 3.0)])),
-        ("cmc<=2",             cmc(CmpOp::Le, 2.0)),
-        ("cmc==7",             cmc(CmpOp::Eq, 7.0)),
-        ("usd<5",              price(CmpOp::Lt, 5.0)),
-        ("year>=2020",         year(CmpOp::Ge, 2020)),
-        ("r:mythic(=3)",       rarity(CmpOp::Eq, 3.0)),
-        ("o:flying",           otext("flying")),
-        ("o:sacrifice",        otext("sacrifice")),
-        ("o:annihilator",      otext("annihilator")),
-        ("name:dragon",        ntext("dragon")),
-        ("kw:Flying",          kw("Flying")),
-        ("c:g or c:r",         FuzzSpec::Or(vec![color(CmpOp::Ge, 1 << 3), color(CmpOp::Ge, 1 << 2)])),
-        // Compounds: plane narrows → expensive residual verify on the CANDIDATE
-        // set (not full N); mixed card/printing-space AND; nested And/Or; a Not.
-        ("t:creature o:flying", FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), otext("flying")])),
-        ("t:creature usd<5",   FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), price(CmpOp::Lt, 5.0)])),
-        ("cmc<=3 o:draw",      FuzzSpec::And(vec![cmc(CmpOp::Le, 3.0), otext("draw")])),
-        ("t:cr (c:g or c:r)",  FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), FuzzSpec::Or(vec![color(CmpOp::Ge, 1 << 3), color(CmpOp::Ge, 1 << 2)])])),
-        ("-t:creature",        FuzzSpec::Not(Box::new(typ(CmpOp::Ge, TYPE_CREATURE)))),
-        ("cmc>=15 (narrow)",   cmc(CmpOp::Ge, 15.0)),
-    ];
+    let queries = calibration_queries();
     let modes = ["card", "printing"];
     // (label, limit, offset): shallow first page vs a deep page (broad queries only reach it).
     let pages = [("shallow", 60usize, 0usize), ("deep", 60usize, 10_000usize)];
@@ -2965,42 +2972,7 @@ fn plan_cost_model_matches_gold() {
     let n_printings = archived.printings.len() as u32;
     eprintln!("real.store: {n_cards} cards, {n_printings} printings\n");
 
-    let color = |op, mask| FuzzSpec::Leaf(FuzzLeaf::Color { op, mask });
-    let typ   = |op, mask| FuzzSpec::Leaf(FuzzLeaf::Type { op, mask });
-    let cmc   = |op, val| FuzzSpec::Leaf(FuzzLeaf::Cmc { op, val });
-    let power = |op, val| FuzzSpec::Leaf(FuzzLeaf::Power { op, val });
-    let price = |op, val| FuzzSpec::Leaf(FuzzLeaf::Price { op, val });
-    let year   = |op, y: i32| FuzzSpec::Leaf(FuzzLeaf::Year { op, year: y });
-    let otext  = |needle: &str| FuzzSpec::Leaf(FuzzLeaf::TextContains { field: TextSearchField::OracleTextLower, needle: needle.to_string() });
-    let ntext  = |needle: &str| FuzzSpec::Leaf(FuzzLeaf::TextContains { field: TextSearchField::NameLower, needle: needle.to_string() });
-    let rarity = |op, val| FuzzSpec::Leaf(FuzzLeaf::Rarity { op, val });
-    let kw     = |value: &str| FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: value.to_string() });
-
-    // Same spread as plan_cost_calibration.
-    let queries: Vec<(&str, FuzzSpec)> = vec![
-        ("cmc>=0 (all)",       cmc(CmpOp::Ge, 0.0)),
-        ("t:creature",         typ(CmpOp::Ge, TYPE_CREATURE)),
-        ("color(bit3)",        color(CmpOp::Ge, 1 << 3)),
-        ("color3 t:creature",  FuzzSpec::And(vec![color(CmpOp::Ge, 1 << 3), typ(CmpOp::Ge, TYPE_CREATURE)])),
-        ("t:creature power>3", FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), power(CmpOp::Gt, 3.0)])),
-        ("cmc<=2",             cmc(CmpOp::Le, 2.0)),
-        ("cmc==7",             cmc(CmpOp::Eq, 7.0)),
-        ("usd<5",              price(CmpOp::Lt, 5.0)),
-        ("year>=2020",         year(CmpOp::Ge, 2020)),
-        ("r:mythic(=3)",       rarity(CmpOp::Eq, 3.0)),
-        ("o:flying",           otext("flying")),
-        ("o:sacrifice",        otext("sacrifice")),
-        ("o:annihilator",      otext("annihilator")),
-        ("name:dragon",        ntext("dragon")),
-        ("kw:Flying",          kw("Flying")),
-        ("c:g or c:r",         FuzzSpec::Or(vec![color(CmpOp::Ge, 1 << 3), color(CmpOp::Ge, 1 << 2)])),
-        ("t:creature o:flying", FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), otext("flying")])),
-        ("t:creature usd<5",   FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), price(CmpOp::Lt, 5.0)])),
-        ("cmc<=3 o:draw",      FuzzSpec::And(vec![cmc(CmpOp::Le, 3.0), otext("draw")])),
-        ("t:cr (c:g or c:r)",  FuzzSpec::And(vec![typ(CmpOp::Ge, TYPE_CREATURE), FuzzSpec::Or(vec![color(CmpOp::Ge, 1 << 3), color(CmpOp::Ge, 1 << 2)])])),
-        ("-t:creature",        FuzzSpec::Not(Box::new(typ(CmpOp::Ge, TYPE_CREATURE)))),
-        ("cmc>=15 (narrow)",   cmc(CmpOp::Ge, 15.0)),
-    ];
+    let queries = calibration_queries();
     let modes = ["card", "printing"];
     let pages = [("shallow", 60usize, 0usize), ("deep", 60usize, 10_000usize)];
     let all_plans = [
@@ -3106,6 +3078,180 @@ fn plan_cost_model_matches_gold() {
         "\nagreement: {n_match} gold-match, {n_tie} near-tie(pass), {n_miss} real-miss  of {n_total}  ({:.1}% pass)",
         100.0 * (n_match + n_tie) as f64 / n_total as f64,
     );
+}
+
+/// #702 step 4 (estimate-regret report): the payoff of the whole plan-selection
+/// sequence. Steps 1+3 give us a calibrated cost model and an estimator; this
+/// asks the load-bearing question directly — *if the router picked plans by
+/// `argmin cost(·|est)` using the ESTIMATOR's cardinality instead of the true
+/// count, how much latency would its mistakes cost?* — measured against the
+/// empirical gold (the plan actually fastest).
+///
+/// Per query × page (card mode): measure every applicable plan (min-of-N, same
+/// discipline as `plan_cost_model_matches_gold`), take `gold` = the fastest.
+/// Then build the router's *consistent belief*: the plan STRUCTURE it knows
+/// exactly (`prepare_candidates`'s `all_match_known`, hence the residual verify
+/// tier), but the CARDINALITY only from `estimate_cardinality(...).est`. Feed
+/// that into the calibrated `plan_cost`, take `est_pick` = its argmin over the
+/// applicable plans, and report
+///
+///     regret = measured_ns[est_pick] / measured_ns[gold]   (1.0× when est_pick == gold)
+///
+/// so a wrong estimate is scored only by the latency it actually costs — the
+/// #702 "estimate regret" figure of merit. Near-1.0× everywhere → the estimator
+/// is good enough to route on as-is; a fat tail → tighten the leaf/plan driving
+/// it (§Cost model, §Estimate regret).
+///
+/// **Card mode only.** The estimator is card-space (`estimate_cardinality`
+/// returns a card-space `Cardinality`), so P1/printing-mode regret would need a
+/// printing-space estimate that doesn't exist yet — out of scope here.
+///
+///     cargo test --release plan_regret_report -- --ignored --nocapture
+///
+/// Same corpus/timing discipline as the other two benches; needs real.store.
+#[test]
+#[ignore = "estimate-regret report; needs real.store; cargo test --release plan_regret_report -- --ignored --nocapture"]
+fn plan_regret_report() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    use super::cost::{PlanFeatures, plan_cost};
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 5;
+    const ITERS: usize = 60;
+    // A pick measuring above this factor of gold is "real" regret; (1.0, MINOR]
+    // is minor (the estimate cost the router a slightly slower but comparable plan).
+    const MINOR: f64 = 1.30;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs to build it)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild, see bench_verify_cost.rs)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len() as u32;
+    let n_printings = archived.printings.len() as u32;
+    eprintln!("real.store: {n_cards} cards, {n_printings} printings (card mode only)\n");
+
+    let queries = calibration_queries();
+    // Card mode only (estimator is card-space); shallow first page vs a deep page.
+    let pages = [("shallow", 60usize, 0usize), ("deep", 60usize, 10_000usize)];
+    let all_plans = [
+        PhysicalPlan::PrintingRangeScan,
+        PhysicalPlan::PlanePopcountOrder,
+        PhysicalPlan::StreamedSelect,
+        PhysicalPlan::GatheredScan,
+    ];
+    let labels = ["P1-range", "P2-popcnt", "P3-stream", "P4-gather"];
+
+    println!(
+        "{:<20} {:>7} {:>8} {:>8} {:>10} {:>10} {:>10} {:>10} {:>8}",
+        "query", "page", "true_tot", "est", "gold", "est_pick", "gold_ns", "est_ns", "regret",
+    );
+
+    let (mut n_none, mut n_minor, mut n_real) = (0usize, 0usize, 0usize);
+    let mut log_sum = 0.0f64; // Σ ln(regret) for the geomean
+    let mut n_configs = 0usize;
+    let mut offenders: Vec<(f64, String)> = Vec::new(); // (regret, "query [page]")
+
+    for (qlabel, spec) in &queries {
+        // Estimator's card-space point estimate (full unsplit filter, as validated).
+        let est = super::estimator::estimate_cardinality(
+            &fuzz_bound_filter(spec, archived), &archived.indexes, &archived.offsets,
+        ).est;
+        for &(plabel, limit, offset) in &pages {
+            // ── Measure each applicable plan (min-of-N), like the other benches ──
+            let mut ns = [None::<u64>; 4];
+            let mut total = 0usize;
+            for (pi, plan) in all_plans.iter().enumerate() {
+                let mut best = u64::MAX;
+                let mut applicable = false;
+                for it in 0..(WARMUP + ITERS) {
+                    // Fresh bind+split per iteration OUTSIDE the timer (memoize mutates res).
+                    let (pe, mut res) = split_planes(
+                        fuzz_bound_filter(spec, archived), &archived.indexes.planes,
+                        &archived.indexes.oracle_trigram.words, true, // unique_is_card
+                    );
+                    let t0 = Instant::now();
+                    let out = black_box(run_query_with_plan(
+                        *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                        &mut res, pe.as_ref(), "card", "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                    ));
+                    let dt = t0.elapsed().as_nanos() as u64;
+                    match out {
+                        Some((t, _)) => {
+                            total = t;
+                            applicable = true;
+                            if it >= WARMUP { best = best.min(dt); }
+                        }
+                        None => break,
+                    }
+                }
+                if applicable { ns[pi] = Some(best); }
+            }
+
+            // ── Actual plan STRUCTURE (the router knows this exactly; only
+            //    cardinality is estimated): all_match_known → residual tier. ──
+            let (pe, mut res) = split_planes(
+                fuzz_bound_filter(spec, archived), &archived.indexes.planes,
+                &archived.indexes.oracle_trigram.words, true,
+            );
+            let prep = prepare_candidates(
+                &archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), Mode::Card, &archived.indexes,
+            );
+            let tier = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+
+            // ── Router's belief: cardinality from `est`, structure `tier` actual. ──
+            let feats_est = PlanFeatures {
+                n_cards, n_printings,
+                matches: est,
+                eval_domain: est.min(n_cards),
+                residual_tier_ns100: tier,
+                limit: limit as u32,
+                offset: offset as u32,
+            };
+
+            let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
+            let est_pick = (0..4)
+                .filter(|&i| ns[i].is_some())
+                .map(|i| (plan_cost(all_plans[i], &feats_est), i))
+                .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+
+            let (Some((gold_ns, gi)), Some((_, ei))) = (gold, est_pick) else { continue };
+            let est_ns = ns[ei].unwrap();
+            let regret = est_ns as f64 / gold_ns as f64;
+
+            n_configs += 1;
+            log_sum += regret.ln();
+            if ei == gi {
+                n_none += 1;
+            } else if regret <= MINOR {
+                n_minor += 1;
+            } else {
+                n_real += 1;
+            }
+            offenders.push((regret, format!("{qlabel} [{plabel}]")));
+
+            println!(
+                "{:<20} {:>7} {:>8} {:>8} {:>10} {:>10} {:>10} {:>10} {:>7.2}x",
+                qlabel, plabel, total, est, labels[gi], labels[ei], gold_ns, est_ns, regret,
+            );
+        }
+    }
+
+    let geomean = if n_configs > 0 { (log_sum / n_configs as f64).exp() } else { 1.0 };
+    println!(
+        "\nregret summary ({n_configs} configs): {n_none} no-regret(est_pick==gold), \
+         {n_minor} minor(1.0,{MINOR}x], {n_real} real(>{MINOR}x)  |  geomean {geomean:.3}x",
+    );
+    offenders.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+    println!("worst offenders:");
+    for (regret, name) in offenders.iter().take(5) {
+        println!("  {regret:>7.2}x  {name}");
+    }
 }
 
 /// format:A AND format:B (two distinct formats) can't be answered by ANDing


### PR DESCRIPTION
#702 step 4. Adds the estimate-regret machinery and the first estimator tightening it motivated. **Fully unwired** — `#[ignore]` benches + one sound, unrouted estimator change; no request-path behavior change.

## What's here

- **`plan_regret_report`** (`#[ignore]`, card mode) — feeds the estimator's `est` where the router would (cardinality from `est`, structure/tier actual), picks `argmin(plan_cost)`, and scores it by the pick's *measured* cost vs gold: `regret = est_ns / gold_ns`. The #702 estimate-regret figure of merit.
- **Trigram-min text estimate** (`estimator.rs`) — `TextContains` returned the N/2 unknown placeholder, which the regret report showed misrouting narrow indexed-text queries onto P3's O(N) floor. Fix uses `trigram_min_posting` (rarest-trigram bound, no intersection): name → sound card-space upper bound (tight `hi`+`est`); oracle → text-space point `est` (est carries no soundness requirement), `hi=N`. Compounds tighten for free via the AND/OR algebra.
- **`plan_regret_fuzz`** (`#[ignore]`) — **modeled** regret (no timing → thousands of queries) over `fuzz_gen` output. Trustworthy because the cost model is 100%-validated vs real timing. Breadth the 44-config timed report can't reach.
- Shared `calibration_queries()` helper (de-dups the query list across the three benches).

## Results (real corpus)

- Timed regret (hand-picked, 44 configs): geomean **1.14× → 1.001×** after the text fix; real-regret configs 3 → 0 (`o:annihilator` est 15754→24, `name:dragon` 15754→363).
- Modeled fuzz sweep (6000 configs): 5634 no-regret, 247 minor, 119 real; geomean **1.043×**. The remaining tail is the *same mechanism* (N/2 placeholder → P3 floor) on **new leaf types the hand-picked set missed**: `border` (TextExact on Border) and non-plane-compiling `devotion`. These are the next estimator-tightening targets.

## Soundness / no behavior change

- Bounds stay sound (`fuzz_row_identity_matches_reference` passes debug+release — the always-on `truth ∈ [lo,hi]` assertion covers the new text bounds).
- Cost-model validation unchanged (87/1/0 — it uses measured cardinality, not `est`).
- Estimator is unwired; nothing in `run_query` routes on it.

## Plan (reordered)

The fuzz sweep reshaped the sequencing: **tighten the estimator before wiring routing**, so `choose_plan`'s debut is optimal rather than gate-fallback on common leaves. The modeled fuzz sweep is the objective "tight enough to wire" gate. Next: an estimator-extensions PR (border via `PLANE_BORDER_OTHER`, devotion where it plane-compiles) driven by the sweep; then step 5 wires `choose_plan` on `argmin(cost·|est)` with a lower-bound gate on the floor-carrying plan (unknown leaves → safe P4), toggle-gated for A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)