### PR TITLE
Engine: Probe Range Selectivity Before And-Skip

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2804,6 +2804,24 @@ fn narrow_candidates(
 /// real traffic argues for moving it.
 static AND_SKIP_THRESHOLD: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_AND_SKIP_THRESHOLD", 2_048));
 
+/// Selectivity floor below which a probed rank-1 range child is included in the
+/// And narrowing even when it would NOT beat the current driver (`k >= best`).
+/// The `AND_SKIP_THRESHOLD` guard classifies range children by worst-case cost
+/// *class*, so it skips a highly selective range (`usd<0.02`) as readily as a
+/// near-total one (`usd<50`) once any driver is selective — but `range_narrowed`'s
+/// two `partition_point` searches yield the real match count `k` for free before
+/// that decision (see `probe_range_k` / `narrow_rec`'s And arm). A child with
+/// `k < best` becomes the new, strictly-smaller driver (fewer residual
+/// verifications, never a regression). This floor additionally admits a range so
+/// small that materializing its sorted vec is below the timing-noise floor even
+/// when it can't lower the driver: bounded well under `AND_SKIP_THRESHOLD` so it
+/// can never re-admit the broad children that guard protects, and deliberately
+/// tiny (64) so it stays clear of the `!"name" set:SLD cn:N` tail — those `cn:N`
+/// sets are far larger than 64 in the common (small collector-number) case, so
+/// they still skip under a tiny exact-name driver, avoiding the 8,192-experiment
+/// regression (docs/issues/local-engine-probe-before-and-skip.md).
+static AND_PROBE_FLOOR: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_AND_PROBE_FLOOR", 64));
+
 /// `-r:x`'s dedicated shape: a rarity comparison, any op (`narrow_rarity` isn't limited to the four
 /// ordered ones the printing-range path needs — see that arm's doc). Index-free — eligibility never
 /// depends on `indexes`, only the actual re-narrow work does. The single source of truth for this
@@ -2866,6 +2884,24 @@ fn and_child_rank(f: &FilterExpr, indexes: &Archived<CardIndexes>) -> u8 {
         }
         _ => 0,
     }
+}
+
+/// The exact match count `k` of a printing-range And child (`usd`/`cn`/`date`/`year`
+/// and their negations — whatever `bare_range_bounds` recognizes), computed with the
+/// same two `partition_point` binary searches `range_narrowed` runs before it
+/// materializes anything, so this probe is (log n, log n) and adds nothing a later
+/// materialization wouldn't already pay. Returns `None` for a non-range child (a
+/// `TextRegex` rank-1 sibling, say), whose selectivity can't be read this cheaply.
+/// The And arm uses `k` to decide inclusion per-query instead of by cost class, and
+/// to order equal-rank range children most-selective-first (removing the old
+/// written-order sensitivity). An empty range yields `k = 0` (lo == hi == 0 from
+/// `bare_range_bounds`), the most selective possible — exactly what a materialized
+/// empty `Printings` vec would report.
+fn probe_range_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Option<usize> {
+    let (idx, lo, hi) = bare_range_bounds(filter, indexes)?;
+    let s = idx.partition_point(|p| u32::from(p.0) < lo);
+    let e = idx.partition_point(|p| u32::from(p.0) < hi);
+    Some(e - s)
 }
 
 /// `broad_ok` says whether a broad printing-range child may materialize its
