### PR TITLE
Regex Trigram-Narrowing: Extract Guaranteed Literal Factors, Narrow, Verify (#734)

### DIFF
--- a/card_engine/Cargo.lock
+++ b/card_engine/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "pyo3",
  "rand",
  "regex",
+ "regex-syntax",
  "rkyv",
  "serde_json",
  "uuid",

--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -18,6 +18,7 @@ alloc-counter = []
 # plain `cargo test` can still link against libpython for Rust unit tests.
 pyo3 = { version = "0.29.0", features = ["uuid"] }
 regex = "1"
+regex-syntax = "0.8" # HIR literal-factor extraction for regex trigram-narrowing (#734)
 memchr = "2"
 serde_json = "1"
 rkyv = "0.8"

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2790,6 +2790,49 @@ fn and_child_rank(f: &FilterExpr) -> u8 {
 /// trick needs it), false where nothing would — a lone broad set at the root
 /// or in a candidate-less And is discarded anyway, so the scatter would be
 /// pure waste (the 10x And regressions of the first benchmark round).
+/// Guaranteed literal factors of a regex pattern — substrings present in **every** match, each ≥3
+/// bytes (so each has at least one trigram). Used to trigram-narrow a `TextRegex` to a loose candidate
+/// set that the walk then re-verifies with the real regex (#734 step 3). Extracted from the RAW pattern
+/// (strip the `(?i)` we add; a case-folded HIR would be classes, not literals) and lowercased to match
+/// the `*_lower` trigram index.
+///
+/// Pass one — concatenations of literals only. Anything a match can *skip over* ends the current run:
+/// a min=0 repetition (`s?`, `.*`), a character class (`.`, `[..]`, `\d`), a zero-width look (`^`, `$`,
+/// `\b`), or an alternation (`a|b`). A min≥1 repetition of a literal keeps it (`a+` still requires one
+/// `a`). Conservative by construction: a factor is emitted only where every match must contain those
+/// exact bytes, so narrowing on them can never drop a real match. `exile|destroy` yields no factor here
+/// (deferred: union the branches' candidates); `^flying$` still yields `flying` (the looks just bound a
+/// run they don't sit inside).
+fn regex_required_factors(pattern: &str) -> Vec<String> {
+    use regex_syntax::hir::{Hir, HirKind, Literal};
+    fn flush(run: &mut Vec<u8>, out: &mut Vec<Vec<u8>>) {
+        if run.len() >= 3 {
+            out.push(std::mem::take(run));
+        } else {
+            run.clear();
+        }
+    }
+    fn walk(hir: &Hir, run: &mut Vec<u8>, out: &mut Vec<Vec<u8>>) {
+        match hir.kind() {
+            HirKind::Literal(Literal(bytes)) => run.extend_from_slice(bytes),
+            HirKind::Capture(c) => walk(&c.sub, run, out),
+            HirKind::Concat(subs) => subs.iter().for_each(|s| walk(s, run, out)),
+            // min≥1 repetition of a literal is still guaranteed (`a+` ⇒ ≥1 `a`); anything else the match can skip.
+            HirKind::Repetition(r) if r.min >= 1 => match r.sub.kind() {
+                HirKind::Literal(Literal(bytes)) => run.extend_from_slice(bytes),
+                _ => flush(run, out),
+            },
+            _ => flush(run, out), // Empty | Class | Look | Alternation | Repetition{min:0}
+        }
+    }
+    let raw = pattern.strip_prefix("(?i)").unwrap_or(pattern);
+    let Ok(hir) = regex_syntax::parse(raw) else { return Vec::new() };
+    let (mut run, mut out) = (Vec::new(), Vec::new());
+    walk(&hir, &mut run, &mut out);
+    flush(&mut run, &mut out);
+    out.iter().map(|b| String::from_utf8_lossy(b).to_lowercase()).collect()
+}
+
 fn narrow_rec(
     filter: &FilterExpr,
     indexes: &Archived<CardIndexes>,
@@ -2942,6 +2985,42 @@ fn narrow_rec(
                 _ => trigram_candidates(&indexes.oracle_trigram.trigrams, word)
                     .and_then(|text_ids| Narrowed::loose(Candidates::Cards(expand_text_ids(&indexes.oracle_trigram, &text_ids)))),
             }
+        }
+
+        // #734 step 3: trigram-narrow a regex by its guaranteed literal factors, then let the walk
+        // re-verify with the real regex. Concatenation ⇒ every factor must appear ⇒ intersect their
+        // (loose) candidate sets. No usable factor (bare alternation / class-only) ⇒ None (full scan).
+        // Only name/oracle carry trigram indexes; artist/flavor regexes are already bound to `*Match`.
+        FilterExpr::TextRegex { field, regex } if matches!(field, TextField::NameLower | TextField::OracleTextLower) => {
+            let is_name = matches!(field, TextField::NameLower);
+            // Only narrow when the trigram index is actually built for this store — fixtures (and any
+            // store without it) leave it `Default`, where `trigram_candidates` returns empty rather
+            // than None and would wrongly narrow to zero. Fall back to the general full-scan path.
+            let built = if is_name {
+                u32::from(indexes.name_trigram.domain) as usize == n_cards
+            } else {
+                u32::from(indexes.oracle_trigram.words.n_cards) as usize == n_cards
+            };
+            if !built {
+                return None;
+            }
+            let factors = regex_required_factors(regex.as_str());
+            if factors.is_empty() {
+                return None;
+            }
+            let mut acc: Option<Vec<u32>> = None;
+            for f in &factors {
+                let cand = if is_name {
+                    trigram_candidates(&indexes.name_trigram, f)
+                } else {
+                    trigram_candidates(&indexes.oracle_trigram.trigrams, f)
+                };
+                let Some(cand) = cand else { continue }; // factor not trigram-indexable: skip, keep the rest
+                acc = Some(acc.map_or(cand.clone(), |prev| intersect_sorted(&prev, &cand)));
+            }
+            let acc = acc?; // no factor produced candidates ⇒ general path (full scan)
+            let ids = if is_name { acc } else { expand_text_ids(&indexes.oracle_trigram, &acc) };
+            Narrowed::loose(Candidates::Cards(ids))
         }
 
         FilterExpr::NumericCmp { lhs, op, rhs } => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2776,6 +2776,10 @@ static AND_SKIP_THRESHOLD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_EN
 fn and_child_rank(f: &FilterExpr) -> u8 {
     match f {
         FilterExpr::Not(_) => 2,
+        // Regex trigram-narrow (#734 step 3) is second-tier: its literal factor may be broad (`flying`),
+        // so pay for it only after cheap plane/posting sources — the And early-stop then skips it when a
+        // selective sibling (`type:dragon`) already narrowed below the threshold.
+        FilterExpr::TextRegex { .. } => 1,
         FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => 1,
         FilterExpr::NumericCmp { lhs, rhs, .. } => {
             let field = |e: &NumExpr| matches!(e, NumExpr::Field(NumField::PriceUsd | NumField::CollectorNumberInt));

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -8518,3 +8518,30 @@ fn router_timing() {
 }
 
 
+/// #734 step 3: the regex literal-factor extractor must emit ONLY guaranteed factors — a factor absent
+/// from some match would wrongly narrow it away (the walk re-verifies, so over-emitting = false
+/// negatives). Optional/`*`/class/alternation/look boundaries must all cut the run.
+#[test]
+fn regex_required_factors_extracts_only_guaranteed() {
+    use super::regex_required_factors as f;
+    // concatenation with a `.*` gap: both surrounding literals are required (the spaces around the gap
+    // are literal too), the optional `s` is dropped
+    assert_eq!(f("draw .* cards?"), vec!["draw ".to_string(), " card".to_string()]);
+    // anchors are zero-width — the literal between them survives
+    assert_eq!(f("^flying$"), vec!["flying".to_string()]);
+    assert_eq!(f("dragon$"), vec!["dragon".to_string()]);
+    assert_eq!(f("^gob"), vec!["gob".to_string()]);
+    // the `(?i)` we prepend is stripped; factors come back lowercased
+    assert_eq!(f("(?i)Dragon"), vec!["dragon".to_string()]);
+    // optional tail char drops below the ≥3 threshold on its own but keeps the mandatory stem
+    assert_eq!(f("colou?r"), vec!["colo".to_string()]); // "r" alone is <3 → dropped
+    // escaped punctuation is a literal
+    assert_eq!(f(r"\{t\}: add"), vec!["{t}: add".to_string()]);
+    // no guaranteed factor ≥3 → empty (full scan): bare alternation, class-only, short, digit class
+    assert!(f("exile|destroy").is_empty(), "alternation has no OUTER guaranteed factor in pass one");
+    assert!(f("^[aeiou]").is_empty());
+    assert!(f(r"\d+").is_empty());
+    assert!(f("a.b").is_empty(), "no run reaches 3 literal bytes");
+    // a min≥1 repetition of a literal is still guaranteed
+    assert_eq!(f("(?i)aaa+"), vec!["aaa".to_string()]);
+}

--- a/docs/changelog/2026-07-22-regex-trigram-narrow.md
+++ b/docs/changelog/2026-07-22-regex-trigram-narrow.md
@@ -1,0 +1,34 @@
+# Regexes narrowed by their guaranteed literal factors (#734)
+
+A regex query used to scan every card — `narrow_rec` had no `TextRegex` arm. Now the engine extracts
+the regex's **guaranteed literal factors** (substrings present in every match) via `regex-syntax`'s
+HIR, trigram-narrows to a loose candidate set, and lets the walk re-verify with the real regex. Same
+"narrow then verify" shape the `TextContains` trigram arm already uses — just with a regex verifier.
+
+Factor extraction is conservative (pass one): a run of literal bytes is a factor only where every
+match must contain it. Anything a match can skip — an optional/`*` quantifier, a character class, a
+zero-width anchor, an alternation — ends the run. So `draw .* cards?` → `["draw ", " card"]` (the
+optional `s` dropped), `^flying$` → `["flying"]` (anchors are zero-width; the literal between them
+survives), `dragon$` → `["dragon"]`. Concatenation means all factors must appear, so their candidate
+sets are intersected. Bare alternation (`exile|destroy`) and literal-free patterns (`^[aeiou]`, `\d+`)
+find no factor and stay a full scan (alternation-union is a deferred follow-up).
+
+Measured on the 97,206-printing corpus (`limit=100`, min of a timed window), totals byte-identical:
+
+| query | unique | before (μs) | after (μs) | speedup |
+|---|---|---:|---:|---:|
+| `o:/draw .* cards?/` | printing | 1734 | 437 | 3.97× |
+| `name:/dragon$/ year:2021` | card | 192 | 61 | 3.14× |
+| `o:/^flying$/` | printing | 316 | 132 | 2.4× |
+| `o:/draw .* cards?/ color:w` | card | 484 | 200 | 2.42× |
+
+A 1,500-query branch-vs-main survey: **0 total-count mismatches, 0 regressions, 18 wins ≥1.15×**;
+tail down p99 821→704 μs (−15%), p100 2011→1564 μs (−22%).
+
+`TextRegex` is ranked as a second-tier `And` source (like ranges): its literal factor may be broad
+(`flying`), so the narrow is paid only after cheap plane/posting sources — the `And` early-stop skips
+it when a selective sibling (`type:dragon`) already narrowed below the threshold, so
+`o:/^flying$/ type:dragon` stays as fast as before rather than paying a wasted broad-trigram pass.
+
+Complements the metacharacter-free `regex → substring` lowering (#735, parser side): that lowers pure
+literals to an *exact* `TextContains` (no verify); this narrows the regexes that keep metacharacters.


### PR DESCRIPTION
Part of #734. A regex query used to scan every card — `narrow_rec` had no `TextRegex` arm. This extracts a regex's **guaranteed literal factors** (substrings present in *every* match) via `regex-syntax`'s HIR, trigram-narrows to a loose candidate set, and lets the walk re-verify with the real regex. Same "narrow then verify" shape as the existing `TextContains` trigram arm.

## Factor extraction (pass one, conservative)

A run of literal bytes is a factor only where every match must contain it — anything a match can skip (optional/`*`, character class, zero-width anchor, alternation) ends the run:

- `draw .* cards?` → `["draw ", " card"]` (optional `s` dropped; the spaces around `.*` are literal)
- `^flying$` → `["flying"]` (anchors are zero-width — the literal between them survives)
- `dragon$` → `["dragon"]`, `^gob` → `["gob"]`
- `exile|destroy`, `^[aeiou]`, `\d+` → no factor → full scan (alternation-union deferred)

Concatenation ⇒ all factors must appear ⇒ intersect their candidate sets. Guaranteed-only by construction, so narrowing never drops a match (the extractor test pins this); the loose set is re-verified by the real regex.

## Measured (97,206-printing corpus, totals byte-identical)

| query | unique | before | after | speedup |
|---|---|---:|---:|---:|
| `o:/draw .* cards?/` | printing | 1734 μs | 437 μs | 3.97× |
| `name:/dragon$/ year:2021` | card | 192 μs | 61 μs | 3.14× |
| `o:/^flying$/` | printing | 316 μs | 132 μs | 2.4× |
| `o:/draw .* cards?/ color:w` | card | 484 μs | 200 μs | 2.42× |

**1,500-query branch-vs-main survey: 0 total-count mismatches, 0 regressions, 18 wins ≥1.15×**; tail p99 821→704 μs (−15%), p100 2011→1564 μs (−22%).

## Crossover handling

`TextRegex` is ranked a second-tier `And` source (like ranges): its factor may be broad (`flying`), so the narrow is paid only after cheap plane/posting sources — the `And` early-stop skips it when a selective sibling (`type:dragon`) already narrowed below `AND_SKIP_THRESHOLD`. So `o:/^flying$/ type:dragon` stays ~as fast as main (19→19 μs) instead of paying a wasted broad-trigram pass. Guarded on the trigram index being built (fixtures fall back to full scan).

## Relationship to #735

Complementary. #735 (parser side) lowers *metacharacter-free* regexes to an exact `TextContains` (no verify); this narrows the regexes that *keep* metacharacters/anchors. Independent changes (Python vs engine); this PR is based on `main`. Design notes: `docs/issues/00734-engine-string-operator-optimizations.md` (lands with #735).

128 engine tests pass (release + debug), incl. the guaranteed-factor extractor test. Changelog: `docs/changelog/2026-07-22-regex-trigram-narrow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)