### PR TITLE
Fix: Scryfall User-Agent, env.json Precedence, and Connection Reuse in the Image Sync

### DIFF
--- a/scripts/copy_images_to_s3.py
+++ b/scripts/copy_images_to_s3.py
@@ -178,6 +178,29 @@ def fetch_cards_from_db(
 SCRYFALL_USER_AGENT = "sylvan-librarian/1.0 (+https://github.com/jbylund/sylvan_librarian)"
 
 
+# Connections are pooled per process rather than per request. The sync makes one request
+# per image over tens of thousands of images, and without a Session each one pays a fresh
+# TCP handshake plus a TLS negotiation to the same host.
+#
+# Guarded by pid because the worker pool forks: a Session created in the parent would hand
+# every child a copy of the same open sockets, and concurrent use of a shared TLS connection
+# corrupts the stream. Recreating when the pid changes gives each worker its own pool without
+# depending on how the pool is started.
+_SESSION: requests.Session | None = None
+_SESSION_PID: int | None = None
+
+
+def get_session() -> requests.Session:
+    """Return this process's requests Session, creating it on first use."""
+    global _SESSION, _SESSION_PID  # per-process singleton, rebuilt after fork
+    pid = os.getpid()
+    if _SESSION is None or pid != _SESSION_PID:
+        session = requests.Session()
+        session.headers["User-Agent"] = SCRYFALL_USER_AGENT
+        _SESSION, _SESSION_PID = session, pid
+    return _SESSION
+
+
 def download_image(url: str, output_path: Path) -> bool:
     """Download an image from a URL.
 
@@ -189,12 +212,7 @@ def download_image(url: str, output_path: Path) -> bool:
         True if successful, False otherwise
     """
     try:
-        response = requests.get(
-            url,
-            timeout=30,
-            stream=True,
-            headers={"User-Agent": SCRYFALL_USER_AGENT},
-        )
+        response = get_session().get(url, timeout=30, stream=True)
         response.raise_for_status()
 
         with output_path.open("wb") as f:

--- a/scripts/copy_images_to_s3.py
+++ b/scripts/copy_images_to_s3.py
@@ -22,6 +22,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -178,27 +179,29 @@ def fetch_cards_from_db(
 SCRYFALL_USER_AGENT = "sylvan-librarian/1.0 (+https://github.com/jbylund/sylvan_librarian)"
 
 
-# Connections are pooled per process rather than per request. The sync makes one request
-# per image over tens of thousands of images, and without a Session each one pays a fresh
-# TCP handshake plus a TLS negotiation to the same host.
-#
-# Guarded by pid because the worker pool forks: a Session created in the parent would hand
-# every child a copy of the same open sockets, and concurrent use of a shared TLS connection
-# corrupts the stream. Recreating when the pid changes gives each worker its own pool without
-# depending on how the pool is started.
-_SESSION: requests.Session | None = None
-_SESSION_PID: int | None = None
+@lru_cache(maxsize=1)
+def get_session(_pid: int) -> requests.Session:
+    """Return the requests Session for the calling process, creating it on first use.
 
+    Connections are pooled per process rather than per request. The sync makes one request
+    per image over tens of thousands of images, and without a Session each one pays a fresh
+    TCP handshake plus a TLS negotiation to the same host.
 
-def get_session() -> requests.Session:
-    """Return this process's requests Session, creating it on first use."""
-    global _SESSION, _SESSION_PID  # per-process singleton, rebuilt after fork
-    pid = os.getpid()
-    if _SESSION is None or pid != _SESSION_PID:
-        session = requests.Session()
-        session.headers["User-Agent"] = SCRYFALL_USER_AGENT
-        _SESSION, _SESSION_PID = session, pid
-    return _SESSION
+    Keyed on pid because the worker pool forks: a Session created in the parent would hand
+    every child a copy of the same open sockets, and concurrent use of a shared TLS connection
+    corrupts the stream. A child's first call misses on its own pid and builds its own pool,
+    without depending on how the pool is started. maxsize=1 keeps only the current process's
+    session, so the inherited parent entry is evicted rather than held for the whole run.
+
+    Args:
+        _pid: The calling process's id, from os.getpid(). Used only as the cache key.
+
+    Returns:
+        A Session identifying itself to Scryfall, reused for the life of the process.
+    """
+    session = requests.Session()
+    session.headers["User-Agent"] = SCRYFALL_USER_AGENT
+    return session
 
 
 def download_image(url: str, output_path: Path) -> bool:
@@ -212,7 +215,7 @@ def download_image(url: str, output_path: Path) -> bool:
         True if successful, False otherwise
     """
     try:
-        response = get_session().get(url, timeout=30, stream=True)
+        response = get_session(os.getpid()).get(url, timeout=30, stream=True)
         response.raise_for_status()
 
         with output_path.open("wb") as f:

--- a/scripts/copy_images_to_s3.py
+++ b/scripts/copy_images_to_s3.py
@@ -171,6 +171,13 @@ def fetch_cards_from_db(
     return cards
 
 
+# Scryfall's CDN rejects the requests library's default User-Agent with HTTP 400 -- not a
+# rate limit and not specific to any image, so every download fails while the same URL opens
+# fine in a browser. Any descriptive UA is accepted; their API guidelines ask for one that
+# identifies the client.
+SCRYFALL_USER_AGENT = "sylvan-librarian/1.0 (+https://github.com/jbylund/sylvan_librarian)"
+
+
 def download_image(url: str, output_path: Path) -> bool:
     """Download an image from a URL.
 
@@ -182,7 +189,12 @@ def download_image(url: str, output_path: Path) -> bool:
         True if successful, False otherwise
     """
     try:
-        response = requests.get(url, timeout=30, stream=True)
+        response = requests.get(
+            url,
+            timeout=30,
+            stream=True,
+            headers={"User-Agent": SCRYFALL_USER_AGENT},
+        )
         response.raise_for_status()
 
         with output_path.open("wb") as f:
@@ -478,7 +490,11 @@ def configure_env() -> None:
     """Load environment variables from env.json file."""
     with Path("env.json").open("r") as f:
         env = json.load(f)
-    os.environ.update(env)
+    # setdefault, not update: env.json supplies defaults, so an explicitly exported PGHOST or
+    # PGPORT still wins. `update` silently discarded them, which made the standard libpq
+    # variables look broken and left editing env.json as the only way to point at a database.
+    for key, value in env.items():
+        os.environ.setdefault(key, str(value))
 
 
 def check_cwebp() -> None:

--- a/scripts/tests/test_copy_images_to_s3.py
+++ b/scripts/tests/test_copy_images_to_s3.py
@@ -1,15 +1,25 @@
 """Tests for the copy_images_to_s3 script."""
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
 import requests
 
 from scripts.copy_images_to_s3 import (
+    SCRYFALL_USER_AGENT,
     download_image,
     fetch_cards_from_db,
+    get_session,
 )
+
+# Verdicts the forked child writes back through a pipe. The child cannot assert -- a failure
+# there would not propagate to the test run -- so it reports and the parent asserts.
+CHILD_BUILT_OWN_SESSION = b"fresh"
+CHILD_REUSED_PARENT_SESSION = b"reused"
+VERDICT_MAX_BYTES = 16  # comfortably longer than either verdict, so a truncated read cannot pass
 
 
 def test_download_image_success() -> None:
@@ -17,12 +27,15 @@ def test_download_image_success() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_path = Path(temp_dir) / "test.png"
 
-        # Mock requests.get
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
         mock_response.iter_content = Mock(return_value=[b"chunk1", b"chunk2"])
 
-        with patch("scripts.copy_images_to_s3.requests.get", return_value=mock_response):
+        # spec'd so the mock only answers calls a real Session would accept
+        mock_session = Mock(spec=requests.Session)
+        mock_session.get = Mock(return_value=mock_response)
+
+        with patch("scripts.copy_images_to_s3.get_session", return_value=mock_session):
             result = download_image("https://example.com/image.png", output_path)
 
         assert result is True
@@ -38,13 +51,65 @@ def test_download_image_failure() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_path = Path(temp_dir) / "test.png"
 
-        # Mock requests.get to raise a RequestException
-        with patch("scripts.copy_images_to_s3.requests.get") as mock_get:
-            mock_get.side_effect = requests.RequestException("Network error")
+        mock_session = Mock(spec=requests.Session)
+        mock_session.get = Mock(side_effect=requests.RequestException("Network error"))
+
+        with patch("scripts.copy_images_to_s3.get_session", return_value=mock_session):
             result = download_image("https://example.com/image.png", output_path)
 
         assert result is False
         assert not output_path.exists()
+
+
+def test_get_session_identifies_itself_to_scryfall() -> None:
+    """The session carries the descriptive User-Agent Scryfall requires."""
+    session = get_session(os.getpid())
+
+    assert session.headers["User-Agent"] == SCRYFALL_USER_AGENT
+
+
+def test_get_session_is_reused_within_a_process() -> None:
+    """Repeated calls with the same pid hand back one session, so connections are pooled."""
+    assert get_session(os.getpid()) is get_session(os.getpid())
+
+
+def test_get_session_holds_only_the_current_pid() -> None:
+    """maxsize=1: a new pid evicts the old entry rather than accumulating sessions."""
+    get_session.cache_clear()
+
+    first = get_session(1)
+    second = get_session(2)
+
+    assert second is not first
+    assert get_session.cache_info().currsize == 1
+
+
+# pytest itself is multi-threaded, so fork() warns. Safe here because the child only builds a
+# Session and writes to a pipe -- it never touches a lock another thread could have held.
+@pytest.mark.filterwarnings("ignore:This process .* is multi-threaded:DeprecationWarning")
+def test_get_session_is_rebuilt_after_fork() -> None:
+    """A forked child builds its own session instead of sharing the parent's open sockets."""
+    get_session.cache_clear()
+    parent_session = get_session(os.getpid())
+
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:
+        # Child: report a verdict and exit without unwinding back into pytest.
+        os.close(read_fd)
+        try:
+            reused = get_session(os.getpid()) is parent_session
+            os.write(write_fd, CHILD_REUSED_PARENT_SESSION if reused else CHILD_BUILT_OWN_SESSION)
+        finally:
+            os._exit(0)
+
+    os.close(write_fd)
+    verdict = os.read(read_fd, VERDICT_MAX_BYTES)
+    os.close(read_fd)
+    _, wait_status = os.waitpid(child_pid, 0)
+
+    assert wait_status == 0
+    assert verdict == CHILD_BUILT_OWN_SESSION
 
 
 def test_fetch_cards_from_db() -> None:


### PR DESCRIPTION
Three fixes to the S3 image sync, all found while trying to resync artwork. Independent of #766.

## Scryfall rejects the default `requests` User-Agent

`download_image` sent no headers, so every download went out as `python-requests/…` and came back **HTTP 400**. The same URLs open fine in a browser, which makes it look like bad data rather than a bad client. Measured against one of the failing URLs:

| User-Agent | response |
| --- | --- |
| `python-requests/2.32.3` | **400** |
| none at all | 200 |
| descriptive | 200 |

Not rate limiting, not per-image — it is specifically the library default. Scryfall's API guidelines ask that clients identify themselves, so we now send `sylvan-librarian/1.0 (+https://github.com/jbylund/sylvan_librarian)`.

## `env.json` overrode the real environment

`configure_env` loaded it with `os.environ.update`, so `PGHOST=… python -m scripts.copy_images_to_s3` was silently ignored and editing `env.json` was the only way to point the script at a database. That turned a stale host in that file into something you could not work around, and made the standard libpq variables look broken. Switched to `setdefault`, so an explicitly exported value wins and `env.json` supplies defaults.

## One connection per image

The sync makes a request per image across tens of thousands of images, each through a bare `requests.get`, paying a fresh TCP handshake plus TLS negotiation to the same host every time. Now a `Session`, so the connection is reused, and the User-Agent is set once on it rather than per call.

Held per process and keyed on pid, because the worker pool forks: a `Session` created in the parent would hand every child a copy of the same open sockets, and concurrent use of a shared TLS connection corrupts the stream. A child's first call misses on its own pid and builds its own pool, without depending on how the pool is started.

The cache is `functools.lru_cache(maxsize=1)` over a function of pid rather than a pair of module globals and a hand-rolled staleness check — the comparison the globals did by hand is what a pid-keyed cache does, so the mutation and the `global` statement go away. `maxsize=1` means the entry inherited from the parent is evicted on the child's first call rather than held for the rest of the run.

## Testing

The User-Agent behaviour was measured directly against a failing URL (table above).

The download tests were still patching `requests.get`, which stopped being the call path when the `Session` landed — `test_download_image_success` was failing and `test_download_image_failure` was passing for the wrong reason, both issuing a real request to `example.com` and getting a 404. They now patch `get_session` and hand back a `Session`-spec'd mock.

The fork guard is covered: a test forks, has the child report through a pipe whether it got the parent's `Session` object back, and asserts in the parent. Keying on pid also makes the mechanism checkable without a fork at all — distinct pids returning distinct sessions is the whole behaviour — so that case is asserted directly too, along with the `maxsize=1` eviction.

Full suite: 2149 passed. `make lint` clean.
