### PR TITLE
Engine: explain / explain_analyze for the Plan-Selection Layer

### DIFF
--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1248,3 +1248,47 @@ class TestFieldSelection:
     def test_unknown_field_raises(self, engine: QueryEngine) -> None:
         with pytest.raises(UnknownFieldError):
             _run(engine, unique="printing", fields=["not_a_real_field"])
+
+
+class TestExplain:
+    """explain()/explain_analyze() (#745): the router's own cost model as an on-demand diagnostic.
+
+    Not a search result — see docs/issues/00745-engine-explain-analyze.md.
+    """
+
+    def test_explain_ranks_applicable_plans_ascending(self, engine: QueryEngine) -> None:
+        filters = parse_scryfall_query("t:creature")
+        rows = engine.explain(filters=filters, unique="card", orderby="edhrec", direction="asc", limit=50, offset=0)
+
+        assert rows, "GatheredScan is always applicable"
+        assert {"plan", "predicted_ns"} <= rows[0].keys()
+        predicted_ns = [row["predicted_ns"] for row in rows]
+        assert predicted_ns == sorted(predicted_ns)
+        assert any(row["plan"] == "GatheredScan" for row in rows)
+
+    def test_explain_analyze_matches_explain_and_times_every_plan(self, engine: QueryEngine) -> None:
+        filters = parse_scryfall_query("t:creature")
+        explained = engine.explain(filters=filters, unique="card", orderby="edhrec", direction="asc", limit=50, offset=0)
+        analyzed = engine.explain_analyze(
+            filters=filters,
+            unique="card",
+            prefer="default",
+            orderby="edhrec",
+            direction="asc",
+            limit=50,
+            offset=0,
+            num_warmups=1,
+            num_trials=3,
+        )
+
+        # Same plans, same order, same predicted_ns -- explain_analyze must never
+        # diverge from explain (they share the engine's acquire_plan_features step).
+        assert [row["plan"] for row in analyzed] == [row["plan"] for row in explained]
+        assert [row["predicted_ns"] for row in analyzed] == [row["predicted_ns"] for row in explained]
+        for row in analyzed:
+            # A structurally-applicable plan's fastpath can still decline at runtime
+            # (empty trials_ns); otherwise warmups are discarded and exactly
+            # num_trials recorded.
+            assert row["trials_ns"] == [] or len(row["trials_ns"]) == 3
+            assert all(t >= 0 for t in row["trials_ns"])
+        assert any(row["plan"] == "GatheredScan" and len(row["trials_ns"]) == 3 for row in analyzed)

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -117,6 +117,7 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum NumExpr {
     Const(f64),
     Field(NumField),
@@ -402,6 +403,14 @@ fn text_field_value<'a>(
 /// exhaustively (no `_` arm), so adding a variant is a compile error until
 /// it's classified in both — deliberately, since a silent default there
 /// would misorder the verifier walk without failing any test.
+///
+/// `Clone` (#745): `explain_analyze` needs a fresh, unmutated tree for every
+/// `run_query_with_plan` call — its own `prepare_candidates` mutates via
+/// `memoize_text_predicates` — so it clones from a pristine snapshot per call
+/// rather than reusing one filter across plans/rounds. Every field here is
+/// cheaply `Clone` already (small `Vec`s, `String`, `regex::Regex` is
+/// internally `Arc`-based); this is a plain derive, not a deep-copy concern.
+#[derive(Clone)]
 pub(crate) enum FilterExpr {
     True,
     And(Vec<FilterExpr>),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3750,6 +3750,19 @@ fn prefer_from_str(s: &str) -> Prefer {
     }
 }
 
+/// The `unique` string → `Mode` mapping, in one place. Anything other than the
+/// literal `"artwork"`/`"printing"` is `Mode::Card` (not just the literal
+/// `"card"`) — see `split_planes`'s `unique_is_card` doc. Shared by `run_query`,
+/// `run_query_with_plan`, `explain_analyze`, and the PyO3 `explain` method so
+/// they can never drift.
+fn mode_from_unique(unique: &str) -> Mode {
+    match unique {
+        "artwork"  => Mode::Artwork,
+        "printing" => Mode::Printing,
+        _          => Mode::Card,
+    }
+}
+
 /// Prefer score for one printing of a card; higher wins, and selection uses a
 /// strict > so the first-in-store-order printing wins ties (matching the tie
 /// behavior of the dedup paths this replaced).
@@ -6171,12 +6184,7 @@ fn run_query<'a>(
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let prefer     = prefer_from_str(prefer);
-
-    let mode = match unique {
-        "artwork"  => Mode::Artwork,
-        "printing" => Mode::Printing,
-        _          => Mode::Card,
-    };
+    let mode       = mode_from_unique(unique);
 
     // #702: plan selection is one cost-based routing layer (`run_query_routed`,
     // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision
@@ -6549,11 +6557,7 @@ fn run_query_with_plan<'a>(
     let sort_col   = orderby_to_col(orderby);
     let descending = direction == "desc";
     let prefer     = prefer_from_str(prefer);
-    let mode = match unique {
-        "artwork"  => Mode::Artwork,
-        "printing" => Mode::Printing,
-        _          => Mode::Card,
-    };
+    let mode       = mode_from_unique(unique);
 
     match plan {
         PhysicalPlan::PrintingRangeScan => {
@@ -6690,6 +6694,12 @@ pub(crate) struct PlanTrial {
 /// Rotates which plan runs first/last each round (`(i + round) % n`) rather than a
 /// fixed order, so no plan systematically benefits from whatever accumulates
 /// round-over-round (allocator state, cache residency).
+///
+/// `trials_ns` is a fair head-to-head *between plans*, not a reproduction of a real
+/// query's wall time: each `run_query_with_plan` call re-runs its own
+/// `prepare_candidates`, whereas `run_query_routed` acquires the shared artifact
+/// once and reuses it. So compare `trials_ns` across plans, not against an
+/// end-to-end `query()` latency for the winner.
 #[allow(clippy::too_many_arguments)]
 fn explain_analyze(
     cards: &[AOracleCard],
@@ -6710,11 +6720,7 @@ fn explain_analyze(
 ) -> Vec<PlanTrial> {
     let sort_col = orderby_to_col(orderby);
     let descending = direction == "desc";
-    let mode = match unique {
-        "artwork"  => Mode::Artwork,
-        "printing" => Mode::Printing,
-        _          => Mode::Card,
-    };
+    let mode = mode_from_unique(unique);
 
     // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
     // the timing loop below starts from `filter`'s untouched, pristine state.
@@ -7248,11 +7254,20 @@ pub(crate) fn count_common_keywords(data: &Archived<CardData>) -> HashMap<String
         .collect()
 }
 
-/// Shared `explain`/`explain_analyze` (#745) filter resolution: parse `filters`'
-/// `to_json()`, bind against `data`'s vocabs, and split off the plane-expressible
-/// part — the same three steps `query()` runs inline. Kept as a private duplicate
-/// rather than a refactor of `query()` itself, so the existing hot search path is
-/// untouched by this change.
+/// Shared filter resolution for `query`/`explain`/`explain_analyze` (#745): parse
+/// `filters`' `to_json()`, bind against `data`'s vocabs, and split off the
+/// plane-expressible part (colors/identity/types) into a bitmap expression. The
+/// single source of truth for these steps — `query`'s hot path calls this too, so
+/// the diagnostics can never route a query differently than a real search would.
+///
+/// The plane split is guarded on the archive carrying planes for this card count;
+/// the format-version bump already rejects pre-plane archives, so this is defense
+/// in depth. `unique_is_card` follows `mode_from_unique` exactly (anything but
+/// `"artwork"`/`"printing"` is card mode) — see `split_planes`'s doc.
+///
+/// No `#[inline]`: this shares a crate with its only hot-path caller (`query`), so
+/// the compiler already inlines at its discretion, and the body is dominated by
+/// Python FFI (`to_json`, `orjson.dumps`) — a call boundary here is unmeasurable.
 fn bind_and_split_filter(py: Python<'_>, filters: &Bound<PyAny>, unique: &str, data: &Archived<CardData>) -> PyResult<(Option<PlaneExpr>, FilterExpr)> {
     let to_json = filters.call_method0("to_json")?;
     let json_bytes: Vec<u8> = py
@@ -7714,15 +7729,6 @@ impl QueryEngine {
         fields: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyTuple>> {
         let resolved_fields = resolve_fields(fields)?;
-        let to_json    = filters.call_method0("to_json")?;
-        let json_bytes: Vec<u8> = py
-            .import("orjson")?
-            .call_method1("dumps", (to_json,))?
-            .extract()?;
-        let json_str = std::str::from_utf8(&json_bytes)
-            .map_err(|e| QueryError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
-        let json_val: Value = serde_json::from_str(json_str)
-            .map_err(|e| QueryError::new_err(format!("bad query JSON: {e}")))?;
         // get_mmap() remaps automatically if the on-disk inode has changed since
         // the last reload, keeping workers off stale (deleted) mappings.
         let mmap = self.get_mmap()?;
@@ -7752,28 +7758,12 @@ impl QueryEngine {
         // validation cannot be the safety boundary; the trusted write path is.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
 
-        // Must run before build_filter so legality shifts resolve in workers
-        // that never executed the load path themselves.
-        sync_format_shifts(&data.format_shifts);
-        let mut filter_expr = build_filter(&json_val)
-            .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
-        filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
-
-        // Consume the plane-expressible part of the filter (colors/identity/
-        // types) into a bitmap expression; run_query evaluates it in a few
-        // hundred word ops instead of per-card dispatch. Guarded on the archive
-        // carrying planes for this card count — the format-version bump already
-        // rejects pre-plane archives, this is defense in depth.
-        let (plane_expr, mut filter_expr) =
-            if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
-                // Matches run_query's own unique -> Mode mapping exactly
-                // (anything other than "artwork"/"printing" is Mode::Card,
-                // not just the literal string "card") -- see split_planes's
-                // unique_is_card doc.
-                split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
-            } else {
-                (None, filter_expr)
-            };
+        // Parse the query, bind it against this archive's vocabs, and consume the
+        // plane-expressible part (colors/identity/types) into a bitmap expression
+        // run_query evaluates in a few hundred word ops instead of per-card
+        // dispatch. Shared verbatim with explain()/explain_analyze() — see
+        // bind_and_split_filter.
+        let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
 
         let (total, page) = run_query(
             &data.cards, &data.printings, &data.offsets, &data.strings, &mut filter_expr, plane_expr.as_ref(),
@@ -7789,9 +7779,15 @@ impl QueryEngine {
     }
 
     /// #745 primitive 1: every applicable plan's predicted cost for this query,
-    /// ranked cheapest first (`result[0]` is what `query()` would actually run) —
-    /// the numbers the router already computes on every query, just exposed
-    /// instead of thrown away. Diagnostic only; safe to call constantly.
+    /// ranked cheapest first — the numbers the router already computes on every
+    /// query, just exposed instead of thrown away. Diagnostic only; safe to call
+    /// constantly.
+    ///
+    /// `result[0]` is what `query()` runs in the common case, with one exception:
+    /// for a bare-range query (`Prep::Range` acquire), a materializing plan's cost
+    /// here is the router's coarse pre-materialize estimate, and the router may
+    /// lazily re-materialize and re-choose on exact features at dispatch — so the
+    /// executed plan can differ from `result[0]`. See the free `explain` fn's doc.
     #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (*, filters, unique="card", orderby="edhrec", direction="asc", limit=100, offset=0))]
     fn explain<'py>(
@@ -7811,11 +7807,7 @@ impl QueryEngine {
 
         let sort_col = orderby_to_col(orderby);
         let descending = direction == "desc";
-        let mode = match unique {
-            "artwork"  => Mode::Artwork,
-            "printing" => Mode::Printing,
-            _          => Mode::Card,
-        };
+        let mode = mode_from_unique(unique);
         let estimates = explain(
             &data.cards, &data.printings, &data.offsets, &data.strings, &mut filter_expr, plane_expr.as_ref(),
             mode, sort_col, descending, limit, offset, &data.indexes,
@@ -7851,10 +7843,16 @@ impl QueryEngine {
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let (plane_expr, filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
 
-        let trials = explain_analyze(
-            &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr, plane_expr.as_ref(),
-            unique, prefer, orderby, direction, limit, offset, &data.indexes, num_warmups, num_trials,
-        );
+        // Release the GIL for the timing loop: it's pure Rust (no Python calls) and
+        // runs plans × (warmups + trials) executions, so a long explain_analyze
+        // shouldn't block other Python threads. The bind above and the PyDict
+        // conversion below stay on the GIL.
+        let trials = py.detach(|| {
+            explain_analyze(
+                &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr, plane_expr.as_ref(),
+                unique, prefer, orderby, direction, limit, offset, &data.indexes, num_warmups, num_trials,
+            )
+        });
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;
         PyList::new(py, rows)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6238,6 +6238,174 @@ fn exec_from_candidates<'a>(
     }
 }
 
+/// Cost features: the query-invariant fields filled once; the four that vary by
+/// count source passed in. Collapses each acquire branch's 8-field literal to one call.
+#[allow(clippy::too_many_arguments)]
+fn mk_plan_feats(
+    n_cards: u32,
+    n_printings: u32,
+    limit: usize,
+    page_offset: usize,
+    matches: u32,
+    eval_domain: u32,
+    scan_units: u32,
+    residual_tier_ns100: u32,
+) -> cost::PlanFeatures {
+    cost::PlanFeatures {
+        n_cards,
+        n_printings,
+        matches,
+        eval_domain,
+        scan_units,
+        residual_tier_ns100,
+        limit: limit as u32,
+        offset: page_offset as u32,
+        broadcast_printings: 0, // PrintingCompose's legality broadcast-down (0 for ranges / precomputed planes)
+        scatter_printings: 0,  // range-slice k — set by both range-plan acquire branches (costed per-plan)
+        project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
+        popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
+        compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
+    }
+}
+
+/// Features for the general candidate path (shared by `acquire_plan_features`'s
+/// fallback branch and `run_query_routed`'s lazy-materialize dispatch fallback).
+/// `matches`/`eval_domain` = candidate CARD count, the broad/narrow proxy the P3/P4
+/// crossover keys on. `scan_units` sums printing counts over the candidate cards
+/// (O(candidates) for narrowed printing/artwork — the ~1-2% overhead in
+/// plan_routing_ab), kept EXACT on purpose: an O(1) estimate would trade the
+/// model's honesty for a couple percent on already-fast queries — do not swap it
+/// for `eval_domain·n_printings/n_cards` without re-justifying.
+#[allow(clippy::too_many_arguments)]
+fn candidate_feats(
+    prep: &PreparedCandidates,
+    filter: &FilterExpr,
+    mode: Mode,
+    offsets: &AOffsets,
+    n_cards: u32,
+    n_printings: u32,
+    limit: usize,
+    page_offset: usize,
+) -> cost::PlanFeatures {
+    let count = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+    let scan = scan_units(mode, prep.candidate_cards.as_deref(), offsets, n_printings, count);
+    mk_plan_feats(n_cards, n_printings, limit, page_offset, count, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
+}
+
+/// The acquire step of `run_query_routed`'s three-step algorithm (see its doc
+/// comment), factored out so `explain`/`explain_analyze` (#745) compute cost
+/// features via this exact same code path — never a second copy that can
+/// silently drift from what the real router would pick. Picks the query's count
+/// source (one of three, by structure) and builds the cost features,
+/// materializing the shared artifact it implies: a True-residual plane's popcount
+/// (`Prep::Plane`), a bare range's index-`k` (`Prep::Range`, nothing materialized),
+/// or `prepare_candidates` (`Prep::Candidates`). Returns the plane popcount bitmap
+/// alongside `Prep::Plane` (empty otherwise) — `run_query_routed`'s dispatch needs
+/// it to execute the winner; a caller that only wants `feats` (`explain`) drops it.
+#[allow(clippy::too_many_arguments)]
+fn acquire_plan_features(
+    cards: &[AOracleCard],
+    printings: &[APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &mut FilterExpr,
+    plane: Option<&PlaneExpr>,
+    mode: Mode,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> (cost::PlanFeatures, Prep, Vec<u64>) {
+    let n_cards = cards.len() as u32;
+    let n_printings = printings.len() as u32;
+
+    // Scratch for the plane bitmap (`Prep::Plane` only). A fresh `Vec` allocates
+    // just once, on the plane branch's `eval_planes`; non-plane queries leave it
+    // empty (no alloc).
+    let mut plane_bits: Vec<u64> = Vec::new();
+
+    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // The ONE plane eval; its popcount IS the exact count. scan_units == count
+        // (Mode::Card breaks at first match); True residual ⇒ tier 0.
+        eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
+        let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
+        (mk_plan_feats(n_cards, n_printings, limit, page_offset, count, count, count, 0), Prep::Plane)
+    } else if PhysicalPlan::CardRangePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Exact in-range printing count `k` from the index partition points (two binary searches, no
+        // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
+        // plan wins — so a competing winner never eats a wasted build (re-deriving the bounds there is
+        // another ~free binary search). `k` rides `synth_printings` (the deferred scatter); `matches`
+        // uses the card-count proxy `min(k, n_cards)` (card total ≤ both). The materializing
+        // alternatives are costed with the range's verify tier (a `0` would under-cost them).
+        let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
+        let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
+        let card_est = k.min(n_cards);
+        let mut feats = mk_plan_feats(n_cards, n_printings, limit, page_offset, card_est, card_est, card_est, verify_cost_tier(filter));
+        // `k` rides `scatter_printings`: this plan's arm charges it as its FUSED one-pass build
+        // (`CARD_RANGE_BUILD_PER_PRINTING_NS`), while a competing PrintingCompose costed off these shared
+        // feats charges the same `k` as its cheaper scatter (`RANGE_SCATTER_…`) plus a separate
+        // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
+        feats.scatter_printings = k;
+        feats.project_printings = k;
+        (feats, Prep::Range)
+    } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
+        // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
+        let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
+        let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
+        let mut feats = mk_plan_feats(n_cards, n_printings, limit, page_offset, k, n_cards, n_printings, verify_cost_tier(filter));
+        feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
+        (feats, Prep::Range)
+    } else if PhysicalPlan::PrintingCompose.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
+        // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
+        // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
+        // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
+        let (printing_matches, broadcast, scatter) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
+        // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
+        // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
+        // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
+        // CardRangePopcount acquire (which sets `scatter`/`project` too) cost this plan's passes
+        // honestly against the fused build. `eval_domain`/`scan_units` cost the *materializing
+        // alternatives* should compose lose: a composable filter narrows via its indices, so they see
+        // ~`matches` candidates (card mode also breaks at the first match ⇒ scan_units = eval_domain) —
+        // the unnarrowed universe would over-cost them and mis-route (measured: `format:X format:Y`/card).
+        let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
+            Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), n_cards as usize, n_printings as usize),
+            Mode::Card => {
+                let rt = printing_matches.min(n_cards as usize);
+                (rt, printing_matches, (n_cards as usize).div_ceil(64), rt, rt)
+            }
+            Mode::Artwork => {
+                let rt = printing_matches.min(n_cards as usize);
+                (printing_matches, printing_matches, (n_printings as usize).div_ceil(64), rt, printing_matches)
+            }
+        };
+        let mut feats = mk_plan_feats(n_cards, n_printings, limit, page_offset, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
+        feats.broadcast_printings = broadcast as u32;
+        feats.scatter_printings = scatter as u32;
+        feats.project_printings = project as u32;
+        feats.popcount_words = popcount_words as u32;
+        // Which paging strategy the fastpath will actually use — decided the same way the fastpath
+        // itself decides (permutation walk / #744 orderby walk / gather fallback).
+        feats.compose_paging = if indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len()) {
+            ComposePaging::Perm
+        } else if matches!(mode, Mode::Printing) && orderby_walk_available(sort_col) {
+            ComposePaging::OrderbyWalk
+        } else {
+            ComposePaging::Gather
+        };
+        (feats, Prep::Range)
+    } else {
+        let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
+        let feats = candidate_feats(&prep, filter, mode, offsets, n_cards, n_printings, limit, page_offset);
+        (feats, Prep::Candidates(prep))
+    };
+
+    (feats, prep, plane_bits)
+}
+
 /// #702: the single cost-based plan-selection layer for ALL unique modes — the
 /// whole of `run_query`'s dispatch (the hand-tuned decision tree it replaced is
 /// gone). Three linear steps, no early returns:
@@ -6293,119 +6461,10 @@ fn run_query_routed<'a>(
             .expect("GatheredScan is always applicable and materializing")
     };
 
-    // Cost features: the query-invariant fields filled once; the four that vary by
-    // count source passed in. Collapses each acquire branch's 8-field literal to one call.
-    let mk_feats = |matches: u32, eval_domain: u32, scan_units: u32, residual_tier_ns100: u32| cost::PlanFeatures {
-        n_cards,
-        n_printings,
-        matches,
-        eval_domain,
-        scan_units,
-        residual_tier_ns100,
-        limit: limit as u32,
-        offset: page_offset as u32,
-        broadcast_printings: 0, // PrintingCompose's legality broadcast-down (0 for ranges / precomputed planes)
-        scatter_printings: 0,  // range-slice k — set by both range-plan acquire branches (costed per-plan)
-        project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
-        popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
-        compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
-    };
-    // Features for the general candidate path (shared by the acquire branch and the
-    // lazy-materialize dispatch). `matches`/`eval_domain` = candidate CARD count, the
-    // broad/narrow proxy the P3/P4 crossover keys on. `scan_units` sums printing counts
-    // over the candidate cards (O(candidates) for narrowed printing/artwork — the ~1-2%
-    // overhead in plan_routing_ab), kept EXACT on purpose: an O(1) estimate would trade
-    // the model's honesty for a couple percent on already-fast queries — do not swap it
-    // for `eval_domain·n_printings/n_cards` without re-justifying.
-    let candidate_feats = |prep: &PreparedCandidates, filter: &FilterExpr| -> cost::PlanFeatures {
-        let count = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
-        let scan = scan_units(mode, prep.candidate_cards.as_deref(), offsets, n_printings, count);
-        mk_feats(count, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
-    };
-
-    // Scratch for the plane bitmap (`Prep::Plane` only). A fresh `Vec` allocates
-    // just once, on the plane branch's `eval_planes`; non-plane queries leave it
-    // empty (no alloc). Owned locally so the router body stays flat statements —
-    // no thread-local / `.with` closure wrapping the whole function.
-    let mut plane_bits: Vec<u64> = Vec::new();
-
     // ── acquire: pick the count source, build features, materialize its artifact ──
-    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // The ONE plane eval; its popcount IS the exact count. scan_units == count
-        // (Mode::Card breaks at first match); True residual ⇒ tier 0.
-        eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
-        let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
-        (mk_feats(count, count, count, 0), Prep::Plane)
-    } else if PhysicalPlan::CardRangePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Exact in-range printing count `k` from the index partition points (two binary searches, no
-        // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
-        // plan wins — so a competing winner never eats a wasted build (re-deriving the bounds there is
-        // another ~free binary search). `k` rides `synth_printings` (the deferred scatter); `matches`
-        // uses the card-count proxy `min(k, n_cards)` (card total ≤ both). The materializing
-        // alternatives are costed with the range's verify tier (a `0` would under-cost them).
-        let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
-        let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        let card_est = k.min(n_cards);
-        let mut feats = mk_feats(card_est, card_est, card_est, verify_cost_tier(filter));
-        // `k` rides `scatter_printings`: this plan's arm charges it as its FUSED one-pass build
-        // (`CARD_RANGE_BUILD_PER_PRINTING_NS`), while a competing PrintingCompose costed off these shared
-        // feats charges the same `k` as its cheaper scatter (`RANGE_SCATTER_…`) plus a separate
-        // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
-        feats.scatter_printings = k;
-        feats.project_printings = k;
-        (feats, Prep::Range)
-    } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
-        // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
-        let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
-        let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        let mut feats = mk_feats(k, n_cards, n_printings, verify_cost_tier(filter));
-        feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
-        (feats, Prep::Range)
-    } else if PhysicalPlan::PrintingCompose.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
-        // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
-        // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
-        // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
-        // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
-        let (printing_matches, broadcast, scatter) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
-        // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
-        // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
-        // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
-        // CardRangePopcount acquire (which sets `scatter`/`project` too) cost this plan's passes
-        // honestly against the fused build. `eval_domain`/`scan_units` cost the *materializing
-        // alternatives* should compose lose: a composable filter narrows via its indices, so they see
-        // ~`matches` candidates (card mode also breaks at the first match ⇒ scan_units = eval_domain) —
-        // the unnarrowed universe would over-cost them and mis-route (measured: `format:X format:Y`/card).
-        let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
-            Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), n_cards as usize, n_printings as usize),
-            Mode::Card => {
-                let rt = printing_matches.min(n_cards as usize);
-                (rt, printing_matches, (n_cards as usize).div_ceil(64), rt, rt)
-            }
-            Mode::Artwork => {
-                let rt = printing_matches.min(n_cards as usize);
-                (printing_matches, printing_matches, (n_printings as usize).div_ceil(64), rt, printing_matches)
-            }
-        };
-        let mut feats = mk_feats(result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
-        feats.broadcast_printings = broadcast as u32;
-        feats.scatter_printings = scatter as u32;
-        feats.project_printings = project as u32;
-        feats.popcount_words = popcount_words as u32;
-        // Which paging strategy the fastpath will actually use — decided the same way the fastpath
-        // itself decides (permutation walk / #744 orderby walk / gather fallback).
-        feats.compose_paging = if indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len()) {
-            ComposePaging::Perm
-        } else if matches!(mode, Mode::Printing) && orderby_walk_available(sort_col) {
-            ComposePaging::OrderbyWalk
-        } else {
-            ComposePaging::Gather
-        };
-        (feats, Prep::Range)
-    } else {
-        let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
-        (candidate_feats(&prep, filter), Prep::Candidates(prep))
-    };
+    let (feats, prep, plane_bits) = acquire_plan_features(
+        cards, printings, offsets, strings, filter, plane, mode, sort_col, descending, limit, page_offset, indexes,
+    );
 
     // ── choose: cheapest applicable plan ──
     let plan = choose(filter, &feats, false);
@@ -6453,7 +6512,7 @@ fn run_query_routed<'a>(
                 Some(page) => page,
                 None => {
                     let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
-                    let feats = candidate_feats(&prep, filter);
+                    let feats = candidate_feats(&prep, filter, mode, offsets, n_cards, n_printings, limit, page_offset);
                     let plan = choose(filter, &feats, true);
                     exec_from_candidates(plan, cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes)
                 }
@@ -6468,9 +6527,9 @@ fn run_query_routed<'a>(
 /// executable without changing `run_query`'s default routing. Returns `None`
 /// when `plan` fails its applicability predicate (or, for `PrintingRangeScan`,
 /// when `printing_range_fastpath` structurally declines with `None`); `Some`
-/// with the result when it ran. `GatheredScan` is always `Some`.
+/// with the result when it ran. `GatheredScan` is always `Some`. Also the
+/// executor `explain_analyze` (#745) drives per plan per timing round.
 #[allow(clippy::too_many_arguments)]
-#[allow(dead_code)] // force entry point; exercised by force_plan_differential_agreement
 fn run_query_with_plan<'a>(
     plan: PhysicalPlan,
     cards: &'a [AOracleCard],
@@ -6548,6 +6607,142 @@ fn run_query_with_plan<'a>(
             ))
         }
     }
