### PR TITLE
Fold Diacritics in Fuzzy Name Search

### DIFF
--- a/api/card_processing.py
+++ b/api/card_processing.py
@@ -7,7 +7,7 @@ import functools
 import re
 from typing import TYPE_CHECKING, Any
 
-from api.parsing.card_query_nodes import calculate_devotion, mana_cost_str_to_dict
+from api.parsing.card_query_nodes import calculate_devotion, fold_accents, mana_cost_str_to_dict
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -238,6 +238,9 @@ def preprocess_card(card: dict[str, Any]) -> list[dict[str, Any]]:  # noqa: PLR0
     # Don't overwrite card_name if already set (for DFCs, it's set before processing faces)
     if "card_name" not in card:
         card["card_name"] = card.get("name")
+    # Accent-folded lowercase name, precomputed once at import so fuzzy name: search can
+    # match "eowyn" against "Éowyn" without folding diacritics on every query (#649).
+    card["card_name_folded"] = fold_accents(card["card_name"].lower())
     card["mana_cost_text"] = card.get("mana_cost")
     card["planeswalker_loyalty_text"] = card.get("loyalty")
     card["card_artist"] = card.get("artist")

--- a/api/db/2026-07-20-01-accent-folded-name.sql
+++ b/api/db/2026-07-20-01-accent-folded-name.sql
@@ -1,0 +1,28 @@
+-- Precomputed accent-folded lowercase card name, so fuzzy `name:` search matches
+-- both accented and unaccented spellings (e.g. "eowyn" finds "Éowyn") without
+-- folding diacritics per query. The authoritative fold logic is fold_accents() in
+-- api/parsing/card_query_nodes.py (NFKD + strip combining marks); every import
+-- recomputes this column from that function. See #649 and
+-- docs/issues/00649-accent-insensitive-name-search.md.
+--
+-- Exact-match search (name=, !"...") intentionally keeps comparing against
+-- card_name/card_name_lower and is untouched by this column.
+
+ALTER TABLE magic.cards ADD COLUMN IF NOT EXISTS card_name_folded text;
+
+-- One-time backfill for rows already in the table, ahead of the next bulk import.
+-- translate() is a bootstrap approximation of fold_accents() covering the
+-- diacritics observed in the Scryfall corpus; the next import overwrites every
+-- row with the real Python computation regardless.
+UPDATE magic.cards
+SET card_name_folded = lower(translate(
+    card_name,
+    'ÁÀÂÄÃÅáàâäãåÉÈÊËéèêëÍÌÎÏíìîïÓÒÔÖÕóòôöõÚÙÛÜúùûüÑñÇçŌō',
+    'AAAAAAaaaaaaEEEEeeeeIIIIiiiiOOOOOoooooUUUUuuuuNnCcOo'
+))
+WHERE card_name_folded IS NULL;
+
+ALTER TABLE magic.cards ALTER COLUMN card_name_folded SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_cards_cardname_folded_lower_trgm
+    ON magic.cards USING gin (lower(card_name_folded) magic.gin_trgm_ops);

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 
 from titlecase import titlecase
 
@@ -479,6 +480,20 @@ def _escape_like_pattern(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
 
 
+def fold_accents(value: str) -> str:
+    """Strip Latin diacritics so accented and unaccented spellings compare equal.
+
+    NFKD-decomposes each character into base letter + combining marks, then drops
+    the marks (unicodedata.combining(c) != 0). This is the single source of truth
+    for accent folding: it's used to precompute card_name_folded at import time
+    (see preprocess_card()) and to fold the search term for fuzzy card_name:
+    queries in both the SQL and Rust engine paths, so the two sides never diverge
+    on what counts as "the same" name (#649).
+    """
+    decomposed = unicodedata.normalize("NFKD", value)
+    return "".join(c for c in decomposed if not unicodedata.combining(c))
+
+
 class ExactNameNode(QueryNode):
     """Represents an exact card name search using the ! prefix syntax from Scryfall.
 
@@ -553,7 +568,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
 
         return {"lhs": self.lhs.to_json(), "op": self.operator, "rhs": self._rhs_to_json()}
 
-    def _rhs_to_json(self) -> object:
+    def _rhs_to_json(self) -> object:  # noqa: PLR0912
         """Compute the JSON-serializable rhs for non-JSONB_ARRAY CardAttributeNode LHS."""
         if not self.lhs.field_infos:
             return _node_to_json(self.rhs)
@@ -585,7 +600,13 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             return NumericValueNode(get_rarity_number(self.rhs.value)).to_json()
 
         if attr in ("card_name", "card_artist") and isinstance(self.rhs, StringValueNode):
-            return {"node_type": "StringValueNode", "kwargs": {"value": titlecase(self.rhs.value)}}
+            value = titlecase(self.rhs.value)
+            # Fold diacritics for fuzzy card_name: search so the Rust engine's
+            # TextContains matches the same way the SQL path does via card_name_folded
+            # (#649); exact/comparison ops keep the literal value, accent-sensitive.
+            if attr == "card_name" and self.operator == ":":
+                value = fold_accents(value)
+            return {"node_type": "StringValueNode", "kwargs": {"value": value}}
 
         return _node_to_json(self.rhs)
 
@@ -789,7 +810,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
                 return super().to_sql(context)
 
             # Regular text field handling with pattern matching
-            return self._handle_text_field_pattern_matching(context, lhs_sql)
+            return self._handle_text_field_pattern_matching(context, lhs_sql, attr)
 
         msg = f"Unknown field type: {field_type}"
         raise NotImplementedError(msg)
@@ -932,7 +953,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         msg = f"Unsupported operator for year search: {operator}"
         raise ValueError(msg)
 
-    def _handle_text_field_pattern_matching(self, context: QueryContext, lhs_sql: str) -> str:
+    def _handle_text_field_pattern_matching(self, context: QueryContext, lhs_sql: str, attr: str) -> str:
         """Handle pattern matching for regular text fields."""
         # Check if RHS is a regex pattern
         if isinstance(self.rhs, RegexValueNode):
@@ -946,6 +967,15 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         else:
             msg = f"Unknown type: {type(self.rhs)}, {locals()}"
             raise TypeError(msg)
+
+        # card_name fuzzy search is accent-folded so "eowyn" matches "Éowyn" (#649);
+        # card_name_folded is precomputed at import time from the same fold_accents().
+        # Exact-match paths (ExactNameNode, name=) deliberately keep using card_name/
+        # card_name_lower so typing the accent still finds only the accented spelling.
+        if attr == "card_name":
+            lhs_sql = "card.card_name_folded"
+            txt_val = fold_accents(txt_val)
+
         words = ["", *(_escape_like_pattern(w) for w in txt_val.lower().split()), ""]
         pattern = "%".join(words)
         return f"(lower({lhs_sql}) LIKE {context.add(pattern)})"

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -102,6 +102,16 @@ _DIGIT = frozenset("0123456789")
 _SPACE = frozenset(" \t\r\n")
 
 
+def _is_word_start(c: str) -> bool:
+    """ASCII identifier start, or any Unicode letter — accented card names, e.g. Éowyn (#649)."""
+    return c in _WORD_START or c.isalpha()
+
+
+def _is_word_cont(c: str) -> bool:
+    """ASCII identifier continuation, or any Unicode letter (#649)."""
+    return c in _WORD_CONT or c.isalpha()
+
+
 # ── Lexer ─────────────────────────────────────────────────────────────────────
 
 
@@ -244,8 +254,8 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
                 j += 1
                 while j < n and src[j] in _DIGIT:
                     j += 1
-            if j < n and src[j] in _WORD_CONT:
-                while j < n and src[j] in _WORD_CONT:
+            if j < n and _is_word_cont(src[j]):
+                while j < n and _is_word_cont(src[j]):
                     j += 1
                 tokens.append(Token(TT.WORD, src[pos:j], start, sb))
             elif "." in src[pos:j]:
@@ -256,9 +266,9 @@ def tokenize(src: str) -> list[Token]:  # noqa: C901, PLR0912, PLR0915
             continue
 
         # Word
-        if c in _WORD_START:
+        if _is_word_start(c):
             j = pos + 1
-            while j < n and src[j] in _WORD_CONT:
+            while j < n and _is_word_cont(src[j]):
                 j += 1
             tokens.append(Token(TT.WORD, src[pos:j], start, sb))
             pos = j

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -223,10 +223,14 @@ def create_basic_parsers() -> dict[str, ParserElement]:
             raise ValueError(msg)
         return word_str
 
-    word = Regex(r"[a-zA-Z_][a-zA-Z0-9_-]*[a-zA-Z0-9_]|[a-zA-Z_]").set_parse_action(make_word)
+    # [^\W\d] is "word char that's not a digit" — i.e. any Unicode letter or underscore
+    # (Python 3 `re` treats `\w`/`\W` as Unicode-aware by default for str patterns), so
+    # bare words can start with accented letters like "Éowyn" (#649) without also
+    # allowing a leading digit.
+    word = Regex(r"[^\W\d][\w-]*\w|[^\W\d]").set_parse_action(make_word)
 
     literal_number = float_number | integer
-    string_value_word = Regex(r"[a-zA-Z0-9_][a-zA-Z0-9_.-]*")
+    string_value_word = Regex(r"\w[\w.-]*")
 
     return {
         "attrop": attrop,
@@ -364,7 +368,7 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
         | attr_attr_condition
     )
 
-    hyphenated_condition = text_attr_word + Literal(":") + Regex(r"[a-zA-Z0-9_][a-zA-Z0-9_-]*")
+    hyphenated_condition = text_attr_word + Literal(":") + Regex(r"\w[\w-]*")
     hyphenated_condition.set_parse_action(make_binary_operator_node)
 
     return {
@@ -579,7 +583,7 @@ def _get_implicit_and_tokenizer() -> ParserElement:
 
     float_tok = Regex(r"\b\d+\.\d*\b").set_parse_action(lambda t: t[0])
 
-    string_value_tok = Regex(r"[a-zA-Z0-9_]([a-zA-Z0-9_.-]*[a-zA-Z0-9_.])?").set_parse_action(lambda t: t[0])
+    string_value_tok = Regex(r"\w([\w.-]*[\w.])?").set_parse_action(lambda t: t[0])
 
     curly_mana_symbol = Regex(r"\{[^}]+\}")
     simple_mana_symbol = Regex(r"[0-9WUBRGCXYZwubrgcxyz]")

--- a/api/parsing/tests/implicit_and_cases.py
+++ b/api/parsing/tests/implicit_and_cases.py
@@ -182,4 +182,9 @@ TESTCASES = [
     # Empty and single-space (edge cases)
     {"query": "", "expected": "", "id": "empty"},
     {"query": "   ", "expected": "", "id": "only_spaces"},
+    # Bare (unquoted) accented words — #649
+    {"query": "Éowyn", "expected": "Éowyn", "id": "bare_accented_word"},
+    {"query": "name:Éowyn", "expected": "name:Éowyn", "id": "attr_bare_accented_value"},
+    {"query": "name:Éowyn type:creature", "expected": "name:Éowyn AND type:creature", "id": "bare_accented_value_with_attr"},
+    {"query": "Éowyn Dúnedain", "expected": "Éowyn AND Dúnedain", "id": "two_bare_accented_words"},
 ]

--- a/api/parsing/tests/test_exact_name_search.py
+++ b/api/parsing/tests/test_exact_name_search.py
@@ -79,8 +79,14 @@ def test_exact_name_combined_with_other_conditions(parse_query, query: str) -> N
         ),
         # #649: exact name search stays accent-sensitive (compares against the
         # unfolded card_name, not card_name_folded) so typing the accent is required.
+        # Both quoted and bare/unquoted accented spellings parse and produce the same SQL.
         (
             '!"Éowyn"',
+            "(lower(card.card_name) LIKE %(p_str_w6lvd3lu)s)",
+            {"p_str_w6lvd3lu": "éowyn"},
+        ),
+        (
+            "!Éowyn",
             "(lower(card.card_name) LIKE %(p_str_w6lvd3lu)s)",
             {"p_str_w6lvd3lu": "éowyn"},
         ),

--- a/api/parsing/tests/test_exact_name_search.py
+++ b/api/parsing/tests/test_exact_name_search.py
@@ -77,6 +77,13 @@ def test_exact_name_combined_with_other_conditions(parse_query, query: str) -> N
             "NOT ((lower(card.card_name) LIKE %(p_str_bGlnaHRuaW5nIGJvbHQ)s))",
             {"p_str_bGlnaHRuaW5nIGJvbHQ": "lightning bolt"},
         ),
+        # #649: exact name search stays accent-sensitive (compares against the
+        # unfolded card_name, not card_name_folded) so typing the accent is required.
+        (
+            '!"Éowyn"',
+            "(lower(card.card_name) LIKE %(p_str_w6lvd3lu)s)",
+            {"p_str_w6lvd3lu": "éowyn"},
+        ),
     ],
 )
 def test_exact_name_sql_generation(parse_query, query: str, expected_sql: str, expected_parameters: dict) -> None:

