### PR TITLE
Extend CardRangePopcount to Collector-Number and Date Ranges

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3916,42 +3916,30 @@ fn bare_range_bounds<'i>(
     }
 }
 
-/// The exact half-open `[lo, hi)` a *bare* `usd` range leaf selects over the price index, or None
-/// for anything else. PR 2a's `CardRangePopcount` is deliberately scoped to price only; `cn`/`date`
-/// share the machinery and are a trivial follow-on (PR 3) — widen this to delegate to
-/// `bare_range_bounds` then. Value snapping matches `narrow_rec`'s `price` closure so the fast path
-/// and the general path can never disagree on which printings the predicate covers. Bounds are
-/// exact (price is integer cents, #688), so the direct slice `idx[lo..hi)` is a *tight* set — the
-/// property that lets its card-existence popcount stand in for the count pass without re-verifying.
-fn usd_bare_range_bounds(filter: &FilterExpr) -> Option<(u32, u32)> {
-    let FilterExpr::NumericCmp { lhs, op, rhs } = filter else { return None };
-    let (op, value) = match (lhs, rhs) {
-        (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => (*op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
-        (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => (flip_op(*op), snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
-        _ => return None,
-    };
-    match int_range_bounds(op, value)? {
-        None => Some((0, 0)), // provably empty: zero-width slice, popcount resolves to 0
-        Some((lo, hi)) => Some((lo, hi)),
-    }
-}
-
-/// Build `CardRangePopcount`'s two bitmaps from an exact `usd` range slice, in a single pass: the
-/// tight printing-space membership set (`range_pbits`, set directly from the value-sorted slice —
-/// never the loose complement `range_narrowed` would pick for a broad range, which over-includes
-/// NULL-priced printings) and its card-existence projection (`card_bits`, each printing's card via
-/// the `printing_to_card` direct array, #690). The card bitmap's popcount is the exact `unique=card`
-/// total; the printing bitmap is the per-printing residual emission re-checks so the representative
-/// printing it shows genuinely satisfies the range.
+/// Build `CardRangePopcount`'s two bitmaps from an exact range slice — `bare_range_bounds` supplies
+/// the index + half-open `[lo, hi)` for whichever range family the leaf is (usd/cn/date) — in a
+/// single pass: the tight printing-space membership set (`range_pbits`, set directly from the
+/// value-sorted slice — never the loose complement `range_narrowed` would pick for a broad range,
+/// which over-includes index-absent printings) and its card-existence projection (`card_bits`, each
+/// printing's card via the `printing_to_card` direct array, #690). The card bitmap's popcount is the
+/// exact `unique=card` total; the printing bitmap is the per-printing residual emission re-checks so
+/// the representative printing it shows genuinely satisfies the range. All three indexes are exact
+/// (price is integer cents #688; cn/date are natively integer), so the slice is tight.
 ///
 /// One fused pass rather than scatter-then-`printing_bits_to_card_bits`: the projection over the
 /// scattered bitmap is the expensive half (a `trailing_zeros` extraction per set bit plus a cursor
 /// branch across every word), and folding it into the scatter loop via a direct `printing_to_card`
 /// lookup measured ~40% cheaper on `usd<50` (~174µs → ~104µs; see `card_range_build_cost_split`),
-/// even though the price-ordered slice makes those lookups random. Bare range only
+/// even though the value-ordered slice makes those lookups random. Bare range only
 /// (`card_range_popcount_applicable` requires no plane), so there is nothing to AND.
-fn build_card_range_bits(lo: u32, hi: u32, indexes: &Archived<CardIndexes>, n_cards: usize, n_printings: usize) -> (Vec<u64>, Vec<u64>) {
-    let idx = &indexes.price_usd;
+fn build_card_range_bits(
+    idx: &Archived<PrintingRangeIndex>,
+    lo: u32,
+    hi: u32,
+    indexes: &Archived<CardIndexes>,
+    n_cards: usize,
+    n_printings: usize,
+) -> (Vec<u64>, Vec<u64>) {
     let ptc = &indexes.printing_to_card;
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
@@ -4341,9 +4329,9 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
     *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
 }
 
-/// `CardRangePopcount` needs `Mode::Card`, a **bare** `usd` range as the whole filter (no plane), and
-/// both sort permutations. `plane.is_none()` is deliberate and load-bearing, on both correctness and
-/// perf grounds:
+/// `CardRangePopcount` needs `Mode::Card`, a **bare** range leaf as the whole filter — usd/cn/date,
+/// whatever `bare_range_bounds` recognizes (no plane) — and both sort permutations. `plane.is_none()`
+/// is deliberate and load-bearing, on both correctness and perf grounds:
 /// - *correctness:* an existential legality plane (`usd<50 f:modern`) would make the card-existence
 ///   AND exact only when the attribute never diverges across a card's printings — a data coincidence
 ///   the engine refuses to bank on (docs/issues/00667-engine-legality-divergent-carveout.md); those
@@ -4353,7 +4341,9 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
 ///   regardless — measured a net loss. So a narrowing plane means don't bother; only the bare range,
 ///   where the alternative is a full scan of a ~99%-broad set, is worth the build.
 ///
-/// The bare-`usd`-leaf shape also excludes range+range (`usd<50 cn<100` is an `And`, not a bare leaf).
+/// The bare-leaf shape also excludes range+range (`usd<50 cn<100` is an `And`, not a bare leaf):
+/// composing two printing-varying ranges is a shared-witness case (`∃p: usd(p) ∧ cn(p)`) that must
+/// AND in *printing* space and project once — the printing-space plane's structure, not this one's.
 fn card_range_popcount_applicable(
     filter: &FilterExpr,
     mode: Mode,
@@ -4367,7 +4357,7 @@ fn card_range_popcount_applicable(
         && matches!(mode, Mode::Card)
         && !cards.is_empty()
         && plane.is_none()
-        && usd_bare_range_bounds(filter).is_some()
+        && bare_range_bounds(filter, indexes).is_some()
         && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
         && indexes.sort_perms.get_inv(sort_col, descending).is_some()
 }
@@ -4860,8 +4850,8 @@ fn run_query_routed<'a>(
         // scan of a near-total set, which reliably loses, so the eager build is rarely wasted: only a
         // narrow range routes elsewhere, and there k (hence the build) is small. If a materializing
         // plan does win, dispatch reads the same bitmap back as a candidate list.
-        let (lo, hi) = usd_bare_range_bounds(filter).expect("applicable ⇒ bare usd range");
-        let (card_bits, range_pbits) = build_card_range_bits(lo, hi, indexes, n_cards as usize, n_printings as usize);
+        let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
+        let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, n_cards as usize, n_printings as usize);
         let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
         // Slice size (in-range printings) drives the build term — the plan's dominant cost.
         let slice_printings: u32 = range_pbits.iter().map(|w| w.count_ones()).sum();
@@ -4994,8 +4984,8 @@ fn run_query_with_plan<'a>(
             if !card_range_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
                 return None;
             }
-            let (lo, hi) = usd_bare_range_bounds(filter).expect("applicability guarantees a bare usd range");
-            let (card_bits, range_pbits) = build_card_range_bits(lo, hi, indexes, cards.len(), printings.len());
+            let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicability guarantees a bare range");
+            let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), printings.len());
             Some(exec_card_range_popcount(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
             ))

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2736,6 +2736,10 @@ fn force_plan_differential_agreement() {
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "edhrec", "asc"),
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 2.0 }), "edhrec", "desc"),
         (FuzzSpec::And(vec![FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), fuzz_leaf_color(&mut rng)]), "edhrec", "asc"),