+}
+
+/// One applicable plan's predicted cost, as `explain` (#745) reports it — exposing
+/// the numbers `run_query_routed`'s `choose` step already computes and discards,
+/// via the identical `acquire_plan_features` acquire step so this can never
+/// silently drift from what the real router would pick.
+pub(crate) struct PlanEstimate {
+    pub(crate) plan: PhysicalPlan,
+    pub(crate) predicted_ns: f64,
+}
+
+/// #745 primitive 1: every applicable plan's predicted cost for this query, ranked
+/// cheapest first (index 0 is `run_query_routed`'s actual pick). Diagnostic only —
+/// this is exactly the acquire+argmin the router runs on every query, just with
+/// every candidate kept instead of only the winner, so it costs nothing beyond
+/// what a normal query already pays and is safe to call constantly. Note: for a
+/// `Prep::Range`-acquired query, the reported cost for a materializing plan
+/// (StreamedSelect/GatheredScan) is the same coarse "broad regime" estimate
+/// `run_query_routed`'s top-level choose uses — not the more precise number its
+/// dispatch would compute if that plan actually won and got lazily re-costed
+/// against a materialized candidate list (see `acquire_plan_features`'s
+/// `PrintingRangeScan`/`PrintingCompose` branches).
+#[allow(clippy::too_many_arguments)]
+fn explain(
+    cards: &[AOracleCard],
+    printings: &[APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &mut FilterExpr,
+    plane: Option<&PlaneExpr>,
+    mode: Mode,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+) -> Vec<PlanEstimate> {
+    let (feats, _prep, _plane_bits) = acquire_plan_features(
+        cards, printings, offsets, strings, filter, plane, mode, sort_col, descending, limit, page_offset, indexes,
+    );
+    let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
+        .into_iter()
+        .filter(|p| p.applicable(filter, mode, cards, plane, sort_col, descending, indexes))
+        .map(|plan| PlanEstimate { plan, predicted_ns: cost::plan_cost(plan, &feats) })
+        .collect();
+    estimates.sort_by(|a, b| a.predicted_ns.partial_cmp(&b.predicted_ns).expect("plan_cost is finite"));
+    estimates
+}
+
+/// One applicable plan's `explain_analyze` (#745) result: the same predicted cost
+/// `explain` reports for this plan, plus raw per-trial timings — deliberately not
+/// pre-reduced (no median/mean here), so a caller can see whether a plan's timing
+/// is bimodal, which this engine has measured happening on identical work before
+/// (00648-engine-verifier-cost-ordering.md's measurement-traps section).
+pub(crate) struct PlanTrial {
+    pub(crate) plan: PhysicalPlan,
+    pub(crate) predicted_ns: f64,
+    pub(crate) trials_ns: Vec<u64>,
+}
+
+/// #745 primitive 2: actually run every applicable plan via `run_query_with_plan`,
+/// `num_warmups` discarded rounds then `num_trials` recorded rounds, returning the
+/// raw per-trial timings alongside each plan's predicted cost (from `explain`, so a
+/// caller never has to zip two separate lists by plan to compare predicted vs
+/// actual).
+///
+/// `filter` is a shared reference and is never mutated in place here — every
+/// `run_query_with_plan` call gets a fresh `.clone()` off this same pristine
+/// snapshot instead. This is the resolution to the correctness question
+/// `docs/issues/00745-engine-explain-analyze.md` raises: `run_query_with_plan`'s
+/// `StreamedSelect`/`GatheredScan` arms each call `prepare_candidates` themselves,
+/// which mutates the filter it's given (`memoize_text_predicates`) — reusing one
+/// `&mut FilterExpr` across calls would let whichever plan happens to run first pay
+/// the one-time memoize cost while every later call (any plan) gets it for free, a
+/// systematic bias the round-rotation below can't fix on its own. Cloning fresh
+/// from the same pristine snapshot for every single call means every call pays the
+/// identical cost every time — the same discipline `plan_cost_calibration`/
+/// `plan_cost_model_matches_gold` already use (tests.rs), just via `Clone` instead
+/// of re-deriving from a `FuzzSpec`, since a real caller only has the bound tree.
+///
+/// Rotates which plan runs first/last each round (`(i + round) % n`) rather than a
+/// fixed order, so no plan systematically benefits from whatever accumulates
+/// round-over-round (allocator state, cache residency).
+#[allow(clippy::too_many_arguments)]
+fn explain_analyze(
+    cards: &[AOracleCard],
+    printings: &[APrinting],
+    offsets: &AOffsets,
+    strings: &AStrings,
+    filter: &FilterExpr,
+    plane: Option<&PlaneExpr>,
+    unique: &str,
+    prefer: &str,
+    orderby: &str,
+    direction: &str,
+    limit: usize,
+    page_offset: usize,
+    indexes: &Archived<CardIndexes>,
+    num_warmups: usize,
+    num_trials: usize,
+) -> Vec<PlanTrial> {
+    let sort_col = orderby_to_col(orderby);
+    let descending = direction == "desc";
+    let mode = match unique {
+        "artwork"  => Mode::Artwork,
+        "printing" => Mode::Printing,
+        _          => Mode::Card,
+    };
+
+    // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
+    // the timing loop below starts from `filter`'s untouched, pristine state.
+    let estimates = explain(cards, printings, offsets, strings, &mut filter.clone(), plane, mode, sort_col, descending, limit, page_offset, indexes);
+
+    let n = estimates.len();
+    let mut trials_ns: Vec<Vec<u64>> = vec![Vec::with_capacity(num_trials); n];
+    for round in 0..(num_warmups + num_trials) {
+        for i in 0..n {
+            let idx = (i + round) % n;
+            let plan = estimates[idx].plan;
+            let mut round_filter = filter.clone();
+            let t0 = std::time::Instant::now();
+            let ran = run_query_with_plan(
+                plan, cards, printings, offsets, strings, &mut round_filter, plane,
+                unique, prefer, orderby, direction, limit, page_offset, indexes,
+            );
+            let dt = t0.elapsed().as_nanos() as u64;
+            // A structurally-applicable plan's fastpath can still decline at runtime
+            // (e.g. PrintingCompose on a sparse total) — deterministic for this
+            // query/data, so a decliner simply never accumulates trials.
+            if ran.is_some() && round >= num_warmups {
+                trials_ns[idx].push(dt);
+            }
+        }
+    }
+
+    estimates.into_iter().zip(trials_ns).map(|(e, trials_ns)| PlanTrial { plan: e.plan, predicted_ns: e.predicted_ns, trials_ns }).collect()
 }
 
 /// #634 Step 2: popcount-skip order phase. Scoped to `unique=card` queries
@@ -7053,6 +7248,51 @@ pub(crate) fn count_common_keywords(data: &Archived<CardData>) -> HashMap<String
         .collect()
 }
 
