### PR TITLE
Engine: Exact-Postings Fields (set:/watermark:) as Compose Leaves

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4638,6 +4638,21 @@ fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) 
         FilterExpr::True => true,
         FilterExpr::And(v) | FilterExpr::Or(v) => v.iter().all(|c| is_printing_composable(c, indexes)),
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, .. } => true,
+        // #746: `set:`/`watermark:` postings leaves. `scatter_bits(indexes.set_codes[value])` /
+        // `indexes.watermarks[value]` is the exact printing bitmap (`tag_postings_leaf_bits`) — a
+        // value-membership intersection, so it's exact for both the non-null `set_code` and the
+        // nullable `watermark` alike (the positive form never complements). An unknown value scatters
+        // nothing (all-zero, exactly "no printing").
+        FilterExpr::TextExact { field: TextField::SetCode | TextField::Watermark, op: CmpOp::Eq, .. } => true,
+        // #746: `-set:VALUE` — all-ones minus the value's postings (`set_code_negated_leaf_bits`),
+        // exact because `set_code` is non-nullable. Guarded on the inner shape (not a bare `Not(_)`)
+        // and deliberately NOT extended to `-watermark:` (nullable — its complement would need a
+        // "has any watermark" known-mask this leaf doesn't build; stays on the general path).
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, .. }) =>
+        {
+            true
+        }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
         // Legality via #667's card `_EXISTS` plane + a divergent repair (see `legality_leaf_bits`).
@@ -4711,6 +4726,41 @@ fn rarity_leaf_bits(c: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: us
         Some(e) => scatter_bits(e.1.iter().map(|p| u32::from(*p)), n_printings),
         None => vec![0u64; wpp],
     }
+}
+
+/// #746: the exact printing-space bitmap for a bare tag-postings leaf (`set:VALUE`/`watermark:VALUE`)
+/// — scatter the value's sorted postings (`indexes.set_codes`/`indexes.watermarks`) into a fresh
+/// bitmap, or all-zero for a value absent from the index (exactly "no printing", matching
+/// `narrow_rec`'s empty-is-exact treatment of an unknown code). This is an intersection with the
+/// postings set, never a complement, so it is exact for the non-nullable `set_code` field and the
+/// nullable `watermark` field alike — the trivalent-NULL trap that keeps negation off the compose
+/// path for a nullable field (see `set_code_negated_leaf_bits`) does not apply to a positive leaf.
+fn tag_postings_leaf_bits(index: &Archived<TagIndex>, value: &str, n_printings: usize) -> Vec<u64> {
+    match index.get(value) {
+        Some(v) => scatter_bits(v.iter().map(|p| u32::from(*p)), n_printings),
+        None => vec![0u64; words_per_plane(n_printings)],
+    }
+}
+
+/// #746: the exact printing-space bitmap for a negated set leaf (`-set:VALUE`) — all-ones with the
+/// value's postings cleared. Exact **only because `set_code` is non-nullable**: every printing
+/// belongs to exactly one set, so "every printing except those in VALUE" is precisely the printings
+/// matching `-set:VALUE`, with no null-valued printing to wrongly include. Cost rides the *positive*
+/// postings size (the bits cleared), never the complement, which is why this is a strictly cheaper
+/// shape than the generic `Not` complement. Deliberately **not** reused for `watermark:` (nullable):
+/// a no-watermark printing satisfies neither `watermark:x` nor `-watermark:x`, so all-ones-minus-
+/// postings would wrongly count it as a `-watermark:x` match — the same trivalent trap dates hit in
+/// docs/issues/done/00741-engine-negated-range-narrowing.md; negating a nullable field would need an
+/// explicit "has any watermark" known-mask, which this leaf does not build.
+fn set_code_negated_leaf_bits(index: &Archived<TagIndex>, value: &str, n_printings: usize) -> Vec<u64> {
+    let mut bits = all_printing_bits(n_printings);
+    if let Some(v) = index.get(value) {
+        for p in v.iter() {
+            let pid = u32::from(*p) as usize;
+            bits[pid >> 6] &= !(1u64 << (pid & 63));
+        }
+    }
+    bits
 }
 
 /// #731: the exact printing bitmap for a usd/cn/date range leaf — scatter the value-sorted index
