### PR TITLE
Narrow CollectionCmp Eq/Gt Via the Containment Index

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -5,7 +5,7 @@ use super::legality::{LEGALITY_LEGAL, LEGALITY_BANNED, LEGALITY_RESTRICTED, form
 
 // ─── Comparison / arithmetic operators ───────────────────────────────────────
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub(crate) enum CmpOp {
     Eq,
     Ne,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2340,6 +2340,7 @@ struct CardData {
 /// whose word-wise ops cost O(n/64) regardless of density. Narrowing is
 /// advisory (the driver re-verifies), so converting between spaces or
 /// representations can only loosen or tighten candidates, never change results.
+#[derive(Debug)]
 enum Candidates {
     Cards(Vec<u32>),
     Printings(Vec<u32>),
@@ -2640,6 +2641,13 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
         FilterExpr::ExactName(_) => Some(false),
         // 2-byte name needles resolve exactly through the bigram index.
         FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => Some(false),
+        // Ge-only guard is deliberate (#700): narrow_rec's CollectionCmp arm
+        // now also narrows Eq/Gt through the same containment postings, but
+        // only loosely — the postings prove `contains(value)`, not the
+        // length condition Eq/Gt additionally require — so they must stay
+        // out of this classifier. Falling through to `None` below for them is
+        // correct: Not's complement trick is only sound over tight sets, and
+        // Eq/Gt never produce one.
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } => {
             Some(matches!(field, CollField::ArtTags | CollField::IsTags | CollField::FrameData))
         }
@@ -3034,7 +3042,22 @@ fn narrow_rec(
             }
         }
 
-        FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge) => {
+        // Ge/Eq/Gt all resolve `matches()` through the same `contains(value)`
+        // test on the collection, per its `coll == {value}` (Eq) and proper-
+        // superset (Gt) definitions — Eq and Gt are strict *subsets* of what
+        // Ge (plain containment) matches, since both additionally require a
+        // length condition (`len == 1` / `len > 1`) that containment alone
+        // doesn't decide. So the same postings this arm already gathers for
+        // `:` are a valid — if not exact — candidate superset for `=`/`>`
+        // too: every Eq/Gt match is also a Ge match, so it's guaranteed to
+        // show up in these postings, just alongside cards the length check
+        // will still need to reject. `narrow_rec`'s driver always re-verifies
+        // with `matches()` regardless of tightness (see `Candidates`'/
+        // `Narrowed`'s doc comments), so declaring the postings loose for
+        // Eq/Gt is enough to stay correct — no separate index for the length
+        // condition is needed. (#700; Le/Lt/Ne genuinely can't reuse this —
+        // they're not expressible as `contains` plus a length check.)
+        FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) => {
             // `complete` marks indexes that post every occurrence of every
             // value — all of them except frame_data, whose dense values are
             // deliberately dropped at build (#628), so absence proves nothing
@@ -3047,11 +3070,18 @@ fn narrow_rec(
                 CollField::IsTags     => (&indexes.is_tags,     false, true),
                 CollField::FrameData  => (&indexes.frame_data,  false, false),
             };
+            // Ge's postings are exact for Ge itself; for Eq/Gt they're only a
+            // loose superset (they prove `contains(value)` but not the length
+            // condition), so the residual `matches()` check the driver always
+            // runs is load-bearing for those two ops.
+            let mk = |set| if matches!(op, CmpOp::Ge) { Narrowed::tight(set) } else { Narrowed::loose(set) };
             match idx.get(value.as_str()) {
-                // Ge is containment, so a value with no postings in a complete
-                // index matches no row: an exact empty narrowing, not "cannot
-                // narrow" — `is:permanent` spent 0.6 ms full-scanning to
-                // return zero results.
+                // A value with no postings in a complete index proves
+                // `contains(value)` false for every row, which makes Ge, Eq,
+                // and Gt all provably empty alike — no row can satisfy any of
+                // them without first satisfying containment. Exact for all
+                // three ops, not just Ge: `is:permanent` spent 0.6 ms
+                // full-scanning to return zero results.
                 None if complete => {
                     Narrowed::tight(if card_space { Candidates::Cards(Vec::new()) } else { Candidates::Printings(Vec::new()) })
                 }
@@ -3061,7 +3091,8 @@ fn narrow_rec(
                     // the range indexes guard against (is:spell is ~60k ids);
                     // past the fraction they scatter to a bitmap when
                     // something will consume it and decline otherwise. Every
-                    // posted row carries the tag, so both paths stay tight.
+                    // posted row carries the tag (Ge tight); Eq/Gt still need
+                    // the length check downstream (loose either way).
                     // Card-space lists need no guard — same argument as
                     // numeric_candidates.
                     if !card_space && range_too_broad_to_narrow(v.len(), n_printings) {
@@ -3069,10 +3100,10 @@ fn narrow_rec(
                             return None;
                         }
                         let bits = scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings);
-                        return Narrowed::tight(Candidates::PrintingBits(bits));
+                        return mk(Candidates::PrintingBits(bits));
                     }
                     let ids: Vec<u32> = v.iter().map(|x| u32::from(*x)).collect();
-                    Narrowed::tight(if card_space { Candidates::Cards(ids) } else { Candidates::Printings(ids) })
+                    mk(if card_space { Candidates::Cards(ids) } else { Candidates::Printings(ids) })
                 }
             }
         }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,7 +4,7 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, range_candidates, narrow_candidates, rarity_candidates,
