### PR TITLE
Fix Ruff Lint Drift: Unused noqa, Widen PLR0913 noqa to Cover PLR0917

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1320,7 +1320,7 @@ class APIResource:
                     timer=timer,
                     fields=resolved_fields,
                 )
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning("Engine query failed for %r, falling back to SQL: %s", query, e, exc_info=True)
             else:
                 if settings.enable_cache:

--- a/api/db/bulk_upsert.py
+++ b/api/db/bulk_upsert.py
@@ -101,7 +101,7 @@ def _dedupe_rows(rows: list[dict[str, Any]], key_cols: list[str]) -> list[dict[s
     return list(unique.values())
 
 
-def bulk_upsert(  # noqa: PLR0913
+def bulk_upsert(  # noqa: PLR0913, PLR0917
     conn: psycopg.Connection,
     table: str,
     rows: list[dict[str, Any]],

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -21,7 +21,7 @@ from api.enums import ResponseShape
 from api.settings import settings
 
 
-def create_test_card(  # noqa: PLR0913
+def create_test_card(  # noqa: PLR0913, PLR0917
     card_id: str | None = None,
     name: str = "Test Card",
     legalities: dict | None = None,

--- a/api/tests/test_card_processing.py
+++ b/api/tests/test_card_processing.py
@@ -15,7 +15,7 @@ _PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 _SAMPLE_DATA_DIR = _PROJECT_ROOT / "docs" / "sample_data"
 
 
-def create_test_card(  # noqa: PLR0913
+def create_test_card(  # noqa: PLR0913, PLR0917
     card_id: str | None = None,
     name: str = "Test Card",
     legalities: dict | None = None,


### PR DESCRIPTION
## Summary

`requirements/test.txt` pins `ruff` with no version, and CI's `uv pip install` grabs
whatever's latest at run time. A ruff release picked up since main's last green Lint
run (2026-07-23T15:26) added `PLR0917` (too-many-positional-arguments, distinct from
the already-suppressed `PLR0913`) and tightened `RUF100`'s unused-`noqa` detection —
broke Lint on both of the last two merges (#739, #740), unrelated to either PR's own
changes. Confirmed via `gh run list --workflow lint.yml --branch main`: green at
15:26, red starting with #739's merge at 19:32.

- `api/api_resource.py:1323` — removed the now-unused `# noqa: BLE001` (newer ruff no
  longer flags this blind-except pattern here).
- `api/db/bulk_upsert.py:104`, `api/tests/test_api_resource.py:24`,
  `api/tests/test_card_processing.py:18` — widened the existing `# noqa: PLR0913` to
  `# noqa: PLR0913, PLR0917`, since these are the same "many named/optional params"
  functions the original `PLR0913` suppression already accepted, and `PLR0917` is
  flagging the same underlying shape under a newer rule code.

Verified against the actual latest ruff release (`uvx ruff@latest check`, 0.16.0 —
matches what CI's unpinned install grabs) in a clean worktree, since the repo's local
`.venv` has an older pinned ruff (0.15.21) that doesn't know about `PLR0917` at all and
would give a misleading "unused noqa" reading for that code. `uvx ruff@latest check`:
all checks passed.

## Test plan

- [x] `uvx ruff@latest check` (matches CI's unpinned-latest install): all checks passed, clean worktree.
- [x] No logic changes — comment/noqa edits only.