### PR TITLE
Docs: Design a Reusable Preference Corpus for prefer_score Tuning

### DIFF
--- a/docs/issues/local-prefer-score-preference-corpus.md
+++ b/docs/issues/local-prefer-score-preference-corpus.md
@@ -65,18 +65,35 @@ A batch should reduce uncertainty, not confirm what is already known. Candidates
 - **Under-covered regions.** Corpus coverage by frame era, set type and artwork age, with sampling
   toward the thin cells. The controlled foil population was 162 pairs corpus-wide and unrepresented
   until deliberately sought.
-- **Never repeat a pair.** Re-asking wastes a slot and risks a contradiction; the corpus already knows
-  what was asked.
+- **Repeat a small fraction deliberately.** Roughly 10% of each batch should be pairs already graded,
+  unmarked. Agreement means a stable preference the model should be confident about; disagreement means
+  the two printings sit below the grader's discrimination threshold, which is a property of the
+  comparison rather than noise. This is intra-rater reliability, scored with Cohen's kappa (agreement
+  corrected for chance), and the psychophysical analogue is a just-noticeable difference. Pairs that
+  flip on re-presentation should be down-weighted in fitting or treated as ties — a model driven to
+  separate them is being asked to reproduce a coin flip. Outside that fraction, do not re-ask.
 
 30 is a reasonable sitting: 47 and 89-card batches were fine, 378 was too long to stay attentive
 through, and the 20-card batch was mostly cards already answered.
 
 ## Fitting, not just accepting
 
