### PR TITLE
Engine: PrintingCompose Permutation-Free Paging Fallback

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -105,6 +105,13 @@ pub(crate) struct PlanFeatures {
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
     pub popcount_words: u32,
+    /// Whether `PrintingCompose` will page via the real permutation walk (`true`) or the
+    /// permutation-free bounded-gather fallback (`false`) — decided by whether `orderby` has a
+    /// card-space permutation (`rarity`/`usd` don't; see
+    /// `docs/issues/local-engine-compose-permutation-fallback.md`). The two strategies have
+    /// different cost shapes (offset-dependent walk vs. visit-every-match gather), so the formula
+    /// branches on this rather than assuming the walk. Ignored by every other plan.
+    pub compose_has_perm: bool,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -261,15 +268,31 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             printings_walked * RANGE_WALK_STEP_NS  // forward-perm walk to fill the page
                 + RANGE_FIXED_COST_NS              // per-query setup
         }
-        // #724 unified compose, any distinct-on. One term per operation it performs:
+        // #724 unified compose, any distinct-on. One term per build operation, plus a paging term
+        // that depends on which strategy `printing_compose_fastpath` will actually use (see
+        // `compose_has_perm`'s doc) — the permutation walk and the permutation-free gather fallback
+        // have different cost shapes, so this must not just assume the walk.
         PhysicalPlan::PrintingCompose => {
-            f64::from(f.broadcast_printings) * LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
+            let build = f64::from(f.broadcast_printings) * LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
                 + f64::from(f.scatter_printings) * RANGE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
                 + f64::from(f.project_printings) * LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
-                + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS  // popcount the result-space bitmap for the total (printing/card/artwork words)
-                + printings_walked * RANGE_WALK_STEP_NS  // forward grouped walk to fill the page
-                + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
-                + RANGE_FIXED_COST_NS  // per-query setup
+                + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS; // popcount the result-space bitmap for the total (printing/card/artwork words)
+            let page = if f.compose_has_perm {
+                printings_walked * RANGE_WALK_STEP_NS  // forward grouped walk to fill the page
+                    + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
+            } else {
+                // gather_composed_page: visits every candidate (eval_domain, same rate GatheredScan's
+                // own permutation-free walk pays per card), tests `pbits` membership per printing
+                // (scan_units — a cheap bit test, not a real residual scan, so the cheap
+                // RANGE_SCATTER_PER_PRINTING_NS rate applies, not GATHER_SCAN_PER_ROW_NS + tier_ns),
+                // and pushes each surviving match into the bounded GatherSelect accumulator (matches,
+                // same per-match rate GatheredScan pays for the same operation). Offset-independent —
+                // unlike the walk above, it costs the same regardless of how deep the page is.
+                eval_domain * GATHER_CARD_PASS_NS
+                    + scan_units * RANGE_SCATTER_PER_PRINTING_NS
+                    + matches * GATHER_PUSH_PER_MATCH_NS
+            };
+            build + page + RANGE_FIXED_COST_NS // per-query setup
         }
         // #634 plane popcount-skip order walk (precomputed bitmap ⇒ no synth):
         PhysicalPlan::PlanePopcountOrder => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1950,6 +1950,20 @@ fn guard_env<T: std::str::FromStr>(name: &str, default: T) -> T {
 // still wins ~1.06-1.15× there).
 static MAX_NARROW_FRACTION: LazyLock<f64> = LazyLock::new(|| guard_env("CARD_ENGINE_MAX_NARROW_FRACTION", 0.25));
 
+/// A different crossover from `MAX_NARROW_FRACTION` above, for a different decision: whether
+/// `printing_compose_fastpath`'s permutation-free `gather_composed_page` fallback is worth its
+/// build cost (see that function's doc). `MAX_NARROW_FRACTION` answers "does narrowing shrink the
+/// candidate set enough to beat a full scan" — this answers "does skipping per-candidate residual
+/// re-verification (compose's whole benefit here, since the fallback still visits every mode-space
+/// candidate regardless of build) beat the cost of building the composed bitmap at all." Those are
+/// different tradeoffs with different crossovers: calibrated directly (`usd<N` swept 15%-98% of
+/// *cards* — the domain this must be checked in, not raw matching printings, see the call site —
+/// card/rarity, interleaved A/B compose on/off), the gather fallback wins clearly below ~82% and
+/// loses above ~93%, both noisy in between; 0.85 sits inside that band, erring toward the general
+/// path (this engine's default lean whenever a crossover region is uncertain, same reasoning
+/// `MAX_NARROW_FRACTION`'s own calibration used).
+static COMPOSE_GATHER_MAX_CARD_FRACTION: LazyLock<f64> = LazyLock::new(|| guard_env("CARD_ENGINE_COMPOSE_GATHER_MAX_CARD_FRACTION", 0.85));
+
 /// Below this many matched ids narrowing always wins regardless of fraction —
 /// gathering a handful of ids is microseconds. Also keeps tiny stores (tests,
 /// partial imports) narrowing, where any match trips the fraction. Not
@@ -4565,6 +4579,43 @@ fn printing_compose_fastpath<'a>(
     if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
         return None;
     }
