### PR TITLE
Printing-Space Bitplanes (#724): Border Slice (Popcount + Walk, 20×)

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -223,7 +223,10 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
 
     match plan {
-        PhysicalPlan::PrintingRangeScan => {
+        // Both printing bare-leaf fast paths walk `walk_printing_page` (page cost ∝ how far the walk
+        // goes to fill the page at `match_rate`); the border total is a popcount/postings-len rather
+        // than a range `k`, but the paging cost — the only cost either carries — is identical.
+        PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan => {
             let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
             (page_span / match_rate) * RANGE_WALK_STEP_NS + RANGE_FIXED_COST_NS
         }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2273,6 +2273,7 @@ struct CardIndexes {
     // see docs/issues/00690-engine-direct-projection-arrays.md.
     printing_to_card: Vec<u32>,
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
+    border_printing: BorderPrintingPlanes,     // printing space: exact bit-per-printing border (#724)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
 }
@@ -2302,6 +2303,7 @@ impl Default for CardIndexes {
             artwork_groups: Vec::new(),
             printing_to_card: Vec::new(),
             planes:         BitPlanes::default(),
+            border_printing: BorderPrintingPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
         }
@@ -5409,7 +5411,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260720;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260721;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -5812,6 +5814,7 @@ impl QueryEngine {
             artwork_groups: artwork_group_counts,
             printing_to_card: build_printing_to_card(&offsets),
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
+            border_printing: build_border_printing_planes(&printings, &strings),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
         };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3881,6 +3881,11 @@ static PRINTING_RANGE_FASTPATH: LazyLock<usize> = LazyLock::new(|| guard_env("CA
 /// queries exactly as before (the general candidate path), `1` (default) enables `CardRangePopcount`.
 static RANGE_BITS_CARD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_RANGE_BITS_CARD", 1));
 
+/// #724 printing-space border-plane fast path (`PrintingPlaneScan`). Binary A/B kill-switch, same
+/// kind as `PRINTING_RANGE_FASTPATH`: `0` routes `border:VALUE`/printing as before (general path),
+/// `1` (default) uses the plane `popcount`/postings total + the printing walk.
+static BORDER_PRINTING_PLANE: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_BORDER_PRINTING_PLANE", 1));
+
 /// The range index and half-open `[lo, hi)` a *bare* range-predicate leaf selects, or None for
 /// anything else (compound, `Ne`, a non-range numeric field). Provably-empty predicates return a
 /// zero-width `[v, v)` so the fastpath's `k` resolves to 0. Reuses the exact bound derivations the
@@ -4156,6 +4161,54 @@ fn printing_range_fastpath<'a>(
     Some((k, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
 }
 
+/// The exact `unique=printing` total for a bare `border:VALUE` leaf, from the #724 printing planes:
+/// `popcount` of the value's plane (black/borderless/white), or its postings length (gold/yellow/
+/// untracked). `None` for anything that isn't a bare `border ==` leaf, or an unknown border value.
+/// This replaces the O(n) count pass — the whole cost of `border:black`/printing today.
+fn border_printing_total(filter: &FilterExpr, bp: &Archived<BorderPrintingPlanes>) -> Option<usize> {
+    let FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } = filter else {
+        return None;
+    };
+    let wpp = words_per_plane(u32::from(bp.n_printings) as usize);
+    if let Some(k) = BORDER_PRINTING_PLANE_VALUES.iter().position(|&v| v == value.as_str()) {
+        return Some(bp.words[k * wpp..(k + 1) * wpp].iter().map(|w| u64::from(*w).count_ones() as usize).sum());
+    }
+    bp.postings.iter().find(|e| e.0.as_str() == value.as_str()).map(|e| e.1.len())
+}
+
+/// `unique=printing` fast path for a bare `border:VALUE` leaf — the plane analogue of
+/// `printing_range_fastpath`: `total` is the plane `popcount`/postings length (no count pass), and
+/// the page is the same `walk_printing_page` (its residual test already handles the border compare,
+/// and early-stops). Returns `None` (declines) for a non-border leaf, an unknown value, or a total
+/// at/below the stream threshold — where the general path gathers/orders differently (same guard as
+/// `printing_range_fastpath`; a genuinely sparse value like `yellow` falls through here).
+#[allow(clippy::too_many_arguments)]
+fn printing_border_fastpath<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    let total = border_printing_total(filter, &indexes.border_printing)?;
+    if total == 0 || page_offset >= total {
+        return Some((total, Vec::new()));
+    }
+    if total <= *STREAM_MIN_MATCHES {
+        return None; // sparse: the general path gathers + globally sorts, ordering ties differently
+    }
+    let perm = indexes.sort_perms.get(sort_col, descending)?;
+    if perm.len() != cards.len() {
+        return None;
+    }
+    Some((total, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
+}
+
 /// The physical plans the cost router (`run_query_routed`) chooses among. Each
 /// carries three declared properties — `applicable` (its correctness precondition),
 /// `cost::plan_cost` (its predicted runtime), and an executor — so the router is a
@@ -4166,8 +4219,11 @@ fn printing_range_fastpath<'a>(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PhysicalPlan {
     /// #695 bare-broad-range fast path under `unique=printing` (executor:
-    /// `printing_range_fastpath`). The one non-materializing plan.
+    /// `printing_range_fastpath`). Non-materializing.
     PrintingRangeScan,
+    /// #724 bare border leaf under `unique=printing`: total from the printing border plane's
+    /// `popcount`/postings, page from the same walk (`printing_border_fastpath`). Non-materializing.
+    PrintingPlaneScan,
     /// #634 Step 2 plane-bitmap popcount-skip order phase (`run_query_streamed_popcount`).
     PlanePopcountOrder,
     /// PR 2a card-space idea 2: a bare `usd` range under `unique=card`, answered as the same
@@ -4182,8 +4238,9 @@ enum PhysicalPlan {
 impl PhysicalPlan {
     /// All plans, argmin-ordered so ties resolve deterministically toward the
     /// cheaper-fixed-cost plan. The router filters this by `applicable`.
-    const ALL: [PhysicalPlan; 5] = [
+    const ALL: [PhysicalPlan; 6] = [
         PhysicalPlan::PrintingRangeScan,
+        PhysicalPlan::PrintingPlaneScan,
         PhysicalPlan::PlanePopcountOrder,
         PhysicalPlan::CardRangePopcount,
         PhysicalPlan::StreamedSelect,
@@ -4211,6 +4268,10 @@ impl PhysicalPlan {
             PhysicalPlan::PrintingRangeScan => {
                 printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
             }
+            PhysicalPlan::PrintingPlaneScan => {
+                printing_plane_scan_applicable(mode, plane, cards)
+                    && border_printing_total(filter, &indexes.border_printing).is_some()
+            }
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
@@ -4223,12 +4284,13 @@ impl PhysicalPlan {
     }
 
     /// Whether the plan runs off the shared materialized prep (plane bitmap /
-    /// candidate list) — true for all but `PrintingRangeScan`, whose whole benefit
-    /// is answering *without* materializing. The router costs non-materializing
-    /// plans from a cheap estimate first (phase 1) and only materializes (phase 2)
-    /// when a materializing plan wins or the non-materializing one declines.
+    /// candidate list) — true for all but the printing bare-leaf fast paths
+    /// (`PrintingRangeScan`/`PrintingPlaneScan`), whose whole benefit is answering
+    /// *without* materializing. The router costs non-materializing plans from a
+    /// cheap estimate first (phase 1) and only materializes (phase 2) when a
+    /// materializing plan wins or the non-materializing one declines.
     fn materializing(self) -> bool {
-        !matches!(self, PhysicalPlan::PrintingRangeScan)
+        !matches!(self, PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan)
     }
 }
 
@@ -4329,6 +4391,13 @@ fn plane_popcount_order_applicable(
 /// `None` for anything it doesn't own).
 fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: &[AOracleCard]) -> bool {
     *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
+}
+
+/// `PrintingPlaneScan` structural eligibility (#724): `unique=printing`, no plane, non-empty store,
+/// flag on. The border-leaf check (`border_printing_total().is_some()`) is applied on top by the
+/// plan's `applicable` arm; `printing_border_fastpath` makes the final accept/decline.
+fn printing_plane_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: &[AOracleCard]) -> bool {
+    *BORDER_PRINTING_PLANE != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
 }
 
 /// `CardRangePopcount` needs `Mode::Card`, a **bare** range leaf as the whole filter — usd/cn/date,
@@ -4870,6 +4939,11 @@ fn run_query_routed<'a>(
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         (mk_feats(k, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
+    } else if PhysicalPlan::PrintingPlaneScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Bare border leaf: exact total from the #724 printing plane popcount / postings len (no
+        // count pass, no materialization). P3/P4 estimated unnarrowed, same as PrintingRangeScan.
+        let total = border_printing_total(filter, &indexes.border_printing).expect("applicable ⇒ border leaf") as u32;
+        (mk_feats(total, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
     } else {
         let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
         (candidate_feats(&prep, filter), Prep::Candidates(prep))
@@ -4911,14 +4985,20 @@ fn run_query_routed<'a>(
             p, cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
         (plan, Prep::Range) => {
-            // P1 walks if it won and its fastpath accepts. Otherwise (a materializing
-            // plan won the estimate, or P1's fastpath declined — rare, since cost
-            // seldom picks P1 when narrow) materialize now and run the best
-            // materializing plan on EXACT features.
-            let p1_page = (plan == PhysicalPlan::PrintingRangeScan)
-                .then(|| printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset))
-                .flatten();
-            match p1_page {
+            // A printing bare-leaf fast path walks if it won and its fastpath accepts. Otherwise (a
+            // materializing plan won the estimate, or the fastpath declined — rare, since cost seldom
+            // picks these when narrow) materialize now and run the best materializing plan on EXACT
+            // features. `Prep::Range` is shared by the range (#695) and border (#724) fast paths.
+            let fast_page = match plan {
+                PhysicalPlan::PrintingRangeScan => {
+                    printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+                }
+                PhysicalPlan::PrintingPlaneScan => {
+                    printing_border_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+                }
+                _ => None,
+            };
+            match fast_page {
                 Some(page) => page,
                 None => {
                     let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
@@ -4972,6 +5052,12 @@ fn run_query_with_plan<'a>(
             }
             // Structural eligibility passed; the fastpath itself decides (None = declined).
             printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+        }
+        PhysicalPlan::PrintingPlaneScan => {
+            if !printing_plane_scan_applicable(mode, plane, cards) {
+                return None;
+            }
+            printing_border_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
         }
         PhysicalPlan::PlanePopcountOrder => {
             if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -427,6 +427,11 @@ pub(crate) struct BorderPrintingPlanes {
     /// `BORDER_PRINTING_PLANE_VALUES.len()` planes, plane-major: bit `p` of plane `k` is
     /// `words[k * words_per_plane(n_printings) + p/64] >> (p%64) & 1`.
     pub(crate) words: Vec<u64>,
+    /// Sparse border values below the plane crossover (gold/yellow + any untracked) → ascending
+    /// printing ids. Scattered into a bitmap at query time — the sparse analogue of a range index
+    /// slice — then fed the *same* popcount+walk as the planes, so every known border value gets the
+    /// exact fast path. Empty for planed and NULL borders.
+    pub(crate) postings: Vec<(String, Vec<u32>)>,
 }
 
 /// Build the #724 printing-space border planes: one pass over printings, setting each planed value's
@@ -436,13 +441,15 @@ pub(crate) fn build_border_printing_planes(printings: &[Printing], strings: &[St
     let n = printings.len();
     let wpp = words_per_plane(n);
     let mut words = vec![0u64; BORDER_PRINTING_PLANE_VALUES.len() * wpp];
+    let mut postings: std::collections::BTreeMap<&str, Vec<u32>> = std::collections::BTreeMap::new();
     for (p, printing) in printings.iter().enumerate() {
         if printing.card_border_id == NONE_STR {
             continue;
         }
         let s = strings[printing.card_border_id as usize].as_str();
-        if let Some(k) = BORDER_PRINTING_PLANE_VALUES.iter().position(|&v| v == s) {
-            words[k * wpp + p / 64] |= 1u64 << (p % 64);
+        match BORDER_PRINTING_PLANE_VALUES.iter().position(|&v| v == s) {
+            Some(k) => words[k * wpp + p / 64] |= 1u64 << (p % 64), // planed value → its one-hot plane
+            None => postings.entry(s).or_default().push(p as u32),  // sparse value → postings (ascending p)
         }
     }
     // Drift check (see #724): a planed value should stay dense enough to earn a plane — postings win
@@ -460,7 +467,8 @@ pub(crate) fn build_border_printing_planes(printings: &[Printing], strings: &[St
             );
         }
     }
-    BorderPrintingPlanes { n_printings: n as u32, words }
+    let postings = postings.into_iter().map(|(v, ids)| (v.to_string(), ids)).collect();
+    BorderPrintingPlanes { n_printings: n as u32, words, postings }
 }
 
 /// Ascending card ids with divergent legality (~556 of 31,508 in production —

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -167,6 +167,14 @@ pub(crate) const PLANE_BORDER_OTHER: usize = PLANE_BORDER + BORDER_TRACKED;
 
 pub(crate) const PLANE_COUNT: usize = PLANE_BORDER + BORDER_PLANES;
 
+/// #724: which border values get a *printing-space* one-hot plane (bit per printing, exact). The
+/// density-chosen broad head only — distinct from #664's card-space `BORDER_TRACKED_VALUES`, which
+/// also tracks `gold`: gold (1,238 printings) is below the printing-space plane/postings crossover
+/// (~3,000 = plane bytes / 4 per posting), so it — and sparser `yellow` — stay on the existing
+/// card-space path until they earn postings (a follow-on); negation is `complement`, which covers
+/// them regardless. See docs/issues/00724-engine-printing-existential-planes.md.
+pub(crate) const BORDER_PRINTING_PLANE_VALUES: [&str; 3] = ["black", "borderless", "white"];
+
 /// The observed [min,max] of whatever cards landed in one bucket plane,
 /// recomputed on every build/reload (never hardcoded from a one-time data
 /// snapshot — a future card outside today's observed range must still
@@ -405,6 +413,54 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
         );
     }
     BitPlanes { n_cards: cards.len() as u32, words, cmc_hi, power_lo, power_hi, toughness_lo, toughness_hi }
+}
+
+/// #724: printing-space border planes — bit per printing, **exact** (unlike #664's card-space
+/// *existential* border plane, whose card bit only means "some printing has this border"). One
+/// one-hot plane per `BORDER_PRINTING_PLANE_VALUES` entry, plane-major, `words_per_plane(n_printings)`
+/// each; printing `p`'s bit is set iff that printing's border is the value. Negation is `complement`
+/// (each printing is or isn't the value — no "other" plane needed). Consumed by the printing-space
+/// popcount-order plan; project up via `printing_bits_to_card_bits` for card/artwork modes.
+#[derive(Archive, Serialize, Deserialize, Default)]
+pub(crate) struct BorderPrintingPlanes {
+    pub(crate) n_printings: u32,
+    /// `BORDER_PRINTING_PLANE_VALUES.len()` planes, plane-major: bit `p` of plane `k` is
+    /// `words[k * words_per_plane(n_printings) + p/64] >> (p%64) & 1`.
+    pub(crate) words: Vec<u64>,
+}
+
+/// Build the #724 printing-space border planes: one pass over printings, setting each planed value's
+/// bit. A `debug_assert` flags density drift — a planed value below the ~3k plane/postings crossover
+/// (it should have been reclassified to postings; see the doc's "fixed plane set + drift-assert").
+pub(crate) fn build_border_printing_planes(printings: &[Printing], strings: &[String]) -> BorderPrintingPlanes {
+    let n = printings.len();
+    let wpp = words_per_plane(n);
+    let mut words = vec![0u64; BORDER_PRINTING_PLANE_VALUES.len() * wpp];
+    for (p, printing) in printings.iter().enumerate() {
+        if printing.card_border_id == NONE_STR {
+            continue;
+        }
+        let s = strings[printing.card_border_id as usize].as_str();
+        if let Some(k) = BORDER_PRINTING_PLANE_VALUES.iter().position(|&v| v == s) {
+            words[k * wpp + p / 64] |= 1u64 << (p % 64);
+        }
+    }
+    // Drift check (see #724): a planed value should stay dense enough to earn a plane — postings win
+    // below ~3,000 printings (plane bytes / 4 per posting). If one drops below, reclassify it.
+    // Only meaningful at production scale: in a small store a "tracked" value is legitimately sparse,
+    // so gate on a corpus large enough that a genuinely-broad value must clear the crossover.
+    const PLANE_POSTINGS_CROSSOVER: usize = 3_000;
+    const DRIFT_CHECK_MIN_PRINTINGS: usize = 50_000;
+    if n >= DRIFT_CHECK_MIN_PRINTINGS {
+        for (k, value) in BORDER_PRINTING_PLANE_VALUES.iter().enumerate() {
+            let popcount: usize = words[k * wpp..(k + 1) * wpp].iter().map(|w| w.count_ones() as usize).sum();
+            debug_assert!(
+                popcount == 0 || popcount >= PLANE_POSTINGS_CROSSOVER,
+                "border printing plane '{value}' has {popcount} printings, below the ~{PLANE_POSTINGS_CROSSOVER} plane/postings crossover — reclassify to postings (#724)",
+            );
+        }
+    }
+    BorderPrintingPlanes { n_printings: n as u32, words }
 }
 
 /// Ascending card ids with divergent legality (~556 of 31,508 in production —

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    assign_artwork_groups, build_bit_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
+    assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
@@ -4468,6 +4468,7 @@ fn bench_checked_vs_unchecked_access() {
         artwork_groups,
         printing_to_card: build_printing_to_card(&offsets),
         planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
+        border_printing: build_border_printing_planes(&printings, &strings),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
     };
@@ -7957,6 +7958,42 @@ fn border_plane_query_kernel() {
     println!("  matching printings: {matches}");
     println!("  popcount + edhrec walk to fill {LIMIT}: {best} ns   (checksum total={sink})");
     println!("  today's per-printing scan (bench_printing_planes): ~869,000 ns");
+}
+
+/// #724 build-side correctness oracle: projecting a printing-space border plane up to card-existence
+/// (`printing_bits_to_card_bits`) must equal #664's card-space border plane for the same value —
+/// both mean "this card has a printing with border=value" (existence projection). Diffed for the
+/// three shared tracked values (black/borderless/white, same plane-index order). Needs a
+/// freshly-built real.store (new archive format). `cargo test --release
+/// border_printing_plane_matches_card_plane_projected -- --ignored --nocapture`
+#[test]
+#[ignore = "#724 border-plane oracle diff; needs a freshly-built real.store"]
+fn border_printing_plane_matches_card_plane_projected() {
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (rebuild after the #724 build-side change)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild for the bumped ARCHIVE_FORMAT_VERSION");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let bp = &archived.indexes.border_printing; // printing-space (#724)
+    let cp = &archived.indexes.planes; // card-space (#664)
+    let wpp_p = super::words_per_plane(n_printings);
+    let wpp_c = super::words_per_plane(n_cards);
+    for (k, value) in super::BORDER_PRINTING_PLANE_VALUES.iter().enumerate() {
+        let printing_bits: Vec<u64> = bp.words[k * wpp_p..(k + 1) * wpp_p].iter().map(|w| u64::from(*w)).collect();
+        let projected = super::printing_bits_to_card_bits(&printing_bits, &archived.offsets, n_cards);
+        let start = (super::PLANE_BORDER + k) * wpp_c;
+        let card_bits: Vec<u64> = cp.words[start..start + wpp_c].iter().map(|w| u64::from(*w)).collect();
+        assert_eq!(projected, card_bits, "border '{value}' (plane {k}): projected-up printing plane != #664 card plane");
+    }
+    eprintln!("OK: {} border printing planes project up to match #664's card planes", super::BORDER_PRINTING_PLANE_VALUES.len());
 }
 
 /// PR 2a build-cost split: for `usd<50`, which half of `CardRangePopcount`'s build dominates —

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7885,6 +7885,80 @@ fn bare_range_bounds_recognizes_leaves_and_rejects_rest() {
     assert!(bounds(&cmc_lt).is_none());
 }
 
+/// #724 de-risk: does `popcount` + a printing walk over a *precomputed* border plane beat today's
+/// per-printing scan for `border:black`/printing (~0.87 ms)? A precomputed plane has no per-query
+/// build (unlike CardRangePopcount's ~105µs), so this should land near #634's ~0.06 ms bare-plane
+/// popcount. Builds the border:black printing bitmap once (simulating the persisted plane), then
+/// times `popcount` (the total) + an edhrec-perm membership walk (the page).
+/// `cargo test --release border_plane_query_kernel -- --ignored --nocapture`
+#[test]
+#[ignore = "#724 border-plane query kernel; needs real.store"]
+fn border_plane_query_kernel() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 30;
+    const ITERS: usize = 300;
+    const LIMIT: usize = 100;
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see bench_verify_cost.rs docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale — rebuild)");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_printings = archived.printings.len();
+    let strings = &archived.strings;
+    let offsets = &archived.offsets;
+
+    // Build the border:black printing bitmap once — simulates the persisted #724 plane (no per-query build).
+    let mut plane = vec![0u64; n_printings.div_ceil(64)];
+    for (pid, p) in archived.printings.iter().enumerate() {
+        if super::str_at(strings, u32::from(p.card_border_id)) == Some("black") {
+            plane[pid >> 6] |= 1u64 << (pid & 63);
+        }
+    }
+    let matches: usize = plane.iter().map(|w| w.count_ones() as usize).sum();
+    let perm = archived.indexes.sort_perms.get(SortCol::EdhrecRank, false).expect("edhrec perm");
+
+    let mut best = u128::MAX;
+    let mut sink = 0usize;
+    for it in 0..(WARMUP + ITERS) {
+        let t0 = Instant::now();
+        // total = popcount (replaces the O(n) count pass)
+        let total: usize = plane.iter().map(|w| w.count_ones() as usize).sum();
+        // page = walk cards in edhrec order, expand to printings, test the plane bit, early-stop
+        let mut page: Vec<u32> = Vec::with_capacity(LIMIT);
+        'walk: for c in perm.iter() {
+            let cid = u32::from(*c) as usize;
+            let start = u32::from(offsets[cid]) as usize;
+            let end = u32::from(offsets[cid + 1]) as usize;
+            for pid in start..end {
+                if (plane[pid >> 6] >> (pid & 63)) & 1 == 1 {
+                    page.push(pid as u32);
+                    if page.len() == LIMIT {
+                        break 'walk;
+                    }
+                }
+            }
+        }
+        black_box(&page);
+        sink = total;
+        let dt = t0.elapsed().as_nanos();
+        if it >= WARMUP {
+            best = best.min(dt);
+        }
+    }
+    println!("\nborder:black/printing via a PRECOMPUTED plane (real.store):");
+    println!("  matching printings: {matches}");
+    println!("  popcount + edhrec walk to fill {LIMIT}: {best} ns   (checksum total={sink})");
+    println!("  today's per-printing scan (bench_printing_planes): ~869,000 ns");
+}
+
 /// PR 2a build-cost split: for `usd<50`, which half of `CardRangePopcount`'s build dominates —
 /// scattering the price slice into a printing bitmap, or projecting that to a card-existence bitmap
 /// — and does building the card bitmap *directly* (`printing_to_card[pid]`, one pass, skipping the

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2342,6 +2342,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
     data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    data.indexes.border_printing = build_border_printing_planes(&data.printings, &data.strings);
     data
 }
 
@@ -2740,6 +2741,9 @@ fn force_plan_differential_agreement() {
         // above already exercise it; add collector_number + year over card-level perms too).
         (FuzzSpec::Leaf(FuzzLeaf::CollectorNumber { op: CmpOp::Lt, val: 100.0 }), "edhrec", "asc"),
         (FuzzSpec::Leaf(FuzzLeaf::Year { op: CmpOp::Ge, year: 2015 }), "edhrec", "desc"),
+        // #724: a bare border leaf routes through PrintingPlaneScan in printing mode (black is ~1/6
+        // of printings, above STREAM_MIN in this corpus → the walk; agreement vs GatheredScan checked).
+        (FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }), "edhrec", "asc"),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -2750,6 +2754,7 @@ fn force_plan_differential_agreement() {
     let modes = ["card", "printing", "artwork"];
     let all_plans = [
         PhysicalPlan::PrintingRangeScan,
+        PhysicalPlan::PrintingPlaneScan,
         PhysicalPlan::PlanePopcountOrder,
         PhysicalPlan::CardRangePopcount,
         PhysicalPlan::StreamedSelect,
@@ -2757,12 +2762,13 @@ fn force_plan_differential_agreement() {
     ];
     let plan_idx = |p: PhysicalPlan| match p {
         PhysicalPlan::PrintingRangeScan => 0,
-        PhysicalPlan::PlanePopcountOrder => 1,
-        PhysicalPlan::CardRangePopcount => 2,
-        PhysicalPlan::StreamedSelect => 3,
-        PhysicalPlan::GatheredScan => 4,
+        PhysicalPlan::PrintingPlaneScan => 1,
+        PhysicalPlan::PlanePopcountOrder => 2,
+        PhysicalPlan::CardRangePopcount => 3,
+        PhysicalPlan::StreamedSelect => 4,
+        PhysicalPlan::GatheredScan => 5,
     };
-    let mut ran = [0u32; 5];
+    let mut ran = [0u32; 6];
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
@@ -3336,7 +3342,7 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (matches / f64::from(f.n_printings)).max(1.0e-6);
     match plan {
-        PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
+        PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan => (vec![page_span / match_rate, 1.0], 0.0),
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
         // Same term vector as P2; the build term is a fixed (hand-set) offset, not a refit param.
         PhysicalPlan::CardRangePopcount => (

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -134,6 +134,44 @@ Per-value density crossover — the same one [#713](00713-is-tag-recovery.md) bu
 printings legal) → plane; a rarely-legal format → postings. Not "a plane per value" — the crossover
 applied per value, overlapping #713's printing-varying categorical work.
 
+## Border: the first slice (concrete design)
+
+Border is the first slice: the biggest bare win (`border:black`/printing 0.87 ms → µs), genuinely
+per-printing (no card-level shortcut, unlike legality), a small closed value set, and #664's
+card-space border plane is there as a correctness oracle to diff against.
+
+**A plane, not a divergent-bit carveout.** We *could* copy legality's trick — a card-level border +
+a "divergent" bit, per-printing only for divergent cards. But border is **16.3% divergent** (vs
+legality's 0%, measured), so the carveout would settle only ~84% of cards at card level and still
+scan the divergent 16% per-printing — a partial win, capped exactly where border is hard, and
+bare-only (no per-printing bits for compounds). The printing plane gives the full win regardless of
+divergence.
+
+**Representation — density-chosen, no "other" plane.** Per-value by the storage crossover (a plane is
+a fixed ~12 KB = 1 bit × n_printings; postings are 4 B/printing, so postings win below ~3,000):
+
+| value | printings | rep |
+|---|---:|---|
+| `black` | 85,046 | plane |
+| `borderless` | 5,701 | plane (just above the line — confirm vs query cost) |
+| `white` | 5,131 | plane (ditto) |
+| `gold` | 1,238 | **postings** (below crossover; and for a positive sparse query the postings list *is* the answer) |
+| `yellow` | 90 | **postings** |
+
+- **No "other" plane.** It was a *card-space existence* artifact: card-mode `-border:black` means
+  "∃ a non-black printing," which `complement(∃black)` gets wrong, so #664 needed an `∃`-untracked
+  term. In **printing space, negation is plain `complement`** (each printing is or isn't black) —
+  exact, no "other." This is even *more* exact than #664: `-border:yellow` (which #664 declines) is
+  just `complement(yellow postings)`.
+- **Fixed plane set, dynamic postings, drift-assert.** The *decision* of which values get planes is
+  hardcoded (`black`/`borderless`/`white`), chosen from measurement — a **dynamic** per-reload
+  decision would make the archive layout data-dependent (variable plane count/indices, a runtime
+  "which values are planed" map for every consumer, non-deterministic across stores) for a decision
+  that essentially never changes, since the distribution is stable. The *postings* side is already
+  dynamic (post whatever non-planed values exist, so a new border color lands in postings with no
+  code change). A build-time assertion flags drift — a planed value shrinking below ~3k or a posted
+  value growing above — so "re-measure and update the constant" surfaces as a failing check.
+
 ## Correctness surface (validated in isolation)
 
 The existential projection: a card can satisfy *both* `∃ legal` and `∃ not-legal` at once (its

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -115,6 +115,30 @@ min ms):
 | `border:black r:rare` | card | 0.316 | card compound (substrate) |
 | `border:black` | artwork | 0.905 | slow — needs PR 2b |
 
+## Result: border slice measured (this PR)
+
+`PrintingPlaneScan` (popcount + reused printing walk) shipped for the bare border/printing case.
+A/B on the same 97,206-printing corpus (`CARD_ENGINE_BORDER_PRINTING_PLANE=0` vs `=1`, min µs, totals
+identical between arms so row identity is preserved):
+
+| query | mode | off µs | on µs | speedup | rows |
+|---|---|---:|---:|---:|---:|
+| `border:black` | printing | 884 | 44 | **20.2×** | 85,046 |
+| `border:borderless` | printing | 222 | 47 | **4.8×** | 5,701 |
+| `f:modern` | printing | 192 | 190 | 1.0× | 73,783 |
+| `f:commander` | printing | 223 | 219 | 1.0× | 96,898 |
+| `r:rare` | printing | 365 | 358 | 1.0× | 36,764 |
+| `border:black r:rare` | printing | 610 | 627 | 1.0× | 31,879 |
+| `f:modern border:black` | printing | 744 | 749 | 1.0× | 65,507 |
+| `border:black` | card | 64 | 64 | 1.0× | 31,169 |
+| `border:black` | artwork | 904 | 929 | 1.0× | 40,956 |
+
+Only the bare-border planed values (`black`, `borderless`) move — the plane is a fixed ~36.5 KB
+(3 planes × ⌈97,206/64⌉ words × 8 B) on top of the archive. Everything else is flat within noise:
+the plan is gated to bare border under `unique=printing`, so no other query path can change (that
+gating *is* the no-regression guarantee, and the flat rows confirm it). Compounds and the card/artwork
+projections are the next slices (the printing-space plan + PR 2b), not this PR.
+
 The load-bearing finding: **legality is ~4× cheaper than border in printing mode at the same
 breadth, because legality settles at the *card* level** (`printing_dependent(Legality) => false`,
 [filter.rs](../../card_engine/src/filter.rs)) — it evaluates once per card (~31.5k) and emits all of

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -98,6 +98,35 @@ So the split is: **#724 delivers bare printing-mode queries standalone** (popcou
 compound pager (#656). #724 is no longer "sequenced last, inert" — it's a near-term win that is *also*
 the substrate for the rest.
 
+## Step-0 measurement: border/rarity are the real targets, not legality
+
+Measured on the current build (no #724; `scripts/bench_printing_planes.py`, 97,206-printing corpus,
+min ms):
+
+| query | mode | min ms | note |
+|---|---|---:|---|
+| `border:black` | printing | 0.869 | the standout bare target |
+| `r:rare` | printing | 0.360 | moderate bare target |
+| `f:modern` | printing | 0.190 | already cheap |
+| `f:commander` (97k) | printing | 0.216 | already cheap despite broad |
+| `f:modern border:black` | printing | 0.741 | compound (substrate) |
+| `border:black r:rare` | printing | 0.608 | compound (substrate) |
+| `border:black` | card | 0.064 | already fast (#667+#634) — *not* a target |
+| `border:black r:rare` | card | 0.316 | card compound (substrate) |
+| `border:black` | artwork | 0.905 | slow — needs PR 2b |
+
+The load-bearing finding: **legality is ~4× cheaper than border in printing mode at the same
+breadth, because legality settles at the *card* level** (`printing_dependent(Legality) => false`,
+[filter.rs](../../card_engine/src/filter.rs)) — it evaluates once per card (~31.5k) and emits all of
+a matching card's printings, dropping to per-printing only for the rare divergent-legality cards.
+**Border and rarity are genuinely per-printing** (`TextField::Border => StrVal::PDep`), so they
+evaluate per printing (~97k) — that scan is the cost.
+
+So #724's *bare*-query win is concentrated on **border and rarity** (per-printing, no card-level
+shortcut); bare legality is already fine. **Start with border** (biggest bare win, `Eq`-only, #664's
+card-space border plane to diff against). Legality's #724 value is for **compounds** (AND'd with
+border/rarity in printing space) and the divergent carveout — lower priority.
+
 ## Which values get a plane
 
 Per-value density crossover — the same one [#713](00713-is-tag-recovery.md) bucket-C uses:

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -30,6 +30,36 @@ A **printing-space** plane is the opposite: one bit per printing, set iff *that 
 
 They also give the total as a `popcount` (O(words), density-independent) and O(1) membership tests.
 
+## Composing a mixed query: two exact strategies (the planner picks by cost)
+
+Take `pX pY cZ` — two printing-varying leaves (`pX`, `pY`: legality/border/rarity, or a range) and
+one card-invariant leaf (`cZ`: color/type). Under `unique=card` the answer is `{card : ∃p, pX(p) ∧
+pY(p) ∧ cZ(card)}`. Because these planes are **exact**, there are two exact ways to evaluate it,
+differing only in cost:
+
+- **A — everything in printing space, project once.** Broadcast `cZ` **down** to printing space
+  (exact — `cZ` is identical across a card's printings), `AND` all three printing bitmaps, then
+  project the survivors to the answer space (card `∃`, or artwork; nothing for `unique=printing`).
+- **B — compose the printing leaves, project up, finish in card space.** `AND` `pX pY` in printing
+  space first — **every surviving bit is, by construction, one printing satisfying both**, so the
+  shared-witness problem is resolved *right there* (a set bit *is* the shared witness). Project that
+  result **up** to card-existence (one `∃`), then `AND` with the `cZ` card plane in card space.
+
+Both are exact. B stays exact because the *only* multi-printing-varying composition (`pX ∧ pY`)
+happens in printing space **before** any projection, and ANDing the projected result with a
+card-invariant plane can't reintroduce shared-witness (`cZ` is constant over a card's printings). The
+load-bearing rule both obey: **two printing-varying leaves must be `AND`'d in printing space** — a
+card-space existence-AND of two separately-`∃`-projected leaves false-positives (a card with a
+`pX` printing and a *separate* `pY` printing).
+
+Where they differ is pure cost: A does the `cZ` step in printing-space words (~1,519) after a
+broadcast; B does it in card-space words (~492) after projecting `pX ∧ pY` up (cheap when that set is
+selective). Neither dominates — so **which strategy runs is a planner cost decision**, the same
+`argmin` that chooses among plans (whether these surface as distinct `PhysicalPlan`s or as one plan
+that costs its projection order internally is an implementation choice). `unique=printing` skips the
+up-projection entirely; `unique=artwork` projects to artwork ids. The exactness of the planes is what
+makes the choice purely about cost rather than correctness.
+
 ## Why — and why there is no benefit yet
 
 These are **prerequisite infrastructure** for the printing-space popcount-order plan, which is where
@@ -61,6 +91,15 @@ query-time correctness so a failure localizes to one side.
 ## Cost
 
 Build-time computation + storage + an **archive-format bump**.
+
+## Subsumes the count-only "PR 5" idea
+
+The sorted-range roadmap's PR 5 ("printing-mode total for legality/rarity/border") is a precomputed
+*scalar* per-value count that answers only a **bare** query's total (`border:black`/printing →
+lookup a number). A printing bitplane's `popcount` **is** that count — plus composition (AND/OR),
+membership, and paging. So #724 subsumes PR 5. PR 5 is worth building standalone only as a *cheaper
+pre-#724 shortcut* (a count table, no per-printing bits, no archive bump) if the bare printing-mode
+total turns out hot before these planes land.
 
 ## Related
 

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -1,8 +1,10 @@
 # Engine: Printing-Space Bitplanes (Legality / Border / Rarity, Bit-per-Printing)
 
-Status: todo, filed as [#724](https://github.com/jbylund/sylvan_librarian/issues/724). Sequenced
-**last**, behind the [printing-space popcount-order plan](local-engine-printing-plane-popcount-order.md)
-that consumes them (see that doc's ship-order step 7).
+Status: todo, filed as [#724](https://github.com/jbylund/sylvan_librarian/issues/724). **Not deferred
+infrastructure** — it ships a standalone win (bare printing-mode plane queries via `popcount` + a
+reused page walk, ~3×) *and* is the substrate the
+[printing-space popcount-order plan](local-engine-printing-plane-popcount-order.md) needs for
+compounds. See "The standalone win" below.
 
 ## What — exact, not existential
 
@@ -60,18 +62,41 @@ that costs its projection order internally is an implementation choice). `unique
 up-projection entirely; `unique=artwork` projects to artwork ids. The exactness of the planes is what
 makes the choice purely about cost rather than correctness.
 
-## Why — and why there is no benefit yet
+## The standalone win: bare queries, in any unique mode
 
-These are **prerequisite infrastructure** for the printing-space popcount-order plan, which is where
-the win is realized (it ANDs printing bitmaps, `popcount`s the total, bit-walks the page). Measured
-targets there (all `unique=printing`): `f:modern border:black` 0.83 ms, bare `border:black` 0.99 ms
-→ microseconds.
+#724 is **not** inert infrastructure — it includes the **popcount + page walk** to answer a *bare*
+printing-varying-plane query itself. Total = `popcount(plane)` (O(words), replaces the O(n) count
+pass); page = #695's printing walk (`walk_printing_page`) with its membership test swapped from a
+range slice to a plane bit. Both are small on top of *building* the planes — the popcount is a
+one-liner, the walk is a reuse. That is a **standalone ~3× on bare `border:black`/`f:modern`/`r:rare`**
+(the count pass is the bulk of the cost), so #724 ships value on its own rather than waiting for the
+full printing-space plan — and it properly subsumes PR 5 (below), whose "precomputed count" is
+exactly this `popcount`.
 
-**On their own these planes provide no query speedup.** The current narrow-and-verify path does not
-`popcount` — it counts by iterating — so a printing plane with no consumer is just a bigger archive.
-The benefit appears only once the popcount-order plan exists and is wired to consume them. Hence the
-sequencing: that plan is built and **validated on the range leaf source first** (`cn<100 usd<50`,
-zero existential planes); these planes plug in afterward as another leaf bitmap.
+**Any unique mode, via a final projection.** The planes are printing-space; the answer is delivered
+in the query's unique space by projecting *once* at the end — a mode-dependent cost term:
+
+| unique mode | final projection | cost term |
+|---|---|---|
+| `printing` | none — the surviving bits *are* the rows | 0 |
+| `card` | ↑ to card-existence via `printing_to_card` ([#690](done/00690-engine-direct-projection-arrays.md)) | O(surviving printings) |
+| `artwork` | ↑ to artwork ids via `printing_to_artwork` | O(surviving printings), **+ needs PR 2b** (global artwork id) |
+
+Two honest scope notes:
+
+- For the **bare** case, `unique=card` is *already* fast via #667's card-space plane + #634 popcount,
+  so #724's standalone bare win is really **printing mode** (and artwork, once PR 2b lands the global
+  id). Bare-card via #724 is redundant with what ships today.
+- Where #724 is the **only** exact option across all three modes is **compounds** (`border:black
+  r:rare`, `usd<50 f:modern`): card-space existence-AND can't compose them, so they must be AND'd in
+  printing space and projected once (see the two strategies above) — that's the full printing-space
+  plan ([local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md)),
+  built on these planes.
+
+So the split is: **#724 delivers bare printing-mode queries standalone** (popcount + walk, ~3×); the
+**printing-space plan** adds compound composition, the two-strategy compose-space choice, and the
+compound pager (#656). #724 is no longer "sequenced last, inert" — it's a near-term win that is *also*
+the substrate for the rest.
 
 ## Which values get a plane
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -248,13 +248,15 @@ printing-space subset, in dependency order:
 6. **Cost-route idea 1 vs this.** The `argmin` already exists; add this plan's cost formula and let
    the offset×selectivity crossover (validated today by `idea1_vs_idea2_probe`) pick between them.
 7. **Printing-space bitplanes — separate track ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)).**
-   The legality/border **leaf source** that unlocks the existential targets (`f:modern`,
-   `border:black`). Sequenced **last, deliberately**: these planes give *no* speedup until steps 1–6
-   exist to consume them via `popcount` + AND + bit-walk (the current verify path doesn't `popcount`,
-   so a plane with no consumer is just a bigger archive). They carry their own correctness surface
-   (the existential projection — a card satisfying both `∃ legal` and `∃ not-legal`) validated in
-   isolation on the build side, and their own archive-format bump. Once landed they plug straight into
-   this plan as another leaf bitmap — the machinery from step 5 is unchanged.
+   The legality/border/rarity **leaf source** for the printing-varying targets (`f:modern`,
+   `border:black`). **Not sequenced last / not inert** — #724 folds in the `popcount` + a reused page
+   walk to answer *bare* printing-mode plane queries **itself** (a standalone ~3×, subsuming PR 5), so
+   it can ship early and independently. What it defers to *this* plan is the **compound** case:
+   composing multiple printing-varying leaves (and broadcasting card-planes) then projecting once —
+   which is where steps 4–6 add value on top. #724 carries its own build cost (per-printing bits +
+   an archive-format bump) and the divergent-legality build correctness, validated in isolation.
+   Once landed, the same planes plug into this plan as leaf bitmaps for compounds — the machinery from
+   step 5 is unchanged.
 
 ## #656 assembly
 

--- a/docs/issues/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/local-engine-sorted-range-fastpath.md
@@ -299,13 +299,17 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   *Impacts:* `usd`/`cn`/`date` under `unique=artwork` (turns PR #689's +7-8% regression into a
   win). *Magnitude:* regression → win. *Depends:* 2a (+3 for cn/date). *Risk:* med — new persisted
   arrays + a format-version bump.
-- [ ] **PR 5 — existential-plane printing-mode total** (legality/rarity/border). Start with the
-  O(1) precomputed per-value count for the bare query; add the `has_V`/`has_notV` classification
-  for the card-mask case if warranted. See
-  [Existential fields](#existential-fields-a-second-cheap-total-mechanism).
-  *Impacts:* bare `r:`/`f:`/`border:` under `unique=printing`. *Magnitude:* ~3× (matches the 3.09
-  printings/card corpus average). *Depends:* Step 0 (gated on it being a real bottleneck).
-  *Risk:* med — independent of the sorted-range PRs.
+- [ ] **PR 5 — printing-mode total for legality/rarity/border** — a precomputed O(1) per-value count
+  answering a **bare** query's total (`border:black`/printing). See
+  [Existential fields](#existential-fields-a-second-cheap-total-mechanism). *Impacts:* bare
+  `r:`/`f:`/`border:` under `unique=printing`. *Magnitude:* ~3× (removes the count pass). *Depends:*
+  Step 0 (gated on it being a real bottleneck).
+  **Largely subsumed by [#724](https://github.com/jbylund/sylvan_librarian/issues/724)** (printing
+  bitplanes): a bitplane's `popcount` *is* this count, and #724 also does composition/membership/paging.
+  So build PR 5 standalone **only** as a cheaper pre-#724 shortcut (a scalar count table, no
+  per-printing bits, no archive bump) if the bare printing-mode total is hot before the bitplanes
+  land; otherwise it falls out of #724. (These are printing-*exact* planes, not "existential" — that
+  term describes the card-space projection; renamed here to match #724.)
 
 **Why this order:** PR 1 first keeps the "small, independent, separable" principle — lowest risk,
 printing-only, validates the walk + harness (contingent on Step 0; else swap with 2a). `2a → 3`

--- a/scripts/bench_printing_planes.py
+++ b/scripts/bench_printing_planes.py
@@ -1,0 +1,123 @@
+"""Step-0 baseline for #724 (printing-space bitplanes): current cost of the impacted query types.
+
+How slow are the query types #724's planes would touch, measured on the *current* build (no #724)?
+
+Build the extension first (`maturin develop --release -m card_engine/Cargo.toml`) and run:
+
+    .venv/bin/python scripts/bench_printing_planes.py --out benchmarks/printing-planes/main.csv
+
+Groups:
+  bare-*      — bare printing-varying-plane queries under unique=printing. #724's *standalone* win
+                (popcount + walk) targets these; measured cost here is what it would remove.
+  compound-*  — 2+ printing-varying leaves under unique=printing/card. The *substrate* case — only
+                #724 (printing-space AND) answers these exactly; measured cost is the ceiling.
+  ref-*       — references: bare-card is already fast via #667+#634 (should NOT be a target);
+                artwork shows current cost (needs PR 2b before #724 helps it).
+
+`total` is the row count (sanity). Reuses the corpus + local-build workflow from bench_bitplanes.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import sys
+import time
+from typing import TYPE_CHECKING
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+if TYPE_CHECKING:
+    import card_engine
+
+WARMUP = 50
+DEFAULT_WINDOW_S = 8.0
+PAGE_LIMIT = 100
+
+# Config columns: group, query, unique, orderby.
+CONFIGS: list[tuple[str, str, str, str]] = [
+    # --- bare printing-mode plane queries: #724's standalone (popcount+walk) targets ---
+    ("bare-legality", "f:modern", "printing", "edhrec"),
+    ("bare-legality", "f:standard", "printing", "edhrec"),
+    ("bare-legality", "f:commander", "printing", "edhrec"),
+    ("bare-border", "border:black", "printing", "edhrec"),
+    ("bare-border", "border:borderless", "printing", "edhrec"),
+    ("bare-rarity", "r:rare", "printing", "edhrec"),
+    ("bare-rarity", "r:mythic", "printing", "edhrec"),
+    # --- compound printing-mode: the substrate case (only #724 composes these exactly) ---
+    ("compound-printing", "border:black r:rare", "printing", "edhrec"),
+    ("compound-printing", "f:modern border:black", "printing", "edhrec"),
+    ("compound-printing", "f:modern r:rare", "printing", "edhrec"),
+    # --- references: bare-card already fast via #667+#634 (not a #724 target) ---
+    ("ref-card-bare", "border:black", "card", "edhrec"),
+    ("ref-card-bare", "f:modern", "card", "edhrec"),
+    ("ref-card-compound", "border:black r:rare", "card", "edhrec"),
+    ("ref-card-compound", "f:modern border:black", "card", "edhrec"),
+    # --- artwork: current cost (needs PR 2b before #724 helps) ---
+    ("ref-artwork", "border:black", "artwork", "edhrec"),
+]
+
+
+def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str], window: float) -> tuple[int, int, float, float]:
+    """Return (total, n, avg_ms, min_ms) for one (query, unique, orderby) config over a timed window."""
+    query, unique, orderby = config
+    filters = parse_scryfall_query(query)
+    kw = {
+        "filters": filters,
+        "unique": unique,
+        "prefer": "default",
+        "orderby": orderby,
+        "direction": "asc",
+        "limit": PAGE_LIMIT,
+        "offset": 0,
+    }
+    total = engine.query(**kw)[0]
+    for _ in range(WARMUP):
+        engine.query(**kw)
+    n = 0
+    best = float("inf")
+    t_start = time.monotonic()
+    deadline = t_start + window
+    now = t_start
+    while now < deadline:
+        t0 = time.monotonic()
+        engine.query(**kw)
+        now = time.monotonic()
+        best = min(best, now - t0)
+        n += 1
+    return total, n, (now - t_start) / n * 1_000, best * 1_000
+
+
+def main() -> None:
+    """Load the corpus once, then time each config over a window and write the CSV."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True)
+    parser.add_argument("--window", type=float, default=DEFAULT_WINDOW_S)
+    args = parser.parse_args()
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = load_engine(args.corpus, args.out.with_suffix(".store"))
+
+    hdr = f"{'group':<18} {'query':<24} {'unique':<9} {'total':>7} {'min ms':>9}"
+    print(hdr)
+    print("-" * len(hdr))
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["group", "query", "unique", "orderby", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby), args.window)
+            writer.writerow([group, query, unique, orderby, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<18} {query:<24} {unique:<9} {total:>7} {min_ms:>9.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ships the first slice of #724 (printing-space bitplanes): a printing-space **border** bitplane plus the `PrintingPlaneScan` router plan that answers a bare `border:` query under `unique=printing` with a `popcount` + the reused printing page walk, instead of a per-printing scan. Started as a docs + de-risk PR on this branch and grew into the working slice end-to-end.

## What ships

**Build-side** (`planes.rs`, `lib.rs`): a `BorderPrintingPlanes` index — one bit per printing, set iff *that printing* has the value (exact, not a card-space `∃` projection). Density-chosen per the ~3,000-printing plane/postings crossover: `black`/`borderless`/`white` get planes, `gold`/`yellow` land in postings (a new border color needs no code change — it just posts). A build-time drift assert flags a planed value dropping below the crossover (or a posted one growing past it). `ARCHIVE_FORMAT_VERSION` bumped.

**Query-side** (`lib.rs`, `cost.rs`): `PrintingPlaneScan`. Total = `popcount(plane)` for a planed value, or postings length for a sparse one; the page reuses #695's `walk_printing_page` with a plane-bit membership test. Negation is plain `complement` — **exact in printing space, no card-space "other" artifact** (that term existed only because a card bit meant "∃ a non-black printing"). Gated to bare border + `unique=printing` via `CARD_ENGINE_BORDER_PRINTING_PLANE`, so no other query path can change.

## Result (A/B, 97,206-printing corpus, min µs)

Same store, flag off vs on; totals identical between arms (row identity preserved):

| query | mode | off µs | on µs | speedup | rows |
|---|---|---:|---:|---:|---:|
| `border:black` | printing | 884 | 44 | **20.2×** | 85,046 |
| `border:borderless` | printing | 222 | 47 | **4.8×** | 5,701 |
| `f:modern` | printing | 192 | 190 | 1.0× | 73,783 |
| `f:commander` | printing | 223 | 219 | 1.0× | 96,898 |
| `r:rare` | printing | 365 | 358 | 1.0× | 36,764 |
| `border:black r:rare` | printing | 610 | 627 | 1.0× | 31,879 |
| `border:black` | card | 64 | 64 | 1.0× | 31,169 |
| `border:black` | artwork | 904 | 929 | 1.0× | 40,956 |

Only the bare-border planed values move; every other query is flat within noise (the gating *is* the no-regression guarantee, and the flat rows confirm it). Plane cost is a fixed ~36.5 KB (3 planes × ⌈97,206/64⌉ words × 8 B) on the archive.

## Correctness

- **Oracle test**: the printing plane projected up to card-existence equals #664's card-space border plane (passes on the real corpus).
- **Fuzz row-identity** and **force-plan-differential** both now exercise `PrintingPlaneScan` for border — the differential checks total + rows + order agree with `GatheredScan`.
- 127 debug-build lib tests pass.

## Scope

This is the **bare border / printing-mode** slice only. Compounds (`border:black r:rare`) and the card/artwork projections are the next slices — the printing-space plan (two-strategy composition) and PR 2b (global artwork id) respectively — and stay flat here by design. Design detail, the two exact composition strategies, and the PR-5 subsumption live in [docs/issues/00724](docs/issues/00724-engine-printing-existential-planes.md).
