### PR TITLE
Estimator Extensions: Border, Devotion, 2-Byte Name (#702)

### DIFF
--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -277,18 +277,22 @@ fn plane_card(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, for
     }
 }
 
-/// Popcount of a single named plane (`PlaneExpr::Plane(idx)`), for leaves whose
-/// value maps to a known plane index directly — even when `compile_plane`
-/// declines to compile the *predicate* exactly (e.g. an untracked border folds
-/// into `PLANE_BORDER_OTHER`, a superset the estimator only needs as a bound).
-/// Guards plane availability like `plane_popcount`.
-fn plane_popcount_at(idx: usize, indexes: &Archived<CardIndexes>, n_cards: u32) -> Option<u32> {
+/// Popcount of an arbitrary already-compiled `PlaneExpr`, for leaves the
+/// estimator can bound via a plane the predicate's own `compile_plane` declines
+/// (an untracked border's OTHER bucket, a devotion saturated superset). Guards
+/// plane availability like `plane_popcount`.
+fn plane_expr_popcount(pe: &PlaneExpr, indexes: &Archived<CardIndexes>, n_cards: u32) -> Option<u32> {
     if n_cards == 0 || u32::from(indexes.planes.n_cards) != n_cards {
         return None;
     }
     let mut bits: Vec<u64> = Vec::new();
-    eval_planes(&PlaneExpr::Plane(idx as u16), &indexes.planes, &mut bits);
+    eval_planes(pe, &indexes.planes, &mut bits);
     Some(bits.iter().map(|w| w.count_ones()).sum())
+}
+
+/// Popcount of a single named plane (see `plane_expr_popcount`).
+fn plane_popcount_at(idx: usize, indexes: &Archived<CardIndexes>, n_cards: u32) -> Option<u32> {
+    plane_expr_popcount(&PlaneExpr::Plane(idx as u16), indexes, n_cards)
 }
 
 /// Card count `end - start` from the numeric index's partition_point bounds,
@@ -374,10 +378,20 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
         // Existence-projection plane → superset {0, c, c}.
         FilterExpr::Legality { .. } => plane_card(f, indexes, n_cards, true),
 
-        // Devotion Ge/Gt: saturated-bucket plane superset {0, c, c}; other ops
-        // are not plane-narrowable → unknown.
-        FilterExpr::Devotion { op: CmpOp::Ge | CmpOp::Gt, .. } => plane_card(f, indexes, n_cards, true),
-        FilterExpr::Devotion { .. } => unknown(n),
+        // Devotion (card-level, two-valued). The planes give 0/1/2/3+ buckets
+        // per color, so the exact compiler answers any comparison within the
+        // saturation boundary EXACTLY (==0/1/2, ≥1/2/3, and the ≤/≠ it accepts) —
+        // exact card count, tight bounds. When it declines — Ge/Gt past 3, where
+        // "3+" can't be split — the saturated superset (count clamped to 3, the
+        // 3+ bucket ⊇ ≥k for k≥3) is a sound upper bound. Superset is Ge-based,
+        // so it's sound only for Ge/Gt; Le/Lt/Eq/Ne that decline stay unknown.
+        FilterExpr::Devotion { op, pips } => match plane_popcount(f, indexes, n_cards) {
+            Some((c, _)) => exact(c),
+            None if matches!(op, CmpOp::Ge | CmpOp::Gt) => compile_devotion_superset(*pips)
+                .and_then(|pe| plane_expr_popcount(&pe, indexes, n_cards))
+                .map_or_else(|| unknown(n), |c| Cardinality { lo: 0, est: c, hi: c }),
+            None => unknown(n),
+        },
 
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } => {
             // Mirror narrow_rec's field dispatch (lib.rs:3040-3047).

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -295,6 +295,23 @@ fn plane_popcount_at(idx: usize, indexes: &Archived<CardIndexes>, n_cards: u32) 
     plane_expr_popcount(&PlaneExpr::Plane(idx as u16), indexes, n_cards)
 }
 
+/// Exact card count for a 2-byte name needle: containment IS bigram membership
+/// (#639 name-bigram index), card-space with no false positives — the dense
+/// plane's popcount or the sparse posting's length (0 if the bigram is absent).
+/// Mirrors `narrow_rec`'s name-2-byte path. None: archive built without bigrams.
+fn name_bigram_count(indexes: &Archived<CardIndexes>, bg: [u8; 2], n_cards: u32) -> Option<u32> {
+    let idx = &indexes.name_bigrams;
+    if u32::from(idx.n_cards) != n_cards {
+        return None;
+    }
+    if let Some(p) = idx.plane_of.get(&bg) {
+        let wpp = (n_cards as usize).div_ceil(64);
+        let start = u32::from(*p) as usize * wpp;
+        return Some(idx.plane_words[start..start + wpp].iter().map(|w| u64::from(*w).count_ones()).sum());
+    }
+    Some(idx.postings.get(&bg).map_or(0, |v| v.len() as u32))
+}
+
 /// Card count `end - start` from the numeric index's partition_point bounds,
 /// WITHOUT materializing the id vec (mirrors `numeric_candidates`). None for
 /// Ne (not selective).
