### PR TITLE
Engine: Card-Space Collection Fields (type:/kw:/otag:) as Compose Leaves

### DIFF
--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -1,0 +1,125 @@
+//! Micro-benchmark: PrintingCompose paging strategy **A vs B** for a `unique=printing`,
+//! `orderby=usd` query whose composed predicate has no card-space sort permutation (the #744 regime).
+//!
+//!   A = `walk_range_orderby_page` — walk the pre-sorted `price_usd` `PrintingRangeIndex` in value
+//!       order, test the composed `pbits` bit per visited entry, stop at `offset+limit`. Cost
+//!       `O((offset+limit)/selectivity)`, but the row it collects is a *random* pid into the store.
+//!   B = `gather_composed_page` — sweep the composed `pbits` (candidate cards in id order, each card's
+//!       printings contiguous ⇒ ~sequential), accumulate every match into a bounded `GatherSelect`,
+//!       one final quickselect by usd. Cost `O(n_matches)` sweep + `O(k log k)` select, offset-
+//!       independent, sequential access.
+//!
+//! The router today ALWAYS picks A (OrderbyWalk) for this regime — B is only a runtime fallback for
+//! A's null-price tail. This bench measures whether A is in fact the winner across a selectivity
+//! sweep, so the cost model's fixed choice can be audited. Predicates are real composable collection
+//! leaves (this PR's feature), from very sparse to near-total, so the composed bitmaps have realistic
+//! pid clustering. Both strategies are asserted to return the identical offset-0 page first.
+//!
+//!     cargo test --release bench_compose_paging -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same file/rebuild contract as bench_verify_cost.rs).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, compose_printing_bits, gather_composed_page, walk_range_orderby_page, CardData, CmpOp, CollField,
+    FilterExpr, Mmap, Mode, Prefer, SortCol, ARCHIVE_HEADER_LEN,
+};
+
+const ITERS: usize = 200;
+const LIMIT: usize = 175; // a Scryfall page
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn best_ns(mut kernel: impl FnMut() -> usize) -> (u128, usize) {
+    let mut best = u128::MAX;
+    let mut rows = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        rows = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    (best, rows)
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_compose_paging() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_printings = data.printings.len();
+    let (cards, printings, offsets, p2c) = (&data.cards, &data.printings, &data.offsets, &data.indexes.printing_to_card);
+    println!("\n{} printings, {} cards from {STORE_PATH}", n_printings, cards.len());
+
+    let coll = |field, value: &str, negate: bool| -> FilterExpr {
+        let leaf = FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value: value.to_string(), value_id: None };
+        if negate { FilterExpr::Not(Box::new(leaf)) } else { leaf }
+    };
+
+    // Selectivity sweep, sparse → near-total. All real composable collection leaves (this PR).
+    // Real-corpus subtypes are title-case.
+    let filters: Vec<(&str, FilterExpr)> = vec![
+        ("type:Octopus (very sparse)", coll(CollField::Subtypes, "Octopus", false)),
+        ("type:Goblin (sparse)", coll(CollField::Subtypes, "Goblin", false)),
+        ("type:Human (mid)", coll(CollField::Subtypes, "Human", false)),
+        ("-type:Human (~85%)", coll(CollField::Subtypes, "Human", true)),
+        ("-type:Goblin (~98%)", coll(CollField::Subtypes, "Goblin", true)),
+        ("-type:Octopus (near-total)", coll(CollField::Subtypes, "Octopus", true)),
+    ];
+
+    // Offsets: page 1 (shallow) and a deep page (~70% through the match set).
+    println!("\n  {:<30} {:>7} {:>6} {:>6} {:>10} {:>10} {:>7}  winner", "predicate", "sel%", "off", "rows", "A walk ns", "B gather ns", "B/A");
+    for (label, filter) in &filters {
+        let pbits = compose_printing_bits(filter, &data.indexes, offsets, printings, n_printings);
+        let total: usize = pbits.iter().map(|w| w.count_ones() as usize).sum();
+        let sel = 100.0 * total as f64 / n_printings as f64;
+        if total == 0 {
+            println!("  {label:<30}  (0 matches — skipped)");
+            continue;
+        }
+        for &offset in &[0usize, (total * 7 / 10).saturating_sub(LIMIT / 2)] {
+            if offset >= total {
+                continue;
+            }
+            let run_a = || {
+                walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset)
+                    .map_or(0, |p| p.len())
+            };
+            let run_b = || {
+                gather_composed_page(Mode::Printing, cards, printings, offsets, &pbits, Prefer::Default, SortCol::PriceUsd, false, LIMIT, offset, u16::from(data.indexes.max_artwork_groups))
+                    .len()
+            };
+            // Cross-check identical page (offset 0 only — A declines into the null-price tail at deep
+            // offsets, where only B is defined; that decline is itself the finding for those rows).
+            let a_page = walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset);
+            let b_page = gather_composed_page(Mode::Printing, cards, printings, offsets, &pbits, Prefer::Default, SortCol::PriceUsd, false, LIMIT, offset, u16::from(data.indexes.max_artwork_groups));
+            if let Some(a_page) = &a_page {
+                let a_ids: Vec<u128> = a_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
+                let b_ids: Vec<u128> = b_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
+                assert_eq!(a_ids, b_ids, "A and B disagree on the page for {label} @ offset {offset}");
+            }
+            let (a_ns, a_rows) = best_ns(run_a);
+            let (b_ns, b_rows) = best_ns(run_b);
+            let a_declined = a_page.is_none();
+            let ratio = b_ns as f64 / a_ns as f64;
+            let winner = if a_declined { "B (A declined)" } else if a_ns < b_ns { "A" } else { "B" };
+            println!(
+                "  {label:<30} {sel:>6.2} {offset:>6} {:>6} {a_ns:>10} {b_ns:>10} {ratio:>6.2}x  {winner}",
+                a_rows.max(b_rows),
+            );
+            let _ = a_rows;
+            let _ = b_rows;
+        }
+    }
+    println!();
+}

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4666,6 +4666,22 @@ fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) 
         {
             true
         }
