### PR TITLE
Consolidate Plan Selection Into One Cost-Based Routing Layer

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -7,10 +7,10 @@
 //! objective the constants were fit against is that `argmin` reproduces the
 //! empirically-fastest ("gold") plan per query × mode × page depth.
 //!
-//! **Unwired**: nothing in `run_query` calls this yet. It is validated by the
-//! `plan_cost_model_matches_gold` test (src/tests.rs), which computes real
-//! `PlanFeatures` (via `prepare_candidates` + `verify_cost_tier`) and checks the
-//! model's argmin against re-measured gold.
+//! `run_query_routed` calls `plan_cost` on every query (it IS the plan selector).
+//! It is also validated by the `plan_cost_model_matches_gold` test (src/tests.rs),
+//! which computes real `PlanFeatures` (via `prepare_candidates` + `verify_cost_tier`)
+//! and checks the model's argmin against re-measured gold.
 //!
 //! ## Units and provenance
 //!
@@ -30,13 +30,36 @@
 //! and plan structure do the deciding (see #702 "Cost model" §). Popcount (P2)
 //! and range-scan (P1) run only when the residual is `True`/absent, so they carry
 //! no verify term at all.
+//!
+//! ## Calibration scope: operating-space via `scan_units` (card + printing)
+//!
+//! The P3/P4 per-card work was originally fit on CARD mode alone, where the loop
+//! breaks at the first matching printing, and it under-predicted printing/artwork
+//! P3/P4 by ~`n_printings/n_cards` (≈3.09) because those modes scan EVERY printing
+//! of every candidate. The fix is `PlanFeatures::scan_units` (not a `mode` branch):
+//! the per-card `card_pass` term is driven by `eval_domain` (candidate cards) and
+//! the per-row residual scan + its verify `tier` by `scan_units` (rows scanned in
+//! the plan's operating space — `≈ eval_domain` for card, printings-under-candidates
+//! for printing/artwork). One mode-agnostic formula; the caller fills `scan_units`
+//! per mode via `scan_units()`. The `_CARD_PASS`/`_SCAN` split of the old lumped
+//! `VISIT` constants was fit to hold card unchanged while correcting printing (see
+//! each constant's doc). Artwork rides the printing path (same all-printings scan);
+//! its confirming validation is still pending a bench run.
+//!
+//! A 1200-query designed refit (`plan_cost_refit`, weighted LSQ, 70/30 train/test)
+//! VALIDATED rather than beat these: P1's fitted STEP=4.14 ≈ 4.5 (test 1.38× ≈
+//! train); P3/P4 could NOT be fit — `SCAN` goes negative because `scan_units` and
+//! `matches` both scale with printing count in the workload, a STRUCTURAL
+//! collinearity no corpus size fixes (P2 stays data-starved: pure-plane queries are
+//! rare). The `_CARD_PASS`/`_SCAN`/`PUSH` split is a physical prior resolving what
+//! data alone cannot. Model sits at ~1.4× absolute (slow bucket), ordering-correct
+//! (argmin==gold 87/88) — the identifiable ceiling for this workload.
 
 use super::*;
 
