### PR TITLE
Docs: File 4 Survey-Driven Follow-Up Issues, Number Their Design Docs

### DIFF
--- a/docs/changelog/2026-07-23-compose-permutation-fallback.md
+++ b/docs/changelog/2026-07-23-compose-permutation-fallback.md
@@ -28,4 +28,4 @@ Every `edhrec`-orderby and plane-only control held flat; `total` parity held eve
 `usd` exercised the no-permutation path). `cargo test` (debug + release) 128/128;
 `test_engine_property.py` + `test_engine_unit.py` 158/158.
 
-Design doc: `docs/issues/local-engine-compose-permutation-fallback.md`.
+Design doc: `docs/issues/done/00740-engine-compose-permutation-fallback.md`.

--- a/docs/changelog/2026-07-23-negated-range-narrowing.md
+++ b/docs/changelog/2026-07-23-negated-range-narrowing.md
@@ -65,4 +65,4 @@ New Rust tests `negated_range_narrowing` and `and_child_rank_matches_narrow_rec_
 test` (debug + release) 131/131; `test_engine_property.py` + `test_engine_unit.py` 158/158; clippy
 unchanged from baseline.
 
-Design doc: `docs/issues/local-engine-negated-range-narrowing.md`.
+Design doc: `docs/issues/done/00741-engine-negated-range-narrowing.md`.

--- a/docs/changelog/2026-07-23-watermark-postings.md
+++ b/docs/changelog/2026-07-23-watermark-postings.md
@@ -27,4 +27,4 @@ Measured (97,206-printing corpus, `unique=card`, interleaved same build):
 Totals unchanged (correctness preserved). New Rust test `watermark_narrowing`; `cargo test`
 (debug + release) 129/129; `test_engine_property.py` and `test_engine_unit.py` pass.
 
-Design doc: `docs/issues/done/local-engine-watermark-postings.md`.
+Design doc: `docs/issues/done/00739-engine-watermark-postings.md`.

