### PR TITLE
Docs: Archive 5 Completed Range/Plane Issues, File Veto-Redundancy Follow-Up

### DIFF
--- a/docs/changelog/2026-07-21-card-range-popcount.md
+++ b/docs/changelog/2026-07-21-card-range-popcount.md
@@ -37,4 +37,4 @@ The plan fires only for a **bare** `usd` range in card mode — deliberately nar
   both), which a card-space existence AND cannot express.
 
 `cn` / `date` share the machinery and are a follow-on (PR 3). Gated by `CARD_ENGINE_RANGE_BITS_CARD`
-(default on) as an A/B kill-switch. Design notes: `docs/issues/local-engine-sorted-range-fastpath.md`.
+(default on) as an A/B kill-switch. Design notes: `docs/issues/done/local-engine-sorted-range-fastpath.md`.

--- a/docs/changelog/2026-07-22-artwork-skip-repped.md
+++ b/docs/changelog/2026-07-22-artwork-skip-repped.md
@@ -40,6 +40,6 @@ total-count mismatches, no regressions** (only sub-10 μs exact-name lookups var
 where the loop isn't the bottleneck. Archive grows +190 KB (+0.27%): the columnar id array
 (97,206 × 2 bytes). `ARCHIVE_FORMAT_VERSION` bumped for the layout change.
 
-Design notes: [`docs/issues/local-engine-artwork-skip-repped.md`](../issues/local-engine-artwork-skip-repped.md)
+Design notes: [`docs/issues/local-engine-artwork-skip-repped.md`](../issues/done/local-engine-artwork-skip-repped.md)
 and the [`APrinting` layout investigation](../issues/local-engine-aprinting-layout.md) it resolves —
 which established (after a corrected profile) that the lever is the residual, not the struct footprint.

--- a/docs/issues/00730-engine-popcount-skip-walk.md
+++ b/docs/issues/00730-engine-popcount-skip-walk.md
@@ -2,7 +2,7 @@
 
 Status: todo, filed as [#730](https://github.com/jbylund/sylvan_librarian/issues/730). Deferred
 optimization split out of the #724 printing-space compose work
-([00724](00724-engine-printing-existential-planes.md)).
+([00724](done/00724-engine-printing-existential-planes.md)).
 
 ## Two ways to page a match bitmap
 
@@ -51,7 +51,7 @@ distribution of real traffic before spending the complexity.
 
 ## Related
 
-- [00724](00724-engine-printing-existential-planes.md) — the printing-space compose plan whose
+- [00724](done/00724-engine-printing-existential-planes.md) — the printing-space compose plan whose
   unification this splits off from.
 - `run_query_streamed_popcount` (`card_engine/src/lib.rs`) — the existing card-space popcount-skip walk
   to generalize.

--- a/docs/issues/00731-engine-compose-universal-evaluator.md
+++ b/docs/issues/00731-engine-compose-universal-evaluator.md
@@ -1,9 +1,10 @@
 # Engine: Printing-Space Compose as the Universal Exact Evaluator
 
-Status: todo, filed as [#731](https://github.com/jbylund/sylvan_librarian/issues/731). The
-generalization of [#724](00724-engine-printing-existential-planes.md)'s printing-space compose from
-"whole filter composable" into the query engine's general evaluation model. Deferred until #724 (the
-substrate) merges.
+Status: **step 1 done** ([#733](https://github.com/jbylund/sylvan_librarian/pull/733) — range leaves
+as compose sources), steps 2-3 todo. Filed as
+[#731](https://github.com/jbylund/sylvan_librarian/issues/731). The generalization of
+[#724](done/00724-engine-printing-existential-planes.md)'s printing-space compose from "whole filter
+composable" into the query engine's general evaluation model. #724 (the substrate) has merged.
 
 ## The model
 
@@ -18,7 +19,7 @@ border/rarity/legality under `AND`/`OR`; this is the generalization to *all* lea
 | kind | leaves | how | status |
 |---|---|---|---|
 | plane read | border, rarity, legality | plane slice (legality: broadcast card `∃`-plane + divergent repair) | built (#724) |
-| range materialize | `usd`, `cn`, `date` | scatter the range index's in-range slice into a bitmap | tooling exists (`build_card_range_bits`/`scatter_bits`) |
+| range materialize | `usd`, `cn`, `date` | scatter the range index's in-range slice into a bitmap | **shipped** (#733) |
 | broadcast down | card-invariant `color`/`type`/`cmc` | broadcast the card plane to printing space; **no repair** (never diverges) | `broadcast_card_bits_to_printings` exists |
 | per-survivor residual | text (`name`/`oracle`/`flavor`), or any leaf | verify on the composed survivors, not as a bitmap | existing residual machinery |
 
@@ -40,7 +41,7 @@ dissolves the "compose leaf vs residual" distinction into a cost decision rather
 card-space existence-`AND` of separately-`∃`-projected leaves false-positives on the shared witness — a
 card with a black printing and a *separate* rare printing satisfies `∃black ∧ ∃rare` but has no single
 black-and-rare printing. Composing in printing space and projecting once is exactly what avoids that
-(see [#724](00724-engine-printing-existential-planes.md)). Card-invariant leaves and card-level
+(see [#724](done/00724-engine-printing-existential-planes.md)). Card-invariant leaves and card-level
 residuals are witness-independent, so they apply *after* the projection.
 
 ## Correctness caveats (both the trivalent-NULL issue)
@@ -65,7 +66,8 @@ wins didn't move the broad survey": the addressable slice was structurally tiny,
 
 Build order (each its own PR, gated by the cost model that already prices synthesis):
 
-1. **Range leaves** (`usd`/`cn`/`date`) as compose sources — reuses `build_card_range_bits`.
+1. **Range leaves** (`usd`/`cn`/`date`) as compose sources — reuses `build_card_range_bits`. **Shipped**
+   ([#733](https://github.com/jbylund/sylvan_librarian/pull/733), also closed #694).
 2. **Card-invariant broadcast leaves** (`color`/`type`/`cmc`) — reuses `broadcast_card_bits_to_printings`.
 3. **Per-survivor residual** for the non-composable remainder (text) — feed compose's exact narrowing
    into the existing residual-verify path (printing-varying residual before the projection, card-invariant
@@ -73,5 +75,5 @@ Build order (each its own PR, gated by the cost model that already prices synthe
 
 ## Related
 
-- [#724](00724-engine-printing-existential-planes.md) — printing-space compose, the substrate.
+- [#724](done/00724-engine-printing-existential-planes.md) — printing-space compose, the substrate.
 - [#730](00730-engine-popcount-skip-walk.md) — deep-pagination popcount-skip walk (orthogonal).

--- a/docs/issues/done/00711-engine-printing-artwork-estimates.md
+++ b/docs/issues/done/00711-engine-printing-artwork-estimates.md
@@ -1,0 +1,174 @@
+# Printing- and Artwork-Space Cardinality Estimates
+
+**Status: superseded, not building.** Filed as
+[#711](https://github.com/jbylund/sylvan_librarian/issues/711). This doc's whole premise was
+extending the card-space cardinality estimator (below) to printing/artwork space so those modes'
+plans could get a cardinality signal for cost-based routing. That premise doesn't hold: the
+estimator was never wired into routing at all, in any space. `card_engine/src/estimator.rs:1-5`
+says so directly — *"Standalone, SOUND, cheap cardinality estimator... **NOT wired into query
+routing**; validated only through the `fuzz_row_identity_matches_reference` harness."*
+`00702-engine-plan-selection-layer.md` explains why: an estimate-before-materialize prototype
+measured ~15% slower and was abandoned for "materialize-then-route" on the *actual* count — every
+plan (card, printing, or artwork mode) now gets an exact cardinality (a popcount, a binary-search
+`k`, or a materialized candidate list's real length), never a statistical estimate. Building a
+printing/artwork-space sibling to a routing mechanism that was dropped card-space-side too would
+solve a problem the shipped design doesn't have.
+
+Follow-on to [00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md).
+The estimator shipped in #704 answers **card-space** cardinality only: it composes
+over the universe `N = n_cards` and projects every printing-space leaf count *down*
+to cards via `project` ([estimator.rs:57](../../../card_engine/src/estimator.rs#L57)).
+This issue adds **native printing-space** (and, generalized, **artwork-space**)
+estimates — the mirror image, composing over `N = n_printings` and expanding
+card-native leaf counts *up*.
+
+## Why
+
+The plan-selection cost model routes each physical plan on cardinality **in that
+plan's own operating space** (#702 "Open questions", `00702…md:285`): card-mode
+gather/popcount consume card-space, but the `unique=printing` fast paths
+(`printing_range_scan_applicable`, [lib.rs:4080](../../../card_engine/src/lib.rs#L4080);
+the range/streamed printing paths at lib.rs ~3787/3851/3930) and artwork-mode
+selection (scratch at lib.rs ~4293) operate in printing/artwork space. Today those
+plans have **no cardinality input** — the estimator is card-only. Projecting the
+card-space answer back up through `project` inverse is exactly the lossy step #702
+warns doesn't distribute over AND/OR. A native estimate in each space avoids the
+round-trip.
+
+## The structural mirror — roles flip
+
+Same recursion shape as `estimate_rec`, universe `N = n_printings`. What changes is
+the leaf layer:
+
+- **Printing-native leaves** become the *easy* case. Artist, flavor, date/year,
+  price/collector-number ranges, printing-space tags (`art_tags`/`is_tags`/
+  `frame_data`), `SetCode`/`Border`/`Watermark` — everything `has_printing_varying_leaf`
+  ([estimator.rs:79](../../../card_engine/src/estimator.rs#L79)) currently flags — is
+  counted *directly* in printing space. The raw postings/CSR/range count `k` **is**
+  the answer (`exact(k)`); no `project` step, no superset widening. This half gets
+  simpler and tighter.
+- **Card-native leaves** become the *hard* case. `cmc`/`power`/`toughness`, colors,
+  types, name, oracle, legality, devotion, rarity — the plane/numeric/name-index
+  leaves — produce a card count `d` that must be **expanded up** to a printing-set
+  size.
+
+## Card→printing expansion (the core)
+
+A card-native leaf matching `d` cards selects the printing set = union of all
+printings of those `d` cards. Its size:
+
+```
+est = d · (n_printings / n_cards)          # average fan-out
+lo  = d                                     # each card ≥ 1 printing (tight in practice)
+hi  = P(d)                                  # top-d prefix sum (see below)
+```
+
+`P(d)` is the tight upper bound. Let `m(c)` = printings of card `c`, sorted
+descending `m₍₁₎ ≥ m₍₂₎ ≥ …`, and `P(d) = Σᵢ₌₁ᵈ m₍ᵢ₎`. The most printings `d` cards
+can cover is when they *are* the `d` most-printed cards. Since `m` is non-increasing,
+`P` is **concave**, so `P(d) ≤ d·m₍₁₎` with equality only at `d=1` — a strict
+improvement over the naive `d · max_printings_per_card` for every `d>1`, and the gap
+blows up fast (5 basic lands ≈ hundreds each; the 6th card is nowhere near). Given
+only `d`, `P(d)` is the information-theoretic supremum.
+
+The lower bound `lo = d` is likewise tight in practice: the minimum is achieved when
+the matched cards are all single-printing, and there are always far more
+single-printing cards than any realistic `d`. (The exact tight lower bound is the
+*ascending* prefix sum, but with a huge run of `m=1` cards it collapses to `d`.)
+
+### New stat: the sorted-descending prefix sum
+
+One per fan-out space. Cheap one-pass build from `offsets`
+([lib.rs:2311](../../../card_engine/src/lib.rs#L2311); `m(c) = offsets[c+1]-offsets[c]`):
+count per card, sort descending, cumulate. Stored raw it's `n_cards` × u32 (~120 kB
+at 30k cards), but it **compresses to near-nothing** via the linear tail: let `h` =
+count of cards with `m>1`; for `d ≥ h` every added card contributes exactly 1, so
+
+```
+P(d) = P(h) + (d − h)    for d ≥ h
+```
+
+Store the explicit head (`m>1` prefixes) + `P(h)`; evaluate the tail by formula.
+Lookup is O(1)/O(log h). Fits the existing `build_*` pattern in `reload_commit`
+(the `CardIndexes { … }` literal, lib.rs ~5229) and the rkyv/mmap bundle.
+
+## AND composition — the payoff: no varying-leaf gate
+
+The card-space estimator gates its AND lower bound (and NOT) on
+`has_printing_varying_leaf` ([estimator.rs:207](../../../card_engine/src/estimator.rs#L207))
+because card-projection doesn't distribute: two varying children can each admit a
+card via *different* printings while no single printing satisfies both, so
+`distinct_cards(A∩B)` isn't the intersection of the projections. **In printing space
+this trap disappears.** A printing is an atomic row that either satisfies the whole
+filter or doesn't, so the AND printing-set is *exactly* `∩` of the children's
+printing-sets. Standard Bonferroni on printing-set sizes is directly sound — **no
+gate**, `lo = max(0, Σlo_i − (k−1)·N)` unconditionally. NOT is likewise a clean
+complement `N − |P|` on the atomic printing rows (no three-valued Null subtlety at
+the printing level — nullability is a card-space artifact).
+
+The `[d, P(d)]` expansion feeds this as any other child's bounds: a mixed AND
+(card-native ∧ printing-native) expands the card-native side to `[d, P(d)]` printings,
+then intersects with the printing-native side's exact `k`. Standard composition, no
+special case.
+
+## Artwork space (generalization)
+
+Artwork space sits between card and printing (`n_cards ≤ n_artworks ≤ n_printings`),
+with `artwork_groups: Vec<u16>` ([lib.rs:2261](../../../card_engine/src/lib.rs#L2261),
+built at lib.rs ~1865) giving artworks-per-card. The expansion machinery is
+**identical with a different multiplicity vector**: a generic
+`expand_card_count(d, stat)` takes `lo=d`, `hi=P_stat(d)`, `est=d·(Σstat/n_cards)`,
+where `stat` is the sorted-descending prefix sum of either `offsets`-widths
+(printing space) or `artwork_groups` (artwork space). Two stats, one code path.
+
+**Subtlety — the cross-fan-out projection.** A *printing-native* leaf (exact `k` in
+printing space) has no card count, so expanding it into *artwork* space isn't the
+card→space path — it's a printing→artwork fan-*in* (`k` printings collapse to ≤ `k`
+artworks; many printings share an `illustration_id`). That needs a printing→artwork
+ratio/map rather than the multiplicity prefix sum. Recommend **phasing**: printing
+space first (all card-native expansions + printing-native exacts), artwork space
+second once the printing→artwork projection primitive is decided. Whether artwork
+routing even needs printing-native leaves projected (vs. only card-native expanded)
+is an open question to settle against real artwork-mode queries.
+
+## Return shape / API
+
+Recursion still composes a single-space `Cardinality { lo, est, hi }`
+([estimator.rs:23](../../../card_engine/src/estimator.rs#L23)) — one universe per pass,
+per #702's decision that projection doesn't thread through composition. Add sibling
+entry points (e.g. `estimate_cardinality_printing`, `…_artwork`) sharing the leaf
+dispatch, parameterized by universe + expansion stat, rather than a both-spaces
+container threaded through the recursion. The decision site assembles whichever
+space(s) a given plan's cost formula consumes.
+
+## Scope / sequencing
+
+1. **Prefix-sum stat + generic `expand_card_count`** — build path, compression,
+   fuzz coverage of the stat alone.
+2. **Printing-space estimator** — `estimate_cardinality_printing`, card-native
+   leaves expand, printing-native leaves exact, ungated AND/NOT. Standalone,
+   fuzz-validated against `unique=printing` materialized truth, **unwired**.
+3. **Artwork-space estimator** — generalize over the multiplicity stat; resolve the
+   printing→artwork cross-projection.
+4. **Wire into the cost model** — feed printing/artwork-space estimates to the
+   printing/artwork-mode plans' cost formulas (depends on #702 step 3+).
+
+## Validation
+
+Mirror #704's contract in the `fuzz_row_identity_matches_reference` harness: the
+`unique=printing` (resp. `unique=artwork`) reference count must always land inside
+`[lo, hi]` — a violation is an algebra bug, fail the test. Estimate *accuracy* is a
+reported distribution, folded into #702's estimate-regret report once the printing/
+artwork-mode plans are cost-modeled. Assert bounds soundness across the same
+default/non-default prefer and mode coverage the card-space estimator uses.
+
+## Open questions
+
+- Does artwork routing need printing-native leaves projected into artwork space, or
+  only card-native leaves expanded? (Decides whether the printing→artwork primitive
+  is in scope here or deferred.)
+- Is the `[d, P(d)]` interval tight enough for the printing-mode plans' cost curves,
+  or does the regret tail demand a `P`-analog that conditions on *which* cards (a
+  leaf correlated with the printing distribution — `is:reprint`, set/rarity filters)?
+- Store one merged multiplicity table (printing + artwork prefix sums) or two? Both
+  are tiny; merge only if the build path is cleaner.

--- a/docs/issues/done/00724-engine-printing-existential-planes.md
+++ b/docs/issues/done/00724-engine-printing-existential-planes.md
@@ -1,17 +1,20 @@
 # Engine: Printing-Space Bitplanes (Legality / Border / Rarity, Bit-per-Printing)
 
-Status: todo, filed as [#724](https://github.com/jbylund/sylvan_librarian/issues/724). **Not deferred
-infrastructure** — it ships a standalone win (bare printing-mode plane queries via `popcount` + a
-reused page walk, ~3×) *and* is the substrate the
-[printing-space popcount-order plan](local-engine-printing-plane-popcount-order.md) needs for
+Status: **done**, filed as [#724](https://github.com/jbylund/sylvan_librarian/issues/724), shipped
+across [#728](https://github.com/jbylund/sylvan_librarian/pull/728) (border slice) and
+[#732](https://github.com/jbylund/sylvan_librarian/pull/732) (rarity + legality + AND/OR compose,
+projected to card & artwork) — see the "Result" sections below for each phase. It shipped a
+standalone win (bare printing-mode plane queries via `popcount` + a reused page walk, ~3×) *and* is
+the substrate the
+[printing-space popcount-order plan](../local-engine-printing-plane-popcount-order.md) needs for
 compounds. See "The standalone win" below.
 
 ## What — exact, not existential
 
 Bit-per-**printing** planes for printing-varying values — legality (per format), border, rarity.
 Today these live only in **card space**, as existence *projections*: legality's `legal_x` plane
-([#667](done/00667-engine-legality-divergent-carveout.md)) and border's plane
-([#664](done/00664-engine-border-planes.md)) set a card's bit to mean "*some* printing satisfies,"
+([#667](00667-engine-legality-divergent-carveout.md)) and border's plane
+([#664](00664-engine-border-planes.md)) set a card's bit to mean "*some* printing satisfies,"
 not *which*. That projection is why they're called "existential" and why they can't be ANDed safely
 (shared witness) — but it's a **card-space artifact**, not a property of the attribute.
 
@@ -79,7 +82,7 @@ in the query's unique space by projecting *once* at the end — a mode-dependent
 | unique mode | final projection | cost term |
 |---|---|---|
 | `printing` | none — the surviving bits *are* the rows | 0 |
-| `card` | ↑ to card-existence via `printing_to_card` ([#690](done/00690-engine-direct-projection-arrays.md)) | O(surviving printings) |
+| `card` | ↑ to card-existence via `printing_to_card` ([#690](00690-engine-direct-projection-arrays.md)) | O(surviving printings) |
 | `artwork` | ↑ to artwork ids via `printing_to_artwork` | O(surviving printings), **+ needs PR 2b** (global artwork id) |
 
 Two honest scope notes:
@@ -90,7 +93,7 @@ Two honest scope notes:
 - Where #724 is the **only** exact option across all three modes is **compounds** (`border:black
   r:rare`, `usd<50 f:modern`): card-space existence-AND can't compose them, so they must be AND'd in
   printing space and projected once (see the two strategies above) — that's the full printing-space
-  plan ([local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md)),
+  plan ([local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md)),
   built on these planes.
 
 So the split is: **#724 delivers bare printing-mode queries standalone** (popcount + walk, ~3×); the
@@ -236,7 +239,7 @@ popcount win applies broadly, not just to compounds. All three unique modes — 
 
 The load-bearing finding: **legality is ~4× cheaper than border in printing mode at the same
 breadth, because legality settles at the *card* level** (`printing_dependent(Legality) => false`,
-[filter.rs](../../card_engine/src/filter.rs)) — it evaluates once per card (~31.5k) and emits all of
+[filter.rs](../../../card_engine/src/filter.rs)) — it evaluates once per card (~31.5k) and emits all of
 a matching card's printings, dropping to per-printing only for the rare divergent-legality cards.
 **Border and rarity are genuinely per-printing** (`TextField::Border => StrVal::PDep`), so they
 evaluate per printing (~97k) — that scan is the cost.
@@ -314,10 +317,10 @@ total turns out hot before these planes land.
 
 ## Related
 
-- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
+- [local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md) —
   the consumer plan; this is its existential leaf source.
-- [00667 legality](done/00667-engine-legality-divergent-carveout.md),
-  [00664 border planes](done/00664-engine-border-planes.md) — the card-space versions this extends
+- [00667 legality](00667-engine-legality-divergent-carveout.md),
+  [00664 border planes](00664-engine-border-planes.md) — the card-space versions this extends
   into printing space.
 - [00713 is-tag recovery](00713-is-tag-recovery.md) — bucket-C; same per-value crossover.
 - #656 — the popcount-order phase extension.

--- a/docs/issues/done/00734-engine-string-operator-optimizations.md
+++ b/docs/issues/done/00734-engine-string-operator-optimizations.md
@@ -1,6 +1,6 @@
 # Engine: String Operator Optimizations (regex→contains, memmem)
 
-Status: **steps 1+2 done** (`ec7d26b`, `84a9ca9`). Filed as
+Status: **done** — both steps shipped (`ec7d26b`, `84a9ca9`), filed as
 [#734](https://github.com/jbylund/sylvan_librarian/issues/734). Two independent, behavior-preserving
 speedups for substring search over text fields (`oracle`/`name`/`flavor`/`artist`).
 
@@ -49,7 +49,7 @@ the per-row scan). Measured end-to-end, `o:/sacrifice a/` / card dropped to the 
 **117 µs** (1,391 results, byte-identical) from a full regex scan.
 
 **Shipped** as a **Python post-parse AST pass** (`lower_literal_regexes` in
-[`api/parsing/rewrite.py`](../../api/parsing/rewrite.py)), *not* an engine change — the equivalence is a
+[`api/parsing/rewrite.py`](../../../api/parsing/rewrite.py)), *not* an engine change — the equivalence is a
 property of the regex, so doing it once at the shared parse seam serves **both** consumers of the AST:
 the SQL path (postgres `gin_trgm_ops`) and the Rust engine (trigram narrow). It rewrites a plain-literal
 `RegexValueNode` → `StringValueNode`, making the AST identical to the substring query. `regex_plain_literal`
@@ -69,11 +69,11 @@ Caveats (handled):
 ## Optimization 2 — `memmem::Finder` for the `TextContains` scan
 
 Build a `memchr::memmem::Finder` once, reuse per candidate — amortizes the Two-Way/prefilter setup,
-the same trick [`sparse_blob`](../../card_engine/src/lib.rs) uses for the oracle-word index. **1.26×**
+the same trick [`sparse_blob`](../../../card_engine/src/lib.rs) uses for the oracle-word index. **1.26×**
 over `str::contains` (bench_substring_finders).
 
 **Shipped** (`84a9ca9`) on the four once-per-query **verify/bind scans** in
-[`filter.rs`](../../card_engine/src/filter.rs) that build `OracleMatch`/`NameMatch`/`ArtistMatch`/
+[`filter.rs`](../../../card_engine/src/filter.rs) that build `OracleMatch`/`NameMatch`/`ArtistMatch`/
 `FlavorMatch` from a substring needle — the `contains` path a memoized substring (or lowered regex)
 query actually hits. A small incremental on top of step 1's access-path win.
 
@@ -99,4 +99,4 @@ memmem (step 2) lands (it drops ~1.3 ns/card, ~200 of the 2300).
 
 - Seed bench + branch `engine-regex-to-contains` (commit b46fdcb).
 - Verify-cost tiers: `card_engine/src/filter.rs` (`verify_cost_tier`, `regex_tier`).
-- [#694/#731](00731-engine-compose-universal-evaluator.md) — the range-compose PR that surfaced these.
+- [#694/#731](../00731-engine-compose-universal-evaluator.md) — the range-compose PR that surfaced these.

--- a/docs/issues/done/local-engine-artwork-skip-repped.md
+++ b/docs/issues/done/local-engine-artwork-skip-repped.md
@@ -1,7 +1,8 @@
 # Artwork gather: skip already-repped groups (default prefer)
 
-**Status:** implemented, measured, byte-identical. Branch `engine-artwork-skip-repped`. Three changes:
-the skip-repped reorder, a columnar `artwork_group_id`, and pre-sizing `group_best` (all below).
+**Status:** done, shipped in [#737](https://github.com/jbylund/sylvan_librarian/pull/737). Three
+changes: the skip-repped reorder, a columnar `artwork_group_id`, and pre-sizing `group_best` (all
+below).
 
 Cumulative vs `main` (97,206-printing corpus, artwork/usd, byte-identical output):
 

--- a/docs/issues/done/local-engine-broad-range-fastpath.md
+++ b/docs/issues/done/local-engine-broad-range-fastpath.md
@@ -9,7 +9,7 @@
 
 Status: design drafted 2026-07-14, no GitHub issue yet — file once the crossover is measured
 and a direction is picked. Surfaced investigating why `usd<50` costs ~0.4–1 ms (see
-[00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md)'s
+[00629-engine-artwork-group-id-bitmasks.md](00629-engine-artwork-group-id-bitmasks.md)'s
 "Expected (honest)" section: "the ~97k price compares still dominate") — but the mechanism
 isn't price-specific. Every `PrintingRangeIndex`-backed field shares it.
 
@@ -159,15 +159,15 @@ unit-checked representation, not a bind-time rewrite keyed on syntactic shape). 
 ## Problem
 
 `usd<50` matches 80,527 of 97,206 printings (83%) — genuinely broad, same shape as the
-`cmc`/`power`/`toughness` queries [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md)
+`cmc`/`power`/`toughness` queries [local-engine-numeric-range-planes.md](local-engine-numeric-range-planes.md)
 fixed with one-hot-interior + cumulative-boundary bitplanes (`cmc<=6`: 0.405 → 0.067 ms, 6.1×).
 That technique doesn't transfer: it needs a small, enumerable value space (~13–17 for
 `cmc`/`power`/`toughness`; price has 4,133 distinct values), *and*, more fundamentally, `cmc`/
 `power`/`toughness` are card-invariant (one value per card, so a plain per-card plane bit is
 exact), while price is printing-varying — `usd<50` for `unique=card` means "*some* printing is
 under $50," an existential predicate over printings, the same shape legality's `∃p: satisfies(p)`
-problem is ([00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)).
-[local-engine-printing-varying-plane-repair-pattern.md](local-engine-printing-varying-plane-repair-pattern.md)
+problem is ([00680-engine-existential-plane-generalization.md](00680-engine-existential-plane-generalization.md)).
+[local-engine-printing-varying-plane-repair-pattern.md](../local-engine-printing-varying-plane-repair-pattern.md)
 names this as the case the plane escape hatch can't cover: an unbounded parameterized threshold
 has no finite set of precomputable existence projections. The prerequisite fix above doesn't
 change that — it makes the *narrowing* exact, not the *existence* projection precomputable.
@@ -283,7 +283,7 @@ it's simpler than it first looked, now that narrowing is exact:
 
 Every existing adaptive guard in this engine (`AND_SKIP_THRESHOLD`, `MAX_NARROW_FRACTION`/
 `NARROW_FLOOR`, `MAX_UNION_FRACTION`) was derived from a benchmark sweep, not analysis — see
-[00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md). This
+[00647-engine-cost-guard-calibration.md](00647-engine-cost-guard-calibration.md). This
 decision needs three axes:
 
 1. **Match rate** (`k/n`).
@@ -344,25 +344,25 @@ fifth (tight/loose) axis to worry about — every field behaves identically ther
 
 ## Related
 
-- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
+- [local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md) —
   the consolidated forward plan for idea 2 (the printing-space popcount plan, #656): parts, ship
   order, target queries, and the #656 assembly. This doc is history; that one is the plan.
 - [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —
   prerequisite `printing_to_card` array, load-bearing for idea 1's per-match card check.
-- [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
+- [local-engine-numeric-range-planes.md](local-engine-numeric-range-planes.md) — the
   analogous fix for `cmc`/`power`/`toughness`; doesn't transfer (card-invariant, not existential).
-- [00629-engine-artwork-group-id-bitmasks.md](done/00629-engine-artwork-group-id-bitmasks.md) —
+- [00629-engine-artwork-group-id-bitmasks.md](00629-engine-artwork-group-id-bitmasks.md) —
   where the `usd<50` cost was first flagged as a floor, not fixed.
-- [00634-engine-permuted-bitmap-order-phase.md](done/00634-engine-permuted-bitmap-order-phase.md)
+- [00634-engine-permuted-bitmap-order-phase.md](00634-engine-permuted-bitmap-order-phase.md)
   — the popcount-skip machinery idea 2 would extend.
-- [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)
+- [00680-engine-existential-plane-generalization.md](00680-engine-existential-plane-generalization.md)
   — the existential-predicate framework `PrintingRangeBits` extends to numeric printing fields.
-- [00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md) — the
+- [00647-engine-cost-guard-calibration.md](00647-engine-cost-guard-calibration.md) — the
   calibration-from-measurement precedent this crossover should follow.
-- [local-engine-printing-varying-plane-repair-pattern.md](local-engine-printing-varying-plane-repair-pattern.md)
+- [local-engine-printing-varying-plane-repair-pattern.md](../local-engine-printing-varying-plane-repair-pattern.md)
   — names price's exact disqualifying shape ("a hypothetical printing-varying numeric field...
   `> 3.7` and `> 3.71` are different, un-precomputable existence projections").
-- [local-engine-probe-before-and-skip.md](local-engine-probe-before-and-skip.md) — the same
+- [local-engine-probe-before-and-skip.md](../local-engine-probe-before-and-skip.md) — the same
   "the binary search already gives you `k` for free" observation, in the AND-skip context.
 - #638 — `tix`/`eur` have no range index at all yet; the same fast path (and the prerequisite
   exactness fix) should cover them once they do.

--- a/docs/issues/done/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/done/local-engine-sorted-range-fastpath.md
@@ -1,13 +1,31 @@
 # Engine: fast path for broad sorted-range predicates, split by unique mode
 
-Status: plan drafted 2026-07-16. **Shipped:** PR 1 (printing-mode Idea 1, [#695]), PR 2a (`usd`,
-`unique=card`, [#725]), PR 3 (`cn`/`date`, `unique=card`, [#726]) — the card-mode range fast path
-(`CardRangePopcount`) now covers all three range families, and Idea 1 covers bare printing ranges.
-**Remaining:** PR 2b (artwork, archive bump), PR 5 (existential-plane printing-mode total), the
-crossover guard, and the printing-space popcount plan
-([local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md)),
-which is where the compound and existential-printing wins converge. PR 4 was dropped (see *Considered
-and dropped*). Supersedes the *planning* half of
+**Status: done.** Plan drafted 2026-07-16. **Shipped:** PR 1 (printing-mode Idea 1, [#695]), PR 2a
+(`usd`, `unique=card`, [#725]), PR 3 (`cn`/`date`, `unique=card`, [#726]) — the card-mode range fast
+path (`CardRangePopcount`) now covers all three range families, and Idea 1 covers bare printing
+ranges. PR 4 was dropped (see *Considered and dropped*). Everything else this doc left open has
+since resolved, not by building it as originally scoped, but by later work landing the same outcome
+through a different mechanism:
+
+- **PR 2b** (artwork range support) and **#656** (the deferred Idea-2 printing-space pager for
+  compounds like `cn<100 usd<50`) — both resolved by
+  [#724](00724-engine-printing-existential-planes.md) (printing-space compose, all three unique
+  modes, no archive bump — a query-time-derived global artwork id instead of the persisted array this
+  doc proposed) and [#733](https://github.com/jbylund/sylvan_librarian/pull/733) (range leaves as
+  compose sources, closing #694 and enabling `cn<100 usd<50`/printing — measured 1271→90µs, the exact
+  gap this doc flagged as "the slowest compound of all... an uncovered gap").
+- **PR 5** (existential printing-mode total for border/rarity) — subsumed by #724's printing
+  bitplanes, exactly as this doc predicted ("Largely subsumed by #724" below): a bitplane's `popcount`
+  *is* the count PR 5 would have computed.
+- **The Idea-1 crossover guard** — resolved as a non-issue: the #702 cost-based router's own
+  `printing_range_route_probe` ([00702](00702-engine-plan-selection-layer.md), lines 289-310)
+  swept the fixed 25% veto boundary against a real cost model across offsets to 20,000 and found the
+  veto already sits at the crossover (model 1.015× vs. tree gold, no regret) — this doc's prediction
+  of a reclaimable moderate band didn't hold up under measurement. Closing this out surfaced a further
+  simplification (the veto is now redundant with the cost model and could be deleted outright):
+  [local-engine-range-veto-redundancy.md](../local-engine-range-veto-redundancy.md).
+
+Supersedes the *planning* half of
 [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md), which is kept as the
 historical record (the shipped price-exactness prerequisite, and the full account of what PR #689
 tried, muddled, and reverted). This doc restates the plan with what we learned since.
@@ -17,11 +35,11 @@ tried, muddled, and reverted). This doc restates the plan with what we learned s
 Broad range predicates over the `PrintingRangeIndex`-backed fields — `usd<50` (83% of printings),
 `cn<100`, `year>2020`, `date>2023-01-01`, and `tix`/`eur` once [#638] indexes them — cost ~0.4–1 ms.
 On `main` a bare broad range leaf has its narrowing **vetoed** (`broad_ok=false` at the root call
-of `narrow_rec`, [lib.rs:2676](../../card_engine/src/lib.rs#L2676) → `range_narrowed`'s
-`!broad_ok` return, [lib.rs:2044](../../card_engine/src/lib.rs#L2044)), so *all three unique modes*
+of `narrow_rec`, [lib.rs:2676](../../../card_engine/src/lib.rs#L2676) → `range_narrowed`'s
+`!broad_ok` return, [lib.rs:2044](../../../card_engine/src/lib.rs#L2044)), so *all three unique modes*
 fall into the same full scan: `run_query_streamed` walks **every card**, expands each to its
 printings, and evaluates the price predicate per printing to accumulate `total`
-([lib.rs:4099-4131](../../card_engine/src/lib.rs#L4099-L4131)). That whole-corpus predicate scan is
+([lib.rs:4099-4131](../../../card_engine/src/lib.rs#L4099-L4131)). That whole-corpus predicate scan is
 the cost floor. It is identical across modes — the tell that we're discarding mode-specific
 structure.
 
@@ -54,14 +72,14 @@ every matching printing is its own row: `total` is exactly `k` from the binary s
 card space *ever*. Only the page remains, and how it's produced depends on the order-by:
 
 - **Card-level order (`edhrec`/`name`, the default).** The [#634] sort permutations are *card-space*
-  (`SortCol::PriceUsd`/`Rarity` return `None`, [lib.rs:1763](../../card_engine/src/lib.rs#L1763)) —
+  (`SortCol::PriceUsd`/`Rarity` return `None`, [lib.rs:1763](../../../card_engine/src/lib.rs#L1763)) —
   there is no printing permutation. But a card-level key is shared by all of a card's printings, so
   card order *is* printing order: walk the existing card permutation in rank order, expand each card
   to its matching printings, early-stop at `offset + limit`. Cost ≈ `(offset + limit) / match_rate`.
 - **Order by the range field itself (`usd<50 order by usd`).** The range index *is* the printing
   permutation for that field — its `[s, e)` slice is already value-sorted. But its within-value
   tiebreak is `pid`, while the canonical key is `(price[dir], edhrec asc, prefer_score asc, pid)`
-  ([`sort_key_bits`](../../card_engine/src/lib.rs#L3355)), and price ties are large (top buckets
+  ([`sort_key_bits`](../../../card_engine/src/lib.rs#L3355)), and price ties are large (top buckets
   ~1,600 printings; `order by usd asc` page 1 is chosen entirely from one bucket). So the index
   serves the *value* order but not the *tie* order. Fix at query time, no new structure: walk
   value-bucket boundaries by count to find which buckets the page `[offset, offset+limit)` overlaps
@@ -80,10 +98,10 @@ card space *ever*. Only the page remains, and how it's produced depends on the o
 **Idea 2 — project the narrowed set to an existence bitmap, feed the popcount-skip pager.** For
 `unique=card`: binary-search → matching printing slice → for each, `printing_to_card[p]`
 ([the #690 direct array](00690-engine-direct-projection-arrays.md)) sets that card's bit; `total` =
-**popcount**; page via `run_query_streamed_popcount` ([lib.rs:3945](../../card_engine/src/lib.rs#L3945)).
+**popcount**; page via `run_query_streamed_popcount` ([lib.rs:3945](../../../card_engine/src/lib.rs#L3945)).
 No predicate evaluation, only a bit-scatter over the `k` matches. This is `PrintingRangeBits`, the
 core of PR #689. `unique=artwork` is the same shape *once a global artwork id exists*: today the
-group id is per-card-local ([lib.rs:1851](../../card_engine/src/lib.rs#L1851)), so the uniqueness key
+group id is per-card-local ([lib.rs:1851](../../../card_engine/src/lib.rs#L1851)), so the uniqueness key
 is the pair `(card, artwork_group_id)` and there is no single integer to scatter — which is why
 [#693] needed a per-query dedup bitmask. Assigning each distinct `(card, local_group)` a stable
 **global artwork id** at build time (a `printing_to_artwork` array plus its `artwork_to_card`
@@ -121,7 +139,7 @@ total = Σ_{has_V && !has_notV}  pcount(c)         # pure-V card: all printings 
 ```
 
 The plane pairs already exist on `main`: legality has `PLANE_LEGAL_EXISTS` + `PLANE_LEGAL_ILLEGAL`
-directly ([planes.rs:72](../../card_engine/src/planes.rs#L72)); border/rarity are one-hot, so
+directly ([planes.rs:72](../../../card_engine/src/planes.rs#L72)); border/rarity are one-hot, so
 `has_notV` is an OR of the other value planes (~5 words per 64 cards). Correctness rests on
 "pure-V ⇒ all printings match V," which holds by construction.
 
@@ -146,7 +164,7 @@ Two refinements:
 
 `border:black`/printing is slow (0.853 ms baseline) because its card-space candidate covers
 ≥87.5% of cards and is discarded to a full scan
-([lib.rs:3815](../../card_engine/src/lib.rs#L3815)) — but the discard is *correct*, not a bug to
+([lib.rs:3815](../../../card_engine/src/lib.rs#L3815)) — but the discard is *correct*, not a bug to
 undo. Keeping a ~90%-card candidate would iterate ~90% of cards instead of 100% while still
 re-checking `border` per printing (the candidate is a loose card-existence set, so no per-printing
 work is skipped), and the card-id materialization overhead roughly cancels the ~10% iteration
@@ -162,7 +180,7 @@ which is why the slowness is printing-specific. Fix the mechanism (PR 5), not th
   three fields; nothing to verify after narrowing.
 - **`printing_to_card` direct array** + `eval` inlining ([#690]) — powers Idea 2's O(k) projection.
 - **`range_narrowed` / `Narrowed.tight` / `broad_ok` / `exact`** plumbing and the binary search
-  that yields `k` for free already exist ([lib.rs:2035](../../card_engine/src/lib.rs#L2035)).
+  that yields `k` for free already exist ([lib.rs:2035](../../../card_engine/src/lib.rs#L2035)).
 
 Confirmed absent from `main`: `PrintingRangeBits`, `must_be_tight`, and any range-family check —
 so nothing is half-landed. PR #689's `printing_to_card` and `eval`-split commits were the ones
@@ -170,7 +188,7 @@ extracted and shipped as [#690]; the rest of that branch is unmerged.
 
 ## Correctness: the NULL over-inclusion trap (Idea 2 only)
 
-`range_narrowed`'s broad **complement** branch ([lib.rs:2051-2056](../../card_engine/src/lib.rs#L2051))
+`range_narrowed`'s broad **complement** branch ([lib.rs:2051-2056](../../../card_engine/src/lib.rs#L2051))
 over-includes printings absent from the index (NULL value), so it is `loose`, not `tight`. This is
 harmless on `main` (broad lone ranges are vetoed, never reaching a card-space existence answer). It
 becomes a real overcount the moment Idea 2 trusts a card bitmap's popcount directly — PR #689
@@ -292,24 +310,18 @@ Ordered by dependency and risk; magnitudes are from PR #689's interleaved-A/B me
   0.416→0.124 (3.36×), `year<2005` 0.280→0.064 (4.40×); usd unchanged; 0 parity mismatches;
   calibration 88/88 gold. *Compounds still excluded* (bare-leaf gate) — they're the printing-space
   plane's job (compose in printing space, project once).
-- [ ] **PR 2b — global artwork id groundwork + `unique=artwork`.** Land `printing_to_artwork` /
-  `artwork_to_card` (build-time enumeration of `(card, local_group)`, persisted, archive format
-  bump) — the [#690] analogue for artwork — then extend the plane to artwork space (popcount over
-  artwork ids).
-  *Impacts:* `usd`/`cn`/`date` under `unique=artwork` (turns PR #689's +7-8% regression into a
-  win). *Magnitude:* regression → win. *Depends:* 2a (+3 for cn/date). *Risk:* med — new persisted
-  arrays + a format-version bump.
-- [ ] **PR 5 — printing-mode total for legality/rarity/border** — a precomputed O(1) per-value count
-  answering a **bare** query's total (`border:black`/printing). See
-  [Existential fields](#existential-fields-a-second-cheap-total-mechanism). *Impacts:* bare
-  `r:`/`f:`/`border:` under `unique=printing`. *Magnitude:* ~3× (removes the count pass). *Depends:*
-  Step 0 (gated on it being a real bottleneck).
-  **Largely subsumed by [#724](https://github.com/jbylund/sylvan_librarian/issues/724)** (printing
-  bitplanes): a bitplane's `popcount` *is* this count, and #724 also does composition/membership/paging.
-  So build PR 5 standalone **only** as a cheaper pre-#724 shortcut (a scalar count table, no
-  per-printing bits, no archive bump) if the bare printing-mode total is hot before the bitplanes
-  land; otherwise it falls out of #724. (These are printing-*exact* planes, not "existential" — that
-  term describes the card-space projection; renamed here to match #724.)
+- [x] **PR 2b — global artwork id groundwork + `unique=artwork`.** Resolved by
+  [#724](00724-engine-printing-existential-planes.md) + [#733], but not as originally scoped:
+  instead of a persisted `printing_to_artwork`/`artwork_to_card` pair (archive format bump), #724
+  derives the global artwork id at query time (`artwork_base[card] + artwork_group_id`, a prefix-sum
+  of the existing `artwork_groups` counts) — no archive change. #733 then made range leaves
+  (`usd`/`cn`/`date`) compose sources under that projection. *Measured* (#733): `cn<100`/artwork
+  910→124µs (7.3×), `usd<50 border:black`/artwork 1291→200µs (6.5×), `usd<50`/artwork 824→211µs
+  (3.9×).
+- [x] **PR 5 — printing-mode total for legality/rarity/border** — subsumed by
+  [#724](00724-engine-printing-existential-planes.md) exactly as predicted below: a printing
+  bitplane's `popcount` *is* this count, plus composition/membership/paging for free. No standalone
+  PR was needed.
 
 **Why this order:** PR 1 first keeps the "small, independent, separable" principle — lowest risk,
 printing-only, validates the walk + harness (contingent on Step 0; else swap with 2a). `2a → 3`
@@ -344,29 +356,26 @@ gated — real but modest, on a combo not yet confirmed hot. (PR 4 was dropped �
   `narrow_candidates_exact` to count scatter-then-discard events and their µs) turns up real waste —
   as a standalone "skip doomed `compile_plane`" it's dead.
 
-### Deferred (explicitly)
+### Deferred, now resolved
 
-- [ ] **Idea-2 printing-space pager** ([#656]) — the mechanism for **compound printing/artwork** (a
-  printing-space popcount total; `cn<100 usd<50`/printing ~1.07 ms is the uncovered gap). Deferred
-  for frequency/effort, *not* deep-offset (measured flat). PR 1 covers bare printing without it.
-  **Full plan (parts, ship order, target queries, #656 assembly):**
-  [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md).
-- [ ] **Idea-1 crossover guard** — widen the fastpath below the 25% veto boundary it shipped at
-  ([#695]) into the moderate band, per the [#647] calibrate-from-measurement precedent. The two
-  plans have *opposite* cost curves in `k`: narrow-and-scan rises ~O(k); the fastpath walk falls
-  ~O((offset+limit)·n_cards / k) (denser matches ⇒ shorter walk). Their min-envelope is a **hump**
-  (rise along narrowing, peak at the crossover, fall along the fastpath) — *not* monotonic;
-  calibration lowers and left-shifts the peak, it doesn't remove it. Today's peak sits in the
-  moderate band (`year<2010`, k≈22k, ~0.45 ms) because the gate is stuck at the veto boundary
-  (~20–24k), far above the real first-page crossover **k ≈ √(n_cards · limit) ≈ 1,800**. So the
-  reclaimable band is ~1.8k–20k.
-  **Why it needs a sweep, not a moved constant:** the walk cost carries `offset`, so the crossover
-  is `(k, offset)`-dependent — deep pages flip it (at offset 5,000, k≈1,800 the walk touches
-  ~280k printings, far worse than a scan). A single `k`-threshold would fix page 1 and regress deep
-  pages; the guard must be offset-aware (and ideally order-by-alignment-aware). Strictly additive to
-  [#695]: it only widens where the fastpath applies, never changes the sub-25% plans.
+- [x] **Idea-2 printing-space pager** ([#656]) — the mechanism for **compound printing/artwork** (a
+  printing-space popcount total; `cn<100 usd<50`/printing ~1.07 ms was the uncovered gap). Resolved
+  by [#724](00724-engine-printing-existential-planes.md) (printing-space compose) +
+  [#733](https://github.com/jbylund/sylvan_librarian/pull/733) (range leaves as compose sources) —
+  see [#656 assembly](#656-assembly-from-pr-1--pr-2a) below. Not the mechanism originally sketched
+  here (a dedicated printing-bitmap popcount-skip pager), but the same outcome.
+- [x] **Idea-1 crossover guard** — resolved as a **non-issue**, not by widening the gate. The #702
+  cost-based router's `printing_range_route_probe`
+  ([00702](00702-engine-plan-selection-layer.md), lines 289-310) swept the fixed 25% veto
+  boundary against a real `(k, offset)`-aware cost model across offsets to 20,000 and found the veto
+  already sits at the crossover (model 1.015× vs. tree gold, no regret) — the reclaimable ~1.8k–20k
+  band predicted below didn't hold up under measurement, so there was nothing to widen into. This did
+  surface a further finding — the veto is now redundant with the cost model and could be deleted
+  outright — split out to
+  [local-engine-range-veto-redundancy.md](../local-engine-range-veto-redundancy.md). The sweep design
+  below is kept as the historical record of the (superseded) plan.
 
-### Crossover guard: sweep design
+### Crossover guard: sweep design (superseded — see above)
 
 Goal: replace the walk branch's veto-boundary gate (`range_too_broad_to_narrow && k > STREAM_MIN_MATCHES`)
 with a calibrated `(k, offset)` predicate that picks the cheaper of narrow-and-scan vs. fastpath-walk.
@@ -397,12 +406,11 @@ deep pages fall back to narrowing exactly where the walk would lose.
 
 ### #656 assembly (from PR 1 + PR 2a)
 
-Consolidated into the printing-space plan doc:
-[local-engine-printing-plane-popcount-order.md § #656 assembly](local-engine-printing-plane-popcount-order.md#656-assembly).
-In short: **#656 ≈ PR 2a's printing bitmaps + PR 1's walk + an AND** — the range→printing bitmap
-(PR 2a/3) and printing-space paging (PR 1's walk) fall out of those two, leaving only the
-bitmap intersection + routing the popcount total into the printing path as net-new work. Landing
-both PR 1 and PR 2a is what reduces #656 to a small follow-up.
+Originally planned to consolidate into the printing-space plan doc as **#656 ≈ PR 2a's printing
+bitmaps + PR 1's walk + an AND**. Landed differently: [#724](00724-engine-printing-existential-planes.md)
+built printing-space compose (AND/OR across border/rarity/legality, projected once to any unique
+mode) directly, and [#733](https://github.com/jbylund/sylvan_librarian/pull/733) made range leaves a
+compose source on top of it — reaching the same compound wins without a dedicated #656 PR.
 
 ### Acceptance (every PR)
 
@@ -418,26 +426,25 @@ both PR 1 and PR 2a is what reduces #656 to a small follow-up.
   (price/rarity return `None`); PR 1 rides the card permutation for card-level orderings and slices
   the range index (boundary-bucket re-sort) for order-by-the-range-field. A *different*
   printing-varying order-by stays on the gathered path.
-- **Global artwork id sizing.** Count of distinct `(card, local_group)` pairs (bounds the
-  `artwork_to_card` array between n_cards and n_printings), and whether the #634 artwork order
-  permutation already keys on a representative printing the global id can align to.
+- **Global artwork id sizing** — *moot:* #724 never persists `artwork_to_card`; it derives the global
+  id at query time from the existing `artwork_groups` prefix sum, so there was no array to size.
 
 ## Related
 
-- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
+- [local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md) —
   the consolidated plan for the deferred Idea-2 printing-space popcount plan (#656): parts, ship
   order, target queries, and the #656 assembly.
 - [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — history:
   price-exactness prerequisite (shipped) and the full PR #689 account.
 - [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —
   `printing_to_card`, load-bearing for Idea 2.
-- [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md)
+- [00680-engine-existential-plane-generalization.md](00680-engine-existential-plane-generalization.md)
   — the existential-plane framework Idea 2 extends.
-- [00634-engine-permuted-bitmap-order-phase.md](done/00634-engine-permuted-bitmap-order-phase.md) —
+- [00634-engine-permuted-bitmap-order-phase.md](00634-engine-permuted-bitmap-order-phase.md) —
   the order permutation Idea 1 walks and the popcount pager Idea 2 feeds.
-- [00655-engine-numeric-range-planes.md](done/00655-engine-numeric-range-planes.md) — the
+- [local-engine-numeric-range-planes.md](local-engine-numeric-range-planes.md) — the
   card-invariant `cmc`/`power`/`toughness` analogue; does not transfer (no existential dimension).
-- [00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md) — the
+- [00647-engine-cost-guard-calibration.md](00647-engine-cost-guard-calibration.md) — the
   guard-from-measurement precedent for Idea 1's crossover.
 - [#638] `tix`/`eur` range index; [#656] printing-space popcount pager; [#693] artwork dedup bitmask.
 

--- a/docs/issues/local-engine-aprinting-layout.md
+++ b/docs/issues/local-engine-aprinting-layout.md
@@ -249,7 +249,7 @@ matters, the real question is reducing per-printing residual verification (e.g. 
 for the artwork-rep pick, or a corrected re-profile to find the true hot field per query shape) — a
 different investigation from struct layout. **Resolution:** that different investigation paid off —
 the residual *is* reducible without any layout change. See
-[artwork skip-repped](./local-engine-artwork-skip-repped.md): skipping already-repped artwork groups
+[artwork skip-repped](./done/local-engine-artwork-skip-repped.md): skipping already-repped artwork groups
 before the residual gives 1.23–1.35× on the `border:black` / artwork / usd path, byte-identical, zero
 archive change.
 

--- a/docs/issues/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/local-engine-printing-plane-popcount-order.md
@@ -60,8 +60,8 @@ is the "decision a threshold can't make" from the planner writeup).
 ## Why — and the honest scope
 
 Two distinct values, only one of them strong (see
-[broad-range-fastpath](local-engine-broad-range-fastpath.md) and the "three findings" in
-[sorted-range-fastpath](local-engine-sorted-range-fastpath.md)):
+[broad-range-fastpath](done/local-engine-broad-range-fastpath.md) and the "three findings" in
+[sorted-range-fastpath](done/local-engine-sorted-range-fastpath.md)):
 
 1. **Offset-independence** for a bare broad printing range. *Weak on its own* — today's O(n) count
    pass is already offset-independent (measured flat, offset 0 vs 5000). #656 is deferred for
@@ -209,7 +209,7 @@ a hunch.
 ## Parts, in ship order
 
 Most pieces already exist or are planned in
-[sorted-range-fastpath's roadmap](local-engine-sorted-range-fastpath.md#pr-order) — this is the
+[sorted-range-fastpath's roadmap](done/local-engine-sorted-range-fastpath.md#pr-order) — this is the
 printing-space subset, in dependency order:
 
 1. **`printing_to_card` direct array — shipped**
@@ -290,7 +290,7 @@ range+range gap proves worth closing.
   paging is the one archive-format bump.
 - **NULL over-inclusion — the #689 lesson.** A range bitmap's `popcount` **over-counts** the moment
   an existential/NULL predicate is trusted directly; this is precisely what
-  [PR #689 got wrong and reverted](local-engine-sorted-range-fastpath.md). The `must_be_tight`
+  [PR #689 got wrong and reverted](done/local-engine-sorted-range-fastpath.md). The `must_be_tight`
   correctness fix is inseparable from the bitmap path and must land with it (PR 2a bundles it).
 - **Two-spaces projection.** Postings/ranges are printing-space; the `unique=card` answer is
   card-space, and projection does **not** distribute over AND/OR. Compose the residual in
@@ -311,16 +311,16 @@ range+range gap proves worth closing.
 
 - [done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) — the cost
   router; where this was the deferred "one real win."
-- [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — historical
+- [local-engine-broad-range-fastpath.md](done/local-engine-broad-range-fastpath.md) — historical
   idea-1/idea-2 crossover analysis (the range-narrowing bitmap source).
-- [local-engine-sorted-range-fastpath.md](local-engine-sorted-range-fastpath.md) — the full
+- [local-engine-sorted-range-fastpath.md](done/local-engine-sorted-range-fastpath.md) — the full
   PR-ordered roadmap; idea 1 shipped as #695; the printing-mode existential-total mechanism (PR 5).
 - [00680-engine-existential-plane-generalization.md](done/00680-engine-existential-plane-generalization.md),
   [00667 legality](done/00667-engine-legality-divergent-carveout.md),
   [00664 border planes](done/00664-engine-border-planes.md) — the existential-plane framework the
   *precomputed* bitmap source extends; #667's planes are **card-space**, which is why
   `f:modern`/printing still needs a printing-space one.
-- [00724-engine-printing-existential-planes.md](00724-engine-printing-existential-planes.md)
+- [00724-engine-printing-existential-planes.md](done/00724-engine-printing-existential-planes.md)
   ([#724](https://github.com/jbylund/sylvan_librarian/issues/724)) — the printing-space bitplanes
   track: this plan's legality/border leaf source, sequenced last.
 - #656 (pager/permutation), #690 (`printing_to_card`, shipped), #689 (reverted attempt / NULL

--- a/docs/issues/local-engine-range-veto-redundancy.md
+++ b/docs/issues/local-engine-range-veto-redundancy.md
@@ -1,0 +1,66 @@
+# Engine: Drop the Redundant Broadness Veto in `printing_range_fastpath`
+
+Status: proposed, not yet implemented or measured. Filed while closing out the "Idea-1 crossover
+guard" question in
+[local-engine-sorted-range-fastpath.md](done/local-engine-sorted-range-fastpath.md).
+
+## The finding
+
+`printing_range_fastpath` ([lib.rs:4228](../../card_engine/src/lib.rs#L4228)) has two independent
+bail conditions before it walks:
+
+1. **`range_too_broad_to_narrow(k, idx.len())`** ([lib.rs:4244](../../card_engine/src/lib.rs#L4244))
+   — a broad/narrow *performance* gate: bail if the range is selective enough that the existing
+   narrowing path already wins.
+2. **`k <= STREAM_MIN_MATCHES`** ([lib.rs:4266](../../card_engine/src/lib.rs#L4266)) — a
+   *correctness* gate: on a tiny index, `run_query_streamed` gathers and sorts globally instead of
+   streaming, with a different tie-break. Unrelated to cost.
+
+Gate 1 duplicates work the #702 cost-based router already does. `PhysicalPlan::PrintingRangeScan`'s
+`applicable()` ([lib.rs:4778](../../card_engine/src/lib.rs#L4778)) has **no** broadness check, so
+today the veto is the *only* thing standing between "any bare range, any `k`" and an attempted walk
+— but `plan_cost(PrintingRangeScan, …)` ([cost.rs:254](../../card_engine/src/cost.rs#L254)) already
+prices the same tradeoff:
+
+```
+match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR)   // MATCH_RATE_FLOOR = 1e-6
+printings_walked = page_span / match_rate
+cost = printings_walked * RANGE_WALK_STEP_NS + RANGE_FIXED_COST_NS
+```
+
+As a range narrows, `matches` shrinks, `match_rate` shrinks, `printings_walked` blows up, and the
+walk's cost rises with it — the argmin in `choose()` ([lib.rs:5417](../../card_engine/src/lib.rs#L5417))
+should already route away from `PrintingRangeScan` for narrow ranges without gate 1's help. This is
+exactly the hypothesis [local-engine-sorted-range-fastpath.md](done/local-engine-sorted-range-fastpath.md)'s
+"Idea-1 crossover guard" question resolved: the #702 doc's `printing_range_route_probe`
+([done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md), lines
+289-310) swept the fixed veto against a pure cost-model route across offsets to 20,000 and found
+them equivalent (model 1.015× vs. tree gold, no regret). If the model already agrees with the veto
+everywhere it was tested, the veto isn't adding a decision the model doesn't already make — it's a
+second, hardcoded copy of it.
+
+## Proposed change
+
+Delete the `range_too_broad_to_narrow` call from `printing_range_fastpath`; keep the
+`STREAM_MIN_MATCHES` bail as-is (it's a correctness constraint, not a cost one). Let `choose()`'s
+argmin be the sole arbiter of whether `PrintingRangeScan` is cheaper than the materializing
+alternatives.
+
+## Why this isn't a trivial delete
+
+`match_rate`'s floor (`MATCH_RATE_FLOOR = 1e-6`) exists to avoid a near-zero divide, which means the
+cost formula's precision degrades for very selective ranges (small `k`) — a regime the #702 probe's
+sweep targeted the *moderate/broad* band (the doc's ~1.8k–20k crossover question), not necessarily
+near-empty ranges. Before deleting the veto, sweep small `k` specifically (down toward `k` = a
+handful of matches) and confirm the model still routes away from `PrintingRangeScan` there, the same
+way [#647](done/00647-engine-cost-guard-calibration.md) calibrated guards from measurement rather
+than intuition.
+
+## Related
+
+- [local-engine-sorted-range-fastpath.md](done/local-engine-sorted-range-fastpath.md) — where this was
+  found, while closing out the Idea-1 crossover guard question.
+- [done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) — the
+  cost-based router and the probe that validated the fixed veto against the cost model.
+- [done/00647-engine-cost-guard-calibration.md](done/00647-engine-cost-guard-calibration.md) —
+  precedent for calibrating a guard from measurement instead of a fixed constant.


### PR DESCRIPTION
## Summary

Reviewed `docs/issues/` against recent merges (#724, #733, #734) and found five docs fully resolved — including deferred items each one had left open, which turned out to be resolved via different mechanisms than originally planned rather than by building them as scoped:

- `00724-engine-printing-existential-planes.md` — header said "todo" but the doc's own "Result" sections show every phase (border, rarity, legality, artwork) shipped and measured across #728/#732.
- `00734-engine-string-operator-optimizations.md` — both optimization steps already marked done, no remaining steps.
- `local-engine-artwork-skip-repped.md` — our own branch, shipped as #737.
- `local-engine-sorted-range-fastpath.md` — PR 2b/#656/PR 5 all resolved by #724+#733; the "Idea-1 crossover guard" question resolved as a non-issue by #702's own probe.
- `local-engine-broad-range-fastpath.md` — the historical-record doc these superseded; archived alongside its successor.

Also updates `00731-engine-compose-universal-evaluator.md` to reflect that only step 1 (range leaves, #733) of its 3-step build order has shipped, and files a new follow-up doc: `local-engine-range-veto-redundancy.md`, proposing to delete the now-redundant `range_too_broad_to_narrow` veto in `printing_range_fastpath` since the cost-based router's `plan_cost` formula already prices the same broad/narrow tradeoff (validated by #702's probe).

All relative links broken by the moves are fixed, including a few pre-existing stale ones found along the way (an off-by-one `../../` path in two already-archived docs, and a stale `00655-...` filename that should have been `local-engine-numeric-range-planes.md`).

## Test plan

- [ ] Docs-only change — no code touched, no tests to run
- [ ] Spot-check a few cross-links render correctly on GitHub