### PR TITLE
Recover the is:/frame: Namespace via Query Rewriting (#713)

### DIFF
--- a/api/parsing/parsing_f.py
+++ b/api/parsing/parsing_f.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from api.parsing.hand_parser import parse_query as _parse_query
+from api.parsing.rewrite import expand_derived_predicates
 
 if TYPE_CHECKING:
     from api.parsing.nodes import Query
@@ -55,4 +56,6 @@ def parse_scryfall_query(query: str) -> Query:
     Returns:
         A Scryfall-specific Query AST.
     """
-    return _parse_query(query)
+    # parse => transform => rest: the derived-predicate rewrite runs on the common AST at
+    # this shared seam, so it applies identically regardless of which parser _parse_query is.
+    return expand_derived_predicates(_parse_query(query))

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -43,6 +43,7 @@ from api.parsing.nodes import (
     TrueNode,
     flatten_nested_operations,
 )
+from api.parsing.rewrite import expand_derived_predicates
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -541,9 +542,11 @@ def parse_search_query(query: str | None) -> Query:
 
     try:
         parsed = expr.parse_string(query, parse_all=True)
+        # parse => transform => rest, mirroring parse_scryfall_query so the derived-predicate
+        # rewrite applies identically to both parsers (kept in lockstep by test_parser_parity).
         if parsed:
-            return to_card_query_ast(flatten_nested_operations(Query(parsed[0])))
-        return to_card_query_ast(Query(BinaryOperatorNode("name", ":", "")))
+            return expand_derived_predicates(to_card_query_ast(flatten_nested_operations(Query(parsed[0]))))
+        return expand_derived_predicates(to_card_query_ast(Query(BinaryOperatorNode("name", ":", ""))))
     except (ValueError, TypeError, IndexError) as e:
         msg = "main query parsing"
         raise create_parsing_error(msg, e, query) from e

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -1,0 +1,82 @@
+"""Post-parse query rewriting: expand derived predicates into subtrees of primitives.
+
+Applied once at the shared parse seam (`parse_scryfall_query`), so both the production
+hand parser and the legacy pyparsing parser get identical treatment: the transform
+operates on the common AST, after parsing and before SQL / Rust-engine serialization
+(`parse => transform => rest`). Nothing parser-specific lives here.
+
+Each expansion is written as a DSL string and re-parsed with the production parser, so a
+definition is expressed in the same language it targets and stays correct by construction
+(no hand-built node trees to drift). Every entry is count-validated against Scryfall's
+live API before landing -- the naive expansion is frequently ~97-99%, not exact -- with
+the rationale and residuals recorded in docs/issues/00713-is-tag-recovery.md.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from api.parsing.hand_parser import parse_query as _parse_query
+from api.parsing.nodes import AndNode, BinaryOperatorNode, NotNode, OrNode, Query
+
+if TYPE_CHECKING:
+    from api.parsing.nodes import QueryNode
+
+# (original alias, lowercased value) -> expansion DSL string. Validated against
+# api.scryfall.com on 2026-07-20 (see docs/issues/00713-is-tag-recovery.md).
+#
+# `frame:modern/old/new` are undocumented-but-live Scryfall aliases (the syntax docs list
+# only the numeric frames + frame-effects); mirrored because they see real use. `is:old`
+# and `is:new` ARE documented. Note `is:new` is the 2015 frame *only* -- deliberately
+# narrower than `frame:new` (every post-"classic" frame) -- and both are mirrored as-is
+# rather than reconciled, since diverging from Scryfall would be the real bug.
+_DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
+    ("frame", "modern"): "frame:2003",
+    ("frame", "old"): "frame:1993 or frame:1997",
+    ("frame", "new"): "frame:2003 or frame:2015 or frame:future",
+    ("is", "old"): "frame:1993 or frame:1997",
+    ("is", "new"): "frame:2015",
+}
+
+
+def _leaf_key(node: QueryNode) -> tuple[str, str] | None:
+    """Return `(alias, value)` for a `field:value` leaf eligible for rewriting, else None."""
+    if not isinstance(node, BinaryOperatorNode) or node.operator != ":":
+        return None
+    alias = getattr(node.lhs, "original_attribute", None)  # the user-facing prefix, e.g. "frame"
+    value = getattr(node.rhs, "value", None)
+    if alias is None or not isinstance(value, str):
+        return None
+    return (alias, value.lower())
+
+
+def _parse_expansion(dsl: str) -> QueryNode:
+    """Parse an expansion DSL string into a subtree (the production parser's output root).
+
+    Uses the production hand parser directly (not `parse_scryfall_query`) so expansion of
+    a synonym does not recurse back through this transform; nesting is handled explicitly
+    by `_expand` re-walking the result.
+    """
+    return _parse_query(dsl).root
+
+
+def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> QueryNode:
+    cls = node.__class__
+    if cls is AndNode:
+        return AndNode([_expand(op, in_progress) for op in node.operands])
+    if cls is OrNode:
+        return OrNode([_expand(op, in_progress) for op in node.operands])
+    if cls is NotNode:
+        return NotNode(_expand(node.operand, in_progress))
+    key = _leaf_key(node)
+    if key is not None and key in _DERIVED_EXPANSIONS and key not in in_progress:
+        # Recurse into the expansion so a definition may itself reference another derived
+        # predicate; `in_progress` breaks any (mis)configured cycle (a -> ... -> a).
+        subtree = _parse_expansion(_DERIVED_EXPANSIONS[key])
+        return _expand(subtree, in_progress | {key})
+    return node
+
+
+def expand_derived_predicates(query: Query) -> Query:
+    """Rewrite derived-predicate leaves (frame synonyms, derivable `is:`) into primitive subtrees."""
+    return Query(_expand(query.root, frozenset()))

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -56,6 +56,12 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     ("is", "mdfc"): "layout:modal_dfc",
     ("is", "meld"): "layout:meld",
     ("is", "leveler"): "layout:leveler",
+    # is:dfc = gameplay double-faced cards. Scryfall's is:dfc additionally counts art_series /
+    # reversible_card / double_faced_token (~2394 art & token entries) that aren't gameplay cards
+    # and aren't in our corpus, so the layout union is the correct set for our data.
+    ("is", "dfc"): "layout:transform or layout:modal_dfc or layout:meld",
+    # Frame-effect (stored in card_frame_data). is:colorshifted == frame:colorshifted exactly (45).
+    ("is", "colorshifted"): "frame:colorshifted",
 }
 
 

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -62,6 +62,12 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     ("is", "dfc"): "layout:transform or layout:modal_dfc or layout:meld",
     # Frame-effect (stored in card_frame_data). is:colorshifted == frame:colorshifted exactly (45).
     ("is", "colorshifted"): "frame:colorshifted",