+    let perm = indexes.sort_perms.get(sort_col, descending).filter(|p| p.len() == cards.len());
+    // No permutation (rarity/usd): before paying for the real build, check whether it's worth it at
+    // all using the same estimate `compose_printing_estimate` already computes cheaply in acquire
+    // (O(log n) partition points / plane popcounts, no scatter) — see `COMPOSE_GATHER_MAX_CARD_FRACTION`'s
+    // doc for why this needs its own threshold, not `MAX_NARROW_FRACTION`. The check must be in
+    // **mode space** (cards for `Card`, artworks for `Artwork`), not raw matching printings: a bare
+    // range's printing-space match count is a poor proxy for how many *candidates*
+    // `gather_composed_page` will actually visit (a card can have several qualifying printings). A
+    // plain `.min(domain)` cap is *not* enough to project it down, though — it saturates to exactly
+    // `domain` for every query whose printing-space count exceeds it (`cn<100`: 35,021 printings vs
+    // 31,508 cards, and `usd<50`: 80,527 vs 31,508 both saturate to the *identical* 31,508, even
+    // though their true card counts are 17,616 vs 31,217 — miles apart), which loses exactly the
+    // signal this check needs. A balls-into-bins estimate — `k` matching printings landing on
+    // `domain` cards, expected distinct cards touched `≈ domain·(1 − e^(−k/domain))` — doesn't
+    // saturate the same way and tracks the true count much better (checked against real totals:
+    // `cn<100` estimate 21,140 vs true 17,616; `usd<50` estimate 29,062 vs true 31,217; clearly
+    // separated, unlike the capped estimate's identical 31,508 for both).
+    if perm.is_none() {
+        let (printing_matches, _, _) = compose_printing_estimate(filter, indexes, offsets, printings.len());
+        // Artwork's true domain is n_artworks (>= n_cards), but getting it exactly means building
+        // artwork_base here — real O(n_cards) work paid just to maybe decline. `cards.len()` is a
+        // cheap, conservative stand-in (n_artworks is always >= it, so this only ever makes the
+        // fraction look *more* broad than reality — errs toward declining, same conservative lean
+        // `COMPOSE_GATHER_MAX_CARD_FRACTION` itself was calibrated with).
+        let domain = match mode {
+            Mode::Printing => printings.len(),
+            Mode::Card | Mode::Artwork => cards.len(),
+        };
+        let est = if matches!(mode, Mode::Printing) {
+            printing_matches as f64 // exact in printing space already, no projection needed
+        } else {
+            domain as f64 * (-(printing_matches as f64) / domain as f64).exp().mul_add(-1.0, 1.0)
+        };
+        if est > domain as f64 * *COMPOSE_GATHER_MAX_CARD_FRACTION {
+            return None;
+        }
+    }
     // Compose once, here (never in acquire) — that single build is the only synthesis, and it is paid
     // only because this plan won. The total is the popcount in the query's result space; the page is
     // the one grouped walk at the mode's granularity, using the composed bits as exact membership.
@@ -4584,14 +4635,20 @@ fn printing_compose_fastpath<'a>(
     if total == 0 || page_offset >= total {
         return Some((total, Vec::new()));
     }
-    if total <= *STREAM_MIN_MATCHES {
-        return None; // sparse: the general path gathers + globally sorts, ordering ties differently
-    }
-    let perm = indexes.sort_perms.get(sort_col, descending)?;
-    if perm.len() != cards.len() {
-        return None;
-    }
-    Some((total, walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm, u16::from(indexes.max_artwork_groups))))
+    let page = match perm {
+        Some(perm) => {
+            if total <= *STREAM_MIN_MATCHES {
+                return None; // sparse: the general path gathers + globally sorts, ordering ties differently
+            }
+            walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm, u16::from(indexes.max_artwork_groups))
+        }
+        // No permutation: already confirmed above (via the cheap estimate) that this composed set is
+        // selective enough to be worth building — page via the bounded GatherSelect fallback, whose
+        // tie-break matches the general path exactly (same GatherSelect, same comparator), so unlike
+        // the branch above there's no separate small-total decline needed here.
+        None => gather_composed_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, u16::from(indexes.max_artwork_groups)),
+    };
+    Some((total, page))
 }
 
 /// The physical plans the cost router (`run_query_routed`) chooses among. Each