+/// Shared `explain`/`explain_analyze` (#745) filter resolution: parse `filters`'
+/// `to_json()`, bind against `data`'s vocabs, and split off the plane-expressible
+/// part — the same three steps `query()` runs inline. Kept as a private duplicate
+/// rather than a refactor of `query()` itself, so the existing hot search path is
+/// untouched by this change.
+fn bind_and_split_filter(py: Python<'_>, filters: &Bound<PyAny>, unique: &str, data: &Archived<CardData>) -> PyResult<(Option<PlaneExpr>, FilterExpr)> {
+    let to_json = filters.call_method0("to_json")?;
+    let json_bytes: Vec<u8> = py
+        .import("orjson")?
+        .call_method1("dumps", (to_json,))?
+        .extract()?;
+    let json_str = std::str::from_utf8(&json_bytes)
+        .map_err(|e| QueryError::new_err(format!("bad UTF-8 from orjson: {e}")))?;
+    let json_val: Value = serde_json::from_str(json_str)
+        .map_err(|e| QueryError::new_err(format!("bad query JSON: {e}")))?;
+
+    // Must run before build_filter so legality shifts resolve in workers that
+    // never executed the load path themselves.
+    sync_format_shifts(&data.format_shifts);
+    let mut filter_expr = build_filter(&json_val)
+        .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
+    filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
+
+    Ok(if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
+        split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
+    } else {
+        (None, filter_expr)
+    })
+}
+
+fn plan_estimate_to_pydict<'py>(py: Python<'py>, e: &PlanEstimate) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("plan", format!("{:?}", e.plan))?;
+    d.set_item("predicted_ns", e.predicted_ns)?;
+    Ok(d)
+}
+
+fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("plan", format!("{:?}", t.plan))?;
+    d.set_item("predicted_ns", t.predicted_ns)?;
+    d.set_item("trials_ns", t.trials_ns.clone())?;
+    Ok(d)
+}
+
 #[pyclass]
 struct QueryEngine {
     shm_path: PathBuf,
@@ -7546,6 +7786,78 @@ impl QueryEngine {
             .collect::<PyResult<Vec<_>>>()?;
         let matches_list = PyList::new(py, matches)?;
         PyTuple::new(py, [total.into_pyobject(py)?.into_any(), matches_list.into_any()])
+    }
+
+    /// #745 primitive 1: every applicable plan's predicted cost for this query,
+    /// ranked cheapest first (`result[0]` is what `query()` would actually run) —
+    /// the numbers the router already computes on every query, just exposed
+    /// instead of thrown away. Diagnostic only; safe to call constantly.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, filters, unique="card", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    fn explain<'py>(
+        &self,
+        py: Python<'py>,
+        filters: &Bound<PyAny>,
+        unique: &str,
+        orderby: &str,
+        direction: &str,
+        limit: usize,
+        offset: usize,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let mmap = self.get_mmap()?;
+        // Safety: see query()'s access_unchecked justification.
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+        let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+
+        let sort_col = orderby_to_col(orderby);
+        let descending = direction == "desc";
+        let mode = match unique {
+            "artwork"  => Mode::Artwork,
+            "printing" => Mode::Printing,
+            _          => Mode::Card,
+        };
+        let estimates = explain(
+            &data.cards, &data.printings, &data.offsets, &data.strings, &mut filter_expr, plane_expr.as_ref(),
+            mode, sort_col, descending, limit, offset, &data.indexes,
+        );
+
+        let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
+        PyList::new(py, rows)
+    }
+
+    /// #745 primitive 2: run every applicable plan `num_warmups + num_trials`
+    /// times each (raw per-trial nanoseconds, not pre-reduced — see `explain_analyze`'s
+    /// doc comment for why), alongside the predicted cost `explain` would report
+    /// for the same plan. Not on the default query path: this multiplies work by
+    /// the number of applicable plans, so it's for ad hoc/interactive diagnosis,
+    /// not every request.
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0, num_warmups=3, num_trials=10))]
+    fn explain_analyze<'py>(
+        &self,
+        py: Python<'py>,
+        filters: &Bound<PyAny>,
+        unique: &str,
+        prefer: &str,
+        orderby: &str,
+        direction: &str,
+        limit: usize,
+        offset: usize,
+        num_warmups: usize,
+        num_trials: usize,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let mmap = self.get_mmap()?;
+        // Safety: see query()'s access_unchecked justification.
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+        let (plane_expr, filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+
+        let trials = explain_analyze(
+            &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr, plane_expr.as_ref(),
+            unique, prefer, orderby, direction, limit, offset, &data.indexes, num_warmups, num_trials,
+        );
+
+        let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;
+        PyList::new(py, rows)
     }
 
     fn size(&self) -> PyResult<usize> {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,8 @@ use super::{
     assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
-    range_too_broad_to_narrow, run_query, run_query_with_plan, PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
+    range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, PlanEstimate, PlanTrial,
+    PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, Mode,
@@ -3014,6 +3015,105 @@ fn force_plan_differential_agreement() {
             "plan {plan:?} was never exercised by the differential corpus — add coverage",
         );
     }
+}
+
+/// #745: `explain` reports a nonempty, cheapest-first ranked list for every mode,
+/// always including `GatheredScan` (universally applicable), and its predicted
+/// costs are exactly what `PhysicalPlan::ALL.filter(applicable)` + `cost::plan_cost`
+/// would compute directly — i.e. `explain` cannot silently diverge from
+/// `run_query_routed`'s own argmin (they share `acquire_plan_features`).
+#[test]
+fn explain_reports_ranked_applicable_plans() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(745_001);
+    let data = fuzz_store_n(&mut rng, 2_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let specs = [
+        FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]),
+        FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }),
+        FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+    ];
+    let modes = [("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)];
+
+    for spec in &specs {
+        for &(mode_label, mode) in &modes {
+            let (pe, mut filter) = split_planes(
+                fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+            );
+            let estimates: Vec<PlanEstimate> = explain(
+                &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &mut filter, pe.as_ref(),
+                mode, SortCol::EdhrecRank, false, 60, 0, &archived.indexes,
+            );
+
+            assert!(!estimates.is_empty(), "GatheredScan is always applicable ({mode_label}, {})", fuzz_describe(spec));
+            assert!(
+                estimates.iter().any(|e| e.plan == PhysicalPlan::GatheredScan),
+                "GatheredScan missing from explain() output ({mode_label}, {})", fuzz_describe(spec),
+            );
+            assert!(
+                estimates.windows(2).all(|w| w[0].predicted_ns <= w[1].predicted_ns),
+                "explain() not sorted ascending ({mode_label}, {})", fuzz_describe(spec),
+            );
+            for e in &estimates {
+                assert!(e.predicted_ns.is_finite() && e.predicted_ns >= 0.0, "non-finite/negative predicted_ns for {:?}", e.plan);
+            }
+        }
+    }
+}
+
+/// #745: `explain_analyze` times every plan `explain` reports, carrying the same
+/// `predicted_ns` alongside real per-trial timings — so a caller never has to zip
+/// two separate calls' results by plan to compare predicted vs actual. Warmups are
+/// small here (test speed, not a calibration run); the assertions are about wiring
+/// (same plan set, matching predicted cost, right trial counts, non-negative
+/// timings), not about the model's accuracy.
+#[test]
+fn explain_analyze_matches_explain_and_times_every_plan() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(745_002);
+    let data = fuzz_store_n(&mut rng, 2_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    const NUM_WARMUPS: usize = 1;
+    const NUM_TRIALS: usize = 3;
+
+    let spec = FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]);
+    let bound = fuzz_bound_filter(&spec, archived);
+
+    // Reference: what explain() alone reports for this same query.
+    let (ref_pe, mut ref_filter) = split_planes(
+        bound.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
+    );
+    let reference: Vec<PlanEstimate> = explain(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &mut ref_filter, ref_pe.as_ref(),
+        Mode::Card, SortCol::EdhrecRank, false, 60, 0, &archived.indexes,
+    );
+
+    let (pe, filter) = split_planes(bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+    let trials: Vec<PlanTrial> = explain_analyze(
+        &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &filter, pe.as_ref(),
+        "card", "default", "edhrec", "asc", 60, 0, &archived.indexes, NUM_WARMUPS, NUM_TRIALS,
+    );
+
+    assert_eq!(trials.len(), reference.len(), "explain_analyze must cover exactly the plans explain() reports");
+    for (t, r) in trials.iter().zip(&reference) {
+        assert_eq!(t.plan, r.plan, "plan order must match explain()'s ranking");
+        assert_eq!(t.predicted_ns, r.predicted_ns, "predicted_ns must be identical to explain()'s for {:?}", t.plan);
+        // A structurally-applicable plan's fastpath can legitimately decline at
+        // runtime (empty trials_ns); when it doesn't decline, it must have run
+        // exactly NUM_TRIALS times (warmups are discarded, never recorded).
+        assert!(
+            t.trials_ns.is_empty() || t.trials_ns.len() == NUM_TRIALS,
+            "{:?}: expected 0 or {NUM_TRIALS} trials, got {}", t.plan, t.trials_ns.len(),
+        );
+    }
+    assert!(
+        trials.iter().any(|t| t.plan == PhysicalPlan::GatheredScan && t.trials_ns.len() == NUM_TRIALS),
+        "GatheredScan is always applicable and never declines",
+    );
 }
 
 /// #702 PR1 estimator accuracy report (NOT an assertion — a reporting tool).