+    # Oracle-text heuristic for creature-lands: 48/49 vs Scryfall, 0 false positives (clean
+    # subset). Its one Scryfall miss (Rising Chicane) is Alchemy-only and absent from our corpus,
+    # so this is effectively exact on our data. `o:become` (substring), NOT `o:becomes` -- the
+    # looser form also catches Crawling Barrens ("they become a 0/0 ..."). The "still a land"
+    # clause is what keeps false positives at zero.
+    ("is", "manland"): "t:land o:become o:creature o:/still a.* land/",
 }
 
 

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -44,6 +44,11 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     ("is", "party"): "t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)",  # exact
     ("is", "outlaw"): "t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling",  # exact
     ("is", "vanilla"): 't:creature o=""',  # empty-oracle equality; -11 subset (Adventure/DFC textless faces + Dryad Arbor)
+    # The intuitive "2/2 for 2" bear. Deliberately NOT exactly Scryfall's is:bear (which is
+    # single-faced and includes Vehicles/Spacecraft): vs Scryfall this is +~14 DFC creatures
+    # and -4 Vehicles/Spacecraft. Scryfall's exact count isn't cross-verifiable anyway (their
+    # DFC/unique face-counting quirk), and this is what people mean by "bear".
+    ("is", "bear"): "t:creature pow=2 tou=2 cmc=2",
     # Layout, exact by direct card_layout field correspondence.
     ("is", "split"): "layout:split",
     ("is", "flip"): "layout:flip",

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from api.parsing.hand_parser import parse_query as _parse_query
-from api.parsing.nodes import AndNode, BinaryOperatorNode, NotNode, OrNode, Query
+from api.parsing.nodes import AndNode, BinaryOperatorNode, NotNode, OrNode, Query, flatten_nested_operations
 
 if TYPE_CHECKING:
     from api.parsing.nodes import QueryNode
@@ -36,6 +36,21 @@ _DERIVED_EXPANSIONS: dict[tuple[str, str], str] = {
     ("frame", "new"): "frame:2003 or frame:2015 or frame:future",
     ("is", "old"): "frame:1993 or frame:1997",
     ("is", "new"): "frame:2015",
+    # Type / subtype based. `kw:changeling` (an ability keyword, subtype is Shapeshifter) picks up
+    # the all-creature-type cards Scryfall counts. Note party IS creature-restricted while outlaw is
+    # NOT (it also matches Kindred non-creature cards carrying an outlaw subtype).
+    ("is", "historic"): "t:legendary or t:artifact or t:saga",  # exact
+    ("is", "permanent"): "t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or t:battle",  # +2 / 25954
+    ("is", "party"): "t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)",  # exact
+    ("is", "outlaw"): "t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling",  # exact
+    ("is", "vanilla"): 't:creature o=""',  # empty-oracle equality; -11 subset (Adventure/DFC textless faces + Dryad Arbor)
+    # Layout, exact by direct card_layout field correspondence.
+    ("is", "split"): "layout:split",
+    ("is", "flip"): "layout:flip",
+    ("is", "transform"): "layout:transform",
+    ("is", "mdfc"): "layout:modal_dfc",
+    ("is", "meld"): "layout:meld",
+    ("is", "leveler"): "layout:leveler",
 }
 
 
@@ -60,23 +75,43 @@ def _parse_expansion(dsl: str) -> QueryNode:
     return _parse_query(dsl).root
 
 
-def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> QueryNode:
+def _expand(node: QueryNode, in_progress: frozenset[tuple[str, str]]) -> tuple[QueryNode, bool]:
+    """Expand derived-predicate leaves in `node`; return `(node, changed)`.
+
+    Returns the *original* node object (and `changed=False`) when no descendant was
+    rewritten, so a query containing no synonym — the overwhelming majority — is walked
+    once but never rebuilt or re-flattened.
+    """
     cls = node.__class__
-    if cls is AndNode:
-        return AndNode([_expand(op, in_progress) for op in node.operands])
-    if cls is OrNode:
-        return OrNode([_expand(op, in_progress) for op in node.operands])
+    if cls is AndNode or cls is OrNode:
+        changed = False
+        operands = []
+        for op in node.operands:
+            new_op, op_changed = _expand(op, in_progress)
+            operands.append(new_op)
+            changed |= op_changed
+        return (cls(operands), True) if changed else (node, False)
     if cls is NotNode:
-        return NotNode(_expand(node.operand, in_progress))
+        new_op, changed = _expand(node.operand, in_progress)
+        return (NotNode(new_op), True) if changed else (node, False)
     key = _leaf_key(node)
     if key is not None and key in _DERIVED_EXPANSIONS and key not in in_progress:
         # Recurse into the expansion so a definition may itself reference another derived
         # predicate; `in_progress` breaks any (mis)configured cycle (a -> ... -> a).
-        subtree = _parse_expansion(_DERIVED_EXPANSIONS[key])
-        return _expand(subtree, in_progress | {key})
-    return node
+        subtree, _ = _expand(_parse_expansion(_DERIVED_EXPANSIONS[key]), in_progress | {key})
+        return subtree, True
+    return node, False
 
 
 def expand_derived_predicates(query: Query) -> Query:
