### PR TITLE
Probe: Verify the Skip Path (do not merge)

### DIFF
--- a/docs/issues/local-ci-skip-stub-masks-failures.md
+++ b/docs/issues/local-ci-skip-stub-masks-failures.md
@@ -124,3 +124,5 @@ was closed afterward.
 - [local-engine-clippy-ci-gate.md](local-engine-clippy-ci-gate.md) — the clippy gate whose red build
   this masked, and where the finding was first recorded. That gate is also what makes the masking
   consequential: before it, `rust-tests.yml` only ran `cargo test`.
+
+Probe: verifying the skip path reports a satisfied check (see #761).


### PR DESCRIPTION
Throwaway probe for #761. Diff is docs-only, and the new gated workflows come from the base branch, so this exercises the path #761 itself cannot: all three suites should report their real job as **skipped** while the check still comes out satisfied. Will be closed once observed.