+        // Card-space collection containment leaves (`type:`/`kw:`/`otag:`) and their already-printing-
+        // space siblings (`art:`/`is:`). `Ge` only — the postings are tight for containment but a loose
+        // superset for `Eq`/`Gt` (they prove `contains(value)`, not the collection-length condition,
+        // ~lib.rs:3441), and the compose path has no residual re-check, so `Eq`/`Gt` stay on the general
+        // path. `FrameData` is excluded (`collection_compose_index` → `None`): it is the one non-
+        // `complete` collection index, so absence there proves nothing and it can't be an exact leaf.
+        FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } => collection_compose_index(indexes, *field).is_some(),
+        // `-type:`/`-kw:`/`-otag:`/`-art:`/`-is:` — the exact complement of the positive leaf (a
+        // collection is never NULL, so no trivalent-NULL trap; see `collection_negated_leaf_bits`).
+        // Guarded on the inner shape (not a bare `Not(_)`) and on `Ge` so a loose `Eq`/`Gt` inner can't
+        // reach it.
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } if collection_compose_index(indexes, *field).is_some()) =>
+        {
+            true
+        }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
         // Legality via #667's card `_EXISTS` plane + a divergent repair (see `legality_leaf_bits`).
@@ -4809,6 +4825,91 @@ fn broadcast_card_bits_to_printings(card_bits: &[u64], offsets: &AOffsets, n_pri
         }
     }
     pbits
+}
+
+/// Scatter each card id's whole printing range (`offsets[c]..offsets[c+1]`) into a fresh printing
+/// bitmap — the card-**id-list** analogue of `broadcast_card_bits_to_printings` (which takes a card
+/// *bitmap*). Used to lift a card-space collection posting list (`subtypes`/`keywords`/`oracle_tags`,
+/// whose postings are card ids) up into the printing domain for composition. O(card ids + their
+/// printings), independent of `n_cards`.
+fn broadcast_card_ids_to_printings(card_ids: impl Iterator<Item = u32>, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    let mut pbits = vec![0u64; words_per_plane(n_printings)];
+    for c in card_ids {
+        let c = c as usize;
+        for p in u32::from(offsets[c]) as usize..u32::from(offsets[c + 1]) as usize {
+            pbits[p >> 6] |= 1u64 << (p & 63);
+        }
+    }
+    pbits
+}
+
+/// Maps a `CollectionCmp` field to its compose backing: the postings index and whether it is
+/// **card-space** (postings are card ids → project each card's printing range up with
+/// `broadcast_card_ids_to_printings`) or **printing-space** (postings are printing ids → scatter
+/// directly, like `set:`/`watermark:`). Returns `None` for `FrameData` — the only non-`complete`
+/// collection index (its dense values are dropped at build, #628, so absence proves nothing there and
+/// it cannot be an exact compose leaf); it stays on the general path. This is the single source of
+/// truth `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their
+/// field tables can't drift apart.
+fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<(&Archived<TagIndex>, bool)> {
+    match field {
+        CollField::Subtypes   => Some((&indexes.subtypes,    true)),
+        CollField::Keywords   => Some((&indexes.keywords,    true)),
+        CollField::OracleTags => Some((&indexes.oracle_tags, true)),
+        CollField::ArtTags    => Some((&indexes.art_tags,    false)),
+        CollField::IsTags     => Some((&indexes.is_tags,     false)),
+        CollField::FrameData  => None,
+    }
+}
+
+/// The exact printing-space bitmap for a bare containment collection leaf (`type:`/`kw:`/`otag:`/
+/// `art:`/`is:`, i.e. `CollectionCmp { op: Ge }`) over a `complete` index. For a card-space field the
+/// value's card-id postings are projected up (every printing of a matching card — subtype/keyword/
+/// oracle-tag are pure **card** properties, so this projection is exact, no per-printing divergence
+/// like legality); for a printing-space field the printing-id postings scatter directly. A value
+/// absent from a complete index matches no row (all-zero) — the same empty-is-exact treatment
+/// `narrow_rec` gives an unknown value. **Ge/containment only** (the caller gates it): the postings
+/// are tight for `Ge`, but only a loose superset for `Eq`/`Gt` (they prove `contains(value)`, not the
+/// collection-length condition, ~lib.rs:3441), and the compose path has no residual re-check, so
+/// `Eq`/`Gt` stay on the general path.
+fn collection_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    match idx.get(value) {
+        None => vec![0u64; words_per_plane(n_printings)],
+        Some(v) if card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
+        Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
+    }
+}
+
+/// The number of printings a containment collection leaf matches (its exact `unique=printing` total),
+/// for the cost-model estimate. Card-space: sum each matching card's printing-range length; printing-
+/// space: the postings length (one posting = one printing). Exact (a valid upper bound and then some),
+/// so the estimate for a bare collection leaf is exact, matching set/watermark. O(card postings) — the
+/// same order as the eventual scatter, cheap for the sparse subtype/keyword/oracle-tag posting lists.
+fn collection_leaf_printing_count(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets) -> usize {
+    match idx.get(value) {
+        None => 0,
+        Some(v) if card_space => v
+            .iter()
+            .map(|c| {
+                let c = u32::from(*c) as usize;
+                (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
+            })
+            .sum(),
+        Some(v) => v.len(),
+    }
+}
+
+/// The exact printing-space bitmap for a **negated** containment collection leaf (`-type:`/`-kw:`/
+/// `-otag:`/`-art:`/`-is:`) over a `complete` index — the positive leaf's bits, complemented. Exact
+/// for all these fields (unlike a nullable scalar like `watermark`): a collection is never NULL — a
+/// card/printing that lacks the value has a definite `contains(value) == false`, so the complement of
+/// the (exact, `Ge`) positive set is precisely the negated match set, with no trivalent-NULL printing
+/// wrongly swept in. Ge only, same reason as the positive leaf (a loose positive set would give a
+/// loose complement).
+fn collection_negated_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    let mut bits = collection_leaf_bits(idx, value, card_space, offsets, n_printings);
+    complement_bits(&mut bits, n_printings);
+    bits
 }
 
 /// Repair the divergent cards' printings authoritatively — overwrite each bit with the per-printing
