### PR TITLE
Engine: Bundle Store/Index and Query Params into QueryCtx/QueryParams

### DIFF
--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -26,8 +26,14 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, compose_printing_bits, gather_composed_page, walk_range_orderby_page, CardData, CmpOp, CollField,
-    FilterExpr, Mmap, Mode, Prefer, SortCol, ARCHIVE_HEADER_LEN,
+    FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortCol, ARCHIVE_HEADER_LEN,
 };
+
+/// This bench's fixed query shape: `unique=printing`, `orderby=usd` ascending,
+/// one page of `LIMIT` — only the offset sweeps.
+fn bench_params(page_offset: usize) -> QueryParams {
+    QueryParams { mode: Mode::Printing, prefer: Prefer::Default, sort_col: SortCol::PriceUsd, descending: false, limit: LIMIT, page_offset }
+}
 
 const ITERS: usize = 200;
 const LIMIT: usize = 175; // a Scryfall page
@@ -59,6 +65,7 @@ fn bench_compose_paging() {
     let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
     let n_printings = data.printings.len();
     let (cards, printings, offsets, p2c) = (&data.cards, &data.printings, &data.offsets, &data.indexes.printing_to_card);
+    let ctx = QueryCtx::from(data);
     println!("\n{} printings, {} cards from {STORE_PATH}", n_printings, cards.len());
 
     let coll = |field, value: &str, negate: bool| -> FilterExpr {
@@ -96,13 +103,13 @@ fn bench_compose_paging() {
                     .map_or(0, |p| p.len())
             };
             let run_b = || {
-                gather_composed_page(Mode::Printing, cards, printings, offsets, &pbits, Prefer::Default, SortCol::PriceUsd, false, LIMIT, offset, u16::from(data.indexes.max_artwork_groups))
+                gather_composed_page(&ctx, &bench_params(offset), &pbits)
                     .len()
             };
             // Cross-check identical page (offset 0 only — A declines into the null-price tail at deep
             // offsets, where only B is defined; that decline is itself the finding for those rows).
             let a_page = walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset);
-            let b_page = gather_composed_page(Mode::Printing, cards, printings, offsets, &pbits, Prefer::Default, SortCol::PriceUsd, false, LIMIT, offset, u16::from(data.indexes.max_artwork_groups));
+            let b_page = gather_composed_page(&ctx, &bench_params(offset), &pbits);
             if let Some(a_page) = &a_page {
                 let a_ids: Vec<u128> = a_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
                 let b_ids: Vec<u128> = b_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3951,6 +3951,103 @@ impl GatherSelect {
     }
 }
 
+// ─── Query context & parameters (#757) ───────────────────────────────────────
+// Every function from here down used to thread the same two arg clusters
+// individually: the five store/index slices off the archive, and the six scalars
+// describing the request. Neither varies within a call chain, and between them
+// they outnumbered the args that actually differ per call better than 2:1. These
+// two structs group them, so a signature's remaining positional args ARE its
+// interesting inputs. Purely a grouping — `QueryCtx` is shared refs under one
+// lifetime, `QueryParams` is six `Copy` scalars; both compile to the same
+// argument passing as before.
+
+/// What came off the archive: the mmap'd store slices and index bundle, borrowed
+/// for the query's duration. Built once per PyO3 entry point right after
+/// `access_unchecked` (`QueryCtx::from(data)`), then threaded as one arg.
+///
+/// The `'a` lifetime is what the executors' return-borrow relationships hang off
+/// (`Vec<(&'a AOracleCard, &'a APrinting)>` — a page borrows the store it came
+/// from), so a single lifetime across all five fields is load-bearing, not
+/// incidental tidiness.
+#[derive(Clone, Copy)]
+struct QueryCtx<'a> {
+    cards: &'a [AOracleCard],
+    printings: &'a [APrinting],
+    offsets: &'a AOffsets,
+    strings: &'a AStrings,
+    indexes: &'a Archived<CardIndexes>,
+}
+
+impl<'a> From<&'a Archived<CardData>> for QueryCtx<'a> {
+    fn from(data: &'a Archived<CardData>) -> Self {
+        QueryCtx {
+            cards: &data.cards,
+            printings: &data.printings,
+            offsets: &data.offsets,
+            strings: &data.strings,
+            indexes: &data.indexes,
+        }
+    }
+}
+
+impl QueryCtx<'_> {
+    /// `cards.len()`/`printings.len()` as the `u32`s the cost model and the
+    /// bitmap/permutation code want; spelled out at enough call sites to be worth
+    /// naming.
+    fn n_cards(&self) -> u32 {
+        self.cards.len() as u32
+    }
+
+    fn n_printings(&self) -> u32 {
+        self.printings.len() as u32
+    }
+}
+
+/// What the request asked for: the query parameters that are fixed for one
+/// query but vary between queries. Deliberately separate from [`QueryCtx`] —
+/// "came off the archive" and "the caller asked for it" are different kinds of
+/// thing, and only the former is tied to the archive's lifetime.
+///
+/// Not every callee uses every field (`acquire_plan_features`/`explain` never
+/// need `prefer`; `prepare_candidates` uses only `mode`). Passing the whole
+/// struct and ignoring the rest is the deliberate trade: one uniform param type
+/// beats five bespoke sub-structs for a layer whose whole problem was too many
+/// distinct shapes.
+///
+/// `filter` is NOT a field here even though it is equally per-query:
+/// `prepare_candidates` needs `&mut FilterExpr`, and `explain_analyze` clones a
+/// fresh filter per (plan, round) off a pristine snapshot for timing fairness
+/// (#752). Both want it as its own arg with its own mutability.
+#[derive(Clone, Copy)]
+struct QueryParams {
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    limit: usize,
+    page_offset: usize,
+}
+
+impl QueryParams {
+    /// The string→enum adapter, in one place. The PyO3 surface takes `unique`/
+    /// `prefer`/`orderby`/`direction` as strings (Scryfall's query-param
+    /// spelling); this is the single boundary where they become enums, so
+    /// `run_query`, `run_query_with_plan`, `explain_analyze`, and the `explain`
+    /// method can't drift in how they interpret them — the four-line
+    /// `orderby_to_col`/`== "desc"`/`prefer_from_str`/`mode_from_unique` block
+    /// each used to repeat.
+    fn from_strs(unique: &str, prefer: &str, orderby: &str, direction: &str, limit: usize, page_offset: usize) -> Self {
+        QueryParams {
+            mode: mode_from_unique(unique),
+            prefer: prefer_from_str(prefer),
+            sort_col: orderby_to_col(orderby),
+            descending: direction == "desc",
+            limit,
+            page_offset,
+        }
+    }
+}
+
 // ─── Query driver ─────────────────────────────────────────────────────────────
 // One structural walk replaces the pre-split linear/hashmap dedup paths and the
 // preferred-printing fast path: grouping is the store's shape, not something to
@@ -4438,19 +4535,14 @@ fn build_card_range_bits(
 /// within a card, printings order by `sort_key_bits` then pid — byte-identical to the streamed
 /// path's emission (`run_query_streamed`), just without the O(n) count pass, since the caller
 /// already has the exact `total` from the index.
-#[allow(clippy::too_many_arguments)]
 fn walk_printing_page<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     leaf: &FilterExpr,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
     perm: &Archived<Vec<u32>>,
 ) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    let QueryCtx { cards, printings, offsets, strings, .. } = *ctx;
+    let QueryParams { sort_col, descending, limit, page_offset, .. } = *params;
     let residual: [&FilterExpr; 1] = [leaf];
     let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -4583,19 +4675,13 @@ fn aligned_page<'a>(
 /// selective range (the existing narrowing already wins, and restricting the walk to dense
 /// predicates keeps its worst case bounded), or an order-by without a card permutation (e.g. the
 /// range field itself — deferred).
-#[allow(clippy::too_many_arguments)]
 fn printing_range_fastpath<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &FilterExpr,
-    indexes: &Archived<CardIndexes>,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    let QueryCtx { cards, printings, indexes, .. } = *ctx;
+    let QueryParams { sort_col, descending, limit, page_offset, .. } = *params;
     let (idx, lo, hi) = bare_range_bounds(filter, indexes)?;
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
@@ -4629,7 +4715,7 @@ fn printing_range_fastpath<'a>(
     if perm.len() != cards.len() {
         return None;
     }
-    Some((k, walk_printing_page(cards, printings, offsets, strings, filter, sort_col, descending, limit, page_offset, perm)))
+    Some((k, walk_printing_page(ctx, params, filter, perm)))
 }
 
 /// The exact `unique=printing` total for a bare `border:VALUE` leaf, from the #724 printing planes:
@@ -5400,20 +5486,13 @@ fn walk_rarity_orderby_page<'a>(
 /// a non-composable filter, or a total at/below the stream threshold — where the general path gathers
 /// and globally sorts, ordering ties differently (same guard as `printing_range_fastpath`; a sparse
 /// value like `border:yellow` falls through here).
-#[allow(clippy::too_many_arguments)]
 fn printing_compose_fastpath<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &FilterExpr,
-    indexes: &Archived<CardIndexes>,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
+    let QueryParams { mode, sort_col, descending, limit, page_offset, .. } = *params;
     if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
         return None;
     }
@@ -5497,7 +5576,7 @@ fn printing_compose_fastpath<'a>(
             if total <= *STREAM_MIN_MATCHES {
                 return None; // sparse: the general path gathers + globally sorts, ordering ties differently
             }
-            walk_grouped_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, perm, u16::from(indexes.max_artwork_groups))
+            walk_grouped_page(ctx, params, &pbits, perm)
         }
         // No permutation. #744: if the orderby has a printing-space value structure (usd/rarity,
         // printing mode), walk it directly — terminating at page_offset+limit rather than visiting
@@ -5519,9 +5598,7 @@ fn printing_compose_fastpath<'a>(
             } else {
                 None
             };
-            walked.unwrap_or_else(|| {
-                gather_composed_page(mode, cards, printings, offsets, &pbits, prefer, sort_col, descending, limit, page_offset, u16::from(indexes.max_artwork_groups))
-            })
+            walked.unwrap_or_else(|| gather_composed_page(ctx, params, &pbits))
         }
     };
     Some((total, page))
