### PR TITLE
Engine: Negated-Range Narrowing (-usd<c, -cn<c, -date/-year)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2709,12 +2709,16 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
         // nullable, and this classifier previously claimed `Some(true)` unconditionally, which the
         // generic Not-arm below would have trusted to bit-complement a tight DateCmp/YearCmp
         // set — wrongly pulling in every NULL-dated printing (absent from the index, not failing a
-        // bound check) as a false match for e.g. `-year:1993`. The four ordered ops now narrow
-        // exactly through `bare_range_bounds`'s own `Not` handling instead (no complement, no NULL
-        // risk); `Eq`'s negation (`Ne`) isn't a representable range either way and correctly
+        // bound check) into the *candidate* set for e.g. `-year:1993`. Not a wrong final answer —
+        // `narrow_candidates_exact`'s exactness check reads the complement's own (always-loose)
+        // `.tight` field, not this classifier, so residual `card_pass` verification still ran and
+        // dropped the NULL-dated printings before any total/page was returned — but a real,
+        // avoidable cost regression (an unnecessary complement built and then fully re-verified) for
+        // any negated `DateCmp`/`YearCmp` query. The four ordered ops now narrow exactly through
+        // `bare_range_bounds`'s own `Not` handling instead (no complement, no NULL risk, no wasted
+        // verification); `Eq`'s negation (`Ne`) isn't a representable range either way and correctly
         // declines via that path already — so nothing is lost by removing this from the "safe to
-        // complement" list, and a real bug (silently wrong `-date`/`-year` results whenever a NULL
-        // release date exists in the corpus) is fixed by it.
+        // complement" list.
         FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => None,
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, .. } => Some(true),
         FilterExpr::ArtistMatch { .. } | FilterExpr::FlavorMatch { .. } => Some(true),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2804,6 +2804,36 @@ fn narrow_candidates(
 /// real traffic argues for moving it.
 static AND_SKIP_THRESHOLD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_AND_SKIP_THRESHOLD", 2_048));
 
+/// Whether `narrow_rec` resolves `Not(inner)` via a fresh, cheap re-narrow (`-r:x`'s dedicated arm,
+/// or `bare_range_bounds`'s `Not` handling for `-usd<c`/`-cn<c`/`-date`/`-year`) rather than falling
+/// through to the generic bit-complement arm (or, for `Eq`/`Ne`, declining outright). `and_child_rank`
+/// has no `indexes` parameter, so — unlike `is_printing_composable`/`compose_printing_bits`/
+/// `compose_printing_estimate`, which all call `bare_range_bounds(filter, indexes)` directly to
+/// double-check — this reimplements the same field/op classification without an index lookup: the
+/// eligibility question ("is this field printing-range-indexed, is this op one of the four ordered
+/// ones") never actually depends on the runtime `indexes` value, only `resolve_numeric_range_leaf`'s
+/// *use* of it (fetching the index reference) does. Must stay in sync with `bare_range_bounds`'s
+/// `Not` arm and `narrow_rec`'s `-r:x` arm — a field/op this says yes to but either of those declines
+/// on reintroduces the same rank/execution mismatch this replaces.
+fn not_child_is_cheap_renarrow(f: &FilterExpr) -> bool {
+    let ordered = |op: CmpOp| matches!(op, CmpOp::Lt | CmpOp::Le | CmpOp::Gt | CmpOp::Ge);
+    let is_range_field = |e: &NumExpr| matches!(e, NumExpr::Field(NumField::PriceUsd | NumField::CollectorNumberInt));
+    match f {
+        // `-r:x`: rarity's own dedicated arm re-narrows for *any* op (`narrow_rarity` isn't limited
+        // to the four ordered ones the printing-range path needs — see that arm's doc).
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }
+        | FilterExpr::NumericCmp { rhs: NumExpr::Field(NumField::RarityInt), .. } => true,
+        // `-usd<c` / `-cn<c`: only the four ordered ops reduce (`Eq`'s negation, `Ne`, isn't a single
+        // range — see `bare_range_bounds`'s doc); only price/collector-number are printing-range-
+        // indexed (cmc/power/toughness are card-space and fall through to the generic complement,
+        // which is a different, correctly-rank-2 cost shape).
+        FilterExpr::NumericCmp { lhs, op, rhs } => ordered(*op) && (is_range_field(lhs) || is_range_field(rhs)),
+        // `-date>c` / `-year>=c`: same ordered-ops-only reduction, no field question (there's only one).
+        FilterExpr::DateCmp { op, .. } | FilterExpr::YearCmp { op, .. } => ordered(*op),
+        _ => false,
+    }
+}
+
 /// Evaluation-cost rank for And children: cheap sources first (postings,
 /// planes, card numerics, trigram lookups), printing-space ranges second
 /// (their broad form pays an O(k) scatter), complements last (broad by
@@ -2817,10 +2847,13 @@ fn and_child_rank(f: &FilterExpr) -> u8 {
         // these cheap shapes was wrongly deprioritized and skipped by the And early-stop as soon as
         // a sibling child had already narrowed — silently losing the negated child's own narrowing,
         // not a correctness bug (the driver's residual verification still catches it) but a real,
-        // avoidable cost regression for `-usd<c` mixed with any other And child).
-        FilterExpr::Not(inner) if matches!(inner.as_ref(), FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }) => {
-            and_child_rank(inner)
-        }
+        // avoidable cost regression for `-usd<c` mixed with any other And child). Guarded on
+        // `not_child_is_cheap_renarrow` rather than the broader `NumericCmp{..}|DateCmp{..}|YearCmp{..}`
+        // shape check this replaces: that broader check fired for e.g. `-cmc:3` or `-usd:5` (negated
+        // equality) too, which `narrow_rec` actually resolves via the generic complement (or declines
+        // outright for `Eq`/`Ne`) — a rank/execution mismatch, same class of bug as the two above it,
+        // caught in review rather than by the differential test.
+        FilterExpr::Not(inner) if not_child_is_cheap_renarrow(inner) => and_child_rank(inner),
         FilterExpr::Not(_) => 2,
         // Regex trigram-narrow (#734 step 3) is second-tier: its literal factor may be broad (`flying`),
         // so pay for it only after cheap plane/posting sources — the And early-stop then skips it when a

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2704,7 +2704,18 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
                 _ => None,
             }
         }
-        FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => Some(true),
+        // Absent deliberately, same reasoning as price above (found while adding negated-range
+        // narrowing, docs/issues/local-engine-negated-range-narrowing.md): `released_at` is
+        // nullable, and this classifier previously claimed `Some(true)` unconditionally, which the
+        // generic Not-arm below would have trusted to bit-complement a tight DateCmp/YearCmp
+        // set — wrongly pulling in every NULL-dated printing (absent from the index, not failing a
+        // bound check) as a false match for e.g. `-year:1993`. The four ordered ops now narrow
+        // exactly through `bare_range_bounds`'s own `Not` handling instead (no complement, no NULL
+        // risk); `Eq`'s negation (`Ne`) isn't a representable range either way and correctly
+        // declines via that path already — so nothing is lost by removing this from the "safe to
+        // complement" list, and a real bug (silently wrong `-date`/`-year` results whenever a NULL
+        // release date exists in the corpus) is fixed by it.
+        FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => None,
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, .. } => Some(true),
         FilterExpr::ArtistMatch { .. } | FilterExpr::FlavorMatch { .. } => Some(true),
         FilterExpr::And(children) | FilterExpr::Or(children) => {
@@ -2795,6 +2806,17 @@ static AND_SKIP_THRESHOLD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_EN
 /// construction, useful only when nothing else narrowed).
 fn and_child_rank(f: &FilterExpr) -> u8 {
     match f {
+        // `-usd<c` / `-cn<c` / `-date>c` / `-year>=c` / `-r:x` all reduce to a fresh, cheap re-narrow
+        // via `negate_op` (see `bare_range_bounds`'s doc, and the `-r:x` arm in `narrow_rec`) — not a
+        // broad complement. Rank them exactly like their un-negated inner form, not the generic
+        // Not-complement's rank 2 below (which used to catch these too: any `Not` wrapping one of
+        // these cheap shapes was wrongly deprioritized and skipped by the And early-stop as soon as
+        // a sibling child had already narrowed — silently losing the negated child's own narrowing,
+        // not a correctness bug (the driver's residual verification still catches it) but a real,
+        // avoidable cost regression for `-usd<c` mixed with any other And child).
+        FilterExpr::Not(inner) if matches!(inner.as_ref(), FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }) => {
+            and_child_rank(inner)
+        }
         FilterExpr::Not(_) => 2,
         // Regex trigram-narrow (#734 step 3) is second-tier: its literal factor may be broad (`flying`),
         // so pay for it only after cheap plane/posting sources — the And early-stop then skips it when a
@@ -3155,6 +3177,32 @@ fn narrow_rec(
                 (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) => narrow_rarity(indexes, n_cards, negate_op(*op), *v),
                 (NumExpr::Const(v), NumExpr::Field(NumField::RarityInt)) => narrow_rarity(indexes, n_cards, negate_op(flip_op(*op)), *v),
                 _ => unreachable!(),
+            }
+        }
+
+        // -usd<c / -cn<c / -date>c / -year>=c: same reasoning as -r:x above (NOT(x op c) ==
+        // x negate_op(op) c, exact per negate_op's doc), but for the printing-range-indexed fields
+        // instead of rarity's card-space postings — `bare_range_bounds` already resolves both the
+        // field dispatch and the negation (see its doc), so this arm is just "ask it, then narrow or
+        // prove empty," not a second implementation of the field-matching logic above. Guarded on
+        // the inner shape so cmc/power/toughness (tight card-space, correctly handled by the
+        // generic Not-complement below) and -r:x (the arm just above) aren't intercepted here.
+        // `broad_ok` is forced `true` regardless of the caller's own value — same choice the
+        // generic Not-arm below already makes for its inner check (always narrows with
+        // `broad_ok: true`): negating a predicate is exactly the shape where the flipped bounds are
+        // worth computing even when broad, since there's no cheaper alternative once we're already
+        // committed to this field (measured: without forcing this, a broad negated range like
+        // `-cn<100` — `cn>=100`, ~64% of printings — declined to a full scan and *regressed* 0.545ms
+        // → 0.661ms vs. before this arm existed at all).
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. })
+                && bare_range_bounds(filter, indexes).is_some() =>
+        {
+            let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");
+            if lo >= hi {
+                Narrowed::tight(Candidates::Printings(Vec::new()))
+            } else {
+                range_narrowed(idx, lo, hi, n_printings, true, true)
             }
         }
 
@@ -4030,21 +4078,44 @@ static PRINTING_COMPOSE: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGI
 /// zero-width `[v, v)` so the fastpath's `k` resolves to 0. Reuses the exact bound derivations the
 /// narrowing path uses (`int_range_bounds`, [`date_range_bounds`], [`year_range_bounds`]) so the
 /// fastpath and `narrow_rec` can never disagree on which printings a predicate covers.