+    build_artist_index, build_range_index, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -322,6 +322,64 @@ fn narrow_candidates_spaces() {
     match narrow_candidates(&and, archived, offsets, &[]) {
         Some(Candidates::Cards(v)) => assert_eq!(v, vec![1]),
         _ => panic!("mixed And must produce card-space candidates"),
+    }
+}
+
+// #700: Eq/Gt reuse the same containment postings Ge narrows through, but
+// loosely — narrow_candidates_exact must report the identical postings for
+// all three ops, tight only for Ge. Uses Keywords (card-space, complete) so
+// the exactness bit narrow_candidates_exact returns isn't itself masked by
+// the printing-space projection (that projection always reports loose,
+// which would hide the Ge-vs-Eq/Gt distinction this test is checking).
+#[test]
+fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
+    let mut keywords: TagIndex = HashMap::new();
+    keywords.insert("Flying".to_string(), vec![1]);
+
+    // offsets for 2 cards with 2 printings each: printings 0-1 → card 0, 2-3 → card 1
+    let raw_offsets = vec![0u32, 2, 4];
+    let printing_to_card = build_printing_to_card(&raw_offsets);
+    let indexes = CardIndexes { keywords, printing_to_card, ..Default::default() };
+    let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
+    let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
+    let offsets_bytes = rkyv::to_bytes::<Error>(&raw_offsets).expect("serialize offsets");
+    let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
+
+    let coll = |op, value: &str| FilterExpr::CollectionCmp { field: CollField::Keywords, op, value: value.to_string(), value_id: None };
+
+    for op in [CmpOp::Eq, CmpOp::Gt] {
+        match narrow_candidates_exact(&coll(op, "Flying"), archived, offsets, &[]) {
+            (Some(Candidates::Cards(v)), tight) => {
+                assert_eq!(v, vec![1], "{op:?} must reuse Ge's exact postings as a candidate superset");
+                assert!(!tight, "{op:?} postings only prove containment, not the length condition — must narrow loose");
+            }
+            other => panic!("{op:?} must narrow via the containment index, got {other:?}"),
+        }
+    }
+    // Ge itself stays tight over the same postings.
+    match narrow_candidates_exact(&coll(CmpOp::Ge, "Flying"), archived, offsets, &[]) {
+        (Some(Candidates::Cards(v)), tight) => {
+            assert_eq!(v, vec![1]);
+            assert!(tight, "Ge's postings are exact containment, must stay tight");
+        }
+        other => panic!("Ge must narrow via the containment index, got {other:?}"),
+    }
+    // A value absent from a complete index proves the empty set for Eq/Gt
+    // too — no row can satisfy either without first satisfying containment.
+    for op in [CmpOp::Eq, CmpOp::Gt, CmpOp::Ge] {
+        match narrow_candidates_exact(&coll(op, "Trample"), archived, offsets, &[]) {
+            (Some(Candidates::Cards(v)), tight) => {
+                assert!(v.is_empty(), "{op:?} over an absent value narrows to the exact empty set");
+                assert!(tight, "{op:?} empty-postings narrowing is exact, not just advisory");
+            }
+            other => panic!("{op:?} over an absent value must narrow to empty, not decline, got {other:?}"),
+        }
+    }
+    // frame_data stays excluded for Eq/Gt too (#628: incomplete index, absence
+    // proves nothing), same as it already is for Ge.
+    let frame = |op| FilterExpr::CollectionCmp { field: CollField::FrameData, op, value: "zombie".to_string(), value_id: None };
+    for op in [CmpOp::Eq, CmpOp::Gt, CmpOp::Ge] {
+        assert!(narrow_candidates(&frame(op), archived, offsets, &[]).is_none(), "{op:?} over frame_data must decline, not narrow");
     }
 }
 