@@ -5592,17 +5669,9 @@ impl PhysicalPlan {
     /// prep is available, `PrintingRangeScan` exactly when the range-estimate prep is,
     /// so filtering `ALL` by `applicable` inside each prep branch yields the right
     /// candidate set with no per-branch plan list.
-    #[allow(clippy::too_many_arguments)]
-    fn applicable(
-        self,
-        filter: &FilterExpr,
-        mode: Mode,
-        cards: &[AOracleCard],
-        plane: Option<&PlaneExpr>,
-        sort_col: SortCol,
-        descending: bool,
-        indexes: &Archived<CardIndexes>,
-    ) -> bool {
+    fn applicable(self, ctx: &QueryCtx, params: &QueryParams, filter: &FilterExpr, plane: Option<&PlaneExpr>) -> bool {
+        let QueryCtx { cards, indexes, .. } = *ctx;
+        let QueryParams { mode, sort_col, descending, .. } = *params;
         match self {
             PhysicalPlan::PrintingRangeScan => {
                 printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
@@ -5641,6 +5710,19 @@ impl PhysicalPlan {
 struct PreparedCandidates {
     candidate_cards: Option<Vec<u32>>,
     all_match_known: bool,
+}
+
+impl PreparedCandidates {
+    /// The card ids to visit: the narrowed list if one was materialized, else
+    /// every card. Boxed because the two arms are different iterator types and
+    /// both P3 and P4 want the same either-or — previously spelled out
+    /// identically at the head of each.
+    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn Iterator<Item = u32> + 's> {
+        match &self.candidate_cards {
+            Some(v) => Box::new(v.iter().copied()),
+            None => Box::new(0..ctx.n_cards()),
+        }
+    }
 }
 
 /// How `run_query_routed` obtained a query's cost features, and the artifact (if
@@ -5786,15 +5868,9 @@ fn card_range_popcount_applicable(
 /// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
 /// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
 /// `!all_match_known` / `*VERIFY_ORDER` guards and in the same order as before.
-fn prepare_candidates(
-    cards: &[AOracleCard],
-    offsets: &AOffsets,
-    strings: &AStrings,
-    filter: &mut FilterExpr,
-    plane: Option<&PlaneExpr>,
-    mode: Mode,
-    indexes: &Archived<CardIndexes>,
-) -> PreparedCandidates {
+fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane: Option<&PlaneExpr>) -> PreparedCandidates {
+    let QueryCtx { cards, offsets, strings, indexes, .. } = *ctx;
+    let mode = params.mode;
     // Candidates in either space project to card ids for the walk; the walk's
     // per-printing verification restores exactness for printing-space losses.
     // A list covering nearly the whole corpus narrows nothing — the walk would
@@ -5900,29 +5976,18 @@ fn prepare_candidates(
 /// P2 executor: evaluate the plane into the popcount thread-local and run the
 /// #634 Step 2 popcount-skip order phase. Caller guarantees applicability
 /// (`plane_popcount_order_applicable`).
-#[allow(clippy::too_many_arguments)]
 fn exec_plane_popcount_order<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     plane_expr: &PlaneExpr,
-    indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     thread_local! {
         static PLANE_BITMAP_POPCOUNT: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
     }
     PLANE_BITMAP_POPCOUNT.with(|cell| {
         let mut bitmap = cell.borrow_mut();
-        eval_planes(plane_expr, &indexes.planes, &mut bitmap);
-        exec_plane_popcount_order_with_bitmap(
-            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes, &bitmap,
-        )
+        eval_planes(plane_expr, &ctx.indexes.planes, &mut bitmap);
+        exec_plane_popcount_order_with_bitmap(ctx, params, plane_expr, &bitmap)
     })
 }
 
@@ -5932,27 +5997,18 @@ fn exec_plane_popcount_order<'a>(
 /// and reuses the same `&[u64]` here, so the plane is never evaluated twice on a
 /// routed query. Caller guarantees `plane_popcount_order_applicable` (a
 /// length-matched forward permutation and an inverse permutation both exist).
-#[allow(clippy::too_many_arguments)]
 fn exec_plane_popcount_order_with_bitmap<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     plane_expr: &PlaneExpr,
-    indexes: &Archived<CardIndexes>,
     bitmap: &[u64],
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let indexes = ctx.indexes;
+    let QueryParams { sort_col, descending, .. } = *params;
     let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
-    run_query_streamed_popcount(
-        cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, bitmap, Some(plane_expr), &indexes.planes, strings, None,
-    )
+    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -5960,27 +6016,18 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
 /// range's printing-space membership set so emission shows an in-range printing. Caller guarantees
 /// `card_range_popcount_applicable` (permutations exist; the shown-printing plane, if any, is
 /// non-existential so it needs no per-printing re-check here).
-#[allow(clippy::too_many_arguments)]
 fn exec_card_range_popcount<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     card_bits: &[u64],
     range_pbits: &[u64],
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let indexes = ctx.indexes;
+    let QueryParams { sort_col, descending, .. } = *params;
     let perm = indexes.sort_perms.get(sort_col, descending).expect("CardRangePopcount applicability guarantees a permutation");
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("CardRangePopcount applicability guarantees an inverse permutation");
-    run_query_streamed_popcount(
-        cards, printings, offsets, prefer, limit, page_offset, perm, inv_perm, card_bits, None, &indexes.planes, strings, Some(range_pbits),
-    )
+    run_query_streamed_popcount(ctx, params, perm, inv_perm, card_bits, None, Some(range_pbits))
 }
 
 /// Prefix-sum the per-card distinct-artwork counts (`artwork_groups`) into artwork-space offsets: a
@@ -6031,21 +6078,15 @@ fn printing_bits_to_artwork_bits(
 /// Artwork semantics). Membership is the exact composed `pbits`, so there is no residual re-evaluation.
 /// The total is a separate `popcount` over the mode's result bitmap; this only builds the requested
 /// page. Forward walk (no popcount-skip) — deep-offset skip is the deferred [#730] optimization.
-#[allow(clippy::too_many_arguments)]
 fn walk_grouped_page<'a>(
-    mode: Mode,
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     pbits: &[u64],
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
     perm: &Archived<Vec<u32>>,
-    max_artwork_groups: u16,
 ) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -6135,20 +6176,15 @@ fn walk_grouped_page<'a>(
 /// `GatherSelect` accumulator `GatheredScan` uses for its own permutation-less case — so tie-break
 /// order matches the general path exactly (same comparator, same struct), unlike the permutation
 /// walk (which is why that one still declines below `STREAM_MIN_MATCHES`; this one doesn't need to).
-#[allow(clippy::too_many_arguments, clippy::needless_range_loop)] // `pid` also drives `is_set`/`printings[pid]` together, same shape as `walk_grouped_page`
+#[allow(clippy::needless_range_loop)] // `pid` also drives `is_set`/`printings[pid]` together, same shape as `walk_grouped_page`
 fn gather_composed_page<'a>(
-    mode: Mode,
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     pbits: &[u64],
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    max_artwork_groups: u16,
 ) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+    let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let candidate_cards = bitmap_card_ids(&printing_bits_to_card_bits(pbits, offsets, cards.len()));
     let n = match mode {
@@ -6222,61 +6258,37 @@ fn gather_composed_page<'a>(
 
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
 /// applicability (`streamed_select_applicable`) and has run `prepare_candidates`.
-#[allow(clippy::too_many_arguments)]
 fn exec_streamed_select<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &FilterExpr,
     prep: &PreparedCandidates,
     plane: Option<&PlaneExpr>,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("StreamedSelect applicability guarantees a permutation");
-    let existential_plane = existential_plane_for(mode, plane, indexes);
-    let card_ids: Box<dyn Iterator<Item = u32>> = match &prep.candidate_cards {
-        Some(v) => Box::new(v.iter().copied()),
-        None    => Box::new(0..cards.len() as u32),
-    };
-    run_query_streamed(
-        cards, printings, offsets, strings, filter, prep.all_match_known, mode, prefer, sort_col, descending, limit,
-        page_offset, perm, card_ids, &indexes.artwork_groups, &indexes.artwork_group_col, u16::from(indexes.max_artwork_groups), existential_plane,
-    )
+    let indexes = ctx.indexes;
+    let perm = indexes
+        .sort_perms
+        .get(params.sort_col, params.descending)
+        .expect("StreamedSelect applicability guarantees a permutation");
+    let existential_plane = existential_plane_for(params.mode, plane, indexes);
+    run_query_streamed(ctx, params, filter, prep.all_match_known, perm, prep.card_ids(ctx), existential_plane)
 }
 
 /// P4 executor: the universal gathered per-card loop + `select_page`. Runs any
 /// query (printing-keyed orderbys, stores without permutations, or anything the
 /// other plans decline). Caller has run `prepare_candidates`.
-#[allow(clippy::too_many_arguments)]
 fn exec_gathered_scan<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &FilterExpr,
     prep: &PreparedCandidates,
     plane: Option<&PlaneExpr>,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let all_match_known = prep.all_match_known;
     let existential_plane = existential_plane_for(mode, plane, indexes);
-    let card_ids: Box<dyn Iterator<Item = u32>> = match &prep.candidate_cards {
-        Some(v) => Box::new(v.iter().copied()),
-        None    => Box::new(0..cards.len() as u32),
-    };
+    let card_ids = prep.card_ids(ctx);
 
     // Gathered path (printing-keyed orderbys, or stores without permutations): push
     // each card's matches directly into the selector, which keeps its buffer bounded
@@ -6321,11 +6333,9 @@ fn exec_gathered_scan<'a>(
     (total, page)
 }
 
+#[allow(clippy::too_many_arguments)] // the PyO3 string surface, adapted in one place; the core takes two structs
 fn run_query<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
     filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
     unique: &str,
@@ -6334,17 +6344,12 @@ fn run_query<'a>(
     direction: &str,
     limit: usize,
     page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    let sort_col   = orderby_to_col(orderby);
-    let descending = direction == "desc";
-    let prefer     = prefer_from_str(prefer);
-    let mode       = mode_from_unique(unique);
-
     // #702: plan selection is one cost-based routing layer (`run_query_routed`,
     // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision
     // tree. `run_query` is the thin string→enum adapter; the core takes enums.
-    run_query_routed(cards, printings, offsets, strings, filter, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes)
+    let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, page_offset);
+    run_query_routed(ctx, &params, filter, plane)
 }
 
 /// `cost::PlanFeatures::scan_units` for a query: the rows the per-row residual
@@ -6372,57 +6377,40 @@ fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n
 /// phase-2 prep branches funnel their P3/P4 winner through here, so the executor
 /// call site exists once. `PlanePopcountOrder` is handled by its own bitmap
 /// executor and `PrintingRangeScan` never reaches here (non-materializing).
-#[allow(clippy::too_many_arguments)]
 fn exec_from_candidates<'a>(
     plan: PhysicalPlan,
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &FilterExpr,
     prep: &PreparedCandidates,
     plane: Option<&PlaneExpr>,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     match plan {
-        PhysicalPlan::StreamedSelect => exec_streamed_select(
-            cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-        ),
-        PhysicalPlan::GatheredScan => exec_gathered_scan(
-            cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-        ),
+        PhysicalPlan::StreamedSelect => exec_streamed_select(ctx, params, filter, prep, plane),
+        PhysicalPlan::GatheredScan => exec_gathered_scan(ctx, params, filter, prep, plane),
         other => unreachable!("exec_from_candidates only runs P3/P4, got {other:?}"),
     }
 }
 
 /// Cost features: the query-invariant fields filled once; the four that vary by
 /// count source passed in. Collapses each acquire branch's 8-field literal to one call.
-#[allow(clippy::too_many_arguments)]
 fn mk_plan_feats(
-    n_cards: u32,
-    n_printings: u32,
-    limit: usize,
-    page_offset: usize,
+    ctx: &QueryCtx,
+    params: &QueryParams,
     matches: u32,
     eval_domain: u32,
     scan_units: u32,
     residual_tier_ns100: u32,
 ) -> cost::PlanFeatures {
     cost::PlanFeatures {
-        n_cards,
-        n_printings,
+        n_cards: ctx.n_cards(),
+        n_printings: ctx.n_printings(),
         matches,
         eval_domain,
         scan_units,
         residual_tier_ns100,
-        limit: limit as u32,
-        offset: page_offset as u32,
+        limit: params.limit as u32,
+        offset: params.page_offset as u32,
         broadcast_printings: 0, // PrintingCompose's legality broadcast-down (0 for ranges / precomputed planes)
         scatter_printings: 0,  // range-slice k — set by both range-plan acquire branches (costed per-plan)
         project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
@@ -6439,20 +6427,10 @@ fn mk_plan_feats(
 /// plan_routing_ab), kept EXACT on purpose: an O(1) estimate would trade the
 /// model's honesty for a couple percent on already-fast queries — do not swap it
 /// for `eval_domain·n_printings/n_cards` without re-justifying.
-#[allow(clippy::too_many_arguments)]
-fn candidate_feats(
-    prep: &PreparedCandidates,
-    filter: &FilterExpr,
-    mode: Mode,
-    offsets: &AOffsets,
-    n_cards: u32,
-    n_printings: u32,
-    limit: usize,
-    page_offset: usize,
-) -> cost::PlanFeatures {
-    let count = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
-    let scan = scan_units(mode, prep.candidate_cards.as_deref(), offsets, n_printings, count);
-    mk_plan_feats(n_cards, n_printings, limit, page_offset, count, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
+fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidates, filter: &FilterExpr) -> cost::PlanFeatures {
+    let count = prep.candidate_cards.as_ref().map_or(ctx.n_cards(), |v| v.len() as u32);
+    let scan = scan_units(params.mode, prep.candidate_cards.as_deref(), ctx.offsets, ctx.n_printings(), count);
+    mk_plan_feats(ctx, params, count, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
 }
 
 /// The acquire step of `run_query_routed`'s three-step algorithm (see its doc
@@ -6465,36 +6443,29 @@ fn candidate_feats(
 /// or `prepare_candidates` (`Prep::Candidates`). Returns the plane popcount bitmap
 /// alongside `Prep::Plane` (empty otherwise) — `run_query_routed`'s dispatch needs
 /// it to execute the winner; a caller that only wants `feats` (`explain`) drops it.
-#[allow(clippy::too_many_arguments)]
 fn acquire_plan_features(
-    cards: &[AOracleCard],
-    printings: &[APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx,
+    params: &QueryParams,
     filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
-    mode: Mode,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> (cost::PlanFeatures, Prep, Vec<u64>) {
-    let n_cards = cards.len() as u32;
-    let n_printings = printings.len() as u32;
+    let QueryCtx { cards, offsets, indexes, .. } = *ctx;
+    let QueryParams { mode, sort_col, descending, .. } = *params;
+    let n_cards = ctx.n_cards();
+    let n_printings = ctx.n_printings();
 
     // Scratch for the plane bitmap (`Prep::Plane` only). A fresh `Vec` allocates
     // just once, on the plane branch's `eval_planes`; non-plane queries leave it
     // empty (no alloc).
     let mut plane_bits: Vec<u64> = Vec::new();
 
-    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, plane) {
         // The ONE plane eval; its popcount IS the exact count. scan_units == count
         // (Mode::Card breaks at first match); True residual ⇒ tier 0.
         eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
-        (mk_plan_feats(n_cards, n_printings, limit, page_offset, count, count, count, 0), Prep::Plane)
-    } else if PhysicalPlan::CardRangePopcount.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+        (mk_plan_feats(ctx, params, count, count, count, 0), Prep::Plane)
+    } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, plane) {
         // Exact in-range printing count `k` from the index partition points (two binary searches, no
         // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
         // plan wins — so a competing winner never eats a wasted build (re-deriving the bounds there is
@@ -6504,7 +6475,7 @@ fn acquire_plan_features(
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let card_est = k.min(n_cards);
-        let mut feats = mk_plan_feats(n_cards, n_printings, limit, page_offset, card_est, card_est, card_est, verify_cost_tier(filter));
+        let mut feats = mk_plan_feats(ctx, params, card_est, card_est, card_est, verify_cost_tier(filter));
         // `k` rides `scatter_printings`: this plan's arm charges it as its FUSED one-pass build
         // (`CARD_RANGE_BUILD_PER_PRINTING_NS`), while a competing PrintingCompose costed off these shared
         // feats charges the same `k` as its cheaper scatter (`RANGE_SCATTER_…`) plus a separate
@@ -6512,15 +6483,15 @@ fn acquire_plan_features(
         feats.scatter_printings = k;
         feats.project_printings = k;
         (feats, Prep::Range)
-    } else if PhysicalPlan::PrintingRangeScan.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+    } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        let mut feats = mk_plan_feats(n_cards, n_printings, limit, page_offset, k, n_cards, n_printings, verify_cost_tier(filter));
+        let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
         (feats, Prep::Range)
-    } else if PhysicalPlan::PrintingCompose.applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
+    } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, plane) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
@@ -6545,7 +6516,7 @@ fn acquire_plan_features(
                 (printing_matches, printing_matches, (n_printings as usize).div_ceil(64), rt, printing_matches)
             }
         };
-        let mut feats = mk_plan_feats(n_cards, n_printings, limit, page_offset, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
+        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
         feats.broadcast_printings = broadcast as u32;
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
@@ -6561,8 +6532,8 @@ fn acquire_plan_features(
         };
         (feats, Prep::Range)
     } else {
-        let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
-        let feats = candidate_feats(&prep, filter, mode, offsets, n_cards, n_printings, limit, page_offset);
+        let prep = prepare_candidates(ctx, params, filter, plane);
+        let feats = candidate_feats(ctx, params, &prep, filter);
         (feats, Prep::Candidates(prep))
     };
 
@@ -6591,25 +6562,12 @@ fn acquire_plan_features(
 /// estimate, so if a *materializing* plan wins there — or `PrintingRangeScan` wins
 /// but its fastpath declines — dispatch materializes lazily and re-chooses on exact
 /// features. That deferral is the "don't pay to materialize a plan you won't run".
-#[allow(clippy::too_many_arguments)]
 fn run_query_routed<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    let n_cards = cards.len() as u32;
-    let n_printings = printings.len() as u32;
-
     // Generic argmin: the cheapest applicable plan. `filter` is passed per call (not
     // captured) so it stays free for `prepare_candidates`'s `&mut`. `materializing`
     // restricts to plans runnable off a materialized prep (the lazy-materialize path
@@ -6617,37 +6575,30 @@ fn run_query_routed<'a>(
     let choose = |filter: &FilterExpr, feats: &cost::PlanFeatures, materializing_only: bool| -> PhysicalPlan {
         PhysicalPlan::ALL
             .into_iter()
-            .filter(|p| {
-                p.applicable(filter, mode, cards, plane, sort_col, descending, indexes) && (!materializing_only || p.materializing())
-            })
+            .filter(|p| p.applicable(ctx, params, filter, plane) && (!materializing_only || p.materializing()))
             .min_by(|a, b| cost::plan_cost(*a, feats).partial_cmp(&cost::plan_cost(*b, feats)).expect("plan_cost is finite"))
             .expect("GatheredScan is always applicable and materializing")
     };
 
     // ── acquire: pick the count source, build features, materialize its artifact ──
-    let (feats, prep, plane_bits) = acquire_plan_features(
-        cards, printings, offsets, strings, filter, plane, mode, sort_col, descending, limit, page_offset, indexes,
-    );
+    let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, plane);
 
     // ── choose: cheapest applicable plan ──
     let plan = choose(filter, &feats, false);
 
     // ── dispatch: run the winner, reusing the acquired artifact ──
     match (plan, &prep) {
-        (PhysicalPlan::PlanePopcountOrder, Prep::Plane) => exec_plane_popcount_order_with_bitmap(
-            cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset,
-            plane.expect("Prep::Plane ⇒ plane"), indexes, &plane_bits,
-        ),
+        (PhysicalPlan::PlanePopcountOrder, Prep::Plane) => {
+            exec_plane_popcount_order_with_bitmap(ctx, params, plane.expect("Prep::Plane ⇒ plane"), &plane_bits)
+        }
         // P3/P4 reuse the plane bitmap as their candidate list — identical to what
         // prepare_candidates yields for a True-residual plane query.
         (p, Prep::Plane) => exec_from_candidates(
-            p, cards, printings, offsets, strings, filter,
+            p, ctx, params, filter,
             &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
-            plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
+            plane,
         ),
-        (p, Prep::Candidates(prep)) => exec_from_candidates(
-            p, cards, printings, offsets, strings, filter, prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-        ),
+        (p, Prep::Candidates(prep)) => exec_from_candidates(p, ctx, params, filter, prep, plane),
         // `Prep::Range` = "cheap estimate acquired, nothing materialized" — shared by CardRangePopcount
         // (#725), PrintingRangeScan (#695), and PrintingCompose (#724). Each winner does its own O(k)
         // work here, so no plan eats a build for a competing winner:
@@ -6655,29 +6606,24 @@ fn run_query_routed<'a>(
         //   - the printing-space fast paths walk (or, if they decline — sparse total — materialize).
         //   - a materializing plan (StreamedSelect/GatheredScan) that beat them narrows + runs.
         (PhysicalPlan::CardRangePopcount, Prep::Range) => {
-            let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
-            let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), printings.len());
-            exec_card_range_popcount(
-                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
-            )
+            let (idx, lo, hi) = bare_range_bounds(filter, ctx.indexes).expect("applicable ⇒ bare range");
+            let (card_bits, range_pbits) =
+                build_card_range_bits(idx, lo, hi, ctx.indexes, ctx.cards.len(), ctx.printings.len());
+            exec_card_range_popcount(ctx, params, &card_bits, &range_pbits)
         }
         (plan, Prep::Range) => {
             let fast_page = match plan {
-                PhysicalPlan::PrintingRangeScan => {
-                    printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
-                }
-                PhysicalPlan::PrintingCompose => {
-                    printing_compose_fastpath(cards, printings, offsets, filter, indexes, mode, prefer, sort_col, descending, limit, page_offset)
-                }
+                PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
+                PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
                 _ => None, // a materializing plan won the estimate — materialize + run it below
             };
             match fast_page {
                 Some(page) => page,
                 None => {
-                    let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
-                    let feats = candidate_feats(&prep, filter, mode, offsets, n_cards, n_printings, limit, page_offset);
+                    let prep = prepare_candidates(ctx, params, filter, plane);
+                    let feats = candidate_feats(ctx, params, &prep, filter);
                     let plan = choose(filter, &feats, true);
-                    exec_from_candidates(plan, cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes)
+                    exec_from_candidates(plan, ctx, params, filter, &prep, plane)
                 }
             }
         }
@@ -6692,27 +6638,15 @@ fn run_query_routed<'a>(
 /// when `printing_range_fastpath` structurally declines with `None`); `Some`
 /// with the result when it ran. `GatheredScan` is always `Some`. Also the
 /// executor `explain_analyze` (#745) drives per plan per timing round.
-#[allow(clippy::too_many_arguments)]
 fn run_query_with_plan<'a>(
     plan: PhysicalPlan,
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
-    unique: &str,
-    prefer: &str,
-    orderby: &str,
-    direction: &str,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
-    let sort_col   = orderby_to_col(orderby);
-    let descending = direction == "desc";
-    let prefer     = prefer_from_str(prefer);
-    let mode       = mode_from_unique(unique);
+    let QueryCtx { cards, indexes, .. } = *ctx;
+    let QueryParams { mode, sort_col, descending, .. } = *params;
 
     match plan {
         PhysicalPlan::PrintingRangeScan => {
@@ -6720,7 +6654,7 @@ fn run_query_with_plan<'a>(
                 return None;
             }
             // Structural eligibility passed; the fastpath itself decides (None = declined).
-            printing_range_fastpath(cards, printings, offsets, strings, filter, indexes, sort_col, descending, limit, page_offset)
+            printing_range_fastpath(ctx, params, filter)
         }
         PhysicalPlan::PrintingCompose => {
             if !printing_compose_applicable(filter, cards, plane, indexes) {
@@ -6728,42 +6662,34 @@ fn run_query_with_plan<'a>(
             }
             // The fastpath composes, projects per mode, and walks — or declines (None) on a sparse
             // total, exactly as under the router.
-            printing_compose_fastpath(cards, printings, offsets, filter, indexes, mode, prefer, sort_col, descending, limit, page_offset)
+            printing_compose_fastpath(ctx, params, filter)
         }
         PhysicalPlan::PlanePopcountOrder => {
             if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
                 return None;
             }
             let plane_expr = plane.expect("applicability guarantees a plane");
-            Some(exec_plane_popcount_order(
-                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, plane_expr, indexes,
-            ))
+            Some(exec_plane_popcount_order(ctx, params, plane_expr))
         }
         PhysicalPlan::CardRangePopcount => {
             if !card_range_popcount_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
                 return None;
             }
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicability guarantees a bare range");
-            let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), printings.len());
-            Some(exec_card_range_popcount(
-                cards, printings, offsets, strings, prefer, sort_col, descending, limit, page_offset, indexes, &card_bits, &range_pbits,
-            ))
+            let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), ctx.printings.len());
+            Some(exec_card_range_popcount(ctx, params, &card_bits, &range_pbits))
         }
         PhysicalPlan::StreamedSelect => {
             if !streamed_select_applicable(cards, sort_col, descending, indexes) {
                 return None;
             }
-            let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
-            Some(exec_streamed_select(
-                cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-            ))
+            let prep = prepare_candidates(ctx, params, filter, plane);
+            Some(exec_streamed_select(ctx, params, filter, &prep, plane))
         }
         PhysicalPlan::GatheredScan => {
             debug_assert!(gathered_scan_applicable());
-            let prep = prepare_candidates(cards, offsets, strings, filter, plane, mode, indexes);
-            Some(exec_gathered_scan(
-                cards, printings, offsets, strings, filter, &prep, plane, mode, prefer, sort_col, descending, limit, page_offset, indexes,
-            ))
+            let prep = prepare_candidates(ctx, params, filter, plane);
+            Some(exec_gathered_scan(ctx, params, filter, &prep, plane))
         }
     }
 }