-/// Cheap, per-query features the cost model consumes. All counts are exact
-/// (from materialized truth / `prepare_candidates`), so this validates the model
-/// *given* true features; estimator regret is a separate later step (#702 step 4).
-#[allow(dead_code)] // consumed only through the (unwired) plan_cost entry point
+/// Cheap, per-query features the cost model consumes, built once per query by
+/// `run_query_routed`'s `acquire` step. All counts are exact or cheap-exact (plane
+/// popcount / range `k` / candidate count), never estimated.
 pub(crate) struct PlanFeatures {
     /// Distinct cards in the corpus (card-space universe).
     pub n_cards: u32,
@@ -45,9 +68,17 @@ pub(crate) struct PlanFeatures {
     /// Result cardinality in the plan's operating space (card total for card
     /// mode, printing total for printing mode). Use measured truth here.
     pub matches: u32,
-    /// Cards the per-card work visits: the narrowed candidate count when
-    /// `prepare_candidates` produced a candidate list, else `n_cards`.
+    /// Candidate CARDS the loop iterates (one `card_pass` each): the narrowed
+    /// candidate count when `prepare_candidates` produced a list, else `n_cards`.
     pub eval_domain: u32,
+    /// Rows the per-row residual scan touches, in the plan's operating space — the
+    /// dominant P3/P4 driver. Card mode breaks at the first matching printing
+    /// (≈ one row per candidate), so `scan_units ≈ eval_domain`; printing/artwork
+    /// scan every printing of every candidate, so it is the printing count under
+    /// those cards (`≈ eval_domain · n_printings/n_cards`). This is the field that
+    /// makes the formula operating-space-correct without a `mode` branch (see the
+    /// module "Calibration scope" note); the caller fills it via `scan_units()`.
+    pub scan_units: u32,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
     pub residual_tier_ns100: u32,
@@ -66,9 +97,15 @@ pub(crate) struct PlanFeatures {
 /// ns per permutation step walked. Fit from usd<5 printing shallow/deep
 /// (match_rate=0.734): (88708−666)ns over (13706−82) steps ≈ 6.5; year>=2020
 /// printing gave ≈3.5. The per-step cost is noisy (printing clustering along the
-/// sort order), so this is a representative middle value — exactness matters
-/// little here because P1, when applicable, wins its rows by 1-2 orders of
-/// magnitude over P3/P4.
+/// sort order), so this is a representative middle value.
+///
+/// CAUTION: `printing_range_route_probe` measures P1 fidelity swinging 0.10×–2.24×
+/// against this single constant — a walk step in printing mode scans a whole card's
+/// printings, whose count varies by query. The earlier claim that exactness "matters
+/// little because P1 wins by 1-2 orders of magnitude" is FALSE at depth: at offset
+/// 20000 P1 leads P3 by only ~2×, and that is exactly where this loose constant
+/// flips the argmin (the model routes off gold-P1). Sharpening P1 needs a per-step
+/// term keyed on printings-scanned, not a scalar — deferred with the printing model.
 const RANGE_WALK_STEP_NS: f64 = 4.5;
 /// Fixed P1 setup (binary searches + walk init). Fit from usd<5 printing shallow
 /// (666ns − 82 steps × RANGE_WALK_STEP_NS ≈ 150ns).
@@ -103,12 +140,20 @@ const PLANE_POPCOUNT_FIXED_COST_NS: f64 = 200.0;
 // O(n_cards) FLOOR that makes P3 lose badly on narrow queries: a 5-row query
 // forced onto P3 measured ~52µs = n_cards × ~1.65ns.
 
-/// ns per card visited in the match phase (card_pass + count). Fit from broad
-/// queries where eval_domain drives P3 and it is nearly independent of match
-/// count across modes: t:creature card 17317 cards → 53542ns (3.09), printing
-/// 17317 → 52791ns (3.05); cmc>=0 card 31508 → 101541ns (3.22), printing 31508 →
-/// 97000ns (3.08). The residual verify tier adds on top (common-mode with P4).
-const STREAM_MATCH_PHASE_PER_CARD_NS: f64 = 3.0;
+/// P3 match phase, split into a per-CANDIDATE-CARD term (`card_pass`, driven by
+/// `eval_domain`) and a per-SCANNED-ROW term (`scan_units`, below). The old lumped
+/// `STREAM_MATCH_PHASE_PER_CARD_NS = 3.0` was fit on CARD mode, where the loop
+/// early-stops at the first matching printing (`scan_units ≈ eval_domain`) so the
+/// two terms are indistinguishable; the sum stays 3.0 there. Printing/artwork scan
+/// EVERY printing of each candidate (`scan_units ≈ eval_domain · n_printings/n_cards`),
+/// which the lumped constant under-priced ~2× (fidelity 0.5, the eval_domain-counts-
+/// cards bug). Split fit: card sum pins `CARD_PASS + SCAN = 3.0`; printing's ~2×
+/// under-prediction at ratio ~3.09 pins the split (`CARD_PASS + 3.09·SCAN ≈ 6.0`).
+const STREAM_CARD_PASS_NS: f64 = 1.56;
+/// ns per printing scanned in the match phase (residual test per row). See
+/// STREAM_CARD_PASS_NS for the split derivation. The residual verify `tier` rides
+/// this term (it is paid per scanned row), common-mode with P4's scan term.
+const STREAM_SCAN_PER_ROW_NS: f64 = 1.44;
 /// ns per match, for the permutation-walk emit. Small — P3 measured nearly flat
 /// in match count once eval_domain is fixed (see STREAM_MATCH_PHASE_PER_CARD_NS),
 /// so this is a minor term.
@@ -127,14 +172,16 @@ const STREAM_FIXED_COST_NS: f64 = 500.0;
 // Vec (O(matches)), then select_page quickselects the page. Visits eval_domain
 // cards, each paying the residual verify tier.
 
-/// ns per card visited in the gathered loop (card_pass + push). Fit with
-/// GATHER_PUSH_PER_MATCH_NS from all-match broad card queries where
-/// eval_domain==matches and tier=0, which pin the sum ≈ 6.3-6.9 (cmc>=0 31508 →
-/// 216667ns = 6.87; t:creature 17317 → 109834 = 6.34; color3 6606 → 40458 =
-/// 6.12). Split so the gathered loop's per-visit cost exceeds P3's
-/// STREAM_MATCH_PHASE_PER_CARD_NS — the measured P4/P3 ≈ 2× ratio on broad
-/// queries — with the remainder attributed to the per-match push.
-const GATHER_VISIT_PER_CARD_NS: f64 = 5.5;
+/// P4 gathered loop, split per-CANDIDATE-CARD (`card_pass`, `eval_domain`) and
+/// per-SCANNED-ROW (`scan_units`), same rationale as STREAM_CARD_PASS_NS. The old
+/// lumped `GATHER_VISIT_PER_CARD_NS = 5.5` was fit on card mode (all-match broad,
+/// eval_domain==matches, tier=0, sum ≈ 6.3-6.9 with GATHER_PUSH); card keeps
+/// `CARD_PASS + SCAN = 5.5`. Printing's ~2× under-prediction at ratio ~3.09 splits
+/// it (`CARD_PASS + 3.09·SCAN ≈ 11`).
+const GATHER_CARD_PASS_NS: f64 = 2.87;
+/// ns per printing scanned in the gathered loop (residual test per row); the verify
+/// `tier` rides this term, common-mode with P3's scan term. See GATHER_CARD_PASS_NS.
+const GATHER_SCAN_PER_ROW_NS: f64 = 2.63;
 /// ns per match pushed into the sort-key Vec + quickselected.
 const GATHER_PUSH_PER_MATCH_NS: f64 = 1.0;
 /// ns per page slot materialized. Fit from the deep-vs-shallow gap on broad
@@ -149,15 +196,15 @@ const GATHER_FIXED_COST_NS: f64 = 200.0;
 
 /// Estimated wall-clock cost of running `plan` on a query with features `f`, in
 /// nanoseconds. Lower is cheaper; the planner routes to `argmin_plan plan_cost`.
-/// Only meaningful for plans that are *applicable* to the query (the caller
-/// filters by the applicability predicates / `run_query_with_plan` returning
-/// `Some`); an inapplicable plan's cost is not defined.
-#[allow(dead_code)] // unwired: routing is a later #702 step; only the test calls this
+/// Only meaningful for plans that are *applicable* to the query (`run_query_routed`
+/// only ever costs `PhysicalPlan::ALL.filter(applicable)`); an inapplicable plan's
+/// cost is not defined.
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
     let n_printings = f64::from(f.n_printings);
     let matches = f64::from(f.matches);
     let eval_domain = f64::from(f.eval_domain);
+    let scan_units = f64::from(f.scan_units);
     let tier_ns = f64::from(f.residual_tier_ns100) / 100.0;
     let limit = f64::from(f.limit);
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
@@ -182,10 +229,17 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             } else {
                 0.0
             };
-            eval_domain * (STREAM_MATCH_PHASE_PER_CARD_NS + tier_ns) + matches * STREAM_EMIT_PER_MATCH_NS + floor + STREAM_FIXED_COST_NS
+            // card_pass is per candidate card; the residual scan + its verify tier
+            // are per scanned printing (scan_units) — the operating-space split.
+            eval_domain * STREAM_CARD_PASS_NS
+                + scan_units * (STREAM_SCAN_PER_ROW_NS + tier_ns)
+                + matches * STREAM_EMIT_PER_MATCH_NS
+                + floor
+                + STREAM_FIXED_COST_NS
         }
         PhysicalPlan::GatheredScan => {
-            eval_domain * (GATHER_VISIT_PER_CARD_NS + tier_ns)
+            eval_domain * GATHER_CARD_PASS_NS
+                + scan_units * (GATHER_SCAN_PER_ROW_NS + tier_ns)
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS
                 + GATHER_FIXED_COST_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -66,7 +66,7 @@ pub(crate) struct PlanFeatures {
     /// Distinct printings in the corpus (printing-space universe).
     pub n_printings: u32,
     /// Result cardinality in the plan's operating space (card total for card
-    /// mode, printing total for printing mode). Use measured truth here.
+    /// mode, printing total for printing/artwork mode). Use measured truth here.
     pub matches: u32,
     /// Candidate CARDS the loop iterates (one `card_pass` each): the narrowed
     /// candidate count when `prepare_candidates` produced a list, else `n_cards`.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3975,17 +3975,17 @@ fn printing_range_fastpath<'a>(
     Some((k, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
 }
 
-/// The four physical plans `run_query` can dispatch to (#702 step 2, the
-/// force-plan seam). Each has an applicability predicate (its correctness
-/// preconditions — the future `choose_plan` eligibility gates) and a callable
-/// executor. `run_query`'s default routing is unchanged: it still picks among
-/// these in exactly the same order, on exactly the same conditions; this enum
-/// only makes each plan *individually addressable* via `run_query_with_plan`.
+/// The physical plans the cost router (`run_query_routed`) chooses among. Each
+/// carries three declared properties — `applicable` (its correctness precondition),
+/// `cost::plan_cost` (its predicted runtime), and an executor — so the router is a
+/// generic argmin over `ALL.filter(applicable)`, not a hand-written decision tree.
+/// Adding a plan is: a variant here, an `applicable` arm, a `plan_cost` arm, and an
+/// executor arm in the router's dispatch. `run_query_with_plan` also makes each
+/// individually forceable (the differential/calibration test seam).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)] // variants only referenced through the (test-facing) force entry point
 enum PhysicalPlan {
     /// #695 bare-broad-range fast path under `unique=printing` (executor:
-    /// `printing_range_fastpath`).
+    /// `printing_range_fastpath`). The one non-materializing plan.
     PrintingRangeScan,
     /// #634 Step 2 plane-bitmap popcount-skip order phase (`run_query_streamed_popcount`).
     PlanePopcountOrder,
@@ -3993,6 +3993,55 @@ enum PhysicalPlan {
     StreamedSelect,
     /// The universal fallback: the gathered per-card loop + `select_page`.
     GatheredScan,
+}
+
+impl PhysicalPlan {
+    /// All plans, argmin-ordered so ties resolve deterministically toward the
+    /// cheaper-fixed-cost plan. The router filters this by `applicable`.
+    const ALL: [PhysicalPlan; 4] = [
+        PhysicalPlan::PrintingRangeScan,
+        PhysicalPlan::PlanePopcountOrder,
+        PhysicalPlan::StreamedSelect,
+        PhysicalPlan::GatheredScan,
+    ];
+
+    /// Whether this plan can *correctly* answer the query — its precondition, not a
+    /// perf judgment (that is `cost::plan_cost`). These predicates also encode prep
+    /// availability: `PlanePopcountOrder` is applicable exactly when the plane-bitmap
+    /// prep is available, `PrintingRangeScan` exactly when the range-estimate prep is,
+    /// so filtering `ALL` by `applicable` inside each prep branch yields the right
+    /// candidate set with no per-branch plan list.
+    #[allow(clippy::too_many_arguments)]
+    fn applicable(
+        self,
+        filter: &FilterExpr,
+        mode: Mode,
+        cards: &[AOracleCard],
+        plane: Option<&PlaneExpr>,
+        sort_col: SortCol,
+        descending: bool,
+        indexes: &Archived<CardIndexes>,
+    ) -> bool {
+        match self {
+            PhysicalPlan::PrintingRangeScan => {
+                printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
+            }
+            PhysicalPlan::PlanePopcountOrder => {
+                plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
+            }
+            PhysicalPlan::StreamedSelect => streamed_select_applicable(cards, sort_col, descending, indexes),
+            PhysicalPlan::GatheredScan => gathered_scan_applicable(),
+        }
+    }
+
+    /// Whether the plan runs off the shared materialized prep (plane bitmap /
+    /// candidate list) — true for all but `PrintingRangeScan`, whose whole benefit
+    /// is answering *without* materializing. The router costs non-materializing
+    /// plans from a cheap estimate first (phase 1) and only materializes (phase 2)
+    /// when a materializing plan wins or the non-materializing one declines.
+    fn materializing(self) -> bool {
+        !matches!(self, PhysicalPlan::PrintingRangeScan)
+    }
 }
 
 /// The shared P3/P4 preparation product (see `prepare_candidates`): the
@@ -4003,6 +4052,23 @@ enum PhysicalPlan {
 struct PreparedCandidates {
     candidate_cards: Option<Vec<u32>>,
     all_match_known: bool,
+}
+
+/// How `run_query_routed` obtained a query's cost features, and the artifact (if
+/// any) the chosen executor reuses. One of three "count sources", picked by query
+/// structure — this is the engine's whole materialization story in one enum.
+enum Prep {
+    /// Bare printing range: features come from the range index's exact `k` (a
+    /// binary search, no scan). Nothing is materialized — `PrintingRangeScan`
+    /// walks; a materializing winner materializes for itself in dispatch. `Plane`
+    /// carries no bitmap because it lives in the caller's reused thread-local
+    /// (`ROUTED_PLANE_BITMAP`), which dispatch reads directly.
+    Range,
+    /// True-residual plane (card): the exact match bitmap (in the thread-local).
+    /// `PlanePopcountOrder` reads it directly; P3/P4 read it as a candidate list.
+    Plane,
+    /// The general residual path: a materialized candidate list.
+    Candidates(PreparedCandidates),
 }
 
 /// Row selection (docs/issues/00667-engine-legality-divergent-carveout.md "Row
@@ -4206,19 +4272,45 @@ fn exec_plane_popcount_order<'a>(
     plane_expr: &PlaneExpr,
     indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
-    let inv_perm =
-        indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
     thread_local! {
         static PLANE_BITMAP_POPCOUNT: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
     }
     PLANE_BITMAP_POPCOUNT.with(|cell| {
         let mut bitmap = cell.borrow_mut();
         eval_planes(plane_expr, &indexes.planes, &mut bitmap);
-        run_query_streamed_popcount(
-            cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, &bitmap, plane_expr, &indexes.planes, strings,
+        exec_plane_popcount_order_with_bitmap(
+            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes, &bitmap,
         )
     })
+}
+
+/// The popcount-skip order phase of P2 with the plane bitmap *already evaluated*
+/// by the caller — the eval-owning split of `exec_plane_popcount_order`. The
+/// #702-step-5 routed path (`run_query_routed`) evaluates the plane once
+/// and reuses the same `&[u64]` here, so the plane is never evaluated twice on a
+/// routed query. Caller guarantees `plane_popcount_order_applicable` (a
+/// length-matched forward permutation and an inverse permutation both exist).
+#[allow(clippy::too_many_arguments)]
+fn exec_plane_popcount_order_with_bitmap<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    plane_expr: &PlaneExpr,
+    indexes: &Archived<CardIndexes>,
+    bitmap: &[u64],
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
+    let inv_perm =
+        indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
+    run_query_streamed_popcount(
+        cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, bitmap, plane_expr, &indexes.planes, strings,
+    )
 }
 
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
@@ -4340,51 +4432,208 @@ fn run_query<'a>(
         _          => Mode::Card,
     };
 
-    // P1 PrintingRangeScan — PR 1 (docs/issues/local-engine-sorted-range-fastpath.md): a bare,
-    // broad range predicate under unique=printing gets its total from the range index's binary
-    // search and its page from an early-stopping permutation walk, skipping the O(n) count pass the
-    // general path pays. Requires no plane component (else the plane's own predicate must also hold,
-    // which this ignores); everything unrecognized returns None and falls through unchanged.
-    if printing_range_scan_applicable(mode, plane, cards)
-        && let Some(result) =
-            printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
-    {
-        return result;
+    // #702: plan selection is one cost-based routing layer (`run_query_routed`,
+    // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision
+    // tree. `run_query` is the thin string→enum adapter; the core takes enums.
+    run_query_routed(cards, printings, offsets, strings, filter, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes)
+}
+
+/// `cost::PlanFeatures::scan_units` for a query: the rows the per-row residual
+/// scan touches, in the plan's operating space. `Mode::Card` breaks at the first
+/// matching printing (≈ one row per candidate), so it is `eval_domain`;
+/// printing/artwork scan every printing of every candidate, so it is the printing
+/// count under those cards (`n_printings` when unnarrowed). The `Some` branch sums
+/// `offsets` ranges over the candidate cards — O(candidates), a routing-time cost
+/// only paid when a candidate list exists.
+#[allow(dead_code)] // consumed by the cost benches (tests.rs) and future all-mode routing
+fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n_printings: u32, eval_domain: u32) -> u32 {
+    match mode {
+        Mode::Card => eval_domain,
+        Mode::Printing | Mode::Artwork => match candidate_cards {
+            None => n_printings,
+            Some(v) => v
+                .iter()
+                .map(|&cid| u32::from(offsets[cid as usize + 1]) - u32::from(offsets[cid as usize]))
+                .sum(),
+        },
     }
+}
 
-    // P2 PlanePopcountOrder — #634 Step 2: when the filter fully consumed to True (split_planes ate
-    // the whole thing), the plane bitmap IS the exact match set at any selectivity — no candidate
-    // materialization, no card_pass, needed at all. Scoped to unique=card for now (see
-    // run_query_streamed_popcount); other modes/residuals fall through to the existing path below,
-    // which already handles them correctly (Step 1 already removes the redundant card_pass there,
-    // just not the O(candidates) counts-buffer fill).
-    if plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        let plane_expr = plane.expect("PlanePopcountOrder applicability guarantees a plane");
-        return exec_plane_popcount_order(
-            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes,
-        );
+/// Dispatch the two candidate-list executors (P3/P4) on a shared `prep`. Both
+/// phase-2 prep branches funnel their P3/P4 winner through here, so the executor
+/// call site exists once. `PlanePopcountOrder` is handled by its own bitmap
+/// executor and `PrintingRangeScan` never reaches here (non-materializing).
+#[allow(clippy::too_many_arguments)]
+fn exec_from_candidates<'a>(
+    plan: PhysicalPlan,
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    prep: &PreparedCandidates,
+    plane: Option<&PlaneExpr>,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    match plan {
+        PhysicalPlan::StreamedSelect => exec_streamed_select(
+            cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+        ),
+        PhysicalPlan::GatheredScan => exec_gathered_scan(
+            cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+        ),
+        other => unreachable!("exec_from_candidates only runs P3/P4, got {other:?}"),
     }
+}
 
-    // Shared P3/P4 candidate preparation (narrowing, plane-∩-candidates composition, and the
-    // memoize/verify-order filter rewrite). Mutates `filter` exactly as before.
-    let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+/// #702: the single cost-based plan-selection layer for ALL unique modes — the
+/// whole of `run_query`'s dispatch (the hand-tuned decision tree it replaced is
+/// gone). Three linear steps, no early returns:
+///
+/// 1. **acquire** — pick the query's *count source* (one of three, by structure)
+///    and build the cost features, materializing the shared artifact it implies:
+///    a True-residual plane's popcount (`Prep::Plane`), a bare range's index-`k`
+///    (`Prep::Range`, nothing materialized), or `prepare_candidates`
+///    (`Prep::Candidates`). This 3-way is the engine's entire materialization story.
+/// 2. **choose** — `argmin cost::plan_cost` over `ALL.filter(applicable)`. No
+///    hand-written plan list; applicability encodes prep availability, so the right
+///    candidates fall out per acquire branch.
+/// 3. **dispatch** — run the winner, reusing the acquired artifact.
+///
+/// Plan choice is a pure performance decision — every plan returns identical rows
+/// (guaranteed by `force_plan_differential_agreement`). Adding a plan is declaring
+/// its `applicable`/`cost`/`materializing`/executor arms; only a genuinely new
+/// count source (a new `Prep`) touches acquire/dispatch. The one subtlety is
+/// `Prep::Range`: it costs `PrintingRangeScan` (non-materializing) from a cheap
+/// estimate, so if a *materializing* plan wins there — or `PrintingRangeScan` wins
+/// but its fastpath declines — dispatch materializes lazily and re-chooses on exact
+/// features. That deferral is the "don't pay to materialize a plan you won't run".
+#[allow(clippy::too_many_arguments)]
+fn run_query_routed<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &mut FilterExpr,
+    plane: Option<&PlaneExpr>,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let n_cards = cards.len() as u32;
+    let n_printings = printings.len() as u32;
 
-    // P3 StreamedSelect vs P4 GatheredScan. Streamed selection when the orderby has a precomputed
-    // permutation — and the query is broad enough for the match/emit split to pay: a narrowed
-    // candidate list at or below the gather threshold can't produce more matches than that, so the
-    // fused path is already microseconds and the match phase would be pure overhead. `maybe_broad`
-    // is the routing/perf choice (not an applicability condition), so it stays here in `run_query`,
-    // not in the applicability predicate.
-    let maybe_broad = prep.candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
-    if maybe_broad && streamed_select_applicable(cards, sort_col, descending, indexes) {
-        return exec_streamed_select(
-            cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-        );
+    // Generic argmin: the cheapest applicable plan. `filter` is passed per call (not
+    // captured) so it stays free for `prepare_candidates`'s `&mut`. `materializing`
+    // restricts to plans runnable off a materialized prep (the lazy-materialize path
+    // below). GatheredScan is always applicable and materializing → min never empty.
+    let choose = |filter: &FilterExpr, feats: &cost::PlanFeatures, materializing_only: bool| -> PhysicalPlan {
+        PhysicalPlan::ALL
+            .into_iter()
+            .filter(|p| {
+                p.applicable(filter, mode, cards, plane, sort_col, descending, indexes) && (!materializing_only || p.materializing())
+            })
+            .min_by(|a, b| cost::plan_cost(*a, feats).partial_cmp(&cost::plan_cost(*b, feats)).expect("plan_cost is finite"))
+            .expect("GatheredScan is always applicable and materializing")
+    };
+
+    // Cost features: the query-invariant fields filled once; the four that vary by
+    // count source passed in. Collapses each acquire branch's 8-field literal to one call.
+    let mk_feats = |matches: u32, eval_domain: u32, scan_units: u32, residual_tier_ns100: u32| cost::PlanFeatures {
+        n_cards,
+        n_printings,
+        matches,
+        eval_domain,
+        scan_units,
+        residual_tier_ns100,
+        limit: limit as u32,
+        offset: page_offset as u32,
+    };
+    // Features for the general candidate path (shared by the acquire branch and the
+    // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
+    // broad/narrow proxy the P3/P4 crossover keys on. `scan_units` sums printing counts
+    // over the candidate cards (O(candidates) for narrowed printing/artwork — the ~1-2%
+    // overhead in plan_routing_ab), kept EXACT on purpose: an O(1) estimate would trade
+    // the model's honesty for a couple percent on already-fast queries — do not swap it
+    // for `eval_domain·n_printings/n_cards` without re-justifying.
+    let candidate_feats = |prep: &PreparedCandidates, filter: &FilterExpr| -> cost::PlanFeatures {
+        let count = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+        let scan = scan_units(mode, prep.candidate_cards.as_deref(), offsets, n_printings, count);
+        mk_feats(count, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
+    };
+
+    // Scratch for the plane bitmap (`Prep::Plane` only). A fresh `Vec` allocates
+    // just once, on the plane branch's `eval_planes`; non-plane queries leave it
+    // empty (no alloc). Owned locally so the router body stays flat statements —
+    // no thread-local / `.with` closure wrapping the whole function.
+    let mut plane_bits: Vec<u64> = Vec::new();
+
+    // ── acquire: pick the count source, build features, materialize its artifact ──
+    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // The ONE plane eval; its popcount IS the exact count. scan_units == count
+        // (Mode::Card breaks at first match); True residual ⇒ tier 0.
+        eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
+        let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
+        (mk_feats(count, count, count, 0), Prep::Plane)
+    } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
+        // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
+        let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
+        let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
+        (mk_feats(k, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
+    } else {
+        let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+        (candidate_feats(&prep, filter), Prep::Candidates(prep))
+    };
+
+    // ── choose: cheapest applicable plan ──
+    let plan = choose(filter, &feats, false);
+
+    // ── dispatch: run the winner, reusing the acquired artifact ──
+    match (plan, &prep) {
+        (PhysicalPlan::PlanePopcountOrder, Prep::Plane) => exec_plane_popcount_order_with_bitmap(
+            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset,
+            plane.expect("Prep::Plane ⇒ plane"), indexes, &plane_bits,
+        ),
+        // P3/P4 reuse the plane bitmap as their candidate list — identical to what
+        // prepare_candidates yields for a True-residual plane query.
+        (p, Prep::Plane) => exec_from_candidates(
+            p, cards, printings, offsets, strings, filter,
+            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
+            plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+        ),
+        (p, Prep::Candidates(prep)) => exec_from_candidates(
+            p, cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+        ),
+        (plan, Prep::Range) => {
+            // P1 walks if it won and its fastpath accepts. Otherwise (a materializing
+            // plan won the estimate, or P1's fastpath declined — rare, since cost
+            // seldom picks P1 when narrow) materialize now and run the best
+            // materializing plan on EXACT features.
+            let p1_page = (plan == PhysicalPlan::PrintingRangeScan)
+                .then(|| printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset))
+                .flatten();
+            match p1_page {
+                Some(page) => page,
+                None => {
+                    let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+                    let feats = candidate_feats(&prep, filter);
+                    let plan = choose(filter, &feats, true);
+                    exec_from_candidates(plan, cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes)
+                }
+            }
+        }
     }
-
-    exec_gathered_scan(
-        cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-    )
 }
 
 /// In-process force/dispatch entry point (#702 step 2): run `plan` for this

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4157,10 +4157,11 @@ enum Prep {
     /// Bare printing range: features come from the range index's exact `k` (a
     /// binary search, no scan). Nothing is materialized — `PrintingRangeScan`
     /// walks; a materializing winner materializes for itself in dispatch. `Plane`
-    /// carries no bitmap because it lives in the caller's reused thread-local
-    /// (`ROUTED_PLANE_BITMAP`), which dispatch reads directly.
+    /// carries no bitmap here because `run_query_routed` owns it locally
+    /// (`plane_bits: Vec<u64>`), passed by reference into dispatch.
     Range,
-    /// True-residual plane (card): the exact match bitmap (in the thread-local).
+    /// True-residual plane (card): the exact match bitmap, owned by
+    /// `run_query_routed`'s local `plane_bits` and passed by reference.
     /// `PlanePopcountOrder` reads it directly; P3/P4 read it as a candidate list.
     Plane,
     /// The general residual path: a materialized candidate list.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3438,6 +3438,70 @@ fn select_page(mut v: Vec<Match>, offset: usize, limit: usize) -> Vec<(u32, u32)
     v.into_iter().map(|(_, c, p)| (c, p)).collect()
 }
 
+/// Streaming, memory-bounded page selector for the gather path. A producer appends a
+/// card's matches (in any order) into `buf()`, then calls `absorb()`: it counts the
+/// batch, drops matches that can't reach the page (`>= cutoff`), and once the buffer
+/// grows a `GATHER_PRUNE_CHUNK` past the page size `k` prunes it back to the `k`
+/// smallest, tightening `cutoff` (the k-th smallest, monotone non-increasing) so
+/// later out-of-page matches are rejected as produced. `finish()` returns the exact
+/// total and the page.
+///
+/// Equivalent — identical total, identical page — to pushing every match and calling
+/// `select_page` once, but the buffer stays ~`k` instead of O(matches). A gather that
+/// never reaches `prune_at` is byte-for-byte that un-pruned path. Verified against the
+/// naive reference in `gather_select_matches_reference` (adversarial orderings, forced
+/// multi-prune) and end-to-end by `fuzz_row_identity_matches_reference`.
+struct GatherSelect {
+    /// The `k` smallest matches seen so far (or every match, before the first prune).
+    best: Vec<Match>,
+    /// Exact count of every match absorbed (pre-drop) — the page-independent total.
+    total: usize,
+    /// The k-th smallest match seen so far; every kept match is `< cutoff`. `None`
+    /// until the first prune.
+    cutoff: Option<Match>,
+    /// Page size (`offset + limit`): the count of smallest matches worth keeping.
+    k: usize,
+    /// Buffer length that triggers a prune (`k + GATHER_PRUNE_CHUNK`).
+    prune_at: usize,
+}
+
+impl GatherSelect {
+    fn new(offset: usize, limit: usize) -> Self {
+        let k = offset.saturating_add(limit);
+        Self { best: Vec::new(), total: 0, cutoff: None, k, prune_at: k.saturating_add(GATHER_PRUNE_CHUNK) }
+    }
+
+    /// The buffer a producer appends a card's matches into directly (no scratch).
+    fn buf(&mut self) -> &mut Vec<Match> {
+        &mut self.best
+    }
+
+    /// Absorb the batch appended to `buf()` since it had length `before`: count it,
+    /// drop the tail's matches `>= cutoff` (compacting in place), then prune to `k`
+    /// and tighten `cutoff` if the buffer has grown past `prune_at`.
+    fn absorb(&mut self, before: usize) {
+        self.total += self.best.len() - before;
+        if let Some(c) = self.cutoff {
+            let mut w = before;
+            for r in before..self.best.len() {
+                if page_cmp(&self.best[r], &c) == std::cmp::Ordering::Less {
+                    self.best[w] = self.best[r];
+                    w += 1;
+                }
+            }
+            self.best.truncate(w);
+        }
+        if self.best.len() >= self.prune_at {
+            self.cutoff = prune_to_smallest(&mut self.best, self.k);
+        }
+    }
+
+    /// The exact total absorbed and the page `[offset, offset+limit)`.
+    fn finish(self, offset: usize, limit: usize) -> (usize, Vec<(u32, u32)>) {
+        (self.total, select_page(self.best, offset, limit))
+    }
+}
+
 // ─── Query driver ─────────────────────────────────────────────────────────────
 // One structural walk replaces the pre-split linear/hashmap dedup paths and the
 // preferred-printing fast path: grouping is the store's shape, not something to
@@ -4403,21 +4467,11 @@ fn exec_gathered_scan<'a>(
         None    => Box::new(0..cards.len() as u32),
     };
 
-    // Gathered path (printing-keyed orderbys, or stores without permutations).
-    // Push matches directly into `best` — the fast, un-pruned path a gather that
-    // stays small never leaves. Once `best` first grows a CHUNK past the page size,
-    // prune it to the page's `k` smallest and take a `cutoff` (the k-th smallest);
-    // thereafter any match `>= cutoff` can't reach the page, so we drop it right
-    // after it's produced (compacting each card's tail in place). The cutoff only
-    // tightens, so the buffer stays ~`k` for the rest of the scan — the win on
-    // whole-corpus results, where the un-pruned buffer is large and cache-hostile,
-    // without changing the result. `total` counts every match (pre-drop), since
-    // dropped/pruned matches are still results, just not on this page.
-    let k = page_offset.saturating_add(limit);
-    let prune_at = k.saturating_add(GATHER_PRUNE_CHUNK);
-    let mut best: Vec<Match> = Vec::new();
-    let mut total = 0usize;
-    let mut cutoff: Option<Match> = None;
+    // Gathered path (printing-keyed orderbys, or stores without permutations): push
+    // each card's matches directly into the selector, which keeps its buffer bounded
+    // at ~k via prune + running cutoff (see GatherSelect) rather than gathering every
+    // match. `total` counts every match; the page is the k smallest.
+    let mut sel = GatherSelect::new(page_offset, limit);
     // artwork-mode scratch, reused per card (#629: group-id-indexed, not illustration_id-keyed)
     let mut group_best: Vec<Option<(u32, f64)>> = Vec::new();
     let mut touched: Vec<u16> = Vec::new();
@@ -4438,32 +4492,16 @@ fn exec_gathered_scan<'a>(
             };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
