### PR TITLE
Engine: Watermark Postings Index

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2263,6 +2263,7 @@ struct CardIndexes {
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
+    watermarks:     TagIndex,        // printing space
     released_at:    PrintingRangeIndex,       // printing space
     price_usd:      PrintingRangeIndex,       // printing space (integer cents, already order-preserving)
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
@@ -2299,6 +2300,7 @@ impl Default for CardIndexes {
             artists:        ArtistIndex::default(),
             flavor:         FlavorIndex::default(),
             set_codes:      HashMap::new(),
+            watermarks:     HashMap::new(),
             released_at:    Vec::new(),
             price_usd:      Vec::new(),
             collector_number: Vec::new(),
@@ -3238,6 +3240,17 @@ fn narrow_rec(
             // be None, but unlike tags the index covers every non-empty code.
             Narrowed::tight(Candidates::Printings(
                 indexes.set_codes.get(value.as_str()).map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(*x)).collect()),
+            ))
+        }
+
+        // watermark: (93% null, 67 distinct values, largest ~0.8% of printings —
+        // sparse enough that postings is the only representation that makes
+        // sense; see docs/issues/done/local-engine-watermark-postings.md). A value
+        // absent from the index appears on no printing, same empty-is-exact
+        // reasoning as SetCode above.
+        FilterExpr::TextExact { field: TextField::Watermark, op: CmpOp::Eq, value } => {
+            Narrowed::tight(Candidates::Printings(
+                indexes.watermarks.get(value.as_str()).map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(*x)).collect()),
             ))
         }
 
@@ -6075,7 +6088,11 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260723;
+// 20260724, not 20260723: #737 already used today's date for its own archive
+// change (columnar artwork_group_id) earlier today, so this bump (adding
+// CardIndexes.watermarks) needs a distinct value to invalidate stores built
+// under that layout — see ARCHIVE_FORMAT_VERSION's doc above.
+const ARCHIVE_FORMAT_VERSION: u32 = 20260724;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -6467,6 +6484,16 @@ impl QueryEngine {
                     let code = p.card_set_code.as_str();
                     if !code.is_empty() {
                         idx.entry(code.to_string()).or_default().push(i as u32);
+                    }
+                }
+                idx
+            },
+            watermarks:     {
+                let mut idx: TagIndex = HashMap::new();
+                for (i, p) in printings.iter().enumerate() {
+                    if p.card_watermark_id != NONE_STR {
+                        let wm = strings[p.card_watermark_id as usize].as_str();
+                        idx.entry(wm.to_string()).or_default().push(i as u32);
                     }
                 }
                 idx

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4526,6 +4526,7 @@ fn bench_checked_vs_unchecked_access() {
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),
+        watermarks:     HashMap::new(),
         released_at:    Vec::new(),
         price_usd:      Vec::new(),
         collector_number: Vec::new(),
@@ -5331,6 +5332,56 @@ fn set_code_and_date_narrowing() {
     }
     // Ne is not selective and must not narrow.
     assert!(narrow_candidates(&FilterExpr::DateCmp { op: CmpOp::Ne, value: 19930805 }, &archived.indexes, &archived.offsets, &archived.cards).is_none());
+}
+
+#[test]
+fn watermark_narrowing() {
+    // Sparse field (93% null, 67 distinct values in real data, largest ~0.8% of
+    // printings) — postings, same shape as SetCode, not a plane. See
+    // docs/issues/done/local-engine-watermark-postings.md.
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 1], vocab);
+    let mut interner = Interner::new();
+    data.printings[0].card_watermark_id = interner.intern("wotc".to_string());
+    data.printings[1].card_watermark_id = interner.intern("set".to_string());
+    data.printings[2].card_watermark_id = NONE_STR; // no watermark — must not appear in any postings list
+    data.strings = interner.strings;
+    let mut watermarks: TagIndex = HashMap::new();
+    for (i, p) in data.printings.iter().enumerate() {
+        if p.card_watermark_id != NONE_STR {
+            watermarks.entry(data.strings[p.card_watermark_id as usize].clone()).or_default().push(i as u32);
+        }
+    }
+    data.indexes.watermarks = watermarks;
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let wotc = FilterExpr::TextExact { field: super::TextField::Watermark, op: CmpOp::Eq, value: "wotc".to_string() };
+    match narrow_candidates(&wotc, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![0]),
+        _ => panic!("watermark must narrow in printing space"),
+    }
+
+    // Unknown watermark: exact empty narrowing, same as an unknown set code —
+    // and the short-circuit this doc's timing (~3us) relies on.
+    let unknown = FilterExpr::TextExact { field: super::TextField::Watermark, op: CmpOp::Eq, value: "notarealvalue".to_string() };
+    match narrow_candidates(&unknown, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty()),
+        _ => panic!("unknown watermark must narrow to the empty set"),
+    }
+
+    // The bug this fixes: before this arm existed, Watermark had no narrow_rec
+    // case at all, so `Or([Watermark(..), <anything narrowable>])` vetoed the
+    // whole Or to None (every child must narrow). Confirm the Or now composes.
+    let set = FilterExpr::TextExact { field: super::TextField::Watermark, op: CmpOp::Eq, value: "set".to_string() };
+    match narrow_candidates(&FilterExpr::Or(vec![wotc, set]), &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(mut v)) => {
+            v.sort_unstable();
+            assert_eq!(v, vec![0, 1]);
+        }
+        _ => panic!("watermark Or must narrow now that both children narrow"),
+    }
 }
 
 #[test]