@@ -4967,6 +5068,24 @@ fn compose_printing_bits(
             };
             set_code_negated_leaf_bits(&indexes.set_codes, value.as_str(), n_printings)
         }
+        // Collection containment leaf (`type:`/`kw:`/`otag:`/`art:`/`is:`, `Ge`) — card-space postings
+        // projected up / printing-space postings scattered (see `collection_leaf_bits`).
+        FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
+            if collection_compose_index(indexes, *field).is_some() =>
+        {
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
+            collection_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
+        }
+        // Negated collection leaf — the exact complement of the positive leaf.
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } if collection_compose_index(indexes, *field).is_some()) =>
+        {
+            let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
+                unreachable!("guarded by the matches! above")
+            };
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            collection_negated_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
+        }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
         | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
             rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)
@@ -5037,6 +5156,29 @@ fn compose_printing_estimate(
                 unreachable!("guarded by the matches! above")
             };
             let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
+            (n_printings.saturating_sub(k), 0, k)
+        }
+        // Collection containment leaf (`type:`/`kw:`/`otag:`/`art:`/`is:`, `Ge`): `k` = the exact
+        // printing count the leaf matches (card-space sums the matching cards' printing ranges,
+        // printing-space is the postings length). The build scatters `k` printings → rides `scatter`,
+        // the cheap range-slice rate.
+        FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
+            if collection_compose_index(indexes, *field).is_some() =>
+        {
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
+            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
+            (k, 0, k)
+        }
+        // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
+        // (small) positive `k` cleared, not the (large) complement it produces — same shape as `-set:`.
+        FilterExpr::Not(inner)
+            if matches!(inner.as_ref(), FilterExpr::CollectionCmp { field, op: CmpOp::Ge, .. } if collection_compose_index(indexes, *field).is_some()) =>
+        {
+            let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
+                unreachable!("guarded by the matches! above")
+            };
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
             (n_printings.saturating_sub(k), 0, k)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
@@ -5315,6 +5457,19 @@ fn printing_compose_fastpath<'a>(
             domain as f64 * (-(printing_matches as f64) / domain as f64).exp().mul_add(-1.0, 1.0)
         };
         if est > domain as f64 * *COMPOSE_GATHER_MAX_CARD_FRACTION {
+            return None;
+        }
+        // Small-total decline (mirrors the `Perm` branch's `total <= STREAM_MIN_MATCHES` below): in the
+        // permutation-free gather regime PrintingCompose has no paging edge over GatheredScan — it just
+        // composes the full printing bitmap and projects it back down, two O(n_cards) passes on top of
+        // the same gather. For a filter that narrows to few candidate cards the residual-eval saving is
+        // tiny while that build/projection dominates, so the candidate/narrowing path wins; decline to
+        // it. The SOUND card-space cardinality upper bound decides — exact for a collection leaf, unlike
+        // the balls-into-bins `est` above which overestimates a clustered predicate's distinct-card
+        // count (goblin: 501 cards but ~1471 `est`) and so can't make this call. This is what keeps a
+        // sparse `type:angel`/`type:goblin` card/usd (newly composable) from regressing onto this path:
+        // the collection compose leaves are a printing-mode orderby-walk win, not a card-mode gather win.
+        if (estimator::estimate_cardinality(filter, indexes, offsets).hi as usize) <= *STREAM_MIN_MATCHES {
             return None;
         }
     }
@@ -7987,3 +8142,5 @@ mod bench_posting_intersect;
 mod bench_word_dict_scan;
 #[cfg(test)]
 mod bench_card_dedup;
+#[cfg(test)]
+mod bench_compose_paging;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2902,6 +2902,37 @@ fn force_plan_differential_agreement() {
             "edhrec",
             "asc",
         ),
