### PR TITLE
Score: Core-Style Artwork Bonus and a Corrected Printing Count (#720)

### DIFF
--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -90,6 +90,43 @@ WITH computed_components AS (
                     WHEN card_set_code IS NULL OR card_set_code NOT IN ('dbl') THEN 20
                     ELSE 0
                 END
+            ),
+            -- Bonus for artwork in Magic's core style, i.e. NOT a licensed crossover and
+            -- not a stylistic departure. Written as a bonus for being on-style rather than
+            -- a penalty for being off-style so every component stays non-negative, like the
+            -- rest of this table.
+            --
+            -- `external-ip` is the Scryfall tagger's parent tag over ~57 licensed
+            -- franchises (Fallout, Warhammer, Marvel, Doctor Who, Fortnite, ...).
+            -- `dungeons-and-dragons` and `the-lord-of-the-rings` are deliberately exempt:
+            -- external IP whose art matches Magic's high-fantasy look. Verified complete --
+            -- no artwork carries a sibling tag (arda, hobbit, abeir-toril, dnd-multiverse)
+            -- without also carrying its parent, so no Middle-earth or Forgotten Realms art
+            -- is demoted by accident.
+            --
+            -- The second clause covers stylistic departures that are not licensed universes:
+            -- anime, comic-style, line-art and word-art-title. Note it applies even to the
+            -- exempt IPs -- Drizzt Do'Urden (afr #338) is tagged dungeons-and-dragons AND
+            -- line-art, and is demoted, because a line-art rendering is a departure from the
+            -- painted core style whoever owns the IP. Confirmed against the artwork.
+            --
+            -- Evidence (docs/issues/00720-prefer-score-artwork-tuning.md): in 177 labelled
+            -- artwork comparisons where exactly one side was off-style, the on-style side
+            -- was chosen 177 times. Blind swap review across weights 6, 9 and 14 gave 78
+            -- "better" and 0 "worse" over 114 changed cards. Fixes both cards that opened
+            -- the issue -- Puresteel Paladin was showing its Fallout printing and Sword of
+            -- the Animist its Marvel one.
+            --
+            -- A year/era term was the obvious alternative and was rejected: it would
+            -- permanently penalise all future art, whereas a tag on the artwork generalises.
+            'art_style', (
+                CASE
+                    WHEN (
+                        card_art_tags ? 'external-ip'
+                        AND NOT (card_art_tags ?| ARRAY['dungeons-and-dragons', 'the-lord-of-the-rings'])
+                    ) OR card_art_tags ?| ARRAY['anime', 'comic-style', 'line-art', 'word-art-title'] THEN 0
+                    ELSE 14
+                END
             )
         ) AS new_components
     FROM magic.cards source