--- a/api/parsing/tests/test_fold_accents.py
+++ b/api/parsing/tests/test_fold_accents.py
@@ -1,0 +1,32 @@
+"""Tests for fold_accents(), the diacritic-folding helper behind #649."""
+
+import pytest
+
+from api.parsing.card_query_nodes import fold_accents
+
+
+@pytest.mark.parametrize(
+    argnames=("value", "expected"),
+    argvalues=[
+        ("eowyn", "eowyn"),
+        ("Lightning Bolt", "Lightning Bolt"),
+        # Accented characters observed in real Scryfall card names (#649).
+        ("Éowyn, Fearless Knight", "Eowyn, Fearless Knight"),
+        ("Círdan the Shipwright", "Cirdan the Shipwright"),
+        ("Andúril, Flame of the West", "Anduril, Flame of the West"),
+        ("Arna Kennerüd, Skycaptain", "Arna Kennerud, Skycaptain"),
+        ("Barad-dûr", "Barad-dur"),
+        ("Bespoke Bō", "Bespoke Bo"),
+        ("Bösium Strip", "Bosium Strip"),
+        ("Dandân", "Dandan"),
+        ("Ghazbán Ogre", "Ghazban Ogre"),
+        ("Altaïr Ibn-La'Ahad", "Altair Ibn-La'Ahad"),
+        ("Araña, Heart of the Spider", "Arana, Heart of the Spider"),
+        ("Arwen Undómiel", "Arwen Undomiel"),
+        ("Song of Eärendil", "Song of Earendil"),
+        ("Déjà Vu", "Deja Vu"),
+    ],
+)
+def test_fold_accents(value: str, expected: str) -> None:
+    """fold_accents() strips diacritics but leaves everything else (including case) untouched."""
+    assert fold_accents(value) == expected

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -34,13 +34,33 @@ from api.parsing.card_query_nodes import (
         # Test field-specific : operator behavior
         (
             "name:lightning",
-            r"(lower(card.card_name) LIKE %(p_str_JWxpZ2h0bmluZyU)s)",
+            r"(lower(card.card_name_folded) LIKE %(p_str_JWxpZ2h0bmluZyU)s)",
             {"p_str_JWxpZ2h0bmluZyU": r"%lightning%"},
         ),
         (
             "name:'lightning bolt'",
-            r"(lower(card.card_name) LIKE %(p_str_JWxpZ2h0bmluZyVib2x0JQ)s)",
+            r"(lower(card.card_name_folded) LIKE %(p_str_JWxpZ2h0bmluZyVib2x0JQ)s)",
             {"p_str_JWxpZ2h0bmluZyVib2x0JQ": r"%lightning%bolt%"},
+        ),
+        # #649: fuzzy name: search folds diacritics and matches against card_name_folded,
+        # so an unaccented query still finds the accented card...
+        (
+            "name:eowyn",
+            r"(lower(card.card_name_folded) LIKE %(p_str_JWVvd3luJQ)s)",
+            {"p_str_JWVvd3luJQ": r"%eowyn%"},
+        ),
+        # ...and typing the accent folds to the exact same SQL/parameters.
+        (
+            'name:"éowyn"',
+            r"(lower(card.card_name_folded) LIKE %(p_str_JWVvd3luJQ)s)",
+            {"p_str_JWVvd3luJQ": r"%eowyn%"},
+        ),
+        # Exact match (!"...") deliberately stays accent-sensitive: it compares against
+        # the unfolded card_name, not card_name_folded.
+        (
+            '!"Éowyn"',
+            r"(lower(card.card_name) LIKE %(p_str_w6lvd3lu)s)",
+            {"p_str_w6lvd3lu": "éowyn"},
         ),
         ("cmc:3", "(card.cmc = %(p_int_Mw)s)", {"p_int_Mw": 3}),  # Numeric field uses exact equality
         ("power:5", "(card.creature_power = %(p_int_NQ)s)", {"p_int_NQ": 5}),  # Numeric field uses exact equality

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -49,9 +49,15 @@ from api.parsing.card_query_nodes import (
             r"(lower(card.card_name_folded) LIKE %(p_str_JWVvd3luJQ)s)",
             {"p_str_JWVvd3luJQ": r"%eowyn%"},
         ),
-        # ...and typing the accent folds to the exact same SQL/parameters.
+        # ...and typing the accent folds to the exact same SQL/parameters, whether quoted...
         (
             'name:"éowyn"',
+            r"(lower(card.card_name_folded) LIKE %(p_str_JWVvd3luJQ)s)",
+            {"p_str_JWVvd3luJQ": r"%eowyn%"},
+        ),
+        # ...or bare/unquoted (both parsers' tokenizers accept non-ASCII bare words, #649).
+        (
+            "name:éowyn",
             r"(lower(card.card_name_folded) LIKE %(p_str_JWVvd3luJQ)s)",
             {"p_str_JWVvd3luJQ": r"%eowyn%"},
         ),

--- a/api/tests/fixtures/engine_cards.json
+++ b/api/tests/fixtures/engine_cards.json
@@ -40,6 +40,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Black Lotus",
+    "card_name_folded": "black lotus",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "lea",
@@ -118,6 +119,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Black Lotus",
+    "card_name_folded": "black lotus",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "leb",
@@ -196,6 +198,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Black Lotus",
+    "card_name_folded": "black lotus",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "2ed",
@@ -274,6 +277,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Black Lotus",
+    "card_name_folded": "black lotus",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "cei",
@@ -352,6 +356,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Black Lotus",
+    "card_name_folded": "black lotus",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "ced",
@@ -434,6 +439,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Counterspell",
+    "card_name_folded": "counterspell",
     "card_oracle_tags": {
       "counter-spell": true
     },
@@ -517,6 +523,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Counterspell",
+    "card_name_folded": "counterspell",
     "card_oracle_tags": {
       "counter-spell": true
     },
@@ -600,6 +607,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Counterspell",
+    "card_name_folded": "counterspell",
     "card_oracle_tags": {
       "counter-spell": true
     },
@@ -683,6 +691,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Counterspell",
+    "card_name_folded": "counterspell",
     "card_oracle_tags": {
       "counter-spell": true
     },
@@ -766,6 +775,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Counterspell",
+    "card_name_folded": "counterspell",
     "card_oracle_tags": {
       "counter-spell": true
     },
@@ -849,6 +859,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Counterspell",
+    "card_name_folded": "counterspell",
     "card_oracle_tags": {
       "counter-spell": true
     },
@@ -932,6 +943,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Dark Ritual",
+    "card_name_folded": "dark ritual",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "lea",
@@ -1014,6 +1026,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Dark Ritual",
+    "card_name_folded": "dark ritual",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "leb",
@@ -1096,6 +1109,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Dark Ritual",
+    "card_name_folded": "dark ritual",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "2ed",
@@ -1178,6 +1192,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Dark Ritual",
+    "card_name_folded": "dark ritual",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "ced",
@@ -1260,6 +1275,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Dark Ritual",
+    "card_name_folded": "dark ritual",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "cei",
@@ -1342,6 +1358,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "wwk",
@@ -1367,7 +1384,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 17.1,
     "price_tix": 0.3,
@@ -1377,7 +1394,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Worldwake",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 158.13266,
     "cubecobra_score": 2.7819135
   },
@@ -1426,6 +1443,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "v13",
@@ -1451,7 +1469,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": null,
     "price_tix": null,
@@ -1461,7 +1479,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "From the Vault: Twenty",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 153.13266,
     "cubecobra_score": 2.7819135
   },
@@ -1510,6 +1528,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "ema",
@@ -1535,7 +1554,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 14.42,
     "price_tix": 0.3,
@@ -1545,7 +1564,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Eternal Masters",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 170.13266,
     "cubecobra_score": 2.7819135
   },
@@ -1594,6 +1613,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "a25",
@@ -1619,7 +1639,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 14.98,
     "price_tix": 0.7,
@@ -1629,7 +1649,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Masters 25",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 170.13266,
     "cubecobra_score": 2.7819135
   },
@@ -1678,6 +1698,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "med",
@@ -1703,7 +1724,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": null,
     "price_tix": 2.82,
@@ -1713,7 +1734,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Mythic Edition",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 143.32175,
     "cubecobra_score": 2.7819135
   },
@@ -1762,6 +1783,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "2xm",
@@ -1787,7 +1809,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 14.67,
     "price_tix": 2.42,
@@ -1797,7 +1819,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Double Masters",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 170.13266,
     "cubecobra_score": 2.7819135
   },
@@ -1846,6 +1868,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "2xm",
@@ -1871,7 +1894,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 18.01,
     "price_tix": null,
@@ -1881,7 +1904,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Double Masters",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 156.13266,
     "cubecobra_score": 2.7819135
   },
@@ -1930,6 +1953,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "sld",
@@ -1955,7 +1979,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 122.14,
     "price_tix": null,
@@ -1965,7 +1989,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Secret Lair Drop",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 148.32175,
     "cubecobra_score": 2.7819135
   },
@@ -2014,6 +2038,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "blc",
@@ -2039,7 +2064,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": 24.09,
     "price_tix": 2.35,
@@ -2049,7 +2074,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Bloomburrow Commander",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 148.32175,
     "cubecobra_score": 2.7819135
   },
@@ -2099,6 +2124,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Jace, the Mind Sculptor",
+    "card_name_folded": "jace, the mind sculptor",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "blc",
@@ -2124,7 +2150,7 @@
       ]
     },
     "mana_cost_text": "{2}{U}{U}",
-    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n\u22121: Return target creature to its owner's hand.\n\u221212: Exile all cards from target player's library, then that player shuffles their hand into their library.",
+    "oracle_text": "+2: Look at the top card of target player's library. You may put that card on the bottom of that player's library.\n0: Draw three cards, then put two cards from your hand on top of your library in any order.\n−1: Return target creature to its owner's hand.\n−12: Exile all cards from target player's library, then that player shuffles their hand into their library.",
     "planeswalker_loyalty": 3,
     "price_eur": null,
     "price_tix": 1.5,
@@ -2134,7 +2160,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Bloomburrow Commander",
-    "type_line": "Legendary Planeswalker \u2014 Jace",
+    "type_line": "Legendary Planeswalker — Jace",
     "prefer_score": 143.32175,
     "cubecobra_score": 2.7819135
   },
@@ -2183,6 +2209,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2265,6 +2292,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2347,6 +2375,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2429,6 +2458,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2511,6 +2541,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2593,6 +2624,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2676,6 +2708,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2759,6 +2792,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2841,6 +2875,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -2923,6 +2958,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Lightning Bolt",
+    "card_name_folded": "lightning bolt",
     "card_oracle_tags": {
       "burn": true
     },
@@ -3009,6 +3045,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "con",
@@ -3040,7 +3077,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": 2.94,
     "price_tix": 0.02,
@@ -3050,7 +3087,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Conflux",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 154.64348,
     "cubecobra_score": 5.9748836
   },
@@ -3103,6 +3140,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "ddh",
@@ -3134,7 +3172,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": null,
     "price_tix": null,
@@ -3144,7 +3182,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Duel Decks: Ajani vs. Nicol Bolas",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 145.32175,
     "cubecobra_score": 5.9748836
   },
@@ -3197,6 +3235,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "m13",
@@ -3228,7 +3267,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": 2.66,
     "price_tix": 0.02,
@@ -3238,7 +3277,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Magic 2013",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 154.64348,
     "cubecobra_score": 5.9748836
   },
@@ -3291,6 +3330,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "e01",
@@ -3322,7 +3362,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": 2.78,
     "price_tix": null,
@@ -3332,7 +3372,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Archenemy: Nicol Bolas",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 162.32175,
     "cubecobra_score": 5.9748836
   },
@@ -3385,6 +3425,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "med",
@@ -3416,7 +3457,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": null,
     "price_tix": 4.61,
@@ -3426,7 +3467,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Mythic Edition",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 143.32175,
     "cubecobra_score": 5.9748836
   },
@@ -3479,6 +3520,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "sld",
@@ -3510,7 +3552,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": 5.91,
     "price_tix": null,
@@ -3520,7 +3562,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Secret Lair Drop",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 148.32175,
     "cubecobra_score": 5.9748836
   },
