### PR TITLE
Fix: Return an Opaque Body for Unhandled Exceptions

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -313,6 +313,12 @@ def _hostname_to_site_name(hostname: str) -> str:
 # Query parameters that must not be forwarded to action handlers.
 DISALLOWED_QUERY_ARGS: frozenset[str] = frozenset(["falcon_response", "request_host"])
 
+# Body for an unhandled exception. Fixed and content-free on purpose: the frames live at throw sites
+# inside query and import paths, so their locals can hold connection and query state. Diagnostics go
+# to the log and the error monitor, which are not attacker-readable; the client gets this and nothing
+# more. Callers must not append exception detail to it.
+INTERNAL_ERROR_DESCRIPTION = "An internal error occurred."
+
 # pylint: disable=c-extension-no-member
 NOT_FOUND = 404
 MIN_IMPORT_INTERVAL = 300
@@ -770,14 +776,11 @@ class APIResource:
                         "locals": {k: v for k, v in iframe.frame.f_locals.items() if error_monitoring.can_serialize(v)},
                     },
                 )
+            # Logged, never returned: exc_info above carries file/function/line, but not locals, and
+            # a self-hoster with no HONEYBADGER_API_KEY has nowhere else to read them.
+            logger.error("Stack detail for %s: %s", path, stack_info)
 
-            raise falcon.HTTPInternalServerError(
-                title="Server Error",
-                description={
-                    "exception": str(oops),
-                    "stack_info": stack_info,
-                },
-            ) from oops
+            raise falcon.HTTPInternalServerError(title="Server Error", description=INTERNAL_ERROR_DESCRIPTION) from oops
         finally:
             duration = (time.monotonic() - before) * 1000
             logger.info("Request duration: %.1f ms / %s", duration, resp.status)

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -16,7 +16,14 @@ import falcon.testing
 import pytest
 
 import api.api_resource as api_resource_module
-from api.api_resource import FALLBACK_SITE_NAME, APIResource, _hostname_to_site_name, _split_words, hostname_to_site_name
+from api.api_resource import (
+    FALLBACK_SITE_NAME,
+    INTERNAL_ERROR_DESCRIPTION,
+    APIResource,
+    _hostname_to_site_name,
+    _split_words,
+    hostname_to_site_name,
+)
 from api.enums import ResponseShape
 from api.settings import settings
 
@@ -402,6 +409,39 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
 
                 # Should call error monitoring
                 mock_error_handler.assert_called_once()
+
+    def test_handle_500_body_carries_no_frame_data(self) -> None:
+        """Test an unhandled exception yields an opaque 500 body.
+
+        The frames at a throw site inside the query or import paths hold connection and query state,
+        so none of it may reach the client. Nothing upstream of this handler would catch the
+        regression, which is why it is asserted on the response rather than on the validation.
+        """
+        mock_req = MagicMock()
+        mock_req.uri = mock_req.path = mock_req.relative_uri = "/search"
+        mock_req.params = {}
+        mock_resp = MagicMock()
+        mock_resp.complete = False
+
+        # A local whose value must never appear in the response body.
+        def raise_error(*args: Any, **kwargs: Any) -> Never:
+            db_password = "correct-horse-battery-staple"
+            msg = f"Test error touching {db_password}"
+            raise RuntimeError(msg)
+
+        with patch.object(self.api_resource, "action_map", {"search": raise_error}):
+            with patch("api.api_resource.error_monitoring.error_handler"):
+                with pytest.raises(falcon.HTTPInternalServerError) as excinfo:
+                    self.api_resource._handle(mock_req, mock_resp)
+
+        description = excinfo.value.description
+        assert description == INTERNAL_ERROR_DESCRIPTION
+        # A dict description is how frame data used to travel; a plain string cannot carry it.
+        assert isinstance(description, str)
+
+        rendered = repr(excinfo.value.to_dict())
+        for leaked in ("db_password", "correct-horse-battery-staple", "stack_info", "locals", "line_no", __file__):
+            assert leaked not in rendered, f"{leaked!r} reached the 500 response body"
 
 
 class TestSearchResponseShape(TestBaseAPIResourceTest):