+        // PR 3: cn/date bare ranges also route through CardRangePopcount in card mode (the Date cases
+        // above already exercise it; add collector_number + year over card-level perms too).
+        (FuzzSpec::Leaf(FuzzLeaf::CollectorNumber { op: CmpOp::Lt, val: 100.0 }), "edhrec", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Year { op: CmpOp::Ge, year: 2015 }), "edhrec", "desc"),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -7879,29 +7883,6 @@ fn bare_range_bounds_recognizes_leaves_and_rejects_rest() {
     assert!(bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0)])).is_none());
     let cmc_lt = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
     assert!(bounds(&cmc_lt).is_none());
-}
-
-/// PR 2a's `CardRangePopcount` is scoped to a single bare `usd` range leaf; `usd_bare_range_bounds`
-/// is the gate that enforces it. It accepts a bare price leaf (either operand order) and rejects
-/// everything the conservative scope excludes: `Ne`, non-price numeric fields, `cn`/`date` (PR 3,
-/// not 2a), and any compound residual — notably the `usd<50 cn<100` range+range shared-witness case,
-/// which is an `And`, not a bare leaf. (Existential-plane exclusion is enforced separately in
-/// `card_range_popcount_applicable` via `plane_expr_is_existential` — see
-/// `plane_expr_is_existential_identifies_legality_only`.)
-#[test]
-fn usd_bare_range_bounds_gates_pr2a_scope() {
-    let cn_lt = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::CollectorNumberInt), op: CmpOp::Lt, rhs: NumExpr::Const(100.0) };
-    // accepts a bare usd leaf; const-on-left flips the op to the same [0, 5000) cents extent.
-    assert_eq!(super::usd_bare_range_bounds(&usd_cmp(CmpOp::Lt, 50.0)), Some((0, 5000)));
-    assert_eq!(
-        super::usd_bare_range_bounds(&FilterExpr::NumericCmp { lhs: NumExpr::Const(50.0), op: CmpOp::Gt, rhs: NumExpr::Field(NumField::PriceUsd) }),
-        Some((0, 5000)),
-    );
-    // rejects: Ne (never narrows), cmc (card-space), cn (PR 3), and the range+range compound.
-    assert!(super::usd_bare_range_bounds(&usd_cmp(CmpOp::Ne, 50.0)).is_none());
-    assert!(super::usd_bare_range_bounds(&FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) }).is_none());
-    assert!(super::usd_bare_range_bounds(&cn_lt()).is_none());
-    assert!(super::usd_bare_range_bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0), cn_lt()])).is_none());
 }
 
 /// PR 2a build-cost split: for `usd<50`, which half of `CardRangePopcount`'s build dominates —