@@ -3573,6 +3615,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Nicol Bolas, Planeswalker",
+    "card_name_folded": "nicol bolas, planeswalker",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "pmei",
@@ -3604,7 +3647,7 @@
       ]
     },
     "mana_cost_text": "{4}{U}{B}{B}{R}",
-    "oracle_text": "+3: Destroy target noncreature permanent.\n\u22122: Gain control of target creature.\n\u22129: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
+    "oracle_text": "+3: Destroy target noncreature permanent.\n−2: Gain control of target creature.\n−9: Nicol Bolas deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents of their choice.",
     "planeswalker_loyalty": 5,
     "price_eur": null,
     "price_tix": null,
@@ -3614,7 +3657,7 @@
     "creature_power_text": null,
     "creature_toughness_text": null,
     "set_name": "Media and Collaboration Promos",
-    "type_line": "Legendary Planeswalker \u2014 Bolas",
+    "type_line": "Legendary Planeswalker — Bolas",
     "prefer_score": 161.64348,
     "cubecobra_score": 5.9748836
   },
@@ -3666,6 +3709,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "lea",
@@ -3700,7 +3744,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "Limited Edition Alpha",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 159.66496,
     "cubecobra_score": 7.6021166
   },
@@ -3752,6 +3796,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "leb",
@@ -3786,7 +3831,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "Limited Edition Beta",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 159.66496,
     "cubecobra_score": 7.6021166
   },
@@ -3838,6 +3883,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "9ed",
@@ -3849,7 +3895,7 @@
     ],
     "card_watermark": null,
     "cmc": 5,
-    "collector_number": "43\u2605",
+    "collector_number": "43★",
     "collector_number_int": 43,
     "creature_power": 4,
     "creature_toughness": 4,
@@ -3872,7 +3918,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "Ninth Edition",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 171.81502,
     "cubecobra_score": 7.6021166
   },
@@ -3924,6 +3970,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "9ed",
@@ -3958,7 +4005,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "Ninth Edition",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 162.81502,
     "cubecobra_score": 7.6021166
   },
@@ -4010,6 +4057,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "10e",
@@ -4021,7 +4069,7 @@
     ],
     "card_watermark": null,
     "cmc": 5,
-    "collector_number": "39\u2605",
+    "collector_number": "39★",
     "collector_number_int": 39,
     "creature_power": 4,
     "creature_toughness": 4,
@@ -4044,7 +4092,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "Tenth Edition",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 171.81502,
     "cubecobra_score": 7.6021166
   },
@@ -4096,6 +4144,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "sld",
@@ -4130,7 +4179,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "Secret Lair Drop",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 173.32175,
     "cubecobra_score": 7.6021166
   },
@@ -4182,6 +4231,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Serra Angel",
+    "card_name_folded": "serra angel",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "plst",
@@ -4216,7 +4266,7 @@
     "creature_power_text": "4",
     "creature_toughness_text": "4",
     "set_name": "The List",
-    "type_line": "Creature \u2014 Angel",
+    "type_line": "Creature — Angel",
     "prefer_score": 169.96523,
     "cubecobra_score": 7.6021166
   },
@@ -4267,6 +4317,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Shivan Dragon",
+    "card_name_folded": "shivan dragon",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "lea",
@@ -4301,7 +4352,7 @@
     "creature_power_text": "5",
     "creature_toughness_text": "5",
     "set_name": "Limited Edition Alpha",
-    "type_line": "Creature \u2014 Dragon",
+    "type_line": "Creature — Dragon",
     "prefer_score": 154.66496,
     "cubecobra_score": 8.824767
   },
@@ -4352,6 +4403,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Shivan Dragon",
+    "card_name_folded": "shivan dragon",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "leb",
@@ -4386,7 +4438,7 @@
     "creature_power_text": "5",
     "creature_toughness_text": "5",
     "set_name": "Limited Edition Beta",
-    "type_line": "Creature \u2014 Dragon",
+    "type_line": "Creature — Dragon",
     "prefer_score": 154.66496,
     "cubecobra_score": 8.824767
   },
@@ -4437,6 +4489,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Shivan Dragon",
+    "card_name_folded": "shivan dragon",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "2ed",
@@ -4471,7 +4524,7 @@
     "creature_power_text": "5",
     "creature_toughness_text": "5",
     "set_name": "Unlimited Edition",
-    "type_line": "Creature \u2014 Dragon",
+    "type_line": "Creature — Dragon",
     "prefer_score": 140.66496,
     "cubecobra_score": 8.824767
   },
@@ -4522,6 +4575,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Shivan Dragon",
+    "card_name_folded": "shivan dragon",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "cei",
@@ -4556,7 +4610,7 @@
     "creature_power_text": "5",
     "creature_toughness_text": "5",
     "set_name": "Intl. Collectors' Edition",
-    "type_line": "Creature \u2014 Dragon",
+    "type_line": "Creature — Dragon",
     "prefer_score": 154.66496,
     "cubecobra_score": 8.824767
   },
@@ -4607,6 +4661,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Shivan Dragon",
+    "card_name_folded": "shivan dragon",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "ced",
@@ -4641,7 +4696,7 @@
     "creature_power_text": "5",
     "creature_toughness_text": "5",
     "set_name": "Collectors' Edition",
-    "type_line": "Creature \u2014 Dragon",
+    "type_line": "Creature — Dragon",
     "prefer_score": 154.66496,
     "cubecobra_score": 8.824767
   },
@@ -4686,6 +4741,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Sol Ring",
+    "card_name_folded": "sol ring",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "lea",
@@ -4760,6 +4816,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Sol Ring",
+    "card_name_folded": "sol ring",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "leb",
@@ -4834,6 +4891,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Sol Ring",
+    "card_name_folded": "sol ring",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "2ed",
@@ -4908,6 +4966,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Sol Ring",
+    "card_name_folded": "sol ring",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "ced",
@@ -4982,6 +5041,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Sol Ring",
+    "card_name_folded": "sol ring",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "cei",
@@ -5060,6 +5120,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "fut",
@@ -5093,7 +5154,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Future Sight",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 135.64348,
     "cubecobra_score": 6.9296994
   },
@@ -5142,6 +5203,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "mma",
@@ -5175,7 +5237,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Modern Masters",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 156.03477,
     "cubecobra_score": 6.9296994
   },
@@ -5224,6 +5286,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "mm2",
@@ -5257,7 +5320,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Modern Masters 2015",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 168.03477,
     "cubecobra_score": 6.9296994
   },
@@ -5306,6 +5369,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "mm3",
@@ -5339,7 +5403,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Modern Masters 2017",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 168.03477,
     "cubecobra_score": 6.9296994
   },
@@ -5389,6 +5453,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "puma",
@@ -5422,7 +5487,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Ultimate Box Topper",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 171.8498,
     "cubecobra_score": 6.9296994
   },
@@ -5471,6 +5536,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "uma",
@@ -5504,7 +5570,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Ultimate Masters",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 164.8498,
     "cubecobra_score": 6.9296994
   },
@@ -5553,6 +5619,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "tsr",
@@ -5586,7 +5653,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Time Spiral Remastered",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 166.64348,
     "cubecobra_score": 6.9296994
   },
@@ -5635,6 +5702,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "plst",
@@ -5668,7 +5736,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "The List",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 135.64348,
     "cubecobra_score": 6.9296994
   },
@@ -5717,6 +5785,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "p30a",
@@ -5750,7 +5819,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "30th Anniversary Play Promos",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 92.034775,
     "cubecobra_score": 6.9296994
   },
@@ -5801,6 +5870,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "pip",
@@ -5834,7 +5904,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Fallout",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 154.8498,
     "cubecobra_score": 6.9296994
   },
@@ -5885,6 +5955,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Tarmogoyf",
+    "card_name_folded": "tarmogoyf",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "pip",
@@ -5918,7 +5989,7 @@
     "creature_power_text": "*",
     "creature_toughness_text": "1+*",
     "set_name": "Fallout",
-    "type_line": "Creature \u2014 Lhurgoyf",
+    "type_line": "Creature — Lhurgoyf",
     "prefer_score": 149.8498,
     "cubecobra_score": 6.9296994
   },
@@ -5972,6 +6043,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Boggart Ram-Gang",
+    "card_name_folded": "boggart ram-gang",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "shm",
@@ -5989,7 +6061,7 @@
     "creature_power": 3,
     "creature_toughness": 3,
     "edhrec_rank": 22985,
-    "flavor_text": "\"We're going to need a bigger gate.\"\n\u2014Bowen, Barrenton guardcaptain",
+    "flavor_text": "\"We're going to need a bigger gate.\"\n—Bowen, Barrenton guardcaptain",
     "mana_cost_jsonb": {
       "R/G": [
         1,
@@ -6008,7 +6080,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "3",
     "set_name": "Shadowmoor",
-    "type_line": "Creature \u2014 Goblin Warrior",
+    "type_line": "Creature — Goblin Warrior",
     "prefer_score": 170.64348,
     "cubecobra_score": 18.537998
   },
@@ -6062,6 +6134,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Boggart Ram-Gang",
+    "card_name_folded": "boggart ram-gang",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "dci",
@@ -6079,7 +6152,7 @@
     "creature_power": 3,
     "creature_toughness": 3,
     "edhrec_rank": 22985,
-    "flavor_text": "\"We're going to need a bigger gate.\"\n\u2014Bowen, Barrenton guardcaptain",
+    "flavor_text": "\"We're going to need a bigger gate.\"\n—Bowen, Barrenton guardcaptain",
     "mana_cost_jsonb": {
       "R/G": [
         1,
@@ -6098,7 +6171,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "3",
     "set_name": "DCI Promos",
-    "type_line": "Creature \u2014 Goblin Warrior",
+    "type_line": "Creature — Goblin Warrior",
     "prefer_score": 156.32175,
     "cubecobra_score": 18.537998
   },
@@ -6152,6 +6225,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Boggart Ram-Gang",
+    "card_name_folded": "boggart ram-gang",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "pd2",
@@ -6169,7 +6243,7 @@
     "creature_power": 3,
     "creature_toughness": 3,
     "edhrec_rank": 22985,
-    "flavor_text": "\"We're going to need a bigger gate.\"\n\u2014Bowen, Barrenton guardcaptain",
+    "flavor_text": "\"We're going to need a bigger gate.\"\n—Bowen, Barrenton guardcaptain",
     "mana_cost_jsonb": {
       "R/G": [
         1,
@@ -6188,7 +6262,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "3",
     "set_name": "Premium Deck Series: Fire and Lightning",
-    "type_line": "Creature \u2014 Goblin Warrior",
+    "type_line": "Creature — Goblin Warrior",
     "prefer_score": 165.64348,
     "cubecobra_score": 18.537998
   },
@@ -6242,6 +6316,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Boggart Ram-Gang",
+    "card_name_folded": "boggart ram-gang",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "plst",
@@ -6259,7 +6334,7 @@
     "creature_power": 3,
     "creature_toughness": 3,
     "edhrec_rank": 22985,
-    "flavor_text": "\"We're going to need a bigger gate.\"\n\u2014Bowen, Barrenton guardcaptain",
+    "flavor_text": "\"We're going to need a bigger gate.\"\n—Bowen, Barrenton guardcaptain",
     "mana_cost_jsonb": {
       "R/G": [
         1,
@@ -6278,7 +6353,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "3",
     "set_name": "The List",
-    "type_line": "Creature \u2014 Goblin Warrior",
+    "type_line": "Creature — Goblin Warrior",
     "prefer_score": 170.64348,
     "cubecobra_score": 18.537998
   },
@@ -6331,6 +6406,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Kitchen Finks",
+    "card_name_folded": "kitchen finks",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "shm",
@@ -6365,7 +6441,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "2",
     "set_name": "Shadowmoor",
-    "type_line": "Creature \u2014 Ouphe",
+    "type_line": "Creature — Ouphe",
     "prefer_score": 173.17154,
     "cubecobra_score": 11.342083
   },
@@ -6418,6 +6494,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Kitchen Finks",
+    "card_name_folded": "kitchen finks",
     "card_oracle_tags": {},
     "card_rarity_int": 2,
     "card_set_code": "f09",
@@ -6452,7 +6529,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "2",
     "set_name": "Friday Night Magic 2009",
-    "type_line": "Creature \u2014 Ouphe",
+    "type_line": "Creature — Ouphe",
     "prefer_score": 156.32175,
     "cubecobra_score": 11.342083
   },
@@ -6505,6 +6582,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Kitchen Finks",
+    "card_name_folded": "kitchen finks",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "mma",
@@ -6539,7 +6617,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "2",
     "set_name": "Modern Masters",
-    "type_line": "Creature \u2014 Ouphe",
+    "type_line": "Creature — Ouphe",
     "prefer_score": 173.17154,
     "cubecobra_score": 11.342083
   },
@@ -6593,6 +6671,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Kitchen Finks",
+    "card_name_folded": "kitchen finks",
     "card_oracle_tags": {},
     "card_rarity_int": 3,
     "card_set_code": "puma",
@@ -6627,7 +6706,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "2",
     "set_name": "Ultimate Box Topper",
-    "type_line": "Creature \u2014 Ouphe",
+    "type_line": "Creature — Ouphe",
     "prefer_score": 176.17154,
     "cubecobra_score": 11.342083
   },
