### PR TITLE
Fix: Bind the API Port to Loopback by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,32 @@ takes them down one at a time: blue is stopped, rebuilt, restarted, and only onc
 does green follow. Because the other stack serves throughout, a deploy has no downtime even when the
 new containers need to re-import the card data from scratch.
 
+#### Binding and Reverse Proxies
+
+The API port binds to `127.0.0.1` by default, so a fresh stack is reachable from the host it runs on
+and nowhere else. This is deliberate: Docker publishes ports by inserting DNAT rules that are
+evaluated *before* the `INPUT` chain where `ufw` and `firewalld` operate, so a published port on
+`0.0.0.0` stays reachable even when the host firewall appears to deny it. Defaulting to loopback fails
+visibly instead of silently.
+
+Pick the line that matches your setup:
+
+- **Reverse proxy on the same host** (nginx, Caddy, or similar as a host process) — nothing to do.
+  Point the proxy at `127.0.0.1:${API_PORT}`.
+- **Reverse proxy in a container on the same Docker network** — delete the `ports:` block for
+  `apiservice` entirely and have the proxy reach `apiservice:8080` directly. No host port needed.
+- **Direct access with no proxy**, e.g. from elsewhere on your LAN — set `BIND_ADDR=0.0.0.0`, or a
+  specific interface address to narrow it. Note that this serves plain HTTP with no TLS, so prefer a
+  proxy if the stack is reachable from outside your network.
+
 #### Environment Variables
 
 The following environment variables can be configured:
 
 **API Service:**
+- `BIND_ADDR` - Host address the API port binds to (default: `127.0.0.1`)
+  - Set to `0.0.0.0` to expose the API on all interfaces, or a specific interface address
+  - See "Binding and Reverse Proxies" above before changing it
 - `ENABLE_ENGINE` - Enable/disable the in-memory Rust query engine (enabled in all environments)
   - When enabled, searches are served from the shared-memory card store with PostgreSQL as fallback
   - When disabled, all searches go through the SQL path

--- a/README.md
+++ b/README.md
@@ -233,18 +233,29 @@ Pick the line that matches your setup:
   Point the proxy at `127.0.0.1:${API_PORT}`.
 - **Reverse proxy in a container on the same Docker network** — delete the `ports:` block for
   `apiservice` entirely and have the proxy reach `apiservice:8080` directly. No host port needed.
-- **Direct access with no proxy**, e.g. from elsewhere on your LAN — set `BIND_ADDR=0.0.0.0`, or a
-  specific interface address to narrow it. Note that this serves plain HTTP with no TLS, so prefer a
-  proxy if the stack is reachable from outside your network.
+- **Direct access with no proxy**, e.g. from elsewhere on your LAN — set `BIND_ADDR=0.0.0.0` in the
+  stack's file under `envs/`, or a specific interface address to narrow it. Note that this serves
+  plain HTTP with no TLS, so prefer a proxy if the stack is reachable from outside your network.
 
 #### Environment Variables
 
 The following environment variables can be configured:
 
-**API Service:**
-- `BIND_ADDR` - Host address the API port binds to (default: `127.0.0.1`)
+**Docker Compose:**
+
+Read by Compose while it renders `docker-compose.yml`, not by the API process — inside its container
+the API always listens on `0.0.0.0:8080`, and these only decide how that socket is published to the
+host. Set them in the stack's file under `envs/` (`envs/dev`, `envs/blue`, `envs/green`) so the value
+applies every time that stack starts; exporting one in the shell overrides the file for a single
+`make <env>-up`.
+
+- `BIND_ADDR` - Host address the published API port binds to (default: `127.0.0.1`)
   - Set to `0.0.0.0` to expose the API on all interfaces, or a specific interface address
   - See "Binding and Reverse Proxies" above before changing it
+- `API_PORT` - Host port the API is published on (default: `28080`)
+  - Already set per environment: `dev` is 28080, `blue` 18080, `green` 18081
+
+**API Service:**
 - `ENABLE_ENGINE` - Enable/disable the in-memory Rust query engine (enabled in all environments)
   - When enabled, searches are served from the shared-memory card store with PostgreSQL as fallback
   - When disabled, all searches go through the SQL path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,11 @@ services:
           memory: 2813m
     memswap_limit: 2813m
     ports:
-      - "${API_PORT:-28080}:8080"
+      # Loopback by default: Docker's published ports are DNAT'd ahead of the INPUT chain, so a
+      # host firewall (ufw/firewalld) does NOT restrict them. Binding 0.0.0.0 would expose the API
+      # to anything that can route here while looking firewalled. Override with BIND_ADDR — see
+      # "Binding and reverse proxies" in the README.
+      - "${BIND_ADDR:-127.0.0.1}:${API_PORT:-28080}:8080"
     ulimits:
       core: 0
     user: 1000:1000


### PR DESCRIPTION
The `apiservice` port mapping had no host address, so Docker published it on `0.0.0.0` and the API answered on every interface the host had.

That is a poor default for a self-hosted app, and it fails in a way the operator cannot see: **Docker publishes ports by inserting DNAT rules that are evaluated before the `INPUT` chain**, so `ufw` and `firewalld` rules do not restrict a published port. A stack that looks firewalled is not.

Binds `127.0.0.1` by default, overridable with `BIND_ADDR`. The README now documents the three topologies a self-hoster is likely to have:

- **Reverse proxy on the same host** — default works, point it at `127.0.0.1:${API_PORT}`
- **Reverse proxy as a container on the same Docker network** — drop the `ports:` block entirely, reach `apiservice:8080` directly
- **Direct access, no proxy** — set `BIND_ADDR=0.0.0.0`

## Verification

`docker compose config` resolves `host_ip: 127.0.0.1` for both the `dev` and `blue` envs, and `0.0.0.0` when `BIND_ADDR` is set.

Nothing else in the repo depends on the old binding: the `client` service reaches the API over the Docker network, the healthcheck runs inside the container against `localhost:8080`, and `scripts/find_missing_cards.py` already used `127.0.0.1`.

## Upgrade note

Two setups need action before deploying this:

- An **off-host reverse proxy** needs `BIND_ADDR` set to an address it can reach.
- A **same-host proxy** must point at `127.0.0.1:${API_PORT}` rather than a hostname that resolves to a LAN address — a hostname-based upstream will stop resolving to a listening socket.