--- a/docs/changelog/2026-07-23-watermark-postings.md
+++ b/docs/changelog/2026-07-23-watermark-postings.md
@@ -1,0 +1,30 @@
+# Watermark postings index
+
+`watermark:` had no narrowing support anywhere in the engine — no postings, no plane, no
+`narrow_rec` arm. Found investigating the single slowest query (1.068ms) in a 1,000-query
+realistic-traffic survey: `watermark:set or artist:thomas` — `artist:thomas` alone narrows
+tightly, but `Or` requires every child to narrow or the whole union bails, so one unindexed
+sibling forced a full scan for both sides.
+
+Real data (97,290 printings) shows watermark is sparse and long-tailed: 93.1% null, 67 distinct
+values, largest (`wotc`) only 0.82% of all printings. Every value is far below this codebase's
+plane-vs-postings crossover (~3,000 printings/value), so a postings index — the same
+`HashMap<String, Vec<u32>>` shape as `set_codes` — is the only representation that fits. Added the
+index plus the matching `narrow_rec` arm, mirroring `SetCode`'s exactly (`card_watermark_id` is
+interned, so the build resolves through the string table instead of checking for an empty inline
+string, the only structural difference).
+
+`ARCHIVE_FORMAT_VERSION` bumped 20260723 → 20260724 (a second same-day bump — #737 already used
+today's date for its own archive change).
+
+Measured (97,206-printing corpus, `unique=card`, interleaved same build):
+
+| query | before | after |
+|---|---:|---:|
+| `watermark:set or artist:thomas` | 1.068 ms | **0.116 ms** (9.2×) |
+| `watermark:notarealvalue` (absent value) | — | **0.003 ms** |
+
+Totals unchanged (correctness preserved). New Rust test `watermark_narrowing`; `cargo test`
+(debug + release) 129/129; `test_engine_property.py` and `test_engine_unit.py` pass.
+
+Design doc: `docs/issues/done/local-engine-watermark-postings.md`.

--- a/docs/issues/done/local-engine-watermark-postings.md
+++ b/docs/issues/done/local-engine-watermark-postings.md
@@ -1,0 +1,78 @@
+# Engine: Watermark Postings Index
+
+**Status: done.** No GitHub issue filed — small, mechanical, found while investigating the
+slowest query in a broad realistic-traffic survey.
+
+## Why
+
+`watermark:` had no narrowing support anywhere in the engine — no postings list, no plane, no
+`narrow_rec` arm at all. Any query touching it fell straight to a full unnarrowed scan
+(`TextExact{field: Watermark, ...}` hit `narrow_rec`'s final `_ => None`). Worse, `Or` requires
+*every* child to narrow or the whole union bails (`lib.rs`'s `FilterExpr::Or` arm, `?` on each
+child) — so `watermark:set or artist:thomas` forced a full scan even though `artist:thomas` alone
+narrows tightly and cheaply. It was the single slowest query (1.068ms) in a 1,000-query survey
+(`benchmarks/survey/survey-2026-07-23-broad.csv`), despite `watermark:` appearing in only 10 of
+those 1,000 queries.
+
+## Data shape (blue DB, 97,290 printings)
+
+| stat | value |
+|---|---:|
+| non-null | 6,753 (6.9%) |
+| distinct values | 67 |
+| largest value (`wotc`) | 797 (0.82% of all printings) |
+| 2nd largest (`set`) | 572 (0.59%) |
+| tail | half the values ≤60 printings; ~15 are singletons |
+
+Every value is far below the plane-vs-postings crossover this codebase uses elsewhere
+(~3,000 printings/value, e.g. border's doc). A plane would cost a fixed ~12KB per tracked value
+for a field that's absent 93% of the time; postings cost `4 bytes × 6,753 nonnull printings` ≈
+27KB total, across all 67 values combined. Not a close call — postings is the only representation
+that fits this shape.
+
+## What shipped
+
+Postings index (`watermarks: TagIndex`, same `HashMap<String, Vec<u32>>` shape as `set_codes`),
+built the same way (`lib.rs` `CardIndexes` literal), plus the matching `narrow_rec` arm
+(`TextField::Watermark, CmpOp::Eq` → `Narrowed::tight(Candidates::Printings(...))`), mirroring
+`SetCode`'s arm exactly. `card_watermark_id` is interned (`NONE_STR` sentinel for absent), unlike
+`card_set_code` (an inline `String`), so the build resolves through `strings` instead of checking
+for an empty string — the only structural difference from `SetCode`'s block.
+
+Archive-format bump: `ARCHIVE_FORMAT_VERSION` 20260723 → **20260724** (not just the next calendar
+day — #737 already used 20260723 for its own archive change earlier the same day, so this needed a
+distinct value to invalidate stores built under that layout).
+
+## Measured
+
+Interleaved, same build, 97,206-printing corpus, `unique=card`, `orderby=toughness` (matching the
+survey config that surfaced this):
+
+| query | before | after |
+|---|---:|---:|
+| `watermark:set or artist:thomas` | 1.068 ms | **0.116 ms** (9.2×) |
+| `watermark:set` (bare) | — | 0.071 ms |
+| `artist:thomas` (bare) | — | 0.084 ms |
+| `watermark:wotc` (most common value) | — | 0.094 ms |
+| `watermark:notarealvalue` (absent value) | — | **0.003 ms** |
+
+Totals unchanged (`watermark:set or artist:thomas` = 744 both before and after) — same rows, just
+narrowed instead of scanned. The absent-value case confirms the short-circuit: a postings miss
+returns an empty *tight* candidate set, which `prepare_candidates` propagates as a known-empty
+(not "unnarrowed") candidate list, so the query returns `total=0` in microseconds with no scan and
+no residual verification — same as an absent set code today.
+
+## Testing
+
+- New Rust test `watermark_narrowing` (`tests.rs`): bare-value narrowing, absent-value empty
+  narrowing, and the `Or`-composes-now regression case directly (the bug this fixes).
+- `cargo test` (debug + release): 129/129 passed.
+- `pytest api/tests/test_engine_property.py` (differential suite vs. reference oracle) and
+  `api/tests/test_engine_unit.py`: all passed.
+
+## Related
+
+- Found via [`scripts/survey_queries.py`](../../scripts/survey_queries.py)'s broad realistic-traffic
+  survey.
+- [00664 border planes](00664-engine-border-planes.md) — the plane-vs-postings crossover this
+  reasons from, for a field dense enough to go the other way.


### PR DESCRIPTION
## Summary

- `watermark:` had no narrowing support anywhere in the engine — no postings, no plane, no `narrow_rec` arm. Found investigating the single slowest query (1.068ms) in a 1,000-query realistic-traffic survey: `watermark:set or artist:thomas` — `artist:thomas` alone narrows tightly, but `Or` requires every child to narrow or the whole union bails, so one unindexed sibling forced a full scan for both sides.
- Real data (97,290 printings): 93.1% null, 67 distinct values, largest (`wotc`) only 0.82% of all printings — far below the plane-vs-postings crossover this codebase uses elsewhere (~3,000 printings/value), so postings (same `TagIndex` shape as `set_codes`) is the only representation that fits.
- Added the index plus the matching `narrow_rec` arm, mirroring `SetCode`'s exactly (`card_watermark_id` is interned, so the build resolves through the string table instead of checking for an empty inline string — the only structural difference).
- `ARCHIVE_FORMAT_VERSION` bumped 20260723 → 20260724 (a second same-day bump — #737 already used today's date for its own archive change).

## Measured

97,206-printing corpus, `unique=card`, interleaved same build:

| query | before | after |
|---|---:|---:|
| `watermark:set or artist:thomas` | 1.068 ms | **0.116 ms** (9.2×) |
| `watermark:notarealvalue` (absent value) | — | **0.003 ms** |

Totals unchanged (correctness preserved).

## Test plan

- [x] New Rust test `watermark_narrowing`: bare narrowing, absent-value empty narrowing, and the `Or`-composes-now regression case directly.
- [x] `cargo test` (debug + release): 129/129 passed.
- [x] `pytest api/tests/test_engine_property.py` (differential suite vs. reference oracle) and `api/tests/test_engine_unit.py`: all passed.

Design doc: `docs/issues/done/local-engine-watermark-postings.md`.