@@ -6680,6 +6759,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Kitchen Finks",
+    "card_name_folded": "kitchen finks",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "uma",
@@ -6714,7 +6794,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "2",
     "set_name": "Ultimate Masters",
-    "type_line": "Creature \u2014 Ouphe",
+    "type_line": "Creature — Ouphe",
     "prefer_score": 185.17154,
     "cubecobra_score": 11.342083
   },
@@ -6767,6 +6847,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Kitchen Finks",
+    "card_name_folded": "kitchen finks",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "mb2",
@@ -6801,7 +6882,7 @@
     "creature_power_text": "3",
     "creature_toughness_text": "2",
     "set_name": "Mystery Booster 2",
-    "type_line": "Creature \u2014 Ouphe",
+    "type_line": "Creature — Ouphe",
     "prefer_score": 171.17154,
     "cubecobra_score": 11.342083
   },
@@ -6850,6 +6931,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Spectral Procession",
+    "card_name_folded": "spectral procession",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "shm",
@@ -6864,7 +6946,7 @@
     "creature_power": null,
     "creature_toughness": null,
     "edhrec_rank": 11565,
-    "flavor_text": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n\u2014Olka, mistmeadow witch",
+    "flavor_text": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n—Olka, mistmeadow witch",
     "mana_cost_jsonb": {
       "2/W": [
         1,
@@ -6932,6 +7014,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Spectral Procession",
+    "card_name_folded": "spectral procession",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "ddk",
@@ -6946,7 +7029,7 @@
     "creature_power": null,
     "creature_toughness": null,
     "edhrec_rank": 11565,
-    "flavor_text": "\"I need never remember my past associates, my victims, my mistakes. Innistrad preserves them all for me.\"\n\u2014Sorin Markov",
+    "flavor_text": "\"I need never remember my past associates, my victims, my mistakes. Innistrad preserves them all for me.\"\n—Sorin Markov",
     "mana_cost_jsonb": {
       "2/W": [
         1,
@@ -7014,6 +7097,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Spectral Procession",
+    "card_name_folded": "spectral procession",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "md1",
@@ -7028,7 +7112,7 @@
     "creature_power": null,
     "creature_toughness": null,
     "edhrec_rank": 11565,
-    "flavor_text": "\"I need never remember my past associates, my victims, my mistakes. Innistrad preserves them all for me.\"\n\u2014Sorin Markov",
+    "flavor_text": "\"I need never remember my past associates, my victims, my mistakes. Innistrad preserves them all for me.\"\n—Sorin Markov",
     "mana_cost_jsonb": {
       "2/W": [
         1,
@@ -7096,6 +7180,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Spectral Procession",
+    "card_name_folded": "spectral procession",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "c14",
@@ -7110,7 +7195,7 @@
     "creature_power": null,
     "creature_toughness": null,
     "edhrec_rank": 11565,
-    "flavor_text": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n\u2014Olka, mistmeadow witch",
+    "flavor_text": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n—Olka, mistmeadow witch",
     "mana_cost_jsonb": {
       "2/W": [
         1,
@@ -7178,6 +7263,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Spectral Procession",
+    "card_name_folded": "spectral procession",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "mm2",
@@ -7192,7 +7278,7 @@
     "creature_power": null,
     "creature_toughness": null,
     "edhrec_rank": 11565,
-    "flavor_text": "\"I need never remember my past associates, my victims, my mistakes. Innistrad preserves them all for me.\"\n\u2014Sorin Markov",
+    "flavor_text": "\"I need never remember my past associates, my victims, my mistakes. Innistrad preserves them all for me.\"\n—Sorin Markov",
     "mana_cost_jsonb": {
       "2/W": [
         1,
@@ -7260,6 +7346,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Spectral Procession",
+    "card_name_folded": "spectral procession",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "plst",
@@ -7274,7 +7361,7 @@
     "creature_power": null,
     "creature_toughness": null,
     "edhrec_rank": 11565,
-    "flavor_text": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n\u2014Olka, mistmeadow witch",
+    "flavor_text": "\"The dead have it easy. They suffer no more. If breaking their rest helps the living, so be it.\"\n—Olka, mistmeadow witch",
     "mana_cost_jsonb": {
       "2/W": [
         1,
@@ -7342,6 +7429,7 @@
       "paupercommander": "legal"
     },
     "card_name": "Monastery Messenger",
+    "card_name_folded": "monastery messenger",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "tdm",
@@ -7382,7 +7470,7 @@
     "creature_power_text": "2",
     "creature_toughness_text": "3",
     "set_name": "Tarkir: Dragonstorm",
-    "type_line": "Creature \u2014 Bird Scout",
+    "type_line": "Creature — Bird Scout",
     "prefer_score": 0.0,
     "cubecobra_score": 0.0
   },
@@ -7429,6 +7517,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Cathedral Membrane",
+    "card_name_folded": "cathedral membrane",
     "card_oracle_tags": {},
     "card_rarity_int": 0,
     "card_set_code": "nph",
@@ -7464,7 +7553,7 @@
     "creature_power_text": "0",
     "creature_toughness_text": "3",
     "set_name": "New Phyrexia",
-    "type_line": "Artifact Creature \u2014 Phyrexian Wall",
+    "type_line": "Artifact Creature — Phyrexian Wall",
     "prefer_score": 0.0,
     "cubecobra_score": 0.0
   },
@@ -7509,6 +7598,7 @@
       "paupercommander": "not_legal"
     },
     "card_name": "Fireball",
+    "card_name_folded": "fireball",
     "card_oracle_tags": {},
     "card_rarity_int": 1,
     "card_set_code": "clb",

--- a/api/tests/fixtures/test_data.sql
+++ b/api/tests/fixtures/test_data.sql
@@ -9,7 +9,7 @@
 
 -- Insert some test cards
 INSERT INTO magic.cards (
-    scryfall_id, oracle_id, card_name, cmc, mana_cost_text, mana_cost_jsonb, devotion, raw_card_blob,
+    scryfall_id, oracle_id, card_name, card_name_folded, cmc, mana_cost_text, mana_cost_jsonb, devotion, raw_card_blob,
     card_types, card_subtypes, card_colors, card_color_identity, card_keywords,
     oracle_text, creature_power, creature_toughness, card_oracle_tags, collector_number, collector_number_int,
     released_at
@@ -18,6 +18,7 @@ INSERT INTO magic.cards (
     '00000000-0000-0000-0000-000000000001',
     '52b91fa6-7562-501c-a1b7-5d41f0c00020',
     'Lightning Bolt',
+    'lightning bolt',
     1,
     '{R}',
     '{"R": [1]}',
@@ -40,6 +41,7 @@ INSERT INTO magic.cards (
     '00000000-0000-0000-0000-000000000002',
     'f2b54404-af3c-529a-b50b-ac1e1214fddd',
     'Serra Angel',
+    'serra angel',
     5,
     '{3}{W}{W}',
     '{"W": [1, 2]}', -- pure-generic braces like {3} are dropped, never a key
@@ -62,6 +64,7 @@ INSERT INTO magic.cards (
     '00000000-0000-0000-0000-000000000003',
     '288bc0d8-1ee9-5af5-b226-38aec9cc1c5d',
     'Black Lotus',
+    'black lotus',
     0,
     '{0}',
     '{}',
@@ -87,6 +90,7 @@ INSERT INTO magic.cards (
     '00000000-0000-0000-0000-000000000004',
     '30d2437a-87c9-4f88-8fb8-b686d6522677',
     'Boggart Ram-Gang',
+    'boggart ram-gang',
     3,
     '{R/G}{R/G}{R/G}',
     '{"R/G": [1, 2, 3]}',
@@ -112,6 +116,7 @@ INSERT INTO magic.cards (
     '00000000-0000-0000-0000-000000000005',
     '0297eeb2-47ec-4f9a-b1ad-4e7286994f00',
     'Cathedral Membrane',
+    'cathedral membrane',
     2,
     '{1}{W/P}',
     '{"W/P": [1]}',
@@ -138,6 +143,7 @@ INSERT INTO magic.cards (
     '00000000-0000-0000-0000-000000000006',
     'aa7714b0-2bfb-458a-8ebf-37ec2c53383e',
     'Fireball',
+    'fireball',
     1,
     '{X}{R}',
     '{"X": [1], "R": [1]}',
@@ -155,6 +161,32 @@ INSERT INTO magic.cards (
     '175',
     175,
     '2022-06-10'
+),
+(
+    -- Éowyn, Fearless Knight (real card, ltr #23): card_name_folded drops the
+    -- diacritic so fuzzy name:eowyn matches this accented name (#649); card_name
+    -- keeps the accent so exact match (!"...") stays accent-sensitive.
+    '00000000-0000-0000-0000-000000000007',
+    '4c9f1a5e-2b3d-4e6f-8a1b-9c0d2e3f4a5b',
+    'Éowyn, Fearless Knight',
+    'eowyn, fearless knight',
+    3,
+    '{1}{W}{W}',
+    '{"W": [1, 2]}',
+    '{"W": [1, 2]}',
+    '{"name": "Éowyn, Fearless Knight", "type": "Legendary Creature", "collector_number": "23"}',
+    '["Legendary", "Creature"]',
+    '["Human", "Noble"]',
+    '{"W": true}',
+    '{"W": true}',
+    '{}',
+    'First strike\nWhenever Éowyn, Fearless Knight attacks, if it''s your turn, another target attacking creature you control gains first strike until end of turn.',
+    3,
+    2,
+    '{}',
+    '23',
+    23,
+    '2023-06-23'
 ) ON CONFLICT (scryfall_id) DO NOTHING;
 
 -- Insert test tags

--- a/api/tests/test_engine_property.py
+++ b/api/tests/test_engine_property.py
@@ -162,6 +162,7 @@ def _make_cards(rng: random.Random) -> list[dict[str, Any]]:
             "oracle_id": f"00000000-0000-0000-0000-{i + 1:012d}",
             "mana_cost_jsonb": mana_cost_jsonb,
             "card_name": name,
+            "card_name_folded": name.lower(),
             "oracle_text": oracle,
             "card_colors": dict.fromkeys(colors, True),
             "card_color_identity": dict.fromkeys(identity, True),

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -148,9 +148,15 @@ class TestContainerIntegration:
         assert "cards" in result
 
         # Should find every creature in test data (Serra Angel, Boggart
-        # Ram-Gang, and the Artifact Creature Cathedral Membrane)
+        # Ram-Gang, the Artifact Creature Cathedral Membrane, and the
+        # Legendary Creature Éowyn, Fearless Knight)
         cards = result["cards"]
-        assert {c["name"] for c in cards} == {"Serra Angel", "Boggart Ram-Gang", "Cathedral Membrane"}
+        assert {c["name"] for c in cards} == {
+            "Serra Angel",
+            "Boggart Ram-Gang",
+            "Cathedral Membrane",
+            "Éowyn, Fearless Knight",
+        }
 
     def test_card_search_by_name(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by name."""
@@ -164,6 +170,21 @@ class TestContainerIntegration:
 
         card = cards[0]
         assert card["name"] == "Lightning Bolt"
+
+    def test_card_search_by_name_folds_accents(self: TestContainerIntegration, api_resource: APIResource) -> None:
+        """#649: an unaccented name: query must find the accented card, and only it."""
+        result = api_resource._search_sql(**search_kwargs("name:eowyn", limit=10))
+
+        cards = result["cards"]
+        assert {c["name"] for c in cards} == {"Éowyn, Fearless Knight"}
+
+        # Exact match stays accent-sensitive: typing the accent finds it...
+        exact_accented = api_resource._search_sql(**search_kwargs('!"Éowyn, Fearless Knight"', limit=10))
+        assert {c["name"] for c in exact_accented["cards"]} == {"Éowyn, Fearless Knight"}
+
+        # ...typing without the accent does not.
+        exact_unaccented = api_resource._search_sql(**search_kwargs('!"Eowyn, Fearless Knight"', limit=10))
+        assert exact_unaccented["cards"] == []
 
     def test_color_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """Test searching for cards by color."""
@@ -227,9 +248,10 @@ class TestContainerIntegration:
     def test_devotion_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """devotion: counts a permanent's colored pips, hybrids (incl. Phyrexian) split."""
         result = api_resource._search_sql(**search_kwargs("devotion:{W}", limit=10))
-        # Serra Angel {W}{W} and Cathedral Membrane {1}{W/P} (Phyrexian W
-        # counts toward W devotion, same as a plain hybrid would)
-        assert {c["name"] for c in result["cards"]} == {"Serra Angel", "Cathedral Membrane"}
+        # Serra Angel {W}{W}, Cathedral Membrane {1}{W/P} (Phyrexian W counts
+        # toward W devotion, same as a plain hybrid would), and Éowyn,
+        # Fearless Knight {1}{W}{W}
+        assert {c["name"] for c in result["cards"]} == {"Serra Angel", "Cathedral Membrane", "Éowyn, Fearless Knight"}
 
     def test_devotion_hybrid_search(self: TestContainerIntegration, api_resource: APIResource) -> None:
         """A color/color hybrid contributes to BOTH colors' devotion."""
@@ -283,9 +305,17 @@ class TestContainerIntegration:
 
         # Should only have our test cards
         cards = result["cards"]
-        assert len(cards) == 6
+        assert len(cards) == 7
         card_names = {card["name"] for card in cards}
-        expected_names = {"Lightning Bolt", "Serra Angel", "Black Lotus", "Boggart Ram-Gang", "Cathedral Membrane", "Fireball"}
+        expected_names = {
+            "Lightning Bolt",
+            "Serra Angel",
+            "Black Lotus",
+            "Boggart Ram-Gang",
+            "Cathedral Membrane",
+            "Fireball",
+            "Éowyn, Fearless Knight",
+        }
         assert card_names == expected_names
 
     def test_random_search_shape_matches_search(self: TestContainerIntegration, api_resource: APIResource) -> None:

--- a/card_engine/card_engine/__init__.py
+++ b/card_engine/card_engine/__init__.py
@@ -51,6 +51,7 @@ ENGINE_COLUMNS: list[str] = [
     "card_layout",
     "card_legalities",
     "card_name",
+    "card_name_folded",
     "card_art_tags",
     "card_oracle_tags",
     "card_rarity_int",

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -245,7 +245,9 @@ fn text_search_field_value<'a>(
     field: TextSearchField,
 ) -> StrVal<'a> {
     match field {
-        TextSearchField::NameLower       => StrVal::Known(card.card_name_lower.as_str()),
+        // Accent-folded (#649): the query word is folded the same way in Python
+        // before it reaches TextContains/NameMatch, so this must match.
+        TextSearchField::NameLower       => StrVal::Known(card.card_name_folded.as_str()),
         TextSearchField::OracleTextLower => opt_sv(str_at(strings, u32::from(card.oracle_text_lower_id))),
         TextSearchField::FlavorTextLower => printing.map_or(StrVal::PDep, |p| opt_sv(str_at(strings, u32::from(p.flavor_text_lower_id)))),
         // Rewritten to ArtistMatch by bind(); printings carry no artist strings.
@@ -890,7 +892,7 @@ impl FilterExpr {
                 let Some(cand) = trigram_candidates(name_trigram, word) else { return };
                 let mut ids: Vec<u32> = cand
                     .into_iter()
-                    .filter(|&cid| cards[cid as usize].card_name_lower.as_str().contains(word.as_str()))
+                    .filter(|&cid| cards[cid as usize].card_name_folded.as_str().contains(word.as_str()))
                     .map(|cid| u32::from(cards[cid as usize].card_name_id))
                     .collect();
                 ids.sort_unstable();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -235,6 +235,10 @@ struct ManaCost {
 struct OracleCard {
     // Hot fields first — fits in the first cache lines for fast filter short-circuiting.
     card_name_lower: InlineStr<61>, // 61 bytes covers every card name in the Scryfall dataset
+    // Accent-folded card_name_lower (e.g. "éowyn" -> "eowyn"), precomputed in Python via
+    // fold_accents() (#649). Backs fuzzy name: search (name_trigram/name_bigrams/TextContains)
+    // so "eowyn" matches "Éowyn"; exact-match paths deliberately keep using card_name_lower.
+    card_name_folded: InlineStr<61>,
     card_colors: u8,
     card_color_identity: u8,
     produced_mana: u8,
@@ -341,6 +345,7 @@ struct Printing {
 /// Printing. Never archived.
 struct CardRow {
     card_name_lower: InlineStr<61>,
+    card_name_folded: InlineStr<61>,
     card_colors: u8,
     card_color_identity: u8,
     produced_mana: u8,
@@ -719,6 +724,8 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
     // Raw strings from the dict; interned to ids as the struct is built below.
     let card_name = opt_str(d, "card_name").unwrap_or_default();
     let card_name_lower = InlineStr::<61>::from_str(&card_name.to_lowercase());
+    // Already lowercased + accent-folded in Python (fold_accents(), #649); read as-is.
+    let card_name_folded = InlineStr::<61>::from_str(&opt_str(d, "card_name_folded").unwrap_or_default());
     let oracle_text = opt_str(d, "oracle_text").unwrap_or_default();
     let oracle_text_lower_id = it.intern(oracle_text.to_lowercase());
     let flavor_text = opt_str(d, "flavor_text").unwrap_or_default();
@@ -735,6 +742,7 @@ fn card_from_pydict(d: &Bound<PyDict>, it: &mut Interner, vocab: &mut VocabInter
         illustration_id: opt_uuid(d, "illustration_id"),
 
         card_name_lower,
+        card_name_folded,
         card_name_id: it.intern(card_name),
         oracle_text_lower_id,
         oracle_text_id: it.intern(oracle_text),
@@ -1185,7 +1193,8 @@ struct NameBigramIndex {
 fn build_name_bigram_index(cards: &[OracleCard]) -> NameBigramIndex {
     let mut lists: HashMap<[u8; 2], Vec<u32>> = HashMap::new();
     for (i, card) in cards.iter().enumerate() {
-        let bytes = card.card_name_lower.as_str().as_bytes();
+        // Folded (#649) — this index backs the same fuzzy name: path as name_trigram.
+        let bytes = card.card_name_folded.as_str().as_bytes();
         let mut seen: Vec<[u8; 2]> = Vec::new(); // names are short; a vec beats a set
         for w in bytes.windows(2) {
             let bg = [w[0], w[1]];
@@ -5198,7 +5207,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260726;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260720;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -5490,6 +5499,7 @@ impl QueryEngine {
                 offsets.push(printings.len() as u32);
                 cards.push(OracleCard {
                     card_name_lower: row.card_name_lower,
+                    card_name_folded: row.card_name_folded,
                     card_colors: row.card_colors,
                     card_color_identity: row.card_color_identity,
                     produced_mana: row.produced_mana,
@@ -5569,7 +5579,7 @@ impl QueryEngine {
         // borrowed by the builders in the CardIndexes literal.
         let artwork_group_counts = assign_artwork_groups(&mut printings, &offsets);
         let indexes = CardIndexes {
-            name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
+            name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
             cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
             power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -155,6 +155,7 @@ fn test_tag_index_str_lookup() {
 fn stub_card(oracle_id: u128, card_types: u16, subtypes: &[&str], vocab: &mut VocabInterner) -> OracleCard {
     OracleCard {
         card_name_lower: InlineStr::from_str(""),
+        card_name_folded: InlineStr::from_str(""),
         card_colors: 0,
         card_color_identity: 0,
         produced_mana: 0,
@@ -2113,11 +2114,14 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
         // conditioned on the creature bit at the real rate; every other card gets a non-empty oracle
         // (loop past the ~1% corpus empties). Textless cards intern "" (never NONE_STR), matching the
         // loader, so an oracle-text search evaluates False on them rather than Null.
-        // Both name fields from one corpus name: card_name_lower (InlineStr) is what contains()
+        // Both name fields from one corpus name: card_name_folded (InlineStr) is what contains()
         // reads; card_name_id is the interned id NameMatch re-keys to after memoization, so it must
         // distinguish names (leaving it NONE_STR collapses every name to one id and over-matches).
+        // card_name_folded is a raw copy here (not actually diacritic-folded) since this fuzzer
+        // tests indexing/algebra parity, not fold_accents() semantics (#649 covers that directly).
         let name = corpus[rng.random_range(0..corpus.len())].0;
         card.card_name_lower = InlineStr::from_str(name);
+        card.card_name_folded = card.card_name_lower;
         card.card_name_id = interner.intern(name.to_string());
         let vanilla = card.card_types & TYPE_CREATURE != 0 && rng.random_bool(VANILLA_CREATURE_FRAC);
         let oracle = if vanilla {
@@ -2263,7 +2267,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
     // Text narrowing indexes — same load-bearing property. name/oracle drive trigram + bigram
     // narrowing and the full-scan memoization; flavor is the printing-space CSR bind() resolves against.
-    data.indexes.name_trigram = build_trigram_index(&data.cards, |c| c.card_name_lower.as_str());
+    data.indexes.name_trigram = build_trigram_index(&data.cards, |c| c.card_name_folded.as_str());
     data.indexes.name_bigrams = build_name_bigram_index(&data.cards);
     data.indexes.oracle_trigram = build_oracle_text_index(&data.cards, &data.strings);
     data.indexes.flavor = build_flavor_index(&data.printings, &data.strings);
@@ -4334,6 +4338,7 @@ fn bench_checked_vs_unchecked_access() {
         );
         let mut card = stub_card((i + 1) as u128, TYPE_CREATURE, &["Benchmark", words[i % 10]], &mut vocab);
         card.card_name_lower = InlineStr::from_str(&name.to_lowercase());
+        card.card_name_folded = card.card_name_lower;
         card.card_name_id = interner.intern(name.clone());
         card.oracle_text_id = interner.intern(oracle.clone());
         card.oracle_text_lower_id = interner.intern(oracle.to_lowercase());
@@ -4356,7 +4361,7 @@ fn bench_checked_vs_unchecked_access() {
     let artwork_groups = assign_artwork_groups(&mut printings, &offsets);
 
     let indexes = CardIndexes {
-        name_trigram:   build_trigram_index(&cards, |c| c.card_name_lower.as_str()),
+        name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
         oracle_trigram: build_oracle_text_index(&cards, &strings),
         cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
         power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
@@ -5920,6 +5925,7 @@ fn text_fixture_store() -> CardData {
         .map(|(i, &(name, text))| {
             let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
             c.card_name_lower = InlineStr::from_str(name);
+            c.card_name_folded = c.card_name_lower;
             c.card_name_id = interner.intern(name.to_string());
             c.oracle_text_lower_id = interner.intern(text.unwrap_or_default().to_string());
             c
@@ -5927,7 +5933,7 @@ fn text_fixture_store() -> CardData {
         .collect();
     let mut data = store_of(cards, &[1usize; 6], vocab);
     data.strings = interner.strings;
-    data.indexes.name_trigram = build_trigram_index(&data.cards, |c| c.card_name_lower.as_str());
+    data.indexes.name_trigram = build_trigram_index(&data.cards, |c| c.card_name_folded.as_str());
     data.indexes.oracle_trigram = build_oracle_text_index(&data.cards, &data.strings);
     data
 }
@@ -6831,6 +6837,7 @@ fn name_bigrams_tiers_and_exactness() {
         let mut c = stub_card(u128::from(i) + 1, TYPE_CREATURE, &[], &mut vocab);
         let name = if i % 64 == 0 { format!("azz qx{i}") } else { format!("azz b{i}") };
         c.card_name_lower = InlineStr::from_str(&name);
+        c.card_name_folded = c.card_name_lower;
         c
     }).collect();
     let data = store_of(cards, &vec![1usize; 4096], vocab);
@@ -6855,7 +6862,7 @@ fn name_bigrams_tiers_and_exactness() {
     assert!(n.tight);
     let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     let brute: Vec<u32> = archived.cards.iter().enumerate()
-        .filter(|(_, c)| c.card_name_lower.as_str().contains("qx"))
+        .filter(|(_, c)| c.card_name_folded.as_str().contains("qx"))
         .map(|(i, _)| i as u32)
         .collect();
     assert_eq!(cand, brute, "bigram membership IS containment for 2-byte needles");
@@ -6879,6 +6886,7 @@ fn name_bigrams_compose_and_memoize() {
     let cards: Vec<OracleCard> = names.iter().enumerate().map(|(i, name)| {
         let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
         c.card_name_lower = InlineStr::from_str(name);
+        c.card_name_folded = c.card_name_lower;
         c.card_name_id = interner.intern(name.to_string());
         c
     }).collect();
@@ -6919,7 +6927,7 @@ fn name_bigrams_compose_and_memoize() {
         _ => panic!("2-byte needle must memoize via bigrams"),
     }
     for (cid, card) in archived.cards.iter().enumerate() {
-        let want = card.card_name_lower.as_str().contains("fi");
+        let want = card.card_name_folded.as_str().contains("fi");
         assert!((f.eval_card(card, &archived.strings) == Tri::True) == want, "NameMatch parity at card {cid}");
     }
 }
@@ -7140,6 +7148,7 @@ fn named_store() -> CardData {
         .map(|(i, name)| {
             let mut c = stub_card((i + 1) as u128, TYPE_CREATURE, &[], &mut vocab);
             c.card_name_lower = InlineStr::from_str(name);
+            c.card_name_folded = c.card_name_lower;
             // Distinct, deliberately store-order-scrambled edhrec ranks: the
             // second "sol ring" (card 3) outranks the first (card 1).
             c.edhrec_rank = Some([40, 60, 10, 20, 30, 50][i]);
@@ -7214,6 +7223,47 @@ fn exact_name_narrows_tight() {
         );
         assert_eq!(total, brute, "totals parity for shape {i}");
     }
+}
+
+// #649: fuzzy name: search is accent-folded. card_name_folded is precomputed in
+// Python (fold_accents(), NFKD strip-combining-marks) and the query word is folded
+// the same way before crossing into Rust, so a user typing "eowyn" (no diacritic)
+// finds "Éowyn" — and typing the accent doesn't change the fuzzy result, since both
+// spellings fold to the same word by the time Rust sees them. ExactName deliberately
+// keeps comparing the unfolded card_name_lower, so only the literal accented
+// spelling narrows to an exact match.
+#[test]
+fn accent_folded_name_search_matches_unaccented_query() {
+    let mut vocab = VocabInterner::new();
+    let rows: [(&str, &str); 2] = [
+        ("éowyn, fearless knight", "eowyn, fearless knight"),
+        ("ferocious knight", "ferocious knight"),
+    ];
+    let cards: Vec<OracleCard> = rows.iter().enumerate().map(|(i, (lower, folded))| {
+        let mut c = stub_card(i as u128 + 1, TYPE_CREATURE, &[], &mut vocab);
+        c.card_name_lower = InlineStr::from_str(lower);
+        c.card_name_folded = InlineStr::from_str(folded);
+        c
+    }).collect();
+    let data = store_of(cards, &[1usize; 2], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    // A query word already folded by Python (whether the user typed "eowyn" or
+    // "Éowyn") must find the accented card and only it.
+    let contains_eowyn = FilterExpr::TextContains { field: TextSearchField::NameLower, word: "eowyn".to_string() };
+    let matches: Vec<u32> = archived.cards.iter().enumerate()
+        .filter(|(_, c)| contains_eowyn.eval_card(c, &archived.strings) == Tri::True)
+        .map(|(i, _)| i as u32)
+        .collect();
+    assert_eq!(matches, vec![0], "unaccented fuzzy query must find only the accented card");
+
+    // Exact match stays accent-sensitive: typing the accent finds it; typing
+    // without the accent does not.
+    let exact_accented = FilterExpr::ExactName("éowyn, fearless knight".to_string());
+    let exact_unaccented = FilterExpr::ExactName("eowyn, fearless knight".to_string());
+    assert!(exact_accented.eval_card(&archived.cards[0], &archived.strings) == Tri::True);
+    assert!(exact_unaccented.eval_card(&archived.cards[0], &archived.strings) == Tri::False);
 }
 
 // order:name sorts pages by name in both directions, breaks the duplicate-name

--- a/docs/changelog/2026-07-20-accent-insensitive-name-search.md
+++ b/docs/changelog/2026-07-20-accent-insensitive-name-search.md
@@ -26,9 +26,12 @@ re-implementing it:
 Exact-match (`!"..."`, `name=`) and regex (`name:/.../`) are untouched and stay accent-sensitive —
 typing the accent still gets you exact-accent matching.
 
+Both parsers' bare-word tokenizers were also widened to accept any Unicode letter (previously
+ASCII-only), so `name:Éowyn` now lexes without quotes — the hand parser via `str.isalpha()`, the
+pyparsing grammar via `\w`/`[^\W\d]`.
+
 See [docs/issues/00649-accent-insensitive-name-search.md](../issues/00649-accent-insensitive-name-search.md)
-for the full design writeup, corpus findings, and a known pre-existing lexer limitation
-(unquoted-bare-word accents) left out of scope.
+for the full design writeup and corpus findings.
 
 ## Trade-offs
 

--- a/docs/changelog/2026-07-20-accent-insensitive-name-search.md
+++ b/docs/changelog/2026-07-20-accent-insensitive-name-search.md
@@ -1,0 +1,45 @@
+# Accent-insensitive fuzzy name search
+
+## Problem
+
+`name:eowyn` didn't match "Éowyn, Fearless Knight". Fuzzy `name:` search was already
+case-insensitive but not diacritic-insensitive: any card whose name carries an accent (é, ñ, ö,
+and 11 other accented base letters found across the real Scryfall corpus) was only reachable by
+typing the accent.
+
+## Fix
+
+Added `fold_accents()` (NFKD decompose + drop combining marks, stdlib `unicodedata`) as the single
+source of truth for diacritic folding, consumed by both matching engines rather than each
+re-implementing it:
+
+- A new `card_name_folded` column, computed once at import time in `preprocess_card()` and indexed
+  with its own trigram GIN index (`api/db/2026-07-20-01-accent-folded-name.sql`).
+- The Rust `card_engine` reads that same column at reload (added to `ENGINE_COLUMNS`) into a new
+  `card_name_folded: InlineStr<61>` field — no Rust-side folding logic needed. `name_trigram`/
+  `name_bigrams` and the `NameLower` fuzzy-match path now read this field instead of
+  `card_name_lower`. `ARCHIVE_FORMAT_VERSION` bumped for the layout change.
+- The query word is folded the same way before it reaches either engine
+  (`_handle_text_field_pattern_matching` for SQL, `_rhs_to_json` for the Rust JSON boundary), so
+  "eowyn" and "Éowyn" both fold to the identical search term.
+
+Exact-match (`!"..."`, `name=`) and regex (`name:/.../`) are untouched and stay accent-sensitive —
+typing the accent still gets you exact-accent matching.
+
+See [docs/issues/00649-accent-insensitive-name-search.md](../issues/00649-accent-insensitive-name-search.md)
+for the full design writeup, corpus findings, and a known pre-existing lexer limitation
+(unquoted-bare-word accents) left out of scope.
+
+## Trade-offs
+
+- Scoped to `card_name` only; `oracle_text`/`flavor_text`/`card_artist` fuzzy search is not folded.
+- Query-time cost is unchanged — the SQL fragment swaps one indexed lowercase column for another;
+  the Rust field is populated once at reload, not computed per query.
+
+---
+
+## Status
+
+**Resolved — merged to main as [PR TBD](https://github.com/jbylund/sylvan_librarian/pull/649).**
+
+See [PR description](../prs/accent-insensitive-name-search.md) for full details of what shipped.

--- a/docs/changelog/2026-07-20-accent-insensitive-name-search.md
+++ b/docs/changelog/2026-07-20-accent-insensitive-name-search.md
@@ -40,6 +40,6 @@ for the full design writeup, corpus findings, and a known pre-existing lexer lim
 
 ## Status
 
-**Resolved — merged to main as [PR TBD](https://github.com/jbylund/sylvan_librarian/pull/649).**
+**Resolved — [PR #716](https://github.com/jbylund/sylvan_librarian/pull/716).**
 
 See [PR description](../prs/accent-insensitive-name-search.md) for full details of what shipped.

--- a/docs/issues/00649-accent-insensitive-name-search.md
+++ b/docs/issues/00649-accent-insensitive-name-search.md
@@ -75,4 +75,6 @@ require it, since "Eowyn" is plain ASCII.
 
 ## Status
 
-**Resolved** — see [PR description](../prs/accent-insensitive-name-search.md).
+**Resolved — [PR #716](https://github.com/jbylund/sylvan_librarian/pull/716).**
+
+See [PR description](../prs/accent-insensitive-name-search.md) for full details of what shipped.

--- a/docs/issues/00649-accent-insensitive-name-search.md
+++ b/docs/issues/00649-accent-insensitive-name-search.md
@@ -78,6 +78,13 @@ folding later does with the text):
 Both parsers were verified to agree via the shared `TESTCASES` parity fixture
 (`implicit_and_cases.py`), which now includes bare accented words.
 
+## Known asymmetry (follow-up filed separately)
+
+Folding is currently symmetric: an accented query (`name:Éowyn`) folds to the same term as its
+unaccented spelling and would match an unaccented card too, if one existed with the same base
+name. See [00718-accent-sensitive-literal-recheck.md](00718-accent-sensitive-literal-recheck.md)
+(#718) for the planned fix — deliberately a separate follow-up PR rather than amending this one.
+
 ## Validation
 
 - `card_engine` unit test `accent_folded_name_search_matches_unaccented_query` (cargo test, debug +

--- a/docs/issues/00649-accent-insensitive-name-search.md
+++ b/docs/issues/00649-accent-insensitive-name-search.md
@@ -53,14 +53,30 @@ inline), which is more surface than this issue asks for.
 `InlineStr<61>` per card (~61 bytes × ~31.5k cards ≈ 2MB), populated once at reload, not computed
 per query.
 
-## Known limitation (not fixed here)
+## Bare (unquoted) accented words
 
-The hand-rolled parser's tokenizer only accepts ASCII in *unquoted* bare words — `name:éowyn`
-(no quotes) fails to lex at all (`Unexpected character 'é'`). Quoting works today:
-`name:"éowyn"` parses and folds correctly. This is a pre-existing lexer restriction
-(`_WORD_START`/`_WORD_CONT` in `hand_parser.py`) affecting all bare non-ASCII tokens, not specific
-to this fix, and out of scope here — the reported issue (typing the *unaccented* form) doesn't
-require it, since "Eowyn" is plain ASCII.
+Both parsers originally only accepted ASCII in *unquoted* bare words — `name:éowyn` (no quotes)
+failed to lex at all (hand parser: `Unexpected character 'é'`; pyparsing: no matching token).
+Quoting already worked (`name:"éowyn"`), since quoted-string lexing never restricted its character
+set — only the bare-word grammars did.
+
+Fixed by widening both parsers' word-character classification to any Unicode letter (not just the
+Latin diacritics `fold_accents()` folds — this is a lexer-acceptance question, independent of what
+folding later does with the text):
+
+- **Hand parser** (`hand_parser.py`): `_is_word_start`/`_is_word_cont` replace the old
+  `_WORD_START`/`_WORD_CONT` frozenset membership checks with `c in <frozenset> or c.isalpha()` —
+  the ASCII fast path is unchanged, non-ASCII letters fall through to `str.isalpha()` (Unicode-aware
+  in Python 3).
+- **pyparsing parser** (`pyparsing_based.py`): the three bare-word regexes (`word`,
+  `string_value_word`, `hyphenated_condition`'s value, and the separate implicit-AND tokenizer's
+  `string_value_tok`) swap ASCII classes for `\w`/`[^\W\d]` — Python's `re` treats `\w`/`\W` as
+  Unicode-aware by default for `str` patterns, and `[^\W\d]` is the standard idiom for "word
+  character that isn't a digit," i.e. a letter or underscore, so bare words still can't start with
+  a digit.
+
+Both parsers were verified to agree via the shared `TESTCASES` parity fixture
+(`implicit_and_cases.py`), which now includes bare accented words.
 
 ## Validation
 
@@ -72,6 +88,10 @@ require it, since "Eowyn" is plain ASCII.
 - `test_integration_testcontainers.py::test_card_search_by_name_folds_accents` — real Postgres,
   real migration, asserts `name:eowyn` finds "Éowyn, Fearless Knight" and only it, and that exact
   match distinguishes the two spellings.
+- `implicit_and_cases.py` — bare accented word cases, exercised by both the hand/pyparsing parity
+  test and the implicit-AND preprocessing test.
+- `test_sql_gen.py` / `test_exact_name_search.py` — bare (unquoted) accented `name:`/`!` cases
+  alongside the quoted ones.
 
 ## Status
 

--- a/docs/issues/00649-accent-insensitive-name-search.md
+++ b/docs/issues/00649-accent-insensitive-name-search.md
@@ -1,0 +1,78 @@
+# Accent-Insensitive Fuzzy Name Search
+
+[#649](https://github.com/jbylund/sylvan_librarian/issues/649)
+
+`name:eowyn` didn't match "Éowyn, Fearless Knight". Fuzzy `name:` search was already
+case-insensitive (`lower(card_name) LIKE ...`) but not diacritic-insensitive, so any card whose
+name carries an accent was only reachable by typing the accent.
+
+A corpus scan (`benchmarks/bitplanes/corpus.jsonl`, real Scryfall card names) turned up 14 distinct
+accented base letters — í ú é ü û ō ö â á ï ñ ó ä à — across acute, grave, circumflex, diaeresis,
+tilde, and macron marks on a/e/i/o/u/n. General diacritic folding is required; a narrow "handle é"
+special case would miss most of them.
+
+## Design
+
+Two independent matching engines exist here — a Postgres SQL path and a Rust `card_engine`
+(primary; SQL is a cost-routed fallback per #712) — and both need to agree on what counts as "the
+same name" or the two would silently diverge on which cards a query returns.
+
+**Single source of truth in Python:** `fold_accents()` in
+[card_query_nodes.py](../../api/parsing/card_query_nodes.py) NFKD-decomposes each character and
+drops combining marks (stdlib `unicodedata`, no new dependency). Both engines consume its output
+rather than each re-implementing folding:
+
+- **Ingest:** `preprocess_card()` computes `card_name_folded = fold_accents(card_name.lower())`
+  once per card and stores it as a real column
+  ([migration](../../api/db/2026-07-20-01-accent-folded-name.sql)) with its own trigram GIN index.
+  The Rust engine reads the same column at reload time (`ENGINE_COLUMNS`) into a new
+  `card_name_folded: InlineStr<61>` field, so it needs zero folding logic of its own — it's plumbing,
+  not computation. This is why `ARCHIVE_FORMAT_VERSION` bumped
+  ([lib.rs:5210](../../card_engine/src/lib.rs#L5210)).
+- **Query side:** the fuzzy-match code path folds the search word the same way before it reaches
+  either engine — `_handle_text_field_pattern_matching` for SQL, `_rhs_to_json` for the JSON that
+  crosses into Rust's `build_text_filter`. Whether the user types "eowyn" or "Éowyn", both fold to
+  the same word by the time either engine sees it.
+- **Rust internals:** `name_trigram`, `name_bigrams`, and the `TextSearchField::NameLower`
+  eval/verification path ([filter.rs](../../card_engine/src/filter.rs)) were repointed from
+  `card_name_lower` to `card_name_folded`. Both indexes exist *only* to serve this fuzzy path
+  (confirmed via grep — `TextField::NameLower`/`TextExact`/`ExactName` are separate enums reading the
+  unfolded field), so the swap is contained.
+
+**What stays accent-sensitive, deliberately:** exact-match (`!"..."`, `name=`) keeps comparing
+against the raw `card_name`/`card_name_lower`. Typing the accent still gets you exact-accent
+matching; this needed no code change since those paths never touched the folded column. Regex
+search (`name:/.../`) is also untouched — folding would change its character-class semantics.
+
+**Scope:** only `card_name`. `oracle_text`/`flavor_text`/`card_artist` fuzzy search is not folded —
+doing so would need their own stored folded columns (they're interned strings in Rust, not
+inline), which is more surface than this issue asks for.
+
+**Cost:** query-time neutral. The SQL fragment goes from `lower(card_name) LIKE` to
+`lower(card_name_folded) LIKE` — same shape, matching functional index. The Rust field is one more
+`InlineStr<61>` per card (~61 bytes × ~31.5k cards ≈ 2MB), populated once at reload, not computed
+per query.
+
+## Known limitation (not fixed here)
+
+The hand-rolled parser's tokenizer only accepts ASCII in *unquoted* bare words — `name:éowyn`
+(no quotes) fails to lex at all (`Unexpected character 'é'`). Quoting works today:
+`name:"éowyn"` parses and folds correctly. This is a pre-existing lexer restriction
+(`_WORD_START`/`_WORD_CONT` in `hand_parser.py`) affecting all bare non-ASCII tokens, not specific
+to this fix, and out of scope here — the reported issue (typing the *unaccented* form) doesn't
+require it, since "Eowyn" is plain ASCII.
+
+## Validation
+
+- `card_engine` unit test `accent_folded_name_search_matches_unaccented_query` (cargo test, debug +
+  release).
+- `test_fold_accents.py` — direct coverage of the fold function against the corpus characters above.
+- `test_sql_gen.py` / `test_exact_name_search.py` — SQL fragment assertions for both the fuzzy and
+  exact paths.
+- `test_integration_testcontainers.py::test_card_search_by_name_folds_accents` — real Postgres,
+  real migration, asserts `name:eowyn` finds "Éowyn, Fearless Knight" and only it, and that exact
+  match distinguishes the two spellings.
+
+## Status
+
+**Resolved** — see [PR description](../prs/accent-insensitive-name-search.md).

--- a/docs/issues/00718-accent-sensitive-literal-recheck.md
+++ b/docs/issues/00718-accent-sensitive-literal-recheck.md
@@ -1,0 +1,94 @@
+# Accent-Sensitive Matching for Accented `name:` Queries
+
+[#718](https://github.com/jbylund/sylvan_librarian/issues/718)
+
+Follow-up to [00649-accent-insensitive-name-search.md](00649-accent-insensitive-name-search.md)
+(#649, shipped in #716). That change made fuzzy `name:` folding **symmetric**: both the stored
+name and the query word are diacritic-folded, so `name:eowyn` and `name:Éowyn` produce the
+identical folded search term and match identically.
+
+## Problem
+
+Symmetric folding is correct for the unaccented direction (`name:eowyn` should match both
+"Eowyn" and "Éowyn", if both existed) but too permissive for the accented direction. Typing the
+accent should narrow the search, not just restate it:
+
+- `name:eowyn` (unaccented) → matches **both** "Eowyn" and "Éowyn".
+- `name:Éowyn` (accented) → should match **only** "Éowyn", not "Eowyn".
+
+Not currently reachable with real Scryfall data (no two cards share a base name differing only by
+diacritics today), so this is a precision refinement, not a live user-facing bug — lower priority
+than #649 was.
+
+## Design
+
+Detecting intent is free: `fold_accents(word) != word` means the user typed at least one accented
+character. The interesting part is what to do with that signal without duplicating the indexing
+work #716 just added.
+
+**Key insight:** don't build a second index. Decompose an accented query into an `AND` of the
+existing folded-fuzzy predicate (which narrows via the existing `name_trigram`/`name_bigrams`
+index, built on `card_name_folded`) and a new *literal* (unfolded, still case-insensitive) contains
+check against `card_name_lower`. The literal check never needs its own index: in `AND`
+composition, `narrow_rec` (`card_engine/src/lib.rs:2781`, `FilterExpr::And` handling at
+`lib.rs:3154`) already narrows using whichever children *can* narrow, and verifies non-narrowing
+children with a plain per-row check on the resulting (already tiny) candidate set — that's the
+existing `every_child_included` / `tight &=` machinery, not something to build. Confirmed by
+reading the exhaustive-match guard rails a new `TextSearchField` variant would need to satisfy:
+
+- `narrow_rec` ends in a catch-all `_ => None` (`lib.rs:3306`) — an unindexed variant just can't
+  narrow on its own, which is exactly what we want.
+- `memoize_text_predicates` (`filter.rs:826`) ends in `_ => {}` (`filter.rs:918`) — no bigram/
+  trigram rewrite attempted, falls through to generic per-row evaluation.
+- `printing_dependent`'s `TextSearchField` match (`filter.rs:572`) and `text_search_field_value`
+  (`filter.rs:241`) *are* exhaustive and need one new arm each — small, mechanical.
+- `verify_cost_tier` matches on `FilterExpr::TextContains { .. }` as a whole, not per-field
+  (`filter.rs:470`) — no change needed; `TEXT_SCAN_NS100` already correctly prices a per-row scan.
+
+So the total Rust surface is: one new enum variant, two one-line match arms, and a small change to
+`build_text_filter` (`filter.rs:1615`) to emit an `And` of two `TextContains` instead of one when
+Python signals an accented query — no new index, no `ARCHIVE_FORMAT_VERSION` bump.
+
+## Implementation plan
+
+**Rust (`card_engine/src/filter.rs`):**
+1. Add `TextSearchField::NameLowerLiteral`.
+2. `text_search_field_value`: `NameLowerLiteral => StrVal::Known(card.card_name_lower.as_str())`.
+3. `printing_dependent`: add `NameLowerLiteral` to the `false` (card-level) arm alongside
+   `NameLower`.
+4. `build_text_filter` (currently: `raw_value.to_lowercase()` → single `TextContains{NameLower,
+   word}` for `card_name` + `:`): if the JSON rhs kwargs carries a `literal_value` key (see below),
+   emit `FilterExpr::And(vec![TextContains{NameLower, folded_word}, TextContains{NameLowerLiteral,
+   literal_word}])` instead.
+
+**Python (`api/parsing/card_query_nodes.py`):**
+- `_rhs_to_json` (`CardBinaryOperatorNode`): for `card_name` + `:`, already computes
+  `fold_accents(value)`. When it differs from the input, include both:
+  `{"value": folded, "literal_value": value}`. Unaccented queries (the common case) omit
+  `literal_value` entirely — zero JSON/behavior change there.
+- `_handle_text_field_pattern_matching` (SQL path): same detection, compound SQL when accented —
+  `(lower(card.card_name_folded) LIKE folded_pattern) AND (lower(card.card_name) LIKE
+  literal_pattern)`. Both fragments already exist independently in the codebase (folded fuzzy,
+  unfolded exact-ish `LIKE`); this just ANDs them together for this one case. No new SQL
+  machinery, no new index — the existing `idx_cards_cardname_folded_lower_trgm` (folded) and
+  `idx_cards_cardname_lower_trgm` (unfolded, pre-existing from #470) cover both sides.
+
+## Test plan
+
+Real Scryfall data can't exercise this (no accented/unaccented pair sharing a base name), so
+coverage is synthetic:
+
+- `card_engine/src/tests.rs`: extend `accent_folded_name_search_matches_unaccented_query` (or add a
+  sibling test) with a *second*, unaccented card sharing the same folded name as the accented
+  fixture card. Assert: unaccented query word matches both cards; accented query word matches only
+  the accented one.
+- `test_sql_gen.py`: assert the compound `AND` SQL and parameters for an accented `name:` query.
+- `test_integration_testcontainers.py`: add the unaccented sibling card to `test_data.sql` (or a
+  dedicated test), assert `name:Éowyn` (accented) returns only the accented card against a real
+  Postgres instance.
+
+## Status
+
+**Open.** Planned as a follow-up PR to #716 rather than amending it — #716 is a clean, reviewable
+unit that fully resolves #649 as reported; this is additional precision beyond what was asked for,
+with its own wire-format change (Python↔Rust JSON) and test story.

--- a/docs/prs/accent-insensitive-name-search.md
+++ b/docs/prs/accent-insensitive-name-search.md
@@ -1,0 +1,89 @@
+# Fold Diacritics in Fuzzy Name Search
+
+Fixes [#649](https://github.com/jbylund/sylvan_librarian/issues/649).
+
+## What
+
+`name:eowyn` now matches "Éowyn, Fearless Knight" — fuzzy `name:` search folds diacritics on both
+the stored name and the search term, so an unaccented query finds accented cards and vice versa.
+Exact-match (`!"..."`, `name=`) and regex (`name:/.../`) are unchanged and stay accent-sensitive.
+
+## Why
+
+Fuzzy name search was already case-insensitive but not diacritic-insensitive. A scan of the real
+Scryfall corpus found 14 distinct accented base letters in card names (í ú é ü û ō ö â á ï ñ ó ä
+à — acute/grave/circumflex/diaeresis/tilde/macron over a/e/i/o/u/n), so this needed general
+diacritic folding, not a one-off `é` special case.
+
+Two independent matching engines read `name:` queries — the Postgres SQL path and the Rust
+`card_engine` (primary; SQL is a cost-routed fallback per #712) — and both needed to agree on
+what counts as "the same name," or they'd silently diverge on which cards a query returns.
+
+## Changes
+
+### `api/parsing/card_query_nodes.py`
+
+- New `fold_accents(value)`: NFKD-decomposes and drops combining marks (stdlib `unicodedata`, no
+  new dependency). This is the single source of truth for diacritic folding — every other change
+  below consumes its output rather than re-implementing folding.
+- `_handle_text_field_pattern_matching`: for `card_name`, matches against `card_name_folded`
+  instead of `card_name` and folds the search term before building the LIKE pattern.
+- `_rhs_to_json` (`CardBinaryOperatorNode`): folds the value for `card_name` fuzzy (`:`) queries
+  before it crosses the PyO3 JSON boundary into Rust, so Rust needs no folding logic of its own.
+
+### `api/card_processing.py`
+
+`preprocess_card()` computes `card_name_folded = fold_accents(card_name.lower())` once per card at
+import time.
+
+### `api/db/2026-07-20-01-accent-folded-name.sql`
+
+New migration: adds the `card_name_folded` column (backfilled for existing rows, `NOT NULL`) and a
+GIN trigram index on `lower(card_name_folded)`.
+
+### `card_engine/` (Rust)
+
+- New `card_name_folded: InlineStr<61>` field on `OracleCard`/`CardRow`, read directly from the
+  `card_name_folded` pydict key (added to `ENGINE_COLUMNS`) — no Rust-side fold computation.
+- `name_trigram`, `name_bigrams`, and the `TextSearchField::NameLower` eval/verification path now
+  read `card_name_folded` instead of `card_name_lower`. Confirmed via grep that both indexes and
+  this field are used *only* by the fuzzy-match path (`TextField::NameLower`/`TextExact`/
+  `ExactName` are separate enums reading the unfolded field), so the swap is contained.
+- `ARCHIVE_FORMAT_VERSION` bumped for the struct layout change.
+
+### Tests
+
+- `card_engine/src/tests.rs`: new `accent_folded_name_search_matches_unaccented_query`; existing
+  fixture builders/brute-force checks updated to populate/read `card_name_folded` alongside
+  `card_name_lower`.
+- `api/parsing/tests/test_fold_accents.py` (new): direct coverage of `fold_accents()` against the
+  corpus characters above.
+- `api/parsing/tests/test_sql_gen.py`, `test_exact_name_search.py`: SQL fragment assertions for
+  both the folded fuzzy path and the unfolded exact path.
+- `api/tests/test_integration_testcontainers.py`: new
+  `test_card_search_by_name_folds_accents` against a real Postgres instance with the real
+  migration applied — `name:eowyn` finds "Éowyn, Fearless Knight" and only it; exact match
+  distinguishes the two spellings. Existing count/set assertions touched by the new fixture card
+  updated.
+- `api/tests/fixtures/engine_cards.json`, `api/tests/test_engine_property.py`: backfilled
+  `card_name_folded` (existing fixture data predates the new required field).
+
+## Correctness
+
+- Exact-match paths (`ExactNameNode`, `name=`) are untouched — they still compare against the raw
+  `card_name`/`card_name_lower`, so typing the accent is still required there. This is intentional:
+  the issue only asks for the fuzzy path to fold, and exact match keeping full precision is the
+  more conservative default.
+- Scoped to `card_name` only. `oracle_text`/`flavor_text`/`card_artist` fuzzy search is not folded —
+  they're interned strings in Rust (not inline), so folding them would need their own stored
+  columns, more surface than this issue asks for.
+- Query-time cost is unchanged: the SQL fragment swaps one indexed lowercase column for another
+  (`lower(card_name) LIKE` → `lower(card_name_folded) LIKE`); the Rust field is populated once at
+  reload, not computed per query.
+- Known, pre-existing, out-of-scope limitation: the hand-rolled parser's tokenizer only accepts
+  ASCII in unquoted bare words, so `name:éowyn` (no quotes) fails to lex. Quoting works today
+  (`name:"éowyn"`). The reported issue (typing the unaccented form) doesn't require this, since
+  "Eowyn" is plain ASCII — see the linked issue doc for detail.
+
+See [docs/issues/00649-accent-insensitive-name-search.md](../issues/00649-accent-insensitive-name-search.md)
+for the full design writeup.

--- a/docs/prs/accent-insensitive-name-search.md
+++ b/docs/prs/accent-insensitive-name-search.md
@@ -7,6 +7,7 @@ Fixes [#649](https://github.com/jbylund/sylvan_librarian/issues/649).
 `name:eowyn` now matches "Éowyn, Fearless Knight" — fuzzy `name:` search folds diacritics on both
 the stored name and the search term, so an unaccented query finds accented cards and vice versa.
 Exact-match (`!"..."`, `name=`) and regex (`name:/.../`) are unchanged and stay accent-sensitive.
+Both parsers also now accept the accent typed *bare* (unquoted) — `name:Éowyn` — not just quoted.
 
 ## Why
 
@@ -51,6 +52,20 @@ GIN trigram index on `lower(card_name_folded)`.
   `ExactName` are separate enums reading the unfolded field), so the swap is contained.
 - `ARCHIVE_FORMAT_VERSION` bumped for the struct layout change.
 
+### `api/parsing/hand_parser.py`
+
+`_is_word_start`/`_is_word_cont` replace the ASCII-only `_WORD_START`/`_WORD_CONT` frozenset
+membership checks with `c in <frozenset> or c.isalpha()`, so bare (unquoted) words can start with
+or contain any Unicode letter, not just ASCII. The ASCII fast path is unchanged.
+
+### `api/parsing/pyparsing_based.py`
+
+The bare-word regexes (`word`, `string_value_word`, `hyphenated_condition`'s value, and the
+implicit-AND tokenizer's `string_value_tok`) swap ASCII character classes for `\w` /
+`[^\W\d]` (Python's `re` is Unicode-aware by default for `str` patterns; `[^\W\d]` is "a word
+character that isn't a digit," i.e. letter-or-underscore) — same widening as the hand parser, kept
+in parity.
+
 ### Tests
 
 - `card_engine/src/tests.rs`: new `accent_folded_name_search_matches_unaccented_query`; existing
@@ -59,7 +74,9 @@ GIN trigram index on `lower(card_name_folded)`.
 - `api/parsing/tests/test_fold_accents.py` (new): direct coverage of `fold_accents()` against the
   corpus characters above.
 - `api/parsing/tests/test_sql_gen.py`, `test_exact_name_search.py`: SQL fragment assertions for
-  both the folded fuzzy path and the unfolded exact path.
+  both the folded fuzzy path and the unfolded exact path, quoted and bare.
+- `api/parsing/tests/implicit_and_cases.py`: bare accented word cases, shared by the hand/pyparsing
+  parity test and the implicit-AND preprocessing test.
 - `api/tests/test_integration_testcontainers.py`: new
   `test_card_search_by_name_folds_accents` against a real Postgres instance with the real
   migration applied — `name:eowyn` finds "Éowyn, Fearless Knight" and only it; exact match
@@ -80,10 +97,10 @@ GIN trigram index on `lower(card_name_folded)`.
 - Query-time cost is unchanged: the SQL fragment swaps one indexed lowercase column for another
   (`lower(card_name) LIKE` → `lower(card_name_folded) LIKE`); the Rust field is populated once at
   reload, not computed per query.
-- Known, pre-existing, out-of-scope limitation: the hand-rolled parser's tokenizer only accepts
-  ASCII in unquoted bare words, so `name:éowyn` (no quotes) fails to lex. Quoting works today
-  (`name:"éowyn"`). The reported issue (typing the unaccented form) doesn't require this, since
-  "Eowyn" is plain ASCII — see the linked issue doc for detail.
+- The tokenizer widening is deliberately about lexer *acceptance* (which characters can appear in a
+  bare word), independent of `fold_accents()`'s Latin-diacritic *folding* scope — a bare word with,
+  say, a Cyrillic or CJK character now lexes fine too; it just won't be accent-folded (out of scope,
+  same as oracle/flavor text above).
 
 See [docs/issues/00649-accent-insensitive-name-search.md](../issues/00649-accent-insensitive-name-search.md)
 for the full design writeup.


### PR DESCRIPTION
# Fold Diacritics in Fuzzy Name Search

Fixes [#649](https://github.com/jbylund/sylvan_librarian/issues/649).

## What

`name:eowyn` now matches "Éowyn, Fearless Knight" — fuzzy `name:` search folds diacritics on both
the stored name and the search term, so an unaccented query finds accented cards and vice versa.
Exact-match (`!"..."`, `name=`) and regex (`name:/.../`) are unchanged and stay accent-sensitive.

## Why

Fuzzy name search was already case-insensitive but not diacritic-insensitive. A scan of the real
Scryfall corpus found 14 distinct accented base letters in card names (í ú é ü û ō ö â á ï ñ ó ä
à — acute/grave/circumflex/diaeresis/tilde/macron over a/e/i/o/u/n), so this needed general
diacritic folding, not a one-off `é` special case.

Two independent matching engines read `name:` queries — the Postgres SQL path and the Rust
`card_engine` (primary; SQL is a cost-routed fallback per #712) — and both needed to agree on
what counts as "the same name," or they'd silently diverge on which cards a query returns.

## Changes

### `api/parsing/card_query_nodes.py`

- New `fold_accents(value)`: NFKD-decomposes and drops combining marks (stdlib `unicodedata`, no
  new dependency). This is the single source of truth for diacritic folding — every other change
  below consumes its output rather than re-implementing folding.
- `_handle_text_field_pattern_matching`: for `card_name`, matches against `card_name_folded`
  instead of `card_name` and folds the search term before building the LIKE pattern.
- `_rhs_to_json` (`CardBinaryOperatorNode`): folds the value for `card_name` fuzzy (`:`) queries
  before it crosses the PyO3 JSON boundary into Rust, so Rust needs no folding logic of its own.

### `api/card_processing.py`

`preprocess_card()` computes `card_name_folded = fold_accents(card_name.lower())` once per card at
import time.

### `api/db/2026-07-20-01-accent-folded-name.sql`

New migration: adds the `card_name_folded` column (backfilled for existing rows, `NOT NULL`) and a
GIN trigram index on `lower(card_name_folded)`.

### `card_engine/` (Rust)

- New `card_name_folded: InlineStr<61>` field on `OracleCard`/`CardRow`, read directly from the
  `card_name_folded` pydict key (added to `ENGINE_COLUMNS`) — no Rust-side fold computation.
- `name_trigram`, `name_bigrams`, and the `TextSearchField::NameLower` eval/verification path now
  read `card_name_folded` instead of `card_name_lower`. Confirmed via grep that both indexes and
  this field are used *only* by the fuzzy-match path (`TextField::NameLower`/`TextExact`/
  `ExactName` are separate enums reading the unfolded field), so the swap is contained.
- `ARCHIVE_FORMAT_VERSION` bumped for the struct layout change.

### Tests

- `card_engine/src/tests.rs`: new `accent_folded_name_search_matches_unaccented_query`; existing
  fixture builders/brute-force checks updated to populate/read `card_name_folded` alongside
  `card_name_lower`.
- `api/parsing/tests/test_fold_accents.py` (new): direct coverage of `fold_accents()` against the
  corpus characters above.
- `api/parsing/tests/test_sql_gen.py`, `test_exact_name_search.py`: SQL fragment assertions for
  both the folded fuzzy path and the unfolded exact path.
- `api/tests/test_integration_testcontainers.py`: new
  `test_card_search_by_name_folds_accents` against a real Postgres instance with the real
  migration applied — `name:eowyn` finds "Éowyn, Fearless Knight" and only it; exact match
  distinguishes the two spellings. Existing count/set assertions touched by the new fixture card
  updated.
- `api/tests/fixtures/engine_cards.json`, `api/tests/test_engine_property.py`: backfilled
  `card_name_folded` (existing fixture data predates the new required field).

## Correctness

- Exact-match paths (`ExactNameNode`, `name=`) are untouched — they still compare against the raw
  `card_name`/`card_name_lower`, so typing the accent is still required there. This is intentional:
  the issue only asks for the fuzzy path to fold, and exact match keeping full precision is the
  more conservative default.
- Scoped to `card_name` only. `oracle_text`/`flavor_text`/`card_artist` fuzzy search is not folded —
  they're interned strings in Rust (not inline), so folding them would need their own stored
  columns, more surface than this issue asks for.
- Query-time cost is unchanged: the SQL fragment swaps one indexed lowercase column for another
  (`lower(card_name) LIKE` → `lower(card_name_folded) LIKE`); the Rust field is populated once at
  reload, not computed per query.
- Known, pre-existing, out-of-scope limitation: the hand-rolled parser's tokenizer only accepts
  ASCII in unquoted bare words, so `name:éowyn` (no quotes) fails to lex. Quoting works today
  (`name:"éowyn"`). The reported issue (typing the unaccented form) doesn't require this, since
  "Eowyn" is plain ASCII — see the linked issue doc for detail.

See [docs/issues/00649-accent-insensitive-name-search.md](../issues/00649-accent-insensitive-name-search.md)
for the full design writeup.