@@ -3393,8 +3429,21 @@ fn narrow_rec(
             // range bitmaps only materialize when a printing-space partner
             // exists to intersect them with; complements only when nothing
             // else narrowed at all.
-            let mut ranked: Vec<(u8, &FilterExpr)> = children.iter().map(|c| (and_child_rank(c, indexes), c)).collect();
-            ranked.sort_by_key(|(r, _)| *r);
+            // Rank children by evaluation cost, and within a rank order the
+            // probeable range children most-selective-first (smallest k). The
+            // probe is two binary searches (probe_range_k), nearly free, and it
+            // both shrinks the driver as fast as possible and removes the old
+            // sensitivity to the order same-rank children happened to be written
+            // in. Non-range children (no probe) sort after the ranges in-rank.
+            let mut ranked: Vec<(u8, Option<usize>, &FilterExpr)> = children
+                .iter()
+                .map(|c| {
+                    let rank = and_child_rank(c, indexes);
+                    let probe = if rank == 1 { probe_range_k(c, indexes) } else { None };
+                    (rank, probe, c)
+                })
+                .collect();
+            ranked.sort_by_key(|(r, probe, _)| (*r, probe.unwrap_or(usize::MAX)));
             let mut card_sets: Vec<Narrowed> = Vec::new();
             let mut printing_sets: Vec<Narrowed> = Vec::new();
             // Tightness of the And requires every child to be represented in
@@ -3402,11 +3451,24 @@ fn narrow_rec(
             // satisfy the skipped children, and a complement taken over a
             // falsely-tight set would drop real matches of the negation.
             let mut every_child_included = true;
-            for (rank, c) in ranked {
+            for (rank, probe, c) in ranked {
                 let best = card_sets.iter().chain(printing_sets.iter()).map(|n| n.set.len()).min();
-                if rank > 0 && best.is_some_and(|b| b <= *AND_SKIP_THRESHOLD) {
-                    every_child_included = false;
-                    break;
+                // A driver this selective already bounds the candidate set the
+                // residual re-verifies, so a costlier (rank>0) child usually
+                // narrows nothing the driver's verification doesn't already do
+                // — skip it. The exception the probe buys: a range child whose
+                // *actual* match count k (already computed, free) beats the
+                // driver (k < best ⇒ it becomes the new, strictly smaller
+                // driver — never a regression) or is under AND_PROBE_FLOOR
+                // (materializing its sorted vec is timing noise). Such a child
+                // is always sparse under a selective driver, so it only ever
+                // takes range_narrowed's cheap vec path. `continue`, not
+                // `break`: a later, smaller-k range child may still qualify.
+                if let Some(b) = best.filter(|&b| rank > 0 && b <= *AND_SKIP_THRESHOLD) {
+                    if !probe.is_some_and(|k| k < b || k <= *AND_PROBE_FLOOR) {
+                        every_child_included = false;
+                        continue;
+                    }
                 }
                 if rank == 2 && !(card_sets.is_empty() && printing_sets.is_empty()) {
                     every_child_included = false;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7,7 +7,7 @@ use super::{
     build_artist_index, build_range_index, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
-    walk_printing_page, aligned_page, bare_range_bounds, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
+    walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, Mode,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
@@ -5717,6 +5717,74 @@ fn and_child_rank_matches_narrow_rec_dispatch() {
     // is irrelevant here (shift: None doesn't even reach it) -- must fall to the generic tier, same as
     // any other Not this classifier doesn't recognize.
     assert_eq!(and_child_rank(&FilterExpr::Not(Box::new(FilterExpr::Legality { shift: None, expected: 0b01 })), indexes), 2);
+}
+
+#[test]
+fn and_skip_probes_range_selectivity() {
+    // The probe-before-and-skip rule (docs/issues/local-engine-probe-before-and-skip.md): once a
+    // driver is selective (`best <= AND_SKIP_THRESHOLD`), a rank-1 printing-range child is no longer
+    // skipped by its worst-case cost *class*. Its real match count `k` (probe_range_k, two binary
+    // searches) decides: include when it would beat the driver (`k < best`) or is under
+    // AND_PROBE_FLOOR; skip when broad. The old rule skipped every range child here identically -- a
+    // wrong-cost decision the differential fuzzer can't catch (both choices return the *same rows*
+    // via residual verification; only the narrowed candidate-set size differs, which is what we
+    // assert on here).
+    const N: usize = 400;
+    let mut vocab = VocabInterner::new();
+    // Card i owns one printing (printing i). Even i are creatures (a 200-card driver); every 40th
+    // card is additionally legendary (a 10-card driver); the rest are instants. Price(printing i) =
+    // i+1 cents, a gradient so `usd<x` selects an exactly dialable prefix of the cards.
+    let cards: Vec<OracleCard> = (0..N)
+        .map(|i| {
+            let types = if i % 40 == 0 {
+                TYPE_CREATURE | TYPE_LEGENDARY
+            } else if i % 2 == 0 {
+                TYPE_CREATURE
+            } else {
+                TYPE_INSTANT
+            };
+            stub_card(i as u128 + 1, types, &[], &mut vocab)
+        })
+        .collect();
+    let mut data = store_of(cards, &[1; N], vocab);
+    for (i, p) in data.printings.iter_mut().enumerate() {
+        p.price_usd = Some(i as u32 + 1); // 1..=400 cents
+    }
+    data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let (indexes, offsets, cards) = (&archived.indexes, &archived.offsets, &archived.cards);
+
+    // FilterExpr isn't Clone, so build fresh nodes per use.
+    let creature = || FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
+    let legendary = || FilterExpr::TypeCmp { mask: TYPE_LEGENDARY, op: CmpOp::Ge };
+    let cmc_lt = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
+    let len = |f: &FilterExpr| narrow_candidates(f, indexes, offsets, cards).map(|c| c.len());
+
+    // probe_range_k reads a range child's exact selectivity; None for a non-range sibling.
+    assert_eq!(probe_range_k(&usd_cmp(CmpOp::Lt, 0.21), indexes), Some(20)); // <21c -> printings 0..=19
+    assert_eq!(probe_range_k(&usd_cmp(CmpOp::Lt, 2.51), indexes), Some(250)); // <251c -> printings 0..=249
+    assert_eq!(probe_range_k(&creature(), indexes), None); // a card-space plane, not a range
+    assert_eq!(probe_range_k(&cmc_lt, indexes), None); // cmc is card-space numeric, not printing-range-indexed
+
+    // Drivers alone.
+    assert_eq!(len(&creature()), Some(200));
+    assert_eq!(len(&legendary()), Some(10));
+
+    // k < best: a selective range (k=20) beats the 200-card driver, so it is included and the And
+    // narrows to the true intersection (even cards among printings 0..=19 = {0,2,..,18} = 10),
+    // rather than being skipped back to the 200-card driver as the cost-class rule would have.
+    assert_eq!(len(&FilterExpr::And(vec![creature(), usd_cmp(CmpOp::Lt, 0.21)])), Some(10));
+    // Broad range (k=250 > best=200 and > floor): skipped -- the candidate set stays the driver.
+    assert_eq!(len(&FilterExpr::And(vec![creature(), usd_cmp(CmpOp::Lt, 2.51)])), Some(200));
+
+    // Floor: under the tiny 10-card driver, a range with best(10) < k <= AND_PROBE_FLOOR(64) is
+    // still included though it cannot lower the driver -- usd<0.51 (k=50) keeps only the legendary
+    // cards priced <51c ({0,40} = 2). One printing past the floor (k=70) is skipped (stays 10).
+    assert_eq!(probe_range_k(&usd_cmp(CmpOp::Lt, 0.51), indexes), Some(50));
+    assert_eq!(probe_range_k(&usd_cmp(CmpOp::Lt, 0.71), indexes), Some(70));
+    assert_eq!(len(&FilterExpr::And(vec![legendary(), usd_cmp(CmpOp::Lt, 0.51)])), Some(2));
+    assert_eq!(len(&FilterExpr::And(vec![legendary(), usd_cmp(CmpOp::Lt, 0.71)])), Some(10));
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────

--- a/docs/issues/local-engine-probe-before-and-skip.md
+++ b/docs/issues/local-engine-probe-before-and-skip.md
@@ -65,18 +65,68 @@ says otherwise, treat this as robustness/option value, not latency.
 
 For rank-1 range children, probe first, then decide:
 
-1. Always run the two binary searches (cost: ~free) to get k.
-2. Include the child when `k < best` (it becomes the new driver; every unit
-   of k below best is a saved driver verification), or when k is under a
-   small floor (sorted-vec cost is noise).
+1. Always run the two binary searches (cost: ~free) to get k (`probe_range_k`).
+2. Include the child when `k < best` (it becomes the new, strictly-smaller
+   driver — every unit of k below best is a saved verification, and it can
+   never regress), or when `k <= AND_PROBE_FLOOR`.
 3. Skip when k is broad AND `best <= AND_SKIP_THRESHOLD` (current behavior).
 4. Rank-2 complements keep their existing rule (sole-source only).
+5. Among rank-1 range children, probe all and process smallest-k first
+   (removes the written-order sensitivity where whichever same-rank child
+   appeared first paid materialization).
+
+`AND_PROBE_FLOOR` shipped at **64**, not an arbitrary "small" value: `k < best`
+is the driver-replacement win and can never regress; the floor is a second,
+riskier admission (a range larger than the driver that can only shrink the
+intersection if correlated). Sized to genuine timing noise — a ≤64-element
+sorted vec builds in well under the benchmark's ~5% floor even under a
+one-card driver — so it can never reproduce the 8,192-experiment tail: the
+`!"name" set:SLD cn:N` canary's `cn:N` sets are far larger than 64 in the
+common (small collector-number) case and still skip under a tiny exact-name
+driver. It is bounded well under `AND_SKIP_THRESHOLD`, so it can never
+re-admit the broad children that guard protects.
 
 This subsumes today's behavior for broad children at the cost of two binary
 searches, and captures the measured ~2x for selective ones. The win is
 largest when the And carries an expensive residual (unmemoized text
 predicates), since each avoided verification then costs more than a numeric
 compare.
+
+## Measured (implementation, baseline fc222fd)
+
+Targeted harness (`scripts/bench_cost_guards.py` and_skip family, median of 3
+reps, fresh subprocess per branch) — the drift-free comparison, since it
+forces include-vs-skip via `CARD_ENGINE_AND_SKIP_THRESHOLD` on one build.
+Ratio is skip ÷ include (>1 ⇒ skipping cost us; ~1 ⇒ equivalent):
+
+| corpus / child | driver K | baseline skip/incl | branch skip/incl |
+| --- | --- | --- | --- |
+| independent `usd<0.02` (selective) | 1024 | 1.19× | 1.19× |
+| independent `usd<0.02` (selective) | **2048** | **1.79×** | **1.00×** |
+| independent `usd<0.02` (selective) | **4096** | **2.08×** | **1.00×** |
+| independent `usd<0.2` (broad) | 2048 | 0.68× | 0.65× |
+| independent `usd<0.2` (broad) | 4096 | 0.63× | 0.62× |
+| correlated `usd<0.2` (broad) | 512–4096 | 0.31–0.46× | 0.31–0.49× |
+
+The selective child's ~1.8–2.1× skip penalty at the 2,048–4,096 operating
+point is eliminated (→1.00×); the broad child is unchanged (skip still
+correctly wins — no regression). At K=1024 the branch still skips the
+selective child (1.19×, unchanged): there k≈1,944 > best, so including it
+can't lower the driver — the probe makes the per-query-optimal call, not a
+blind include. Crossover sits exactly at k, as it should.
+
+Broad survey (`scripts/survey_queries.py`, 520 queries): no measurable
+systematic effect. The aggregate min-ms shift (~0.92× geomean) is cross-run
+machine drift on a co-tenanted box — untouched single-predicate queries
+(`artist:avon`, `type:planeswalker`, `name:angel`), which the And arm never
+touches, moved by the same ~0.82× as everything else. One genuine mover
+stands out above the drift: `(tou=5 usd>50) or (name:counter set:otj)`
+improved **2.99×** (118 µs → 39 µs) — the selective-range-under-selective-
+driver And (`tou=5 usd>50`), exactly the shape this change targets. Matches
+the design's "~none on the wild corpus, real for interactive collector-style
+conjunctions" prediction. Full Rust suite (debug + release) green, incl. the
+#677 differential row-identity fuzzer and a new `and_skip_probes_range_selectivity`
+unit test.
 
 ## Considerations
 


### PR DESCRIPTION
## Summary

`narrow_rec`'s `And` arm (engine path) skipped **every** rank-1 printing-range child once any
gathered set fell below `AND_SKIP_THRESHOLD`, classifying children by worst-case cost *class*: a
highly selective range like `usd<0.02` was skipped as readily as a near-total `usd<50`, even though
`range_narrowed`'s two `partition_point` searches yield the real match count `k` almost for free
*before* the skip decision fires. This probes that `k` first and makes the inclusion decision
per-query instead of by cost class. Engine narrowing only — a pure candidate-selection speed dial;
totals/rows are identical (the residual verifier is unchanged), which the parity checks and the
differential fuzzer confirm.

Design/measurements: `docs/issues/local-engine-probe-before-and-skip.md`.

## Changes

- `probe_range_k` computes a range child's exact `k` via the same two binary searches
  `range_narrowed` already runs (reuses `bare_range_bounds`, so `usd`/`cn`/`date`/`year` and their
  negations are covered, `None` for non-range children).
- `And` arm: a rank-1 range child under a selective driver is now included when `k < best` (it
  becomes the new, strictly-smaller driver — can never regress) or `k <= AND_PROBE_FLOOR`; skipped
  only when genuinely broad. Equal-rank range children are probed and processed smallest-`k` first,
  removing the old written-order sensitivity.
- New `AND_PROBE_FLOOR` constant (64, env-overridable like the sibling guards), sized to genuine
  benchmark noise so it can never re-admit the broad children `AND_SKIP_THRESHOLD` protects nor
  reproduce the 8,192-experiment `!"name" set:SLD cn:N` tail.
- Rank-2 complement handling and `every_child_included` tightness bookkeeping unchanged.
- New `and_skip_probes_range_selectivity` unit test (asserts the cost decision the differential
  fuzzer can't see: same rows, different candidate-set size).

## Related issues

none (local design doc; not yet filed)

---

## Performance (delete if not perf-related)

`scripts/bench_cost_guards.py` and_skip family, median of 3 reps, fresh subprocess per branch,
skip-path times (`CARD_ENGINE_AND_SKIP_THRESHOLD` forced) — before = current skip, after = probe-then-skip.
`total` is the query's row count (parity: identical before/after).

| Benchmark (query @ driver K) | total | Before (µs) | After (µs) | Change |
|------------------------------|------:|------------:|-----------:|--------|
| `cmc<65 usd<0.02` @ 2048 (selective) | 88 | 144 | 80 | **1.79× faster** |
| `cmc<130 usd<0.02` @ 4096 (selective) | 184 | 217 | 105 | **2.07× faster** |
| `cmc<65 usd<0.2` @ 2048 (broad) | 812 | 173 | 172 | 1.01× (unchanged) |
| `cmc<130 usd<0.2` @ 4096 (broad) | 1623 | 185 | 183 | 1.01× (unchanged) |
| `cmc<32 usd<0.2` @ 1024 (broad) | 1009 | 77 | 78 | 0.98× (unchanged) |
| `cmc<130 usd<0.2` @ 2048 (half corpus) | 831 | 152 | 154 | 0.98× (unchanged) |

**Geometric mean:** 1.93× faster on the selective-child rows; broad-child rows unchanged (within noise).
**Test corpus:** synthetic exact-selectivity corpora (`build_guard_corpus.py`, 97,206 printings / 31,508 cards), independent + correlated + half variants.

At driver K=1024 the selective child is *still* skipped on both builds (there `k ≈ 1,944 > best`, so
including it cannot lower the driver) — the probe makes the per-query-optimal call, not a blind
include. The crossover now sits exactly at `k`.

Broad survey (`scripts/survey_queries.py`, 520 mixed/wild queries): **no measurable systematic
effect** — the aggregate min-ms shift is cross-run drift on a co-tenanted box (untouched
single-predicate queries like `type:planeswalker`/`name:angel`, which the `And` arm never touches,
moved by the same factor as everything else). One genuine mover above the drift:
`(tou=5 usd>50) or (name:counter set:otj)` **2.99× faster** (118 → 39 µs), the selective-range-under-
selective-driver `And` this change targets. This matches the design's honest expectation: ~none on
the Common-Crawl wild corpus (almost no price-lower-bound conjunctions), real for interactive
collector-style queries that corpus under-samples. Justified as correctness-of-cost-model /
per-query-optimal robustness, not a promised broad-latency win.

---

## Reviewer notes

- Focus: the `And`-arm loop in `narrow_rec` (`break` → `continue` so a later smaller-`k` range child
  can still qualify — equivalent for non-probe children since they were all skipped identically), and
  `AND_PROBE_FLOOR`'s sizing rationale.
- Correctness is a non-question by construction (narrowing feeds a verifier that re-checks every row);
  the full Rust suite is green in **both debug and release**, including the #677 differential
  row-identity fuzzer and the new unit test. Guard-sweep parity (`total` identical across forced
  branches) held on every row.
