### PR TITLE
Add CardRangePopcount Fast Path for Bare usd Ranges Under unique=card

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -237,11 +237,11 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         // popcount), plus the query-time build over the range slice — the dominant term (see the
         // CARD_RANGE_BUILD_PER_PRINTING_NS note).
         PhysicalPlan::CardRangePopcount => {
-            f64::from(f.range_build_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS
-                + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS
-                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS
-                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS
-                + PLANE_POPCOUNT_FIXED_COST_NS
+            f64::from(f.range_build_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS  // query-time build: k in-range printings -> card-existence bitmap (+ printing membership); the plane plan gets this precomputed
+                + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS  // scatter the match (card) bits through the inverse permutation
+                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS  // popcount total + word-scan skip to the page offset
+                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of cards
+                + PLANE_POPCOUNT_FIXED_COST_NS  // fixed per-query overhead
         }
         PhysicalPlan::StreamedSelect => {
             // The small-total gather branch (run_query_streamed) scans all

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -214,7 +214,11 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
             (page_span / match_rate) * RANGE_WALK_STEP_NS + RANGE_FIXED_COST_NS
         }
-        PhysicalPlan::PlanePopcountOrder => {
+        // CardRangePopcount runs the identical popcount-skip order phase as PlanePopcountOrder; its
+        // only extra work is building the range's card-existence bitmap in acquire (O(n_printings),
+        // small and paid before this cost is consulted), so it shares the formula. `matches` is the
+        // card-existence popcount either way.
+        PhysicalPlan::PlanePopcountOrder | PhysicalPlan::CardRangePopcount => {
             matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS
                 + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -86,6 +86,10 @@ pub(crate) struct PlanFeatures {
     pub limit: u32,
     /// Page offset.
     pub offset: u32,
+    /// `CardRangePopcount` only: printings in the range slice it scatters+projects into the
+    /// card-existence bitmap at query time (`e - s`). Drives that plan's build term; `0` for every
+    /// other plan (their bitmaps are precomputed or they don't build one).
+    pub range_build_printings: u32,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -131,6 +135,15 @@ const PLANE_POPCOUNT_PER_WORD_NS: f64 = 1.0;
 const PLANE_POPCOUNT_EMIT_PER_CARD_NS: f64 = 2.0;
 /// Fixed P2 setup (plane eval into the bitmap, buffers).
 const PLANE_POPCOUNT_FIXED_COST_NS: f64 = 200.0;
+
+// ─── CardRangePopcount: PlanePopcountOrder's terms + a query-time build ──────
+// Unlike the plane plan's precomputed bitmap, this one builds its card-existence bitmap at query
+// time in a single fused scatter+project pass over the in-range printing slice. That build is the
+// plan's dominant cost, so it gets its own per-slice-printing term; without it the model
+// under-predicts this plan ~3x and could route a narrow bare range here when the candidate path is
+// cheaper. ~1.3 ns/printing, from card_range_build_cost_split on the real corpus (~104us for the
+// 80,527-printing usd<50 slice).
+pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.3;
 
 // ─── P3: StreamedSelect ─────────────────────────────────────────────────────
 // Match phase walks eval_domain cards computing per-card counts, then either
@@ -214,12 +227,18 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
             (page_span / match_rate) * RANGE_WALK_STEP_NS + RANGE_FIXED_COST_NS
         }
-        // CardRangePopcount runs the identical popcount-skip order phase as PlanePopcountOrder; its
-        // only extra work is building the range's card-existence bitmap in acquire (O(n_printings),
-        // small and paid before this cost is consulted), so it shares the formula. `matches` is the
-        // card-existence popcount either way.
-        PhysicalPlan::PlanePopcountOrder | PhysicalPlan::CardRangePopcount => {
+        PhysicalPlan::PlanePopcountOrder => {
             matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS
+                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS
+                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS
+                + PLANE_POPCOUNT_FIXED_COST_NS
+        }
+        // Same popcount-skip order phase as PlanePopcountOrder (`matches` is the card-existence
+        // popcount), plus the query-time build over the range slice — the dominant term (see the
+        // CARD_RANGE_BUILD_PER_PRINTING_NS note).
+        PhysicalPlan::CardRangePopcount => {
+            f64::from(f.range_build_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS
+                + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS
                 + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS
                 + PLANE_POPCOUNT_FIXED_COST_NS

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4825,6 +4825,7 @@ fn run_query_routed<'a>(
         residual_tier_ns100,
         limit: limit as u32,
         offset: page_offset as u32,
+        range_build_printings: 0, // CardRangePopcount overrides this in its acquire branch
     };
     // Features for the general candidate path (shared by the acquire branch and the
     // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
@@ -4862,7 +4863,15 @@ fn run_query_routed<'a>(
         let (lo, hi) = usd_bare_range_bounds(filter).expect("applicable ⇒ bare usd range");
         let (card_bits, range_pbits) = build_card_range_bits(lo, hi, indexes, n_cards as usize, n_printings as usize);
         let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
-        (mk_feats(count, count, count, 0), Prep::RangeCardBits { card_bits, range_pbits })
+        // Slice size (in-range printings) drives the build term — the plan's dominant cost.
+        let slice_printings: u32 = range_pbits.iter().map(|w| w.count_ones()).sum();
+        // Unlike the plane branch, the residual here is the range, not True: CardRangePopcount's exact
+        // bitmap needs no re-verify (its formula ignores tier), but the materializing alternatives in
+        // dispatch DO re-verify the range per candidate, so they must be costed with its verify tier —
+        // `0` would under-cost them and let a mis-cheap StreamedSelect beat the plan that actually wins.
+        let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
+        feats.range_build_printings = slice_printings;
+        (feats, Prep::RangeCardBits { card_bits, range_pbits })
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3874,6 +3874,11 @@ static VERIFY_ORDER: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_V
 /// timing). A binary switch, not a calibrated threshold.
 static PRINTING_RANGE_FASTPATH: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_PRINTING_RANGE_FASTPATH", 1));
 
+/// Card-mode range→card-existence popcount fast path (PR 2a / card-space idea 2). Same kind of
+/// binary A/B kill-switch as `PRINTING_RANGE_FASTPATH`, not a calibrated threshold: `0` routes these
+/// queries exactly as before (the general candidate path), `1` (default) enables `CardRangePopcount`.
+static RANGE_BITS_CARD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_RANGE_BITS_CARD", 1));
+
 /// The range index and half-open `[lo, hi)` a *bare* range-predicate leaf selects, or None for
 /// anything else (compound, `Ne`, a non-range numeric field). Provably-empty predicates return a
 /// zero-width `[v, v)` so the fastpath's `k` resolves to 0. Reuses the exact bound derivations the
@@ -3909,6 +3914,49 @@ fn bare_range_bounds<'i>(
         }
         _ => None,
     }
+}
+
+/// The exact half-open `[lo, hi)` a *bare* `usd` range leaf selects over the price index, or None
+/// for anything else. PR 2a's `CardRangePopcount` is deliberately scoped to price only; `cn`/`date`
+/// share the machinery and are a trivial follow-on (PR 3) — widen this to delegate to
+/// `bare_range_bounds` then. Value snapping matches `narrow_rec`'s `price` closure so the fast path
+/// and the general path can never disagree on which printings the predicate covers. Bounds are
+/// exact (price is integer cents, #688), so the direct slice `idx[lo..hi)` is a *tight* set — the
+/// property that lets its card-existence popcount stand in for the count pass without re-verifying.
+fn usd_bare_range_bounds(filter: &FilterExpr) -> Option<(u32, u32)> {
+    let FilterExpr::NumericCmp { lhs, op, rhs } = filter else { return None };
+    let (op, value) = match (lhs, rhs) {
+        (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => (*op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
+        (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => (flip_op(*op), snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
+        _ => return None,
+    };
+    match int_range_bounds(op, value)? {
+        None => Some((0, 0)), // provably empty: zero-width slice, popcount resolves to 0
+        Some((lo, hi)) => Some((lo, hi)),
+    }
+}
+
+/// Build `CardRangePopcount`'s two bitmaps from an exact `usd` range slice: the tight printing-space
+/// membership set (scattered directly from the value-sorted slice — never the loose complement
+/// `range_narrowed` would pick for a broad range, which over-includes NULL-priced printings), and
+/// its card-existence projection. The card bitmap's popcount is the exact `unique=card` total; the
+/// printing bitmap is the per-printing residual emission re-checks so the representative printing it
+/// shows genuinely satisfies the range. Bare range only (`card_range_popcount_applicable` requires no
+/// plane), so there is nothing to AND — see that predicate for why compounds are excluded.
+fn build_card_range_bits(
+    lo: u32,
+    hi: u32,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    n_cards: usize,
+    n_printings: usize,
+) -> (Vec<u64>, Vec<u64>) {
+    let idx = &indexes.price_usd;
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    let range_pbits = scatter_bits(idx[s..e].iter().map(|p| u32::from(p.1)), n_printings);
+    let card_bits = printing_bits_to_card_bits(&range_pbits, offsets, n_cards);
+    (card_bits, range_pbits)
 }
 
 /// Page for a `unique=printing` bare-range query ordered by a *card-level* key: walk that key's
@@ -4125,6 +4173,9 @@ enum PhysicalPlan {
     PrintingRangeScan,
     /// #634 Step 2 plane-bitmap popcount-skip order phase (`run_query_streamed_popcount`).
     PlanePopcountOrder,
+    /// PR 2a card-space idea 2: a bare `usd` range under `unique=card`, answered as the same
+    /// popcount-skip order phase over the range's card-existence bitmap (`exec_card_range_popcount`).
+    CardRangePopcount,
     /// Streamed selection over the sort permutation (`run_query_streamed`).
     StreamedSelect,
     /// The universal fallback: the gathered per-card loop + `select_page`.
@@ -4134,9 +4185,10 @@ enum PhysicalPlan {
 impl PhysicalPlan {
     /// All plans, argmin-ordered so ties resolve deterministically toward the
     /// cheaper-fixed-cost plan. The router filters this by `applicable`.
-    const ALL: [PhysicalPlan; 4] = [
+    const ALL: [PhysicalPlan; 5] = [
         PhysicalPlan::PrintingRangeScan,
         PhysicalPlan::PlanePopcountOrder,
+        PhysicalPlan::CardRangePopcount,
         PhysicalPlan::StreamedSelect,
         PhysicalPlan::GatheredScan,
     ];
@@ -4164,6 +4216,9 @@ impl PhysicalPlan {
             }
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
+            }
+            PhysicalPlan::CardRangePopcount => {
+                card_range_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
             PhysicalPlan::StreamedSelect => streamed_select_applicable(cards, sort_col, descending, indexes),
             PhysicalPlan::GatheredScan => gathered_scan_applicable(),
@@ -4204,6 +4259,10 @@ enum Prep {
     /// `run_query_routed`'s local `plane_bits` and passed by reference.
     /// `PlanePopcountOrder` reads it directly; P3/P4 read it as a candidate list.
     Plane,
+    /// Bare `usd` range (card): the range's card-existence bitmap (its popcount is the exact total)
+    /// and printing-space membership set (emission's per-printing residual). `CardRangePopcount`
+    /// reads both; a materializing winner reads the card bitmap as a candidate list.
+    RangeCardBits { card_bits: Vec<u64>, range_pbits: Vec<u64> },
     /// The general residual path: a materialized candidate list.
     Candidates(PreparedCandidates),
 }
@@ -4273,6 +4332,37 @@ fn plane_popcount_order_applicable(
 /// `None` for anything it doesn't own).
 fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: &[AOracleCard]) -> bool {
     *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
+}
+
+/// `CardRangePopcount` needs `Mode::Card`, a **bare** `usd` range as the whole filter (no plane), and
+/// both sort permutations. `plane.is_none()` is deliberate and load-bearing, on both correctness and
+/// perf grounds:
+/// - *correctness:* an existential legality plane (`usd<50 f:modern`) would make the card-existence
+///   AND exact only when the attribute never diverges across a card's printings — a data coincidence
+///   the engine refuses to bank on (docs/issues/00667-engine-legality-divergent-carveout.md); those
+///   printing-varying compounds are the printing-space plane's job.
+/// - *perf:* a card-invariant plane (`usd<50 c:g`) already narrows the query hard, so the existing
+///   narrowed-verify path is fast, whereas this plan pays an O(k) build over the whole range slice
+///   regardless — measured a net loss. So a narrowing plane means don't bother; only the bare range,
+///   where the alternative is a full scan of a ~99%-broad set, is worth the build.
+///
+/// The bare-`usd`-leaf shape also excludes range+range (`usd<50 cn<100` is an `And`, not a bare leaf).
+fn card_range_popcount_applicable(
+    filter: &FilterExpr,
+    mode: Mode,
+    cards: &[AOracleCard],
+    plane: Option<&PlaneExpr>,
+    sort_col: SortCol,
+    descending: bool,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    *RANGE_BITS_CARD != 0
+        && matches!(mode, Mode::Card)
+        && !cards.is_empty()
+        && plane.is_none()
+        && usd_bare_range_bounds(filter).is_some()
+        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
 }
 
 // ─── Shared P3/P4 candidate preparation ─────────────────────────────────────
@@ -4446,7 +4536,35 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
     run_query_streamed_popcount(
-        cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, bitmap, plane_expr, &indexes.planes, strings,
+        cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, bitmap, Some(plane_expr), &indexes.planes, strings, None,
+    )
+}
+
+/// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
+/// range's card-existence projection (built in `acquire`) rather than a plane, and it threads the
+/// range's printing-space membership set so emission shows an in-range printing. Caller guarantees
+/// `card_range_popcount_applicable` (permutations exist; the shown-printing plane, if any, is
+/// non-existential so it needs no per-printing re-check here).
+#[allow(clippy::too_many_arguments)]
+fn exec_card_range_popcount<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+    card_bits: &[u64],
+    range_pbits: &[u64],
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let perm = indexes.sort_perms.get(sort_col, descending).expect("CardRangePopcount applicability guarantees a permutation");
+    let inv_perm =
+        indexes.sort_perms.get_inv(sort_col, descending).expect("CardRangePopcount applicability guarantees an inverse permutation");
+    run_query_streamed_popcount(
+        cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, card_bits, None, &indexes.planes, strings, Some(range_pbits),
     )
 }
 
@@ -4727,6 +4845,18 @@ fn run_query_routed<'a>(
         eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
         (mk_feats(count, count, count, 0), Prep::Plane)
+    } else if PhysicalPlan::CardRangePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Build the range's card-existence bitmap now; its popcount is the exact count (like the
+        // plane branch above, scan_units == count, all_match ⇒ tier 0). The build is O(k) over the
+        // range slice — the plan's dominant cost — but for a bare range the alternative is a full
+        // scan of a near-total set, which reliably loses, so the eager build is rarely wasted: only a
+        // narrow range routes elsewhere, and there k (hence the build) is small. If a materializing
+        // plan does win, dispatch reads the same bitmap back as a candidate list.
+        let (lo, hi) = usd_bare_range_bounds(filter).expect("applicable ⇒ bare usd range");
+        let (card_bits, range_pbits) =
+            build_card_range_bits(lo, hi, indexes, offsets, n_cards as usize, n_printings as usize);
+        let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
+        (mk_feats(count, count, count, 0), Prep::RangeCardBits { card_bits, range_pbits })
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
@@ -4754,6 +4884,22 @@ fn run_query_routed<'a>(
             &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
             plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
+        (PhysicalPlan::CardRangePopcount, Prep::RangeCardBits { card_bits, range_pbits }) => exec_card_range_popcount(
+            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, card_bits, range_pbits,
+        ),
+        // A materializing plan beat CardRangePopcount on the estimate: reuse the already-built
+        // card-existence bitmap as a candidate list (dropped when >7/8, matching prepare_candidates)
+        // and re-verify the range residual per card (all_match_known: false) so the range still gates
+        // which printing is shown.
+        (p, Prep::RangeCardBits { card_bits, .. }) => {
+            let ids = bitmap_card_ids(card_bits);
+            let candidate_cards = (ids.len() < cards.len() - cards.len() / 8).then_some(ids);
+            exec_from_candidates(
+                p, cards, printings, offsets, strings, filter,
+                &PreparedCandidates { candidate_cards, all_match_known: false },
+                plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+            )
+        }
         (p, Prep::Candidates(prep)) => exec_from_candidates(
             p, cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
@@ -4829,6 +4975,17 @@ fn run_query_with_plan<'a>(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes,
             ))
         }
+        PhysicalPlan::CardRangePopcount => {
+            if !card_range_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+                return None;
+            }
+            let (lo, hi) = usd_bare_range_bounds(filter).expect("applicability guarantees a bare usd range");
+            let (card_bits, range_pbits) =
+                build_card_range_bits(lo, hi, indexes, offsets, cards.len(), printings.len());
+            Some(exec_card_range_popcount(
+                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
+            ))
+        }
         PhysicalPlan::StreamedSelect => {
             if !streamed_select_applicable(cards, sort_col, descending, indexes) {
                 return None;
@@ -4872,9 +5029,10 @@ fn run_query_streamed_popcount<'a>(
     perm: &Archived<Vec<u32>>,
     inv_perm: &Archived<Vec<u32>>,
     bitmap: &[u64],
-    plane: &PlaneExpr,
+    plane: Option<&PlaneExpr>,
     planes: &Archived<BitPlanes>,
     strings: &AStrings,
+    range_bits: Option<&[u64]>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
@@ -4930,7 +5088,7 @@ fn run_query_streamed_popcount<'a>(
         // blindly -- verify against `eval_plane_expr_for_printing` too. Cheap
         // even then: bounded by `limit` emitted cards, not the candidate set,
         // and only pays the extra check at all for legality-touching planes.
-        let existential = plane_expr_is_existential(plane);
+        let existential = plane.is_some_and(plane_expr_is_existential);
         let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
         'walk: while word_idx < permuted.len() {
             let mut w = permuted[word_idx];
@@ -4946,7 +5104,16 @@ fn run_query_streamed_popcount<'a>(
                 let card = &cards[cid as usize];
                 let start = u32::from(offsets[cid as usize]) as usize;
                 let end = u32::from(offsets[cid as usize + 1]) as usize;
-                let satisfies = |pid: usize| !existential || eval_plane_expr_for_printing(plane, planes, cid, &printings[pid], strings);
+                // Two per-printing residuals the card-existence bitmap can't encode: an existential
+                // plane (legality — the card matching doesn't pin which printing is legal) and the
+                // range membership (CardRangePopcount — the shown printing must actually be in range,
+                // not just belong to a card that has some in-range printing). Both are cheap: bounded
+                // by `limit` emitted cards, an O(1) bit test for the range, checked only when present.
+                let satisfies = |pid: usize| {
+                    (!existential
+                        || eval_plane_expr_for_printing(plane.expect("existential ⇒ plane"), planes, cid, &printings[pid], strings))
+                        && range_bits.is_none_or(|rb| bitmap_contains(rb, pid as u32))
+                };
                 let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
                     (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
                 } else {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3936,26 +3936,33 @@ fn usd_bare_range_bounds(filter: &FilterExpr) -> Option<(u32, u32)> {
     }
 }
 
-/// Build `CardRangePopcount`'s two bitmaps from an exact `usd` range slice: the tight printing-space
-/// membership set (scattered directly from the value-sorted slice — never the loose complement
-/// `range_narrowed` would pick for a broad range, which over-includes NULL-priced printings), and
-/// its card-existence projection. The card bitmap's popcount is the exact `unique=card` total; the
-/// printing bitmap is the per-printing residual emission re-checks so the representative printing it
-/// shows genuinely satisfies the range. Bare range only (`card_range_popcount_applicable` requires no
-/// plane), so there is nothing to AND — see that predicate for why compounds are excluded.
-fn build_card_range_bits(
-    lo: u32,
-    hi: u32,
-    indexes: &Archived<CardIndexes>,
-    offsets: &AOffsets,
-    n_cards: usize,
-    n_printings: usize,
-) -> (Vec<u64>, Vec<u64>) {
+/// Build `CardRangePopcount`'s two bitmaps from an exact `usd` range slice, in a single pass: the
+/// tight printing-space membership set (`range_pbits`, set directly from the value-sorted slice —
+/// never the loose complement `range_narrowed` would pick for a broad range, which over-includes
+/// NULL-priced printings) and its card-existence projection (`card_bits`, each printing's card via
+/// the `printing_to_card` direct array, #690). The card bitmap's popcount is the exact `unique=card`
+/// total; the printing bitmap is the per-printing residual emission re-checks so the representative
+/// printing it shows genuinely satisfies the range.
+///
+/// One fused pass rather than scatter-then-`printing_bits_to_card_bits`: the projection over the
+/// scattered bitmap is the expensive half (a `trailing_zeros` extraction per set bit plus a cursor
+/// branch across every word), and folding it into the scatter loop via a direct `printing_to_card`
+/// lookup measured ~40% cheaper on `usd<50` (~174µs → ~104µs; see `card_range_build_cost_split`),
+/// even though the price-ordered slice makes those lookups random. Bare range only
+/// (`card_range_popcount_applicable` requires no plane), so there is nothing to AND.
+fn build_card_range_bits(lo: u32, hi: u32, indexes: &Archived<CardIndexes>, n_cards: usize, n_printings: usize) -> (Vec<u64>, Vec<u64>) {
     let idx = &indexes.price_usd;
+    let ptc = &indexes.printing_to_card;
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
-    let range_pbits = scatter_bits(idx[s..e].iter().map(|p| u32::from(p.1)), n_printings);
-    let card_bits = printing_bits_to_card_bits(&range_pbits, offsets, n_cards);
+    let mut range_pbits = vec![0u64; n_printings.div_ceil(64)];
+    let mut card_bits = vec![0u64; n_cards.div_ceil(64)];
+    for p in idx[s..e].iter() {
+        let pid = u32::from(p.1) as usize;
+        range_pbits[pid >> 6] |= 1u64 << (pid & 63);
+        let cid = u32::from(ptc[pid]) as usize;
+        card_bits[cid >> 6] |= 1u64 << (cid & 63);
+    }
     (card_bits, range_pbits)
 }
 
@@ -4853,8 +4860,7 @@ fn run_query_routed<'a>(
         // narrow range routes elsewhere, and there k (hence the build) is small. If a materializing
         // plan does win, dispatch reads the same bitmap back as a candidate list.
         let (lo, hi) = usd_bare_range_bounds(filter).expect("applicable ⇒ bare usd range");
-        let (card_bits, range_pbits) =
-            build_card_range_bits(lo, hi, indexes, offsets, n_cards as usize, n_printings as usize);
+        let (card_bits, range_pbits) = build_card_range_bits(lo, hi, indexes, n_cards as usize, n_printings as usize);
         let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
         (mk_feats(count, count, count, 0), Prep::RangeCardBits { card_bits, range_pbits })
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
@@ -4980,8 +4986,7 @@ fn run_query_with_plan<'a>(
                 return None;
             }
             let (lo, hi) = usd_bare_range_bounds(filter).expect("applicability guarantees a bare usd range");
-            let (card_bits, range_pbits) =
-                build_card_range_bits(lo, hi, indexes, offsets, cards.len(), printings.len());
+            let (card_bits, range_pbits) = build_card_range_bits(lo, hi, indexes, cards.len(), printings.len());
             Some(exec_card_range_popcount(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
             ))

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7894,6 +7894,87 @@ fn usd_bare_range_bounds_gates_pr2a_scope() {
     assert!(super::usd_bare_range_bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0), cn_lt()])).is_none());
 }
 
+/// PR 2a build-cost split: for `usd<50`, which half of `CardRangePopcount`'s build dominates —
+/// scattering the price slice into a printing bitmap, or projecting that to a card-existence bitmap
+/// — and does building the card bitmap *directly* (`printing_to_card[pid]`, one pass, skipping the
+/// intermediate) help? The slice is in price order, so the direct path's `printing_to_card` reads
+/// are random (vs the projection's sequential `offsets` cursor), so it is not obviously a win —
+/// hence measured. Kernel timing over the real slice; same discipline as the other probes.
+#[test]
+#[ignore = "CardRangePopcount build-cost split; needs real.store; cargo test --release card_range_build_cost_split -- --ignored --nocapture"]
+fn card_range_build_cost_split() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 30;
+    const ITERS: usize = 300;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let idx = &archived.indexes.price_usd;
+    let ptc = &archived.indexes.printing_to_card;
+    let offsets = &archived.offsets;
+    let s = idx.partition_point(|p| u32::from(p.0) < 0); // usd<50 -> [0, 5000) cents
+    let e = idx.partition_point(|p| u32::from(p.0) < 5000);
+    let k = e - s;
+
+    // A: scatter the price slice into a printing bitmap.
+    let mut a = u128::MAX;
+    for it in 0..(WARMUP + ITERS) {
+        let t0 = Instant::now();
+        let pb = super::scatter_bits(idx[s..e].iter().map(|p| u32::from(p.1)), n_printings);
+        black_box(&pb);
+        if it >= WARMUP {
+            a = a.min(t0.elapsed().as_nanos());
+        }
+    }
+    // B: project that printing bitmap to a card-existence bitmap (pbits built once, reused).
+    let pbits = super::scatter_bits(idx[s..e].iter().map(|p| u32::from(p.1)), n_printings);
+    let mut b = u128::MAX;
+    for it in 0..(WARMUP + ITERS) {
+        let t0 = Instant::now();
+        let cb = super::printing_bits_to_card_bits(&pbits, offsets, n_cards);
+        black_box(&cb);
+        if it >= WARMUP {
+            b = b.min(t0.elapsed().as_nanos());
+        }
+    }
+    // C: build both bitmaps in one pass via printing_to_card (the "direct card bitmap" idea).
+    let mut c = u128::MAX;
+    for it in 0..(WARMUP + ITERS) {
+        let t0 = Instant::now();
+        let mut rp = vec![0u64; n_printings.div_ceil(64)];
+        let mut cb = vec![0u64; n_cards.div_ceil(64)];
+        for p in idx[s..e].iter() {
+            let pid = u32::from(p.1) as usize;
+            rp[pid >> 6] |= 1u64 << (pid & 63);
+            let cid = u32::from(ptc[pid]) as usize;
+            cb[cid >> 6] |= 1u64 << (cid & 63);
+        }
+        black_box(&rp);
+        black_box(&cb);
+        if it >= WARMUP {
+            c = c.min(t0.elapsed().as_nanos());
+        }
+    }
+
+    println!("\nusd<50 build cost (k={k} printings, n_cards={n_cards}, min of {ITERS}):");
+    println!("  A scatter -> printing bitmap : {a:>7} ns");
+    println!("  B project -> card bitmap     : {b:>7} ns");
+    println!("  current total (A + B)        : {:>7} ns", a + b);
+    println!("  C direct both, one pass      : {c:>7} ns");
+}
+
 #[test]
 fn printing_range_walk_matches_naive_page() {
     let leaf = usd_cmp(CmpOp::Lt, 50.0);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2729,6 +2729,13 @@ fn force_plan_differential_agreement() {
         (FuzzSpec::Leaf(FuzzLeaf::Date { op: CmpOp::Gt, value: 1990_0000 }), "edhrec", "desc"),
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "usd", "asc"),
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "usd", "desc"),
+        // Bare broad price over a card-level perm -> CardRangePopcount (PR 2a) in card mode; a narrow
+        // price at low density -> its argmin fallback to the candidate path. price AND a color plane
+        // stays on the general path (CardRangePopcount is bare-range-only) — kept as a plain
+        // agreement case covering the non-applicable branch.
+        (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "edhrec", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 2.0 }), "edhrec", "desc"),
+        (FuzzSpec::And(vec![FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), fuzz_leaf_color(&mut rng)]), "edhrec", "asc"),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -2740,16 +2747,18 @@ fn force_plan_differential_agreement() {
     let all_plans = [
         PhysicalPlan::PrintingRangeScan,
         PhysicalPlan::PlanePopcountOrder,
+        PhysicalPlan::CardRangePopcount,
         PhysicalPlan::StreamedSelect,
         PhysicalPlan::GatheredScan,
     ];
     let plan_idx = |p: PhysicalPlan| match p {
         PhysicalPlan::PrintingRangeScan => 0,
         PhysicalPlan::PlanePopcountOrder => 1,
-        PhysicalPlan::StreamedSelect => 2,
-        PhysicalPlan::GatheredScan => 3,
+        PhysicalPlan::CardRangePopcount => 2,
+        PhysicalPlan::StreamedSelect => 3,
+        PhysicalPlan::GatheredScan => 4,
     };
-    let mut ran = [0u32; 4];
+    let mut ran = [0u32; 5];
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
@@ -3323,7 +3332,7 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     let match_rate = (matches / f64::from(f.n_printings)).max(1.0e-6);
     match plan {
         PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
-        PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
+        PhysicalPlan::PlanePopcountOrder | PhysicalPlan::CardRangePopcount => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
         PhysicalPlan::StreamedSelect => {
             let floor = if u64::from(f.matches) <= *STREAM_MIN_MATCHES as u64 { n_cards } else { 0.0 };
             (vec![eval_domain, scan_units, matches, floor, 1.0], scan_units * tier_ns)
@@ -7860,6 +7869,29 @@ fn bare_range_bounds_recognizes_leaves_and_rejects_rest() {
     assert!(bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0)])).is_none());
     let cmc_lt = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
     assert!(bounds(&cmc_lt).is_none());
