### PR TITLE
Chore: npm audit fix — Clear 4 High-Severity Dev-Dependency Advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1970,9 +1970,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3971,9 +3971,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4220,9 +4220,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
-      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4549,9 +4549,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4569,7 +4569,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5663,9 +5663,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5764,9 +5764,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears the dependabot alerts that have been showing on every push. `npm audit` now reports **0 vulnerabilities**.

## Scope

`npm audit fix` with **no `--force`**, so every fix landed inside the existing semver ranges: `package.json` is untouched and only `package-lock.json` changes — 6 packages, 19 insertions / 19 deletions.

| Package | | |
| --- | --- | --- |
| `brace-expansion` | 2.1.1 → 2.1.2 | (also 1.1.15 → 1.1.16 under `test-exclude`) |
| `js-yaml` | 3.14.2 → 3.15.0 | |
| `nanoid` | 3.3.14 → 3.3.16 | |
| `postcss` | 8.5.15 → 8.5.23 | |
| `svgo` | 4.0.1 → 4.0.2 | |

Advisories cleared: `brace-expansion` and `js-yaml` DoS (exponential / quadratic expansion), `postcss` path traversal via `sourceMappingURL` auto-loading, and `svgo`'s `removeScripts` plugin leaving some executable scripts intact.

## Severity in context

All of these are **devDependencies** — build and test tooling (`jest`, `postcss-cli`, `cssnano`, `prettier`, `terser`), not shipped runtime code. None were reachable from the served application, so "4 high" overstates the practical exposure here. Still worth clearing: it's a no-cost fix and it stops the alerts masking a future one that *does* matter.

## Verification

jest alone isn't sufficient here — it never touches the CSS/SVG toolchain, which is where `postcss` and `svgo` live. So:

- `npx jest` → 4 suites, **6964 tests passed** (what CI's `js-test` runs)
- `npm run format:check` → clean
- `npx postcss api/static/styles.css --use cssnano` → succeeds. This is also what exercises `svgo`, which has no direct use in the repo and is reached via `cssnano → cssnano-preset-default → postcss-svgo → svgo`
- `npx terser api/static/app.js --compress --mangle` → output **byte-identical** to the committed `api/static/app.min.js`. `terser` itself wasn't bumped, so this confirms no incidental drift in the one artifact that is checked in

## Unrelated observation

`npm` emits `EBADENGINE` locally: `package.json` requires `node >=26.1.0` and `.nvmrc` pins `26.1.0`, but my local node is `v26.0.0`. Pre-existing and not caused by this change — CI is unaffected because `js-tests.yml` uses `node-version: '26'`, which resolves to the latest 26.x. Mentioning it only so it isn't mistaken for fallout from this PR.