### PR TITLE
Range Leaves as Composable Bitmap Sources: Artwork Ranges + Compounds (#694/#731)

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -86,16 +86,20 @@ pub(crate) struct PlanFeatures {
     pub limit: u32,
     /// Page offset.
     pub offset: u32,
-    /// Printings scattered to **build the printing-space bitmap** — the first synthesis pass: the range
-    /// slice (`CardRangePopcount` fuses this straight into card bits; `PrintingCompose` scatters it into
-    /// a printing bitmap) and the legality broadcast-down. Border/rarity are precomputed planes → `0`.
-    /// Costed at `SCATTER_PER_PRINTING_NS`.
-    pub synth_printings: u32,
-    /// Printings scattered in the **projection pass** — printing-bitmap → card/artwork existence — that
-    /// `PrintingCompose` runs *on top of* `synth_printings` (a second O(k) pass). `CardRangePopcount`
-    /// leaves this `0` because it fuses build+project into one pass; setting it in acquire (both plans
-    /// do) is what lets the shared feats cost compose's extra pass honestly, so a bare range doesn't
-    /// mis-route to compose. Costed at `SCATTER_PER_PRINTING_NS`; `0` for printing mode (no projection).
+    /// Printings the legality **broadcast-down** synthesizes (card ∃-plane → printing bitmap) in
+    /// `PrintingCompose`. `0` for border/rarity (precomputed planes) and for bare ranges (no broadcast).
+    /// Costed at `LINEAR_PASS_PER_PRINTING_NS`.
+    pub broadcast_printings: u32,
+    /// The range index's in-range slice `k` — the printings a range leaf contributes. Charged at a
+    /// DIFFERENT rate per plan (same `k`, different physical op): `PrintingCompose` scatters it into a
+    /// printing bitmap (`RANGE_SCATTER_PER_PRINTING_NS`, cheap, then a separate `project_printings` pass),
+    /// while `CardRangePopcount` fuses scatter+project in one pass (`CARD_RANGE_BUILD_PER_PRINTING_NS`).
+    /// Set by both range-plan acquire branches so the shared feats cost either winner honestly — the
+    /// fused op being cheaper than compose's two passes is why a bare range routes to CardRangePopcount.
+    pub scatter_printings: u32,
+    /// Printings scattered in `PrintingCompose`'s **projection pass** — printing bitmap → card/artwork
+    /// existence, a second O(set) pass on top of the build. `0` for printing mode (no projection) and
+    /// for non-compose plans. Costed at `LINEAR_PASS_PER_PRINTING_NS`.
     pub project_printings: u32,
     /// 64-bit words of the **result-space** bitmap the total popcount + skip-scan touches — the field
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
@@ -147,13 +151,27 @@ const PLANE_POPCOUNT_EMIT_PER_CARD_NS: f64 = 2.0;
 /// Fixed P2 setup (plane eval into the bitmap, buffers).
 const PLANE_POPCOUNT_FIXED_COST_NS: f64 = 200.0;
 
-/// Per-printing cost of scattering one printing into a bitmap at query time — the single physical op
-/// (write a bit into a word) behind every `synth_printings`: `CardRangePopcount`'s range-slice build,
-/// and `PrintingCompose`'s legality broadcast-down + card/artwork projection-up. Measured ~1.3 ns/printing
-/// (`card_range_build_cost_split`, the ~80.5k-printing `usd<50` slice) and ~1.5 ns/printing
-/// (`legality_compose_kernel_costs`, the broad formats) — the same kernel from two probes, so one
-/// constant at the midpoint. Load-bearing: without it the model under-predicts these plans and mis-routes.
-pub(crate) const SCATTER_PER_PRINTING_NS: f64 = 1.4;
+/// Per-printing cost of a **linear offset-walk** over set printings — the two passes that share this
+/// rate: `PrintingCompose`'s legality broadcast-DOWN (card ∃-plane → printing bitmap) and its
+/// projection-UP (printing bitmap → card/artwork existence, `printing_bits_to_card_bits`, which walks
+/// the set bits advancing a card cursor). Measured ~1.5 ns/printing: `legality_compose_kernel_costs`
+/// broad formats (~1.49), and `card_range_build_cost_split`'s B pass (122125ns / 80527 = 1.52).
+/// Carries `broadcast_printings` and `project_printings` — the midpoint of the two probes.
+pub(crate) const LINEAR_PASS_PER_PRINTING_NS: f64 = 1.50;
+
+/// Per-printing cost of `PrintingCompose`'s range **scatter** — `range_leaf_bits` reads the value-sorted
+/// index's contiguous in-range slice and scatters each pid into a printing bitmap (sequential read +
+/// random-write). Measured ~0.4 ns/printing (`card_range_build_cost_split`'s A pass 28583ns / 80527 =
+/// 0.355; `range_compose_kernel_costs` 0.36 at broad density) — far cheaper than a linear pass because
+/// there is no per-card cursor and the writes are the only work. Carries `scatter_printings` in compose.
+pub(crate) const RANGE_SCATTER_PER_PRINTING_NS: f64 = 0.36;
+
+/// Per-printing cost of `CardRangePopcount`'s **fused build** — `build_card_range_bits` sets the printing
+/// bit AND the card bit (via `printing_to_card`) in one pass over the range slice, fusing compose's
+/// scatter+project (0.4 + 1.5 = 1.9) into a single ~1.2 ns/printing pass (`card_range_build_cost_split`'s
+/// C 98333ns / 80527 = 1.22). Carries `scatter_printings` in CardRangePopcount's arm — the same `k` as
+/// compose's scatter but a cheaper op, which is exactly why a bare range routes here, not to compose.
+pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.22;
 
 // ─── P3: StreamedSelect ─────────────────────────────────────────────────────
 // Match phase walks eval_domain cards computing per-card counts, then either
@@ -245,8 +263,9 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         }
         // #724 unified compose, any distinct-on. One term per operation it performs:
         PhysicalPlan::PrintingCompose => {
-            f64::from(f.synth_printings) * SCATTER_PER_PRINTING_NS  // build the printing bitmap: legality broadcast-down / range scatter (border/rarity read a plane → 0)
-                + f64::from(f.project_printings) * SCATTER_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
+            f64::from(f.broadcast_printings) * LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
+                + f64::from(f.scatter_printings) * RANGE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
+                + f64::from(f.project_printings) * LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
                 + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the result-space bitmap for the total (printing/card/artwork words)
                 + printings_walked * RANGE_WALK_STEP_NS  // forward grouped walk to fill the page
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
@@ -262,7 +281,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         // #725 bare range, unique=card: PlanePopcountOrder's popcount-skip walk over a card bitmap
         // *built at query time* from the range slice — same walk terms, plus the build synth.
         PhysicalPlan::CardRangePopcount => {
-            f64::from(f.synth_printings) * SCATTER_PER_PRINTING_NS  // build the card-existence bitmap from the range slice
+            f64::from(f.scatter_printings) * CARD_RANGE_BUILD_PER_PRINTING_NS  // fused one-pass build: scatter+project the range slice straight into card bits
                 + matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS  // scatter matches through the inverse permutation
                 + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the card bitmap + skip-scan to the offset
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of cards

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -86,12 +86,17 @@ pub(crate) struct PlanFeatures {
     pub limit: u32,
     /// Page offset.
     pub offset: u32,
-    /// Printings **scattered into a bitmap at query time** (one term per plan that synthesizes rather
-    /// than reads a precomputed bitmap): the range slice `CardRangePopcount` builds, and the legality
-    /// broadcast-down + card/artwork projection-up `PrintingCompose` does (border/rarity are precomputed
-    /// planes → contribute `0`). `0` for plans that read a precomputed bitmap or build nothing. Costed
-    /// at `SCATTER_PER_PRINTING_NS` — one physical op (write a bit into a word), so one constant.
+    /// Printings scattered to **build the printing-space bitmap** — the first synthesis pass: the range
+    /// slice (`CardRangePopcount` fuses this straight into card bits; `PrintingCompose` scatters it into
+    /// a printing bitmap) and the legality broadcast-down. Border/rarity are precomputed planes → `0`.
+    /// Costed at `SCATTER_PER_PRINTING_NS`.
     pub synth_printings: u32,
+    /// Printings scattered in the **projection pass** — printing-bitmap → card/artwork existence — that
+    /// `PrintingCompose` runs *on top of* `synth_printings` (a second O(k) pass). `CardRangePopcount`
+    /// leaves this `0` because it fuses build+project into one pass; setting it in acquire (both plans
+    /// do) is what lets the shared feats cost compose's extra pass honestly, so a bare range doesn't
+    /// mis-route to compose. Costed at `SCATTER_PER_PRINTING_NS`; `0` for printing mode (no projection).
+    pub project_printings: u32,
     /// 64-bit words of the **result-space** bitmap the total popcount + skip-scan touches — the field
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
@@ -240,7 +245,8 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         }
         // #724 unified compose, any distinct-on. One term per operation it performs:
         PhysicalPlan::PrintingCompose => {
-            f64::from(f.synth_printings) * SCATTER_PER_PRINTING_NS  // synthesize: legality broadcast-down + card/artwork projection-up (border/rarity + printing mode contribute 0)
+            f64::from(f.synth_printings) * SCATTER_PER_PRINTING_NS  // build the printing bitmap: legality broadcast-down / range scatter (border/rarity read a plane → 0)
+                + f64::from(f.project_printings) * SCATTER_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
                 + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the result-space bitmap for the total (printing/card/artwork words)
                 + printings_walked * RANGE_WALK_STEP_NS  // forward grouped walk to fill the page
                 + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -434,11 +434,15 @@ pub(crate) enum FilterExpr {
 /// per kernel, 3 repeated runs — see that file for the per-op numbers):
 ///
 /// - field loads and integer/float/mask compares (TypeCmp, ColorCmp,
-///   NumericCmp, ExactName, TextExact, Legality, DateCmp, YearCmp): 1.8-5.6 ns
-///   measured; NumericCmp is the priciest member (NumExpr::eval() indirection
-///   on both sides costs more than a direct field load), so the constant sits
-///   above it.
-pub(crate) const MASK_COMPARE_NS100: u32 = 600;
+///   NumericCmp, ExactName, TextExact, Legality, DateCmp, YearCmp): 2.0-3.8 ns
+///   measured (2026-07 re-run: Legality 2.05, YearCmp/DateCmp 2.3-2.6,
+///   ColorCmp 2.20, ExactName/TextExact 2.57, NumericCmp 3.16-3.83). NumericCmp
+///   is the priciest member (NumExpr::eval() indirection on both sides costs
+///   more than a direct field load), so the constant sits just above it.
+///   Was 600 — pinned to a stale 5.6 ns NumericCmp measurement; the recalibrated
+///   ceiling (~3.8) fixes StreamedSelect over-pricing a mask-compare residual
+///   ~1.6x (e.g. `f:legacy or year:2020` mis-routing to compose, #731).
+pub(crate) const MASK_COMPARE_NS100: u32 = 400;
 /// - bounded lookups: a binary search over a bind/memoize-resolved id set
 ///   (ArtistMatch/FlavorMatch/NameMatch/OracleMatch), a card collection
 ///   (CollectionCmp), and anchored-literal regexes (a memcmp at a known

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4372,58 +4372,59 @@ fn compose_printing_bits(
     }
 }
 
-/// Cheap cost-model estimate for a composable filter: `(matches, build_printings)` **without** paying
-/// legality's broadcast. Border/rarity leaves are precomputed planes — their exact `popcount` is a
-/// cheap slice read and they synthesize nothing (`build 0`). A legality leaf is *synthesized* at query
-/// time (broadcast + repair), so its cost is estimated from the cheap card `_EXISTS` `popcount` scaled
-/// to printings, and that same count is charged as `build_printings` — the broadcast the fast path pays
-/// **only if this plan wins** (this is why acquire estimates rather than composing: it avoids a second,
-/// throwaway broadcast). `AND` takes the min (intersection upper bound); `OR` the capped sum. Used only
-/// for plan choice — the fast path recomputes the exact total. Measured build cost ≈ 1.5 ns/printing
-/// (`legality_compose_kernel_costs`), ~the range-scatter rate, so `synth_printings` carries it.
+/// Cheap cost-model estimate for a composable filter: `(matches, broadcast_printings, scatter_printings)`
+/// **without** paying legality's broadcast. The two synthesis kinds are returned separately because they
+/// cost different rates (`LINEAR_PASS_PER_PRINTING_NS` vs `RANGE_SCATTER_PER_PRINTING_NS`): a legality
+/// leaf is *broadcast* at query time (card `_EXISTS` popcount scaled to printings → `broadcast`), while a
+/// range leaf *scatters* its index slice `k` (→ `scatter`). Border/rarity are precomputed planes — a
+/// cheap `popcount` slice read, synthesizing nothing (both `0`). The fast path pays the broadcast/scatter
+/// **only if this plan wins** (why acquire estimates rather than composing — it avoids a throwaway pass).
+/// `AND` takes the min matches (intersection upper bound) and sums each build kind; `OR` the capped sum.
+/// Used only for plan choice — the fast path recomputes the exact total.
 fn compose_printing_estimate(
     filter: &FilterExpr,
     indexes: &Archived<CardIndexes>,
     offsets: &AOffsets,
     n_printings: usize,
-) -> (usize, usize) {
+) -> (usize, usize, usize) {
     let popcount = |bits: &[u64]| bits.iter().map(|w| w.count_ones() as usize).sum::<usize>();
     match filter {
-        FilterExpr::True => (n_printings, 0),
+        FilterExpr::True => (n_printings, 0, 0),
         FilterExpr::And(v) => v
             .iter()
             .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
-            .fold((n_printings, 0), |(m, b), (cm, cb)| (m.min(cm), b + cb)),
+            .fold((n_printings, 0, 0), |(m, bc, sc), (cm, cbc, csc)| (m.min(cm), bc + cbc, sc + csc)),
         FilterExpr::Or(v) => {
-            let (m, b) = v
+            let (m, bc, sc) = v
                 .iter()
                 .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
-                .fold((0usize, 0usize), |(m, b), (cm, cb)| (m + cm, b + cb));
-            (m.min(n_printings), b)
+                .fold((0usize, 0usize, 0usize), |(m, bc, sc), (cm, cbc, csc)| (m + cm, bc + cbc, sc + csc));
+            (m.min(n_printings), bc, sc)
         }
         // Precomputed planes: exact cheap popcount, nothing synthesized.
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
-            (popcount(&border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)), 0)
+            (popcount(&border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)), 0, 0)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
-            (popcount(&rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)), 0)
+            (popcount(&rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)), 0, 0)
         }
-        // Legality: estimate from the cheap card ∃-plane popcount scaled to printings — no broadcast.
+        // Legality: estimate from the cheap card ∃-plane popcount scaled to printings; that count is the
+        // broadcast-down the fast path pays (a linear pass) → rides `broadcast`.
         FilterExpr::Legality { shift: Some(shift), expected } => {
             let n_cards = offsets.len() - 1;
             let card_exists = legality_candidate_bits(indexes, n_cards, *shift, *expected, false).map_or(0, |b| popcount(&b));
             let est = if n_cards == 0 { 0 } else { card_exists * n_printings / n_cards };
-            (est, est)
+            (est, est, 0)
         }
         // Range: `k` in-range printings from the index partition points (O(log n), no scatter here);
-        // matches ≈ k, and k rides `build` — the scatter the fast path pays into the printing bitmap.
+        // matches ≈ k, and k rides `scatter` — the cheap range-slice scatter into the printing bitmap.
         FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }
             if bare_range_bounds(filter, indexes).is_some() =>
         {
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");
             let k = idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo);
