### PR TITLE
Engine: Clean Clippy Across Both Crates and Gate It in CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -21,8 +21,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Pinned, not @stable, because the clippy steps below run with `-D warnings`:
+      # every Rust release adds lints, so a floating toolchain turns release day into a
+      # red build on whichever PR happens to be open, for code that didn't change. This
+      # exact drift bit PR #760 (local 1.96 was clean, CI's 1.97 flagged byte_char_slices).
+      # Bumping is then a deliberate PR where the new lints get reviewed on purpose —
+      # keep this in step with what contributors run locally (`rustup update stable`).
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: clippy
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache Cargo registry and build artifacts
         uses: Swatinem/rust-cache@v2
@@ -36,3 +38,16 @@ jobs:
 
       - name: Test shared_cache
         run: cargo test --manifest-path shared_cache/Cargo.toml
+
+      # Lint runs after the tests on purpose: a real test failure is the more
+      # useful signal, and `-D warnings` would otherwise abort the job before the
+      # tests ever ran. --all-targets covers tests.rs and the bench modules, which
+      # is where most of the backlog this gate was introduced with actually lived.
+      # These are steps in the existing job rather than a job of their own so no
+      # new required check is added (which would also need a rust-tests-skip.yml
+      # stub to keep no-Rust PRs from hanging on a check that never runs).
+      - name: Clippy card_engine
+        run: cargo clippy --manifest-path card_engine/Cargo.toml --all-targets -- -D warnings
+
+      - name: Clippy shared_cache
+        run: cargo clippy --manifest-path shared_cache/Cargo.toml --all-targets -- -D warnings

--- a/card_engine/src/bench_mana.rs
+++ b/card_engine/src/bench_mana.rs
@@ -279,9 +279,13 @@ fn bench_mana_representations() {
         })
         .collect();
 
