### PR TITLE
Docs: Add a security- Prefix Convention for Unfixed Findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ gatherer_data/
 prof
 *.min.js
 configs/postgres/conf/postgresql.conf
+
+# Unfixed security findings — this repo is public, so committing these publishes a
+# working recipe against the live deployment. Rename off the prefix once fixed. See CLAUDE.md.
+docs/issues/security-*
+# Credential files (github.pat and friends) — .env and env.json are covered above.
+*.pat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,34 @@ intent, so a reader can tell backlog from background at a glance:
   design study, or rejected-but-preserved approach that is *not* todo work and shouldn't be read as a
   backlog item (e.g. `reference-engine-printing-varying-plane-repair-pattern.md`). Promote to `local-`
   or a number only if it actually becomes planned work.
+- `security-slug.md` — **unfixed security findings**: the one exception to "all of it, tracked". This
+  repo is public, so committing a description of a live, unfixed vulnerability publishes a working
+  recipe against the running deployment — permanently, since removing the file later does not remove
+  it from history. `docs/issues/security-*` is gitignored to make that mechanical rather than a thing
+  to remember. **When the finding is fixed, rename it off the prefix** (to `local-`, a number, or
+  `done/`) and commit it — at that point the write-up is a useful record instead of a map, and it
+  should not stay invisible.
+
+  Two caveats that come with the gitignore. It protects against `git add -A` and `git clean -fd`, but
+  **not** `git clean -fdx`, which deletes ignored files. And these docs exist on one machine only, so
+  a finding worth keeping needs a home outside the working tree — see below.
+
+  **The design doc for the fix usually needs the prefix too, and the bar is not "did I omit the
+  specifics."** It is whether a reader could derive the attack from what remains. A doc explaining
+  *why* a boundary is missing generally shows *where* it is missing, so in practice these fail the
+  test even when written carefully — default to `security-` and rename once the fix lands. Only a
+  genuinely general architecture note, one that would read the same had no vulnerability prompted it,
+  belongs in-tree before the fix.
+
+  While fixing, keep commit messages boring and factual (`Refactor: Extract Router from APIResource`,
+  not `Fix: unauthenticated admin endpoints`). Commits on a public repo are visible in real time, and
+  a message that advertises the defect narrows the window between disclosure and deploy.
+
+  Findings split by blast radius, and it changes where they belong. A defect in code or compose that
+  **ships in the repo** affects everyone who deploys it, so it gates tagged releases (see
+  [#778](https://github.com/jbylund/sylvan_librarian/issues/778)) — fix before releasing and there is
+  never a vulnerable version to disclose. A misconfiguration of *our* host (nginx, a stray credential)
+  affects only us and needs no disclosure path at all.
 
 **Length and scope:** issue docs are not subject to the ~100-line length ideal in the global markdown
 rules — they are the deep source of truth, so length should match the material (measurements, rejected

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,60 +109,23 @@ should match the story: long enough to explain the mechanism and show evidence, 
 
 ## Issue Tracking
 
-`docs/issues/` holds the deep design/implementation notes for both engine and product work — this
-is the primary source of truth, tracked in git (all of it, no exceptions; `docs/issues/done/` for
-finished work). GitHub issues are secondary: a triage-and-status layer that must stand on its own —
-a reader should understand the problem and the gist of the approach from the GitHub issue alone,
-without needing to open the doc — but the doc is where the real depth (measurements, rejected
-alternatives, iteration history) lives, so the GitHub issue doesn't need to duplicate all of that,
-just link to it.
+`docs/issues/` holds the deep design/implementation notes for engine and product work — the primary
+source of truth, tracked in git, with `done/` for finished work. GitHub issues are a secondary
+triage layer that must stand on its own, and link to the doc rather than duplicating its depth.
 
-**Naming:** `#####-slug.md`, 5-digit zero-padded GitHub issue (or PR, if no issue exists)
-number, e.g. `00623-engine-flavor-absent-gram-bitmap.md` for #623. Prefer the issue number over its
-merging PR's number when both exist. Docs with no GitHub issue of their own use a prefix that signals
-intent, so a reader can tell backlog from background at a glance:
+Naming: `#####-slug.md` by GitHub issue number (`00623-engine-flavor-absent-gram-bitmap.md`), or a
+prefix when there is no issue — `local-` for proposed work, `reference-` for material that is
+deliberately not scheduled, `security-` for unfixed findings.
 
-- `local-slug.md` — **proposed / not-yet-filed work**: a design or fix meant to happen but not yet
-  filed as an issue (e.g. `local-engine-range-veto-redundancy.md`). When a `local-` doc later gets a
-  GitHub issue, rename it to the assigned number.
-- `reference-slug.md` — **reference material that is deliberately not scheduled**: a general pattern,
-  design study, or rejected-but-preserved approach that is *not* todo work and shouldn't be read as a
-  backlog item (e.g. `reference-engine-printing-varying-plane-repair-pattern.md`). Promote to `local-`
-  or a number only if it actually becomes planned work.
-- `security-slug.md` — **unfixed security findings**: the one exception to "all of it, tracked". This
-  repo is public, so committing a description of a live, unfixed vulnerability publishes a working
-  recipe against the running deployment — permanently, since removing the file later does not remove
-  it from history. `docs/issues/security-*` is gitignored to make that mechanical rather than a thing
-  to remember. **When the finding is fixed, rename it off the prefix** (to `local-`, a number, or
-  `done/`) and commit it — at that point the write-up is a useful record instead of a map, and it
-  should not stay invisible.
+**`security-*` is gitignored and must never be committed** — this repo is public, so publishing an
+unfixed finding is a working recipe against the live deployment, permanently. This applies to the
+*design doc for the fix* as much as to the finding itself: the bar is not whether specifics were
+omitted but whether a reader could derive the issue from what remains. Default to the prefix, keep
+fix commit messages factual rather than descriptive of the defect, and rename off the prefix once
+the fix ships.
 
-  Two caveats that come with the gitignore. It protects against `git add -A` and `git clean -fd`, but
-  **not** `git clean -fdx`, which deletes ignored files. And these docs exist on one machine only, so
-  a finding worth keeping needs a home outside the working tree — see below.
+Issue docs are exempt from the ~100-line ideal in the global markdown rules; **one shippable idea per
+doc** governs instead.
 
-  **The design doc for the fix usually needs the prefix too, and the bar is not "did I omit the
-  specifics."** It is whether a reader could derive the attack from what remains. A doc explaining
-  *why* a boundary is missing generally shows *where* it is missing, so in practice these fail the
-  test even when written carefully — default to `security-` and rename once the fix lands. Only a
-  genuinely general architecture note, one that would read the same had no vulnerability prompted it,
-  belongs in-tree before the fix.
-
-  While fixing, keep commit messages boring and factual (`Refactor: Extract Router from APIResource`,
-  not `Fix: unauthenticated admin endpoints`). Commits on a public repo are visible in real time, and
-  a message that advertises the defect narrows the window between disclosure and deploy.
-
-  Findings split by blast radius, and it changes where they belong. A defect in code or compose that
-  **ships in the repo** affects everyone who deploys it, so it gates tagged releases (see
-  [#778](https://github.com/jbylund/sylvan_librarian/issues/778)) — fix before releasing and there is
-  never a vulnerable version to disclose. A misconfiguration of *our* host (nginx, a stray credential)
-  affects only us and needs no disclosure path at all.
-
-**Length and scope:** issue docs are not subject to the ~100-line length ideal in the global markdown
-rules — they are the deep source of truth, so length should match the material (measurements, rejected
-alternatives, iteration history). What governs instead is **one shippable idea per doc**: the split
-signal is not line count but whether the doc holds multiple *independent* ideas that would land as
-separate PRs. When it does, extract each into its own doc and cross-link. In practice docs cluster
-around 100–300 lines; treat ~500 as the prompt to check for an independent idea hiding inside. The
-other global conventions still apply in full — cross-link rather than duplicate, and prefer a
-well-linked narrative over bare index docs.
+Full conventions — prefix rationale, the security caveats and blast-radius rule, length and scope:
+[docs/issues/README.md](docs/issues/README.md). Read it before creating or renaming an issue doc.

--- a/docs/issues/00778-tagged-releases-and-awesome-selfhosted.md
+++ b/docs/issues/00778-tagged-releases-and-awesome-selfhosted.md
@@ -57,6 +57,8 @@ placement decision, not merely the first of several.
 
 ## Phase 1 — releases and changelog (do now)
 
+**Prerequisite: review/address findings from the July 2026 security audit.**
+
 1. Write `CHANGELOG.md`. There is raw material in `docs/changelog/`, currently a set of dated
    per-change notes rather than a released-version history.
 2. Choose an initial version. The project is well past a `0.1`-shaped state, but calling it `1.0.0`

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,0 +1,83 @@
+# Issue Doc Conventions
+
+`docs/issues/` holds the deep design and implementation notes for engine and product work. This is
+the primary source of truth. The essentials are summarized in [CLAUDE.md](../../CLAUDE.md#issue-tracking);
+this doc is the full version.
+
+## Relationship to GitHub issues
+
+GitHub issues are a secondary triage-and-status layer, and they must stand on their own — a reader
+should understand the problem and the gist of the approach from the GitHub issue alone, without
+opening the doc. But the doc is where the real depth lives (measurements, rejected alternatives,
+iteration history), so the GitHub issue does not need to duplicate that. Link to it instead.
+
+## Naming
+
+`#####-slug.md`, with a 5-digit zero-padded GitHub issue number — or a PR number if no issue exists.
+For example `00623-engine-flavor-absent-gram-bitmap.md` for #623. Prefer the issue number over its
+merging PR's number when both exist. Finished work moves to `done/`.
+
+Docs with no GitHub issue of their own take a prefix that signals intent, so a reader can tell
+backlog from background at a glance:
+
+- **`local-slug.md` — proposed / not-yet-filed work.** A design or fix meant to happen but not yet
+  filed as an issue, e.g. `local-engine-range-veto-redundancy.md`. When a `local-` doc later gets a
+  GitHub issue, rename it to the assigned number.
+- **`reference-slug.md` — reference material that is deliberately not scheduled.** A general pattern,
+  design study, or rejected-but-preserved approach that is *not* todo work and should not be read as
+  a backlog item, e.g. `reference-engine-printing-varying-plane-repair-pattern.md`. Promote to
+  `local-` or a number only if it actually becomes planned work.
+- **`security-slug.md` — unfixed security findings.** Never committed; see below.
+
+## Unfixed security findings
+
+The one exception to "all of it, tracked". This repo is public, so committing a description of a
+live, unfixed vulnerability publishes a working recipe against the running deployment — permanently,
+since removing the file later does not remove it from history. `docs/issues/security-*` is gitignored
+to make that mechanical rather than something to remember.
+
+**When the finding is fixed, rename it off the prefix** (to `local-`, a number, or `done/`) and
+commit it. At that point the write-up is a useful record rather than a map, and it should not stay
+invisible.
+
+### The design doc for a fix usually needs the prefix too
+
+The bar is not "did I omit the specifics." It is whether a reader could derive the issue from what
+remains. A doc explaining *why* a boundary is missing generally shows *where* it is missing, so in
+practice these fail the test even when written carefully — default to `security-` and rename once the
+fix lands. Only a genuinely general architecture note, one that would read the same had no
+vulnerability prompted it, belongs in-tree before the fix.
+
+### While fixing
+
+Keep commit messages boring and factual — `Refactor: Extract Router from APIResource`, not
+`Fix: unauthenticated admin endpoints`. Commits on a public repo are visible in real time, and a
+message that advertises the defect narrows the window between disclosure and deploy.
+
+### Two caveats that come with the gitignore
+
+- It protects against `git add -A` and `git clean -fd`, but **not** `git clean -fdx`, which
+  deletes ignored files.
+- These docs then exist on one machine only. A finding worth keeping needs a home outside the
+  working tree.
+
+### Findings split by blast radius
+
+This changes where they belong. A defect in code or compose that **ships in the repo** affects
+everyone who deploys it, so it gates tagged releases (see
+[#778](https://github.com/jbylund/sylvan_librarian/issues/778)) — fix before releasing and there is
+never a vulnerable version to disclose. A misconfiguration of *our own* host (nginx, a stray
+credential) affects only us and needs no disclosure path at all.
+
+## Length and scope
+
+Issue docs are not subject to the ~100-line length ideal in the global markdown rules. They are the
+deep source of truth, so length should match the material.
+
+What governs instead is **one shippable idea per doc**. The split signal is not line count but
+whether the doc holds multiple *independent* ideas that would land as separate PRs. When it does,
+extract each into its own doc and cross-link. In practice docs cluster around 100–300 lines; treat
+~500 as the prompt to check for an independent idea hiding inside.
+
+The other global conventions still apply in full — cross-link rather than duplicate, and prefer a
+well-linked narrative over bare index docs.


### PR DESCRIPTION
Adds a `security-slug.md` prefix to the `docs/issues/` naming conventions, for findings that are not yet fixed.

`docs/issues/` is otherwise tracked without exception. But this repo is public, so committing a description of a live unfixed vulnerability publishes a working recipe against the running deployment — permanently, since removing the file later does not remove it from history. `docs/issues/security-*` is gitignored so that exclusion is mechanical rather than something to remember.

Findings are renamed off the prefix and committed once fixed, at which point the write-up is a useful record instead of a map.

Two caveats are documented alongside the convention:

- The gitignore protects against `git add -A` and `git clean -fd`, but **not** `git clean -fdx`, which targets ignored files.
- These docs then exist on one machine only, so a finding worth keeping needs a home outside the working tree.

The guidance also covers the design doc for a fix, where the bar is not "did I omit the specifics" but whether a reader could derive the issue from what remains — in practice these fail that test, so they default to the prefix too.

Also ignores `*.pat` (credential files alongside the already-ignored `.env` and `env.json`), and notes the release prerequisite in the #778 doc.