+        // Card-space collection compose leaf (subtype) OR'd with a near-total legality — the
+        // motivating `type:goblin or format:legacy` shape (#752-followup): the subtype's card-id
+        // postings are projected up to printings and OR'd with legality's printing bitmap, then paged
+        // by the #744 orderby walk under `usd`/printing (no card permutation for usd). Checked vs
+        // GatheredScan in every mode.
+        (
+            FuzzSpec::Or(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Subtypes, op: CmpOp::Ge, value: "human".to_string() }),
+                FuzzSpec::Leaf(FuzzLeaf::Legality { shift: Some(FUZZ_SHIFTS[0]), expected: FUZZ_STATUSES[0] }),
+            ]),
+            "usd",
+            "asc",
+        ),
+        (
+            FuzzSpec::Or(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".to_string() }),
+                FuzzSpec::Leaf(FuzzLeaf::Legality { shift: Some(FUZZ_SHIFTS[0]), expected: FUZZ_STATUSES[0] }),
+            ]),
+            "rarity",
+            "desc",
+        ),
+        // Negated card-space collection leaf (exact complement) mixed with a border plane in printing
+        // space — forces the `Not(CollectionCmp)` compose arm through the walk.
+        (
+            FuzzSpec::And(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+                FuzzSpec::Not(Box::new(FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".to_string() }))),
+            ]),
+            "usd",
+            "asc",
+        ),
     ];
     for _ in 0..RANDOM_QUERIES {
         let orderby = SORTS[rng.random_range(0..SORTS.len())];
@@ -5719,6 +5750,153 @@ fn set_watermark_compose_leaves() {
     // And a positive watermark mixed with an unsupported leaf still declines as a whole.
     let unsupported = FilterExpr::And(vec![wm("wotc"), FilterExpr::Not(Box::new(wm("set")))]);
     assert!(!super::is_printing_composable(&unsupported, &archived.indexes), "-watermark inside an And keeps the whole And off the compose path");
+}
+
+/// Card-space collection containment fields (`type:`/`kw:`/`otag:`) and their printing-space siblings
+/// (`art:`/`is:`) as PrintingCompose leaves: `compose_printing_bits` must be bit-for-bit the residual
+/// path's truth for the positive `Ge` leaf, its negation, mixes with a range, and absent values —
+/// while `Eq`/`Gt` (loose) and `FrameData` (non-complete) must stay OFF the compose path.
+#[test]
+fn collection_compose_leaves() {
+    let mut vocab = VocabInterner::new();
+    // Register every collection value up front so it lands in coll_vocab before store_of consumes
+    // vocab; capture the ids for the printing-space fields (set after store_of builds the printings).
+    let commander = vocab.intern("commander".to_string()).unwrap();
+    let showcase = vocab.intern("showcase".to_string()).unwrap();
+    // card0 subtypes [goblin]; card1 [goblin, warrior]; card2 [elf].
+    let mut cards = vec![
+        stub_card(1, TYPE_CREATURE, &["goblin"], &mut vocab),
+        stub_card(2, TYPE_CREATURE, &["goblin", "warrior"], &mut vocab),
+        stub_card(3, TYPE_CREATURE, &["elf"], &mut vocab),
+    ];
+    // keywords (card-space): card0 [Flying]; card2 [Flying, Haste]; card1 none.
+    cards[0].card_keywords = vec![vocab.intern("Flying".to_string()).unwrap()];
+    cards[2].card_keywords = vec![vocab.intern("Flying".to_string()).unwrap(), vocab.intern("Haste".to_string()).unwrap()];
+    // oracle_tags (card-space): card0 [removal]; card1 [ramp]; card2 none.
+    cards[0].card_oracle_tags = vec![vocab.intern("removal".to_string()).unwrap()];
+    cards[1].card_oracle_tags = vec![vocab.intern("ramp".to_string()).unwrap()];
+
+    let mut data = store_of(cards, &[2, 2, 2], vocab); // pids 0,1 | 2,3 | 4,5
+    // is_tags (printing-space) — card0's two printings DIVERGE (pid0 has commander, pid1 doesn't), so
+    // `is:commander` is genuinely printing-dependent, not card-invariant. art_tags (printing-space):
+    // pid2/pid5 showcase.
+    let is_tags_by_pid: [&[u16]; 6] = [&[commander], &[], &[commander], &[], &[], &[commander]];
+    let art_tags_by_pid: [&[u16]; 6] = [&[], &[], &[showcase], &[], &[], &[showcase]];
+    for (p, (is_t, art_t)) in data.printings.iter_mut().zip(is_tags_by_pid.iter().zip(art_tags_by_pid.iter())) {
+        p.card_is_tags = is_t.to_vec();
+        p.card_art_tags = art_t.to_vec();
+    }
+    // Released years for the range-leaf mixes: pid4 dateless (fails any year).
+    let year_by_pid = [Some(20200101), Some(20230101), Some(20200101), Some(20230101), None, Some(20240101)];
+    for (p, y) in data.printings.iter_mut().zip(year_by_pid) {
+        p.released_at_int = y;
+    }
+    // Build the collection indexes the way reload_commit does (card-space over cards, printing-space
+    // over printings), plus the released_at range for the mixes.
+    data.indexes.subtypes = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_subtypes);
+    data.indexes.keywords = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_keywords);
+    data.indexes.oracle_tags = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
+    data.indexes.art_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
+    data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
+    data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
+
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_printings = archived.printings.len();
+
+    // The compose path keys the TagIndex on the value *string*, but the brute `matches()` reference
+    // compares the bound vocab *id* — so resolve `value_id` (the same partition_point `bind` runs), or
+    // the reference would treat every value as unknown and match nothing.
+    let coll = |field, op, value: &str| -> FilterExpr {
+        let (vocab, sorted) = (&archived.coll_vocab, &archived.coll_vocab_sorted);
+        let i = sorted.partition_point(|id| vocab[u16::from(*id) as usize].as_str() < value);
+        let value_id = sorted.get(i).map(|id| u16::from(*id)).filter(|&id| vocab[id as usize].as_str() == value);
+        FilterExpr::CollectionCmp { field, op, value: value.to_string(), value_id }
+    };
+    let ge = |field, v: &str| coll(field, CmpOp::Ge, v);
+    let not = |f: FilterExpr| FilterExpr::Not(Box::new(f));
+    let year = |y: i32| FilterExpr::YearCmp { op: CmpOp::Eq, year: y };
+
+    // Ground truth: the general per-candidate residual path (card_pass settles the card-invariant
+    // part, residual_matches the per-printing part) — exactly what the materializing plan runs,
+    // independent of anything the compose path touches.
+    let brute = |f: &FilterExpr| -> Vec<u32> {
+        let mut out = Vec::new();
+        let mut residual: Vec<&FilterExpr> = Vec::new();
+        let mut is_or = false;
+        for c in 0..archived.cards.len() {
+            let card = &archived.cards[c];
+            let tri = f.card_pass(card, &archived.strings, &mut residual, &mut is_or);
+            let (lo, hi) = (u32::from(archived.offsets[c]), u32::from(archived.offsets[c + 1]));
+            for pid in lo..hi {
+                let matched = match tri {
+                    Tri::True => true,
+                    Tri::False | Tri::Null => false,
+                    Tri::PrintingDep => FilterExpr::residual_matches(card, &archived.printings[pid as usize], &archived.strings, &residual, is_or),
+                };
+                if matched {
+                    out.push(pid);
+                }
+            }
+        }
+        out
+    };
+    let composed = |f: &FilterExpr| -> Vec<u32> {
+        let bits = super::compose_printing_bits(f, &archived.indexes, &archived.offsets, &archived.printings, n_printings);
+        (0..n_printings as u32).filter(|&p| bits[p as usize >> 6] & (1u64 << (p & 63)) != 0).collect()
+    };
+
+    let cases: Vec<(&str, FilterExpr)> = vec![
+        // Card-space positive containment — every printing of a matching card (exact card property).
+        ("type:goblin", ge(CollField::Subtypes, "goblin")),
+        ("type:elf", ge(CollField::Subtypes, "elf")),
+        ("type:absent", ge(CollField::Subtypes, "sliver")),
+        ("kw:Flying", ge(CollField::Keywords, "Flying")),
+        ("otag:ramp", ge(CollField::OracleTags, "ramp")),
+        // Card-space negation — exact complement (collection is never NULL).
+        ("-type:goblin", not(ge(CollField::Subtypes, "goblin"))),
+        ("-type:absent (-> all)", not(ge(CollField::Subtypes, "sliver"))),
+        ("-kw:Flying", not(ge(CollField::Keywords, "Flying"))),
+        // Printing-space positive/negation (scatter directly; the divergent is:commander printings).
+        ("is:commander", ge(CollField::IsTags, "commander")),
+        ("-is:commander", not(ge(CollField::IsTags, "commander"))),
+        ("art:showcase", ge(CollField::ArtTags, "showcase")),
+        // Mixes with a range, both And and Or, card-space × printing-space × range.
+        ("type:goblin year:2023", FilterExpr::And(vec![ge(CollField::Subtypes, "goblin"), year(2023)])),
+        ("type:goblin or year:2023", FilterExpr::Or(vec![ge(CollField::Subtypes, "goblin"), year(2023)])),
+        ("kw:Flying and is:commander", FilterExpr::And(vec![ge(CollField::Keywords, "Flying"), ge(CollField::IsTags, "commander")])),
+        ("type:goblin or is:commander", FilterExpr::Or(vec![ge(CollField::Subtypes, "goblin"), ge(CollField::IsTags, "commander")])),
+        ("-type:elf and year:2020", FilterExpr::And(vec![not(ge(CollField::Subtypes, "elf")), year(2020)])),
+    ];
+    for (label, f) in &cases {
+        assert!(super::is_printing_composable(f, &archived.indexes), "{label} must be printing-composable");
+        let mut got = composed(f);
+        got.sort_unstable();
+        let mut want = brute(f);
+        want.sort_unstable();
+        assert_eq!(got, want, "compose_printing_bits disagrees with the residual path for {label}");
+        // The estimate feeds plan choice: a valid upper bound at minimum, and exact for a bare leaf.
+        let (est_matches, _, _) = super::compose_printing_estimate(f, &archived.indexes, &archived.offsets, n_printings);
+        assert!(est_matches >= want.len(), "compose_printing_estimate undercounts for {label}: {est_matches} < {}", want.len());
+        if matches!(f, FilterExpr::CollectionCmp { .. } | FilterExpr::Not(_)) {
+            assert_eq!(est_matches, want.len(), "bare collection-leaf estimate must be exact for {label}");
+        }
+    }
+
+    // Loose ops (`Eq`/`Gt`) must NOT compose — the postings prove containment, not the length
+    // condition, and the compose path has no residual re-check. FrameData (non-complete) must not
+    // compose in ANY op. A negated loose/FrameData inner must not sneak on via the Not arm either.
+    for op in [CmpOp::Eq, CmpOp::Gt] {
+        let f = coll(CollField::Subtypes, op, "goblin");
+        assert!(!super::is_printing_composable(&f, &archived.indexes), "type:goblin op={op:?} (loose) must stay off the compose path");
+        assert!(!super::is_printing_composable(&not(f), &archived.indexes), "-(loose collection) must stay off the compose path");
+    }
+    let frame = coll(CollField::FrameData, CmpOp::Ge, "showcase");
+    assert!(!super::is_printing_composable(&frame, &archived.indexes), "frame: (non-complete) must stay off the compose path");
+    assert!(!super::is_printing_composable(&not(frame), &archived.indexes), "-frame: must stay off the compose path");
+    // A loose Eq inside an And keeps the whole And off the compose path.
+    let mixed = FilterExpr::And(vec![ge(CollField::Subtypes, "goblin"), coll(CollField::Keywords, CmpOp::Eq, "Flying")]);
+    assert!(!super::is_printing_composable(&mixed, &archived.indexes), "a loose Eq collection inside an And keeps the whole And off the compose path");
 }
 
 #[test]