+/// Which printing-range index a bare `NumericCmp` targets, plus its op normalized to `field op
+/// const` order (`flip_op` undoes a `const op field` parse) — shared by `bare_range_bounds`'s direct
+/// and negated (`Not`) cases so the field/operand-order dispatch is written once. Only
+/// price/collector-number are printing-range-indexed; cmc/power/toughness/rarity are card-space and
+/// belong to other paths.
+fn resolve_numeric_range_leaf<'i>(
+    lhs: &NumExpr,
+    op: CmpOp,
+    rhs: &NumExpr,
+    indexes: &'i Archived<CardIndexes>,
+) -> Option<(&'i Archived<PrintingRangeIndex>, CmpOp, f64)> {
+    match (lhs, rhs) {
+        (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => Some((&indexes.price_usd, op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))),
+        (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => Some((&indexes.price_usd, flip_op(op), snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR))),
+        (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => Some((&indexes.collector_number, op, *v)),
+        (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => Some((&indexes.collector_number, flip_op(op), *v)),
+        _ => None,
+    }
+}
+
+/// Bare bounds for a printing-range-indexed comparison — `usd`/`cn`/`date`/`year` — and, since
+/// `NOT(x op c) == x negate_op(op) c` is exact under this engine's null semantics (`negate_op`'s own
+/// doc: verified against `tri()`'s actual `NumVal::Null` short-circuit, the same guarantee
+/// `narrow_rec`'s `-r:x` arm already relies on), a `Not` wrapping one of these four shapes too —
+/// `-usd<50` becomes `usd>=50`'s bounds directly, no complement, no residual. `Eq`/`Ne` don't reduce
+/// this way (`Ne` isn't a single half-open range), but nothing needs to special-case that:
+/// `int_range_bounds`/`date_range_bounds`/`year_range_bounds` already return `None` for `Ne`
+/// (`negate_op(Eq) == Ne`), so a negated equality falls out on its own. Every caller of this function
+/// — `narrow_rec`'s own range narrowing, `is_printing_composable`, `compose_printing_estimate`,
+/// `compose_printing_bits` — gets the negated shape for free; none of them special-case `Not`
+/// themselves (docs/issues/local-engine-negated-range-narrowing.md).
 fn bare_range_bounds<'i>(
     filter: &FilterExpr,
     indexes: &'i Archived<CardIndexes>,
 ) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
     match filter {
         FilterExpr::NumericCmp { lhs, op, rhs } => {
-            // Only price/collector-number are printing-range-indexed; cmc/power/toughness/rarity are
-            // card-space and belong to other paths. Value snapping matches narrow_rec's `price` closure.
-            let (idx, op, value) = match (lhs, rhs) {
-                (NumExpr::Field(NumField::PriceUsd), NumExpr::Const(v)) => (&indexes.price_usd, *op, snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
-                (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => (&indexes.price_usd, flip_op(*op), snap_to_nearest_cent(*v * PRICE_CENTS_PER_DOLLAR)),
-                (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => (&indexes.collector_number, *op, *v),
-                (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => (&indexes.collector_number, flip_op(*op), *v),
-                _ => return None,
-            };
+            let (idx, op, value) = resolve_numeric_range_leaf(lhs, *op, rhs, indexes)?;
             match int_range_bounds(op, value)? {
                 None => Some((idx, 0, 0)),
                 Some((lo, hi)) => Some((idx, lo, hi)),
@@ -4058,6 +4129,24 @@ fn bare_range_bounds<'i>(
             let (lo, hi) = year_range_bounds(*op, *year)?;
             Some((&indexes.released_at, lo, hi))
         }
+        FilterExpr::Not(inner) => match inner.as_ref() {
+            FilterExpr::NumericCmp { lhs, op, rhs } => {
+                let (idx, op, value) = resolve_numeric_range_leaf(lhs, negate_op(*op), rhs, indexes)?;
+                match int_range_bounds(op, value)? {
+                    None => Some((idx, 0, 0)),
+                    Some((lo, hi)) => Some((idx, lo, hi)),
+                }
+            }
+            FilterExpr::DateCmp { op, value } => {
+                let (lo, hi) = date_range_bounds(negate_op(*op), *value)?;
+                Some((&indexes.released_at, lo, hi))
+            }
+            FilterExpr::YearCmp { op, year } => {
+                let (lo, hi) = year_range_bounds(negate_op(*op), *year)?;
+                Some((&indexes.released_at, lo, hi))
+            }
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -4328,10 +4417,18 @@ fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) 
         // #731: usd/cn/date range leaves — the in-range index slice scatters into an exact printing
         // bitmap (`range_leaf_bits`). `bare_range_bounds` recognizes the printing-range-indexed shape
         // and returns its `[lo,hi)` bounds: the ordered ops, and `Eq` too (a narrow `[v, v+1)`). Only
-        // `Ne`, a negation, or a card-space field (cmc/power/rarity) yields `None` → stays on the
-        // general path. This is what lets a range compose with border/rarity/legality — and
-        // range∧range — exactly, in any distinct-on.
+        // `Ne` or a card-space field (cmc/power/rarity) yields `None` → stays on the general path.
+        // This is what lets a range compose with border/rarity/legality — and range∧range — exactly,
+        // in any distinct-on.
         FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } => {
+            bare_range_bounds(filter, indexes).is_some()
+        }
+        // `-usd<50` etc.: `bare_range_bounds` reduces this to the flipped comparison's bounds
+        // directly (see its doc) — composable exactly like the bare case above. Guarded on the
+        // inner shape (not a bare `Not(_)` catch-all) so this doesn't also try to claim
+        // `-border:`/`-r:`/`-f:`, which have their own dedicated (non-range) Not handling elsewhere
+        // and stay non-composable here, same as before this arm existed.
+        FilterExpr::Not(inner) if matches!(inner.as_ref(), FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }) => {
             bare_range_bounds(filter, indexes).is_some()
         }
         _ => false,
@@ -4499,7 +4596,7 @@ fn compose_printing_bits(
         FilterExpr::Legality { shift: Some(shift), expected } => {
             legality_leaf_bits(*shift, *expected, indexes, offsets, printings, n_printings)
         }
-        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }
+        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } | FilterExpr::Not(_)
             if bare_range_bounds(filter, indexes).is_some() =>
         {
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");
@@ -4554,9 +4651,10 @@ fn compose_printing_estimate(
             let est = if n_cards == 0 { 0 } else { card_exists * n_printings / n_cards };
             (est, est, 0)
         }
-        // Range: `k` in-range printings from the index partition points (O(log n), no scatter here);
-        // matches ≈ k, and k rides `scatter` — the cheap range-slice scatter into the printing bitmap.
-        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. }
+        // Range (bare or negated — `-usd<50` etc., see `bare_range_bounds`'s doc): `k` in-range
+        // printings from the index partition points (O(log n), no scatter here); matches ≈ k, and k
+        // rides `scatter` — the cheap range-slice scatter into the printing bitmap.
+        FilterExpr::NumericCmp { .. } | FilterExpr::DateCmp { .. } | FilterExpr::YearCmp { .. } | FilterExpr::Not(_)
             if bare_range_bounds(filter, indexes).is_some() =>
         {
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2804,21 +2804,29 @@ fn narrow_candidates(
 /// real traffic argues for moving it.
 static AND_SKIP_THRESHOLD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_AND_SKIP_THRESHOLD", 2_048));
 
-/// Whether `narrow_rec` resolves `Not(inner)` via a fresh, cheap re-narrow (`-r:x`'s dedicated arm,
-/// or `bare_range_bounds`'s `Not` handling for `-usd<c`/`-cn<c`/`-date`/`-year`) rather than falling
-/// through to the generic bit-complement arm (or, for `Eq`/`Ne`, declining outright). `and_child_rank`
-/// has no `indexes` parameter, so — unlike `is_printing_composable`/`compose_printing_bits`/
-/// `compose_printing_estimate`, which all call `bare_range_bounds(filter, indexes)` directly to
-/// double-check — this reimplements the same field/op classification without an index lookup: the
-/// eligibility question ("is this field printing-range-indexed, is this op one of the four ordered
-/// ones") never actually depends on the runtime `indexes` value, only `resolve_numeric_range_leaf`'s
-/// *use* of it (fetching the index reference) does. Must stay in sync with `bare_range_bounds`'s
-/// `Not` arm and `narrow_rec`'s `-r:x` arm — a field/op this says yes to but either of those declines
-/// on reintroduces the same rank/execution mismatch this replaces.
+/// Whether `narrow_rec` resolves `Not(inner)` via a fresh, cheap re-narrow — `-f:x`'s or `-r:x`'s own
+/// dedicated arm (reads a status/rarity plane directly), or `bare_range_bounds`'s `Not` handling for
+/// `-usd<c`/`-cn<c`/`-date`/`-year` — rather than falling through to the generic bit-complement arm
+/// (or, for `Eq`/`Ne`, declining outright). `and_child_rank` has no `indexes` parameter, so — unlike
+/// `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate`, which all call
+/// `bare_range_bounds(filter, indexes)` directly to double-check — this reimplements the same
+/// field/op classification without an index lookup: none of these three arms' eligibility questions
+/// ("is this format's plane tracked," "is this field printing-range-indexed," "is this op one of the
+/// four ordered ones") actually depend on the runtime `indexes` *value* — only their actual narrowing
+/// work does. Must stay in sync with all three dedicated arms (`narrow_rec`'s `-f:x`/`-r:x` arms and
+/// `bare_range_bounds`'s `Not` handling) — a shape this says yes to but any of those declines on
+/// reintroduces the same rank/execution mismatch this replaces.
 fn not_child_is_cheap_renarrow(f: &FilterExpr) -> bool {
     let ordered = |op: CmpOp| matches!(op, CmpOp::Lt | CmpOp::Le | CmpOp::Gt | CmpOp::Ge);
     let is_range_field = |e: &NumExpr| matches!(e, NumExpr::Field(NumField::PriceUsd | NumField::CollectorNumberInt));
     match f {
+        // `-f:x` / `-banned:x` / `-restricted:x`: reads the status's own `_ABSENT`/`_ILLEGAL` plane
+        // directly (`legality_candidate_bits(..., true)`), not a complement of the positive plane —
+        // same "dedicated re-narrow, not a complement" shape as `-r:x` below, so it shares its bare
+        // form's rank rather than the generic Not-complement's. `status_plane_bases(*expected).is_some()`
+        // mirrors the dedicated arm's own guard exactly: an untracked format (no indexed plane) isn't
+        // this shape and correctly falls through to the generic tier instead.
+        FilterExpr::Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some() => true,
         // `-r:x`: rarity's own dedicated arm re-narrows for *any* op (`narrow_rarity` isn't limited
         // to the four ordered ones the printing-range path needs — see that arm's doc).
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }
@@ -2840,9 +2848,10 @@ fn not_child_is_cheap_renarrow(f: &FilterExpr) -> bool {
 /// construction, useful only when nothing else narrowed).
 fn and_child_rank(f: &FilterExpr) -> u8 {
     match f {
-        // `-usd<c` / `-cn<c` / `-date>c` / `-year>=c` / `-r:x` all reduce to a fresh, cheap re-narrow
-        // via `negate_op` (see `bare_range_bounds`'s doc, and the `-r:x` arm in `narrow_rec`) — not a
-        // broad complement. Rank them exactly like their un-negated inner form, not the generic
+        // `-usd<c` / `-cn<c` / `-date>c` / `-year>=c` / `-r:x` / `-f:x` all reduce to a fresh, cheap
+        // re-narrow (`negate_op` for the first four, see `bare_range_bounds`'s doc; a dedicated plane
+        // read for `-r:x`/`-f:x`, see their `narrow_rec` arms) — not a broad complement. Rank them
+        // exactly like their un-negated inner form, not the generic
         // Not-complement's rank 2 below (which used to catch these too: any `Not` wrapping one of
         // these cheap shapes was wrongly deprioritized and skipped by the And early-stop as soon as
         // a sibling child had already narrowed — silently losing the negated child's own narrowing,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2804,65 +2804,56 @@ fn narrow_candidates(
 /// real traffic argues for moving it.
 static AND_SKIP_THRESHOLD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_AND_SKIP_THRESHOLD", 2_048));
 
-/// Whether `narrow_rec` resolves `Not(inner)` via a fresh, cheap re-narrow — `-f:x`'s or `-r:x`'s own
-/// dedicated arm (reads a status/rarity plane directly), or `bare_range_bounds`'s `Not` handling for
-/// `-usd<c`/`-cn<c`/`-date`/`-year` — rather than falling through to the generic bit-complement arm
-/// (or, for `Eq`/`Ne`, declining outright). `and_child_rank` has no `indexes` parameter, so — unlike
-/// `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate`, which all call
-/// `bare_range_bounds(filter, indexes)` directly to double-check — this reimplements the same
-/// field/op classification without an index lookup: none of these three arms' eligibility questions
-/// ("is this format's plane tracked," "is this field printing-range-indexed," "is this op one of the
-/// four ordered ones") actually depend on the runtime `indexes` *value* — only their actual narrowing
-/// work does. Must stay in sync with all three dedicated arms (`narrow_rec`'s `-f:x`/`-r:x` arms and
-/// `bare_range_bounds`'s `Not` handling) — a shape this says yes to but any of those declines on
-/// reintroduces the same rank/execution mismatch this replaces.
-fn not_child_is_cheap_renarrow(f: &FilterExpr) -> bool {
-    let ordered = |op: CmpOp| matches!(op, CmpOp::Lt | CmpOp::Le | CmpOp::Gt | CmpOp::Ge);
-    let is_range_field = |e: &NumExpr| matches!(e, NumExpr::Field(NumField::PriceUsd | NumField::CollectorNumberInt));
-    match f {
-        // `-f:x` / `-banned:x` / `-restricted:x`: reads the status's own `_ABSENT`/`_ILLEGAL` plane
-        // directly (`legality_candidate_bits(..., true)`), not a complement of the positive plane —
-        // same "dedicated re-narrow, not a complement" shape as `-r:x` below, so it shares its bare
-        // form's rank rather than the generic Not-complement's. `status_plane_bases(*expected).is_some()`
-        // mirrors the dedicated arm's own guard exactly: an untracked format (no indexed plane) isn't
-        // this shape and correctly falls through to the generic tier instead.
-        FilterExpr::Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some() => true,
-        // `-r:x`: rarity's own dedicated arm re-narrows for *any* op (`narrow_rarity` isn't limited
-        // to the four ordered ones the printing-range path needs — see that arm's doc).
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), .. }
-        | FilterExpr::NumericCmp { rhs: NumExpr::Field(NumField::RarityInt), .. } => true,
-        // `-usd<c` / `-cn<c`: only the four ordered ops reduce (`Eq`'s negation, `Ne`, isn't a single
-        // range — see `bare_range_bounds`'s doc); only price/collector-number are printing-range-
-        // indexed (cmc/power/toughness are card-space and fall through to the generic complement,
-        // which is a different, correctly-rank-2 cost shape).
-        FilterExpr::NumericCmp { lhs, op, rhs } => ordered(*op) && (is_range_field(lhs) || is_range_field(rhs)),
-        // `-date>c` / `-year>=c`: same ordered-ops-only reduction, no field question (there's only one).
-        FilterExpr::DateCmp { op, .. } | FilterExpr::YearCmp { op, .. } => ordered(*op),
-        _ => false,
-    }
+/// `-r:x`'s dedicated shape: a rarity comparison, any op (`narrow_rarity` isn't limited to the four
+/// ordered ones the printing-range path needs — see that arm's doc). Index-free — eligibility never
+/// depends on `indexes`, only the actual re-narrow work does. The single source of truth for this
+/// shape: `narrow_rec`'s own `-r:x` arm gates on this function directly (not a separate inline
+/// `matches!`), and so does `and_child_rank` — the two can no longer drift apart.
+fn is_rarity_negation_shape(f: &FilterExpr) -> bool {
+    matches!(
+        f,
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), rhs: NumExpr::Const(_), .. }
+            | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), rhs: NumExpr::Field(NumField::RarityInt), .. }
+    )
+}
+
+/// `-f:x`/`-banned:x`/`-restricted:x`'s dedicated shape: a tracked-format `Legality` leaf.
+/// Index-free (`status_plane_bases` takes only `expected`). The single source of truth for this
+/// shape: `narrow_rec`'s own `-f:x` arm gates on this function directly, and so does `and_child_rank`.
+fn is_legality_negation_shape(f: &FilterExpr) -> bool {
+    matches!(f, FilterExpr::Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some())
 }
 
 /// Evaluation-cost rank for And children: cheap sources first (postings,
 /// planes, card numerics, trigram lookups), printing-space ranges second
 /// (their broad form pays an O(k) scatter), complements last (broad by
 /// construction, useful only when nothing else narrowed).
-fn and_child_rank(f: &FilterExpr) -> u8 {
+fn and_child_rank(f: &FilterExpr, indexes: &Archived<CardIndexes>) -> u8 {
     match f {
-        // `-usd<c` / `-cn<c` / `-date>c` / `-year>=c` / `-r:x` / `-f:x` all reduce to a fresh, cheap
-        // re-narrow (`negate_op` for the first four, see `bare_range_bounds`'s doc; a dedicated plane
-        // read for `-r:x`/`-f:x`, see their `narrow_rec` arms) — not a broad complement. Rank them
-        // exactly like their un-negated inner form, not the generic
-        // Not-complement's rank 2 below (which used to catch these too: any `Not` wrapping one of
-        // these cheap shapes was wrongly deprioritized and skipped by the And early-stop as soon as
-        // a sibling child had already narrowed — silently losing the negated child's own narrowing,
-        // not a correctness bug (the driver's residual verification still catches it) but a real,
-        // avoidable cost regression for `-usd<c` mixed with any other And child). Guarded on
-        // `not_child_is_cheap_renarrow` rather than the broader `NumericCmp{..}|DateCmp{..}|YearCmp{..}`
-        // shape check this replaces: that broader check fired for e.g. `-cmc:3` or `-usd:5` (negated
-        // equality) too, which `narrow_rec` actually resolves via the generic complement (or declines
-        // outright for `Eq`/`Ne`) — a rank/execution mismatch, same class of bug as the two above it,
-        // caught in review rather than by the differential test.
-        FilterExpr::Not(inner) if not_child_is_cheap_renarrow(inner) => and_child_rank(inner),
+        // `-r:x` / `-f:x`: dedicated re-narrows, not a broad complement — rank them exactly like
+        // their un-negated inner form. Guarded on the same index-free predicates `narrow_rec`'s own
+        // `-r:x`/`-f:x` arms gate on (not a separate shape check), so a shape either function
+        // recognizes, the other does too, by construction.
+        FilterExpr::Not(inner) if is_rarity_negation_shape(inner) || is_legality_negation_shape(inner) => and_child_rank(inner, indexes),
+        // `-usd<c` / `-cn<c` / `-date>c` / `-year>=c`: same "cheap re-narrow, not a complement"
+        // reasoning, but delegated to `bare_range_bounds` itself (called on the `Not` node `f`, not
+        // the unwrapped `inner` — its own `Not` arm is what applies `negate_op` before checking
+        // representability, so calling it on `inner` directly would wrongly accept `Eq`, whose
+        // negation `Ne` isn't a representable range). `and_child_rank` now takes `indexes` for
+        // exactly this: unlike the index-free rarity/legality shapes, this is the one dedicated arm
+        // whose real implementation (`resolve_numeric_range_leaf`'s index lookup) already needs it,
+        // so there's no way to mirror it index-free without a second, driftable implementation — call
+        // the real thing directly instead, the same way `is_printing_composable`/`compose_printing_bits`/
+        // `compose_printing_estimate` already do.
+        FilterExpr::Not(inner) if bare_range_bounds(f, indexes).is_some() => and_child_rank(inner, indexes),
+        // Any other `Not` (a card-space numeric like `-cmc:3`, negated equality on price/cn/date/year,
+        // or a plain generic complement) falls to the broad-complement-or-decline tier — this used to
+        // be the *only* arm here, silently catching every negated cheap shape above too (bug 1), then
+        // (after that fix) still catching `-cmc:3`/negated-equality because the guard was too broad
+        // (bug 4), then still catching `-f:x` because the guard didn't know about it at all (bug 4
+        // follow-up) — each found because a shape recognized here disagreed with what `narrow_rec`
+        // actually dispatched to. The three guards above are now `narrow_rec`'s own guards, not
+        // reimplementations, so a future fourth dedicated arm can't drift from this one silently.
         FilterExpr::Not(_) => 2,
         // Regex trigram-narrow (#734 step 3) is second-tier: its literal factor may be broad (`flying`),
         // so pay for it only after cheap plane/posting sources — the And early-stop then skips it when a
@@ -3194,9 +3185,10 @@ fn narrow_rec(
         // both `∃p: status(p)` and `∃p: ¬status(p)` at once) instead of
         // reading the status's `_ABSENT`/`_ILLEGAL` plane directly, which is
         // what this arm does.
-        FilterExpr::Not(inner)
-            if matches!(inner.as_ref(), FilterExpr::Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some()) =>
-        {
+        // Gated on `is_legality_negation_shape` (also `and_child_rank`'s guard for this shape) rather
+        // than an inline `matches!` — one definition of "is this the -f:x shape," not two that could
+        // silently disagree (see that function's doc).
+        FilterExpr::Not(inner) if is_legality_negation_shape(inner) => {
             let FilterExpr::Legality { shift: Some(shift), expected } = inner.as_ref() else { unreachable!() };
             Narrowed::loose(Candidates::CardBits(legality_candidate_bits(indexes, n_cards, *shift, *expected, true)?))
         }
@@ -3211,13 +3203,9 @@ fn narrow_rec(
         // the logically-negated operator (Not(Eq(v)) == Ne(v), verified
         // against tri()'s actual Null handling in negate_op's doc comment),
         // which is a different and correct operation.
-        FilterExpr::Not(inner)
-            if matches!(
-                inner.as_ref(),
-                FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), rhs: NumExpr::Const(_), .. }
-                    | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), rhs: NumExpr::Field(NumField::RarityInt), .. }
-            ) =>
-        {
+        // Gated on `is_rarity_negation_shape` (also `and_child_rank`'s guard for this shape) rather
+        // than an inline `matches!` — same single-source-of-truth reasoning as `-f:x` above.
+        FilterExpr::Not(inner) if is_rarity_negation_shape(inner) => {
             let FilterExpr::NumericCmp { lhs, op, rhs } = inner.as_ref() else { unreachable!() };
             match (lhs, rhs) {
                 (NumExpr::Field(NumField::RarityInt), NumExpr::Const(v)) => narrow_rarity(indexes, n_cards, negate_op(*op), *v),
@@ -3405,7 +3393,7 @@ fn narrow_rec(
             // range bitmaps only materialize when a printing-space partner
             // exists to intersect them with; complements only when nothing
             // else narrowed at all.
-            let mut ranked: Vec<(u8, &FilterExpr)> = children.iter().map(|c| (and_child_rank(c), c)).collect();
+            let mut ranked: Vec<(u8, &FilterExpr)> = children.iter().map(|c| (and_child_rank(c, indexes), c)).collect();
             ranked.sort_by_key(|(r, _)| *r);
             let mut card_sets: Vec<Narrowed> = Vec::new();
             let mut printing_sets: Vec<Narrowed> = Vec::new();

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    assign_name_ranks,
+    and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
@@ -5662,6 +5662,38 @@ fn negated_range_narrowing() {
         Some(Candidates::Printings(v)) => assert_eq!(v, vec![0]),
         other => panic!("expected tight printing narrowing, got {other:?}"),
     }
+}
+
+#[test]
+fn and_child_rank_matches_narrow_rec_dispatch() {
+    // Review catch (not caught by the differential test: rank/execution mismatches are a cost
+    // question, not a correctness one, so they can't surface as a wrong final answer). Each case
+    // here mirrors a `narrow_rec`/`bare_range_bounds` dispatch decision `and_child_rank` has no
+    // `indexes` to double-check directly, per `not_child_is_cheap_renarrow`'s doc.
+    let usd = |op: CmpOp, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(v) };
+    let cmc = |op: CmpOp, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op, rhs: NumExpr::Const(v) };
+    let rarity = |op: CmpOp, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(v) };
+
+    // -usd<c: reduces to usd>=c via bare_range_bounds's Not handling -- same cheap tier (1) as its
+    // un-negated form, not the generic complement's rank 2.
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0)))), and_child_rank(&usd(CmpOp::Lt, 50.0)));
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0)))), 1);
+
+    // -usd:c (negated equality): Ne isn't a representable range, so bare_range_bounds declines and
+    // narrow_rec falls through to the generic Not-arm (which itself declines via tight_narrow_space,
+    // per docs/issues/local-engine-negated-range-narrowing.md) -- must NOT get the cheap-tier rank.
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Eq, 5.0)))), 2);
+
+    // -cmc:c (any op): cmc/power/toughness aren't printing-range-indexed, so bare_range_bounds never
+    // matches this field -- narrow_rec falls through to the generic bit-complement arm (tight in card
+    // space, unrelated to this feature), which is the same cost shape as any other Not-complement.
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(cmc(CmpOp::Lt, 3.0)))), 2);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(cmc(CmpOp::Eq, 3.0)))), 2);
+
+    // -r:x (any op): rarity's own dedicated narrow_rec arm re-narrows regardless of op -- must keep
+    // its pre-existing cheap-tier rank (0), matching the un-negated bare rarity comparison's rank.
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0)))), and_child_rank(&rarity(CmpOp::Eq, 2.0)));
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0)))), 0);
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5694,6 +5694,18 @@ fn and_child_rank_matches_narrow_rec_dispatch() {
     // its pre-existing cheap-tier rank (0), matching the un-negated bare rarity comparison's rank.
     assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0)))), and_child_rank(&rarity(CmpOp::Eq, 2.0)));
     assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0)))), 0);