@@ -4656,9 +4713,7 @@ impl PhysicalPlan {
             PhysicalPlan::PrintingRangeScan => {
                 printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
             }
-            PhysicalPlan::PrintingCompose => {
-                printing_compose_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
-            }
+            PhysicalPlan::PrintingCompose => printing_compose_applicable(filter, cards, plane, indexes),
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
@@ -4780,30 +4835,22 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
 }
 
 /// `PrintingCompose` applicability (#724), all three distinct-ons: a composable printing-space `filter`
-/// (border/rarity/legality, `AND`/`OR`), the planes built, no folded plane, the forward sort permutation
-/// present, flag on. `plane.is_none()` is load-bearing: under `unique=card` a *bare* border/rarity is
-/// `compile_plane`-consumed into an existential plane (`plane.is_some()`) → the faster #634 card-plane
-/// path handles it, so this plan declines there; under `unique=printing`/`artwork` nothing folds to a
-/// plane, so it picks up bare leaves too. Only the forward permutation is needed — the unified grouped
-/// walk never uses the inverse (that was the popcount-skip walk's, deferred to [#730]).
-fn printing_compose_applicable(
-    filter: &FilterExpr,
-    _mode: Mode,
-    cards: &[AOracleCard],
-    plane: Option<&PlaneExpr>,
-    sort_col: SortCol,
-    descending: bool,
-    indexes: &Archived<CardIndexes>,
-) -> bool {
+/// (border/rarity/legality, `AND`/`OR`), the planes built, no folded plane, flag on. `plane.is_none()`
+/// is load-bearing: under `unique=card` a *bare* border/rarity is `compile_plane`-consumed into an
+/// existential plane (`plane.is_some()`) → the faster #634 card-plane path handles it, so this plan
+/// declines there; under `unique=printing`/`artwork` nothing folds to a plane, so it picks up bare
+/// leaves too. **No longer requires a sort permutation** (dropped `sort_col`/`descending` params to
+/// match): `printing_compose_fastpath` pages via the forward grouped walk (`walk_grouped_page`) when
+/// one exists for the query's `sort_col`, or via a permutation-free bounded-gather fallback
+/// (`gather_composed_page`) when it doesn't (`rarity`/`usd` —
+/// docs/issues/local-engine-compose-permutation-fallback.md) — either way the total (a popcount over
+/// the already-exact composed bits) and the page are both correct; only *which* paging strategy runs
+/// depends on the permutation's presence, decided inside the fastpath itself.
+fn printing_compose_applicable(filter: &FilterExpr, cards: &[AOracleCard], plane: Option<&PlaneExpr>, indexes: &Archived<CardIndexes>) -> bool {
     // Mode-agnostic: the cost model arbitrates overlap with the specialized range plans. All three
     // range/compose plans are non-materializing (estimate-in-acquire), so nothing is eagerly built —
     // a losing plan costs only a binary search, never a wasted scatter.
-    *PRINTING_COMPOSE != 0
-        && !cards.is_empty()
-        && plane.is_none()
-        && is_printing_composable(filter, indexes)
-        && printing_compose_indexes_built(indexes)
-        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+    *PRINTING_COMPOSE != 0 && !cards.is_empty() && plane.is_none() && is_printing_composable(filter, indexes) && printing_compose_indexes_built(indexes)
 }
 
 /// `CardRangePopcount` needs `Mode::Card`, a **bare** range leaf as the whole filter — usd/cn/date,
@@ -5183,6 +5230,102 @@ fn walk_grouped_page<'a>(
     page
 }
 