-            (k, k)
+            (k, 0, k)
         }
         _ => unreachable!("compose_printing_estimate on a non-composable filter — gated by is_printing_composable"),
     }
@@ -5314,9 +5315,10 @@ fn run_query_routed<'a>(
         residual_tier_ns100,
         limit: limit as u32,
         offset: page_offset as u32,
-        synth_printings: 0,  // CardRangePopcount / PrintingCompose override this in their acquire branches
-        project_printings: 0, // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
-        popcount_words: 0,   // PrintingCompose overrides this (result-space bitmap words)
+        broadcast_printings: 0, // PrintingCompose's legality broadcast-down (0 for ranges / precomputed planes)
+        scatter_printings: 0,  // range-slice k — set by both range-plan acquire branches (costed per-plan)
+        project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
+        popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
     };
     // Features for the general candidate path (shared by the acquire branch and the
     // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
@@ -5355,10 +5357,11 @@ fn run_query_routed<'a>(
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let card_est = k.min(n_cards);
         let mut feats = mk_feats(card_est, card_est, card_est, verify_cost_tier(filter));
-        // Fused build+project in one pass (`synth`); `project` is set to what PrintingCompose would do
-        // as a *separate* pass, so costing compose off these shared feats reflects its extra scatter and
-        // a bare range doesn't mis-route to it.
-        feats.synth_printings = k;
+        // `k` rides `scatter_printings`: this plan's arm charges it as its FUSED one-pass build
+        // (`CARD_RANGE_BUILD_PER_PRINTING_NS`), while a competing PrintingCompose costed off these shared
+        // feats charges the same `k` as its cheaper scatter (`RANGE_SCATTER_…`) plus a separate
+        // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
+        feats.scatter_printings = k;
         feats.project_printings = k;
         (feats, Prep::Range)
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
@@ -5367,18 +5370,19 @@ fn run_query_routed<'a>(
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let mut feats = mk_feats(k, n_cards, n_printings, verify_cost_tier(filter));
-        feats.synth_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores synth
+        feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
         (feats, Prep::Range)
     } else if PhysicalPlan::PrintingCompose.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
         // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