@@ -6788,27 +6714,11 @@ pub(crate) struct PlanEstimate {
 /// dispatch would compute if that plan actually won and got lazily re-costed
 /// against a materialized candidate list (see `acquire_plan_features`'s
 /// `PrintingRangeScan`/`PrintingCompose` branches).
-#[allow(clippy::too_many_arguments)]
-fn explain(
-    cards: &[AOracleCard],
-    printings: &[APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
-    filter: &mut FilterExpr,
-    plane: Option<&PlaneExpr>,
-    mode: Mode,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
-) -> Vec<PlanEstimate> {
-    let (feats, _prep, _plane_bits) = acquire_plan_features(
-        cards, printings, offsets, strings, filter, plane, mode, sort_col, descending, limit, page_offset, indexes,
-    );
+fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane: Option<&PlaneExpr>) -> Vec<PlanEstimate> {
+    let (feats, _prep, _plane_bits) = acquire_plan_features(ctx, params, filter, plane);
     let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
         .into_iter()
-        .filter(|p| p.applicable(filter, mode, cards, plane, sort_col, descending, indexes))
+        .filter(|p| p.applicable(ctx, params, filter, plane))
         .map(|plan| PlanEstimate { plan, predicted_ns: cost::plan_cost(plan, &feats) })
         .collect();
     estimates.sort_by(|a, b| a.predicted_ns.partial_cmp(&b.predicted_ns).expect("plan_cost is finite"));
@@ -6855,31 +6765,17 @@ pub(crate) struct PlanTrial {
 /// `prepare_candidates`, whereas `run_query_routed` acquires the shared artifact
 /// once and reuses it. So compare `trials_ns` across plans, not against an
 /// end-to-end `query()` latency for the winner.
-#[allow(clippy::too_many_arguments)]
 fn explain_analyze(
-    cards: &[AOracleCard],
-    printings: &[APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx,
+    params: &QueryParams,
     filter: &FilterExpr,
     plane: Option<&PlaneExpr>,
-    unique: &str,
-    prefer: &str,
-    orderby: &str,
-    direction: &str,
-    limit: usize,
-    page_offset: usize,
-    indexes: &Archived<CardIndexes>,
     num_warmups: usize,
     num_trials: usize,
 ) -> Vec<PlanTrial> {
-    let sort_col = orderby_to_col(orderby);
-    let descending = direction == "desc";
-    let mode = mode_from_unique(unique);
-
     // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
     // the timing loop below starts from `filter`'s untouched, pristine state.
-    let estimates = explain(cards, printings, offsets, strings, &mut filter.clone(), plane, mode, sort_col, descending, limit, page_offset, indexes);
+    let estimates = explain(ctx, params, &mut filter.clone(), plane);
 
     let n = estimates.len();
     let mut trials_ns: Vec<Vec<u64>> = vec![Vec::with_capacity(num_trials); n];
@@ -6889,10 +6785,7 @@ fn explain_analyze(
             let plan = estimates[idx].plan;
             let mut round_filter = filter.clone();
             let t0 = std::time::Instant::now();
-            let ran = run_query_with_plan(
-                plan, cards, printings, offsets, strings, &mut round_filter, plane,
-                unique, prefer, orderby, direction, limit, page_offset, indexes,
-            );
+            let ran = run_query_with_plan(plan, ctx, params, &mut round_filter, plane);
             let dt = t0.elapsed().as_nanos() as u64;
             // A structurally-applicable plan's fastpath can still decline at runtime
             // (e.g. PrintingCompose on a sparse total) — deterministic for this
@@ -6919,22 +6812,18 @@ fn explain_analyze(
 /// True (e.g. `t:creature power>3`, residual = `power>3`) still go through
 /// `run_query_streamed`'s Step-1-improved-but-not-popcount path — extending
 /// this to non-True residuals is a reasonable fast-follow, not required here.
-#[allow(clippy::too_many_arguments)]
 fn run_query_streamed_popcount<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    prefer: Prefer,
-    limit: usize,
-    page_offset: usize,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     perm: &Archived<Vec<u32>>,
     inv_perm: &Archived<Vec<u32>>,
     bitmap: &[u64],
     plane: Option<&PlaneExpr>,
-    planes: &Archived<BitPlanes>,
-    strings: &AStrings,
     range_bits: Option<&[u64]>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
+    let QueryParams { prefer, limit, page_offset, .. } = *params;
+    let planes = &indexes.planes;
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
     if total == 0 || page_offset >= total {
@@ -7048,27 +6937,20 @@ fn run_query_streamed_popcount<'a>(
 /// Streamed selection: match phase records per-card match counts (total is
 /// their sum), then either gathers (small totals — byte-identical to the
 /// gathered path) or walks the orderby permutation emitting only page cards.
-#[allow(clippy::too_many_arguments)]
 fn run_query_streamed<'a>(
-    cards: &'a [AOracleCard],
-    printings: &'a [APrinting],
-    offsets: &AOffsets,
-    strings: &AStrings,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
     filter: &FilterExpr,
     all_match_known: bool,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    limit: usize,
-    page_offset: usize,
     perm: &Archived<Vec<u32>>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
-    artwork_groups: &Archived<Vec<u16>>,
-    artwork_group_col: &Archived<Vec<u16>>,
-    max_artwork_groups: u16,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let artwork_groups = &indexes.artwork_groups;
+    let artwork_group_col = &indexes.artwork_group_col;
+    let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
     let mut seen_words = [0u64; ARTWORK_GROUP_WORDS]; // #629: artwork-mode match-count scratch
@@ -7920,10 +7802,8 @@ impl QueryEngine {
         // bind_and_split_filter.
         let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
 
-        let (total, page) = run_query(
-            &data.cards, &data.printings, &data.offsets, &data.strings, &mut filter_expr, plane_expr.as_ref(),
-            unique, prefer, orderby, direction, limit, offset, &data.indexes,
-        );
+        let ctx = QueryCtx::from(data);
+        let (total, page) = run_query(&ctx, &mut filter_expr, plane_expr.as_ref(), unique, prefer, orderby, direction, limit, offset);
 
         let matches: Vec<Bound<PyDict>> = page
             .iter()
@@ -7943,7 +7823,7 @@ impl QueryEngine {
     /// here is the router's coarse pre-materialize estimate, and the router may
     /// lazily re-materialize and re-choose on exact features at dispatch — so the
     /// executed plan can differ from `result[0]`. See the free `explain` fn's doc.
-    #[allow(clippy::too_many_arguments)]
+        #[allow(clippy::too_many_arguments)] // the PyO3 keyword surface; the free `explain` fn it calls takes 4
     #[pyo3(signature = (*, filters, unique="card", orderby="edhrec", direction="asc", limit=100, offset=0))]
     fn explain<'py>(
         &self,
@@ -7960,13 +7840,20 @@ impl QueryEngine {
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
 
-        let sort_col = orderby_to_col(orderby);
-        let descending = direction == "desc";
-        let mode = mode_from_unique(unique);
-        let estimates = explain(
-            &data.cards, &data.printings, &data.offsets, &data.strings, &mut filter_expr, plane_expr.as_ref(),
-            mode, sort_col, descending, limit, offset, &data.indexes,
-        );
+        // This method's signature has never taken `prefer` (it predates #757), and
+        // substituting the default here is behavior-preserving *for what explain
+        // reports*: `cost::plan_cost`/`PlanFeatures` don't read `prefer` at all, so
+        // both the argmin and every `predicted_ns` are prefer-blind regardless of what
+        // is passed. That is a gap in the cost model, not a property of execution —
+        // `prefer` genuinely changes the work done (it picks each card's representative
+        // printing, and `Prefer::Default` specifically lets `gather_composed_page`
+        // early-break on the first set printing instead of scoring every printing of
+        // the card, and `run_query_streamed_popcount` likewise). So an `explain` for a
+        // non-default `prefer` predicts the same numbers while the real query would do
+        // more per-card work. `explain_analyze` does take `prefer` and really runs the
+        // plans, so its `trials_ns` reflect it even though its `predicted_ns` doesn't.
+        let params = QueryParams::from_strs(unique, "default", orderby, direction, limit, offset);
+        let estimates = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
         PyList::new(py, rows)
@@ -8002,12 +7889,9 @@ impl QueryEngine {
         // runs plans × (warmups + trials) executions, so a long explain_analyze
         // shouldn't block other Python threads. The bind above and the PyDict
         // conversion below stay on the GIL.
-        let trials = py.detach(|| {
-            explain_analyze(
-                &data.cards, &data.printings, &data.offsets, &data.strings, &filter_expr, plane_expr.as_ref(),
-                unique, prefer, orderby, direction, limit, offset, &data.indexes, num_warmups, num_trials,
-            )
-        });
+        let ctx = QueryCtx::from(data);
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let trials = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;
         PyList::new(py, rows)

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -9,7 +9,7 @@ use super::{
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
-    prepare_candidates, verify_cost_tier, scan_units, Mode,
+    prepare_candidates, verify_cost_tier, scan_units, Mode, QueryCtx, QueryParams, Prefer,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -24,6 +24,30 @@ use std::sync::OnceLock;
 // Trait bringing random_range/random_bool/random into scope for the #677 fuzzer
 // helpers below (SmallRng's inherent methods live on this extension trait).
 use rand::RngExt;
+
+/// `QueryParams` for a test driving `explain`, whose only meaningful inputs are
+/// `mode` and `limit`/`offset`: `prefer` is not read by the cost model at all
+/// (`cost::PlanFeatures` has no such field), and `SortCol::EdhrecRank`/ascending
+/// is the default orderby these tests were written against.
+fn explain_params(mode: Mode, limit: usize) -> QueryParams {
+    QueryParams { mode, prefer: Prefer::Default, sort_col: SortCol::EdhrecRank, descending: false, limit, page_offset: 0 }
+}
+
+/// `QueryParams` from the enum-space inputs a kernel-level test drives directly
+/// (rather than through the string surface `QueryParams::from_strs` adapts).
+/// `prefer` is `Default` — the value every one of these call sites passed
+/// explicitly before the bundle.
+fn kernel_params(mode: Mode, sort_col: SortCol, descending: bool, limit: usize, page_offset: usize) -> QueryParams {
+    QueryParams { mode, prefer: Prefer::Default, sort_col, descending, limit, page_offset }
+}
+
+/// `QueryParams` for a test calling a function that reads only `mode` —
+/// `prepare_candidates` narrows and rewrites the filter without consulting the
+/// orderby or the page. The remaining fields are inert for such a call; if a
+/// callee ever starts reading them, that is a signal to pass real values here.
+fn mode_only_params(mode: Mode) -> QueryParams {
+    explain_params(mode, 100)
+}
 
 /// String-sorted permutation of the vocab ids, as reload_commit builds it.
 fn sorted_vocab_ids(vocab: &[String]) -> Vec<u16> {
@@ -687,10 +711,7 @@ fn rarity_shared_witness_declines_same_field_and_cross_field() {
     // mythic, so it must be zero, not a false positive from independently
     // narrowing each fact.
     let mut residual_check = cross_field;
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual_check, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut residual_check, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 0, "no card in this fixture is both format-A-legal and mythic");
 }
 
@@ -1187,10 +1208,7 @@ fn legality_cross_status_shared_witness_falls_back_to_correct_result() {
     assert!(plane.is_none(), "shared-witness AND must not partially promote either leaf into the plane");
     assert!(matches!(residual, FilterExpr::And(_)), "both legality children must remain in the residual");
 
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 0, "no single printing is both banned and restricted in C at once");
 }
 
@@ -1215,10 +1233,7 @@ fn banned_plane_row_selection_preserves_divergent_printing_correctness() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let run = |filter: &mut FilterExpr, unique: &str| {
-        run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            filter, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        )
+        run_query(&QueryCtx::from(archived), filter, None, unique, "default", "edhrec", "asc", 100, 0)
     };
 
     // banned:C, unique=printing: exactly the one banned printing.
@@ -1264,10 +1279,7 @@ fn legal_plane_narrowing_preserves_divergent_printing_correctness() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let run = |filter: &mut FilterExpr, unique: &str| {
-        run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            filter, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        )
+        run_query(&QueryCtx::from(archived), filter, None, unique, "default", "edhrec", "asc", 100, 0)
     };
 
     // f:A, unique=printing: exactly the one legal printing, not the not-legal one.
@@ -1390,10 +1402,7 @@ fn legality_plane_promotion_respects_mode_through_split_planes() {
             assert!(plane.is_none(), "unique=printing/artwork must decline the fold, not just patch around it");
             assert!(matches!(residual, FilterExpr::Legality { .. }), "the original Legality node must survive for per-printing verification");
         }
-        run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut residual, plane.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        )
+        run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), unique, "default", "edhrec", "asc", 100, 0)
     };
 
     let (total, page) = run_mode("printing");
@@ -1442,10 +1451,7 @@ fn legality_compound_and_respects_row_selection_for_unique_card() {
     assert!(plane.is_some(), "format:A AND t:creature (one format, no shared-witness issue) must compile whole");
     assert!(matches!(residual, FilterExpr::True));
 
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1);
     assert_eq!(
         u128::from(page[0].1.scryfall_id),
@@ -1489,10 +1495,7 @@ fn legality_and_date_residual_must_be_checked_together() {
         "date> isn't plane-compilable, so it must remain a real residual, not collapse to True"
     );
 
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 0, "no single printing is both legal in A and released after the cutoff");
 }
 
@@ -2449,17 +2452,11 @@ fn fuzz_check_case(archived: &Archived<CardData>, spec: &FuzzSpec, ctx: &str, or
         // Full page (offset 0): total + every row satisfies. Unplaned = raw filter, plane = None;
         // plane path = split_planes + the promoted plane (unique_is_card matches the real caller).
         let mut plain = fuzz_bound_filter(spec, archived);
-        let (t0, p0) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, strings,
-            &mut plain, None, mode, "default", orderby, direction, full_limit, 0, &archived.indexes,
-        );
+        let (t0, p0) = run_query(&QueryCtx::from(archived), &mut plain, None, mode, "default", orderby, direction, full_limit, 0);
         let (pe, mut residual) = split_planes(
             fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
         );
-        let (t1, p1) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, strings,
-            &mut residual, pe.as_ref(), mode, "default", orderby, direction, full_limit, 0, &archived.indexes,
-        );
+        let (t1, p1) = run_query(&QueryCtx::from(archived), &mut residual, pe.as_ref(), mode, "default", orderby, direction, full_limit, 0);
 
         assert_eq!(t0, expected, "unplaned total mismatch (mode={mode}, orderby={orderby}, dir={direction}, {ctx})");
         assert_eq!(t1, expected, "plane-path total mismatch (mode={mode}, orderby={orderby}, dir={direction}, {ctx})");
@@ -2476,10 +2473,7 @@ fn fuzz_check_case(archived: &Archived<CardData>, spec: &FuzzSpec, ctx: &str, or
             let (full0, full1) = (ids(&p0), ids(&p1));
 
             let mut plain_pg = fuzz_bound_filter(spec, archived);
-            let (_, pg0) = run_query(
-                &archived.cards, &archived.printings, &archived.offsets, strings,
-                &mut plain_pg, None, mode, "default", orderby, direction, plimit, offset, &archived.indexes,
-            );
+            let (_, pg0) = run_query(&QueryCtx::from(archived), &mut plain_pg, None, mode, "default", orderby, direction, plimit, offset);
             assert_eq!(
                 ids(&pg0), full0[offset..offset + plimit].to_vec(),
                 "unplaned pagination slice mismatch (mode={mode}, orderby={orderby}, dir={direction}, offset={offset}, {ctx})",
@@ -2489,10 +2483,7 @@ fn fuzz_check_case(archived: &Archived<CardData>, spec: &FuzzSpec, ctx: &str, or
             let (pe_pg, mut residual_pg) = split_planes(
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
             );
-            let (_, pg1) = run_query(
-                &archived.cards, &archived.printings, &archived.offsets, strings,
-                &mut residual_pg, pe_pg.as_ref(), mode, "default", orderby, direction, plimit, offset, &archived.indexes,
-            );
+            let (_, pg1) = run_query(&QueryCtx::from(archived), &mut residual_pg, pe_pg.as_ref(), mode, "default", orderby, direction, plimit, offset);
             assert_eq!(
                 ids(&pg1), full1[offset..offset + plimit].to_vec(),
                 "plane pagination slice mismatch (mode={mode}, orderby={orderby}, dir={direction}, offset={offset}, {ctx})",
@@ -2522,18 +2513,12 @@ fn fuzz_check_row_identity(
         }
     };
     let mut plain = fuzz_bound_filter(spec, archived);
-    let (_, p0) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, strings,
-        &mut plain, None, mode, "default", orderby, direction, limit, offset, &archived.indexes,
-    );
+    let (_, p0) = run_query(&QueryCtx::from(archived), &mut plain, None, mode, "default", orderby, direction, limit, offset);
     check(&p0, "unplaned");
     let (pe, mut residual) = split_planes(
         fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, mode == "card",
     );
-    let (_, p1) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, strings,
-        &mut residual, pe.as_ref(), mode, "default", orderby, direction, limit, offset, &archived.indexes,
-    );
+    let (_, p1) = run_query(&QueryCtx::from(archived), &mut residual, pe.as_ref(), mode, "default", orderby, direction, limit, offset);
     check(&p1, "plane path");
 }
 
@@ -2961,7 +2946,6 @@ fn force_plan_differential_agreement() {
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
-    let strings = &archived.strings;
     // Same rows regardless of tie order.
     let id_multiset = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
         let mut v: Vec<u128> = page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
@@ -2999,8 +2983,8 @@ fn force_plan_differential_agreement() {
                     fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
                 );
                 let (ref_total, ref_page) = run_query_with_plan(
-                    PhysicalPlan::GatheredScan, &archived.cards, &archived.printings, &archived.offsets, strings,
-                    &mut ref_res, ref_pe.as_ref(), mode, prefer, orderby, direction, full_limit, 0, &archived.indexes,
+                    PhysicalPlan::GatheredScan, &QueryCtx::from(archived),
+                    &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0), &mut ref_res, ref_pe.as_ref(),
                 )
                 .expect("GatheredScan is always applicable");
                 ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
@@ -3015,8 +2999,8 @@ fn force_plan_differential_agreement() {
                         fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
                     );
                     let out = run_query_with_plan(
-                        plan, &archived.cards, &archived.printings, &archived.offsets, strings,
-                        &mut res, pe.as_ref(), mode, prefer, orderby, direction, full_limit, 0, &archived.indexes,
+                        plan, &QueryCtx::from(archived),
+                        &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0), &mut res, pe.as_ref(),
                     );
                     let Some((total, page)) = out else { continue };
                     ran[plan_idx(plan)] += 1;
@@ -3074,8 +3058,7 @@ fn explain_reports_ranked_applicable_plans() {
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
             );
             let estimates: Vec<PlanEstimate> = explain(
-                &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &mut filter, pe.as_ref(),
-                mode, SortCol::EdhrecRank, false, 60, 0, &archived.indexes,
+                &QueryCtx::from(archived), &explain_params(mode, 60), &mut filter, pe.as_ref(),
             );
 
             assert!(!estimates.is_empty(), "GatheredScan is always applicable ({mode_label}, {})", fuzz_describe(spec));
@@ -3119,14 +3102,13 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
         bound.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
     );
     let reference: Vec<PlanEstimate> = explain(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &mut ref_filter, ref_pe.as_ref(),
-        Mode::Card, SortCol::EdhrecRank, false, 60, 0, &archived.indexes,
+        &QueryCtx::from(archived), &explain_params(Mode::Card, 60), &mut ref_filter, ref_pe.as_ref(),
     );
 
     let (pe, filter) = split_planes(bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
     let trials: Vec<PlanTrial> = explain_analyze(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &filter, pe.as_ref(),
-        "card", "default", "edhrec", "asc", 60, 0, &archived.indexes, NUM_WARMUPS, NUM_TRIALS,
+        &QueryCtx::from(archived), &QueryParams::from_strs("card", "default", "edhrec", "asc", 60, 0),
+        &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS,
     );
 
     assert_eq!(trials.len(), reference.len(), "explain_analyze must cover exactly the plans explain() reports");
@@ -3368,8 +3350,8 @@ fn plan_cost_calibration() {
                         );
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
-                            *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                            &mut res, pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                            *plan, &QueryCtx::from(archived),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out {
@@ -3491,8 +3473,8 @@ fn plan_cost_model_matches_gold() {
                         );
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
-                            *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                            &mut res, pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                            *plan, &QueryCtx::from(archived),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out {
@@ -3513,7 +3495,7 @@ fn plan_cost_model_matches_gold() {
                     &archived.indexes.oracle_trigram.words, unique_is_card,
                 );
                 let prep = prepare_candidates(
-                    &archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), mode_enum, &archived.indexes,
+                    &QueryCtx::from(archived), &mode_only_params(mode_enum), &mut res, pe.as_ref(),
                 );
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
                 // Tier reflects the residual AFTER memoize (what the walk pays).
@@ -3733,8 +3715,8 @@ fn plan_cost_refit() {
                         );
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
-                            *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                            &mut res, pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                            *plan, &QueryCtx::from(archived),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { best = best.min(dt); } } None => break }
@@ -3746,7 +3728,7 @@ fn plan_cost_refit() {
                     fuzz_bound_filter(spec, archived), &archived.indexes.planes,
                     &archived.indexes.oracle_trigram.words, unique_is_card,
                 );
-                let prep = prepare_candidates(&archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), mode_enum, &archived.indexes);
+                let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(mode_enum), &mut res, pe.as_ref());
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
                 let feats = PlanFeatures {
                     n_cards, n_printings, matches: total as u32, eval_domain,
@@ -3922,8 +3904,8 @@ fn printing_range_route_probe() {
                     );
                     let t0 = Instant::now();
                     let out = black_box(run_query_with_plan(
-                        *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                        &mut res, pe.as_ref(), "printing", "default", "edhrec", "asc", LIMIT, offset, &archived.indexes,
+                        *plan, &QueryCtx::from(archived),
+                        &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, pe.as_ref(),
                     ));
                     let dt = t0.elapsed().as_nanos() as u64;
                     match out {
@@ -3943,7 +3925,7 @@ fn printing_range_route_probe() {
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes,
                 &archived.indexes.oracle_trigram.words, false,
             );
-            let prep = prepare_candidates(&archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), Mode::Printing, &archived.indexes);
+            let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Printing), &mut res, pe.as_ref());
             let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
             let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
             let feats = PlanFeatures {
@@ -4144,8 +4126,8 @@ fn idea1_vs_idea2_probe() {
                 let (pe, mut res) = split_planes(fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, false);
                 let t0 = Instant::now();
                 let out = black_box(run_query_with_plan(
-                    PhysicalPlan::PrintingRangeScan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                    &mut res, pe.as_ref(), "printing", "default", "edhrec", "asc", LIMIT, offset, &archived.indexes,
+                    PhysicalPlan::PrintingRangeScan, &QueryCtx::from(archived),
+                    &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, pe.as_ref(),
                 ));
                 let dt = t0.elapsed().as_nanos() as u64;
                 match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { i1 = i1.min(dt); } } None => break }