### PR DESCRIPTION
## Summary

Implements #745: turns the plan-selection cost model into a callable diagnostic instead of leaving it reachable only from `cargo test`/`cargo bench`. See [docs/issues/00745-engine-explain-analyze.md](https://github.com/jbylund/sylvan_librarian/blob/main/docs/issues/00745-engine-explain-analyze.md) for the full design.

- **`explain(query) -> Vec<PlanEstimate>`** — every applicable plan's predicted cost, ranked cheapest first. Factors `run_query_routed`'s acquire step (which count source, which cost features) into a shared `acquire_plan_features` function, so `explain`'s numbers can never silently drift from what the real router computes — it's the same code path, not a second copy.
- **`explain_analyze(query, num_warmups, num_trials) -> Vec<PlanTrial>`** — actually runs each applicable plan via the existing `run_query_with_plan` force-dispatch seam and returns raw per-trial timings (not pre-reduced, so bimodal timing is visible), alongside each plan's `predicted_ns` from `explain` so callers never have to zip two result lists by plan.
- Resolves the doc's open correctness question: `run_query_with_plan`'s `StreamedSelect`/`GatheredScan` arms each call `prepare_candidates` themselves, which mutates the filter via `memoize_text_predicates`. `FilterExpr` now derives `Clone` (every field was already cheaply cloneable), and `explain_analyze` clones fresh from one pristine snapshot for every single `(plan, round)` call — so every call pays the identical cost, and no plan is advantaged by reusing another call's memoized tree. Same discipline the existing `plan_cost_calibration`/`plan_cost_model_matches_gold` benches already use, via `Clone` instead of re-deriving from a `FuzzSpec`.
- Rotates which plan runs first/last each round so no plan systematically benefits from allocator/cache state left over from a previous round.
- Exposed as two `QueryEngine` PyO3 methods (`explain`, `explain_analyze`), returning `list[dict]` — in-process only, no HTTP surface (per the doc's "Where to expose" section).

## Test plan

- [x] `cargo test --lib` (133 passed, 25 ignored) — includes two new fuzz-corpus tests (`explain_reports_ranked_applicable_plans`, `explain_analyze_matches_explain_and_times_every_plan`)
- [x] `cargo clippy --lib --tests` — 66 warnings before and after (net zero new warnings introduced)
- [x] `force_plan_differential_agreement` still passes (regression check on the `run_query_routed` acquire-step refactor)
- [x] `api/tests/test_engine_unit.py` (157 passed, incl. 2 new `TestExplain` tests through the real PyO3 boundary)
- [x] `api/tests/test_engine_property.py` (3 passed)
- [x] Manual smoke test via `maturin develop --release` + live Python call

🤖 Generated with [Claude Code](https://claude.com/claude-code)