### PR TITLE
Engine: PrintingCompose Orderby-Range-Index Walk

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -105,13 +105,12 @@ pub(crate) struct PlanFeatures {
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
     pub popcount_words: u32,
-    /// Whether `PrintingCompose` will page via the real permutation walk (`true`) or the
-    /// permutation-free bounded-gather fallback (`false`) — decided by whether `orderby` has a
-    /// card-space permutation (`rarity`/`usd` don't; see
-    /// `docs/issues/local-engine-compose-permutation-fallback.md`). The two strategies have
-    /// different cost shapes (offset-dependent walk vs. visit-every-match gather), so the formula
-    /// branches on this rather than assuming the walk. Ignored by every other plan.
-    pub compose_has_perm: bool,
+    /// Which of `PrintingCompose`'s three paging strategies will actually run (see `ComposePaging`),
+    /// decided the same way `printing_compose_fastpath` decides. The three have different cost shapes
+    /// — the permutation walk and the #744 orderby-index walk are both offset-dependent (fill the page
+    /// in ~`page_span/selectivity` steps), while the permutation-free gather visits every match — so
+    /// the formula branches on this rather than assuming one. Ignored by every other plan.
+    pub compose_paging: super::ComposePaging,
 }
 
 // ─── P1: PrintingRangeScan ──────────────────────────────────────────────────
@@ -277,10 +276,16 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 + f64::from(f.scatter_printings) * RANGE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
                 + f64::from(f.project_printings) * LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
                 + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS; // popcount the result-space bitmap for the total (printing/card/artwork words)
-            let page = if f.compose_has_perm {
-                printings_walked * RANGE_WALK_STEP_NS  // forward grouped walk to fill the page
-                    + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
-            } else {
+            let page = match f.compose_paging {
+                // Perm (forward grouped walk) and OrderbyWalk (#744 value-index/plane walk) share the
+                // offset-dependent walk shape: fill the page in ~page_span/selectivity steps, then emit
+                // one page. OrderbyWalk terminates at page_offset+limit just like the permutation walk,
+                // which is exactly why the COMPOSE_GATHER breadth gate is bypassed for it — broad is its
+                // best case, not its worst.
+                super::ComposePaging::Perm | super::ComposePaging::OrderbyWalk => {
+                    printings_walked * RANGE_WALK_STEP_NS  // walk to fill the page
+                        + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
+                }
                 // gather_composed_page: visits every candidate (eval_domain, same rate GatheredScan's
                 // own permutation-free walk pays per card), tests `pbits` membership per printing
                 // (scan_units — a cheap bit test, not a real residual scan, so the cheap
@@ -288,9 +293,11 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // and pushes each surviving match into the bounded GatherSelect accumulator (matches,
                 // same per-match rate GatheredScan pays for the same operation). Offset-independent —
                 // unlike the walk above, it costs the same regardless of how deep the page is.
-                eval_domain * GATHER_CARD_PASS_NS
-                    + scan_units * RANGE_SCATTER_PER_PRINTING_NS
-                    + matches * GATHER_PUSH_PER_MATCH_NS
+                super::ComposePaging::Gather => {
+                    eval_domain * GATHER_CARD_PASS_NS
+                        + scan_units * RANGE_SCATTER_PER_PRINTING_NS
+                        + matches * GATHER_PUSH_PER_MATCH_NS
+                }
             };
             build + page + RANGE_FIXED_COST_NS // per-query setup
         }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4798,31 +4798,21 @@ fn broadcast_card_bits_to_printings(card_bits: &[u64], offsets: &AOffsets, n_pri
     pbits
 }
 