+/// Permutation-free counterpart to `walk_grouped_page`, for when `orderby` has no card-space
+/// permutation (`rarity`/`usd` — the representative printing depends on `prefer` and can't be
+/// precomputed, see `ArchivedSortPermutations::get`'s doc). Same per-card grouping logic (`pbits`
+/// membership, best-`prefer_score` representative per group) and same exactness (`pbits` already
+/// consumed the whole filter — no residual, no `card_pass`), but instead of walking a permutation
+/// front-to-back with an early stop, it visits only the candidate cards (`bitmap_card_ids` over the
+/// card-projected `pbits` — cards with zero surviving printings are skipped entirely, an
+/// optimization the rank-order permutation walk can't make) and pushes into the same bounded
+/// `GatherSelect` accumulator `GatheredScan` uses for its own permutation-less case — so tie-break
+/// order matches the general path exactly (same comparator, same struct), unlike the permutation
+/// walk (which is why that one still declines below `STREAM_MIN_MATCHES`; this one doesn't need to).
+#[allow(clippy::too_many_arguments, clippy::needless_range_loop)] // `pid` also drives `is_set`/`printings[pid]` together, same shape as `walk_grouped_page`
+fn gather_composed_page<'a>(
+    mode: Mode,
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &AOffsets,
+    pbits: &[u64],
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    max_artwork_groups: u16,
+) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+    let candidate_cards = bitmap_card_ids(&printing_bits_to_card_bits(pbits, offsets, cards.len()));
+    let n = match mode {
+        Mode::Artwork => usize::from(max_artwork_groups),
+        Mode::Card => 1,
+        Mode::Printing => 0,
+    };
+    let mut group_best: Vec<Option<(u32, f64)>> = vec![None; n];
+    let mut touched: Vec<u16> = Vec::new();
+    let mut sel = GatherSelect::new(page_offset, limit);
+    for cid in candidate_cards {
+        let card = &cards[cid as usize];
+        let start = u32::from(offsets[cid as usize]) as usize;
+        let end = u32::from(offsets[cid as usize + 1]) as usize;
+        let before = sel.buf().len();
+        match mode {
+            // Printing: every set printing is its own row (no grouping).
+            Mode::Printing => {
+                for pid in start..end {
+                    if is_set(pid) {
+                        sel.buf().push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
+                    }
+                }
+            }
+            // Card, default prefer: printings are stored prefer-desc within a card (same invariant
+            // `push_card_matches` relies on), so the first *set* printing in range is already the
+            // chosen one — no score to compute, no `touched`/`group_best` bookkeeping, an O(1) early
+            // break instead of scanning the rest of the card's printings. This matters here (unlike
+            // `walk_grouped_page`, which pays the same unconditional score-every-candidate cost) since
+            // this loop isn't bounded by page size — it visits every candidate card, so a per-printing
+            // cost that scales with total matches rather than `limit` is the dominant term for a broad
+            // composed set.
+            Mode::Card if matches!(prefer, Prefer::Default) => {
+                if let Some(pid) = (start..end).find(|&pid| is_set(pid)) {
+                    sel.buf().push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
+                }
+            }
+            // Card (non-default prefer) / Artwork: one best-prefer representative per group.
+            Mode::Card | Mode::Artwork => {
+                touched.clear();
+                for pid in start..end {
+                    if !is_set(pid) {
+                        continue;
+                    }
+                    let gid = match mode {
+                        Mode::Artwork => u16::from(printings[pid].artwork_group_id) as usize,
+                        _ => 0, // Card: everything collapses into one group
+                    };
+                    debug_assert!(gid < group_best.len(), "group_best must be pre-sized to max_artwork_groups");
+                    let score = prefer_score(card, &printings[pid], prefer);
+                    match &group_best[gid] {
+                        None => {
+                            group_best[gid] = Some((pid as u32, score));
+                            touched.push(gid as u16);
+                        }
+                        Some((_, best)) if score > *best => group_best[gid] = Some((pid as u32, score)),
+                        _ => {}
+                    }
+                }
+                for &gid in &touched {
+                    let (bp, _) = group_best[gid as usize].take().unwrap(); // take: resets group_best for the next card
+                    sel.buf().push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
+                }
+            }
+        }
+        sel.absorb(before);
+    }
+    let (_total, page_ids) = sel.finish(page_offset, limit); // total already known exactly via popcount; only the page is wanted here
+    page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect()
+}
+
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
 /// applicability (`streamed_select_applicable`) and has run `prepare_candidates`.
 #[allow(clippy::too_many_arguments)]
@@ -5439,6 +5582,7 @@ fn run_query_routed<'a>(
         scatter_printings: 0,  // range-slice k — set by both range-plan acquire branches (costed per-plan)
         project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
+        compose_has_perm: false, // PrintingCompose overrides this (which paging strategy it'll actually use)
     };
     // Features for the general candidate path (shared by the acquire branch and the
     // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