@@ -496,6 +513,12 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
             // so the min is a sound card-space upper bound: tight hi AND est.
             match trigram_min_posting(&indexes.name_trigram, word) {
                 Some(c) => exact((c as u32).min(n)),
+                // 2-byte needle: no trigram, but containment IS bigram membership
+                // (#639) — exact card count. <2 bytes: no index → unknown.
+                None if word.len() == 2 => {
+                    let bg = [word.as_bytes()[0], word.as_bytes()[1]];
+                    name_bigram_count(indexes, bg, n).map_or_else(|| unknown(n), exact)
+                }
                 None => unknown(n),
             }
         }

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -277,6 +277,20 @@ fn plane_card(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, for
     }
 }
 
+/// Popcount of a single named plane (`PlaneExpr::Plane(idx)`), for leaves whose
+/// value maps to a known plane index directly — even when `compile_plane`
+/// declines to compile the *predicate* exactly (e.g. an untracked border folds
+/// into `PLANE_BORDER_OTHER`, a superset the estimator only needs as a bound).
+/// Guards plane availability like `plane_popcount`.
+fn plane_popcount_at(idx: usize, indexes: &Archived<CardIndexes>, n_cards: u32) -> Option<u32> {
+    if n_cards == 0 || u32::from(indexes.planes.n_cards) != n_cards {
+        return None;
+    }
+    let mut bits: Vec<u64> = Vec::new();
+    eval_planes(&PlaneExpr::Plane(idx as u16), &indexes.planes, &mut bits);
+    Some(bits.iter().map(|w| w.count_ones()).sum())
+}
+
 /// Card count `end - start` from the numeric index's partition_point bounds,
 /// WITHOUT materializing the id vec (mirrors `numeric_candidates`). None for
 /// Ne (not selective).
@@ -439,6 +453,24 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
             let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
             project(k as u32, n_cards, n_printings)
+        }
+
+        // Border (#664/#680 planes): a tracked value maps to its one-hot plane
+        // (exact existential card count); an untracked value ("yellow", …) folds
+        // into the shared OTHER bucket — a sound superset upper bound, same as
+        // narrow_rec's border narrowing (lib.rs ~3128). compile_plane declines
+        // untracked values for *exact* narrowing, but the estimator only needs a
+        // bound, so read the plane popcount directly.
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
+            let (idx, tracked) = BORDER_TRACKED_VALUES
+                .iter()
+                .position(|&v| v == value.as_str())
+                .map_or((PLANE_BORDER_OTHER, false), |i| (PLANE_BORDER + i, true));
+            match plane_popcount_at(idx, indexes, n_cards) {
+                Some(c) if tracked => exact(c),                    // one-hot: exact
+                Some(c) => Cardinality { lo: 0, est: c, hi: c },   // OTHER: superset upper bound
+                None => unknown(n),
+            }
         }
 
         // Indexable text contains (#702 step 4 fix): the match set ⊆ the cards/


### PR DESCRIPTION
Packs three sweep-driven estimator tightenings that the modeled-regret fuzz sweep (`plan_regret_fuzz`, #709) flagged as the top regret offenders. Each is unwired, sound (fuzz `truth ∈ [lo,hi]` assertion), and its own commit for bisectability. No request-path behavior change.

## Extensions (each via existing planes/indexes)

- **Border** — `TextExact{Border,Eq}`: tracked value → its #664/#680 one-hot plane (exact); untracked ("yellow", …) → `PLANE_BORDER_OTHER` (sound superset upper bound). `compile_plane` declines untracked for *exact* narrowing, but the estimator only needs a bound, so it reads the plane popcount directly.
- **Devotion** — planes give 0/1/2/3+ buckets per color; any comparison within the boundary compiles **exactly** (`exact(c)` — tightened from the old conservative `{0,c,c}`, since devotion is card-invariant two-valued like Color/Type). Ge/Gt past 3 fall back to `compile_devotion_superset` (the 3+ bucket ⊇ ≥k for k≥3), sound for Ge/Gt only.
- **2-byte name** — `trigram_min_posting` needs ≥3 bytes; a 2-byte name needle is a single bigram, and containment IS card-space bigram membership → exact count via the #639 name-bigram index (dense plane popcount / sparse posting len).

## Regret impact (modeled fuzz sweep, 6000 configs, real corpus)

| after | geomean | real-regret (>1.3×) |
|---|---|---|
| text only (#709) | 1.043× | 119 |
| + border | 1.015× | 68 |
| + devotion | 1.011× | 55 |
| + 2-byte name | **1.0076×** | **45** |

**Gate-territory reached:** the remaining tail is no longer single-leaf estimator gaps. It's (a) near-`STREAM_MIN` crossover flips where the estimate is *accurate* but straddles 1024 (`oracle:among` true 992 / est 1247) — which the step-5 lower-bound gate handles (`oracle` leaves have `hi=N, lo=0` → not provably broad → safe P4), and (b) contrived contradictory compounds (`toughness==5 AND type` → true 0) at negligible absolute cost. Chasing these is the gate's job, not the estimator's — so this is the right place to stop.

Full suite green (debug); estimator unwired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)