-/// The exact printing-space bitmap for a bare legality leaf (`f:modern` etc.), built the #724 way from
-/// #667's card-space `_EXISTS` plane plus a divergent repair, rather than a full per-printing legality
-/// plane — legality is only ~1.8% divergent (`legal_divergent`), so the card plane broadcast is exact
-/// for the other 98.2% and only the divergent cards need per-printing fix-up. `∃-legal` over-sets a
-/// divergent card (it sets every printing, but only some are legal), so the repair is **authoritative**:
-/// it *overwrites* each divergent printing's bit to its true value (set and clear, re-derived from the
-/// printing's own `card_legalities` word — no stored postings), which is why the broadcast needs no
-/// pre-masking. Empty if the planes aren't built for this store.
-fn legality_leaf_bits(
+/// Repair the divergent cards' printings authoritatively — overwrite each bit with the per-printing
+/// truth (`(word >> shift) & 0b11 == expected`, the same test filter.rs:1253 applies). Authoritative
+/// (set AND clear) so either build direction can over-set/over-clear a divergent card without a
+/// pre-mask pass. Iterates the global `legal_divergent` list (a superset of the per-format divergent
+/// set); a card divergent in another format but not this one has all its printings agree here, so its
+/// repair is a no-op. Callers gate this on there being any per-format divergence at all (#744).
+fn repair_divergent_printings(
+    pbits: &mut [u64],
     shift: u8,
     expected: u64,
-    indexes: &Archived<CardIndexes>,
+    legal_divergent: &Archived<Vec<u16>>,
     offsets: &AOffsets,
     printings: &[APrinting],
-    n_printings: usize,
-) -> Vec<u64> {
-    let n_cards = offsets.len() - 1;
-    let Some(card_bits) = legality_candidate_bits(indexes, n_cards, shift, expected, false) else {
-        return vec![0u64; words_per_plane(n_printings)];
-    };
-    let mut pbits = broadcast_card_bits_to_printings(&card_bits, offsets, n_printings);
-    // Repair the divergent cards' printings authoritatively — overwrite each bit with the per-printing
-    // truth (`(word >> shift) & 0b11 == expected`, the same test filter.rs:1253 applies). Overwriting
-    // both directions is what lets the broadcast above over-set them without a pre-clear pass.
-    for cid in indexes.legal_divergent.iter() {
+) {
+    for cid in legal_divergent.iter() {
         let c = u16::from(*cid) as usize;
         for p in u32::from(offsets[c]) as usize..u32::from(offsets[c + 1]) as usize {
             let legal = (u64::from(printings[p].card_legalities) >> shift) & 0b11 == expected;
@@ -4833,7 +4823,86 @@ fn legality_leaf_bits(
             }
         }
     }
+}
+
+/// #724 build: broadcast the *legal* (`_EXISTS`) card plane down and repair. Cheapest when the legal
+/// set is the *minority* (e.g. `oldschool`, ~3% legal) — the broadcast touches only set (legal) cards.
+fn legality_leaf_bits_from_exists(
+    shift: u8,
+    expected: u64,
+    exists: &[u64],
+    legal_divergent: &Archived<Vec<u16>>,
+    offsets: &AOffsets,
+    printings: &[APrinting],
+    n_printings: usize,
+) -> Vec<u64> {
+    let mut pbits = broadcast_card_bits_to_printings(exists, offsets, n_printings);
+    repair_divergent_printings(&mut pbits, shift, expected, legal_divergent, offsets, printings);
     pbits
+}
+
+/// #744 build: start printing-space all-ones and clear each *illegal* (`_ABSENT`) card's printing
+/// range. Cheapest when the legal set is the *majority* (a near-universal format like `commander`,
+/// ~99.7% legal): the clear touches only the tiny illegal set + its printings, not the ~99.7% of cards
+/// a legal-side broadcast would. Skips the repair pass entirely when this format has zero divergent
+/// cards (`exists ∧ absent` empty — true for `commander` in the real corpus). Produces bit-for-bit the
+/// same bitmap as `legality_leaf_bits_from_exists` — the authoritative repair overwrites every
+/// divergent printing to its per-printing truth regardless of the starting side.
+#[allow(clippy::too_many_arguments)]
+fn legality_leaf_bits_from_absent(
+    shift: u8,
+    expected: u64,
+    exists: &[u64],
+    absent: &[u64],
+    legal_divergent: &Archived<Vec<u16>>,
+    offsets: &AOffsets,
+    printings: &[APrinting],
+    n_printings: usize,
+) -> Vec<u64> {
+    let mut pbits = all_printing_bits(n_printings);
+    for cid in bitmap_card_ids(absent) {
+        let c = cid as usize;
+        for p in u32::from(offsets[c]) as usize..u32::from(offsets[c + 1]) as usize {
+            pbits[p >> 6] &= !(1u64 << (p & 63));
+        }
+    }
+    // Divergent-in-this-format cards (∃ legal ∧ ∃ illegal printing) are exactly `exists ∧ absent`;
+    // repair only if there are any (skip the whole pass for a format with none, e.g. commander).
+    let divergent = exists.iter().zip(absent.iter()).map(|(&a, &b)| (a & b).count_ones()).sum::<u32>();
+    if divergent > 0 {
+        repair_divergent_printings(&mut pbits, shift, expected, legal_divergent, offsets, printings);
+    }
+    pbits
+}
+
+/// The exact printing-space bitmap for a bare legality leaf (`f:modern` etc.), built the #724 way from
+/// #667's card-space `_EXISTS`/`_ABSENT` planes plus a divergent repair, rather than a full per-printing
+/// legality plane. **Builds from whichever side is sparser** (#744): the legal-card popcount decides —
+/// majority-legal (`commander`) clears the tiny illegal set from an all-ones start; minority-legal
+/// (`oldschool`) broadcasts the small legal set. Same "pick the cheaper side" shape `range_narrowed`
+/// uses (`if k <= idx.len() - k`), and both directions yield the identical bitmap (the repair is
+/// authoritative). Empty if the planes aren't built for this store.
+fn legality_leaf_bits(
+    shift: u8,
+    expected: u64,
+    indexes: &Archived<CardIndexes>,
+    offsets: &AOffsets,
+    printings: &[APrinting],
+    n_printings: usize,
+) -> Vec<u64> {
+    let n_cards = offsets.len() - 1;
+    let Some(exists) = legality_candidate_bits(indexes, n_cards, shift, expected, false) else {
+        return vec![0u64; words_per_plane(n_printings)];
+    };
+    let legal_cards = exists.iter().map(|w| w.count_ones() as usize).sum::<usize>();
+    if legal_cards * 2 > n_cards {
+        // Majority legal: the *illegal* set is the sparse side — build from `_ABSENT`.
+        let absent =
+            legality_candidate_bits(indexes, n_cards, shift, expected, true).expect("exists resolved ⇒ absent resolves");
+        legality_leaf_bits_from_absent(shift, expected, &exists, &absent, &indexes.legal_divergent, offsets, printings, n_printings)
+    } else {
+        legality_leaf_bits_from_exists(shift, expected, &exists, &indexes.legal_divergent, offsets, printings, n_printings)
+    }
 }
 
 /// #724: materialize `filter`'s **exact** printing-space membership bitmap (`n_printings` bits, tail
@@ -4961,13 +5030,17 @@ fn compose_printing_estimate(
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
             (popcount(&rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)), 0, 0)
         }
-        // Legality: estimate from the cheap card ∃-plane popcount scaled to printings; that count is the
-        // broadcast-down the fast path pays (a linear pass) → rides `broadcast`.
+        // Legality: matches ≈ the legal-∃ cards' printings (existence-scaled from the cheap card
+        // ∃-plane popcount). The build cost rides the *sparser* side (#744): a majority-legal format
+        // clears its tiny illegal set instead of broadcasting the ~all legal one, so `broadcast` is
+        // scaled from `min(legal, illegal)` cards, not `legal` — otherwise the model would keep costing
+        // the pre-#744 full broadcast a near-universal format no longer pays.
         FilterExpr::Legality { shift: Some(shift), expected } => {
             let n_cards = offsets.len() - 1;
-            let card_exists = legality_candidate_bits(indexes, n_cards, *shift, *expected, false).map_or(0, |b| popcount(&b));
-            let est = if n_cards == 0 { 0 } else { card_exists * n_printings / n_cards };
-            (est, est, 0)
+            let legal = legality_candidate_bits(indexes, n_cards, *shift, *expected, false).map_or(0, |b| popcount(&b));
+            let illegal = legality_candidate_bits(indexes, n_cards, *shift, *expected, true).map_or(0, |b| popcount(&b));
+            let scale = |c: usize| (c * n_printings).checked_div(n_cards).unwrap_or(0);
+            (scale(legal), scale(legal.min(illegal)), 0)
         }
         // Range (bare or negated — `-usd<50` etc., see `bare_range_bounds`'s doc): `k` in-range
         // printings from the index partition points (O(log n), no scatter here); matches ≈ k, and k
@@ -4983,6 +5056,188 @@ fn compose_printing_estimate(
     }
 }
 