@@ -4276,8 +4258,8 @@ fn plan_regret_report() {
                     );
                     let t0 = Instant::now();
                     let out = black_box(run_query_with_plan(
-                        *plan, &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                        &mut res, pe.as_ref(), "card", "default", "edhrec", "asc", limit, offset, &archived.indexes,
+                        *plan, &QueryCtx::from(archived),
+                        &QueryParams::from_strs("card", "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
                     ));
                     let dt = t0.elapsed().as_nanos() as u64;
                     match out {
@@ -4298,9 +4280,7 @@ fn plan_regret_report() {
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes,
                 &archived.indexes.oracle_trigram.words, true,
             );
-            let prep = prepare_candidates(
-                &archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), Mode::Card, &archived.indexes,
-            );
+            let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Card), &mut res, pe.as_ref());
             let tier = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
 
             // ── Router's belief: cardinality from `est`, structure `tier` actual. ──
@@ -4420,9 +4400,7 @@ fn plan_regret_fuzz() {
         let (pe, mut res) = split_planes(
             fuzz_bound_filter(&spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
         );
-        let prep = prepare_candidates(
-            &archived.cards, &archived.offsets, &archived.strings, &mut res, pe.as_ref(), Mode::Card, &archived.indexes,
-        );
+        let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Card), &mut res, pe.as_ref());
         let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
         let tier = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
 
