### PR TITLE
Consolidate the Printing-Space PlanePopcountOrder Plan Into One Doc

### DIFF
--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -1,0 +1,60 @@
+# Engine: Printing-Space Existential Bitplanes (Legality / Border / Frame)
+
+Status: todo, filed as [#724](https://github.com/jbylund/sylvan_librarian/issues/724). Sequenced
+**last**, behind the [printing-space popcount-order plan](local-engine-printing-plane-popcount-order.md)
+that consumes them (see that doc's ship-order step 7).
+
+## What
+
+Bit-per-**printing** planes for printing-varying categorical/existential values — legality (per
+format), border, frame. Today these live only in **card space**: legality's `legal_x` plane
+([#667](done/00667-engine-legality-divergent-carveout.md)) and border's plane
+([#664](done/00664-engine-border-planes.md)) are existence *projections* — a card's bit means
+"*some* printing satisfies," not *which* printing. That answers `unique=card` but can neither answer
+per-printing membership nor feed a printing-space `popcount`.
+
+A printing-space plane (one bit per printing) gives, for a printing-varying value: the exact
+per-printing match set, its total as a `popcount` (O(words), density-independent), and O(1)
+membership tests.
+
+## Why — and why there is no benefit yet
+
+These are **prerequisite infrastructure** for the printing-space popcount-order plan, which is where
+the win is realized (it ANDs printing bitmaps, `popcount`s the total, bit-walks the page). Measured
+targets there (all `unique=printing`): `f:modern border:black` 0.83 ms, bare `border:black` 0.99 ms
+→ microseconds.
+
+**On their own these planes provide no query speedup.** The current narrow-and-verify path does not
+`popcount` — it counts by iterating — so a printing plane with no consumer is just a bigger archive.
+The benefit appears only once the popcount-order plan exists and is wired to consume them. Hence the
+sequencing: that plan is built and **validated on the range leaf source first** (`cn<100 usd<50`,
+zero existential planes); these planes plug in afterward as another leaf bitmap.
+
+## Which values get a plane
+
+Per-value density crossover — the same one [#713](00713-is-tag-recovery.md) bucket-C uses:
+**mid-band/broad → plane**, sparse → postings, saturated → complement-count. `f:modern` (76% of
+printings legal) → plane; a rarely-legal format → postings. Not "a plane per value" — the crossover
+applied per value, overlapping #713's printing-varying categorical work.
+
+## Correctness surface (validated in isolation)
+
+The existential projection: a card can satisfy *both* `∃ legal` and `∃ not-legal` at once (its
+printings disagree) — the #667 divergent-carveout lesson. The printing-space plane is per-printing
+exact, so it sidesteps the projection ambiguity, but building it correctly from bulk data and
+composing `Not` carries its own equivalence-testing surface — kept separate from the consumer plan's
+query-time correctness so a failure localizes to one side.
+
+## Cost
+
+Build-time computation + storage + an **archive-format bump**.
+
+## Related
+
+- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
+  the consumer plan; this is its existential leaf source.
+- [00667 legality](done/00667-engine-legality-divergent-carveout.md),
+  [00664 border planes](done/00664-engine-border-planes.md) — the card-space versions this extends
+  into printing space.
+- [00713 is-tag recovery](00713-is-tag-recovery.md) — bucket-C; same per-value crossover.
+- #656 — the popcount-order phase extension.

--- a/docs/issues/done/00702-engine-plan-selection-layer.md
+++ b/docs/issues/done/00702-engine-plan-selection-layer.md
@@ -337,6 +337,9 @@ corner (though #656 flags it as a known ~1.07ms gap). **Decision pending:** buil
 #689) and cost-route idea-1/idea-2 — real work for a rare-but-known-gap win — vs leave it
 deferred. This is a prioritization call, not a technical unknown.
 
+→ Extracted to an active plan (parts, ship order, target queries):
+[local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md).
+
 ## Keeping costs/plans current as the engine changes
 
 The constants are fit to a point-in-time measurement, so the design has to say

--- a/docs/issues/local-engine-broad-range-fastpath.md
+++ b/docs/issues/local-engine-broad-range-fastpath.md
@@ -344,6 +344,9 @@ fifth (tight/loose) axis to worry about — every field behaves identically ther
 
 ## Related
 
+- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
+  the consolidated forward plan for idea 2 (the printing-space popcount plan, #656): parts, ship
+  order, target queries, and the #656 assembly. This doc is history; that one is the plan.
 - [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —
   prerequisite `printing_to_card` array, load-bearing for idea 1's per-match card check.
 - [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -20,15 +20,26 @@ The match bitmap has a few sources, and they share this one paging plan:
 - a **precomputed existential printing bitplane** for a printing-varying value (legality, frame,
   border) — e.g. a bit-per-printing "modern-legal" plane;
 - **a postings list scattered into a bitmap on demand** — O(matches) to build, for any value that
-  has printing-space postings.
+  has printing-space postings;
+- **a card-space bitplane broadcast into printing space on demand** — a card-invariant predicate
+  (`c:green`, `t:creature`, `cmc`) is naturally a *card* plane; give each printing its card's bit via
+  `printing_to_card`, O(n_printings). This is the **cheap, exact** direction — unlike the
+  `printing→card` projection (§ caveats), `card→printing` broadcast needs no distinct-count, because
+  the predicate does not vary by printing.
 
 Once a bitmap exists the total is a `popcount` — **O(words) (~1,500 words here ≈ microseconds),
 independent of match density** — and the page is read off the sort order. So density gates which
 *representation you store* (postings for sparse, a plane for broad/mid, complement for saturated),
 **not the cost of the count**. This is the key reason even a *broad* predicate is fine, and why a
-broad **compound** is the real win: build each leaf's bitmap (from a range, postings, or a plane),
-`AND` them in O(words), and `popcount` the result — far cheaper than intersecting two broad postings
-lists (`f:modern` ∩ `usd<50` = a 76k list against an 80k list). It's also why a broad
+broad **compound** is the real win: build each leaf's bitmap (from a range, postings, a plane, or a
+broadcast card-plane), `AND` them in O(words), and `popcount` the result.
+
+The card→printing broadcast is what makes a **mixed compound** — a card-invariant leaf AND a
+printing-varying one — computable entirely in printing space: `f:modern c:green` becomes
+"`c:green` card-plane broadcast to printings, AND `f:modern` printing-plane, `popcount`, page,"
+versus today's per-printing legality scan over the green-narrowed set. Same for `border:black
+t:creature`, `c:g usd<50`, etc. It also beats intersecting two broad postings lists (`f:modern` ∩
+`usd<50` = a 76k list against an 80k list). It's also why a broad
 printing-varying value like `f:modern` is a target here, not the non-target the range-only framing
 would suggest (see below).
 
@@ -67,6 +78,7 @@ exactly what an `argmin` over two cost curves expresses and a fixed threshold ca
 | query shape | mode | today | with this plan |
 |---|---|---|---|
 | `cn<100 usd<50` (range + range, both broad) | printing / artwork | **~1.07 ms** (full scan, two residuals — the uncovered gap) | ~2×, offset-independent |
+| mixed compound: card-invariant × printing-varying (`f:modern c:green`, `c:g usd<50`) | printing / artwork | per-printing scan over the card-narrowed set | broadcast the card-plane in, `AND` the printing bitmap, `popcount`, page |
 | bare broad range at deep offset (`usd<50` @ offset 5000) | printing | flat already | marginal (value #1) |
 | broad existential printing values — `f:modern` (**76% of printings legal**), `border:black` | printing / artwork | full scan + per-printing existence check; the #667 *card-space* legality plane makes `f:modern`/**card** fast, but printing mode has no such plane | a precomputed existential **printing** bitplane → `popcount` total + O(words) page |
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -75,25 +75,44 @@ exactly what an `argmin` over two cost curves expresses and a fixed threshold ca
 
 ## Target queries
 
-| query shape | mode | today | with this plan |
-|---|---|---|---|
-| `cn<100 usd<50` (range + range, both broad) | printing / artwork | **~1.07 ms** (full scan, two residuals — the uncovered gap) | ~2×, offset-independent |
-| mixed compound: card-invariant × printing-varying (`f:modern c:green`, `c:g usd<50`) | printing / artwork | per-printing scan over the card-narrowed set | broadcast the card-plane in, `AND` the printing bitmap, `popcount`, page |
-| bare broad range at deep offset (`usd<50` @ offset 5000) | printing | flat already | marginal (value #1) |
-| broad existential printing values — `f:modern` (**76% of printings legal**), `border:black` | printing / artwork | full scan + per-printing existence check; the #667 *card-space* legality plane makes `f:modern`/**card** fast, but printing mode has no such plane | a precomputed existential **printing** bitplane → `popcount` total + O(words) page |
+Measured on `main` (corpus.jsonl, `limit=100`, min of a timed window). The rule is clean: a query
+is slow **iff it is broad printing-varying with no narrowing leaf**.
 
-`f:modern` is broad (76% legal), so it does *not* narrow — the earlier "selective, already fast"
-framing was measuring card mode, where the #667 card-space plane does the work. Printing mode pays
-a per-printing existence check over that broad set, which a printing-space legality bitplane
-collapses to a `popcount`.
+| query | printing-varying leaves | narrowing leaf? | min | target? |
+|---|---|---|---|---|
+| `cn<100 usd<50` | 2 (ranges, both broad) | no | **1.18 ms** | **yes** |
+| `border:black` (bare) | 1 (87%, saturated) | no | **0.99 ms** | **yes** |
+| `f:modern border:black` | 2 (both broad) | no | **0.83 ms** | **yes** (shared-witness) |
+| `r:rare` (bare) | 1 (38%) | no | 0.42 ms | modest |
+| `f:modern r:rare` | 2 | no | 0.38 ms | modest |
+| `f:modern` (bare, 76%) | 1 | no | 0.20 ms | modest |
+| `f:modern c:green` | 1 | **yes** (`c:green`) | 0.082 ms | modest (all-plane) |
+| `f:modern c:green r:rare` | 2 | **yes** (`c:green`) | 0.116 ms | modest (all-plane) |
 
-Explicit non-targets: genuinely **sparse** values (`r:rare`, `is:promo`) narrow cheaply to postings —
-no plane earns its keep. **Card mode** broadly is served elsewhere (the #667 card-space legality
-planes; card-space idea 2 for ranges, PR 2a/3). Which representation a printing-varying value gets —
-plane vs positive-postings vs complement-postings — is a per-value density call (mid-band/broad →
-plane, sparse → postings, saturated → complement-count); the printing-mode existential-total
-mechanism is sketched under
-[sorted-range-fastpath § Existential fields](local-engine-sorted-range-fastpath.md#existential-fields-a-second-cheap-total-mechanism).
+**Narrowing sets the priority, but is not a hard non-target.** Whenever a card-invariant leaf narrows
+(`c:green` → ~18k printings), the current path is already fast (0.08–0.12 ms) — the per-printing
+verify runs over a tiny candidate set. Those queries are lower-priority. But they are still
+*improvable* by the same all-plane path: plane-AND + `popcount` is O(words) regardless of the
+candidate-set size, so it beats the per-printing verify (O(candidates)) even after narrowing — you
+broadcast the card leaf into printing space (cheap), `AND` the printing planes, `popcount`, page.
+That would take the 0.224 ms `f:modern border:black c:green` well under 0.1 ms.
+
+So the target set is: **big wins** on broad printing-varying with *no* narrowing leaf
+(`cn<100 usd<50` 1.18 ms, `border:black` 0.99 ms, `f:modern border:black` 0.83 ms — a minority of
+traffic, since real queries usually carry a filter); **modest wins** on the common narrowed
+compounds (already sub-ms, ~2–4× via the all-plane path). The gating cost either way is the same
+(next section).
+
+**Shared witness — a correctness reason, not just speed.** With 2+ printing-varying leaves
+(`f:modern border:black`), a match needs *one printing* satisfying **both** (`∃p: modern(p) ∧
+black(p)`) — not "some printing modern" and "some printing black." AND-ing the per-printing bitmaps
+enforces that by construction (a printing bit survives only if set in every leaf's bitmap); composing
+card-level existence projections would false-positive (a card with a modern printing and a *separate*
+black-bordered one). So for multi-leaf printing-varying compounds this plan is the *correct*
+composition, not merely the faster one.
+
+Non-target: **card mode** (served by the #667 card-space legality planes + card-space idea 2,
+PR 2a/3) — this plan is a printing/artwork thing.
 
 ## Parts, in ship order
 
@@ -111,9 +130,14 @@ printing-space subset, in dependency order:
 3. **Card-space idea-2 (`PrintingRangeBits`) — planned, not printing-space** (PR 2a/3 in the
    roadmap). Lands the range-bitmap→popcount machinery + the `must_be_tight` correctness fix in
    `unique=card` first, where the bitmap composes. This is the reusable core.
-4. **#656 — printing-space pager + per-sort-column printing permutation.** The gating build: a
-   printing-space sort order to page off, an **archive-format bump**. Without it there is nowhere to
-   read the page from in printing mode.
+4. **#656 — extend the popcount-order phase to compound residuals + printing/artwork.** As filed,
+   #656 is a follow-on to #634 (design in [00634](done/00634-engine-permuted-bitmap-order-phase.md)):
+   for a **card-level** orderby (edhrec, cmc…) the printing/artwork page is a *weighted set-bit walk*
+   over #634's **existing** card permutation (card weights via `offsets`-diff / artwork groups) — no
+   new permutation, no archive bump. Its compound-residual path needs each residual to expose a
+   bitmap to `AND` (ranges via PR 2a/3; existential values via their planes, below). A **printing-level**
+   orderby (usd, rarity — printing-varying) additionally needs a printing-space sort order — *that* is
+   the one archive-bump piece, and it is arguably beyond #656 as currently scoped.
 5. **The `PrintingPlanePopcountOrder` plan itself.** Build + AND + `popcount` the range bitmap(s) in
    printing space, page off the #656 permutation. Register as a new `PhysicalPlan` with its
    `applicable` / `materializing` / `cost::plan_cost` / executor arms — the #702 router makes this a
@@ -140,7 +164,15 @@ range+range gap proves worth closing.
 
 ## Prerequisites & caveats
 
-- **#656 is the blocker** (pager + permutation; archive-format bump).
+- **Existential targets need precomputed *printing-space* existential planes.** The `f:modern` /
+  `border:black` wins all assume a bit-per-printing legality / border plane to `AND` and `popcount`.
+  Neither exists: legality's #667 plane and border's #664 plane are **card-space** (they answer "some
+  printing legal," not which). Building the printing-space versions is a separate track from the
+  range idea-2 parts above — a build-time computation + storage + archive bump — and its own per-value
+  density call (`f:modern` broad → plane; a sparse legality value → postings). The range parts (1–6)
+  do not deliver the existential wins; that is a parallel piece.
+- **#656 is a partial blocker** (the popcount-order extension; see part 4). Printing-level-orderby
+  paging is the one archive-format bump.
 - **NULL over-inclusion — the #689 lesson.** A range bitmap's `popcount` **over-counts** the moment
   an existential/NULL predicate is trusted directly; this is precisely what
   [PR #689 got wrong and reverted](local-engine-sorted-range-fastpath.md). The `must_be_tight`

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -180,12 +180,25 @@ printing-space subset, in dependency order:
    bitmap to `AND` (ranges via PR 2a/3; existential values via their planes, below). A **printing-level**
    orderby (usd, rarity — printing-varying) additionally needs a printing-space sort order — *that* is
    the one archive-bump piece, and it is arguably beyond #656 as currently scoped.
-5. **The `PrintingPlanePopcountOrder` plan itself.** Build + AND + `popcount` the range bitmap(s) in
-   printing space, page off the #656 permutation. Register as a new `PhysicalPlan` with its
-   `applicable` / `materializing` / `cost::plan_cost` / executor arms — the #702 router makes this a
-   *declaration*, not a tree edit.
+5. **The `PrintingPlanePopcountOrder` plan itself — validated on the range leaf source.** Build + AND
+   + `popcount` the range bitmap(s) in printing space, page off the #656 permutation. Register as a
+   new `PhysicalPlan` with its `applicable` / `materializing` / `cost::plan_cost` / executor arms —
+   the #702 router makes this a *declaration*, not a tree edit. Prove the whole plan on **ranges
+   only** (`cn<100 usd<50`/printing, the confirmed 1.18 ms target, **zero** existential planes): a
+   range leaf yields a printing bitmap with no new precomputed structure (the `partition_point` slice
+   scattered, PR 2a's `printing_bits`) and is **exact**, so the AND / `popcount` / bit-walk / router
+   machinery is validated against the #702 brute-force reference on a clean source before any
+   existential plane exists.
 6. **Cost-route idea 1 vs this.** The `argmin` already exists; add this plan's cost formula and let
    the offset×selectivity crossover (validated today by `idea1_vs_idea2_probe`) pick between them.
+7. **Printing-space existential planes — separate track ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)).**
+   The legality/border **leaf source** that unlocks the existential targets (`f:modern`,
+   `border:black`). Sequenced **last, deliberately**: these planes give *no* speedup until steps 1–6
+   exist to consume them via `popcount` + AND + bit-walk (the current verify path doesn't `popcount`,
+   so a plane with no consumer is just a bigger archive). They carry their own correctness surface
+   (the existential projection — a card satisfying both `∃ legal` and `∃ not-legal`) validated in
+   isolation on the build side, and their own archive-format bump. Once landed they plug straight into
+   this plan as another leaf bitmap — the machinery from step 5 is unchanged.
 
 ## #656 assembly
 
@@ -206,13 +219,15 @@ range+range gap proves worth closing.
 
 ## Prerequisites & caveats
 
-- **Existential targets need precomputed *printing-space* existential planes.** The `f:modern` /
-  `border:black` wins all assume a bit-per-printing legality / border plane to `AND` and `popcount`.
-  Neither exists: legality's #667 plane and border's #664 plane are **card-space** (they answer "some
-  printing legal," not which). Building the printing-space versions is a separate track from the
-  range idea-2 parts above — a build-time computation + storage + archive bump — and its own per-value
-  density call (`f:modern` broad → plane; a sparse legality value → postings). The range parts (1–6)
-  do not deliver the existential wins; that is a parallel piece.
+- **Existential targets need precomputed *printing-space* existential planes** — now tracked as
+  [#724](https://github.com/jbylund/sylvan_librarian/issues/724) (see ship-order step 7). The
+  `f:modern` / `border:black` wins all assume a bit-per-printing legality / border plane to `AND` and
+  `popcount`. Neither exists: legality's #667 plane and border's #664 plane are **card-space** (they
+  answer "some printing legal," not which). Building the printing-space versions is a separate track
+  from the range idea-2 parts above — a build-time computation + storage + archive bump — and its own
+  per-value density call (`f:modern` broad → plane; a sparse legality value → postings). The range
+  parts (1–6) do not deliver the existential wins; that is a parallel piece, sequenced last because it
+  is inert without this plan as its consumer.
 - **#656 is a partial blocker** (the popcount-order extension; see part 4). Printing-level-orderby
   paging is the one archive-format bump.
 - **NULL over-inclusion — the #689 lesson.** A range bitmap's `popcount` **over-counts** the moment
@@ -247,5 +262,8 @@ range+range gap proves worth closing.
   [00664 border planes](done/00664-engine-border-planes.md) — the existential-plane framework the
   *precomputed* bitmap source extends; #667's planes are **card-space**, which is why
   `f:modern`/printing still needs a printing-space one.
+- [00724-engine-printing-existential-planes.md](00724-engine-printing-existential-planes.md)
+  ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)) — the printing-space existential
+  planes track: this plan's legality/border leaf source, sequenced last.
 - #656 (pager/permutation), #690 (`printing_to_card`, shipped), #689 (reverted attempt / NULL
   lesson), #634 (card-mode `PlanePopcountOrder`).

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -14,15 +14,23 @@ in **card** mode ([#634](done/00634-engine-permuted-bitmap-order-phase.md)). For
 predicate under `unique=printing`/`artwork`, build a printing-existence bitmap, take its `popcount`
 as the **exact total**, then read the page directly off the bitmap in printing sort order.
 
-The match bitmap has two sources, and they share this one paging plan:
+The match bitmap has a few sources, and they share this one paging plan:
 
 - a **query-time range narrowing** (`usd`/`cn`/`date`) — the original idea 2, this doc's main focus;
 - a **precomputed existential printing bitplane** for a printing-varying value (legality, frame,
-  border) — e.g. a bit-per-printing "modern-legal" plane.
+  border) — e.g. a bit-per-printing "modern-legal" plane;
+- **a postings list scattered into a bitmap on demand** — O(matches) to build, for any value that
+  has printing-space postings.
 
-Only the source differs; the `popcount` total and the sort-order page-off are identical. The
-existential source is why a broad printing-varying value like `f:modern` is a target here, not the
-non-target the range-only framing would suggest (see below).
+Once a bitmap exists the total is a `popcount` — **O(words) (~1,500 words here ≈ microseconds),
+independent of match density** — and the page is read off the sort order. So density gates which
+*representation you store* (postings for sparse, a plane for broad/mid, complement for saturated),
+**not the cost of the count**. This is the key reason even a *broad* predicate is fine, and why a
+broad **compound** is the real win: build each leaf's bitmap (from a range, postings, or a plane),
+`AND` them in O(words), and `popcount` the result — far cheaper than intersecting two broad postings
+lists (`f:modern` ∩ `usd<50` = a 76k list against an 80k list). It's also why a broad
+printing-varying value like `f:modern` is a target here, not the non-target the range-only framing
+would suggest (see below).
 
 Contrast with the two plans that ship today for these queries:
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -14,6 +14,16 @@ in **card** mode ([#634](done/00634-engine-permuted-bitmap-order-phase.md)). For
 predicate under `unique=printing`/`artwork`, build a printing-existence bitmap, take its `popcount`
 as the **exact total**, then read the page directly off the bitmap in printing sort order.
 
+The match bitmap has two sources, and they share this one paging plan:
+
+- a **query-time range narrowing** (`usd`/`cn`/`date`) — the original idea 2, this doc's main focus;
+- a **precomputed existential printing bitplane** for a printing-varying value (legality, frame,
+  border) — e.g. a bit-per-printing "modern-legal" plane.
+
+Only the source differs; the `popcount` total and the sort-order page-off are identical. The
+existential source is why a broad printing-varying value like `f:modern` is a target here, not the
+non-target the range-only framing would suggest (see below).
+
 Contrast with the two plans that ship today for these queries:
 
 - `PrintingRangeScan` (idea 1, shipped [#695](https://github.com/jbylund/sylvan_librarian/pull/695)):
@@ -50,11 +60,20 @@ exactly what an `argmin` over two cost curves expresses and a fixed threshold ca
 |---|---|---|---|
 | `cn<100 usd<50` (range + range, both broad) | printing / artwork | **~1.07 ms** (full scan, two residuals — the uncovered gap) | ~2×, offset-independent |
 | bare broad range at deep offset (`usd<50` @ offset 5000) | printing | flat already | marginal (value #1) |
-| broad existential (`border:black`) | printing | ~3× the card total | ~3× via the existential-total path (PR 5) |
+| broad existential printing values — `f:modern` (**76% of printings legal**), `border:black` | printing / artwork | full scan + per-printing existence check; the #667 *card-space* legality plane makes `f:modern`/**card** fast, but printing mode has no such plane | a precomputed existential **printing** bitplane → `popcount` total + O(words) page |
 
-Explicit non-targets: **selective** values (`r:rare`, `f:modern`) already narrow and are fast
-(0.18–0.36 ms) — they don't need this. Card-mode compounds are covered by the already-planned
-card-space idea-2 (PR 2a/3), not this.
+`f:modern` is broad (76% legal), so it does *not* narrow — the earlier "selective, already fast"
+framing was measuring card mode, where the #667 card-space plane does the work. Printing mode pays
+a per-printing existence check over that broad set, which a printing-space legality bitplane
+collapses to a `popcount`.
+
+Explicit non-targets: genuinely **sparse** values (`r:rare`, `is:promo`) narrow cheaply to postings —
+no plane earns its keep. **Card mode** broadly is served elsewhere (the #667 card-space legality
+planes; card-space idea 2 for ranges, PR 2a/3). Which representation a printing-varying value gets —
+plane vs positive-postings vs complement-postings — is a per-value density call (mid-band/broad →
+plane, sparse → postings, saturated → complement-count); the printing-mode existential-total
+mechanism is sketched under
+[sorted-range-fastpath § Existential fields](local-engine-sorted-range-fastpath.md#existential-fields-a-second-cheap-total-mechanism).
 
 ## Parts, in ship order
 
@@ -120,9 +139,14 @@ range+range gap proves worth closing.
 
 - [done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) — the cost
   router; where this was the deferred "one real win."
-- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — idea-1/idea-2
-  crossover analysis + the "#656 assembly from PR 1 + PR 2a" note.
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — historical
+  idea-1/idea-2 crossover analysis (the range-narrowing bitmap source).
 - [local-engine-sorted-range-fastpath.md](local-engine-sorted-range-fastpath.md) — the full
-  PR-ordered roadmap; idea 1 shipped as #695.
+  PR-ordered roadmap; idea 1 shipped as #695; the printing-mode existential-total mechanism (PR 5).
+- [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md),
+  [00667 legality](done/00667-engine-legality-divergent-carveout.md),
+  [00664 border planes](done/00664-engine-border-planes.md) — the existential-plane framework the
+  *precomputed* bitmap source extends; #667's planes are **card-space**, which is why
+  `f:modern`/printing still needs a printing-space one.
 - #656 (pager/permutation), #690 (`printing_to_card`, shipped), #689 (reverted attempt / NULL
   lesson), #634 (card-mode `PlanePopcountOrder`).

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -126,6 +126,36 @@ replaces the verify, so `f:modern border:black` should go from 0.75 ms to micros
 Non-target: **card mode** (served by the #667 card-space legality planes + card-space idea 2,
 PR 2a/3) — this plan is a printing/artwork thing.
 
+## Cost, and routing against today's plan
+
+This is a **new `PhysicalPlan`**, not a replacement. For `c:green border:black f:modern` the router
+has (at least) two applicable plans, and the #702 `argmin` picks the cheaper per query:
+
+- **narrow-and-verify (today):** narrow by the card-plane leaf(s), then verify the printing-varying
+  residual per candidate. Cost ≈ `candidates × (verify-tier × #printing-varying leaves)` — grows with
+  both the candidate count *and* the number of printing-varying conditions (which is why
+  `f:modern c:green` 0.082 ms → `f:modern border:black c:green` 0.224 ms).
+- **all-plane popcount (this plan):** project each card-plane leaf into printing space, `AND` all the
+  printing bitmaps, `popcount` the total, bit-walk the page. Cost ≈
+  - `Σ(printings of each projected card-plane)` — **projection, the distinguishing term** (∝ how many
+    card-planes must be broadcast, each O(its matching printings));
+  - `#planes × words` — the ANDs;
+  - `words` — the `popcount`;
+  - `(offset+limit)/match_rate` — the page bit-walk (idea-1's walk term).
+
+The point: the all-plane cost is **independent of the candidate count and of the number of
+printing-varying leaves** (each is just one more O(words) AND), whereas narrow-and-verify scales with
+both. So the `argmin` flips to the all-plane plan exactly as printing-varying leaves multiply or the
+candidate set stays large — the crossover the measured 0.082 → 0.224 ms jump previews, expressed as a
+cost comparison rather than a hand-tuned threshold. Adding the plan is declaring its `applicable`,
+this `plan_cost`, and an executor arm; the #702 router does the selection.
+
+This is one plan across the whole target set, not several: `f:modern border:black` is simply the
+**zero-projection** instance (both leaves are already printing planes, nothing to broadcast), and
+`c:green border:black f:modern` is the same plan with one projection. There is no separate
+"existential-total" plan versus "mixed-compound" plan — just this plan at projection count 0, 1,
+2, …, its projection cost term falling to zero when no card-plane leaf is present.
+
 ## Parts, in ship order
 
 Most pieces already exist or are planned in

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -151,9 +151,14 @@ range+range gap proves worth closing.
   of [done/00702](done/00702-engine-plan-selection-layer.md).
 - **`unique=artwork` needs a global artwork id** (`printing_to_artwork`/`artwork_to_card`, PR 2b —
   another archive bump) before the plane can popcount over artwork ids.
-- **Frequency, not feasibility.** Deep-paged broad-range printing is a cold corner (the #702 survey
-  confirmed); the compound range+range gap is a real but rare ~1.07 ms. This is deferred on
-  cost/benefit, and it is the kind of latent win the planner exists to make cheap to add later.
+- **Frequency — and the generalization changes the calculus.** Feasibility was never the question;
+  this was deferred on cost/benefit. But that estimate was made against the *range-only* framing,
+  where deep-paged broad ranges and compound range+range are a cold corner the #702 survey confirmed.
+  The existential (`f:modern`/printing) and especially the **mixed-compound** (`f:modern c:green`)
+  targets are *common* query shapes — `f:modern` + other filters is a heavily-used pattern in
+  practice — not a rare corner. So the broadened plan is worth materially more than the deferred
+  range-only idea-2 was; the re-estimate, not any new feasibility question, is the reason to revisit
+  the deferral. Still gated on #656.
 
 ## Related
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -1,0 +1,104 @@
+# Engine: Printing-Space PlanePopcountOrder (the deferred "idea 2")
+
+Status: todo, not yet a filed issue. Extracted from the #702 planner writeup
+([done/00702](done/00702-engine-plan-selection-layer.md)), where this was "the one real speed win
+found" but deferred. The gating prerequisite is the printing-space pager/permutation,
+[#656](https://github.com/jbylund/sylvan_librarian/issues/656). This doc is the entry point; the
+mechanism detail and measurements live in the two range-fastpath docs linked throughout — it does
+not duplicate them.
+
+## What it is
+
+A fifth physical plan: the printing-space analogue of `PlanePopcountOrder`, which today runs only
+in **card** mode ([#634](done/00634-engine-permuted-bitmap-order-phase.md)). For a broad
+predicate under `unique=printing`/`artwork`, build a printing-existence bitmap, take its `popcount`
+as the **exact total**, then read the page directly off the bitmap in printing sort order.
+
+Contrast with the two plans that ship today for these queries:
+
+- `PrintingRangeScan` (idea 1, shipped [#695](https://github.com/jbylund/sylvan_librarian/pull/695)):
+  walks the sort permutation from the top; cost grows ~`(offset+limit)/match_rate`.
+- `GatheredScan`: full scan + quickselect; pays an O(n) count pass.
+
+The popcount plan is **flat in offset** (scales with page size, not depth) and gets the total from
+a `popcount` instead of a count pass. The idea-1-vs-idea-2 winner is an **offset × selectivity
+crossover** — exactly what the cost router's `argmin` can express and a fixed threshold cannot (this
+is the "decision a threshold can't make" from the planner writeup).
+
+## Why — and the honest scope
+
+Two distinct values, only one of them strong (see
+[broad-range-fastpath](local-engine-broad-range-fastpath.md) and the "three findings" in
+[sorted-range-fastpath](local-engine-sorted-range-fastpath.md)):
+
+1. **Offset-independence** for a bare broad printing range. *Weak on its own* — today's O(n) count
+   pass is already offset-independent (measured flat, offset 0 vs 5000). #656 is deferred for
+   frequency/effort, **not** because deep-offset is slow.
+2. **A printing-space popcount total** that removes the count pass for **compound range+range
+   printing/artwork** — the real target, and the slowest uncovered gap in the store.
+
+## Target queries
+
+| query shape | mode | today | with this plan |
+|---|---|---|---|
+| `cn<100 usd<50` (range + range, both broad) | printing / artwork | **~1.07 ms** (full scan, two residuals — the uncovered gap) | ~2×, offset-independent |
+| bare broad range at deep offset (`usd<50` @ offset 5000) | printing | flat already | marginal (value #1) |
+| broad existential (`border:black`) | printing | ~3× the card total | ~3× via the existential-total path (PR 5) |
+
+Explicit non-targets: **selective** values (`r:rare`, `f:modern`) already narrow and are fast
+(0.18–0.36 ms) — they don't need this. Card-mode compounds are covered by the already-planned
+card-space idea-2 (PR 2a/3), not this.
+
+## Parts, in ship order
+
+Most pieces already exist or are planned in
+[sorted-range-fastpath's roadmap](local-engine-sorted-range-fastpath.md#pr-order) — this is the
+printing-space subset, in dependency order:
+
+1. **`printing_to_card` direct array — shipped**
+   ([#690](done/00690-engine-direct-projection-arrays.md)). Powers the one-shot
+   projection; load-bearing for both ideas.
+2. **`PrintingRangeScan` (idea 1) — shipped**
+   ([#695](https://github.com/jbylund/sylvan_librarian/pull/695)). Bare broad printing ranges. Most
+   of #656's pieces fall out of it plus card-mode idea-2 — see the "#656 assembly" note in
+   [broad-range-fastpath](local-engine-broad-range-fastpath.md).
+3. **Card-space idea-2 (`PrintingRangeBits`) — planned, not printing-space** (PR 2a/3 in the
+   roadmap). Lands the range-bitmap→popcount machinery + the `must_be_tight` correctness fix in
+   `unique=card` first, where the bitmap composes. This is the reusable core.
+4. **#656 — printing-space pager + per-sort-column printing permutation.** The gating build: a
+   printing-space sort order to page off, an **archive-format bump**. Without it there is nowhere to
+   read the page from in printing mode.
+5. **The `PrintingPlanePopcountOrder` plan itself.** Build + AND + `popcount` the range bitmap(s) in
+   printing space, page off the #656 permutation. Register as a new `PhysicalPlan` with its
+   `applicable` / `materializing` / `cost::plan_cost` / executor arms — the #702 router makes this a
+   *declaration*, not a tree edit.
+6. **Cost-route idea 1 vs this.** The `argmin` already exists; add this plan's cost formula and let
+   the offset×selectivity crossover (validated today by `idea1_vs_idea2_probe`) pick between them.
+
+## Prerequisites & caveats
+
+- **#656 is the blocker** (pager + permutation; archive-format bump).
+- **NULL over-inclusion — the #689 lesson.** A range bitmap's `popcount` **over-counts** the moment
+  an existential/NULL predicate is trusted directly; this is precisely what
+  [PR #689 got wrong and reverted](local-engine-sorted-range-fastpath.md). The `must_be_tight`
+  correctness fix is inseparable from the bitmap path and must land with it (PR 2a bundles it).
+- **Two-spaces projection.** Postings/ranges are printing-space; the `unique=card` answer is
+  card-space, and projection does **not** distribute over AND/OR. Compose the residual in
+  printing-space (exact, cheap), project once via `printing_to_card`. See the "Two spaces" section
+  of [done/00702](done/00702-engine-plan-selection-layer.md).
+- **`unique=artwork` needs a global artwork id** (`printing_to_artwork`/`artwork_to_card`, PR 2b —
+  another archive bump) before the plane can popcount over artwork ids.
+- **Frequency, not feasibility.** Deep-paged broad-range printing is a cold corner (the #702 survey
+  confirmed); the compound range+range gap is a real but rare ~1.07 ms. This is deferred on
+  cost/benefit, and it is the kind of latent win the planner exists to make cheap to add later.
+
+## Related
+
+- [done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) — the cost
+  router; where this was the deferred "one real win."
+- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — idea-1/idea-2
+  crossover analysis + the "#656 assembly from PR 1 + PR 2a" note.
+- [local-engine-sorted-range-fastpath.md](local-engine-sorted-range-fastpath.md) — the full
+  PR-ordered roadmap; idea 1 shipped as #695.
+- #656 (pager/permutation), #690 (`printing_to_card`, shipped), #689 (reverted attempt / NULL
+  lesson), #634 (card-mode `PlanePopcountOrder`).

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -87,6 +87,7 @@ is slow **iff it is broad printing-varying with no narrowing leaf**.
 | `f:modern r:rare` | 2 | no | 0.38 ms | modest |
 | `f:modern` (bare, 76%) | 1 | no | 0.20 ms | modest |
 | `f:modern c:green` | 1 | **yes** (`c:green`) | 0.082 ms | modest (all-plane) |
+| `f:modern border:black c:green` | 2 | **yes** (`c:green`) | 0.224 ms | modest (all-plane, ~5–7× → ~0.04 ms) |
 | `f:modern c:green r:rare` | 2 | **yes** (`c:green`) | 0.116 ms | modest (all-plane) |
 
 **Narrowing sets the priority, but is not a hard non-target.** Whenever a card-invariant leaf narrows
@@ -95,7 +96,10 @@ verify runs over a tiny candidate set. Those queries are lower-priority. But the
 *improvable* by the same all-plane path: plane-AND + `popcount` is O(words) regardless of the
 candidate-set size, so it beats the per-printing verify (O(candidates)) even after narrowing — you
 broadcast the card leaf into printing space (cheap), `AND` the printing planes, `popcount`, page.
-That would take the 0.224 ms `f:modern border:black c:green` well under 0.1 ms.
+The cost that grows in a narrowed compound is the *multi*-printing-varying verify: `f:modern c:green`
+(one printing-varying leaf) is 0.082 ms, and adding a second (`border:black`) triples it to 0.224 ms,
+because the per-candidate verify now checks two conditions each; the plane AND collapses that to
+O(words), taking `f:modern border:black c:green` to ~0.04 ms (~5–7×).
 
 So the target set is: **big wins** on broad printing-varying with *no* narrowing leaf
 (`cn<100 usd<50` 1.18 ms, `border:black` 0.99 ms, `f:modern border:black` 0.83 ms — a minority of

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -37,6 +37,13 @@ Two distinct values, only one of them strong (see
 2. **A printing-space popcount total** that removes the count pass for **compound range+range
    printing/artwork** — the real target, and the slowest uncovered gap in the store.
 
+The crossover is real and depth-scaled (measured via `idea1_vs_idea2_probe`, edhrec sort): the
+popcount plan wins from offset **~500–2000** at 30% match rate, ~5000 at mid-density, ~10–20k at
+high density, and the ratio reaches **35× at offset 20,000**. Those deep ratios are on
+already-sub-millisecond queries (~50–170µs of absolute savings at realistic depth), which is why
+value #1 alone is weak — but the winner-flips-on-two-variables shape (offset *and* selectivity) is
+exactly what an `argmin` over two cost curves expresses and a fixed threshold cannot.
+
 ## Target queries
 
 | query shape | mode | today | with this plan |
@@ -60,8 +67,8 @@ printing-space subset, in dependency order:
    projection; load-bearing for both ideas.
 2. **`PrintingRangeScan` (idea 1) — shipped**
    ([#695](https://github.com/jbylund/sylvan_librarian/pull/695)). Bare broad printing ranges. Most
-   of #656's pieces fall out of it plus card-mode idea-2 — see the "#656 assembly" note in
-   [broad-range-fastpath](local-engine-broad-range-fastpath.md).
+   of #656's pieces fall out of it plus the card-mode idea-2 core — see [#656 assembly](#656-assembly)
+   below.
 3. **Card-space idea-2 (`PrintingRangeBits`) — planned, not printing-space** (PR 2a/3 in the
    roadmap). Lands the range-bitmap→popcount machinery + the `must_be_tight` correctness fix in
    `unique=card` first, where the bitmap composes. This is the reusable core.
@@ -74,6 +81,23 @@ printing-space subset, in dependency order:
    *declaration*, not a tree edit.
 6. **Cost-route idea 1 vs this.** The `argmin` already exists; add this plan's cost formula and let
    the offset×selectivity crossover (validated today by `idea1_vs_idea2_probe`) pick between them.
+
+## #656 assembly
+
+#656 is not a from-scratch build once idea-1 (#695) and the card-space idea-2 core (PR 2a) land —
+it is mostly assembly:
+
+| #656 needs | built by | notes |
+|---|---|---|
+| range → **printing** existence bitmap | PR 2a/3 | `PrintingRangeBits` already carries `printing_bits` (card-mode row selection tests it via `eval_plane_expr_for_printing`), so it is built regardless. |
+| **popcount total** | PR 2a | PR 2a popcounts *card* bits; the identical step over printing bits is a trivial transfer. |
+| **printing-space paging** | #695 | idea-1's permutation walk (expand to printings, test membership, early-stop) *is* the printing pager — swap the membership test from "in `[lo, hi)`" to "in the intersected printing bitmap." |
+
+So **#656 ≈ PR 2a's printing bitmaps + #695's walk + an AND.** The only net-new work is
+intersecting ≥2 printing bitmaps and routing the popcount total into the printing path; the
+`Mode::Card`-only `run_query_streamed_popcount` is *not* reused (idea-1's walk is the printing-mode
+pager). This is why landing both #695 and PR 2a first reduces #656 to a small follow-up, if the
+range+range gap proves worth closing.
 
 ## Prerequisites & caveats
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -111,6 +111,14 @@ card-level existence projections would false-positive (a card with a modern prin
 black-bordered one). So for multi-leaf printing-varying compounds this plan is the *correct*
 composition, not merely the faster one.
 
+**Both halves are cheap off the intersected plane, and the cost today is the count, not the page.**
+The total is one `popcount` (O(words)); the page walks the sort order testing membership bits and
+early-stops — for a broad result (~67% pass for `f:modern border:black`) that is ~150 O(1) bit-tests
+to fill a 100-row page. Measured, `f:modern border:black` is **offset-flat** (0.755 / 0.746 / 0.763 ms
+at offset 0 / 5k / 20k), and so is `cn<100 usd<50` (1.09 / 1.11 ms) — confirming today's cost is the
+O(n) count-and-verify pass, not the paging. The `popcount` replaces the count and the bit-test walk
+replaces the verify, so `f:modern border:black` should go from 0.75 ms to microseconds.
+
 Non-target: **card mode** (served by the #667 card-space legality planes + card-space idea 2,
 PR 2a/3) — this plan is a printing/artwork thing.
 

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -302,7 +302,8 @@ confirmed hot.
 - [ ] **Idea-2 printing-space pager** ([#656]) — the mechanism for **compound printing/artwork** (a
   printing-space popcount total; `cn<100 usd<50`/printing ~1.07 ms is the uncovered gap). Deferred
   for frequency/effort, *not* deep-offset (measured flat). PR 1 covers bare printing without it.
-  See [#656 assembly](#656-assembly-from-pr-1--pr-2a) — most of its pieces fall out of PR 1 + PR 2a.
+  **Full plan (parts, ship order, target queries, #656 assembly):**
+  [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md).
 - [ ] **Idea-1 crossover guard** — widen the fastpath below the 25% veto boundary it shipped at
   ([#695]) into the moderate band, per the [#647] calibrate-from-measurement precedent. The two
   plans have *opposite* cost curves in `k`: narrow-and-scan rises ~O(k); the fastpath walk falls
@@ -349,22 +350,12 @@ deep pages fall back to narrowing exactly where the walk would lose.
 
 ### #656 assembly (from PR 1 + PR 2a)
 
-#656 is not a from-scratch build once PR 1 and PR 2a land — it's mostly assembly. It needs three
-things, and PR 1/PR 2a build all but the glue:
-
-| #656 needs | Built by | Notes |
-|---|---|---|
-| range → **printing** existence bitmap | **PR 2a/3** | `PrintingRangeBits` already carries `printing_bits` (card-mode row selection needs it — `eval_plane_expr_for_printing` tests it), so it's built regardless. |
-| **popcount total** | **PR 2a** | PR 2a popcounts *card* bits; the identical step over printing bits is a trivial transfer. |
-| **printing-space paging** | **PR 1** | PR 1's card-permutation walk (expand to printings, test membership, early-stop) *is* the printing pager — swap the test from "in `[lo, hi)`" to "in the intersected printing bitmap." |
-
-So `#656 ≈ PR 2a's printing bitmaps + PR 1's walk + an AND`. The only net-new work is intersecting
-≥2 printing bitmaps and routing the popcount total into the printing path; the `Mode::Card`-only
-`run_query_streamed_popcount` is *not* reused (PR 1's walk is the printing-mode pager instead).
-**Assembly plan:** (1) intersect the per-leaf `printing_bits` for the compound; (2) `total =
-popcount` of the result; (3) page via PR 1's walk with membership against the intersected bitmap.
-This is the argument for landing *both* PR 1 and PR 2a rather than treating them as either/or —
-together they reduce #656 to a small follow-up, if the range+range gap proves worth closing.
+Consolidated into the printing-space plan doc:
+[local-engine-printing-plane-popcount-order.md § #656 assembly](local-engine-printing-plane-popcount-order.md#656-assembly).
+In short: **#656 ≈ PR 2a's printing bitmaps + PR 1's walk + an AND** — the range→printing bitmap
+(PR 2a/3) and printing-space paging (PR 1's walk) fall out of those two, leaving only the
+bitmap intersection + routing the popcount total into the printing path as net-new work. Landing
+both PR 1 and PR 2a is what reduces #656 to a small follow-up.
 
 ### Acceptance (every PR)
 
@@ -386,6 +377,9 @@ together they reduce #656 to a small follow-up, if the range+range gap proves wo
 
 ## Related
 
+- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
+  the consolidated plan for the deferred Idea-2 printing-space popcount plan (#656): parts, ship
+  order, target queries, and the #656 assembly.
 - [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — history:
   price-exactness prerequisite (shipped) and the full PR #689 account.
 - [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —


### PR DESCRIPTION
The printing-space popcount-order plan ("idea 2") — the #702 planner's deferred "one real speed win," gated on the #656 pager/permutation — was scattered across the archived `done/00702`, `sorted-range-fastpath.md`, and `broad-range-fastpath.md`.

Consolidate it into one **self-contained** doc, [`local-engine-printing-plane-popcount-order.md`](../blob/engine-printing-popcount-plan/docs/issues/local-engine-printing-plane-popcount-order.md), with the real content (not just links):
- **what it is** — a fifth `PhysicalPlan`, the printing-space analogue of card-mode `PlanePopcountOrder` (#634); flat-in-offset, popcount total.
- **why + honest scope** — offset-independence is weak (today's count pass is already flat); the real target is the count pass on **compound range+range printing/artwork** (`cn<100 usd<50`/printing, the ~1.07 ms uncovered gap). Includes the measured offset×selectivity crossover (~500–2000 to 35× at offset 20k).
- **parts in ship order** — `printing_to_card` (#690, shipped) → idea-1 `PrintingRangeScan` (#695, shipped) → card-space idea-2 core (PR 2a/3) → **#656** pager/permutation (blocker, archive bump) → the plan itself → cost-route vs idea-1.
- **#656 assembly** — the table showing #656 ≈ PR 2a's printing bitmaps + #695's walk + an AND.
- **target queries + non-targets**, and caveats (the #689 NULL-over-inclusion lesson, two-spaces projection, artwork global-id prereq).

**Keeps the records:** `sorted-range-fastpath` keeps idea-1 (#695) + the card-mode roadmap + the NULL-trap/existential-total sections; its #656-assembly section and deferred bullet now point here. `broad-range-fastpath` keeps the #689 history. Archived `done/00702` gets a pointer only. Both live docs gain a Related link here. Docs only. Part of #702 / prerequisite #656.