### PR TITLE
Chore: Prune Orphaned rand Subtree From shared_cache's Lockfile

### DIFF
--- a/shared_cache/Cargo.lock
+++ b/shared_cache/Cargo.lock
@@ -44,26 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,18 +71,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "rand_core",
 ]
 
 [[package]]
@@ -287,12 +255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rancor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,23 +262,6 @@ checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
 dependencies = [
  "ptr_meta",
 ]
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rend"
@@ -370,7 +315,6 @@ dependencies = [
  "libc",
  "memmap2",
  "pyo3",
- "rand",
  "rkyv",
  "xxhash-rust",
 ]


### PR DESCRIPTION
One file, 56 deletions, 0 insertions.

## The problem

`shared_cache/Cargo.lock` carried `rand` and its five transitive dependencies:

```
rand 0.10.1   rand_core 0.10.1   chacha20 0.10.1
getrandom 0.4.3   cpufeatures 0.3.0   r-efi 6.0.0
```

The crate depends on none of them:

- `shared_cache/Cargo.toml` declares only `pyo3`, `rkyv`, `memmap2`, `libc`, `xxhash-rust`.
- Nothing under `shared_cache/src/` references `rand`.
- `cargo tree` shows **zero** `rand` nodes in its dependency graph.

`card_engine` is the crate that genuinely needs it (`rand = "0.10"`, used by the #677 fuzzer in `tests.rs`), and **both** lockfiles contained the identical six entries — so this was `card_engine`'s subtree sitting in the wrong lockfile.

## Why it mattered (and why it didn't)

**No build impact.** Cargo ignores lockfile entries unreachable from the manifest, so these pinned nothing and changed no resolution.

**The cost was a recurring spurious diff.** Every `cargo` invocation in that crate rewrote the file, so anyone running cargo there gets a modified file they didn't touch — and it had to be reverted repeatedly across #759/#760/#761 to keep those diffs honest. With the new CI gate running `cargo test` and `cargo clippy` on `shared_cache`, CI regenerates it too.

## What this does

Lets cargo rewrite the file — **not** `cargo update`, which would have bumped every dependency. The diff is therefore pure pruning: **0 insertions**, so no retained package changed version.

Verified on the result: `cargo test` passes and `cargo clippy --all-targets -- -D warnings` passes.

## Incidental note

This PR is a useful first exercise of the #761 gating in its *partial* form: the only changed file matches `(^|/)Cargo\.(toml|lock)$`, which appears in both the rust and python patterns but not the js one. So `rust-test` and `python-test` should run while `js-test` reports `skipped` — and under the new `strict` policy all three must still come out satisfied for this to be mergeable. Worth a glance at the checks to confirm a partial skip behaves.