@@ -4532,10 +4510,7 @@ fn legality_shared_witness_and_falls_back_to_correct_result() {
     assert!(plane.is_none(), "shared-witness AND must not partially promote either leaf into the plane");
     assert!(matches!(residual, FilterExpr::And(_)), "both legality children must remain in the residual");
 
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 0, "no single printing is legal in both A and B at once");
 }
 
@@ -4643,10 +4618,7 @@ fn run_query_walk_dedups_and_prefers() {
 
     let mut creatures = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
     let mut run = |unique: &str, prefer: &str| {
-        run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut creatures, None, unique, prefer, "edhrec", "asc", 100, 0, &archived.indexes,
-        )
+        run_query(&QueryCtx::from(archived), &mut creatures, None, unique, prefer, "edhrec", "asc", 100, 0)
     };
 
     // unique=card, default prefer: one result per matching card; the walk's
@@ -4688,10 +4660,7 @@ fn run_query_artwork_groups_shared_illustrations() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let mut all = FilterExpr::True;
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut all, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut all, None, "artwork", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 3); // illustrations {1, 2, 4}
     // Group {printings 0, 2}: printing 0 has the higher prefer score (desc order)
     // and must be the group's representative.
@@ -5128,10 +5097,7 @@ fn all_match_promotion_never_fires_for_printing_space_tight_results() {
         op: CmpOp::Eq,
         rhs: NumExpr::Const(100.0),
     };
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut cn_eq_100, None, "printing", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut cn_eq_100, None, "printing", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1, "cn=100 must match exactly one printing, not both of card 0's printings");
     assert_eq!(u128::from(page[0].1.scryfall_id), 1); // the cn=100 printing specifically
 
@@ -5142,10 +5108,7 @@ fn all_match_promotion_never_fires_for_printing_space_tight_results() {
         op: CmpOp::Eq,
         rhs: NumExpr::Const(100.0),
     };
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut cn_eq_100b, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut cn_eq_100b, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1);
     assert_eq!(u128::from(page[0].0.oracle_id), 1);
 }
@@ -5173,10 +5136,7 @@ fn all_match_promotion_correct_for_card_space_exact_predicate() {
         op: CmpOp::Gt,
         rhs: NumExpr::Const(3.0),
     };
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut power_gt_3, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut power_gt_3, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1); // only card0 (power 5)
 
     let mut power_gt_3p = FilterExpr::NumericCmp {
@@ -5184,10 +5144,7 @@ fn all_match_promotion_correct_for_card_space_exact_predicate() {
         op: CmpOp::Gt,
         rhs: NumExpr::Const(3.0),
     };
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut power_gt_3p, None, "printing", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut power_gt_3p, None, "printing", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 2); // card0's 2 printings, all matching (power is card-level)
 }
 
@@ -5237,10 +5194,7 @@ fn popcount_skip_tie_breaking_preserves_group_order_both_directions() {
     assert!(matches!(residual, FilterExpr::True), "t:creature must fully plane-consume");
 
     let mut run = |direction: &str| {
-        run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut residual, plane.as_ref(), "card", "default", "cmc", direction, 100, 0, &archived.indexes,
-        )
+        run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "cmc", direction, 100, 0)
     };
 
     let (total, page) = run("asc");