--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -5,6 +5,31 @@ WITH computed_components AS (
     SELECT
         scryfall_id,
         JSONB_BUILD_OBJECT(
+            -- How heavily this ARTWORK has been reprinted, as a proxy for how canonical it
+            -- is. The numerator counts rows sharing the illustration, so it must count only
+            -- real printing events -- three kinds of row are not:
+            --
+            --   non-English  the same printing already counted in its English row. Mark
+            --                Poole's Birds of Paradise art picked up 4bb (Spanish) and fbb
+            --                (French) on top of the English 4th Edition printing.
+            --   memorabilia  World Championship decks, Collectors' Edition and 30th
+            --                Anniversary: not tournament-legal, not real sets. Four of the
+            --                eight on that same artwork are BLACK-bordered (30a x2, ced,
+            --                cei), so a border test alone misses half of them.
+            --   gold/yellow  any remaining non-standard product Scryfall types as something
+            --                other than memorabilia.
+            --
+            -- Together these took Poole's art from 21 counted printings to 11, against
+            -- Marcelo Vignali's 12 -- reversing which artwork the site shows for that card.
+            --
+            -- White borders are deliberately NOT filtered: 2ed-6ed are white-bordered and
+            -- perfectly real, and dropping them would penalise exactly the core-set reprints
+            -- this component should reward.
+            --
+            -- Evidence (docs/issues/00720-prefer-score-artwork-tuning.md): a 47-card blind
+            -- swap review returned 11 better, 36 same, 0 worse, and a later 378-card review
+            -- against production added 2 more with no regressions. This changes only the
+            -- numerator -- it does not stop such printings being displayed.
             'illustration_count', (
                 SELECT
                     ROUND((23 * LN(1 + COUNT(*)) / LN(40))::numeric, 4)
@@ -12,7 +37,10 @@ WITH computed_components AS (
                 WHERE (
                     query_target_cards.illustration_id = source.illustration_id AND
                     query_target_cards.illustration_id IS NOT NULL AND
-                    query_target_cards.card_name = source.card_name
+                    query_target_cards.card_name = source.card_name AND
+                    query_target_cards.raw_card_blob ->> 'lang' = 'en' AND
+                    COALESCE(query_target_cards.raw_card_blob ->> 'set_type', '') <> 'memorabilia' AND
+                    COALESCE(query_target_cards.card_border, '') NOT IN ('gold', 'yellow')
                 )
             ),
             'rarity', (

--- a/docs/issues/00720-prefer-score-artwork-tuning.md
+++ b/docs/issues/00720-prefer-score-artwork-tuning.md
@@ -216,11 +216,59 @@ stays non-negative, matching the rest of the table.
   (`ghirapur-grand-prix`, `cho-arrim` — set-specific Magic content, not style).
 - **Weight 14 is evidenced, not optimal.** Every step has been free; the stopping signal is the first
   "worse" verdict.
-- **`illustration_count`'s numerator is still wrong** — it counts rows, so finish variants and every
-  foreign-language printing inflate it. The original Pure Steel Paladin report remains unfixed.
+- **The printing count is filtered but not deduplicated.** One artwork can still take several credits
+  from a single set: Universes Beyond sets print four treatments of one picture, and 7th–10th Edition
+  model the foil as a separate `★` collector number. Collapsing to one credit per set was built and
+  reviewed and did **not** survive — see below.
 - **Feature/weight separation lives only in the Python tooling.** The SQL still fuses extraction and
   weights, so coefficient search needs the scripts. Lifting weights into config is the remaining
   refactor.
+
+## The second change: what the printing count counts
+
+`illustration_count` is a proxy for how canonical an artwork is, but its numerator counted every row
+sharing the illustration — including rows that are not printing events. Mark Poole's Birds of Paradise
+art counted 21: eight memorabilia (`30a` ×2, `ced`, `cei`, `ptc`, `wc00` ×2, `wc98`) and two
+foreign-language (`4bb`, `fbb`), leaving 11 real printings against Marcelo Vignali's 12. Filtering
+those three categories reverses which artwork the card shows.
+
+Border alone is not the discriminator: four of Poole's eight memorabilia rows are *black*-bordered, so
+a border test misses half. `set_type = 'memorabilia'` catches all eight. White borders are deliberately
+kept — `2ed`–`6ed` are real core sets, and dropping them would penalise the reprints the component
+should reward.
+
+Evidence: a 47-card blind swap review returned **11 better, 36 same, 0 worse**; a later 378-card review
+against production added 2 more with no regressions. It changes only the numerator — those printings
+can still be displayed.
+
+## Counting rules that were built and rejected
+
+- **One credit per set (dedup).** Principled — a set including an artwork twice is one editorial
+  decision — but reviewed at **28 better / 22 worse**. Losses concentrated 17–1 on 7th–10th Edition
+  `★` foils, where collapsing the foil twin removed the only thing separating a core-set artwork from
+  an older alternative. Never independently earned its place.
+- **Excluding `promo` sets.** Zeroes the count for 1,018 artworks that exist only as promos, telling
+  the score they were never printed. Rejected on that alone.
+- **Collapsing child sets into parents** (`blc`→`blb`). The largest effect measured — 16,357 duplicate
+  credits across 10,502 artworks — but `parent_set_code` is absent from our data and would need a
+  `magic.set_parents` table. Release date is a usable proxy (87 of 91 changes) but systematically fails
+  on late-released promos (`pltc` is 16 months after `ltr`). Deferred, not rejected.
+
+## Frame and finish: two corrections worth recording
+
+Reviewers of this work should know two hypotheses failed in instructive ways.
+
+**Frame weights cannot be moved one at a time.** The ladder is 1993=10, 1997=25, 2003=30, 2015=42, and
+every single-weight change perturbs two gaps. Raising `frame_2003` to widen 1997↔2003 also narrowed
+2003↔2015 and was reviewed at 8 better / 22 worse. Lowering `frame_1997` instead narrowed 1993↔1997,
+sending 161 of 179 swaps to the *oldest* frame. Only moving both old frames together isolates the gap.
+
+**Foil is not invisible, and confounded batches said it was.** Six accidental foil-vs-nonfoil pairs came
+back 6/6 "no difference", suggesting the `finish` component could be deleted. A deliberately controlled
+batch — same card, set, artwork, frame, border, rarity, scan quality, promo types and stamp, differing
+only in finish — returned **24 nonfoil, 0 foil, 26 same**. The earlier reading was small-sample noise.
+Only 162 such controlled pairs exist corpus-wide; everything else that looks like a foil pair is a
+special foil or a different promo product.
 
 ## Related
 

--- a/docs/issues/00720-prefer-score-artwork-tuning.md
+++ b/docs/issues/00720-prefer-score-artwork-tuning.md
@@ -1,0 +1,231 @@
+# Prefer-Score Artwork Selection: Tuneable Weights and a Measured Objective
+
+Status: **in progress.** Tracked as [#720](https://github.com/jbylund/sylvan_librarian/issues/720),
+which carries the standalone problem statement. One component (`art_style`) is evidenced and ready to
+land; the labelling and swap-review tooling that produced it is built and working. This doc is the
+depth: what was measured, what was wrong, and why the shipped answer is not the one it looked like for
+most of the investigation.
+
+Companion: [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the labelling
+instrument, its schema, sampling strategy, and fitting method.
+
+## Why this cannot be hand-written
+
+The governing fact, in the maintainer's words: *for any given card I can generally tell you which
+printing I most prefer, but it is obviously hard for me to write down a scoring function that reproduces
+that perfectly.*
+
+A reliable oracle for the outputs, no closed form for the function. The scarce resource is the
+maintainer's judgment, so the job is to harvest it cheaply and convert it into weights rather than keep
+guessing at coefficients.
+
+## The reported failures, and why they were misleading
+
+Two cards showed a printing other than the one that should clearly win: **Pure Steel Paladin** (an
+artwork with many surge-foil printings winning) and **Sword of the Animist** (a Universes Beyond art
+with 2 printings beating one with ~9). Both trace to `illustration_count`, the only component that
+refers to the artwork at all.
+
+The arithmetic accounts for Sword of the Animist exactly: 2 → 9 printings is worth **7.51** points,
+while `extended_art` alone is **12**. The term's *entire* range across 1 → 40 printings is **18.83** —
+less than `frame` (42) or `language` (40).
+
+But the fix was neither rescaling that term nor fixing its numerator. Chasing those two cards led to a
+general finding they were only symptoms of.
+
+## What the corpus actually looks like
+
+Measured on blue (97,306 printings / 31,508 cards / 45,824 distinct artworks), English, basic lands
+excluded.
+
+| | |
+| --- | --- |
+| Multi-printing cards | 18,337 |
+| Cards with ≥2 visually distinct looks | 13,816 |
+| Multi-printing cards where every printing looks alike | 4,521 |
+| Exact top-score ties | 8,597 (46.9%) |
+| …where the tie spans different artworks | 384 (2.1%) |
+| Cards where two *visually distinct* looks score identically | 1,697 (12.3%) |
+
+Attributing the 4,245 tied look-pairs: **3,319 (78%) differ by artwork**, 410 by frame version, 365 by
+an unscored frame treatment, 206 by border. The mechanism is that `illustration_count` is the only
+artwork-referring component, so two arts of one card with matching reprint counts tie *exactly* — and
+counts collide constantly. Two arts each printed once both score `23·ln(2)/ln(40)` = 4.32.
+
+## The finding: off-style artwork
+
+Community art tags (`art:`, 10,807 of them) describe the *picture*. Across labelled comparisons where
+exactly one artwork carried an off-style tag:
+
+| definition | on-style side chosen | rate |
+| --- | --- | --- |
+| 8 hand-picked style tags | 153/153 | 100% |
+| `external-ip` raw | 117/125 | 94% |
+| **`external-ip` minus `dungeons-and-dragons` / `the-lord-of-the-rings`** | **115/115** | **100%** |
+| that OR `anime` / `comic-style` / `line-art` | 159/159 | 100% |
+| **…and `word-art-title`** | **177/177** | **100%** |
+
+Raw `external-ip` has **exactly 8 exceptions, and the two exemptions remove exactly those 8**. D&D and
+Lord of the Rings are external IP whose art matches Magic's high-fantasy style; Fallout, Warhammer,
+Doctor Who and Marvel do not. Adding the non-IP stylistic departures (anime, comic, line art, word-art-title) widens
+coverage to 177 observations at no loss of accuracy. `word-art-title` was added last, on 18/18 evidence
+from the stratified batch plus a direct statement of dislike; it newly demotes 247 artworks (88 of its
+312 were already caught by `external-ip`) but moves only 4 cards, since few of them compete against an
+untagged sibling.
+
+`external-ip` is the Scryfall tagger's parent over ~57 licensed franchises
+([tagger.scryfall.com/tags/artwork/external-ip](https://tagger.scryfall.com/tags/artwork/external-ip)) —
+Assassin's Creed, Cowboy Bebop, Doctor Who, Fallout, Final Fantasy, Fortnite, Furby, Marvel, Monopoly,
+Star Trek, Stranger Things, TMNT, Warhammer and so on. Of those, only D&D and Lord of the Rings were
+judged consistent with Magic's core look.
+
+**The exemption is complete, verified.** Every artwork carrying a sibling tag (`arda`, `hobbit`,
+`abeir-toril`, `dnd-multiverse`) also carries its parent, so exempting the two parent tags catches all
+Middle-earth and Forgotten Realms art — zero orphans. Without that check, a card tagged only `arda`
+would have been silently demoted.
+
+**One deliberate edge case.** The exemption applies to the `external-ip` clause only, not to the
+style-departure clause, so Drizzt Do'Urden (AFR #338) — tagged `dungeons-and-dragons` *and* `line-art` —
+is still demoted. A line-art rendering is a departure from the painted core style whoever owns the IP.
+It is the single card in AFR affected, and the demotion was confirmed correct against the artwork.
+
+Corpus reach: 7,311 artworks are `external-ip`, 5,472 after exemptions, **6,193** under the final
+definition — 14% of all artworks.
+
+### Why a tag and not a year
+
+An era term tested well: 2003–2020 art wins **82%** of its cross-era comparisons, 2021+ wins **21.6%**.
+Rejected because **it permanently penalises all future art** — every future set lands in the disliked
+bucket by construction, needing perpetual re-tuning. A tag on the artwork generalises (new anime-styled
+art gets tagged; new core-style art does not) and *explains* the era correlation rather than restating
+it, since the crossover sets are recent. It also expresses the D&D/LotR distinction, which no year term
+or "is Universes Beyond" flag can — UB (27.8%) and 2021+ non-UB (21.7%) are statistically
+indistinguishable, so a UB flag would be both weak and wrong-shaped.
+
+## What was tried and did not survive
+
+Recorded because the failures were more instructive than the successes, and several were convincing at
+the time.
+
+- **`art_age` as a linear feature.** Batch 1 said it beat the whole scoring function (73.3% vs 65.2%
+  cross-validated) and it was reported as the strongest result in the analysis. On the cleaner batch-2
+  labels it **reversed** — `art_pop` won at 76.7% and the baseline rose to 75.5%. Two causes: batch 1
+  showed whole cards, so a preference for older *frames* masqueraded as one for older *artwork*; and the
+  preference is non-monotonic (peak 2003–2020), which a linear term with a declared non-negative sign
+  cannot represent at all.
+- **A monotonic sign for age.** Declaring signs presumes monotonicity. For age that was false, and the
+  constraint actively prevented the model fitting the truth.
+- **Artist identity.** 94.2% of within-card artwork pairs differ by artist, but 84% differ by artist
+  *and* age together; only 793 corpus pairs vary age with artist held constant. Artist prominence and
+  reuse were weak alone (63.5% / 67.9%). Prominence and total printings correlate at 0.986, so they
+  cannot both be fitted; reparameterising as (prominence, printings-per-artwork) drops that to 0.697.
+- **Perceptual hashing to filter near-duplicate artworks.** Built and calibrated. Only 3 of 183
+  labelled pairs fell in the "same art" band, and `other` verdicts spread evenly across distance
+  (median 43.5 vs 45.6 for decided), so the high no-preference rate is genuine indifference, not a
+  filtering failure. Superseded by cheaper exact filters: excluding promos (Scryfall gives a promo
+  recolour its own `illustration_id`) and the `dbl` set (530 cards reprinted in black and white).
+- **Lowering `extended_art`.** See below.
+- **A partial-credit tier for Portal Three Kingdoms.** `romance-of-the-three-kingdoms` is external IP by
+  the tagger's reckoning but a 1999 Magic set, not a modern crossover — judged "ok, not great", so a
+  middle tier was built and measured. Dropped: across the entire range from 0 to full credit it moved
+  only **5 cards** (3 at the candidate weight of 7, and 7 vs 8 were identical). Most P3K cards were never
+  reprinted, so their art has nothing to compete against. Not worth a third tier for a distinction that
+  changes nothing visible.
+
+## The `extended_art` cautionary tale
+
+Reviewed three times, three different answers:
+
+| review | result |
+| --- | --- |
+| 12 → 10.5, art crops shown | 4 better / 5 same / **0 worse** — looks like a free win |
+| 12 → 10.5, whole cards shown | 4 better / 1 same / **4 worse** — a wash |
+| 12 → 10, whole cards, larger step | 3 better / **29 worse** — **net −26** |
+
+The first reading was an artifact: extended art is a *frame* property, and the page was showing art
+crops, in which an extended-art printing and its normal sibling are identical images. Every real
+disagreement was forced into "no difference." Trusted, it would have shipped a clearly harmful change
+on an apparent zero-regression result.
+
+Two rules now encoded in the tooling: **show whole cards when the decision is about a printing**, and
+**a step too small to move enough cards yields no information** (12 → 10.8 moved 6 cards).
+
+## `art_style`: the evidence
+
+Swap review at each weight, judged blind, on whole cards:
+
+| step | better | same | **worse** |
+| --- | --- | --- | --- |
+| 0 → 6 | 28 | 24 | **0** |
+| 6 → 9 | 13 | 1 | **0** |
+| 9 → 14 | 37 | 11 | **0** |
+| **cumulative** | **78** | **36** | **0** |
+
+**114 swaps, not one regression.** The better-rate rises with weight (54% → 93% → 77%), which is
+mechanically sensible: a small weight only flips near-ties, which read as "same"; a larger one overcomes
+real gaps where an off-style printing was winning decisively on other components. Saturation is ~150
+cards at weight 30, so 14 captures most of the available effect.
+
+## It fixes both cards that opened the issue
+
+| card | current | with `art_style=14` |
+| --- | --- | --- |
+| **Puresteel Paladin** | `pip/456` — Fallout | `cmm/51` |
+| **Sword of the Animist** | `msc/452` — Marvel | `plst/ORI-240` |
+
+Both were showing a crossover-universe printing, and neither appeared in any labelled batch, so this is
+genuine out-of-sample validation. Note the original diagnosis of Puresteel Paladin was "lots of surge
+foil printings inflating the count" — surge foil is a *Fallout* treatment, so the reported symptom was
+real but pointed at `illustration_count` when the cause was the crossover set.
+
+## Two interaction findings
+
+**Changes are entangled.** `art_style=6` alone moves 53 cards, `extended_art=10` alone moves 34, their
+union 86 — but **jointly they move 101**. Fifteen cards move only when both weights move, and no
+one-component-at-a-time loop can reach them.
+
+**Ties dominate small steps.** With 46.9% of multi-printing cards exactly tied at the top, any epsilon
+on a component that differs between tied printings flips them all at once, so swap count jumps
+discontinuously from zero. Swaps must be split into **tie-breaks** (old pick was arbitrary; almost any
+change is an improvement) and **overrides** (a strict ranking reversed — the ones worth eyeballing).
+Step search targets overrides only.
+
+## What ships
+
+One new component, nothing else changed. `extended_art` stays at 12.
+
+```sql
+'art_style', (
+    CASE WHEN NOT (
+        (card_art_tags ? 'external-ip'
+         AND NOT (card_art_tags ?| ARRAY['dungeons-and-dragons','the-lord-of-the-rings']))
+        OR card_art_tags ?| ARRAY['anime','comic-style','line-art']
+    ) THEN 14 ELSE 0 END
+),
+```
+
+Expressed as a bonus for being on-style rather than a penalty on being off-style, so every component
+stays non-negative, matching the rest of the table.
+
+## Open
+
+- **The tag set is partly a hypothesis.** 533 further candidates exist — art tags whose artworks
+  concentrate in few sets, a measurable proxy separating style/setting tags from content tags like
+  `sky` or `fire` (content tags span 450–520 sets, style tags 2–53). Scanning them needs more than 517
+  observations without multiple-comparison inflation, and the filter has known false positives
+  (`ghirapur-grand-prix`, `cho-arrim` — set-specific Magic content, not style).
+- **Weight 14 is evidenced, not optimal.** Every step has been free; the stopping signal is the first
+  "worse" verdict.
+- **`illustration_count`'s numerator is still wrong** — it counts rows, so finish variants and every
+  foreign-language printing inflate it. The original Pure Steel Paladin report remains unfixed.
+- **Feature/weight separation lives only in the Python tooling.** The SQL still fuses extraction and
+  weights, so coefficient search needs the scripts. Lifting weights into config is the remaining
+  refactor.
+
+## Related
+
+- [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — labelling instrument.
+- [00707-engine-3key-ordering-parity.md](00707-engine-3key-ordering-parity.md) — `prefer_score` is the
+  third sort key and where plans may diverge.
+- [`api/sql/backfill_prefer_scores.sql`](../../api/sql/backfill_prefer_scores.sql) — the scoring
+  definition.

--- a/docs/issues/local-prefer-score-label-harness.md
+++ b/docs/issues/local-prefer-score-label-harness.md
@@ -1,0 +1,317 @@
+# Prefer-Score Label Harness: Pairwise Screening and Weight Fitting
+
+Status: proposed, not started. Split out of
+[00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) once it became clear this
+is an independent deliverable: 00720 is the scoring defect, this is the instrument for fixing it and for
+preventing the next one. Not filed as a GitHub issue of its own — it is the first step of #720.
+
+## Why an instrument is needed at all
+
+The governing fact, in the maintainer's words: *for any given card I can generally tell you which
+printing I most prefer, but it is obviously hard for me to write down a scoring function that reproduces
+that perfectly.*
+
+That is a favourable situation — a **reliable oracle for the outputs** with **no closed form for the
+function** — and it dictates the approach. The scarce resource is the maintainer's judgment, so the job
+is to harvest it cheaply and convert it into weights, rather than to keep guessing at coefficients.
+
+## Collect pairwise judgments, with an explicit "no preference"
+
+Show **two** printings; the answer is *a*, *b*, or *other*.
+
+`other` absorbs both "they are equally good" and "I cannot tell". Collapsing them is fine for a first
+pass, but note it is the **one irreversible decision** in this design: every other choice here can be
+revisited because labels re-score against any future config, whereas a distinction never recorded cannot
+be recovered for labels already collected. If `other` turns out frequent, splitting it costs a re-label
+of that batch. One extra button now is the cheap insurance.
+
+Also: **do not show the labeler the scored features** (first-use date, reprint count) before the verdict.
+Those are the model's inputs; displaying them makes the label partly a function of them, so the fit would
+learn a rule the labeler inferred from the same numbers being fitted. The label has to be an independent
+target. An optional *reveal-after-verdict* mode is safe and useful — the rate at which the labeler would
+change their mind is itself a measurement of how much of "iconic" is visual versus statistical.
+
+Not a grid of all printings with one click for the winner. Three reasons, in increasing order of
+importance:
+
+1. **It is the model's native input.** The fitting surrogate is `P(i beats j) = sigmoid(w·(x_i − x_j))`
+   — literally a function of pairs. Pick-best-of-k yields a partial ranking that has to be decomposed
+   into pairs anyway, or else needs the Plackett-Luce generalization.
+2. **Lower cognitive load per decision.** Two images compare reliably; nine invite decision fatigue,
+   and fatigue is noise in the only signal that matters.
+3. **"No preference" is information no forced choice can produce.** Making the maintainer pick between
+   two printings they are genuinely indifferent about *manufactures* a preference. Given that 46.9% of
+   multi-printing cards are exact scoring ties, and 4,521 multi-printing cards have no visually distinct
+   printings at all (00720's measurement table), knowing *which* indifferences are real is precisely the
+   missing signal.
+
+### Ties are a modelled outcome, not discarded data
+
+Standard Bradley-Terry has no tie outcome, but the extensions do: **Rao-Kupper** (1967) adds a threshold
+so ties occur when the latent score difference falls inside a band, and **Davidson** (1970) adds an
+explicit tie propensity parameter. The Rao-Kupper formulation is the more useful one here because its
+threshold has a direct reading: **the just-noticeable difference** — how large a score gap has to be
+before the maintainer actually cares.
+
+That threshold is a valuable output in its own right, independent of the weights. It tells you the
+resolution of the scoring function; gaps below it are noise, and a deterministic tiebreak (00720 step 2)
+is the right answer for pairs that fall inside it rather than more weight tuning.
+
+## Which pair to show
+
+Any two printings of a card that has multiple — **not** restricted to the top-2 by current score.
+Restricting to top-2 makes the sampler *config-dependent*: it asks "is the current pick right?", which is
+useful validation but biases the label distribution toward today's weights, and labels are meant to
+outlive configs. Arbitrary pairs give better coverage of the feature space and stay valid regardless.
+
+### Screen out pairs that look identical
+
+The wasted click is not the low-margin pair, it is the **visually indistinguishable** one. If two
+printings share artwork, border and frame treatment, there is no preference to elicit and asking
+manufactures noise. So group printings by a **visual signature** —
+`(illustration_id, border, frame-treatment keys)` — and only ever show pairs of *distinct signatures*.
+
+`finish` is excluded from the signature: a foil and a nonfoil of the same art share the same scan image,
+so they are visually identical even though the physical cards differ.
+
+Measured pool (blue, English, basic lands excluded):
+
+| looks per card | cards | pairs |
+| --- | --- | --- |
+| 1 — never screen | 17,688 | 0 |
+| 2 | 8,170 | 8,170 |
+| 3 | 2,783 | 8,349 |
+| 4–6 | 2,172 | 18,533 |
+| 7–12 | 584 | 19,524 |
+| 13+ | 107 | 21,113 |
+
+**Start with the 8,170 two-look cards.** One click each, no sampling decision, and each click is a
+*complete* answer for that card — they are 59% of the 13,816 screenable cards.
+
+**Sample cards, then pairs within a card — never pairs uniformly.** The 107 cards with 13+ looks
+generate 21,113 pairs: 28% of the whole pool from 0.8% of the cards. Uniform pair sampling would spend
+most of the labeling budget on a handful of heavily-reprinted cards.
+
+Beyond that, in rough order of information per click:
+
+| Sampler | Why |
+| --- | --- |
+| Two-look cards | One click resolves the card completely |
+| Config disagreement | Each label directly discriminates between two candidate configs |
+| Exact ties across distinct looks | Currently settled by store order, so any label is new information |
+| Small margin | Where the function is least confident |
+
+### Prefer pairs that differ in exactly one dimension
+
+The strongest available lever: choose pairs differing in **one** scored dimension, holding everything
+else constant. That turns collection from observational into a designed experiment — the feature
+difference vector has a single nonzero entry, so the label identifies that dimension with no confounding
+and means exactly "this frame is better than that one, all else equal".
+
+Measured availability over the 75,689 distinct-look pairs:
+
+| dimensions differing | pairs |
+| --- | --- |
+| **1** | **28,895** |
+| 2 | 23,483 |
+| 3 | 18,223 |
+| 4 | 5,088 |
+
+Single-dimension breakdown: **artwork only 12,763**, frame version 7,482, treatment 5,795, border 2,855.
+
+**But sign-discovery is not what labels are needed for.** The maintainer already knows the signs — which
+frame is preferred, which border — and what is genuinely unknown is *how to weight them against each
+other*. So single-dimension pairs mostly buy information already available for free, and the phase that
+would collect them is dropped.
+
+That is fortunate, because they could not have supplied magnitudes anyway. With `P = sigmoid(w·Δx)` and
+one nonzero entry in `Δx`, a deterministic answer drives that coefficient toward infinity — the MLE is
+degenerate. Regularization tames the divergence but then the *prior*, not the data, sets relative
+magnitudes.
+
+### Declare the signs; fit only the magnitudes
+
+Record the known orderings as configuration — `2015 > 2003 > 1997 > 1993`, `black > white`,
+`nonfoil > foil > etched`, `extended_art > 0` — and fit subject to them. This:
+
+- removes the degeneracy, since only magnitudes remain free;
+- shrinks the unknowns to the **exchange rates**, roughly *n−1* numbers for *n* dimensions (overall scale
+  being arbitrary) — call it 8–12 rather than 15–20;
+- guarantees the fit can never contradict a known preference, which is what keeps the output auditable;
+- directs every label at something actually unknown.
+
+Implementation needs no constrained solver: **reparameterize as non-negative increments.** Pin an
+ordinal's worst level at 0 and express each step as `softplus(θ)`, so `w_1997 = softplus(θ₁)`,
+`w_2003 = w_1997 + softplus(θ₂)`, and so on; boolean sign constraints use the same trick. The problem
+stays unconstrained in `θ`, so any gradient optimizer works. This is monotone / ordered logistic
+regression.
+
+**Test the declarations.** Once conflict labels exist, check whether any contradicts a declared ordering.
+A contradiction means either the declaration is wrong or that label is noise, and both are worth knowing.
+Note also that a violation may indicate a missing *interaction* rather than a wrong sign — "I prefer 2015"
+may really be "I prefer 2015 usually, but a retro frame suits older art". If violations cluster in a
+subset rather than scattering, that is evidence for a context term.
+
+### So labels are for exactly two things
+
+1. **Exchange rates** — the 23,483 two-dimension **conflict** pairs, where dimensions oppose (better
+   frame, less-reprinted art). This is precisely the reported bug: `extended_art` = 12 against 7.51 points
+   of popularity. A handful of well-chosen pairs brackets each rate; closer to a binary search than to
+   bulk collection.
+2. **What predicts artwork preference** — the art-only pairs below. The one dimension where no sign can be
+   declared, because "better art" is not a monotone function of any feature currently available.
+
+### The art-only pairs are the first experiment to run
+
+The 12,763 pairs differing *only* in artwork are pure artwork preference with everything else held
+constant, and the only current score difference across them is `illustration_count`. So labeling a sample
+answers a question with no fitting at all: **does reprint count predict artwork preference better than
+chance?** Given that artwork identity is otherwise invisible to the score (00720), a negative result is
+immediate evidence for `art_first_appearance`, obtainable before any harness exists beyond the labeling
+page itself.
+
+### Labels key on the signature, not the printing
+
+Because within-signature printings are visually identical, a verdict applies to the whole signature
+group. That decomposes the problem cleanly: **labels choose between looks; the deterministic tiebreak
+chooses a printing within a look.** It is also why the corpus's 46.9% exact-tie rate is mostly harmless
+(00720) — most of those ties are within a single look.
+
+### A later refinement: perceptual hashing
+
+The attribute tuple is a proxy for "do these look different", and a good one, at zero cost — no image
+fetching. A perceptual hash over the CDN images would be ground truth and would catch cases the tuple
+misses (a re-cropped or recoloured variant sharing an `illustration_id`, or two distinct
+`illustration_id`s that are near-identical). Worth doing only if the tuple proves insufficient in
+practice; it adds an image-fetch pipeline for a refinement of a filter, not a new capability.
+
+## Label schema
+
+```
+(card_key, look_a, look_b, shown_printing_a, shown_printing_b,
+ verdict, labeler, labeled_at, look_set_hash, dims_differing)
+verdict ∈ {a, b, other}
+```
+
+`look_a` / `look_b` are the visual signatures being compared — that is what the verdict is *about*. The
+`shown_printing_*` ids are kept only for provenance (which exact image was on screen), since any printing
+within a look is interchangeable by construction.
+
+- **Record the pair and the verdict, never "beat the current config's pick".** A label phrased relative
+  to a config encodes that config and dies the moment a weight changes. A pair verdict re-scores against
+  any future config indefinitely. This single decision determines whether the labeling effort survives
+  the first refactor.
+- **`look_set_hash`** over the card's distinct looks at label time. A genuinely new *look* should
+  re-surface the card; a new printing that merely duplicates an existing look should not, which is a
+  further reason to key on looks rather than printings.
+- **Keep every verdict, including `other`.** It is training data for the tie threshold, not a skipped
+  card — with the caveat above that `other` conflates indifference with uncertainty.
+- **`dims_differing`** records which scored dimensions differed for this pair, so the two phases below
+  can be analysed separately without recomputing signatures.
+- **Allow re-labeling** and keep the history rather than overwriting. Disagreement between a maintainer's
+  own labels over time is the measurement of labeling noise, and the fit needs to know that number.
+
+## Where to store it
+
+Undecided, and worth deciding before building:
+
+- **Checked-in file** (JSONL under `docs/` or a `labels/` directory) — reviewable in PRs, portable
+  across environments, trivially diffable, no schema migration. Awkward to append to from a web page.
+- **Postgres table** — natural to write from the labeling page, queryable alongside `magic.cards` for
+  the samplers. Needs a migration, and the labels then live only in whichever environment collected
+  them.
+
+A file is probably right initially: the volume is small (thousands of rows at most), the review value is
+real, and the samplers can join against a temporary import.
+
+## The tool needs no new API surface
+
+Every field required is already exposed, and image URLs derive client-side from `set_code` +
+`collector_number` against the CDN exactly as `app.js`'s `buildImageUrl` does:
+
+```
+/search?q=!"Sword of the Animist"&unique=printing
+       &fields=scryfall_id,set_code,collector_number,illustration_id,prefer_score
+```
+
+So it is a static page plus label persistence. The samplers need one query over `magic.cards` (the
+measurement queries in 00720 are the same shape).
+
+## Fitting: two optimizations, not one
+
+**Agreement rate is a step function.** It is the fraction of judgments a config reproduces; as the
+weights vary continuously the ordering only changes when two printings' scores *cross*, so agreement is
+piecewise constant and its gradient is zero almost everywhere. It cannot be gradient-descended. That is
+exactly why the logistic surrogate exists — its log-likelihood *is* smooth in `w`.
+
+So use both, in order:
+
+1. **Fit** the Rao-Kupper / logistic model to get a good `w` and the tie threshold, cheaply and with
+   gradients. Optimizes a proxy.
+2. **Evaluate** with agreement rate on **held-out** labels. Optimizes nothing; it is the honest number.
+3. **Locally scan** around the fitted point (Nelder-Mead, random restarts, CMA-ES) to recover what the
+   surrogate's mismatch cost. Grid search is out — exponential at 15-20 parameters.
+
+Step 3 is only affordable because of the feature/weight separation in 00720 step 4: with a materialized
+feature matrix, re-scoring a candidate config is a matrix-vector product over the contested cards —
+milliseconds — rather than a full-table `UPDATE` plus an engine reload. Without that separation a scan
+is infeasible and only step 1 is available.
+
+### Encoding
+
+- **One-hot the ordinals** (`frame`, `rarity`, `finish`, `border`) so each level is learned
+  independently rather than inheriting today's hand-imposed spacing — including discovering whether
+  common and uncommon genuinely tie at 16, as the current weights assert.
+- **Supply the reprint-count curve as basis functions** (`ln n`, `sqrt n`, `n`, `ln(distinct_sets)`,
+  `art_first_appearance`) rather than one fixed transform. This also **adjudicates 00720's numerator
+  question empirically** instead of by argument.
+- **Fit within-card only.** Every comparison is between printings of the same card, so card-level
+  attributes cancel and cannot leak into the weights. This is a grouped/conditional fit.
+
+### What cannot be learned
+
+Comparisons are within-card, so **a feature whose value never varies within a card is unidentifiable at
+any label volume**. Three current components are at risk, and they share a shape:
+
+| Component | Varies within a card? |
+| --- | --- |
+| `language` (en: 40) | Only if foreign printings are shown |
+| `has_paper` (6) | Only for cards with digital-only printings |
+| `artwork_set` (not `dbl`: 20) | Only for cards printed in that one set |
+
+All three are **exclusions dressed as scores** — "never show a foreign printing". `language` at 40
+dominates nearly every other component precisely because it is enforcing a filter rather than expressing
+a preference. Converting them to hard filters removes them from the fit and leaves scoring to genuinely
+comparable candidates, which also makes the remaining weights readable. Worth doing regardless of
+fitting.
+
+And fitting cannot invent features. If no feature encodes iconicity, agreement plateaus and the answer
+is a new feature, not more labels.
+
+## Guards
+
+**Hold out labels.** With 15-20 parameters and a few hundred labels, tuning to labeling noise is the
+obvious failure mode. There is direct precedent in this repo: the cost-model calibration in
+`card_engine/src/tests.rs` fits its coefficients with a **70/30 train/test split by query index**
+specifically "so held-out fidelity reveals overfitting", and names the hazard "the 22-query trap". Same
+discipline: report held-out agreement, treat train-set agreement as diagnostic only.
+
+**Report the hard subset separately.** If most labeled cards have an obvious answer, every config scores
+about the same and overall agreement cannot discriminate. Report agreement on config-disagreement and
+small-margin cards apart from the overall rate.
+
+**Blast radius is a separate number.** Agreement is measured on hundreds of labels; the corpus is 97k
+printings. A config can satisfy every label while moving thousands of unlabeled cards. So also report,
+for two configs, how many cards change representative printing plus a sample of which — agreement says
+"right where we know", blast radius says "how much else moved".
+
+## Rejected
+
+- **Grid pick-best-of-k as the primary format.** Kept as a possible secondary for cards where a pair is
+  genuinely ambiguous, but it forces a choice where indifference is the truth, and it does not produce
+  the tie data the threshold needs.
+- **Gradient-boosted variants (LambdaMART and similar).** Interpretability is a real requirement here —
+  a human has to read the weights and agree with them — and a tree ensemble does not offer that. The
+  linear fit gets most of the benefit and keeps it.
+- **Per-card overrides.** Treats the symptom, unbounded manual burden, and hides scoring bugs rather
+  than surfacing them.

--- a/docs/issues/local-prefer-score-tuning-loop.md
+++ b/docs/issues/local-prefer-score-tuning-loop.md
@@ -1,0 +1,76 @@
+# A closed tuning loop for `prefer_score`
+
+The tuning in [#720](00720-prefer-score-artwork-tuning.md) worked but the *process* did not. Each
+change took a bespoke script, a hand-built review page and a hand-written analysis, and the analysis
+was wrong three separate times. This is a design for replacing that with one loop: propose a change,
+grade ~20 cards, accept or reject, repeat — with a single number going up.
+
+## The objective already exists
+
+`gen_labeller.py` produced 202 cards where the artwork was chosen directly from all distinct artworks
+for that card. That gives an accuracy measure: **does the score's top pick match the chosen artwork?**
+
+| config | agreement |
+| --- | --- |
+| production today | 160/202 = 79.2% |
+| `+ art_style=14` | 168/202 = 83.2% |
+| `+ count filter` (#766) | 168/202 = 83.2% |
+
+This is the hit rate to drive up. It is cheap (a dot product over cached levels), it is not the thing
+being tuned against directly if a holdout is kept, and it makes "did that help" answerable in
+milliseconds instead of a labelling session.
+
+## The loop
+
+1. **Propose.** Pick a component and a magnitude that moves ~20 cards. `step` already binary-searches
+   for a target swap count; the loop drives it over every component in turn rather than one by name.
+2. **Pre-screen on the objective.** Compute the hit rate. A candidate that lowers it on the labelled
+   set is discarded without spending any grading — most will be.
+3. **Grade 20.** Only survivors reach a review page: blind, randomised sides, whole cards.
+4. **Decide.** Accept on a pre-registered rule (below), fold into the baseline, and repeat.
+
+Step 2 is what makes this cheaper than what we did. Of the changes tried in #720, `frame_2003=33`,
+`frame_1997=22` and dedup would all have been rejected before any grading.
+
+## The decision rule has to be fixed in advance
+
+With ~20 cards and most verdicts landing on "no difference", the counts are small. Accept when
+`better - worse >= 3` and `worse <= 1`; reject when `worse >= 3`; otherwise grade 20 more, to a cap of
+60, then reject. Registering it in advance matters because in #720 the rule moved with the data:
+`finish_foil=8` was scored 100–5 and recommended, and only a controlled batch later showed its sign
+was backwards.
+
+## What the loop must carry over
+
+Five failures from #720, each of which cost a wasted grading session. The loop is only worth building
+if it makes them structurally impossible.
+
+- **Confounding.** Every batch must report what varies across its pairs before the reviewer starts.
+  Three sessions were spent on frame-vs-finish comparisons where both moved together, and the
+  conclusion was wrong until a batch isolated one.
+- **Coupled parameters.** Frame weights form a ladder (1993/1997/2003/2015); moving one perturbs two
+  gaps. The proposer must move declared groups together and describe the change as a gap, not a value.
+- **Destination-specific verdicts.** A verdict answers "is this printing better than that one", so it
+  transfers only when a later config lands on the same printing. `load_judged` does this now.
+- **Blinding.** Sides must be randomised and labelled left/right. The first three batches showed
+  `CURRENT` and `PROPOSED` outright.
+- **Selection on the evaluation set.** Fitting three things against one set of 89 labels made every
+  p-value optimistic. Hold out a third of the labels, never fit against them, and report holdout
+  agreement at accept time.
+
+## Where the current tooling stops
+
+`prefer_weights.py` has the pieces — validated level extraction, `step`, blinded review,
+destination-aware exclusion — but they are subcommands a human drives one at a time. Missing:
+the hit-rate objective as a first-class command, the labelled set as a tracked artifact rather than
+files in `~/Downloads`, the accept/reject rule in code, and a run log so a component's history is
+recoverable. The scoring definition also still lives in SQL with weights fused into it, so an accepted
+change is hand-copied — the weights should move to config that both the SQL and the tooling read.
+
+## Related
+
+- [00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) — the tuning this
+  process was derived from, and the record of what it got wrong.
+- [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the labelling
+  instrument that produces the objective.
+- [`scripts/prefer_weights.py`](../../scripts/prefer_weights.py) — the existing pieces.

--- a/scripts/prefer_weights.py
+++ b/scripts/prefer_weights.py
@@ -1,0 +1,1002 @@
+#!/usr/bin/env python3
+"""Score printings from raw component levels, so weights become data.
+
+Today `api/sql/backfill_prefer_scores.sql` fuses feature extraction with weight
+application -- each CASE emits an already-weighted number (`WHEN frame ? '2015' THEN
+42`), so the weights cannot be recovered from the output and changing one costs a
+full-table UPDATE plus an engine reload. That makes any kind of coefficient search
+impossible.
+
+This module extracts the *level* of each component per printing once, then applies a
+weight table in Python. Re-scoring a candidate weighting is then a dot product over
+rows already in memory: milliseconds, not minutes.
+
+`validate` checks the separation is faithful by reproducing the stored prefer_score
+from levels x weights. If that does not match, no diff built on it can be trusted.
+
+Usage:
+    python scripts/prefer_weights.py validate
+    python scripts/prefer_weights.py swaps --set art_style=6 --scale extended_art=0.9
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import random
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DB_CONTAINER, DB_USER, DB_NAME = "sylvan_blue-postgres-1", "foouser", "magic"
+
+# The weights currently baked into backfill_prefer_scores.sql, lifted out verbatim.
+# `art_style` is new and defaults to 0 so the baseline is bit-identical to today.
+WEIGHTS: dict[str, float] = {
+    "language_en": 40.0,
+    "frame_2015": 42.0,
+    "frame_2003": 30.0,
+    "frame_1997": 25.0,
+    "frame_1993": 10.0,
+    "artwork_set_ok": 20.0,  # not the dbl (black-and-white) set
+    "rarity_common": 16.0,
+    "rarity_uncommon": 16.0,
+    "rarity_rare": 11.0,
+    "rarity_mythic": 0.0,
+    "highres_scan": 16.0,
+    "border_black": 14.0,
+    "extended_art": 12.0,
+    "finish_nonfoil": 10.0,
+    "finish_foil": 5.0,
+    "non_showcase": 10.0,
+    "has_paper": 6.0,
+    "legendary_frame": 5.0,
+    "illustration_count": 23.0,  # coefficient of ln(1+n)/ln(40)
+    # NEW: on-style bonus. Awarded when the artwork carries none of the off-style art
+    # tags. Measured 153/153 -- in every labelled comparison where exactly one artwork
+    # was off-style tagged, the untagged one was chosen. Expressed as a bonus for being
+    # on-style rather than a penalty so every component stays non-negative, matching the
+    # rest of the table.
+    "art_style": 0.0,
+}
+
+# Off-style art tags. Community-curated descriptions OF THE ARTWORK, which is why these
+# are used instead of a year/era term: a term on year permanently penalises all future
+# art, whereas a tag generalises -- new anime-styled art gets tagged, new core-style art
+# does not. This list is a hypothesis; 533 further candidates exist (art tags whose
+# artworks concentrate in few sets) and are unscanned.
+# On-style is the DEFAULT; a printing loses the bonus by carrying external-ip (the
+# Scryfall tagger's parent for ~57 licensed franchises) or a non-IP stylistic departure.
+#
+# D&D and Lord of the Rings are exempt: external IP whose art matches Magic's high-fantasy
+# look. Verified that exempting only these two parents is complete -- zero artworks carry a
+# sibling tag (arda, hobbit, abeir-toril, dnd-multiverse) without also carrying its parent,
+# so no Middle-earth or Forgotten Realms art slips through.
+STYLE_EXEMPT_TAGS = ("dungeons-and-dragons", "the-lord-of-the-rings")
+# Non-IP stylistic departures: not external universes, but not the core look either.
+STYLE_DEPARTURE_TAGS = ("anime", "comic-style", "line-art", "word-art-title")
+# A partial-credit tier for romance-of-the-three-kingdoms (Portal Three Kingdoms: external
+# IP, but a 1999 Magic set rather than a modern crossover) was built and measured, then
+# dropped. Across the whole 0-to-full range it moved only 5 cards, and 3 at the candidate
+# weight -- most P3K cards were never reprinted, so their art has nothing to compete with.
+# Not worth a third tier for a distinction that changes nothing visible.
+
+ILLUS_NORM = math.log(40)  # the ln(40) denominator in the current SQL
+
+# prefer_score is stored as a postgres `real`; this covers f32 rounding at these magnitudes.
+VALIDATE_TOLERANCE = 1e-2
+# Two scores closer than this are the same number in f32 -- the swap is a tie-break, not an
+# override, and the review page reports the two differently.
+SCORE_EPSILON = 1e-9
+# A card needs at least this many printings to have a choice worth reviewing.
+MIN_PRINTINGS = 2
+# Upper bound on the binary search for a step size, in weight points. Every component sits
+# well below this, so hitting it means the component cannot reach the target swap count.
+STEP_SEARCH_CEILING = 512
+# Fair coin for the left/right assignment in blind review.
+COIN = 0.5
+# Generated review pages go to the system temp dir rather than a hardcoded /tmp.
+OUT_DIR = Path(tempfile.gettempdir())
+
+# Rows the printing count should ignore, as a candidate fix to `illustration_count`.
+#
+# The component is meant to measure how heavily an ARTWORK has been reprinted, but its
+# numerator counts every row sharing the illustration, including rows that are not real
+# printing events:
+#
+#   memorabilia  World Championship decks, Collectors' Edition, International Collectors'
+#                Edition and 30th Anniversary -- none tournament-legal, none a real set.
+#                Four of Birds of Paradise's eight are BLACK-bordered (30a x2, ced, cei),
+#                so a border test alone misses half of them.
+#   gold/yellow  any remaining non-standard product Scryfall types as something other
+#                than memorabilia. Belt-and-braces against the above.
+#   non-English  the same printing event already counted in its English row (4bb, fbb).
+#
+# Not filtered: white borders. 2ed-6ed are white-bordered and perfectly real, and
+# dropping them would penalise exactly the core-set reprints the component should reward.
+COUNTED_PRINTING_SQL = """
+    COALESCE(o.raw_card_blob ->> 'lang', '') = 'en'
+    AND COALESCE(o.raw_card_blob ->> 'set_type', '') <> 'memorabilia'
+    AND COALESCE(o.card_border, '') NOT IN ('gold', 'yellow')
+"""
+
+# Swap review shows the WHOLE CARD, not Scryfall's art_crop. The decision under review
+# is "which printing does the site display", so the reviewer must see what the site
+# would show. Art crops actively mislead here: extended_art, border and frame are frame
+# properties a crop cannot show, so an extended-art printing and its normal sibling
+# appear as duplicate images and every verdict comes back "no difference".
+#
+# Sourced from Scryfall's `normal` rather than the project CDN: the CDN 403s on
+# printings the site does not carry (e.g. pw26/20), which would leave the reviewer
+# comparing a broken image against a card. Scryfall covers 94,718/94,718.
+LEVELS_EXTRA_IMAGE = "raw_card_blob -> 'image_uris' ->> 'normal'"
+
+LEVELS_SQL = """
+SELECT c.scryfall_id::text AS sid,
+       c.card_name,
+       c.prefer_score,
+       (SELECT count(*) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL
+           AND o.card_name = c.card_name)                              AS illus_n,
+       (SELECT count(*) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL
+           AND o.card_name = c.card_name AND ({counted}))              AS illus_n_real,
+       (SELECT count(DISTINCT o.card_set_code) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL
+           AND o.card_name = c.card_name AND ({counted}))              AS illus_n_set,
+       COALESCE(c.raw_card_blob ->> 'set_type', '')                   AS set_type,
+       c.card_rarity_int                                              AS rarity,
+       COALESCE(c.card_border, '')                                    AS border,
+       CASE WHEN c.card_frame_data ? '2015' THEN '2015'
+            WHEN c.card_frame_data ? '2003' THEN '2003'
+            WHEN c.card_frame_data ? '1997' THEN '1997'
+            WHEN c.card_frame_data ? '1993' THEN '1993' ELSE '' END    AS frame,
+       COALESCE(c.card_frame_data ? 'Extendedart', false)             AS extended,
+       ((c.raw_card_blob ->> 'image_status') = 'highres_scan')          AS highres,
+       COALESCE(c.raw_card_blob -> 'games' ? 'paper', false)           AS paper,
+       ((c.raw_card_blob ->> 'lang') = 'en')                           AS en,
+       COALESCE(c.raw_card_blob -> 'frame_effects' ? 'legendary', false) AS legendary,
+       COALESCE(c.raw_card_blob -> 'frame_effects' ? 'showcase', false)  AS showcase,
+       CASE WHEN c.raw_card_blob -> 'finishes' ? 'nonfoil' THEN 'nonfoil'
+            WHEN c.raw_card_blob -> 'finishes' ? 'foil' THEN 'foil'
+            ELSE 'other' END                                          AS finish,
+       (c.card_set_code <> 'dbl')                                     AS artwork_set_ok,
+       ((c.card_art_tags ? 'external-ip' AND NOT (c.card_art_tags ?| {exempt}))
+         OR c.card_art_tags ?| {departure})                           AS off_style,
+       c.card_set_code, c.collector_number,
+       c.raw_card_blob -> 'image_uris' ->> 'art_crop'                 AS art_url,
+       c.raw_card_blob -> 'image_uris' ->> 'normal'                   AS card_url
+FROM magic.cards c
+WHERE {where}
+"""
+
+
+def run_query(sql: str) -> list[dict[str, str]]:
+    """Run SQL in the blue postgres container and return CSV rows as dicts."""
+    proc = subprocess.run(
+        ["docker", "exec", "-i", DB_CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-v", "ON_ERROR_STOP=1", "--csv", "-f", "-"],
+        input=sql,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"psql failed:\n{proc.stderr}")
+    return list(csv.DictReader(io.StringIO(proc.stdout)))
+
+
+def t(v: str) -> bool:
+    """Postgres CSV renders booleans as 't'/'f'."""
+    return v == "t"
+
+
+def score(row: dict[str, str], w: dict[str, float], illus_key: str = "illus_n") -> float:
+    """Sum of weighted component levels, mirroring backfill_prefer_scores.sql.
+
+    `illus_key` selects which printing count feeds `illustration_count`: "illus_n" is
+    what the SQL does today, "illus_n_real" applies COUNTED_PRINTING_SQL. Everything
+    else is identical, so a diff between the two isolates the counting rule.
+    """
+    s = 0.0
+    n = float(row[illus_key] or 0)
+    s += round(w["illustration_count"] * math.log1p(n) / ILLUS_NORM, 4)
+    rar = row["rarity"]
+    s += {"0": w["rarity_common"], "1": w["rarity_uncommon"], "2": w["rarity_rare"], "3": w["rarity_mythic"]}.get(rar, 0.0)
+    s += w["border_black"] if row["border"] == "black" else 0.0
+    s += w.get(f"frame_{row['frame']}", 0.0) if row["frame"] else 0.0
+    s += w["extended_art"] if t(row["extended"]) else 0.0
+    s += w["highres_scan"] if t(row["highres"]) else 0.0
+    s += w["has_paper"] if t(row["paper"]) else 0.0
+    s += w["language_en"] if t(row["en"]) else 0.0
+    s += w["legendary_frame"] if t(row["legendary"]) else 0.0
+    s += 0.0 if t(row["showcase"]) else w["non_showcase"]
+    s += {"nonfoil": w["finish_nonfoil"], "foil": w["finish_foil"]}.get(row["finish"], 0.0)
+    s += w["artwork_set_ok"] if t(row["artwork_set_ok"]) else 0.0
+    s += 0.0 if t(row["off_style"]) else w["art_style"]
+    return s
+
+
+# Target swap count for a proposed step. Small on purpose: the point is a change you
+# can eyeball in seconds and judge as a net-positive or net-negative trade. A fixed
+# percentage step does not do this -- extended_art at -10% moves 6 cards while
+# art_style at +6 moves 53, so the same percentage is unreviewable in one case and
+# uninformative in the other.
+TARGET_SWAPS = (6, 9)
+
+
+def level(row: dict[str, str], comp: str) -> float:
+    """Multiplier that `comp`'s weight is applied to for this printing.
+
+    Lets a single-component step be evaluated as base_score + delta * level, which is
+    one multiply-add per row instead of rescoring every component.
+    """
+    if comp == "illustration_count":
+        return round(math.log1p(float(row["illus_n"] or 0)) / ILLUS_NORM, 6)
+    if comp.startswith("rarity_"):
+        return (
+            1.0
+            if row["rarity"] == {"rarity_common": "0", "rarity_uncommon": "1", "rarity_rare": "2", "rarity_mythic": "3"}[comp]
+            else 0.0
+        )
+    if comp.startswith("frame_"):
+        return 1.0 if row["frame"] == comp.removeprefix("frame_") else 0.0
+    if comp.startswith("finish_"):
+        return 1.0 if row["finish"] == comp.removeprefix("finish_") else 0.0
+    flags = {
+        "border_black": row["border"] == "black",
+        "extended_art": t(row["extended"]),
+        "highres_scan": t(row["highres"]),
+        "has_paper": t(row["paper"]),
+        "language_en": t(row["en"]),
+        "legendary_frame": t(row["legendary"]),
+        "non_showcase": not t(row["showcase"]),
+        "artwork_set_ok": t(row["artwork_set_ok"]),
+        "art_style": not t(row["off_style"]),
+    }
+    return 1.0 if flags[comp] else 0.0
+
+
+def side(r: dict[str, str]) -> dict[str, str]:
+    """One side of a swap: the full card image plus its set/collector for provenance."""
+    loc = f"{r['card_set_code']}/{r['collector_number']}"
+    return {"img": r["card_url"] or r["art_url"] or "", "art": r["art_url"] or "", "loc": loc}
+
+
+def pg_arr(tags: tuple[str, ...]) -> str:
+    """Render a tuple as a postgres ARRAY[...] literal."""
+    return "ARRAY[" + ", ".join("'" + t + "'" for t in tags) + "]"
+
+
+def load(where: str) -> list[dict[str, str]]:
+    """Fetch component levels for every printing matching `where`."""
+    return run_query(
+        LEVELS_SQL.format(
+            exempt=pg_arr(STYLE_EXEMPT_TAGS), departure=pg_arr(STYLE_DEPARTURE_TAGS), counted=COUNTED_PRINTING_SQL, where=where
+        )
+    )
+
+
+def cmd_validate() -> None:
+    """Reproduce the stored prefer_score from levels x weights."""
+    rows = load("c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL")
+    worst = 0.0
+    bad = 0
+    for r in rows:
+        got, want = score(r, WEIGHTS), float(r["prefer_score"])
+        d = abs(got - want)
+        worst = max(worst, d)
+        # prefer_score is a postgres `real`; ~1e-3 covers f32 rounding at these magnitudes
+        bad += d > VALIDATE_TOLERANCE
+    print(f"{len(rows)} printings checked against the stored prefer_score")
+    print(f"  max absolute difference : {worst:.6f}")
+    print(f"  rows differing > 0.01   : {bad}")
+    print(
+        "\n  "
+        + (
+            "PASS - extraction is faithful, so weight diffs can be trusted."
+            if bad == 0
+            else "FAIL - the level extraction does not match the SQL; do not trust diffs."
+        )
+    )
+
+
+def apply_overrides(sets: list[str], scales: list[str]) -> dict[str, float]:
+    """Build a weight table from WEIGHTS plus `--set COMP=VALUE` / `--scale COMP=FACTOR`."""
+    w = dict(WEIGHTS)
+    for spec in sets:
+        k, v = spec.split("=", 1)
+        if k not in w:
+            sys.exit(f"unknown component {k!r}")
+        w[k] = float(v)
+    for spec in scales:
+        k, v = spec.split("=", 1)
+        if k not in w:
+            sys.exit(f"unknown component {k!r}")
+        w[k] *= float(v)
+    return w
+
+
+def cmd_swaps(sets: list[str], scales: list[str], out: Path, limit: int) -> None:
+    """Show which card the site would display differently under a proposed weighting."""
+    proposed = apply_overrides(sets, scales)
+    changed = [(k, WEIGHTS[k], proposed[k]) for k in WEIGHTS if WEIGHTS[k] != proposed[k]]
+    if not changed:
+        sys.exit("no weight actually changed")
+    print("proposed change:")
+    for k, a, b in changed:
+        print(f"  {k:20s} {a:7.2f} -> {b:7.2f}")
+
+    rows = load(
+        "c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL "
+        "AND c.raw_card_blob -> 'image_uris' ->> 'art_crop' IS NOT NULL"
+    )
+    by_card: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        by_card.setdefault(r["card_name"], []).append(r)
+
+    swaps = []
+    multi = 0
+    for name, printings in by_card.items():
+        if len(printings) < MIN_PRINTINGS:
+            continue
+        multi += 1
+        old = max(printings, key=lambda r: (score(r, WEIGHTS), r["sid"]))
+        new = max(printings, key=lambda r: (score(r, proposed), r["sid"]))
+        if old["sid"] != new["sid"]:
+            swaps.append((name, old, new))
+    print(f"\n  multi-printing cards : {multi}")
+    print(f"  representative swaps : {len(swaps)}  ({100 * len(swaps) / multi:.2f}%)")
+
+    swaps.sort(key=lambda s: s[0])
+    payload = [{"card": n, "old": side(o), "new": side(w2)} for n, o, w2 in swaps[:limit]]
+    out.write_text(
+        REVIEW_PAGE.replace("__SWAPS__", json.dumps(payload, separators=(",", ":")))
+        .replace("__DESC__", json.dumps(", ".join(f"{k} {a:g}->{b:g}" for k, a, b in changed)))
+        .replace("__SLUG__", json.dumps("-".join(f"{k}{b:g}" for k, _, b in changed)[:60]))
+    )
+    print(f"  review page ({len(payload)} of {len(swaps)}) -> {out}")
+
+
+REVIEW_PAGE = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Swap review</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { margin:0; font:15px/1.4 system-ui, sans-serif; display:flex; flex-direction:column; min-height:100vh; }
+  header { padding:.6rem 1rem; border-bottom:1px solid #8885; display:flex; gap:1rem; align-items:baseline; }
+  #chg { font:12px monospace; opacity:.75; }
+  #prog { margin-left:auto; font-variant-numeric:tabular-nums; opacity:.7; }
+  main { flex:1; display:grid; grid-template-columns:1fr 1fr; gap:1rem; padding:1rem; align-content:start; }
+  .side { display:grid; gap:.4rem; justify-items:center; }
+  .side img { width:100%; max-width:400px; border-radius:10px; display:block; }
+  .tag { font:12px monospace; opacity:.7; }
+  button.act { font:inherit; padding:.5rem .9rem; border-radius:8px; cursor:pointer; background:none;
+               border:1px solid #8888; }
+  footer { display:flex; gap:.75rem; justify-content:center; padding:.75rem; border-top:1px solid #8885; }
+  #done { display:none; padding:2rem; text-align:center; }
+</style></head><body>
+<header><strong id="card"></strong><span id="chg"></span><span id="prog"></span></header>
+<main id="stage">
+  <div class="side"><img id="leftImg"><span class="tag">LEFT &mdash; <span id="leftLoc"></span></span></div>
+  <div class="side"><img id="rightImg"><span class="tag">RIGHT &mdash; <span id="rightLoc"></span></span></div>
+</main>
+<div id="done"><p><strong>All swaps reviewed.</strong> Download the verdicts below.</p></div>
+<footer>
+  <button class="act" id="pickLeft">Left is better (&larr;)</button>
+  <button class="act" id="same">No real difference (space)</button>
+  <button class="act" id="pickRight">Right is better (&rarr;)</button>
+  <button class="act" id="undo">Undo (u)</button>
+  <button class="act" id="toggle">Show art crop (a)</button>
+  <button class="act" id="dl">Download verdicts</button>
+</footer>
+<script>
+const SWAPS = __SWAPS__, DESC = __DESC__, SLUG = __SLUG__;
+const KEY = 'prefer-swap-review-' + SLUG;
+let st = JSON.parse(localStorage.getItem(KEY) || '{"v":{},"order":[]}');
+if (!st.order) st = {v: st, order: Object.keys(st)};   // migrate older saved state
+let v = st.v, order = st.order;
+const save = () => localStorage.setItem(KEY, JSON.stringify({v, order}));
+const $ = i => document.getElementById(i);
+$('chg').textContent = DESC;
+function todo() { return SWAPS.filter(s => !(s.card in v)); }
+let showArt = false;
+function render() {
+  const q = todo();
+  $('prog').textContent = `${SWAPS.length - q.length} / ${SWAPS.length}`;
+  if (!q.length) { $('stage').style.display='none'; $('done').style.display='block'; $('card').textContent=''; return; }
+  const s = q[0];
+  $('card').textContent = s.card;
+  // s.flip decides which physical side the PROPOSED printing occupies. Assigned per card
+  // in Python, so the reviewer cannot learn "right is always the proposal" and score the
+  // change rather than the card. rec() maps the side back to a verdict.
+  const L = s.flip ? s.new : s.old, R = s.flip ? s.old : s.new;
+  $('leftImg').src  = showArt && L.art ? L.art : L.img;
+  $('rightImg').src = showArt && R.art ? R.art : R.img;
+  $('leftLoc').textContent = L.loc; $('rightLoc').textContent = R.loc;
+  const n = q[1]; if (n) { [n.old.img, n.new.img].forEach(u => { const i=new Image(); i.src=u; }); }
+}
+function rec(verdict) { const q = todo(); if (!q.length) return;
+  v[q[0].card] = verdict; order.push(q[0].card); save(); render(); }
+function pick(sideChosen) { const q = todo(); if (!q.length) return;
+  const proposedIsLeft = !!q[0].flip;
+  rec(sideChosen === (proposedIsLeft ? 'left' : 'right') ? 'better' : 'worse'); }
+function undo() { const c = order.pop(); if (c === undefined) return; delete v[c]; save(); render(); }
+$('undo').onclick = undo;
+$('toggle').onclick = () => { showArt = !showArt;
+  $('toggle').textContent = showArt ? 'Show whole card (a)' : 'Show art crop (a)'; render(); };
+$('pickLeft').onclick  = () => pick('left');
+$('pickRight').onclick = () => pick('right');
+$('same').onclick      = () => rec('same');
+$('dl').onclick = () => {
+  const meta = Object.fromEntries(SWAPS.map(s => [s.card, {changes: s.changes || [DESC], kind: s.kind || null}]));
+  // Destinations are recorded so a later batch can tell whether a previously-judged card is
+  // being re-asked about the SAME printing (skip it) or a different one (must ask again).
+  const locs = Object.fromEntries(SWAPS.map(s => [s.card, {from: s.old.loc, to: s.new.loc}]));
+  const body = Object.entries(v).map(([c,d]) =>
+      JSON.stringify({card:c, verdict:d, from:(locs[c]||{}).from, to:(locs[c]||{}).to,
+                      changes:(meta[c]||{}).changes, kind:(meta[c]||{}).kind})).join('\\n')+'\\n';
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([body], {type:'application/x-ndjson'}));
+  a.download = 'swap-verdicts-' + SLUG + '.jsonl'; a.click();
+};
+addEventListener('keydown', e => {
+  if (e.key === 'ArrowRight') pick('right');
+  else if (e.key === 'ArrowLeft') pick('left');
+  else if (e.key === ' ') { e.preventDefault(); rec('same'); }
+  else if (e.key === 'a') $('toggle').click();
+  else if (e.key === 'u') undo();
+});
+render();
+</script></body></html>
+"""
+
+
+def count_swaps(cards: list[list[tuple[float, float, str]]], delta: float) -> tuple[int, int]:
+    """(tie_breaks, overrides) induced by shifting one component's weight by `delta`.
+
+    The split matters. 46.9% of multi-printing cards have an exact top score, so today
+    their representative is decided by store order, arbitrarily. Any epsilon on a
+    component that differs between those tied printings flips all of them at once --
+    which is why swap count jumps discontinuously from 0 and a small target band can be
+    unreachable.
+
+    Those are TIE BREAKS: the previous pick was arbitrary, so almost any principled
+    change is an improvement and they need little scrutiny. An OVERRIDE reverses a
+    strictly-ranked decision and is the thing actually worth eyeballing.
+    """
+    ties = over = 0
+    for pr in cards:
+        old = max(pr, key=lambda x: (x[0], x[2]))
+        new = max(pr, key=lambda x: (x[0] + delta * x[1], x[2]))
+        if old[2] == new[2]:
+            continue
+        if abs(old[0] - new[0]) < SCORE_EPSILON:
+            ties += 1
+        else:
+            over += 1
+    return ties, over
+
+
+def cmd_step(comp: str, direction: str, out: Path) -> None:
+    """Find the smallest change to one component that moves TARGET_SWAPS cards."""
+    if comp not in WEIGHTS:
+        sys.exit(f"unknown component {comp!r}; known: {', '.join(sorted(WEIGHTS))}")
+    rows = load(
+        "c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL "
+        "AND c.raw_card_blob -> 'image_uris' ->> 'art_crop' IS NOT NULL"
+    )
+    by: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        by.setdefault(r["card_name"], []).append(r)
+    multi = {k: v for k, v in by.items() if len(v) > 1}
+    cards = [[(score(r, WEIGHTS), level(r, comp), r["sid"]) for r in v] for v in multi.values()]
+
+    lo, hi = TARGET_SWAPS
+    sign = 1.0 if direction == "up" else -1.0
+    # Expand until the target band is reached or exceeded, then bisect for the
+    # smallest step that lands in it. Swap count is a step function of delta, so an
+    # exact hit is not guaranteed -- take the closest.
+    step, best = 0.25, None
+    while step <= STEP_SEARCH_CEILING:
+        if count_swaps(cards, sign * step)[1] >= lo:
+            break
+        step *= 2
+    a, b = 0.0, step
+    for _ in range(40):
+        mid = (a + b) / 2
+        _, c = count_swaps(cards, sign * mid)
+        if best is None or abs(c - (lo + hi) / 2) < abs(best[1] - (lo + hi) / 2):
+            best = (mid, c)
+        if c < lo:
+            a = mid
+        elif c > hi:
+            b = mid
+        else:
+            best = (mid, c)
+            break
+    delta, got = best
+    ties, _ = count_swaps(cards, sign * delta)
+    new_w = WEIGHTS[comp] + sign * delta
+    print(f"{comp}: {WEIGHTS[comp]:.4g} -> {new_w:.4g}   ({direction} {sign * delta:+.4g})")
+    print(f"  overrides : {got}   (target {lo}-{hi}) -- reversals of a strict ranking, review these")
+    print(f"  tie-breaks: {ties}        -- previously decided by store order, essentially free")
+
+    w = dict(WEIGHTS)
+    w[comp] = new_w
+    swaps = []
+    for name, v in multi.items():
+        old = max(v, key=lambda r: (score(r, WEIGHTS), r["sid"]))
+        new = max(v, key=lambda r: (score(r, w), r["sid"]))
+        if old["sid"] != new["sid"]:
+            swaps.append((name, old, new))
+    payload = [{"card": n, "old": side(o), "new": side(x)} for n, o, x in sorted(swaps, key=lambda s: s[0])]
+    out.write_text(
+        REVIEW_PAGE.replace("__SWAPS__", json.dumps(payload, separators=(",", ":")))
+        .replace("__DESC__", json.dumps(f"{comp} {WEIGHTS[comp]:g} -> {new_w:g}"))
+        .replace("__SLUG__", json.dumps(f"{comp}{new_w:g}"))
+    )
+    print(f"  review page -> {out}")
+
+
+def load_judged(paths: list[Path]) -> dict[str, set[str | None]]:
+    """Cards already given a verdict in a previous review.
+
+    A baseline shift alone does not stop a card being re-asked: if it swaps to the same
+    printing at both the accepted weight and the proposed one, it belongs to the
+    baseline's swap set and reappears identically. Filtering on prior verdicts is what
+    keeps each review page to genuinely new decisions.
+    """
+    seen: dict[str, set[str | None]] = {}
+    for p in paths:
+        for line in p.read_text().splitlines():
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            # `to` is absent in verdict files downloaded before destinations were recorded.
+            # None then means "judged, destination unknown" and suppresses the card entirely,
+            # which is the old, conservative behaviour.
+            seen.setdefault(r["card"], set()).add(r.get("to"))
+    return seen
+
+
+# Branch count is inherent: the command spans joint-vs-independent review, an optional
+# accepted baseline, and prior-verdict filtering, and splitting them would separate code
+# that has to agree on one payload shape.
+def cmd_review(  # noqa: C901, PLR0912, PLR0915
+    changes: list[str],
+    out: Path,
+    joint: bool = False,
+    base_over: list[str] | None = None,
+    judged: dict[str, set[str | None]] | None = None,
+) -> None:
+    """One review page covering several proposed changes at once.
+
+    Each swap records which change produced it, but the page does NOT show that: a
+    reviewer told "this one is the style change" would judge it differently from one
+    told nothing. Blind review, attributed analysis.
+
+    A card that swaps under two changes to the SAME printing is reviewed once and
+    credited to both; to different printings, it appears once per change.
+    """
+    # The baseline can carry already-accepted changes. Without this every review would be
+    # measured against the original config, so a second increment would re-show swaps
+    # already judged and hide the ones the increment actually adds.
+    base_w = dict(WEIGHTS)
+    for spec in base_over or []:
+        comp, val = spec.split("=", 1)
+        if comp not in base_w:
+            sys.exit(f"unknown component {comp!r}")
+        base_w[comp] = float(val)
+    if base_over:
+        print("  baseline (already accepted): " + ", ".join(f"{c.split('=')[0]}={c.split('=')[1]}" for c in base_over))
+
+    rows = load("c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL")
+    # Memorabilia is already excluded from the printing COUNT, but that never stopped it
+    # being displayed: 191 cards currently show one, 187 of them 30a, which Scryfall tags
+    # with the 2015 frame (42 pts) while every one of its 592 printings is a lowres scan.
+    by: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        by.setdefault(r["card_name"], []).append(r)
+    multi = {k: v for k, v in by.items() if len(v) > 1}
+    if judged:
+        before = len(multi)
+        multi = {k: v for k, v in multi.items() if k not in judged}
+        print(f"  excluding {before - len(multi)} cards already judged in a previous review")
+    base = {k: max(v, key=lambda r: (score(r, base_w), r["sid"])) for k, v in multi.items()}
+
+    items: dict[tuple[str, str], dict] = {}
+    if joint:
+        w = dict(base_w)
+        for spec in changes:
+            comp, val = spec.split("=", 1)
+            if comp not in base_w:
+                sys.exit(f"unknown component {comp!r}")
+            w[comp] = float(val)
+        desc = " + ".join(f"{c.split('=')[0]} {base_w[c.split('=')[0]]:g}->{float(c.split('=')[1]):g}" for c in changes)
+        n_tie = n_over = 0
+        for name, printings in multi.items():
+            old = base[name]
+            new = max(printings, key=lambda r: (score(r, w), r["sid"]))
+            if old["sid"] == new["sid"]:
+                continue
+            kind = "tie" if abs(score(old, base_w) - score(new, base_w)) < SCORE_EPSILON else "override"
+            n_tie += kind == "tie"
+            n_over += kind == "override"
+            items[(name, new["sid"])] = {"card": name, "old": side(old), "new": side(new), "kind": kind, "changes": [desc]}
+        print(f"  JOINT {desc}")
+        print(f"    {n_over} overrides, {n_tie} tie-breaks")
+        payload = sorted(items.values(), key=lambda i: i["card"])
+        slug = (
+            ("from" + "-".join(c.replace("=", "") for c in (base_over or [])) + "-" if base_over else "")
+            + "joint-"
+            + "-".join(c.replace("=", "") for c in changes)[:40]
+        )
+        out.write_text(
+            REVIEW_PAGE.replace("__SWAPS__", json.dumps(payload, separators=(",", ":")))
+            .replace("__DESC__", json.dumps(f"{len(payload)} proposed swaps"))
+            .replace("__SLUG__", json.dumps(slug))
+        )
+        print(f"\n  {len(payload)} swaps to review -> {out}")
+        print(f"  download will be named: swap-verdicts-{slug}.jsonl")
+        return
+    for spec in changes:
+        comp, val = spec.split("=", 1)
+        if comp not in WEIGHTS:
+            sys.exit(f"unknown component {comp!r}")
+        w = dict(base_w)
+        w[comp] = float(val)
+        desc = f"{comp} {base_w[comp]:g}->{float(val):g}"
+        n_tie = n_over = 0
+        for name, printings in multi.items():
+            old = base[name]
+            new = max(printings, key=lambda r: (score(r, w), r["sid"]))
+            if old["sid"] == new["sid"]:
+                continue
+            kind = "tie" if abs(score(old, base_w) - score(new, base_w)) < SCORE_EPSILON else "override"
+            n_tie += kind == "tie"
+            n_over += kind == "override"
+            key = (name, new["sid"])
+            if key in items:
+                items[key]["changes"].append(desc)
+            else:
+                items[key] = {"card": name, "old": side(old), "new": side(new), "kind": kind, "changes": [desc]}
+        print(f"  {desc:34s} {n_over:4d} overrides  {n_tie:4d} tie-breaks")
+
+    payload = sorted(items.values(), key=lambda i: i["card"])
+    slug = ("from" + "-".join(c.replace("=", "") for c in (base_over or [])) + "-" if base_over else "") + "-".join(
+        c.replace("=", "") for c in changes
+    )[:50]
+    out.write_text(
+        REVIEW_PAGE.replace("__SWAPS__", json.dumps(payload, separators=(",", ":")))
+        .replace("__DESC__", json.dumps(f"{len(payload)} proposed swaps"))
+        .replace("__SLUG__", json.dumps(slug))
+    )
+    print(f"\n  {len(payload)} swaps to review -> {out}")
+    print(f"  download will be named: swap-verdicts-{slug}.jsonl")
+
+
+# Seed for the left/right assignment in swap review. Fixed so a regenerated page puts the
+# same cards on the same sides -- a reviewer who resumes must not be re-asked a card with
+# the sides reversed, or their two answers would contradict each other.
+REVIEW_FLIP_SEED = 20260725
+
+
+# Same shape as cmd_review: one proposal can change the numerator, the candidate set and a
+# weight at once, and they must be reviewed together because they interact -- dedup alone
+# regressed 17 core-set foils that a finish weight masked.
+def cmd_countfix(  # noqa: C901, PLR0912, PLR0913, PLR0915, PLR0917
+    out: Path,
+    base_over: list[str] | None = None,
+    judged: dict[str, set[str | None]] | None = None,
+    dedup: bool = False,
+    prop_over: list[str] | None = None,
+    drop_memo: bool = False,
+    from_main: bool = False,
+) -> None:
+    """Review the swaps from changing what `illustration_count` counts.
+
+    Not a weight change: every weight is held at its accepted value and only the
+    numerator moves, from "every row sharing the illustration" to COUNTED_PRINTING_SQL.
+    That isolates the counting rule -- any swap on this page is caused by fake or
+    duplicate printings inflating an artwork's reprint count, nothing else.
+
+    `--base` matters here. WEIGHTS holds art_style at 0 so `validate` can reproduce the
+    un-backfilled database; without `--base art_style=14` this would measure against the
+    pre-#766 config and re-ask swaps that change has already settled.
+    """
+    w = dict(WEIGHTS)
+    for spec in base_over or []:
+        comp, val = spec.split("=", 1)
+        if comp not in w:
+            sys.exit(f"unknown component {comp!r}")
+        w[comp] = float(val)
+    if base_over:
+        print("  baseline (already accepted): " + ", ".join(base_over))
+
+    rows = load("c.raw_card_blob ->> 'lang' = 'en' AND c.prefer_score IS NOT NULL")
+    # Memorabilia is already excluded from the printing COUNT, but that never stopped it
+    # being displayed: 191 cards currently show one, 187 of them 30a, which Scryfall tags
+    # with the 2015 frame (42 pts) while every one of its 592 printings is a lowres scan.
+    # Dropping it from candidacy is safe -- no card is memorabilia-only.
+    by: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        by.setdefault(r["card_name"], []).append(r)
+    multi = {k: v for k, v in by.items() if len(v) > 1}
+    # Applies to the PROPOSAL side only. Filtering both sides would hold the change constant
+    # and hide its own effect -- an earlier run did exactly that and silently dropped the 219
+    # cards this fixes from the review.
+    prop_rows = {k: [r for r in v if r["set_type"] != "memorabilia"] for k, v in multi.items()} if drop_memo else multi
+    if drop_memo:
+        print(
+            f"  proposal drops {sum(len(v) for v in multi.values()) - sum(len(v) for v in prop_rows.values())}"
+            f" memorabilia printings from candidacy"
+        )
+    # dedup builds ON TOP of the already-reviewed exclusion rule: baseline counts real
+    # rows, proposal counts distinct sets among them. Reviewing it against the unfixed
+    # numerator instead would re-ask the 47 cards already judged.
+    # from_main pins the baseline to what production scores today, so one review covers
+    # the whole accumulated change rather than the delta from a config never shipped.
+    old_key, new_key = ("illus_n_real", "illus_n_set") if dedup else ("illus_n", "illus_n_real")
+    if from_main:
+        old_key = "illus_n"
+    inflated = sum(1 for r in rows if r[old_key] != r[new_key])
+    print(f"  numerator: {old_key} -> {new_key}")
+    print(f"  printings whose artwork count changes : {inflated} of {len(rows)}")
+    print(f"  multi-printing cards                  : {len(multi)}")
+    # Weights that apply to the PROPOSAL side only. A numerator change and a weight change
+    # are often entangled -- dedup alone regressed 17 core-set foils because frame(+5) and
+    # finish(-5) cancel exactly, leaving the count as the only separator -- so the pair has
+    # to be reviewed as one proposal, not two.
+    w_new = dict(w)
+    for spec in prop_over or []:
+        comp, val = spec.split("=", 1)
+        if comp not in w_new:
+            sys.exit(f"unknown component {comp!r}")
+        w_new[comp] = float(val)
+    if prop_over:
+        print(
+            "  proposal also changes: "
+            + ", ".join(f"{c.split('=')[0]} {w[c.split('=')[0]]:g}->{c.split('=')[1]}" for c in prop_over)
+        )
+
+    # Exclusion is per DESTINATION, not per card. A verdict answers "is this printing better
+    # than that one", so it only carries over when the proposal lands on the same printing
+    # again; a card judged in an earlier batch that now moves somewhere else is a new
+    # question. Filtering by card name (the original behaviour) silently dropped those.
+    rng = random.Random(REVIEW_FLIP_SEED)
+    swaps = []
+    skipped = reasked = 0
+    for name, printings in multi.items():
+        cand = prop_rows.get(name) or printings
+        old = max(printings, key=lambda r: (score(r, w, old_key), r["sid"]))
+        new = max(cand, key=lambda r: (score(r, w_new, new_key), r["sid"]))
+        if old["sid"] == new["sid"]:
+            continue
+        seen = (judged or {}).get(name)
+        if seen is not None:
+            dest = side(new)["loc"]
+            if dest in seen or None in seen:  # None = legacy file with no destination recorded
+                skipped += 1
+                continue
+            reasked += 1
+        swaps.append({"card": name, "old": side(old), "new": side(new)})
+    if judged:
+        print(f"  skipped {skipped} cards already judged on this same destination")
+        print(f"  re-asking {reasked} judged cards that now move somewhere different")
+    swaps.sort(key=lambda s: s["card"])
+    for s in swaps:  # after sorting, so the seed maps card -> side stably
+        s["flip"] = rng.random() < COIN
+    print(f"  proposal shown on the left for {sum(s['flip'] for s in swaps)} of {len(swaps)}")
+    slug = ("illus-count-set-dedup" if dedup else "illus-count-real-printings") + (
+        "-" + "-".join(c.replace("=", "") for c in prop_over) if prop_over else ""
+    )
+    out.write_text(
+        REVIEW_PAGE.replace("__SWAPS__", json.dumps(swaps, separators=(",", ":")))
+        .replace("__DESC__", json.dumps(f"{len(swaps)} proposed swaps"))
+        .replace("__SLUG__", json.dumps(slug))
+    )
+    print(f"\n  {len(swaps)} swaps to review -> {out}")
+    print(f"  download will be named: swap-verdicts-{slug}.jsonl")
+
+
+# Controlled foil-vs-nonfoil pairs: same card, same artwork, same SET, same frame data,
+# same border, same rarity, same scan quality. The only difference is the finish, which is
+# what makes this a test of `finish_foil` rather than a test of whatever else moved.
+#
+# Needed because every earlier batch confounded finish with frame: of 69 same-artwork pairs
+# in the dedup+foil review, 63 also changed frame (62/62 preferred the newer frame) and only
+# 6 isolated finish (6/6 "no difference"). Six is too few to justify deleting a component
+# that moves 11,411 printings.
+FINISH_PAIR_SQL = """
+WITH e AS (
+  SELECT c.card_name, c.illustration_id, c.card_set_code, c.card_frame_data, c.card_border,
+         c.card_rarity_int, c.raw_card_blob ->> 'image_status' AS img,
+         c.raw_card_blob ->> 'collector_number' AS cn,
+         c.raw_card_blob -> 'image_uris' ->> 'normal' AS url,
+         CASE WHEN c.raw_card_blob -> 'finishes' ? 'nonfoil' THEN 'nonfoil'
+              WHEN c.raw_card_blob -> 'finishes' ? 'foil' THEN 'foil' ELSE 'etched' END AS fin,
+         -- Sorted, so ["showcase","legendary"] and ["legendary","showcase"] compare equal --
+         -- raw text comparison reported those as different treatments when they are not.
+         (SELECT COALESCE(array_agg(x ORDER BY x), '{{}}')
+            FROM jsonb_array_elements_text(COALESCE(c.raw_card_blob -> 'frame_effects', '[]'::jsonb)) x
+         ) AS effects,
+         -- The decisive one: without it the foil side is usually a *special* foil
+         -- (textured / surgefoil / ripplefoil) or a different promo product, which is a
+         -- visible treatment difference and not the plain foil-vs-nonfoil question.
+         (SELECT COALESCE(array_agg(x ORDER BY x), '{{}}')
+            FROM jsonb_array_elements_text(COALESCE(c.raw_card_blob -> 'promo_types', '[]'::jsonb)) x
+         ) AS promo_types,
+         COALESCE(c.raw_card_blob ->> 'security_stamp', '') AS stamp,
+         COALESCE(c.raw_card_blob ->> 'full_art', 'f')      AS full_art,
+         COALESCE(c.raw_card_blob ->> 'textless', 'f')      AS textless,
+         COALESCE(c.raw_card_blob ->> 'promo', 'f')         AS promo
+  FROM magic.cards c
+  WHERE c.raw_card_blob ->> 'lang' = 'en' AND c.illustration_id IS NOT NULL
+    AND c.raw_card_blob -> 'image_uris' ->> 'normal' IS NOT NULL),
+-- Grouped rather than self-joined: a self-join on jsonb frame data over 94k rows does not
+-- finish, while one pass bucketing by the same key does. A bucket qualifies when it holds
+-- both finishes, and everything in the key is by construction identical between them.
+grouped AS (
+  SELECT card_name, card_set_code,
+         min(cn)  FILTER (WHERE fin = 'nonfoil') AS nonfoil_cn,
+         min(url) FILTER (WHERE fin = 'nonfoil') AS nonfoil_url,
+         min(cn)  FILTER (WHERE fin = 'foil')    AS foil_cn,
+         min(url) FILTER (WHERE fin = 'foil')    AS foil_url
+  FROM e
+  GROUP BY card_name, illustration_id, card_set_code,
+           card_frame_data::text, COALESCE(card_border, ''), card_rarity_int, img,
+           effects, promo_types, stamp, full_art, textless, promo
+  HAVING count(*) FILTER (WHERE fin = 'nonfoil') > 0
+     AND count(*) FILTER (WHERE fin = 'foil')    > 0)
+SELECT card_name, card_set_code, nonfoil_cn, nonfoil_url, foil_cn, foil_url FROM grouped
+"""
+
+
+def cmd_finishtest(out: Path, n: int) -> None:
+    """Blind foil-vs-nonfoil review on pairs where nothing else differs.
+
+    Stratified one-per-set before sampling, because the unstratified population is
+    dominated by the 7th-10th Edition `*` foils -- a verdict drawn only from those would
+    say something about 2003-era foil stock, not about foil in general.
+    """
+    rows = run_query(FINISH_PAIR_SQL)
+    by_set: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        by_set.setdefault(r["card_set_code"], []).append(r)
+    rng = random.Random(REVIEW_FLIP_SEED)
+    for v in by_set.values():
+        rng.shuffle(v)
+    picked: list[dict[str, str]] = []
+    while len(picked) < n and any(by_set.values()):  # round-robin across sets
+        for code in sorted(by_set):
+            if by_set[code] and len(picked) < n:
+                picked.append(by_set[code].pop())
+    print(f"  {len(rows)} controlled pairs across {len(by_set)} sets -> sampling {len(picked)}")
+
+    swaps = []
+    for r in sorted(picked, key=lambda x: x["card_name"]):
+        loc = f"{r['card_set_code']}/"
+        swaps.append(
+            {
+                "card": r["card_name"],
+                "old": {"img": r["nonfoil_url"], "art": "", "loc": loc + r["nonfoil_cn"]},
+                "new": {"img": r["foil_url"], "art": "", "loc": loc + r["foil_cn"]},
+                "flip": rng.random() < COIN,
+            }
+        )
+    print(f"  foil shown on the left for {sum(s['flip'] for s in swaps)} of {len(swaps)}")
+    slug = "finish-foil-vs-nonfoil"
+    out.write_text(
+        REVIEW_PAGE.replace("__SWAPS__", json.dumps(swaps, separators=(",", ":")))
+        .replace("__DESC__", json.dumps("same set, same art, same frame -- only the finish differs"))
+        .replace("__SLUG__", json.dumps(slug))
+    )
+    print(f"\n  {len(swaps)} pairs to review -> {out}")
+    print("  'better' in the output means FOIL was preferred; 'worse' means nonfoil")
+    print(f"  download will be named: swap-verdicts-{slug}.jsonl")
+
+
+def main() -> None:
+    """Parse arguments and dispatch to a subcommand."""
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("validate")
+    sw = sub.add_parser("swaps")
+    sw.add_argument("--set", action="append", default=[], metavar="COMP=VALUE")
+    sw.add_argument("--scale", action="append", default=[], metavar="COMP=FACTOR")
+    sw.add_argument("--limit", type=int, default=400, help="max swaps to put in the review page")
+    sw.add_argument("-o", "--out", type=Path, default=OUT_DIR / "swaps.html")
+    st = sub.add_parser("step", help="smallest change to one component that yields ~6-9 swaps")
+    st.add_argument("component")
+    st.add_argument("direction", choices=("up", "down"))
+    st.add_argument("-o", "--out", type=Path, default=OUT_DIR / "step.html")
+    rv = sub.add_parser("review", help="one blind review page covering several proposed changes")
+    rv.add_argument("--change", action="append", required=True, metavar="COMP=VALUE")
+    rv.add_argument(
+        "--joint",
+        action="store_true",
+        help="apply all --change values simultaneously and review the resulting "
+        "config, rather than reviewing each change independently. Not the same "
+        "set: measured art_style=6 + extended_art=10 jointly moves 101 cards vs "
+        "86 for the union, because 15 only move when both weights move.",
+    )
+    rv.add_argument(
+        "--base",
+        action="append",
+        default=[],
+        metavar="COMP=VALUE",
+        help="already-accepted weights to measure the change against, so an increment shows only what it newly adds",
+    )
+    rv.add_argument(
+        "--judged",
+        type=Path,
+        nargs="*",
+        default=[],
+        help="previous swap-verdict JSONL files; their cards are excluded so the page only asks new questions",
+    )
+    rv.add_argument("-o", "--out", type=Path, default=OUT_DIR / "review.html")
+    cf = sub.add_parser("countfix", help="review swaps from excluding fake/duplicate rows from the illustration_count numerator")
+    cf.add_argument(
+        "--base",
+        action="append",
+        default=[],
+        metavar="COMP=VALUE",
+        help="already-accepted weights to measure against; pass art_style=14 "
+        "so the baseline is the shipped config, not the pre-#766 one",
+    )
+    cf.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        dest="prop",
+        metavar="COMP=VALUE",
+        help="weight change applied to the PROPOSAL side only, reviewed jointly with the numerator change",
+    )
+    cf.add_argument(
+        "--from-main",
+        action="store_true",
+        dest="from_main",
+        help="baseline is the stored production score, not an intermediate config",
+    )
+    cf.add_argument(
+        "--no-memorabilia",
+        action="store_true",
+        dest="drop_memo",
+        help="also stop memorabilia products being DISPLAYED, not just counted",
+    )
+    cf.add_argument(
+        "--judged", type=Path, nargs="*", default=[], help="previous swap-verdict JSONL files; their cards are excluded"
+    )
+    cf.add_argument(
+        "--dedup",
+        action="store_true",
+        help="review the NEXT step: one credit per set, on top of the exclusion "
+        "rule. Bare set is deliberate -- frame/border/finish differences are "
+        "already priced by their own components, so keeping them in the dedup "
+        "key would count a retro-frame reprint twice.",
+    )
+    cf.add_argument("-o", "--out", type=Path, default=OUT_DIR / "countfix.html")
+    ft = sub.add_parser("finishtest", help="blind foil-vs-nonfoil review with everything else held equal")
+    ft.add_argument("-n", type=int, default=50, help="number of pairs to sample")
+    ft.add_argument("-o", "--out", type=Path, default=OUT_DIR / "finishtest.html")
+    a = ap.parse_args()
+    if a.cmd == "validate":
+        cmd_validate()
+    elif a.cmd == "finishtest":
+        cmd_finishtest(a.out, a.n)
+    elif a.cmd == "countfix":
+        cmd_countfix(a.out, a.base, load_judged(a.judged) if a.judged else None, a.dedup, a.prop, a.drop_memo, a.from_main)
+    elif a.cmd == "review":
+        cmd_review(a.change, a.out, a.joint, a.base, load_judged(a.judged) if a.judged else None)
+    elif a.cmd == "step":
+        cmd_step(a.component, a.direction, a.out)
+    else:
+        cmd_swaps(a.set, a.scale, a.out, a.limit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two changes to `backfill_prefer_scores.sql`, the design docs behind them, and the harness that produced the evidence. Closes the investigation in #720.

## 1. `art_style` — a bonus for core-style artwork

Not a licensed crossover, not a stylistic departure. Written as a bonus for being on-style rather than a penalty, so every component stays non-negative like the rest of the table.

```sql
'art_style', (
    CASE
        WHEN (card_art_tags ? 'external-ip'
              AND NOT (card_art_tags ?| ARRAY['dungeons-and-dragons','the-lord-of-the-rings']))
          OR card_art_tags ?| ARRAY['anime','comic-style','line-art','word-art-title'] THEN 0
        ELSE 14
    END
),
```

`external-ip` is the Scryfall tagger's parent over ~57 licensed franchises. D&D and Lord of the Rings are exempt — external IP whose art matches Magic's high-fantasy look. Raw `external-ip` scores 117/125; the two exemptions remove exactly those 8 misses.

## 2. The printing count now counts only real printings

`illustration_count` is a proxy for how canonical an artwork is, but its numerator counted every row sharing the illustration. Three kinds of row are not printing events and now stop counting: **non-English** (the same printing already counted in English), **`memorabilia`** (World Championship decks, Collectors' Edition, 30th Anniversary), and **gold/yellow borders**.

Mark Poole's Birds of Paradise artwork counted 21 printings — eight memorabilia (`30a` ×2, `ced`, `cei`, `ptc`, `wc00` ×2, `wc98`) and two foreign (`4bb`, `fbb`) — leaving 11 against Marcelo Vignali's 12. The card now shows Vignali.

Border alone is not the discriminator: four of those eight memorabilia rows are **black**-bordered, so a border test misses half. White borders are deliberately kept — `2ed`–`6ed` are real core sets, and dropping them would penalise the core-set reprints this component should reward. Only the numerator changes; these printings can still be displayed.

## Evidence

| change | own review | in the 378-card review against production |
| --- | --- | --- |
| `art_style` | 177/177 labelled comparisons; **78 better, 0 worse** over 114 cards | **143 better, 0 worse**, 38 same |
| count filter | **11 better, 36 same, 0 worse** over 47 cards | **2 better, 0 worse** |

Agreement with 202 directly-labelled artwork choices rises from **79.2% to 83.2%**.

Reviews are blind and whole-card: sides are randomised and labelled left/right, and pages show the full card rather than an art crop, because frame, border and finish are invisible in a crop. Both cards that opened the issue are fixed and neither appeared in any labelled batch:

| card | before | after |
| --- | --- | --- |
| Puresteel Paladin | `pip/456` — Fallout | `cmm/51` |
| Sword of the Animist | `msc/452` — Marvel | `plst/ORI-240` |

## Verification

- **Exemption is complete** — no artwork carries a sibling tag (`arda`, `hobbit`, `abeir-toril`, `dnd-multiverse`) without its parent, so no Middle-earth or Forgotten Realms art is demoted by accident.
- **No `NULL` `card_art_tags`**, so that branch cannot silently misclassify.
- By set: `ltr` 853/853 on-style, `afr` 401/402, `pip` 0/1068, `40k` 0/617. The AFR exception is Drizzt Do'Urden #338, tagged `dungeons-and-dragons` **and** `line-art` — a line-art rendering is a departure whoever owns the IP. Deliberate, confirmed against the artwork.
- `prefer_weights.py validate` reproduces the stored `prefer_score` from levels × weights exactly — 0.000000 across all 94,718 printings — which is what makes the diffs above trustworthy.

## Not included, deliberately

- **Deduplicating to one credit per set.** Principled, and rejected on evidence: **28 better / 22 worse**, with losses concentrated 17–1 on 7th–10th Edition `★` foils.
- **Excluding `promo` sets** — zeroes the count for 1,018 artworks that exist only as promos.
- **Collapsing child sets into parents** (`blc`→`blb`) — the largest effect measured, but `parent_set_code` is absent from our data and needs a `set_parents` table. Deferred.
- **Frame and finish reweighting** — recorded in the doc as two instructive failures: frame weights cannot be moved one at a time without perturbing an adjacent gap, and a controlled batch found nonfoil beats foil **24–0**, overturning a 6/6 "no difference" reading taken from confounded pairs.
- **Nothing stops memorabilia being *displayed*** — 191 cards still show one. That needs `highres_scan` reweighting plus a display exclusion, which measured 22 better / 9 worse alone and is left for a follow-up.

## Also here

`scripts/prefer_weights.py` — the harness. Both changes cite reviews only it can reproduce. It extracts each component's raw level per printing and applies weights in Python, so re-scoring a candidate is a dot product rather than a full-table UPDATE plus an engine reload.

`docs/issues/local-prefer-score-tuning-loop.md` — a design for replacing this process with a closed loop, since the tuning worked but the analysis was wrong three separate times.