+
+    // -f:x (a tracked format, expected=LEGALITY_LEGAL=0b01): reads the status's own _ABSENT plane
+    // directly (narrow_rec's dedicated -f:x arm), the same "not a complement" shape as -r:x above --
+    // must also keep its bare form's cheap-tier rank (0), not the generic complement's rank 2.
+    let legal_fmt = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(legal_fmt()))), and_child_rank(&legal_fmt()));
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(legal_fmt()))), 0);
+
+    // -f:x for an untracked format (no shift resolved, i.e. absent from loaded data): status_plane_bases
+    // is irrelevant here (shift: None doesn't even reach it) -- must fall to the generic tier, same as
+    // any other Not this classifier doesn't recognize.
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(FilterExpr::Legality { shift: None, expected: 0b01 }))), 2);
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5555,6 +5555,115 @@ fn price_narrowing_bound_matches_direct_comparison_on_and_off_grid() {
     }
 }
 
+#[test]
+fn negated_range_narrowing() {
+    // docs/issues/local-engine-negated-range-narrowing.md: NOT(x op c) == x negate_op(op) c is
+    // exact under this engine's null semantics, so -usd<0.25 narrows identically to usd>=0.25 --
+    // including on the no-price printing, which must fail *both* forms, not just the direct one.
+    let mut vocab = VocabInterner::new();
+    let cards = vec![stub_card(1, TYPE_CREATURE, &[], &mut vocab), stub_card(2, TYPE_CREATURE, &[], &mut vocab)];
+    let mut data = store_of(cards, &[2, 2], vocab); // card 0: pids 0,1; card 1: pids 2,3
+    data.printings[0].price_usd = Some(10); // $0.10
+    data.printings[1].price_usd = Some(30); // $0.30
+    data.printings[2].price_usd = None; // no price -- must fail both usd<0.25 and -usd<0.25
+    data.printings[3].price_usd = Some(1000); // $10.00
+    data.printings[0].collector_number_int = Some(5);
+    data.printings[1].collector_number_int = Some(150);
+    data.printings[2].collector_number_int = None;
+    data.printings[3].collector_number_int = Some(200);
+    data.printings[0].released_at_int = Some(19_930_805);
+    data.printings[1].released_at_int = Some(20_241_115);
+    data.printings[2].released_at_int = None;
+    data.printings[3].released_at_int = Some(20_200_101);
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let not_usd_lt_25 = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::PriceUsd),
+        op: CmpOp::Lt,
+        rhs: NumExpr::Const(0.25),
+    }));
+    let usd_ge_25 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Ge, rhs: NumExpr::Const(0.25) };
+    // pid1 ($0.30) and pid3 ($10.00) satisfy both forms; pid0 ($0.10) fails both directly; pid2
+    // (no price) fails both -- the trivalent guarantee, not just the ordinary in-range cases.
+    for (i, f) in [&not_usd_lt_25, &usd_ge_25].into_iter().enumerate() {
+        match narrow_candidates(f, &archived.indexes, &archived.offsets, &archived.cards) {
+            Some(Candidates::Printings(v)) => assert_eq!(v, vec![1, 3], "form {i}"),
+            other => panic!("expected tight printing narrowing, got {other:?}"),
+        }
+    }
+
+    // The motivating example: -usd<0.25 usd<5 -- only pid1 ($0.30) survives both halves (pid3 at
+    // $10.00 fails usd<5; pid0/pid2 already fail the first half above). Checked end-to-end via
+    // run_query, not narrow_candidates directly: with only 4 printings, the first child alone
+    // already narrows below AND_SKIP_THRESHOLD, so the And arm's (separate, pre-existing, correct)
+    // early-stop skips evaluating the second child as a *narrowing* source -- residual verification
+    // still catches it, so the final answer is exact either way, just not through narrow_candidates
+    // alone on a corpus this tiny.
+    let usd_lt_5 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(5.0) };
+    let mut compound = FilterExpr::And(vec![not_usd_lt_25, usd_lt_5]);
+    let (total, page) = super::run_query(
+        &archived.cards,
+        &archived.printings,
+        &archived.offsets,
+        &archived.strings,
+        &mut compound,
+        None,
+        "printing",
+        "default",
+        "edhrec",
+        "asc",
+        100,
+        0,
+        &archived.indexes,
+    );
+    assert_eq!(total, 1);
+    assert_eq!(page.len(), 1);
+    let got_cents = page[0].1.price_usd.as_ref().map(|v| u32::from(*v));
+    assert_eq!(got_cents, Some(30), "must be pid1 ($0.30), the only printing satisfying both halves");
+
+    // Same compound is printing-composable (#731/#724's PrintingCompose), and its composed bits
+    // agree with narrow_candidates -- the compose path (is_printing_composable /
+    // compose_printing_bits) shares bare_range_bounds with narrow_rec, not a second implementation.
+    assert!(super::is_printing_composable(&compound, &archived.indexes));
+    let n_printings = archived.printings.len();
+    let pbits = super::compose_printing_bits(&compound, &archived.indexes, &archived.offsets, &archived.printings, n_printings);
+    let set_bits: Vec<u32> = (0..n_printings as u32).filter(|&p| pbits[p as usize >> 6] & (1u64 << (p & 63)) != 0).collect();
+    assert_eq!(set_bits, vec![1]);
+
+    // -cn<50 -> cn>=50: pid1 (150) and pid3 (200); not pid0 (5) or pid2 (no collector number).
+    let not_cn_lt_50 = FilterExpr::Not(Box::new(FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::CollectorNumberInt),
+        op: CmpOp::Lt,
+        rhs: NumExpr::Const(50.0),
+    }));
+    match narrow_candidates(&not_cn_lt_50, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![1, 3]),
+        other => panic!("expected tight printing narrowing, got {other:?}"),
+    }
+
+    // -year:1993 doesn't reduce (negate_op(Eq) == Ne, and Ne isn't a single half-open range) --
+    // must decline cleanly, not silently narrow to something wrong.
+    assert!(
+        narrow_candidates(
+            &FilterExpr::Not(Box::new(FilterExpr::YearCmp { op: CmpOp::Eq, year: 1993 })),
+            &archived.indexes,
+            &archived.offsets,
+            &archived.cards,
+        )
+        .is_none()
+    );
+    // -date>=20200101 -> date<20200101: only pid0 (1993-08-05); pid2 (no date) fails both forms.
+    let not_date_ge = FilterExpr::Not(Box::new(FilterExpr::DateCmp { op: CmpOp::Ge, value: 20_200_101 }));
+    match narrow_candidates(&not_date_ge, &archived.indexes, &archived.offsets, &archived.cards) {
+        Some(Candidates::Printings(v)) => assert_eq!(v, vec![0]),
+        other => panic!("expected tight printing narrowing, got {other:?}"),
+    }
+}
+
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────
 
 /// A color/type-diverse store for plane parity: colorless, mono, guild pairs,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5668,44 +5668,55 @@ fn negated_range_narrowing() {
 fn and_child_rank_matches_narrow_rec_dispatch() {
     // Review catch (not caught by the differential test: rank/execution mismatches are a cost
     // question, not a correctness one, so they can't surface as a wrong final answer). Each case
-    // here mirrors a `narrow_rec`/`bare_range_bounds` dispatch decision `and_child_rank` has no
-    // `indexes` to double-check directly, per `not_child_is_cheap_renarrow`'s doc.
+    // here mirrors a real `narrow_rec` dispatch decision -- `and_child_rank` now gates its Not-arms
+    // on the *same* predicates (`is_rarity_negation_shape`/`is_legality_negation_shape`) and the
+    // *same* function (`bare_range_bounds`) narrow_rec's own dedicated arms use, so this is really
+    // testing that consistency held, not reimplementing a second copy to compare against.
+    //
+    // An empty store's indexes suffice: `bare_range_bounds`'s Not-arm resolves purely from field/op
+    // (`int_range_bounds` et al. are closed-form, no index contents inspected), and the two shape
+    // predicates are index-free by construction (see their docs).
+    let data = store_of(vec![], &[], VocabInterner::new());
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let indexes = &archived.indexes;
+
     let usd = |op: CmpOp, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op, rhs: NumExpr::Const(v) };
     let cmc = |op: CmpOp, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op, rhs: NumExpr::Const(v) };
     let rarity = |op: CmpOp, v: f64| FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(v) };
 
     // -usd<c: reduces to usd>=c via bare_range_bounds's Not handling -- same cheap tier (1) as its
     // un-negated form, not the generic complement's rank 2.
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0)))), and_child_rank(&usd(CmpOp::Lt, 50.0)));
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0)))), 1);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0))), indexes), and_child_rank(&usd(CmpOp::Lt, 50.0), indexes));
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Lt, 50.0))), indexes), 1);
 
     // -usd:c (negated equality): Ne isn't a representable range, so bare_range_bounds declines and
     // narrow_rec falls through to the generic Not-arm (which itself declines via tight_narrow_space,
     // per docs/issues/local-engine-negated-range-narrowing.md) -- must NOT get the cheap-tier rank.
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Eq, 5.0)))), 2);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(usd(CmpOp::Eq, 5.0))), indexes), 2);
 
     // -cmc:c (any op): cmc/power/toughness aren't printing-range-indexed, so bare_range_bounds never
     // matches this field -- narrow_rec falls through to the generic bit-complement arm (tight in card
     // space, unrelated to this feature), which is the same cost shape as any other Not-complement.
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(cmc(CmpOp::Lt, 3.0)))), 2);
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(cmc(CmpOp::Eq, 3.0)))), 2);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(cmc(CmpOp::Lt, 3.0))), indexes), 2);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(cmc(CmpOp::Eq, 3.0))), indexes), 2);
 
     // -r:x (any op): rarity's own dedicated narrow_rec arm re-narrows regardless of op -- must keep
     // its pre-existing cheap-tier rank (0), matching the un-negated bare rarity comparison's rank.
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0)))), and_child_rank(&rarity(CmpOp::Eq, 2.0)));
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0)))), 0);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0))), indexes), and_child_rank(&rarity(CmpOp::Eq, 2.0), indexes));
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(rarity(CmpOp::Eq, 2.0))), indexes), 0);
 
     // -f:x (a tracked format, expected=LEGALITY_LEGAL=0b01): reads the status's own _ABSENT plane
     // directly (narrow_rec's dedicated -f:x arm), the same "not a complement" shape as -r:x above --
     // must also keep its bare form's cheap-tier rank (0), not the generic complement's rank 2.
     let legal_fmt = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(legal_fmt()))), and_child_rank(&legal_fmt()));
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(legal_fmt()))), 0);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(legal_fmt())), indexes), and_child_rank(&legal_fmt(), indexes));
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(legal_fmt())), indexes), 0);
 
     // -f:x for an untracked format (no shift resolved, i.e. absent from loaded data): status_plane_bases
     // is irrelevant here (shift: None doesn't even reach it) -- must fall to the generic tier, same as
     // any other Not this classifier doesn't recognize.