-Enough pairwise data makes this a ranking problem rather than a search over hand-set weights: logistic
-regression on feature differences, which is Bradley-Terry with covariates. `fit_artwork_score.py`
-prototyped this with a softplus reparameterisation to keep declared signs, and 5-fold CV. It was
-abandoned because the corpus was too small and confounded — not because the approach was wrong.
+Enough pairwise data makes this a ranking problem rather than a search over hand-set weights. The named
+methods, and where each applies:
+
+| method | what it gives us |
+| --- | --- |
+| **Bradley-Terry with covariates** | strength `exp(β·x)` from component levels, so `P(A>B) = logistic(β·(x_A − x_B))` — plain logistic regression on feature *differences*, and `β` is component contribution. Equivalently **conditional logit** / McFadden choice model; **Thurstone-Mosteller** is the probit-link variant. |
+| **Rao-Kupper** or **Davidson** | an explicit indifference threshold, so the 481 ties are modelled rather than discarded |
+| **Plackett-Luce** | the grid picks, where one of N artworks is chosen. Expanding a pick into N−1 pairwise rows (what #720 did) overstates the effective sample size, because they share the chosen item |
+| **Elo / Glicko / TrueSkill** | sequential updating; Glicko and TrueSkill carry a per-item variance, which is where preference stability naturally lives. Rates items, not features, so it does not give component contributions directly |
+| **uncertainty sampling**, **query-by-committee** | which pairs to show next. Query-by-committee is the formal version of "show pairs where live candidates disagree"; **expected information gain** / **BALD** is the information-theoretic form |
+| **SPRT** (Wald) | accept/reject on a running batch, in place of fixed count thresholds |
+| **Cohen's kappa** | intra-rater agreement on the repeated fraction |
+
+`fit_artwork_score.py` prototyped the first of these with a softplus reparameterisation to keep declared
+signs, plus 5-fold CV. It was abandoned because the corpus was too small and confounded — not because
+the approach was wrong.
 
 Two cautions carried from #720. Collinear features produce meaningless individual coefficients: illustration
 count and artist prominence correlated at 0.986, so their split was noise. And declared monotonic signs
@@ -115,7 +132,9 @@ CREATE TABLE labels.printing_preference (
     what_varied   text[]  NOT NULL,          -- artwork / frame / border / finish / scan / set_type
     batch_id      text    NOT NULL,
     graded_at     timestamptz NOT NULL DEFAULT now(),
-    PRIMARY KEY (printing_a, printing_b, shown_as)
+    -- One row per grading, not per pair: repeated presentations are the reliability signal, so
+    -- the key admits several verdicts for the same pair and they are aggregated when fitting.
+    PRIMARY KEY (printing_a, printing_b, shown_as, graded_at)
 );
 ```
 

--- a/docs/issues/local-prefer-score-preference-corpus.md
+++ b/docs/issues/local-prefer-score-preference-corpus.md
@@ -54,6 +54,11 @@ The existing 202 grid picks give a second, coarser view: agreement with a direct
 rose from 79.2% to 83.2% with #766. Keep both — the pairwise measure is sensitive, the grid measure is
 interpretable.
 
+Grid picks are also a lossy way to collect this. Preferences arrive in bands rather than as a single
+winner, and sorting a card's artworks into four bands yields the complete pairwise matrix instead of
+N−1 observations sharing one item — plus within-band ties, which the grid cannot produce at all. See
+[local-prefer-score-tier-labelling.md](local-prefer-score-tier-labelling.md).
+
 ## Choosing the ~30
 
 A batch should reduce uncertainty, not confirm what is already known. Candidates, cheapest first:

--- a/docs/issues/local-prefer-score-preference-corpus.md
+++ b/docs/issues/local-prefer-score-preference-corpus.md
@@ -94,12 +94,47 @@ cannot represent a preference with an interior peak, which is what artwork age t
 - **Positional bias.** With randomised sides it is measurable — test against the actual side split, not
   50%. A run reported as significant at p=0.032 was p=0.192 once the null was right.
 
-## Storage
+## Storage: Postgres as the working store, git as the record
 
-The corpus belongs in the repo, not in `~/Downloads`. Ten files there share filenames across batches,
-and one session's verdicts were recorded against the wrong batch because two runs produced the same
-download name. A single append-only JSONL under `docs/data/` or a `magic.preferences` table, keyed by
-printing pair, with the generator recording `what_varied` and `shown_as` at write time.
+Anywhere is better than `~/Downloads`, where ten files share filenames across batches — one session's
+verdicts were graded against a contaminated batch and nearly analysed as a clean one because two runs
+produced the same download name.
+
+Postgres is the right working store. Votes join directly against `magic.cards`, so feature extraction
+and coverage analysis become queries instead of Python that re-reads CSV; a uniqueness constraint on
+the printing pair makes re-asking impossible rather than merely discouraged; and the labelling page can
+write as it goes, removing the download-and-rename step that lost a session's work.
+
+```sql
+CREATE TABLE labels.printing_preference (
+    card_name     text    NOT NULL,
+    printing_a    uuid    NOT NULL,          -- scryfall_id, ordered so (a,b) is canonical
+    printing_b    uuid    NOT NULL,
+    verdict       text    NOT NULL CHECK (verdict IN ('a', 'b', 'tie')),
+    shown_as      text    NOT NULL CHECK (shown_as IN ('whole_card', 'art_crop')),
+    what_varied   text[]  NOT NULL,          -- artwork / frame / border / finish / scan / set_type
+    batch_id      text    NOT NULL,
+    graded_at     timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (printing_a, printing_b, shown_as)
+);
+```
+
+**Not in the `magic` schema.** `2025-09-29-great-reset.sql` opens with
+`DROP SCHEMA IF EXISTS magic CASCADE`, and `magic.query_log` sits inside it — the established pattern
+for DB-resident data here is expendable telemetry, rebuildable from Scryfall. Preferences are the
+opposite: hours of human judgement that cannot be regenerated at any price. A separate `labels` schema
+keeps them outside the blast radius.
+
+Even so, the durable record should be a git-tracked export, with the table as the working copy. The
+database is rebuildable by design and exists twice (blue and green); the corpus is neither. An export
+also makes the evidence in #720 and #766 reproducible by someone who does not have this machine's
+containers, which it currently is not.
+
+**Incremental path.** Direct writes need an endpoint, and the review pages open over `file://`, so
+that means either serving them from the API or a CORS allowance. Neither is required to start: add an
+`import-votes` command that loads a downloaded JSONL into the table idempotently, keyed on the pair.
+That captures the 1,070 preferences already collected — which is the pressing part, since they are
+currently one `rm` away from gone — and direct writes can follow.
 
 ## Related
 

--- a/docs/issues/local-prefer-score-preference-corpus.md
+++ b/docs/issues/local-prefer-score-preference-corpus.md
@@ -1,0 +1,110 @@
+# A preference corpus for `prefer_score`, and batches chosen to be informative
+
+The tuning in [#720](00720-prefer-score-artwork-tuning.md) produced **1,070 directional preferences
+and 481 ties** across ten grading sessions. Almost none of it is reusable, because each verdict was
+collected to answer one specific proposal. This is a design for making the preferences the durable
+artifact and the proposals disposable.
+
+Complements [local-prefer-score-tuning-loop.md](local-prefer-score-tuning-loop.md), which covers the
+propose/accept control flow. This doc is about the data and how batches get chosen.
+
+## The problem: labels are welded to proposals
+
+A swap review asks "the score currently shows A, this change would show B — which is better?" The
+answer is about A and B, but it was *recorded* against a change. When the next candidate moves the same
+card to C, the verdict is silent, and there is no way to tell without recomputing. Destination-matching
+recovered some of it late in #720, but the accounting was wrong for several rounds before that: a
+config was credited with verdicts belonging to a different destination, which made a change with a
+backwards sign look like the best-evidenced option in the whole session.
+
+The corpus fixes this by storing what was actually learned. `A > B for card C` is durable. It stays
+true regardless of which parameter set surfaced the comparison, so every future candidate can be scored
+against every preference ever given.
+
+## The primitive
+
+One record per comparison:
+
+```
+card, printing_a, printing_b, verdict ∈ {a, b, tie}, shown_as ∈ {whole_card, art_crop},
+batch_id, timestamp, what_varied
+```
+
+`what_varied` is computed at generation time — artwork / frame / border / finish / scan / set-type —
+not inferred later. Three separate wrong conclusions in #720 came from discovering after the fact that
+a batch confounded two properties: 63 of 69 "foil vs nonfoil" pairs also changed frame, and the
+6-of-69 that isolated finish said the opposite of the 50 controlled pairs collected afterwards.
+
+`shown_as` matters because verdicts are not comparable across it. An art-crop batch cannot speak to
+frame or finish, and one that showed crops for a frame-only change returned "no difference" on
+everything and nearly shipped a harmful weight.
+
+## Offline evaluation
+
+With the corpus in place, scoring a parameter set costs no labelling:
+
+> for every directional preference, does the score rank the two printings the same way?
+
+Agreement over the corpus is the objective. It is a dot product per row over levels already extracted
+by `prefer_weights.py`, so a candidate is evaluated in milliseconds. Ties are informative separately —
+a parameter set that puts a large gap between two printings the grader called indistinguishable is
+overconfident, which is exactly the defect behind the 5-point foil penalty.
+
+The existing 202 grid picks give a second, coarser view: agreement with a directly chosen artwork, which
+rose from 79.2% to 83.2% with #766. Keep both — the pairwise measure is sensitive, the grid measure is
+interpretable.
+
+## Choosing the ~30
+
+A batch should reduce uncertainty, not confirm what is already known. Candidates, cheapest first:
+
+- **Disagreement between parameter sets.** Hold several live candidates and show the pairs they rank
+  differently. Every verdict then discriminates rather than re-confirming.
+- **Small margins.** Pairs the current score separates by fractions of a point are where it is
+  guessing. Birds of Paradise sat at 0.0008 between two artworks.
+- **Under-covered regions.** Corpus coverage by frame era, set type and artwork age, with sampling
+  toward the thin cells. The controlled foil population was 162 pairs corpus-wide and unrepresented
+  until deliberately sought.
+- **Never repeat a pair.** Re-asking wastes a slot and risks a contradiction; the corpus already knows
+  what was asked.
+
+30 is a reasonable sitting: 47 and 89-card batches were fine, 378 was too long to stay attentive
+through, and the 20-card batch was mostly cards already answered.
+
+## Fitting, not just accepting
+
+Enough pairwise data makes this a ranking problem rather than a search over hand-set weights: logistic
+regression on feature differences, which is Bradley-Terry with covariates. `fit_artwork_score.py`
+prototyped this with a softplus reparameterisation to keep declared signs, and 5-fold CV. It was
+abandoned because the corpus was too small and confounded — not because the approach was wrong.
+
+Two cautions carried from #720. Collinear features produce meaningless individual coefficients: illustration
+count and artist prominence correlated at 0.986, so their split was noise. And declared monotonic signs
+cannot represent a preference with an interior peak, which is what artwork age turned out to be.
+
+## Guards
+
+- **Blinding.** Randomise sides, label them left/right, and never name the proposal. The first three
+  batches in #720 labelled them `CURRENT` and `PROPOSED`.
+- **Holdout.** Reserve a third of the corpus, never fit against it, report holdout agreement at accept
+  time. Three things were fitted against one set of 89 labels, making every p-value optimistic.
+- **Coupled parameters.** Declare groups (the frame ladder 1993/1997/2003/2015) and move them together.
+  Raising `frame_2003` to widen one gap narrowed another and was rejected 8–22; lowering `frame_1997`
+  sent 161 of 179 swaps to the oldest frame.
+- **Positional bias.** With randomised sides it is measurable — test against the actual side split, not
+  50%. A run reported as significant at p=0.032 was p=0.192 once the null was right.
+
+## Storage
+
+The corpus belongs in the repo, not in `~/Downloads`. Ten files there share filenames across batches,
+and one session's verdicts were recorded against the wrong batch because two runs produced the same
+download name. A single append-only JSONL under `docs/data/` or a `magic.preferences` table, keyed by
+printing pair, with the generator recording `what_varied` and `shown_as` at write time.
+
+## Related
+
+- [local-prefer-score-tuning-loop.md](local-prefer-score-tuning-loop.md) — propose/accept control flow.
+- [00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) — the tuning that
+  produced the corpus, and the record of what went wrong.
+- [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the labelling instrument.
+- [`scripts/prefer_weights.py`](../../scripts/prefer_weights.py) — level extraction and review pages.

--- a/docs/issues/local-prefer-score-tier-labelling.md
+++ b/docs/issues/local-prefer-score-tier-labelling.md
@@ -1,0 +1,108 @@
+# Tier labelling: sort a card's artworks into bands instead of picking one
+
+The grid labeller asks which of a card's distinct artworks is best. That discards most of what the
+grader knows. Preferences arrive in bands — "these two are clearly best, these three are fine, these
+eight I dislike" — and a single pick collapses all of it to one item.
+
+Feeds the corpus described in
+[local-prefer-score-preference-corpus.md](local-prefer-score-preference-corpus.md).
+
+## Why it is worth rebuilding the UI for
+
+For a card with ten distinct artworks sorted into bands of 2 / 3 / 4 / 1:
+
+| labelling mode | observations from one card |
+| --- | --- |
+| pick best of 10 | 9 directional, every one sharing the chosen item |
+| bands of 2 / 3 / 4 / 1 | **35 directional + 10 ties** — the complete pairwise matrix |
+
+Roughly four times the information, for arguably less effort than deliberating over a single winner.
+Cross-band pairs are preferences, within-band pairs are ties.
+
+Ties are the part that matters most. They are currently only produced by swap review, never by the grid,
+which is why the 481 collected so far all come from "no real difference" on a proposal. Rao-Kupper and
+Davidson cannot be fitted without them, and a parameter set that puts a wide gap between two artworks
+the grader considers equivalent is overconfident in a way nothing presently measures.
+
+## Interaction
+
+Drag and drop, with a keyboard path for speed.
+
+```
+  Wall of Wood                                            card 12 / 30
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  unassigned                                                      │
+  │   ┌────┐ ┌────┐ ┌────┐                                           │
+  │   │ 4  │ │ 7  │ │ 9  │                                           │
+  │   └────┘ └────┘ └────┘                                           │
+  └──────────────────────────────────────────────────────────────────┘
+  ┌──────────────────────────────────────────────────────────────────┐
+  │ 1  love it        ┌────┐ ┌────┐                                  │
+  │                   │ 2  │ │ 5  │                                  │
+  ├───────────────────┴────┴─┴────┴──────────────────────────────────┤
+  │ 2  good           ┌────┐ ┌────┐ ┌────┐                           │
+  │                   │ 1  │ │ 6  │ │10  │                           │
+  ├───────────────────┴────┴─┴────┴─┴────┴───────────────────────────┤
+  │ 3  fine           ┌────┐                                         │
+  │                   │ 3  │                                         │
+  ├───────────────────┴────┴─────────────────────────────────────────┤
+  │ 4  dislike        ┌────┐                                         │
+  │                   │ 8  │                                         │
+  └──────────────────────────────────────────────────────────────────┘
+       [ submit (enter) ]   [ skip card (s) ]   [ undo (u) ]
+```
+
+- **Art crops, not whole cards.** The judgement is about the picture, so `shown_as = art_crop`. This is
+  the one task where a crop is correct rather than misleading — the opposite of swap review, where a
+  crop hid the frame difference that was the entire point.
+- **Drag to place, number keys to go fast.** Dragging thirteen thumbnails is a lot of mouse travel;
+  pressing `1`–`4` assigns the focused thumbnail and advances focus, so a card can be graded without
+  the pointer. Drag is for deliberate revision, keys for throughput. Support both.
+- **Start everything unassigned.** Pre-seeding a band biases toward it, and an untouched card must be
+  distinguishable from one deliberately graded as uniform.
+- **Unassigned items are dropped, not tied.** Leaving three thumbnails in the pool means "no opinion
+  recorded", and the pairs involving them are simply not emitted. The submit button should say how many
+  will be skipped.
+- **Explicit submit.** Bands get revised as the grader looks across the card; auto-committing on drop
+  would record intermediate states.
+- **Fixed four bands.** A free-form count would drift between sessions and make older labels harder to
+  interpret. Four is enough to express the structure described above.
+
+## What a submission records
+
+Each submission emits, for that card:
+
+- every cross-band pair, as a directional preference, higher band wins
+- every within-band pair, as a tie
+- nothing at all for pairs involving an unassigned artwork
+
+Band *identity* is deliberately not stored as a rating. "Top band" on a card with ten strong artworks
+is not the same absolute standard as on a card with two, so bands are only ever a source of within-card
+pairs. Storing them as a global 1–4 score would make those incomparable numbers look comparable.
+
+## Fitting
+
+Bands are an ordinal response, so the direct treatment is an **ordered logit** (proportional odds), or
+the **graded response model** from item response theory. Prefer expanding to pairs and reusing the
+Bradley-Terry-with-ties estimator already described in the corpus doc: it avoids a second estimator, and
+it keeps grid submissions, tier submissions and swap verdicts in one comparable pool.
+
+Within-band pairs should not be weighted as heavily as repeat-confirmed ties. A band groups artworks the
+grader did not trouble to separate, which is weaker evidence than two printings independently judged
+indistinguishable when shown alone.
+
+## Cost
+
+This obsoletes `gen_labeller.py`'s grid page — the tier page is a rewrite, not an addition, and drag and
+drop with a keyboard fallback is meaningfully more UI than a row of images and a keypress. The 202
+existing grid picks stay valid: a pick is a band of one against a band of everything else, so they
+convert without loss.
+
+## Related
+
+- [local-prefer-score-preference-corpus.md](local-prefer-score-preference-corpus.md) — storage,
+  offline evaluation, batch selection.
+- [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the grid labeller this
+  replaces.
+- [00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) — the tuning that
+  produced the existing labels.

--- a/docs/issues/local-prefer-score-tier-labelling.md
+++ b/docs/issues/local-prefer-score-tier-labelling.md
@@ -1,15 +1,16 @@
-# Tier labelling: sort a card's artworks into bands instead of picking one
+# Tier labelling: sort a card's printings into bands instead of picking one
 
 The grid labeller asks which of a card's distinct artworks is best. That discards most of what the
-grader knows. Preferences arrive in bands — "these two are clearly best, these three are fine, these
-eight I dislike" — and a single pick collapses all of it to one item.
+grader knows, in two ways: preferences arrive in bands — "these two are clearly best, these three are
+fine, these eight I dislike" — and a single pick collapses all of it to one item; and by showing one
+tile per artwork it can only ever teach the score about artwork, never about frame, border or finish.
 
 Feeds the corpus described in
 [local-prefer-score-preference-corpus.md](local-prefer-score-preference-corpus.md).
 
 ## Why it is worth rebuilding the UI for
 
-For a card with ten distinct artworks sorted into bands of 2 / 3 / 4 / 1:
+For a card with ten printings sorted into bands of 2 / 3 / 4 / 1:
 
 | labelling mode | observations from one card |
 | --- | --- |
@@ -21,7 +22,7 @@ Cross-band pairs are preferences, within-band pairs are ties.
 
 Ties are the part that matters most. They are currently only produced by swap review, never by the grid,
 which is why the 481 collected so far all come from "no real difference" on a proposal. Rao-Kupper and
-Davidson cannot be fitted without them, and a parameter set that puts a wide gap between two artworks
+Davidson cannot be fitted without them, and a parameter set that puts a wide gap between two printings
 the grader considers equivalent is overconfident in a way nothing presently measures.
 
 ## Interaction
@@ -52,9 +53,10 @@ Drag and drop, with a keyboard path for speed.
        [ submit (enter) ]   [ skip card (s) ]   [ undo (u) ]
 ```
 
-- **Art crops, not whole cards.** The judgement is about the picture, so `shown_as = art_crop`. This is
-  the one task where a crop is correct rather than misleading — the opposite of swap review, where a
-  crop hid the frame difference that was the entire point.
+- **Whole cards, not art crops.** `shown_as = whole_card`. The score decides which *printing* to
+  display, and it has components for frame, border, finish, extended art and scan quality as well as
+  artwork. Labels that show only the picture cannot identify any of those coefficients — which is
+  precisely why #720 got frame-versus-finish wrong three times. See below.
 - **Drag to place, number keys to go fast.** Dragging thirteen thumbnails is a lot of mouse travel;
   pressing `1`–`4` assigns the focused thumbnail and advances focus, so a card can be graded without
   the pointer. Drag is for deliberate revision, keys for throughput. Support both.
@@ -68,15 +70,48 @@ Drag and drop, with a keyboard path for speed.
 - **Fixed four bands.** A free-form count would drift between sessions and make older labels harder to
   interpret. Four is enough to express the structure described above.
 
+## Whole printings are what makes the other components learnable
+
+The grid labeller showed one representative per `illustration_id`, so every label it produced was about
+artwork. `frame`, `border`, `finish`, `extended_art` and `highres_scan` never varied within a comparison,
+which makes their coefficients unidentifiable from that data no matter how much of it is collected.
+
+That is the root cause of the worst mistake in #720. `finish_foil` was raised on the strength of 100
+better / 5 worse, and the sign turned out to be backwards: in all 62 informative pairs the foil printing
+also carried a newer frame, so the two components were perfectly confounded and the fit credited the
+wrong one. It took a deliberately controlled batch — same card, set, artwork, frame, border, rarity, scan
+and promo type, differing only in finish — to find that nonfoil actually wins 24–0.
+
+Showing whole printings fixes this by construction. When the same artwork appears twice in different
+frames and the grader puts them in different bands, *that is the frame signal*, measured directly rather
+than inferred from a swap.
+
+### Which printings to show
+
+A heavily reprinted card has more printings than anyone will tier, so the set has to be sampled — and
+the sampling is where identifiability is won or lost. Choose 8–12 printings per card to **span the
+component space**: different frame eras, both borders, foil and nonfoil, extended and normal, more than
+one artwork. Deliberately include same-artwork/different-frame and same-frame/different-artwork pairs
+so each component varies against a held background.
+
+The formal version is experimental design — maximise the conditioning of the feature matrix (a
+D-optimal criterion) rather than sampling printings uniformly. Uniform sampling reproduces the corpus's
+natural correlations, which is how frame and finish became inseparable in the first place.
+
+Expect this to feel repetitive: several tiles will be the same picture. That is intended, and it is the
+opposite of the earlier complaint about seeing duplicate artwork in the grid labeller. There, repeated
+art was noise because the task was to choose a picture; here the difference between two printings of one
+picture is the entire measurement.
+
 ## What a submission records
 
 Each submission emits, for that card:
 
 - every cross-band pair, as a directional preference, higher band wins
 - every within-band pair, as a tie
-- nothing at all for pairs involving an unassigned artwork
+- nothing at all for pairs involving an unassigned printing
 
-Band *identity* is deliberately not stored as a rating. "Top band" on a card with ten strong artworks
+Band *identity* is deliberately not stored as a rating. "Top band" on a card with ten strong printings
 is not the same absolute standard as on a card with two, so bands are only ever a source of within-card
 pairs. Storing them as a global 1–4 score would make those incomparable numbers look comparable.
 
@@ -87,16 +122,19 @@ the **graded response model** from item response theory. Prefer expanding to pai
 Bradley-Terry-with-ties estimator already described in the corpus doc: it avoids a second estimator, and
 it keeps grid submissions, tier submissions and swap verdicts in one comparable pool.
 
-Within-band pairs should not be weighted as heavily as repeat-confirmed ties. A band groups artworks the
+Within-band pairs should not be weighted as heavily as repeat-confirmed ties. A band groups printings the
 grader did not trouble to separate, which is weaker evidence than two printings independently judged
 indistinguishable when shown alone.
 
 ## Cost
 
 This obsoletes `gen_labeller.py`'s grid page — the tier page is a rewrite, not an addition, and drag and
-drop with a keyboard fallback is meaningfully more UI than a row of images and a keypress. The 202
-existing grid picks stay valid: a pick is a band of one against a band of everything else, so they
-convert without loss.
+drop with a keyboard fallback is meaningfully more UI than a row of images and a keypress. Sampling
+printings for conditioning rather than uniformly is additional work again.
+
+The 202 existing grid picks stay valid but stay limited: a pick is a band of one against a band of
+everything else, so it converts without loss, and it still says nothing about frame, border or finish.
+Those 202 cards are worth regrading as printings once the page exists.
 
 ## Related
 


### PR DESCRIPTION
Design doc only, no behaviour change. Follows on from #766.

#720 produced **1,070 directional preferences and 481 ties** across ten grading sessions, and almost none of it is reusable — each verdict was recorded against one proposal, so when a later candidate moves the same card elsewhere the verdict is silent. Late in that work a config was credited with verdicts belonging to a different destination, which made a change with a backwards sign look like the best-evidenced option in the session.

## The idea

Store the preference, not the proposal. `A beats B for card C` stays true regardless of which parameter set surfaced the comparison, so every future candidate can be scored against every preference ever given — a dot product over levels `prefer_weights.py` already extracts, in milliseconds rather than another grading session.

Batches of ~30 are then chosen to be *informative*: pairs where live candidates disagree, pairs the current score separates by fractions of a point (Birds of Paradise sat at 0.0008), and under-covered regions — never repeating a pair.

## Why the metadata matters

Records carry `what_varied` and `shown_as`, both computed at generation time. Three wrong conclusions in #720 came from discovering *afterwards* that a batch confounded two properties: 63 of 69 "foil vs nonfoil" pairs also changed frame, and the six that isolated finish said the opposite of the 50 controlled pairs collected later.

## Guards

Each one is there because a specific failure argued for it — blinding with randomised sides, a holdout never fitted against, declared groups for coupled parameters like the frame ladder, and testing positional bias against the real side split rather than 50% (a result reported at p=0.032 was p=0.192 once the null was right).