@@ -4819,6 +4869,22 @@ fn compose_printing_bits(
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
             border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)
         }
+        // #746: `set:VALUE`/`watermark:VALUE` postings leaves — scatter the value's printing ids.
+        FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
+            tag_postings_leaf_bits(&indexes.set_codes, value.as_str(), n_printings)
+        }
+        FilterExpr::TextExact { field: TextField::Watermark, op: CmpOp::Eq, value } => {
+            tag_postings_leaf_bits(&indexes.watermarks, value.as_str(), n_printings)
+        }
+        // #746: `-set:VALUE` — all-ones minus the value's postings (exact; `set_code` is non-null).
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, .. }) =>
+        {
+            let FilterExpr::TextExact { value, .. } = inner.as_ref() else {
+                unreachable!("guarded by the matches! above")
+            };
+            set_code_negated_leaf_bits(&indexes.set_codes, value.as_str(), n_printings)
+        }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
             rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)
@@ -4868,6 +4934,28 @@ fn compose_printing_estimate(
         // Precomputed planes: exact cheap popcount, nothing synthesized.
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
             (popcount(&border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)), 0, 0)
+        }
+        // #746: `set:`/`watermark:` postings — matches = the value's postings length `k` (each
+        // posting is one distinct printing), synthesized by scattering `k` ids → rides `scatter`
+        // (the same cheap range-slice scatter rate). O(1) here: the length, no bitmap built.
+        FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
+            let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
+            (k, 0, k)
+        }
+        FilterExpr::TextExact { field: TextField::Watermark, op: CmpOp::Eq, value } => {
+            let k = indexes.watermarks.get(value.as_str()).map_or(0, |v| v.len());
+            (k, 0, k)
+        }
+        // #746: `-set:VALUE` — matches = all printings minus the value's postings; the scatter cost
+        // rides the (small) positive postings size cleared, not the (large) complement it produces.
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, .. }) =>
+        {
+            let FilterExpr::TextExact { value, .. } = inner.as_ref() else {
+                unreachable!("guarded by the matches! above")
+            };
+            let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
+            (n_printings.saturating_sub(k), 0, k)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5492,6 +5492,135 @@ fn watermark_narrowing() {
     }
 }
 