-    // Query specs: (label, pips, cmc) — mana= uses all ops, devotion the
-    // color lanes only. Distribution-realistic shapes.
-    let mana_queries: &[(&str, &[(&str, u8)], f32)] = &[
+    // mana= uses all ops, devotion the color lanes only. Distribution-realistic shapes.
+    type ManaQuery<'a> = (
+        &'a str,              // label
+        &'a [(&'a str, u8)],  // pips, as (symbol, count) pairs
+        f32,                  // cmc
+    );
+    let mana_queries: &[ManaQuery] = &[
         ("mana ge {B}{B}", &[("B", 2)], 2.0),
         ("mana ge {W}", &[("W", 1)], 1.0),
         ("mana ge {R/G}", &[("R/G", 1)], 1.0),

--- a/card_engine/src/bench_text_search.rs
+++ b/card_engine/src/bench_text_search.rs
@@ -56,10 +56,10 @@ fn bench_text_search_contenders() {
     let mut texts: Vec<&str> = Vec::new();
     for card in data.cards.iter() {
         let gid = u32::from(card.oracle_text_lower_id);
-        if seen.insert(gid) {
-            if let Some(s) = str_at(&data.strings, gid) {
-                texts.push(s);
-            }
+        if seen.insert(gid)
+            && let Some(s) = str_at(&data.strings, gid)
+        {
+            texts.push(s);
         }
     }
     println!("\n{} distinct oracle texts from {STORE_PATH}", texts.len());

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -103,12 +103,12 @@ fn field_num(card: &AOracleCard, printing: Option<&APrinting>, f: NumField) -> N
         v.map_or(NumVal::Null, |cents| NumVal::Known(f64::from(cents) / 100.0))
     }
     match f {
-        NumField::Cmc                => known(card.cmc.as_ref().map(|v| u8::from(*v) as f32)),
-        NumField::Power              => known(card.creature_power.as_ref().map(|v| i8::from(*v) as f32)),
-        NumField::Toughness          => known(card.creature_toughness.as_ref().map(|v| i8::from(*v) as f32)),
-        NumField::Loyalty            => known(card.planeswalker_loyalty.as_ref().map(|v| u8::from(*v) as f32)),
+        NumField::Cmc                => known(card.cmc.as_ref().map(|v| f32::from(*v))),
+        NumField::Power              => known(card.creature_power.as_ref().map(|v| f32::from(*v))),
+        NumField::Toughness          => known(card.creature_toughness.as_ref().map(|v| f32::from(*v))),
+        NumField::Loyalty            => known(card.planeswalker_loyalty.as_ref().map(|v| f32::from(*v))),
         NumField::EdhrEc             => known(card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32)),
-        NumField::RarityInt          => printing.map_or(NumVal::PDep, |p| known(p.card_rarity_int.as_ref().map(|v| u8::from(*v) as f32))),
+        NumField::RarityInt          => printing.map_or(NumVal::PDep, |p| known(p.card_rarity_int.as_ref().map(|v| f32::from(*v)))),
         NumField::CollectorNumberInt => printing.map_or(NumVal::PDep, |p| known(p.collector_number_int.as_ref().map(|v| u16::from(*v) as f32))),
         NumField::PriceUsd           => printing.map_or(NumVal::PDep, |p| known_cents(p.price_usd.as_ref().map(|v| u32::from(*v)))),
         NumField::PriceEur           => printing.map_or(NumVal::PDep, |p| known_cents(p.price_eur.as_ref().map(|v| u32::from(*v)))),
@@ -291,9 +291,9 @@ pub(crate) enum ColorField {
 
 fn card_colors(card: &AOracleCard, f: ColorField) -> u8 {
     match f {
-        ColorField::Colors        => u8::from(card.card_colors),
-        ColorField::ColorIdentity => u8::from(card.card_color_identity),
-        ColorField::ProducedMana  => u8::from(card.produced_mana),
+        ColorField::Colors        => card.card_colors,
+        ColorField::ColorIdentity => card.card_color_identity,
+        ColorField::ProducedMana  => card.produced_mana,
     }
 }
 
@@ -325,6 +325,10 @@ fn collection<'a>(
     }
 }
 
+// enum_variant_names: the `Lower` suffix is load-bearing, not noise — these name the
+// case/accent-folded store columns (`card_name_lower`, `oracle_text_lower`, …) that search
+// actually reads, as distinct from the display columns of the same fields.
+#[allow(clippy::enum_variant_names)]
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum TextSearchField {
     NameLower,
@@ -1728,7 +1732,7 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
     build_text_filter(attr, op, rhs)
 }
 
-fn rhs_value_str<'a>(rhs: &'a Value) -> &'a str {
+fn rhs_value_str(rhs: &Value) -> &str {
     rhs["kwargs"]["value"].as_str().unwrap_or("")
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1024,16 +1024,16 @@ fn tokenize_words_ge4(text: &str, mut emit: impl FnMut(&str)) {
     for (i, &b) in bytes.iter().enumerate() {
         if is_word_byte(b) {
             start.get_or_insert(i);
-        } else if let Some(s) = start.take() {
-            if i - s >= 4 {
-                emit(&text[s..i]);
-            }
+        } else if let Some(s) = start.take()
+            && i - s >= 4
+        {
+            emit(&text[s..i]);
         }
     }
-    if let Some(s) = start {
-        if bytes.len() - s >= 4 {
-            emit(&text[s..]);
-        }
+    if let Some(s) = start
+        && bytes.len() - s >= 4
+    {
+        emit(&text[s..]);
     }
 }
 
@@ -1712,10 +1712,10 @@ pub(crate) fn flavor_fingerprint(s: &str) -> u128 {
             break;
         }
         for w in b.windows(n) {
-            if w.iter().all(|c| c.is_ascii_lowercase()) {
-                if let Some(&i) = map.get(w) {
-                    fp |= 1u128 << i;
-                }
+            if w.iter().all(|c| c.is_ascii_lowercase())
+                && let Some(&i) = map.get(w)
+            {
+                fp |= 1u128 << i;
             }
         }
     }
@@ -2237,10 +2237,10 @@ fn build_rarity_index(printings: &[Printing], offsets: &[u32]) -> RarityIndex {
         let range = offsets[card] as usize..offsets[card + 1] as usize;
         let mut mask: u8 = 0;
         for p in &printings[range] {
-            if let Some(r) = p.card_rarity_int {
-                if (r as usize) < idx.len() {
-                    mask |= 1 << r;
-                }
+            if let Some(r) = p.card_rarity_int
+                && (r as usize) < idx.len()
+            {
+                mask |= 1 << r;
             }
         }
         let mut bits = mask;
@@ -2369,6 +2369,7 @@ fn narrow_rarity(indexes: &Archived<CardIndexes>, n_cards: usize, op: CmpOp, val
 // (~31.5k), printing-level indexes post Printing indices (~97k). Candidates
 // carry their space (see Candidates) and convert at combine points.
 #[derive(Archive, Serialize, Deserialize)]
+#[derive(Default)]
 struct CardIndexes {
     name_trigram:   SortedTrigramIndex, // card space
     oracle_trigram: OracleTextIndex, // card space (via dense text ids)
@@ -2405,42 +2406,6 @@ struct CardIndexes {
     arith_tuple:    ArithTupleIndex,           // card space: joint (cmc,power,toughness,loyalty) postings for arith predicates (#743)
 }
 
-impl Default for CardIndexes {
-    fn default() -> Self {
-        CardIndexes {
-            name_trigram:   SortedTrigramIndex::default(),
-            oracle_trigram: OracleTextIndex::default(),
-            cmc:            Vec::new(),
-            power:          Vec::new(),
-            toughness:      Vec::new(),
-            rarity:         Default::default(),
-            subtypes:       HashMap::new(),
-            keywords:       HashMap::new(),
-            oracle_tags:    HashMap::new(),
-            art_tags:       HashMap::new(),
-            is_tags:        HashMap::new(),
-            frame_data:     HashMap::new(),
-            artists:        ArtistIndex::default(),
-            flavor:         FlavorIndex::default(),
-            set_codes:      HashMap::new(),
-            watermarks:     HashMap::new(),
-            released_at:    Vec::new(),
-            price_usd:      Vec::new(),
-            collector_number: Vec::new(),
-            sort_perms:     SortPermutations::default(),
-            artwork_groups: Vec::new(),
-            artwork_group_col: Vec::new(),
-            max_artwork_groups: 0,
-            printing_to_card: Vec::new(),
-            planes:         BitPlanes::default(),
-            border_printing: BorderPrintingPlanes::default(),
-            rarity_printing: RarityPrintingPlanes::default(),
-            name_bigrams:   NameBigramIndex::default(),
-            legal_divergent: Vec::new(),
-            arith_tuple:    ArithTupleIndex::default(),
-        }
-    }
-}
 
 #[derive(Archive, Serialize, Deserialize)]
 struct CardData {
@@ -3099,22 +3064,21 @@ fn narrow_rec(
         && !matches!(filter, FilterExpr::True)
         && u32::from(indexes.planes.n_cards) as usize == n_cards
         && n_cards > 0
+        && let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words)
     {
-        if let Some(pe) = compile_plane(filter, &indexes.planes, &indexes.oracle_trigram.words) {
-            let mut bits: Vec<u64> = Vec::new();
-            eval_planes(&pe, &indexes.planes, &mut bits);
-            // Legality's planes are existence projections, not true-for-
-            // every-printing facts (docs/issues/engine-legality-divergent-
-            // carveout.md) -- `tight`'s contract needs the latter (see
-            // `Narrowed`'s doc and the dedicated `Legality` arms below), so a
-            // compiled expression touching them can only narrow loosely here,
-            // same as if it had fallen through to those arms directly.
-            return if plane_expr_is_existential(&pe) {
-                Narrowed::loose(Candidates::CardBits(bits))
-            } else {
-                Narrowed::tight(Candidates::CardBits(bits))
-            };
-        }
+        let mut bits: Vec<u64> = Vec::new();
+        eval_planes(&pe, &indexes.planes, &mut bits);
+        // Legality's planes are existence projections, not true-for-
+        // every-printing facts (docs/issues/engine-legality-divergent-
+        // carveout.md) -- `tight`'s contract needs the latter (see
+        // `Narrowed`'s doc and the dedicated `Legality` arms below), so a
+        // compiled expression touching them can only narrow loosely here,
+        // same as if it had fallen through to those arms directly.
+        return if plane_expr_is_existential(&pe) {
+            Narrowed::loose(Candidates::CardBits(bits))
+        } else {
+            Narrowed::tight(Candidates::CardBits(bits))
+        };
     }
 
     match filter {
@@ -3598,11 +3562,11 @@ fn narrow_rec(
                 // is always sparse under a selective driver, so it only ever
                 // takes range_narrowed's cheap vec path. `continue`, not
                 // `break`: a later, smaller-k range child may still qualify.
-                if let Some(b) = best.filter(|&b| rank > 0 && b <= *AND_SKIP_THRESHOLD) {
-                    if !probe.is_some_and(|k| k < b || k <= *AND_PROBE_FLOOR) {
-                        every_child_included = false;
-                        continue;
-                    }
+                if let Some(b) = best.filter(|&b| rank > 0 && b <= *AND_SKIP_THRESHOLD)
+                    && !probe.is_some_and(|k| k < b || k <= *AND_PROBE_FLOOR)
+                {
+                    every_child_included = false;
+                    continue;
                 }
                 if rank == 2 && !(card_sets.is_empty() && printing_sets.is_empty()) {
                     every_child_included = false;
@@ -3810,10 +3774,10 @@ fn f32_sort_bits(v: f32) -> u32 {
 /// store order in `select_page`.
 fn sort_key_bits(card: &AOracleCard, p: &APrinting, sort_col: SortCol, descending: bool) -> u128 {
     let primary: Option<f32> = match sort_col {
-        SortCol::Cmc        => card.cmc.as_ref().map(|v| u8::from(*v) as f32),
-        SortCol::Power      => card.creature_power.as_ref().map(|v| i8::from(*v) as f32),
-        SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| i8::from(*v) as f32),
-        SortCol::Rarity     => p.card_rarity_int.as_ref().map(|v| u8::from(*v) as f32),
+        SortCol::Cmc        => card.cmc.as_ref().map(|v| f32::from(*v)),
+        SortCol::Power      => card.creature_power.as_ref().map(|v| f32::from(*v)),
+        SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| f32::from(*v)),
+        SortCol::Rarity     => p.card_rarity_int.as_ref().map(|v| f32::from(*v)),
         // Raw cents, not dollars -- order-preserving either way (this is a sort key, not an
         // exposed value), and cents fit exactly in f32 (max real price 514,202 cents, f32
         // represents any integer up to 2^24 exactly), so skip the /100.0 dollars conversion.
@@ -4106,6 +4070,9 @@ const ARTWORK_GROUP_WORDS: usize = 8;
 // `Mode::Printing`/`Artwork` below are unaffected -- their planes, if any,
 // were never folded to begin with when existential (`unique_is_card`).
 #[allow(clippy::too_many_arguments)]
+// needless_range_loop: `pid` is the printing's absolute id, used for `artwork_group_id`
+// lookups alongside the residual test — a slice iterator would lose the id.
+#[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn card_match_count(
     card: &AOracleCard,
@@ -4139,8 +4106,8 @@ fn card_match_count(
                 if all_match {
                     return u32::from(start < end);
                 }
-                for pid in start..end {
-                    if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                for p in &printings[start..end] {
+                    if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
                         return 1;
                     }
                 }
@@ -4151,8 +4118,8 @@ fn card_match_count(
                     return (end - start) as u32;
                 }
                 let mut n = 0u32;
-                for pid in start..end {
-                    if FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                for p in &printings[start..end] {
+                    if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
                         n += 1;
                     }
                 }
@@ -4160,11 +4127,11 @@ fn card_match_count(
             }
             Mode::Artwork => {
                 seen_words.fill(0);
-                for pid in start..end {
-                    if !all_match && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                for p in &printings[start..end] {
+                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
                         continue;
                     }
-                    let gid = u16::from(printings[pid].artwork_group_id) as usize;
+                    let gid = u16::from(p.artwork_group_id) as usize;
                     seen_words[gid / 64] |= 1u64 << (gid % 64);
                 }
                 seen_words.iter().map(|w| w.count_ones()).sum()
@@ -4227,6 +4194,9 @@ fn card_match_count(
 /// this (their planes are never folded this way, see `unique_is_card`), and a
 /// card-invariant `all_match` needs no check (every printing already agrees).
 #[allow(clippy::too_many_arguments)]
+// needless_range_loop: `pid` is the printing's identity, not a cursor — it is pushed into
+// the emitted match tuple (`pid as u32`), so the loop needs the absolute index.
+#[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn push_card_matches(
     card: &AOracleCard,
@@ -4245,7 +4215,7 @@ fn push_card_matches(
     strings: &AStrings,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     out: &mut Vec<Match>,
-    group_best: &mut Vec<Option<(u32, f64)>>,
+    group_best: &mut [Option<(u32, f64)>],
     touched: &mut Vec<u16>,
 ) {
     match mode {
@@ -4535,6 +4505,8 @@ fn build_card_range_bits(
 /// within a card, printings order by `sort_key_bits` then pid — byte-identical to the streamed
 /// path's emission (`run_query_streamed`), just without the O(n) count pass, since the caller
 /// already has the exact `total` from the index.
+// needless_range_loop: `pid` is pushed into the match tuple, so the absolute index is the point.
+#[allow(clippy::needless_range_loop)]
 fn walk_printing_page<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
@@ -6078,6 +6050,9 @@ fn printing_bits_to_artwork_bits(
 /// Artwork semantics). Membership is the exact composed `pbits`, so there is no residual re-evaluation.
 /// The total is a separate `popcount` over the mode's result bitmap; this only builds the requested
 /// page. Forward walk (no popcount-skip) — deep-offset skip is the deferred [#730] optimization.
+// needless_range_loop: same shape as `gather_composed_page` — `pid` is both the membership
+// probe and the emitted row identity.
+#[allow(clippy::needless_range_loop)]
 fn walk_grouped_page<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
@@ -6812,6 +6787,8 @@ fn explain_analyze(
 /// True (e.g. `t:creature power>3`, residual = `power>3`) still go through
 /// `run_query_streamed`'s Step-1-improved-but-not-popcount path — extending
 /// this to non-True residuals is a reasonable fast-follow, not required here.
+// needless_range_loop: `pid` is the chosen printing's id, returned to the caller.
+#[allow(clippy::needless_range_loop)]
 fn run_query_streamed_popcount<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
@@ -7362,10 +7339,10 @@ impl QueryEngine {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("stat shm: {e}")))?;
 
         let mut guard = self.cached_mmap.lock().unwrap();
-        if let Some(ref c) = *guard {
-            if c.inode == path_inode {
-                return Ok(Arc::clone(&c.mmap));
-            }
+        if let Some(ref c) = *guard
+            && c.inode == path_inode
+        {
+            return Ok(Arc::clone(&c.mmap));
         }
         // Inode changed (new reload) or first call: open and map the current file.
         let file = std::fs::File::open(&self.shm_path)
@@ -7441,8 +7418,11 @@ impl QueryEngine {
         // The lock file is separate so it persists across archive replacements.
         // Held until reload_commit()/reload_abort() drops the Staging.
         let lock_path = self.shm_path.with_extension("lock");
+        // truncate(false) is explicit, not incidental: nothing is ever written to this file — it
+        // exists only as an flock target — so opening it must never disturb whatever is already
+        // there, including for a worker that already holds it open.
         let lock_file = std::fs::OpenOptions::new()
-            .write(true).create(true).open(&lock_path)
+            .write(true).create(true).truncate(false).open(&lock_path)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("open lock: {e}")))?;
         // LOCK_EX blocks until we hold the lock; released automatically on drop.
         loop {
@@ -7479,7 +7459,7 @@ impl QueryEngine {
         })?;
         for item in db_rows.iter() {
             if let Ok(d) = item.cast::<PyDict>() {
-                staging.rows.push(card_from_pydict(&d, &mut staging.interner, &mut staging.vocab, &mut staging.artists, &mut staging.mana)?);
+                staging.rows.push(card_from_pydict(d, &mut staging.interner, &mut staging.vocab, &mut staging.artists, &mut staging.mana)?);
             }
         }
         Ok(())
@@ -7752,6 +7732,7 @@ impl QueryEngine {
         self.reload_commit()
     }
 
+    #[allow(clippy::too_many_arguments)] // the PyO3 keyword surface; `run_query` behind it takes 9
     #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0, fields=None))]
     fn query<'py>(
         &self,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -136,12 +136,12 @@ fn test_trigram_index_archive_and_lookup() {
         .expect("access trigram index");
 
     // Key present -- length check
-    let abc = archived.get(&[b'a', b'b', b'c']).expect("abc must be present");
+    let abc = archived.get(b"abc").expect("abc must be present");
     assert_eq!(abc.len(), 3);
 
     // Key present -- value iteration (elements are rend::u32_le, not u32)
     let foo: Vec<u32> = archived
-        .get(&[b'f', b'o', b'o'])
+        .get(b"foo")
         .expect("foo must be present")
         .iter()
         .map(|x| u32::from(*x))
@@ -149,7 +149,7 @@ fn test_trigram_index_archive_and_lookup() {
     assert_eq!(foo, vec![10, 20, 30, 40]);
 
     // Key absent
-    assert!(archived.get(&[b'z', b'z', b'z']).is_none());
+    assert!(archived.get(b"zzz").is_none());
 }
 
 // Verify that HashMap<String, Vec<u32>> (the tag index value type) supports
@@ -2677,7 +2677,7 @@ fn arith_tuple_narrowing_matches_reference() {
                 assert!(is_arith_tuple_route(&mk()), "seed={seed} {label} {op:?}: must route to the tuple index");
                 for negated in [false, true] {
                     let filter = if negated { FilterExpr::Not(Box::new(mk())) } else { mk() };
-                    let ref_set = reference(&archived, &filter);
+                    let ref_set = reference(archived, &filter);
                     let ctx = format!("seed={seed} {label} {op:?} negated={negated}");
                     match narrow_candidates_exact(&filter, indexes, offsets, cards) {
                         (Some(Candidates::Cards(v)), tight) => {
@@ -2797,10 +2797,11 @@ fn gather_select_matches_reference() {
 /// result (always `Some`) as the reference, then for every other plan call
 /// `run_query_with_plan`; if it returns `Some` (it was applicable), assert
 /// against the reference on three axes at the full offset-0 page:
-///   - `total` equality,
-///   - `scryfall_id` multiset equality — same *rows*,
-///   - **2-key ordering** equality — the `(primary, edhrec_rank)` value
-///     sequence (top 64 bits of `sort_key_bits`).
+/// - `total` equality,
+/// - `scryfall_id` multiset equality — same *rows*,
+/// - **2-key ordering** equality — the `(primary, edhrec_rank)` value
+///   sequence (top 64 bits of `sort_key_bits`).
+///
 /// The 2-key value sequence is the ordering-parity contract (#702): plans agree
 /// on the two SQL-defined keys they're guaranteed to, and diverge only past
 /// them (key 3, prefer_score, and below — see the `PREFERS` comment below and
@@ -3571,6 +3572,9 @@ fn plan_cost_model_matches_gold() {
 
 /// Solve `A c = b` (A is n×n, row-major) by Gaussian elimination with partial
 /// pivoting. `None` if singular (rank-deficient — collinear features). Small n.
+// needless_range_loop: `c` indexes two different rows of `a` in the same statement; a slice
+// iterator would need split_at_mut and obscure the elimination step.
+#[allow(clippy::needless_range_loop)]
 fn solve_normal_eqs(mut a: Vec<Vec<f64>>, mut b: Vec<f64>) -> Option<Vec<f64>> {
     let n = b.len();
     for col in 0..n {
@@ -3692,9 +3696,15 @@ fn plan_cost_refit() {
         &["CARD_PASS", "SCAN", "EMIT", "FLOOR/card", "FIXED"],
         &["CARD_PASS", "SCAN", "PUSH", "SELECT", "FIXED"],
     ];
-    // Per-plan fit rows: (terms, y_minus_offset, y, is_train). 70/30 train/test by
-    // query index so held-out fidelity reveals overfitting (the 22-query trap).
-    let mut rows: [Vec<(Vec<f64>, f64, f64, bool)>; 4] = Default::default();
+    // One observation in a plan's least-squares fit. 70/30 train/test by query index so
+    // held-out fidelity reveals overfitting (the 22-query trap).
+    type FitRow = (
+        Vec<f64>, // design-matrix terms, one per cost coefficient being fitted
+        f64,      // measured ns minus the plan's fixed offset (the value actually regressed on)
+        f64,      // measured ns, unadjusted
+        bool,     // in the training split?
+    );
+    let mut rows: [Vec<FitRow>; 4] = Default::default();
     let t_start = Instant::now();
 
     for (qi, (_qlabel, spec)) in queries.iter().enumerate() {
@@ -3816,11 +3826,12 @@ fn plan_cost_refit() {
 /// For each range query × page depth (printing mode, edhrec sort = MISALIGNED, the
 /// case the walk pays for), measure P1/P3/P4 (min-of-N), then compare two pickers
 /// against empirical gold:
-///   - TREE: what `run_query` dispatches — P1 iff the fastpath fired
-///     (`run_query_with_plan(P1)` is `Some`), else P3/P4 via the `maybe_broad` gate.
-///   - MODEL: `argmin cost::plan_cost` on the TRUE features (matches = measured
-///     printing total; for a range query this is the index's exact `k`, so there is
-///     no estimation error to muddy the plan-choice question).
+/// - TREE: what `run_query` dispatches — P1 iff the fastpath fired
+///   (`run_query_with_plan(P1)` is `Some`), else P3/P4 via the `maybe_broad` gate.
+/// - MODEL: `argmin cost::plan_cost` on the TRUE features (matches = measured
+///   printing total; for a range query this is the index's exact `k`, so there is
+///   no estimation error to muddy the plan-choice question).
+///
 /// Reports per-row regret (picked_ns/gold_ns) and geomean regret for each. A model
 /// geomean below the tree's — with the gap on deep+moderate rows — is the win that
 /// justifies printing routing; parity means printing ties too (report, don't build).
@@ -5288,7 +5299,7 @@ fn frame_postings_thresholded_at_build() {
         }
     }
     let idx = build_thresholded_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
-    assert!(idx.get("2015").is_none(), "dominant value must be dropped by the threshold");
+    assert!(!idx.contains_key("2015"), "dominant value must be dropped by the threshold");
     assert_eq!(idx.get("Showcase").map(|v| v.len()), Some(40));
 
     // Wired into narrowing: selective value narrows in printing space, the
@@ -7796,8 +7807,8 @@ fn name_bigrams_tiers_and_exactness() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let idx = &archived.indexes.name_bigrams;
 
-    assert!(idx.plane_of.get(&[b'z', b'z']).is_some(), "4,096-name bigram must promote to a plane");
-    assert!(idx.postings.get(&[b'q', b'x']).is_some(), "64-name bigram stays a posting list");
+    assert!(idx.plane_of.get(b"zz").is_some(), "4,096-name bigram must promote to a plane");
+    assert!(idx.postings.get(b"qx").is_some(), "64-name bigram stays a posting list");
 
     let rec = |w: &str| {
         let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: w.to_string() };
@@ -8445,7 +8456,7 @@ fn verify_order_spellings_agree_end_to_end() {
         c.edhrec_rank = Some(i + 1);
         cards.push(c);
     }
-    let mut data = store_of(cards, &vec![2usize; 12], vocab);
+    let mut data = store_of(cards, &[2usize; 12], vocab);
     data.strings = strings.strings;
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
@@ -8657,6 +8668,8 @@ fn lanes_ge_matches_scalar_compare() {
 /// `n_cards` cards with populated edhrec/cmc sort keys, 1-4 printings each, prices heavily
 /// clustered onto a few hot values (so the price index has large equal-value tie buckets) plus
 /// ~15% NULL, and a real price range index built over them.
+// needless_range_loop: `i` is both the synthesized card id (`i as u128`) and the `ranks` index.
+#[allow(clippy::needless_range_loop)]
 fn printing_range_fixture(seed: u64, n_cards: usize) -> CardData {
     use rand::SeedableRng;
     let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
@@ -9096,8 +9109,13 @@ fn card_range_build_cost_split() {
     let idx = &archived.indexes.price_usd;
     let ptc = &archived.indexes.printing_to_card;
     let offsets = &archived.offsets;
-    let s = idx.partition_point(|p| u32::from(p.0) < 0); // usd<50 -> [0, 5000) cents
-    let e = idx.partition_point(|p| u32::from(p.0) < 5000);
+    // The benched range is `usd<50`: every price below HI_CENTS, over the value-sorted price index.
+    const HI_CENTS: u32 = 5_000;
+    // The low bound is 0 and prices are unsigned, so the slice starts at the front of the index by
+    // definition — no binary search needed. (The partition point this replaced tested `< 0`, always
+    // false: it returned the right answer, 0, but read as if it were searching for something.)
+    let s = 0usize;
+    let e = idx.partition_point(|p| u32::from(p.0) < HI_CENTS);
     let k = e - s;
 
     // A: scatter the price slice into a printing bitmap.
@@ -9161,7 +9179,7 @@ fn printing_range_walk_matches_naive_page() {
                     let got = walk_printing_page(
                         &QueryCtx::from(archived), &kernel_params(Mode::Printing, sc, desc, lim, off), &leaf, perm,
                     );
-                    let want = naive_printing_page(&archived, &leaf, sc, desc, off, lim);
+                    let want = naive_printing_page(archived, &leaf, sc, desc, off, lim);
                     assert_eq!(page_scryfall_ids(&got), want, "walk seed {seed} desc {desc} off {off} lim {lim}");
                 }
             }
@@ -9196,7 +9214,7 @@ fn printing_range_aligned_page_matches_naive_incl_tie_buckets() {
                         continue;
                     }
                     let got = aligned_page(idx, s, e, &archived.cards, &archived.printings, &archived.indexes.printing_to_card, desc, off, lim);
-                    let want = naive_printing_page(&archived, &leaf, SortCol::PriceUsd, desc, off, lim);
+                    let want = naive_printing_page(archived, &leaf, SortCol::PriceUsd, desc, off, lim);
                     assert_eq!(page_scryfall_ids(&got), want, "aligned seed {seed} desc {desc} off {off} lim {lim} k {k}");
                 }
             }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -127,9 +127,9 @@ fn trigram_fully_unindexed_word_is_empty_not_unnarrowed() {
 #[test]
 fn test_trigram_index_archive_and_lookup() {
     let mut idx: HashMap<[u8; 3], Vec<u32>> = HashMap::new();
-    idx.insert([b'a', b'b', b'c'], vec![1, 2, 3]);
-    idx.insert([b'x', b'y', b'z'], vec![4, 5]);
-    idx.insert([b'f', b'o', b'o'], vec![10, 20, 30, 40]);
+    idx.insert(*b"abc", vec![1, 2, 3]);
+    idx.insert(*b"xyz", vec![4, 5]);
+    idx.insert(*b"foo", vec![10, 20, 30, 40]);
 
     let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize trigram index");
     let archived = rkyv::access::<rkyv::Archived<HashMap<[u8; 3], Vec<u32>>>, Error>(&bytes)

--- a/docs/issues/00757-engine-query-ctx-arg-bundle.md
+++ b/docs/issues/00757-engine-query-ctx-arg-bundle.md
@@ -237,7 +237,8 @@ docs rather than folded in here:
   Python-only. `cargo clippy --all-targets` emits 68 warnings today. That means the 25 `#[allow]`s
   this change sheds are being maintained by hand for a lint nothing enforces — so the payoff will
   quietly regress without a `-D warnings` gate. Highest-leverage cleanup in the crate, and a
-  prerequisite for this one's benefit sticking.
+  prerequisite for this one's benefit sticking. **Done** in
+  [local-engine-clippy-ci-gate.md](local-engine-clippy-ci-gate.md), stacked directly on this change.
 - **`lib.rs` is 8146 lines** and already carved by 30 `// ───` section banners that map cleanly onto
   modules. The split is close to mechanical: `mod tests` sits at the crate root
   ([lib.rs:8130](../../card_engine/src/lib.rs#L8130)) importing ~100 names via `use super::{…}`, and

--- a/docs/issues/local-engine-clippy-ci-gate.md
+++ b/docs/issues/local-engine-clippy-ci-gate.md
@@ -1,0 +1,104 @@
+# Engine: Clean Clippy and Gate It in CI
+
+Status: **implemented 2026-07-24** on `engine-clippy-clean` (stacked on
+[#757](00757-engine-query-ctx-arg-bundle.md)). Not filed as a GitHub issue — found while scoping #757,
+implemented immediately after it.
+
+## The finding
+
+Clippy was not running in CI at all, and was not clean.
+
+- [rust-tests.yml](../../.github/workflows/rust-tests.yml) ran only `cargo test` for the two crates.
+- [lint.yml](../../.github/workflows/lint.yml) is Python-only: its `paths` filter is `**/*.py`,
+  `requirements/**`, `pyproject.toml`, and itself. No Rust path can trigger it.
+- `cargo clippy --all-targets` emitted **68 warnings** on `card_engine` and 3 on `shared_cache`.
+
+The consequence worth naming: `card_engine` carried 25 hand-written
+`#[allow(clippy::too_many_arguments)]` attributes — deliberate, maintained-by-hand suppressions for a
+lint **nothing enforced**. Two functions were over the same threshold with no `allow` at all
+(`run_query` at 13/7, the PyO3 `query` at 10/7), which is what a silent lint looks like after a while.
+This is also why the gate is a prerequisite for #757's payoff rather than an unrelated chore: that
+change sheds 15 of those attributes, and without enforcement the count just drifts back up.
+
+## What changed
+
+**Fixed, not suppressed** (the bulk):
+
+| Lint | n | Resolution |
+| --- | --- | --- |
+| `useless_conversion` | 13 | `u8::from(*v) as f32` → `f32::from(*v)`; the archived 1-byte ints need no endian unwrap, and `f32::from` states the widening without an `as` cast's lossy-looking ambiguity |
+| `collapsible_if` | 8 | Collapsed to let-chains (edition 2024), **hand-reindented** — `clippy --fix` leaves the bodies at their old depth and there is no rustfmt in this repo to clean up after it |
+| `needless_range_loop` | 4 | Rewrote to slice iteration where the index was only an index |
+| `doc_list_item_without_indentation` | 10 | Two doc comments had a paragraph immediately after a 3-space-indented list, so markdown absorbed it as a lazy continuation; dedented the markers and added the blank `///` separator |
+| `type_complexity` | 2 | Promoted the tuple's existing explanatory comment into a named type (`FitRow`, `ManaQuery`) with per-field comments |
+| `derivable_impls` | 1 | 36-line hand-written `impl Default for CardIndexes` → `#[derive(Default)]` (every field was already its type's default) |
+| `ptr_arg` | 1 | `push_card_matches`'s `group_best: &mut Vec<_>` → `&mut [_]`; it indexes and assigns but never resizes, and the slice says so in the type |
+| `needless_borrow`, `needless_lifetimes`, `unnecessary_get_then_check`, `byte_char_slices`, … | ~15 | Machine-applied via `clippy --fix`, reviewed by hand |
+
+**Suppressed with a stated reason** (12 `needless_range_loop` + 2 naming/API):
+
+- 10 loops in `lib.rs` keep `#[allow(clippy::needless_range_loop)]` at function level because `pid` is
+  the printing's *identity*, not a cursor — it goes into the emitted match tuple as `pid as u32`. A
+  slice iterator would lose it. This follows the precedent already in the file at
+  `gather_composed_page`, whose allow carried exactly this rationale.
+- `solve_normal_eqs` indexes two different rows of `a` in one statement (split_at_mut would obscure
+  the elimination step); `printing_range_fixture`'s `i` is both a synthesized card id and a `ranks`
+  index.
+- `TextSearchField`'s `enum_variant_names`: the shared `Lower` suffix is load-bearing — it names the
+  case/accent-folded store columns search actually reads, not the display columns.
+- The three PyO3 keyword surfaces (`query` 10/7, `explain` 8/7, and `run_query` behind them) keep
+  `too_many_arguments`: `self` counts toward clippy's 7, and the keyword list is the API.
+
+## Two substantive findings
+
+Neither was a live bug, but both were code that read as if it did something it didn't.
+
+**A comparison that was always false.** In `bench_range_compose_kernels`:
+
+```rust
+let s = idx.partition_point(|p| u32::from(p.0) < 0); // usd<50 -> [0, 5000) cents
+```
+
+Prices are unsigned, so this predicate is never true and `partition_point` returns 0 — which is the
+*correct* low bound for a range starting at 0, so the bench was right by accident. It read as a binary
+search for something. Replaced with an explicit `let s = 0usize` plus a named `HI_CENTS` for the real
+bound (per the repo's named-constants convention) and a comment saying why no search is needed. This
+was the one lint reported at `error:` level, not `warning:` — `absurd_extreme_comparisons` is
+deny-by-default, so `cargo clippy` had been exiting non-zero the whole time and nothing was watching.
+
+**An open mode that didn't say what it meant.** The reload lock file was opened
+`.write(true).create(true)` with no `truncate`, which clippy flags as undefined intent. Nothing is
+ever written to that file — it exists only as an `flock` target — so truncation must never happen.
+Added an explicit `.truncate(false)` and a comment; behavior is unchanged, the intent is now in the
+code.
+
+## The gate
+
+Two `cargo clippy --all-targets -- -D warnings` steps (one per crate) added to the **existing**
+`rust-test` job rather than as a new job. Three reasons, in order:
+
+1. A new job means a new required check, which means
+   [rust-tests-skip.yml](../../.github/workflows/rust-tests-skip.yml) needs a matching stub job or
+   PRs touching no `.rs` file hang forever on a check that never runs. Steps in the existing job need
+   no such coordination.
+2. `rust-tests.yml`'s `paths` filter (`**/*.rs`, `**/Cargo.*`) is already exactly the right trigger.
+3. Placed **after** the test steps deliberately: `-D warnings` aborts the job, so lint-first would
+   hide a genuine test failure behind a style nit.
+
+`--all-targets` matters — most of the 68 warnings were in `tests.rs` and the bench modules, which a
+bare `cargo clippy` never compiles.
+
+## Follow-up: `shared_cache` has the same arg-bundling smell
+
+The three `shared_cache` warnings are all `too_many_arguments`, and two of them are the same pattern
+#757 fixed in the engine: `write_init_headers` takes nine layout parameters both call sites already
+hold as separate values, and `do_insert` takes the seven fields of the entry being written. Both want
+a struct. `set` (8) is the crate's public cache-write surface and mirrors the HTTP response it stores,
+so grouping it would be an API change. All three are allowed with those reasons recorded inline; the
+bundling is worth its own change and is not folded in here.
+
+## Related
+
+- [00757-engine-query-ctx-arg-bundle.md](00757-engine-query-ctx-arg-bundle.md) — the arg-bundling work
+  this is stacked on; it sheds 15 of the `too_many_arguments` allows, and this gate is what keeps them
+  shed.

--- a/docs/issues/local-engine-clippy-ci-gate.md
+++ b/docs/issues/local-engine-clippy-ci-gate.md
@@ -88,6 +88,46 @@ Two `cargo clippy --all-targets -- -D warnings` steps (one per crate) added to t
 `--all-targets` matters — most of the 68 warnings were in `tests.rs` and the bench modules, which a
 bare `cargo clippy` never compiles.
 
+## The gate needs a pinned toolchain
+
+First CI run of this branch failed, and the failure is instructive: `byte_char_slices` flagged three
+`[b'a', b'b', b'c']` array literals in `tests.rs`. Locally clean, because local clippy was **1.96.0**
+and CI's `dtolnay/rust-toolchain@stable` resolved to **1.97.0**, which added that lint.
+
+`-D warnings` on a floating `@stable` means every Rust release (~6 weeks) turns into a red build on
+whichever PR is open at the time, for code that didn't change — and it can't be reproduced locally
+until the contributor happens to update. So the toolchain is now **pinned to 1.97.1** in
+[rust-tests.yml](../../.github/workflows/rust-tests.yml). Bumping it becomes a deliberate PR where the
+new lints get reviewed on purpose, instead of a surprise on unrelated work.
+
+The three literals were fixed (`*b"abc"`), not suppressed. Verified against 1.97.1 locally after
+`rustup update stable`, so local and CI now agree exactly.
+
+## Separate pre-existing finding: the skip-stub pattern can mask a real failure
+
+Worth its own fix, and **not introduced here** — it affects the `unit-tests`/`js-tests` pairs the same
+way. On this PR, *both* Rust workflows ran:
+
+| Workflow | Steps | Result |
+| --- | --- | --- |
+| `rust-tests-skip.yml` | 3 | success |
+| `rust-tests.yml` | 11 | **failure** |
+
+Both declare `name: Rust Tests` with a job named `rust-test`, so they report a check of the same name.
+`gh pr checks 760` showed **4 passed, 0 failed** — it surfaced only the stub. The real failure was
+visible solely by listing workflow runs directly.
+
+The cause is that `paths-ignore` cannot express "no Rust files changed". It runs when *any* changed
+file falls outside the ignore list, so a PR touching both `.rs` and non-`.rs` files (this one changes
+`.rs` files *and* this doc) satisfies `rust-tests.yml`'s `paths` **and** `rust-tests-skip.yml`'s
+`paths-ignore`. Both fire; one is a no-op success. If `rust-test` is a required status check, its state
+is then ambiguous.
+
+`check-ci-sync.yml` doesn't catch this — it only verifies the two path lists mirror each other, which
+they correctly do. The fix is structural: one workflow with a change-detection job (`dorny/paths-filter`
+or a `git diff` step) gating the real steps, rather than two workflows racing to report the same check
+name. That changes CI semantics repo-wide, so it is deliberately not folded in here.
+
 ## Follow-up: `shared_cache` has the same arg-bundling smell
 
 The three `shared_cache` warnings are all `too_many_arguments`, and two of them are the same pattern

--- a/shared_cache/src/gen_cache.rs
+++ b/shared_cache/src/gen_cache.rs
@@ -49,6 +49,11 @@ pub struct GenerationalSharedCache {
 /// Write CoordHeader + PageHeaders into a (possibly zeroed) mmap. Called under the flock
 /// in open() and also by invalidate() (which uses the spinlock instead). Having this as a
 /// free function lets both call sites avoid duplicating the layout arithmetic.
+// too_many_arguments: nine layout parameters that the two call sites (open() under the flock,
+// invalidate() under the spinlock) already hold as separate values. Bundling them into a
+// `Layout` struct is the right cleanup — the same treatment #757 gave the engine's query
+// layer — but it belongs in its own change, not a lint pass.
+#[allow(clippy::too_many_arguments)]
 fn write_init_headers(
     mmap: &mut MmapMut,
     n_pages: usize,
@@ -243,6 +248,10 @@ impl GenerationalSharedCache {
         }
     }
 
+    // too_many_arguments: the fields of the entry being written, pre-hashed by the caller so
+    // the probe loop above and this insert share one hash computation. Bundleable (see
+    // write_init_headers' note).
+    #[allow(clippy::too_many_arguments)]
     fn do_insert(
         &mut self,
         page_idx: usize,
@@ -656,6 +665,10 @@ impl GenerationalSharedCache {
         false
     }
 
+    // too_many_arguments: this is the crate's public cache-write surface and mirrors the HTTP
+    // response it stores (status/headers/body plus the counts and TTL). Grouping these would
+    // change the public API, so it is deliberately left alone here.
+    #[allow(clippy::too_many_arguments)]
     pub fn set(
         &mut self,
         key: &[u8],


### PR DESCRIPTION
**Stacked on #759** (base is `engine-query-ctx-arg-bundle`, not `main`). `run_query`'s 13/7 `too_many_arguments` warning is exactly what #759 fixes, so a `-D warnings` gate on a main-based branch would conflict with it. Review/merge #759 first; the base retargets to `main` automatically.

## The finding

Clippy was not running in CI at all, and was not clean.

- `rust-tests.yml` ran only `cargo test` for the two crates.
- `lint.yml` is Python-only — its `paths` filter is `**/*.py`, `requirements/**`, `pyproject.toml`, and itself. No Rust path can trigger it.
- `cargo clippy --all-targets` emitted **68 warnings** on `card_engine`, 3 on `shared_cache`.
- One of them (`absurd_extreme_comparisons`) is **deny-by-default**, so `cargo clippy` had been **exiting 101** the whole time, not merely warning. Verified against `main`.

Why this matters beyond tidiness: `card_engine` carried **25 hand-maintained `#[allow(clippy::too_many_arguments)]`** attributes — deliberate suppressions for a lint nothing enforced — and two functions were over the same threshold with no `allow` at all. #759 sheds 15 of those attributes; without a gate the count just drifts back up.

## Fixed, not suppressed

| Lint | n | Resolution |
| --- | --- | --- |
| `useless_conversion` | 13 | `u8::from(*v) as f32` → `f32::from(*v)` — the archived 1-byte ints need no endian unwrap, and `f32::from` states the widening without an `as` cast's lossy-looking ambiguity |
| `collapsible_if` | 8 | Collapsed to edition-2024 let-chains, **hand-reindented** (see note below) |
| `doc_list_item_without_indentation` | 10 | Two doc comments had a paragraph right after a 3-space-indented list, so markdown absorbed it as a lazy continuation |
| `needless_range_loop` | 4 | Rewrote to slice iteration where the index was only an index |
| `type_complexity` | 2 | Promoted each tuple's existing explanatory comment into a named type (`FitRow`, `ManaQuery`) with per-field comments |
| `derivable_impls` | 1 | 36-line `impl Default for CardIndexes` → `#[derive(Default)]` (every field was already its type's default) |
| `ptr_arg` | 1 | `push_card_matches`'s `group_best: &mut Vec<_>` → `&mut [_]`; it indexes and assigns but never resizes, and the slice says so in the type |
| `needless_borrow`, `needless_lifetimes`, `unnecessary_get_then_check`, `byte_char_slices`, … | ~15 | Machine-applied, reviewed by hand |

## Suppressed, with the reason recorded inline

- **10 loops** keep `needless_range_loop` at function level because `pid` is the printing's *identity*, not a cursor — it goes into the emitted match tuple as `pid as u32`. This follows the precedent already in the file at `gather_composed_page`, whose allow carried exactly this rationale.
- `solve_normal_eqs` indexes two different rows of `a` in one statement; `printing_range_fixture`'s `i` is both a synthesized card id and a `ranks` index.
- `TextSearchField`'s `enum_variant_names`: the shared `Lower` suffix names the case/accent-folded store columns search actually reads, not the display columns.
- The three PyO3 keyword surfaces keep `too_many_arguments` — `self` counts toward clippy's 7, and the keyword list is the API.

## Two findings that read as if they did something they didn't

Neither was a live bug.

**A comparison that was always false.** A bench computed `partition_point(|p| u32::from(p.0) < 0)` on an unsigned price. Never true → returns 0, which *is* the correct low bound for a range starting at 0 — right by accident, but it read as a binary search for something. Now an explicit `let s = 0usize` plus a named `HI_CENTS` for the real bound and a comment saying why no search is needed. This is the lint that was failing the build.

**An open mode that didn't state its intent.** The reload lock file was opened `.write(true).create(true)` with no `truncate`. Nothing is ever written to it — it exists only as an `flock` target — so truncation must never happen. Added `.truncate(false)` explicitly; behavior unchanged, intent now in the code.

## The gate

Two `cargo clippy --all-targets -- -D warnings` steps added to the **existing** `rust-test` job rather than as a new job:

1. A new job means a new required check, which would also need a matching `rust-tests-skip.yml` stub or PRs touching no `.rs` file hang forever on a check that never runs.
2. `rust-tests.yml`'s `paths` filter (`**/*.rs`, `**/Cargo.*`) is already the right trigger.
3. Placed **after** the test steps deliberately — `-D warnings` aborts the job, so lint-first would hide a genuine test failure behind a style nit.

`--all-targets` matters: most of the 68 warnings were in `tests.rs` and the bench modules, which a bare `cargo clippy` never compiles.

## Note for anyone running `clippy --fix` here again

It collapses nested `if`s into let-chains but leaves the bodies at their **old indentation depth**, and this repo has no rustfmt to clean up after it. All 8 sites needed manual reindentation. (Relatedly: `cargo fmt` on this crate would be a ~12,800-line diff, or ~3,900 with `max_width = 140`, and it flattens the deliberate column alignment in the `match` arms — so it stays off.)

## Follow-up: `shared_cache` has the same arg-bundling smell

Its three warnings are all `too_many_arguments`, and two are the pattern #759 fixed: `write_init_headers` takes nine layout parameters both call sites already hold separately, and `do_insert` takes the seven fields of the entry being written. Both want a struct. `set` (8) is the public cache-write surface and mirrors the HTTP response it stores, so grouping it would be an API change. All three allowed with those reasons inline; the bundling is worth its own change.

## Verification

`cargo test` 139/139 in debug **and** release on `card_engine`; `clippy --all-targets -- -D warnings` passes on both crates.

Notes: [docs/issues/local-engine-clippy-ci-gate.md](https://github.com/jbylund/sylvan_librarian/blob/engine-clippy-clean/docs/issues/local-engine-clippy-ci-gate.md).