@@ -5522,6 +5666,10 @@ fn run_query_routed<'a>(
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
+        // Which paging strategy the fastpath will actually use — a real permutation walk (cheap,
+        // offset-dependent) or the permutation-free bounded-gather fallback (visits every match,
+        // offset-independent cost). Decided the same way the fastpath itself decides.
+        feats.compose_has_perm = indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len());
         (feats, Prep::Range)
     } else {
         let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
@@ -5626,7 +5774,7 @@ fn run_query_with_plan<'a>(
             printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
         }
         PhysicalPlan::PrintingCompose => {
-            if !printing_compose_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+            if !printing_compose_applicable(filter, cards, plane, indexes) {
                 return None;
             }
             // The fastpath composes, projects per mode, and walks — or declines (None) on a sparse

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2552,9 +2552,12 @@ fn fuzz_row_identity_matches_reference() {
     const NUM_SEEDS: u64 = 96;
     const RANDOM_FILTERS_PER_STORE: usize = 10;
     const MAX_DEPTH: u8 = 3;
-    // edhrec/name/cmc have sort permutations (streamed path + inverse perms); usd has none, so it
-    // falls to the gathered, printing-keyed path. `desc` exercises the inverse perms / descending key.
-    const SORTS: [&str; 4] = ["edhrec", "name", "cmc", "usd"];
+    // edhrec/name/cmc have sort permutations (streamed path + inverse perms); usd/rarity have
+    // none, so they fall to the gathered, printing-keyed path (and, for a composable filter,
+    // PrintingCompose's own gather_composed_page fallback — see
+    // docs/issues/local-engine-compose-permutation-fallback.md). `desc` exercises the inverse
+    // perms / descending key.
+    const SORTS: [&str; 5] = ["edhrec", "name", "cmc", "usd", "rarity"];
     let pick_order = |rng: &mut rand::rngs::SmallRng| (SORTS[rng.random_range(0..SORTS.len())], if rng.random_bool(0.5) { "desc" } else { "asc" });
 
     // Small stores: broad predicate + structural combinatorics through the gather / small-total paths.
@@ -2726,7 +2729,7 @@ fn force_plan_differential_agreement() {
     const CORPUS_CARDS: usize = 6_000;
     const MAX_DEPTH: u8 = 3;
     const RANDOM_QUERIES: usize = 150;
-    const SORTS: [&str; 4] = ["edhrec", "name", "cmc", "usd"];
+    const SORTS: [&str; 5] = ["edhrec", "name", "cmc", "usd", "rarity"];
 
     let mut rng = rand::rngs::SmallRng::seed_from_u64(70_202);
     let data = fuzz_store_n(&mut rng, CORPUS_CARDS);
@@ -3288,7 +3291,7 @@ fn plan_cost_model_matches_gold() {
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -3515,7 +3518,7 @@ fn plan_cost_refit() {
                     scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -3713,7 +3716,7 @@ fn printing_range_route_probe() {
                 scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
             };
 
             // ── Three pickers ──
@@ -4074,7 +4077,7 @@ fn plan_regret_report() {
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -4201,7 +4204,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/docs/changelog/2026-07-23-compose-permutation-fallback.md
+++ b/docs/changelog/2026-07-23-compose-permutation-fallback.md
@@ -1,0 +1,31 @@
+# PrintingCompose permutation-free paging fallback
+
+`orderby=rarity`/`usd` have no card-space sort permutation (the representative printing depends on
+`prefer` and can't be precomputed), which made `PrintingCompose` decline outright for those orderbys
+regardless of how well a query's predicate narrowed — even though it already computes the exact
+composed bitmap and total *before* the permutation check, then threw both away.
+
+Added `gather_composed_page`: a permutation-free paging strategy reusing the same `GatherSelect`
+bounded accumulator `GatheredScan` already uses for its own permutation-less case, fed from the
+already-exact composed bits (no residual re-verification needed). Also fixed a real inefficiency
+copied from the permutation-based walk (`walk_grouped_page`): it always computed `prefer_score` for
+every matching printing, even under the common `Prefer::Default` case, where the first match is
+already the answer — fine when bounded by page size, not fine when visiting every candidate.
+
+Building the composed bitmap only pays for itself when narrowing actually shrinks the candidate set;
+for a near-total match it's pure overhead. Added `COMPOSE_GATHER_MAX_CARD_FRACTION` (0.85, measured
+directly, a different crossover from the existing `MAX_NARROW_FRACTION`) to decline in that case —
+using a balls-into-bins estimate (`domain·(1 − e^(−k/domain))`) rather than a naive `.min(domain)`
+cap, since the cap saturates identically for very different queries (checked: `cn<100` and `usd<50`
+both exceed `n_cards` and capped to the same value, losing the signal needed to tell them apart).
+
+Measured (97,206-printing corpus): `cn<100`/card/rarity 0.643-0.708ms → 0.298ms (2.2-2.4×),
+`cn<100 usd<50`/printing/rarity 1.154ms → 0.412ms (2.8×), `year>2020`/card/rarity 0.520ms → 0.339ms
+(1.53×). Near-total-broad bare ranges (`usd<50` at 99% of cards) correctly hold flat via the guard.
+Every `edhrec`-orderby and plane-only control held flat; `total` parity held everywhere.
+
+`fuzz_row_identity_matches_reference`'s sort sweep extended to include `rarity` (previously only
+`usd` exercised the no-permutation path). `cargo test` (debug + release) 128/128;
+`test_engine_property.py` + `test_engine_unit.py` 158/158.
+
+Design doc: `docs/issues/local-engine-compose-permutation-fallback.md`.

--- a/docs/issues/local-engine-compose-permutation-fallback.md
+++ b/docs/issues/local-engine-compose-permutation-fallback.md
@@ -1,0 +1,110 @@
+# Engine: `PrintingCompose` Permutation-Free Paging Fallback
+
+**Status: done.** No GitHub issue filed. Found while investigating a broad-survey slow query
+(`docs/issues/done/local-engine-watermark-postings.md`'s companion investigation).
+
+## Measured problem
+
+`SortCol::Rarity`/`PriceUsd` have no card-space sort permutation (`lib.rs:1762-1774`, doc: "the
+sort key depends on the prefer-chosen printing and cannot be precomputed"). That's a real
+correctness constraint, not an oversight — but it made `PrintingCompose`, `CardRangePopcount`, and
+`StreamedSelect` all decline outright whenever `orderby=rarity` or `orderby=usd`, regardless of how
+well the predicate narrows, because their applicability checks required a permutation for
+*paging*, even for plans whose *total* doesn't depend on one at all.
+
+`printing_compose_fastpath` (`lib.rs:4565`) already computed the exact composed bitmap and total
+unconditionally, before any permutation check — then discarded both and declined if no permutation
+existed. Border/rarity/legality bare queries don't have this problem (`split_planes` extracts them
+into `plane: Option<&PlaneExpr>` upstream of plan selection, and `prepare_candidates` has its own
+permutation-independent handling for that), but range leaves (`usd`/`cn`/`date`) only ever reached
+exactness through the permutation-gated compose plan.
+
+## What shipped
+
+1. **`gather_composed_page`** (new function, mirrors `walk_grouped_page`'s per-card/per-artwork
+   grouping logic exactly, minus the permutation): projects the composed `pbits` to the mode's
+   candidate ids (`bitmap_card_ids`), then pushes matches into `GatherSelect` — the same bounded,
+   pruned accumulator `GatheredScan` already uses for its own permutation-less case. No residual, no
+   `card_pass` — `pbits` is already exact.
+2. **A `Prefer::Default` fast path inside it**: printings are stored prefer-desc within a card, so
+   the first *set* printing is already the chosen one — no score to compute, no group bookkeeping.
+   This mattered here specifically (unlike `walk_grouped_page`, which is bounded by page size via
+   early-stop) because this loop visits every candidate regardless of `limit`/`offset`.
+3. **`printing_compose_applicable`** no longer requires a permutation (dropped `sort_col`/
+   `descending` params to match `printing_range_scan_applicable`'s tailored-signature precedent).
+4. **A dedicated broadness guard, `COMPOSE_GATHER_MAX_CARD_FRACTION`** (default 0.85): building
+   `pbits` only pays for itself when narrowing actually shrinks the candidate set
+   `gather_composed_page` visits. For a near-total match (e.g. `usd<50`/card at 99% of all cards),
+   the build is pure overhead with no compensating benefit — measured regressing 0.41ms → 0.49ms
+   before the guard existed. This is a *different* crossover from `MAX_NARROW_FRACTION` (a different
+   question — "is the build worth it without a cheap post-build walk" vs. "does narrowing shrink
+   the eval domain at all") and needed its own measurement, not reuse of the 0.25 constant.
+5. **`compose_has_perm`** (new `PlanFeatures` field): tells `cost::plan_cost`'s `PrintingCompose`
+   arm which paging strategy will actually run, since the two have different cost shapes (offset-
+   dependent walk vs. visit-every-match gather).
+
+## The estimation trap (two dead ends before landing this)
+
+The guard needs a cheap *mode-space* estimate (candidate cards/artworks, not raw matching
+printings) — `compose_printing_estimate` only gives a printing-space count, and:
+
+- **Checking the raw printing-space fraction directly** was wrong: `cn<100` is 36% of *printings*
+  (several low-collector-number printings per reprinted card) but the number that actually matters
+  is much lower. This wrongly declined a query that's genuinely worth composing.
+- **Projecting with a naive `.min(domain)` cap** was *also* wrong, in a way that took a second
+  round to find: both `cn<100` (35,021 matching printings) and `usd<50` (80,527) exceed `n_cards`
+  (31,508), so both saturate to the *identical* capped value. The cost model's only differentiating
+  signal collapsed for the two cases that most needed distinguishing.
+- **What actually works**: a balls-into-bins estimate — `k` matching printings landing across
+  `domain` cards, expected distinct cards touched ≈ `domain·(1 − e^(−k/domain))`. One `exp()` call,
+  doesn't saturate, and tracks the true count well enough to separate the cases that need
+  separating (checked against real totals: `cn<100` estimate 21,140 vs. true 17,616; `usd<50`
+  estimate 29,062 vs. true 31,217 — clearly distinguishable, unlike the identical capped estimate).
+
+For `Mode::Artwork`, the true domain is `n_artworks` (≥ `n_cards`), but computing it exactly means
+building `artwork_base` — real O(n_cards) work paid just to *maybe* decline. `cards.len()` is used
+as a cheap, conservative stand-in instead (only ever makes the estimated fraction look more broad
+than reality, erring toward declining — same conservative lean the threshold itself was calibrated
+with).
+
+## Measured (targeted, `scripts/bench_compose_permutation_fallback.py`, 97,206-printing corpus)
+
+| query | unique | orderby | before (ms) | after (ms) | change |
+|---|---|---|---:|---:|---|
+| `usd<50` | card | rarity | 0.413 | 0.408 | flat |
+| `usd<50` | card | usd | 0.420 | 0.411 | flat |
+| `usd<50` | artwork | rarity | 0.757 | 0.752 | flat |
+| `cn<100` | card | rarity | 0.643-0.708 | 0.298 | **2.2-2.4×** |
+| `cn<100` | artwork | rarity | 0.857 | 0.465 | **1.84×** |
+| `year>2020` | card | rarity | 0.520 | 0.339 | **1.53×** |
+| `year>2020` | artwork | rarity | 0.741 | 0.557 | **1.33×** |
+| `cn<100 usd<50` | printing | rarity | 1.154 | 0.412 | **2.8×** |
+| `cn<100 usd<50` | card | rarity | 0.825 | 0.320 | **2.6×** |
+| `border:black` (control) | card | rarity | 0.358 | 0.345 | flat |
+| `t:creature` (control) | card | edhrec | 0.063 | 0.062 | flat |
+
+Every `edhrec`-orderby control and every plane-only control (`border:black`, `r:rare`, `f:modern`)
+held flat. `total` parity held across every row, every run. Full CSVs under
+`benchmarks/compose-permutation-fallback/` (untracked, per the performance-PR workflow).
+
+Broad realistic-traffic survey (`scripts/survey_queries.py`, same seed, 1000 queries): no new
+regressions; `rarity`/`usd`-orderby groups' p90 improved, everything else flat within noise.
+
+## Testing
+
+- New/widened Rust coverage: `fuzz_row_identity_matches_reference`'s `SORTS` sweep extended to
+  include `rarity` (previously only `usd` exercised the no-permutation path at all) — this is a
+  differential suite against a reference oracle, across random filter structures, all three
+  distinct-ons, both directions. `cargo test` (debug + release): 128/128 passed both times across
+  every iteration of this change.
+- `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
+
+## Related
+
+- [done/local-engine-watermark-postings.md](done/local-engine-watermark-postings.md) — the sibling
+  investigation this was found alongside.
+- [done/00724-engine-printing-existential-planes.md](done/00724-engine-printing-existential-planes.md)
+  — `PrintingCompose`'s substrate.
+- [00731-engine-compose-universal-evaluator.md](00731-engine-compose-universal-evaluator.md) — the
+  compose leaf-source generalization this builds on top of.
+- `docs/workflows/performance-pr-workflow.md` — the measure-first process this followed.

--- a/scripts/bench_compose_permutation_fallback.py
+++ b/scripts/bench_compose_permutation_fallback.py
@@ -1,0 +1,106 @@
+"""Targeted benchmark for the PrintingCompose permutation-fallback idea.
+
+`orderby=rarity`/`usd` have no card-space sort permutation (`SortCol::Rarity`/`PriceUsd` return
+`None` — the representative printing depends on `prefer` and cannot be precomputed). Today that
+makes `PrintingCompose`/`CardRangePopcount`/`StreamedSelect`/(`PrintingRangeScan`'s non-aligned
+case) all decline outright, even though `printing_compose_fastpath` already computes an exact
+composed bitmap and total *before* the permutation check — it's just thrown away. Times
+engine.query() for a fixed set of (query, unique, orderby) configs so the same script run on two
+builds (main baseline vs. this branch) produces directly comparable CSVs.
+
+    .venv/bin/python scripts/bench_compose_permutation_fallback.py \
+        --out benchmarks/compose-permutation-fallback/baseline-main-<sha>.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. `total` doubles as the
+parity check — must be identical across builds for every config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+# `edhrec` rows are controls (already fast via a real permutation; must not regress). `rarity`/`usd`
+# rows are the affected case for every group except `control` and `printing`+`usd` (already fast via
+# PrintingRangeScan's aligned_page, since predicate and orderby are both usd).
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # Bare usd range: card/artwork are broken on both rarity and usd orderby; printing is broken
+    # only on rarity (usd is the aligned case, already fast).
+    ("bare_usd", "usd<50", "card", "edhrec", "default"),
+    ("bare_usd", "usd<50", "card", "rarity", "default"),
+    ("bare_usd", "usd<50", "card", "usd", "default"),
+    ("bare_usd", "usd<50", "artwork", "edhrec", "default"),
+    ("bare_usd", "usd<50", "artwork", "rarity", "default"),
+    ("bare_usd", "usd<50", "artwork", "usd", "default"),
+    ("bare_usd", "usd<50", "printing", "edhrec", "default"),
+    ("bare_usd", "usd<50", "printing", "rarity", "default"),
+    ("bare_usd", "usd<50", "printing", "usd", "default"),
+    # Bare cn / date ranges: same shape, no aligned-case escape hatch at all (cn/date are never the
+    # orderby), so every non-edhrec row here is affected.
+    ("bare_cn", "cn<100", "card", "edhrec", "default"),
+    ("bare_cn", "cn<100", "card", "rarity", "default"),
+    ("bare_cn", "cn<100", "artwork", "rarity", "default"),
+    ("bare_cn", "cn<100", "printing", "rarity", "default"),
+    ("bare_year", "year>2020", "card", "edhrec", "default"),
+    ("bare_year", "year>2020", "card", "rarity", "default"),
+    ("bare_year", "year>2020", "artwork", "rarity", "default"),
+    # Range + plane compounds (#733's shared-witness compose case).
+    ("compound_range_plane", "usd<50 border:black", "card", "edhrec", "default"),
+    ("compound_range_plane", "usd<50 border:black", "card", "rarity", "default"),
+    ("compound_range_plane", "usd<50 border:black", "artwork", "rarity", "default"),
+    ("compound_range_plane", "cn<100 f:modern", "card", "rarity", "default"),
+    # Range + range compound.
+    ("compound_range_range", "cn<100 usd<50", "printing", "edhrec", "default"),
+    ("compound_range_range", "cn<100 usd<50", "printing", "rarity", "default"),
+    ("compound_range_range", "cn<100 usd<50", "card", "rarity", "default"),
+    # Controls: plane-only (border/rarity/legality), no range leaf at all — already exact-without-
+    # permutation via split_planes + prepare_candidates's own plane handling. Must stay flat.
+    ("control", "border:black", "card", "rarity", "default"),
+    ("control", "r:rare", "card", "rarity", "default"),
+    ("control", "f:modern", "card", "usd", "default"),
+    ("control", "t:creature", "card", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=5.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<21} {'query':<22} {'unique':<9} {'orderby':<8} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<21} {query:<22} {unique:<9} {orderby:<8} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- `orderby=rarity`/`usd` have no card-space sort permutation (representative printing depends on `prefer`, can't be precomputed), which made `PrintingCompose` decline outright for those orderbys — even though it already computes the exact composed bitmap/total *before* the permutation check, then threw both away.
- Added `gather_composed_page`: reuses the same `GatherSelect` bounded accumulator `GatheredScan` already uses for permutation-less paging, fed from the already-exact composed bits (no residual re-verification).
- Fixed a real inefficiency copied from `walk_grouped_page`: it always computed `prefer_score` for every matching printing even under `Prefer::Default`, where the first match is already the answer — harmless when bounded by page size, not harmless when visiting every candidate.
- Added `COMPOSE_GATHER_MAX_CARD_FRACTION` (0.85, measured directly — a different crossover from the existing `MAX_NARROW_FRACTION`) to decline building the composed bitmap when narrowing wouldn't shrink the candidate set enough to be worth it. Uses a balls-into-bins estimate (`domain·(1 − e^(−k/domain))`) rather than a naive `.min(domain)` cap — the cap saturates identically for very different queries (`usd<50` and `cn<100` both exceed `n_cards` and cap to the same value), losing the signal needed to route between them correctly.

## Performance

97,206-printing corpus, `scripts/bench_compose_permutation_fallback.py`, min ms, interleaved same build:

| Benchmark | Before (ms) | After (ms) | Change |
|---|---:|---:|---|
| `usd<50` / card / rarity | 0.413 | 0.408 | flat (correctly declined — near-total match) |
| `usd<50` / artwork / rarity | 0.757 | 0.752 | flat |
| `cn<100` / card / rarity | 0.643-0.708 | 0.298 | **2.2-2.4×** |
| `cn<100` / artwork / rarity | 0.857 | 0.465 | **1.84×** |
| `year>2020` / card / rarity | 0.520 | 0.339 | **1.53×** |
| `year>2020` / artwork / rarity | 0.741 | 0.557 | **1.33×** |
| `cn<100 usd<50` / printing / rarity | 1.154 | 0.412 | **2.8×** |
| `cn<100 usd<50` / card / rarity | 0.825 | 0.320 | **2.6×** |
| `border:black` (control) / card / rarity | 0.358 | 0.345 | flat |
| `t:creature` (control) / card / edhrec | 0.063 | 0.062 | flat |

`total` parity held on every row across every run. Every `edhrec`-orderby control and every plane-only control held flat. Broad realistic-traffic survey (`scripts/survey_queries.py`, 1000 queries, same seed): no new regressions, `rarity`/`usd`-orderby groups' p90 improved.

## Test plan

- [x] New/widened Rust coverage: `fuzz_row_identity_matches_reference`'s sort sweep extended to include `rarity` (previously only `usd` exercised the no-permutation path at all) — differential suite against a reference oracle, all three distinct-ons, both directions.
- [x] `cargo test` (debug + release): 128/128 passed.
- [x] `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
- [x] `cargo clippy`: unchanged from baseline (42 warnings, verified via a clean `main` worktree diff).

Design doc: `docs/issues/local-engine-compose-permutation-fallback.md` (includes the two estimation dead ends before landing the balls-into-bins approach, and the artwork-mode domain simplification to avoid a redundant O(n_cards) build in the cheap pre-check).