+// #746: `set:`/`watermark:` postings leaves join the PrintingCompose leaf table. This is the
+// differential test the design doc calls for: for every filter shape (both `set:` polarities,
+// `watermark:` positive, and mixes with a year range) the exact `compose_printing_bits` bitmap must
+// agree — printing for printing — with the general per-candidate residual-check path (`card_pass` +
+// `residual_matches`, the same two functions the materializing plan verifies with). A compose leaf
+// that's fast because it's *wrong* fails here, not just slow.
+#[test]
+fn set_watermark_compose_leaves() {
+    let mut vocab = VocabInterner::new();
+    let cards = vec![
+        stub_card(1, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(2, TYPE_CREATURE, &[], &mut vocab),
+        stub_card(3, TYPE_CREATURE, &[], &mut vocab),
+    ];
+    let mut data = store_of(cards, &[2, 2, 2], vocab); // pids 0,1 | 2,3 | 4,5
+    let mut interner = Interner::new();
+    // Set codes span card boundaries (card 1 owns pid2=dmu and pid3=dmu; card 0 owns pid0=dmu,
+    // pid1=lea — a card whose printings straddle a set, so `set:`/`-set:` is genuinely
+    // printing-dependent, not card-invariant).
+    let set_codes_by_pid = ["dmu", "lea", "dmu", "dmu", "lea", "neo"];
+    for (p, code) in data.printings.iter_mut().zip(set_codes_by_pid) {
+        p.card_set_code = InlineStr::from_str(code);
+    }
+    // Watermark is nullable: pid1/pid4/pid5 have none (must satisfy neither `watermark:x` nor its
+    // negation — but we only compose the positive form, so this just tests they're excluded).
+    let watermark_by_pid = [Some("wotc"), None, Some("set"), Some("wotc"), None, None];
+    for (p, wm) in data.printings.iter_mut().zip(watermark_by_pid) {
+        p.card_watermark_id = wm.map_or(NONE_STR, |s| interner.intern(s.to_string()));
+    }
+    data.strings = interner.strings;
+    // Released dates give a mix of years for the range-leaf mixes (pid4 dateless — fails any year).
+    let year_by_pid = [Some(20200101), Some(20230101), Some(20200101), Some(20230101), None, Some(20240101)];
+    for (p, y) in data.printings.iter_mut().zip(year_by_pid) {
+        p.released_at_int = y;
+    }
+    // set_codes / watermarks / released_at built the way reload_commit builds them.
+    let mut set_codes: TagIndex = HashMap::new();
+    let mut watermarks: TagIndex = HashMap::new();
+    for (i, p) in data.printings.iter().enumerate() {
+        set_codes.entry(p.card_set_code.as_str().to_string()).or_default().push(i as u32);
+        if p.card_watermark_id != NONE_STR {
+            watermarks.entry(data.strings[p.card_watermark_id as usize].clone()).or_default().push(i as u32);
+        }
+    }
+    data.indexes.set_codes = set_codes;
+    data.indexes.watermarks = watermarks;
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_printings = archived.printings.len();
+
+    let set = |code: &str| FilterExpr::TextExact { field: super::TextField::SetCode, op: CmpOp::Eq, value: code.to_string() };
+    let not_set = |code: &str| FilterExpr::Not(Box::new(set(code)));
+    let wm = |v: &str| FilterExpr::TextExact { field: super::TextField::Watermark, op: CmpOp::Eq, value: v.to_string() };
+    let year = |y: i32| FilterExpr::YearCmp { op: CmpOp::Eq, year: y };
+
+    // Ground truth: the general per-candidate residual-check path. `card_pass` settles the
+    // card-invariant part; `residual_matches` settles the per-printing residual — exactly what the
+    // materializing plan runs, and independent of anything the compose path touches.
+    let brute = |f: &FilterExpr| -> Vec<u32> {
+        let mut out = Vec::new();
+        let mut residual: Vec<&FilterExpr> = Vec::new();
+        let mut is_or = false;
+        for c in 0..archived.cards.len() {
+            let card = &archived.cards[c];
+            let tri = f.card_pass(card, &archived.strings, &mut residual, &mut is_or);
+            let (lo, hi) = (u32::from(archived.offsets[c]), u32::from(archived.offsets[c + 1]));
+            for pid in lo..hi {
+                let matched = match tri {
+                    Tri::True => true,
+                    Tri::False => false,
+                    Tri::PrintingDep => {
+                        FilterExpr::residual_matches(card, &archived.printings[pid as usize], &archived.strings, &residual, is_or)
+                    }
+                    Tri::Null => false,
+                };
+                if matched {
+                    out.push(pid);
+                }
+            }
+        }
+        out
+    };
+    let composed = |f: &FilterExpr| -> Vec<u32> {
+        let bits = super::compose_printing_bits(f, &archived.indexes, &archived.offsets, &archived.printings, n_printings);
+        (0..n_printings as u32).filter(|&p| bits[p as usize >> 6] & (1u64 << (p & 63)) != 0).collect()
+    };
+
+    // Every shape must be composable, and its composed bits must equal the brute-force truth.
+    let cases: Vec<(&str, FilterExpr)> = vec![
+        ("set:dmu", set("dmu")),
+        ("-set:dmu", not_set("dmu")),
+        ("set:zzz (absent)", set("zzz")),
+        ("-set:zzz (absent -> all)", not_set("zzz")),
+        ("watermark:wotc", wm("wotc")),
+        ("watermark:set", wm("set")),
+        ("watermark:nope (absent)", wm("nope")),
+        ("set:dmu year:2023", FilterExpr::And(vec![set("dmu"), year(2023)])),
+        ("-set:dmu year:2023", FilterExpr::And(vec![not_set("dmu"), year(2023)])),
+        ("watermark:wotc year:2020", FilterExpr::And(vec![wm("wotc"), year(2020)])),
+        ("set:dmu or watermark:set", FilterExpr::Or(vec![set("dmu"), wm("set")])),
+        ("-set:dmu or watermark:wotc", FilterExpr::Or(vec![not_set("dmu"), wm("wotc")])),
+    ];
+    for (label, f) in &cases {
+        assert!(super::is_printing_composable(f, &archived.indexes), "{label} must be printing-composable");
+        let mut got = composed(f);
+        got.sort_unstable();
+        let mut want = brute(f);
+        want.sort_unstable();
+        assert_eq!(got, want, "compose_printing_bits disagrees with the residual path for {label}");
+        // The estimate feeds plan choice and must be a valid upper bound on the true match count
+        // (AND takes the min-of-children intersection bound, OR the capped sum — never an
+        // undercount, which would misprice the plan). For a bare leaf it's exact (postings length).
+        let (est_matches, _, _) = super::compose_printing_estimate(f, &archived.indexes, &archived.offsets, n_printings);
+        assert!(est_matches >= want.len(), "compose_printing_estimate undercounts for {label}: {est_matches} < {}", want.len());
+        if matches!(f, FilterExpr::TextExact { .. } | FilterExpr::Not(_)) {
+            assert_eq!(est_matches, want.len(), "bare-leaf estimate must be exact for {label}");
+        }
+    }
+
+    // The negated form of the NULLABLE field must NOT be a compose leaf (its all-ones-minus-postings
+    // complement would wrongly include no-watermark printings — the trivalent trap the doc flags).
+    let not_wm = FilterExpr::Not(Box::new(wm("wotc")));
+    assert!(!super::is_printing_composable(&not_wm, &archived.indexes), "-watermark: must stay off the compose path (nullable field)");
+    // And a positive watermark mixed with an unsupported leaf still declines as a whole.
+    let unsupported = FilterExpr::And(vec![wm("wotc"), FilterExpr::Not(Box::new(wm("set")))]);
+    assert!(!super::is_printing_composable(&unsupported, &archived.indexes), "-watermark inside an And keeps the whole And off the compose path");
+}
+
 #[test]
 fn broad_ranges_decline_to_narrow() {
     // Fraction rule: past MAX_NARROW_FRACTION of the index, gathering candidates

--- a/docs/issues/00746-engine-tag-postings-compose.md
+++ b/docs/issues/00746-engine-tag-postings-compose.md
@@ -1,8 +1,8 @@
 # Engine: Exact-Postings Fields (`set:`/`watermark:`) as Compose Leaves
 
-**Status: proposed**, filed as [#746](https://github.com/jbylund/sylvan_librarian/issues/746), not
-yet implemented or measured. Filed investigating why `-set:dmu year:2023`
-(0.450ms, printing/edhrec) costs noticeably more than `year:2023` alone (0.259ms) despite excluding
+**Status: implemented**, filed as [#746](https://github.com/jbylund/sylvan_librarian/issues/746).
+Filed investigating why `-set:dmu year:2023`
+(0.451ms, printing/edhrec) costs noticeably more than `year:2023` alone (0.268ms) despite excluding
 only 2 of its 9,234 matches. A step 4 for
 [#731](00731-engine-compose-universal-evaluator.md)'s leaf-source table, alongside step 1 (range
 leaves, shipped) and the sibling work this session added:
@@ -61,6 +61,66 @@ measured for scattering an index/postings slice into a bitmap, so it's the right
 Total materialization: roughly 5-10μs, against the current path's ~190μs gap over `year:2023` alone
 — potentially close to an order of magnitude on this shape. Not measured yet; this is a napkin
 estimate from calibrated per-op constants, not a benchmark.
+
+## Measured (`scripts/bench_tag_postings_compose.py`, 97,206-printing corpus, min ms)
+
+| query | unique | orderby | total | before (μs) | after (μs) | change |
+|---|---|---|---:|---:|---:|---|
+| `-set:dmu year:2023` (motivating) | printing | edhrec | 9,232 | 451 | 57 | **7.9×** |
+| `-set:dmu year:2023` | card | edhrec | 4,325 | 266 | 80 | **3.3×** |
+| `-set:dmu year:2023` | printing | rarity | 9,232 | 471 | 126 | **3.7×** |
+| `-set:dmu year:2023` | artwork | edhrec | 5,577 | 457 | 86 | **5.3×** |
+| `-set:dmu` (bare — was the generic complement) | printing | edhrec | 96,770 | 1,077 | 44 | **24.5×** |
+| `set:dmu year:2023` (positive, selective) | printing | edhrec | 2 | 37 | 47 | 0.79× |
+| `set:dmu year:2023` | card | edhrec | 1 | 36 | 38 | flat |
+| `year:2023` (range control) | printing | edhrec | 9,234 | 268 | 271 | flat |
+| `set:dmu` (bare) | printing | edhrec | 436 | 86 | 82 | flat |
+| `set:dmu r:mythic` | printing | edhrec | 49 | 35 | 35 | flat |
+| `-set:dmu border:black` (broad) | card | edhrec | 31,055 | 629 | 595 | flat |
+| `watermark:wotc` (bare) | printing | edhrec | 797 | 110 | 104 | flat |
+| `watermark:wotc year:2023` | printing | edhrec | 22 | 76 | 77 | flat |
+| `border:black` (control) | card | rarity | 31,169 | 398 | 346 | flat |
+| `t:creature` (control) | card | edhrec | 17,317 | 66 | 62 | flat |
+| `usd<50` (control) | card | rarity | 31,217 | 447 | 417 | flat |
+| `f:modern` (control) | card | edhrec | 22,264 | 63 | 61 | flat |
+
+`total` parity held on every row. Geometric mean over the five clearly-improved rows: **6.6×**.
+
+The one regression is the positive selective intersection `set:dmu year:2023` (printing), +10μs at
+the ~40μs floor: the compound now qualifies for `PrintingCompose`, so it builds the full composed
+printing bitmap instead of narrowing to `set:dmu`'s 436 postings and residual-checking the year.
+This is the same tradeoff step 1 (range leaves) already makes for any selective positive
+intersection — the shape becoming composable is exactly the point, and the negated form it's paired
+with wins 8×. The broad realistic-traffic survey (`scripts/survey_queries.py`, 520 queries, seed 42)
+shows the real `set:` traffic in it (`set:stx`, `set:ltr`, `set:otj`) improving and no new slow
+pattern; nothing outside this shape moves beyond the noise floor.
+
+`-set:dmu border:black` (broad, 31k matches, card mode) stays flat rather than improving — a broad
+card-space result is roughly as expensive to project up from the composed bitmap as it is to narrow,
+so the planner sees no clear win either way. The gains are on shapes where a small, exact leaf can
+gate a materializing path down to a compose one, not on ones already dominated by their broad side.
+
+## Testing
+
+- New Rust test `set_watermark_compose_leaves` (`tests.rs`): the differential check — for both `set:`
+  polarities, `watermark:` positive, and mixes with a year range (`And`/`Or`), the exact
+  `compose_printing_bits` bitmap must agree printing-for-printing with the general per-candidate
+  residual-check path (`card_pass` + `residual_matches`), on a store whose set codes straddle card
+  boundaries (so `set:`/`-set:` is genuinely printing-dependent) and whose watermark is nullable.
+  Also asserts `compose_printing_estimate` is a valid match-count upper bound (exact for bare
+  leaves), that `-watermark:` (nullable) is **not** composable, and that a `-watermark:` inside an
+  `And` keeps the whole `And` off the compose path.
+- `cargo test` (debug + release): 132/132 passed.
+- `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158 passed.
+- `cargo clippy`: no new warnings (the ones at `lib.rs:4773`/`4797`/`4798` predate this change).
+
+## Scope shipped
+
+`set:` (positive and negated) and `watermark:`'s **positive** form. Negated `watermark:` is
+deliberately not a compose leaf: `watermark` is nullable, so "all-ones minus postings" would wrongly
+count no-watermark printings as matching `-watermark:x` — it stays on the general path (its
+`tight_narrow_space` classifier already declines it) until an explicit "has any watermark"
+known-mask is built. See the correctness caveat below.
 
 ## Correctness caveat — must not apply uniformly to both fields
 

--- a/scripts/bench_tag_postings_compose.py
+++ b/scripts/bench_tag_postings_compose.py
@@ -1,0 +1,97 @@
+"""Targeted benchmark for exact-postings fields (`set:`/`watermark:`) as compose leaves (#746).
+
+`set:`/`watermark:` are backed by a plain postings `TagIndex`, so before this change they were not
+in `is_printing_composable`/`compose_printing_bits`'s leaf table at all: any `And` mixing them with a
+range/border/rarity/legality leaf fell out of the cheap `PrintingCompose` plan to a materializing
+one. `-set:dmu year:2023` (the motivating query) cost ~0.45ms vs `year:2023` alone at ~0.26ms
+despite excluding only 2 of 9,234 matches. Adding `set:` (both polarities — `set_code` is non-null,
+so "all-ones minus postings" is exact) and `watermark:`'s positive form (nullable, so only the
+positive form composes) as compose leaves lets the whole compound stay in `PrintingCompose`.
+
+    .venv/bin/python scripts/bench_tag_postings_compose.py \
+        --out benchmarks/tag-postings-compose/baseline-main-<sha>.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. `total` doubles as the
+parity check — must be identical across builds for every config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # The motivating example, across unique/orderby — before this change the `And` fell out of the
+    # PrintingCompose plan because `-set:dmu` was not a compose leaf; `year:2023` alone stayed cheap.
+    ("motivating", "-set:dmu year:2023", "printing", "edhrec", "default"),
+    ("motivating", "-set:dmu year:2023", "card", "edhrec", "default"),
+    ("motivating", "-set:dmu year:2023", "printing", "rarity", "default"),
+    ("motivating", "-set:dmu year:2023", "artwork", "edhrec", "default"),
+    # Positive-set compound — the same shape without the negation.
+    ("positive_and", "set:dmu year:2023", "printing", "edhrec", "default"),
+    ("positive_and", "set:dmu year:2023", "card", "edhrec", "default"),
+    # Leaf controls: each side of the motivating `And` alone. `year:2023` already composed (range
+    # leaf); `set:dmu`/`-set:dmu` are the newly-composable leaves.
+    ("leaf", "year:2023", "printing", "edhrec", "default"),
+    ("leaf", "set:dmu", "printing", "edhrec", "default"),
+    ("leaf", "-set:dmu", "printing", "edhrec", "default"),
+    ("leaf", "set:dmu", "card", "edhrec", "default"),
+    # Set composed with the other exact leaves (border/rarity) — generalizes for free once `set:` is
+    # a leaf, since `is_printing_composable` already recurses through `And`/`Or`.
+    ("set_mixed", "set:dmu r:mythic", "printing", "edhrec", "default"),
+    ("set_mixed", "-set:dmu border:black", "card", "edhrec", "default"),
+    # Watermark: positive form only (nullable field — negated form is deliberately not a compose leaf
+    # without a "has any watermark" known-mask). `watermark:` had no compose leaf before either.
+    ("watermark", "watermark:wotc", "printing", "edhrec", "default"),
+    ("watermark", "watermark:wotc year:2023", "printing", "edhrec", "default"),
+    ("watermark", "watermark:wotc r:mythic", "card", "edhrec", "default"),
+    # Controls: unaffected shapes, must not regress.
+    ("control", "border:black", "card", "rarity", "default"),
+    ("control", "t:creature", "card", "edhrec", "default"),
+    ("control", "usd<50", "card", "rarity", "default"),
+    ("control", "f:modern", "card", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=5.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<14} {'query':<26} {'unique':<9} {'orderby':<8} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<14} {query:<26} {unique:<9} {orderby:<8} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`set:`/`watermark:` are backed by a plain postings `TagIndex`, so they were not in the
`PrintingCompose` leaf table at all: any `And`/`Or` mixing them with a range/border/rarity/legality
leaf fell out of the cheap non-materializing compose plan into a materializing one. `-set:dmu
year:2023` cost 0.451ms vs `year:2023` alone at 0.268ms despite excluding only 2 of 9,234 matches.
This adds `set:` (both polarities) and `watermark:`'s positive form as compose leaves so the whole
compound stays in `PrintingCompose`. Engine path only — parser and SQL fallback untouched.

## Changes

- `set:VALUE`/`watermark:VALUE` scatter their postings into the exact printing bitmap
  (`tag_postings_leaf_bits`); `-set:VALUE` is all-ones with the value's postings cleared
  (`set_code_negated_leaf_bits`) — exact because `set_code` is non-nullable.
- Widens `is_printing_composable` / `compose_printing_bits` / `compose_printing_estimate` only. No
  new `PhysicalPlan` variant, no archive-layout change (reuses the existing
  `set_codes`/`watermarks` `TagIndex`). Since `is_printing_composable` already recurses through
  `And`/`Or`, this generalizes to any mix with ranges/border/rarity/legality for free.
- `watermark:` composes **positive only**: it is nullable, so a negated compose leaf ("all-ones
  minus postings") would wrongly count no-watermark printings as matching `-watermark:x` — the same
  trivalent-NULL trap #741 fixed for dates. It stays on the general path pending a "has any
  watermark" known-mask.

## Related issues

Implements #746. Step 4 of #731's leaf-source table, alongside #739 (the postings index this
reuses) and #741 (the NULL-negation discipline followed here).

---

## Performance

`scripts/bench_tag_postings_compose.py`, 97,206-printing corpus, min-of-window, `total` = parity.

| Benchmark | total | Before (µs) | After (µs) | Change |
|-----------|------:|------------:|-----------:|--------|
| `-set:dmu year:2023` printing/edhrec (motivating) | 9,232 | 451 | 57 | **7.9×** |
| `-set:dmu year:2023` card/edhrec | 4,325 | 266 | 80 | **3.3×** |
| `-set:dmu year:2023` printing/rarity | 9,232 | 471 | 126 | **3.7×** |
| `-set:dmu year:2023` artwork/edhrec | 5,577 | 457 | 86 | **5.3×** |
| `-set:dmu` bare printing/edhrec | 96,770 | 1,077 | 44 | **24.5×** |
| `set:dmu year:2023` printing/edhrec (positive, selective) | 2 | 37 | 47 | 0.79× |
| `set:dmu year:2023` card/edhrec | 1 | 36 | 38 | flat |
| `year:2023` printing/edhrec (range control) | 9,234 | 268 | 271 | flat |
| `set:dmu` bare printing/edhrec | 436 | 86 | 82 | flat |
| `-set:dmu border:black` card/edhrec (broad) | 31,055 | 629 | 595 | flat |
| `watermark:wotc` bare printing/edhrec | 797 | 110 | 104 | flat |
| `watermark:wotc year:2023` printing/edhrec | 22 | 76 | 77 | flat |
| `border:black` card/rarity (control) | 31,169 | 398 | 346 | flat |
| `t:creature` card/edhrec (control) | 17,317 | 66 | 62 | flat |
| `usd<50` card/rarity (control) | 31,217 | 447 | 417 | flat |
| `f:modern` card/edhrec (control) | 22,264 | 63 | 61 | flat |

**Geometric mean:** 6.6× over the five clearly-improved rows.
**Test corpus:** 97,206-printing export (`benchmarks/bitplanes/corpus.jsonl`); broad screen via
`scripts/survey_queries.py` (520 queries, seed 42) shows the real `set:` traffic (`set:stx`,
`set:ltr`, `set:otj`) improving and no new slow pattern.

`total` parity held on every row. The one regression — positive selective `set:dmu year:2023`
(printing), +10µs at the ~40µs floor — is the shape now qualifying for compose and building the full
composed bitmap instead of narrowing to 436 postings: the identical tradeoff step 1 (range leaves)
already makes for selective positive intersections, and the negated form it's paired with wins 8×.

---

## Reviewer notes

- **Correctness focus is the negation asymmetry.** `-set:` is a compose leaf; `-watermark:` is
  deliberately not (see the `set_code_negated_leaf_bits` doc comment and the caveat in
  `docs/issues/00746-engine-tag-postings-compose.md`). The new differential test
  `set_watermark_compose_leaves` asserts `compose_printing_bits` agrees printing-for-printing with
  the general residual path (`card_pass` + `residual_matches`) for both `set:` polarities and
  positive `watermark:` — on a store whose set codes straddle card boundaries and whose watermark is
  nullable — and asserts `-watermark:` (alone and inside an `And`) stays off the compose path.
- `cargo test` debug + release 132/132; `pytest` engine property + unit 158/158; clippy no new
  warnings.
- Rebase note: this touches the same
  `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` functions as other
  in-flight compose work; a rebase against a moved-on `main` may be needed.