--- a/docs/changelog/2026-07-21-card-range-popcount-cn-date.md
+++ b/docs/changelog/2026-07-21-card-range-popcount-cn-date.md
@@ -10,12 +10,12 @@ correctness surface — cn/date are printing-varying integer ranges exactly like
 Measured on the 97,206-printing corpus (`limit=100`, min of an 8 s window, same build, kill-switch
 off vs on):
 
-| query | before | after | speedup |
+| query | before (μs) | after (μs) | speedup |
 |---|---:|---:|---:|
-| `cn<100` / card | 0.589 ms | 0.088 ms | 6.66× |
-| `cn<100` / card, offset 700 | 0.595 ms | 0.092 ms | 6.47× |
-| `year>=2015` / card | 0.416 ms | 0.124 ms | 3.36× |
-| `year<2005` / card | 0.280 ms | 0.064 ms | 4.40× |
+| `cn<100` / card | 589 | 88 | 6.66× |
+| `cn<100` / card, offset 700 | 595 | 92 | 6.47× |
+| `year>=2015` / card | 416 | 124 | 3.36× |
+| `year<2005` / card | 280 | 64 | 4.40× |
 
 Offset-flat, same as usd. Totals byte-identical off vs on; the usd rows and every control are
 unchanged; calibration stays 88/88 gold.