+/// The two `orderby` values with no card-space sort permutation (`SortCol::PriceUsd`/`Rarity` — see
+/// `ArchivedSortPermutations::get`, which returns `None` for both because the representative printing's
+/// key can't be precomputed). Each nonetheless has a printing-space value-ordered structure a
+/// `unique=printing` page can be walked directly: price cents in the `price_usd` `PrintingRangeIndex`,
+/// rarity ints in the `rarity_printing` planes/postings. #744's walk uses one to emit a page in sort
+/// order without visiting every candidate — the opposite shape from `gather_composed_page`. Any other
+/// `orderby` either has a permutation (`walk_grouped_page`) or falls to the gather fallback.
+fn orderby_walk_available(sort_col: SortCol) -> bool {
+    matches!(sort_col, SortCol::PriceUsd | SortCol::Rarity)
+}
+
+/// Assemble a `unique=printing` page from value-buckets yielded by `next_bucket` in page (sort-key)
+/// order, each already filtered to its `pbits`-matching pids. Skips whole buckets by match count up to
+/// `page_offset`, collects the complete buckets the page window overlaps, then sorts that (small)
+/// collected set by the full sort key and windows it — byte-identical order to
+/// `select_page`/`gather_composed_page`, because a value-bucket shares one primary sort key so no
+/// cross-bucket tie is possible (the primary dominates the top 64 bits of `sort_key_bits`).
+///
+/// Returns `None` when the buckets are exhausted before `page_offset+limit` matches were collected AND
+/// fewer than `total` matches were seen — i.e. the remaining rows are *null-value* matches (present in
+/// `pbits`, absent from the value structure, and sorting last since a missing primary maps to
+/// `u32::MAX`), which this walk can't order — so the caller falls back to `gather_composed_page`. When
+/// every match lives in the buckets (`collected` reaches `total`, no null tail), a short last page is
+/// windowed normally.
+#[allow(clippy::too_many_arguments)]
+fn collect_orderby_page<'a>(
+    mut next_bucket: impl FnMut() -> Option<Vec<u32>>,
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    printing_to_card: &AOffsets,
+    sort_col: SortCol,
+    descending: bool,
+    total: usize,
+    limit: usize,
+    page_offset: usize,
+) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+    let want = page_offset + limit;
+    let mut collected: Vec<u32> = Vec::new();
+    let mut cum = 0usize; // matches seen (skipped + collected) so far
+    let mut first_touched = 0usize; // matches before the first collected bucket (the offset skip)
+    let mut started = false;
+    while cum < want {
+        let Some(bucket) = next_bucket() else { break };
+        let m = bucket.len();
+        if m == 0 {
+            continue;
+        }
+        // Whole buckets entirely before the page window are skipped by count (not collected).
+        if !started && cum + m <= page_offset {
+            cum += m;
+            continue;
+        }
+        if !started {
+            started = true;
+            first_touched = cum;
+        }
+        collected.extend(bucket);
+        cum += m;
+    }
+    // Exhausted the value structure short of the page, with matches still unaccounted for → those are
+    // null-value matches (sort last); decline so gather handles them. A short last page with the whole
+    // match set already collected (`cum == total`) is fine — window it.
+    if cum < want && cum < total {
+        return None;
+    }
+    let matches: Vec<Match> = collected
+        .iter()
+        .map(|&pid| {
+            let cid = u32::from(printing_to_card[pid as usize]);
+            (sort_key_bits(&cards[cid as usize], &printings[pid as usize], sort_col, descending), cid, pid)
+        })
+        .collect();
+    // Quickselect the page rather than a full sort: a rarity bucket (common) can be tens of thousands
+    // of matches, so the `O(n log n)` sort's log factor is the dominant cost there — `select_page`
+    // (same `page_cmp` comparator) is `O(collected + limit·log limit)`. `page_offset - first_touched`
+    // rebases the offset onto the collected touched buckets.
+    Some(
+        select_page(matches, page_offset - first_touched, limit)
+            .into_iter()
+            .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
+            .collect(),
+    )
+}
+
+/// #744 orderby walk for a range-indexed sort column (`usd` — the only such `SortCol`; cn/date are
+/// range-indexed but never an `orderby`). Walks the value-sorted `(value, pid)` index as value-buckets
+/// in page order — forward from the low end ascending, backward from the high end descending, the same
+/// directional bucket formation `aligned_page` uses — but tests `pbits` per entry (the index covers
+/// *every* printing with the value, not just this filter's matches). See `collect_orderby_page`.
+#[allow(clippy::too_many_arguments)]
+fn walk_range_orderby_page<'a>(
+    idx: &Archived<PrintingRangeIndex>,
+    pbits: &[u64],
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    printing_to_card: &AOffsets,
+    sort_col: SortCol,
+    descending: bool,
+    total: usize,
+    limit: usize,
+    page_offset: usize,
+) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+    let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
+    let (mut lo, mut hi) = (0usize, idx.len());
+    let next = move || -> Option<Vec<u32>> {
+        if lo >= hi {
+            return None;
+        }
+        let (bs, be) = if descending {
+            let v = u32::from(idx[hi - 1].0);
+            let mut b = hi - 1;
+            while b > lo && u32::from(idx[b - 1].0) == v {
+                b -= 1;
+            }
+            (b, hi)
+        } else {
+            let v = u32::from(idx[lo].0);
+            let mut b = lo + 1;
+            while b < hi && u32::from(idx[b].0) == v {
+                b += 1;
+            }
+            (lo, b)
+        };
+        if descending { hi = bs } else { lo = be }
+        Some((bs..be).map(|t| u32::from(idx[t].1)).filter(|&pid| is_set(pid as usize)).collect())
+    };
+    collect_orderby_page(next, cards, printings, printing_to_card, sort_col, descending, total, limit, page_offset)
+}
+
+/// #744 orderby walk for `orderby=rarity`. Rarity has no `PrintingRangeIndex`, but the exact
+/// `rarity_printing` planes/postings *are* a printing-space value-bucketed structure: one bucket per
+/// rarity int (interior values read their one-hot plane, the sparse tail its postings). Walks those
+/// buckets in rarity-value page order (ascending value ascending, descending value descending), each
+/// intersected with `pbits`. Null-rarity matches (in `pbits`, in no bucket) sort last and are handled
+/// by `collect_orderby_page`'s null-tail decline. See `collect_orderby_page`.
+#[allow(clippy::too_many_arguments)]
+fn walk_rarity_orderby_page<'a>(
+    rp: &Archived<RarityPrintingPlanes>,
+    pbits: &[u64],
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    printing_to_card: &AOffsets,
+    descending: bool,
+    total: usize,
+    limit: usize,
+    page_offset: usize,
+    n_printings: usize,
+) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+    // Every rarity int present: interior [0..3] (planes, always laid out) + the postings' ints.
+    let mut values: Vec<u8> = RARITY_PRINTING_PLANE_INTS.to_vec();
+    values.extend(rp.postings.iter().map(|e| e.0));
+    values.sort_unstable();
+    if descending {
+        values.reverse();
+    }
+    let wpp = words_per_plane(n_printings);
+    let mut vi = 0usize;
+    let next = move || -> Option<Vec<u32>> {
+        let int = *values.get(vi)?;
+        vi += 1;
+        let pids: Vec<u32> = if let Some(k) = RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == int) {
+            let plane = &rp.words[k * wpp..(k + 1) * wpp];
+            let mut out = Vec::new();
+            for (wi, (pw, bw)) in plane.iter().zip(pbits.iter()).enumerate() {
+                let mut w = u64::from(*pw) & bw;
+                while w != 0 {
+                    out.push(((wi as u32) << 6) | w.trailing_zeros());
+                    w &= w - 1;
+                }
+            }
+            out
+        } else {
+            match rp.postings.iter().find(|e| e.0 == int) {
+                Some(e) => e.1.iter().map(|p| u32::from(*p)).filter(|&pid| pbits[pid as usize >> 6] & (1u64 << (pid & 63)) != 0).collect(),
+                None => Vec::new(),
+            }
+        };
+        Some(pids)
+    };
+    collect_orderby_page(next, cards, printings, printing_to_card, SortCol::Rarity, descending, total, limit, page_offset)
+}
+
 /// `unique=printing` fast path for a composable printing-space expression (bare `border:`/`r:` or an
 /// `AND`/`OR`/`NOT` of them, #724) — the plane analogue of `printing_range_fastpath`: `total` is the
 /// composed bitmap's `popcount` (no count pass), and the page is the same `walk_printing_page` (its