@@ -1464,8 +1522,12 @@ enum FuzzLeaf {
     // one of the fixed operand pairs in `fuzz_arith_pair` (kept as an id, not a stored NumExpr,
     // so FuzzLeaf stays Clone without NumExpr needing to be).
     Arith { shape: u8, op: CmpOp },
-    // Set-containment against a single value (`CollectionCmp`) — subtypes/keywords/tags. `Ge` (`:`)
-    // narrows via the tag index; other ops are residual. `value` resolves to a vocab id via bind.
+    // Set-containment against a single value (`CollectionCmp`) — subtypes/keywords/tags. `Ge` (`:`),
+    // `Eq` (`=`), and `Gt` (`>`) all narrow via the tag index (#700): all three require
+    // `contains(value)`, so the same postings serve as an exact candidate set for `Ge` and a loose
+    // superset for `Eq`/`Gt`, which still need a residual `matches()` check for the length condition
+    // (`len == 1` / `len > 1`) the postings alone don't decide. `Le`/`Lt`/`Ne` stay fully residual —
+    // not expressible as containment plus a length check. `value` resolves to a vocab id via bind.
     Collection { field: CollField, op: CmpOp, value: String },
     // Artist predicate: `TextContains(ArtistLower)` that bind() rewrites to `ArtistMatch` (printing-
     // space, CSR-indexed via the artist vocab). `word` is a lowercased artist name.

--- a/docs/issues/00700-engine-collection-eq-gt-containment-index.md
+++ b/docs/issues/00700-engine-collection-eq-gt-containment-index.md
@@ -1,0 +1,87 @@
+# Narrow CollectionCmp Eq/Gt via the Containment Index
+
+[#700](https://github.com/jbylund/sylvan_librarian/issues/700).
+
+## Measured problem
+
+`narrow_rec`'s `CollectionCmp` arm only narrows `Ge` (`:`, plain containment) through the
+per-value containment index (`subtypes`/`keywords`/`oracle_tags`/`art_tags`/`is_tags`). `Eq` (`=`)
+and `Gt` (`>`) fell through to a full scan of every card/printing, even though both ops still
+require `contains(value)` as a precondition.
+
+Benchmarked (`scripts/bench_collection_eq_gt.py`, `benchmarks/bitplanes/corpus.jsonl`, 97,206
+printings, `main` @ `bf6f788` vs. this branch, release build, 3s timed window per config, min-of-N):
+
+| Query | Before | After | Speedup |
+|---|---|---|---|
+| `subtype=Human` | 0.310 ms | 0.112 ms | 2.8x |
+| `subtype>Human` | 0.417 ms | 0.078 ms | 5.3x |
+| `keyword=Flying` | 0.291 ms | 0.081 ms | 3.6x |
+| `keyword>Flying` | 0.396 ms | 0.084 ms | 4.7x |
+| `otag=removal` | 0.109 ms | 0.023 ms | 4.8x |
+| `otag>removal` | 0.443 ms | 0.126 ms | 3.5x |
+| `art=human` | 0.546 ms | 0.233 ms | 2.3x |
+| `art>human` | 0.863 ms | 0.254 ms | 3.4x |
+| `is=spell` | 0.483 ms | 0.003 ms | 179x |
+
+Full table in the PR. Geomean 2.6x over the 12 non-degenerate queries above (4.8x if the `is:`
+pair is included — see Acceptance for why that one's an outlier, not a representative win).
+
+## Where the cost is
+
+`Eq`/`Gt` fell outside the arm's `matches!(op, CmpOp::Ge)` guard entirely, so `narrow_rec` returned
+`None` for them and the driver ran its residual `FilterExpr::matches` linear scan over the whole
+card/printing set — the same cost `:` used to pay before #628-era indexing existed for it.
+
+## Proposed approach
+
+`matches()`'s own definitions make the subset relationship exact, not approximate:
+
+- `Ge` (`:`): `contains(value)`
+- `Eq` (`=`): `coll == {value}` ⟺ `len == 1 ∧ contains(value)`
+- `Gt` (`>`): proper superset of `{value}` ⟺ `contains(value) ∧ len > 1`
+
+Both `Eq` and `Gt` imply `contains(value)`, so every row they can possibly match is already inside
+the Ge postings for that value — the postings are a sound (if not exact) candidate superset for
+all three ops. Concretely: widen the arm's guard to `Ge | Eq | Gt`, keep gathering postings exactly
+as before, and pick tightness by op — `Ge` stays `Narrowed::tight`, `Eq`/`Gt` become
+`Narrowed::loose`. Loose is enough: narrowing is purely advisory in this engine (see `Candidates`'/
+`Narrowed`'s doc comments in `card_engine/src/lib.rs`) — the driver always re-runs `matches()` on
+every candidate regardless of tightness, so the length condition the postings can't decide gets
+checked there for free. The empty-postings case (`None if complete`) stays exact for all three ops
+unchanged: no postings for `value` means `contains(value)` is false everywhere, which makes `Ge`,
+`Eq`, and `Gt` all provably empty at once.
+
+`frame_data` stays excluded for `Eq`/`Gt` too, same as `Ge` (#628 — its index is deliberately
+incomplete, so absence proves nothing there). `tight_narrow_space`'s `Ge`-only guard already
+excludes `Eq`/`Gt` from the `Not`-complement fast path — correct as-is, since their narrowing is
+loose, not tight; left unchanged, just newly commented.
+
+Rejected: a second index keyed by `(value, len)` to make `Eq`/`Gt` exact. Not worth it — the
+residual check the driver already runs makes the extra index pure duplication for a case that's
+already fast without it.
+
+## Acceptance
+
+- `fuzz_row_identity_matches_reference` (`card_engine/src/tests.rs`) already generates
+  `CollectionCmp` filters across all six `CmpOp`s against biased-vocabulary stores and asserts every
+  row `run_query` returns is accepted by the trusted linear-scan oracle — it exercises the new loose
+  narrowing path automatically. Green in debug and `--release`.
+- New unit test `narrow_candidates_eq_gt_reuse_ge_postings_loosely` (`tests.rs`) asserts
+  `narrow_candidates_exact` returns identical postings for `Ge`/`Eq`/`Gt` over the same value, tight
+  only for `Ge`; confirms the empty-postings case stays tight for all three; confirms `frame_data`
+  still declines for `Eq`/`Gt`.
+- `subtype=`/`subtype>`, `keyword=`/`keyword>`, `otag=`/`otag>`, `art=`/`art>` all improve (table
+  above); `subtype:`/`keyword:`/`otag:`/`art:` (already-indexed `Ge` controls) and
+  `subtype!=`/`subtype<`/`subtype<=` (genuinely un-indexable, must stay full-scan) show no
+  regression. `total` is identical before/after for every query — the narrowing is advisory-only,
+  so result counts can't move.
+- `art=plane`/`art>plane` (a broad tag — 73,722 of 97,206 postings, over `MAX_NARROW_FRACTION`'s 25%
+  threshold) show ~1.0x: the scatter-to-bitmap path pays nearly the same cost as a full scan once
+  the postings are that broad, so the win here is real but small. Reported honestly rather than
+  cherry-picked out of the table.
+- `is=spell`/`is>spell` show a 179-181x speedup, but it's a degenerate case: this corpus's
+  `card_is_tags` is empty for all 97,206 rows (a query-rewrite change, #713/#714, moved most `is:`
+  values off this index), so both only exercise the exact-empty-postings branch, not the loose
+  `Some(v)` path a populated index would hit. Kept in the benchmark for coverage, called out
+  separately so the headline geomean isn't inflated by an index that's currently always empty.

--- a/scripts/bench_collection_eq_gt.py
+++ b/scripts/bench_collection_eq_gt.py
@@ -1,0 +1,179 @@
+"""Targeted benchmark for #700: narrow CollectionCmp Eq/Gt via the containment index.
+
+Times engine.query() for a fixed set of `subtype:`/`keyword:`/`otag:`/`art:`/`is:` queries against a
+corpus JSONL export, so the same script run on two builds (main baseline vs. branch) produces
+directly comparable CSVs. No SQL side, no Docker: build the engine locally
+(`maturin develop --release -m card_engine/Cargo.toml`) and run:
+
+    .venv/bin/python scripts/bench_collection_eq_gt.py \
+        --corpus benchmarks/bitplanes/corpus.jsonl \
+        --out benchmarks/collection-eq-gt/branch-<sha>.csv
+
+Reuses `benchmarks/bitplanes/corpus.jsonl` (97,206 rows) rather than re-exporting -- confirmed its
+columns are byte-identical to `card_engine.ENGINE_COLUMNS` for this branch before trusting it.
+
+The `total` column doubles as a parity check: it must be identical across builds for every config,
+or the comparison is void (this change is narrowing-only, so `=`/`>` result counts must not move).
+
+Every `eq`/`gt` group query is paired with the corresponding `:` (Ge) query as an in-group control
+(already indexed, must not regress) and, where informative, the matching un-optimizable op (`!=`/
+`<`/`<=`) as an "excluded-ops" control that must stay on the full scan, unchanged.
+
+Note: this corpus's `card_is_tags` is empty for all 97,206 rows (every `is:` query below returns 0),
+so the `istags` group only exercises the exact-empty-postings path (`None if complete`), not the
+`Some(v)` loose-narrowing path a populated index would hit. Kept anyway for coverage/regression
+purposes; it is not expected to show a timing win.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import card_engine  # noqa: E402
+from api.parsing import parse_scryfall_query  # noqa: E402
+
+# (group, query, unique, orderby, prefer) -- direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Subtypes (CollField::Subtypes, card-space, complete index). "Human" is the most common
+    # subtype in the corpus (10,567 postings) -- big enough that a full scan pays real cost.
+    ("subtypes", "subtype=Human", "card", "edhrec", "default"),
+    ("subtypes", "subtype>Human", "card", "edhrec", "default"),
+    ("subtypes", "subtype:Human", "card", "edhrec", "default"),  # control: already indexed (Ge)
+    # Keywords (CollField::Keywords, card-space, complete index). "Flying" is the most common
+    # keyword (9,060 postings).
+    ("keywords", "keyword=Flying", "card", "edhrec", "default"),
+    ("keywords", "keyword>Flying", "card", "edhrec", "default"),
+    ("keywords", "kw:Flying", "card", "edhrec", "default"),  # control
+    # Oracle tags (CollField::OracleTags, card-space, complete index). "removal" is a mid-size tag
+    # (18,275 postings); "triggered-ability" is the broadest tag in the corpus (40,924 postings) --
+    # card-space narrowing pays no broadness guard, unlike the printing-space fields below.
+    ("otags", "otag=removal", "card", "edhrec", "default"),
+    ("otags", "otag>removal", "card", "edhrec", "default"),
+    ("otags", "otag:removal", "card", "edhrec", "default"),  # control
+    ("otags", "otag=triggered-ability", "card", "edhrec", "default"),
+    ("otags", "otag>triggered-ability", "card", "edhrec", "default"),
+    ("otags", "otag:triggered-ability", "card", "edhrec", "default"),  # control
+    # Art tags (CollField::ArtTags, printing-space, complete index). "human" (20,651 postings) sits
+    # under MAX_NARROW_FRACTION's 25% broad-scatter threshold (~24k of 97,206 printings) so it
+    # exercises the plain-ids path; "plane" (73,722 postings) sits well over it, exercising the
+    # scatter-to-bitmap path instead.
+    ("atags", "art=human", "card", "edhrec", "default"),
+    ("atags", "art>human", "card", "edhrec", "default"),
+    ("atags", "art:human", "card", "edhrec", "default"),  # control
+    ("atags", "art=plane", "card", "edhrec", "default"),
+    ("atags", "art>plane", "card", "edhrec", "default"),
+    ("atags", "art:plane", "card", "edhrec", "default"),  # control
+    # Is tags (CollField::IsTags, printing-space, complete index). card_is_tags is empty for every
+    # row in this corpus (see module docstring) -- these only cover the exact-empty-postings path.
+    ("istags", "is=spell", "card", "edhrec", "default"),
+    ("istags", "is>spell", "card", "edhrec", "default"),
+    ("istags", "is:spell", "card", "edhrec", "default"),  # control
+    # Excluded ops (#700 out of scope: Le/Lt/Ne genuinely can't reuse the containment index) --
+    # these must stay full-scan and unchanged before/after.
+    ("excluded-ops", "subtype!=Human", "card", "edhrec", "default"),
+    ("excluded-ops", "subtype<Human", "card", "edhrec", "default"),
+    ("excluded-ops", "subtype<=Human", "card", "edhrec", "default"),
+    # Unaffected controls: existing containment / non-collection queries that must not regress.
+    ("control", "t:creature", "card", "edhrec", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+]
+
+WARMUP = 20
+BATCH_SIZE = 2000
+
+
+def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> card_engine.QueryEngine:
+    """Build a fresh engine store from the corpus JSONL via the staged reload API."""
+    engine = card_engine.QueryEngine(str(shm_path))
+    if not engine.reload_begin():
+        msg = "reload_begin returned False (stale archive published concurrently?)"
+        raise RuntimeError(msg)
+    t0 = time.monotonic()
+    batch: list[dict] = []
+    with corpus.open() as fh:
+        for line in fh:
+            batch.append(json.loads(line))
+            if len(batch) == BATCH_SIZE:
+                engine.add_batch(batch)
+                batch.clear()
+    if batch:
+        engine.add_batch(batch)
+    engine.reload_commit()
+    print(f"Engine loaded: {engine.size():,} printings in {time.monotonic() - t0:.1f}s", flush=True)
+    return engine
+
+
+def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str, str], window: float) -> tuple[int, int, float, float]:
+    """Return (total, n, avg_ms, min_ms) for one (query, unique, orderby, prefer) config over a fixed timed window."""
+    query, unique, orderby, prefer = config
+    filters = parse_scryfall_query(query)
+    kw = {
+        "filters": filters,
+        "unique": unique,
+        "prefer": prefer,
+        "orderby": orderby,
+        "direction": "asc",
+        "limit": 100,
+        "offset": 0,
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n = 0
+    best = float("inf")
+    t_start = time.monotonic()
+    deadline = t_start + window
+    now = t_start
+    while now < deadline:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1_000, best * 1_000
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=3.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<13} {'query':<24} {'unique':<9} {'orderby':<8} {'prefer':<9} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(
+                f"{group:<13} {query:<24} {unique:<9} {orderby:<8} {prefer:<9} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`t=human` / `t>human` (and their keyword/oracle-tag/art-tag/is-tag equivalents) fell through to a
full scan even though `=` and `>` both require `contains(value)` — the same precondition `:` (`Ge`)
already narrows through the per-value containment index. This widens `narrow_rec`'s `CollectionCmp`
arm to reuse the same postings for `Eq`/`Gt`, marking them as a loose candidate superset instead of
declining to narrow at all; the driver's existing residual `matches()` check (which always runs,
regardless of tightness) verifies the length condition (`len == 1` / `len > 1`) those two ops
additionally require. `frame_data` stays excluded for all three ops (incomplete index, #628);
`Le`/`Lt`/`Ne` are untouched — not expressible as containment plus a length check.

Design doc: `docs/issues/00700-engine-collection-eq-gt-containment-index.md`.

## Changes

- `card_engine/src/lib.rs`: widen the `CollectionCmp` narrowing arm's guard from `Ge` to
  `Ge | Eq | Gt`; tightness now depends on `op` (`Ge` tight, `Eq`/`Gt` loose) via a small `mk`
  closure, reusing the existing postings-gather/broad-scatter logic unchanged. Comment on
  `tight_narrow_space` explaining why its `Ge`-only guard stays as-is.
- `card_engine/src/tests.rs`: updated the stale `FuzzLeaf::Collection` comment (`Ge` no longer the
  only narrowing op); new unit test `narrow_candidates_eq_gt_reuse_ge_postings_loosely` asserting
  `Eq`/`Gt` return identical postings to `Ge` but `tight == false`, the empty-postings case stays
  exact for all three ops, and `frame_data` still declines for `Eq`/`Gt`.
- `card_engine/src/filter.rs`: added `Debug` to `CmpOp` (test assertion messages only).
- `scripts/bench_collection_eq_gt.py`: new targeted benchmark, pattern-matched on
  `scripts/bench_bitplanes.py`, covering all five `CollField`s across `=`/`>`/`:`/excluded-ops.

## Related issues

Fixes #700

---

## Performance

Corpus: `benchmarks/bitplanes/corpus.jsonl` (97,206 printings). `main` @ `bf6f788` vs. this branch
@ `22e3089`, release build, 3s timed window per config, min-of-N. Full config list and script:
`scripts/bench_collection_eq_gt.py`.

| Query | Before (ms) | After (ms) | Change |
|---|---|---|---|
| `subtype=Human` | 0.310 | 0.114 | 2.72x |
| `subtype>Human` | 0.417 | 0.080 | 5.19x |
| `subtype:Human` (control) | 0.062 | 0.064 | 0.97x |
| `keyword=Flying` | 0.291 | 0.082 | 3.56x |
| `keyword>Flying` | 0.396 | 0.086 | 4.59x |
| `kw:Flying` (control) | 0.060 | 0.062 | 0.97x |
| `otag=removal` | 0.109 | 0.023 | 4.79x |
| `otag>removal` | 0.443 | 0.128 | 3.48x |
| `otag:removal` (control) | 0.066 | 0.067 | 0.98x |
| `otag=triggered-ability` | 0.169 | 0.106 | 1.59x |
| `otag>triggered-ability` | 0.505 | 0.230 | 2.20x |
| `otag:triggered-ability` (control) | 0.086 | 0.088 | 0.98x |
| `art=human` | 0.546 | 0.232 | 2.36x |
| `art>human` | 0.863 | 0.251 | 3.44x |
| `art:human` (control) | 0.263 | 0.263 | 1.00x |
| `art=plane` (broad, >25% postings) | 0.496 | 0.481 | 1.03x |
| `art>plane` (broad) | 0.617 | 0.602 | 1.02x |
| `art:plane` (control) | 0.622 | 0.623 | 1.00x |
| `is=spell` (empty index, see note) | 0.483 | 0.003 | 178.89x |
| `is>spell` (empty index, see note) | 0.489 | 0.003 | 181.11x |
| `is:spell` (control) | 0.003 | 0.003 | 1.00x |
| `subtype!=Human` (excluded op) | 0.309 | 0.302 | 1.02x |
| `subtype<Human` (excluded op) | 0.277 | 0.265 | 1.05x |
| `subtype<=Human` (excluded op) | 0.314 | 0.306 | 1.03x |
| `t:creature` (control) | 0.062 | 0.064 | 0.97x |
| `cmc>6` (control) | 0.058 | 0.059 | 0.98x |

**Geometric mean:** 2.64x over the 12 real (non-degenerate) `=`/`>` queries above; 4.83x if the
`is:` pair is included, but that pair is a corpus artifact, not a representative win — see note
below.
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl`, 97,206 printings (untracked benchmark scratch,
not part of this PR's diff).

`total` is byte-identical between builds for every single query (26/26) — this change is
narrowing-only and can't move result counts; that parity doubles as the correctness check the
benchmark contributes on top of the differential fuzzer below.

Two things worth calling out honestly rather than cherry-picking around:
- `art=plane`/`art>plane` show ~1.0x: `plane` is a broad art tag (73,722 of 97,206 postings, over
  `MAX_NARROW_FRACTION`'s 25% threshold), so the scatter-to-bitmap path pays nearly the same cost as
  a full scan once the postings are that broad. Real, just small.
- `is=spell`/`is>spell`'s huge speedup is a corpus artifact: this export's `card_is_tags` is empty
  for all 97,206 rows (most `is:` values moved off this index in #713/#714's query-rewrite work), so
  both queries only exercise the exact-empty-postings branch (`None if complete`), not the loose
  `Some(v)` path a populated index would actually hit. Kept in the benchmark for coverage, but
  excluded from the headline geomean so it isn't inflated by an index that's currently always empty.

## Correctness

`fuzz_row_identity_matches_reference` (`card_engine/src/tests.rs`) already generates
`CollectionCmp` filters across all six `CmpOp`s (including `Eq`/`Gt`) against biased-vocabulary
stores and asserts every row `run_query` returns is accepted by the trusted linear-scan oracle — it
exercises the new loose-narrowing path automatically, no new differential-fuzz machinery needed.
Green in both debug and `--release` (debug catches `debug_assert!` tripwires release builds miss).
`make test-unit` (2041 tests) and `make test-integration` (21 tests, Docker/testcontainers) both
green.

## Reviewer notes

The only behavioral change is narrowing tightness for `Eq`/`Gt` — no new index, no new SQL/parser
surface (`api/` is untouched). The interesting bit to review is the `mk` closure in the
`CollectionCmp` arm and the updated `tight_narrow_space` comment confirming `Eq`/`Gt` are correctly
excluded from the `Not`-complement fast path (their narrowing is loose, so complementing it would
be unsound).