--- a/docs/changelog/2026-07-21-card-range-popcount-cn-date.md
+++ b/docs/changelog/2026-07-21-card-range-popcount-cn-date.md
@@ -1,0 +1,25 @@
+# CardRangePopcount extended to collector-number and date ranges (#726)
+
+Follow-on to the bare-`usd` fast path: a bare `cn` or date/`year` range under `unique=card` is now
+answered by the same `CardRangePopcount` plan (card-existence bitmap → `popcount` total → page off
+the sort permutation) instead of a full scan with a per-card count pass. The plan's gate widened from
+usd-only to any bare range leaf `bare_range_bounds` recognizes (usd/collector_number/released_at);
+the build takes the range index rather than hardcoding the price index. No new plan and no new
+correctness surface — cn/date are printing-varying integer ranges exactly like usd.
+
+Measured on the 97,206-printing corpus (`limit=100`, min of an 8 s window, same build, kill-switch
+off vs on):
+
+| query | before | after | speedup |
+|---|---:|---:|---:|
+| `cn<100` / card | 0.589 ms | 0.088 ms | 6.66× |
+| `cn<100` / card, offset 700 | 0.595 ms | 0.092 ms | 6.47× |
+| `year>=2015` / card | 0.416 ms | 0.124 ms | 3.36× |
+| `year<2005` / card | 0.280 ms | 0.064 ms | 4.40× |
+
+Offset-flat, same as usd. Totals byte-identical off vs on; the usd rows and every control are
+unchanged; calibration stays 88/88 gold.
+
+Compound ranges (`usd<50 cn<100`) remain out of scope: composing two printing-varying ranges is a
+shared-witness case (`∃p: usd(p) ∧ cn(p)`) that must AND in printing space and project to card space
+once — the printing-space plan's structure, not this card-space one's.

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -279,10 +279,14 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   (`usd<50 f:modern`) and range+range (`usd<50 cn<100`) are excluded on **correctness** grounds
   (shared-witness / legality divergence — printing-space's job, not card-space). *Depends:* —.
   *Gate:* `CARD_ENGINE_RANGE_BITS_CARD` A/B.
-- [ ] **PR 3 — extend Idea 2 to `collector_number` + `released_at`.** Same machinery as 2a, new
-  `DateCmp`/`YearCmp`/`cn` arms.
-  *Impacts:* `cn`/`year`/`date` under `unique=card` (+ their compounds). *Magnitude:* −46% to −78%.
-  *Depends:* 2a. *Risk:* low.
+- [x] **PR 3 — extend `CardRangePopcount` to `collector_number` + `released_at`** — shipped. The
+  gate became `bare_range_bounds` (already returns index + `[lo,hi)` for usd/cn/date), and
+  `build_card_range_bits` takes the index rather than hardcoding `price_usd`; `usd_bare_range_bounds`
+  removed. No new plan, no new correctness surface (cn/date are printing-varying integer ranges like
+  usd). *Measured* (off→on): `cn<100`/card 0.589→0.088 (**6.66×**), offset 700 6.47×, `year>=2015`
+  0.416→0.124 (3.36×), `year<2005` 0.280→0.064 (4.40×); usd unchanged; 0 parity mismatches;
+  calibration 88/88 gold. *Compounds still excluded* (bare-leaf gate) — they're the printing-space
+  plane's job (compose in printing space, project once).
 - [ ] **PR 4 — compound-query structural pre-checks** (`has_conflicting_range_families`,
   `contains_range_family_leaf`): skip a `compile_plane` fold that will be discarded, for 2+
   existential leaves in one `And` and for range leaves under `unique=printing`/`artwork`.

--- a/scripts/bench_range_bits.py
+++ b/scripts/bench_range_bits.py
@@ -47,6 +47,11 @@ CONFIGS: list[tuple[str, str, str, str, int]] = [
     ("target-usd-card", "usd<50", "card", "edhrec", 0),
     ("target-usd-card", "usd<50", "card", "edhrec", 700),
     ("target-usd-card", "usd<2", "card", "edhrec", 0),
+    # PR 3: cn/date bare ranges, same plan
+    ("target-cn-date", "cn<100", "card", "edhrec", 0),
+    ("target-cn-date", "cn<100", "card", "edhrec", 700),
+    ("target-cn-date", "year>=2015", "card", "edhrec", 0),
+    ("target-cn-date", "year<2005", "card", "edhrec", 0),
     ("target-usd-plane", "usd<50 f:modern", "card", "edhrec", 0),
     ("target-usd-plane", "usd<50 t:creature", "card", "edhrec", 0),
     ("target-usd-plane", "usd<50 c:g", "card", "edhrec", 0),


### PR DESCRIPTION
Follow-on to #725 (`CardRangePopcount` for bare `usd` ranges), extending the same plan to the other two range families — `cn` (collector number) and date/`year` — under `unique=card`.

## What changed

Small and mechanical, as planned:

- The applicability gate widened from `usd_bare_range_bounds` (price-only) to **`bare_range_bounds`**, which already recognizes usd/cn/date and returns the index + `[lo, hi)`.
- `build_card_range_bits` now takes that index instead of hardcoding `price_usd`.
- `usd_bare_range_bounds` removed (subsumed).

**No new plan, no new correctness surface.** `cn` and `released_at` are printing-varying integer ranges exactly like `usd` (cn/date are natively integer; the slice is tight), so the same card-existence-popcount machinery, the same exclusions (existential planes, range+range compounds), and the same cost model all apply unchanged.

## Performance

97,206-printing corpus, `limit=100`, min of an 8 s window, same build, kill-switch off vs on:

| Benchmark | Before (μs) | After (μs) | Change |
|---|---:|---:|---:|
| `cn<100` / card | 589 | 88 | **6.66×** |
| `cn<100` / card, offset 700 | 595 | 92 | **6.47×** |
| `year>=2015` / card | 416 | 124 | **3.36×** |
| `year<2005` / card | 280 | 64 | **4.40×** |

Offset-flat, same as usd. The usd rows and every control are unchanged. `cn<100` at 6.66× is the largest win in the family.

## Scope

Bare range only, same as #725 — compound ranges (`usd<50 cn<100`) stay out: composing two printing-varying ranges is a shared-witness case (`∃p: usd(p) ∧ cn(p)`) that must AND in *printing* space and project to card space once, which is the printing-space plane's structure, not this card-space plan's.

## Correctness

- **Differential agreement** — added bare `collector_number` and `year` cases to `force_plan_differential_agreement` (date was already covered); every plan agrees with `GatheredScan` on total + rows + 2-key order at full limit.
- **Parity** — `total` byte-identical off vs on across the targeted set (0 mismatches).
- **Calibration** — `plan_cost_model_matches_gold` still 88/88 gold.
- 2,077 Python unit tests pass; clippy clean.