-        let before = best.len();
+        let before = sel.buf().len();
         push_card_matches(
             card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
-            sort_col, descending, strings, existential_plane, &mut best, &mut group_best, &mut touched,
+            sort_col, descending, strings, existential_plane, sel.buf(), &mut group_best, &mut touched,
         );
-        total += best.len() - before;
-        // Once a cutoff exists, drop this card's matches that can't reach the page
-        // (>= cutoff) — compact the just-appended tail in place so the buffer stays ~k.
-        if let Some(c) = cutoff {
-            let mut w = before;
-            for r in before..best.len() {
-                if page_cmp(&best[r], &c) == std::cmp::Ordering::Less {
-                    best[w] = best[r];
-                    w += 1;
-                }
-            }
-            best.truncate(w);
-        }
-        if best.len() >= prune_at {
-            cutoff = prune_to_smallest(&mut best, k);
-        }
+        sel.absorb(before);
     }
 
-    // `best` now holds the true k smallest (pruned) or every match (never pruned);
-    // either way it contains the page. `total` is the exact count.
-    let page = select_page(best, page_offset, limit)
+    let (total, page_ids) = sel.finish(page_offset, limit);
+    let page = page_ids
         .into_iter()
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
         .collect();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3384,6 +3384,38 @@ fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descendin
 /// pre-split pointer comparison produced.
 type Match = (u128, u32, u32);
 
+/// The page comparator (`select_page`'s order): sort key, then pid. pid is unique,
+/// so this is a total order over `Match`.
+fn page_cmp(a: &Match, b: &Match) -> std::cmp::Ordering {
+    a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2))
+}
+
+/// Number of matches the gather buffer may grow *past* the page (`offset+limit`)
+/// before it is pruned back down (see `exec_gathered_scan`). Bounds the buffer at
+/// ~`page + CHUNK` ≈ 128KB of `Match` (32 B each — `u128`'s 16-byte alignment pads
+/// the trailing two `u32`s) — L2-resident — on whole-corpus results, while leaving
+/// any gather that never reaches this size byte-for-byte the un-pruned path.
+/// Amortized O(1)/match (a prune every CHUNK matches costs O(page+CHUNK)).
+const GATHER_PRUNE_CHUNK: usize = 4096;
+
+/// Discard all but the `k` smallest matches (by `page_cmp`) in place, and return a
+/// **cutoff**: the `(k+1)`-th smallest, i.e. a value every kept match is `<`. Those
+/// dropped are `>=` the cutoff, so they can never enter a page of size `<= k` —
+/// pruning preserves the true k-smallest of everything seen so far. The cutoff lets
+/// the caller reject later matches `>= cutoff` before they bloat the buffer; it only
+/// tightens across prunes (the k-th smallest is monotone non-increasing). Returns
+/// `None` when there was nothing to prune (`len <= k`), i.e. no cutoff yet exists.
+fn prune_to_smallest(v: &mut Vec<Match>, k: usize) -> Option<Match> {
+    if v.len() > k {
+        v.select_nth_unstable_by(k, page_cmp);
+        let cutoff = v[k];
+        v.truncate(k);
+        Some(cutoff)
+    } else {
+        None
+    }
+}
+
 /// Quickselect the page `[offset, offset+limit)` into position and sort only that
 /// segment. The first select bounds the page from above (everything past it stays
 /// unsorted); the second bounds it from below and is skipped in the common
@@ -4372,7 +4404,20 @@ fn exec_gathered_scan<'a>(
     };
 
     // Gathered path (printing-keyed orderbys, or stores without permutations).
+    // Push matches directly into `best` — the fast, un-pruned path a gather that
+    // stays small never leaves. Once `best` first grows a CHUNK past the page size,
+    // prune it to the page's `k` smallest and take a `cutoff` (the k-th smallest);
+    // thereafter any match `>= cutoff` can't reach the page, so we drop it right
+    // after it's produced (compacting each card's tail in place). The cutoff only
+    // tightens, so the buffer stays ~`k` for the rest of the scan — the win on
+    // whole-corpus results, where the un-pruned buffer is large and cache-hostile,
+    // without changing the result. `total` counts every match (pre-drop), since
+    // dropped/pruned matches are still results, just not on this page.
+    let k = page_offset.saturating_add(limit);
+    let prune_at = k.saturating_add(GATHER_PRUNE_CHUNK);
     let mut best: Vec<Match> = Vec::new();
+    let mut total = 0usize;
+    let mut cutoff: Option<Match> = None;
     // artwork-mode scratch, reused per card (#629: group-id-indexed, not illustration_id-keyed)
     let mut group_best: Vec<Option<(u32, f64)>> = Vec::new();
     let mut touched: Vec<u16> = Vec::new();
@@ -4393,13 +4438,31 @@ fn exec_gathered_scan<'a>(
             };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
+        let before = best.len();
         push_card_matches(
             card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
             sort_col, descending, strings, existential_plane, &mut best, &mut group_best, &mut touched,
         );