-        let (printing_matches, broadcast) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
-        // `synth` = the first pass (build the printing bitmap: legality broadcast / range scatter);
-        // `project` = the second pass (printing→card/artwork), 0 for printing mode. Keeping them
-        // separate is what lets a bare range's CardRangePopcount acquire (which sets `project` too) cost
-        // this plan's extra projection honestly. `eval_domain`/`scan_units` cost the *materializing
+        let (printing_matches, broadcast, scatter) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
+        // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
+        // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
+        // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
+        // CardRangePopcount acquire (which sets `scatter`/`project` too) cost this plan's passes
+        // honestly against the fused build. `eval_domain`/`scan_units` cost the *materializing
         // alternatives* should compose lose: a composable filter narrows via its indices, so they see
         // ~`matches` candidates (card mode also breaks at the first match ⇒ scan_units = eval_domain) —
         // the unnarrowed universe would over-cost them and mis-route (measured: `format:X format:Y`/card).
@@ -5394,7 +5398,8 @@ fn run_query_routed<'a>(
             }
         };
         let mut feats = mk_feats(result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
-        feats.synth_printings = broadcast as u32;
+        feats.broadcast_printings = broadcast as u32;
+        feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
         (feats, Prep::Range)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4178,10 +4178,10 @@ fn printing_range_fastpath<'a>(
 /// where the residual applies the correct trivalent semantics. Anything else (a text search, a range,
 /// an arithmetic compare) is likewise non-composable. A composable expression's bits are **exact** (a
 /// set bit *is* a matching printing), so no per-printing re-check is needed.
-fn is_printing_composable(filter: &FilterExpr) -> bool {
+fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> bool {
     match filter {
         FilterExpr::True => true,
-        FilterExpr::And(v) | FilterExpr::Or(v) => v.iter().all(is_printing_composable),
+        FilterExpr::And(v) | FilterExpr::Or(v) => v.iter().all(|c| is_printing_composable(c, indexes)),
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, .. } => true,
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
@@ -4189,6 +4189,14 @@ fn is_printing_composable(filter: &FilterExpr) -> bool {
         // Only a plane-backed status (legal/banned/restricted) with a present format; an absent format
         // (`shift: None`) matches nothing and stays on the general path.
         FilterExpr::Legality { shift: Some(_), expected } => status_plane_bases(*expected).is_some(),
+        // #731: usd/cn/date range leaves — the in-range index slice scatters into an exact printing
+        // bitmap (`range_leaf_bits`). `bare_range_bounds` recognizes the printing-range-indexed shape
+        // (and the `[lo,hi)` bounds); a non-range op (`Eq`/`Ne`), a negation, or a card-space field
+        // (cmc/power/rarity) yields `None` → stays on the general path. This is what lets a range
+        // compose with border/rarity/legality — and range∧range — exactly, in any distinct-on.
+        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => {
+            bare_range_bounds(filter, indexes).is_some()
+        }
         _ => false,
     }
 }
@@ -4239,6 +4247,22 @@ fn rarity_leaf_bits(c: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: us
         Some(e) => scatter_bits(e.1.iter().map(|p| u32::from(*p)), n_printings),
         None => vec![0u64; wpp],
     }
+}
+
+/// #731: the exact printing bitmap for a usd/cn/date range leaf — scatter the value-sorted index
+/// slice `[lo, hi)` (the same slice `build_card_range_bits` walks). Index-absent printings (no
+/// price/collector-number/date) aren't in the index at all, so they're excluded by construction —
+/// this is an intersection with the in-range set, never a complement, so the trivalent-NULL trap that
+/// keeps `Not` off the compose path doesn't apply here.
+fn range_leaf_bits(idx: &Archived<PrintingRangeIndex>, lo: u32, hi: u32, n_printings: usize) -> Vec<u64> {
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    let mut bits = vec![0u64; n_printings.div_ceil(64)];
+    for p in idx[s..e].iter() {
+        let pid = u32::from(p.1) as usize;
+        bits[pid >> 6] |= 1u64 << (pid & 63);
+    }
+    bits
 }
 
 /// Broadcast a card-space bitmap **down** to printing space: set every printing of each set card. The
@@ -4338,6 +4362,12 @@ fn compose_printing_bits(
         FilterExpr::Legality { shift: Some(shift), expected } => {
             legality_leaf_bits(*shift, *expected, indexes, offsets, printings, n_printings)
         }
+        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }
+            if bare_range_bounds(filter, indexes).is_some() =>
+        {
+            let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");
+            range_leaf_bits(idx, lo, hi, n_printings)
+        }
         _ => unreachable!("compose_printing_bits on a non-composable filter — gated by is_printing_composable"),
     }
 }