@@ -5275,19 +5229,13 @@ fn popcount_skip_offset_lands_inside_tied_group() {
 
     // Full ascending order is [card3, card1, card0, card2, card4] (oracle ids
     // [4,2,1,3,5]); offset=2 must skip card3 and card1, landing on card0.
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, plane.as_ref(), "card", "default", "cmc", "asc", 100, 2, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "cmc", "asc", 100, 2);
     assert_eq!(total, 5);
     let order: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
     assert_eq!(order, vec![1, 3, 5]);
 
     // offset at exactly total must yield an empty page, not panic.
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, plane.as_ref(), "card", "default", "cmc", "asc", 100, 5, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut residual, plane.as_ref(), "card", "default", "cmc", "asc", 100, 5);
     assert_eq!(total, 5);
     assert!(page.is_empty());
 }
@@ -5308,18 +5256,12 @@ fn popcount_skip_matches_non_popcount_path() {
     assert!(matches!(residual_true, FilterExpr::True));
 
     // Popcount path: plane present, residual True.
-    let (total_pc, page_pc) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual_true, plane.as_ref(), "card", "default", "cmc", "desc", 100, 1, &archived.indexes,
-    );
+    let (total_pc, page_pc) = run_query(&QueryCtx::from(archived), &mut residual_true, plane.as_ref(), "card", "default", "cmc", "desc", 100, 1);
 
     // Non-popcount path: same logical filter, but passed as a real predicate
     // (not pre-consumed to True) with no plane, forcing the counts-buffer path.
     let mut creature_raw = FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge };
-    let (total_old, page_old) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut creature_raw, None, "card", "default", "cmc", "desc", 100, 1, &archived.indexes,
-    );
+    let (total_old, page_old) = run_query(&QueryCtx::from(archived), &mut creature_raw, None, "card", "default", "cmc", "desc", 100, 1);
 
     assert_eq!(total_pc, total_old);
     let ids_pc: Vec<u128> = page_pc.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
@@ -5420,14 +5362,8 @@ fn streamed_selection_matches_gathered() {
                         // Fresh filter per store: run_query may memoize text
                         // predicates into store-specific string ids, so a
                         // filter must never outlive the store it ran against.
-                        let (tg, pg) = run_query(
-                            &gathered.cards, &gathered.printings, &gathered.offsets, &gathered.strings,
-                            &mut filt(), None, unique, prefer, orderby, direction, 10, offset, &gathered.indexes,
-                        );
-                        let (ts, ps) = run_query(
-                            &streamed.cards, &streamed.printings, &streamed.offsets, &streamed.strings,
-                            &mut filt(), None, unique, prefer, orderby, direction, 10, offset, &streamed.indexes,
-                        );
+                        let (tg, pg) = run_query(&QueryCtx::from(gathered), &mut filt(), None, unique, prefer, orderby, direction, 10, offset);
+                        let (ts, ps) = run_query(&QueryCtx::from(streamed), &mut filt(), None, unique, prefer, orderby, direction, 10, offset);
                         let ids = |v: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<(u128, u128)> {
                             v.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
                         };
@@ -5488,10 +5424,7 @@ fn artwork_group_ids_handle_more_than_64_groups() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let mut filter = usd_cmp(CmpOp::Lt, 50.0);
-    let (total, page) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut filter, None, "artwork", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, page) = run_query(&QueryCtx::from(archived), &mut filter, None, "artwork", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 69); // every group has >= 1 passing printing
     let chosen: Vec<u128> = page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
     // store_of assigns scryfall_id = printing index + 1, so printing 0 is
@@ -6117,21 +6050,7 @@ fn negated_range_narrowing() {
     // alone on a corpus this tiny.
     let usd_lt_5 = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::PriceUsd), op: CmpOp::Lt, rhs: NumExpr::Const(5.0) };
     let mut compound = FilterExpr::And(vec![not_usd_lt_25, usd_lt_5]);
-    let (total, page) = super::run_query(
-        &archived.cards,
-        &archived.printings,
-        &archived.offsets,
-        &archived.strings,
-        &mut compound,
-        None,
-        "printing",
-        "default",
-        "edhrec",
-        "asc",
-        100,
-        0,
-        &archived.indexes,
-    );
+    let (total, page) = super::run_query(&QueryCtx::from(archived), &mut compound, None, "printing", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1);
     assert_eq!(page.len(), 1);
     let got_cents = page[0].1.price_usd.as_ref().map(|v| u32::from(*v));
@@ -6362,7 +6281,6 @@ fn orderby_walk_matches_gather_composed() {
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let n_printings = archived.printings.len();
-    let mga = u16::from(archived.indexes.max_artwork_groups);
 
     let border = |v: &str| FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: v.to_string() };
     let leg = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
@@ -6386,8 +6304,7 @@ fn orderby_walk_matches_gather_composed() {
                 for &offset in &[0usize, 50, 200] {
                     let limit = 100usize;
                     let gather = super::gather_composed_page(
-                        Mode::Printing, &archived.cards, &archived.printings, &archived.offsets, &pbits,
-                        super::Prefer::Default, sort_col, descending, limit, offset, mga,
+                        &QueryCtx::from(archived), &kernel_params(Mode::Printing, sort_col, descending, limit, offset), &pbits,
                     );
                     let walk = match sort_col {
                         SortCol::PriceUsd => super::walk_range_orderby_page(
@@ -6651,15 +6568,9 @@ fn run_query_plane_path_parity() {
     for make in &filters {
         for unique in ["card", "printing", "artwork"] {
             let mut plain = make();
-            let (t0, p0) = run_query(
-                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-            );
+            let (t0, p0) = run_query(&QueryCtx::from(archived), &mut plain, None, unique, "default", "edhrec", "asc", 100, 0);
             let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
-            let (t1, p1) = run_query(
-                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-            );
+            let (t1, p1) = run_query(&QueryCtx::from(archived), &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0);
             assert_eq!(t0, t1, "totals must agree (unique={unique})");
             let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
                 page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
@@ -6934,15 +6845,9 @@ fn run_query_numeric_plane_path_parity() {
     for make in &filters {
         for unique in ["card", "printing", "artwork"] {
             let mut plain = make();
-            let (t0, p0) = run_query(
-                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                &mut plain, None, unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-            );
+            let (t0, p0) = run_query(&QueryCtx::from(archived), &mut plain, None, unique, "default", "edhrec", "asc", 100, 0);
             let (pe, mut residual) = split_planes(make(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
-            let (t1, p1) = run_query(
-                &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0, &archived.indexes,
-            );
+            let (t1, p1) = run_query(&QueryCtx::from(archived), &mut residual, pe.as_ref(), unique, "default", "edhrec", "asc", 100, 0);
             assert_eq!(t0, t1, "totals must agree (unique={unique})");
             let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<u128> {
                 page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
@@ -7083,10 +6988,7 @@ fn run_query_memoizes_only_full_scans() {
     };
 
     let mut f = FilterExpr::Or(vec![oracle("draw"), broad_sibling()]);
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut f, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 6, "every card matches the Or (empty keywords pass Le)");
     match &f {
         FilterExpr::Or(children) => assert!(
@@ -7098,10 +7000,7 @@ fn run_query_memoizes_only_full_scans() {
 
     // Narrowable single predicate: candidates exist, no rewrite.
     let mut g = oracle("draw");
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut g, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut g, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1);
     assert!(matches!(g, FilterExpr::TextContains { .. }), "narrowable query stays unrewritten");
 }
@@ -7475,19 +7374,13 @@ fn border_shared_witness_correctness() {
     );
 
     let mut f = and_both;
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut f, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 0, "unplaned: no printing is both black and borderless");
 
     let (pe, mut residual) = split_planes(
         FilterExpr::And(vec![border("black"), border("borderless")]), bounds, words, true,
     );
-    let (total2, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut residual, pe.as_ref(), "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total2, _) = run_query(&QueryCtx::from(archived), &mut residual, pe.as_ref(), "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total2, 0, "planed: falls back to the same correct zero result, not a false positive from independent narrowing");
 }
 
@@ -7816,10 +7709,7 @@ fn adaptive_narrowing_run_query_parity() {
             })
             .count();
         let mut f2 = f;
-        let (total, _) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut f2, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        );
+        let (total, _) = run_query(&QueryCtx::from(archived), &mut f2, None, "card", "default", "edhrec", "asc", 100, 0);
         assert_eq!(total, brute, "narrowing must stay advisory-sound");
     }
 }
@@ -7856,10 +7746,7 @@ fn not_over_partial_and_is_blocked() {
         })
         .count();
     let mut f = FilterExpr::Not(Box::new(FilterExpr::And(vec![goblin(), unindexable()])));
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut f, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, brute);
     assert_eq!(total, 6, "every card matches -(goblin and name:q)");
 }
@@ -7883,10 +7770,7 @@ fn not_over_price_range_keeps_boundary_matches() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let mut f = FilterExpr::Not(Box::new(usd_cmp(CmpOp::Gt, 5.0)));
-    let (total, _) = run_query(
-        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-        &mut f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-    );
+    let (total, _) = run_query(&QueryCtx::from(archived), &mut f, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, 1, "the boundary-priced card matches -usd>5 and must not be complemented away");
 }
 
@@ -7978,10 +7862,7 @@ fn name_bigrams_compose_and_memoize() {
             })
             .count();
         let mut f2 = f;
-        let (total, _) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut f2, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        );
+        let (total, _) = run_query(&QueryCtx::from(archived), &mut f2, None, "card", "default", "edhrec", "asc", 100, 0);
         assert_eq!(total, brute);
     }
 
@@ -8284,10 +8165,7 @@ fn exact_name_narrows_tight() {
             .iter()
             .filter(|c| f.eval_card(c, &archived.strings) == Tri::True)
             .count();
-        let (total, _) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            f, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        );
+        let (total, _) = run_query(&QueryCtx::from(archived), f, None, "card", "default", "edhrec", "asc", 100, 0);
         assert_eq!(total, brute, "totals parity for shape {i}");
     }
 }
@@ -8344,10 +8222,7 @@ fn order_name_sorts_and_paginates() {
 
     let run = |direction: &str, limit: usize, offset: usize| -> Vec<String> {
         let mut all = FilterExpr::True;
-        let (total, page) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut all, None, "card", "default", "name", direction, limit, offset, &archived.indexes,
-        );
+        let (total, page) = run_query(&QueryCtx::from(archived), &mut all, None, "card", "default", "name", direction, limit, offset);
         assert_eq!(total, 6);
         page.iter().map(|(c, _)| c.card_name_lower.as_str().to_string()).collect()
     };
