### PR TITLE
Engine: Arith-Expression Tuple Postings (power+toughness<4, cmc+1<power)

### DIFF
--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -80,7 +80,7 @@ fn attr_to_num_field(attr: &str) -> Option<NumField> {
 /// Numeric operand during evaluation. PDep occurs only in the card-level pass
 /// (printing = None) for printing-level fields.
 #[derive(Clone, Copy)]
-enum NumVal {
+pub(crate) enum NumVal {
     Known(f64),
     Null,
     PDep,
@@ -131,25 +131,35 @@ impl NumExpr {
     // still-self-recursive eval() left both `bl NumExpr::eval` calls in
     // FilterExpr::tri's NumericCmp arm untouched. Splitting the Arith case
     // into its own (separately named, not force-inlined) function makes
-    // eval() itself non-recursive, so the attribute now actually applies:
+    // eval_with() itself non-recursive, so the attribute now actually applies:
     // for the common Const/Field leaf case (e.g. `usd<50`, no arithmetic),
-    // eval()'s whole body -- including field_num, already small enough to
-    // inline on its own -- folds directly into tri(), eliminating both
-    // calls' prologue/epilogue/jump-table tax. Arith (`cmc+1<power`) is
-    // colder and still recurses through eval_arith, unaffected either way.
+    // eval_with()'s whole body -- including the fetch closure (field_num,
+    // already small enough to inline on its own) -- folds directly into tri(),
+    // eliminating both calls' prologue/epilogue/jump-table tax. Arith
+    // (`cmc+1<power`) is colder and still recurses through eval_arith_with,
+    // unaffected either way.
+    //
+    // Generic over the field-fetch (#743) so the real per-card path (fetch =
+    // field_num) and the tuple-scan path (fetch = one tuple key's four fields)
+    // share this one evaluator — no second copy of the recursion /
+    // NULL-propagation / div-by-zero logic to drift (the
+    // and_child_rank/narrow_rec single-source-of-truth lesson from #741). The
+    // per-card call site (tri's NumericCmp arm) passes a concrete closure, so
+    // monomorphization + #[inline(always)] reproduce the pre-#743 hand-written
+    // match exactly.
     #[inline(always)]
-    fn eval(&self, card: &AOracleCard, printing: Option<&APrinting>) -> NumVal {
+    fn eval_with<F: Fn(NumField) -> NumVal>(&self, fetch: &F) -> NumVal {
         match self {
             NumExpr::Const(v) => NumVal::Known(*v),
-            NumExpr::Field(f) => field_num(card, printing, *f),
-            NumExpr::Arith(lhs, op, rhs) => Self::eval_arith(lhs, *op, rhs, card, printing),
+            NumExpr::Field(f) => fetch(*f),
+            NumExpr::Arith(lhs, op, rhs) => Self::eval_arith_with(lhs, *op, rhs, fetch),
         }
     }
 
-    fn eval_arith(lhs: &NumExpr, op: ArithOp, rhs: &NumExpr, card: &AOracleCard, printing: Option<&APrinting>) -> NumVal {
+    fn eval_arith_with<F: Fn(NumField) -> NumVal>(lhs: &NumExpr, op: ArithOp, rhs: &NumExpr, fetch: &F) -> NumVal {
         // Null dominates PDep: Null op anything is Null for every
         // printing, so the card-level result is already exact.
-        match (lhs.eval(card, printing), rhs.eval(card, printing)) {
+        match (lhs.eval_with(fetch), rhs.eval_with(fetch)) {
             (NumVal::Null, _) | (_, NumVal::Null) => NumVal::Null,
             (NumVal::PDep, _) | (_, NumVal::PDep) => NumVal::PDep,
             (NumVal::Known(l), NumVal::Known(r)) => match op {
@@ -162,6 +172,100 @@ impl NumExpr {
             },
         }
     }
+}
+
+/// The trivalent result of a `lhs op rhs` numeric comparison, over any field-fetch.
+/// Shared by `FilterExpr::tri`'s `NumericCmp` arm (fetch = `field_num`) and the #743
+/// arith-tuple scan (fetch = the four card-level fields of one tuple key) so both go
+/// through the exact same Null/PDep handling. `#[inline(always)]` + monomorphization
+/// keeps the hot `tri` arm byte-for-byte with its former inline match.
+#[inline(always)]
+pub(crate) fn numeric_cmp_tri<F: Fn(NumField) -> NumVal>(lhs: &NumExpr, op: CmpOp, rhs: &NumExpr, fetch: &F) -> Tri {
+    match (lhs.eval_with(fetch), rhs.eval_with(fetch)) {
+        (NumVal::Null, _) | (_, NumVal::Null) => Tri::Null, // missing field: SQL NULL
+        (NumVal::PDep, _) | (_, NumVal::PDep) => Tri::PrintingDep,
+        (NumVal::Known(a), NumVal::Known(b)) => tri_bool(cmp(op, a, b)),
+    }
+}
+
+/// Card-level numeric fields the #743 joint-tuple index covers: all card-scoped (not
+/// printing-dependent), all small bounded integer domains, confirmed low joint
+/// cardinality (531-564 distinct combinations — see docs/issues/00743). A numeric
+/// expression is tuple-evaluable iff every `NumField` it references (recursively
+/// through `Arith`) is one of these; any other field (edhrec, price*, rarity, cn,
+/// prefer) disqualifies the whole expression.
+pub(crate) fn num_field_in_arith_tuple_scope(f: NumField) -> bool {
+    matches!(f, NumField::Cmc | NumField::Power | NumField::Toughness | NumField::Loyalty)
+}
+
+fn num_expr_all_in_tuple_scope(e: &NumExpr) -> bool {
+    match e {
+        NumExpr::Const(_) => true,
+        NumExpr::Field(f) => num_field_in_arith_tuple_scope(*f),
+        NumExpr::Arith(l, _, r) => num_expr_all_in_tuple_scope(l) && num_expr_all_in_tuple_scope(r),
+    }
+}
+
+/// A bare single-field `{cmc,power,toughness} op const` comparison — already handled
+/// exactly by `narrow_rec`'s dedicated single-field numeric-index arms. The tuple route
+/// must decline these (the direct index is at least as good, and re-routing their
+/// negation would desync `and_child_rank`'s ranking from `narrow_rec`'s dispatch — the
+/// exact mismatch class #741 fought). Loyalty is intentionally excluded: it has no
+/// dedicated numeric index, so the tuple route is its only narrowing.
+fn is_bare_dedicated_numeric(f: &FilterExpr) -> bool {
+    matches!(
+        f,
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc | NumField::Power | NumField::Toughness), rhs: NumExpr::Const(_), .. }
+            | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), rhs: NumExpr::Field(NumField::Cmc | NumField::Power | NumField::Toughness), .. }
+    )
+}
+
+/// Single source of truth (#741 precedent) for "does this filter take the #743 arith-tuple
+/// route": a `NumericCmp` whose every referenced field is in `num_field_in_arith_tuple_scope`,
+/// and which is *not* one of the bare single-field shapes the dedicated numeric-index arms
+/// already own. Both `narrow_rec` (positive fallback and the negated arm) and `and_child_rank`
+/// gate on this one function, so the narrowing dispatch and its cost ranking cannot drift.
+/// A mixed expression (e.g. `usd+1<power`, an in-scope field with a printing-level one) fails
+/// the scope check and declines here entirely — it is never partially narrowed.
+pub(crate) fn is_arith_tuple_route(f: &FilterExpr) -> bool {
+    match f {
+        FilterExpr::NumericCmp { lhs, rhs, .. } => {
+            num_expr_all_in_tuple_scope(lhs) && num_expr_all_in_tuple_scope(rhs) && !is_bare_dedicated_numeric(f)
+        }
+        _ => false,
+    }
+}
+
+/// Evaluate a tuple-routed `NumericCmp` against one joint tuple key's four field values
+/// (each `None` = the card has no value for that field, i.e. SQL NULL). Reuses
+/// `numeric_cmp_tri`/`NumExpr::eval_with` — the identical evaluator the per-card path
+/// uses — so the differential test's exact-agreement claim holds by construction, not by
+/// a parallel reimplementation. Returns `Tri::True`/`Tri::False`/`Tri::Null`; `PrintingDep`
+/// cannot occur (all four fields are card-level), and any out-of-scope field would be an
+/// `is_arith_tuple_route` bug, caught by the debug_assert (CI runs debug).
+pub(crate) fn eval_arith_tuple_tri(
+    lhs: &NumExpr,
+    op: CmpOp,
+    rhs: &NumExpr,
+    cmc: Option<f64>,
+    power: Option<f64>,
+    toughness: Option<f64>,
+    loyalty: Option<f64>,
+) -> Tri {
+    let fetch = |f: NumField| -> NumVal {
+        let v = match f {
+            NumField::Cmc => cmc,
+            NumField::Power => power,
+            NumField::Toughness => toughness,
+            NumField::Loyalty => loyalty,
+            _ => {
+                debug_assert!(false, "out-of-scope field reached arith-tuple eval; is_arith_tuple_route is wrong");
+                None
+            }
+        };
+        v.map_or(NumVal::Null, NumVal::Known)
+    };
+    numeric_cmp_tri(lhs, op, rhs, &fetch)
 }
 
 fn cmp(op: CmpOp, a: f64, b: f64) -> bool {
@@ -1123,11 +1227,7 @@ impl FilterExpr {
             FilterExpr::ExactName(lower) => tri_bool(card.card_name_lower.as_str() == lower.as_str()),
 
             FilterExpr::NumericCmp { lhs, op, rhs } => {
-                match (lhs.eval(card, printing), rhs.eval(card, printing)) {
-                    (NumVal::Null, _) | (_, NumVal::Null) => Tri::Null, // missing field: SQL NULL
-                    (NumVal::PDep, _) | (_, NumVal::PDep) => Tri::PrintingDep,
-                    (NumVal::Known(a), NumVal::Known(b)) => tri_bool(cmp(*op, a, b)),
-                }
+                numeric_cmp_tri(lhs, *op, rhs, &|f| field_num(card, printing, f))
             }
 
             FilterExpr::TextContains { field, word } => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1465,6 +1465,114 @@ fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Opti
     Some(result)
 }
 
+// ─── Arith-expression tuple postings (#743) ──────────────────────────────────
+// cmc/power/toughness/loyalty are all card-level and draw from a small bounded
+// joint domain (531 distinct (power,toughness,cmc) triples, 564 with loyalty,
+// across ~31.5k cards — checked against the corpus). Any numeric predicate that
+// is a pure function of only these four fields (an Arith expression, a
+// field-vs-field compare, or a bare loyalty compare — see is_arith_tuple_route)
+// can be evaluated once per distinct combination instead of once per card, then
+// resolved to cards via postings: the same dictionary-encode-then-postings shape
+// set_codes/watermarks/rarity use for a single low-cardinality field, extended to
+// a joint tuple.
+
+/// One card's joint numeric key. Derived Hash/Eq handle the NULL (`None`) cases
+/// natively at build-time interning — no sentinel encoding. `f64::from` on the
+/// stored ints is lossless (all four domains fit exactly in f32, so also f64) and
+/// matches field_num's own widening exactly (the differential test asserts this).
+#[derive(Archive, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+struct ArithTupleKey {
+    cmc: Option<u8>,
+    power: Option<i8>,
+    toughness: Option<i8>,
+    loyalty: Option<u8>,
+}
+
+/// Joint (cmc,power,toughness,loyalty) postings. `keys[t]` is combination `t`'s field
+/// values (for query-time re-evaluation) and `postings[t]` its sorted card ids; the two
+/// are parallel. `n_cards` gates applicability (0 = unbuilt, e.g. a test fixture store),
+/// like every other index's domain check.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct ArithTupleIndex {
+    keys: Vec<ArithTupleKey>,
+    postings: Vec<Vec<u32>>,
+    n_cards: u32,
+}
+
+/// Intern each card's (cmc,power,toughness,loyalty) into a dense combination id and
+/// accumulate card postings under it. Cards are visited in ascending index order, so
+/// every postings row is naturally sorted. The id space is the number of distinct
+/// combinations (~564), far below any width concern — EdhrEc is excluded from the key
+/// precisely because it would blow this up to ~card-count distinct values (#743).
+fn build_arith_tuple_index(cards: &[OracleCard]) -> ArithTupleIndex {
+    let mut interner: HashMap<ArithTupleKey, usize> = HashMap::new();
+    let mut keys: Vec<ArithTupleKey> = Vec::new();
+    let mut postings: Vec<Vec<u32>> = Vec::new();
+    for (i, c) in cards.iter().enumerate() {
+        let key = ArithTupleKey {
+            cmc: c.cmc,
+            power: c.creature_power,
+            toughness: c.creature_toughness,
+            loyalty: c.planeswalker_loyalty,
+        };
+        let id = *interner.entry(key).or_insert_with(|| {
+            keys.push(key);
+            postings.push(Vec::new());
+            keys.len() - 1
+        });
+        postings[id].push(i as u32);
+    }
+    ArithTupleIndex { keys, postings, n_cards: cards.len() as u32 }
+}
+
+/// Narrow a tuple-routed `NumericCmp` (`is_arith_tuple_route`) to a card-space candidate
+/// set: evaluate the predicate against each of the ~564 distinct combinations and union
+/// the postings of those whose result equals `want`. `want = Tri::True` for the positive
+/// arm; `Tri::False` for the negation (`Not(cmp)`) — recomputing from scratch rather than
+/// complementing sidesteps the NULL-inclusion trap (a NULL-valued combination is `Tri::Null`,
+/// excluded from *both* polarities, exactly as tri()'s three-valued logic requires). Every
+/// field is card-level, so a combination's verdict holds for all of a card's printings: the
+/// result is exact and `tight` in both polarities. Returns None (→ existing scan) when the
+/// index isn't built for this store.
+fn arith_tuple_narrow(filter: &FilterExpr, idx: &Archived<ArithTupleIndex>, n_cards: usize, want: Tri) -> Option<Narrowed> {
+    if u32::from(idx.n_cards) as usize != n_cards || n_cards == 0 {
+        return None; // store without this index (fixture) — fall back to the general path
+    }
+    let FilterExpr::NumericCmp { lhs, op, rhs } = filter else { return None };
+    // First pass: evaluate the predicate against each of the ~564 distinct combinations, collecting
+    // the matching combination ids and the total card count they cover. This is the whole per-value
+    // cost of the narrowing (arithmetic on four small ints, no indirection past the key array).
+    let mut matched: Vec<usize> = Vec::new();
+    let mut count: usize = 0;
+    for (t, key) in idx.keys.iter().enumerate() {
+        // Widen exactly as field_num does (see ArithTupleKey's doc): u8/i8 → f64 is lossless and
+        // matches field_num's `_ as f32 as f64` for these domains. The archived Option<u8>/<i8>
+        // store their scalars natively (no endian wrapper), so `f64::from(*v)` reads them directly.
+        let cmc = key.cmc.as_ref().map(|v| f64::from(*v));
+        let power = key.power.as_ref().map(|v| f64::from(*v));
+        let toughness = key.toughness.as_ref().map(|v| f64::from(*v));
+        let loyalty = key.loyalty.as_ref().map(|v| f64::from(*v));
+        if eval_arith_tuple_tri(lhs, *op, rhs, cmc, power, toughness, loyalty) == want {
+            matched.push(t);
+            count += idx.postings[t].len();
+        }
+    }
+    let post_ids = || matched.iter().flat_map(|&t| idx.postings[t].iter().map(|x| u32::from(*x)));
+    // Representation split (#636 convention, BITS_PROMOTE): a broad result becomes a card bitmap via
+    // an O(count) scatter — no sort, and the word-wise form And/Or actually want for a broad set —
+    // while a sparse result keeps the sorted-vec merge path. Each card belongs to exactly one
+    // combination, so the selected postings rows are disjoint; the vec is sorted (combination order
+    // isn't card order) to restore the sorted-Cards invariant, reserving `count` up front to avoid
+    // the realloc churn that made the broad gather ~3× a bare numeric slice before this split.
+    if count > *BITS_PROMOTE {
+        return Narrowed::tight(Candidates::CardBits(scatter_bits(post_ids(), n_cards)));
+    }
+    let mut result: Vec<u32> = Vec::with_capacity(count);
+    result.extend(post_ids());
+    result.sort_unstable();
+    Narrowed::tight(Candidates::Cards(result))
+}
+
 // ─── Tag index ───────────────────────────────────────────────────────────────
 // tag name -> sorted list of store indices that have that tag. Card-level
 // collections (subtypes/keywords/oracle_tags) post card ids; printing-level ones
@@ -2294,6 +2402,7 @@ struct CardIndexes {
     rarity_printing: RarityPrintingPlanes,     // printing space: exact bit-per-printing rarity (#724)
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
+    arith_tuple:    ArithTupleIndex,           // card space: joint (cmc,power,toughness,loyalty) postings for arith predicates (#743)
 }
 
 impl Default for CardIndexes {
@@ -2328,6 +2437,7 @@ impl Default for CardIndexes {
             rarity_printing: RarityPrintingPlanes::default(),
             name_bigrams:   NameBigramIndex::default(),
             legal_divergent: Vec::new(),
+            arith_tuple:    ArithTupleIndex::default(),
         }
     }
 }
@@ -2864,6 +2974,11 @@ fn and_child_rank(f: &FilterExpr, indexes: &Archived<CardIndexes>) -> u8 {
         // the real thing directly instead, the same way `is_printing_composable`/`compose_printing_bits`/
         // `compose_printing_estimate` already do.
         FilterExpr::Not(inner) if bare_range_bounds(f, indexes).is_some() => and_child_rank(inner, indexes),
+        // `-(arith tuple predicate)`: a cheap exact re-narrow (#743 negated arm), not a broad
+        // complement — rank it like its positive inner form, gated on the same `is_arith_tuple_route`
+        // predicate `narrow_rec`'s own negated arm dispatches on (not a second shape check), so the
+        // ranking can't drift from what actually executes (the #741 rank/execution-mismatch lesson).
+        FilterExpr::Not(inner) if is_arith_tuple_route(inner) => and_child_rank(inner, indexes),
         // Any other `Not` (a card-space numeric like `-cmc:3`, negated equality on price/cn/date/year,
         // or a plain generic complement) falls to the broad-complement-or-decline tier — this used to
         // be the *only* arm here, silently catching every negated cheap shape above too (bug 1), then
@@ -3174,6 +3289,12 @@ fn narrow_rec(
                 (NumExpr::Const(v), NumExpr::Field(NumField::PriceUsd)) => price(flip_op(*op), v),
                 (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => cn(*op, v),
                 (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => cn(flip_op(*op), v),
+                // Everything the dedicated single-field arms above didn't consume: arith expressions
+                // (`cmc+1<power`), field-vs-field (`power<toughness`), and bare loyalty compares — all
+                // over only card-level fields. `is_arith_tuple_route` is the shared gate (also used by
+                // the negated arm and `and_child_rank`); a mixed/out-of-scope expression (`usd+1<power`)
+                // fails it and declines here, falling to the existing full scan (#743).
+                _ if is_arith_tuple_route(filter) => arith_tuple_narrow(filter, &indexes.arith_tuple, n_cards, Tri::True),
                 _ => None,
             }
         }
@@ -3274,6 +3395,19 @@ fn narrow_rec(
             } else {
                 range_narrowed(idx, lo, hi, n_printings, true, true)
             }
+        }
+
+        // -(arith tuple predicate), e.g. `-power+toughness<4` / `-cmc+1<power`. Same "recompute, don't
+        // complement" reasoning as -r:x/-usd<c above, but for the #743 card-space joint-tuple index:
+        // re-run the tiny per-combination scan collecting `Tri::False` instead of `Tri::True`, so
+        // NULL-valued combinations (Tri::Null) are excluded from the negation exactly as three-valued
+        // logic requires — no complement, hence none of the NULL-inclusion trap the generic Not arm
+        // (below) handles by staying loose. The four fields are card-level, so a False verdict holds for
+        // every printing: exact and tight. Gated on `is_arith_tuple_route(inner)` — the same single
+        // source of truth the positive arm and `and_child_rank` use, so a bare `-cmc:3` (dedicated arm,
+        // routes through the generic complement) is deliberately not intercepted here.
+        FilterExpr::Not(inner) if is_arith_tuple_route(inner) => {
+            arith_tuple_narrow(inner, &indexes.arith_tuple, n_cards, Tri::False)
         }
 
         // Ge/Eq/Gt all resolve `matches()` through the same `contains(value)`
@@ -6430,11 +6564,12 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-// 20260724, not 20260723: #737 already used today's date for its own archive
-// change (columnar artwork_group_id) earlier today, so this bump (adding
-// CardIndexes.watermarks) needs a distinct value to invalidate stores built
-// under that layout — see ARCHIVE_FORMAT_VERSION's doc above.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260724;
+// 20260725: adding CardIndexes.arith_tuple (#743) changes the archived layout, so
+// stores built under the previous version must be invalidated and rebuilt. The
+// current calendar date (20260723) and 20260724 were both already consumed by
+// earlier same-window archive changes (#737 columnar artwork_group_id, #741
+// watermark postings), so this takes the next distinct value — see the doc above.
+const ARCHIVE_FORMAT_VERSION: u32 = 20260725;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -6856,6 +6991,7 @@ impl QueryEngine {
             rarity_printing: build_rarity_printing_planes(&printings),
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
+            arith_tuple:    build_arith_tuple_index(&cards),
         };
 
         #[cfg(feature = "alloc-counter")]

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4,7 +4,7 @@ use super::{
     build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
-    build_artist_index, build_range_index, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
+    build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -2353,6 +2353,10 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.cmc = build_numeric_index(&data.cards, |c| c.cmc.map(i16::from));
     data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(i16::from));
     data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness.map(i16::from));
+    // #743 arith-tuple postings — load-bearing like the numeric indexes above: an unbuilt index
+    // (n_cards mismatch) makes arith_tuple_narrow decline, so building it here is what actually
+    // exercises the new positive/negated narrowing through run_query in fuzz_row_identity_matches_reference.
+    data.indexes.arith_tuple = build_arith_tuple_index(&data.cards);
     data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
     data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
@@ -2623,6 +2627,106 @@ fn fuzz_row_identity_matches_reference() {
         let offset = if rng.random_bool(0.5) { 0 } else { rng.random_range(0..800) };
         let ctx = format!("corpus-rowid, filter={}", fuzz_describe(&spec));
         fuzz_check_row_identity(archived, &spec, &ctx, orderby, direction, mode, 100, offset);
+    }
+}
+
+/// #743: the arith-tuple narrowing must return *exactly* the per-card scan + `tri`/`eval` reference,
+/// in both polarities (bare and negated), for the in-scope shapes `is_arith_tuple_route` routes to
+/// the joint tuple index (arith expressions, field-vs-field, bare loyalty), over every comparison op.
+/// This is the direct check `fuzz_row_identity_matches_reference` only exercises through full
+/// `run_query`: it inspects the candidate set itself and asserts it is tight and byte-identical to the
+/// reference — the exactness guarantee `tight` rests on. The reference is `FilterExpr::matches` (which
+/// evaluates through the same `tri`/`eval` the driver's residual uses); a card's verdict is
+/// printing-independent for these card-level fields, so any printing witnesses it.
+#[test]
+fn arith_tuple_narrowing_matches_reference() {
+    use rand::SeedableRng;
+
+    let field = |f| NumExpr::Field(f);
+    let konst = NumExpr::Const;
+    let arith = |l, o, r| NumExpr::Arith(Box::new(l), o, Box::new(r));
+    let cmp = |lhs, op, rhs| FilterExpr::NumericCmp { lhs, op, rhs };
+
+    // The result of a filter over one archived store, as a sorted card-id vec, via the per-card
+    // reference scan (matches == tri==True; for a `Not`, matches == tri(inner)==False — exactly the
+    // Tri::False set the negated arm builds).
+    let reference = |archived: &Archived<CardData>, filter: &FilterExpr| -> Vec<u32> {
+        let strings = &archived.strings;
+        (0..archived.cards.len() as u32)
+            .filter(|&cid| {
+                let card = &archived.cards[cid as usize];
+                let p0 = u32::from(archived.offsets[cid as usize]) as usize;
+                filter.matches(card, &archived.printings[p0], strings)
+            })
+            .collect()
+    };
+
+    // Corpus-like fixtures (real null/value distributions for cmc/power/toughness/loyalty) across a
+    // few seeds, so both selective and broad predicates and their negations are covered.
+    for seed in [1u64, 7, 42, 100] {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        let data = fuzz_store_n(&mut rng, 1_500);
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+        let indexes = &archived.indexes;
+        let offsets = &archived.offsets;
+        let cards = &archived.cards[..];
+        let n_cards = cards.len();
+        // narrow_candidates_exact declines (None) above this breadth — the >75%-of-domain cap. A
+        // decline for an in-scope filter is only ever this cap, never a narrowing failure.
+        let broad_cap = n_cards - n_cards / 4;
+
+        // Builder closures — each returns a fresh NumericCmp (FilterExpr isn't Clone), parameterized
+        // by op, so the same predicate can be built bare and again inside a `Not`.
+        for op in [CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge, CmpOp::Eq, CmpOp::Ne] {
+            let builders: [(&str, &dyn Fn() -> FilterExpr); 6] = [
+                ("loyalty op 4", &|| cmp(field(NumField::Loyalty), op, konst(4.0))),
+                ("power op toughness", &|| cmp(field(NumField::Power), op, field(NumField::Toughness))),
+                ("cmc+1 op power", &|| cmp(arith(field(NumField::Cmc), ArithOp::Add, konst(1.0)), op, field(NumField::Power))),
+                ("power+toughness op 4", &|| cmp(arith(field(NumField::Power), ArithOp::Add, field(NumField::Toughness)), op, konst(4.0))),
+                ("cmc*2 op toughness", &|| cmp(arith(field(NumField::Cmc), ArithOp::Mul, konst(2.0)), op, field(NumField::Toughness))),
+                ("toughness-power op 0", &|| cmp(arith(field(NumField::Toughness), ArithOp::Sub, field(NumField::Power)), op, konst(0.0))),
+            ];
+            for (label, mk) in builders {
+                assert!(is_arith_tuple_route(&mk()), "seed={seed} {label} {op:?}: must route to the tuple index");
+                for negated in [false, true] {
+                    let filter = if negated { FilterExpr::Not(Box::new(mk())) } else { mk() };
+                    let ref_set = reference(&archived, &filter);
+                    let ctx = format!("seed={seed} {label} {op:?} negated={negated}");
+                    match narrow_candidates_exact(&filter, indexes, offsets, cards) {
+                        (Some(Candidates::Cards(v)), tight) => {
+                            assert!(tight, "{ctx}: card-level in-scope narrowing must be tight (exact)");
+                            assert_eq!(v, ref_set, "{ctx}: tuple narrowing must equal the per-card reference");
+                        }
+                        (Some(other), _) => panic!("{ctx}: expected card-space candidates, got {other:?}"),
+                        (None, _) => assert!(
+                            ref_set.len() > broad_cap,
+                            "{ctx}: declined but the reference isn't broad ({} of {n_cards}) — a narrowing failure, not the breadth cap",
+                            ref_set.len()
+                        ),
+                    }
+                }
+            }
+        }
+
+        // Out-of-scope: `usd+1<power` mixes a printing-level field (usd) with a card-level one — it must
+        // NOT route to the tuple index and must decline to the existing full-scan path, in either
+        // polarity, never partially narrowed. A pure out-of-scope arith (`usd*2<cmc`) likewise.
+        let mixed = || cmp(arith(field(NumField::PriceUsd), ArithOp::Add, konst(1.0)), CmpOp::Lt, field(NumField::Power));
+        let pure_oos = || cmp(arith(field(NumField::PriceUsd), ArithOp::Mul, konst(2.0)), CmpOp::Lt, field(NumField::Cmc));
+        assert!(!is_arith_tuple_route(&mixed()), "seed={seed}: mixed in/out-of-scope arith must not route to the tuple index");
+        assert!(!is_arith_tuple_route(&pure_oos()), "seed={seed}: pure out-of-scope arith must not route to the tuple index");
+        assert!(narrow_candidates(&mixed(), indexes, offsets, cards).is_none(), "seed={seed}: mixed-field arith must decline (full scan)");
+        assert!(narrow_candidates(&pure_oos(), indexes, offsets, cards).is_none(), "seed={seed}: out-of-scope arith must decline (full scan)");
+        // The negated arm gates on is_arith_tuple_route(inner) too, so a negated mixed expression also
+        // stays off the tuple path.
+        assert!(!is_arith_tuple_route(&mixed()), "seed={seed}: -(mixed) inner must not route either");
+
+        // Bare single-field cmc/power/toughness vs const stay on their dedicated numeric-index arms
+        // (not the tuple route), so their negation ranking can't drift; loyalty (no dedicated arm) does route.
+        assert!(!is_arith_tuple_route(&cmp(field(NumField::Cmc), CmpOp::Lt, konst(3.0))), "bare cmc<c is owned by the dedicated numeric arm");
+        assert!(!is_arith_tuple_route(&cmp(field(NumField::Power), CmpOp::Ge, konst(2.0))), "bare power>=c is owned by the dedicated numeric arm");
+        assert!(is_arith_tuple_route(&cmp(field(NumField::Loyalty), CmpOp::Lt, konst(3.0))), "bare loyalty<c has no dedicated arm -> tuple route");
     }
 }
 