+        total += best.len() - before;
+        // Once a cutoff exists, drop this card's matches that can't reach the page
+        // (>= cutoff) — compact the just-appended tail in place so the buffer stays ~k.
+        if let Some(c) = cutoff {
+            let mut w = before;
+            for r in before..best.len() {
+                if page_cmp(&best[r], &c) == std::cmp::Ordering::Less {
+                    best[w] = best[r];
+                    w += 1;
+                }
+            }
+            best.truncate(w);
+        }
+        if best.len() >= prune_at {
+            cutoff = prune_to_smallest(&mut best, k);
+        }
     }
 
-    let total = best.len();
+    // `best` now holds the true k smallest (pruned) or every match (never pruned);
+    // either way it contains the page. `total` is the exact count.
     let page = select_page(best, page_offset, limit)
         .into_iter()
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -8,7 +8,7 @@ use super::{
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
-    prepare_candidates, verify_cost_tier, Mode,
+    prepare_candidates, verify_cost_tier, scan_units, Mode,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
@@ -2822,6 +2822,31 @@ fn calibration_queries() -> Vec<(&'static str, FuzzSpec)> {
     ]
 }
 
+/// A large, diverse calibration corpus generated via the #677 fuzzer — for the
+/// cost-model FIT/validation benches, where 22 hand-picked queries were too few
+/// and too collinear (`scan_units`/`matches`/`page_span` all rose together) to
+/// identify the per-plan constants. Random `fuzz_gen` spans predicate types,
+/// selectivities, and compounds (plane∧expensive-residual shapes decouple scan
+/// from match count), deduped by description. NOT used by the fast correctness
+/// test (`cost_route_matches_legacy` keeps the small hand set).
+fn generate_calibration_corpus(n: usize, seed: u64) -> Vec<(String, FuzzSpec)> {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(n);
+    let mut guard = 0usize;
+    while out.len() < n && guard < n * 50 {
+        guard += 1;
+        let depth = rng.random_range(1..=3u8);
+        let spec = fuzz_gen(&mut rng, depth);
+        let desc = fuzz_describe(&spec);
+        if seen.insert(desc.clone()) {
+            out.push((desc, spec));
+        }
+    }
+    out
+}
+
 /// #702 step 3 (cost calibration): time each *applicable* physical plan on the
 /// REAL corpus archive, across a spread of query selectivities × unique modes ×
 /// page depths, so the per-plan cost formulas can be fit to measured runtime and