@@ -4990,7 +5245,6 @@ fn compose_printing_estimate(
 /// a non-composable filter, or a total at/below the stream threshold — where the general path gathers
 /// and globally sorts, ordering ties differently (same guard as `printing_range_fastpath`; a sparse
 /// value like `border:yellow` falls through here).
-#[allow(clippy::too_many_arguments)]
 #[allow(clippy::too_many_arguments)]
 fn printing_compose_fastpath<'a>(
     cards: &'a [AOracleCard],
@@ -5009,23 +5263,29 @@ fn printing_compose_fastpath<'a>(
         return None;
     }
     let perm = indexes.sort_perms.get(sort_col, descending).filter(|p| p.len() == cards.len());
-    // No permutation (rarity/usd): before paying for the real build, check whether it's worth it at
-    // all using the same estimate `compose_printing_estimate` already computes cheaply in acquire
-    // (O(log n) partition points / plane popcounts, no scatter) — see `COMPOSE_GATHER_MAX_CARD_FRACTION`'s
-    // doc for why this needs its own threshold, not `MAX_NARROW_FRACTION`. The check must be in
-    // **mode space** (cards for `Card`, artworks for `Artwork`), not raw matching printings: a bare
-    // range's printing-space match count is a poor proxy for how many *candidates*
-    // `gather_composed_page` will actually visit (a card can have several qualifying printings). A
-    // plain `.min(domain)` cap is *not* enough to project it down, though — it saturates to exactly
-    // `domain` for every query whose printing-space count exceeds it (`cn<100`: 35,021 printings vs
-    // 31,508 cards, and `usd<50`: 80,527 vs 31,508 both saturate to the *identical* 31,508, even
-    // though their true card counts are 17,616 vs 31,217 — miles apart), which loses exactly the
-    // signal this check needs. A balls-into-bins estimate — `k` matching printings landing on
-    // `domain` cards, expected distinct cards touched `≈ domain·(1 − e^(−k/domain))` — doesn't
-    // saturate the same way and tracks the true count much better (checked against real totals:
-    // `cn<100` estimate 21,140 vs true 17,616; `usd<50` estimate 29,062 vs true 31,217; clearly
-    // separated, unlike the capped estimate's identical 31,508 for both).
-    if perm.is_none() {
+    // #744: a printing-mode page ordered by a permutation-less orderby with a printing-space
+    // value structure (`usd`/`rarity`) is walked directly (below), terminating at page_offset+limit
+    // — cost O((offset+limit)/selectivity), the *opposite* shape from `gather_composed_page`. The
+    // `COMPOSE_GATHER_MAX_CARD_FRACTION` gate must NOT apply to that branch: its premise ("broad ⇒ not
+    // worth composing") is backwards here, where a broad predicate is the walk's *best* case.
+    let walk_col = perm.is_none() && matches!(mode, Mode::Printing) && orderby_walk_available(sort_col);
+    // No permutation (rarity/usd) AND no orderby walk (card/artwork mode): before paying for the real
+    // build, check whether the gather is worth it at all using the same estimate
+    // `compose_printing_estimate` already computes cheaply in acquire (O(log n) partition points /
+    // plane popcounts, no scatter) — see `COMPOSE_GATHER_MAX_CARD_FRACTION`'s doc for why this needs
+    // its own threshold, not `MAX_NARROW_FRACTION`. The check must be in **mode space** (cards for
+    // `Card`, artworks for `Artwork`), not raw matching printings: a bare range's printing-space match
+    // count is a poor proxy for how many *candidates* `gather_composed_page` will actually visit (a
+    // card can have several qualifying printings). A plain `.min(domain)` cap is *not* enough to
+    // project it down, though — it saturates to exactly `domain` for every query whose printing-space
+    // count exceeds it (`cn<100`: 35,021 printings vs 31,508 cards, and `usd<50`: 80,527 vs 31,508
+    // both saturate to the *identical* 31,508, even though their true card counts are 17,616 vs 31,217
+    // — miles apart), which loses exactly the signal this check needs. A balls-into-bins estimate —
+    // `k` matching printings landing on `domain` cards, expected distinct cards touched
+    // `≈ domain·(1 − e^(−k/domain))` — doesn't saturate the same way and tracks the true count much
+    // better (checked against real totals: `cn<100` estimate 21,140 vs true 17,616; `usd<50` estimate
+    // 29,062 vs true 31,217; clearly separated, unlike the capped estimate's identical 31,508 for both).
+    if perm.is_none() && !walk_col {
         let (printing_matches, _, _) = compose_printing_estimate(filter, indexes, offsets, printings.len());
         // Artwork's true domain is n_artworks (>= n_cards), but getting it exactly means building
         // artwork_base here — real O(n_cards) work paid just to maybe decline. `cards.len()` is a
@@ -5071,11 +5331,30 @@ fn printing_compose_fastpath<'a>(
             }
             walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm, u16::from(indexes.max_artwork_groups))
         }
-        // No permutation: already confirmed above (via the cheap estimate) that this composed set is
-        // selective enough to be worth building — page via the bounded GatherSelect fallback, whose
-        // tie-break matches the general path exactly (same GatherSelect, same comparator), so unlike
-        // the branch above there's no separate small-total decline needed here.
-        None => gather_composed_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, u16::from(indexes.max_artwork_groups)),
+        // No permutation. #744: if the orderby has a printing-space value structure (usd/rarity,
+        // printing mode), walk it directly — terminating at page_offset+limit rather than visiting
+        // every candidate. Falls back to the gather below when the walk declines (the null-value tail,
+        // or a page past the value structure). Otherwise (card/artwork, or any other orderby), the
+        // gather fallback pages via the bounded GatherSelect, whose tie-break matches the general path
+        // exactly (same GatherSelect, same comparator) — so no separate small-total decline is needed.
+        None => {
+            let walked = if walk_col {
+                match sort_col {
+                    SortCol::PriceUsd => walk_range_orderby_page(
+                        &indexes.price_usd, &pbits, cards, printings, &indexes.printing_to_card, sort_col, descending, total, limit, page_offset,
+                    ),
+                    SortCol::Rarity => walk_rarity_orderby_page(
+                        &indexes.rarity_printing, &pbits, cards, printings, &indexes.printing_to_card, descending, total, limit, page_offset, printings.len(),
+                    ),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            walked.unwrap_or_else(|| {
+                gather_composed_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, u16::from(indexes.max_artwork_groups))
+            })
+        }
     };
     Some((total, page))
 }
@@ -5107,6 +5386,24 @@ enum PhysicalPlan {
     StreamedSelect,
     /// The universal fallback: the gathered per-card loop + `select_page`.
     GatheredScan,
+}
+
+/// Which paging strategy `PrintingCompose` (`printing_compose_fastpath`) runs for a query — a 3-way
+/// distinction the cost model (`cost::plan_cost`'s `PrintingCompose` arm) needs because the three have
+/// different cost shapes. `run_query_routed` picks the same variant the fastpath will.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ComposePaging {
+    /// A card-space sort permutation exists → the forward grouped walk (`walk_grouped_page`).
+    /// Offset-dependent: fills the page in ~`page_span/selectivity` steps.
+    Perm,
+    /// No permutation, but the orderby has a printing-space value structure and mode is Printing
+    /// (`usd`/`rarity`, #744) → the direct orderby walk (`walk_range_orderby_page`/
+    /// `walk_rarity_orderby_page`). Offset-dependent, same shape as `Perm`; the COMPOSE_GATHER breadth
+    /// gate is bypassed for it (broad is its best case).
+    OrderbyWalk,
+    /// No permutation and no orderby walk → the permutation-free bounded gather
+    /// (`gather_composed_page`), which visits every match (offset-independent cost).
+    Gather,
 }
 
 impl PhysicalPlan {
@@ -6011,7 +6308,7 @@ fn run_query_routed<'a>(
         scatter_printings: 0,  // range-slice k — set by both range-plan acquire branches (costed per-plan)
         project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
-        compose_has_perm: false, // PrintingCompose overrides this (which paging strategy it'll actually use)
+        compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
     };
     // Features for the general candidate path (shared by the acquire branch and the
     // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