-    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(FilterExpr::Legality { shift: None, expected: 0b01 }))), 2);
+    assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(FilterExpr::Legality { shift: None, expected: 0b01 })), indexes), 2);
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────

--- a/docs/changelog/2026-07-23-negated-range-narrowing.md
+++ b/docs/changelog/2026-07-23-negated-range-narrowing.md
@@ -31,14 +31,30 @@ reused the same overly-broad shape check (`Not(inner)` where `inner` merely *loo
 other three consumers do. `-cmc:3` and negated-equality forms (`-usd:5`, `Ne` isn't a representable
 range) were getting ranked as the cheap re-narrow tier when they actually run the generic
 bit-complement or decline outright — never a wrong answer, just eager evaluation in the wrong order.
-Fixed with a small `indexes`-free classifier (`not_child_is_cheap_renarrow`) mirroring the real
-dispatch, verified not to regress the pre-existing `-r:x` ranking, plus a direct unit test asserting
-the rank values themselves (this class of bug can't be caught any other way — it's invisible to
-correctness checks). A follow-up question caught one more gap in the same fix: `-f:x`/`-banned:x`/
-`-restricted:x` (negated `Legality`, a tracked format) has its own dedicated plane-read arm too — a
-third "not a complement" shape alongside `-r:x` and the range arm, still missing from the classifier
-and still falling to the generic tier (predates this PR entirely; bug 1 never reached it). Added the
-same way, plus two more unit test assertions.
+Fixed with a small `indexes`-free classifier mirroring the real dispatch, verified not to regress the
+pre-existing `-r:x` ranking, plus a direct unit test asserting the rank values themselves (this class
+of bug can't be caught any other way — it's invisible to correctness checks). A follow-up question
+caught one more gap in the same fix: `-f:x`/`-banned:x`/`-restricted:x` (negated `Legality`, a tracked
+format) has its own dedicated plane-read arm too — a third "not a complement" shape alongside `-r:x`
+and the range arm, still missing from the classifier and still falling to the generic tier (predates
+this PR entirely; bug 1 never reached it). Added the same way, plus two more unit test assertions.
+
+Two rounds of the same class of bug in one PR was a signal, not a coincidence: the classifier and
+`narrow_rec`'s own dedicated arms were independent implementations of "which shapes are cheap," kept
+in sync only by a comment. Refactored to close the drift risk structurally instead: extracted
+`is_rarity_negation_shape`/`is_legality_negation_shape` as the *single* implementation each shape
+check has — `narrow_rec`'s own `-r:x`/`-f:x` arms now gate on these functions directly (replacing
+their inline `matches!` guards), and `and_child_rank` calls the same two. The range case can't go
+fully index-free the same way (`resolve_numeric_range_leaf` genuinely needs `indexes`), so
+`and_child_rank` now takes `indexes: &Archived<CardIndexes>` and calls `bare_range_bounds` directly —
+the same function `narrow_rec`'s own `Not` handling and the three other compose-path consumers
+already call, rather than keeping a second reimplementation around to drift again. (Must be called on
+the `Not` node itself, not the unwrapped inner — `bare_range_bounds`'s `Not` arm is what applies
+`negate_op` before checking representability.) Caught one more latent issue while unifying the rarity
+predicate: the inline check being replaced matched any `rhs` for a `RarityInt` `lhs` (should require
+`Const`, matching the real arm) — never exercised in practice, tightened while merging the two copies
+into one. A fourth dedicated `Not` arm added to `narrow_rec` in the future can no longer drift from
+`and_child_rank` silently.
 
 Measured (97,206-printing corpus): `-usd<0.25 usd<5` (the survey's #1 slowest query before this fix)
 0.901ms → 0.165ms (edhrec, 5.5×), 0.933ms → 0.353ms (rarity, 2.6×); `-usd<50` 0.896ms → 0.080ms

--- a/docs/changelog/2026-07-23-negated-range-narrowing.md
+++ b/docs/changelog/2026-07-23-negated-range-narrowing.md
@@ -23,12 +23,26 @@ to a full scan (regressing 0.545ms → 0.661ms) because the new arm passed the c
 through, unlike the pre-existing generic Not-arm, which always forces `broad_ok: true` for its inner
 check. Matching that choice fixed it.
 
+A fourth issue found via code review, another cost-only mismatch: bug 1's fix for `and_child_rank`
+reused the same overly-broad shape check (`Not(inner)` where `inner` merely *looks like* a
+`NumericCmp`/`DateCmp`/`YearCmp`, regardless of field or op) rather than the actual dispatch condition
+(`PriceUsd`/`CollectorNumberInt` with the four ordered ops, or `RarityInt` at any op) —
+`and_child_rank` has no `indexes` to call `bare_range_bounds` directly and double-check the way the
+other three consumers do. `-cmc:3` and negated-equality forms (`-usd:5`, `Ne` isn't a representable
+range) were getting ranked as the cheap re-narrow tier when they actually run the generic
+bit-complement or decline outright — never a wrong answer, just eager evaluation in the wrong order.
+Fixed with a small `indexes`-free classifier (`not_child_is_cheap_renarrow`) mirroring the real
+dispatch, verified not to regress the pre-existing `-r:x` ranking, plus a direct unit test asserting
+the rank values themselves (this class of bug can't be caught any other way — it's invisible to
+correctness checks).
+
 Measured (97,206-printing corpus): `-usd<0.25 usd<5` (the survey's #1 slowest query before this fix)
 0.901ms → 0.165ms (edhrec, 5.5×), 0.933ms → 0.353ms (rarity, 2.6×); `-usd<50` 0.896ms → 0.080ms
 (11.2×); `-cn<100` back to baseline after the `broad_ok` fix. `total` parity held everywhere; broad
 survey shows the motivating query no longer in the top 10 slowest, no new regressions.
 
-New Rust test `negated_range_narrowing`. `cargo test` (debug + release) 129/129;
-`test_engine_property.py` + `test_engine_unit.py` 158/158; clippy unchanged from baseline.
+New Rust tests `negated_range_narrowing` and `and_child_rank_matches_narrow_rec_dispatch`. `cargo
+test` (debug + release) 131/131; `test_engine_property.py` + `test_engine_unit.py` 158/158; clippy
+unchanged from baseline.
 
 Design doc: `docs/issues/local-engine-negated-range-narrowing.md`.

--- a/docs/changelog/2026-07-23-negated-range-narrowing.md
+++ b/docs/changelog/2026-07-23-negated-range-narrowing.md
@@ -1,0 +1,33 @@
+# Negated-range narrowing (`-usd<c`, `-cn<c`, `-date`/`-year`)
+
+`NOT(x < c) == x >= c` is exact under this engine's null semantics — a NULL-valued printing fails a
+direct comparison and its negation both, the same trivalent convention border/price/legality already
+follow. `bare_range_bounds`, the single shared funnel every consumer of "is this a bare printing-range
+comparison, what are its bounds" already goes through, now recognizes `Not` wrapping one of the four
+ordered comparisons (`Lt/Le/Gt/Ge`) by flipping the op via the already-existing `negate_op` and
+falling through to the same bounds computation — `is_printing_composable`, `compose_printing_estimate`,
+`compose_printing_bits`, and `narrow_rec` each needed one new guard clause, no logic duplicated.
+
+Two real bugs found via the differential test for this, not by guessing: `and_child_rank` blanket-
+classified every `Not(_)` as the cheapest-last "complement" rank, silently dropping a negated range's
+narrowing contribution whenever `And`'s early-stop had already narrowed via a sibling (a cost
+regression, not a correctness one — residual verification still caught what narrowing skipped); and
+`tight_narrow_space` unconditionally claimed `DateCmp`/`YearCmp` were safe to bit-complement despite
+`released_at` being nullable — the same trap `price` was already excluded from, just never extended
+to dates, meaning `-year:1993`-shaped queries were silently over-including NULL-dated printings via
+the pre-existing generic complement path. Both fixed.
+
+A third issue surfaced via benchmarking: a broad negated range (`-cn<100`, ~64% of printings) declined
+to a full scan (regressing 0.545ms → 0.661ms) because the new arm passed the caller's own `broad_ok`
+through, unlike the pre-existing generic Not-arm, which always forces `broad_ok: true` for its inner
+check. Matching that choice fixed it.
+
+Measured (97,206-printing corpus): `-usd<0.25 usd<5` (the survey's #1 slowest query before this fix)
+0.901ms → 0.165ms (edhrec, 5.5×), 0.933ms → 0.353ms (rarity, 2.6×); `-usd<50` 0.896ms → 0.080ms
+(11.2×); `-cn<100` back to baseline after the `broad_ok` fix. `total` parity held everywhere; broad
+survey shows the motivating query no longer in the top 10 slowest, no new regressions.
+
+New Rust test `negated_range_narrowing`. `cargo test` (debug + release) 129/129;
+`test_engine_property.py` + `test_engine_unit.py` 158/158; clippy unchanged from baseline.
+
+Design doc: `docs/issues/local-engine-negated-range-narrowing.md`.

--- a/docs/changelog/2026-07-23-negated-range-narrowing.md
+++ b/docs/changelog/2026-07-23-negated-range-narrowing.md
@@ -8,14 +8,15 @@ ordered comparisons (`Lt/Le/Gt/Ge`) by flipping the op via the already-existing 
 falling through to the same bounds computation — `is_printing_composable`, `compose_printing_estimate`,
 `compose_printing_bits`, and `narrow_rec` each needed one new guard clause, no logic duplicated.
 
-Two real bugs found via the differential test for this, not by guessing: `and_child_rank` blanket-
-classified every `Not(_)` as the cheapest-last "complement" rank, silently dropping a negated range's
-narrowing contribution whenever `And`'s early-stop had already narrowed via a sibling (a cost
-regression, not a correctness one — residual verification still caught what narrowing skipped); and
-`tight_narrow_space` unconditionally claimed `DateCmp`/`YearCmp` were safe to bit-complement despite
-`released_at` being nullable — the same trap `price` was already excluded from, just never extended
-to dates, meaning `-year:1993`-shaped queries were silently over-including NULL-dated printings via
-the pre-existing generic complement path. Both fixed.
+Two bugs found via the differential test for this, not by guessing — both cost regressions, not
+correctness bugs, since residual verification caught what each one over-included or skipped:
+`and_child_rank` blanket-classified every `Not(_)` as the cheapest-last "complement" rank, silently
+dropping a negated range's narrowing contribution whenever `And`'s early-stop had already narrowed
+via a sibling; and `tight_narrow_space` unconditionally claimed `DateCmp`/`YearCmp` were safe to
+bit-complement despite `released_at` being nullable — the same trap `price` was already excluded
+from, just never extended to dates, meaning `-year:1993`-shaped queries built and fully re-verified
+an over-inclusive (NULL-dated-printing-including) candidate set via the pre-existing generic
+complement path, rather than ever returning a wrong answer. Both fixed.
 
 A third issue surfaced via benchmarking: a broad negated range (`-cn<100`, ~64% of printings) declined
 to a full scan (regressing 0.545ms → 0.661ms) because the new arm passed the caller's own `broad_ok`

--- a/docs/changelog/2026-07-23-negated-range-narrowing.md
+++ b/docs/changelog/2026-07-23-negated-range-narrowing.md
@@ -34,7 +34,11 @@ bit-complement or decline outright — never a wrong answer, just eager evaluati
 Fixed with a small `indexes`-free classifier (`not_child_is_cheap_renarrow`) mirroring the real
 dispatch, verified not to regress the pre-existing `-r:x` ranking, plus a direct unit test asserting
 the rank values themselves (this class of bug can't be caught any other way — it's invisible to
-correctness checks).
+correctness checks). A follow-up question caught one more gap in the same fix: `-f:x`/`-banned:x`/
+`-restricted:x` (negated `Legality`, a tracked format) has its own dedicated plane-read arm too — a
+third "not a complement" shape alongside `-r:x` and the range arm, still missing from the classifier
+and still falling to the generic tier (predates this PR entirely; bug 1 never reached it). Added the
+same way, plus two more unit test assertions.
 
 Measured (97,206-printing corpus): `-usd<0.25 usd<5` (the survey's #1 slowest query before this fix)
 0.901ms → 0.165ms (edhrec, 5.5×), 0.933ms → 0.353ms (rarity, 2.6×); `-usd<50` 0.896ms → 0.080ms

--- a/docs/issues/00731-engine-compose-universal-evaluator.md
+++ b/docs/issues/00731-engine-compose-universal-evaluator.md
@@ -21,6 +21,7 @@ border/rarity/legality under `AND`/`OR`; this is the generalization to *all* lea
 | plane read | border, rarity, legality | plane slice (legality: broadcast card `∃`-plane + divergent repair) | built (#724) |
 | range materialize | `usd`, `cn`, `date` | scatter the range index's in-range slice into a bitmap | **shipped** (#733) |
 | broadcast down | card-invariant `color`/`type`/`cmc` | broadcast the card plane to printing space; **no repair** (never diverges) | `broadcast_card_bits_to_printings` exists |
+| postings scatter | `set`, `watermark` | `TagIndex` postings scattered into a bitmap (or cleared from all-ones for `NOT` — cheap on *both* polarities since cost rides the small positive postings, not the complement) | proposed, [local-engine-tag-postings-compose.md](local-engine-tag-postings-compose.md) |
 | per-survivor residual | text (`name`/`oracle`/`flavor`), or any leaf | verify on the composed survivors, not as a bitmap | existing residual machinery |
 
 ## Materialize vs. verify — one cost axis, both exact

--- a/docs/issues/local-engine-negated-range-narrowing.md
+++ b/docs/issues/local-engine-negated-range-narrowing.md
@@ -80,6 +80,36 @@ when broad, since there's no cheaper alternative once committed to the field). M
 choice for the new arm (force `true` unconditionally, not the caller's `broad_ok`) fixed it —
 `-cn<100` now matches or slightly beats the original baseline instead of regressing.
 
+## A fourth issue found via code review: `and_child_rank`'s guard was still too broad
+
+Bug 1's fix (delegate to the inner shape's own rank instead of hardcoding 2) used the same
+overly-broad shape check the rest of this PR had to tighten elsewhere: `Not(inner) if
+matches!(inner.as_ref(), NumericCmp{..}|DateCmp{..}|YearCmp{..})`. That fires for *any* field and
+*any* op, but the real dispatch in `narrow_rec`/`bare_range_bounds` only takes the cheap path for
+`PriceUsd`/`CollectorNumberInt` with the four ordered ops (`Lt`/`Le`/`Gt`/`Ge`), or `RarityInt` at any
+op (its own dedicated `-r:x` arm). Everything else — `-cmc:c`/`-power:c`/`-toughness:c` (card-space,
+any op) and negated equality on price/cn/date/year (`Ne` isn't a representable range) — actually
+resolves via the generic bit-complement arm, or declines outright. `and_child_rank` has no `indexes`
+parameter, so unlike `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` (all
+of which call `bare_range_bounds(filter, indexes)` directly to double-check), it couldn't reuse that
+function and instead re-approximated its shape check — too loosely.
+
+Concretely: `-cmc:3` inside an `And` got ranked as if it were the cheap re-narrow path (tier 0, via
+the recursive `and_child_rank(inner)` call landing on `NumericCmp`'s "not price/cn" fallback branch),
+when execution actually runs the generic complement (a real but comparatively costly card-space
+bit-complement) — same rank/execution mismatch as bugs 1 and 2, just a *narrower* recurrence of bug 1
+that its own fix didn't fully close. Not a correctness bug (same reasoning as bugs 1 and 2: residual
+verification catches whatever the mismatch skips or wastes) — the `And` arm would still evaluate
+these children, just in the wrong order relative to their actual cost.
+
+Fixed by extracting `not_child_is_cheap_renarrow` — a small, `indexes`-free field/op classifier
+mirroring `bare_range_bounds`'s `Not` arm plus the pre-existing `-r:x` carve-out (verified this
+doesn't regress `-r:x`'s own ranking, which the old, broader guard got right only by accident) — and
+using it as the guard instead of the bare shape `matches!`. Caught in review, not by the differential
+test: rank/execution mismatches are a cost question, not a correctness one, so nothing about a wrong
+final answer would ever surface it. Added a direct unit test (`and_child_rank_matches_narrow_rec_dispatch`)
+asserting the ranks this class of bug can't be caught any other way.
+
 ## Measured (`scripts/bench_negated_range_narrowing.py`, 97,206-printing corpus, min ms)
 
 | query | unique | orderby | before | after | change |
@@ -109,7 +139,11 @@ before this fix — no longer appears in the top 10; no new slow patterns introd
   not something this feature needed to defeat), `is_printing_composable`/`compose_printing_bits`
   agreement, `-cn<100`, and the `-year:1993`/`-date>=c` cases (including confirming the `Ne`-shaped
   negation correctly declines rather than computing a wrong answer).
-- `cargo test` (debug + release): 129/129 passed.
+- New Rust test `and_child_rank_matches_narrow_rec_dispatch` (bug 4): directly asserts the rank
+  values for `-usd<c` (matches its un-negated form), `-usd:c`/`-cmc:c` (must fall to the generic
+  tier, not the cheap one), and `-r:x` (must keep its pre-existing cheap rank at any op) — the only
+  way to cover a rank/execution mismatch, since it can't be observed through a correctness check.
+- `cargo test` (debug + release): 131/131 passed.
 - `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
 - `cargo clippy`: unchanged from baseline (42 warnings).
 

--- a/docs/issues/local-engine-negated-range-narrowing.md
+++ b/docs/issues/local-engine-negated-range-narrowing.md
@@ -115,14 +115,50 @@ in the same fix: `narrow_rec` has a *third* dedicated re-narrow arm besides `-r:
 arm — `-f:x`/`-banned:x`/`-restricted:x` (a negated `Legality` with a tracked format), which reads the
 status's `_ABSENT`/`_ILLEGAL` plane directly rather than complementing (the comment on that arm
 explains why: complementing the positive plane would wrongly drop real matches for a divergent card
-that can satisfy both the status and its negation across different printings). `not_child_is_cheap_renarrow`
-didn't check for this shape either, so `-f:modern` inside an `And` was *still* falling to the generic
-tier (rank 2) instead of sharing bare `Legality`'s rank (0) — this predates the whole PR (it was part
-of the original blanket `Not(_) => 2`, bug 1 never actually reached it). Fixed the same way: added a
-`Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some()` case to the
-classifier (mirroring the dedicated arm's own guard exactly — `status_plane_bases` needs no `indexes`
-either, so the same `indexes`-free reasoning applies), plus two more unit test assertions (tracked and
-untracked format).
+that can satisfy both the status and its negation across different printings). The classifier didn't
+check for this shape either, so `-f:modern` inside an `And` was *still* falling to the generic tier
+(rank 2) instead of sharing bare `Legality`'s rank (0) — this predates the whole PR (it was part of
+the original blanket `Not(_) => 2`, bug 1 never actually reached it). Fixed the same way at the time:
+added a `Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some()` case to the
+classifier, plus two more unit test assertions (tracked and untracked format).
+
+## Closing the drift risk structurally, not just documenting it
+
+Two rounds of the same bug in one PR (bug 4, then its `-f:x` follow-up) is a pattern, not a
+coincidence: the classifier and `narrow_rec`'s own dedicated arms were two independent
+implementations of "which `Not(inner)` shapes are cheap," kept in sync only by a comment saying so.
+That's exactly the shape of hazard this codebase's "one shared function, every consumer goes through
+it" convention (`bare_range_bounds` itself, `resolve_numeric_range_leaf`) exists to prevent — it just
+hadn't been applied to this specific classification yet.
+
+Refactored so there is no second implementation left to drift:
+
+- **`is_rarity_negation_shape(f)`** and **`is_legality_negation_shape(f)`** — extracted, `indexes`-free
+  predicates (eligibility for both never depended on `indexes`, only the actual re-narrow work does).
+  `narrow_rec`'s own `-r:x` and `-f:x` arms now gate on these functions directly, replacing their
+  former inline `matches!` guards. `and_child_rank` calls the *same* functions. A shape either
+  recognizes, the other now does too, by construction — there is only one definition of each shape,
+  not two that happen to agree today.
+- **The range case (`-usd<c`/`-cn<c`/`-date`/`-year`)** can't be made fully index-free the same way —
+  its real implementation (`resolve_numeric_range_leaf`) genuinely needs `indexes` to fetch the index
+  reference. Rather than keep a second, index-free reimplementation of its eligibility logic (the
+  previous fix's approach, and the thing that could still drift), `and_child_rank` now takes
+  `indexes: &Archived<CardIndexes>` and calls `bare_range_bounds(f, indexes)` directly — the exact
+  function `narrow_rec`'s own `Not` handling, `is_printing_composable`, `compose_printing_bits`, and
+  `compose_printing_estimate` already call. One caveat worth noting explicitly: this must be called on
+  the `Not` node itself, not the unwrapped inner expression — `bare_range_bounds`'s own `Not` arm is
+  what applies `negate_op` before checking representability, so calling it on the bare inner would
+  wrongly accept `Eq` (whose negation, `Ne`, isn't representable), silently reintroducing bug 4.
+- Along the way, caught a latent over-broad pattern in the rarity predicate itself while extracting it:
+  the inline check being replaced used `NumericCmp { lhs: Field(RarityInt), .. }` (matching *any*
+  `rhs`, including another field), but the real `-r:x` arm requires the other side to be `Const` —
+  tightened to match exactly. Never exercised in practice (the parser doesn't appear to produce
+  field-vs-field numeric comparisons), but worth fixing while unifying the two copies into one.
+
+Net effect: adding a fourth dedicated `Not` arm to `narrow_rec` in the future is no longer something
+`and_child_rank` can silently miss — either it's expressed as a predicate `and_child_rank` already
+calls, or (for a future index-dependent case) it's a direct call to the real function, following the
+range case's pattern.
 
 ## Measured (`scripts/bench_negated_range_narrowing.py`, 97,206-printing corpus, min ms)
 
@@ -153,10 +189,13 @@ before this fix — no longer appears in the top 10; no new slow patterns introd
   not something this feature needed to defeat), `is_printing_composable`/`compose_printing_bits`
   agreement, `-cn<100`, and the `-year:1993`/`-date>=c` cases (including confirming the `Ne`-shaped
   negation correctly declines rather than computing a wrong answer).
-- New Rust test `and_child_rank_matches_narrow_rec_dispatch` (bug 4): directly asserts the rank
-  values for `-usd<c` (matches its un-negated form), `-usd:c`/`-cmc:c` (must fall to the generic
-  tier, not the cheap one), and `-r:x` (must keep its pre-existing cheap rank at any op) — the only
-  way to cover a rank/execution mismatch, since it can't be observed through a correctness check.
+- New Rust test `and_child_rank_matches_narrow_rec_dispatch` (bug 4 and its refactor): directly
+  asserts the rank values for `-usd<c` (matches its un-negated form), `-usd:c`/`-cmc:c` (must fall
+  to the generic tier, not the cheap one), `-r:x`, and `-f:x` (both must keep their pre-existing
+  cheap rank, tracked and untracked format) — the only way to cover a rank/execution mismatch, since
+  it can't be observed through a correctness check. Threads a minimal empty-store `&Archived<CardIndexes>`
+  through now that `and_child_rank` takes one (an empty store suffices: `bare_range_bounds`'s `Not`
+  handling resolves purely from field/op, never index contents).
 - `cargo test` (debug + release): 131/131 passed.
 - `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
 - `cargo clippy`: unchanged from baseline (42 warnings).

--- a/docs/issues/local-engine-negated-range-narrowing.md
+++ b/docs/issues/local-engine-negated-range-narrowing.md
@@ -54,14 +54,19 @@ Both surfaced by the differential test for this feature, not guessed at up front
    (`Some(true)`, no null check) — but `released_at` is nullable, and the generic Not-arm's
    complement doesn't exclude NULL-dated printings the way `bare_range_bounds`'s direct approach
    does. This is the *same* trap `price` was already excluded from years ago (see the comment right
-   above it), just never extended to dates. This was a **real, silent correctness bug**: `-year:1993`
-   (or any negated `DateCmp`/`YearCmp` equality) would have wrongly included every NULL-release-date
-   printing as a match, via the pre-existing generic complement path — nothing about *this* feature
+   above it), just never extended to dates. Like bug 1, this was **not a correctness bug** — the
+   over-inclusive complement it builds is always marked `Narrowed::loose`, and
+   `narrow_candidates_exact`'s exactness check (`all_match_known`) reads that concrete `.tight` field,
+   not this classifier, so residual `card_pass` verification still ran and dropped every NULL-dated
+   printing before any total/page was returned. The real cost was purely wasted work: `-year:1993`
+   (or any negated `DateCmp`/`YearCmp` equality) built and then fully re-verified an unnecessarily
+   broad candidate set, via the pre-existing generic complement path — nothing about *this* feature
    introduced it, my test's `Ne` case just exercised a corner the existing suite hadn't covered
    before. Fixed by excluding `DateCmp`/`YearCmp` from `tight_narrow_space`, mirroring `price`'s
    exclusion exactly. The four ordered ops don't lose anything (they now narrow through the new,
-   correct arm instead); only the previously-silently-wrong `Eq`/`Ne` negation is affected, and it
-   now correctly declines instead of computing a wrong answer.
+   correct arm instead, with no wasted verification); the previously-mislabeled `Eq`/`Ne` negation is
+   the only shape affected, and it now correctly declines up front instead of paying for a doomed
+   complement.
 
 ## A third issue found via benchmarking, not testing
 

--- a/docs/issues/local-engine-negated-range-narrowing.md
+++ b/docs/issues/local-engine-negated-range-narrowing.md
@@ -1,0 +1,117 @@
+# Engine: Negated-Range Narrowing (`-usd<c`, `-cn<c`, `-date`/`-year`)
+
+**Status: done.** No GitHub issue filed. Found investigating `-usd<0.25 usd<5`, the slowest query
+in a broad realistic-traffic survey (1.131ms) after the watermark and compose-permutation-fallback
+fixes landed.
+
+## The idea
+
+`NOT(x < c) == x >= c` — and this isn't an approximation, it's exact under this engine's null
+semantics. A NULL-valued printing fails a direct comparison (`x < c`) *and* fails its negation
+(`-x < c`) both — the same trivalent convention every nullable field in this engine already follows
+(border, price, legality). So a negated ordered comparison isn't a case requiring the generic
+bit-complement machinery (which needs a *tight* child and can't safely handle nullable fields,
+docs on `tight_narrow_space`) — it's just the flipped comparison, computed directly, no complement
+at all. This holds for `Lt↔Ge` and `Le↔Gt`; `Eq↔Ne` doesn't reduce further since `Ne` isn't a single
+half-open range (that's fine — `int_range_bounds`/`date_range_bounds`/`year_range_bounds` already
+return `None` for `Ne`, so a negated equality declines on its own, no special-casing needed).
+
+## Where it lives: one shared function, four small call sites
+
+`bare_range_bounds` (`lib.rs`) was already the single funnel every consumer of "is this filter a
+bare printing-range comparison, and what are its bounds" goes through — `is_printing_composable`,
+`compose_printing_estimate`, `compose_printing_bits`, and `narrow_rec`'s own range arms all call it
+rather than each having their own field/op dispatch. Teaching *that one function* to also recognize
+`Not(NumericCmp{Lt/Le/Gt/Ge})`/`Not(DateCmp)`/`Not(YearCmp)` — flip the op via the already-existing
+`negate_op` (used since the `-r:x` rarity case), then fall through to the exact same bounds
+computation as the direct case — means every consumer gets the negated shape for free. Each of the
+four call sites needed exactly one new guard clause (`Not(inner) if matches!(inner.as_ref(), ...)`),
+zero new logic duplicated. `negate_op` was already verified against `filter.rs`'s actual `tri()`
+null-short-circuit (see its doc comment) — the same correctness guarantee this reuses, not a new
+one.
+
+This was a deliberate choice over doing the equivalent rewrite in Python (`api/parsing/rewrite.py`,
+the seam `#734`'s `lower_literal_regexes` uses): unlike that case, Postgres already treats
+`NOT (price_usd < 25)` and `price_usd >= 25` identically (native three-valued `NULL` semantics), so
+the SQL side gets nothing from receiving the rewritten form — only the Rust engine's own
+composability/narrowing decisions actually need the equivalence, and `bare_range_bounds` already
+being a shared funnel made a small, contained Rust change cheaper than routing through a second
+parser layer for no cross-consumer benefit.
+
+## Two bugs found and fixed along the way
+
+Both surfaced by the differential test for this feature, not guessed at up front:
+
+1. **`and_child_rank` blanket-classified every `Not(_)` as rank 2** ("complement, broad by
+   construction, useful only as sole source"). That's right for the *generic* Not-complement, but
+   wrong for a negated range/rarity comparison, which is a cheap, exact re-narrow — same cost as its
+   un-negated form. The `And` arm's early-stop (`AND_SKIP_THRESHOLD`) was silently dropping the
+   negated child's narrowing contribution whenever a sibling had already narrowed first. Not a
+   correctness bug (residual verification still catches whatever narrowing skips), but a real,
+   avoidable cost regression for any `-usd<c`/`-r:x` mixed into an `And`. Fixed by delegating to the
+   inner shape's own rank instead of hardcoding 2.
+2. **`tight_narrow_space` unconditionally claimed `DateCmp`/`YearCmp` were safe to bit-complement**
+   (`Some(true)`, no null check) — but `released_at` is nullable, and the generic Not-arm's
+   complement doesn't exclude NULL-dated printings the way `bare_range_bounds`'s direct approach
+   does. This is the *same* trap `price` was already excluded from years ago (see the comment right
+   above it), just never extended to dates. This was a **real, silent correctness bug**: `-year:1993`
+   (or any negated `DateCmp`/`YearCmp` equality) would have wrongly included every NULL-release-date
+   printing as a match, via the pre-existing generic complement path — nothing about *this* feature
+   introduced it, my test's `Ne` case just exercised a corner the existing suite hadn't covered
+   before. Fixed by excluding `DateCmp`/`YearCmp` from `tight_narrow_space`, mirroring `price`'s
+   exclusion exactly. The four ordered ops don't lose anything (they now narrow through the new,
+   correct arm instead); only the previously-silently-wrong `Eq`/`Ne` negation is affected, and it
+   now correctly declines instead of computing a wrong answer.
+
+## A third issue found via benchmarking, not testing
+
+A broad negated range (`-cn<100` ≡ `cn>=100`, ~64% of printings) initially *regressed* relative to
+the pre-this-PR baseline (0.545ms → 0.661ms) even though it now "narrows." Root cause: my new
+`narrow_rec` arm passed the caller's own `broad_ok` through to `range_narrowed`, so a broad flipped
+range simply declined (falling to a full scan) exactly like a broad *positive* range would. But the
+pre-existing generic Not-arm always forces `broad_ok: true` for its inner check — a deliberate
+choice (negating a predicate is exactly the shape where the flipped bounds are worth computing even
+when broad, since there's no cheaper alternative once committed to the field). Matching that same
+choice for the new arm (force `true` unconditionally, not the caller's `broad_ok`) fixed it —
+`-cn<100` now matches or slightly beats the original baseline instead of regressing.
+
+## Measured (`scripts/bench_negated_range_narrowing.py`, 97,206-printing corpus, min ms)
+
+| query | unique | orderby | before | after | change |
+|---|---|---|---:|---:|---|
+| `-usd<0.25 usd<5` (motivating example) | card | edhrec | 0.901 | 0.165 | **5.5×** |
+| `-usd<0.25 usd<5` | card | rarity | 0.933 | 0.353 | **2.6×** |
+| `-usd<0.25 usd<5` | printing | rarity | 1.479 | 0.400 | **3.7×** |
+| `-usd<0.25 usd<5` | artwork | rarity | 1.244 | 0.574 | **2.2×** |
+| `usd>=0.25 usd<5` (equivalent direct form, control) | card | rarity | 0.362 | 0.354 | flat |
+| `-usd<50` (bare, selective) | card | rarity | 0.896 | 0.080 | **11.2×** |
+| `-cn<100` (bare, broad — the regression found and fixed) | card | rarity | 0.545 | 0.537 | flat (was 0.661 before the `broad_ok` fix) |
+| `-year>2020` (bare) | card | rarity | 0.498 | 0.366 | **1.4×** |
+| `usd<50` (control) | card | rarity | 0.420 | 0.406 | flat |
+| `border:black` (control) | card | rarity | 0.355 | 0.341 | flat |
+| `t:creature` (control) | card | edhrec | 0.063 | 0.061 | flat |
+
+`total` parity held on every row across every run. The broad realistic-traffic survey
+(`scripts/survey_queries.py`, 1000 queries): `-usd<0.25 usd<5` — the survey's #1 slowest query
+before this fix — no longer appears in the top 10; no new slow patterns introduced.
+
+## Testing
+
+- New Rust test `negated_range_narrowing`: bare `-usd<c` narrowing (including the NULL-price
+  exclusion, checked on both the direct and negated forms), the motivating `-usd<0.25 usd<5`
+  compound checked end-to-end via `run_query` (not `narrow_candidates` alone — a corpus this small
+  hits `AND_SKIP_THRESHOLD`'s early-stop, which is a separate, correct, pre-existing optimization,
+  not something this feature needed to defeat), `is_printing_composable`/`compose_printing_bits`
+  agreement, `-cn<100`, and the `-year:1993`/`-date>=c` cases (including confirming the `Ne`-shaped
+  negation correctly declines rather than computing a wrong answer).
+- `cargo test` (debug + release): 129/129 passed.
+- `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
+- `cargo clippy`: unchanged from baseline (42 warnings).
+
+## Related
+
+- [local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) —
+  the sibling investigation this branches from; both found while chasing the same broad-survey
+  slow-query list.
+- [done/local-engine-watermark-postings.md](done/local-engine-watermark-postings.md) — the first
+  fix in this same investigation thread.

--- a/docs/issues/local-engine-negated-range-narrowing.md
+++ b/docs/issues/local-engine-negated-range-narrowing.md
@@ -110,6 +110,20 @@ test: rank/execution mismatches are a cost question, not a correctness one, so n
 final answer would ever surface it. Added a direct unit test (`and_child_rank_matches_narrow_rec_dispatch`)
 asserting the ranks this class of bug can't be caught any other way.
 
+A follow-up question during the same review ("is `-r:x` the only other field?") caught one more gap
+in the same fix: `narrow_rec` has a *third* dedicated re-narrow arm besides `-r:x` and the new range
+arm — `-f:x`/`-banned:x`/`-restricted:x` (a negated `Legality` with a tracked format), which reads the
+status's `_ABSENT`/`_ILLEGAL` plane directly rather than complementing (the comment on that arm
+explains why: complementing the positive plane would wrongly drop real matches for a divergent card
+that can satisfy both the status and its negation across different printings). `not_child_is_cheap_renarrow`
+didn't check for this shape either, so `-f:modern` inside an `And` was *still* falling to the generic
+tier (rank 2) instead of sharing bare `Legality`'s rank (0) — this predates the whole PR (it was part
+of the original blanket `Not(_) => 2`, bug 1 never actually reached it). Fixed the same way: added a
+`Legality { shift: Some(_), expected } if status_plane_bases(*expected).is_some()` case to the
+classifier (mirroring the dedicated arm's own guard exactly — `status_plane_bases` needs no `indexes`
+either, so the same `indexes`-free reasoning applies), plus two more unit test assertions (tracked and
+untracked format).
+
 ## Measured (`scripts/bench_negated_range_narrowing.py`, 97,206-printing corpus, min ms)
 
 | query | unique | orderby | before | after | change |

--- a/makefile
+++ b/makefile
@@ -143,7 +143,8 @@ ensure_ruff: ensure_uv
 
 ensure_uv:
 	@python -m uv --version > /dev/null || \
-	python -m pip install uv
+	python -m pip install uv || \
+	uv pip install --python "$$(command -v python)" uv
 
 lint: ruff_lint prettier_lint # @doc lint all python files
 	true

--- a/scripts/bench_negated_range_narrowing.py
+++ b/scripts/bench_negated_range_narrowing.py
@@ -1,0 +1,87 @@
+"""Targeted benchmark for negated-range narrowing (`-usd<c`, `-cn<c`, `-date`/`-year`).
+
+`NOT(x op c) == x negate_op(op) c` is exact under this engine's null semantics (a null-valued
+printing fails a direct comparison and its negation both) — `bare_range_bounds` now recognizes this
+shape directly (see docs/issues/local-engine-negated-range-narrowing.md), so a negated range
+narrows/composes exactly like its already-simplified equivalent, instead of falling to a full scan
+regardless of orderby or permutation availability. `usd>=0.25`-shaped rows are the algebraically-
+equivalent direct form, included as a target for parity (the negated form should match it, not just
+beat its own past self).
+
+    .venv/bin/python scripts/bench_negated_range_narrowing.py \
+        --out benchmarks/negated-range/baseline-main-<sha>.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. `total` doubles as the
+parity check — must be identical across builds for every config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # The motivating example, across orderby and unique — before this fix, none of these narrowed
+    # or composed at all (Not wasn't a recognized range shape anywhere), so every row here paid a
+    # full scan regardless of whether a permutation existed for the requested orderby.
+    ("negated_and", "-usd<0.25 usd<5", "card", "edhrec", "default"),
+    ("negated_and", "-usd<0.25 usd<5", "card", "rarity", "default"),
+    ("negated_and", "-usd<0.25 usd<5", "printing", "rarity", "default"),
+    ("negated_and", "-usd<0.25 usd<5", "artwork", "rarity", "default"),
+    # The algebraically-equivalent direct form (usd>=0.25 usd<5) — already fine before this fix
+    # (no negation involved); the negated form above should now match it, not just beat itself.
+    ("equivalent_direct", "usd>=0.25 usd<5", "card", "edhrec", "default"),
+    ("equivalent_direct", "usd>=0.25 usd<5", "card", "rarity", "default"),
+    # Bare negated ranges, one per family.
+    ("bare_negated", "-usd<50", "card", "rarity", "default"),
+    ("bare_negated", "-cn<100", "card", "rarity", "default"),
+    ("bare_negated", "-year>2020", "card", "rarity", "default"),
+    # Controls: unaffected shapes, must not regress.
+    ("control", "usd<50", "card", "rarity", "default"),
+    ("control", "border:black", "card", "rarity", "default"),
+    ("control", "t:creature", "card", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=5.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<19} {'query':<20} {'unique':<9} {'orderby':<8} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<19} {query:<20} {unique:<9} {orderby:<8} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Branched from `engine-printing-compose-permutation-fallback` (#740, now merged — this branch is rebased directly onto `main`) — found while investigating `-usd<0.25 usd<5`, the slowest query in a broad survey after #739/#740 landed.

- `NOT(x < c) == x >= c` is exact under this engine's null semantics (a NULL-valued printing fails a direct comparison and its negation both — the same trivalent convention border/price/legality already follow). `bare_range_bounds`, the single shared funnel every consumer already goes through, now recognizes `Not` wrapping one of the four ordered comparisons by flipping the op via the already-existing `negate_op` — `is_printing_composable`, `compose_printing_estimate`, `compose_printing_bits`, and `narrow_rec` each needed one new guard clause, no logic duplicated.
- **Two bugs found via the differential test for this feature, not by guessing — both cost regressions, not correctness bugs:**
  - `and_child_rank` blanket-classified every `Not(_)` as the cheapest-last "complement" rank, silently dropping a negated range's narrowing contribution whenever `And`'s early-stop had already narrowed via a sibling. Residual verification still caught it.
  - `tight_narrow_space` unconditionally claimed `DateCmp`/`YearCmp` were safe to bit-complement despite `released_at` being nullable — the same trap `price` was already excluded from, just never extended to dates. `-year:1993`-shaped queries built and fully re-verified an over-inclusive (NULL-dated-printing-including) candidate set via the pre-existing generic complement path — `narrow_candidates_exact`'s exactness check reads the complement's own (always-loose) `.tight` field, not this classifier, so residual `card_pass` verification still ran and dropped the NULL-dated printings before any total/page was returned. Wasted work, not a wrong answer.
- **A third issue found via benchmarking**: a broad negated range (`-cn<100`, ~64% of printings) declined to a full scan and regressed (0.545ms → 0.661ms) because the new arm passed the caller's own `broad_ok` through, unlike the pre-existing generic `Not`-arm, which always forces `broad_ok: true`. Fixed by matching that choice.

## Performance

97,206-printing corpus, `scripts/bench_negated_range_narrowing.py`, min ms, interleaved same build:

| Benchmark | Before (ms) | After (ms) | Change |
|---|---:|---:|---|
| `-usd<0.25 usd<5` (motivating example) / card / edhrec | 0.901 | 0.165 | **5.5×** |
| `-usd<0.25 usd<5` / card / rarity | 0.933 | 0.353 | **2.6×** |
| `-usd<0.25 usd<5` / printing / rarity | 1.479 | 0.400 | **3.7×** |
| `-usd<0.25 usd<5` / artwork / rarity | 1.244 | 0.574 | **2.2×** |
| `usd>=0.25 usd<5` (equivalent direct form, control) | 0.362 | 0.354 | flat |
| `-usd<50` (bare, selective) | 0.896 | 0.080 | **11.2×** |
| `-cn<100` (bare, broad — the regression found and fixed) | 0.545 | 0.537 | flat (was 0.661 before the `broad_ok` fix) |
| `-year>2020` (bare) | 0.498 | 0.366 | **1.4×** |
| `usd<50` / `border:black` / `t:creature` (controls) | — | — | flat |

`total` parity held on every row. Broad realistic-traffic survey (`scripts/survey_queries.py`, 1000 queries): `-usd<0.25 usd<5` — the survey's #1 slowest query before this fix — no longer appears in the top 10; no new slow patterns introduced.

## Test plan

- [x] New Rust test `negated_range_narrowing`: bare narrowing (including the NULL-price exclusion on both direct and negated forms), the motivating compound checked end-to-end via `run_query`, `is_printing_composable`/`compose_printing_bits` agreement, `-cn<100`, and `-year:1993`/`-date>=c` (confirming `Ne`-shaped negation correctly declines instead of computing a wrong answer).
- [x] `cargo test` (debug + release): 129/129 passed.
- [x] `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
- [x] `cargo clippy`: unchanged from baseline (42 warnings, verified via a clean worktree diff).

Design doc: `docs/issues/local-engine-negated-range-narrowing.md`.