@@ -4386,6 +4416,15 @@ fn compose_printing_estimate(
             let est = if n_cards == 0 { 0 } else { card_exists * n_printings / n_cards };
             (est, est)
         }
+        // Range: `k` in-range printings from the index partition points (O(log n), no scatter here);
+        // matches ≈ k, and k rides `build` — the scatter the fast path pays into the printing bitmap.
+        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }
+            if bare_range_bounds(filter, indexes).is_some() =>
+        {
+            let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");
+            let k = idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo);
+            (k, k)
+        }
         _ => unreachable!("compose_printing_estimate on a non-composable filter — gated by is_printing_composable"),
     }
 }
@@ -4412,7 +4451,7 @@ fn printing_compose_fastpath<'a>(
     limit: usize,
     page_offset: usize,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
-    if !is_printing_composable(filter) || !printing_compose_indexes_built(indexes) {
+    if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
         return None;
     }
     // Compose once, here (never in acquire) — that single build is the only synthesis, and it is paid
@@ -4527,7 +4566,10 @@ impl PhysicalPlan {
     /// estimate first (phase 1) and only materializes (phase 2) when a materializing plan wins or the
     /// non-materializing one declines.
     fn materializing(self) -> bool {
-        !matches!(self, PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingCompose)
+        !matches!(
+            self,
+            PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingCompose | PhysicalPlan::CardRangePopcount
+        )
     }
 }
 
@@ -4555,10 +4597,6 @@ enum Prep {
     /// `run_query_routed`'s local `plane_bits` and passed by reference.
     /// `PlanePopcountOrder` reads it directly; P3/P4 read it as a candidate list.
     Plane,
-    /// Bare `usd` range (card): the range's card-existence bitmap (its popcount is the exact total)
-    /// and printing-space membership set (emission's per-printing residual). `CardRangePopcount`
-    /// reads both; a materializing winner reads the card bitmap as a candidate list.
-    RangeCardBits { card_bits: Vec<u64>, range_pbits: Vec<u64> },
     /// The general residual path: a materialized candidate list.
     Candidates(PreparedCandidates),
 }
@@ -4646,10 +4684,13 @@ fn printing_compose_applicable(
     descending: bool,
     indexes: &Archived<CardIndexes>,
 ) -> bool {
+    // Mode-agnostic: the cost model arbitrates overlap with the specialized range plans. All three
+    // range/compose plans are non-materializing (estimate-in-acquire), so nothing is eagerly built —
+    // a losing plan costs only a binary search, never a wasted scatter.
     *PRINTING_COMPOSE != 0
         && !cards.is_empty()
         && plane.is_none()
-        && is_printing_composable(filter)
+        && is_printing_composable(filter, indexes)
         && printing_compose_indexes_built(indexes)
         && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
 }
@@ -5274,6 +5315,7 @@ fn run_query_routed<'a>(
         limit: limit as u32,
         offset: page_offset as u32,
         synth_printings: 0,  // CardRangePopcount / PrintingCompose override this in their acquire branches
+        project_printings: 0, // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
         popcount_words: 0,   // PrintingCompose overrides this (result-space bitmap words)
     };
     // Features for the general candidate path (shared by the acquire branch and the
@@ -5303,63 +5345,57 @@ fn run_query_routed<'a>(
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
         (mk_feats(count, count, count, 0), Prep::Plane)
     } else if PhysicalPlan::CardRangePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Build the range's card-existence bitmap now; its popcount is the exact count (like the