-    """Rewrite derived-predicate leaves (frame synonyms, derivable `is:`) into primitive subtrees."""
-    return Query(_expand(query.root, frozenset()))
+    """Rewrite derived-predicate leaves (frame synonyms, derivable `is:`) into primitive subtrees.
+
+    Only rebuilds when a synonym was actually present; otherwise the query is returned
+    untouched. When something was rewritten, re-flatten — a synonym expanding to an And/Or
+    subtree inside a compound would otherwise leave non-canonical nesting (`(A AND (B)) AND C`),
+    so the result matches the canonical tree of the equivalent hand-written query.
+    """
+    root, changed = _expand(query.root, frozenset())
+    if not changed:
+        return query
+    return flatten_nested_operations(Query(root))

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -1,0 +1,51 @@
+"""Derived-predicate rewrite (api/parsing/rewrite.py).
+
+A synonym must parse to exactly the same AST as its canonical expansion — verified
+against BOTH parsers via the `parse_query` fixture, since the rewrite runs at the shared
+post-parse seam. Mappings are validated against Scryfall's live API in
+docs/issues/00713-is-tag-recovery.md.
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+
+# (synonym query, canonical expansion) — the two must produce identical ASTs.
+EQUIVALENCES = [
+    ("frame:modern", "frame:2003"),
+    ("frame:old", "frame:1993 or frame:1997"),
+    ("frame:new", "frame:2003 or frame:2015 or frame:future"),
+    ("is:old", "frame:1993 or frame:1997"),
+    ("is:new", "frame:2015"),
+    # composes under negation and inside compounds
+    ("-frame:old", "-(frame:1993 or frame:1997)"),
+    ("t:goblin frame:modern", "t:goblin frame:2003"),
+]
+
+
+@pytest.mark.parametrize(("synonym", "expansion"), EQUIVALENCES, ids=[s for s, _ in EQUIVALENCES])
+def test_synonym_expands_to_canonical(parse_query, synonym: str, expansion: str) -> None:
+    """Each synonym parses to the same AST as its hand-written expansion (both parsers)."""
+    assert parse_query(synonym) == parse_query(expansion)
+
+
+@pytest.mark.parametrize(("synonym", "expansion"), EQUIVALENCES, ids=[s for s, _ in EQUIVALENCES])
+def test_synonym_generates_same_sql(synonym: str, expansion: str) -> None:
+    """The rewrite is real end-to-end: synonym and expansion emit identical SQL + params."""
+    assert generate_sql_query(parse_scryfall_query(synonym)) == generate_sql_query(parse_scryfall_query(expansion))
+
+
+def test_unimplemented_is_tag_passes_through(parse_query) -> None:
+    """A not-yet-implemented `is:` value (bucket C) is left untouched, not mangled."""
+    root = parse_query("is:promo").root
+    assert root.operator == ":"
+    assert root.lhs.original_attribute == "is"
+    assert root.rhs.value == "promo"
+
+
+def test_real_frame_value_not_rewritten(parse_query) -> None:
+    """A genuine frame edition (`frame:2003`) is a plain leaf, not re-expanded."""
+    root = parse_query("frame:2003").root
+    assert root.operator == ":"
+    assert root.lhs.original_attribute == "frame"
+    assert root.rhs.value == "2003"

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -23,6 +23,7 @@ EQUIVALENCES = [
     ("is:party", "t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)"),
     ("is:outlaw", "t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling"),
     ("is:vanilla", 't:creature o=""'),
+    ("is:bear", "t:creature pow=2 tou=2 cmc=2"),
     # layout family
     ("is:split", "layout:split"),
     ("is:flip", "layout:flip"),

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -17,9 +17,23 @@ EQUIVALENCES = [
     ("frame:new", "frame:2003 or frame:2015 or frame:future"),
     ("is:old", "frame:1993 or frame:1997"),
     ("is:new", "frame:2015"),
+    # type / subtype based
+    ("is:historic", "t:legendary or t:artifact or t:saga"),
+    ("is:permanent", "t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or t:battle"),
+    ("is:party", "t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)"),
+    ("is:outlaw", "t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling"),
+    ("is:vanilla", 't:creature o=""'),
+    # layout family
+    ("is:split", "layout:split"),
+    ("is:flip", "layout:flip"),
+    ("is:transform", "layout:transform"),
+    ("is:mdfc", "layout:modal_dfc"),
+    ("is:meld", "layout:meld"),
+    ("is:leveler", "layout:leveler"),
     # composes under negation and inside compounds
     ("-frame:old", "-(frame:1993 or frame:1997)"),
     ("t:goblin frame:modern", "t:goblin frame:2003"),
+    ("t:goblin is:party", "t:goblin t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)"),
 ]
 
 

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -33,6 +33,7 @@ EQUIVALENCES = [
     ("is:leveler", "layout:leveler"),
     ("is:dfc", "layout:transform or layout:modal_dfc or layout:meld"),
     ("is:colorshifted", "frame:colorshifted"),
+    ("is:manland", "t:land o:become o:creature o:/still a.* land/"),
     # composes under negation and inside compounds
     ("-frame:old", "-(frame:1993 or frame:1997)"),
     ("t:goblin frame:modern", "t:goblin frame:2003"),
@@ -40,13 +41,21 @@ EQUIVALENCES = [
 ]
 
 
-@pytest.mark.parametrize(("synonym", "expansion"), EQUIVALENCES, ids=[s for s, _ in EQUIVALENCES])
+@pytest.mark.parametrize(
+    argnames=["synonym", "expansion"],
+    argvalues=EQUIVALENCES,
+    ids=[s for s, _ in EQUIVALENCES],
+)
 def test_synonym_expands_to_canonical(parse_query, synonym: str, expansion: str) -> None:
     """Each synonym parses to the same AST as its hand-written expansion (both parsers)."""
     assert parse_query(synonym) == parse_query(expansion)
 
 
-@pytest.mark.parametrize(("synonym", "expansion"), EQUIVALENCES, ids=[s for s, _ in EQUIVALENCES])
+@pytest.mark.parametrize(
+    argnames=["synonym", "expansion"],
+    argvalues=EQUIVALENCES,
+    ids=[s for s, _ in EQUIVALENCES],
+)
 def test_synonym_generates_same_sql(synonym: str, expansion: str) -> None:
     """The rewrite is real end-to-end: synonym and expansion emit identical SQL + params."""
     assert generate_sql_query(parse_scryfall_query(synonym)) == generate_sql_query(parse_scryfall_query(expansion))

--- a/api/parsing/tests/test_rewrite.py
+++ b/api/parsing/tests/test_rewrite.py
@@ -31,6 +31,8 @@ EQUIVALENCES = [
     ("is:mdfc", "layout:modal_dfc"),
     ("is:meld", "layout:meld"),
     ("is:leveler", "layout:leveler"),
+    ("is:dfc", "layout:transform or layout:modal_dfc or layout:meld"),
+    ("is:colorshifted", "frame:colorshifted"),
     # composes under negation and inside compounds
     ("-frame:old", "-(frame:1993 or frame:1997)"),
     ("t:goblin frame:modern", "t:goblin frame:2003"),

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -603,16 +603,13 @@ def test_art_tag_sql_translation(parse_query, input_query: str, expected_sql: st
             r"(card.card_is_tags @> %(p_dict_eydtb2RhbC1kZmMnOiBUcnVlfQ)s)",
             {"p_dict_eydtb2RhbC1kZmMnOiBUcnVlfQ": {"modal-dfc": True}},
         ),
-        # Common is: tags
+        # Generic is: fallback for tags with no rewrite (is:spell is deferred, so still
+        # lowers to a raw card_is_tags lookup). Rewritten tags (is:permanent, is:party,
+        # the layout family, …) are covered by test_rewrite.py.
         (
             "is:spell",
             r"(card.card_is_tags @> %(p_dict_eydzcGVsbCc6IFRydWV9)s)",
             {"p_dict_eydzcGVsbCc6IFRydWV9": {"spell": True}},
-        ),
-        (
-            "is:permanent",
-            r"(card.card_is_tags @> %(p_dict_eydwZXJtYW5lbnQnOiBUcnVlfQ)s)",
-            {"p_dict_eydwZXJtYW5lbnQnOiBUcnVlfQ": {"permanent": True}},
         ),
     ],
 )

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1102,13 +1102,11 @@ class TestTags:
         assert total == 27
 
     def test_is_permanent(self, engine: QueryEngine) -> None:
+        # is:permanent is rewritten to a type-union (api/parsing/rewrite.py), so it no longer
+        # consults the synthetic "permanent" tag -- it matches every permanent-type card,
+        # including 2 the fixture left untagged (hence 62, not the 60 tagged "permanent").
         total, _ = _run(engine, "is:permanent")
-        assert total == 60
-
-    def test_is_spell_and_permanent_disjoint(self, engine: QueryEngine) -> None:
-        total_spell, _ = _run(engine, "is:spell")
-        total_perm, _ = _run(engine, "is:permanent")
-        assert total_spell + total_perm == 87
+        assert total == 62
 
     def test_otag_burn(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, "otag:burn")

--- a/docs/issues/00713-is-tag-recovery.md
+++ b/docs/issues/00713-is-tag-recovery.md
@@ -1,0 +1,158 @@
+# Recovering the `is:` / derived-predicate namespace
+
+[#713](https://github.com/jbylund/sylvan_librarian/issues/713)
+
+Grew out of the `frame:` synonym investigation
+(`frame:modern` returned 0 after a full scan — see [Frame synonyms](#related)); the `is:`
+namespace is the same failure mode at much larger scale.
+
+## The failure mode
+
+`is:` queries **parse correctly** and lower to a `card_is_tags` collection lookup — but
+`card_is_tags` is **empty for every card**. Scryfall provides no bulk dump for that
+collection (it's the one ingest with no bulk source), so it was never populated. Result:
+**every `is:` predicate silently returns 0** after a full-corpus scan — a wrong answer that
+looks like a working query, plus the wasted scan (the `frame:modern` pathology, namespace-wide).
+
+Most of these are recoverable *without* the missing tag source, because the facts are either
+derivable from data we already ingest or present as ordinary fields in the bulk `default-cards`
+file we already download. Only a minority are genuinely blocked.
+
+## The validation discipline (non-negotiable)
+
+Measured `is:bear` against its "obvious" expansion on Scryfall's live API (`unique=cards`):
+
+| query | count |
+|---|---|
+| `is:bear` | 1038 |
+| `t:creature pow=2 tou=2 mv=2` | 1048 |
+| `pow=2 tou=2 mv=2` (no `t:creature`) | 1052 |
+| `pow=2 tou=2 mv=2 -is:dfc` | 1056 |
+
+The naive `t:creature` rewrite is wrong in **both** directions. Diffing the sets:
+`is:bear` *includes* 4 non-creatures (Vehicles/Spacecraft — it's any 2/2-for-2 *permanent*, not
+just creatures) and *excludes* 14 double-faced cards (all `//`). So the concept is "single-faced
+2/2-for-2 permanent" — but even `pow=2 tou=2 mv=2 -is:dfc` (1056) doesn't reconcile to 1038:
+Scryfall's multi-face + `unique=cards` evaluation (which face's P/T counts, how a negated `is:`
+interacts with the default extras filter) is undocumented and not cleanly reproducible by set
+algebra.
+
+Lesson: **"derivable" does not mean "the naive expansion is exact," and some exact counts aren't
+worth reverse-engineering.** Policy: **exact parity required and achievable for common predicates**
+(`is:reprint` — a clean build-time derivation, no face games); **documented ~1–2% divergence
+acceptable for niche ones** (`is:bear` → `pow=2 tou=2 mv=2 -is:dfc`, close enough). Every rewrite
+carries an API-validated count test regardless, so the divergence is *known* rather than silent.
+
+**Where the residual lives (validated on `is:bear` and `is:vanilla`).** The correct primitive-level
+rewrite lands ~97–99%; the entire gap is consistently (a) multi-faced/Adventure **face evaluation**
+(Scryfall judges the relevant face; a whole-card text/stat test disagrees) plus (b) a few **type
+edge cases** (Vehicles/Spacecraft for `is:bear`; Dryad Arbor for `is:vanilla`). The gaps cluster
+rather than scatter, so the one lever that would tighten *all* rewrites is per-face evaluation —
+not per-predicate patching. And since this engine has its own multi-face model, those residuals may
+not even align with Scryfall's, which is a further argument for "clean rewrite + documented
+divergence" over chasing exact counts. Also: `o:""`/`o:/^$/` is a **trap** — the empty-match regex
+matches every card; "no text" must be written as the negation `-o:/./`.
+
+## Four recovery paths
+
+| bucket | needs | one-line mechanism |
+|---|---|---|
+| **A. Query-rewrite** | *nothing new* | bind-time macro → AST over fields we already ingest |
+| **B. Build-time bit** | one ingest/build pass, no external source | derive a per-card/printing bit from ingested data |
+| **C. Bulk field (dropped)** | extend existing bulk ingest | store a `default-cards` field we currently discard |
+| **D. No bulk source** | scrape / curated list | Tagger-derived or hand-curated, genuinely blocked |
+
+The rewrite layer (A) is the same mechanism as the `frame:` synonyms: expand at the parser seam
+that feeds *both* SQL and engine, so no engine change and correct-by-construction (given the
+primitives). B and C need ingest work but no external source. D is the only truly blocked set.
+
+## Classification
+
+Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **validate before shipping**.
+
+### A — Query-rewrite (no new data; fields already ingested)
+
+| predicate | expansion | conf |
+|---|---|---|
+| `frame:modern` | `frame:2003` | ✓ |
+| `is:old` / `frame:old` | `(frame:1993 or frame:1997)` | ✓ |
+| `is:new` | `frame:2015` | ✓ |
+| `frame:new` | `frame:2003 or frame:2015 or frame:future` (undocumented alias; positive union — matches the validated Scryfall count and is safe against any frameless printing, unlike a `-(old)` complement) | ✓ |
+| `is:split`/`is:flip`/`is:transform`/`is:dfc`/`is:mdfc`/`is:meld`/`is:leveler` | `card_layout` value | ✓ |
+| `is:spell` / `is:permanent` / `is:historic` | type-line predicate | ✓ |
+| `is:party` / `is:outlaw` | subtype set | ✓ |
+| `is:bear` | `t:creature pow=2 tou=2 mv=2` (~10-card residual, see above) | ~ |
+| `is:hybrid` / `is:phyrexian` | mana-cost symbol test (`mana_cost_jsonb`) | ~ |
+| `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ~ |
+| `is:vanilla` | `t:creature -o:/./` (NOT `o:""`/`o:/^$/` — the empty-match regex matches *all* creatures); 348 vs 359, residual = Adventure/DFC faces + Dryad Arbor | ~ |
+| `has:watermark` | `card_watermark` present | ✓ |
+
+Not cleanly rewritable (text-pattern / fuzzy — defer or approximate): `is:frenchvanilla`,
+`is:manland`, `is:modal`, `is:default`/`is:atypical`.
+
+### B — Build-time bit (derive from ingested data, no external source)
+
+| predicate | derivation | conf |
+|---|---|---|
+| `is:reprint` / `not:reprint` / `is:unique` | group by `oracle_id`, order by `released_at`; earliest printing = not-reprint | ✓ |
+| `prints`/`sets`/`papersets` comparisons | count per `oracle_id` at build | ✓ |
+| `is:commander` | legendary creature ∨ "can be your commander" text | ~ |
+| `is:newinpauper` | first pauper-rarity printing per card | ~ |
+
+`is:reprint` is the priority here — common (pairs with `f:modern` workflows), currently silently
+empty, and cleanly derivable.
+
+### C — Bulk `default-cards` field we currently drop (verify field names against the bulk schema)
+
+Not in the store today (confirmed absent from the ingested corpus keys), but present on each card
+object in the bulk file we already fetch — so recoverable by storing the field, **not** blocked:
+
+| predicate(s) | source field |
+|---|---|
+| `is:promo` + promo types (`is:prerelease`/`is:buyabox`/`is:fnm`/`is:judge_gift`/…) | `promo`, `promo_types` |
+| `is:reserved` | `reserved` |
+| `is:digital` | `digital` |
+| `is:foil`/`is:nonfoil`/`is:etched`/`is:glossy` | `finishes` |
+| `is:full` (full art) | `full_art` |
+| `is:booster` | `booster` |
+| `is:spotlight` | `story_spotlight` |
+| `is:hires` | `highres_image` |
+| `has:indicator` | `color_indicator` |
+| `game:paper`/`mtgo`/`arena`, `in:<game>` | `games` |
+| `stamp:oval`/`acorn`/`triangle`/`arena` | `security_stamp` |
+
+### D — No bulk source (Tagger-derived / curated — deferred)
+
+The land-cycle shortcuts (`is:fetchland`, `is:dual`, `is:shockland`, `is:bikeland`,
+`is:checkland`, `is:painland`, … ~25 of them) and curated WotC lists (`is:gamechanger`,
+`is:masterpiece`). These have no `default-cards` field; Scryfall builds them from the Tagger
+project or hand-maintained lists. Blocked without scraping or maintaining our own list. Niche
+enough to defer.
+
+## Recommended plan
+
+Do buckets **A, B, C** (in that order — cheapest-first), defer D. All independent PRs off `main`,
+none touching the #702 engine-routing branch:
+
+1. **Query-rewrite layer** (A) + the `frame:` synonyms — purely parser, zero new data, rescues the
+   largest definable chunk. Each rewrite validated against the live API + a differential test.
+   **Landed:** `api/parsing/rewrite.py` — a post-parse transform at the shared `parse_scryfall_query`
+   seam (applies to both parsers; parity-tested), with `frame:modern/old/new` + `is:old`/`is:new`
+   and `test_rewrite.py`. Remaining A rows (`is:bear`, `is:vanilla`, `is:spell`, layout-based) are
+   follow-ups needing their own API-validated expansions.
+2. **`is:reprint` build-time bit** (B) — one derivation, common predicate, currently broken.
+3. **Ingest the dropped boolean fields** (C) — recovers promo/reserved/digital/foil/etc. as normal
+   lookups.
+
+Each predicate carries an API-validated count test so a future Scryfall change (the undocumented
+aliases especially) trips a tripwire.
+
+## Related
+
+- Frame synonyms + query-tree rewriting (this doc's parent thread) — the rewrite seam is
+  `get_frame_data_comparison_object` / node-construction, feeding both SQL and engine.
+- [00667-engine-legality-divergent-carveout.md](done/00667-engine-legality-divergent-carveout.md) —
+  legality is the analogous per-printing existence-projection problem.
+- [00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md) — the "observed
+  values" dictionary (leaf cardinality 0 for absent values) is the same build-time artifact this
+  namespace would populate; the two-spaces estimator consumes it.

--- a/docs/issues/00713-is-tag-recovery.md
+++ b/docs/issues/00713-is-tag-recovery.md
@@ -85,7 +85,7 @@ Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **valida
 | `is:party` | `t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)` | ✓ **exact** (3820) — `kw:changeling` (→ `card_keywords`) recovers the all-type creatures |
 | `is:outlaw` | `(t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling)` — **no** `t:creature` (unlike party: includes Kindred non-creatures) | ✓ **exact** (1334) |
 | `is:dfc` | `layout:transform or layout:modal_dfc` (double-faced union; verify) | ~ |
-| `is:bear` | `t:creature pow=2 tou=2 mv=2` (~10-card residual, see above) | ~ |
+| `is:bear` | `t:creature pow=2 tou=2 cmc=2` — the intuitive "2/2 for 2"; deliberately *not* Scryfall-exact (+~14 DFC creatures, −4 Vehicles/Spacecraft; their exact count isn't cross-verifiable) | ~ |
 | `is:hybrid` / `is:phyrexian` | mana-cost symbol test (`mana_cost_jsonb`) | ~ |
 | `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ~ |
 | `is:vanilla` | our engine: `t:creature o=""` (empty-string equality — clean; the `o:/^$/` empty-match regex is a Scryfall-only trap that matches *all* creatures); −11 subset vs 359 = Adventure/DFC textless faces + Dryad Arbor | ~ |
@@ -141,9 +141,12 @@ none touching the #702 engine-routing branch:
 1. **Query-rewrite layer** (A) + the `frame:` synonyms — purely parser, zero new data, rescues the
    largest definable chunk. Each rewrite validated against the live API + a differential test.
    **Landed:** `api/parsing/rewrite.py` — a post-parse transform at the shared `parse_scryfall_query`
-   seam (applies to both parsers; parity-tested), with `frame:modern/old/new` + `is:old`/`is:new`
-   and `test_rewrite.py`. Remaining A rows (`is:bear`, `is:vanilla`, `is:spell`, layout-based) are
-   follow-ups needing their own API-validated expansions.
+   seam (applies to both parsers; parity-tested; rebuilds only when a synonym actually fires), with
+   `frame:modern/old/new`, `is:old`/`is:new`, `is:historic`/`is:permanent`/`is:party`/`is:outlaw`/
+   `is:vanilla`/`is:bear`, and the layout family (`is:split/flip/transform/mdfc/meld/leveler`), plus
+   `test_rewrite.py`. Remaining A: the quick-validate candidates (`is:colorshifted`, `is:dfc`,
+   `is:hybrid`, `is:phyrexian`) and the deferred/fuzzy ones (`is:spell`, `is:modal`,
+   `is:frenchvanilla`, `is:default`/`is:atypical`, `is:manland`).
 2. **`is:reprint` build-time bit** (B) — one derivation, common predicate, currently broken.
 3. **Ingest the dropped boolean fields** (C) — recovers promo/reserved/digital/foil/etc. as normal
    lookups.

--- a/docs/issues/00713-is-tag-recovery.md
+++ b/docs/issues/00713-is-tag-recovery.md
@@ -84,9 +84,9 @@ Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **valida
 | `is:spell` | `-t:land` | ~ (+85 / 32069 — not every non-land is castable) |
 | `is:party` | `t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)` | ✓ **exact** (3820) — `kw:changeling` (→ `card_keywords`) recovers the all-type creatures |
 | `is:outlaw` | `(t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling)` — **no** `t:creature` (unlike party: includes Kindred non-creatures) | ✓ **exact** (1334) |
-| `is:dfc` | `layout:transform or layout:modal_dfc` (double-faced union; verify) | ~ |
+| `is:dfc` | `layout:transform or layout:modal_dfc or layout:meld` — gameplay DFCs. Scryfall's `is:dfc` also counts `art_series`/`reversible_card`/`double_faced_token` (~2394 art/token entries not in gameplay data), so the layout union is correct for our corpus | ✓ |
 | `is:bear` | `t:creature pow=2 tou=2 cmc=2` — the intuitive "2/2 for 2"; deliberately *not* Scryfall-exact (+~14 DFC creatures, −4 Vehicles/Spacecraft; their exact count isn't cross-verifiable) | ~ |
-| `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ~ |
+| `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ✓ **exact** (45) |
 | `is:vanilla` | our engine: `t:creature o=""` (empty-string equality — clean; the `o:/^$/` empty-match regex is a Scryfall-only trap that matches *all* creatures); −11 subset vs 359 = Adventure/DFC textless faces + Dryad Arbor | ~ |
 | `has:watermark` | `card_watermark` present | ✓ |
 
@@ -143,10 +143,11 @@ none touching the #702 engine-routing branch:
    **Landed:** `api/parsing/rewrite.py` — a post-parse transform at the shared `parse_scryfall_query`
    seam (applies to both parsers; parity-tested; rebuilds only when a synonym actually fires), with
    `frame:modern/old/new`, `is:old`/`is:new`, `is:historic`/`is:permanent`/`is:party`/`is:outlaw`/
-   `is:vanilla`/`is:bear`, and the layout family (`is:split/flip/transform/mdfc/meld/leveler`), plus
-   `test_rewrite.py`. Remaining A: the quick-validate candidates (`is:colorshifted`, `is:dfc`) and
-   the deferred/fuzzy ones (`is:spell`, `is:modal`, `is:frenchvanilla`, `is:default`/`is:atypical`,
-   `is:manland`). `is:hybrid`/`is:phyrexian` moved to B (ingest flag — no clean rewrite).
+   `is:vanilla`/`is:bear`, the layout family (`is:split/flip/transform/mdfc/meld/leveler`),
+   `is:dfc`, and `is:colorshifted`, plus `test_rewrite.py`. **Bucket A is now complete** except the
+   inherently-unsuitable ones, left deferred: `is:spell` (false positives), `is:modal`,
+   `is:frenchvanilla`, `is:default`/`is:atypical`, `is:manland`. `is:hybrid`/`is:phyrexian` moved to
+   B (ingest flag — no clean rewrite).
 2. **`is:reprint` build-time bit** (B) — one derivation, common predicate, currently broken.
 3. **Ingest the dropped boolean fields** (C) — recovers promo/reserved/digital/foil/etc. as normal
    lookups.

--- a/docs/issues/00713-is-tag-recovery.md
+++ b/docs/issues/00713-is-tag-recovery.md
@@ -86,7 +86,6 @@ Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **valida
 | `is:outlaw` | `(t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling)` — **no** `t:creature` (unlike party: includes Kindred non-creatures) | ✓ **exact** (1334) |
 | `is:dfc` | `layout:transform or layout:modal_dfc` (double-faced union; verify) | ~ |
 | `is:bear` | `t:creature pow=2 tou=2 cmc=2` — the intuitive "2/2 for 2"; deliberately *not* Scryfall-exact (+~14 DFC creatures, −4 Vehicles/Spacecraft; their exact count isn't cross-verifiable) | ~ |
-| `is:hybrid` / `is:phyrexian` | mana-cost symbol test (`mana_cost_jsonb`) | ~ |
 | `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ~ |
 | `is:vanilla` | our engine: `t:creature o=""` (empty-string equality — clean; the `o:/^$/` empty-match regex is a Scryfall-only trap that matches *all* creatures); −11 subset vs 359 = Adventure/DFC textless faces + Dryad Arbor | ~ |
 | `has:watermark` | `card_watermark` present | ✓ |
@@ -102,6 +101,7 @@ Not cleanly rewritable (text-pattern / fuzzy — defer or approximate): `is:fren
 | `prints`/`sets`/`papersets` comparisons | count per `oracle_id` at build | ✓ |
 | `is:commander` | legendary creature ∨ "can be your commander" text | ~ |
 | `is:newinpauper` | first pauper-rarity printing per card | ~ |
+| `is:hybrid` / `is:phyrexian` | ingest flag: any hybrid / Phyrexian symbol in the raw mana cost. *Not* a rewrite — the DSL only does exact-symbol containment (`m:{g/w}`), so a rewrite would be a brittle ~15-term OR over an open, growing symbol set; trivial to set at ingest instead | ✓ |
 
 `is:reprint` is the priority here — common (pairs with `f:modern` workflows), currently silently
 empty, and cleanly derivable.
@@ -144,9 +144,9 @@ none touching the #702 engine-routing branch:
    seam (applies to both parsers; parity-tested; rebuilds only when a synonym actually fires), with
    `frame:modern/old/new`, `is:old`/`is:new`, `is:historic`/`is:permanent`/`is:party`/`is:outlaw`/
    `is:vanilla`/`is:bear`, and the layout family (`is:split/flip/transform/mdfc/meld/leveler`), plus
-   `test_rewrite.py`. Remaining A: the quick-validate candidates (`is:colorshifted`, `is:dfc`,
-   `is:hybrid`, `is:phyrexian`) and the deferred/fuzzy ones (`is:spell`, `is:modal`,
-   `is:frenchvanilla`, `is:default`/`is:atypical`, `is:manland`).
+   `test_rewrite.py`. Remaining A: the quick-validate candidates (`is:colorshifted`, `is:dfc`) and
+   the deferred/fuzzy ones (`is:spell`, `is:modal`, `is:frenchvanilla`, `is:default`/`is:atypical`,
+   `is:manland`). `is:hybrid`/`is:phyrexian` moved to B (ingest flag — no clean rewrite).
 2. **`is:reprint` build-time bit** (B) — one derivation, common predicate, currently broken.
 3. **Ingest the dropped boolean fields** (C) — recovers promo/reserved/digital/foil/etc. as normal
    lookups.

--- a/docs/issues/00713-is-tag-recovery.md
+++ b/docs/issues/00713-is-tag-recovery.md
@@ -78,13 +78,17 @@ Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **valida
 | `is:old` / `frame:old` | `(frame:1993 or frame:1997)` | ✓ |
 | `is:new` | `frame:2015` | ✓ |
 | `frame:new` | `frame:2003 or frame:2015 or frame:future` (undocumented alias; positive union — matches the validated Scryfall count and is safe against any frameless printing, unlike a `-(old)` complement) | ✓ |
-| `is:split`/`is:flip`/`is:transform`/`is:dfc`/`is:mdfc`/`is:meld`/`is:leveler` | `card_layout` value | ✓ |
-| `is:spell` / `is:permanent` / `is:historic` | type-line predicate | ✓ |
-| `is:party` / `is:outlaw` | subtype set | ✓ |
+| `is:historic` | `t:legendary or t:artifact or t:saga` | ✓ **exact** (7881=7881) |
+| `is:permanent` | `t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or t:battle` | ✓ near-exact (+2 / 25954) |
+| `is:split`/`is:flip`/`is:transform`/`is:mdfc`/`is:meld`/`is:leveler` | `layout:<value>` (`card_layout` is ingested + `layout:` is queryable; exact by field correspondence) | ✓ |
+| `is:spell` | `-t:land` | ~ (+85 / 32069 — not every non-land is castable) |
+| `is:party` | `t:creature (t:cleric or t:rogue or t:warrior or t:wizard or kw:changeling)` | ✓ **exact** (3820) — `kw:changeling` (→ `card_keywords`) recovers the all-type creatures |
+| `is:outlaw` | `(t:assassin or t:mercenary or t:pirate or t:rogue or t:warlock or kw:changeling)` — **no** `t:creature` (unlike party: includes Kindred non-creatures) | ✓ **exact** (1334) |
+| `is:dfc` | `layout:transform or layout:modal_dfc` (double-faced union; verify) | ~ |
 | `is:bear` | `t:creature pow=2 tou=2 mv=2` (~10-card residual, see above) | ~ |
 | `is:hybrid` / `is:phyrexian` | mana-cost symbol test (`mana_cost_jsonb`) | ~ |
 | `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ~ |
-| `is:vanilla` | `t:creature -o:/./` (NOT `o:""`/`o:/^$/` — the empty-match regex matches *all* creatures); 348 vs 359, residual = Adventure/DFC faces + Dryad Arbor | ~ |
+| `is:vanilla` | our engine: `t:creature o=""` (empty-string equality — clean; the `o:/^$/` empty-match regex is a Scryfall-only trap that matches *all* creatures); −11 subset vs 359 = Adventure/DFC textless faces + Dryad Arbor | ~ |
 | `has:watermark` | `card_watermark` present | ✓ |
 
 Not cleanly rewritable (text-pattern / fuzzy — defer or approximate): `is:frenchvanilla`,

--- a/docs/issues/00713-is-tag-recovery.md
+++ b/docs/issues/00713-is-tag-recovery.md
@@ -88,10 +88,11 @@ Confidence: ✓ = definition doc-confirmed / measured; ~ = approximate, **valida
 | `is:bear` | `t:creature pow=2 tou=2 cmc=2` — the intuitive "2/2 for 2"; deliberately *not* Scryfall-exact (+~14 DFC creatures, −4 Vehicles/Spacecraft; their exact count isn't cross-verifiable) | ~ |
 | `is:colorshifted` | `frame:colorshifted` (frame-effect in `card_frame_data`) | ✓ **exact** (45) |
 | `is:vanilla` | our engine: `t:creature o=""` (empty-string equality — clean; the `o:/^$/` empty-match regex is a Scryfall-only trap that matches *all* creatures); −11 subset vs 359 = Adventure/DFC textless faces + Dryad Arbor | ~ |
+| `is:manland` | `t:land o:become o:creature o:/still a.* land/` — creature-land oracle-text heuristic; 48/49 vs Scryfall, 0 false positives, and its only miss (Alchemy-only Rising Chicane) is absent from our corpus → effectively exact here | ~ |
 | `has:watermark` | `card_watermark` present | ✓ |
 
 Not cleanly rewritable (text-pattern / fuzzy — defer or approximate): `is:frenchvanilla`,
-`is:manland`, `is:modal`, `is:default`/`is:atypical`.
+`is:modal`, `is:default`/`is:atypical`.
 
 ### B — Build-time bit (derive from ingested data, no external source)
 
@@ -144,9 +145,9 @@ none touching the #702 engine-routing branch:
    seam (applies to both parsers; parity-tested; rebuilds only when a synonym actually fires), with
    `frame:modern/old/new`, `is:old`/`is:new`, `is:historic`/`is:permanent`/`is:party`/`is:outlaw`/
    `is:vanilla`/`is:bear`, the layout family (`is:split/flip/transform/mdfc/meld/leveler`),
-   `is:dfc`, and `is:colorshifted`, plus `test_rewrite.py`. **Bucket A is now complete** except the
-   inherently-unsuitable ones, left deferred: `is:spell` (false positives), `is:modal`,
-   `is:frenchvanilla`, `is:default`/`is:atypical`, `is:manland`. `is:hybrid`/`is:phyrexian` moved to
+   `is:dfc`, `is:colorshifted`, and `is:manland`, plus `test_rewrite.py`. **Bucket A is now complete**
+   except the inherently-unsuitable ones, left deferred: `is:spell` (false positives), `is:modal`,
+   `is:frenchvanilla`, `is:default`/`is:atypical`. `is:hybrid`/`is:phyrexian` moved to
    B (ingest flag — no clean rewrite).
 2. **`is:reprint` build-time bit** (B) — one derivation, common predicate, currently broken.
 3. **Ingest the dropped boolean fields** (C) — recovers promo/reserved/digital/foil/etc. as normal


### PR DESCRIPTION
## Summary

The entire `is:` search namespace was **silently returning 0**: `is:` queries parse fine and lower
to a `card_is_tags` lookup, but that collection is empty for every card (Scryfall has no bulk dump
for it, so it was never populated) — a wrong answer that looks like a working query, plus a wasted
full-corpus scan. Same failure mode as the undocumented `frame:` word-aliases (`frame:modern` →
`"Modern"` → matches nothing → 0).

This PR recovers the **derivable** part of that namespace with a single **post-parse query-rewrite**:
a bind-time transform that expands each derived predicate into a subtree of primitives the engine
already supports. It rescues 20 `frame:`/`is:` predicates with no engine, schema, or ingest change.

Design doc (full 92-tag classification, per-tag validation, and the B/C/D follow-up plan):
[docs/issues/00713-is-tag-recovery.md](../blob/derived-predicate-rewrite/docs/issues/00713-is-tag-recovery.md).

## Approach

`expand_derived_predicates` runs at the shared `parse_scryfall_query` seam — `parse => transform =>
rest` — so it operates on the common AST **after** parsing and applies identically to both the
production hand parser and the legacy pyparsing parser (kept in lockstep by `test_parser_parity`,
which is why the pyparsing entry applies it too). Properties:

- **Correct by construction.** Each expansion is written as a DSL string and re-parsed by the
  production parser, so a definition is expressed in the same language it targets — no hand-built
  node trees to drift.
- **Cheap.** The transform returns the parsed tree untouched when no synonym is present (the
  overwhelming majority of queries); it only rebuilds + re-flattens when a rewrite actually fires.
- **Validated, not guessed.** Every entry was count-checked against Scryfall's live API. The naive
  expansion is frequently ~97–99%, *not* exact (e.g. the "obvious" `is:bear` stat rewrite is wrong
  in both directions), and each residual is documented — exact where achievable, documented
  divergence where not.

## What landed (20 rewrites)

| predicate(s) | expansion | vs Scryfall |
|---|---|---|
| `frame:modern` | `frame:2003` | exact |
| `frame:old` / `is:old` | `frame:1993 or frame:1997` | exact |
| `frame:new` | `frame:2003 or frame:2015 or frame:future` | exact |
| `is:new` | `frame:2015` | exact (documented — narrower than `frame:new`) |
| `is:historic` | `t:legendary or t:artifact or t:saga` | exact |
| `is:party` | `t:creature (…cleric/rogue/warrior/wizard or kw:changeling)` | exact |
| `is:outlaw` | `(…assassin/mercenary/pirate/rogue/warlock or kw:changeling)` | exact |
| `is:colorshifted` | `frame:colorshifted` | exact |
| `is:split/flip/transform/mdfc/meld/leveler` | `layout:<value>` | exact (field correspondence) |
| `is:dfc` | `layout:transform or layout:modal_dfc or layout:meld` | exact on gameplay data* |
| `is:permanent` | the six permanent types | +2 / 25954 |
| `is:manland` | `t:land o:become o:creature o:/still a.* land/` | 48/49, 0 FP; exact on our data** |
| `is:vanilla` | `t:creature o=""` | −11 subset (Adventure/DFC textless faces + Dryad Arbor) |
| `is:bear` | `t:creature pow=2 tou=2 cmc=2` | intuitive 2/2-for-2 (deliberately not Scryfall-exact) |

\* Scryfall's `is:dfc` also counts `art_series`/`reversible_card`/`double_faced_token` (~2394
art/token entries) not present in gameplay data. \*\* the one Scryfall miss (Rising Chicane) is
Alchemy-only, absent from our corpus.

Two non-obvious findings baked into the expansions: changelings carry the ability as a *keyword*
(`kw:changeling`, subtype is Shapeshifter), and `is:party` is creature-restricted while `is:outlaw`
is not (it also matches Kindred non-creature cards).

## Tests

`api/parsing/tests/test_rewrite.py`: each synonym must expand to the identical AST as its canonical
form **and** emit identical SQL, run against **both** parsers via the shared fixture; plus
composition under negation/compounds and pass-through of un-rewritten tags (`is:promo`) and real
frame values (`frame:2003`). `test_sql_gen.py` updated (dropped the now-rewritten `is:permanent`
generic-fallback case). `test_parser_parity` green throughout; full parsing suite green (1445).

## Out of scope (follow-ups, all documented in the issue doc)

- **Deferred / inherently unsuitable for a rewrite:** `is:spell` (bidirectional, false positives),
  `is:modal`, `is:frenchvanilla`, `is:default`/`is:atypical`.
- **Bucket B — build-time bit:** `is:reprint`/`is:unique` (from `oracle_id` + release order), the
  legality set, and `is:hybrid`/`is:phyrexian` (ingest flag — mana search is exact-symbol only).
- **Bucket C — bulk field we currently drop** (~33): finishes/promo/promo-types/reserved/digital/…
- **Bucket D — no bulk source** (~24): the land cycles + `is:masterpiece`/`is:gamechanger`.

Part of #713.