--- a/docs/issues/done/00781-api-port-exposure.md
+++ b/docs/issues/done/00781-api-port-exposure.md
@@ -1,0 +1,95 @@
+# The API Port Was Published on All Interfaces
+
+**Severity: high. Found 2026-07-26. Fixed 2026-07-27 in
+[#781](https://github.com/jbylund/sylvan_librarian/pull/781), with the matching nginx upstream change
+on the host.**
+
+`docker-compose.yml` published the API with `ports: - "${API_PORT:-28080}:8080"`. Docker binds that on
+`0.0.0.0`, so the service answered directly, in cleartext, with nginx entirely out of the path — a
+plain `curl` to the origin address on port 18080 returned `200` for both `/get_pid` and `/search`.
+
+Everything the proxy provides was bypassed: TLS, the HTTPS redirect, and any rate limiting added
+later. It also defeated proxy-level fixes for anything else — a `location` block denying a path counts
+for nothing when the backend is directly reachable, which is why this had to land before or with any
+nginx-side control.
+
+Green (18081) and dev (28080) were both closed from outside at audit time, so this was one stack's
+port rather than the pattern. But the compose file treated all three identically; only the host's
+firewall was making the difference.
+
+This ships in the repo, so it was a self-hoster's exposure too, not only ours.
+
+## The fix was not the obvious one-liner
+
+`127.0.0.1:${API_PORT}:8080` looks right and would have broken the site. The nginx upstream was:
+
+```nginx
+upstream sylvan_librarian {
+    server atlas:18080 max_fails=3 fail_timeout=10s;  # blue
+    server atlas:18081 max_fails=3 fail_timeout=10s;  # green
+    keepalive 128;
+    keepalive_requests 1000;
+}
+```
+
+`atlas` resolved to a LAN address, not loopback. Binding the containers to loopback would have made
+**both** upstreams unreachable, and `proxy_next_upstream` would have had nowhere left to fail over to
+— a full outage rather than a degraded one, and one the compose healthcheck would not have caught,
+since it runs inside the container against `localhost:8080` and would have kept reporting healthy.
+The nginx config also lives on the host rather than in this repo, so the compose half could not land
+on its own.
+
+What made the fix viable: **nginx runs on `atlas` itself**, so the upstream could point at
+`127.0.0.1:1808x`. That made it two coordinated edits, one of them outside this repo, and the
+out-of-tree half had to be in place *before* the next `make rolling-deploy`. Both are done.
+
+## What the default should be for a self-hoster
+
+Our topology is not the interesting question; the shipped default is. Three topologies cover
+essentially every self-hoster:
+
+| topology | wants |
+| --- | --- |
+| reverse proxy as a host process (ours) | `127.0.0.1` only |
+| reverse proxy as a container on the same Docker network | **no published port at all** — the proxy reaches `apiservice:8080` directly |
+| no proxy, direct LAN or WAN access | a routable interface |
+
+Most self-hosters are in one of the first two, because TLS effectively requires a proxy — Caddy,
+Traefik, nginx-proxy-manager. Only the third wants `0.0.0.0`, and that person knows they want it.
+
+### Why the default should be loopback, not `0.0.0.0`
+
+The decisive argument is not "defence in depth", it is that **Docker's published ports bypass host
+firewalls**. Publishing a port inserts DNAT rules that are evaluated before the `INPUT` chain where
+`ufw` and `firewalld` operate, so a self-hoster who ran `ufw deny 18080` is still fully exposed and
+believes they are not. A `0.0.0.0` default therefore breaks the operator's mental model silently,
+which is the worst property a default can have. Loopback fails the other way: visibly, immediately,
+and fixed by setting one variable.
+
+The usual objection — that loopback ruins first-run UX — mostly does not apply. Someone running
+`make dev-up` browses `localhost` anyway. It only bites when the stack runs on a different machine
+than the browser, and that operator should be making a deliberate choice.
+
+### What shipped
+
+```yaml
+ports:
+  - "${BIND_ADDR:-127.0.0.1}:${API_PORT:-28080}:8080"
+```
+
+One variable, safe default, and every topology reachable: host proxy works untouched, LAN access is
+`BIND_ADDR=0.0.0.0`, and the container-proxy case can drop the `ports:` block entirely. The three
+topologies are documented under "Binding and Reverse Proxies" in the README — the escape hatch is only
+useful if it is discoverable.
+
+A single default covers all of `envs/{blue,green,dev}`: the production pair sits behind the host nginx
+and dev is browsed locally, so none of them needed an override.
+
+## Related
+
+Part of the July 2026 review. Its scope, the verified-clean list, and the severity rationale that
+depended on other findings from the same pass are in the review notes, which are tracked out of tree
+per [the `security-` convention](../README.md#unfixed-security-findings).
+
+The proxy-side controls this undermined while it stood — HSTS and rate limiting — were both examined
+after the bind was fixed and deliberately not adopted; that reasoning is recorded in the same notes.

--- a/docs/issues/done/00782-error-response-disclosure.md
+++ b/docs/issues/done/00782-error-response-disclosure.md
@@ -1,0 +1,59 @@
+# 500 Responses Returned Stack Frames and Local Variables
+
+**Severity: medium (latent, never reachable from outside). Found 2026-07-26. Fixed 2026-07-27 in
+[#782](https://github.com/jbylund/sylvan_librarian/pull/782).**
+
+The unhandled-exception branch in `_handle` caught every exception, walked `inspect.trace()`, and
+serialized each frame into the `HTTPInternalServerError` description — file, function, line, and every
+local that `error_monitoring.can_serialize` accepted:
+
+```python
+"locals": {k: v for k, v in iframe.frame.f_locals.items() if error_monitoring.can_serialize(v)},
+```
+
+## Latent, not live
+
+This could not be triggered from outside. `/search?limit=abc`, malformed UTF-8 in `q`, negative
+`num_cards`, and a bogus `shape` all returned clean 400s or 200s — the validation in front of it was
+doing its job, and that is worth stating plainly rather than recording this as an active leak.
+
+What made it worth fixing anyway is that the protection was entirely upstream of the handler. The
+disclosure was one unvalidated code path away, the frames in scope at a throw site inside `_run_query`
+or the import path include connection and query state, and nothing about the handler would have flagged
+the regression. The severity was a property of the validation, not of the handler.
+
+## What shipped
+
+Frames and locals still go to the log and the error monitor; the client gets a fixed string:
+
+```json
+{"title": "Server Error", "description": "An internal error occurred."}
+```
+
+One wrinkle worth recording, because the obvious version of this fix is wrong: the frame list was
+**never actually logged**. It was built solely to be serialized into the response. Deleting the
+construction along with the description — the natural reading of "stop returning it" — would have
+dropped the locals entirely, since `exc_info=True` carries file, function, and line but not locals, and
+a deployment without `HONEYBADGER_API_KEY` has nowhere else to read them. So the fix moved the list to
+a `logger.error` call rather than removing it.
+
+`INTERNAL_ERROR_DESCRIPTION` is a plain string rather than a dict, so there is no structured slot for a
+future caller to append detail into.
+
+### The test is the durable half
+
+Nothing upstream of the handler would catch a regression here, so the assertion belongs on the
+response. `test_handle_500_body_carries_no_frame_data` plants a local at the throw site and asserts the
+rendered body carries neither its name, its value, nor any frame key.
+
+It was verified by reverting the handler to the previous form and confirming the test **fails**, with
+the planted value visible in the body. A test of this shape that has never been seen to fail is not
+evidence of anything.
+
+## Related
+
+Part of the July 2026 review; its scope and verified-clean list are in the review notes, tracked out of
+tree per [the `security-` convention](../README.md#unfixed-security-findings).
+
+The sibling `TypeError` branch still returns `str(oops)` on a 400, which can expose a handler
+signature. Left as is: it is caller error, and the names it reveals are public API parameters.


### PR DESCRIPTION
The unhandled-exception branch in `_handle` built a per-frame list — file, function, line, and every
serializable local — and passed it as the `HTTPInternalServerError` description, so it was returned to
the caller. Frames at a throw site inside the query or import paths hold connection and query state.

The frame list is kept, but logged instead of returned. It was never actually logged before, only
serialized into the response, so simply dropping it would have lost the locals altogether: `exc_info`
carries file, function, and line but not locals, and a deployment without `HONEYBADGER_API_KEY` has
nowhere else to read them. Callers now get a fixed string:

```json
{"title": "Server Error", "description": "An internal error occurred."}
```

`INTERNAL_ERROR_DESCRIPTION` is deliberately a plain string rather than a dict, so there is no
structured slot for a caller to append detail into later.

## Test

The new test plants a `db_password` local at the throw site and asserts the rendered body contains
neither the name, the value, nor any frame key (`stack_info`, `locals`, `line_no`, the test's own
filename).

Worth stating that it was checked the only way that means anything: reverting the handler to the
previous form makes it **fail**, with the planted value visibly in the body. Nothing upstream of this
handler would catch the regression, which is why the assertion is on the response rather than on the
input validation.

1,646 unit tests pass; `ruff check` and `ruff format --check` clean. Integration tests not run locally
(Docker).

## Two issue docs declassified

Both finished findings move in tree, per the convention in `docs/issues/README.md` — once fixed, a
write-up is a record rather than a map. Each is named for its PR, since neither finding had a GitHub
issue.

- **`done/00782-error-response-disclosure.md`** — this change. Records that the frame list was never
  logged before, which is what makes the obvious form of the fix lose the locals outright.
- **`done/00781-api-port-exposure.md`** — the port-binding write-up from #781, now that the fix and its
  out-of-repo nginx half are both live.

Three things were removed from the #781 doc on the way in:

- the origin IP from the reproduction — DNS-discoverable today, but permanent in history, and it would
  foreclose ever fronting the host with a CDN
- a section about an interaction with work that has not shipped
- two links to gitignored docs, which would have been dead for anyone reading the public repo

## Not included

The `TypeError` branch just above still returns `str(oops)` on a 400, which can expose a handler
signature. Left alone: it is caller error, the names are public API parameters, and it is outside this
change.