-        // plane branch above, scan_units == count, all_match ⇒ tier 0). The build is O(k) over the
-        // range slice — the plan's dominant cost — but for a bare range the alternative is a full
-        // scan of a near-total set, which reliably loses, so the eager build is rarely wasted: only a
-        // narrow range routes elsewhere, and there k (hence the build) is small. If a materializing
-        // plan does win, dispatch reads the same bitmap back as a candidate list.
+        // Exact in-range printing count `k` from the index partition points (two binary searches, no
+        // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
+        // plan wins — so a competing winner never eats a wasted build (re-deriving the bounds there is
+        // another ~free binary search). `k` rides `synth_printings` (the deferred scatter); `matches`
+        // uses the card-count proxy `min(k, n_cards)` (card total ≤ both). The materializing
+        // alternatives are costed with the range's verify tier (a `0` would under-cost them).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
-        let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, n_cards as usize, n_printings as usize);
-        let count: u32 = card_bits.iter().map(|w| w.count_ones()).sum();
-        // Slice size (in-range printings) drives the build term — the plan's dominant cost.
-        let slice_printings: u32 = range_pbits.iter().map(|w| w.count_ones()).sum();
-        // Unlike the plane branch, the residual here is the range, not True: CardRangePopcount's exact
-        // bitmap needs no re-verify (its formula ignores tier), but the materializing alternatives in
-        // dispatch DO re-verify the range per candidate, so they must be costed with its verify tier —
-        // `0` would under-cost them and let a mis-cheap StreamedSelect beat the plan that actually wins.
-        let mut feats = mk_feats(count, count, count, verify_cost_tier(filter));
-        feats.synth_printings = slice_printings;
-        (feats, Prep::RangeCardBits { card_bits, range_pbits })
+        let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
+        let card_est = k.min(n_cards);
+        let mut feats = mk_feats(card_est, card_est, card_est, verify_cost_tier(filter));
+        // Fused build+project in one pass (`synth`); `project` is set to what PrintingCompose would do
+        // as a *separate* pass, so costing compose off these shared feats reflects its extra scatter and
+        // a bare range doesn't mis-route to it.
+        feats.synth_printings = k;
+        feats.project_printings = k;
+        (feats, Prep::Range)
     } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        (mk_feats(k, n_cards, n_printings, verify_cost_tier(filter)), Prep::Range)
+        let mut feats = mk_feats(k, n_cards, n_printings, verify_cost_tier(filter));
+        feats.synth_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores synth
+        (feats, Prep::Range)
     } else if PhysicalPlan::PrintingCompose.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
         // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
         let (printing_matches, broadcast) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
-        // `eval_domain`/`scan_units` here cost the *materializing alternatives* (StreamedSelect/
-        // GatheredScan) should this plan lose — so they must reflect the narrowed reality those plans
-        // see, not the unnarrowed universe. A composable filter narrows via its indices (#667 legality,
-        // border/rarity), so the alternatives iterate ~`matches` candidates; in card mode they also
-        // break at the first matching printing (`scan_units()` ⇒ `eval_domain`). Passing n_cards/
-        // n_printings instead over-costs them ~3-4× and spuriously wins broad-but-narrowable legality
-        // compounds for compose (measured: `format:X format:Y`/card regressed).
-        let (result_total, synth, popcount_words, eval_domain, scan_units) = match mode {
-            // printing: no projection; total popcount over the printing bitmap. The alternatives scan
-            // every printing (no early break), so the unnarrowed universe is the right estimate.
-            Mode::Printing => (printing_matches, broadcast, (n_printings as usize).div_ceil(64), n_cards as usize, n_printings as usize),
-            // card: project every matching printing up, popcount card bitmap. Alternatives narrow to
-            // ~matches candidates and break at the first match ⇒ eval_domain = scan_units = matches.
+        // `synth` = the first pass (build the printing bitmap: legality broadcast / range scatter);
+        // `project` = the second pass (printing→card/artwork), 0 for printing mode. Keeping them
+        // separate is what lets a bare range's CardRangePopcount acquire (which sets `project` too) cost
+        // this plan's extra projection honestly. `eval_domain`/`scan_units` cost the *materializing
+        // alternatives* should compose lose: a composable filter narrows via its indices, so they see
+        // ~`matches` candidates (card mode also breaks at the first match ⇒ scan_units = eval_domain) —
+        // the unnarrowed universe would over-cost them and mis-route (measured: `format:X format:Y`/card).
+        let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
+            Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), n_cards as usize, n_printings as usize),
             Mode::Card => {
                 let rt = printing_matches.min(n_cards as usize);
-                (rt, broadcast + printing_matches, (n_cards as usize).div_ceil(64), rt, rt)
+                (rt, printing_matches, (n_cards as usize).div_ceil(64), rt, rt)
             }