--- a/docs/issues/00753-engine-collection-compose-leaves.md
+++ b/docs/issues/00753-engine-collection-compose-leaves.md
@@ -1,0 +1,122 @@
+# #753 Engine: Card-Space Collection Fields (type:/kw:/otag:) as Compose Leaves
+
+Stacks on #746 (set:/watermark: compose leaves) and #744 (orderby-range-index walk). Merge after
+them, or rebase once they land.
+
+## Measured problem
+
+`type:goblin or format:legacy` (`unique=printing`, `orderby=usd`) cost **~575 µs** on the composite
+baseline (main + #744/#746/#748-51), returning 96,445 rows. Two independent declines forced it to a
+full `GatheredScan`:
+
+- PrintingCompose declined — `CollectionCmp{field: Subtypes}` was not in `is_printing_composable`'s
+  table (`_ => false`).
+- Generic Or-narrowing declined — the near-total `format:legacy` child trips `narrow_rec`'s Or
+  near-total guard (`len > domain − domain/4`).
+
+So it gathered every card, computed the usd sort key per card, and quickselected. This is the exact
+pathology bare `format:commander` had before #744.
+
+## Approach
+
+Make a card-space collection containment leaf (`type:`/`kw:`/`otag:` = `CollectionCmp{op: Ge}` over
+`Subtypes`/`Keywords`/`OracleTags`) a PrintingCompose leaf by **projecting its card-id postings up to
+printing space**: set every printing of each matching card (`broadcast_card_ids_to_printings`, the
+card-id-list analogue of the existing `broadcast_card_bits_to_printings`). The projection is **exact**
+— a subtype/keyword/oracle-tag is a pure card property, so every printing of a goblin is a goblin; no
+per-printing divergence/repair like legality. Wired into all three compose functions via a shared
+`collection_compose_index` field table.
+
+The already-printing-space siblings `art:`/`is:` (`ArtTags`/`IsTags`) scatter their printing-id
+postings directly (identical to `set:`/`watermark:`), no projection.
+
+### Correctness scoping
+
+- **`complete` fields only.** `Subtypes`/`Keywords`/`OracleTags`/`ArtTags`/`IsTags` post every
+  occurrence of every value → absence proves absence, membership is exact. `FrameData` is NOT
+  complete (dense values dropped at build, #628) — excluded (`collection_compose_index → None`),
+  stays on the general path.
+- **`Ge`/containment only.** The postings are tight for `Ge`, but only a loose superset for
+  `Eq`/`Gt` (they prove `contains(value)`, not the collection-length condition). The compose path has
+  **no residual re-check**, so a loose leaf would return wrong rows — `Eq`/`Gt` stay on the general
+  path (where `narrow_rec`'s driver re-verifies with `matches()`). Gated, not marked-loose.
+- **Negation is exact.** `-type:goblin` = the complement of the (exact, card-projected) positive set.
+  A collection is never NULL — a card/printing lacking the value has a definite
+  `contains == false` — so there is no trivalent-NULL trap (the reason `-watermark:` stays off the
+  compose path). Added for all five complete fields.
+- **No shared-witness problem.** The leaf is card-invariant (every printing of a card agrees), so
+  ANDing it with a per-printing predicate (`type:goblin border:black`) is exact — unlike a predicate
+  exact only in isolation.
+
+## The paging question (A vs B) — measured, cost model audited
+
+For a near-total composed predicate with `orderby=usd`, `mode=Printing`, two paging strategies:
+
+- **A = `walk_range_orderby_page` (#744):** walk the pre-sorted `price_usd` index, test `pbits` per
+  entry, stop at `offset+limit`. `O((offset+limit)/selectivity)`, random access into the store.
+- **B = `gather_composed_page` (#740):** sweep `pbits` linearly (card-contiguous), accumulate every
+  match, one final quickselect. `O(n_matches)` sweep, sequential access.
+
+The user hypothesis was that B's linear access beats A's random walk for a near-total predicate, and
+that the cost model may pick A unfairly. **Measured directly** (`bench_compose_paging.rs`, kernel
+micro-bench on real.store, offset-0 page and a ~70%-deep page, both strategies asserted to return the
+identical page first):
+
+| predicate | sel% | offset | A µs | B µs | winner |
+|---|---|---|---|---|---|
+| type:Octopus | 0.10 | 0 | 76 | 11 | B (A declines — null-price tail) |
+| type:Goblin | 1.55 | 0 | 12 | 27 | A |
+| type:Goblin | 1.55 | deep | 76 | 27 | B |
+| type:Human | 10.9 | 0 | 3.5 | 63 | A (18×) |
+| -type:Human | 89.1 | 0 | 3.4 | 593 | **A (174×)** |
+| -type:Goblin | 98.5 | 0 | 3.7 | 637 | **A (174×)** |
+| -type:Octopus | 99.9 | 0 | 3.9 | 647 | **A (167×)** |
+| -type:Goblin | 98.5 | deep | 124 | 1557 | **A (13×)** |
+
+**Finding: the hypothesis is refuted.** For a near-total predicate A dominates B by 167–174× at page
+1 and still 10–14× at a deep offset — because A terminates after ~`offset+limit` steps (almost every
+walked entry passes `pbits`), so its "random access" touches only ~`limit` rows; B must sweep and
+quickselect all ~90k matches. B wins only at low selectivity or deep offset — precisely the regime
+where A's `(offset+limit)/selectivity` cost is high enough that the router **doesn't pick
+PrintingCompose at all** (it routes to `GatheredScan`, which is B-shaped). The very-sparse case where
+B wins is already B: A declines into its null-price tail and the fastpath falls back to
+`gather_composed_page`.
+
+**Cost-model verdict: fair, no change.** The router always picks `ComposePaging::OrderbyWalk` (A) for
+this regime, which is correct — A wins wherever PrintingCompose wins. Making B a cost-selectable
+PrintingCompose sub-strategy would be dead code, redundant with the existing `GatheredScan` plan.
+Confirmed end-to-end: sparse `type:goblin` (1.5%) stays flat at ~58 µs (narrowing path, not the walk),
+while near-total `type:goblin or format:legacy` uses the walk at ~56 µs.
+
+## Card-mode gather-regime regression + fix
+
+Making collection leaves composable exposed a pre-existing cost-model gap: a **sparse** composable
+predicate in the **permutation-free gather regime** (card/artwork mode, `orderby=usd`/`rarity` — no
+card permutation, no printing orderby walk) was newly routed to PrintingCompose, which there has no
+paging edge over `GatheredScan` — it just composes the full printing bitmap and projects it back down
+(two O(n_cards) passes) on top of the same gather. Measured regressions (survey): `type:angel`
+card/usd 53→77 µs, `type:goblin` card/usd 55→82 µs, `type:zombie type:elf` 12→29 µs.
+
+Fixed with a small-total decline in `printing_compose_fastpath`'s gather-regime block, mirroring the
+`Perm` branch's existing `total <= STREAM_MIN_MATCHES` decline: if the SOUND card-space cardinality
+upper bound (`estimator::estimate_cardinality(...).hi` — exact for a collection leaf) is
+`<= STREAM_MIN_MATCHES`, decline to the candidate/narrowing path. The balls-into-bins breadth `est`
+already in that block can't make this call — it overestimates a clustered predicate's distinct-card
+count (goblin: 501 cards but ~1471 `est`). Post-fix all three regress-ers are back to baseline and
+the printing-mode wins are unchanged. Only affects card/artwork mode (printing mode takes the orderby
+walk, never this block), so the motivating query is untouched.
+
+## Out of scope
+
+A bare **positive near-total printing-space** leaf (`is:permanent`, 78% of printings) does not route
+to the walk — its scatter estimate = the full match count, which correctly costs high, so it stays on
+`GatheredScan` (~730 µs, unchanged from composite; not a regression). Legality/negations avoid this
+by building from the sparse side. Bare near-total *positive* leaves are not a useful query shape
+(78% of the DB); the sparse-side trick for them is a possible follow-up.
+
+## Acceptance
+
+`scripts/bench_collection_compose.py`; motivating group must improve, controls flat, `total` parity
+identical across builds. Differential: `collection_compose_leaves` (direct compose vs residual truth)
+plus `fuzz_row_identity_matches_reference` / `force_plan_differential_agreement` (now route collection
+leaves through the compose path against the GatheredScan reference).

--- a/scripts/bench_collection_compose.py
+++ b/scripts/bench_collection_compose.py
@@ -1,0 +1,98 @@
+"""Targeted benchmark for card-space collection fields (type:/kw:/otag:) as PrintingCompose leaves.
+
+`type:goblin or format:legacy` (unique=printing, orderby=usd) cost ~585us on the composite baseline:
+the `Subtypes` leaf wasn't a compose leaf, so PrintingCompose declined, AND the near-total
+`format:legacy` child tripped generic Or-narrowing's near-total guard — so it fell to a full
+`GatheredScan` (gather every card, compute the usd key per card, quickselect). Identical pathology to
+bare `format:commander` before #744.
+
+This change projects a card-space collection leaf's card-id postings up to printing space (exact — a
+subtype/keyword/oracle-tag is a pure card property) so an Or/And mixing it with legality/range/
+border composes into an exact printing bitmap and reaches #744's orderby-range-index walk.
+
+    .venv/bin/python scripts/bench_collection_compose.py \
+        --out benchmarks/collection-compose/baseline-main-<sha>.csv
+
+Reuses the corpus JSONL and local-build workflow from bench_bitplanes.py. `total` doubles as the
+parity check — must be identical across builds for every config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+
+# (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
+# `total` doubles as the parity check (identical across builds for every row).
+CONFIGS: list[tuple[str, str, str, str, str]] = [
+    # ── Motivating group: card-space collection OR near-total legality, printing/usd (and rarity) ──
+    ("collection_or_legality", "type:goblin or format:legacy", "printing", "usd", "default"),
+    ("collection_or_legality", "type:goblin or format:legacy", "printing", "rarity", "default"),
+    ("collection_or_legality", "kw:flying or f:commander", "printing", "usd", "default"),
+    ("collection_or_legality", "otag:removal or f:modern", "printing", "usd", "default"),
+    # unique=card: the composed printing bitmap projects up to a card-existence bitmap.
+    ("collection_or_legality", "type:goblin or format:legacy", "card", "usd", "default"),
+    # ── Negation (card-space, near-total): the exact complement of the projected set ──
+    ("collection_negation", "-type:goblin", "printing", "usd", "default"),
+    ("collection_negation", "-type:goblin f:legacy", "printing", "usd", "default"),
+    ("collection_negation", "-otag:removal", "printing", "usd", "default"),
+    # ── Mid-selectivity card-space collection alone, printing/usd ──
+    ("collection_mid", "type:human", "printing", "usd", "default"),
+    # ── Controls: must stay flat / must not regress ──
+    # #744 bare legality (already fast) — must not regress.
+    ("control", "f:commander", "printing", "usd", "default"),
+    # Sparse card-space collection alone: cost model keeps it on the narrowing path (A would be slow) —
+    # must stay flat, proving the router doesn't route sparse composables to the walk.
+    ("control", "type:goblin", "printing", "usd", "default"),
+    # Card-space narrowing with a card permutation (edhrec) — unaffected by the printing compose path.
+    ("control", "type:goblin", "card", "edhrec", "default"),
+    # Positive near-total PRINTING-space leaf: stays on GatheredScan (its scatter estimate = full match
+    # count costs high; legality/negations build from the sparse side instead). Out-of-scope known
+    # limitation — tracked here so it stays flat, not silently regresses.
+    ("control", "is:permanent", "printing", "usd", "default"),
+    # General card-mode query, unrelated to collections.
+    ("control", "t:creature or t:artifact", "card", "edhrec", "default"),
+]
+
+
+def main() -> None:
+    """Load the corpus, time every config, and write the results CSV."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
+    parser.add_argument("--window", type=float, default=5.0, help="timed seconds per config")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --out)")
+    args = parser.parse_args()
+
+    rev = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    shm_path = args.shm_path or args.out.with_suffix(".store")
+    engine = load_engine(args.corpus, shm_path)
+
+    hdr = f"{'group':<24} {'query':<32} {'unique':<9} {'orderby':<8} {'total':>7} {'avg ms':>8} {'min ms':>8}"
+    print(f"\nrev {rev}, window {args.window:.0f}s per config\n{hdr}\n{'-' * len(hdr)}", flush=True)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["rev", "group", "query", "unique", "orderby", "prefer", "total", "n", "avg_ms", "min_ms"])
+        for group, query, unique, orderby, prefer in CONFIGS:
+            total, n, avg_ms, min_ms = bench_one(engine, (query, unique, orderby, prefer), args.window)
+            writer.writerow([rev, group, query, unique, orderby, prefer, total, n, f"{avg_ms:.4f}", f"{min_ms:.4f}"])
+            fh.flush()
+            print(f"{group:<24} {query:<32} {unique:<9} {orderby:<8} {total:>7} {avg_ms:>8.3f} {min_ms:>8.3f}", flush=True)
+
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes card-space collection containment leaves — `type:goblin` (`CollectionCmp{Subtypes}`) and its
siblings `kw:`/`otag:` (`Keywords`/`OracleTags`) — **PrintingCompose leaves** by projecting their
card-id postings up to printing space. The projection is exact: a subtype/keyword/oracle-tag is a
pure *card* property (every printing of a goblin is a goblin), so there is no per-printing divergence
to repair. This lets an `Or`/`And` mixing a collection predicate with legality/range/border compose
into an exact printing bitmap and reach #744's orderby-range-index walk, instead of falling to a full
`GatheredScan`. The already-printing-space siblings `art:`/`is:` scatter directly (like `set:`), and
the negated form (`-type:`) is the exact complement.

Engine path only (parser/SQL unaffected). Built on #744 (orderby-range-index walk) and #746
(set:/watermark: compose leaves), both now merged; this branch is rebased onto `main` as a single
commit.

Motivating query `type:goblin or format:legacy` (`unique=printing orderby=usd`) cost ~596 µs on
current main: the `Subtypes` leaf wasn't composable AND the near-total `format:legacy` child tripped
generic Or-narrowing's near-total guard, so it gathered every card and quickselected — the exact
pathology bare `format:commander` had before #744.

## Changes

- `CollectionCmp{op: Ge}` over `Subtypes`/`Keywords`/`OracleTags`/`ArtTags`/`IsTags` and its `Not`
  wired into `is_printing_composable` / `compose_printing_bits` / `compose_printing_estimate` via a
  shared `collection_compose_index` field table; new `broadcast_card_ids_to_printings` projection.
- **`Ge`/containment only.** The postings are tight for `Ge` but a loose superset for `Eq`/`Gt`
  (prove `contains(value)`, not the length condition); the compose path has no residual re-check, so
  `Eq`/`Gt` stay on the general path. `FrameData` excluded (non-`complete`).
- Small-total decline in `printing_compose_fastpath`'s permutation-free gather regime (card/artwork
  mode), keyed on the sound card-space cardinality bound — keeps a sparse newly-composable predicate
  on the cheaper candidate path (mirrors the `Perm` branch's `STREAM_MIN_MATCHES` decline).
- Differential test `collection_compose_leaves` (compose vs residual truth, across ops/polarities);
  `bench_compose_paging.rs` kernel micro-bench; `scripts/bench_collection_compose.py` targeted bench.
  The existing `fuzz_row_identity_matches_reference` / `force_plan_differential_agreement` now route
  collection leaves through the compose path against the `GatheredScan` reference.

## Related issues

Design note: `docs/issues/00753-engine-collection-compose-leaves.md`. Built on #744 and #746 (merged).

---

## Performance

Targeted bench (`scripts/bench_collection_compose.py`, corpus = 97,206 printings from the blue DB),
`min` per query, `total` is the parity column (**identical across both builds** — the correctness
check). Measured on an idle machine (Docker fully stopped), current `main` (`a153d82`, #752 merged)
vs this rebased branch (`942b3bd`).

| Benchmark (unique/orderby) | total | main (µs) | branch (µs) | vs main |
|---|---|---|---|---|
| `type:goblin or format:legacy` printing/usd | 96445 | 596 | 56 | **10.6×** |
| `type:goblin or format:legacy` printing/rarity | 96445 | 544 | 176 | 3.1× |
| `kw:flying or f:commander` printing/usd | 96930 | 590 | 65 | 9.1× |
| `otag:removal or f:modern` printing/usd | 78015 | 634 | 119 | 5.3× |
| `-type:goblin` printing/usd | 95700 | 876 | 52 | **16.8×** |
| `-type:goblin f:legacy` printing/usd | 94939 | 882 | 57 | 15.5× |
| `-otag:removal` printing/usd | 78931 | 870 | 81 | 10.7× |
| `type:human` printing/usd | 10567 | 96 | 65 | 1.5× |
| `f:commander` printing/usd (control) | 96898 | 52 | 51 | 1.0× |
| `type:goblin` printing/usd (control, sparse) | 1506 | 58 | 57 | 1.0× |
| `type:goblin` card/edhrec (control) | 501 | 56 | 55 | 1.0× |
| `type:goblin or format:legacy` card/usd (control) | 31422 | 311 | 310 | 1.0× |
| `is:permanent` printing/usd (control, known limit) | 75855 | 781 | 707 | 1.1× |
| `t:creature or t:artifact` card/edhrec (control) | 19632 | 64 | 64 | 1.0× |

**Geometric mean over the eight non-control rows vs current main: ~7.1× (range 1.5–16.8×).**
`type:goblin or format:legacy` in card mode is flat — a near-total card-mode predicate declines via
the compose breadth gate (no cheap paging; no permutation for `usd`), which is expected and unchanged.

**Broad regression screen** (`scripts/survey_queries.py`, 520 queries — generated + wild):
**0 parity mismatches** across all 520 queries (every query returns an identical `total` on both
builds). Per-query diff: the worst branch-slower delta is **+21 µs** (`id:gw -(color:gw or set:mom)`,
667→688 µs, ~3%), and the top dozen are all 8–21 µs on query shapes this PR doesn't touch —
run-to-run noise. The collection-compose wins surface in the broad mix too
(`type:goblin or format:legacy` −555 µs; `is:commander or usd>20 or type:equipment` −86 µs).

**Test corpus:** blue-DB export (`benchmarks/bitplanes/corpus.jsonl`, 97,206 printings / 31,508
cards).

### A-vs-B paging (measured; cost model audited)

For a near-total composed predicate with `orderby=usd`, two paging strategies were measured directly
(`bench_compose_paging.rs`): **A** = #744's orderby-range-index walk (terminate at `offset+limit`),
**B** = #740-style linear `pbits` sweep + final quickselect. **A dominates B by 167–174× at page 1
and 10–14× at a deep offset** for a near-total predicate — it terminates after ~`offset+limit` steps
(almost every walked entry passes `pbits`), so its "random access" touches only ~`limit` rows, while
B must sweep and quickselect all ~90k matches. The hypothesis that B's linear access wins for
near-total is refuted. B wins only at low selectivity / deep offset — exactly where A's cost is high
enough that the router doesn't pick PrintingCompose (it routes to `GatheredScan`, which is B-shaped).
**Cost-model verdict: fair, no change** — the router always picks A (`OrderbyWalk`) for this regime,
which is correct; making B a cost-selectable PrintingCompose sub-strategy would be dead code
redundant with `GatheredScan`. Confirmed end-to-end: sparse `type:goblin` printing/usd stays flat at
~57 µs (narrowing path), near-total uses the walk at ~56 µs.

---

## Reviewer notes

Correctness surface to scrutinize: the **exactness/tightness claims**.
- Projection is exact because collection membership is card-invariant (no shared-witness problem);
  differential-tested against the residual path.
- `Ge` only — `Eq`/`Gt` postings are loose and deliberately gated off the compose path (no residual
  re-check there). Negation is exact because a collection is never NULL (unlike the `-watermark:`
  trivalent trap, kept off deliberately).
- `is:permanent` (positive near-total printing-space, 78%) does **not** route to the walk — its
  scatter estimate = full match count costs high, so it stays on `GatheredScan` (~700 µs, unchanged);
  legality/negations avoid this by building from the sparse side. Noted as out of scope in the design
  doc (bare near-total *positive* leaves aren't a useful query shape).

Tests pass debug + release (139 passed); differential fuzzers now exercise the new path.