--- a/docs/issues/00743-engine-arith-tuple-postings.md
+++ b/docs/issues/00743-engine-arith-tuple-postings.md
@@ -1,0 +1,131 @@
+# Engine: Arith-Expression Tuple Postings (`power+toughness<4`, `cmc+1<power`)
+
+**Status: proposed**, filed as [#743](https://github.com/jbylund/sylvan_librarian/issues/743). Found
+via `scripts/survey_queries.py` while checking the survey's remaining slowest queries after #739–#741
+landed (same pass as the sibling
+[00744-engine-compose-orderby-range-walk.md](00744-engine-compose-orderby-range-walk.md), which
+covers the other half of that list).
+
+## Measured problem
+
+Broad survey (`benchmarks/survey/branch-c6484a3.csv`, 97,206-printing corpus):
+
+| query | unique/orderby | min ms | total |
+|---|---|---:|---:|
+| `power+toughness<4` | card/rarity | 0.486 | 3,975 |
+| `cmc+1<power` | printing/edhrec | 0.374 | 1,199 |
+
+Both are `arith`-shaped (`NumExpr::Arith`, this project's `cmc+1<power`-style DSL extension).
+Neither `narrow_rec` nor `is_printing_composable` has any arm matching a `FilterExpr::NumericCmp`
+where either side is `Arith(...)` (checked directly — no matches anywhere in `lib.rs`), so every
+arith query today is a full, unnarrowed `GatheredScan`: evaluate `NumExpr::eval` per card, `O(n_cards)`
+regardless of how selective the predicate actually is.
+
+## Where the cost is
+
+Same "no dedicated index, falls to generic per-candidate evaluation" shape every other predicate in
+this survey-driven thread had before it got its own index (watermark, `-usd<c`, etc.) — just for
+*combinations* of numeric card fields instead of one field's raw value.
+
+## Proposed approach
+
+Cmc/power/toughness aren't independently free-form — Magic cards draw from a small, real-world-bounded
+set of joint values. Checked directly, both against the local corpus export and the live blue DB
+(identical count either way):
+
+```sql
+select count(*) from (select creature_power, creature_toughness, cmc from magic.cards group by 1, 2, 3) t;
+-- 531
+```
+
+531 distinct `(power, toughness, cmc)` triples across 31,508 cards. Adding `planeswalker_loyalty`
+brings it to 564 — still tiny. Any predicate that's a pure function of these fields can be evaluated
+against the ~531–564 distinct combinations directly (microseconds) instead of every card, then
+resolved to cards via postings — the same dictionary-encode-then-postings shape `set_codes`/
+`watermarks`/rarity already use for a single low-cardinality field, just for a joint tuple.
+
+### Structure
+
+1. **`ArithTupleIndex`** (build-time, once): compute each card's `(cmc, power, toughness, loyalty)`
+   key — `(Option<u8>, Option<i8>, Option<i8>, Option<u8>)`. Rust's derived `Hash`/`Eq` on the tuple
+   handles the NULL cases directly; no sentinel encoding needed. Intern into a dense `u16` id
+   (same pattern as `VocabInterner`), and build postings (tuple-id → card ids) alongside a parallel
+   `Vec<TupleKey>` (tuple-id → its own field values, for query-time re-evaluation).
+2. **Eligibility check** (mirroring this thread's `bare_range_bounds`/`is_rarity_negation_shape`
+   single-source-of-truth precedent — one function both the narrowing arm and any future ranking
+   code call, not two copies that can drift): a `NumericCmp{lhs, op, rhs}` qualifies iff every
+   `NumField` referenced anywhere in `lhs`/`rhs` — recursively through nested `Arith` — is one of
+   `{Cmc, Power, Toughness, Loyalty}`. A reference to any other field disqualifies the *whole*
+   expression; falls back to today's scan unchanged.
+3. **Narrowing**: evaluate the full `NumExpr` tree against each of the ~531–564 tuple keys — exact,
+   not approximate, using the same NULL-propagation `eval_arith` already implements (`Null op
+   anything = Null`, `Div` by zero = `Null`). Collect the tuple-ids where the result is `Tri::True`,
+   union their postings. Exact, **tight**, card-space — no residual `card_pass` needed for the arith
+   part at all.
+4. **Negation is free**: re-run the same tiny scan checking for `Tri::False` (or negate the
+   comparison op before evaluating) instead of complementing a candidate set. No NULL-inclusion risk
+   at all — this shape sidesteps the entire class of problem `local-engine-negated-range-narrowing.md`
+   spent three fixes on, structurally, by recomputing from scratch instead of complementing.
+
+### The one real implementation decision: shared evaluator, or a second one?
+
+`NumExpr::eval`/`eval_arith` (`filter.rs`) already implement exactly the recursion/NULL-propagation
+this needs, but operate on `&AOracleCard`/`Option<&APrinting>` (real archived structs), not a bare
+tuple. Two honest options:
+
+- **(a)** A small, self-contained evaluator scoped to the tuple's 4 fields (~20–30 lines), backed by
+  a differential test asserting agreement with `NumExpr::eval` against every real tuple in the corpus.
+- **(b)** Parameterize `field_num`'s fetch step behind a small trait/closure so the real per-card
+  path and this tuple-scan path share one evaluator.
+
+This thread's last two commits (the `and_child_rank`/`narrow_rec` unification) are a fresh, direct
+lesson that duplicated classification/evaluation logic drifts — (b) is the principled choice if it
+doesn't require reshaping `filter.rs` more than this is worth; (a) plus a real differential test (not
+just "it runs") is the acceptable fallback if it does. Decide once actually implementing, not here.
+
+## Scope / non-goals
+
+- **In scope**: `Cmc`, `Power`, `Toughness`, `Loyalty` — all card-level (not printing-dependent), all
+  small bounded integer domains, confirmed low joint cardinality (531–564 distinct combinations).
+- **Explicitly out of scope: `EdhrEc`.** Card-level, but **31,444 distinct values across 31,508
+  cards** (checked directly) — effectively unique per card. Including it in the joint tuple would
+  balloon the dictionary to roughly card-count size and defeat the entire premise.
+- **Explicitly out of scope: `PriceUsd`/`PriceEur`/`PriceTix`/`RarityInt`/`CollectorNumberInt`/
+  `PreferScore`.** All printing-level (vary per printing, not per card) — a real historical bug shape
+  (`usd+1<power`, referenced directly in `field_num`'s own doc comment) mixes a printing-level field
+  with a card-level one. Must be excluded from eligibility entirely: an expression mixing one in-scope
+  and one out-of-scope field doesn't get to use this path at all, not partially.
+
+## Expected cost
+
+Not yet measured — a sizing, not a promise, same convention this thread has followed throughout:
+~531–564 tuple evaluations (arithmetic on small ints, no memory indirection beyond the dictionary
+itself) is the same shape of cost this thread's other newly-narrowed queries dropped to (low tens of
+μs down from hundreds). Likely two orders of magnitude off the current ~0.4–0.5ms, if the pattern
+holds — measure once built, not asserted here.
+
+## Acceptance
+
+- `power+toughness<4`/card/rarity and `cmc+1<power`/printing/edhrec: must drop from ~0.4–0.5ms into
+  the single-digit-to-low-tens-of-μs range.
+- New Rust differential test: for a fuzzed sample of `NumericCmp`/`Arith` shapes restricted to the
+  four in-scope fields, the tuple-postings narrowing's result set must exactly match the existing
+  per-card scan + `Tri::eval` reference (same pattern `fuzz_row_identity_matches_reference` already
+  uses) — both polarities, bare and negated.
+- A query mixing an in-scope and out-of-scope field (e.g. `usd+1<power`) must correctly decline (fall
+  to the existing path) — a dedicated test case, not just documented reasoning.
+- New targeted benchmark script (`scripts/bench_arith_tuple_postings.py`, following
+  `bench_negated_range_narrowing.py`'s pattern): the two measured queries above, their negated forms,
+  at least one compound (`And`'d with an unrelated filter), and controls (a bare non-arith numeric
+  comparison, an out-of-scope arith expression) that must hold flat.
+- Broad survey re-run: both entries must drop out of the current top-20; nothing else regresses.
+
+## Related
+
+- [00744-engine-compose-orderby-range-walk.md](00744-engine-compose-orderby-range-walk.md) — sibling
+  doc from the same survey pass, covering the `format:commander`/`format:legacy` cluster (#3–6)
+  instead of the arith cluster (#8/#15 in `branch-c6484a3.csv`).
+- [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — where the
+  `and_child_rank`/`narrow_rec` single-source-of-truth precedent (relevant to the shared-evaluator
+  decision above) came from.
+- `docs/workflows/performance-pr-workflow.md` — the process this doc follows.

--- a/docs/issues/00743-engine-arith-tuple-postings.md
+++ b/docs/issues/00743-engine-arith-tuple-postings.md
@@ -64,7 +64,7 @@ resolved to cards via postings — the same dictionary-encode-then-postings shap
    part at all.
 4. **Negation is free**: re-run the same tiny scan checking for `Tri::False` (or negate the
    comparison op before evaluating) instead of complementing a candidate set. No NULL-inclusion risk
-   at all — this shape sidesteps the entire class of problem `local-engine-negated-range-narrowing.md`
+   at all — this shape sidesteps the entire class of problem `00741-engine-negated-range-narrowing.md`
    spent three fixes on, structurally, by recomputing from scratch instead of complementing.
 
 ### The one real implementation decision: shared evaluator, or a second one?
@@ -125,7 +125,7 @@ holds — measure once built, not asserted here.
 - [00744-engine-compose-orderby-range-walk.md](00744-engine-compose-orderby-range-walk.md) — sibling
   doc from the same survey pass, covering the `format:commander`/`format:legacy` cluster (#3–6)
   instead of the arith cluster (#8/#15 in `branch-c6484a3.csv`).
-- [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — where the
-  `and_child_rank`/`narrow_rec` single-source-of-truth precedent (relevant to the shared-evaluator
-  decision above) came from.
+- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) —
+  where the `and_child_rank`/`narrow_rec` single-source-of-truth precedent (relevant to the
+  shared-evaluator decision above) came from.
 - `docs/workflows/performance-pr-workflow.md` — the process this doc follows.

--- a/docs/issues/00744-engine-compose-orderby-range-walk.md
+++ b/docs/issues/00744-engine-compose-orderby-range-walk.md
@@ -23,7 +23,7 @@ Root cause has two independent parts, both avoidable:
    97,206 printings) — for a predicate whose *true* information content is "308 printings are
    excluded," not "96,898 are included."
 2. **The paging is expensive because there's no permutation for `orderby=usd`.** Per
-   `local-engine-compose-permutation-fallback.md`, `usd`/`rarity` have no card-space sort
+   `done/00740-engine-compose-permutation-fallback.md`, `usd`/`rarity` have no card-space sort
    permutation, so `printing_compose_fastpath` either walks via `gather_composed_page` (visit every
    candidate card, compute a sort key, quickselect — `O(n_cards)` regardless of selectivity) or
    declines composing outright via `COMPOSE_GATHER_MAX_CARD_FRACTION` when the predicate is this
@@ -135,7 +135,7 @@ as every other doc in this thread.
 
 ## Related
 
-- [local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) —
+- [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md) —
   where `gather_composed_page` and `COMPOSE_GATHER_MAX_CARD_FRACTION` came from; this doc's paging
   fix is the case that guard was never meant to cover.
 - [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — sibling

--- a/docs/issues/00744-engine-compose-orderby-range-walk.md
+++ b/docs/issues/00744-engine-compose-orderby-range-walk.md
@@ -1,0 +1,145 @@
+# Engine: PrintingCompose Orderby-Range-Index Walk
+
+**Status: proposed**, filed as [#744](https://github.com/jbylund/sylvan_librarian/issues/744). Found
+via `scripts/survey_queries.py` while checking the survey's remaining slowest queries after #739–#741
+landed.
+
+## Measured problem
+
+`format:commander`, `unique=printing`, `orderby=usd`: **0.578ms**, `total=96,898` (of 97,206
+printings — Commander legality is a near-total match, only 308 printings excluded, 0.32%).
+`type:goblin or format:legacy`/printing/usd (0.583ms) and `format:legacy`/printing/rarity
+(0.534ms) are the same shape. These are now the #3–#6 slowest entries in the broad survey
+(`benchmarks/survey/branch-c6484a3.csv`), just below the `Not(Or(...))` pair at #1/#2 (out of
+scope here — see "Related").
+
+Root cause has two independent parts, both avoidable:
+
+1. **The build is expensive because it broadcasts from the majority side.** `legality_leaf_bits`
+   (via `compose_printing_bits`) builds the printing-space bitmap by broadcasting the *legal*
+   card-plane down to printings (`broadcast_card_bits_to_printings` touches every *set* card — i.e.
+   every legal one). For Commander that's ~99.68% of all cards: the build is effectively a full
+   `O(n_cards + n_printings)` pass (`LINEAR_PASS_PER_PRINTING_NS = 1.50` in `cost.rs`, ~146μs over
+   97,206 printings) — for a predicate whose *true* information content is "308 printings are
+   excluded," not "96,898 are included."
+2. **The paging is expensive because there's no permutation for `orderby=usd`.** Per
+   `local-engine-compose-permutation-fallback.md`, `usd`/`rarity` have no card-space sort
+   permutation, so `printing_compose_fastpath` either walks via `gather_composed_page` (visit every
+   candidate card, compute a sort key, quickselect — `O(n_cards)` regardless of selectivity) or
+   declines composing outright via `COMPOSE_GATHER_MAX_CARD_FRACTION` when the predicate is this
+   broad (as it is here: 99.68% > 85% → declines). Either way, the query falls back to plain
+   `GatheredScan` — visit everything, sort/quickselect, ~0.578ms.
+
+Neither cost is inherent to the predicate. Both are avoidable because `orderby=usd` has its own
+pre-sorted `PrintingRangeIndex` (`indexes.price_usd`) sitting unused, and Commander's *exclusion*
+set is what's actually sparse.
+
+## Proposed approach: two independent fixes, same feature
+
+### 1. Build from whichever side is sparser
+
+`status_plane_bases` already returns both `(exists_base, absent_base)` for every tracked format —
+the "_ABSENT"/"_ILLEGAL" plane the existing `-f:x` (negated Legality) arm already reads directly
+(`legality_candidate_bits(..., negated: true)`). Extend `compose_printing_bits`'s Legality build to
+choose adaptively: if the format's legal-card popcount exceeds `n_cards / 2`, build from the
+*absent* plane (start printing-space at all-1s, clear each illegal card's printing range down) and
+skip the divergent repair pass entirely when the format has zero divergent cards (true for
+Commander in the real corpus — checked, see "Real numbers" below); otherwise build from the
+*exists* plane as today. This is exactly the same "pick the cheaper side" shape `range_narrowed`
+already uses (`if k <= idx.len() - k`) — same pattern, different representation, not a new idea.
+
+This is a strict improvement to `compose_printing_bits` alone, independent of the paging fix below
+— it helps `walk_grouped_page` and `gather_composed_page` too, for any near-universal Legality
+predicate, regardless of orderby.
+
+### 2. Walk the orderby's own range index when there's no permutation and mode is Printing
+
+New paging branch inside `printing_compose_fastpath`, alongside `walk_grouped_page` (has
+permutation) and `gather_composed_page` (#740's fallback): when `sort_col` resolves to one of the
+printing-range-indexed fields (`PriceUsd`/`CollectorNumberInt`/released-at — the same set
+`bare_range_bounds` already knows) **and** `mode == Printing`, walk that field's *own* sorted index
+directly — same shape as `aligned_page`'s bucket walk, but testing the already-built `pbits` bit per
+visited entry instead of assuming unconditional membership in a contiguous slice. Terminates once
+`offset + limit` matches are collected, so cost is `O((offset+limit) / selectivity)`, not
+`O(n_cards)` — the *opposite* of `gather_composed_page`'s shape, and the reason
+`COMPOSE_GATHER_MAX_CARD_FRACTION` must **not** gate this branch: that guard's premise (broad ⇒ not
+worth it) is backwards for this walk, where broad is the *best* case.
+
+Scoped to `mode == Printing` only: `unique=card`/`artwork`'s row sort key is the *representative*
+printing's price (chosen via `prefer`), and walking `price_usd` in order and taking "first
+occurrence per card" is only correct if `prefer` happens to correlate with price — the same reason
+`usd`/`rarity` never got a card-space permutation in the first place. Not attempting that here.
+
+### Cost-model update
+
+`cost.rs`'s `compose_has_perm: bool` needs to become a 3-way distinction (permutation walk /
+orderby-index walk / gather-quickselect) — the same mechanism #740 introduced, one more variant.
+`run_query_routed` decides which of the three applies the same way `printing_compose_fastpath`
+itself will.
+
+## Expected cost (worked from real numbers, not guessed)
+
+Real corpus counts (`benchmarks/bitplanes/corpus.jsonl`, checked directly rather than assumed):
+`n_printings=97,206`, Commander-illegal printings=308 (0.32%), **0 divergent cards for Commander**
+(no per-card repair pass needed at all — every printing of a card agrees on Commander legality in
+this corpus).
+
+Using `cost.rs`'s own calibrated constants:
+
+| step | cost model | estimate |
+|---|---|---:|
+| build (illegal-side broadcast, ~308 printings' cards, no repair) | `LINEAR_PASS_PER_PRINTING_NS × ~450` | ~0.7μs |
+| total (popcount, `97,206/64` words) | `PLANE_POPCOUNT_PER_WORD_NS × 1,519` | ~1.5μs |
+| walk (`(0+100)/0.9968 ≈ 100` steps) | `RANGE_WALK_STEP_NS × 100` | ~0.45μs |
+| fixed | `RANGE_FIXED_COST_NS` | ~0.15μs |
+| **engine-internal total** | | **~2.8μs** |
+
+This lines up with the *original* `~20μs` estimate as plausible, maybe even conservative on the
+engine-internal side — but the engine's own cost-model constants don't capture everything: the
+broad survey's fastest measured queries span from **~2μs** (exact-name lookups, `!"Sol Ring"`-style
+— a comparably cheap "look up a small thing, stop early" shape) up to **~80μs** for the aligned
+range walk (`-usd<50`/card/rarity, `total=555`, itself a small-output aligned bucket walk that
+*should* be cost-model-cheap too, by this same math). That gap isn't explained by anything in this
+doc, and probably reflects overhead outside the Rust engine's own cost model (PyO3 call/argument
+marshaling, cost-model plan-selection dispatch before the winning plan even runs) that varies by
+query shape in a way not worth guessing at here. **Realistic expectation: somewhere in the
+single-digit-to-low-tens-of-μs range, not a promise of an exact number** — measure once built, same
+as every other doc in this thread.
+
+## Scope / non-goals
+
+- `unique=card`/`artwork` with `orderby=usd`/`rarity`: out of scope, see above (`prefer`-dependent
+  representative selection).
+- The plane-side "pick the sparser side" build optimization is scoped to Legality only for now —
+  it's the one field where "mostly-true for a popular format" is a common real pattern. Rarity
+  (5 discrete values, no single dominant one) and Border don't obviously have the same imbalance;
+  revisit only if a similar broad-single-value case turns up.
+- `type:goblin or format:legacy`/printing/usd (#3 in the survey) is **not** fixed by this alone —
+  `card_subtype` (`type:goblin`) isn't in `is_printing_composable`'s recognized leaf set at all, so
+  the whole `Or` declines composability regardless of this change. Separate gap, not addressed here.
+- The `Not(Or(...))` pair (`border:black -(name:ancient or pow=5)`, `id:gw -(color:gw or set:mom)`)
+  currently ranked #1/#2 in the survey: unrelated, different shape, not addressed here.
+
+## Acceptance
+
+- `format:commander`/`format:legacy` (bare), printing mode, `usd`/`rarity` orderby: must drop from
+  ~0.5–0.6ms to the single-digit-to-low-tens-of-μs range.
+- `total` parity with today's (already-correct) numbers on every affected query.
+- Every `unique=card`/`artwork` query, every already-fast printing-mode query (aligned range,
+  permutation-orderby), and every plane-only control: must hold flat.
+- New Rust test mirroring `and_child_rank_matches_narrow_rec_dispatch`'s spirit: a small store with
+  a known illegal-card set, asserting the sparse-side build produces the same bits as today's
+  broadcast-from-legal build (differential, not just "it runs"), plus the new walk producing the
+  same page as `gather_composed_page` would for the same query (differential agreement, same
+  pattern `fuzz_row_identity_matches_reference` already uses elsewhere).
+
+## Related
+
+- [local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) —
+  where `gather_composed_page` and `COMPOSE_GATHER_MAX_CARD_FRACTION` came from; this doc's paging
+  fix is the case that guard was never meant to cover.
+- [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — sibling
+  investigation from the same survey-driven thread; also has the `and_child_rank`/`narrow_rec`
+  single-source-of-truth precedent this doc's paging branch should follow when it's implemented.
+- [done/00667-engine-legality-divergent-carveout.md](done/00667-engine-legality-divergent-carveout.md)
+  — the existing `_EXISTS`/`_ABSENT` plane pair and divergent-repair mechanism this reuses.

--- a/docs/issues/00744-engine-compose-orderby-range-walk.md
+++ b/docs/issues/00744-engine-compose-orderby-range-walk.md
@@ -138,8 +138,9 @@ as every other doc in this thread.
 - [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md) —
   where `gather_composed_page` and `COMPOSE_GATHER_MAX_CARD_FRACTION` came from; this doc's paging
   fix is the case that guard was never meant to cover.
-- [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — sibling
-  investigation from the same survey-driven thread; also has the `and_child_rank`/`narrow_rec`
-  single-source-of-truth precedent this doc's paging branch should follow when it's implemented.
+- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) —
+  sibling investigation from the same survey-driven thread; also has the `and_child_rank`/
+  `narrow_rec` single-source-of-truth precedent this doc's paging branch should follow when it's
+  implemented.
 - [done/00667-engine-legality-divergent-carveout.md](done/00667-engine-legality-divergent-carveout.md)
   — the existing `_EXISTS`/`_ABSENT` plane pair and divergent-repair mechanism this reuses.

--- a/docs/issues/00745-engine-explain-analyze.md
+++ b/docs/issues/00745-engine-explain-analyze.md
@@ -1,0 +1,114 @@
+# Engine: `explain` / `explain_analyze` for the Plan-Selection Layer
+
+**Status: proposed**, filed as [#745](https://github.com/jbylund/sylvan_librarian/issues/745). Builds
+directly on
+[00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md)
+(landed): that issue gave the engine a single cost-based router
+(`run_query_routed`, lib.rs) that argmins `cost::plan_cost` over
+`PhysicalPlan::ALL.filter(applicable)` (6 variants: `PrintingRangeScan`,
+`PrintingCompose`, `PlanePopcountOrder`, `CardRangePopcount`,
+`StreamedSelect`, `GatheredScan` — lib.rs ~4843), plus a force/dispatch seam
+(`run_query_with_plan`, lib.rs ~5900) that runs any one named plan directly.
+This note proposes turning that machinery into a callable diagnostic
+primitive instead of leaving it reachable only from `cargo test`/`cargo bench`.
+
+## The gap
+
+Every query already computes `cost::plan_cost` for *every* applicable plan
+inside the router's `choose` closure — then throws away all but the argmin
+(lib.rs ~5718). Nothing captures the discarded numbers.
+
+On the "actual cost" side, #702 step 3 built exactly this kind of harness —
+but only for a fixed, committed corpus: `plan_cost_calibration` (tests.rs
+~3077) times each applicable plan min-of-n to fit the model's constants, and
+`plan_cost_model_matches_gold` (tests.rs ~3185) checks argmin-vs-gold on that
+same corpus. Both are validation benches, not tools — there's no way to ask
+"what would every plan cost, predicted and actual, for *this* query I'm
+looking at right now" without writing a new `#[bench]`.
+
+## Two primitives
+
+- **`explain(query) -> Vec<(PhysicalPlan, PredictedCost)>`** — enumerate
+  `PhysicalPlan::ALL.filter(|p| p.applicable(...))`, call `cost::plan_cost`
+  on each, return the ranked list. This is just exposing numbers the router
+  already computes; it costs nothing beyond what every query pays today, so
+  it's safe to call constantly (dev builds, tests, an internal endpoint).
+- **`explain_analyze(query, num_warmups, num_trials) -> Map<PhysicalPlan,
+  Vec<Duration>>`** — actually run each applicable plan via
+  `run_query_with_plan`, `num_warmups` discarded rounds then `num_trials`
+  recorded rounds, and return the **raw per-trial timings**, not a
+  pre-reduced median. Loop shape:
+
+  ```
+  for round in 0..num_warmups + num_trials:
+      order = rotate(applicable_plans, round)   # not the same order every round
+      for plan in order:
+          t = time(run_query_with_plan(plan, ...))
+          if round >= num_warmups: record(plan, t)
+  ```
+
+  Rotating which plan goes first/last each round (rather than a fixed
+  `a();b();c()`) avoids handing one plan a systematic advantage from
+  whatever accumulates round-over-round (allocator state, cache residency).
+  Returning raw timings rather than a summary lets the caller compute a
+  median themselves and — as important — see whether a plan's timing is
+  bimodal, which this engine has measured happening on identical work
+  before ([00648-engine-verifier-cost-ordering.md](done/00648-engine-verifier-cost-ordering.md)'s
+  measurement-traps section). Given plans here run sub-few-ms, 3 warmups +
+  10 trials × 6 plans is a small fraction of a second per call.
+
+## Mis-plan signal
+
+`argmin(predicted)` vs `argmin(median(actual))` disagreeing is the thing
+worth flagging — generalizing `plan_cost_model_matches_gold` from "pass/fail
+against one frozen corpus" from a manual recalibration run into something
+callable against any query on demand. Run over the existing survey corpus
+(`scripts/survey_queries.py`) and the mismatch rate becomes a standing
+health check for the cost model between the periodic recalibration benches
+#702 already calls for.
+
+## Open correctness question before trusting the timings
+
+`run_query_with_plan` takes `filter: &mut FilterExpr` (lib.rs ~5900) —
+mutable, not `&`. The verifier pipeline already has at least one step
+(`memoize_text_predicates`, per the verifier-cost-ordering doc) that mutates
+cost-relevant state on the filter tree as a side effect of running. Before
+trusting `explain_analyze`'s relative timings under interleaving, confirm
+either that each plan invocation gets a fresh/cloned `FilterExpr` or that
+repeated invocation against the same mutated tree is idempotent and doesn't
+advantage whichever plan happens to run first in a round. If it isn't, the
+rotation above only partially compensates — the fix would be cloning
+`filter` per call, at some extra cost per round.
+
+## Where to expose
+
+Land as an in-process Rust function first — callable from tests, benches,
+and a small standalone binary — mirroring how the force/dispatch seam
+itself started internal-only. Whether it later grows an HTTP surface (an
+internal/dev-only Falcon route, gated off in prod) is a separate, later
+decision. It should never sit on the default request path: it multiplies
+work by the number of applicable plans (typically 2–4 of the 6 variants),
+which is fine for an on-demand debug call and wrong for every query.
+
+## Non-goals
+
+- Not a routing mechanism — the router already routes on `argmin
+  cost(plan)`; this sits alongside it as a diagnostic, not a replacement.
+- Not a replacement for the committed calibration corpus — `plan_cost_calibration`
+  and `plan_cost_model_matches_gold` stay as the CI-facing regression gate;
+  `explain_analyze` is for ad hoc/interactive use and off-CI recalibration
+  runs (per #702's "Keeping costs/plans current" section).
+- No join-order search or new plan enumeration — same non-goal #702 already
+  states; this only makes the existing fixed plan set individually
+  measurable on demand.
+
+## Related
+
+- [00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) —
+  the cost model, `PhysicalPlan`, `run_query_with_plan`, and the calibration
+  harness this builds on.
+- [00648-engine-verifier-cost-ordering.md](done/00648-engine-verifier-cost-ordering.md) —
+  source of the interleaved-measurement discipline and the documented
+  bimodal-timing / env-var-size measurement traps.
+- [docs/prs/verifier-cost-ordering.md](../prs/verifier-cost-ordering.md) —
+  the three-rounds-of-manual-measurement process this would make repeatable.

--- a/docs/issues/00746-engine-tag-postings-compose.md
+++ b/docs/issues/00746-engine-tag-postings-compose.md
@@ -7,7 +7,7 @@ only 2 of its 9,234 matches. A step 4 for
 [#731](00731-engine-compose-universal-evaluator.md)'s leaf-source table, alongside step 1 (range
 leaves, shipped) and the sibling work this session added:
 [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md)
-and [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md).
+and [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md).
 
 ## The finding
 
@@ -67,7 +67,7 @@ estimate from calibrated per-op constants, not a benchmark.
 `#731`'s own caveat applies here directly: **`NOT` over a nullable field needs a "known" mask** — a
 null-valued printing satisfies neither the direct predicate nor its negation (the same trivalent trap
 `tight_narrow_space` had for `DateCmp`/`YearCmp`, fixed this session in
-[local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md)). `set_code` has
+[done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md)). `set_code` has
 no null case (every printing belongs to exactly one set) — "all-ones minus postings" is exact.
 `watermark` **is** nullable (`card_watermark_id != NONE_STR` gates the postings build in
 `reload_commit`, see [00739-engine-watermark-postings.md](done/00739-engine-watermark-postings.md)) —
@@ -100,7 +100,7 @@ known-mask question.
   its table doesn't yet enumerate.
 - [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md) —
   sibling fix from the same broad-survey investigation.
-- [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — where the
+- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) — where the
   nullable-field `NOT` trap was found and fixed for dates; the same discipline applies to watermark
   here.
 - [done/00739-engine-watermark-postings.md](done/00739-engine-watermark-postings.md) — the

--- a/docs/issues/00746-engine-tag-postings-compose.md
+++ b/docs/issues/00746-engine-tag-postings-compose.md
@@ -6,8 +6,8 @@ yet implemented or measured. Filed investigating why `-set:dmu year:2023`
 only 2 of its 9,234 matches. A step 4 for
 [#731](00731-engine-compose-universal-evaluator.md)'s leaf-source table, alongside step 1 (range
 leaves, shipped) and the sibling work this session added:
-[local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) and
-[local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md).
+[done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md)
+and [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md).
 
 ## The finding
 
@@ -70,7 +70,7 @@ null-valued printing satisfies neither the direct predicate nor its negation (th
 [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md)). `set_code` has
 no null case (every printing belongs to exactly one set) — "all-ones minus postings" is exact.
 `watermark` **is** nullable (`card_watermark_id != NONE_STR` gates the postings build in
-`reload_commit`, see [local-engine-watermark-postings.md](done/local-engine-watermark-postings.md)) —
+`reload_commit`, see [00739-engine-watermark-postings.md](done/00739-engine-watermark-postings.md)) —
 "all-ones minus postings" would wrongly count no-watermark printings as matching `-watermark:x`. The
 negated compose leaf should therefore cover `set:` only, or `watermark:` needs an explicit
 known-mask subtraction (a third small postings-derived bitmap of "has any watermark") before its
@@ -98,10 +98,10 @@ known-mask question.
 
 - [#731](00731-engine-compose-universal-evaluator.md) — the parent plan; this is a step-4 leaf kind
   its table doesn't yet enumerate.
-- [local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) —
+- [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md) —
   sibling fix from the same broad-survey investigation.
 - [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — where the
   nullable-field `NOT` trap was found and fixed for dates; the same discipline applies to watermark
   here.
-- [done/local-engine-watermark-postings.md](done/local-engine-watermark-postings.md) — the
+- [done/00739-engine-watermark-postings.md](done/00739-engine-watermark-postings.md) — the
   `set_codes`/`watermarks` `TagIndex` this reuses.

--- a/docs/issues/00746-engine-tag-postings-compose.md
+++ b/docs/issues/00746-engine-tag-postings-compose.md
@@ -1,0 +1,107 @@
+# Engine: Exact-Postings Fields (`set:`/`watermark:`) as Compose Leaves
+
+**Status: proposed**, filed as [#746](https://github.com/jbylund/sylvan_librarian/issues/746), not
+yet implemented or measured. Filed investigating why `-set:dmu year:2023`
+(0.450ms, printing/edhrec) costs noticeably more than `year:2023` alone (0.259ms) despite excluding
+only 2 of its 9,234 matches. A step 4 for
+[#731](00731-engine-compose-universal-evaluator.md)'s leaf-source table, alongside step 1 (range
+leaves, shipped) and the sibling work this session added:
+[local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) and
+[local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md).
+
+## The finding
+
+`year:2023` alone qualifies for `PrintingRangeScan` (`bare_range_bounds(filter, indexes).is_some()`
+for the *whole* filter) — a non-materializing binary-search plan, effectively free. `-set:dmu
+year:2023` is an `And`, so `bare_range_bounds` returns `None` for the compound as a whole regardless
+of how cheap one side is; `PrintingRangeScan` is inapplicable and the query falls to a materializing
+plan. There, `narrow_rec`'s `And` arm ([lib.rs:3338](../../card_engine/src/lib.rs#L3338)) narrows via
+`year:2023` (rank 1) to 9,234 candidates, then correctly skips `-set:dmu`'s narrowing contribution
+(rank 2, "complements only pay as sole source") — `-set:dmu` becomes a per-candidate residual check
+instead. Per the engine's own measured cost model (`MASK_COMPARE_NS100` ≈ 4ns/candidate,
+filter.rs:427-445), that residual check alone should cost ~37μs for 9,234 candidates — the observed
+gap is ~190μs, so most of it is the materializing path's general overhead (allocation, sort-key
+computation, accumulator bookkeeping), not the predicate itself.
+
+## The idea
+
+`is_printing_composable`/`compose_printing_bits` ([lib.rs:4393](../../card_engine/src/lib.rs#L4393),
+[lib.rs:4551](../../card_engine/src/lib.rs#L4551)) already turn border, rarity, legality, and
+range leaves into exact printing-space bitmaps, composed with `AND`/`OR` — #731's model. `set:`/
+`watermark:` aren't in that table at all today: they're backed by a plain postings `TagIndex`
+(`indexes.set_codes`/`indexes.watermarks`, a `HashMap<String, Vec<u32>>` of sorted printing ids), no
+plane, no leaf-bits function, positive or negated.
+
+Adding one is cheap and reuses an existing primitive: `scatter_bits`
+([lib.rs:2406](../../card_engine/src/lib.rs#L2406)) already does exactly this for border's
+non-plane postings fallback (`border_leaf_bits`, lib.rs:4443). A `set:dmu` leaf is
+`scatter_bits(indexes.set_codes["dmu"], n_printings)` — the same shape, just keyed off a different
+index.
+
+**The negated form is the interesting part, and it's cheaper than the range case.** Negating a range
+can flip to a large second range (`-cn<100` ⇒ `cn>=100`, ~64% of printings — why `broad_ok` mattered
+in the negated-range-narrowing work). Negating a small exact-postings set doesn't have that problem:
+`-set:dmu` is "start from all-ones, clear these 436 bits" — cost rides the *positive* postings size
+(436) regardless of polarity, never the complement (96,770). That's a strictly cheaper shape than
+anything currently in the compose table, and it's exactly why the generic `Not`-arm (which requires a
+tight child and pays for a full complement) isn't the right tool here — a dedicated leaf-bits
+function sidesteps it the same way `range_leaf_bits` already does for ranges.
+
+## Estimated cost
+
+Using the engine's own calibrated constant (`RANGE_SCATTER_PER_PRINTING_NS = 0.36ns`, cost.rs:174 —
+measured for scattering an index/postings slice into a bitmap, so it's the right rate to reuse here):
+
+| step | count | cost |
+|---|---:|---:|
+| scatter `year:2023` into a bitmap | 9,234 | ~3.3μs |
+| clear `set:dmu`'s postings from it | 436 | ~0.16μs |
+| popcount the result | ~1,519 words | low single-digit μs |
+
+Total materialization: roughly 5-10μs, against the current path's ~190μs gap over `year:2023` alone
+— potentially close to an order of magnitude on this shape. Not measured yet; this is a napkin
+estimate from calibrated per-op constants, not a benchmark.
+
+## Correctness caveat — must not apply uniformly to both fields
+
+`#731`'s own caveat applies here directly: **`NOT` over a nullable field needs a "known" mask** — a
+null-valued printing satisfies neither the direct predicate nor its negation (the same trivalent trap
+`tight_narrow_space` had for `DateCmp`/`YearCmp`, fixed this session in
+[local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md)). `set_code` has
+no null case (every printing belongs to exactly one set) — "all-ones minus postings" is exact.
+`watermark` **is** nullable (`card_watermark_id != NONE_STR` gates the postings build in
+`reload_commit`, see [local-engine-watermark-postings.md](done/local-engine-watermark-postings.md)) —
+"all-ones minus postings" would wrongly count no-watermark printings as matching `-watermark:x`. The
+negated compose leaf should therefore cover `set:` only, or `watermark:` needs an explicit
+known-mask subtraction (a third small postings-derived bitmap of "has any watermark") before its
+complement is safe — the same shape `tight_narrow_space`'s bug taught, don't re-learn it here.
+
+## Scope
+
+No new `PhysicalPlan` variant — this slots entirely into the existing `PrintingCompose` plan. Its
+applicability (`printing_compose_applicable`), cost (`plan_cost`'s `PrintingCompose` arm, already
+priced off `RANGE_SCATTER_PER_PRINTING_NS`), and execution (`printing_compose_fastpath` /
+`gather_composed_page` / `walk_grouped_page`) all key off `is_printing_composable` /
+`compose_printing_bits` / `compose_printing_estimate` — the three functions this widens. The planner
+doesn't gain a new choice to reason about; `PrintingCompose` just becomes applicable to more filter
+shapes, the same way step 1 (range leaves) widened it without adding a plan.
+
+Add `TextExact{SetCode, Eq}` (and its `Not`, per the caveat above) to those three functions, mirroring
+`border`'s arms. Since `is_printing_composable` already recurses through `And`/`Or`, this generalizes
+immediately to any mix with ranges/border/rarity/legality — no new per-combination logic. Measure with
+a targeted
+`scripts/bench_*.py` before/after per the performance PR workflow, using `-set:dmu year:2023` as the
+motivating query and `set:dmu`/`year:2023` alone as controls, before touching `watermark:`'s
+known-mask question.
+
+## Related
+
+- [#731](00731-engine-compose-universal-evaluator.md) — the parent plan; this is a step-4 leaf kind
+  its table doesn't yet enumerate.
+- [local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) —
+  sibling fix from the same broad-survey investigation.
+- [local-engine-negated-range-narrowing.md](local-engine-negated-range-narrowing.md) — where the
+  nullable-field `NOT` trap was found and fixed for dates; the same discipline applies to watermark
+  here.
+- [done/local-engine-watermark-postings.md](done/local-engine-watermark-postings.md) — the
+  `set_codes`/`watermarks` `TagIndex` this reuses.

--- a/docs/issues/done/00739-engine-watermark-postings.md
+++ b/docs/issues/done/00739-engine-watermark-postings.md
@@ -1,7 +1,7 @@
 # Engine: Watermark Postings Index
 
-**Status: done.** No GitHub issue filed — small, mechanical, found while investigating the
-slowest query in a broad realistic-traffic survey.
+**Status: done**, shipped as [#739](https://github.com/jbylund/sylvan_librarian/pull/739) — small,
+mechanical, found while investigating the slowest query in a broad realistic-traffic survey.
 
 ## Why
 

--- a/docs/issues/done/00740-engine-compose-permutation-fallback.md
+++ b/docs/issues/done/00740-engine-compose-permutation-fallback.md
@@ -1,7 +1,8 @@
 # Engine: `PrintingCompose` Permutation-Free Paging Fallback
 
-**Status: done.** No GitHub issue filed. Found while investigating a broad-survey slow query
-(`docs/issues/done/local-engine-watermark-postings.md`'s companion investigation).
+**Status: done**, shipped as [#740](https://github.com/jbylund/sylvan_librarian/pull/740). Found
+while investigating a broad-survey slow query (`docs/issues/done/00739-engine-watermark-postings.md`'s
+companion investigation).
 
 ## Measured problem
 
@@ -101,10 +102,10 @@ regressions; `rarity`/`usd`-orderby groups' p90 improved, everything else flat w
 
 ## Related
 
-- [done/local-engine-watermark-postings.md](done/local-engine-watermark-postings.md) — the sibling
+- [00739-engine-watermark-postings.md](00739-engine-watermark-postings.md) — the sibling
   investigation this was found alongside.
-- [done/00724-engine-printing-existential-planes.md](done/00724-engine-printing-existential-planes.md)
+- [00724-engine-printing-existential-planes.md](00724-engine-printing-existential-planes.md)
   — `PrintingCompose`'s substrate.
-- [00731-engine-compose-universal-evaluator.md](00731-engine-compose-universal-evaluator.md) — the
-  compose leaf-source generalization this builds on top of.
+- [../00731-engine-compose-universal-evaluator.md](../00731-engine-compose-universal-evaluator.md) —
+  the compose leaf-source generalization this builds on top of.
 - `docs/workflows/performance-pr-workflow.md` — the measure-first process this followed.

--- a/docs/issues/done/00741-engine-negated-range-narrowing.md
+++ b/docs/issues/done/00741-engine-negated-range-narrowing.md
@@ -1,8 +1,8 @@
 # Engine: Negated-Range Narrowing (`-usd<c`, `-cn<c`, `-date`/`-year`)
 
-**Status: done.** No GitHub issue filed. Found investigating `-usd<0.25 usd<5`, the slowest query
-in a broad realistic-traffic survey (1.131ms) after the watermark and compose-permutation-fallback
-fixes landed.
+**Status: done**, shipped as [#741](https://github.com/jbylund/sylvan_librarian/pull/741). Found
+investigating `-usd<0.25 usd<5`, the slowest query in a broad realistic-traffic survey (1.131ms)
+after the watermark and compose-permutation-fallback fixes landed.
 
 ## The idea
 
@@ -202,8 +202,8 @@ before this fix — no longer appears in the top 10; no new slow patterns introd
 
 ## Related
 
-- [local-engine-compose-permutation-fallback.md](local-engine-compose-permutation-fallback.md) —
+- [00740-engine-compose-permutation-fallback.md](00740-engine-compose-permutation-fallback.md) —
   the sibling investigation this branches from; both found while chasing the same broad-survey
   slow-query list.
-- [done/local-engine-watermark-postings.md](done/local-engine-watermark-postings.md) — the first
+- [00739-engine-watermark-postings.md](00739-engine-watermark-postings.md) — the first
   fix in this same investigation thread.


### PR DESCRIPTION
## Summary

Four proposed design docs from the same broad-survey investigation thread (#739–#742) — none
implemented yet, docs only. Each got a GitHub issue filed and was renamed from `local-slug.md` to
the assigned `#####-slug.md`, per this repo's `docs/issues` naming convention (issue number over PR
number when both exist; `local-` only for docs with no issue of their own).

- [#743](https://github.com/jbylund/sylvan_librarian/issues/743) — arith-expression tuple postings:
  dictionary-encode `(cmc, power, toughness, loyalty)` into postings (531–564 distinct tuples in real
  data, verified against both the corpus export and the live DB) instead of a full per-card scan for
  `power+toughness<4`-style queries.
- [#744](https://github.com/jbylund/sylvan_librarian/issues/744) — compose orderby-range-index walk:
  `format:commander`/`legacy` costing ~0.5–0.6ms in printing mode despite being a near-total match,
  from broadcasting the majority legality side and lacking a permutation for usd/rarity orderby.
- [#745](https://github.com/jbylund/sylvan_librarian/issues/745) — `explain`/`explain_analyze`: expose
  the plan-selection router's per-plan cost/timing numbers as a callable diagnostic instead of only
  reachable from `cargo bench`.
- [#746](https://github.com/jbylund/sylvan_librarian/issues/746) — tag-postings compose leaves: add
  `set:`/`watermark:` as `PrintingCompose` leaves via the existing `scatter_bits` primitive, same shape
  border's postings fallback already uses.

Each doc's status line now links its assigned issue; internal cross-links between the four (and to
already-shipped docs) were updated to the new filenames.

## Test plan

- [x] Docs only, no code changes.
- [x] Verified every internal markdown link in all 4 files resolves to a real file (one exception,
      `local-engine-negated-range-narrowing.md`, is expected — that doc lands with #741, not yet merged).