@@ -2952,12 +2977,17 @@ fn plan_cost_model_matches_gold() {
     use std::time::Instant;
     use super::cost::{PlanFeatures, plan_cost};
     const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
-    const WARMUP: usize = 5;
-    const ITERS: usize = 60;
+    const WARMUP: usize = 10;
+    const ITERS: usize = 150;
     // Near-tie band: a model pick measuring within this factor of gold is
     // indifferent (a pass); above REAL_MISS it is a genuine misroute.
     const TIE: f64 = 1.15;
     const REAL_MISS: f64 = 1.30;
+    // Fidelity floor: below this measured ns, a plan's runtime is dominated by
+    // timing jitter (a 200ns query ±50ns reads as 1.25× off with a PERFECT model),
+    // so fit error and noise are inseparable. Reporting fidelity split at this
+    // floor isolates the model error we can actually reduce by re-fitting.
+    const FIDELITY_FLOOR_NS: u64 = 2_000;
 
     let Ok(file) = std::fs::File::open(STORE_PATH) else {
         eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs to build it)");
@@ -2990,6 +3020,13 @@ fn plan_cost_model_matches_gold() {
     );
 
     let (mut n_match, mut n_tie, mut n_miss) = (0usize, 0usize, 0usize);
+    // Per-mode ABSOLUTE fidelity of plan_cost vs measured ns: geomean of
+    // |ln(model/measured)| over every applicable plan measurement, plus the count
+    // beyond 2×. Routing only needs ordering, but a model whose numbers *mean*
+    // something is the maintainability goal — this quantifies how far off it is.
+    // Indexed [mode 0=card 1=printing][bucket 0=fast(<floor) 1=slow(≥floor)] so the
+    // re-fittable model error (slow) is separated from irreducible jitter (fast).
+    let (mut fid_ln, mut fid_n, mut fid_2x) = ([[0.0f64; 2]; 2], [[0usize; 2]; 2], [[0usize; 2]; 2]);
 
     for (qlabel, spec) in &queries {
         for &mode in &modes {
@@ -3040,6 +3077,7 @@ fn plan_cost_model_matches_gold() {
                     n_cards, n_printings,
                     matches: total as u32,
                     eval_domain,
+                    scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
@@ -3051,6 +3089,19 @@ fn plan_cost_model_matches_gold() {
                     .filter(|&i| ns[i].is_some())
                     .map(|i| (plan_cost(all_plans[i], &feats), i))
                     .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+
+                // Absolute fidelity: model cost vs measured, per applicable plan,
+                // bucketed fast/slow at FIDELITY_FLOOR_NS.
+                let mode_ix = if unique_is_card { 0 } else { 1 };
+                for i in 0..4 {
+                    if let Some(meas) = ns[i] {
+                        let r = plan_cost(all_plans[i], &feats) / meas as f64;
+                        let b = (meas >= FIDELITY_FLOOR_NS) as usize;
+                        fid_ln[mode_ix][b] += r.ln().abs();
+                        fid_n[mode_ix][b] += 1;
+                        if !(0.5..=2.0).contains(&r) { fid_2x[mode_ix][b] += 1; }
+                    }
+                }
 
                 let (Some((gold_ns, gi)), Some((_, mi))) = (gold, model) else { continue };
                 let model_ns = ns[mi].unwrap();
@@ -3079,6 +3130,591 @@ fn plan_cost_model_matches_gold() {
         "\nagreement: {n_match} gold-match, {n_tie} near-tie(pass), {n_miss} real-miss  of {n_total}  ({:.1}% pass)",
         100.0 * (n_match + n_tie) as f64 / n_total as f64,
     );
+    let geo = |m: usize, b: usize| (fid_ln[m][b] / fid_n[m][b].max(1) as f64).exp();
+    println!("\ncost-model fidelity (geomean |model/measured|, want ~1.0), split at {FIDELITY_FLOOR_NS}ns:");
+    for (m, name) in [(0, "card"), (1, "printing")] {
+        println!(
+            "  {name:<9} slow(≥floor, re-fittable) {:.2}× ({}/{} beyond 2×)   fast(<floor, jitter) {:.2}× ({}/{} beyond 2×)",
+            geo(m, 1), fid_2x[m][1], fid_n[m][1], geo(m, 0), fid_2x[m][0], fid_n[m][0],
+        );
+    }
+    println!("(slow-bucket geomean is the real model error; fast-bucket is dominated by sub-µs timing floor, not re-fittable)");
+}
+
+/// Solve `A c = b` (A is n×n, row-major) by Gaussian elimination with partial
+/// pivoting. `None` if singular (rank-deficient — collinear features). Small n.
+fn solve_normal_eqs(mut a: Vec<Vec<f64>>, mut b: Vec<f64>) -> Option<Vec<f64>> {
+    let n = b.len();
+    for col in 0..n {
+        let piv = (col..n).max_by(|&r1, &r2| a[r1][col].abs().partial_cmp(&a[r2][col].abs()).unwrap())?;
+        if a[piv][col].abs() < 1e-9 {
+            return None;
+        }
+        a.swap(col, piv);
+        b.swap(col, piv);
+        for r in 0..n {
+            if r == col {
+                continue;
+            }
+            let f = a[r][col] / a[col][col];
+            for c in col..n {
+                a[r][c] -= f * a[col][c];
+            }
+            b[r] -= f * b[col];
+        }
+    }
+    Some((0..n).map(|i| b[i] / a[i][i]).collect())
+}
+
+/// The cost formula's terms for `plan`, as `(free-param term vector, known offset)`
+/// — EXACTLY mirroring `cost::plan_cost` so a weighted least-squares fit of the
+/// term vector yields drop-in constants. Free params per plan (order = printed
+/// labels in `plan_cost_refit`):
+///   P1 [STEP, FIXED]; P2 [SCATTER, WORD, EMIT, FIXED];
+///   P3 [CARD_PASS, SCAN, EMIT, FLOOR/card, FIXED]; P4 [CARD_PASS, SCAN, PUSH, SELECT, FIXED].
+/// The verify `tier` rides `scan_units` with a fixed coefficient (1), so it is a
+/// known offset, not a fitted param.
+fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f64) {
+    let n_cards = f64::from(f.n_cards);
+    let matches = f64::from(f.matches);
+    let eval_domain = f64::from(f.eval_domain);
+    let scan_units = f64::from(f.scan_units);
+    let tier_ns = f64::from(f.residual_tier_ns100) / 100.0;
+    let limit = f64::from(f.limit);
+    let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
+    let match_rate = (matches / f64::from(f.n_printings)).max(1.0e-6);
+    match plan {
+        PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
+        PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
+        PhysicalPlan::StreamedSelect => {
+            let floor = if u64::from(f.matches) <= *STREAM_MIN_MATCHES as u64 { n_cards } else { 0.0 };
+            (vec![eval_domain, scan_units, matches, floor, 1.0], scan_units * tier_ns)
+        }
+        PhysicalPlan::GatheredScan => (vec![eval_domain, scan_units, matches, page_span, 1.0], scan_units * tier_ns),
+    }
+}
+
+/// #702 (cost-model re-fit): the formulas are LINEAR in their constants, so fit
+/// them by weighted least squares (weight 1/measured² → minimizes *relative*
+/// error, what a ratio-based model wants) on the slow bucket (≥ floor, where model
+/// error is separable from timing jitter), across card+printing jointly (so the
+/// card_pass/scan split is identifiable — collinear within card alone). Prints the
+/// fitted constants + before/after slow-bucket fidelity so a human can adopt them
+/// into cost.rs with provenance. Reporting tool, not an assertion.
+///
+///     cargo test --release plan_cost_refit -- --ignored --nocapture
+///
+/// Same corpus/timing discipline as `plan_cost_model_matches_gold`; needs real.store.
+#[test]
+#[ignore = "cost-model re-fit; needs real.store; cargo test --release plan_cost_refit -- --ignored --nocapture"]
+fn plan_cost_refit() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    use super::cost::PlanFeatures;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const FLOOR_NS: u64 = 2_000; // fit only where model error > timing jitter
+    // Env-tunable (defaults sized for ~5-10 min of CPU on the real corpus). More
+    // queries beats more iters for identifiability: the fit averages timing noise
+    // across queries, so a big corpus with modest iters de-correlates features
+    // better than a small corpus hammered many times.
+    let corpus_n: usize = std::env::var("REFIT_CORPUS_N").ok().and_then(|s| s.parse().ok()).unwrap_or(1200);
+    let iters: usize = std::env::var("REFIT_ITERS").ok().and_then(|s| s.parse().ok()).unwrap_or(30);
+    let seed: u64 = std::env::var("REFIT_SEED").ok().and_then(|s| s.parse().ok()).unwrap_or(0xC057);
+    const WARMUP: usize = 5;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs to build it)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild, see bench_verify_cost.rs)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len() as u32;
+    let n_printings = archived.printings.len() as u32;
+
+    let queries = generate_calibration_corpus(corpus_n, seed);
+    eprintln!(
+        "real.store: {n_cards} cards, {n_printings} printings | corpus {} queries × 2 modes × 2 pages, {iters} iters, fit slow(≥{FLOOR_NS}ns)\n",
+        queries.len(),
+    );
+    let modes = ["card", "printing"];
+    let pages = [("shallow", 60usize, 0usize), ("deep", 60usize, 10_000usize)];
+    let all_plans = [PhysicalPlan::PrintingRangeScan, PhysicalPlan::PlanePopcountOrder, PhysicalPlan::StreamedSelect, PhysicalPlan::GatheredScan];
+    let plan_labels = ["P1-range", "P2-popcnt", "P3-stream", "P4-gather"];
+    let param_labels: [&[&str]; 4] = [
+        &["STEP", "FIXED"],
+        &["SCATTER", "WORD", "EMIT", "FIXED"],
+        &["CARD_PASS", "SCAN", "EMIT", "FLOOR/card", "FIXED"],
+        &["CARD_PASS", "SCAN", "PUSH", "SELECT", "FIXED"],
+    ];
+    // Per-plan fit rows: (terms, y_minus_offset, y, is_train). 70/30 train/test by
+    // query index so held-out fidelity reveals overfitting (the 22-query trap).
+    let mut rows: [Vec<(Vec<f64>, f64, f64, bool)>; 4] = Default::default();
+    let t_start = Instant::now();
+
+    for (qi, (_qlabel, spec)) in queries.iter().enumerate() {
+        let is_train = qi % 10 < 7;
+        for &mode in &modes {
+            let unique_is_card = mode == "card";
+            let mode_enum = if unique_is_card { Mode::Card } else { Mode::Printing };
+            for &(_plabel, limit, offset) in &pages {
+                let mut ns = [None::<u64>; 4];
+                let mut total = 0usize;
+                for (pi, plan) in all_plans.iter().enumerate() {
+                    let mut best = u64::MAX;
+                    let mut applicable = false;
+                    for it in 0..(WARMUP + iters) {
+                        let (pe, mut res) = split_planes(
+                            fuzz_bound_filter(spec, archived), &archived.indexes.planes,
+                            &archived.indexes.oracle_trigram.words, unique_is_card,
+                        );
+                        let t0 = Instant::now();
+                        let out = black_box(run_query_with_plan(
+                            *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                            &mut res, pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                        ));
+                        let dt = t0.elapsed().as_nanos() as u64;
+                        match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { best = best.min(dt); } } None => break }
+                    }
+                    if applicable { ns[pi] = Some(best); }
+                }
+
+                let (pe, mut res) = split_planes(
+                    fuzz_bound_filter(spec, archived), &archived.indexes.planes,
+                    &archived.indexes.oracle_trigram.words, unique_is_card,
+                );
+                let prep = prepare_candidates(&archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), mode_enum, &archived.indexes);
+                let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+                let feats = PlanFeatures {
+                    n_cards, n_printings, matches: total as u32, eval_domain,
+                    scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
+                    residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
+                    limit: limit as u32, offset: offset as u32,
+                };
+                for (pi, plan) in all_plans.iter().enumerate() {
+                    if let Some(meas) = ns[pi] {
+                        if meas < FLOOR_NS { continue; }
+                        let (terms, offset_ns) = cost_terms(*plan, &feats);
+                        rows[pi].push((terms, meas as f64 - offset_ns, meas as f64, is_train));
+                    }
+                }
+            }
+        }
+        if qi % 100 == 99 {
+            eprintln!("  measured {}/{} queries ({:.0}s elapsed)", qi + 1, queries.len(), t_start.elapsed().as_secs_f64());
+        }
+    }
+
+    eprintln!("\nmeasurement done in {:.0}s\n", t_start.elapsed().as_secs_f64());
+    // Geomean |ln(model/measured)| over a row subset for a given constant vector.
+    let fidelity = |plan_rows: &[(Vec<f64>, f64, f64, bool)], fit: &[f64], train: bool| -> (f64, usize) {
+        let mut ln = 0.0;
+        let mut n = 0usize;
+        for (terms, y_adj, y, is_train) in plan_rows {
+            if *is_train != train { continue; }
+            let fitted = terms.iter().zip(fit).map(|(t, c)| t * c).sum::<f64>() + (y - y_adj);
+            ln += (fitted / y).ln().abs();
+            n += 1;
+        }
+        (if n > 0 { (ln / n as f64).exp() } else { f64::NAN }, n)
+    };
+
+    // Per plan: weighted normal equations (w = 1/y²) on TRAIN rows; report fitted
+    // constants + train AND held-out-test fidelity (test ≈ train ⇒ genuine fit).
+    for (pi, plan_rows) in rows.iter().enumerate() {
+        let p = param_labels[pi].len();
+        let n_train = plan_rows.iter().filter(|r| r.3).count();
+        if n_train < p * 3 {
+            println!("{:<10}: only {n_train} train rows for {p} params — skip\n", plan_labels[pi]);
+            continue;
+        }
+        let mut a = vec![vec![0.0f64; p]; p];
+        let mut b = vec![0.0f64; p];
+        for (terms, y_adj, y, is_train) in plan_rows {
+            if !is_train { continue; }
+            let w = 1.0 / (y * y);
+            for i in 0..p {
+                for j in 0..p { a[i][j] += w * terms[i] * terms[j]; }
+                b[i] += w * terms[i] * y_adj;
+            }
+        }
+        let Some(fit) = solve_normal_eqs(a, b) else {
+            println!("{:<10}: normal equations singular (collinear) — keep current\n", plan_labels[pi]);
+            continue;
+        };
+        let (train_fid, ntr) = fidelity(plan_rows, &fit, true);
+        let (test_fid, nte) = fidelity(plan_rows, &fit, false);
+        let neg = fit.iter().any(|&c| c < 0.0);
+        println!(
+            "{:<10}  fit on {ntr} train rows{}:",
+            plan_labels[pi],
+            if neg { "  [!] has NEGATIVE (unphysical) constants — overfit/collinear" } else { "" },
+        );
+        for (lbl, c) in param_labels[pi].iter().zip(&fit) {
+            println!("    {lbl:<11} = {c:>10.3}");
+        }
+        println!("    fidelity: train {train_fid:.2}× ({ntr} rows)   TEST(held-out) {test_fid:.2}× ({nte} rows)\n");
+    }
+    println!("(adopt only constants that are NON-NEGATIVE and whose TEST fidelity ≈ train and beats the current ~1.4×; then re-run plan_cost_model_matches_gold + plan_routing_ab to validate)");
+}
+
+/// #702 (printing-mode routing probe): does cost-based routing beat the LEGACY
+/// TREE on `unique=printing` bare-range queries? Card-mode routing only tied the
+/// tree (`plan_routing_ab`), so before building printing routing we test the
+/// hypothesis that the tree's P1 gate — `range_too_broad_to_narrow`, a fixed
+/// `k/index_len > 0.25` ratio that IGNORES page depth and sort alignment — misroutes
+/// where the true P1-vs-P4 crossover moves. P1's misaligned walk costs
+/// `(offset+limit)/match_rate`, so a *moderately*-broad range at a *deep* page is
+/// where a depth-blind ratio should mispredict.
+///
+/// For each range query × page depth (printing mode, edhrec sort = MISALIGNED, the
+/// case the walk pays for), measure P1/P3/P4 (min-of-N), then compare two pickers
+/// against empirical gold:
+///   - TREE: what `run_query` dispatches — P1 iff the fastpath fired
+///     (`run_query_with_plan(P1)` is `Some`), else P3/P4 via the `maybe_broad` gate.
+///   - MODEL: `argmin cost::plan_cost` on the TRUE features (matches = measured
+///     printing total; for a range query this is the index's exact `k`, so there is
+///     no estimation error to muddy the plan-choice question).
+/// Reports per-row regret (picked_ns/gold_ns) and geomean regret for each. A model
+/// geomean below the tree's — with the gap on deep+moderate rows — is the win that
+/// justifies printing routing; parity means printing ties too (report, don't build).
+///
+///     cargo test --release printing_range_route_probe -- --ignored --nocapture
+///
+/// Same corpus/timing discipline as `plan_cost_model_matches_gold`; needs real.store.
+#[test]
+#[ignore = "printing-route probe; needs real.store; cargo test --release printing_range_route_probe -- --ignored --nocapture"]
+fn printing_range_route_probe() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    use super::cost::{PlanFeatures, plan_cost};
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 5;
+    const ITERS: usize = 60;
+    const LIMIT: usize = 60;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs to build it)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild, see bench_verify_cost.rs)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len() as u32;
+    let n_printings = archived.printings.len() as u32;
+    eprintln!("real.store: {n_cards} cards, {n_printings} printings (printing mode, edhrec sort = misaligned)\n");
+
+    // Bare price/year ranges spanning the broad/narrow margin; `total` reveals each
+    // one's true match_rate (of the priced/dated index) at run time.
+    let price = |op, val: f64| FuzzSpec::Leaf(FuzzLeaf::Price { op, val });
+    let year  = |op, y: i32|   FuzzSpec::Leaf(FuzzLeaf::Year { op, year: y });
+    let queries: Vec<(&str, FuzzSpec)> = vec![
+        ("usd<0.25", price(CmpOp::Lt, 0.25)),
+        ("usd<0.5",  price(CmpOp::Lt, 0.5)),
+        ("usd<1",    price(CmpOp::Lt, 1.0)),
+        ("usd<2",    price(CmpOp::Lt, 2.0)),
+        ("usd<5",    price(CmpOp::Lt, 5.0)),
+        ("usd<20",   price(CmpOp::Lt, 20.0)),
+        ("usd>=1",   price(CmpOp::Ge, 1.0)),
+        ("usd>=5",   price(CmpOp::Ge, 5.0)),
+        ("year>=2020", year(CmpOp::Ge, 2020)),
+        ("year>=2010", year(CmpOp::Ge, 2010)),
+        ("year>=2000", year(CmpOp::Ge, 2000)),
+    ];
+    // Shallow → progressively deeper: the depth axis the tree's ratio ignores.
+    let offsets = [0usize, 1_000, 5_000, 10_000, 20_000];
+    let all_plans = [PhysicalPlan::PrintingRangeScan, PhysicalPlan::PlanePopcountOrder, PhysicalPlan::StreamedSelect, PhysicalPlan::GatheredScan];
+    let labels = ["P1", "P2", "P3", "P4"];
+    let sort_col = orderby_to_col("edhrec");
+    let descending = false;
+
+    println!(
+        "{:<12} {:>7} {:>7}  {:>4} {:>9} {:>7}  {:>4} {:>9} {:>7}",
+        "query", "total", "offset", "gold", "gold_ns", "", "tree", "tree_ns", "t/g", // header spacing
+    );
+    println!(
+        "{:<12} {:>7} {:>7}  {:>4} {:>9} {:>7}  {:>4} {:>9} {:>7}",
+        "", "", "", "", "", "", "model", "model_ns", "m/g",
+    );
+
+    // geomean accumulators (sum of ln regret) over scored rows.
+    let (mut tree_ln, mut model_ln, mut n_scored, mut n_model_wins) = (0.0f64, 0.0f64, 0usize, 0usize);
+
+    for (qlabel, spec) in &queries {
+        for &offset in &offsets {
+            // ── Measure each applicable plan (min-of-N) ──
+            let mut ns = [None::<u64>; 4];
+            let mut total = 0usize;
+            for (pi, plan) in all_plans.iter().enumerate() {
+                let mut best = u64::MAX;
+                let mut applicable = false;
+                for it in 0..(WARMUP + ITERS) {
+                    let (pe, mut res) = split_planes(
+                        fuzz_bound_filter(spec, archived), &archived.indexes.planes,
+                        &archived.indexes.oracle_trigram.words, false, // unique_is_card=false (printing)
+                    );
+                    let t0 = Instant::now();
+                    let out = black_box(run_query_with_plan(
+                        *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                        &mut res, pe.as_ref(), "printing", "default", "edhrec", "asc", LIMIT, offset, &archived.indexes,
+                    ));
+                    let dt = t0.elapsed().as_nanos() as u64;
+                    match out {
+                        Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { best = best.min(dt); } }
+                        None => break,
+                    }
+                }
+                if applicable { ns[pi] = Some(best); }
+            }
+
+            // Only score rows the page can actually reach — else every plan returns an
+            // empty page early and the comparison is meaningless.
+            if total <= offset + LIMIT { continue; }
+
+            // ── Features (true count = measured printing total = the index's k) ──
+            let (pe, mut res) = split_planes(
+                fuzz_bound_filter(spec, archived), &archived.indexes.planes,
+                &archived.indexes.oracle_trigram.words, false,
+            );
+            let prep = prepare_candidates(&archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), Mode::Printing, &archived.indexes);
+            let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+            let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+            let feats = PlanFeatures {
+                n_cards, n_printings, matches: total as u32, eval_domain,
+                scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
+                residual_tier_ns100,
+                limit: LIMIT as u32, offset: offset as u32,
+            };
+
+            // ── Three pickers ──
+            let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
+            let model = (0..4).filter(|&i| ns[i].is_some())
+                .map(|i| (plan_cost(all_plans[i], &feats), i))
+                .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            // TREE: P1 iff the fastpath fired (force-seam Some), else the P3/P4 maybe_broad gate.
+            let tree_i = if ns[0].is_some() {
+                0
+            } else {
+                let maybe_broad = prep.candidate_cards.as_ref().is_none_or(|v| v.len() > *STREAM_MIN_MATCHES);
+                if maybe_broad && streamed_select_applicable(&archived.cards, sort_col, descending, &archived.indexes) { 2 } else { 3 }
+            };
+
+            let (Some((gold_ns, gi)), Some((_, mi))) = (gold, model) else { continue };
+            let tree_ns = ns[tree_i].expect("tree pick was measured");
+            let model_ns = ns[mi].unwrap();
+            let tree_reg = tree_ns as f64 / gold_ns as f64;
+            let model_reg = model_ns as f64 / gold_ns as f64;
+            tree_ln += tree_reg.ln();
+            model_ln += model_reg.ln();
+            n_scored += 1;
+            if model_ns < tree_ns { n_model_wins += 1; }
+
+            // Per-plan FIDELITY: modeled cost vs measured ns (model_ns/meas_ns).
+            // A faithful cost model has this ~constant across plans (argmin then
+            // reproduces gold); ratios that differ *by plan* are what flip picks.
+            let fid = |i: usize| ns[i].map(|meas| {
+                let mc = plan_cost(all_plans[i], &feats);
+                format!("{}:{:>7}/{:<7}={:.2}", labels[i], meas, mc as u64, mc / meas as f64)
+            }).unwrap_or_default();
+
+            println!(
+                "{:<12} {:>7} {:>7}  gold={:<3} tree={:<3}({:.2}x) model={:<3}({:.2}x)  | {}  {}  {}  {}",
+                qlabel, total, offset,
+                labels[gi], labels[tree_i], tree_reg, labels[mi], model_reg,
+                fid(0), fid(1), fid(2), fid(3),
+            );
+        }
+    }
+
+    let g = |ln: f64| (ln / n_scored.max(1) as f64).exp();
+    println!(
+        "\n{n_scored} scored rows | geomean regret  tree {:.3}x  model {:.3}x  | model strictly faster on {n_model_wins}/{n_scored}",
+        g(tree_ln), g(model_ln),
+    );
+    println!("(model geomean below tree, gap on deep+moderate rows => printing routing is a real win; parity => printing ties too)");
+}
+
+/// Cost-representative idea-2 kernel (see docs/issues/local-engine-sorted-range-fastpath.md):
+/// range binary-search → scatter the `k` matching printings into a printing-space existence
+/// bitmap → popcount-skip to `page_offset` → emit `limit` printings (resolving pid→card, the
+/// representative emit work). This times idea-2's WORK so it can be compared to idea-1's
+/// measured walk WITHOUT first building the deferred #656 printing-space pager — the whole
+/// point of the probe is to decide whether that build is worth funding.
+///
+/// The emitted page is deliberately NOT sort-correct: bits are scattered in pid order, not
+/// sort order. That does not affect the COST being measured — scatter is O(k), the popcount-skip
+/// scans the same number of words to reach the offset-th set bit, and emit touches `limit`
+/// printings — all independent of which bits are set where. A shipping idea-2 would need a
+/// printing permutation to make the page correct (that is #656); its cost is what this measures.
+/// Returns `(k, checksum)` (checksum defeats dead-code elimination of the emit) or `None` when
+/// `filter` is not a bare range.
+fn idea2_printing_cost_kernel(
+    filter: &FilterExpr,
+    archived: &Archived<CardData>,
+    page_offset: usize,
+    limit: usize,
+) -> Option<(usize, u64)> {
+    let (idx, lo, hi) = bare_range_bounds(filter, &archived.indexes)?;
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    let k = e - s;
+    let n_printings = archived.printings.len();
+    thread_local! {
+        static I2_BITS: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+    I2_BITS.with(|cell| {
+        let mut bits = cell.borrow_mut();
+        bits.clear();
+        bits.resize(n_printings.div_ceil(64), 0);
+        // Scatter: O(k), one bit set per matching printing.
+        for t in s..e {
+            let pid = u32::from(idx[t].1);
+            bits[(pid >> 6) as usize] |= 1u64 << (pid & 63);
+        }
+        if k == 0 || page_offset >= k {
+            return Some((k, 0));
+        }
+        // Popcount-skip: accumulate word popcounts to the offset-th set bit — cheap
+        // O(words-to-offset) word ops, vs idea-1's per-card printing rescan.
+        let mut skip = page_offset;
+        let mut wi = 0usize;
+        while wi < bits.len() {
+            let wc = bits[wi].count_ones() as usize;
+            if skip < wc {
+                break;
+            }
+            skip -= wc;
+            wi += 1;
+        }
+        // Emit: walk `limit` set bits from the boundary word, resolving pid→card
+        // (printing_to_card) and touching the printing — representative emit work.
+        let ptc = &archived.indexes.printing_to_card;
+        let mut checksum = 0u64;
+        let mut emitted = 0usize;
+        'walk: while wi < bits.len() {
+            let mut w = bits[wi];
+            while w != 0 {
+                let bit = w.trailing_zeros();
+                w &= w - 1;
+                if skip > 0 {
+                    skip -= 1;
+                    continue;
+                }
+                let pid = (wi as u32) << 6 | bit;
+                let cid = u32::from(ptc[pid as usize]);
+                // The printing_to_card lookup is the emit's dominant per-row cost; fold
+                // cid+pid into a checksum so the walk isn't optimized away.
+                checksum ^= u64::from(cid).wrapping_mul(0x9E3779B9) ^ u64::from(pid);
+                emitted += 1;
+                if emitted == limit {
+                    break 'walk;
+                }
+            }
+            wi += 1;
+        }
+        Some((k, checksum))
+    })
+}
+
+/// #702 (idea-1 vs idea-2 probe): the ONE cell the design doc says the two mechanisms
+/// genuinely compete — `unique=printing`, broad range, unrelated (card-level) order-by —
+/// swept across page depth. idea-1 (P1, built) walks the card permutation at cost
+/// `(offset+limit)/match_rate`; idea-2 (range→printing bitmap→popcount-skip, NOT built —
+/// needs #656) is offset-independent-ish. This measures BOTH (idea-2 via the cost kernel
+/// above, so no #656 build is needed to decide whether #656 is worth building) and reports
+/// the crossover offset per query. A crossover at a realistic depth for realistic match-rates
+/// ⇒ idea-2 is worth building; a crossover only at extreme depth ⇒ leave it deferred.
+///
+///     cargo test --release idea1_vs_idea2_probe -- --ignored --nocapture
+///
+/// Same corpus/timing discipline as the other probes; needs real.store.
+#[test]
+#[ignore = "idea-1 vs idea-2 crossover probe; needs real.store; cargo test --release idea1_vs_idea2_probe -- --ignored --nocapture"]
+fn idea1_vs_idea2_probe() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 5;
+    const ITERS: usize = 60;
+    const LIMIT: usize = 60;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs to build it)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild, see bench_verify_cost.rs)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_printings = archived.printings.len();
+    eprintln!("real.store: {} cards, {n_printings} printings (printing mode, edhrec sort = unrelated order-by)\n", archived.cards.len());
+
+    let price = |op, val: f64| FuzzSpec::Leaf(FuzzLeaf::Price { op, val });
+    let year  = |op, y: i32|   FuzzSpec::Leaf(FuzzLeaf::Year { op, year: y });
+    let queries: Vec<(&str, FuzzSpec)> = vec![
+        ("usd<0.25", price(CmpOp::Lt, 0.25)), ("usd<0.5", price(CmpOp::Lt, 0.5)),
+        ("usd<1", price(CmpOp::Lt, 1.0)), ("usd<2", price(CmpOp::Lt, 2.0)),
+        ("usd<5", price(CmpOp::Lt, 5.0)), ("usd<20", price(CmpOp::Lt, 20.0)),
+        ("usd>=1", price(CmpOp::Ge, 1.0)),
+        ("year>=2020", year(CmpOp::Ge, 2020)), ("year>=2010", year(CmpOp::Ge, 2010)),
+        ("year>=2000", year(CmpOp::Ge, 2000)),
+    ];
+    let offsets = [0usize, 500, 1_000, 2_000, 5_000, 10_000, 20_000];
+
+    println!("{:<12} {:>7} {:>7} {:>6}  {:>9} {:>9} {:>7}", "query", "total", "rate%", "offset", "i1(P1)_ns", "i2_ns", "i1/i2");
+
+    for (qlabel, spec) in &queries {
+        let mut crossover: Option<usize> = None;
+        for &offset in &offsets {
+            // idea-1: force P1 (min-of-N).
+            let mut i1 = u64::MAX;
+            let mut total = 0usize;
+            let mut applicable = false;
+            for it in 0..(WARMUP + ITERS) {
+                let (pe, mut res) = split_planes(fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, false);
+                let t0 = Instant::now();
+                let out = black_box(run_query_with_plan(
+                    PhysicalPlan::PrintingRangeScan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                    &mut res, pe.as_ref(), "printing", "default", "edhrec", "asc", LIMIT, offset, &archived.indexes,
+                ));
+                let dt = t0.elapsed().as_nanos() as u64;
+                match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { i1 = i1.min(dt); } } None => break }
+            }
+            if !applicable || total <= offset + LIMIT { continue; }
+
+            // idea-2: the cost kernel (min-of-N).
+            let mut i2 = u64::MAX;
+            for it in 0..(WARMUP + ITERS) {
+                let (_pe, res) = split_planes(fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, false);
+                let t0 = Instant::now();
+                let out = black_box(idea2_printing_cost_kernel(&res, archived, offset, LIMIT));
+                let dt = t0.elapsed().as_nanos() as u64;
+                if out.is_some() && it >= WARMUP { i2 = i2.min(dt); }
+            }
+
+            let rate = 100.0 * total as f64 / n_printings as f64;
+            let ratio = i1 as f64 / i2 as f64;
+            if ratio > 1.0 && crossover.is_none() { crossover = Some(offset); }
+            println!(
+                "{:<12} {:>7} {:>6.1} {:>6}  {:>9} {:>9} {:.2}x  {}",
+                qlabel, total, rate, offset, i1, i2, ratio,
+                if ratio > 1.0 { "<-- idea-2 faster" } else { "" },
+            );
+        }
+        match crossover {
+            Some(off) => println!("  => {qlabel}: idea-2 wins from offset ~{off}\n"),
+            None => println!("  => {qlabel}: idea-1 wins at every tested depth\n"),
+        }
+    }
+    println!("(crossover at a realistic depth for realistic match-rates => #656 idea-2 is worth building; only-extreme-depth => leave deferred)");
 }
 
 /// #702 step 4 (estimate-regret report): the payoff of the whole plan-selection