@@ -4543,6 +4647,7 @@ fn bench_checked_vs_unchecked_access() {
         rarity_printing: build_rarity_printing_planes(&printings),
         name_bigrams:   build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
+        arith_tuple:    build_arith_tuple_index(&cards),
     };
     let data = CardData {
         cards,

--- a/docs/issues/done/00743-engine-arith-tuple-postings.md
+++ b/docs/issues/done/00743-engine-arith-tuple-postings.md
@@ -1,9 +1,9 @@
 # Engine: Arith-Expression Tuple Postings (`power+toughness<4`, `cmc+1<power`)
 
-**Status: proposed**, filed as [#743](https://github.com/jbylund/sylvan_librarian/issues/743). Found
+**Status: done**, shipped for [#743](https://github.com/jbylund/sylvan_librarian/issues/743). Found
 via `scripts/survey_queries.py` while checking the survey's remaining slowest queries after #739–#741
 landed (same pass as the sibling
-[00744-engine-compose-orderby-range-walk.md](00744-engine-compose-orderby-range-walk.md), which
+[00744-engine-compose-orderby-range-walk.md](../00744-engine-compose-orderby-range-walk.md), which
 covers the other half of that list).
 
 ## Measured problem
@@ -83,6 +83,20 @@ lesson that duplicated classification/evaluation logic drifts — (b) is the pri
 doesn't require reshaping `filter.rs` more than this is worth; (a) plus a real differential test (not
 just "it runs") is the acceptable fallback if it does. Decide once actually implementing, not here.
 
+**Resolved: (b), and it needed almost no reshaping.** `NumExpr::eval` was already carefully split into
+a non-recursive `eval` (`#[inline(always)]`) delegating the `Arith` case to a separate recursive
+`eval_arith` — that split is *why* the hot per-card path inlines (see the long comment on the impl: an
+`#[inline(always)]` on a self-recursive function is ignored by LLVM). Generalizing the fetch step to a
+`Fn(NumField) -> NumVal` closure preserves that split exactly: `eval_with<F>` is still non-recursive
+and force-inlined, `eval_arith_with<F>` is still the colder recursive one. The per-card call site
+(`FilterExpr::tri`'s `NumericCmp` arm) passes `&|f| field_num(card, printing, f)`; monomorphization +
+inlining reproduce the pre-#743 hand-written match byte-for-byte, confirmed by the broad-survey
+percentiles holding (p50/p75 unchanged) and every numeric control staying flat. `tri`'s `NumericCmp`
+arm and the tuple scan now both go through one shared `numeric_cmp_tri<F>` — a single evaluator, no
+second copy of the recursion / NULL-propagation / div-by-zero logic. The tuple entry point
+(`eval_arith_tuple_tri`) builds the four-field closure and calls it; an out-of-scope field would be an
+`is_arith_tuple_route` bug and trips a `debug_assert!` (CI runs debug).
+
 ## Scope / non-goals
 
 - **In scope**: `Cmc`, `Power`, `Toughness`, `Loyalty` — all card-level (not printing-dependent), all
@@ -96,36 +110,83 @@ just "it runs") is the acceptable fallback if it does. Decide once actually impl
   with a card-level one. Must be excluded from eligibility entirely: an expression mixing one in-scope
   and one out-of-scope field doesn't get to use this path at all, not partially.
 
-## Expected cost
+## One regression found via benchmarking, and the fix
 
-Not yet measured — a sizing, not a promise, same convention this thread has followed throughout:
-~531–564 tuple evaluations (arithmetic on small ints, no memory indirection beyond the dictionary
-itself) is the same shape of cost this thread's other newly-narrowed queries dropped to (low tens of
-μs down from hundreds). Likely two orders of magnitude off the current ~0.4–0.5ms, if the pattern
-holds — measure once built, not asserted here.
+The first working version narrowed a *broad* arith predicate (`cmc>=power`, ~50% of cards) by
+gathering every matching card id from ~280 scattered postings rows into a sorted `Vec` — ~3× the cost
+of a bare numeric index's single contiguous slice for the same result size (measured: 17k-card result
+at 194 µs vs. a bare numeric's 69 µs). Harmless for a *lone* broad query (still beats the ~450 µs full
+scan), but inside an `And` with a selective sibling (`cmc>=power cn:1`, `cmc>=power oracle:search`) the
+broad set was built first and then thrown away against the selective side — a real regression
+(66 → 171 µs, 133 → 194 µs). Same class as #741's "broad negated range now narrows and regresses."
 
