### PR TITLE
Refresh Engine Fast-Path Docs After CardRangePopcount (Drop PR 4, Quantify the #724 Lever)

### DIFF
--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -1,21 +1,34 @@
-# Engine: Printing-Space Existential Bitplanes (Legality / Border / Frame)
+# Engine: Printing-Space Bitplanes (Legality / Border / Rarity, Bit-per-Printing)
 
 Status: todo, filed as [#724](https://github.com/jbylund/sylvan_librarian/issues/724). Sequenced
 **last**, behind the [printing-space popcount-order plan](local-engine-printing-plane-popcount-order.md)
 that consumes them (see that doc's ship-order step 7).
 
-## What
+## What — exact, not existential
 
-Bit-per-**printing** planes for printing-varying categorical/existential values — legality (per
-format), border, frame. Today these live only in **card space**: legality's `legal_x` plane
+Bit-per-**printing** planes for printing-varying values — legality (per format), border, rarity.
+Today these live only in **card space**, as existence *projections*: legality's `legal_x` plane
 ([#667](done/00667-engine-legality-divergent-carveout.md)) and border's plane
-([#664](done/00664-engine-border-planes.md)) are existence *projections* — a card's bit means
-"*some* printing satisfies," not *which* printing. That answers `unique=card` but can neither answer
-per-printing membership nor feed a printing-space `popcount`.
+([#664](done/00664-engine-border-planes.md)) set a card's bit to mean "*some* printing satisfies,"
+not *which*. That projection is why they're called "existential" and why they can't be ANDed safely
+(shared witness) — but it's a **card-space artifact**, not a property of the attribute.
 
-A printing-space plane (one bit per printing) gives, for a printing-varying value: the exact
-per-printing match set, its total as a `popcount` (O(words), density-independent), and O(1)
-membership tests.
+A **printing-space** plane is the opposite: one bit per printing, set iff *that printing* satisfies —
+**exact, not existential**. That changes everything about how they compose and get used:
+
+- **AND / OR / NOT compose exactly in printing space.** `border:black AND r:rare` is the printings
+  that are *both* — the shared witness holds bit-by-bit, no projection ambiguity.
+- **Two ways to use the composed result:** (a) answer a `unique=printing` query **directly** — the
+  surviving bits *are* the rows; or (b) project **once** to card or artwork space (the single `∃`:
+  "does this card/artwork have any surviving printing?") and finish the query there. Composing first
+  and projecting once is what stays exact — unlike card-space existence-AND, which projects per-leaf
+  *before* the AND and false-positives.
+- **The divergent-carveout complexity disappears.** #667's dual `has_legal`/`has_notlegal` planes
+  exist only because per-printing legality was projected to a card bit and could diverge; in printing
+  space each printing's legality is just its own bit — exact, no carveout. So these are not only
+  exact but *simpler* than the card-space planes they extend.
+
+They also give the total as a `popcount` (O(words), density-independent) and O(1) membership tests.
 
 ## Why — and why there is no benefit yet
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -20,7 +20,7 @@ as the **exact total**, then read the page directly off the bitmap in printing s
 The match bitmap has a few sources, and they share this one paging plan:
 
 - a **query-time range narrowing** (`usd`/`cn`/`date`) — the original idea 2, this doc's main focus;
-- a **precomputed existential printing bitplane** for a printing-varying value (legality, frame,
+- a **precomputed printing bitplane** for a printing-varying value (legality, frame,
   border) — e.g. a bit-per-printing "modern-legal" plane;
 - **a postings list scattered into a bitmap on demand** — O(matches) to build, for any value that
   has printing-space postings;
@@ -159,6 +159,36 @@ This is one plan across the whole target set, not several: `f:modern border:blac
 "existential-total" plan versus "mixed-compound" plan — just this plan at projection count 0, 1,
 2, …, its projection cost term falling to zero when no card-plane leaf is present.
 
+### Compose-space is a cost choice, not a fixed direction
+
+"Project the card-plane *into* printing space" above is only **one** of two exact orders when a query
+mixes card-invariant and printing-varying leaves. Projection runs **both ways**, and only one
+direction is lossy:
+
+- **`card→printing` (broadcast)** is *exact* — a card-invariant value (`c:green`) is identical across
+  all of a card's printings, so broadcasting its bit down loses nothing.
+- **`printing→card` (`∃`)** is the *existential* projection — lossy, so it must be the **last** step
+  and done **once**.
+
+So for one printing-varying leaf plus card-invariant leaves (`c:green border:black`/card), **both
+orders are exact** and it's purely a cost decision:
+
+- *compose in printing:* broadcast `c:green` down, AND with `border:black`, project up once — cost in
+  printing-space words (~1,519) plus the broadcast;
+- *compose in card:* project `border:black` up to card-existence (the one `∃`), AND with the
+  `c:green` card plane — cost in card-space words (~492) plus that projection.
+
+Neither dominates; it depends on the plane sizes, the answer mode (`unique=printing` needs no
+up-projection at all), and which projection is cheaper. The router picks per query — a `min` over the
+two orders, the same shape as its choice among plans. The bitplanes serve all of this: answer a
+`unique=printing` query from the surviving bits directly, or project once to card/artwork to finish
+there.
+
+The **one hard constraint is correctness, not cost:** **2+ printing-varying leaves must compose in
+printing space** (`border:black r:rare` — AND the two printing planes, *then* project up once); a
+card-space existence-AND of two `∃`-projected leaves false-positives (a card with a black printing
+and a *separate* rare one). With ≤1 printing-varying leaf, either order is exact and cost decides.
+
 ### The build term, now measured — and why #724 is the lever
 
 `CardRangePopcount` (#725/#726) shipped the range leaf source of exactly this shape and **measured
@@ -170,7 +200,7 @@ the popcount+walk is only ~40 µs.
 
 That gap is the whole argument for persistent bitplanes: a **precomputed** printing bitplane has *no*
 build — the #634 card-plane popcount plan runs a bare plane in ~0.06 ms. So [#724](https://github.com/jbylund/sylvan_librarian/issues/724)
-(printing-space existential planes) doesn't just *enable* the existential targets (`f:modern`,
+(the printing bitplanes) don't just *enable* the printing-varying targets (`f:modern`,
 `border:black`, which have no cheap query-time build at all) — for the range targets it **deletes the
 ~105 µs build term**, taking `usd`/card from ~0.143 ms toward that ~0.06 ms plane floor. The build
 being the dominant, measurable cost is what makes "persist the bitplane" a quantified win rather than
@@ -210,14 +240,14 @@ printing-space subset, in dependency order:
    + `popcount` the range bitmap(s) in printing space, page off the #656 permutation. Register as a
    new `PhysicalPlan` with its `applicable` / `materializing` / `cost::plan_cost` / executor arms —
    the #702 router makes this a *declaration*, not a tree edit. Prove the whole plan on **ranges
-   only** (`cn<100 usd<50`/printing, the confirmed 1.18 ms target, **zero** existential planes): a
+   only** (`cn<100 usd<50`/printing, the confirmed 1.18 ms target, **zero** printing bitplanes): a
    range leaf yields a printing bitmap with no new precomputed structure — the `partition_point`
    slice scattered directly, exactly the `range_pbits` `CardRangePopcount` already builds — and is
    **exact**, so the AND / `popcount` / bit-walk / router machinery is validated against the #702
-   brute-force reference on a clean source before any existential plane exists.
+   brute-force reference on a clean source before any printing bitplane exists.
 6. **Cost-route idea 1 vs this.** The `argmin` already exists; add this plan's cost formula and let
    the offset×selectivity crossover (validated today by `idea1_vs_idea2_probe`) pick between them.
-7. **Printing-space existential planes — separate track ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)).**
+7. **Printing-space bitplanes — separate track ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)).**
    The legality/border **leaf source** that unlocks the existential targets (`f:modern`,
    `border:black`). Sequenced **last, deliberately**: these planes give *no* speedup until steps 1–6
    exist to consume them via `popcount` + AND + bit-walk (the current verify path doesn't `popcount`,
@@ -245,7 +275,7 @@ range+range gap proves worth closing.
 
 ## Prerequisites & caveats
 
-- **Existential targets need precomputed *printing-space* existential planes** — now tracked as
+- **Printing-varying targets need precomputed *printing-space* bitplanes** — now tracked as
   [#724](https://github.com/jbylund/sylvan_librarian/issues/724) (see ship-order step 7). The
   `f:modern` / `border:black` wins all assume a bit-per-printing legality / border plane to `AND` and
   `popcount`. Neither exists: legality's #667 plane and border's #664 plane are **card-space** (they
@@ -289,7 +319,7 @@ range+range gap proves worth closing.
   *precomputed* bitmap source extends; #667's planes are **card-space**, which is why
   `f:modern`/printing still needs a printing-space one.
 - [00724-engine-printing-existential-planes.md](00724-engine-printing-existential-planes.md)
-  ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)) — the printing-space existential
-  planes track: this plan's legality/border leaf source, sequenced last.
+  ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)) — the printing-space bitplanes
+  track: this plan's legality/border leaf source, sequenced last.
 - #656 (pager/permutation), #690 (`printing_to_card`, shipped), #689 (reverted attempt / NULL
   lesson), #634 (card-mode `PlanePopcountOrder`).

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -1,11 +1,14 @@
 # Engine: Printing-Space PlanePopcountOrder (the deferred "idea 2")
 
-Status: todo, not yet a filed issue. Extracted from the #702 planner writeup
-([done/00702](done/00702-engine-plan-selection-layer.md)), where this was "the one real speed win
-found" but deferred. The gating prerequisite is the printing-space pager/permutation,
-[#656](https://github.com/jbylund/sylvan_librarian/issues/656). This doc is the entry point; the
-mechanism detail and measurements live in the two range-fastpath docs linked throughout — it does
-not duplicate them.
+Status: the printing-space plan itself is **todo** (gated on the printing-space pager/permutation,
+[#656](https://github.com/jbylund/sylvan_librarian/issues/656)), but its **card-space groundwork has
+shipped**: `CardRangePopcount` ([#725](https://github.com/jbylund/sylvan_librarian/pull/725),
+[#726](https://github.com/jbylund/sylvan_librarian/pull/726)) proved the range→bitmap→`popcount`→bit-walk
+machinery on the `unique=card` range leaf source (usd/cn/date), and the kernel bench there **measured
+the build cost** this plan's whole value hinges on (see § Cost). Extracted from the #702 planner
+writeup ([done/00702](done/00702-engine-plan-selection-layer.md)), where this was "the one real speed
+win found" but deferred. This doc is the entry point; the mechanism detail and measurements live in
+the two range-fastpath docs linked throughout — it does not duplicate them.
 
 ## What it is
 
@@ -156,6 +159,23 @@ This is one plan across the whole target set, not several: `f:modern border:blac
 "existential-total" plan versus "mixed-compound" plan — just this plan at projection count 0, 1,
 2, …, its projection cost term falling to zero when no card-plane leaf is present.
 
+### The build term, now measured — and why #724 is the lever
+
+`CardRangePopcount` (#725/#726) shipped the range leaf source of exactly this shape and **measured
+the build** — the query-time scatter+project that turns a range into a bitmap, i.e. the projection
+term above at projection-count-1. On `usd<50`'s ~80k-printing slice it is ~**105 µs** (a single fused
+scatter+`printing_to_card` pass; ~40% cheaper than scatter-then-project — see `card_range_build_cost_split`),
+and it **dominates** the query: `usd<50`/card lands at ~0.143 ms, of which the build is ~105 µs and
+the popcount+walk is only ~40 µs.
+
+That gap is the whole argument for persistent bitplanes: a **precomputed** printing bitplane has *no*
+build — the #634 card-plane popcount plan runs a bare plane in ~0.06 ms. So [#724](https://github.com/jbylund/sylvan_librarian/issues/724)
+(printing-space existential planes) doesn't just *enable* the existential targets (`f:modern`,
+`border:black`, which have no cheap query-time build at all) — for the range targets it **deletes the
+~105 µs build term**, taking `usd`/card from ~0.143 ms toward that ~0.06 ms plane floor. The build
+being the dominant, measurable cost is what makes "persist the bitplane" a quantified win rather than
+a hunch.
+
 ## Parts, in ship order
 
 Most pieces already exist or are planned in
@@ -169,9 +189,15 @@ printing-space subset, in dependency order:
    ([#695](https://github.com/jbylund/sylvan_librarian/pull/695)). Bare broad printing ranges. Most
    of #656's pieces fall out of it plus the card-mode idea-2 core — see [#656 assembly](#656-assembly)
    below.
-3. **Card-space idea-2 (`PrintingRangeBits`) — planned, not printing-space** (PR 2a/3 in the
-   roadmap). Lands the range-bitmap→popcount machinery + the `must_be_tight` correctness fix in
-   `unique=card` first, where the bitmap composes. This is the reusable core.
+3. **Card-space range popcount (`CardRangePopcount`) — shipped**
+   ([#725](https://github.com/jbylund/sylvan_librarian/pull/725) usd,
+   [#726](https://github.com/jbylund/sylvan_librarian/pull/726) cn/date). The `unique=card` reusable
+   core: a bare range's exact direct slice is, in one fused pass, scattered into a printing membership
+   bitmap *and* projected to a card-existence bitmap (via `printing_to_card`); `popcount` = exact
+   total; page off the #634 permutation. The "`must_be_tight`" idea landed as **building the direct
+   slice ourselves** (always tight) rather than trusting `range_narrowed`'s loose broad complement —
+   not a `PrintingRangeBits`/`printing_bits` struct as this doc first guessed. Bare leaf only;
+   compounds and existential planes deliberately excluded (that's this printing-space plan's job).
 4. **#656 — extend the popcount-order phase to compound residuals + printing/artwork.** As filed,
    #656 is a follow-on to #634 (design in [00634](done/00634-engine-permuted-bitmap-order-phase.md)):
    for a **card-level** orderby (edhrec, cmc…) the printing/artwork page is a *weighted set-bit walk*
@@ -185,10 +211,10 @@ printing-space subset, in dependency order:
    new `PhysicalPlan` with its `applicable` / `materializing` / `cost::plan_cost` / executor arms —
    the #702 router makes this a *declaration*, not a tree edit. Prove the whole plan on **ranges
    only** (`cn<100 usd<50`/printing, the confirmed 1.18 ms target, **zero** existential planes): a
-   range leaf yields a printing bitmap with no new precomputed structure (the `partition_point` slice
-   scattered, PR 2a's `printing_bits`) and is **exact**, so the AND / `popcount` / bit-walk / router
-   machinery is validated against the #702 brute-force reference on a clean source before any
-   existential plane exists.
+   range leaf yields a printing bitmap with no new precomputed structure — the `partition_point`
+   slice scattered directly, exactly the `range_pbits` `CardRangePopcount` already builds — and is
+   **exact**, so the AND / `popcount` / bit-walk / router machinery is validated against the #702
+   brute-force reference on a clean source before any existential plane exists.
 6. **Cost-route idea 1 vs this.** The `argmin` already exists; add this plan's cost formula and let
    the offset×selectivity crossover (validated today by `idea1_vs_idea2_probe`) pick between them.
 7. **Printing-space existential planes — separate track ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)).**
@@ -202,19 +228,19 @@ printing-space subset, in dependency order:
 
 ## #656 assembly
 
-#656 is not a from-scratch build once idea-1 (#695) and the card-space idea-2 core (PR 2a) land —
-it is mostly assembly:
+#656 is not a from-scratch build now that idea-1 (#695) and `CardRangePopcount` (#725/#726) have
+landed — it is mostly assembly:
 
 | #656 needs | built by | notes |
 |---|---|---|
-| range → **printing** existence bitmap | PR 2a/3 | `PrintingRangeBits` already carries `printing_bits` (card-mode row selection tests it via `eval_plane_expr_for_printing`), so it is built regardless. |
-| **popcount total** | PR 2a | PR 2a popcounts *card* bits; the identical step over printing bits is a trivial transfer. |
+| range → **printing** membership bitmap | #725/#726 | `CardRangePopcount`'s fused build already produces exactly this (`range_pbits`, the tight direct-slice scatter) alongside the card bitmap; it's the same artifact #656 would AND. |
+| **popcount total** | #725/#726 | `CardRangePopcount` popcounts the *card* bitmap; the identical step over the *printing* bitmap (`range_pbits`) is a trivial transfer. |
 | **printing-space paging** | #695 | idea-1's permutation walk (expand to printings, test membership, early-stop) *is* the printing pager — swap the membership test from "in `[lo, hi)`" to "in the intersected printing bitmap." |
 
-So **#656 ≈ PR 2a's printing bitmaps + #695's walk + an AND.** The only net-new work is
+So **#656 ≈ `CardRangePopcount`'s `range_pbits` + #695's walk + an AND.** The only net-new work is
 intersecting ≥2 printing bitmaps and routing the popcount total into the printing path; the
 `Mode::Card`-only `run_query_streamed_popcount` is *not* reused (idea-1's walk is the printing-mode
-pager). This is why landing both #695 and PR 2a first reduces #656 to a small follow-up, if the
+pager). Landing #695 and `CardRangePopcount` first is what reduces #656 to a small follow-up, if the
 range+range gap proves worth closing.
 
 ## Prerequisites & caveats

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -1,8 +1,13 @@
 # Engine: fast path for broad sorted-range predicates, split by unique mode
 
-Status: plan drafted 2026-07-16; PR 1 (printing-mode slice) is up for review as [#695] (open, not
-merged), gated at the 25% veto boundary. Remaining slices (card/artwork planes, existential-plane
-total) and the crossover guard are unstarted. Supersedes the *planning* half of
+Status: plan drafted 2026-07-16. **Shipped:** PR 1 (printing-mode Idea 1, [#695]), PR 2a (`usd`,
+`unique=card`, [#725]), PR 3 (`cn`/`date`, `unique=card`, [#726]) — the card-mode range fast path
+(`CardRangePopcount`) now covers all three range families, and Idea 1 covers bare printing ranges.
+**Remaining:** PR 2b (artwork, archive bump), PR 5 (existential-plane printing-mode total), the
+crossover guard, and the printing-space popcount plan
+([local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md)),
+which is where the compound and existential-printing wins converge. PR 4 was dropped (see *Considered
+and dropped*). Supersedes the *planning* half of
 [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md), which is kept as the
 historical record (the shipped price-exactness prerequisite, and the full account of what PR #689
 tried, muddled, and reverted). This doc restates the plan with what we learned since.

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -287,12 +287,6 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   0.416→0.124 (3.36×), `year<2005` 0.280→0.064 (4.40×); usd unchanged; 0 parity mismatches;
   calibration 88/88 gold. *Compounds still excluded* (bare-leaf gate) — they're the printing-space
   plane's job (compose in printing space, project once).
-- [ ] **PR 4 — compound-query structural pre-checks** (`has_conflicting_range_families`,
-  `contains_range_family_leaf`): skip a `compile_plane` fold that will be discarded, for 2+
-  existential leaves in one `And` and for range leaves under `unique=printing`/`artwork`.
-  *Impacts:* 2+ existential-leaf compounds (`usd<50 f:modern`, `r:rare border:black`); removes
-  narrow-and-discard waste. *Magnitude:* small but broad. *Depends:* 2a's range-family concept.
-  *Risk:* low — pure "skip doomed work."
 - [ ] **PR 2b — global artwork id groundwork + `unique=artwork`.** Land `printing_to_artwork` /
   `artwork_to_card` (build-time enumeration of `(card, local_group)`, persisted, archive format
   bump) — the [#690] analogue for artwork — then extend the plane to artwork space (popcount over
@@ -309,11 +303,37 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   *Risk:* med — independent of the sorted-range PRs.
 
 **Why this order:** PR 1 first keeps the "small, independent, separable" principle — lowest risk,
-printing-only, validates the walk + harness (contingent on Step 0; else swap with 2a). `2a → 3 → 4`
+printing-only, validates the walk + harness (contingent on Step 0; else swap with 2a). `2a → 3`
 is the core value block on the default `unique=card` path in dependency order (2a lays the plane, 3
-reuses it, 4 cleans up the compound waste 2a introduces). `2b` follows 3 so the artwork plane
-inherits all three fields at once. `5` last and gated — real but modest, on a combo not yet
-confirmed hot.
+reuses it). `2b` follows 3 so the artwork plane inherits all three fields at once. `5` last and
+gated — real but modest, on a combo not yet confirmed hot. (PR 4 was dropped — see below.)
+
+### Considered and dropped
+
+- **PR 4 — compound structural pre-checks** (`has_conflicting_range_families` /
+  `contains_range_family_leaf`, to skip a `compile_plane` fold that would be discarded). **Dropped as
+  not worth a PR**, once we looked at what it would actually save (established while sequencing after
+  PR 3 merged):
+  - The `compile_plane`-then-discard it targeted is **cheap**. `compile_plane` only builds a
+    `PlaneExpr` — references into *precomputed* plane indices (`cmp_expr`, `compile_border_cmp`,
+    `compile_rarity_cmp`); no evaluation, no scan (except the narrow oracle-word-bonus arm, which
+    copies a `Bits` slice). The discard happens in `split_planes` for an existential plane
+    (legality/rarity/border) under a shared-witness `And` or a printing/artwork existential leaf, but
+    what's thrown away is a small AST + a few index lookups. Skipping it saves ~nothing.
+  - The range side is cheaper still: `usd`/`cn`/`date` never `compile_plane` (it returns `None` for
+    them); a bare range's whole cost is two `partition_point`s, and the bare-range fast paths (PR 1 /
+    `CardRangePopcount`) are already lazy (printing) or reuse-the-build-on-fallback (card) — no
+    materialize-then-discard to skip.
+  - The *only* O(k) waste that could exist is a **broad range in a compound** scattered into a bitmap
+    (`range_narrowed`'s `broad_ok` branch, ~tens of µs on the smaller/complement side) and then
+    dropped by `narrow_candidates_exact`'s >¾-domain cutoff. But that lives in `narrow_rec`, not
+    `compile_plane`; it's small; and its firing conditions (`broad_ok` threaded true *and* the result
+    exceeding ¾) are unconfirmed.
+
+  So the original bullet conflated a cheap AST discard with a hypothetical O(k) narrow-discard, and
+  neither justifies a PR. Revisit only if a measurement (instrument `range_narrowed` /
+  `narrow_candidates_exact` to count scatter-then-discard events and their µs) turns up real waste —
+  as a standalone "skip doomed `compile_plane`" it's dead.
 
 ### Deferred (explicitly)
 


### PR DESCRIPTION
Docs-only. Brings the engine fast-path design docs up to date now that `CardRangePopcount` (#725/#726) has shipped and #723 (the consolidated printing-space plan doc) has merged.

## `local-engine-printing-plane-popcount-order.md` (the printing-space plan)

Written before `CardRangePopcount` existed, so it framed the card-space range core as future ("planned", "validate on ranges"). Corrected to reality:
- **Status + ship-order step 3:** the card-space groundwork is **shipped** (`CardRangePopcount`, #725 usd / #726 cn/date), not planned.
- **How `must_be_tight` actually landed:** building the exact direct slice ourselves (always tight), *not* a `PrintingRangeBits`/`printing_bits` struct as the doc first guessed. Fixed step 3, step 5, and the #656-assembly table to reference the `range_pbits` the fused build already produces.
- **New "build term, now measured" subsection** in § Cost: the kernel bench pinned the query-time build at ~105 µs on `usd<50` (the dominant term; popcount+walk is only ~40 µs). That quantifies the **#724 lever** — a *precomputed* printing bitplane deletes the build, taking `usd`/card from ~0.143 ms toward the ~0.06 ms plane floor. So "persist the bitplane" is now a measured win, not a hunch.

## `local-engine-sorted-range-fastpath.md`

- **Refreshed the stale Status line** — it still said "PR 1 up for review as #695 (open, not merged)… remaining slices unstarted." PR 1/2a/3 are all merged.
- **Dropped PR 4** from the PR-order list and moved it to a new **"Considered and dropped"** section with the reasoning: the `compile_plane`-then-discard it targeted is cheap (an AST of precomputed-index references, no eval), usd/cn/date never `compile_plane`, and the only O(k) candidate (a broad-range scatter-then-discard) lives in `narrow_rec`, is small, and is unconfirmed. Revisit only if measurement shows real waste.

No code changes.

## Conceptual correction: printing-space bitplanes are *exact*, not existential

Retitled the #724 doc (`Printing-Space Bitplanes`, dropping "existential") and reworked its "What":

- A printing-space plane is **bit-per-printing exact** — the bit means *that printing* satisfies. "Existential" describes the *card-space* projection it replaces (`∃ printing`), which is a card-space artifact, not a property of the attribute.
- So **AND/OR/NOT compose exactly in printing space**; the composed result either answers `unique=printing` directly or projects **once** to card/artwork. The #667 divergent-carveout complexity vanishes in printing space.
- Plan-doc cost section: **projection is bidirectional** (`card→printing` broadcast is exact; `printing→card` is the one deferred `∃`), so **which space to compose in is a per-query cost choice** the router makes — neither order dominates. The only hard constraint is correctness: **2+ printing-varying leaves must compose in printing space** first, then project once.

(Filename slug still says `existential`; left as-is to avoid breaking links — the H1/content are corrected.)
