### PR TITLE
Printing-Space Compose: Rarity + Legality + AND/OR, Projected to Card & Artwork (#724)

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -237,10 +237,13 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 + PLANE_POPCOUNT_FIXED_COST_NS
         }
         // Same popcount-skip order phase as PlanePopcountOrder (`matches` is the card-existence
-        // popcount), plus the query-time build over the range slice — the dominant term (see the
-        // CARD_RANGE_BUILD_PER_PRINTING_NS note).
-        PhysicalPlan::CardRangePopcount => {
-            f64::from(f.range_build_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS  // query-time build: k in-range printings -> card-existence bitmap (+ printing membership); the plane plan gets this precomputed
+        // popcount), plus the query-time build/**projection** — the dominant term (see the
+        // CARD_RANGE_BUILD_PER_PRINTING_NS note). `range_build_printings` is the number of printings
+        // projected up to card space: the range slice size for CardRangePopcount, the composed
+        // popcount for PrintingComposePopcount. This is *the* printing→card projection cost the
+        // printing-space model pays — and it is 0 for the printing-mode plan, which never projects.
+        PhysicalPlan::CardRangePopcount | PhysicalPlan::PrintingComposePopcount => {
+            f64::from(f.range_build_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS  // query-time projection: printings -> card-existence bitmap (+ printing membership); the printing-mode plan gets this for free (0)
                 + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS  // scatter the match (card) bits through the inverse permutation
                 + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS  // popcount total + word-scan skip to the page offset
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of cards

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -86,12 +86,16 @@ pub(crate) struct PlanFeatures {
     pub limit: u32,
     /// Page offset.
     pub offset: u32,
-    /// Printings **synthesized at query time** — the query-time-build cost shared by the plans that
-    /// don't read a precomputed bitmap: the range slice `CardRangePopcount` scatters+projects, the
-    /// composed printings `PrintingComposePopcount` projects, and the legality **broadcast** a
-    /// `PrintingPlaneScan` composes (border/rarity are precomputed planes → `0`; legality is not). `0`
-    /// for plans that read a precomputed bitmap or build nothing. Measured ≈ 1.3–1.5 ns/printing.
-    pub range_build_printings: u32,
+    /// Printings **scattered into a bitmap at query time** (one term per plan that synthesizes rather
+    /// than reads a precomputed bitmap): the range slice `CardRangePopcount` builds, and the legality
+    /// broadcast-down + card/artwork projection-up `PrintingCompose` does (border/rarity are precomputed
+    /// planes → contribute `0`). `0` for plans that read a precomputed bitmap or build nothing. Costed
+    /// at `SCATTER_PER_PRINTING_NS` — one physical op (write a bit into a word), so one constant.
+    pub synth_printings: u32,
+    /// 64-bit words of the **result-space** bitmap the total popcount + skip-scan touches — the field
+    /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
+    /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
+    pub popcount_words: u32,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -138,20 +142,13 @@ const PLANE_POPCOUNT_EMIT_PER_CARD_NS: f64 = 2.0;
 /// Fixed P2 setup (plane eval into the bitmap, buffers).
 const PLANE_POPCOUNT_FIXED_COST_NS: f64 = 200.0;
 
-// ─── CardRangePopcount: PlanePopcountOrder's terms + a query-time build ──────
-// Unlike the plane plan's precomputed bitmap, this one builds its card-existence bitmap at query
-// time in a single fused scatter+project pass over the in-range printing slice. That build is the
-// plan's dominant cost, so it gets its own per-slice-printing term; without it the model
-// under-predicts this plan ~3x and could route a narrow bare range here when the candidate path is
-// cheaper. ~1.3 ns/printing, from card_range_build_cost_split on the real corpus (~104us for the
-// 80,527-printing usd<50 slice).
-pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.3;
-
-/// Per-printing cost of a `PrintingPlaneScan`'s legality **broadcast** (card ∃-legal plane → printing
-/// bits) — the query-time synthesis a legality leaf pays that a border/rarity plane read does not.
-/// ~1.5 ns/printing, measured on the real corpus by `legality_compose_kernel_costs` (~90–145 µs for the
-/// broad formats). Same scatter kernel as the range build, calibrated independently to its own probe.
-pub(crate) const COMPOSE_BROADCAST_PER_PRINTING_NS: f64 = 1.5;
+/// Per-printing cost of scattering one printing into a bitmap at query time — the single physical op
+/// (write a bit into a word) behind every `synth_printings`: `CardRangePopcount`'s range-slice build,
+/// and `PrintingCompose`'s legality broadcast-down + card/artwork projection-up. Measured ~1.3 ns/printing
+/// (`card_range_build_cost_split`, the ~80.5k-printing `usd<50` slice) and ~1.5 ns/printing
+/// (`legality_compose_kernel_costs`, the broad formats) — the same kernel from two probes, so one
+/// constant at the midpoint. Load-bearing: without it the model under-predicts these plans and mis-routes.
+pub(crate) const SCATTER_PER_PRINTING_NS: f64 = 1.4;
 
 // ─── P3: StreamedSelect ─────────────────────────────────────────────────────
 // Match phase walks eval_domain cards computing per-card counts, then either
@@ -230,38 +227,40 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let limit = f64::from(f.limit);
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
 
+    // Printings walked to fill the page in a forward-permutation walk (both printing-space plans):
+    // roughly `page_span` rows at density `match_rate`.
+    let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
+    let printings_walked = page_span / match_rate;
     match plan {
-        // Both printing bare-leaf fast paths walk `walk_printing_page` (page cost ∝ how far the walk
-        // goes to fill the page at `match_rate`); the border total is a popcount/postings-len rather
-        // than a range `k`, but the paging cost — the only cost either carries — is identical.
-        PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan => {
-            let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
-            // Walk cost + the query-time synthesis both share: 0 for a range or a border/rarity plane
-            // read, the legality broadcast (≈1.5 ns/printing, `legality_compose_kernel_costs`) otherwise.
-            // This is what makes the router reject compose for a bare legality query (broadcast > the
-            // existing streamed path) while still choosing it for a compound that replaces a full scan.
-            (page_span / match_rate) * RANGE_WALK_STEP_NS
-                + RANGE_FIXED_COST_NS
-                + f64::from(f.range_build_printings) * COMPOSE_BROADCAST_PER_PRINTING_NS
+        // #695 bare range, unique=printing: total is the range index's `k` (no synth, no popcount pass),
+        // page is a forward permutation walk. So just the walk + fixed setup.
+        PhysicalPlan::PrintingRangeScan => {
+            printings_walked * RANGE_WALK_STEP_NS  // forward-perm walk to fill the page
+                + RANGE_FIXED_COST_NS              // per-query setup
         }
+        // #724 unified compose, any distinct-on. One term per operation it performs:
+        PhysicalPlan::PrintingCompose => {
+            f64::from(f.synth_printings) * SCATTER_PER_PRINTING_NS  // synthesize: legality broadcast-down + card/artwork projection-up (border/rarity + printing mode contribute 0)
+                + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the result-space bitmap for the total (printing/card/artwork words)
+                + printings_walked * RANGE_WALK_STEP_NS  // forward grouped walk to fill the page
+                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
+                + RANGE_FIXED_COST_NS  // per-query setup
+        }
+        // #634 plane popcount-skip order walk (precomputed bitmap ⇒ no synth):
         PhysicalPlan::PlanePopcountOrder => {
-            matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS
-                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS
-                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS
-                + PLANE_POPCOUNT_FIXED_COST_NS
-        }
-        // Same popcount-skip order phase as PlanePopcountOrder (`matches` is the card-existence
-        // popcount), plus the query-time build/**projection** — the dominant term (see the
-        // CARD_RANGE_BUILD_PER_PRINTING_NS note). `range_build_printings` is the number of printings
-        // projected up to card space: the range slice size for CardRangePopcount, the composed
-        // popcount for PrintingComposePopcount. This is *the* printing→card projection cost the
-        // printing-space model pays — and it is 0 for the printing-mode plan, which never projects.
-        PhysicalPlan::CardRangePopcount | PhysicalPlan::PrintingComposePopcount => {
-            f64::from(f.range_build_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS  // query-time projection: printings -> card-existence bitmap (+ printing membership); the printing-mode plan gets this for free (0)
-                + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS  // scatter the match (card) bits through the inverse permutation
-                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS  // popcount total + word-scan skip to the page offset
+            matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS  // scatter matches through the inverse permutation
+                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the card bitmap + skip-scan to the offset
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of cards
-                + PLANE_POPCOUNT_FIXED_COST_NS  // fixed per-query overhead
+                + PLANE_POPCOUNT_FIXED_COST_NS  // per-query setup
+        }
+        // #725 bare range, unique=card: PlanePopcountOrder's popcount-skip walk over a card bitmap
+        // *built at query time* from the range slice — same walk terms, plus the build synth.
+        PhysicalPlan::CardRangePopcount => {
+            f64::from(f.synth_printings) * SCATTER_PER_PRINTING_NS  // build the card-existence bitmap from the range slice
+                + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS  // scatter matches through the inverse permutation
+                + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the card bitmap + skip-scan to the offset
+                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of cards
+                + PLANE_POPCOUNT_FIXED_COST_NS  // per-query setup
         }
         PhysicalPlan::StreamedSelect => {
             // The small-total gather branch (run_query_streamed) scans all

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -86,9 +86,11 @@ pub(crate) struct PlanFeatures {
     pub limit: u32,
     /// Page offset.
     pub offset: u32,
-    /// `CardRangePopcount` only: printings in the range slice it scatters+projects into the
-    /// card-existence bitmap at query time (`e - s`). Drives that plan's build term; `0` for every
-    /// other plan (their bitmaps are precomputed or they don't build one).
+    /// Printings **synthesized at query time** — the query-time-build cost shared by the plans that
+    /// don't read a precomputed bitmap: the range slice `CardRangePopcount` scatters+projects, the
+    /// composed printings `PrintingComposePopcount` projects, and the legality **broadcast** a
+    /// `PrintingPlaneScan` composes (border/rarity are precomputed planes → `0`; legality is not). `0`
+    /// for plans that read a precomputed bitmap or build nothing. Measured ≈ 1.3–1.5 ns/printing.
     pub range_build_printings: u32,
 }
 
@@ -144,6 +146,12 @@ const PLANE_POPCOUNT_FIXED_COST_NS: f64 = 200.0;
 // cheaper. ~1.3 ns/printing, from card_range_build_cost_split on the real corpus (~104us for the
 // 80,527-printing usd<50 slice).
 pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.3;
+
+/// Per-printing cost of a `PrintingPlaneScan`'s legality **broadcast** (card ∃-legal plane → printing
+/// bits) — the query-time synthesis a legality leaf pays that a border/rarity plane read does not.
+/// ~1.5 ns/printing, measured on the real corpus by `legality_compose_kernel_costs` (~90–145 µs for the
+/// broad formats). Same scatter kernel as the range build, calibrated independently to its own probe.
+pub(crate) const COMPOSE_BROADCAST_PER_PRINTING_NS: f64 = 1.5;
 
 // ─── P3: StreamedSelect ─────────────────────────────────────────────────────
 // Match phase walks eval_domain cards computing per-card counts, then either
@@ -228,7 +236,13 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         // than a range `k`, but the paging cost — the only cost either carries — is identical.
         PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan => {
             let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
-            (page_span / match_rate) * RANGE_WALK_STEP_NS + RANGE_FIXED_COST_NS
+            // Walk cost + the query-time synthesis both share: 0 for a range or a border/rarity plane
+            // read, the legality broadcast (≈1.5 ns/printing, `legality_compose_kernel_costs`) otherwise.
+            // This is what makes the router reject compose for a bare legality query (broadcast > the
+            // existing streamed path) while still choosing it for a compound that replaces a full scan.
+            (page_span / match_rate) * RANGE_WALK_STEP_NS
+                + RANGE_FIXED_COST_NS
+                + f64::from(f.range_build_printings) * COMPOSE_BROADCAST_PER_PRINTING_NS
         }
         PhysicalPlan::PlanePopcountOrder => {
             matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5333,16 +5333,32 @@ fn run_query_routed<'a>(
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
         // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
         let (printing_matches, broadcast) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
-        let (result_total, synth, popcount_words) = match mode {
-            // printing: no projection; total popcount over the printing bitmap.
-            Mode::Printing => (printing_matches, broadcast, (n_printings as usize).div_ceil(64)),
-            // card: project every matching printing up (~printing_matches scatters), popcount card bitmap.
-            Mode::Card => (printing_matches.min(n_cards as usize), broadcast + printing_matches, (n_cards as usize).div_ceil(64)),
-            // artwork: same projection; popcount the artwork bitmap (n_artworks ≤ n_printings — use that
-            // upper bound for the estimate; the tiny popcount term makes the difference immaterial).
-            Mode::Artwork => (printing_matches, broadcast + printing_matches, (n_printings as usize).div_ceil(64)),
+        // `eval_domain`/`scan_units` here cost the *materializing alternatives* (StreamedSelect/
+        // GatheredScan) should this plan lose — so they must reflect the narrowed reality those plans
+        // see, not the unnarrowed universe. A composable filter narrows via its indices (#667 legality,
+        // border/rarity), so the alternatives iterate ~`matches` candidates; in card mode they also
+        // break at the first matching printing (`scan_units()` ⇒ `eval_domain`). Passing n_cards/
+        // n_printings instead over-costs them ~3-4× and spuriously wins broad-but-narrowable legality
+        // compounds for compose (measured: `format:X format:Y`/card regressed).
+        let (result_total, synth, popcount_words, eval_domain, scan_units) = match mode {
+            // printing: no projection; total popcount over the printing bitmap. The alternatives scan
+            // every printing (no early break), so the unnarrowed universe is the right estimate.
+            Mode::Printing => (printing_matches, broadcast, (n_printings as usize).div_ceil(64), n_cards as usize, n_printings as usize),
+            // card: project every matching printing up, popcount card bitmap. Alternatives narrow to
+            // ~matches candidates and break at the first match ⇒ eval_domain = scan_units = matches.
+            Mode::Card => {
+                let rt = printing_matches.min(n_cards as usize);
+                (rt, broadcast + printing_matches, (n_cards as usize).div_ceil(64), rt, rt)
+            }
+            // artwork: same projection; popcount the artwork bitmap (n_artworks ≤ n_printings — upper
+            // bound for the estimate). Alternatives group all printings per candidate (no early break),
+            // so scan_units is the matching printings under the ~matches candidate cards.
+            Mode::Artwork => {
+                let rt = printing_matches.min(n_cards as usize);
+                (printing_matches, broadcast + printing_matches, (n_printings as usize).div_ceil(64), rt, printing_matches)
+            }
         };
-        let mut feats = mk_feats(result_total as u32, n_cards, n_printings, verify_cost_tier(filter));
+        let mut feats = mk_feats(result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
         feats.synth_printings = synth as u32;
         feats.popcount_words = popcount_words as u32;
         (feats, Prep::Range)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3883,16 +3883,11 @@ static PRINTING_RANGE_FASTPATH: LazyLock<usize> = LazyLock::new(|| guard_env("CA
 /// queries exactly as before (the general candidate path), `1` (default) enables `CardRangePopcount`.
 static RANGE_BITS_CARD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_RANGE_BITS_CARD", 1));
 
-/// #724 printing-space border-plane fast path (`PrintingPlaneScan`). Binary A/B kill-switch, same
-/// kind as `PRINTING_RANGE_FASTPATH`: `0` routes `border:VALUE`/printing as before (general path),
-/// `1` (default) uses the plane `popcount`/postings total + the printing walk.
-static BORDER_PRINTING_PLANE: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_BORDER_PRINTING_PLANE", 1));
-
-/// #724 card-mode projection (`PrintingComposePopcount`). Binary A/B kill-switch: `0` routes a
-/// composable printing-space compound (`border:black r:rare` etc.) under `unique=card` as before (the
-/// general narrowed-verify path), `1` (default) composes in printing space, projects up, and runs the
-/// popcount-skip card walk.
-static PRINTING_COMPOSE_CARD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_PRINTING_COMPOSE_CARD", 1));
+/// #724 unified printing-space compose plan (`PrintingCompose`). Binary A/B kill-switch, same kind as
+/// `PRINTING_RANGE_FASTPATH`: `0` routes every composable printing-space query (border/rarity/legality,
+/// `AND`/`OR`, any distinct-on) as before (general path), `1` (default) composes in printing space,
+/// projects to the result space, and pages with the grouped walk.
+static PRINTING_COMPOSE: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_PRINTING_COMPOSE", 1));
 
 /// The range index and half-open `[lo, hi)` a *bare* range-predicate leaf selects, or None for
 /// anything else (compound, `Ne`, a non-range numeric field). Provably-empty predicates return a
@@ -4347,18 +4342,6 @@ fn compose_printing_bits(
     }
 }
 
-/// `popcount` of the composed printing-space bitmap — the `unique=printing` total, replacing the O(n)
-/// count pass. Caller guarantees `is_printing_composable(filter)`.
-fn compose_printing_total(
-    filter: &FilterExpr,
-    indexes: &Archived<CardIndexes>,
-    offsets: &AOffsets,
-    printings: &[APrinting],
-    n_printings: usize,
-) -> usize {
-    compose_printing_bits(filter, indexes, offsets, printings, n_printings).iter().map(|w| w.count_ones() as usize).sum()
-}
-
 /// Cheap cost-model estimate for a composable filter: `(matches, build_printings)` **without** paying
 /// legality's broadcast. Border/rarity leaves are precomputed planes — their exact `popcount` is a
 /// cheap slice read and they synthesize nothing (`build 0`). A legality leaf is *synthesized* at query
@@ -4367,7 +4350,7 @@ fn compose_printing_total(
 /// **only if this plan wins** (this is why acquire estimates rather than composing: it avoids a second,
 /// throwaway broadcast). `AND` takes the min (intersection upper bound); `OR` the capped sum. Used only
 /// for plan choice — the fast path recomputes the exact total. Measured build cost ≈ 1.5 ns/printing
-/// (`legality_compose_kernel_costs`), ~the range-scatter rate, so `range_build_printings` carries it.
+/// (`legality_compose_kernel_costs`), ~the range-scatter rate, so `synth_printings` carries it.
 fn compose_printing_estimate(
     filter: &FilterExpr,
     indexes: &Archived<CardIndexes>,
@@ -4415,22 +4398,39 @@ fn compose_printing_estimate(
 /// and globally sorts, ordering ties differently (same guard as `printing_range_fastpath`; a sparse
 /// value like `border:yellow` falls through here).
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn printing_compose_fastpath<'a>(
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
     offsets: &AOffsets,
-    strings: &AStrings,
     filter: &FilterExpr,
     indexes: &Archived<CardIndexes>,
+    mode: Mode,
+    prefer: Prefer,
     sort_col: SortCol,
     descending: bool,
     limit: usize,
     page_offset: usize,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
-    if !is_printing_composable(filter) {
+    if !is_printing_composable(filter) || !printing_compose_indexes_built(indexes) {
         return None;
     }
-    let total = compose_printing_total(filter, indexes, offsets, printings, printings.len());
+    // Compose once, here (never in acquire) — that single build is the only synthesis, and it is paid
+    // only because this plan won. The total is the popcount in the query's result space; the page is
+    // the one grouped walk at the mode's granularity, using the composed bits as exact membership.
+    let pbits = compose_printing_bits(filter, indexes, offsets, printings, printings.len());
+    let total: usize = match mode {
+        Mode::Printing => pbits.iter().map(|w| w.count_ones() as usize).sum(),
+        Mode::Card => printing_bits_to_card_bits(&pbits, offsets, cards.len()).iter().map(|w| w.count_ones() as usize).sum(),
+        Mode::Artwork => {
+            let base = build_artwork_base(&indexes.artwork_groups);
+            let n_artworks = *base.last().expect("artwork_base has n_cards+1 entries") as usize;
+            printing_bits_to_artwork_bits(&pbits, printings, &indexes.printing_to_card, &base, n_artworks)
+                .iter()
+                .map(|w| w.count_ones() as usize)
+                .sum()
+        }
+    };
     if total == 0 || page_offset >= total {
         return Some((total, Vec::new()));
     }
@@ -4441,7 +4441,7 @@ fn printing_compose_fastpath<'a>(
     if perm.len() != cards.len() {
         return None;
     }
-    Some((total, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
+    Some((total, walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm)))
 }
 
 /// The physical plans the cost router (`run_query_routed`) chooses among. Each
@@ -4456,19 +4456,17 @@ enum PhysicalPlan {
     /// #695 bare-broad-range fast path under `unique=printing` (executor:
     /// `printing_range_fastpath`). Non-materializing.
     PrintingRangeScan,
-    /// #724 bare border leaf under `unique=printing`: total from the printing border plane's
-    /// composed `popcount`, page from the same walk (`printing_compose_fastpath`). Non-materializing.
-    PrintingPlaneScan,
+    /// #724 unified compose plan: a composable printing-space expr (border/rarity/legality, AND/OR)
+    /// under **any** distinct-on. Composes once in printing space, projects to the query's result space
+    /// (printing = none, card / artwork = existence bitmap), and pages with the one grouped walk
+    /// (`printing_compose_fastpath` → `walk_grouped_page`). Non-materializing (composes in the fast
+    /// path, only if it wins). Deep-offset popcount-skip is deferred ([#730]).
+    PrintingCompose,
     /// #634 Step 2 plane-bitmap popcount-skip order phase (`run_query_streamed_popcount`).
     PlanePopcountOrder,
     /// PR 2a card-space idea 2: a bare `usd` range under `unique=card`, answered as the same
     /// popcount-skip order phase over the range's card-existence bitmap (`exec_card_range_popcount`).
     CardRangePopcount,
-    /// #724 card-mode projection: a composable printing-space expr (border/rarity, AND/OR/NOT) under
-    /// `unique=card`, composed in printing space then projected up to a card-existence bitmap
-    /// (`printing_bits_to_card_bits`) and finished by the same popcount-skip walk CardRangePopcount
-    /// uses (`exec_card_range_popcount`). The projection is the only added cost over the printing case.
-    PrintingComposePopcount,
     /// Streamed selection over the sort permutation (`run_query_streamed`).
     StreamedSelect,
     /// The universal fallback: the gathered per-card loop + `select_page`.
@@ -4478,12 +4476,11 @@ enum PhysicalPlan {
 impl PhysicalPlan {
     /// All plans, argmin-ordered so ties resolve deterministically toward the
     /// cheaper-fixed-cost plan. The router filters this by `applicable`.
-    const ALL: [PhysicalPlan; 7] = [
+    const ALL: [PhysicalPlan; 6] = [
         PhysicalPlan::PrintingRangeScan,
-        PhysicalPlan::PrintingPlaneScan,
+        PhysicalPlan::PrintingCompose,
         PhysicalPlan::PlanePopcountOrder,
         PhysicalPlan::CardRangePopcount,
-        PhysicalPlan::PrintingComposePopcount,
         PhysicalPlan::StreamedSelect,
         PhysicalPlan::GatheredScan,
     ];
@@ -4509,10 +4506,8 @@ impl PhysicalPlan {
             PhysicalPlan::PrintingRangeScan => {
                 printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
             }
-            PhysicalPlan::PrintingPlaneScan => {
-                printing_plane_scan_applicable(mode, plane, cards)
-                    && is_printing_composable(filter)
-                    && printing_compose_indexes_built(indexes)
+            PhysicalPlan::PrintingCompose => {
+                printing_compose_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
@@ -4520,22 +4515,19 @@ impl PhysicalPlan {
             PhysicalPlan::CardRangePopcount => {
                 card_range_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
-            PhysicalPlan::PrintingComposePopcount => {
-                printing_compose_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
-            }
             PhysicalPlan::StreamedSelect => streamed_select_applicable(cards, sort_col, descending, indexes),
             PhysicalPlan::GatheredScan => gathered_scan_applicable(),
         }
     }
 
     /// Whether the plan runs off the shared materialized prep (plane bitmap /
-    /// candidate list) — true for all but the printing bare-leaf fast paths
-    /// (`PrintingRangeScan`/`PrintingPlaneScan`), whose whole benefit is answering
-    /// *without* materializing. The router costs non-materializing plans from a
-    /// cheap estimate first (phase 1) and only materializes (phase 2) when a
-    /// materializing plan wins or the non-materializing one declines.
+    /// candidate list) — true for all but the printing-space fast paths
+    /// (`PrintingRangeScan`/`PrintingCompose`), whose whole benefit is answering from a cheap estimate
+    /// and composing/walking only if they win. The router costs non-materializing plans from a cheap
+    /// estimate first (phase 1) and only materializes (phase 2) when a materializing plan wins or the
+    /// non-materializing one declines.
     fn materializing(self) -> bool {
-        !matches!(self, PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan)
+        !matches!(self, PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingCompose)
     }
 }
 
@@ -4567,10 +4559,6 @@ enum Prep {
     /// and printing-space membership set (emission's per-printing residual). `CardRangePopcount`
     /// reads both; a materializing winner reads the card bitmap as a candidate list.
     RangeCardBits { card_bits: Vec<u64>, range_pbits: Vec<u64> },
-    /// `PrintingComposePopcount` under `unique=artwork` (#724): the composed printing membership
-    /// (`pbits`, drives the per-card artwork grouping in the walk) and the projected artwork-existence
-    /// bitmap (`artwork_bits`, whose popcount is the exact distinct-artwork total).
-    ComposeArtwork { pbits: Vec<u64>, artwork_bits: Vec<u64> },
     /// The general residual path: a materialized candidate list.
     Candidates(PreparedCandidates),
 }
@@ -4642,11 +4630,28 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
     *PRINTING_RANGE_FASTPATH != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
 }
 
-/// `PrintingPlaneScan` structural eligibility (#724): `unique=printing`, no plane, non-empty store,
-/// flag on. The composability check (`is_printing_composable(filter)`) is applied on top by the
-/// plan's `applicable` arm; `printing_compose_fastpath` makes the final accept/decline.
-fn printing_plane_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: &[AOracleCard]) -> bool {
-    *BORDER_PRINTING_PLANE != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
+/// `PrintingCompose` applicability (#724), all three distinct-ons: a composable printing-space `filter`
+/// (border/rarity/legality, `AND`/`OR`), the planes built, no folded plane, the forward sort permutation
+/// present, flag on. `plane.is_none()` is load-bearing: under `unique=card` a *bare* border/rarity is
+/// `compile_plane`-consumed into an existential plane (`plane.is_some()`) → the faster #634 card-plane
+/// path handles it, so this plan declines there; under `unique=printing`/`artwork` nothing folds to a
+/// plane, so it picks up bare leaves too. Only the forward permutation is needed — the unified grouped
+/// walk never uses the inverse (that was the popcount-skip walk's, deferred to [#730]).
+fn printing_compose_applicable(
+    filter: &FilterExpr,
+    _mode: Mode,
+    cards: &[AOracleCard],
+    plane: Option<&PlaneExpr>,
+    sort_col: SortCol,
+    descending: bool,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    *PRINTING_COMPOSE != 0
+        && !cards.is_empty()
+        && plane.is_none()
+        && is_printing_composable(filter)
+        && printing_compose_indexes_built(indexes)
+        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
 }
 
 /// `CardRangePopcount` needs `Mode::Card`, a **bare** range leaf as the whole filter — usd/cn/date,
@@ -4678,33 +4683,6 @@ fn card_range_popcount_applicable(
         && !cards.is_empty()
         && plane.is_none()
         && bare_range_bounds(filter, indexes).is_some()
-        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
-        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
-}
-
-/// `PrintingComposePopcount` needs `Mode::Card` or `Mode::Artwork`, a composable printing-space
-/// `filter` (border/rarity/legality, `AND`/`OR`), no folded plane, and both sort permutations. It
-/// composes once in printing space and projects to the query's unique space (card-existence, or
-/// artwork-existence via `build_artwork_base`). `plane.is_none()` is the same division of labor as
-/// `CardRangePopcount`: a *bare* border/rarity under `unique=card` is `compile_plane`-consumed into an
-/// existential plane (`plane.is_some()`) → the faster #634 plane path handles it, so this plan declines
-/// there. Under `unique=artwork` nothing folds to a plane (existential planes are card-only), so it
-/// also picks up bare border/rarity/legality — the projection replaces the general count pass.
-fn printing_compose_popcount_applicable(
-    filter: &FilterExpr,
-    mode: Mode,
-    cards: &[AOracleCard],
-    plane: Option<&PlaneExpr>,
-    sort_col: SortCol,
-    descending: bool,
-    indexes: &Archived<CardIndexes>,
-) -> bool {
-    *PRINTING_COMPOSE_CARD != 0
-        && matches!(mode, Mode::Card | Mode::Artwork)
-        && !cards.is_empty()
-        && plane.is_none()
-        && is_printing_composable(filter)
-        && printing_compose_indexes_built(indexes)
         && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
         && indexes.sort_perms.get_inv(sort_col, descending).is_some()
 }
@@ -4953,14 +4931,16 @@ fn printing_bits_to_artwork_bits(
     abits
 }
 
-/// `unique=artwork` page walk over a composed printing bitmap — the artwork analogue of
-/// `walk_printing_page`. Per card it collapses the matching (set) printings to distinct **artworks**:
-/// one representative per `artwork_group_id`, the best-`prefer_score` matching printing (exactly
-/// `push_card_matches`'s Artwork arm), then pages those in sort order. Membership is the exact composed
-/// `pbits`, so there is no residual re-evaluation. The total is a separate `popcount` (see
-/// `printing_bits_to_artwork_bits`); this only builds the requested page.
+/// The #724 unified compose page walk (all three distinct-ons): walk the sort permutation from the
+/// front and, per card, collapse the matching (set) printings to the mode's **granularity** —
+/// `Printing` emits every set printing, `Card` one best-`prefer_score` representative for the card,
+/// `Artwork` one best-`prefer_score` representative per `artwork_group_id` (exactly the general path's
+/// Artwork semantics). Membership is the exact composed `pbits`, so there is no residual re-evaluation.
+/// The total is a separate `popcount` over the mode's result bitmap; this only builds the requested
+/// page. Forward walk (no popcount-skip) — deep-offset skip is the deferred [#730] optimization.
 #[allow(clippy::too_many_arguments)]
-fn walk_artwork_page<'a>(
+fn walk_grouped_page<'a>(
+    mode: Mode,
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
     offsets: &AOffsets,
@@ -4975,7 +4955,7 @@ fn walk_artwork_page<'a>(
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
-    let mut group_best: Vec<Option<(u32, f64)>> = Vec::new(); // per gid: (best matching pid, its prefer score)
+    let mut group_best: Vec<Option<(u32, f64)>> = Vec::new(); // per group key: (best matching pid, its prefer score)
     let mut touched: Vec<u16> = Vec::new();
     let mut scratch: Vec<Match> = Vec::new();
     let mut skip = page_offset;
@@ -4983,32 +4963,49 @@ fn walk_artwork_page<'a>(
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
-        touched.clear();
-        for pid in start..end {
-            if !is_set(pid) {
-                continue;
-            }
-            let gid = u16::from(printings[pid].artwork_group_id) as usize;
-            if group_best.len() <= gid {
-                group_best.resize(gid + 1, None);
-            }
-            let score = prefer_score(card, &printings[pid], prefer);
-            match &group_best[gid] {
-                None => {
-                    group_best[gid] = Some((pid as u32, score));
-                    touched.push(gid as u16);
-                }
-                Some((_, best)) if score > *best => group_best[gid] = Some((pid as u32, score)),
-                _ => {}
-            }
-        }
-        if touched.is_empty() {
-            continue;
-        }
         scratch.clear();
-        for &gid in &touched {
-            let (bp, _) = group_best[gid as usize].take().unwrap(); // take: resets group_best for the next card
-            scratch.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
+        match mode {
+            // Printing: every set printing is its own row (no grouping).
+            Mode::Printing => {
+                for pid in start..end {
+                    if is_set(pid) {
+                        scratch.push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
+                    }
+                }
+            }
+            // Card / Artwork: one best-prefer representative per group — a single group for Card, one
+            // per `artwork_group_id` for Artwork.
+            Mode::Card | Mode::Artwork => {
+                touched.clear();
+                for pid in start..end {
+                    if !is_set(pid) {
+                        continue;
+                    }
+                    let gid = match mode {
+                        Mode::Artwork => u16::from(printings[pid].artwork_group_id) as usize,
+                        _ => 0, // Card: everything collapses into one group
+                    };
+                    if group_best.len() <= gid {
+                        group_best.resize(gid + 1, None);
+                    }
+                    let score = prefer_score(card, &printings[pid], prefer);
+                    match &group_best[gid] {
+                        None => {
+                            group_best[gid] = Some((pid as u32, score));
+                            touched.push(gid as u16);
+                        }
+                        Some((_, best)) if score > *best => group_best[gid] = Some((pid as u32, score)),
+                        _ => {}
+                    }
+                }
+                for &gid in &touched {
+                    let (bp, _) = group_best[gid as usize].take().unwrap(); // take: resets group_best for the next card
+                    scratch.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
+                }
+            }
+        }
+        if scratch.is_empty() {
+            continue;
         }
         if skip >= scratch.len() {
             skip -= scratch.len();
@@ -5024,31 +5021,6 @@ fn walk_artwork_page<'a>(
         skip = 0;
     }
     page
-}
-
-/// `PrintingComposePopcount` executor for `unique=artwork`: the artwork total is `popcount(artwork_bits)`
-/// (the projected distinct illustrations), and the page is `walk_artwork_page` over the composed
-/// `pbits`. The card-mode counterpart is `exec_card_range_popcount`.
-#[allow(clippy::too_many_arguments)]
-fn exec_printing_compose_artwork<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
-    pbits: &[u64],
-    artwork_bits: &[u64],
-) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    let total: usize = artwork_bits.iter().map(|w| w.count_ones() as usize).sum();
-    if total == 0 || page_offset >= total {
-        return (total, Vec::new());
-    }
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("PrintingComposePopcount applicability guarantees a permutation");
-    (total, walk_artwork_page(cards, printings, offsets, pbits, prefer, sort_col, descending, limit, page_offset, perm))
 }
 
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
@@ -5301,7 +5273,8 @@ fn run_query_routed<'a>(
         residual_tier_ns100,
         limit: limit as u32,
         offset: page_offset as u32,
-        range_build_printings: 0, // CardRangePopcount overrides this in its acquire branch
+        synth_printings: 0,  // CardRangePopcount / PrintingCompose override this in their acquire branches
+        popcount_words: 0,   // PrintingCompose overrides this (result-space bitmap words)
     };
     // Features for the general candidate path (shared by the acquire branch and the
     // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
@@ -5346,47 +5319,32 @@ fn run_query_routed<'a>(
         // dispatch DO re-verify the range per candidate, so they must be costed with its verify tier —
         // `0` would under-cost them and let a mis-cheap StreamedSelect beat the plan that actually wins.
         let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
-        feats.range_build_printings = slice_printings;
+        feats.synth_printings = slice_printings;
         (feats, Prep::RangeCardBits { card_bits, range_pbits })
-    } else if PhysicalPlan::PrintingComposePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // #724 projection: compose the exact printing-space bitmap once, then project up to the query's
-        // unique space and finish with a popcount-order walk. The projection is O(composed popcount);
-        // that count rides `range_build_printings`, the projection cost term (0 for the printing-mode
-        // plan, which never projects). Composed bits are exact ⇒ no per-candidate re-verify (tier 0),
-        // but dispatch's materializing alternatives DO re-check the filter, so cost them at real tier.
-        let pbits = compose_printing_bits(filter, indexes, offsets, printings, n_printings as usize);
-        let projected_printings: u32 = pbits.iter().map(|w| w.count_ones()).sum();
-        if matches!(mode, Mode::Artwork) {
-            // Artwork: project to artwork-existence (global id = artwork_base[card] + artwork_group_id),
-            // popcount = distinct matching illustrations. No stored global-id array — derived here.
-            let artwork_base = build_artwork_base(&indexes.artwork_groups);
-            let n_artworks = *artwork_base.last().expect("artwork_base has n_cards+1 entries") as usize;
-            let artwork_bits = printing_bits_to_artwork_bits(&pbits, printings, &indexes.printing_to_card, &artwork_base, n_artworks);
-            let count: u32 = artwork_bits.iter().map(|w| w.count_ones()).sum();
-            let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
-            feats.range_build_printings = projected_printings;
-            (feats, Prep::ComposeArtwork { pbits, artwork_bits })
-        } else {
-            let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards as usize);
-            let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
-            let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
-            feats.range_build_printings = projected_printings;
-            (feats, Prep::RangeCardBits { card_bits, range_pbits: pbits })
-        }
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         (mk_feats(k, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
-    } else if PhysicalPlan::PrintingPlaneScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Composable printing-space expr (border/rarity/legality, AND/OR): estimate the total and the
-        // synthesis cost cheaply — border/rarity are free plane reads, but legality is a query-time
-        // broadcast, so acquire must NOT compose here (that would pay the broadcast twice; the fast path
-        // pays it once, only if this plan wins). `range_build_printings` charges the broadcast.
-        let (matches, build_printings) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
-        let mut feats = mk_feats(matches as u32, n_cards, n_printings, verify_cost_tier(filter));
-        feats.range_build_printings = build_printings as u32;
+    } else if PhysicalPlan::PrintingCompose.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
+        // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
+        // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
+        // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
+        let (printing_matches, broadcast) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
+        let (result_total, synth, popcount_words) = match mode {
+            // printing: no projection; total popcount over the printing bitmap.
+            Mode::Printing => (printing_matches, broadcast, (n_printings as usize).div_ceil(64)),
+            // card: project every matching printing up (~printing_matches scatters), popcount card bitmap.
+            Mode::Card => (printing_matches.min(n_cards as usize), broadcast + printing_matches, (n_cards as usize).div_ceil(64)),
+            // artwork: same projection; popcount the artwork bitmap (n_artworks ≤ n_printings — use that
+            // upper bound for the estimate; the tiny popcount term makes the difference immaterial).
+            Mode::Artwork => (printing_matches, broadcast + printing_matches, (n_printings as usize).div_ceil(64)),
+        };
+        let mut feats = mk_feats(result_total as u32, n_cards, n_printings, verify_cost_tier(filter));
+        feats.synth_printings = synth as u32;
+        feats.popcount_words = popcount_words as u32;
         (feats, Prep::Range)
     } else {
         let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
@@ -5409,13 +5367,9 @@ fn run_query_routed<'a>(
             &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
             plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
-        (PhysicalPlan::CardRangePopcount | PhysicalPlan::PrintingComposePopcount, Prep::RangeCardBits { card_bits, range_pbits }) => {
-            // Both project a printing bitmap to card-existence and finish with the same popcount-skip
-            // walk over the composed/range membership (`range_pbits`) — an exact shown-printing set.
-            exec_card_range_popcount(
-                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, card_bits, range_pbits,
-            )
-        }
+        (PhysicalPlan::CardRangePopcount, Prep::RangeCardBits { card_bits, range_pbits }) => exec_card_range_popcount(
+            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, card_bits, range_pbits,
+        ),
         // A materializing plan beat CardRangePopcount on the estimate: reuse the already-built
         // card-existence bitmap as a candidate list (dropped when >7/8, matching prepare_candidates)
         // and re-verify the range residual per card (all_match_known: false) so the range still gates
@@ -5429,34 +5383,20 @@ fn run_query_routed<'a>(
                 plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
             )
         }
-        (PhysicalPlan::PrintingComposePopcount, Prep::ComposeArtwork { pbits, artwork_bits }) => exec_printing_compose_artwork(
-            cards, printings, offsets, prefer, sort_col, descending, limit, page_offset, indexes, pbits, artwork_bits,
-        ),
-        // A materializing plan beat the artwork projection: narrow to the cards with a matching
-        // printing (projected from pbits) and re-verify the filter per printing on the general path.
-        (p, Prep::ComposeArtwork { pbits, .. }) => {
-            let ids = bitmap_card_ids(&printing_bits_to_card_bits(pbits, offsets, cards.len()));
-            let candidate_cards = (ids.len() < cards.len() - cards.len() / 8).then_some(ids);
-            exec_from_candidates(
-                p, cards, printings, offsets, strings, filter,
-                &PreparedCandidates { candidate_cards, all_match_known: false },
-                plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-            )
-        }
         (p, Prep::Candidates(prep)) => exec_from_candidates(
             p, cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
         (plan, Prep::Range) => {
-            // A printing bare-leaf fast path walks if it won and its fastpath accepts. Otherwise (a
+            // A printing-space fast path walks if it won and its fastpath accepts. Otherwise (a
             // materializing plan won the estimate, or the fastpath declined — rare, since cost seldom
             // picks these when narrow) materialize now and run the best materializing plan on EXACT
-            // features. `Prep::Range` is shared by the range (#695) and border (#724) fast paths.
+            // features. `Prep::Range` is shared by the range (#695) and compose (#724) fast paths.
             let fast_page = match plan {
                 PhysicalPlan::PrintingRangeScan => {
                     printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
                 }
-                PhysicalPlan::PrintingPlaneScan => {
-                    printing_compose_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+                PhysicalPlan::PrintingCompose => {
+                    printing_compose_fastpath(cards, printings, offsets, filter, indexes, mode, prefer, sort_col, descending, limit, page_offset)
                 }
                 _ => None,
             };
@@ -5515,14 +5455,13 @@ fn run_query_with_plan<'a>(
             // Structural eligibility passed; the fastpath itself decides (None = declined).
             printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
         }
-        PhysicalPlan::PrintingPlaneScan => {
-            if !printing_plane_scan_applicable(mode, plane, cards)
-                || !is_printing_composable(filter)
-                || !printing_compose_indexes_built(indexes)
-            {
+        PhysicalPlan::PrintingCompose => {
+            if !printing_compose_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
                 return None;
             }
-            printing_compose_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+            // The fastpath composes, projects per mode, and walks — or declines (None) on a sparse
+            // total, exactly as under the router.
+            printing_compose_fastpath(cards, printings, offsets, filter, indexes, mode, prefer, sort_col, descending, limit, page_offset)
         }
         PhysicalPlan::PlanePopcountOrder => {
             if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
@@ -5541,24 +5480,6 @@ fn run_query_with_plan<'a>(
             let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), printings.len());
             Some(exec_card_range_popcount(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
-            ))
-        }
-        PhysicalPlan::PrintingComposePopcount => {
-            if !printing_compose_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-                return None;
-            }
-            let pbits = compose_printing_bits(filter, indexes, offsets, printings, printings.len());
-            if matches!(mode, Mode::Artwork) {
-                let artwork_base = build_artwork_base(&indexes.artwork_groups);
-                let n_artworks = *artwork_base.last().expect("artwork_base has n_cards+1 entries") as usize;
-                let artwork_bits = printing_bits_to_artwork_bits(&pbits, printings, &indexes.printing_to_card, &artwork_base, n_artworks);
-                return Some(exec_printing_compose_artwork(
-                    cards, printings, offsets, prefer, sort_col, descending, limit, page_offset, indexes, &pbits, &artwork_bits,
-                ));
-            }
-            let card_bits = printing_bits_to_card_bits(&pbits, offsets, cards.len());
-            Some(exec_card_range_popcount(
-                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &pbits,
             ))
         }
         PhysicalPlan::StreamedSelect => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2274,6 +2274,7 @@ struct CardIndexes {
     printing_to_card: Vec<u32>,
     planes:         BitPlanes,                 // card space: transposed low-cardinality dims (#630)
     border_printing: BorderPrintingPlanes,     // printing space: exact bit-per-printing border (#724)
+    rarity_printing: RarityPrintingPlanes,     // printing space: exact bit-per-printing rarity (#724)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
 }
@@ -2304,6 +2305,7 @@ impl Default for CardIndexes {
             printing_to_card: Vec::new(),
             planes:         BitPlanes::default(),
             border_printing: BorderPrintingPlanes::default(),
+            rarity_printing: RarityPrintingPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
         }
@@ -3886,6 +3888,12 @@ static RANGE_BITS_CARD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGIN
 /// `1` (default) uses the plane `popcount`/postings total + the printing walk.
 static BORDER_PRINTING_PLANE: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_BORDER_PRINTING_PLANE", 1));
 
+/// #724 card-mode projection (`PrintingComposePopcount`). Binary A/B kill-switch: `0` routes a
+/// composable printing-space compound (`border:black r:rare` etc.) under `unique=card` as before (the
+/// general narrowed-verify path), `1` (default) composes in printing space, projects up, and runs the
+/// popcount-skip card walk.
+static PRINTING_COMPOSE_CARD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_PRINTING_COMPOSE_CARD", 1));
+
 /// The range index and half-open `[lo, hi)` a *bare* range-predicate leaf selects, or None for
 /// anything else (compound, `Ne`, a non-range numeric field). Provably-empty predicates return a
 /// zero-width `[v, v)` so the fastpath's `k` resolves to 0. Reuses the exact bound derivations the
@@ -4165,25 +4173,125 @@ fn printing_range_fastpath<'a>(
 /// `popcount` of the value's plane (black/borderless/white), or its postings length (gold/yellow/
 /// untracked). `None` for anything that isn't a bare `border ==` leaf, or an unknown border value.
 /// This replaces the O(n) count pass — the whole cost of `border:black`/printing today.
-fn border_printing_total(filter: &FilterExpr, bp: &Archived<BorderPrintingPlanes>) -> Option<usize> {
-    let FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } = filter else {
-        return None;
-    };
-    let wpp = words_per_plane(u32::from(bp.n_printings) as usize);
-    if let Some(k) = BORDER_PRINTING_PLANE_VALUES.iter().position(|&v| v == value.as_str()) {
-        return Some(bp.words[k * wpp..(k + 1) * wpp].iter().map(|w| u64::from(*w).count_ones() as usize).sum());
+/// #724: structural check — is `filter` composable **entirely** from printing-space planes/postings?
+/// Cheap (no materialization); this is what plan applicability gates on. Composable leaves: a bare
+/// `border ==` value ([`BorderPrintingPlanes`]) and a bare rarity `== const` ([`RarityPrintingPlanes`],
+/// equality only — ordinal `r>=rare` still takes the general path); composable interior: `And`/`Or`/
+/// `True`. `Not` is deliberately **excluded**: over a nullable field, negation is not the plane's
+/// `complement` (a null-border printing satisfies neither `border:black` nor `-border:black` under
+/// three-valued logic, but `complement` would count it), so `-border:black` stays on the general path
+/// where the residual applies the correct trivalent semantics. Anything else (a text search, a range,
+/// an arithmetic compare) is likewise non-composable. A composable expression's bits are **exact** (a
+/// set bit *is* a matching printing), so no per-printing re-check is needed.
+fn is_printing_composable(filter: &FilterExpr) -> bool {
+    match filter {
+        FilterExpr::True => true,
+        FilterExpr::And(v) | FilterExpr::Or(v) => v.iter().all(is_printing_composable),
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, .. } => true,
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
+        | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
+        _ => false,
     }
-    bp.postings.iter().find(|e| e.0.as_str() == value.as_str()).map(|e| e.1.len())
 }
 
-/// `unique=printing` fast path for a bare `border:VALUE` leaf — the plane analogue of
-/// `printing_range_fastpath`: `total` is the plane `popcount`/postings length (no count pass), and
-/// the page is the same `walk_printing_page` (its residual test already handles the border compare,
-/// and early-stops). Returns `None` (declines) for a non-border leaf, an unknown value, or a total
-/// at/below the stream threshold — where the general path gathers/orders differently (same guard as
-/// `printing_range_fastpath`; a genuinely sparse value like `yellow` falls through here).
+/// Whether the printing-space plane indexes are actually built for this store (production always
+/// builds them; some unit-test fixture stores don't). A built index reports its store's printing count
+/// in `n_printings`; a `Default` (unbuilt) index reports 0. Gating applicability on this lets the plan
+/// decline cleanly (→ general path) rather than index into an empty word array.
+fn printing_compose_indexes_built(indexes: &Archived<CardIndexes>) -> bool {
+    u32::from(indexes.border_printing.n_printings) > 0 && u32::from(indexes.rarity_printing.n_printings) > 0
+}
+
+/// All-ones printing-space bitmap over the `n_printings` domain (tail bits masked to 0). Built by
+/// complementing a zero vec, so the tail-clear contract is `complement_bits`'s single source of truth.
+fn all_printing_bits(n_printings: usize) -> Vec<u64> {
+    let mut bits = vec![0u64; words_per_plane(n_printings)];
+    complement_bits(&mut bits, n_printings);
+    bits
+}
+
+/// The exact printing-space bitmap for a bare `border == value` leaf: a copy of the value's plane
+/// slice, its scattered postings, or all-zero for an unknown value (exactly "no printing").
+fn border_leaf_bits(value: &str, bp: &Archived<BorderPrintingPlanes>, n_printings: usize) -> Vec<u64> {
+    let wpp = words_per_plane(n_printings);
+    if let Some(k) = BORDER_PRINTING_PLANE_VALUES.iter().position(|&v| v == value) {
+        return bp.words[k * wpp..(k + 1) * wpp].iter().map(|w| u64::from(*w)).collect();
+    }
+    match bp.postings.iter().find(|e| e.0.as_str() == value) {
+        Some(e) => scatter_bits(e.1.iter().map(|p| u32::from(*p)), n_printings),
+        None => vec![0u64; wpp],
+    }
+}
+
+/// The exact printing-space bitmap for a bare rarity `== c` leaf. `c` is the rarity int as a float;
+/// a non-integer or out-of-range value matches nothing (all-zero). Interior ints (common..mythic)
+/// read their plane slice; the sparse tail (special/bonus) scatters its postings.
+fn rarity_leaf_bits(c: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: usize) -> Vec<u64> {
+    let wpp = words_per_plane(n_printings);
+    // Only an exact non-negative integer can equal a stored rarity int; anything else matches nothing.
+    if c < 0.0 || c.fract() != 0.0 || c > f64::from(u8::MAX) {
+        return vec![0u64; wpp];
+    }
+    let int = c as u8;
+    if let Some(k) = RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == int) {
+        return rp.words[k * wpp..(k + 1) * wpp].iter().map(|w| u64::from(*w)).collect();
+    }
+    match rp.postings.iter().find(|e| e.0 == int) {
+        Some(e) => scatter_bits(e.1.iter().map(|p| u32::from(*p)), n_printings),
+        None => vec![0u64; wpp],
+    }
+}
+
+/// #724: materialize `filter`'s **exact** printing-space membership bitmap (`n_printings` bits, tail
+/// masked to 0), composing planes/postings with `AND`/`OR`/`NOT`. Assumes `is_printing_composable`
+/// (the caller gates it) — `unreachable!()` on any other shape. The surviving bits *are* the matching
+/// printings: for `unique=printing` `popcount` is the total; for `unique=card` project up with
+/// `printing_bits_to_card_bits`. This is the substrate the printing-space popcount-order plan consumes.
+fn compose_printing_bits(filter: &FilterExpr, indexes: &Archived<CardIndexes>, n_printings: usize) -> Vec<u64> {
+    let wpp = words_per_plane(n_printings);
+    match filter {
+        FilterExpr::True => all_printing_bits(n_printings),
+        FilterExpr::And(v) => {
+            // empty And is vacuously true; start all-ones (tail masked) and intersect each child.
+            let mut acc = all_printing_bits(n_printings);
+            for child in v.iter() {
+                and_bits_into(&mut acc, &compose_printing_bits(child, indexes, n_printings));
+            }
+            acc
+        }
+        FilterExpr::Or(v) => {
+            let mut acc = vec![0u64; wpp];
+            for child in v.iter() {
+                or_bits_into(&mut acc, &compose_printing_bits(child, indexes, n_printings));
+            }
+            acc
+        }
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
+            border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
+        | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)
+        }
+        _ => unreachable!("compose_printing_bits on a non-composable filter — gated by is_printing_composable"),
+    }
+}
+
+/// `popcount` of the composed printing-space bitmap — the `unique=printing` total, replacing the O(n)
+/// count pass. Caller guarantees `is_printing_composable(filter)`.
+fn compose_printing_total(filter: &FilterExpr, indexes: &Archived<CardIndexes>, n_printings: usize) -> usize {
+    compose_printing_bits(filter, indexes, n_printings).iter().map(|w| w.count_ones() as usize).sum()
+}
+
+/// `unique=printing` fast path for a composable printing-space expression (bare `border:`/`r:` or an
+/// `AND`/`OR`/`NOT` of them, #724) — the plane analogue of `printing_range_fastpath`: `total` is the
+/// composed bitmap's `popcount` (no count pass), and the page is the same `walk_printing_page` (its
+/// residual test evaluates the full composed filter, and early-stops). Returns `None` (declines) for
+/// a non-composable filter, or a total at/below the stream threshold — where the general path gathers
+/// and globally sorts, ordering ties differently (same guard as `printing_range_fastpath`; a sparse
+/// value like `border:yellow` falls through here).
 #[allow(clippy::too_many_arguments)]
-fn printing_border_fastpath<'a>(
+fn printing_compose_fastpath<'a>(
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
     offsets: &AOffsets,
@@ -4195,7 +4303,10 @@ fn printing_border_fastpath<'a>(
     limit: usize,
     page_offset: usize,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
-    let total = border_printing_total(filter, &indexes.border_printing)?;
+    if !is_printing_composable(filter) {
+        return None;
+    }
+    let total = compose_printing_total(filter, indexes, printings.len());
     if total == 0 || page_offset >= total {
         return Some((total, Vec::new()));
     }
@@ -4222,13 +4333,18 @@ enum PhysicalPlan {
     /// `printing_range_fastpath`). Non-materializing.
     PrintingRangeScan,
     /// #724 bare border leaf under `unique=printing`: total from the printing border plane's
-    /// `popcount`/postings, page from the same walk (`printing_border_fastpath`). Non-materializing.
+    /// composed `popcount`, page from the same walk (`printing_compose_fastpath`). Non-materializing.
     PrintingPlaneScan,
     /// #634 Step 2 plane-bitmap popcount-skip order phase (`run_query_streamed_popcount`).
     PlanePopcountOrder,
     /// PR 2a card-space idea 2: a bare `usd` range under `unique=card`, answered as the same
     /// popcount-skip order phase over the range's card-existence bitmap (`exec_card_range_popcount`).
     CardRangePopcount,
+    /// #724 card-mode projection: a composable printing-space expr (border/rarity, AND/OR/NOT) under
+    /// `unique=card`, composed in printing space then projected up to a card-existence bitmap
+    /// (`printing_bits_to_card_bits`) and finished by the same popcount-skip walk CardRangePopcount
+    /// uses (`exec_card_range_popcount`). The projection is the only added cost over the printing case.
+    PrintingComposePopcount,
     /// Streamed selection over the sort permutation (`run_query_streamed`).
     StreamedSelect,
     /// The universal fallback: the gathered per-card loop + `select_page`.
@@ -4238,11 +4354,12 @@ enum PhysicalPlan {
 impl PhysicalPlan {
     /// All plans, argmin-ordered so ties resolve deterministically toward the
     /// cheaper-fixed-cost plan. The router filters this by `applicable`.
-    const ALL: [PhysicalPlan; 6] = [
+    const ALL: [PhysicalPlan; 7] = [
         PhysicalPlan::PrintingRangeScan,
         PhysicalPlan::PrintingPlaneScan,
         PhysicalPlan::PlanePopcountOrder,
         PhysicalPlan::CardRangePopcount,
+        PhysicalPlan::PrintingComposePopcount,
         PhysicalPlan::StreamedSelect,
         PhysicalPlan::GatheredScan,
     ];
@@ -4270,13 +4387,17 @@ impl PhysicalPlan {
             }
             PhysicalPlan::PrintingPlaneScan => {
                 printing_plane_scan_applicable(mode, plane, cards)
-                    && border_printing_total(filter, &indexes.border_printing).is_some()
+                    && is_printing_composable(filter)
+                    && printing_compose_indexes_built(indexes)
             }
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
             PhysicalPlan::CardRangePopcount => {
                 card_range_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
+            }
+            PhysicalPlan::PrintingComposePopcount => {
+                printing_compose_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
             PhysicalPlan::StreamedSelect => streamed_select_applicable(cards, sort_col, descending, indexes),
             PhysicalPlan::GatheredScan => gathered_scan_applicable(),
@@ -4394,8 +4515,8 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
 }
 
 /// `PrintingPlaneScan` structural eligibility (#724): `unique=printing`, no plane, non-empty store,
-/// flag on. The border-leaf check (`border_printing_total().is_some()`) is applied on top by the
-/// plan's `applicable` arm; `printing_border_fastpath` makes the final accept/decline.
+/// flag on. The composability check (`is_printing_composable(filter)`) is applied on top by the
+/// plan's `applicable` arm; `printing_compose_fastpath` makes the final accept/decline.
 fn printing_plane_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: &[AOracleCard]) -> bool {
     *BORDER_PRINTING_PLANE != 0 && matches!(mode, Mode::Printing) && plane.is_none() && !cards.is_empty()
 }
@@ -4429,6 +4550,31 @@ fn card_range_popcount_applicable(
         && !cards.is_empty()
         && plane.is_none()
         && bare_range_bounds(filter, indexes).is_some()
+        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
+}
+
+/// `PrintingComposePopcount` needs `Mode::Card`, a composable printing-space `filter` (border/rarity,
+/// `AND`/`OR`/`NOT`), no folded plane, and both sort permutations. `plane.is_none()` is the same
+/// division of labor as `CardRangePopcount`: a *bare* border/rarity in card mode `compile_plane`
+/// exact-consumes into an existential plane (`plane.is_some()`) → the faster #634 plane path handles
+/// it, so this plan declines. It fires exactly where `compile_plane` **declines** — the shared-witness
+/// compounds (`border:black r:rare`) — composing them exactly in printing space and projecting once.
+fn printing_compose_popcount_applicable(
+    filter: &FilterExpr,
+    mode: Mode,
+    cards: &[AOracleCard],
+    plane: Option<&PlaneExpr>,
+    sort_col: SortCol,
+    descending: bool,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    *PRINTING_COMPOSE_CARD != 0
+        && matches!(mode, Mode::Card)
+        && !cards.is_empty()
+        && plane.is_none()
+        && is_printing_composable(filter)
+        && printing_compose_indexes_built(indexes)
         && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
         && indexes.sort_perms.get_inv(sort_col, descending).is_some()
 }
@@ -4933,6 +5079,21 @@ fn run_query_routed<'a>(
         let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
         feats.range_build_printings = slice_printings;
         (feats, Prep::RangeCardBits { card_bits, range_pbits })
+    } else if PhysicalPlan::PrintingComposePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // #724 card projection: compose the exact printing-space bitmap, project it up to a
+        // card-existence bitmap, and reuse CardRangePopcount's popcount-skip walk (the composed pbits
+        // are the shown-printing membership — exact, no re-verify). The projection is O(composed
+        // popcount); that count rides `range_build_printings`, the same projection cost term the walk
+        // pays — and it is 0 for the printing-mode plan, which never projects.
+        let pbits = compose_printing_bits(filter, indexes, n_printings as usize);
+        let projected_printings: u32 = pbits.iter().map(|w| w.count_ones()).sum();
+        let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards as usize);
+        let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
+        // Composed bits are exact, so no per-candidate re-verify (tier 0) — but the materializing
+        // alternatives in dispatch DO re-check the filter, so cost them with the real verify tier.
+        let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
+        feats.range_build_printings = projected_printings;
+        (feats, Prep::RangeCardBits { card_bits, range_pbits: pbits })
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
@@ -4940,9 +5101,9 @@ fn run_query_routed<'a>(
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         (mk_feats(k, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
     } else if PhysicalPlan::PrintingPlaneScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Bare border leaf: exact total from the #724 printing plane popcount / postings len (no
-        // count pass, no materialization). P3/P4 estimated unnarrowed, same as PrintingRangeScan.
-        let total = border_printing_total(filter, &indexes.border_printing).expect("applicable ⇒ border leaf") as u32;
+        // Composable printing-space expr (border/rarity, AND/OR/NOT): exact total from the #724
+        // composed popcount (no count pass). P3/P4 estimated unnarrowed, same as PrintingRangeScan.
+        let total = compose_printing_total(filter, indexes, n_printings as usize) as u32;
         (mk_feats(total, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
     } else {
         let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
@@ -4965,9 +5126,13 @@ fn run_query_routed<'a>(
             &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
             plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
-        (PhysicalPlan::CardRangePopcount, Prep::RangeCardBits { card_bits, range_pbits }) => exec_card_range_popcount(
-            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, card_bits, range_pbits,
-        ),
+        (PhysicalPlan::CardRangePopcount | PhysicalPlan::PrintingComposePopcount, Prep::RangeCardBits { card_bits, range_pbits }) => {
+            // Both project a printing bitmap to card-existence and finish with the same popcount-skip
+            // walk over the composed/range membership (`range_pbits`) — an exact shown-printing set.
+            exec_card_range_popcount(
+                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, card_bits, range_pbits,
+            )
+        }
         // A materializing plan beat CardRangePopcount on the estimate: reuse the already-built
         // card-existence bitmap as a candidate list (dropped when >7/8, matching prepare_candidates)
         // and re-verify the range residual per card (all_match_known: false) so the range still gates
@@ -4994,7 +5159,7 @@ fn run_query_routed<'a>(
                     printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
                 }
                 PhysicalPlan::PrintingPlaneScan => {
-                    printing_border_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+                    printing_compose_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
                 }
                 _ => None,
             };
@@ -5054,10 +5219,13 @@ fn run_query_with_plan<'a>(
             printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
         }
         PhysicalPlan::PrintingPlaneScan => {
-            if !printing_plane_scan_applicable(mode, plane, cards) {
+            if !printing_plane_scan_applicable(mode, plane, cards)
+                || !is_printing_composable(filter)
+                || !printing_compose_indexes_built(indexes)
+            {
                 return None;
             }
-            printing_border_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+            printing_compose_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
         }
         PhysicalPlan::PlanePopcountOrder => {
             if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
@@ -5076,6 +5244,16 @@ fn run_query_with_plan<'a>(
             let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), printings.len());
             Some(exec_card_range_popcount(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
+            ))
+        }
+        PhysicalPlan::PrintingComposePopcount => {
+            if !printing_compose_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+                return None;
+            }
+            let pbits = compose_printing_bits(filter, indexes, printings.len());
+            let card_bits = printing_bits_to_card_bits(&pbits, offsets, cards.len());
+            Some(exec_card_range_popcount(
+                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &pbits,
             ))
         }
         PhysicalPlan::StreamedSelect => {
@@ -5497,7 +5675,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260721;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260722;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -5901,6 +6079,7 @@ impl QueryEngine {
             printing_to_card: build_printing_to_card(&offsets),
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             border_printing: build_border_printing_planes(&printings, &strings),
+            rarity_printing: build_rarity_printing_planes(&printings),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
         };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4190,6 +4190,10 @@ fn is_printing_composable(filter: &FilterExpr) -> bool {
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, .. } => true,
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
+        // Legality via #667's card `_EXISTS` plane + a divergent repair (see `legality_leaf_bits`).
+        // Only a plane-backed status (legal/banned/restricted) with a present format; an absent format
+        // (`shift: None`) matches nothing and stays on the general path.
+        FilterExpr::Legality { shift: Some(_), expected } => status_plane_bases(*expected).is_some(),
         _ => false,
     }
 }
@@ -4242,12 +4246,75 @@ fn rarity_leaf_bits(c: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: us
     }
 }
 
+/// Broadcast a card-space bitmap **down** to printing space: set every printing of each set card. The
+/// inverse of `printing_bits_to_card_bits`, used to lift a card-settled fact (a legality that doesn't
+/// diverge across the card's printings) into the printing domain for composition. Iterates set cards
+/// only, so it is O(set cards + their printings), not O(n_cards).
+fn broadcast_card_bits_to_printings(card_bits: &[u64], offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    let mut pbits = vec![0u64; words_per_plane(n_printings)];
+    for (i, &word) in card_bits.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            let c = (((i as u32) << 6) | w.trailing_zeros()) as usize;
+            w &= w - 1;
+            for p in u32::from(offsets[c]) as usize..u32::from(offsets[c + 1]) as usize {
+                pbits[p >> 6] |= 1u64 << (p & 63);
+            }
+        }
+    }
+    pbits
+}
+
+/// The exact printing-space bitmap for a bare legality leaf (`f:modern` etc.), built the #724 way from
+/// #667's card-space `_EXISTS` plane plus a divergent repair, rather than a full per-printing legality
+/// plane — legality is only ~1.8% divergent (`legal_divergent`), so the card plane broadcast is exact
+/// for the other 98.2% and only the divergent cards need per-printing fix-up. `∃-legal` over-sets a
+/// divergent card (it sets every printing, but only some are legal), so the repair is **authoritative**:
+/// it *overwrites* each divergent printing's bit to its true value (set and clear, re-derived from the
+/// printing's own `card_legalities` word — no stored postings), which is why the broadcast needs no
+/// pre-masking. Empty if the planes aren't built for this store.
+fn legality_leaf_bits(
+    shift: u8,
+    expected: u64,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    printings: &[APrinting],
+    n_printings: usize,
+) -> Vec<u64> {
+    let n_cards = offsets.len() - 1;
+    let Some(card_bits) = legality_candidate_bits(indexes, n_cards, shift, expected, false) else {
+        return vec![0u64; words_per_plane(n_printings)];
+    };
+    let mut pbits = broadcast_card_bits_to_printings(&card_bits, offsets, n_printings);
+    // Repair the divergent cards' printings authoritatively — overwrite each bit with the per-printing
+    // truth (`(word >> shift) & 0b11 == expected`, the same test filter.rs:1253 applies). Overwriting
+    // both directions is what lets the broadcast above over-set them without a pre-clear pass.
+    for cid in indexes.legal_divergent.iter() {
+        let c = u16::from(*cid) as usize;
+        for p in u32::from(offsets[c]) as usize..u32::from(offsets[c + 1]) as usize {
+            let legal = (u64::from(printings[p].card_legalities) >> shift) & 0b11 == expected;
+            if legal {
+                pbits[p >> 6] |= 1u64 << (p & 63);
+            } else {
+                pbits[p >> 6] &= !(1u64 << (p & 63));
+            }
+        }
+    }
+    pbits
+}
+
 /// #724: materialize `filter`'s **exact** printing-space membership bitmap (`n_printings` bits, tail
-/// masked to 0), composing planes/postings with `AND`/`OR`/`NOT`. Assumes `is_printing_composable`
-/// (the caller gates it) — `unreachable!()` on any other shape. The surviving bits *are* the matching
+/// masked to 0), composing planes/postings with `AND`/`OR`. Assumes `is_printing_composable` (the
+/// caller gates it) — `unreachable!()` on any other shape. The surviving bits *are* the matching
 /// printings: for `unique=printing` `popcount` is the total; for `unique=card` project up with
 /// `printing_bits_to_card_bits`. This is the substrate the printing-space popcount-order plan consumes.
-fn compose_printing_bits(filter: &FilterExpr, indexes: &Archived<CardIndexes>, n_printings: usize) -> Vec<u64> {
+fn compose_printing_bits(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    printings: &[APrinting],
+    n_printings: usize,
+) -> Vec<u64> {
     let wpp = words_per_plane(n_printings);
     match filter {
         FilterExpr::True => all_printing_bits(n_printings),
@@ -4255,14 +4322,14 @@ fn compose_printing_bits(filter: &FilterExpr, indexes: &Archived<CardIndexes>, n
             // empty And is vacuously true; start all-ones (tail masked) and intersect each child.
             let mut acc = all_printing_bits(n_printings);
             for child in v.iter() {
-                and_bits_into(&mut acc, &compose_printing_bits(child, indexes, n_printings));
+                and_bits_into(&mut acc, &compose_printing_bits(child, indexes, offsets, printings, n_printings));
             }
             acc
         }
         FilterExpr::Or(v) => {
             let mut acc = vec![0u64; wpp];
             for child in v.iter() {
-                or_bits_into(&mut acc, &compose_printing_bits(child, indexes, n_printings));
+                or_bits_into(&mut acc, &compose_printing_bits(child, indexes, offsets, printings, n_printings));
             }
             acc
         }
@@ -4273,14 +4340,71 @@ fn compose_printing_bits(filter: &FilterExpr, indexes: &Archived<CardIndexes>, n
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
             rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)
         }
+        FilterExpr::Legality { shift: Some(shift), expected } => {
+            legality_leaf_bits(*shift, *expected, indexes, offsets, printings, n_printings)
+        }
         _ => unreachable!("compose_printing_bits on a non-composable filter — gated by is_printing_composable"),
     }
 }
 
 /// `popcount` of the composed printing-space bitmap — the `unique=printing` total, replacing the O(n)
 /// count pass. Caller guarantees `is_printing_composable(filter)`.
-fn compose_printing_total(filter: &FilterExpr, indexes: &Archived<CardIndexes>, n_printings: usize) -> usize {
-    compose_printing_bits(filter, indexes, n_printings).iter().map(|w| w.count_ones() as usize).sum()
+fn compose_printing_total(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    printings: &[APrinting],
+    n_printings: usize,
+) -> usize {
+    compose_printing_bits(filter, indexes, offsets, printings, n_printings).iter().map(|w| w.count_ones() as usize).sum()
+}
+
+/// Cheap cost-model estimate for a composable filter: `(matches, build_printings)` **without** paying
+/// legality's broadcast. Border/rarity leaves are precomputed planes — their exact `popcount` is a
+/// cheap slice read and they synthesize nothing (`build 0`). A legality leaf is *synthesized* at query
+/// time (broadcast + repair), so its cost is estimated from the cheap card `_EXISTS` `popcount` scaled
+/// to printings, and that same count is charged as `build_printings` — the broadcast the fast path pays
+/// **only if this plan wins** (this is why acquire estimates rather than composing: it avoids a second,
+/// throwaway broadcast). `AND` takes the min (intersection upper bound); `OR` the capped sum. Used only
+/// for plan choice — the fast path recomputes the exact total. Measured build cost ≈ 1.5 ns/printing
+/// (`legality_compose_kernel_costs`), ~the range-scatter rate, so `range_build_printings` carries it.
+fn compose_printing_estimate(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    n_printings: usize,
+) -> (usize, usize) {
+    let popcount = |bits: &[u64]| bits.iter().map(|w| w.count_ones() as usize).sum::<usize>();
+    match filter {
+        FilterExpr::True => (n_printings, 0),
+        FilterExpr::And(v) => v
+            .iter()
+            .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
+            .fold((n_printings, 0), |(m, b), (cm, cb)| (m.min(cm), b + cb)),
+        FilterExpr::Or(v) => {
+            let (m, b) = v
+                .iter()
+                .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
+                .fold((0usize, 0usize), |(m, b), (cm, cb)| (m + cm, b + cb));
+            (m.min(n_printings), b)
+        }
+        // Precomputed planes: exact cheap popcount, nothing synthesized.
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
+            (popcount(&border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)), 0)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
+        | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            (popcount(&rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)), 0)
+        }
+        // Legality: estimate from the cheap card ∃-plane popcount scaled to printings — no broadcast.
+        FilterExpr::Legality { shift: Some(shift), expected } => {
+            let n_cards = offsets.len() - 1;
+            let card_exists = legality_candidate_bits(indexes, n_cards, *shift, *expected, false).map_or(0, |b| popcount(&b));
+            let est = if n_cards == 0 { 0 } else { card_exists * n_printings / n_cards };
+            (est, est)
+        }
+        _ => unreachable!("compose_printing_estimate on a non-composable filter — gated by is_printing_composable"),
+    }
 }
 
 /// `unique=printing` fast path for a composable printing-space expression (bare `border:`/`r:` or an
@@ -4306,7 +4430,7 @@ fn printing_compose_fastpath<'a>(
     if !is_printing_composable(filter) {
         return None;
     }
-    let total = compose_printing_total(filter, indexes, printings.len());
+    let total = compose_printing_total(filter, indexes, offsets, printings, printings.len());
     if total == 0 || page_offset >= total {
         return Some((total, Vec::new()));
     }
@@ -5085,7 +5209,7 @@ fn run_query_routed<'a>(
         // are the shown-printing membership — exact, no re-verify). The projection is O(composed
         // popcount); that count rides `range_build_printings`, the same projection cost term the walk
         // pays — and it is 0 for the printing-mode plan, which never projects.
-        let pbits = compose_printing_bits(filter, indexes, n_printings as usize);
+        let pbits = compose_printing_bits(filter, indexes, offsets, printings, n_printings as usize);
         let projected_printings: u32 = pbits.iter().map(|w| w.count_ones()).sum();
         let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards as usize);
         let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
@@ -5101,10 +5225,14 @@ fn run_query_routed<'a>(
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         (mk_feats(k, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
     } else if PhysicalPlan::PrintingPlaneScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Composable printing-space expr (border/rarity, AND/OR/NOT): exact total from the #724
-        // composed popcount (no count pass). P3/P4 estimated unnarrowed, same as PrintingRangeScan.
-        let total = compose_printing_total(filter, indexes, n_printings as usize) as u32;
-        (mk_feats(total, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
+        // Composable printing-space expr (border/rarity/legality, AND/OR): estimate the total and the
+        // synthesis cost cheaply — border/rarity are free plane reads, but legality is a query-time
+        // broadcast, so acquire must NOT compose here (that would pay the broadcast twice; the fast path
+        // pays it once, only if this plan wins). `range_build_printings` charges the broadcast.
+        let (matches, build_printings) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
+        let mut feats = mk_feats(matches as u32, n_cards, n_printings, verify_cost_tier(filter));
+        feats.range_build_printings = build_printings as u32;
+        (feats, Prep::Range)
     } else {
         let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
         (candidate_feats(&prep, filter), Prep::Candidates(prep))
@@ -5250,7 +5378,7 @@ fn run_query_with_plan<'a>(
             if !printing_compose_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
                 return None;
             }
-            let pbits = compose_printing_bits(filter, indexes, printings.len());
+            let pbits = compose_printing_bits(filter, indexes, offsets, printings, printings.len());
             let card_bits = printing_bits_to_card_bits(&pbits, offsets, cards.len());
             Some(exec_card_range_popcount(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &pbits,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4567,6 +4567,10 @@ enum Prep {
     /// and printing-space membership set (emission's per-printing residual). `CardRangePopcount`
     /// reads both; a materializing winner reads the card bitmap as a candidate list.
     RangeCardBits { card_bits: Vec<u64>, range_pbits: Vec<u64> },
+    /// `PrintingComposePopcount` under `unique=artwork` (#724): the composed printing membership
+    /// (`pbits`, drives the per-card artwork grouping in the walk) and the projected artwork-existence
+    /// bitmap (`artwork_bits`, whose popcount is the exact distinct-artwork total).
+    ComposeArtwork { pbits: Vec<u64>, artwork_bits: Vec<u64> },
     /// The general residual path: a materialized candidate list.
     Candidates(PreparedCandidates),
 }
@@ -4678,12 +4682,14 @@ fn card_range_popcount_applicable(
         && indexes.sort_perms.get_inv(sort_col, descending).is_some()
 }
 
-/// `PrintingComposePopcount` needs `Mode::Card`, a composable printing-space `filter` (border/rarity,
-/// `AND`/`OR`/`NOT`), no folded plane, and both sort permutations. `plane.is_none()` is the same
-/// division of labor as `CardRangePopcount`: a *bare* border/rarity in card mode `compile_plane`
-/// exact-consumes into an existential plane (`plane.is_some()`) → the faster #634 plane path handles
-/// it, so this plan declines. It fires exactly where `compile_plane` **declines** — the shared-witness
-/// compounds (`border:black r:rare`) — composing them exactly in printing space and projecting once.
+/// `PrintingComposePopcount` needs `Mode::Card` or `Mode::Artwork`, a composable printing-space
+/// `filter` (border/rarity/legality, `AND`/`OR`), no folded plane, and both sort permutations. It
+/// composes once in printing space and projects to the query's unique space (card-existence, or
+/// artwork-existence via `build_artwork_base`). `plane.is_none()` is the same division of labor as
+/// `CardRangePopcount`: a *bare* border/rarity under `unique=card` is `compile_plane`-consumed into an
+/// existential plane (`plane.is_some()`) → the faster #634 plane path handles it, so this plan declines
+/// there. Under `unique=artwork` nothing folds to a plane (existential planes are card-only), so it
+/// also picks up bare border/rarity/legality — the projection replaces the general count pass.
 fn printing_compose_popcount_applicable(
     filter: &FilterExpr,
     mode: Mode,
@@ -4694,7 +4700,7 @@ fn printing_compose_popcount_applicable(
     indexes: &Archived<CardIndexes>,
 ) -> bool {
     *PRINTING_COMPOSE_CARD != 0
-        && matches!(mode, Mode::Card)
+        && matches!(mode, Mode::Card | Mode::Artwork)
         && !cards.is_empty()
         && plane.is_none()
         && is_printing_composable(filter)
@@ -4904,6 +4910,145 @@ fn exec_card_range_popcount<'a>(
     run_query_streamed_popcount(
         cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, card_bits, None, &indexes.planes, strings, Some(range_pbits),
     )
+}
+
+/// Prefix-sum the per-card distinct-artwork counts (`artwork_groups`) into artwork-space offsets: a
+/// card `c`'s distinct artworks are the contiguous global ids `[artwork_base[c], artwork_base[c+1])`,
+/// so global artwork id = `artwork_base[c] + artwork_group_id`. `artwork_base.last()` is `n_artworks`.
+/// Derived at query time from data already in the store — no stored global-id array (#724 PR 2b).
+fn build_artwork_base(artwork_groups: &Archived<Vec<u16>>) -> Vec<u32> {
+    let mut base = Vec::with_capacity(artwork_groups.len() + 1);
+    let mut acc = 0u32;
+    base.push(0);
+    for c in artwork_groups.iter() {
+        acc += u32::from(u16::from(*c));
+        base.push(acc);
+    }
+    base
+}
+
+/// Project composed printing bits up to **artwork** space: set the global artwork id
+/// (`artwork_base[card] + artwork_group_id`) of every matching printing. `popcount` of the result is
+/// the `unique=artwork` total — the distinct matching illustrations — replacing the O(candidates ×
+/// printings) count pass the general path pays.
+fn printing_bits_to_artwork_bits(
+    pbits: &[u64],
+    printings: &[APrinting],
+    printing_to_card: &AOffsets,
+    artwork_base: &[u32],
+    n_artworks: usize,
+) -> Vec<u64> {
+    let mut abits = vec![0u64; n_artworks.div_ceil(64)];
+    for (i, &word) in pbits.iter().enumerate() {
+        let mut w = word;
+        while w != 0 {
+            let pid = (((i as u32) << 6) | w.trailing_zeros()) as usize;
+            w &= w - 1;
+            let card = u32::from(printing_to_card[pid]) as usize;
+            let gid = u16::from(printings[pid].artwork_group_id) as usize;
+            let aid = artwork_base[card] as usize + gid;
+            abits[aid >> 6] |= 1u64 << (aid & 63);
+        }
+    }
+    abits
+}
+
+/// `unique=artwork` page walk over a composed printing bitmap — the artwork analogue of
+/// `walk_printing_page`. Per card it collapses the matching (set) printings to distinct **artworks**:
+/// one representative per `artwork_group_id`, the best-`prefer_score` matching printing (exactly
+/// `push_card_matches`'s Artwork arm), then pages those in sort order. Membership is the exact composed
+/// `pbits`, so there is no residual re-evaluation. The total is a separate `popcount` (see
+/// `printing_bits_to_artwork_bits`); this only builds the requested page.
+#[allow(clippy::too_many_arguments)]
+fn walk_artwork_page<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    pbits: &[u64],
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    perm: &Archived<Vec<u32>>,
+) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+    let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
+    let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
+    let mut group_best: Vec<Option<(u32, f64)>> = Vec::new(); // per gid: (best matching pid, its prefer score)
+    let mut touched: Vec<u16> = Vec::new();
+    let mut scratch: Vec<Match> = Vec::new();
+    let mut skip = page_offset;
+    for cid in perm.iter().map(|x| u32::from(*x)) {
+        let card = &cards[cid as usize];
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end = u32::from(offsets[cid as usize + 1]) as usize;
+        touched.clear();
+        for pid in start..end {
+            if !is_set(pid) {
+                continue;
+            }
+            let gid = u16::from(printings[pid].artwork_group_id) as usize;
+            if group_best.len() <= gid {
+                group_best.resize(gid + 1, None);
+            }
+            let score = prefer_score(card, &printings[pid], prefer);
+            match &group_best[gid] {
+                None => {
+                    group_best[gid] = Some((pid as u32, score));
+                    touched.push(gid as u16);
+                }
+                Some((_, best)) if score > *best => group_best[gid] = Some((pid as u32, score)),
+                _ => {}
+            }
+        }
+        if touched.is_empty() {
+            continue;
+        }
+        scratch.clear();
+        for &gid in &touched {
+            let (bp, _) = group_best[gid as usize].take().unwrap(); // take: resets group_best for the next card
+            scratch.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
+        }
+        if skip >= scratch.len() {
+            skip -= scratch.len();
+            continue;
+        }
+        scratch.sort_unstable_by(cmp);
+        for m in scratch.iter().skip(skip) {
+            page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
+            if page.len() == limit {
+                return page;
+            }
+        }
+        skip = 0;
+    }
+    page
+}
+
+/// `PrintingComposePopcount` executor for `unique=artwork`: the artwork total is `popcount(artwork_bits)`
+/// (the projected distinct illustrations), and the page is `walk_artwork_page` over the composed
+/// `pbits`. The card-mode counterpart is `exec_card_range_popcount`.
+#[allow(clippy::too_many_arguments)]
+fn exec_printing_compose_artwork<'a>(
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+    pbits: &[u64],
+    artwork_bits: &[u64],
+) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let total: usize = artwork_bits.iter().map(|w| w.count_ones() as usize).sum();
+    if total == 0 || page_offset >= total {
+        return (total, Vec::new());
+    }
+    let perm = indexes.sort_perms.get(sort_col, descending).expect("PrintingComposePopcount applicability guarantees a permutation");
+    (total, walk_artwork_page(cards, printings, offsets, pbits, prefer, sort_col, descending, limit, page_offset, perm))
 }
 
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
@@ -5204,20 +5349,30 @@ fn run_query_routed<'a>(
         feats.range_build_printings = slice_printings;
         (feats, Prep::RangeCardBits { card_bits, range_pbits })
     } else if PhysicalPlan::PrintingComposePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // #724 card projection: compose the exact printing-space bitmap, project it up to a
-        // card-existence bitmap, and reuse CardRangePopcount's popcount-skip walk (the composed pbits
-        // are the shown-printing membership — exact, no re-verify). The projection is O(composed
-        // popcount); that count rides `range_build_printings`, the same projection cost term the walk
-        // pays — and it is 0 for the printing-mode plan, which never projects.
+        // #724 projection: compose the exact printing-space bitmap once, then project up to the query's
+        // unique space and finish with a popcount-order walk. The projection is O(composed popcount);
+        // that count rides `range_build_printings`, the projection cost term (0 for the printing-mode
+        // plan, which never projects). Composed bits are exact ⇒ no per-candidate re-verify (tier 0),
+        // but dispatch's materializing alternatives DO re-check the filter, so cost them at real tier.
         let pbits = compose_printing_bits(filter, indexes, offsets, printings, n_printings as usize);
         let projected_printings: u32 = pbits.iter().map(|w| w.count_ones()).sum();
-        let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards as usize);
-        let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
-        // Composed bits are exact, so no per-candidate re-verify (tier 0) — but the materializing
-        // alternatives in dispatch DO re-check the filter, so cost them with the real verify tier.
-        let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
-        feats.range_build_printings = projected_printings;
-        (feats, Prep::RangeCardBits { card_bits, range_pbits: pbits })
+        if matches!(mode, Mode::Artwork) {
+            // Artwork: project to artwork-existence (global id = artwork_base[card] + artwork_group_id),
+            // popcount = distinct matching illustrations. No stored global-id array — derived here.
+            let artwork_base = build_artwork_base(&indexes.artwork_groups);
+            let n_artworks = *artwork_base.last().expect("artwork_base has n_cards+1 entries") as usize;
+            let artwork_bits = printing_bits_to_artwork_bits(&pbits, printings, &indexes.printing_to_card, &artwork_base, n_artworks);
+            let count: u32 = artwork_bits.iter().map(|w| w.count_ones()).sum();
+            let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
+            feats.range_build_printings = projected_printings;
+            (feats, Prep::ComposeArtwork { pbits, artwork_bits })
+        } else {
+            let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards as usize);
+            let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
+            let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
+            feats.range_build_printings = projected_printings;
+            (feats, Prep::RangeCardBits { card_bits, range_pbits: pbits })
+        }
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
@@ -5267,6 +5422,20 @@ fn run_query_routed<'a>(
         // which printing is shown.
         (p, Prep::RangeCardBits { card_bits, .. }) => {
             let ids = bitmap_card_ids(card_bits);
+            let candidate_cards = (ids.len() < cards.len() - cards.len() / 8).then_some(ids);
+            exec_from_candidates(
+                p, cards, printings, offsets, strings, filter,
+                &PreparedCandidates { candidate_cards, all_match_known: false },
+                plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+            )
+        }
+        (PhysicalPlan::PrintingComposePopcount, Prep::ComposeArtwork { pbits, artwork_bits }) => exec_printing_compose_artwork(
+            cards, printings, offsets, prefer, sort_col, descending, limit, page_offset, indexes, pbits, artwork_bits,
+        ),
+        // A materializing plan beat the artwork projection: narrow to the cards with a matching
+        // printing (projected from pbits) and re-verify the filter per printing on the general path.
+        (p, Prep::ComposeArtwork { pbits, .. }) => {
+            let ids = bitmap_card_ids(&printing_bits_to_card_bits(pbits, offsets, cards.len()));
             let candidate_cards = (ids.len() < cards.len() - cards.len() / 8).then_some(ids);
             exec_from_candidates(
                 p, cards, printings, offsets, strings, filter,
@@ -5379,6 +5548,14 @@ fn run_query_with_plan<'a>(
                 return None;
             }
             let pbits = compose_printing_bits(filter, indexes, offsets, printings, printings.len());
+            if matches!(mode, Mode::Artwork) {
+                let artwork_base = build_artwork_base(&indexes.artwork_groups);
+                let n_artworks = *artwork_base.last().expect("artwork_base has n_cards+1 entries") as usize;
+                let artwork_bits = printing_bits_to_artwork_bits(&pbits, printings, &indexes.printing_to_card, &artwork_base, n_artworks);
+                return Some(exec_printing_compose_artwork(
+                    cards, printings, offsets, prefer, sort_col, descending, limit, page_offset, indexes, &pbits, &artwork_bits,
+                ));
+            }
             let card_bits = printing_bits_to_card_bits(&pbits, offsets, cards.len());
             Some(exec_card_range_popcount(
                 cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &pbits,

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -175,6 +175,14 @@ pub(crate) const PLANE_COUNT: usize = PLANE_BORDER + BORDER_PLANES;
 /// them regardless. See docs/issues/00724-engine-printing-existential-planes.md.
 pub(crate) const BORDER_PRINTING_PLANE_VALUES: [&str; 3] = ["black", "borderless", "white"];
 
+/// #724: which rarity ints get a *printing-space* one-hot plane (bit per printing, exact). The four
+/// interior rarities (`common`=0, `uncommon`=1, `rare`=2, `mythic`=3, matching `rarity_text_to_int`)
+/// — all broad enough to earn a plane. The sparse tail (`special`=4, `bonus`=5) stays in postings,
+/// the density analogue of border's gold/yellow. Only the equality case (`r:rare`) is planed here;
+/// ordinal comparisons (`r>=rare`) still take the existing rarity path. Parallels
+/// `BORDER_PRINTING_PLANE_VALUES` — see docs/issues/00724-engine-printing-existential-planes.md.
+pub(crate) const RARITY_PRINTING_PLANE_INTS: [u8; RARITY_INTERIOR] = [0, 1, 2, 3];
+
 /// The observed [min,max] of whatever cards landed in one bucket plane,
 /// recomputed on every build/reload (never hardcoded from a one-time data
 /// snapshot — a future card outside today's observed range must still
@@ -469,6 +477,53 @@ pub(crate) fn build_border_printing_planes(printings: &[Printing], strings: &[St
     }
     let postings = postings.into_iter().map(|(v, ids)| (v.to_string(), ids)).collect();
     BorderPrintingPlanes { n_printings: n as u32, words, postings }
+}
+
+/// #724: printing-space rarity planes — bit per printing, **exact** (unlike #670's card-space
+/// *existential* rarity planes, whose card bit means "some printing has this rarity"). One one-hot
+/// plane per `RARITY_PRINTING_PLANE_INTS` entry (common/uncommon/rare/mythic), plane-major,
+/// `words_per_plane(n_printings)` each; printing `p`'s bit is set iff that printing's rarity int is
+/// the value. The sparse tail (special/bonus) lands in `postings`, keyed by int. Composed and
+/// projected exactly the same way as `BorderPrintingPlanes`.
+#[derive(Archive, Serialize, Deserialize, Default)]
+pub(crate) struct RarityPrintingPlanes {
+    pub(crate) n_printings: u32,
+    /// `RARITY_PRINTING_PLANE_INTS.len()` planes, plane-major: bit `p` of plane `k` is
+    /// `words[k * words_per_plane(n_printings) + p/64] >> (p%64) & 1`.
+    pub(crate) words: Vec<u64>,
+    /// Sparse rarity ints below the plane crossover (special=4/bonus=5) → ascending printing ids,
+    /// keyed by rarity int. Scattered into a bitmap at query time, same as border's postings.
+    pub(crate) postings: Vec<(u8, Vec<u32>)>,
+}
+
+/// Build the #724 printing-space rarity planes: one pass over printings, setting each interior
+/// rarity's bit and posting the sparse tail. Mirrors `build_border_printing_planes` (see its
+/// drift-assert rationale); rarity's four interior values are all far above the crossover.
+pub(crate) fn build_rarity_printing_planes(printings: &[Printing]) -> RarityPrintingPlanes {
+    let n = printings.len();
+    let wpp = words_per_plane(n);
+    let mut words = vec![0u64; RARITY_PRINTING_PLANE_INTS.len() * wpp];
+    let mut postings: std::collections::BTreeMap<u8, Vec<u32>> = std::collections::BTreeMap::new();
+    for (p, printing) in printings.iter().enumerate() {
+        let Some(r) = printing.card_rarity_int else { continue }; // null rarity contributes no bit
+        match RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == r) {
+            Some(k) => words[k * wpp + p / 64] |= 1u64 << (p % 64), // interior rarity → its one-hot plane
+            None => postings.entry(r).or_default().push(p as u32),  // special/bonus → postings (ascending p)
+        }
+    }
+    const PLANE_POSTINGS_CROSSOVER: usize = 3_000;
+    const DRIFT_CHECK_MIN_PRINTINGS: usize = 50_000;
+    if n >= DRIFT_CHECK_MIN_PRINTINGS {
+        for (k, int) in RARITY_PRINTING_PLANE_INTS.iter().enumerate() {
+            let popcount: usize = words[k * wpp..(k + 1) * wpp].iter().map(|w| w.count_ones() as usize).sum();
+            debug_assert!(
+                popcount == 0 || popcount >= PLANE_POSTINGS_CROSSOVER,
+                "rarity printing plane int {int} has {popcount} printings, below the ~{PLANE_POSTINGS_CROSSOVER} plane/postings crossover — reclassify to postings (#724)",
+            );
+        }
+    }
+    let postings = postings.into_iter().collect();
+    RarityPrintingPlanes { n_printings: n as u32, words, postings }
 }
 
 /// Ascending card ids with divergent legality (~556 of 31,508 in production —

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2756,6 +2756,18 @@ fn force_plan_differential_agreement() {
             "edhrec",
             "asc",
         ),
+        // #724 legality compose: a legality AND border compound. Legality's printing bitmap is built
+        // from #667's card `_EXISTS` plane + the authoritative divergent repair (legality_leaf_bits),
+        // then AND'd with border in printing space. The fuzz corpus is 40% divergent-legality, so this
+        // forces the repair path; agreement vs GatheredScan is checked in both printing and card modes.
+        (
+            FuzzSpec::And(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Legality { shift: Some(FUZZ_SHIFTS[0]), expected: FUZZ_STATUSES[0] }),
+                FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+            ]),
+            "edhrec",
+            "asc",
+        ),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -3356,7 +3368,13 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (matches / f64::from(f.n_printings)).max(1.0e-6);
     match plan {
-        PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan => (vec![page_span / match_rate, 1.0], 0.0),
+        PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
+        // Same walk terms as the range fast path, plus the legality broadcast as a fixed offset
+        // (range_build_printings is 0 for border/rarity, so this matches PrintingRangeScan there).
+        PhysicalPlan::PrintingPlaneScan => (
+            vec![page_span / match_rate, 1.0],
+            f64::from(f.range_build_printings) * super::cost::COMPOSE_BROADCAST_PER_PRINTING_NS,
+        ),
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
         // Same term vector as P2; the build/projection term is a fixed (hand-set) offset, not a refit
         // param. PrintingComposePopcount shares the formula (same executor + projection cost term).
@@ -7980,6 +7998,108 @@ fn border_plane_query_kernel() {
     println!("  matching printings: {matches}");
     println!("  popcount + edhrec walk to fill {LIMIT}: {best} ns   (checksum total={sink})");
     println!("  today's per-printing scan (bench_printing_planes): ~869,000 ns");
+}
+
+/// #724 legality-compose kernel costs (real.store): the three query-time operations the broadcast +
+/// divergent-repair legality leaf pays, which a precomputed legality *printing* plane would avoid. This
+/// quantifies the plane-vs-broadcast tradeoff and calibrates the cost model's build term instead of
+/// hand-picking it. Reports, per real legality format (`_EXISTS` plane density varies), the broadcast
+/// (card→printing) and projection (printing→card) kernels, plus the divergent repair once (~format
+/// -independent, driven by the divergent-card printing count).
+/// `cargo test --release legality_compose_kernel_costs -- --ignored --nocapture`
+#[test]
+#[ignore = "#724 legality-compose kernel costs; needs real.store"]
+fn legality_compose_kernel_costs() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 20;
+    const ITERS: usize = 200;
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let offsets = &archived.offsets;
+    let wpp_c = super::words_per_plane(n_cards);
+    let planes = &archived.indexes.planes;
+    let divergent = &archived.indexes.legal_divergent;
+
+    // Time a closure to its minimum over ITERS (min = least-contended, matches the other kernels).
+    let bench = |f: &mut dyn FnMut() -> u64| -> (u128, u64) {
+        let mut best = u128::MAX;
+        let mut sink = 0u64;
+        for it in 0..ITERS {
+            let t0 = Instant::now();
+            sink = sink.wrapping_add(black_box(f()));
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                best = best.min(dt);
+            }
+        }
+        (best, sink)
+    };
+
+    println!("\n#724 legality-compose kernel costs (real.store: {n_cards} cards, {n_printings} printings)");
+    println!("divergent-legality cards: {} ({:.1}%)", divergent.len(), 100.0 * divergent.len() as f64 / n_cards as f64);
+    println!("{:>6}  {:>10}  {:>11}  {:>12}  {:>13}  {:>12}", "fmt", "∃cards", "bcast-prtg", "bcast ns", "project ns", "ns/prtg");
+
+    for f in 0..super::MAX_FORMATS {
+        let base = (super::PLANE_LEGAL_EXISTS + f) * wpp_c;
+        let card_bits: Vec<u64> = planes.words[base..base + wpp_c].iter().map(|w| u64::from(*w)).collect();
+        let set_cards: u64 = card_bits.iter().map(|w| w.count_ones() as u64).sum();
+        if set_cards == 0 {
+            continue; // format not loaded / no legal cards
+        }
+        // (1) broadcast: card ∃-legal bits → printing bits.
+        let (bcast_ns, _) = bench(&mut || {
+            let pb = super::broadcast_card_bits_to_printings(&card_bits, offsets, n_printings);
+            pb.iter().map(|w| w.count_ones() as u64).sum()
+        });
+        let pbits = super::broadcast_card_bits_to_printings(&card_bits, offsets, n_printings);
+        let bcast_printings: u64 = pbits.iter().map(|w| w.count_ones() as u64).sum();
+        // (2) projection: printing bits → card bits.
+        let (proj_ns, _) = bench(&mut || {
+            let cb = super::printing_bits_to_card_bits(&pbits, offsets, n_cards);
+            cb.iter().map(|w| w.count_ones() as u64).sum()
+        });
+        let per_prtg = bcast_ns as f64 / bcast_printings.max(1) as f64;
+        println!("{f:>6}  {set_cards:>10}  {bcast_printings:>11}  {bcast_ns:>12}  {proj_ns:>13}  {per_prtg:>12.3}");
+    }
+
+    // (3) repair: overwrite each divergent card's printings from the per-printing legality word, for
+    // one representative shift (0). Format-independent — driven by the divergent printing count.
+    let shift = 0u8;
+    let expected = super::status_plane_bases(0b01).map(|_| 0b01u64).unwrap_or(0b01);
+    let mut div_printings = 0u64;
+    for cid in divergent.iter() {
+        let c = u16::from(*cid) as usize;
+        div_printings += (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as u64;
+    }
+    let (repair_ns, sink) = bench(&mut || {
+        let mut hits = 0u64;
+        for cid in divergent.iter() {
+            let c = u16::from(*cid) as usize;
+            for p in u32::from(offsets[c]) as usize..u32::from(offsets[c + 1]) as usize {
+                if (u64::from(archived.printings[p].card_legalities) >> shift) & 0b11 == expected {
+                    hits += 1;
+                }
+            }
+        }
+        hits
+    });
+    println!(
+        "repair: {} divergent cards, {div_printings} printings, {repair_ns} ns ({:.3} ns/printing)  (sink={sink})",
+        divergent.len(),
+        repair_ns as f64 / div_printings.max(1) as f64,
+    );
 }
 
 /// #724 build-side correctness oracle: projecting a printing-space border plane up to card-existence

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2742,11 +2742,11 @@ fn force_plan_differential_agreement() {
         // above already exercise it; add collector_number + year over card-level perms too).
         (FuzzSpec::Leaf(FuzzLeaf::CollectorNumber { op: CmpOp::Lt, val: 100.0 }), "edhrec", "asc"),
         (FuzzSpec::Leaf(FuzzLeaf::Year { op: CmpOp::Ge, year: 2015 }), "edhrec", "desc"),
-        // #724: a bare border leaf routes through PrintingPlaneScan in printing mode (black is ~1/6
+        // #724: a bare border leaf routes through PrintingCompose in printing mode (black is ~1/6
         // of printings, above STREAM_MIN in this corpus → the walk; agreement vs GatheredScan checked).
         (FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }), "edhrec", "asc"),
         // #724 compose: a border AND rarity compound is composable in printing space (both are exact
-        // planes) — PrintingPlaneScan AND's the two bitmaps, popcounts the total, and walks the
+        // planes) — PrintingCompose AND's the two bitmaps, popcounts the total, and walks the
         // composed filter. Forces the plane-on-plane AND path and checks agreement vs GatheredScan.
         (
             FuzzSpec::And(vec![
@@ -2778,23 +2778,21 @@ fn force_plan_differential_agreement() {
     let modes = ["card", "printing", "artwork"];
     let all_plans = [
         PhysicalPlan::PrintingRangeScan,
-        PhysicalPlan::PrintingPlaneScan,
+        PhysicalPlan::PrintingCompose,
         PhysicalPlan::PlanePopcountOrder,
         PhysicalPlan::CardRangePopcount,
-        PhysicalPlan::PrintingComposePopcount,
         PhysicalPlan::StreamedSelect,
         PhysicalPlan::GatheredScan,
     ];
     let plan_idx = |p: PhysicalPlan| match p {
         PhysicalPlan::PrintingRangeScan => 0,
-        PhysicalPlan::PrintingPlaneScan => 1,
+        PhysicalPlan::PrintingCompose => 1,
         PhysicalPlan::PlanePopcountOrder => 2,
         PhysicalPlan::CardRangePopcount => 3,
-        PhysicalPlan::PrintingComposePopcount => 4,
-        PhysicalPlan::StreamedSelect => 5,
-        PhysicalPlan::GatheredScan => 6,
+        PhysicalPlan::StreamedSelect => 4,
+        PhysicalPlan::GatheredScan => 5,
     };
-    let mut ran = [0u32; 7];
+    let mut ran = [0u32; 6];
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
@@ -3264,7 +3262,7 @@ fn plan_cost_model_matches_gold() {
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
-                    range_build_printings: 0,
+                    synth_printings: 0, popcount_words: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -3368,19 +3366,20 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (matches / f64::from(f.n_printings)).max(1.0e-6);
     match plan {
+        // [WALK, FIXED].
         PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
-        // Same walk terms as the range fast path, plus the legality broadcast as a fixed offset
-        // (range_build_printings is 0 for border/rarity, so this matches PrintingRangeScan there).
-        PhysicalPlan::PrintingPlaneScan => (
-            vec![page_span / match_rate, 1.0],
-            f64::from(f.range_build_printings) * super::cost::COMPOSE_BROADCAST_PER_PRINTING_NS,
+        // [POPCOUNT(result words), WALK(printings walked), EMIT, FIXED]; synth (SCATTER) is a hand-set
+        // offset, not a refit param.
+        PhysicalPlan::PrintingCompose => (
+            vec![f64::from(f.popcount_words), page_span / match_rate, limit, 1.0],
+            f64::from(f.synth_printings) * super::cost::SCATTER_PER_PRINTING_NS,
         ),
+        // [PERM_SCATTER, POPCOUNT(card words), EMIT, FIXED].
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
-        // Same term vector as P2; the build/projection term is a fixed (hand-set) offset, not a refit
-        // param. PrintingComposePopcount shares the formula (same executor + projection cost term).
-        PhysicalPlan::CardRangePopcount | PhysicalPlan::PrintingComposePopcount => (
+        // Same term vector as PlanePopcountOrder; synth (SCATTER) is a hand-set offset, not a refit param.
+        PhysicalPlan::CardRangePopcount => (
             vec![matches, n_cards / 64.0, limit, 1.0],
-            f64::from(f.range_build_printings) * super::cost::CARD_RANGE_BUILD_PER_PRINTING_NS,
+            f64::from(f.synth_printings) * super::cost::SCATTER_PER_PRINTING_NS,
         ),
         PhysicalPlan::StreamedSelect => {
             let floor = if u64::from(f.matches) <= *STREAM_MIN_MATCHES as u64 { n_cards } else { 0.0 };
@@ -3489,7 +3488,7 @@ fn plan_cost_refit() {
                     scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
-                    range_build_printings: 0,
+                    synth_printings: 0, popcount_words: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -3687,7 +3686,7 @@ fn printing_range_route_probe() {
                 scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
-                range_build_printings: 0,
+                synth_printings: 0, popcount_words: 0,
             };
 
             // ── Three pickers ──
@@ -4048,7 +4047,7 @@ fn plan_regret_report() {
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
-                range_build_printings: 0,
+                synth_printings: 0, popcount_words: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -4175,7 +4174,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
-                range_build_printings: 0,
+                synth_printings: 0, popcount_words: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
-    assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
+    assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
@@ -2343,6 +2343,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
     data.indexes.border_printing = build_border_printing_planes(&data.printings, &data.strings);
+    data.indexes.rarity_printing = build_rarity_printing_planes(&data.printings);
     data
 }
 
@@ -2744,6 +2745,17 @@ fn force_plan_differential_agreement() {
         // #724: a bare border leaf routes through PrintingPlaneScan in printing mode (black is ~1/6
         // of printings, above STREAM_MIN in this corpus → the walk; agreement vs GatheredScan checked).
         (FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }), "edhrec", "asc"),
+        // #724 compose: a border AND rarity compound is composable in printing space (both are exact
+        // planes) — PrintingPlaneScan AND's the two bitmaps, popcounts the total, and walks the
+        // composed filter. Forces the plane-on-plane AND path and checks agreement vs GatheredScan.
+        (
+            FuzzSpec::And(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+                FuzzSpec::Leaf(FuzzLeaf::Rarity { op: CmpOp::Eq, val: 2.0 }),
+            ]),
+            "edhrec",
+            "asc",
+        ),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -2757,6 +2769,7 @@ fn force_plan_differential_agreement() {
         PhysicalPlan::PrintingPlaneScan,
         PhysicalPlan::PlanePopcountOrder,
         PhysicalPlan::CardRangePopcount,
+        PhysicalPlan::PrintingComposePopcount,
         PhysicalPlan::StreamedSelect,
         PhysicalPlan::GatheredScan,
     ];
@@ -2765,10 +2778,11 @@ fn force_plan_differential_agreement() {
         PhysicalPlan::PrintingPlaneScan => 1,
         PhysicalPlan::PlanePopcountOrder => 2,
         PhysicalPlan::CardRangePopcount => 3,
-        PhysicalPlan::StreamedSelect => 4,
-        PhysicalPlan::GatheredScan => 5,
+        PhysicalPlan::PrintingComposePopcount => 4,
+        PhysicalPlan::StreamedSelect => 5,
+        PhysicalPlan::GatheredScan => 6,
     };
-    let mut ran = [0u32; 6];
+    let mut ran = [0u32; 7];
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
@@ -3344,8 +3358,9 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     match plan {
         PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingPlaneScan => (vec![page_span / match_rate, 1.0], 0.0),
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
-        // Same term vector as P2; the build term is a fixed (hand-set) offset, not a refit param.
-        PhysicalPlan::CardRangePopcount => (
+        // Same term vector as P2; the build/projection term is a fixed (hand-set) offset, not a refit
+        // param. PrintingComposePopcount shares the formula (same executor + projection cost term).
+        PhysicalPlan::CardRangePopcount | PhysicalPlan::PrintingComposePopcount => (
             vec![matches, n_cards / 64.0, limit, 1.0],
             f64::from(f.range_build_printings) * super::cost::CARD_RANGE_BUILD_PER_PRINTING_NS,
         ),
@@ -4475,6 +4490,7 @@ fn bench_checked_vs_unchecked_access() {
         printing_to_card: build_printing_to_card(&offsets),
         planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
         border_printing: build_border_printing_planes(&printings, &strings),
+        rarity_printing: build_rarity_printing_planes(&printings),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
     };
@@ -8000,6 +8016,42 @@ fn border_printing_plane_matches_card_plane_projected() {
         assert_eq!(projected, card_bits, "border '{value}' (plane {k}): projected-up printing plane != #664 card plane");
     }
     eprintln!("OK: {} border printing planes project up to match #664's card planes", super::BORDER_PRINTING_PLANE_VALUES.len());
+}
+
+/// #724 build-side correctness oracle (rarity): projecting a printing-space rarity plane up to
+/// card-existence must equal #670's card-space rarity plane for the same int — both mean "this card
+/// has a printing at this rarity." The printing plane for `RARITY_PRINTING_PLANE_INTS[k]` (= k, the
+/// interior rarities 0..4) projects to card plane `PLANE_RARITY + k`. Same real.store + format guard
+/// as the border oracle. `cargo test --release rarity_printing_plane_matches_card_plane_projected --
+/// --ignored --nocapture`
+#[test]
+#[ignore = "#724 rarity-plane oracle diff; needs a freshly-built real.store"]
+fn rarity_printing_plane_matches_card_plane_projected() {
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (rebuild after the #724 rarity build-side change)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild for the bumped ARCHIVE_FORMAT_VERSION");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let rp = &archived.indexes.rarity_printing; // printing-space (#724)
+    let cp = &archived.indexes.planes; // card-space (#670)
+    let wpp_p = super::words_per_plane(n_printings);
+    let wpp_c = super::words_per_plane(n_cards);
+    for (k, int) in super::RARITY_PRINTING_PLANE_INTS.iter().enumerate() {
+        let printing_bits: Vec<u64> = rp.words[k * wpp_p..(k + 1) * wpp_p].iter().map(|w| u64::from(*w)).collect();
+        let projected = super::printing_bits_to_card_bits(&printing_bits, &archived.offsets, n_cards);
+        let start = (super::PLANE_RARITY + k) * wpp_c;
+        let card_bits: Vec<u64> = cp.words[start..start + wpp_c].iter().map(|w| u64::from(*w)).collect();
+        assert_eq!(projected, card_bits, "rarity int {int} (plane {k}): projected-up printing plane != #670 card plane");
+    }
+    eprintln!("OK: {} rarity printing planes project up to match #670's card planes", super::RARITY_PRINTING_PLANE_INTS.len());
 }
 
 /// PR 2a build-cost split: for `usd<50`, which half of `CardRangePopcount`'s build dominates —

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -139,6 +139,41 @@ the plan is gated to bare border under `unique=printing`, so no other query path
 gating *is* the no-regression guarantee, and the flat rows confirm it). Compounds and the card/artwork
 projections are the next slices (the printing-space plan + PR 2b), not this PR.
 
+## Result: rarity planes + printing-space compose + card projection (follow-on PR)
+
+The follow-on adds rarity printing planes (common/uncommon/rare/mythic; special/bonus in postings),
+printing-space `AND`/`OR` composition, and the printing→card projection with its cost term. A/B on the
+same corpus (`CARD_ENGINE_BORDER_PRINTING_PLANE` + `CARD_ENGINE_PRINTING_COMPOSE_CARD`, min µs, totals
+identical between arms):
+
+| query | mode | off µs | on µs | speedup | what |
+|---|---|---:|---:|---:|---|
+| `r:rare` | printing | 356 | 44 | **8.0×** | rarity plane (bare) |
+| `r:mythic` | printing | 141 | 51 | **2.8×** | rarity plane (bare) |
+| `border:black r:rare` | printing | 621 | 53 | **11.7×** | compose (AND two planes) |
+| `border:black r:rare` | card | 326 | 102 | **3.2×** | compose + project up |
+| `border:black` | printing | 864 | 44 | 19.5× | border (from the first slice) |
+| `f:modern border:black` | printing | 752 | 739 | 1.0× | legality not yet composable → flat |
+| `f:modern r:rare` | printing | 298 | 296 | 1.0× | ditto |
+| `border:black` | card | 66 | 64 | 1.0× | bare card defers to #664+#634 plane |
+| `border:black` | artwork | 907 | 910 | 1.0× | needs PR 2b |
+
+Two things this validates directly:
+
+- **Composition is exact and fast.** `border:black r:rare`/printing ANDs the two exact printing planes
+  and popcounts — 11.7×, matching `GatheredScan` on total + rows + order (the forced-plan differential).
+- **The projection cost term is real and mode-gated.** The *same* compound costs 53 µs in printing mode
+  and 102 µs in card mode; the ~49 µs delta *is* the printing→card scatter (`printing_bits_to_card_bits`),
+  which is exactly **0 in printing mode** (`range_build_printings = 0`) — the cost term does what the
+  model says. Card is still 3.2× over the general narrowed path it replaces.
+
+Scope honesty: `NOT` is deliberately **not** composable — over a nullable field the plane `complement`
+isn't the trivalent negation (a null-border printing satisfies neither `border:black` nor
+`-border:black`), so `-border:black` stays on the general path. Legality is not yet a printing plane, so
+`f:modern …` compounds stay flat (a later slice). Bare `unique=card` border/rarity correctly defer to the
+existing #664/#670 card planes (`compile_plane` exact-consumes them), so this plan fires only where
+`compile_plane` **declines** — the shared-witness compounds. `unique=artwork` awaits PR 2b.
+
 The load-bearing finding: **legality is ~4× cheaper than border in printing mode at the same
 breadth, because legality settles at the *card* level** (`printing_dependent(Legality) => false`,
 [filter.rs](../../card_engine/src/filter.rs)) — it evaluates once per card (~31.5k) and emits all of

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -169,10 +169,47 @@ Two things this validates directly:
 
 Scope honesty: `NOT` is deliberately **not** composable — over a nullable field the plane `complement`
 isn't the trivalent negation (a null-border printing satisfies neither `border:black` nor
-`-border:black`), so `-border:black` stays on the general path. Legality is not yet a printing plane, so
-`f:modern …` compounds stay flat (a later slice). Bare `unique=card` border/rarity correctly defer to the
-existing #664/#670 card planes (`compile_plane` exact-consumes them), so this plan fires only where
-`compile_plane` **declines** — the shared-witness compounds. `unique=artwork` awaits PR 2b.
+`-border:black`), so `-border:black` stays on the general path. Bare `unique=card` border/rarity
+correctly defer to the existing #664/#670 card planes (`compile_plane` exact-consumes them), so this
+plan fires only where `compile_plane` **declines** — the shared-witness compounds. `unique=artwork`
+awaits PR 2b.
+
+## Result: legality via broadcast + divergent repair (no new plane)
+
+Legality composes without a per-printing plane at all — reusing #667's card-space `_EXISTS` plane. A
+legality leaf's printing bitmap is `broadcast(∃-legal) | authoritative-repair(divergent)`: legality is
+only ~1.8% divergent (`legal_divergent`), so the card plane broadcast down is exact for 98.2% of cards
+and only the ~556 divergent cards' printings are overwritten from their own `card_legalities` word (no
+stored postings). Kernel costs (`legality_compose_kernel_costs`, real corpus):
+
+| op | cost | scaling |
+|---|---|---|
+| broadcast (card ∃ → printing) | 22–145 µs | ~1.5 ns/printing |
+| projection (printing → card) | 26–145 µs | ~1.5 ns/printing |
+| **repair** (divergent overwrite) | **5.5 µs** | negligible (~11k printings) |
+
+The repair is free; the broadcast is the whole cost, at ~1.5 ns/printing (≈ the range-scatter rate).
+So the cost model charges the broadcast as a build term (`range_build_printings ×
+COMPOSE_BROADCAST_PER_PRINTING_NS`), and — crucially — **acquire estimates rather than composing** (the
+`_EXISTS` popcount scaled to printings), so the broadcast is paid once, in the fast path, only if the
+plan wins. That removed a latent *double* broadcast (acquire + fast path both composing) that had been
+inflating every legality query. A/B (min µs, both flags):
+
+| query | mode | off | on | speedup |
+|---|---|---:|---:|---:|
+| `f:modern border:black` | printing | 754 | 174 | **4.3×** |
+| `f:modern r:rare` | printing | 297 | 174 | **1.7×** |
+| `f:modern border:black` | card | 341 | 290 | 1.2× |
+| `f:modern` (bare) | printing | 190 | 167 | 1.1× (no regression) |
+| `border:black r:rare` | printing | 638 | 54 | 11.8× |
+
+No hand-exclusion: the cost model routes bare legality to the general path or a single-broadcast compose
+(whichever the term says is cheaper) and reserves the broadcast for compounds that replace a full scan.
+
+**Partial vote for planes.** The broadcast is ~1.5 ns/printing but ~100–145 µs for *broad* formats
+(modern/commander/…), which a precomputed legality *printing* plane (≈12 KB, a free slice read) would
+erase. So the end state is a per-format frequency×breadth crossover — planes for the hot broad formats,
+broadcast+repair for the long tail — the same plane-vs-postings decision one level up. Not this PR.
 
 The load-bearing finding: **legality is ~4× cheaper than border in printing mode at the same
 breadth, because legality settles at the *card* level** (`printing_dependent(Legality) => false`,

--- a/docs/issues/00724-engine-printing-existential-planes.md
+++ b/docs/issues/00724-engine-printing-existential-planes.md
@@ -211,6 +211,29 @@ No hand-exclusion: the cost model routes bare legality to the general path or a 
 erase. So the end state is a per-format frequency×breadth crossover — planes for the hot broad formats,
 broadcast+repair for the long tail — the same plane-vs-postings decision one level up. Not this PR.
 
+## Result: artwork projection (the third unique mode)
+
+`unique=artwork` now composes too, via the same substrate. The dense global artwork id is **derived at
+query time** (no stored array, no archive change): `global_id = artwork_base[card] + artwork_group_id`,
+where `artwork_base` is the prefix-sum of the per-card distinct-artwork counts already in
+`artwork_groups`. So the printing bits project up to an artwork-existence bitmap, and — the key win —
+the artwork **total is `popcount(artwork_bits)`**, replacing the O(candidates × printings) count pass
+that made artwork mode ~14× slower than card. The page walk (`walk_artwork_page`) collapses each card's
+matching printings to distinct artworks (best-`prefer_score` representative per group, exactly the
+general path's semantics) and pages in sort order. A/B (min µs, totals identical between arms):
+
+| query | mode | off | on | speedup |
+|---|---|---:|---:|---:|
+| `border:black` | artwork | 925 | 190 | **4.9×** |
+| `border:black r:rare` | artwork | 648 | 110 | **5.9×** |
+| `f:modern border:black` | artwork | 792 | 286 | 2.8× |
+| `r:mythic` | artwork | 153 | 70 | 2.2× |
+
+Folded into `PrintingComposePopcount` (now `Mode::Card | Mode::Artwork`): bare border/rarity/legality
+also route here under `unique=artwork` (nothing folds to a card plane there), so the count-pass →
+popcount win applies broadly, not just to compounds. All three unique modes — printing (walk), card
+(↑ card-existence), artwork (↑ artwork-existence) — are now the one compose-then-project model.
+
 The load-bearing finding: **legality is ~4× cheaper than border in printing mode at the same
 breadth, because legality settles at the *card* level** (`printing_dependent(Legality) => false`,
 [filter.rs](../../card_engine/src/filter.rs)) — it evaluates once per card (~31.5k) and emits all of

--- a/docs/issues/00730-engine-popcount-skip-walk.md
+++ b/docs/issues/00730-engine-popcount-skip-walk.md
@@ -1,0 +1,57 @@
+# Engine: Popcount-Skip Walk for Deep Pagination, Generalized to All Distinct-Ons
+
+Status: todo, filed as [#730](https://github.com/jbylund/sylvan_librarian/issues/730). Deferred
+optimization split out of the #724 printing-space compose work
+([00724](00724-engine-printing-existential-planes.md)).
+
+## Two ways to page a match bitmap
+
+Once a query's matches are a bitmap in the result space, the page can be produced two ways:
+
+- **Forward grouped walk** (`walk_printing_page` / `walk_artwork_page`, and card after the #724
+  unification): walk the sort permutation from the front, collapse each card's matching printings to
+  the distinct-on's granularity (printing = every set printing, artwork = one representative per
+  `artwork_group_id`, card = one per card), and emit until `offset + limit` rows have passed. Cost is
+  O(rows visited) = O(offset + limit) worth of the sort order.
+- **Popcount-skip order** (`run_query_streamed_popcount`, the #634/#725 card-space walk): word-scan the
+  match bitmap + per-card counts to land directly on the O-th match, then emit `limit`. Cost is
+  O(bitmap words) to skip + O(limit) to emit — **independent of how deep the offset is**.
+
+At `offset = 0` they're equivalent (the forward walk fills the page immediately). The skip only wins at
+**deep pagination** — page 50 of a broad result — where the forward walk pays for the rows before the
+page and the skip does not.
+
+## What the #724 unification changed
+
+#724 unified printing / card / artwork compose onto the *one* forward grouped walk (one plan, one cost
+formula parameterized by output space). That was the right clarity/correctness call, but it moved **card
+compose off the popcount-skip walk** it previously inherited from `CardRangePopcount`. So card compose
+now pays the forward-walk offset cost for deep pages. Acceptable because deep pagination is rare in
+card-search UIs (page 0 dominates), but it is a regression at the tail worth recording.
+
+## The idea
+
+1. **Restore popcount-skip for deep offsets** — route the compose plan to a skip-order walk when
+   `offset` is large enough that visiting the preceding rows dominates (a cost-model decision, or a
+   fixed threshold).
+2. **Generalize popcount-skip to all three distinct-ons.** Today only card space has it. The bitmaps a
+   skip walk needs already exist after #724:
+   - **printing** — skip over the composed printing bitmap directly.
+   - **card** — the card-existence projection (already built).
+   - **artwork** — the artwork-existence projection + per-card artwork counts (`artwork_groups`, already
+     stored) to skip whole cards' artwork spans.
+
+   So this is a walk-side addition, not a new index — the projection substrate is in place.
+
+## Why deferred
+
+Deep pagination is rare, and unifying the three modes onto one walk was the larger win. This is a
+targeted optimization to build once/if deep-offset compose queries prove hot — measure the offset
+distribution of real traffic before spending the complexity.
+
+## Related
+
+- [00724](00724-engine-printing-existential-planes.md) — the printing-space compose plan whose
+  unification this splits off from.
+- `run_query_streamed_popcount` (`card_engine/src/lib.rs`) — the existing card-space popcount-skip walk
+  to generalize.

--- a/docs/issues/00731-engine-compose-universal-evaluator.md
+++ b/docs/issues/00731-engine-compose-universal-evaluator.md
@@ -1,0 +1,77 @@
+# Engine: Printing-Space Compose as the Universal Exact Evaluator
+
+Status: todo, filed as [#731](https://github.com/jbylund/sylvan_librarian/issues/731). The
+generalization of [#724](00724-engine-printing-existential-planes.md)'s printing-space compose from
+"whole filter composable" into the query engine's general evaluation model. Deferred until #724 (the
+substrate) merges.
+
+## The model
+
+Every query leaf that has an index can be turned into — or tested against — an **exact printing-space
+bitmap**. Compose those bitmaps with `AND`/`OR`/`NOT` in printing space, then project **once** to the
+query's unique space (`printing` = the bits themselves; `card`/`artwork` = a single `∃`-projection).
+That one pipeline answers arbitrary queries exactly, at any distinct-on. #724 built it for
+border/rarity/legality under `AND`/`OR`; this is the generalization to *all* leaf kinds.
+
+## Leaf sources — each yields an exact printing bitmap
+
+| kind | leaves | how | status |
+|---|---|---|---|
+| plane read | border, rarity, legality | plane slice (legality: broadcast card `∃`-plane + divergent repair) | built (#724) |
+| range materialize | `usd`, `cn`, `date` | scatter the range index's in-range slice into a bitmap | tooling exists (`build_card_range_bits`/`scatter_bits`) |
+| broadcast down | card-invariant `color`/`type`/`cmc` | broadcast the card plane to printing space; **no repair** (never diverges) | `broadcast_card_bits_to_printings` exists |
+| per-survivor residual | text (`name`/`oracle`/`flavor`), or any leaf | verify on the composed survivors, not as a bitmap | existing residual machinery |
+
+## Materialize vs. verify — one cost axis, both exact
+
+An indexed printing-varying leaf can **either** be materialized as a bitmap and `AND`'d, **or** verified
+per surviving printing. Both are exact; the planner picks by which side is smaller:
+
+- composed set large, range broad → materialize the range bitmap and `AND` (O(range) build + O(words)).
+- composed set already small → iterate its set bits and read each printing's field directly
+  (O(survivors), no index, no full bitmap).
+
+This is the same density crossover the border plane-vs-postings decision embodies, one level up — and it
+dissolves the "compose leaf vs residual" distinction into a cost decision rather than a correctness one.
+
+## The load-bearing rule (why printing space at all)
+
+**Two or more printing-varying leaves must be `AND`'d in printing space _before_ the `∃`-projection.** A
+card-space existence-`AND` of separately-`∃`-projected leaves false-positives on the shared witness — a
+card with a black printing and a *separate* rare printing satisfies `∃black ∧ ∃rare` but has no single
+black-and-rare printing. Composing in printing space and projecting once is exactly what avoids that
+(see [#724](00724-engine-printing-existential-planes.md)). Card-invariant leaves and card-level
+residuals are witness-independent, so they apply *after* the projection.
+
+## Correctness caveats (both the trivalent-NULL issue)
+
+- **Ranges: intersect the in-range slice, never complement the out-of-range one.** `usd<20` is the
+  printings the index places in `[min, 20)`; a no-price printing is in neither slice and must be
+  excluded — intersecting the in-range slice does that, complementing `≥20` would wrongly keep it.
+- **`NOT` over a nullable field needs a "known" mask.** A null-border printing satisfies neither
+  `border:black` nor `-border:black`; the plane `complement` isn't the trivalent negation. `NOT` is
+  excluded from compose until the known-mask is added.
+
+## Why it matters
+
+#724 today requires the *whole* filter composable, so only ~0.5% of realistic traffic qualifies
+(measured, `survey_queries.py` — most queries mix border/rarity/legality with color/type/name). Making
+ranges and card-invariant leaves bitmap sources, plus deferring text to per-survivor residual, expands
+the addressable slice to most real queries — `r:rare border:black usd<20`, `f:modern c=g t:creature` —
+each an exact printing-space composition projected once. This is the direct answer to "why the targeted
+wins didn't move the broad survey": the addressable slice was structurally tiny, not the wins small.
+
+## Scope / sequencing
+
+Build order (each its own PR, gated by the cost model that already prices synthesis):
+
+1. **Range leaves** (`usd`/`cn`/`date`) as compose sources — reuses `build_card_range_bits`.
+2. **Card-invariant broadcast leaves** (`color`/`type`/`cmc`) — reuses `broadcast_card_bits_to_printings`.
+3. **Per-survivor residual** for the non-composable remainder (text) — feed compose's exact narrowing
+   into the existing residual-verify path (printing-varying residual before the projection, card-invariant
+   after).
+
+## Related
+
+- [#724](00724-engine-printing-existential-planes.md) — printing-space compose, the substrate.
+- [#730](00730-engine-popcount-skip-walk.md) — deep-pagination popcount-skip walk (orthogonal).


### PR DESCRIPTION
Stacked on #728 (border slice). Turns #724's printing-space planes into the full **compose-then-project** model across all three unique modes.

## What ships

- **Rarity printing planes** (`common`/`uncommon`/`rare`/`mythic`; `special`/`bonus` postings). Oracle-diffed vs #670's card planes on `real.store`.
- **`compose_printing_bits`** — `AND`/`OR` of border + rarity + legality leaves into one exact printing bitmap (`NOT` excluded: over a nullable field the plane complement isn't the trivalent negation).
- **Legality without a plane** — a legality leaf's printing bitmap is `broadcast(#667 card ∃-plane) | authoritative-repair(divergent)`. Legality is ~1.8% divergent, so the broadcast is exact for 98.2% and the ~556 divergent cards are overwritten from their own `card_legalities` word. No stored postings, no new plane.
- **`PrintingComposePopcount`** projects the composed bits to the query's unique space and finishes with a popcount-order walk — now `Mode::Card | Mode::Artwork`:
  - **card** → card-existence bitmap, reuse the popcount-skip card walk.
  - **artwork** → artwork-existence bitmap; the global artwork id is *derived at query time* (`artwork_base[card] + artwork_group_id`, prefix-summed from the already-stored `artwork_groups`) — **no archive change**. The artwork total becomes `popcount`, replacing the O(candidates×printings) count pass that made artwork ~14× slower than card.
- **Printing mode** (`PrintingPlaneScan`) generalized to any composable expr — total is the composed popcount, page reuses `walk_printing_page`.

## Cost model (measured, not hand-tuned)

Kernel probe (`legality_compose_kernel_costs`, real corpus): broadcast **~1.5 ns/printing** (22–145 µs), projection ~1.5 ns/printing, divergent repair **5.5 µs (negligible)**. A legality leaf is *synthesized* at query time, so **acquire estimates** the total + build cost (card ∃-popcount scaled to printings) rather than composing — the broadcast is paid once, in the fast path, only if the plan wins. This removed a latent **double-broadcast**. The broadcast rides `range_build_printings × COMPOSE_BROADCAST_PER_PRINTING_NS` (1.5 ns). No hand-exclusion — the router decides.

## Result — targeted A/B (97,206-printing corpus; `off` ≡ main routing, `on` = branch)

Same store, `CARD_ENGINE_PRINTING_COMPOSE=0` vs `1`; ordered by speedup; `rows` is identical between arms (the parity check).

| query | mode | off µs | on µs | speedup | rows |
|---|---|---:|---:|---:|---:|
| `border:black` | printing | 865 | 46 | **18.6×** | 85,046 |
| `border:black r:rare` | printing | 631 | 50 | **12.7×** | 31,879 |
| `r:rare` | printing | 378 | 46 | **8.3×** | 36,764 |
| `border:borderless` | printing | 222 | 46 | **4.8×** | 5,701 |
| `border:black` | artwork | 900 | 194 | **4.6×** | 40,956 |
| `f:modern border:black` | printing | 731 | 170 | **4.3×** | 65,507 |
| `border:black r:rare` | card | 330 | 101 | **3.3×** | 10,567 |
| `r:mythic` | printing | 146 | 48 | **3.1×** | 8,924 |
| `f:modern r:rare` | printing | 311 | 170 | **1.8×** | 25,708 |
| `f:modern border:black` | card | 358 | 308 | 1.2× | 22,262 |
| `f:modern` | printing | 191 | 167 | 1.1× | 73,783 |
| `f:commander` | printing | 218 | 205 | 1.1× | 96,898 |
| `f:standard` | printing | 83 | 82 | 1.0× | 17,428 |
| `border:black` | card | 65 | 66 | 1.0× | 31,169 |
| `f:modern` | card | 61 | 63 | 1.0× | 22,264 |

**Geomean speedup over the 9 impacted queries: 5.3×** (covering 311,052 result rows). The flat rows are compose-ineligible (bare card border/rarity fold to the #664/#670 planes; legality-only compounds route to the general path) — confirming no regression.

## Correctness

- Oracle diffs (border ×3, rarity ×4) equal the card planes on `real.store`.
- `force_plan_differential` forces the compose plans on border∧rarity and legality∧border compounds in **all three modes** — all agree with `GatheredScan` (total + rows + 2-key order). Fuzz corpus is **40% divergent-legality**, far harsher than production's 1.8%.
- 127 debug tests pass. Archive +54 KB (border+rarity planes); legality and artwork add **no** stored state. Format `20260722`.

## Architecture: one compose plan + per-op cost

All three distinct-ons run one `PrintingCompose` plan over one grouped walk (`walk_grouped_page`, granularity printing/card/artwork), and the cost model is now one honest sum of per-operation terms per plan — no shared formulas, `synth_printings` (query-time bitmap scatters) and `popcount_words` (result-space size) making the down-broadcast and artwork-space popcount costs explicit; `SCATTER_PER_PRINTING_NS` unified. 6 plans (was 7), one `CARD_ENGINE_PRINTING_COMPOSE` flag. Card compose moved onto the forward walk (deep-offset popcount-skip deferred to #730).

## Follow-ups

`NOT` (per-field known-set), and **legality printing planes for hot broad formats** — the kernel probe shows the broadcast is ~100–145 µs for broad formats, which a ~12 KB plane would erase; a per-format frequency×breadth crossover, the same plane-vs-postings decision one level up.

Details in [docs/issues/00724](docs/issues/00724-engine-printing-existential-planes.md).