+}
+
+/// PR 2a's `CardRangePopcount` is scoped to a single bare `usd` range leaf; `usd_bare_range_bounds`
+/// is the gate that enforces it. It accepts a bare price leaf (either operand order) and rejects
+/// everything the conservative scope excludes: `Ne`, non-price numeric fields, `cn`/`date` (PR 3,
+/// not 2a), and any compound residual — notably the `usd<50 cn<100` range+range shared-witness case,
+/// which is an `And`, not a bare leaf. (Existential-plane exclusion is enforced separately in
+/// `card_range_popcount_applicable` via `plane_expr_is_existential` — see
+/// `plane_expr_is_existential_identifies_legality_only`.)
+#[test]
+fn usd_bare_range_bounds_gates_pr2a_scope() {
+    let cn_lt = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op: CmpOp::Lt, rhs: NumExpr::Const(100.0) };
+    // accepts a bare usd leaf; const-on-left flips the op to the same [0, 5000) cents extent.
+    assert_eq!(super::usd_bare_range_bounds(&usd_cmp(CmpOp::Lt, 50.0)), Some((0, 5000)));
+    assert_eq!(
+        super::usd_bare_range_bounds(&FilterExpr::NumericCmp { lhs: NumExpr::Const(50.0), op: CmpOp::Gt, rhs: NumExpr::Field(NumField::PriceUsd) }),
+        Some((0, 5000)),
+    );
+    // rejects: Ne (never narrows), cmc (card-space), cn (PR 3), and the range+range compound.
+    assert!(super::usd_bare_range_bounds(&usd_cmp(CmpOp::Ne, 50.0)).is_none());
+    assert!(super::usd_bare_range_bounds(&FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) }).is_none());
+    assert!(super::usd_bare_range_bounds(&cn_lt()).is_none());
+    assert!(super::usd_bare_range_bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0), cn_lt()])).is_none());
 }
 
 #[test]

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3228,6 +3228,7 @@ fn plan_cost_model_matches_gold() {
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
+                    range_build_printings: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -3332,7 +3333,12 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     let match_rate = (matches / f64::from(f.n_printings)).max(1.0e-6);
     match plan {
         PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
-        PhysicalPlan::PlanePopcountOrder | PhysicalPlan::CardRangePopcount => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
+        PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
+        // Same term vector as P2; the build term is a fixed (hand-set) offset, not a refit param.
+        PhysicalPlan::CardRangePopcount => (
+            vec![matches, n_cards / 64.0, limit, 1.0],
+            f64::from(f.range_build_printings) * super::cost::CARD_RANGE_BUILD_PER_PRINTING_NS,
+        ),
         PhysicalPlan::StreamedSelect => {
             let floor = if u64::from(f.matches) <= *STREAM_MIN_MATCHES as u64 { n_cards } else { 0.0 };
             (vec![eval_domain, scan_units, matches, floor, 1.0], scan_units * tier_ns)
@@ -3440,6 +3446,7 @@ fn plan_cost_refit() {
                     scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
+                    range_build_printings: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -3637,6 +3644,7 @@ fn printing_range_route_probe() {
                 scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
+                range_build_printings: 0,
             };
 
             // ── Three pickers ──
@@ -3997,6 +4005,7 @@ fn plan_regret_report() {
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
+                range_build_printings: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -4123,6 +4132,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
+                range_build_printings: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/docs/changelog/2026-07-21-card-range-popcount.md
+++ b/docs/changelog/2026-07-21-card-range-popcount.md
@@ -1,0 +1,36 @@
+# Card-mode fast path for bare `usd` range queries (#725)
+
+A bare price range under `unique=card` (e.g. `usd<50`, the default unique mode) is now answered by a
+new `CardRangePopcount` plan instead of a full scan with a per-card count pass. The range's exact
+printing slice is projected to a card-existence bitmap whose **popcount is the exact total** (no count
+pass), and the page is read off the existing sort permutation — the same popcount-skip order phase the
+plane plan (#634) already uses, fed a range-derived bitmap rather than a precomputed plane.
+
+Measured on the 97,206-printing corpus (`limit=100`, min of an 8 s window, same build, kill-switch
+off vs on):
+
+| query | before | after | speedup |
+|---|---:|---:|---:|
+| `usd<50` / card | 0.339 ms | 0.214 ms | 1.58× |
+| `usd<50` / card, offset 700 | 0.348 ms | 0.218 ms | 1.60× |
+| `usd<2` / card | 0.463 ms | 0.185 ms | 2.51× |
+
+Offset-flat, because the cost was always the count pass, not the paging. Totals are byte-identical
+off vs on across the targeted set (the parity guard), and the broad 520-query survey and the 88-query
+cost calibration are unchanged.
+
+## Scope
+
+The plan fires only for a **bare** `usd` range in card mode — deliberately narrow:
+
+- **Compounds with a card-invariant plane** (`usd<50 c:g`, `usd<50 t:creature`) stay on the existing
+  narrowed-verify path: the plane already narrows the query hard, so that path is faster than paying to
+  build the whole range bitmap.
+- **Existential-legality compounds** (`usd<50 f:modern`) are excluded on correctness grounds — a
+  card-existence AND is exact only when legality never diverges across a card's printings, which the
+  engine refuses to assume (#667). Those belong in printing space.
+- **Range+range** (`usd<50 cn<100`) is excluded — it is a shared-witness case (one printing must satisfy
+  both), which a card-space existence AND cannot express.
+
+`cn` / `date` share the machinery and are a follow-on (PR 3). Gated by `CARD_ENGINE_RANGE_BITS_CARD`
+(default on) as an A/B kill-switch. Design notes: `docs/issues/local-engine-sorted-range-fastpath.md`.

--- a/docs/changelog/2026-07-21-card-range-popcount.md
+++ b/docs/changelog/2026-07-21-card-range-popcount.md
@@ -1,23 +1,27 @@
 # Card-mode fast path for bare `usd` range queries (#725)
 
 A bare price range under `unique=card` (e.g. `usd<50`, the default unique mode) is now answered by a
-new `CardRangePopcount` plan instead of a full scan with a per-card count pass. The range's exact
-printing slice is projected to a card-existence bitmap whose **popcount is the exact total** (no count
-pass), and the page is read off the existing sort permutation — the same popcount-skip order phase the
-plane plan (#634) already uses, fed a range-derived bitmap rather than a precomputed plane.
+new `CardRangePopcount` plan instead of a full scan with a per-card count pass. In one pass over the
+range's exact printing slice it builds a card-existence bitmap (each printing's card via the
+`printing_to_card` direct array) whose **popcount is the exact total** (no count pass), and the page
+is read off the existing sort permutation — the same popcount-skip order phase the plane plan (#634)
+already uses, fed a range-derived bitmap rather than a precomputed plane.
 
 Measured on the 97,206-printing corpus (`limit=100`, min of an 8 s window, same build, kill-switch
 off vs on):
 
 | query | before | after | speedup |
 |---|---:|---:|---:|
-| `usd<50` / card | 0.339 ms | 0.214 ms | 1.58× |
-| `usd<50` / card, offset 700 | 0.348 ms | 0.218 ms | 1.60× |
-| `usd<2` / card | 0.463 ms | 0.185 ms | 2.51× |
+| `usd<50` / card | 0.340 ms | 0.143 ms | 2.38× |
+| `usd<50` / card, offset 700 | 0.345 ms | 0.144 ms | 2.38× |
+| `usd<2` / card | 0.457 ms | 0.131 ms | 3.48× |
 
 Offset-flat, because the cost was always the count pass, not the paging. Totals are byte-identical
 off vs on across the targeted set (the parity guard), and the broad 520-query survey and the 88-query
-cost calibration are unchanged.
+cost calibration are unchanged. The build is a single fused pass (scatter the printing bitmap and set
+the card bit together) rather than scatter-then-project — a kernel bench showed the projection was
+the expensive half, and fusing it is ~40% cheaper (it's most of the query cost, since there is no
+precomputed structure — a persisted printing bitplane would be the next step, cf. #724).
 
 ## Scope
 

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -260,11 +260,21 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   *Measured* (same-build off vs on, 97,206-printing corpus, min ms): `usd<50` 0.75→0.04,
   `cn<100` 0.87→0.04, `year>2020` 0.74→0.04, aligned `usd<50 order by usd` 1.06→0.05
   (−90 to −95%); card/artwork/compound/selective controls flat; broad survey unchanged.
-- [ ] **PR 2a — Idea 2, `PrintingRangeBits` for `usd`, `unique=card`.** Project via
-  `printing_to_card` → card existence bitmap → popcount total → streamed-popcount page. Bundles the
-  `must_be_tight` correctness fix (inseparable — the bug is created by this path).
-  *Impacts:* `usd<50`/card, `usd` AND a composable plane (`usd<50 f:modern`), deep-page card.
-  *Magnitude:* −43%. *Depends:* —. *Risk:* med — new plane variant + a bundled correctness fix.
+- [x] **PR 2a — Idea 2, `usd`, `unique=card`** — shipped as the `CardRangePopcount` plan. A bare
+  `usd` range projects its exact direct-slice printings → card-existence bitmap → popcount total →
+  the #634 streamed-popcount page (range membership threaded into emission so the shown printing is
+  in range). The `must_be_tight` idea landed as *building the direct slice ourselves* (always tight)
+  rather than trusting `range_narrowed`'s loose broad complement.
+  *Measured* (97,206-printing corpus, `limit=100`, min ms, kill-switch off→on): `usd<50`/card
+  0.339→0.214 (1.58×), offset 700 0.348→0.218 (1.60×), `usd<2` 0.463→0.185 (2.51×), and up to 5.9×
+  on the broad survey (`usd<0.25` 0.730→0.123). 0 total-parity mismatches across the targeted set and
+  the 520-query survey; calibration 88/88 gold; no control regressions.
+  **Scope narrowed from the original plan, on measurement:** *bare* range only. Composable-plane
+  compounds (`usd<50 c:g`) were dropped — the plane already narrows them, so the existing path is
+  faster than building the whole range bitmap (measured a regression when forced). Existential
+  (`usd<50 f:modern`) and range+range (`usd<50 cn<100`) are excluded on **correctness** grounds
+  (shared-witness / legality divergence — printing-space's job, not card-space). *Depends:* —.
+  *Gate:* `CARD_ENGINE_RANGE_BITS_CARD` A/B.
 - [ ] **PR 3 — extend Idea 2 to `collector_number` + `released_at`.** Same machinery as 2a, new
   `DateCmp`/`YearCmp`/`cn` arms.
   *Impacts:* `cn`/`year`/`date` under `unique=card` (+ their compounds). *Magnitude:* −46% to −78%.

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -266,9 +266,13 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   in range). The `must_be_tight` idea landed as *building the direct slice ourselves* (always tight)
   rather than trusting `range_narrowed`'s loose broad complement.
   *Measured* (97,206-printing corpus, `limit=100`, min ms, kill-switch off→on): `usd<50`/card
-  0.339→0.214 (1.58×), offset 700 0.348→0.218 (1.60×), `usd<2` 0.463→0.185 (2.51×), and up to 5.9×
-  on the broad survey (`usd<0.25` 0.730→0.123). 0 total-parity mismatches across the targeted set and
-  the 520-query survey; calibration 88/88 gold; no control regressions.
+  0.340→0.143 (2.38×), offset 700 0.345→0.144 (2.38×), `usd<2` 0.457→0.131 (3.48×). 0 total-parity
+  mismatches across the targeted set and the 520-query survey; calibration 88/88 gold; no control
+  regressions. The build is a single fused pass (scatter printing bit + set card bit via
+  `printing_to_card` together): a kernel bench (`card_range_build_cost_split`) found the
+  scatter-then-project's *projection* was the expensive half (143µs vs 30µs on `usd<50`), and fusing
+  it is ~40% cheaper (174µs→104µs) — that build is most of the query cost, so a persisted printing
+  bitplane (#724) would be the next lever.
   **Scope narrowed from the original plan, on measurement:** *bare* range only. Composable-plane
   compounds (`usd<50 c:g`) were dropped — the plane already narrows them, so the existing path is
   faster than building the whole range bitmap (measured a regression when forced). Existential

--- a/scripts/bench_range_bits.py
+++ b/scripts/bench_range_bits.py
@@ -22,6 +22,7 @@ import csv
 import pathlib
 import sys
 import time
+from typing import TYPE_CHECKING
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -29,7 +30,8 @@ sys.path.insert(0, str(REPO_ROOT))
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 
-import card_engine  # noqa: E402
+if TYPE_CHECKING:
+    import card_engine
 
 WARMUP = 50
 DEFAULT_WINDOW_S = 8.0
@@ -57,7 +59,7 @@ CONFIGS: list[tuple[str, str, str, str, int]] = [
     ("control-invariant", "c:g", "card", "edhrec", 0),
     # --- controls: selective / name lookup ---
     ("control-selective", "r:rare", "card", "edhrec", 0),
-    ('control-selective', '!"Sol Ring"', "card", "edhrec", 0),
+    ("control-selective", '!"Sol Ring"', "card", "edhrec", 0),
     # --- correctness: range+range card (shared-witness); total is the guard ---
     ("correctness-rr", "usd<50 cn<100", "card", "edhrec", 0),
 ]
@@ -94,6 +96,7 @@ def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str, int]
 
 
 def main() -> None:
+    """Load the corpus once, then time each config over a window and write the CSV."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--out", type=pathlib.Path, required=True)
@@ -116,7 +119,9 @@ def main() -> None:
             total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, offset), args.window)
             writer.writerow([rev, group, query, unique, orderby, offset, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
             fh.flush()
-            print(f"{group:<18} {query:<20} {unique:<9} {orderby:<8} {offset:>6} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+            print(
+                f"{group:<18} {query:<20} {unique:<9} {orderby:<8} {offset:>6} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True
+            )
 
     print(f"\nWrote {args.out}")
 

--- a/scripts/bench_range_bits.py
+++ b/scripts/bench_range_bits.py
@@ -1,0 +1,125 @@
+"""Targeted bench for PR 2a (card-space idea-2, `PrintingRangeBits` for usd).
+
+Build the extension first (`maturin develop --release -m card_engine/Cargo.toml`)
+and run:
+
+    .venv/bin/python scripts/bench_range_bits.py --out benchmarks/range-bits/main.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. A/B is
+same-build off-vs-on via the CARD_ENGINE_RANGE_BITS_CARD kill-switch env var; set
+it to 0 for the baseline pass and 1 (default) for the branch pass, same store.
+
+Config tuple is (group, query, unique, orderby, offset); prefer=default,
+direction=asc, limit=100 throughout. `total` doubles as a cross-build parity
+check — it MUST be identical off vs on (a changed total means the fast path is
+fast because it's wrong).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+import card_engine  # noqa: E402
+
+WARMUP = 50
+DEFAULT_WINDOW_S = 8.0
+PAGE_LIMIT = 100
+
+# (group, query, unique, orderby, offset). Groups:
+#   target-*      — the queries PR 2a should speed up (card-mode range + composable plane)
+#   control-*     — must NOT regress (printing ranges own #695; card-invariant planes; selective)
+#   correctness-* — range+range card is a shared-witness case; PR 2a must keep it correct AND
+#                   not wrongly compose two card-existence bitmaps (total is the parity guard)
+CONFIGS: list[tuple[str, str, str, str, int]] = [
+    # --- targets: bare card range (broad + narrow + deep page) ---
+    ("target-usd-card", "usd<50", "card", "edhrec", 0),
+    ("target-usd-card", "usd<50", "card", "edhrec", 700),
+    ("target-usd-card", "usd<2", "card", "edhrec", 0),
+    ("target-usd-plane", "usd<50 f:modern", "card", "edhrec", 0),
+    ("target-usd-plane", "usd<50 t:creature", "card", "edhrec", 0),
+    ("target-usd-plane", "usd<50 c:g", "card", "edhrec", 0),
+    # --- controls: printing-mode ranges are #695's domain, must stay fast ---
+    ("control-printing", "usd<50", "printing", "edhrec", 0),
+    ("control-printing", "cn<100", "printing", "edhrec", 0),
+    # --- controls: card-invariant planes (already fast, must not regress) ---
+    ("control-invariant", "f:modern", "card", "edhrec", 0),
+    ("control-invariant", "t:creature", "card", "edhrec", 0),
+    ("control-invariant", "c:g", "card", "edhrec", 0),
+    # --- controls: selective / name lookup ---
+    ("control-selective", "r:rare", "card", "edhrec", 0),
+    ('control-selective', '!"Sol Ring"', "card", "edhrec", 0),
+    # --- correctness: range+range card (shared-witness); total is the guard ---
+    ("correctness-rr", "usd<50 cn<100", "card", "edhrec", 0),
+]
+
+
+def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str, int], window: float) -> tuple[int, int, float, float]:
+    """Return (total, n, avg_ms, min_ms) for one (query, unique, orderby, offset) config over a timed window."""
+    query, unique, orderby, offset = config
+    filters = parse_scryfall_query(query)
+    kw = {
+        "filters": filters,
+        "unique": unique,
+        "prefer": "default",
+        "orderby": orderby,
+        "direction": "asc",
+        "limit": PAGE_LIMIT,
+        "offset": offset,
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n = 0
+    best = float("inf")
+    t_start = time.monotonic()
+    deadline = t_start + window
+    now = t_start
+    while now < deadline:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1_000, best * 1_000
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True)
+    parser.add_argument("--window", type=float, default=DEFAULT_WINDOW_S)
+    parser.add_argument("--rev", type=str, default="")
+    args = parser.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    shm_path = args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+    rev = args.rev or "?"
+
+    hdr = f"{'group':<18} {'query':<20} {'unique':<9} {'orderby':<8} {'offset':>6} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(hdr)
+    print("-" * len(hdr))
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "offset", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, offset in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, offset), args.window)
+            writer.writerow([rev, group, query, unique, orderby, offset, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<18} {query:<20} {unique:<9} {orderby:<8} {offset:>6} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Card-space "idea 2" from the sorted-range roadmap (`docs/issues/local-engine-sorted-range-fastpath.md`), scoped to `usd`. A bare price range under `unique=card` (the default unique mode) was served by a full scan with a per-card count pass; it is now a new **`CardRangePopcount`** plan.

## What it does

In one pass over the range's exact printing slice (`idx[s..e]`, integer cents so it's tight — never `range_narrowed`'s loose NULL-including complement) it builds a **card-existence bitmap** (each printing's card via the `printing_to_card` direct array, #690). Its `popcount` is the exact `unique=card` total — no count pass — and the page is read off the existing sort permutation. It is the same popcount-skip order phase the plane plan (#634) already uses, fed a range-derived bitmap instead of a precomputed plane; the range's printing-membership set is threaded into emission so the representative printing shown is genuinely in range.

Wired into the #702 cost router as a normal declaration: a `PhysicalPlan` variant, an `applicable` predicate, a `plan_cost` arm (P2's popcount formula plus a build term over the range slice, the plan's dominant cost), acquire/dispatch, and the force seam. Gated by `CARD_ENGINE_RANGE_BITS_CARD` (default on) as an A/B kill-switch.

## Performance

97,206-printing corpus, `limit=100`, min of an 8 s window, same build, kill-switch off vs on:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `usd<50` / card | 0.340 ms | 0.143 ms | **2.38×** |
| `usd<50` / card, offset 700 | 0.345 ms | 0.144 ms | **2.38×** |
| `usd<2` / card | 0.457 ms | 0.131 ms | **3.48×** |
| `usd<0.25` / card (from the broad survey) | 0.705 ms | 0.099 ms | **7.1×** |

Offset-flat, because the cost was always the count pass, not the paging. Corpus: `benchmarks/bitplanes/corpus.jsonl`; targeted set: `scripts/bench_range_bits.py`.

### Build cost

The build is a single fused pass — scatter the printing bit and set the card bit (`printing_to_card[pid]`) together — rather than scatter-then-`printing_bits_to_card_bits`. A kernel bench (`card_range_build_cost_split`) showed the projection over the scattered bitmap was the expensive half (143 µs vs 30 µs scatter on `usd<50`), and fusing it is ~40% cheaper (174 µs → 104 µs) even though the price-ordered slice makes the `printing_to_card` reads random. That build is most of the query's cost since there's no precomputed structure — a persisted printing bitplane (#724) is the next lever.

## Scope — deliberately narrow (bare range only)

- **Composable-plane compounds** (`usd<50 c:g`, `usd<50 t:creature`) stay on the existing narrowed-verify path: the plane already narrows the query hard, so paying to build the whole range bitmap is a net loss (measured a regression when forced). No change to those.
- **Existential-legality compounds** (`usd<50 f:modern`) are excluded on **correctness** grounds — a card-existence AND is exact only when legality never diverges across a card's printings, which the engine refuses to assume (#667). Printing space's job.
- **Range+range** (`usd<50 cn<100`) is excluded — a shared-witness case (one printing must satisfy both) a card-space existence AND cannot express.

`cn` / `date` share the machinery and are a follow-on (PR 3).

## Correctness

- **Differential agreement** — `force_plan_differential_agreement` forces every plan (now including `CardRangePopcount`) and checks total + row-multiset + 2-key order against `GatheredScan` at full limit; new bare-price and price+color cases added.
- **Parity** — `total` is byte-identical off vs on across the targeted set and the full 520-query survey (0 mismatches).
- **Branch vs real main** (not just the kill-switch): 0/520 total-parity mismatches on the survey, and geomean branch/main = 0.984× (branch faster, pulled down by the usd wins) — so adding the plan to `PhysicalPlan::ALL` imposes no measurable router overhead on the queries that never use it.
- **Calibration** — `plan_cost_model_matches_gold` still 88/88 gold with the new plan in the argmin.
- **Scope gate** — `usd_bare_range_bounds_gates_pr2a_scope` pins the leaf-shape gate (rejects `Ne`, non-price fields, `cn`/`date`, and the range+range `And`).
- 2,077 Python unit tests pass.
