### PR TITLE
Faster unique=artwork Gather: Skip Repped Groups, Columnar Group Id, Pre-Sized Scratch

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2268,6 +2268,7 @@ struct CardIndexes {
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
+    artwork_group_col: Vec<u16>,               // printing space: pid -> artwork_group_id (columnar; lets the gather skip read gid without touching the wide struct)
     // printing space: printing_id -> card_id, direct lookup. Replaces a
     // partition_point search on `offsets` in cards_of_printings' hot paths —
     // see docs/issues/00690-engine-direct-projection-arrays.md.
@@ -2302,6 +2303,7 @@ impl Default for CardIndexes {
             collector_number: Vec::new(),
             sort_perms:     SortPermutations::default(),
             artwork_groups: Vec::new(),
+            artwork_group_col: Vec::new(),
             printing_to_card: Vec::new(),
             planes:         BitPlanes::default(),
             border_printing: BorderPrintingPlanes::default(),
@@ -3813,6 +3815,7 @@ fn push_card_matches(
     card: &AOracleCard,
     cid: u32,
     printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
     start: usize,
     end: usize,
     all_match: bool,
@@ -3916,7 +3919,9 @@ fn push_card_matches(
                 // group is already repped: repped groups never pay the residual verification (a
                 // struct read) again, and no score comparison is needed (first qualifying wins).
                 for pid in start..end {
-                    let gid = u16::from(printings[pid].artwork_group_id) as usize;
+                    // Read gid from the columnar side array, not the wide struct: repped-group
+                    // printings (the majority) then never touch the struct at all.
+                    let gid = u16::from(artwork_group_col[pid]) as usize;
                     if group_best.len() <= gid {
                         group_best.resize(gid + 1, None);
                     }
@@ -5198,7 +5203,7 @@ fn exec_streamed_select<'a>(
     };
     run_query_streamed(
         cards, printings, offsets, strings, filter, prep.all_match_known, mode, prefer, sort_col, descending, limit,
-        page_offset, perm, card_ids, &indexes.artwork_groups, existential_plane,
+        page_offset, perm, card_ids, &indexes.artwork_groups, &indexes.artwork_group_col, existential_plane,
     )
 }
 
@@ -5256,7 +5261,7 @@ fn exec_gathered_scan<'a>(
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
         push_card_matches(
-            card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+            card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
             sort_col, descending, strings, existential_plane, sel.buf(), &mut group_best, &mut touched,
         );
         sel.absorb(before);
@@ -5816,6 +5821,7 @@ fn run_query_streamed<'a>(
     perm: &Archived<Vec<u32>>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     artwork_groups: &Archived<Vec<u16>>,
+    artwork_group_col: &Archived<Vec<u16>>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let mut residual: Vec<&FilterExpr> = Vec::new();
@@ -5894,7 +5900,7 @@ fn run_query_streamed<'a>(
             let start = u32::from(offsets[cid as usize]) as usize;
             let end   = u32::from(offsets[cid as usize + 1]) as usize;
             push_card_matches(
-                card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+                card, cid, printings, artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
                 sort_col, descending, strings, existential_plane, &mut best, &mut group_best, &mut touched,
             );
         }
@@ -5932,7 +5938,7 @@ fn run_query_streamed<'a>(
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         scratch.clear();
         push_card_matches(
-            card, cid, printings, start, end, all_match, &residual, residual_is_or, mode, prefer,
+            card, cid, printings, artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
             sort_col, descending, strings, existential_plane, &mut scratch, &mut group_best, &mut touched,
         );
         scratch.sort_unstable_by(cmp);
@@ -6057,7 +6063,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260722;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260723;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -6458,6 +6464,10 @@ impl QueryEngine {
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             artwork_groups: artwork_group_counts,
+            // Columnar copy of each printing's assigned artwork_group_id, derived here — the single
+            // production spot where assign_artwork_groups (above) has just filled it. Archived with
+            // the store, so it is never recomputed post-load and cannot drift from the struct field.
+            artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
             printing_to_card: build_printing_to_card(&offsets),
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             border_printing: build_border_printing_planes(&printings, &strings),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5108,10 +5108,16 @@ fn walk_grouped_page<'a>(
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
-    // per group key: (best matching pid, its prefer score). Pre-sized to max_artwork_groups so the
-    // grouping loop needs no per-printing resize check (Card mode collapses to index 0).
-    let mut group_best: Vec<Option<(u32, f64)>> =
-        if matches!(mode, Mode::Card | Mode::Artwork) { vec![None; usize::from(max_artwork_groups)] } else { Vec::new() };
+    // per group key: (best matching pid, its prefer score). Pre-sized so the grouping loop needs no
+    // per-printing resize check: Artwork needs one slot per group, Card collapses to a single group
+    // (gid 0), Printing does no grouping. Card's fixed len 1 also keeps the loop safe if a
+    // degenerate store leaves max_artwork_groups at 0.
+    let n = match mode {
+        Mode::Artwork => usize::from(max_artwork_groups),
+        Mode::Card => 1,
+        Mode::Printing => 0,
+    };
+    let mut group_best: Vec<Option<(u32, f64)>> = vec![None; n];
     let mut touched: Vec<u16> = Vec::new();
     let mut scratch: Vec<Match> = Vec::new();
     let mut skip = page_offset;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2269,6 +2269,7 @@ struct CardIndexes {
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     artwork_group_col: Vec<u16>,               // printing space: pid -> artwork_group_id (columnar; lets the gather skip read gid without touching the wide struct)
+    max_artwork_groups: u16,                   // max distinct artwork groups of any single card; group_best is pre-sized to this so the hot loop needs no bounds/resize check
     // printing space: printing_id -> card_id, direct lookup. Replaces a
     // partition_point search on `offsets` in cards_of_printings' hot paths —
     // see docs/issues/00690-engine-direct-projection-arrays.md.
@@ -2304,6 +2305,7 @@ impl Default for CardIndexes {
             sort_perms:     SortPermutations::default(),
             artwork_groups: Vec::new(),
             artwork_group_col: Vec::new(),
+            max_artwork_groups: 0,
             printing_to_card: Vec::new(),
             planes:         BitPlanes::default(),
             border_printing: BorderPrintingPlanes::default(),
@@ -3920,11 +3922,10 @@ fn push_card_matches(
                 // struct read) again, and no score comparison is needed (first qualifying wins).
                 for pid in start..end {
                     // Read gid from the columnar side array, not the wide struct: repped-group
-                    // printings (the majority) then never touch the struct at all.
+                    // printings (the majority) then never touch the struct at all. `group_best` is
+                    // pre-sized by the caller to max_artwork_groups, so no per-printing resize check.
                     let gid = u16::from(artwork_group_col[pid]) as usize;
-                    if group_best.len() <= gid {
-                        group_best.resize(gid + 1, None);
-                    }
+                    debug_assert!(gid < group_best.len(), "group_best must be pre-sized to max_artwork_groups");
                     if group_best[gid].is_some() {
                         continue;
                     }
@@ -3940,9 +3941,7 @@ fn push_card_matches(
                     let p = &printings[pid];
                     if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
                     let gid = u16::from(p.artwork_group_id) as usize;
-                    if group_best.len() <= gid {
-                        group_best.resize(gid + 1, None);
-                    }
+                    debug_assert!(gid < group_best.len(), "group_best must be pre-sized to max_artwork_groups");
                     let score = prefer_score(card, p, prefer);
                     match &group_best[gid] {
                         None => {
@@ -4592,7 +4591,7 @@ fn printing_compose_fastpath<'a>(
     if perm.len() != cards.len() {
         return None;
     }
-    Some((total, walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm)))
+    Some((total, walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm, u16::from(indexes.max_artwork_groups))))
 }
 
 /// The physical plans the cost router (`run_query_routed`) chooses among. Each
@@ -5104,11 +5103,15 @@ fn walk_grouped_page<'a>(
     limit: usize,
     page_offset: usize,
     perm: &Archived<Vec<u32>>,
+    max_artwork_groups: u16,
 ) -> Vec<(&'a AOracleCard, &'a APrinting)> {
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
-    let mut group_best: Vec<Option<(u32, f64)>> = Vec::new(); // per group key: (best matching pid, its prefer score)
+    // per group key: (best matching pid, its prefer score). Pre-sized to max_artwork_groups so the
+    // grouping loop needs no per-printing resize check (Card mode collapses to index 0).
+    let mut group_best: Vec<Option<(u32, f64)>> =
+        if matches!(mode, Mode::Card | Mode::Artwork) { vec![None; usize::from(max_artwork_groups)] } else { Vec::new() };
     let mut touched: Vec<u16> = Vec::new();
     let mut scratch: Vec<Match> = Vec::new();
     let mut skip = page_offset;
@@ -5138,9 +5141,7 @@ fn walk_grouped_page<'a>(
                         Mode::Artwork => u16::from(printings[pid].artwork_group_id) as usize,
                         _ => 0, // Card: everything collapses into one group
                     };
-                    if group_best.len() <= gid {
-                        group_best.resize(gid + 1, None);
-                    }
+                    debug_assert!(gid < group_best.len(), "group_best must be pre-sized to max_artwork_groups");
                     let score = prefer_score(card, &printings[pid], prefer);
                     match &group_best[gid] {
                         None => {
@@ -5203,7 +5204,7 @@ fn exec_streamed_select<'a>(
     };
     run_query_streamed(
         cards, printings, offsets, strings, filter, prep.all_match_known, mode, prefer, sort_col, descending, limit,
-        page_offset, perm, card_ids, &indexes.artwork_groups, &indexes.artwork_group_col, existential_plane,
+        page_offset, perm, card_ids, &indexes.artwork_groups, &indexes.artwork_group_col, u16::from(indexes.max_artwork_groups), existential_plane,
     )
 }
 
@@ -5239,8 +5240,10 @@ fn exec_gathered_scan<'a>(
     // at ~k via prune + running cutoff (see GatherSelect) rather than gathering every
     // match. `total` counts every match; the page is the k smallest.
     let mut sel = GatherSelect::new(page_offset, limit);
-    // artwork-mode scratch, reused per card (#629: group-id-indexed, not illustration_id-keyed)
-    let mut group_best: Vec<Option<(u32, f64)>> = Vec::new();
+    // artwork-mode scratch, reused per card (#629: group-id-indexed, not illustration_id-keyed).
+    // Pre-sized to max_artwork_groups so the grouping loop needs no per-printing resize check.
+    let mut group_best: Vec<Option<(u32, f64)>> =
+        if matches!(mode, Mode::Artwork) { vec![None; usize::from(u16::from(indexes.max_artwork_groups))] } else { Vec::new() };
     let mut touched: Vec<u16> = Vec::new();
     // card_pass residual: the top-level children still printing-dependent for
     // the current card (reused buffer; see FilterExpr::card_pass).
@@ -5822,6 +5825,7 @@ fn run_query_streamed<'a>(
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     artwork_groups: &Archived<Vec<u16>>,
     artwork_group_col: &Archived<Vec<u16>>,
+    max_artwork_groups: u16,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let mut residual: Vec<&FilterExpr> = Vec::new();
@@ -5878,8 +5882,10 @@ fn run_query_streamed<'a>(
         return (total, Vec::new());
     }
 
-    // artwork-mode emission scratch (#629), reused across cards below
-    let mut group_best: Vec<Option<(u32, f64)>> = Vec::new();
+    // artwork-mode emission scratch (#629), reused across cards below. Pre-sized to
+    // max_artwork_groups so the grouping loop needs no per-printing resize check.
+    let mut group_best: Vec<Option<(u32, f64)>> =
+        if matches!(mode, Mode::Artwork) { vec![None; usize::from(max_artwork_groups)] } else { Vec::new() };
     let mut touched: Vec<u16> = Vec::new();
     let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
 
@@ -6463,6 +6469,7 @@ impl QueryEngine {
             price_usd:      build_range_index(&printings, |p| p.price_usd),
             collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
+            max_artwork_groups: artwork_group_counts.iter().copied().max().unwrap_or(0),
             artwork_groups: artwork_group_counts,
             // Columnar copy of each printing's assigned artwork_group_id, derived here — the single
             // production spot where assign_artwork_groups (above) has just filled it. Archived with

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3910,23 +3910,45 @@ fn push_card_matches(
             // lands, up to ~385 distinct illustrations) at O(printings) instead
             // of the O(printings²) a linear per-printing scan would cost.
             touched.clear();
-            for pid in start..end {
-                let p = &printings[pid];
-                if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
-                let gid = u16::from(p.artwork_group_id) as usize;
-                if group_best.len() <= gid {
-                    group_best.resize(gid + 1, None);
+            if matches!(prefer, Prefer::Default) {
+                // Printings are stored prefer-desc, so the first residual-qualifying printing of
+                // each group is its best-prefer rep. Read `gid` first and skip any printing whose
+                // group is already repped: repped groups never pay the residual verification (a
+                // struct read) again, and no score comparison is needed (first qualifying wins).
+                for pid in start..end {
+                    let gid = u16::from(printings[pid].artwork_group_id) as usize;
+                    if group_best.len() <= gid {
+                        group_best.resize(gid + 1, None);
+                    }
+                    if group_best[gid].is_some() {
+                        continue;
+                    }
+                    let p = &printings[pid];
+                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
+                    group_best[gid] = Some((pid as u32, 0.0));
+                    touched.push(gid as u16);
                 }
-                let score = prefer_score(card, p, prefer);
-                match &group_best[gid] {
-                    None => {
-                        group_best[gid] = Some((pid as u32, score));
-                        touched.push(gid as u16);
+            } else {
+                // Custom prefer: iteration order != prefer order, so every printing must be
+                // considered and the max-prefer rep kept per group.
+                for pid in start..end {
+                    let p = &printings[pid];
+                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
+                    let gid = u16::from(p.artwork_group_id) as usize;
+                    if group_best.len() <= gid {
+                        group_best.resize(gid + 1, None);
                     }
-                    Some((_, best_score)) if score > *best_score => {
-                        group_best[gid] = Some((pid as u32, score));
+                    let score = prefer_score(card, p, prefer);
+                    match &group_best[gid] {
+                        None => {
+                            group_best[gid] = Some((pid as u32, score));
+                            touched.push(gid as u16);
+                        }
+                        Some((_, best_score)) if score > *best_score => {
+                            group_best[gid] = Some((pid as u32, score));
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
             for &gid in touched.iter() {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -256,6 +256,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         name_bigrams: build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards, &printings, &offsets),
+        max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,
         artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
         printing_to_card: build_printing_to_card(&offsets),
@@ -281,6 +282,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
 /// single production build spot in `reload_commit`. Returns the per-card counts (for asserts).
 fn reassign_artwork_grouping(data: &mut CardData) -> Vec<u16> {
     let counts = assign_artwork_groups(&mut data.printings, &data.offsets);
+    data.indexes.max_artwork_groups = counts.iter().copied().max().unwrap_or(0);
     data.indexes.artwork_groups = counts.clone();
     data.indexes.artwork_group_col = data.printings.iter().map(|p| p.artwork_group_id).collect();
     counts
@@ -4528,6 +4530,7 @@ fn bench_checked_vs_unchecked_access() {
         price_usd:      Vec::new(),
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
+        max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,
         artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
         printing_to_card: build_printing_to_card(&offsets),
@@ -8200,6 +8203,7 @@ fn range_compose_kernel_costs() {
             let page = super::walk_grouped_page(
                 super::Mode::Card, &archived.cards, &archived.printings, offsets, &pbits,
                 super::Prefer::Default, super::SortCol::EdhrecRank, false, LIMIT, 0, perm,
+                u16::from(archived.indexes.max_artwork_groups),
             );
             page.len() as u64
         });

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -257,6 +257,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups,
+        artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
         printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
@@ -272,6 +273,17 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         indexes,
         format_shifts: HashMap::new(),
     }
+}
+
+/// Recompute both artwork-grouping-derived index fields (per-card counts and the per-printing
+/// columnar copy) from the current printings, keeping them in sync. Call after a fixture mutates
+/// `illustration_id` post-`store_of` so no site can update one and forget the other — mirrors the
+/// single production build spot in `reload_commit`. Returns the per-card counts (for asserts).
+fn reassign_artwork_grouping(data: &mut CardData) -> Vec<u16> {
+    let counts = assign_artwork_groups(&mut data.printings, &data.offsets);
+    data.indexes.artwork_groups = counts.clone();
+    data.indexes.artwork_group_col = data.printings.iter().map(|p| p.artwork_group_id).collect();
+    counts
 }
 
 // Verify that narrow_candidates returns printing-space candidates for art tags
@@ -4431,7 +4443,7 @@ fn run_query_artwork_groups_shared_illustrations() {
     // store_of already assigned artwork_group_id from the original (all-distinct)
     // illustration_ids, so it must be recomputed after this mutation.
     data.printings[2].illustration_id = 1;
-    data.indexes.artwork_groups = assign_artwork_groups(&mut data.printings, &data.offsets);
+    reassign_artwork_grouping(&mut data);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
@@ -4517,6 +4529,7 @@ fn bench_checked_vs_unchecked_access() {
         collector_number: Vec::new(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         artwork_groups,
+        artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
         printing_to_card: build_printing_to_card(&offsets),
         planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
         border_printing: build_border_printing_planes(&printings, &strings),
@@ -5141,7 +5154,7 @@ fn streamed_selection_matches_gathered() {
         }
         if with_perms {
             data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
-            data.indexes.artwork_groups = assign_artwork_groups(&mut data.printings, &data.offsets);
+            reassign_artwork_grouping(&mut data);
         }
         rkyv::to_bytes::<Error>(&data).expect("serialize")
     };
@@ -5194,7 +5207,7 @@ fn artwork_group_counts_dedup_illustrations() {
     data.printings[1].illustration_id = 7; // same art, different printing
     data.printings[2].illustration_id = 9;
     data.printings[3].illustration_id = 7;
-    let counts = assign_artwork_groups(&mut data.printings, &data.offsets);
+    let counts = reassign_artwork_grouping(&mut data);
     assert_eq!(counts, vec![2]);
     // 0 = first-seen (printing 0's illustration 7), 1 = next distinct (printing 2's
     // illustration 9); printings 1 and 3 share illustration 7's group.
@@ -5217,7 +5230,7 @@ fn artwork_group_ids_handle_more_than_64_groups() {
     // keep their distinct store_of-assigned illustration -- 69 distinct
     // groups total, past the 64-bit single-word threshold.
     data.printings[1].illustration_id = data.printings[0].illustration_id;
-    data.indexes.artwork_groups = assign_artwork_groups(&mut data.printings, &data.offsets);
+    reassign_artwork_grouping(&mut data);
     assert_eq!(data.indexes.artwork_groups, vec![69]);
 
     // Printing 0 has the higher prefer_score (store_of orders descending) but

--- a/docs/changelog/2026-07-22-artwork-skip-repped.md
+++ b/docs/changelog/2026-07-22-artwork-skip-repped.md
@@ -1,0 +1,45 @@
+# Faster `unique=artwork` gather: skip repped groups, columnar gid, pre-sized scratch
+
+Three changes to the `unique=artwork` grouping loop, which picks one best-`prefer_score`
+representative per artwork group. Profiling `border:black -(name:…)` / artwork / usd (a broad
+`GatheredScan`, since `usd` has no sort permutation) showed the dominant cost was **per-printing
+residual verification** of the printing-varying `border` predicate — reading the wide `APrinting`
+struct on every printing to find a black-bordered rep.
+
+**Skip already-repped groups.** Printings are stored prefer-desc within a card, so for the default
+prefer the *first* residual-qualifying printing of a group is its rep — every later printing of that
+group is dead weight. The loop now reads the group id first and skips any printing whose group is
+already repped, *before* the residual. Repped groups (the majority; ~2.4 printings/group) never
+re-pay the residual, and the rep needs no score comparison. Custom prefer keeps the full max-score
+scan (iteration order ≠ prefer order).
+
+**Columnar `artwork_group_id`.** A pid-indexed `artwork_group_col: Vec<u16>` the gather reads for the
+group id instead of the wide struct, so repped-group printings never touch the struct at all. Built
+once in `reload_commit` beside `assign_artwork_groups` and archived, so it is never recomputed
+post-load and cannot drift. Helps `all_match=true` artwork scans, where the gid read is the only
+per-printing work.
+
+**Pre-sized `group_best`.** The rep scratch is indexed only by `artwork_group_id` (Card mode collapses
+to index 0), so its max index is a fixed store property — the largest distinct-artwork count of any
+card (385 in the corpus; p50 1, p99 6). Stored as `CardIndexes.max_artwork_groups` and used to
+pre-size the scratch once per query, dropping the per-printing `len() <= gid` bounds/resize check from
+all three artwork grouping loops.
+
+Measured on the 97,206-printing corpus (`limit=100`, min of a timed window), totals byte-identical:
+
+| query | unique | orderby | before (μs) | after (μs) | speedup |
+|---|---|---|---:|---:|---:|
+| `border:black` | artwork | usd | 1166 | 845 | 1.38× |
+| `t:creature` | artwork | usd | 320 | 244 | 1.31× |
+| `c:r` | artwork | usd | 156 | 122 | 1.28× |
+| `border:black -(name:storm or name:dragon)` | artwork | usd | 1543 | 1245 | 1.24× |
+
+A 520-query branch-vs-main survey (`survey_queries.py --count 400 --wild 120 --seed 42`): **0
+total-count mismatches, no regressions** (only sub-10 μs exact-name lookups vary, within noise); p100
+1089 → 933 μs (−14%). Card/printing modes and the residual-dominated `-(name:…)` query are unaffected
+where the loop isn't the bottleneck. Archive grows +190 KB (+0.27%): the columnar id array
+(97,206 × 2 bytes). `ARCHIVE_FORMAT_VERSION` bumped for the layout change.
+
+Design notes: [`docs/issues/local-engine-artwork-skip-repped.md`](../issues/local-engine-artwork-skip-repped.md)
+and the [`APrinting` layout investigation](../issues/local-engine-aprinting-layout.md) it resolves —
+which established (after a corrected profile) that the lever is the residual, not the struct footprint.

--- a/docs/issues/local-engine-aprinting-layout.md
+++ b/docs/issues/local-engine-aprinting-layout.md
@@ -1,0 +1,279 @@
+# Engine: `APrinting` Layout — Stop Streaming Unused Bytes
+
+Status: design note, unfiled. `APrinting` is a wide row struct; any query that scans many printings
+streams the whole thing to read a few fields. Two complementary moves — **shrink** the struct and
+**split** hot vs cold fields — cut that memory traffic. Benefits every broad scan, not one query.
+
+## Problem: row storage is memory-bandwidth-bound on wide scans
+
+`APrinting` is ~146 B of data (160 B aligned to its `u128`s — measured `size_of` 160, align 16):
+22 fields, two `u128` UUIDs, a `u64` legalities word, three archived `Vec`s, a dozen `u32`/`Option`s.
+A hot loop reads a couple of narrow fields per printing but pulls the whole cache line(s) each time.
+On a broad result that is pure DRAM traffic.
+
+Profiled on `border:black -(name:storm or name:dragon)` / `unique=artwork` / `orderby=usd` (main after
+#736, ~1.6 ms; `CARD_ENGINE_PROF_STAGE` stage-delta timers, since reverted):
+
+| phase | time | % |
+|---|---:|---:|
+| loop overhead | 49 µs | 3% |
+| verification (`card_pass`, `-(names)`) | 431 µs | 26% |
+| **stream 95,600 `APrinting` structs to read `artwork_group_id`** | **925 µs** | **55%** |
+| `group_best` bookkeeping + emit | 215 µs | 13% |
+| `prefer_score` + `usd` sort-key + quickselect | ~75 µs | 4% |
+
+The dominant 55% is *just touching the structs* — reading a 2-byte field from 95,600 matches streams
+~12 MB. Not the ordering (sort-key 2%), not grouping bookkeeping (13%), not a `group_best` cache miss
+(an early wrong guess; that access is ~sequential). It is bytes-per-visit on a wide struct.
+
+## Struct anatomy: ~⅔ is dead weight for a common scan
+
+Read-site survey (`card_engine/src/lib.rs`) sorts the fields by what a broad scan actually needs:
+
+| bucket | ~bytes | fields |
+|---|---:|---|
+| **hot** (common scan / sort / group) | ~46 B | `artwork_group_id`, `prefer_score`, `price_usd`, `released_at_int`, `card_rarity_int`, `collector_number_int`, `flavor_text_lower_id`, `card_artist_vid`, `card_set_code` |
+| **display-only** (the 100-row output page) | ~52 B | `scryfall_id` (16), `illustration_id` (16), `set_name_id`, `flavor_text_id`, `collector_number_id`, `card_border_id`, `card_watermark_id` |
+| **rare-predicate** (only when that filter is present) | ~48 B | `card_art_tags`/`card_is_tags`/`card_frame_data` Vecs (24), `card_legalities` (8, divergent-only ~1.8%), `price_eur`/`price_tix` (16) |
+
+Border/watermark *filter* via the printing planes (#664/#724), so their `_id` fields are output-only;
+`illustration_id` is superseded by `artwork_group_id` in hot paths (#629) — only build (artwork-group
+assignment, tiebreak sort) and output read it. So ~98 B of every streamed struct is display-only or
+rare-predicate — dead weight for the common scan.
+
+## The shrink ladder
+
+> **⚠ STOP — see "MEASURED" below.** Both a rung-1 eviction prototype *and* a columnar `artwork_group_id`
+> prototype came out **flat**. A probe then showed the profiled 55% was the per-printing `border`
+> residual verification, **not** `artwork_group_id` streaming — so this whole ladder targets the wrong
+> cost for the surfacing query. Kept for the analysis, but **don't implement it** on this evidence.
+
+Ordered by how you'd actually do it. Eviction leads on purpose — width-packing's *value* depends on it:
+packing alone stalls at 144 B (the `u128`s force align-16, so most of the 27 B of savings becomes
+padding that rounds back up), and eviction is what drops align to 8 so the later savings land in fine
+steps. Each rung is its own archive-format bump, but rungs 1–2 are batchable.
+
+### 1. Evict the two `u128` UUIDs — ~32 B (~22%), the pivotal first move
+
+`scryfall_id` (output-only) and `illustration_id` (build + output; superseded in hot paths by
+`artwork_group_id`, #629) → side `Vec<u128>` arrays. **No index field needed:** `scryfall_id` is unique
+per printing, so the array is 1:1 with printings and the printing's own **pid is the index**
+(`scryfall_ids[pid]`). The 100-row output page does the lookup; hot scans never touch them.
+
+It's **pivotal, not just −32 B**: those two `u128`s are what force the struct to align-16 (the 16-B
+size quantization that would otherwise cap the width pack in §2 at 144 B). Evicting them drops
+`APrinting` to align-8, so every later rung's savings quantize in finer 8-B steps and can actually land.
+And it's the **lowest-risk** rung: both fields are cold (output/build only), build reads `CardRow`
+pre-split (untouched), and output resolution is the `str_at`-style lookup the extractors already use.
+
+`illustration_id` *could* dedup further — it's shared by same-art printings (~40,334 distinct vs 97,206),
+so it could live once per artwork group instead of per pid (~645 KB vs ~1.5 MB). But it's cold
+(output/build only), so that's cold footprint, not hot bandwidth — evict per-pid for simplicity; dedup
+only if cold memory matters. `scryfall_id` is unique, so it's per-pid regardless.
+
+**Returning the UUID in the output page.** Same mechanism the output already uses for `oracle_text` /
+`set_name` / `collector_number`: those read an *id* from the struct and resolve it with `str_at(strings,
+id)` — a side-table lookup, not a stored value. UUIDs are just the inline exception. After eviction the
+extractor changes from `p.scryfall_id` to `scryfall_ids[pid]`; the pid is already known per row (`Match =
+(sort_key, cid, pid)`), so carry it in the page tuple and pass it (plus the uuid arrays) into the
+extractor context alongside the `strings` table it already receives. Cost: 100 output rows × one cold-array
+lookup ≈ µs — the whole point of the split is you pay the side lookup only for the rows you *return*, not
+the ~95,600 you *scan*. For `unique=cards` it's the rep printing's pid, which the page already picked.
+
+**Future UUID search (`illustration_id:` / `scryfall_id:`) — eviction enables it, doesn't block it.**
+Not searchable today, but on the someday list; when added, it's an *equality lookup*, which wants a
+dedicated **index**, never a scan of the inline field (scanning 97,206 `u128`s per query is both slow and
+re-introduces the exact struct-streaming this doc removes — Scryfall answers these by lookup, not scan).
+Build once at load: `scryfall_id:X` → sorted `(u128, pid)` / hashmap → one pid; `illustration_id:X` →
+`u128 → art group → printings` (~40,334 entries), projected to cards for `unique=cards` — a narrowing leaf
+through the normal `narrow_rec` path. So the value and the search key are two structures with two jobs —
+side array (render the UUID in output) + index (answer `uuid:X`) — and the index is built from the same
+values wherever they live. The inline field served *neither* job well (bloated every hot scan, wrong
+structure for search), so supporting UUID search is an argument *for* eviction, not against it.
+
+### 2. Width / sentinel packing — ~24 B (more if `prefer_score` is re-encoded), no restructure
+
+With eviction (§1) having dropped align to 8, these savings now quantize finely instead of rounding
+back up. Drop `Option` (archived 8 B for `Option<u32>`, no niche) for a bare value + reserved sentinel,
+and narrow where the corpus allows. Corpus maxima (97,206 printings) validate every choice:
+
+| field | now | proposed | sentinel / rep | corpus max → headroom |
+|---|---:|---:|---|---|
+| `price_usd` | `Option<u32>` 8 B | `u32` 4 B | `u32::MAX` = None | 514,202 ¢ ($5,142) ≪ 4.29 B |
+| `price_eur` | `Option<u32>` 8 B | `u32` 4 B | `u32::MAX` = None | 3,097,514 ¢ ≪ 4.29 B |
+| `released_at_int` | `Option<u32>` 8 B | `u16` 2 B | days since 1990; `u16::MAX` = None | 2026 ≈ 13,176 days ≪ 65,535 |
+| `prefer_score` | `Option<f32>` 8 B | see below | — | 954 distinct, range 84.85–209.30 |
+| `card_rarity_int` | `Option<u8>` 2 B | `u8` 1 B | `u8::MAX` = None | 0–5 |
+| `collector_number_int` | `Option<u16>` 4 B | `u16` 2 B | `u16::MAX` = None | — |
+| `price_tix` | `Option<u32>` 8 B | `u32` 4 B (sentinel) | `u32::MAX` = None | 49,106 ¢ (491 tix) |
+
+Notes: `released_at` → **days-since-1990** is the standout (8 → 2 B on a *hot* field) but is a
+*representation* change (load `yyyymmdd`→days; date/year filter bounds → days — `year:2020` becomes a
+clean `[days(2020-01-01), days(2021-01-01))`; output days→date). The range index and prefer-sort stay
+correct (days are monotonic). `price_tix` **fits `u16`** (491 of 655 tix) but with tight headroom on a
+cold field — keep it a `u32`-sentinel unless every byte counts (else clamp `> 65,534` on load).
+Everything else is a pure type swap. Precedent for sentinels: `NONE_STR`, `ARTIST_NONE`. Do the trivial
+swaps (prices, rarity/cn_int) first — batchable with §1; the representation changes below are heavier.
+
+**`prefer_score` — re-encode as a within-card rank (its own sub-ladder).** It's an `f32` (954 distinct,
+84.85–209.30) but the *value* is never meaningful — it's only an **ordering key within a card**: the
+build sorts each card's printings descending-`prefer_score` (storage order = prefer order), and the
+score is read for (a) rep selection [max within a group], (b) printing-mode within-card ordering, (c)
+the sort key's 3rd-level tiebreak `(primary, edhrec_rank, prefer_score)`. So:
+
+- **f16 (4 B)** — measured 0 rep-winner flips across 18,474 multi-printing cards; keeps a global value,
+  so it preserves (c) too. Zero behavior change.
+- **`u16` within-card rank (2 B)** — max ~385 printings/card (basic lands), so 0–512 fits. Covers (a)/(b)
+  exactly; (c)'s *cross-card* case (two different cards tied on primary **and** `edhrec_rank`) degrades to
+  the pid tiebreak — rare, cosmetic.
+- **drop entirely (0 B)** — storage order already *is* the rank, so rep = first-matching printing per
+  group (Card mode does this today; Artwork mode + `card_match_count` would adopt it) and the sort key's
+  within-card ordering is already identical to its pid tiebreak. Trades leaning on the storage-order
+  invariant + two rep-selection code changes for the last 2 B.
+
+The cross-card caveat (c) is **measured to be vestigial**: non-null `edhrec_rank` is *unique per card*
+(0 of 31,508 shared), so the `prefer_score` sort tiebreak only fires among the **65 NULL-edhrec cards
+(0.2%)** that collapse into the `edhrec = MAX` bucket — and only in that trailing block. So dropping
+`prefer_score` reorders at most those 65 edhrec-less cards (prefer → pid); `drop` (0 B) and the `u16`
+rank are both safe, with `f16` reserved for making even that 65-card tail byte-exact. (Data-dependent:
+assumes edhrec ranks stay unique and NULL-edhrec cards stay few.) **Chosen first step: the `u16` rank**
+(keeps behavior explicit; revisit `drop`/storage-order later).
+
+**Where the rank is assigned (build-time, free from the existing sort).** In the commit/grouping pass
+(`reload_commit`): the rows are already `sort_unstable_by(oracle_id, then prefer_score desc, …)`, then
+split into `cards`/`printings`/`offsets`. A printing's position within its card's contiguous range *is*
+its prefer-rank (0 = highest score), so it's a one-liner at the `printings.push`:
+`prefer_rank = printings.len() − offsets.last()` (= `pid − card_start`), or a small post-pass beside
+`assign_artwork_groups`/`assign_name_ranks` (which already walk by card range). The DB `f32` stays a
+parse-time `CardRow` field feeding that sort and is never archived; the archived `Printing` carries only
+`prefer_rank: u16`. Reader flips: `prefer_score()`'s Default arm and `sort_key_bits` invert to "lower
+rank wins / sort ascending"; the build sort is unchanged. Caveat: the Python output extractor exposes
+`prefer_score` — grep the API/frontend before dropping the value from output.
+
+**Derived-data redundancy — don't store `*_lower` / `*_folded`.** A lowercased/accent-folded string is
+*always* recoverable from its original, so storing an id for both is pure redundancy. Store one **dense**
+id (into a per-field dense space that fits `u16`, not the shared global interner which can exceed `u16`)
+and derive the other via a side map — or resolve the case-insensitive search into original-id space at
+bind time (case-variant collisions just expand the match set slightly; exact, once per query).
+Corpus-verified distinct counts (all < 65,535):
+
+| pair | field(s) today | distinct | proposed | Δ | notes |
+|---|---|---:|---|---:|---|
+| flavor (`APrinting`) | `flavor_text_id` + `flavor_text_lower_id`, two `u32` = 8 B | 26,443 orig / 26,321 lower | one dense `u16` = 2 B | **−6 B / printing** | 46% of printings have no flavor (sentinel); lower is many-to-one (120 case collisions) |
+| oracle (`AOracleCard`) | `oracle_text_id` + `oracle_text_lower_id`, two `u32` = 8 B | 29,088 orig = 29,088 lower (bijective) | one dense `u16` = 2 B | −6 B / card | per-*card*, so streams less, but read in the `card_pass` verify phase |
+| name (`AOracleCard`) | `card_name_id` `u32` + `card_name_folded` **`InlineStr<61>`** ≈ 65 B | 31,511 names | one dense `u16` + side folded-string array | **≈ −63 B / card** | the standout: the folded name is stored *inline*; a dense id + side array frees ~63 B — but fuzzy `name:` scans read the folded string, so verify the per-candidate indirection is acceptable |
+
+The flavor case is the direct `APrinting` win (−6 B, per printing). The `AOracleCard` cases stream less
+often (per card, not per printing) but `AOracleCard` *is* touched in every query's `card_pass` verify
+loop (the ~26% phase), and `card_name_folded`'s inline 61 B is a large per-card field — so the name case
+is worth more than "a tiny bit." Precedent: `FlavorIndex` / `oracle_trigram` already key on **dense text
+ids**, so the dense-id spaces largely exist; this just makes the stored field reference them.
+
+### 3. Hot/cold split + columnar gather fields — the big one (~98 B out)
+
+Push all display-only and rare-predicate fields to side arrays (indexed by pid), touched only for the
+output page or when that rare predicate is present. The struct then holds only the ~46 B hot set →
+broad scans stream ~46 B vs ~146 B (**~3×**). Equivalently, from the other direction, **pull the hot
+gather fields into pid-indexed columns** (`artwork_group_id: Vec<u16>`, `prefer_score`, and a
+*pid-indexed* `price_usd` — distinct from the value-sorted range index, which can't answer "pid X's
+price"). Same principle, same endgame: the row holds only what hot loops read. Rungs 1–2 are already
+the split applied to its easiest members; this is the rest of it.
+
+**Worked example: `card_legalities` (8 B) — intern and/or evict.** The clearest case, and a distinct
+technique (dictionary-encoding a high-repeat field). Corpus: **583 distinct legality words** across
+97,206 printings (0.6% unique; 23 formats × 4 statuses = `legal`/`not_legal`/`restricted`/`banned`,
+≈46 bits → the `u64`). Only 10 bits id them all; top-256 cover 97.9%. Two options, stackable:
+
+- **Intern** → `u16` id into a 583-entry dictionary (~4.7 KB): 8 B → 2 B per printing (−6 B), total
+  ~778 KB → ~199 KB.
+- **Evict — it barely needs to be per-printing at all.** Legalities are card-invariant except for the
+  ~1.8% *divergent* cards; the common case is answered by the `_EXISTS` card planes (#667), and the raw
+  `u64` is read *only* during divergent repair. So drop it from the struct entirely and keep a side
+  array for the ~11,329 divergent printings alone (interned `u16` → ~23 KB): **−8 B on all 97,206
+  structs**, one dict indirection on the already-rare divergent path.
+
+## The crossover: columns for wide scans, rows for narrow materialization
+
+Columns/split win when a scan reads **few fields across many rows** (the gather loop). Rows win when
+you read **many fields of few rows** — materializing the 100-row page, where one struct load beats N
+column cache lines. So keep the display fields co-located in a side *row* (one lookup per output row),
+not scattered across N columns. Measure the materialization crossover before committing.
+
+## Size → cache-line ladder
+
+The real magic number is the **64 B cache line**; **16 B** is the struct's alignment (forced by the
+`u128`s), so size lands on 16-B boundaries until they're evicted. Streaming cost tracks lines-per-struct:
+
+| layout | size | cache lines |
+|---|---:|---:|
+| current | 160 B | 2.5 |
+| width-pack *in place* (align still 16) | 144 B | 2.25 |
+| evict `u128`s (align 16→8) + width-pack | ~104 B | ~1.6 |
+| hot set only (hot/cold split) | ~48–64 B | 1.0 |
+
+Width-packing alone is ~10% (2.5→2.25 lines) — alignment eats it. The qualitative win is reaching **one
+cache line** (≤64 B), which needs the hot/cold split; the `u128` eviction is the enabler.
+
+## MEASURED (2026-07): incremental shrink is a dead end above one cache line
+
+A prototype of rung 1 (evict both `u128`s → 128 B) was built and measured end-to-end (fresh archive,
+totals byte-identical). Result: **flat — 0 speedup** on every probe (`border:black -(names)` artwork/usd
+1491→1490 µs; `usd<50` artwork/usd, `year>=2015` printing/usd, `t:creature` all within noise). So the
+size→line table above **overstates the incremental payoff**: streaming here is bound by *cache lines
+touched per struct*, not footprint, and at >64 B reading one field pulls ~one line/struct whether it's
+160 B or 128 B — the stride shrank, the line count didn't. Nothing pays until the struct crosses **≤64 B**
+(structs share lines) or the hot field is pulled into a **narrow contiguous column** the scan reads
+instead of the struct.
+
+**Consequence:** rungs 1–2 (evict + width + flavor + reorder), which all keep the struct >64 B until the
+very end, are **not worth doing for the gather cost** — the eviction prototype alone needed a ~20-site
+test rework (`scryfall_id` is the printing-identity anchor in the differential tests) for zero measured
+gain.
+
+**And the columnar prototype was flat too — because the profile was misattributed.** A dense
+`artwork_group_id: Vec<u16>` the gather reads instead of the struct also measured flat (1491→1483 µs).
+A one-line probe explained it: on `border:black -(names)` / artwork the grouping loop runs with
+`all_match=false`, so it calls `residual_matches(&printings[pid], …)` to verify **`border:black` per
+printing** (`border` is printing-varying → can't settle at card level; not using the border plane here).
+That per-printing residual reads the struct — and the earlier "925 µs readonly stage" **included it**
+(the residual ran before the stage's `continue`). So the 55% was the **per-printing `border` residual
+verification, not `artwork_group_id` streaming**; both layout experiments left the residual untouched,
+hence flat.
+
+**Corrected conclusion: the `APrinting`-layout thesis targets the wrong cost for this query.** The gather
+cost here is per-printing residual verification of a printing-varying predicate (`border`), inherent to
+`unique=artwork` needing a black-bordered *rep* per artwork group. Struct footprint / `artwork_group_id`
+access are not the lever. Neither shrinking nor columnar-izing `artwork_group_id` helps. **Recommend
+stopping the layout effort** (a p100 shape; real traffic is narrow + relevance-ordered). If this tail ever
+matters, the real question is reducing per-printing residual verification (e.g. plane-narrowing `border`
+for the artwork-rep pick, or a corrected re-profile to find the true hot field per query shape) — a
+different investigation from struct layout. **Resolution:** that different investigation paid off —
+the residual *is* reducible without any layout change. See
+[artwork skip-repped](./local-engine-artwork-skip-repped.md): skipping already-repped artwork groups
+before the residual gives 1.23–1.35× on the `border:black` / artwork / usd path, byte-identical, zero
+archive change.
+
+## Precedent
+
+The engine already applies struct-of-arrays selectively — this generalizes it:
+[`printing_to_card`](00690-engine-direct-projection-arrays.md) (pid-indexed column), the bit-planes
+(per-value bit-columns), and the value-sorted range indexes.
+
+## Cost, open questions, priority
+
+- **Cost:** an rkyv archive-format change (`ARCHIVE_FORMAT_VERSION` bump); rung 3 is a broad
+  field-access refactor.
+- **Field set:** derive columns/hot-set from what the O(printings) loops actually read
+  (`push_card_matches`, `card_match_count`, sort-key/prefer/verify), not by guessing.
+- **`prefer=default` shortcut:** printings are stored default-prefer-desc, so first-seen-per-group is
+  the rep — drops the `prefer_score` read for the common case, so the `gid` column alone suffices there.
+- **Priority:** unproven. Surfaced by a p100 broad `unique=artwork` shape; real traffic skews narrow +
+  relevance-ordered. Do rung 1 (evict — cheap, general, and it unblocks the rest) plus the trivial §2
+  swaps opportunistically; gate the heavier §2 items and rung 3 on evidence that broad gather-sort /
+  artwork queries matter.
+
+## Related
+
+- [#690](00690-engine-direct-projection-arrays.md) — direct-projection array precedent.
+- #629 — artwork groups (`artwork_group_id`); #664/#724 — border/rarity printing planes.
+- `exec_gathered_scan` / `push_card_matches` (`card_engine/src/lib.rs`) — the gather path this targets.

--- a/docs/issues/local-engine-artwork-skip-repped.md
+++ b/docs/issues/local-engine-artwork-skip-repped.md
@@ -1,7 +1,16 @@
 # Artwork gather: skip already-repped groups (default prefer)
 
-**Status:** implemented, measured, byte-identical. Branch `engine-artwork-skip-repped`. Two changes:
-the skip-repped reorder (below) and a columnar `artwork_group_id` (further down).
+**Status:** implemented, measured, byte-identical. Branch `engine-artwork-skip-repped`. Three changes:
+the skip-repped reorder, a columnar `artwork_group_id`, and pre-sizing `group_best` (all below).
+
+Cumulative vs `main` (97,206-printing corpus, artwork/usd, byte-identical output):
+
+| query | main | branch | speedup |
+|---|---:|---:|---:|
+| `border:black -(name:storm or name:dragon)` | ~1543 µs | ~1245 µs | **1.24×** |
+| `border:black` | ~1166 µs | ~845 µs | **1.38×** |
+| `t:creature` | ~320 µs | ~244 µs | **1.31×** |
+| `c:r` | ~156 µs | ~122 µs | **1.28×** |
 
 ## The lever
 
@@ -55,6 +64,17 @@ four fixtures mutate `illustration_id` after `store_of` and re-derive grouping b
 through one helper (`reassign_artwork_grouping`) that rebuilds *both* the per-card counts and the
 column together, so no site can update one and forget the other. Costs one archive-format bump
 (`ARCHIVE_FORMAT_VERSION`) and ~190 KB. Byte-identical output; all 128 tests pass.
+
+## Also: pre-size `group_best`, drop the per-printing resize check
+
+`group_best` (the per-group best-rep scratch) is indexed only by `artwork_group_id` — Card mode
+collapses to index 0 — so its maximum index is a fixed property of the store: the largest
+distinct-artwork count of any single card (**385** in the corpus; p50 is 1, p99 is 6). Stored as
+`CardIndexes.max_artwork_groups` and used to pre-size the scratch once per query, so the three artwork
+grouping loops (`push_card_matches` ×2, `walk_grouped_page`) no longer run a `len() <= gid`
+bounds/resize check on every printing (the check only ever fired during warmup, then never again). A
+`debug_assert` guards the invariant. Biggest effect where the loop iterates the most printings
+(`t:creature` ~281→244 µs); flat where the residual dominates. Byte-identical.
 
 ## Remaining cost / possible next levers (not pursued)
 

--- a/docs/issues/local-engine-artwork-skip-repped.md
+++ b/docs/issues/local-engine-artwork-skip-repped.md
@@ -1,6 +1,7 @@
 # Artwork gather: skip already-repped groups (default prefer)
 
-**Status:** implemented, measured, byte-identical. Branch `engine-artwork-skip-repped`.
+**Status:** implemented, measured, byte-identical. Branch `engine-artwork-skip-repped`. Two changes:
+the skip-repped reorder (below) and a columnar `artwork_group_id` (further down).
 
 ## The lever
 
@@ -33,15 +34,27 @@ returned-row-id fingerprint)
 
 Zero archive-format change. All engine tests pass (128).
 
-## Rejected: columnar `artwork_group_id` (V2)
+## Also landed: columnar `artwork_group_id` (V2)
 
-Prototyped a pid-indexed `artwork_group_col: Vec<u16>` so repped-group printings read the group id from
-a compact side array instead of the struct. **Flat on the target query** (`border` residual, not the
-gid read, is the remaining cost) — it only helped `all_match=true` artwork scans (`t:creature`
-320→280 µs, `c:r` 156→125 µs), where the gid read *is* the only per-printing work. And it introduced a
-sync hazard: `artwork_group_id` is a placeholder in the store and **recomputed post-load** (via
-`assign_artwork_groups` at 4+ sites), so a duplicated column goes stale on reload unless every recompute
-site also rebuilds it. Marginal, localized gain + an archive bump + reload-sync fragility → dropped.
+A pid-indexed `artwork_group_col: Vec<u16>` so the gather reads the group id from a compact contiguous
+side array instead of the wide struct — repped-group printings (the majority) then never touch the
+struct at all. **Flat on the target `border` query** (the residual, not the gid read, is the remaining
+cost there), but a real win on `all_match=true` artwork scans, where the gid read *is* the only
+per-printing work:
+
+| query [artwork/usd] | skip-repped only | + columnar |
+|---|---:|---:|
+| `t:creature` | ~306 µs | ~281 µs (**1.14× vs main**) |
+| `c:r` | ~149 µs | ~124 µs (**1.26× vs main**) |
+
+**No drift hazard.** An earlier prototype panicked in four test fixtures and I mistakenly concluded the
+column was unsafe on production reload. It isn't: `assign_artwork_groups` runs *exactly once* in
+production (`reload_commit`, before archiving), so `artwork_group_id` — and the column derived from it
+right there — is stored in the archive and never recomputed post-load. The drift was test-fixture-only:
+four fixtures mutate `illustration_id` after `store_of` and re-derive grouping by hand. They now go
+through one helper (`reassign_artwork_grouping`) that rebuilds *both* the per-card counts and the
+column together, so no site can update one and forget the other. Costs one archive-format bump
+(`ARCHIVE_FORMAT_VERSION`) and ~190 KB. Byte-identical output; all 128 tests pass.
 
 ## Remaining cost / possible next levers (not pursued)
 

--- a/docs/issues/local-engine-artwork-skip-repped.md
+++ b/docs/issues/local-engine-artwork-skip-repped.md
@@ -1,0 +1,52 @@
+# Artwork gather: skip already-repped groups (default prefer)
+
+**Status:** implemented, measured, byte-identical. Branch `engine-artwork-skip-repped`.
+
+## The lever
+
+For `unique=artwork`, the gather picks one best-`prefer_score` representative per artwork group.
+The [APrinting-layout investigation](./local-engine-aprinting-layout.md) established (after a
+misattributed profile) that the real gather cost on `border:black -(names)` / artwork / usd is
+**per-printing residual verification of a printing-varying predicate** (`border`) — the loop calls
+`residual_matches(&printings[pid], …)` on every printing to find a black-bordered rep, reading the
+wide struct each time. Struct footprint was *not* the lever (both eviction and columnar
+`artwork_group_id` measured flat).
+
+The fix attacks the residual directly. Printings are stored **prefer-desc within a card**, so for the
+**default prefer** the *first* residual-qualifying printing of a group is already its rep — every later
+printing of that group is dead weight. So: read the group id first, and `continue` past any printing
+whose group is already repped, **before** touching the residual. Repped groups (the majority — ~2.4
+printings/group) never pay the residual verification again, and the rep needs no `prefer_score`
+comparison (first qualifying wins, so the default branch also stops reading `prefer_score` entirely).
+
+Custom prefer keeps the full max-score scan (iteration order ≠ prefer order, so every printing must be
+considered). The change is confined to `push_card_matches`'s `Mode::Artwork` arm.
+
+## Measured (97,206-printing corpus, min of a timed window, byte-identical output verified by
+returned-row-id fingerprint)
+
+| query [artwork/usd] | main | branch | speedup |
+|---|---:|---:|---:|
+| `border:black -(name:storm or name:dragon)` | ~1543 µs | ~1256 µs | **1.23×** |
+| `border:black` | ~1166 µs | ~861 µs | **1.35×** |
+| `t:creature` | ~320 µs | ~306 µs | 1.05× |
+
+Zero archive-format change. All engine tests pass (128).
+
+## Rejected: columnar `artwork_group_id` (V2)
+
+Prototyped a pid-indexed `artwork_group_col: Vec<u16>` so repped-group printings read the group id from
+a compact side array instead of the struct. **Flat on the target query** (`border` residual, not the
+gid read, is the remaining cost) — it only helped `all_match=true` artwork scans (`t:creature`
+320→280 µs, `c:r` 156→125 µs), where the gid read *is* the only per-printing work. And it introduced a
+sync hazard: `artwork_group_id` is a placeholder in the store and **recomputed post-load** (via
+`assign_artwork_groups` at 4+ sites), so a duplicated column goes stale on reload unless every recompute
+site also rebuilds it. Marginal, localized gain + an archive bump + reload-sync fragility → dropped.
+
+## Remaining cost / possible next levers (not pursued)
+
+The surfacing query's residual ~1256 µs still splits across the per-card name check (`card_pass`, ~430
+µs), the ~40k first-per-group `border` residual reads, and the ~40k emit `price_usd` reads (usd sort
+key). Further levers, if this tail ever matters: the `border_printing` bitplane as the per-printing
+membership test (turn the remaining border checks into bit-tests, `#731` step 3), or a columnar
+`price_usd` for the emit sort key.

--- a/docs/issues/local-engine-artwork-skip-repped.md
+++ b/docs/issues/local-engine-artwork-skip-repped.md
@@ -41,7 +41,9 @@ returned-row-id fingerprint)
 | `border:black` | ~1166 µs | ~861 µs | **1.35×** |
 | `t:creature` | ~320 µs | ~306 µs | 1.05× |
 
-Zero archive-format change. All engine tests pass (128).
+This change alone needs **no** archive-format change (it only reorders the existing loop). The
+columnar `artwork_group_id` added below *does* change the layout and bumps `ARCHIVE_FORMAT_VERSION` —
+so the PR as a whole is not format-neutral. All engine tests pass (128).
 
 ## Also landed: columnar `artwork_group_id` (V2)
 


### PR DESCRIPTION
## Summary

Three changes to the `unique=artwork` grouping loop (which picks one best-`prefer_score`
representative per artwork group). Profiling `border:black -(name:…)` / artwork / `usd` — a broad
`GatheredScan`, since `usd` has no sort permutation — showed the dominant cost was **per-printing
residual verification** of the printing-varying `border` predicate, reading the wide `APrinting`
struct on every printing to find a black-bordered rep. (An earlier profile misattributed this to
`artwork_group_id` streaming; the corrected finding is in the linked design notes.)

1. **Skip already-repped groups.** Printings are stored prefer-desc within a card, so for the default
   prefer the *first* residual-qualifying printing of a group is its rep — later printings of that
   group are dead weight. The loop reads the group id first and skips any printing whose group is
   already repped, *before* the residual. Repped groups (the majority) never re-pay the residual, and
   the rep needs no score comparison. Custom prefer keeps the full max-score scan.

2. **Columnar `artwork_group_id`.** A pid-indexed `artwork_group_col: Vec<u16>` the gather reads for
   the group id instead of the wide struct, so repped-group printings never touch the struct. Built
   once in `reload_commit` beside `assign_artwork_groups` and archived — never recomputed post-load,
   so it cannot drift. Helps `all_match=true` artwork scans, where the gid read is the only
   per-printing work.

3. **Pre-sized `group_best`.** The rep scratch is indexed only by `artwork_group_id` (Card mode
   collapses to index 0), so its max index is a fixed store property: the largest distinct-artwork
   count of any card (385 in the corpus; p50 1, p99 6). Stored as `CardIndexes.max_artwork_groups`
   and used to pre-size the scratch once per query, dropping the per-printing `len() <= gid` check
   from all three artwork grouping loops.

## Performance

Targeted set, 97,206-printing corpus (`benchmarks/bitplanes/corpus.jsonl`), `limit=100`, min of a
timed window. `total` is identical across builds (parity check).

| Benchmark | unique/orderby | total | Before (μs) | After (μs) | Change |
|---|---|---:|---:|---:|---:|
| `border:black` | artwork/usd | 40956 | 1166 | 845 | 1.38× |
| `t:creature` | artwork/usd | 22510 | 320 | 244 | 1.31× |
| `c:r` | artwork/usd | 9072 | 156 | 122 | 1.28× |
| `border:black -(name:storm or name:dragon)` | artwork/usd | 40334 | 1543 | 1245 | 1.24× |

**Geometric mean over the impacted rows: 1.30×.**

Broad regression screen — `survey_queries.py --count 400 --wild 120 --seed 42`, 520 queries
branch-vs-main: **0 total-count mismatches, no regressions** (only sub-10 μs exact-name lookups vary,
within noise). Percentiles flat-to-better; p100 1089 → 933 μs (−14%). The overall geomean is ~1.00×
as expected — artwork-grouping queries are a minority of the mix, and card/printing modes plus the
residual-dominated `-(name:…)` query are unaffected where the loop isn't the bottleneck.

**Memory:** archive grows **+190 KB (+0.27%)** on the 68 MB archive — the columnar id array
(97,206 × 2 bytes). `ARCHIVE_FORMAT_VERSION` bumped for the layout change.

## Correctness

Output is byte-identical (verified by a returned-row-id fingerprint on the targeted set and the
0-mismatch parity column on the 520-query survey). All 128 engine tests pass. The four test fixtures
that mutate `illustration_id` post-`store_of` now re-derive both grouping fields through one helper
(`reassign_artwork_grouping`) so they cannot fall out of sync; a `debug_assert` guards the pre-size
invariant in CI's debug build.

## Design notes

- [`docs/issues/local-engine-artwork-skip-repped.md`](docs/issues/local-engine-artwork-skip-repped.md)
- [`docs/issues/local-engine-aprinting-layout.md`](docs/issues/local-engine-aprinting-layout.md) — the
  investigation this resolves (established, after a corrected profile, that the lever is the residual,
  not the struct footprint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