@@ -6095,10 +6392,15 @@ fn run_query_routed<'a>(
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
-        // Which paging strategy the fastpath will actually use — a real permutation walk (cheap,
-        // offset-dependent) or the permutation-free bounded-gather fallback (visits every match,
-        // offset-independent cost). Decided the same way the fastpath itself decides.
-        feats.compose_has_perm = indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len());
+        // Which paging strategy the fastpath will actually use — decided the same way the fastpath
+        // itself decides (permutation walk / #744 orderby walk / gather fallback).
+        feats.compose_paging = if indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len()) {
+            ComposePaging::Perm
+        } else if matches!(mode, Mode::Printing) && orderby_walk_available(sort_col) {
+            ComposePaging::OrderbyWalk
+        } else {
+            ComposePaging::Gather
+        };
         (feats, Prep::Range)
     } else {
         let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
-    range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
+    range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, Mode,
@@ -3395,7 +3395,7 @@ fn plan_cost_model_matches_gold() {
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -3622,7 +3622,7 @@ fn plan_cost_refit() {
                     scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
-                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
+                    broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -3820,7 +3820,7 @@ fn printing_range_route_probe() {
                 scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
             };
 
             // ── Three pickers ──
@@ -4181,7 +4181,7 @@ fn plan_regret_report() {
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -4308,7 +4308,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
-                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_has_perm: false,
+                broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));
@@ -6019,6 +6019,121 @@ fn and_skip_probes_range_selectivity() {
     assert_eq!(probe_range_k(&usd_cmp(CmpOp::Lt, 0.71), indexes), Some(70));
     assert_eq!(len(&FilterExpr::And(vec![legendary(), usd_cmp(CmpOp::Lt, 0.51)])), Some(2));
     assert_eq!(len(&FilterExpr::And(vec![legendary(), usd_cmp(CmpOp::Lt, 0.71)])), Some(10));
+}
+
+// ─── #744: PrintingCompose orderby-range-index walk ─────────────────────────────
+
+/// Part 1 differential: the #744 sparse-side (`_ABSENT`) legality build must produce **bit-for-bit**
+/// the same printing bitmap as the pre-#744 broadcast-from-`_EXISTS` build, on stores with a real
+/// illegal/divergent card mix (fuzz stores are ~40% divergent). Also cross-checks both against the
+/// direct per-printing truth (`(word >> shift) & 0b11 == expected`), so this proves the bits are
+/// *correct*, not merely that the two builds happen to agree. Mirrors
+/// `and_child_rank_matches_narrow_rec_dispatch`'s "test the two sources produce the same thing" spirit.
+#[test]
+fn legality_sparse_side_build_matches_broadcast() {
+    use rand::SeedableRng;
+    for seed in 0..48u64 {
+        let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
+        let data = fuzz_store(&mut rng);
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+        let n_cards = archived.cards.len();
+        let n_printings = archived.printings.len();
+        for shift in [0u8, 2, 4] {
+            for expected in [0b01u64, 0b10, 0b11] {
+                let Some(exists) = super::legality_candidate_bits(&archived.indexes, n_cards, shift, expected, false) else {
+                    continue;
+                };
+                let absent = super::legality_candidate_bits(&archived.indexes, n_cards, shift, expected, true).expect("absent side resolves");
+                let from_exists = super::legality_leaf_bits_from_exists(
+                    shift, expected, &exists, &archived.indexes.legal_divergent, &archived.offsets, &archived.printings, n_printings,
+                );
+                let from_absent = super::legality_leaf_bits_from_absent(
+                    shift, expected, &exists, &absent, &archived.indexes.legal_divergent, &archived.offsets, &archived.printings, n_printings,
+                );
+                assert_eq!(
+                    from_exists, from_absent,
+                    "sparse-side (_ABSENT) build disagrees with broadcast (_EXISTS) build (seed={seed}, shift={shift}, expected={expected:#04b})"
+                );
+                let adaptive =
+                    super::legality_leaf_bits(shift, expected, &archived.indexes, &archived.offsets, &archived.printings, n_printings);
+                assert_eq!(adaptive, from_exists, "adaptive legality_leaf_bits picked a differing build (seed={seed}, shift={shift})");
+                // Direct per-printing truth: the build must equal it on every printing.
+                for p in 0..n_printings {
+                    let want = (u64::from(archived.printings[p].card_legalities) >> shift) & 0b11 == expected;
+                    let got = from_exists[p >> 6] & (1u64 << (p & 63)) != 0;
+                    assert_eq!(got, want, "bit {p} wrong vs per-printing truth (seed={seed}, shift={shift}, expected={expected:#04b})");
+                }
+            }
+        }
+    }
+}
+
+/// Part 2 differential: the #744 orderby walk (`walk_range_orderby_page` for `usd`,
+/// `walk_rarity_orderby_page` for `rarity`) must produce the **identical** printing-mode page — same
+/// rows, same order — as `gather_composed_page` (the #740 reference the walk replaces on the fast
+/// path), across composable filters, both orderbys, both directions, and several offsets. Same
+/// differential-vs-reference pattern `fuzz_row_identity_matches_reference` uses. A larger store keeps
+/// enough non-null-valued matches that the walk actually fires (rather than declining to the
+/// null-value tail); `walked_any` guards against the test going vacuous if that ever stops holding.
+#[test]
+fn orderby_walk_matches_gather_composed() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(4242);
+    let data = fuzz_store_n(&mut rng, 4_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_printings = archived.printings.len();
+    let mga = u16::from(archived.indexes.max_artwork_groups);
+
+    let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
+    let leg = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
+    let filters: [(&str, FilterExpr); 3] = [
+        ("legality", leg()),
+        ("border:black", border("black")),
+        ("legality∧border", FilterExpr::And(vec![leg(), border("black")])),
+    ];
+    let ids = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
+        page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+    };
+
+    let mut walked_any = false;
+    for (name, filter) in &filters {
+        assert!(super::is_printing_composable(filter, &archived.indexes), "{name} must be composable");
+        let pbits = super::compose_printing_bits(filter, &archived.indexes, &archived.offsets, &archived.printings, n_printings);
+        let total: usize = pbits.iter().map(|w| w.count_ones() as usize).sum();
+        for orderby in ["usd", "rarity"] {
+            let sort_col = orderby_to_col(orderby);
+            for &descending in &[false, true] {
+                for &offset in &[0usize, 50, 200] {
+                    let limit = 100usize;
+                    let gather = super::gather_composed_page(
+                        Mode::Printing, &archived.cards, &archived.printings, &archived.offsets, &pbits,
+                        super::Prefer::Default, sort_col, descending, limit, offset, mga,
+                    );
+                    let walk = match sort_col {
+                        SortCol::PriceUsd => super::walk_range_orderby_page(
+                            &archived.indexes.price_usd, &pbits, &archived.cards, &archived.printings,
+                            &archived.indexes.printing_to_card, sort_col, descending, total, limit, offset,
+                        ),
+                        SortCol::Rarity => super::walk_rarity_orderby_page(
+                            &archived.indexes.rarity_printing, &pbits, &archived.cards, &archived.printings,
+                            &archived.indexes.printing_to_card, descending, total, limit, offset, n_printings,
+                        ),
+                        _ => None,
+                    };
+                    if let Some(walk) = walk {
+                        walked_any = true;
+                        assert_eq!(
+                            ids(&walk), ids(&gather),
+                            "walk vs gather_composed_page page differs ({name}, orderby={orderby}, desc={descending}, offset={offset})"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    assert!(walked_any, "the orderby walk never fired on this fixture — the differential would be vacuous");
 }
 
 // ─── Bitplanes (#630) ─────────────────────────────────────────────────────────

--- a/docs/issues/00744-engine-compose-orderby-range-walk.md
+++ b/docs/issues/00744-engine-compose-orderby-range-walk.md
@@ -1,8 +1,9 @@
 # Engine: PrintingCompose Orderby-Range-Index Walk
 
-**Status: proposed**, filed as [#744](https://github.com/jbylund/sylvan_librarian/issues/744). Found
-via `scripts/survey_queries.py` while checking the survey's remaining slowest queries after #739–#741
-landed.
+**Status: implemented**, PR pending, filed as
+[#744](https://github.com/jbylund/sylvan_librarian/issues/744). Found via `scripts/survey_queries.py`
+while checking the survey's remaining slowest queries after #739–#741 landed. Measured results in
+"Results" below; branch `engine-compose-orderby-range-walk`.
 
 ## Measured problem
 
@@ -55,27 +56,46 @@ predicate, regardless of orderby.
 ### 2. Walk the orderby's own range index when there's no permutation and mode is Printing
 
 New paging branch inside `printing_compose_fastpath`, alongside `walk_grouped_page` (has
-permutation) and `gather_composed_page` (#740's fallback): when `sort_col` resolves to one of the
-printing-range-indexed fields (`PriceUsd`/`CollectorNumberInt`/released-at — the same set
-`bare_range_bounds` already knows) **and** `mode == Printing`, walk that field's *own* sorted index
-directly — same shape as `aligned_page`'s bucket walk, but testing the already-built `pbits` bit per
-visited entry instead of assuming unconditional membership in a contiguous slice. Terminates once
-`offset + limit` matches are collected, so cost is `O((offset+limit) / selectivity)`, not
-`O(n_cards)` — the *opposite* of `gather_composed_page`'s shape, and the reason
-`COMPOSE_GATHER_MAX_CARD_FRACTION` must **not** gate this branch: that guard's premise (broad ⇒ not
-worth it) is backwards for this walk, where broad is the *best* case.
+permutation) and `gather_composed_page` (#740's fallback): when `mode == Printing` and `sort_col` is
+a *permutation-less* orderby with a printing-space value-ordered structure, walk that structure's
+value-buckets in page order — same shape as `aligned_page`'s bucket walk, but testing the
+already-built `pbits` bit per visited entry (the structure covers *every* printing with the value,
+not just this filter's matches) instead of assuming unconditional membership in a contiguous slice.
+Terminates once `offset + limit` matches are collected, so cost is
+`O((offset+limit-th match's bucket) / selectivity)`, not `O(n_cards)` — the *opposite* of
+`gather_composed_page`'s shape, and the reason `COMPOSE_GATHER_MAX_CARD_FRACTION` must **not** gate
+this branch: that guard's premise (broad ⇒ not worth it) is backwards for this walk, where broad is
+the *best* case.
+
+The permutation-less orderbys are exactly `usd` and `rarity` (`SortCol::PriceUsd`/`Rarity` — the two
+`ArchivedSortPermutations::get` returns `None` for), and each has such a structure:
+
+- **`usd`** walks the `price_usd` `PrintingRangeIndex` (value-sorted `(cents, pid)`) — many small
+  value-buckets, so both directions fill a 100-row page in ~`100/selectivity` visited entries: **μs**.
+- **`rarity`** walks the exact `rarity_printing` planes/postings as one bucket per rarity int (there
+  is no `PrintingRangeIndex` for rarity, but the planes *are* a printing-space value-bucketed
+  structure). Only six buckets, and hugely uneven, so cost is direction-dependent: **descending**
+  (rarest first) touches a tiny top bucket → **μs**; **ascending** (common first) must collect the
+  whole common bucket before it can order the page, `O(commons)` ≈ tens of thousands of key
+  computations → **~170μs**, still a 3× win over the gather/scan baseline but not μs. This asymmetry
+  is inherent (few, uneven buckets, no within-bucket order index) — quickselect (`select_page`, not a
+  full sort) keeps the ascending case as cheap as it can be. Null-value matches (no price / no
+  rarity) sort last and aren't in the structure; the walk declines to `gather_composed_page` when a
+  page reaches into that tail (never for a broad offset-0 page).
 
 Scoped to `mode == Printing` only: `unique=card`/`artwork`'s row sort key is the *representative*
-printing's price (chosen via `prefer`), and walking `price_usd` in order and taking "first
-occurrence per card" is only correct if `prefer` happens to correlate with price — the same reason
+printing's price/rarity (chosen via `prefer`), and walking value order and taking "first occurrence
+per card" is only correct if `prefer` happens to correlate with the value — the same reason
 `usd`/`rarity` never got a card-space permutation in the first place. Not attempting that here.
 
 ### Cost-model update
 
-`cost.rs`'s `compose_has_perm: bool` needs to become a 3-way distinction (permutation walk /
-orderby-index walk / gather-quickselect) — the same mechanism #740 introduced, one more variant.
-`run_query_routed` decides which of the three applies the same way `printing_compose_fastpath`
-itself will.
+`cost.rs`'s `compose_has_perm: bool` became a 3-way `ComposePaging` enum (`Perm` walk / `OrderbyWalk`
+/ `Gather` quickselect) — the same mechanism #740 introduced, one more variant. `run_query_routed`
+picks the variant the same way `printing_compose_fastpath` does. The `Legality` build-cost estimate
+(`compose_printing_estimate`) now scales `broadcast` from `min(legal, illegal)` cards, not `legal`,
+so the model no longer charges a near-universal format the full legal-side broadcast it stopped
+paying under part 1.
 
 ## Expected cost (worked from real numbers, not guessed)
 
@@ -122,16 +142,57 @@ as every other doc in this thread.
 
 ## Acceptance
 
-- `format:commander`/`format:legacy` (bare), printing mode, `usd`/`rarity` orderby: must drop from
-  ~0.5–0.6ms to the single-digit-to-low-tens-of-μs range.
-- `total` parity with today's (already-correct) numbers on every affected query.
+- `format:commander`/`format:legacy` (bare), printing mode, `usd` orderby: drop from ~0.5–0.6ms to
+  the single-digit-to-low-tens-of-μs range. **Met** (52μs, ~12×).
+- Same queries, `rarity` orderby: **partially met** — `rarity` has no `PrintingRangeIndex`, only six
+  hugely-uneven plane buckets, so the walk is direction-dependent (see approach §2): descending
+  hits μs (~51μs), ascending is `O(commons)` ≈ 170μs (3× win, not μs). Inherent, documented.
+- `total` parity with today's (already-correct) numbers on every affected query. **Held** (0
+  mismatches across the targeted set and the 520-query survey).
 - Every `unique=card`/`artwork` query, every already-fast printing-mode query (aligned range,
-  permutation-orderby), and every plane-only control: must hold flat.
-- New Rust test mirroring `and_child_rank_matches_narrow_rec_dispatch`'s spirit: a small store with
-  a known illegal-card set, asserting the sparse-side build produces the same bits as today's
-  broadcast-from-legal build (differential, not just "it runs"), plus the new walk producing the
-  same page as `gather_composed_page` would for the same query (differential agreement, same
-  pattern `fuzz_row_identity_matches_reference` already uses elsewhere).
+  permutation-orderby), and every plane-only control: hold flat. **Held** (the permutation-orderby
+  printing queries actually *improved* — part 1's cheaper build is orderby-independent).
+- New Rust tests (`legality_sparse_side_build_matches_broadcast`,
+  `orderby_walk_matches_gather_composed`): the sparse-side build produces bit-for-bit the same bitmap
+  as the broadcast-from-legal build (differential + a per-printing-truth cross-check), and the walk
+  produces the identical page as `gather_composed_page` across both orderbys, both directions, and
+  several offsets. `fuzz_row_identity_matches_reference` additionally exercises the walk end-to-end
+  (it forces `PrintingCompose` under `usd`/`rarity` at `limit=100`).
+
+## Results
+
+Measured on `benchmarks/bitplanes/corpus.jsonl` (97,206 printings), `main` @ `fc222fd` vs. this
+branch, `scripts/bench_compose_orderby_range_walk.py` (5s window/config, min-ms, `direction=asc`).
+Sub-millisecond throughout, given in μs:
+
+| query | unique | orderby | main (μs) | branch (μs) | change | total |
+|---|---|---|---:|---:|---|---:|
+| `f:commander` | printing | usd | 607 | 52 | **11.7×** | 96,898 |
+| `f:legacy` | printing | usd | 613 | 52 | **11.8×** | 96,439 |
+| `f:modern` | printing | usd | 687 | 89 | **7.7×** | 73,783 |
+| `f:pioneer` | printing | usd | 474 | 135 | **3.5×** | 47,416 |
+| `f:commander` | printing | rarity (asc) | 555 | 174 | **3.2×** | 96,898 |
+| `f:legacy` | printing | rarity (asc) | 552 | 173 | **3.2×** | 96,439 |
+| `f:commander` | printing | edhrec (perm) | 202 | 44 | **4.6×** (part 1 build) | 96,898 |
+| `border:black` | printing | rarity (asc) | 1,097 | 159 | **6.9×** (rarity walk) | 85,046 |
+| `f:commander` | card | usd | 274 | 274 | flat | 31,451 |
+| `f:commander` | artwork | rarity | 567 | 533 | flat | 45,980 |
+| `usd<50` (aligned) | printing | usd | 49 | 50 | flat | 80,527 |
+| `f:modern` | card | usd (plane) | 232 | 239 | flat | 22,264 |
+| `t:creature` | card | edhrec | 66 | 67 | flat | 17,317 |
+
+`f:commander`/printing/rarity **descending** measured 51μs (vs 174μs ascending) — the direction
+asymmetry §2 predicts. Geomean speedup over the eight moved rows above: **~5.6×**.
+
+Broad survey (`scripts/survey_queries.py --seed 42 --count 400 --wild 120`, `main` vs branch, 520
+common queries): **0 total-parity mismatches, 0 regressions** (>10% and >10μs). Six queries improved,
+including the two motivating shapes present in the wild corpus (`format:commander`/printing/usd
+577→52μs, `format:legacy`/printing/rarity 576→181μs) and `year:2023 border:black`/printing/rarity
+(115→62μs). By-orderby p90: rarity 456→332μs, usd 216→203μs; by-unique p90: printing 221→203μs.
+
+`cargo test` (debug + release): 133/133. `pytest api/tests/test_engine_property.py
+api/tests/test_engine_unit.py`: 158/158. CSVs under `benchmarks/compose-orderby-range-walk/`
+(untracked, per the performance-PR workflow).
 
 ## Related
 

--- a/scripts/bench_compose_orderby_range_walk.py
+++ b/scripts/bench_compose_orderby_range_walk.py
@@ -1,0 +1,112 @@
+"""Targeted benchmark for the PrintingCompose orderby-range-index walk (#744).
+
+`format:commander`/`format:legacy` bare, `unique=printing`, `orderby=usd`/`rarity` cost ~0.5-0.6ms
+even though the legality predicate excludes almost nothing (Commander drops 0.32% of printings).
+Two independent causes (see docs/issues/00744-engine-compose-orderby-range-walk.md):
+
+  1. `compose_printing_bits`'s Legality build broadcasts from the *legal* (majority) card plane — an
+     effectively full O(n_cards + n_printings) pass for a near-universal format.
+  2. `orderby=usd` has no card-space permutation, so paging either visits every candidate
+     (`gather_composed_page`, O(n_cards)) or declines composing via `COMPOSE_GATHER_MAX_CARD_FRACTION`
+     and falls back to a full `GatheredScan`.
+
+The fix builds from whichever legality side is sparser, and (for `mode==Printing` with a
+range-indexed orderby, i.e. `usd`) walks the orderby's own `PrintingRangeIndex`, terminating at
+`offset+limit` matches.
+
+    .venv/bin/python scripts/bench_compose_orderby_range_walk.py \
+        --out benchmarks/compose-orderby-range-walk/baseline-main-<sha>.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. `total` doubles as the
+parity check — must be identical across builds for every config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+# `total` doubles as the parity check (identical across builds for every row).
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # ── Motivating group: near-universal legality, printing mode, usd/rarity orderby ──
+    # usd is the range-indexed orderby (fixed by the new walk); rarity has no range index and rides
+    # only the sparser-side build (part 1) — both listed so the split is visible.
+    ("commander_printing", "f:commander", "printing", "usd", "default"),
+    ("commander_printing", "f:commander", "printing", "rarity", "default"),
+    ("legacy_printing", "f:legacy", "printing", "usd", "default"),
+    ("legacy_printing", "f:legacy", "printing", "rarity", "default"),
+    # Divergent-heavy near-majority format: exercises the sparser-side build WITH the divergent repair
+    # pass still running (modern is 70.7% legal → builds from the absent side, but has divergent cards).
+    ("modern_printing", "f:modern", "printing", "usd", "default"),
+    ("modern_printing", "f:modern", "printing", "rarity", "default"),
+    # Minority-legal format: <50% legal → still builds from the exists side (unchanged arm). Control
+    # that the "pick the sparser side" branch leaves the majority-illegal case alone.
+    ("pioneer_printing", "f:pioneer", "printing", "usd", "default"),
+    ("pioneer_printing", "f:pioneer", "printing", "rarity", "default"),
+
+    # ── Controls: unique=card / artwork (out of scope — prefer-dependent representative). Hold flat. ──
+    ("commander_card", "f:commander", "card", "usd", "default"),
+    ("commander_card", "f:commander", "card", "rarity", "default"),
+    ("commander_artwork", "f:commander", "artwork", "usd", "default"),
+    ("commander_artwork", "f:commander", "artwork", "rarity", "default"),
+    ("legacy_card", "f:legacy", "card", "usd", "default"),
+
+    # ── Controls: already-fast printing-mode paths. Hold flat. ──
+    # Permutation orderby (edhrec) → walk_grouped_page, unaffected by either change.
+    ("commander_printing_perm", "f:commander", "printing", "edhrec", "default"),
+    # Aligned range: predicate and orderby both usd → PrintingRangeScan's aligned_page.
+    ("aligned_usd", "usd<50", "printing", "usd", "default"),
+    # Bare border compose, printing mode (precomputed plane, no legality broadcast).
+    ("border_printing", "border:black", "printing", "rarity", "default"),
+    # Bare usd range, printing/rarity — permutation-free gather fallback (#740), no legality build.
+    ("bare_usd_printing", "usd<50", "printing", "rarity", "default"),
+
+    # ── Controls: plane-only card path (split_planes + card popcount). Hold flat. ──
+    ("plane_card", "f:modern", "card", "usd", "default"),
+    ("plane_card", "f:commander", "card", "edhrec", "default"),
+    ("general", "t:creature", "card", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=5.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<24} {'query':<16} {'unique':<9} {'orderby':<8} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<24} {query:<16} {unique:<9} {orderby:<8} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`format:commander`/printing/`orderby=usd` cost ~0.6ms even though Commander legality excludes only 0.32% of printings (308 of 97,206). Two independent, avoidable causes: the `Legality` compose build broadcast the *legal* (near-universal) card plane down to printings — an effectively full `O(n_cards + n_printings)` pass — and `usd`/`rarity` have no card-space sort permutation, so paging fell back to visiting every candidate (`gather_composed_page`) or declined composing outright and ran a full `GatheredScan`. This PR fixes both. Engine path only (no parser/SQL changes).

## Changes

- **Build legality bits from the sparser side.** `compose_printing_bits` now picks the cheaper of the `_EXISTS`/`_ABSENT` planes (same "pick the cheaper side" shape `range_narrowed` uses): a majority-legal format clears its tiny illegal set from an all-ones start instead of broadcasting the ~all legal set, and skips the divergent-repair pass entirely when the format has zero divergent cards. Produces bit-for-bit the same bitmap as the old broadcast build; helps every paging strategy, orderby-independent.
- **Orderby-value-structure walk.** New paging branch in `printing_compose_fastpath` for the two permutation-less orderbys under `mode == Printing`: `usd` walks the `price_usd` `PrintingRangeIndex`, `rarity` walks the `rarity_printing` planes, testing the composed `pbits` per visited entry and terminating at `offset+limit`. `COMPOSE_GATHER_MAX_CARD_FRACTION` is bypassed for this branch — broad is its best case, not its worst.
- **Cost model.** `cost.rs`'s `compose_has_perm: bool` becomes a 3-way `ComposePaging` enum (`Perm` / `OrderbyWalk` / `Gather`); `run_query_routed` picks the variant the fastpath will. The `Legality` build estimate now scales from `min(legal, illegal)` cards so it reflects the sparser-side build.
- New differential tests: `legality_sparse_side_build_matches_broadcast`, `orderby_walk_matches_gather_composed`.

## Related issues

Implements #744. Design doc: `docs/issues/00744-engine-compose-orderby-range-walk.md`.

---

## Performance

Targeted (`scripts/bench_compose_orderby_range_walk.py`, 97,206-printing corpus, 5s window, min-ms, `direction=asc`):

| Benchmark | Before (μs) | After (μs) | Change | total |
|-----------|------------:|-----------:|--------|------:|
| `f:commander` printing usd | 607 | 52 | **11.7×** | 96,898 |
| `f:legacy` printing usd | 613 | 52 | **11.8×** | 96,439 |
| `f:modern` printing usd | 687 | 89 | **7.7×** | 73,783 |
| `f:pioneer` printing usd | 474 | 135 | **3.5×** | 47,416 |
| `f:commander` printing rarity (asc) | 555 | 174 | **3.2×** | 96,898 |
| `f:legacy` printing rarity (asc) | 552 | 173 | **3.2×** | 96,439 |
| `f:commander` printing edhrec (perm) | 202 | 44 | **4.6×** | 96,898 |
| `border:black` printing rarity (asc) | 1,097 | 159 | **6.9×** | 85,046 |
| `f:commander` card usd (control) | 274 | 274 | flat | 31,451 |
| `f:commander` artwork rarity (control) | 567 | 533 | flat | 45,980 |
| `usd<50` printing usd — aligned (control) | 49 | 50 | flat | 80,527 |
| `t:creature` card edhrec (control) | 66 | 67 | flat | 17,317 |

**Geometric mean:** ~5.6× over the eight moved rows.
**Test corpus:** `benchmarks/bitplanes/corpus.jsonl` (97,206 printings) for the targeted set; broad screen `scripts/survey_queries.py --seed 42 --count 400 --wild 120` (520 queries, wild slice from prod scryfall.com/search traffic).

`usd` orderby drops to μs in both directions. `rarity` is direction-dependent (six hugely-uneven plane buckets, no within-bucket order index): descending hits μs (~51μs), ascending is `O(commons)` ≈ 170μs — a 3× win but not μs; inherent, documented in the design doc. `total` parity held on every row. Broad survey: **0 parity mismatches, 0 regressions** (>10% & >10μs); rarity p90 456→332μs, printing p90 221→203μs.

`cargo test` debug + release: 133/133. `pytest api/tests/test_engine_property.py api/tests/test_engine_unit.py`: 158/158.

---

## Reviewer notes

- The walk covers exactly the two permutation-less orderbys (`usd`, `rarity`). For `rarity` it uses the `rarity_printing` planes as a value-bucketed structure (there is no `PrintingRangeIndex` for rarity) — the ascending-direction `O(commons)` cost is inherent and can't reach μs; see the design doc's approach §2.
- Null-value matches (no price / no rarity) sort last and aren't in the value structure; the walk declines to `gather_composed_page` when a page reaches into that tail (never for a broad offset-0 page). Correctness is covered by `orderby_walk_matches_gather_composed` and `fuzz_row_identity_matches_reference`.
- `unique=card`/`artwork` with `usd`/`rarity` is deliberately out of scope (the row sort key is the `prefer`-chosen representative's value).