@@ -8361,10 +8236,7 @@ fn order_name_sorts_and_paginates() {
     // in both directions: card 3 (rank 20) before card 0 (rank 60).
     let ids = |direction: &str| -> Vec<u128> {
         let mut all = FilterExpr::True;
-        let (_, page) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut all, None, "card", "default", "name", direction, 100, 0, &archived.indexes,
-        );
+        let (_, page) = run_query(&QueryCtx::from(archived), &mut all, None, "card", "default", "name", direction, 100, 0);
         page.iter()
             .filter(|(c, _)| c.card_name_lower.as_str() == "sol ring")
             .map(|(c, _)| u128::from(c.oracle_id))
@@ -8579,10 +8451,7 @@ fn verify_order_spellings_agree_end_to_end() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
 
     let run = |mut filter: FilterExpr| {
-        let (total, page) = run_query(
-            &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-            &mut filter, None, "card", "default", "edhrec", "asc", 100, 0, &archived.indexes,
-        );
+        let (total, page) = run_query(&QueryCtx::from(archived), &mut filter, None, "card", "default", "edhrec", "asc", 100, 0);
         let ids: Vec<u128> = page.iter().map(|(c, _)| u128::from(c.oracle_id)).collect();
         (total, ids)
     };
@@ -9114,9 +8983,7 @@ fn range_compose_kernel_costs() {
         // (3) grouped card walk: fill one page of best-representative rows in edhrec order.
         let (walk_ns, _) = bench(&mut || {
             let page = super::walk_grouped_page(
-                super::Mode::Card, &archived.cards, &archived.printings, offsets, &pbits,
-                super::Prefer::Default, super::SortCol::EdhrecRank, false, LIMIT, 0, perm,
-                u16::from(archived.indexes.max_artwork_groups),
+                &QueryCtx::from(archived), &kernel_params(Mode::Card, SortCol::EdhrecRank, false, LIMIT, 0), &pbits, perm,
             );
             page.len() as u64
         });
@@ -9292,7 +9159,7 @@ fn printing_range_walk_matches_naive_page() {
                 let perm = archived.indexes.sort_perms.get(sc, desc).expect("perm exists");
                 for &(off, lim) in &[(0usize, 10usize), (0, 100), (5, 20), (50, 50), (300, 25)] {
                     let got = walk_printing_page(
-                        &archived.cards, &archived.printings, &archived.offsets, &archived.strings, &leaf, sc, desc, lim, off, perm,
+                        &QueryCtx::from(archived), &kernel_params(Mode::Printing, sc, desc, lim, off), &leaf, perm,
                     );
                     let want = naive_printing_page(&archived, &leaf, sc, desc, off, lim);
                     assert_eq!(page_scryfall_ids(&got), want, "walk seed {seed} desc {desc} off {off} lim {lim}");
@@ -9369,8 +9236,7 @@ fn printing_range_fastpath_gates_card_walk_at_stream_threshold() {
         let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
         let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
         let leaf = usd_cmp(CmpOp::Lt, 50.0);
-        let ix = &archived.indexes;
-        let fp = |sc| printing_range_fastpath(&archived.cards, &archived.printings, &archived.offsets, &archived.strings, &leaf, ix, sc, false, 100, 0);
+        let fp = |sc| printing_range_fastpath(&QueryCtx::from(archived), &kernel_params(Mode::Printing, sc, false, 100, 0), &leaf);
         // Every printing is priced $1 < $50, so the true match count is n; when the fastpath fires
         // its reported total must equal it (total == k == match count), end to end.
         match fp(SortCol::EdhrecRank) {
@@ -9427,10 +9293,7 @@ fn router_timing() {
                     let full = fuzz_bound_filter(spec, archived);
                     let t0 = Instant::now();
                     let (_pe, mut res) = split_planes(full, planes, words, uic);
-                    let out = run_query(
-                        &archived.cards, &archived.printings, &archived.offsets, &archived.strings,
-                        &mut res, _pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset, &archived.indexes,
-                    );
+                    let out = run_query(&QueryCtx::from(archived), &mut res, _pe.as_ref(), mode, "default", "edhrec", "asc", limit, offset);
                     let dt = t0.elapsed().as_nanos() as u64;
                     black_box(&out.1);
                     if it >= WARMUP {

--- a/docs/issues/00757-engine-query-ctx-arg-bundle.md
+++ b/docs/issues/00757-engine-query-ctx-arg-bundle.md
@@ -1,26 +1,19 @@
-# Engine: Bundle the Store/Index Slice Args into a `QueryCtx`
+# Engine: Bundle the Plan-Selection Layer's Repeated Args into Two Borrow Structs
 
-Status: proposed, not yet implemented. Tracked as #757. Filed from the #752
-([00745-engine-explain-analyze.md](done/00745-engine-explain-analyze.md)) review — the `explain`/
+Status: **implemented 2026-07-24** on `engine-query-ctx-arg-bundle`. Tracked as #757. Filed from the
+#752 ([00745-engine-explain-analyze.md](done/00745-engine-explain-analyze.md)) review — the `explain`/
 `explain_analyze` primitives pushed the plan-selection layer's argument lists past the point where
-threading them individually reads well.
+threading them individually reads well. Revised the same day before implementing: scope widened (two
+structs, not one; 13 all-five-slice functions, not 6) and the priority re-argued — see
+[Do it now, not "next time"](#do-it-now-not-next-time). Measured outcome in
+[Outcome](#outcome-as-landed).
 
 ## The finding
 
-The plan-selection functions all take the same store/index slices individually, plus a
-`#[allow(clippy::too_many_arguments)]` to silence the resulting lint. After #752 the counts are:
+Two distinct arg clusters repeat across the whole layer, and neither varies within a call chain.
 
-| Function | Args | Location |
-| --- | --- | --- |
-| `acquire_plan_features` | 13 | [lib.rs:6314](../../card_engine/src/lib.rs#L6314) |
-| `explain` | 12 | [lib.rs:6637](../../card_engine/src/lib.rs#L6637) |
-| `explain_analyze` | 15 | [lib.rs:6704](../../card_engine/src/lib.rs#L6704) |
-| `run_query_routed` | 13 | [lib.rs:6440](../../card_engine/src/lib.rs#L6440) |
-| `run_query_with_plan` | 15 | [lib.rs:6541](../../card_engine/src/lib.rs#L6541) |
-| `candidate_feats` | 8 | [lib.rs:6288](../../card_engine/src/lib.rs#L6288) |
-
-Five of the leading args are identical across all of them and never vary within a call chain — they
-come straight off the mmap'd `Archived<CardData>` the caller already holds:
+**Cluster A — what came off the archive.** Five slices, straight off the mmap'd `Archived<CardData>`
+the caller already holds:
 
 ```rust
 cards:    &[AOracleCard],
@@ -30,13 +23,50 @@ strings:  &AStrings,
 indexes:  &Archived<CardIndexes>,
 ```
 
-The remaining args (`filter`, `plane`, `mode`, `sort_col`, `descending`, `limit`, `page_offset`,
-and the timing knobs) are the ones that actually differ per query or per call — those are the
-meaningful signal, and they're currently buried among the boilerplate five.
+**Cluster B — what the request asked for.** Six scalars, fixed for the duration of one query:
+
+```rust
+mode: Mode, prefer: Prefer, sort_col: SortCol, descending: bool, limit: usize, page_offset: usize
+```
+
+Between them they account for **191 of the 265 parameters** on the 22 functions below. The args that
+actually differ per call — `filter`, `plane`, `prep`, `plan`, the bitmaps, the timing knobs — are the
+meaningful signal, and they are outnumbered better than 2:1 by the boilerplate.
+
+| Function | Args | of which cluster A | cluster B | varying | Location |
+| --- | --- | --- | --- | --- | --- |
+| `walk_printing_page` | 10 | 4 | 4 | 2 | [lib.rs:4442](../../card_engine/src/lib.rs#L4442) |
+| `printing_range_fastpath` | 10 | 5 | 4 | 1 | [lib.rs:4587](../../card_engine/src/lib.rs#L4587) |
+| `printing_compose_fastpath` | 11 | 4 | 6 | 1 | [lib.rs:5404](../../card_engine/src/lib.rs#L5404) |
+| `prepare_candidates` | 7 | 4 | 1 | 2 | [lib.rs:5789](../../card_engine/src/lib.rs#L5789) |
+| `exec_plane_popcount_order` | 11 | 5 | 5 | 1 | [lib.rs:5904](../../card_engine/src/lib.rs#L5904) |
+| `exec_plane_popcount_order_with_bitmap` | 12 | 5 | 5 | 2 | [lib.rs:5936](../../card_engine/src/lib.rs#L5936) |
+| `exec_card_range_popcount` | 12 | 5 | 5 | 2 | [lib.rs:5964](../../card_engine/src/lib.rs#L5964) |
+| `walk_grouped_page` | 12 | 3 | 6 | 3 | [lib.rs:6035](../../card_engine/src/lib.rs#L6035) |
+| `gather_composed_page` | 11 | 3 | 6 | 2 | [lib.rs:6139](../../card_engine/src/lib.rs#L6139) |
+| `exec_streamed_select` | 14 | 5 | 6 | 3 | [lib.rs:6226](../../card_engine/src/lib.rs#L6226) |
+| `exec_gathered_scan` | 14 | 5 | 6 | 3 | [lib.rs:6258](../../card_engine/src/lib.rs#L6258) |
+| `run_query` | 13 | 5 | 3 | 5 | [lib.rs:6324](../../card_engine/src/lib.rs#L6324) |
+| `exec_from_candidates` | 15 | 5 | 6 | 4 | [lib.rs:6376](../../card_engine/src/lib.rs#L6376) |
+| `mk_plan_feats` | 8 | 0 | 2 | 6 | [lib.rs:6407](../../card_engine/src/lib.rs#L6407) |
+| `candidate_feats` | 8 | 1 | 3 | 4 | [lib.rs:6443](../../card_engine/src/lib.rs#L6443) |
+| `acquire_plan_features` | 12 | 5 | 5 | 2 | [lib.rs:6469](../../card_engine/src/lib.rs#L6469) |
+| `run_query_routed` | 13 | 5 | 6 | 2 | [lib.rs:6595](../../card_engine/src/lib.rs#L6595) |
+| `run_query_with_plan` | 14 | 5 | 3 | 6 | [lib.rs:6696](../../card_engine/src/lib.rs#L6696) |
+| `explain` | 12 | 5 | 5 | 2 | [lib.rs:6792](../../card_engine/src/lib.rs#L6792) |
+| `explain_analyze` | 15 | 5 | 3 | 7 | [lib.rs:6859](../../card_engine/src/lib.rs#L6859) |
+| `run_query_streamed_popcount` | 13 | 4 | 3 | 6 | [lib.rs:6923](../../card_engine/src/lib.rs#L6923) |
+| `run_query_streamed` | 18 | 4 | 6 | 8 | [lib.rs:7052](../../card_engine/src/lib.rs#L7052) |
+
+Thirteen of these take all five of cluster A. (The original filing listed six functions; it was
+scoped to the plan-selection entry points and missed the executors, the fastpaths, and the streamed
+walkers, which carry the same two clusters.) The counts drive **25** `#[allow(clippy::too_many_arguments)]`
+in `lib.rs`, and two functions are over the threshold with *no* allow at all — `run_query` (13/7) and
+the PyO3 `query` (10/7) are live clippy warnings today.
 
 ## Proposed change
 
-Introduce a borrow-only context struct grouping the invariant slices:
+Two borrow-only structs, built once per query at the PyO3 entry point and threaded as single args:
 
 ```rust
 struct QueryCtx<'a> {
@@ -46,17 +76,53 @@ struct QueryCtx<'a> {
     strings:   &'a AStrings,
     indexes:   &'a Archived<CardIndexes>,
 }
+
+struct QueryParams {
+    mode: Mode, prefer: Prefer, sort_col: SortCol, descending: bool,
+    limit: usize, page_offset: usize,
+}
 ```
 
-Built once at each PyO3 entry point (`query`, `explain`, `explain_analyze`) right after
-`access_unchecked`, then threaded as a single `ctx: &QueryCtx` argument. Every function in the
-table above drops five args; several fall back under clippy's threshold and can shed their
-`#[allow(clippy::too_many_arguments)]`.
-
-`QueryCtx` holds only shared references with a single lifetime, so it's a zero-cost grouping — no
+`QueryCtx` holds only shared references under a single lifetime, so it's a zero-cost grouping — no
 ownership change, no clone, and the existing `'a` return-borrow relationships (e.g.
 `run_query_routed`'s `Vec<(&'a AOracleCard, &'a APrinting)>`) carry through the struct's lifetime
-unchanged.
+unchanged. `QueryParams` is six `Copy` scalars.
+
+The two clusters' 191 parameters become 43 struct args (one or two per function), so conservatively
+the table's 265 parameters drop to **117**. The real number is lower, because several functions'
+remaining `&str` args fold into the constructors below. `exec_gathered_scan` goes
+from 14 args to `(ctx, filter, prep, plane, params)`. Most of the 25 `#[allow]`s go with it.
+
+### Two constructors that each collapse a duplicated block
+
+- **`QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset)`.** The
+  `orderby_to_col` / `direction == "desc"` / `prefer_from_str` / `mode_from_unique` block is
+  copy-pasted at four sites in `lib.rs` — [6339](../../card_engine/src/lib.rs#L6339),
+  [6712](../../card_engine/src/lib.rs#L6712), [6876](../../card_engine/src/lib.rs#L6876),
+  [7963](../../card_engine/src/lib.rs#L7963) — plus several in `tests.rs`. This is also what lets
+  `run_query`, `run_query_with_plan`, and `explain_analyze` stop taking four `&str`s each: they take
+  `&QueryParams` and the string→enum adapter exists once.
+- **`impl<'a> From<&'a Archived<CardData>> for QueryCtx<'a>`.** Every construction site is
+  `&data.cards, &data.printings, &data.offsets, &data.strings, …, &data.indexes` — the PyO3 methods
+  and, more importantly, **46 `run_query` call sites in `tests.rs`**, which get *shorter*: one
+  `let ctx = QueryCtx::from(&archived);` per test fn, reused across that fn's calls.
+
+### Fold in the adjacent duplication
+
+These are too small to be their own PRs and sit in exactly the signatures being touched:
+
+- `PhysicalPlan::applicable(filter, mode, cards, plane, sort_col, descending, indexes)` — 7 args, 6
+  call sites in `run_query_routed`/`explain`/`acquire_plan_features` — becomes
+  `applicable(&ctx, &params, filter, plane)`.
+- [exec_streamed_select](../../card_engine/src/lib.rs#L6244) and
+  [exec_gathered_scan](../../card_engine/src/lib.rs#L6276) both open with the identical
+  `existential_plane_for` + `Box<dyn Iterator<Item = u32>>` candidate-ids preamble. One method on
+  `PreparedCandidates`.
+- [exec_plane_popcount_order](../../card_engine/src/lib.rs#L5904) is a ten-line thread-local wrapper
+  around `_with_bitmap`, and both spell out the full 11/12-arg list.
+- [mk_plan_feats](../../card_engine/src/lib.rs#L6407) exists purely to avoid an 8-field struct
+  literal, and needs its own `#[allow]` to do it. With the two structs in place it takes those plus
+  the four fields that actually vary by count source.
 
 ## Why this isn't purely mechanical
 
@@ -64,19 +130,120 @@ unchanged.
   `&mut FilterExpr`, and `explain_analyze` deliberately clones a fresh filter per `(plan, round)`
   off a pristine snapshot (the #752 fairness discipline). Folding it into an immutable-borrow ctx
   would fight both. Keep it out.
-- **`mode`/`sort_col`/`descending` are query params, not store state** — they belong in the
-  per-call arg list, not the ctx. The split is "what came off the archive" vs. "what the request
-  asked for"; only the former goes in `QueryCtx`.
+- **The A/B split is the whole design.** `mode`/`sort_col`/`descending` are request state, not store
+  state, so they do not belong in `QueryCtx` — but that argues for a second struct, not for leaving
+  them loose. Anything that is neither "came off the archive" nor "the request asked for it" stays a
+  positional arg; that residue is the column worth reading in the table above.
+- **Not every function wants both.** `acquire_plan_features` and `explain` have no use for `prefer`;
+  `prepare_candidates` uses only `mode`. Passing `&QueryParams` and ignoring fields is the right
+  trade (uniform signatures beat five bespoke sub-structs), but it does mean the struct is a
+  superset for some callees — worth stating rather than discovering in review.
 - **Behavior must be identical.** `force_plan_differential_agreement` and the existing
   `query()`/`explain` parity tests are the regression guard — this is a signature refactor with no
-  intended behavior change, so those passing unchanged is the acceptance bar.
+  intended behavior change, so those passing unchanged is the acceptance bar. Run `cargo test` in
+  **debug** as well as release: CI's `rust-test` job is a debug build, so a release-only local run
+  skips the engine's `debug_assert` tripwires.
 
-## Priority
+## Do it now, not "next time"
 
-Low — cosmetic/readability, no correctness or performance stake (a borrow struct compiles to the
-same argument passing). Worth doing next time this layer is opened for a feature change rather than
-as a standalone churn PR, since it touches the signature of every plan-selection function and would
-conflict with any in-flight work there.
+The original filing deferred this — "best done next time this layer is opened for a feature change
+rather than as standalone churn, since it touches the signature of every plan-selection function and
+would conflict with any in-flight work there." That rationale does not hold as of 2026-07-24, and the
+inverse one does:
+
+- **The layer is quiet.** The only open engine PR is #692, which touches `filter.rs` and nothing
+  else. Every other open PR is images / fonts / query-runner / DFC work.
+- **The next four engine issues all land here.** #754 (plane-subtree compose leaf + general `Not`
+  arm), [#731](00731-engine-compose-universal-evaluator.md) (compose as the universal exact
+  evaluator), [#730](00730-engine-popcount-skip-walk.md) (popcount-skip walk generalized to all
+  distinct-ons), and #656 each add plans or args to these exact signatures. Landing the bundle first
+  means they build on 4-arg signatures instead of each pushing a 15-arg list to 16 — which is the
+  "do it while the layer is open" intent, just resolved in the other direction.
+
+Priority is still **low-stakes** (no correctness or performance effect — a borrow struct compiles to
+the same argument passing), but it is now **well-timed**, which is a different claim than the
+original "low priority".
+
+## Outcome (as landed)
+
+**Parameters across the 22 functions: 265 → 104**, i.e. 161 removed — better than the 117 estimated
+above. The estimate assumed each function would trade its cluster members for one or two struct args
+and keep everything else. Five functions did better than that, because args they took *individually*
+turned out to be derivable from `ctx.indexes`:
+
+- `run_query_streamed` 18 → 7: `artwork_groups`, `artwork_group_col`, and `max_artwork_groups` are
+  all `ctx.indexes` fields, so the caller no longer projects them out one at a time.
+- `run_query_streamed_popcount` 13 → 7: same for `planes`.
+- `walk_grouped_page` 12 → 4 and `gather_composed_page` 11 → 3: same for `max_artwork_groups`.
+- `printing_compose_fastpath` 11 → 3, `printing_range_fastpath` 10 → 3, `exec_from_candidates` 15 → 6,
+  `run_query_routed` 13 → 4, `acquire_plan_features` 12 → 4.
+
+`#[allow(clippy::too_many_arguments)]` in `lib.rs`: **25 → 10**. One of the survivors turned out to be
+*already* stale before this change (`run_query_streamed`'s), and the pymethod `explain`'s is still
+required — `self` counts toward clippy's 7, so its 8 keyword params trip the lint even though the free
+`explain` it delegates to now takes 4. The remaining ten are all genuine: the per-printing kernels
+(`push_card_matches` 18, `card_match_count` 12), the value-index walkers, and the three PyO3 keyword
+surfaces.
+
+Bodies were left byte-identical wherever possible by destructuring at the top of each function
+(`let QueryCtx { cards, printings, .. } = *ctx;`), so the diff is signatures and call sites rather
+than logic — which is what makes "behavior is identical" checkable by reading it.
+
+**Guard:** `cargo test` passes 139/139 in **both** debug and release (debug matters — CI's `rust-test`
+job is a debug build, so release-only runs skip the `debug_assert` tripwires), including
+`force_plan_differential_agreement`, `explain_reports_ranked_applicable_plans`, and
+`explain_analyze_matches_explain_and_times_every_plan`.
+
+### Deliberately left alone
+
+`aligned_page`, `walk_range_orderby_page`, and `walk_rarity_orderby_page` keep explicit slice args.
+They are a different family: each walks *its own value-sorted index slice* against `printing_to_card`,
+not the query's store view, so a `QueryCtx` would be a misleading thing to hand them (it advertises
+access to `offsets`/`strings` they have no business reading). They were never in the finding's table.
+
+### Test-side shape
+
+Three helpers in `tests.rs` carry the params a kernel test needs: `kernel_params(mode, sort_col,
+descending, limit, page_offset)` for enum-space call sites, `explain_params(mode, limit)`, and
+`mode_only_params(mode)` for `prepare_candidates` (which reads nothing but `mode` — the helper's doc
+says so, and says to pass real values if a callee ever starts reading the rest).
+
+## Follow-up this surfaced: the cost model ignores `prefer`
+
+Building `QueryParams` for the PyO3 `explain` method forced the question of what to pass for `prefer`,
+which that method's signature has never accepted. The answer is that it doesn't currently matter *for
+what explain reports* — `cost.rs` contains **zero** references to `prefer`, and `cost::PlanFeatures`
+has no such field, so both the argmin and every `predicted_ns` are prefer-blind no matter what is
+passed.
+
+That is a gap in the cost model, not a property of execution. `prefer` genuinely changes the work a
+plan does: it selects each card's representative printing, and `Prefer::Default` specifically lets
+`gather_composed_page` early-break on the first set printing instead of scoring every printing of the
+card (`run_query_streamed_popcount` has the same find-first vs. score-all split). So an `explain` for
+a non-default `prefer` predicts numbers for work the real query wouldn't do, and `explain_analyze` —
+which *does* take `prefer` and really runs the plans — will show `trials_ns` responding to it while
+its own `predicted_ns` does not.
+
+Worth its own issue: either model `prefer`'s per-card cost in `PlanFeatures`, or add `prefer` to the
+`explain` surface and document the estimate as prefer-independent on purpose. Not folded in here —
+this PR is a signature refactor with no behavior change, and either fix changes reported numbers.
+
+## Not in scope
+
+Both of these turned up alongside this finding and are independent PRs, so they belong in their own
+docs rather than folded in here:
+
+- **Clippy is not in CI, and is not clean.** `rust-tests.yml` runs only `cargo test`; `lint.yml` is
+  Python-only. `cargo clippy --all-targets` emits 68 warnings today. That means the 25 `#[allow]`s
+  this change sheds are being maintained by hand for a lint nothing enforces — so the payoff will
+  quietly regress without a `-D warnings` gate. Highest-leverage cleanup in the crate, and a
+  prerequisite for this one's benefit sticking.
+- **`lib.rs` is 8146 lines** and already carved by 30 `// ───` section banners that map cleanly onto
+  modules. The split is close to mechanical: `mod tests` sits at the crate root
+  ([lib.rs:8130](../../card_engine/src/lib.rs#L8130)) importing ~100 names via `use super::{…}`, and
+  a private `use newmod::*;` at the root keeps all of them resolving through `super::` unchanged.
+  Sequence it *after* this change, so the new module boundaries carry 4-arg signatures rather than
+  15-arg ones.
 
 ## Related
 
@@ -84,3 +251,6 @@ conflict with any in-flight work there.
   that pushed the arg counts up and surfaced this.
 - [done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) — the
   cost-based router (`run_query_routed`, `acquire_plan_features`) whose signatures this cleans up.
+- [local-engine-range-veto-redundancy.md](local-engine-range-veto-redundancy.md) — the other
+  standing cleanup in this layer, but a *semantic* one (a hardcoded second copy of a cost decision)
+  that needs measurement first, unlike this one.


### PR DESCRIPTION
Closes #757.

Two arg clusters repeated across the whole plan-selection layer and never varied within a call chain: the five store/index slices off the archive, and the six scalars describing the request. Between them they accounted for **191 of the 265 parameters** on the 22 functions involved, burying the args that actually differ per call.

Group them as `QueryCtx<'a>` (shared refs under one lifetime, built once per PyO3 entry point via `QueryCtx::from(data)`) and `QueryParams` (six `Copy` scalars).

## Result

| | before | after |
| --- | --- | --- |
| Parameters across the 22 functions | 265 | **104** |
| `#[allow(clippy::too_many_arguments)]` in lib.rs | 25 | **10** |

The reduction beat the design doc's 117 estimate because five functions took args that are `ctx.indexes` fields the caller was projecting out one at a time: `run_query_streamed` 18 → 7 (`artwork_groups`, `artwork_group_col`, `max_artwork_groups`), `run_query_streamed_popcount` 13 → 7 (`planes`), `walk_grouped_page` 12 → 4, `gather_composed_page` 11 → 3.

## Two constructors that each collapse a duplicated block

- `QueryParams::from_strs` replaces the `orderby_to_col` / `== "desc"` / `prefer_from_str` / `mode_from_unique` quartet that was copy-pasted at four sites.
- `From<&Archived<CardData>> for QueryCtx` makes the 46 `run_query` call sites in `tests.rs` *shorter* rather than churned — one `ctx` per test fn.

## Also folded in

These sit in the signatures being touched, so they'd be pure re-churn as separate PRs:

- `PhysicalPlan::applicable` 7 args → 4.
- `PreparedCandidates::card_ids` replaces the identical boxed-iterator preamble at the head of both P3 and P4.
- `mk_plan_feats` / `candidate_feats` shed their invariant leading args.

## Scope notes

- Bodies are left **byte-identical wherever possible** by destructuring at the top of each function (`let QueryCtx { cards, printings, .. } = *ctx;`), so this is signatures and call sites, not logic — which is what makes "behavior is identical" checkable by reading it.
- `filter` stays a separate `&mut` arg: `prepare_candidates` needs `&mut`, and `explain_analyze` clones a fresh filter per (plan, round) off a pristine snapshot for timing fairness (#752).
- `aligned_page` and the two orderby walkers keep explicit slices on purpose — each walks its own value-sorted index slice against `printing_to_card`, not the query's store view, so a `QueryCtx` would advertise access they have no business having.

## Verification

`cargo test` **139/139 in both debug and release** — debug matters, since CI's `rust-test` job is a debug build and a release-only run skips the engine's `debug_assert` tripwires. Includes `force_plan_differential_agreement`, `explain_reports_ranked_applicable_plans`, and `explain_analyze_matches_explain_and_times_every_plan`, which are the acceptance bar the design doc named.

## Follow-up this surfaced: the cost model ignores `prefer`

Building `QueryParams` for the PyO3 `explain` method forced the question of what to pass for `prefer`, which that method has never accepted. `cost.rs` contains **zero** references to `prefer`, so both the argmin and every `predicted_ns` are prefer-blind regardless — but that is a gap in the model, not a property of execution. `prefer` genuinely changes the work done: `Prefer::Default` is what lets `gather_composed_page` early-break on the first set printing instead of scoring every printing of the card (`run_query_streamed_popcount` has the same split). So `explain_analyze` will show `trials_ns` responding to `prefer` while its own `predicted_ns` does not. Worth its own issue; not folded in here because either fix changes reported numbers.

Design doc (full arg-count table, measured outcome, rejected foldings): [docs/issues/00757-engine-query-ctx-arg-bundle.md](https://github.com/jbylund/sylvan_librarian/blob/engine-query-ctx-arg-bundle/docs/issues/00757-engine-query-ctx-arg-bundle.md).