@@ -3210,6 +3846,7 @@ fn plan_regret_report() {
                 n_cards, n_printings,
                 matches: est,
                 eval_domain: est.min(n_cards),
+                scan_units: est.min(n_cards), // card-mode regret report ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
@@ -3336,7 +3973,8 @@ fn plan_regret_fuzz() {
 
         for &(limit, offset) in &pages {
             let mk = |matches: u32, evd: u32| PlanFeatures {
-                n_cards, n_printings, matches, eval_domain: evd, residual_tier_ns100: tier,
+                n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
+                residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
             };
             let feats_true = mk(true_total, eval_domain);
@@ -7143,6 +7781,68 @@ fn printing_range_fastpath_gates_card_walk_at_stream_threshold() {
         let (aligned_total, _) = fp(SortCol::PriceUsd).expect("aligned exempt from stream gate");
         assert_eq!(aligned_total, n, "aligned total must equal the true match count at n={n}");
     }
+}
+
+/// #702 router timing: absolute `run_query` (the cost router) latency over the
+/// calibration set × modes × pages, min-of-N, on the real corpus. Used to A/B two
+/// versions of `run_query_routed` against each other (git-stash one, run, restore,
+/// run) since the tree-vs-router bench retired with the tree. Prints per-config ns
+/// and per-mode + grand totals (sum of the min times).
+///
+///     cargo test --release router_timing -- --ignored --nocapture
+#[test]
+#[ignore = "router timing; needs real.store; cargo test --release router_timing -- --ignored --nocapture"]
+fn router_timing() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 5;
+    const ITERS: usize = 50;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let planes = &archived.indexes.planes;
+    let words = &archived.indexes.oracle_trigram.words;
+    let pages = [("shallow", 60usize, 0usize), ("deep", 60usize, 10_000usize)];
+    let modes = ["card", "printing", "artwork"];
+
+    let mut grand: u64 = 0;
+    for &mode in &modes {
+        let uic = mode == "card";
+        let mut mode_total: u64 = 0;
+        for (qlabel, spec) in &calibration_queries() {
+            for &(plabel, limit, offset) in &pages {
+                let mut best = u64::MAX;
+                for it in 0..(WARMUP + ITERS) {
+                    let full = fuzz_bound_filter(spec, archived);
+                    let t0 = Instant::now();
+                    let (_pe, mut res) = split_planes(full, planes, words, uic);
+                    let out = run_query(
+                        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
+                        &mut res, _pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                    );
+                    let dt = t0.elapsed().as_nanos() as u64;
+                    black_box(&out.1);
+                    if it >= WARMUP {
+                        best = best.min(dt);
+                    }
+                }
+                mode_total += best;
+                println!("{qlabel:<22} {mode:>8} {plabel:>7} {best:>10}ns");
+            }
+        }
+        println!("  -> {mode} total: {mode_total}ns\n");
+        grand += mode_total;
+    }
+    println!("GRAND TOTAL (sum of per-config min ns): {grand}");
 }
 
 

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -9,6 +9,7 @@ use super::{
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, Mode,
+    GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
     ArithOp, ArtistIndex, CardData, CardIndexes, Candidates, ColorField, NumExpr, NumField, RarityIndex,
@@ -2537,6 +2538,77 @@ fn fuzz_row_identity_matches_reference() {
         let offset = if rng.random_bool(0.5) { 0 } else { rng.random_range(0..800) };
         let ctx = format!("corpus-rowid, filter={}", fuzz_describe(&spec));
         fuzz_check_row_identity(archived, &spec, &ctx, orderby, direction, mode, 100, offset);
+    }
+}
+
+/// Deterministic pseudo-random / adversarial `Match` keys for `GatherSelect` (pid =
+/// index, so every match is distinct and `page_cmp` is a total order).
+fn build_gather_matches(n: usize, ordering: u32) -> Vec<Match> {
+    (0..n)
+        .map(|i| {
+            let key: u128 = match ordering {
+                // splitmix-style scramble: deterministic, no ordering structure
+                0 => {
+                    let mut x = (i as u128).wrapping_add(0x9E37_79B9_7F4A_7C15);
+                    x ^= x >> 30;
+                    x = x.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+                    x ^= x >> 27;
+                    x
+                }
+                1 => i as u128,           // ascending: after the 1st prune every later match is rejected
+                2 => (n - 1 - i) as u128, // descending: every later match beats the cutoff → prune repeatedly
+                3 => 0,                   // all ties: page_cmp must break by pid
+                _ => (i % 8) as u128,     // clustered / heavy ties
+            };
+            (key, i as u32, i as u32) // (sort_key, cid, pid)
+        })
+        .collect()
+}
+
+/// `GatherSelect` (the bounded gather buffer in `exec_gathered_scan`) must, for any
+/// match sequence in any batching, produce the identical `(total, page)` as gathering
+/// every match and calling `select_page` once — the reference the P4 rewrite rests on.
+/// This drives the prune + running-cutoff algorithm (`prune_to_smallest`, `page_cmp`)
+/// directly on adversarial orderings and sizes forced well past `prune_at` (multiple
+/// prune cycles), so it doesn't depend on a fuzz store happening to exceed the
+/// threshold — and it asserts the buffer actually stays bounded.
+#[test]
+fn gather_select_matches_reference() {
+    for &limit in &[1usize, 10, 60] {
+        for &offset in &[0usize, 5, 50, 500] {
+            let k = offset + limit;
+            let prune_at = k + GATHER_PRUNE_CHUNK;
+            // sizes: empty, exactly the page (no prune), either side of prune_at (one
+            // prune), and well past it (several prune cycles + cutoff tightening).
+            for &n in &[0, k, prune_at - 1, prune_at + 1, 2 * GATHER_PRUNE_CHUNK + k] {
+                for ordering in 0..5 {
+                    let matches = build_gather_matches(n, ordering);
+                    let ref_total = matches.len();
+                    let ref_page = select_page(matches.clone(), offset, limit);
+
+                    // Feed the matches in deterministically-varying batches (mimics the
+                    // per-card pushes), so `absorb` fires at buffer fills unaligned with
+                    // prune_at.
+                    let mut sel = GatherSelect::new(offset, limit);
+                    let (mut i, mut step) = (0usize, 0usize);
+                    while i < matches.len() {
+                        let batch = (1 + step % 7).min(matches.len() - i);
+                        let before = sel.buf().len();
+                        sel.buf().extend_from_slice(&matches[i..i + batch]);
+                        sel.absorb(before);
+                        i += batch;
+                        step += 1;
+                    }
+                    let ctx = format!("n={n} off={offset} lim={limit} ord={ordering}");
+                    // The bounded-memory promise: never more than a chunk past the page.
+                    assert!(sel.best.len() <= prune_at, "buffer unbounded: {ctx}");
+
+                    let (total, page) = sel.finish(offset, limit);
+                    assert_eq!(total, ref_total, "total mismatch: {ctx}");
+                    assert_eq!(page, ref_page, "page mismatch: {ctx}");
+                }
+            }
+        }
     }
 }
 

--- a/docs/issues/00702-engine-plan-selection-layer.md
+++ b/docs/issues/00702-engine-plan-selection-layer.md
@@ -174,12 +174,55 @@ the cost curves are flat and only bites where they diverge steeply.
   Estimate tightness is thus a *derived* requirement, not a goal — the global
   "est == truth %" is the wrong target.
 
+### Is the cost model correct? Card mode yes, printing/artwork no (2026-07-20)
+
+A routing cost model needs correct *ordering* between plans, not accurate
+absolute predictions. The model achieves that **only in card mode** — where its
+constants were fit and where `plan_cost_model_matches_gold` validated the argmin.
+`printing_range_route_probe` exposed that in **printing mode it under-predicts
+P3/P4 by ~3×** (model/measured ≈ 0.3–0.5; P1 fidelity swings 0.1×–2.2×). The
+under-prediction factor is `n_printings/n_cards` (≈3.09): `eval_domain` counts
+CARDS, but a printing-mode P3/P4 visits every card *and scans all its printings*
+(~`n_printings` units) and emits printing rows, neither of which the card-fit
+formula prices. It survived validation only because P1's dominance on the broad
+printing ranges kept the misestimate from flipping the argmin — until the probe's
+deep pages, where it did (2 rows routed off gold-P1).
+
+**Design conclusion — enrich features, don't branch on mode.** The fix is not a
+`mode` argument to `plan_cost` (that hard-codes the mode→work mapping and every
+new plan/mode must be threaded through it). Mode is a *proxy* for two work
+quantities the features should state directly: units *scanned* and units *emitted*,
+each in the plan's operating space. The caller — which knows the mode — populates
+`eval_domain`/emit in that space, and one mode-agnostic formula then prices card,
+printing, and artwork alike (artwork's illustration-groups are just another count).
+An explicit `mode`/executor argument is warranted only if a genuinely different
+code path has a different *per-unit constant*, and even then a work-term is
+cleaner than a categorical switch. This is prerequisite work for a unified
+all-mode router — which, since card and printing both TIE the legacy tree, is a
+structural-unification goal, not a speed one.
+
 ## Scope / sequencing
 
 Everything validated against truth before anything reroutes. The force-plan
 seam (step 2) comes *before* calibration because you can't measure a plan's
 cost without being able to execute that specific plan — making plans
 individually addressable is the prerequisite for the run-all-plans harness.
+
+The target these steps converge on — the single router, in pseudocode — is
+[local-engine-unified-router-target.md](./local-engine-unified-router-target.md).
+
+**Status (2026-07-20): LANDED.** Steps 1–5 done and, past the A/B, step 6's
+structural half too: `run_query` is now a 4-line string→enum adapter delegating to
+the one cost-based router `run_query_routed` (all modes); the legacy decision tree,
+the `CARD_ENGINE_PLAN_SELECT` toggle, and the `maybe_broad` routing threshold are
+deleted (377 LOC net). What step 6 did NOT retire, because they aren't tree-routing
+thresholds: `STREAM_MIN_MATCHES` (now the cost model's P3 small-total floor) and the
+7/8 narrowing cutoff + memoize gate (inside `prepare_candidates`, shared by the
+router). Correctness rests on the tree-independent durable tests
+(`force_plan_differential_agreement`, `fuzz_row_identity_matches_reference`). The
+value delivered is structural (one principled layer, extensible) at performance
+parity — not a speed win (see Results below); the one real speed win, idea-1/idea-2,
+remains deferred.
 
 1. **Estimator** — standalone, sound bounds, fuzz-validated, *unwired*.
    (Shipped: #704.)
@@ -208,6 +251,91 @@ individually addressable is the prerequisite for the run-all-plans harness.
 
 Filter trees are tiny, so `choose_plan`, the estimator, and the cost model are
 all per-query noise; they run once per query, not per card.
+
+## Results so far — and where the win actually is (2026-07-20)
+
+Steps 1–4 shipped (#704/#708/#709/#710). The router (`run_query_routed`, all modes)
+materializes candidates once (single plane eval / one `prepare_candidates`, no
+double-eval) — or, for printing bare-ranges, takes the exact range-`k` without
+materializing — and routes `argmin plan_cost` on the *actual* count. It is now the
+default and only path (the legacy tree, toggle, and the tree-vs-router A/B benches
+were deleted with the landing above); the findings below were measured during the
+toggle-gated A/B and hold.
+
+**Card-mode routing is a tie, not a win.** A/B on the real corpus
+(then-`plan_routing_ab`, min-of-n): geomean routed/legacy **1.010×**, 41 tie / 3
+marginally-slower / 0 faster. Cost-routing *reproduces* the hand-tuned tree's
+plan choices — the tree's thresholds already sit at the cost crossovers — so
+there is no card-mode speed to win. The residual ~1% is the argmin's own f64
+evals on sub-µs queries. An earlier estimate-*before*-materialize prototype was
+~15% slower (double plane eval + lo-cliff pessimism) and was abandoned for the
+materialize-then-route shape above.
+
+**This intermediate state is a deliberate structural *downgrade*.** The toggle,
+the routed path, and the legacy tree now coexist — strictly *more* branching
+than before. That is only justified as time-boxed scaffolding for the A/B, and
+is debt to be repaid per steps 5–6: the routed path is the seed of the single
+`route()`; the tree and thresholds get *deleted*, not accumulated. Landing
+card-mode routing on its own buys parity-for-principle only, so it should ship
+bundled with — or just before — the first frontier win below, never as "we
+replaced the tree with an equal-speed cost model."
+
+**The printing-mode P1 win was hypothesized — and measurement falsified it.**
+The hypothesis: the tree's P1 gate (`range_too_broad_to_narrow`, a fixed
+`k/index_len > 0.25` ratio) ignores page depth and sort alignment, while P1's
+misaligned walk costs `(offset+limit)/match_rate`, so a *moderately*-broad range
+at a *deep* page should misroute onto P1's blind walk where the ratio can't see
+it. The `printing_range_route_probe` bench (src/tests.rs) tested exactly that —
+11 bare price/year ranges across the broad/narrow margin × offsets to 20000,
+printing mode, misaligned edhrec sort — comparing the tree's pick and the cost
+model's pick to empirical gold:
+
+> **54 scored rows: tree geomean regret 1.000× (gold on every row); model
+> 1.015×, strictly faster on 0.** P1 wins broad ranges at *every* depth tested,
+> including offset 20000 — because P3/P4 in printing mode both pay the full
+> O(n_cards) match phase, which dominates P1's blind-but-early-stopping walk. So
+> `range_too_broad_to_narrow` already sits at the P1/P4 crossover; depth doesn't
+> move it. The naive cost model was slightly *worse* — 2 deep rows (offset 20000)
+> where its `(offset+limit)/match_rate` walk term over-penalizes P1 and it routes
+> away at 1.32×/1.70×.
+
+So printing ranges tie too (the tree marginally ahead). Combined with the
+card-mode tie, **cost-based routing has now matched-or-slightly-lost to the
+hand-tuned tree everywhere measured** — the thresholds are genuinely well-placed.
+This is the load-bearing finding: #702 as a *speed* play has no evidence behind
+it on today's plans. What remains is (a) the purely structural argument (one cost
+rule vs scattered thresholds — but the cost model carries its own calibration
+burden, so this is not obviously a net simplification), and (b) whether a
+genuinely *unexpressed* decision exists that the tree cannot make at all — the
+place to look before spending more, not another mode of the same P1/P3/P4 menu.
+
+**Artwork not separately probed** — only P3/P4 apply (the same crossover the tree
+sits on in card mode), so absent a new signal it is expected to tie as well.
+
+**The one real win found: idea-1 vs idea-2 at depth (a genuinely *unexpressed*
+decision).** `idea1_vs_idea2_probe` (src/tests.rs) measured idea-1 (P1, built) against
+a cost-representative idea-2 kernel (range → printing existence bitmap → popcount-skip
+→ emit; the deferred #656 mechanism, timed without building it) on `unique=printing`
+broad ranges × page depth, edhrec (unrelated) sort — the one cell the sorted-range doc
+says the two genuinely compete. idea-2 is **flat in offset** (~19–54µs, scaling with `k`
+not depth); idea-1 grows ~`(offset+limit)/match_rate`. So there is a real crossover, and
+its depth scales inversely with match-rate:
+
+> `usd<0.25` (30%) & `usd>=1` (24%): idea-2 wins from offset **~500–2000**; mid-rate
+> (~50–65%) ~5000; high-rate (73–90%) ~10–20k. Ratios reach 35× at offset 20000.
+
+This is the first evidence *for* the cost-routing thesis: the idea-1/idea-2 winner is an
+offset×match_rate crossover — exactly what a cost comparison expresses and a fixed
+threshold cannot — and the tree cannot pick idea-2 at all because idea-2 does not exist.
+Caveats keeping this honest: (1) the kernel is an **optimistic lower bound** — a correct
+idea-2 needs bits in sort order (#656's printing permutation), adding scatter cost, so
+real crossovers land somewhat deeper; (2) absolute savings at *realistic* depth (offset
+500–2000) are ~50–170µs on already-sub-ms queries — the 35× ratios are all at offset
+20000, which nobody pages to; (3) deep-paged broad-range printing queries are a rare
+corner (though #656 flags it as a known ~1.07ms gap). **Decision pending:** build idea-2
+(#656 printing-space pager + permutation, with the NULL over-inclusion care that reverted
+#689) and cost-route idea-1/idea-2 — real work for a rare-but-known-gap win — vs leave it
+deferred. This is a prioritization call, not a technical unknown.
 
 ## Keeping costs/plans current as the engine changes
 

--- a/docs/issues/local-engine-unified-router-target.md
+++ b/docs/issues/local-engine-unified-router-target.md
@@ -1,0 +1,205 @@
+# The Unified Router: Target-State Pseudocode
+
+Companion to [00702-engine-plan-selection-layer.md](./00702-engine-plan-selection-layer.md).
+That doc argues *why* the scattered decision tree in `run_query` should become one
+plan-selection layer and sequences the work; this doc pinned down *what the end state
+looks like* so the incremental PRs had a shared target to converge on.
+
+**Landed 2026-07-20** (`run_query_routed`, lib.rs). The organizing principle held:
+**there is exactly one routing function**, and mode (card/printing/artwork) is a
+*filter over the plan set* — never a branch in control flow. What actually got
+deleted: the `CARD_ENGINE_PLAN_SELECT` toggle, the legacy `run_query` decision-tree
+body (now a 4-line string→enum adapter delegating to `run_query_routed`), and the
+`maybe_broad` `STREAM_MIN_MATCHES` *routing* threshold. What deliberately STAYED,
+because they are not tree-routing thresholds: `STREAM_MIN_MATCHES` itself (now the
+cost model's P3 small-total floor, `cost.rs`), the 7/8 narrowing cutoff and the
+memoize gate (both inside `prepare_candidates`, shared by the router). Divergences
+from this sketch, learned by measurement, are noted inline below.
+
+## Plans as data
+
+The tree and the thresholds are gone. Each plan owns its eligibility and its cost;
+adding a plan is adding a row here (compile-time-forced complete — see #702 "Keeping
+costs/plans current").
+
+```
+enum Plan { PrintingRangeScan, PlanePopcountOrder, StreamedSelect, GatheredScan }
+
+# Which plans could *correctly* answer this query. These predicates ARE the former
+# tree's structural conditions, but now they gate eligibility ONLY — never speed.
+# GatheredScan has no gate: it is the universal fallback and always in the set, so
+# the set is never empty.
+fn applicable(plan, q, mode) -> bool:
+    match plan:
+        PrintingRangeScan  -> mode == Printing
+                              and q.filter.is_bare_range()       # single range pred, no plane
+                              # NOT order-alignment: the fastpath serves aligned
+                              # (index slice) and misaligned (perm walk) alike.
+        PlanePopcountOrder -> mode == Card
+                              and q.filter.reduces_to_plane()    # residual == True
+        StreamedSelect     -> q.order.is_perm_backed()           # any mode
+        GatheredScan       -> true                               # universal reference
+```
+
+The three modes collapse into this filter — there is no `if card … elif printing …`
+anywhere. Card gets `{P2, P3, P4}`, printing gets `{P1, P3, P4}`, artwork gets
+`{P3, P4}`, all by the same predicate evaluation. This is `PhysicalPlan::applicable`
+as landed (the P1 arm also checks `bare_range_bounds(filter).is_some()`).
+
+## Cardinality estimation (built, but NOT wired into the landed router)
+
+A cheap, sound, per-operating-space estimator exists (#704): `Cardinality {lo, est,
+hi}`, bounds a hard invariant (`truth ∈ [lo,hi]`), composed via
+AND→independence / OR→Bonferroni / NOT→complement (see #702 "Cardinality
+estimation"). **The landed `run_query_routed` does not call it.** Materialize-then-
+route won over estimate-then-route (below), so the router derives features from
+*exact/cheap* counts in `acquire` — a plane's popcount, a range's binary-search `k`,
+a residual's candidate count — never `estimate_cardinality`. The estimator stays
+available for a future plan whose count is neither free-from-prep nor cheap-exact
+(where a sound estimate would be the only affordable input); today no plan needs it.
+
+## The count source — how features are obtained (as landed: exact, in `acquire`)
+
+The load-bearing question is *how you get the count*, and the answer that landed is:
+**always an exact or cheap-exact count, from `acquire`, never the estimator.** The
+count is free-or-cheap for every plan the engine has: a True-residual plane's count
+IS its popcount; a bare range's is a binary-search `k`; a residual's is
+`prepare_candidates`. So the router routes on those directly.
+
+This is the lesson from the card-mode prototype: the naive "estimate → route →
+execute" pipeline was ~15% slower because estimating meant a plane eval the executor
+then *repeated* (#702 Results). Materialize-then-route avoids that double work — the
+count-deriving prep IS the execution input, reused. The one place nothing is
+materialized up front is the bare range (`Prep::Range`): its discriminating feature,
+`k`, is free from the index, so `PrintingRangeScan` is costed without materializing,
+and a materializing winner materializes lazily in dispatch (see "The one router").
+
+The earlier sketch imagined a `count_source()` that *estimated* when no shared prefix
+existed; that branch never landed, because the only no-shared-prefix case (the range)
+has an exact-`k` that is cheaper than any estimate. If idea-2 or a future plan ever
+introduces a case where the count is genuinely expensive to get exactly, *that* is
+when the estimator above gets wired in.
+
+## The one router (as landed: `run_query_routed`)
+
+Flat — three named steps, no early returns, no plan-named `if`-cascade:
+
+```
+fn run_query_routed(q, mode, page):
+    # acquire: pick the count source (one of three, by query structure), build the
+    # cost features (mk_feats fills the query-invariant fields), materialize the
+    # shared artifact it implies. This 3-way IS the whole materialization story.
+    (feats, prep) =
+        if PlanePopcountOrder.applicable(q):    # True-residual plane (card)
+            eval the plane once → popcount is the exact count;   Prep::Plane
+        elif PrintingRangeScan.applicable(q):   # bare printing range
+            exact k from the range index (no scan);              Prep::Range
+        else:
+            prepare_candidates();                                Prep::Candidates
+
+    # choose: cheapest applicable plan — no hand-written plan list.
+    plan = argmin(PhysicalPlan::ALL.filter(|p| p.applicable(q)), |p| plan_cost(p, feats))
+
+    # dispatch: run the winner, reusing prep's artifact.
+    match (plan, prep):
+        (PlanePopcountOrder, Plane)  → popcount executor, reuse the bitmap
+        (P3|P4, Plane)               → candidate-list executor, bitmap AS the list
+        (P3|P4, Candidates(prep))    → candidate-list executor, reuse prep
+        (plan,  Range)               → P1 walks if it won & its fastpath accepts;
+                                        else materialize lazily + re-argmin on exact feats
+```
+
+This realizes the "one routing function, plans-as-data" goal — per-plan knowledge
+lives on `PhysicalPlan` (`ALL`, `applicable`, `materializing`, `cost::plan_cost`, an
+executor arm), and `choose` is a generic argmin over `ALL.filter(applicable)` that
+never names a plan. Adding a plan is declaring those arms; only a genuinely new
+count source (a new `Prep` variant — e.g. idea-2's printing-space bitmap) touches
+acquire/dispatch.
+
+Two honest departures from the earlier sketch, learned building it:
+
+- **The count source is not a separate `count_source()` — it's the acquire branch.**
+  *How* you get the count is entangled with *which* plan you weigh: a plane's count
+  IS its bitmap, a range's is a free binary search, a residual's is
+  `prepare_candidates`. Each yields a different-shaped artifact (`Prep`), so it can't
+  collapse to one uniform helper. The 3-way is isolated in acquire; that's as
+  factored as it goes.
+- **`Prep::Range` defers materialization** — the one irreducible bit of staging (the
+  original sketch's "phases"), now a `match` arm, not an early-return. It costs the
+  non-materializing `PrintingRangeScan` from a cheap estimate; if a materializing
+  plan wins there, dispatch materializes lazily and re-chooses on exact features.
+  That is the "don't pay to materialize a plan you won't run".
+
+The sketch's "trivial escape" for `plans == [GatheredScan]` didn't land and wasn't
+needed: features come from acquire (not a separate estimator pass), so a single-plan
+argmin is already free.
+
+## Cost model
+
+One formula per plan, constants fit on the real corpus ([cost.rs](../../card_engine/src/cost.rs)).
+`argmin` cares about *ratios*, which is what makes P1's bad tail visible: the tree
+took P1 unconditionally; here P1 competes and *loses* when its walk is pathological
+(narrow range under a misaligned sort — the idea-1/idea-2 crossover, the founding
+motivation).
+
+```
+fn plan_cost(plan, f) -> ns:                                          # eval_domain = candidate CARDS
+    match plan:                                                       # scan_units  = rows scanned (operating space)
+        PrintingRangeScan  -> (page_span / match_rate)·STEP + FIXED   # blind-walk tail
+        PlanePopcountOrder -> matches·SCATTER + words·WORD + FIXED    # O(words) floor
+        StreamedSelect     -> eval_domain·CARD_PASS + scan_units·(SCAN+tier) + small_total_floor + FIXED
+        GatheredScan       -> eval_domain·CARD_PASS + scan_units·(SCAN+tier) + matches·PUSH + page·SELECT + FIXED
+```
+
+The per-card `card_pass` and per-scanned-row `scan` terms are split (the `tier`
+verify cost rides `scan_units`, where it is paid): this is the operating-space fix
+(`scan_units`) that made the model correct for printing/artwork, not just card.
+
+## Two things that are load-bearing and non-obvious
+
+1. **Routing on the exact count from `acquire` is where the value is, not the argmin.**
+   A CBO that estimates on every query taxes the fast paths (the plane eval that gets
+   repeated — the ~15% v1 regression). The landed design is free on those paths because
+   the count-deriving prep IS the execution input, reused: a plane's popcount, a
+   residual's candidate list. The one non-materializing plan (`PrintingRangeScan`) is
+   costed from the range index's free `k`, so *it* pays nothing up front either.
+
+2. **`Prep::Range`'s lazy materialization is what preserves parity there.** Because P1
+   is costed from a cheap estimate, a materializing plan that wins the range case must
+   materialize *after* the argmin — the deferral means a broad range that P1 serves in
+   µs never pays `prepare_candidates`, while a range better served by P3/P4 materializes
+   exactly once. This is the sole surviving bit of "stage the decision, don't pay to
+   cost a plan you won't run" — now a `match` arm, not a control-flow phase.
+
+## What each mode yields (measured 2026-07-20 — supersedes earlier hypotheses)
+
+- **Card** — tie. Cost-routing reproduces the tuned tree's choices (the thresholds
+  already sit at the cost crossovers). Value is structural, not speed. (A/B geomean
+  1.010×, see #702.)
+- **Printing (P1 vs P3/P4)** — tie, NOT the win once hypothesized. The tree's
+  `range_too_broad_to_narrow` ratio already sits at the P1/P4 crossover; P1 wins broad
+  ranges at *every* depth tested (P3/P4 pay a full O(n_cards) match phase). Measured:
+  tree gold 54/54, `printing_range_route_probe`. The earlier "tree takes P1
+  unconditionally → cost bails P1→P4" story was falsified — the tree *does* guard narrow.
+- **Artwork** — tie, like card (only P3/P4 apply). Confirming A/B, not a headline.
+- **The actual win — idea-1 vs idea-2 (a plan not yet in `applicable()`):** the tree
+  can't pick idea-2 (range → printing existence bitmap → popcount-skip) because it
+  isn't built (#656). idea-2 is offset-independent; idea-1 (P1) grows ~`(offset+limit)/
+  match_rate`, so they cross at a depth that scales inversely with match-rate (offset
+  ~500–2000 for low-selectivity broad ranges, deeper for high). This IS the cost-shaped,
+  tree-inexpressible decision the whole effort was aiming at — measured in
+  `idea1_vs_idea2_probe`, real but confined to deep-paged broad printing ranges. Adding
+  idea-2 means a fifth `Plan` row (gate: `mode==Printing ∧ bare_range ∧ ¬aligned`) plus
+  its cost formula — the "plans as data" test of this design.
+
+## Cost-model calibration scope (FIXED — was prerequisite)
+
+`plan_cost` was originally fit and validated for CARD mode only, under-predicting
+printing/artwork P3/P4 by ~3× (= `n_printings/n_cards`) because `eval_domain` counted
+CARDS while those plans scan all printings. **Fixed** via features-not-mode
+(`PlanFeatures::scan_units`, see #702 "Is the cost model correct?"): the caller
+populates scan counts in the plan's operating space, one mode-agnostic formula.
+Printing fidelity 1.83×→1.50× (now on par with card), and the deep-printing routing
+mispicks are gone. A 1200-query designed refit confirmed the constants are at the
+identifiable ceiling (~1.4× absolute, ordering-correct); further tightening is blocked
+by structural collinearity, not effort — so this is done, not deferred.


### PR DESCRIPTION
## Summary

Replaces the hand-tuned plan-selection decision tree in `run_query` with a single cost-based routing layer (`run_query_routed`) covering all unique modes, and improves the gather fallback (P4) with a bounded, cache-friendly page selector.

The routing change is **at broad performance parity** — its value is structural: one principled `argmin cost` layer replacing a scattered tree of hand-maintained, pairwise-disjoint-by-construction preconditions. The gather change is a real **p99 tail win** on broad results under a non-permutation sort. Results are byte-identical everywhere.

Design docs: [00702-engine-plan-selection-layer.md](../blob/engine-plan-cost-route/docs/issues/00702-engine-plan-selection-layer.md) (why/sequencing/measured findings) and [local-engine-unified-router-target.md](../blob/engine-plan-cost-route/docs/issues/local-engine-unified-router-target.md) (the landed structure).

## Changes

- **One routing layer (`run_query_routed`).** `run_query` is now a thin string→enum adapter; plan choice is `argmin cost::plan_cost` over `PhysicalPlan::ALL.filter(applicable)` — no hand-written plan lists. Three linear steps: **acquire** (pick the query's count source — plane popcount / range `k` / `prepare_candidates`) → **choose** → **dispatch**. Per-plan knowledge lives on `PhysicalPlan` (`applicable` / `materializing` / `cost::plan_cost` / an executor arm), so adding a plan is declaring those arms, not editing a tree.
- **Deleted** with the tree: the `CARD_ENGINE_PLAN_SELECT` A/B toggle and the `maybe_broad`/`STREAM_MIN_MATCHES` *routing* threshold. `STREAM_MIN_MATCHES` survives as the cost model's P3 small-total floor; the 7/8 narrowing cutoff stays inside `prepare_candidates` (shared).
- **Operating-space cost model (`PlanFeatures::scan_units`).** The per-plan `plan_cost` was card-mode-fit and under-predicted printing/artwork P3/P4 by ~`n_printings/n_cards`; `scan_units` (rows the residual scan touches, in the plan's operating space) makes it correct with no `mode` branch. Card behavior unchanged.
- **Bounded gather (P4).** `exec_gathered_scan` streamed every match into an unbounded `Vec` then quickselected — O(matches) memory, cache-hostile on whole-corpus results. Now it pushes directly (a gather that stays small is byte-for-byte the old fast path), and once the buffer first grows a chunk past the page size, prunes to the `k = offset+limit` smallest and keeps a **running cutoff** — later matches `>= cutoff` can't reach the page and are dropped as produced, so the buffer stays ~`k`. Identical page + total; also bounds gather memory at ~`k` instead of O(matches).

## Performance

Broad survey (`scripts/survey_queries.py`, seed 42, 400 generated + 120 wild = 520 queries) on `benchmarks/bitplanes/corpus.jsonl` (97,206 printings / 31,508 cards). Speedup = `main / branch` (>1.0 faster, <1.0 slower). **0 total-count mismatches across all 520 queries.**

| pctile | main (µs) | branch (µs) | speedup |
|---|---|---|---|
| p50 | 54 | 54 | 1.00x |
| p90 | 177 | 177 | 1.00x |
| p95 | 248 | 249 | 0.99x |
| p99 | 708 | 617 | **1.15x** |
| p100 | 1047 | 1043 | 1.00x |

**Broad geomean: 0.996x** (≈ parity). The routing `argmin` adds ~1% to common `edhrec`-sorted queries — the "cost-routing ties the tuned tree" result measured directly during development — which the bounded gather buys back at the tail. By orderby: `rarity` 1.017x / `usd` 1.010x (P4-gather, faster), `edhrec` 0.992x (330 queries, the ~1% routing tax).

**Target — P4-gather beneficiaries** (broad results under a non-permutation sort, where the bounded gather replaces a whole-corpus quickselect):

| query | mode/sort | main (µs) | branch (µs) | speedup |
|---|---|---|---|---|
| `format:legacy` | printing/rarity | 708 | 536 | 1.32x |
| `type:goblin or format:legacy` | printing/usd | 749 | 617 | 1.21x |
| `format:commander` | printing/usd | 724 | 611 | 1.19x |
| `power+toughness<4` | card/rarity | 478 | 458 | 1.05x |
| `format:modern or set:bro or name:da` | card/rarity | 290 | 275 | 1.06x |

(Single-run survey; per-query tail values are noisy at ±tens of µs — the p99 win is stable across repeated runs, ~0.62ms branch vs 0.71ms main.)

## Correctness

Plan choice is a pure performance decision — every plan returns identical rows. This is enforced by the two tree-independent durable tests: `force_plan_differential_agreement` (every applicable plan's rows == `GatheredScan`, across card/printing/artwork) and `fuzz_row_identity_matches_reference` (engine rows == a brute-force reference). The bounded gather's page identity rides the latter. The broad survey independently confirms 0 total-count mismatches vs `main`. **No archive-format change.** Debug + release suites green (124).

## Notes

- The idea-1/idea-2 crossover (offset-independent paging of deep, broad printing ranges) is characterized but **deferred** — it needs the #656 printing-space permutation, and the survey confirmed it's a cold corner not present in realistic traffic.
- Follow-up flagged during this work: anchored/prefix regexes (`/^…/`) are cheaper than general string scans but bucket with them in `verify_cost_tier`. Harmless to routing (the tier is common-mode between P3/P4 and cancels), but it feeds `order_children_by_verify_cost`, so an anchored regex is ordered as if expensive — worth a separate cheaper tier.

Closes #702