-            // artwork: same projection; popcount the artwork bitmap (n_artworks ≤ n_printings — upper
-            // bound for the estimate). Alternatives group all printings per candidate (no early break),
-            // so scan_units is the matching printings under the ~matches candidate cards.
             Mode::Artwork => {
                 let rt = printing_matches.min(n_cards as usize);
-                (printing_matches, broadcast + printing_matches, (n_printings as usize).div_ceil(64), rt, printing_matches)
+                (printing_matches, printing_matches, (n_printings as usize).div_ceil(64), rt, printing_matches)
             }
         };
         let mut feats = mk_feats(result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
-        feats.synth_printings = synth as u32;
+        feats.synth_printings = broadcast as u32;
+        feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
         (feats, Prep::Range)
     } else {
@@ -5383,30 +5419,23 @@ fn run_query_routed<'a>(
             &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
             plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
-        (PhysicalPlan::CardRangePopcount, Prep::RangeCardBits { card_bits, range_pbits }) => exec_card_range_popcount(
-            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, card_bits, range_pbits,
-        ),
-        // A materializing plan beat CardRangePopcount on the estimate: reuse the already-built
-        // card-existence bitmap as a candidate list (dropped when >7/8, matching prepare_candidates)
-        // and re-verify the range residual per card (all_match_known: false) so the range still gates
-        // which printing is shown.
-        (p, Prep::RangeCardBits { card_bits, .. }) => {
-            let ids = bitmap_card_ids(card_bits);
-            let candidate_cards = (ids.len() < cards.len() - cards.len() / 8).then_some(ids);
-            exec_from_candidates(
-                p, cards, printings, offsets, strings, filter,
-                &PreparedCandidates { candidate_cards, all_match_known: false },
-                plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-            )
-        }
         (p, Prep::Candidates(prep)) => exec_from_candidates(
             p, cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
         ),
+        // `Prep::Range` = "cheap estimate acquired, nothing materialized" — shared by CardRangePopcount
+        // (#725), PrintingRangeScan (#695), and PrintingCompose (#724). Each winner does its own O(k)
+        // work here, so no plan eats a build for a competing winner:
+        //   - CardRangePopcount builds its card bitmap from the (re-derived, ~free) range bounds now.
+        //   - the printing-space fast paths walk (or, if they decline — sparse total — materialize).
+        //   - a materializing plan (StreamedSelect/GatheredScan) that beat them narrows + runs.
+        (PhysicalPlan::CardRangePopcount, Prep::Range) => {
+            let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
+            let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), printings.len());
+            exec_card_range_popcount(
+                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
+            )
+        }
         (plan, Prep::Range) => {
-            // A printing-space fast path walks if it won and its fastpath accepts. Otherwise (a
-            // materializing plan won the estimate, or the fastpath declined — rare, since cost seldom
-            // picks these when narrow) materialize now and run the best materializing plan on EXACT
-            // features. `Prep::Range` is shared by the range (#695) and compose (#724) fast paths.
             let fast_page = match plan {
                 PhysicalPlan::PrintingRangeScan => {
                     printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
@@ -5414,7 +5443,7 @@ fn run_query_routed<'a>(
                 PhysicalPlan::PrintingCompose => {
                     printing_compose_fastpath(cards, printings, offsets, filter, indexes, mode, prefer, sort_col, descending, limit, page_offset)
                 }
-                _ => None,
+                _ => None, // a materializing plan won the estimate — materialize + run it below
             };
             match fast_page {
                 Some(page) => page,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4191,9 +4191,10 @@ fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) 
         FilterExpr::Legality { shift: Some(_), expected } => status_plane_bases(*expected).is_some(),
         // #731: usd/cn/date range leaves — the in-range index slice scatters into an exact printing
         // bitmap (`range_leaf_bits`). `bare_range_bounds` recognizes the printing-range-indexed shape
-        // (and the `[lo,hi)` bounds); a non-range op (`Eq`/`Ne`), a negation, or a card-space field
-        // (cmc/power/rarity) yields `None` → stays on the general path. This is what lets a range
-        // compose with border/rarity/legality — and range∧range — exactly, in any distinct-on.
+        // and returns its `[lo,hi)` bounds: the ordered ops, and `Eq` too (a narrow `[v, v+1)`). Only
+        // `Ne`, a negation, or a card-space field (cmc/power/rarity) yields `None` → stays on the
+        // general path. This is what lets a range compose with border/rarity/legality — and
+        // range∧range — exactly, in any distinct-on.
         FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => {
             bare_range_bounds(filter, indexes).is_some()
         }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3274,7 +3274,7 @@ fn plan_cost_model_matches_gold() {
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
-                    synth_printings: 0, project_printings: 0, popcount_words: 0,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -3380,18 +3380,19 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
     match plan {
         // [WALK, FIXED].
         PhysicalPlan::PrintingRangeScan => (vec![page_span / match_rate, 1.0], 0.0),
-        // [POPCOUNT(result words), WALK(printings walked), EMIT, FIXED]; synth (SCATTER) is a hand-set
-        // offset, not a refit param.
+        // [POPCOUNT(result words), WALK(printings walked), EMIT, FIXED]; the build passes (broadcast +
+        // scatter + project) are hand-set offsets, not refit params.
         PhysicalPlan::PrintingCompose => (
             vec![f64::from(f.popcount_words), page_span / match_rate, limit, 1.0],
-            (f64::from(f.synth_printings) + f64::from(f.project_printings)) * super::cost::SCATTER_PER_PRINTING_NS,
+            (f64::from(f.broadcast_printings) + f64::from(f.project_printings)) * super::cost::LINEAR_PASS_PER_PRINTING_NS
+                + f64::from(f.scatter_printings) * super::cost::RANGE_SCATTER_PER_PRINTING_NS,
         ),
         // [PERM_SCATTER, POPCOUNT(card words), EMIT, FIXED].
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
-        // Same term vector as PlanePopcountOrder; synth (SCATTER) is a hand-set offset, not a refit param.
+        // Same term vector as PlanePopcountOrder; the fused build (CARD_RANGE_BUILD) is a hand-set offset.
         PhysicalPlan::CardRangePopcount => (
             vec![matches, n_cards / 64.0, limit, 1.0],
-            f64::from(f.synth_printings) * super::cost::SCATTER_PER_PRINTING_NS,
+            f64::from(f.scatter_printings) * super::cost::CARD_RANGE_BUILD_PER_PRINTING_NS,
         ),
         PhysicalPlan::StreamedSelect => {
             let floor = if u64::from(f.matches) <= *STREAM_MIN_MATCHES as u64 { n_cards } else { 0.0 };
@@ -3500,7 +3501,7 @@ fn plan_cost_refit() {
                     scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
-                    synth_printings: 0, project_printings: 0, popcount_words: 0,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -3698,7 +3699,7 @@ fn printing_range_route_probe() {
                 scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
-                synth_printings: 0, project_printings: 0, popcount_words: 0,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
             };
 
             // ── Three pickers ──
@@ -4059,7 +4060,7 @@ fn plan_regret_report() {
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
-                synth_printings: 0, project_printings: 0, popcount_words: 0,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -4186,7 +4187,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
-                synth_printings: 0, project_printings: 0, popcount_words: 0,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));
@@ -8111,6 +8112,89 @@ fn legality_compose_kernel_costs() {
         divergent.len(),
         repair_ns as f64 / div_printings.max(1) as f64,
     );
+}
+
+/// #731 range-compose kernel costs (real.store): the two operations a range compose leaf adds — the
+/// **range scatter** (`range_leaf_bits`: gather the value-sorted index's in-range slice into a printing
+/// bitmap, a random-write scatter) and the **card projection + grouped walk** it feeds. Reports each at
+/// several densities so the `SCATTER_PER_PRINTING_NS` and `RANGE_WALK_STEP_NS` cost constants are fit
+/// from measurement, not guessed. Companion to `legality_compose_kernel_costs` (which covers the
+/// broadcast + projection kernels). `cargo test --release range_compose_kernel_costs -- --ignored --nocapture`
+#[test]
+#[ignore = "#731 range-compose kernel costs; needs real.store"]
+fn range_compose_kernel_costs() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+    const WARMUP: usize = 20;
+    const ITERS: usize = 200;
+    const LIMIT: usize = 100; // one page — matches the default result page the grouped walk fills
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch — rebuild");
+        return;
+    }
+    let archived = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_cards = archived.cards.len();
+    let n_printings = archived.printings.len();
+    let offsets = &archived.offsets;
+    let idx = &archived.indexes.price_usd; // printing-space range index (integer cents), value-sorted
+    let perm = archived.indexes.sort_perms.get(super::SortCol::EdhrecRank, false).expect("edhrec perm");
+
+    let bench = |f: &mut dyn FnMut() -> u64| -> (u128, u64) {
+        let mut best = u128::MAX;
+        let mut sink = 0u64;
+        for it in 0..ITERS {
+            let t0 = Instant::now();
+            sink = sink.wrapping_add(black_box(f()));
+            let dt = t0.elapsed().as_nanos();
+            if it >= WARMUP {
+                best = best.min(dt);
+            }
+        }
+        (best, sink)
+    };
+
+    println!("\n#731 range-compose kernel costs (real.store: {n_cards} cards, {n_printings} printings, {} priced)", idx.len());
+    println!(
+        "{:>8}  {:>10}  {:>10}  {:>11}  {:>10}  {:>10}  {:>9}",
+        "hi(cents)", "set-prtg", "scatter", "ns/prtg", "project", "∃cards", "card-walk"
+    );
+    // Density sweep: hi at percentiles of the value-sorted index (0 = min value).
+    for pct in [5usize, 25, 50, 75, 90, 100] {
+        let k = (idx.len() * pct / 100).min(idx.len().saturating_sub(1));
+        let hi = u32::from(idx[k].0).saturating_add(1);
+        // (1) range scatter: in-range slice [0, hi) → printing bitmap.
+        let (scatter_ns, _) = bench(&mut || {
+            let pb = super::range_leaf_bits(idx, 0, hi, n_printings);
+            pb.iter().map(|w| w.count_ones() as u64).sum()
+        });
+        let pbits = super::range_leaf_bits(idx, 0, hi, n_printings);
+        let set_prtg: u64 = pbits.iter().map(|w| w.count_ones() as u64).sum();
+        // (2) projection: printing bits → card bits (the total-computing pass for unique=card).
+        let (proj_ns, _) = bench(&mut || {
+            let cb = super::printing_bits_to_card_bits(&pbits, offsets, n_cards);
+            cb.iter().map(|w| w.count_ones() as u64).sum()
+        });
+        let card_bits = super::printing_bits_to_card_bits(&pbits, offsets, n_cards);
+        let exists_cards: u64 = card_bits.iter().map(|w| w.count_ones() as u64).sum();
+        // (3) grouped card walk: fill one page of best-representative rows in edhrec order.
+        let (walk_ns, _) = bench(&mut || {
+            let page = super::walk_grouped_page(
+                super::Mode::Card, &archived.cards, &archived.printings, offsets, &pbits,
+                super::Prefer::Default, super::SortCol::EdhrecRank, false, LIMIT, 0, perm,
+            );
+            page.len() as u64
+        });
+        let per_prtg = scatter_ns as f64 / set_prtg.max(1) as f64;
+        println!(
+            "{hi:>8}  {set_prtg:>10}  {scatter_ns:>10}  {per_prtg:>11.3}  {proj_ns:>10}  {exists_cards:>10}  {walk_ns:>9}"
+        );
+    }
 }
 
 /// #724 build-side correctness oracle: projecting a printing-space border plane up to card-existence

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2768,6 +2768,18 @@ fn force_plan_differential_agreement() {
             "edhrec",
             "asc",
         ),
+        // #731 range compose: a range AND border compound. The collector-number range scatters its
+        // in-range index slice into a printing bitmap (`range_leaf_bits`), AND'd with the border plane,
+        // projected once per mode — the shared-witness case `CardRangePopcount` explicitly declined.
+        // Forced in all three modes (incl. artwork, the #694 gap) and checked against GatheredScan.
+        (
+            FuzzSpec::And(vec![
+                FuzzSpec::Leaf(FuzzLeaf::CollectorNumber { op: CmpOp::Lt, val: 100.0 }),
+                FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+            ]),
+            "edhrec",
+            "asc",
+        ),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -3262,7 +3274,7 @@ fn plan_cost_model_matches_gold() {
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
-                    synth_printings: 0, popcount_words: 0,
+                    synth_printings: 0, project_printings: 0, popcount_words: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -3372,7 +3384,7 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
         // offset, not a refit param.
         PhysicalPlan::PrintingCompose => (
             vec![f64::from(f.popcount_words), page_span / match_rate, limit, 1.0],
-            f64::from(f.synth_printings) * super::cost::SCATTER_PER_PRINTING_NS,
+            (f64::from(f.synth_printings) + f64::from(f.project_printings)) * super::cost::SCATTER_PER_PRINTING_NS,
         ),
         // [PERM_SCATTER, POPCOUNT(card words), EMIT, FIXED].
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
@@ -3488,7 +3500,7 @@ fn plan_cost_refit() {
                     scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
-                    synth_printings: 0, popcount_words: 0,
+                    synth_printings: 0, project_printings: 0, popcount_words: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -3686,7 +3698,7 @@ fn printing_range_route_probe() {
                 scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
-                synth_printings: 0, popcount_words: 0,
+                synth_printings: 0, project_printings: 0, popcount_words: 0,
             };
 
             // ── Three pickers ──
@@ -4047,7 +4059,7 @@ fn plan_regret_report() {
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
-                synth_printings: 0, popcount_words: 0,
+                synth_printings: 0, project_printings: 0, popcount_words: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -4174,7 +4186,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
-                synth_printings: 0, popcount_words: 0,
+                synth_printings: 0, project_printings: 0, popcount_words: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/docs/changelog/2026-07-22-range-composable-leaves.md
+++ b/docs/changelog/2026-07-22-range-composable-leaves.md
@@ -1,0 +1,52 @@
+# Range leaves become composable, closing the artwork-range gap (#694/#731)
+
+A `usd`/`cn`/`date` range leaf is now an exact **printing-space bitmap source** for the unified
+`PrintingCompose` plan, not just a card-space fast path. Compose scatters the range index's in-range
+slice into a printing bitmap, ANDs/ORs it with other composable leaves (border/rarity/legality/other
+ranges) in printing space, and projects once to the query's unique space. This closes #694's last gap
+— a range under `unique=artwork` — and enables compound ranges (`usd<50 cn<100`, `usd<50 border:black`)
+in every distinct-on, which the card-space `CardRangePopcount` plan explicitly declined (a two-range
+`∃p: usd(p) ∧ cn(p)` is a shared-witness case that must AND in printing space before projecting).
+
+`CardRangePopcount` also stops materializing in acquire: it now does only the two binary searches for
+the exact in-range count `k` and defers the card-bitmap build to dispatch, paid only if it wins. All
+three range/compose plans are estimate-in-acquire; nothing eagerly materializes a losing plan.
+
+Measured on the 97,206-printing corpus (`limit=100`, min of a timed window, compose kill-switch off
+vs on):
+
+| query | unique | before (μs) | after (μs) | speedup |
+|---|---|---:|---:|---:|
+| `usd<50 border:black` | printing | 1267 | 77 | 16.5× |
+| `usd<50 cn<100` | printing | 1271 | 90 | 14.1× |
+| `cn<100` | artwork | 910 | 124 | 7.3× |
+| `usd<50 cn<100` | card | 917 | 140 | 6.6× |
+| `usd<50 border:black` | artwork | 1291 | 200 | 6.5× |
+| `usd<50` | artwork | 824 | 211 | 3.9× |
+
+Bare `usd<50` at `card`/`printing` stays flat (still routed to CardRangePopcount / PrintingRangeScan).
+Totals are byte-identical off vs on across a 1,500-query branch-vs-main survey (0 count mismatches),
+and the distribution is unchanged (p50 42 μs, p90 184 μs both builds).
+
+## Cost calibration this exposed
+
+Two cost-model constants were fit from fresh kernel measurements to route the new compositions
+correctly. Both are measurement-backed, not tuned to a single query.
+
+**Range scatter is not a projection.** The old model charged one `SCATTER_PER_PRINTING_NS = 1.4`
+constant for every query-time bitmap op. Kernels (`card_range_build_cost_split`,
+`range_compose_kernel_costs`, `legality_compose_kernel_costs`) show three distinct rates:
+
+- range **scatter** (`range_leaf_bits`, contiguous read + random write): **0.36 ns/printing**
+- **linear pass** (legality broadcast-down + printing→card projection, both offset-walks): **1.50 ns/printing**
+- CardRangePopcount's **fused build** (scatter + project in one pass via `printing_to_card`): **1.22 ns/printing**
+
+Split into `RANGE_SCATTER_PER_PRINTING_NS` / `LINEAR_PASS_PER_PRINTING_NS` / `CARD_RANGE_BUILD_PER_PRINTING_NS`
+with a new `scatter_printings` feature. The fused build being cheaper than compose's two passes
+(1.22 < 0.36 + 1.50) is exactly why a bare range routes to CardRangePopcount, and the model now says so.
+
+**Mask-compare verify tier was stale.** `MASK_COMPARE_NS100` was `600` (6.0 ns/row), pinned to a
+NumericCmp that a 2026-07 re-run of `bench_verify_cost` now measures at 3.83 ns (Legality 2.05, YearCmp
+2.39). At 6.0 ns/row it over-charged `StreamedSelect`'s scan term ~1.6× and mis-routed
+`format:legacy or year:2020` / card onto compose (215 → 364 μs). Recalibrated to `400` (a conservative
+ceiling just above the priciest measured member); the query routes back to `StreamedSelect` at **206 μs**.


### PR DESCRIPTION
Makes `usd`/`cn`/`date` range leaves exact **printing-space bitmap sources** for the unified `PrintingCompose` plan, closing the last gap in #694 (a range under `unique=artwork`) and enabling compound ranges (`usd<50 cn<100`, `usd<50 border:black`) in every distinct-on. This is step 1 of #731's "compose as the universal evaluator."

Compose scatters the range index's in-range slice into a printing bitmap, ANDs/ORs it with other composable leaves (border/rarity/legality/other ranges) in printing space, then projects once to the query's unique space. A two-range query is a shared-witness case (`∃p: usd(p) ∧ cn(p)`) that must AND in printing space *before* projecting — exactly what the card-space `CardRangePopcount` plan declined, and what this provides. `CardRangePopcount` also stops materializing in acquire (defers its build to dispatch, paid only if it wins).

## Measured (97,206-printing corpus, `limit=100`, min of a timed window, compose off vs on, same build)

| query | unique | before (μs) | after (μs) | speedup |
|---|---|---:|---:|---:|
| `usd<50 border:black` | printing | 1267 | 77 | 16.5× |
| `usd<50 cn<100` | printing | 1271 | 90 | 14.1× |
| `cn<100` | artwork | 910 | 124 | 7.3× |
| `usd<50 cn<100` | card | 917 | 140 | 6.6× |
| `usd<50 border:black` | artwork | 1291 | 200 | 6.5× |
| `usd<50` | artwork | 824 | 211 | 3.9× |

Bare `usd<50` at `card`/`printing` stays flat (routed to CardRangePopcount / PrintingRangeScan). **Totals byte-identical off vs on**; a 1,500-query branch-vs-main survey had **0 count mismatches** and a flat distribution (p50 42 μs, p90 184 μs both builds).

## Cost calibration this exposed

Two constants fit from fresh kernel measurements (`card_range_build_cost_split`, `range_compose_kernel_costs`, `legality_compose_kernel_costs`, `bench_verify_cost`) — measurement-backed, not tuned to one query:

- **Range scatter ≠ projection.** Split the single `SCATTER_PER_PRINTING_NS = 1.4` into three measured rates: range scatter **0.36 ns/printing**, linear pass (broadcast-down + projection) **1.50**, CardRangePopcount fused build **1.22**. The fused build being cheaper than compose's two passes (1.22 < 0.36 + 1.50) is why a bare range routes to CardRangePopcount — the model now says so.
- **Mask-compare tier was stale.** `MASK_COMPARE_NS100` was `600` (6.0 ns/row), pinned to a NumericCmp that now measures 3.83 ns; it over-charged `StreamedSelect` ~1.6× and mis-routed `format:legacy or year:2020`/card onto compose (215→364 μs). Recalibrated to `400` → routes back to StreamedSelect at **206 μs**.

Design notes: [#731](https://github.com/jbylund/sylvan_librarian/issues/731). Closes #694. Changelog: `docs/changelog/2026-07-22-range-composable-leaves.md`. 127 engine tests pass (release + debug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)