-## Acceptance
+Fixed with the #636 representation split the codebase already uses: a first pass counts the covered
+cards, and a result above `BITS_PROMOTE` becomes a `CardBits` bitmap via an O(count) `scatter_bits`
+(no sort, and the word-wise form `And`/`Or` want for a broad set) instead of a sorted vec; sparse
+results keep the vec path, now with the `count` reserved up front. After: `cmc>=power cn:1` 66 → 72 µs
+(back to parity, within noise), `cmc>=power oracle:search` 133 → 80 µs (now an improvement), and the
+negated targets got faster too (their sets exceed `BITS_PROMOTE`). Broad-survey re-run: **zero
+regressions >15%** across all 520 queries, `total` parity on every row.
 
-- `power+toughness<4`/card/rarity and `cmc+1<power`/printing/edhrec: must drop from ~0.4–0.5ms into
-  the single-digit-to-low-tens-of-μs range.
-- New Rust differential test: for a fuzzed sample of `NumericCmp`/`Arith` shapes restricted to the
-  four in-scope fields, the tuple-postings narrowing's result set must exactly match the existing
-  per-card scan + `Tri::eval` reference (same pattern `fuzz_row_identity_matches_reference` already
-  uses) — both polarities, bare and negated.
-- A query mixing an in-scope and out-of-scope field (e.g. `usd+1<power`) must correctly decline (fall
-  to the existing path) — a dedicated test case, not just documented reasoning.
-- New targeted benchmark script (`scripts/bench_arith_tuple_postings.py`, following
-  `bench_negated_range_narrowing.py`'s pattern): the two measured queries above, their negated forms,
-  at least one compound (`And`'d with an unrelated filter), and controls (a bare non-arith numeric
-  comparison, an out-of-scope arith expression) that must hold flat.
-- Broad survey re-run: both entries must drop out of the current top-20; nothing else regresses.
+## Measured (`scripts/bench_arith_tuple_postings.py`, 97,206-printing corpus, min µs)
+
+| query | unique/orderby | before | after | change | total (parity) |
+|---|---|---:|---:|---|---:|
+| `power+toughness<4` | card/rarity | 484 | 105 | **4.6×** | 3,975 |
+| `cmc+1<power` | printing/edhrec | 387 | 65 | **6.0×** | 1,199 |
+| `power+toughness<4` | card/edhrec | 440 | 83 | **5.3×** | 3,975 |
+| `cmc+1<power` | card/edhrec | 395 | 61 | **6.5×** | 414 |
+| `-power+toughness<4` | card/rarity | 540 | 142 | **3.8×** | 13,337 |
+| `-cmc+1<power` | printing/edhrec | 417 | 116 | **3.6×** | 44,596 |
+| `power<toughness` (field-vs-field) | card/edhrec | 389 | 69 | **5.6×** | 4,680 |
+| `loyalty>=4` (bare, no dedicated index) | card/edhrec | 211 | 61 | **3.5×** | 219 |
+| `power+toughness<4 t:creature` (compound) | card/edhrec | 225 | 87 | **2.6×** | 3,971 |
+| `cmc+1<power c:g` (compound) | card/edhrec | 143 | 61 | **2.3×** | 133 |
+| `power>4` (control, bare numeric) | card/power | 59 | 58 | flat | 2,248 |
+| `cmc>6` (control, bare numeric) | card/cmc | 57 | 56 | flat | 1,344 |
+| `usd+1<power` (control, out-of-scope — declines) | card/edhrec | 646 | 657 | flat | 11,861 |
+| `t:creature` (control) | card/edhrec | 61 | 60 | flat | 17,317 |
+
+Geometric mean **4.15×** over the ten impacted rows; controls flat; `total` identical across builds
+on every row. Broad survey (`scripts/survey_queries.py`, seed 42, 520 queries): both entries left the
+top-30 entirely (`power+toughness<4` was #8, `cmc+1<power` #11); p90 182 → 165 µs, p99 580 → 569 µs,
+max 1.040 → 1.016 ms; no query regressed.
+
+## Memory (archive layout changed — new `CardIndexes.arith_tuple`)
+
+`QueryEngine.mem_stats()` on the same corpus, `--features alloc-counter` build:
+
+| | before | after | Δ |
+|---|---:|---:|---:|
+| `archive_bytes` | 71,745,580 | 71,880,648 | +135,068 (+0.19%) |
+| `indexes_rkyv_bytes` | 25,731,884 | 25,866,952 | +135,068 (+0.52%) |
+| `reload_peak` | 156,192,010 | 156,192,009 | ~0 |
+
+The whole cost of the new index: ~135 KB (564 keys + ~31.5k card-id postings), all in the indexes
+component, `reload_peak` unchanged.
+
+## Testing
+
+- New Rust test `arith_tuple_narrowing_matches_reference`: for every op (`<`/`≤`/`>`/`≥`/`=`/`≠`) over
+  a bare loyalty compare, field-vs-field (`power<toughness`), and four arith shapes, across four
+  corpus-like fixture seeds, both polarities — the narrowing's candidate set must be **tight** and
+  byte-identical to the per-card `matches` (i.e. `tri`/`eval`) reference (a decline is only ever the
+  >75% breadth cap, asserted). Plus dedicated assertions that `usd+1<power` (in/out-of-scope mix) and
+  `usd*2<cmc` (pure out-of-scope) do **not** route and decline to the full scan, that bare
+  `cmc<c`/`power>=c` stay on their dedicated numeric arms, and that bare `loyalty<c` (no dedicated
+  index) does route.
+- The existing `fuzz_row_identity_matches_reference` now also exercises this path end-to-end through
+  `run_query` (its `FuzzLeaf::Arith`/`Loyalty` shapes route to the tuple index once the fixture store
+  builds `arith_tuple`), including the out-of-scope arith shapes (price-mixed) that must decline.
+- `cargo test` (debug + release): 132/132 passed. `pytest api/tests/test_engine_*`: 158/158.
+  `cargo clippy`: no new warnings.
 
 ## Related
 
-- [00744-engine-compose-orderby-range-walk.md](00744-engine-compose-orderby-range-walk.md) — sibling
+- [00744-engine-compose-orderby-range-walk.md](../00744-engine-compose-orderby-range-walk.md) — sibling
   doc from the same survey pass, covering the `format:commander`/`format:legacy` cluster (#3–6)
   instead of the arith cluster (#8/#15 in `branch-c6484a3.csv`).
-- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) —
+- [00741-engine-negated-range-narrowing.md](00741-engine-negated-range-narrowing.md) —
   where the `and_child_rank`/`narrow_rec` single-source-of-truth precedent (relevant to the
   shared-evaluator decision above) came from.
 - `docs/workflows/performance-pr-workflow.md` — the process this doc follows.

--- a/scripts/bench_arith_tuple_postings.py
+++ b/scripts/bench_arith_tuple_postings.py
@@ -1,0 +1,94 @@
+"""Targeted benchmark for arith-expression tuple postings (`power+toughness<4`, `cmc+1<power`).
+
+`NumExpr::Arith`-shaped numeric comparisons over only card-level integer fields
+(`cmc`/`power`/`toughness`/`loyalty`) draw from a tiny joint domain (~531-564 distinct
+combinations across ~31.5k cards). #743 evaluates the predicate once per distinct combination
+against an `ArithTupleIndex` and unions the matching combos' card postings, instead of a full
+`GatheredScan` evaluating `NumExpr::eval` per card. Negation recomputes with `Tri::False` (no
+complement, so no NULL-inclusion trap). Both polarities are exact and tight in card space.
+
+    .venv/bin/python scripts/bench_arith_tuple_postings.py \
+        --out benchmarks/arith-tuple-postings/baseline-main-<sha>.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. `total` doubles as the
+parity check — must be identical across builds for every config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # The two survey-identified motivating queries, at the exact unique/orderby they surfaced at
+    # (docs/issues/00743). Before #743 both were full unnarrowed GatheredScans.
+    ("motivating", "power+toughness<4", "card", "rarity", "default"),
+    ("motivating", "cmc+1<power", "printing", "edhrec", "default"),
+    # Same queries across other uniques/orderbys — the narrowing is card-space, so the win should
+    # carry regardless of the distinct-on / permutation availability.
+    ("motivating", "power+toughness<4", "card", "edhrec", "default"),
+    ("motivating", "cmc+1<power", "card", "edhrec", "default"),
+    # Negated forms — recomputed with Tri::False, not a complement (the point of the design).
+    ("negated", "-power+toughness<4", "card", "rarity", "default"),
+    ("negated", "-cmc+1<power", "printing", "edhrec", "default"),
+    # Field-vs-field (no arith, no const) and a loyalty predicate — also newly tuple-routed, since
+    # neither had a dedicated card-space arm before.
+    ("other_shapes", "power<toughness", "card", "edhrec", "default"),
+    ("other_shapes", "loyalty>=4", "card", "edhrec", "default"),
+    # Compound: an eligible arith predicate AND'd with an unrelated (non-arith) filter — the tuple
+    # narrowing should feed the And and hold up.
+    ("compound", "power+toughness<4 t:creature", "card", "edhrec", "default"),
+    ("compound", "cmc+1<power c:g", "card", "edhrec", "default"),
+    # Controls that must hold flat:
+    #   - a bare non-arith numeric comparison (dedicated single-field index, untouched path)
+    ("control", "power>4", "card", "power", "default"),
+    ("control", "cmc>6", "card", "cmc", "default"),
+    #   - an out-of-scope arith expr (mixes printing-level usd with card-level power): must decline
+    #     to the existing full-scan path, NOT get partially narrowed.
+    ("control", "usd+1<power", "card", "edhrec", "default"),
+    ("control", "t:creature", "card", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=5.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<13} {'query':<26} {'unique':<9} {'orderby':<8} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<13} {query:<26} {unique:<9} {orderby:<8} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`NumExpr::Arith`-shaped numeric comparisons over only card-level integer fields
(`cmc`/`power`/`toughness`/`loyalty`) had no narrowing arm anywhere — every one was a full
unnarrowed `GatheredScan` evaluating `NumExpr::eval` per card, regardless of true selectivity. But
these four fields draw from a tiny joint domain: **531 distinct `(power,toughness,cmc)` triples, 564
with loyalty, across ~31.5k cards**. This adds an `ArithTupleIndex` that interns each card's
`(cmc,power,toughness,loyalty)` key into combination→card postings, and narrows an eligible
`NumericCmp` by evaluating the predicate against the ~564 distinct combinations and unioning the
matching combinations' postings — exact and tight in card space. Affects the engine path only (no
parser/SQL change). Design + iteration log: `docs/issues/done/00743-engine-arith-tuple-postings.md`.

## Changes

- **`ArithTupleIndex`** (new `CardIndexes` field): joint `(cmc,power,toughness,loyalty)` postings,
  built once at reload. Archive layout changes, so `ARCHIVE_FORMAT_VERSION` is bumped (`20260725`).
- **Shared evaluator, not a second copy.** `NumExpr::eval` is generalized to a `Fn(NumField)->NumVal`
  fetch closure (`eval_with`), preserving the documented non-recursive/`#[inline(always)]` split that
  keeps the hot per-card path folded into `tri`. `tri`'s `NumericCmp` arm and the tuple scan both go
  through one `numeric_cmp_tri` — one definition of the recursion / NULL-propagation / div-by-zero.
- **`is_arith_tuple_route`** is the single source of truth (the `#741` `bare_range_bounds`
  precedent): both `narrow_rec` (positive fallback + a dedicated negated arm) and `and_child_rank`
  gate on it, so dispatch and cost-ranking can't drift. An expression mixing an in-scope field with a
  printing-level one (`usd+1<power`) fails the scope check and declines to the existing scan entirely.
- **Negation recomputes, never complements**: the `-cmp` arm re-runs the tiny scan collecting
  `Tri::False`, so NULL-valued combinations are excluded from both polarities structurally — none of
  the NULL-inclusion trap `#741` needed three fixes for.
- Broad results materialize as a `CardBits` bitmap (`#636` `BITS_PROMOTE` convention) instead of a
  sorted vec — fixes a benchmark-found regression where a broad arith `And`'d with a selective sibling
  paid a wasteful scattered gather.

## Related issues

Fixes #743.

---

## Performance

`scripts/bench_arith_tuple_postings.py`, 97,206-printing corpus, **min µs**, `total` = parity:

| Benchmark | Before (µs) | After (µs) | Change | total |
|-----------|-----:|-----:|--------|------:|
| `power+toughness<4` — card/rarity | 484 | 105 | **4.6×** | 3,975 |
| `cmc+1<power` — printing/edhrec | 387 | 65 | **6.0×** | 1,199 |
| `power+toughness<4` — card/edhrec | 440 | 83 | **5.3×** | 3,975 |
| `cmc+1<power` — card/edhrec | 395 | 61 | **6.5×** | 414 |
| `-power+toughness<4` — card/rarity | 540 | 142 | **3.8×** | 13,337 |
| `-cmc+1<power` — printing/edhrec | 417 | 116 | **3.6×** | 44,596 |
| `power<toughness` (field-vs-field) — card/edhrec | 389 | 69 | **5.6×** | 4,680 |
| `loyalty>=4` (bare, no dedicated index) — card/edhrec | 211 | 61 | **3.5×** | 219 |
| `power+toughness<4 t:creature` (compound) — card/edhrec | 225 | 87 | **2.6×** | 3,971 |
| `cmc+1<power c:g` (compound) — card/edhrec | 143 | 61 | **2.3×** | 133 |
| `power>4` (control, bare numeric) — card/power | 59 | 58 | flat | 2,248 |
| `cmc>6` (control, bare numeric) — card/cmc | 57 | 56 | flat | 1,344 |
| `usd+1<power` (control, out-of-scope — declines) — card/edhrec | 646 | 657 | flat | 11,861 |
| `t:creature` (control) — card/edhrec | 61 | 60 | flat | 17,317 |

**Geometric mean:** 4.15× faster over the ten impacted rows; controls flat; `total` identical across
builds on every row.
**Test corpus:** the shared 97,206-printing blue-DB export (`benchmarks/bitplanes/corpus.jsonl`).

Broad survey (`scripts/survey_queries.py`, seed 42, 520 queries): both targets left the top-30
(`power+toughness<4` was #8, `cmc+1<power` #11); p90 182→165 µs, p99 580→569 µs, max 1.040→1.016 ms;
**zero regressions >15%**, `total` parity on all 520.

### Memory (archive layout changed — new `arith_tuple` index)

`QueryEngine.mem_stats()`, same corpus, `--features alloc-counter` build:

| | Before | After | Δ |
|---|---:|---:|---:|
| `archive_bytes` | 71,745,580 | 71,880,648 | +135,068 (+0.19%) |
| `indexes_rkyv_bytes` | 25,731,884 | 25,866,952 | +135,068 (+0.52%) |
| `reload_peak` | 156,192,010 | 156,192,009 | ~0 |

~135 KB total (564 keys + ~31.5k card-id postings), all in the indexes component; peak unchanged.

---

## Deployment notes

`ARCHIVE_FORMAT_VERSION` bumped to `20260725` — reader processes rebuild the store on first load (the
header mismatch is treated as absent, per the existing invalidation path). No DB migration.

---

## Reviewer notes

- Correctness rests on the tuple narrowing being **exact and tight**: every one of the four fields is
  card-level (identical across a card's printings), so a combination's verdict holds for all its
  printings, and it composes tightly under `And`/`Or` (no shared-witness problem). New test
  `arith_tuple_narrowing_matches_reference` asserts the candidate set is byte-identical to the
  per-card `matches`/`tri` reference for every op, both polarities, plus the `usd+1<power` decline;
  `fuzz_row_identity_matches_reference` now also exercises the path end-to-end.
- The shared-evaluator decision (option (b) in the design doc) is the one judgement call — I kept
  `NumExpr::eval`'s inlining split intact; the broad-survey percentiles and numeric controls holding
  flat are the evidence the hot path didn't regress.
- `cargo test` (debug + release): 132/132. `pytest api/tests/test_engine_*`: 158/158. `cargo clippy`:
  no new warnings.
