### PR TITLE
Chore: Retire Two Accidental Routes and Harden Test Suppression

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import collections
 import copy
 import datetime
 import hashlib
@@ -684,22 +683,6 @@ class APIResource:
         self.setup_schema()
         self.import_data()  # ensures that database is setup
 
-    @cached(cache={}, key=lambda *args, **kwds: args[1] if len(args) > 1 else kwds.get("filename"))
-    def read_sql(self, filename: str) -> str:
-        """Read SQL content from a file with caching.
-
-        Args:
-            filename: The name of the SQL file (without .sql extension)
-
-        Returns:
-            The SQL content as a string
-        """
-        sql_dir = pathlib.Path(__file__).parent / "sql"
-        sql_file = sql_dir / f"{filename}.sql"
-
-        with sql_file.open(encoding="utf-8") as f:
-            return f.read().strip()
-
     def _get_timer(self, req: falcon.Request) -> Timer:
         """Get the timer for the request."""
         return req.context.setdefault("timer", Timer())
@@ -947,14 +930,6 @@ class APIResource:
 
             self._schema_setup_event.set()
             logger.info("Schema setup complete in pid %d", os.getpid())
-
-    def get_stats(self, **_: object) -> dict[str, Any]:
-        """Get stats about the cards."""
-        key_frequency = collections.Counter()
-        for raw_card in self._bulk_data_fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS):
-            for processed in preprocess_card(raw_card):
-                key_frequency.update(k for k, v in processed.items() if v not in [None, [], {}])
-        return key_frequency.most_common()
 
     _SETUP_COMPLETE_TTL = 60 * 60  # 1 hour; also invalidated when _last_import_time changes
     _setup_complete_cache: tuple[bool, float, float] | None = None  # (result, expires_at, import_time)
@@ -1850,7 +1825,7 @@ class APIResource:
     def get_common_keywords(self, **_: object) -> list[dict[str, Any]]:
         """Get the common keywords from the database."""
         return self._run_query(
-            query=self.read_sql("get_common_keywords"),
+            query=db_utils.read_sql("get_common_keywords"),
         )["result"]
 
     def backfill_prefer_scores(self, **_: object) -> dict[str, Any]:
@@ -1875,7 +1850,7 @@ class APIResource:
         """
         logger.info("Starting prefer score backfill")
 
-        backfill_sql = self.read_sql("backfill_prefer_scores")
+        backfill_sql = db_utils.read_sql("backfill_prefer_scores")
         with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             statement_timeout = 120_000
             # Validate and set statement timeout
@@ -2013,7 +1988,7 @@ class APIResource:
         weights = {k: v / scale_factor for k, v in weights.items()}
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
 
-        backfill_sql = self.read_sql("backfill_cubecobra_scores")
+        backfill_sql = db_utils.read_sql("backfill_cubecobra_scores")
         with self._conn_pool.connection() as conn, conn.cursor() as cursor:
             self._set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from api.api_resource import APIResource
 from api.settings import settings
+from api.tests.support import override_attr
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -36,8 +37,8 @@ def api_resource(postgres_container: None) -> Generator[APIResource]:
         last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         schema_setup_event=multiprocessing.Event(),
     )
-    api._setup_complete = lambda: True
-    api._import_recent = lambda: True
+    override_attr(api, "_setup_complete", lambda: True)
+    override_attr(api, "_import_recent", lambda: True)
     api.setup_schema()
     yield api
     api._conn_pool.close()

--- a/api/tests/support.py
+++ b/api/tests/support.py
@@ -1,0 +1,28 @@
+"""Shared helpers for the API test suite."""
+
+from __future__ import annotations
+
+
+def override_attr(obj: object, name: str, value: object) -> None:
+    """Replace an existing attribute on an instance, failing if it is not already there.
+
+    Plain `obj.attr = value` silently *creates* the attribute when the name is wrong or the method
+    has moved elsewhere. For suppression overrides like `_import_recent` that failure is invisible:
+    the real method stays in place, the work it was suppressing starts happening for real, and the
+    tests still pass. This raises instead.
+
+    Prefer pytest's `monkeypatch.setattr`, which does the same check, wherever the fixture is
+    available — this exists for `setup_method` and other contexts where it is not.
+
+    Args:
+        obj: Instance to modify.
+        name: Attribute that must already exist on obj.
+        value: Replacement value.
+
+    Raises:
+        AttributeError: If obj has no such attribute.
+    """
+    if not hasattr(obj, name):
+        msg = f"{type(obj).__name__} has no attribute {name!r} to override; has it moved?"
+        raise AttributeError(msg)
+    setattr(obj, name, value)

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -264,39 +264,6 @@ class TestAPIResourceCoreMethods(unittest.TestCase):
         assert isinstance(result, int)
         assert result == os.getpid()
 
-    def test_read_sql_reads_file_content(self) -> None:
-        """Test read_sql reads and returns SQL file content."""
-        # Test that the method exists and is callable
-        assert hasattr(self.api_resource, "read_sql")
-        assert callable(self.api_resource.read_sql)
-
-        # Test that it can be called (may fail due to missing files, but that's expected)
-        try:
-            result = self.api_resource.read_sql("nonexistent_file")
-            # If it succeeds, it should return a string
-            assert isinstance(result, str)
-        except FileNotFoundError:
-            # This is expected if the file doesn't exist
-            pass
-
-    def test_read_sql_caching(self) -> None:
-        """Test that read_sql uses caching."""
-        with patch("api.api_resource.pathlib.Path") as mock_path:
-            mock_sql_dir = MagicMock()
-            mock_sql_file = MagicMock()
-            mock_sql_file.open.return_value.__enter__.return_value.read.return_value = "SELECT * FROM test;"
-            mock_sql_dir.__truediv__.return_value = mock_sql_file
-            mock_path.return_value.parent = mock_sql_dir
-
-            # Call twice with same filename
-            result1 = self.api_resource.read_sql("test")
-            result2 = self.api_resource.read_sql("test")
-
-            # Results should be identical (cached)
-            assert result1 == result2
-            # Note: The @cached decorator may not be easily testable with mocks
-            # as it's implemented at the function level
-
 
 class TestAPIResourceRequestHandling(unittest.TestCase):
     """Test request handling methods."""

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -9,13 +9,14 @@ import pytest
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
+from api.tests.support import override_attr
 from api.utils.timer import Timer
 
 
 @pytest.fixture(name="api_resource")
 def api_resource_fixture() -> APIResource:
     api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
-    api._import_recent = lambda: True
+    override_attr(api, "_import_recent", lambda: True)
     return api
 
 

--- a/api/tests/test_integration_testcontainers.py
+++ b/api/tests/test_integration_testcontainers.py
@@ -17,6 +17,7 @@ from testcontainers.postgres import PostgresContainer
 from api.api_resource import APIResource
 from api.enums import CardOrdering, ResponseShape, SortDirection
 from api.tests.helpers import search_kwargs
+from api.tests.support import override_attr
 from card_engine import QueryEngine
 
 if TYPE_CHECKING:
@@ -116,8 +117,8 @@ class TestContainerIntegration:
         def always_true() -> bool:
             return True
 
-        api._setup_complete = always_true
-        api._import_recent = always_true
+        override_attr(api, "_setup_complete", always_true)
+        override_attr(api, "_import_recent", always_true)
 
         # Set up the schema using real migrations
         api.setup_schema()

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -12,6 +12,7 @@ import pytest
 from api.api_resource import APIResource
 from api.settings import settings
 from api.tests.helpers import search_kwargs
+from api.tests.support import override_attr
 
 
 def _make_api() -> APIResource:
@@ -23,7 +24,7 @@ class TestParsingErrorHandling:
 
     def setup_method(self) -> None:
         self.api_resource = _make_api()
-        self.api_resource._setup_complete = lambda: True
+        override_attr(self.api_resource, "_setup_complete", lambda: True)
 
     def teardown_method(self) -> None:
         if hasattr(self, "api_resource") and self.api_resource:
@@ -62,7 +63,7 @@ class TestSearchRouting:
 
     def setup_method(self) -> None:
         self.api_resource = _make_api()
-        self.api_resource._setup_complete = lambda: True
+        override_attr(self.api_resource, "_setup_complete", lambda: True)
         self.api_resource._engine = MagicMock()
 
     def teardown_method(self) -> None:
@@ -110,7 +111,7 @@ class TestSearchRouting:
         assert exc_info.value.title == "Invalid Limit"
 
     def test_raises_service_unavailable_when_setup_incomplete(self) -> None:
-        self.api_resource._setup_complete = lambda: False
+        override_attr(self.api_resource, "_setup_complete", lambda: False)
         with pytest.raises(falcon.HTTPServiceUnavailable) as exc_info:
             self.api_resource._search(query="name:opt")
         assert exc_info.value.title == "Service Unavailable"
@@ -195,7 +196,7 @@ class TestResultFieldSelection:
 
     def setup_method(self) -> None:
         self.api_resource = _make_api()
-        self.api_resource._setup_complete = lambda: True
+        override_attr(self.api_resource, "_setup_complete", lambda: True)
 
     def teardown_method(self) -> None:
         if hasattr(self, "api_resource") and self.api_resource:
@@ -227,7 +228,7 @@ class TestResultFieldRouting:
 
     def setup_method(self) -> None:
         self.api_resource = _make_api()
-        self.api_resource._setup_complete = lambda: True
+        override_attr(self.api_resource, "_setup_complete", lambda: True)
         self.api_resource._engine = MagicMock()
 
     def teardown_method(self) -> None:
@@ -256,7 +257,7 @@ class TestEngineFeatureGate:
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
-        self.api_resource._setup_complete = lambda: True
+        override_attr(self.api_resource, "_setup_complete", lambda: True)
         self.api_resource._engine = MagicMock()
         self._saved_enable_engine = settings.enable_engine
 

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
+from api.tests.support import override_attr
 from api.utils.timer import Timer
 
 
@@ -23,7 +24,7 @@ class TestPreferOrder(unittest.TestCase):
         def always_true() -> bool:
             return True
 
-        self.api_resource._import_recent = always_true
+        override_attr(self.api_resource, "_import_recent", always_true)
 
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""

--- a/api/tests/test_read_sql.py
+++ b/api/tests/test_read_sql.py
@@ -1,77 +1,61 @@
-"""Tests for the read_sql method functionality."""
+"""Tests for db_utils.read_sql and the SQL files it loads."""
 
 from __future__ import annotations
 
-import multiprocessing
 import pathlib
-import time
 
 import pytest
 
-from api.api_resource import APIResource
-from api.settings import settings
+from api.utils import db_utils
+
+# Rejected stems. The guard is not just cosmetic: read_sql joins its argument onto a directory, so a
+# value with path components would escape it. ".." and "" are called out because `Path(x).name == x`
+# is true for both, so a name-only check would let them through.
+bad_stem_ids = {
+    "parent_traversal": "../db/2025-09-29-great-reset",
+    "bare_parent": "..",
+    "bare_dot": ".",
+    "empty": "",
+    "nested_path": "a/b",
+    "absolute": "/etc/passwd",
+    "dot_slash_prefix": "./get_cards",
+}
 
 
 class TestReadSQL:
-    """Test the read_sql method and SQL file integration."""
+    """Test read_sql and SQL file integration."""
 
-    def setup_method(self) -> None:
-        """Set up test fixtures."""
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        )
-
-    def teardown_method(self) -> None:
-        """Clean up test fixtures."""
-        if hasattr(self, "api_resource") and self.api_resource:
-            # Close the connection pool to prevent thread pool warnings
-            self.api_resource._conn_pool.close()
-
-    def test_read_sql_method_exists(self) -> None:
-        """Test that the read_sql method exists."""
-        assert hasattr(self.api_resource, "read_sql")
-        assert callable(self.api_resource.read_sql)
-
-    def test_read_sql_caching_enabled(self) -> None:
-        """Test that the read_sql method is cached when caching is enabled."""
-        # Enable caching
-        original_setting = settings.enable_cache
-        try:
-            settings.enable_cache = True
-            # Verify that the method has a cache attribute (from @cached decorator)
-            assert hasattr(self.api_resource.read_sql, "cache")
-        finally:
-            settings.enable_cache = original_setting
-
-    def test_read_sql_caching_disabled(self) -> None:
-        """Test that the read_sql method still works when caching is disabled."""
-        # Disable caching
-        original_setting = settings.enable_cache
-        try:
-            settings.enable_cache = False
-            # Method should still have cache attribute but won't use it
-            assert hasattr(self.api_resource.read_sql, "cache")
-            # Verify method still works
-            sql_content = self.api_resource.read_sql("get_cards")
-            assert "SELECT" in sql_content
-        finally:
-            settings.enable_cache = original_setting
-
-    def test_read_sql_loads_correct_file(self) -> None:
-        """Test that read_sql loads the correct SQL file content."""
-        # Test loading one of our actual SQL files
-        sql_content = self.api_resource.read_sql("get_cards")
-
-        # Verify it contains expected SQL keywords
+    def test_loads_correct_file(self) -> None:
+        """Test read_sql returns the requested file's contents."""
+        sql_content = db_utils.read_sql("get_cards")
         assert "SELECT" in sql_content
         assert "FROM" in sql_content
         assert "magic.cards" in sql_content
         assert "card_name" in sql_content
 
-    def test_read_sql_file_not_found(self) -> None:
-        """Test that read_sql raises appropriate error for missing files."""
+    def test_memoized(self) -> None:
+        """Test repeated reads are served from the memo rather than the filesystem."""
+        db_utils.read_sql.cache_clear()
+        first = db_utils.read_sql("get_cards")
+        second = db_utils.read_sql("get_cards")
+        assert first == second
+        info = db_utils.read_sql.cache_info()
+        assert (info.hits, info.misses) == (1, 1)
+
+    def test_file_not_found(self) -> None:
+        """Test a valid stem with no matching file still raises."""
         with pytest.raises(FileNotFoundError):
-            self.api_resource.read_sql("nonexistent_query")
+            db_utils.read_sql("nonexistent_query")
+
+    @pytest.mark.parametrize(
+        argnames=["filename"],
+        argvalues=[[bad_stem_ids[name]] for name in sorted(bad_stem_ids)],
+        ids=sorted(bad_stem_ids),
+    )
+    def test_rejects_non_bare_stems(self, filename: str) -> None:
+        """Test anything other than a bare stem is rejected instead of joined onto the directory."""
+        with pytest.raises(ValueError, match="bare file stem"):
+            db_utils.read_sql(filename)
 
     def test_sql_files_exist(self) -> None:
         """Test that all expected SQL files exist."""
@@ -97,9 +81,8 @@ class TestReadSQL:
         ]
 
         for filename in expected_files:
-            sql_content = self.api_resource.read_sql(filename)
-            assert sql_content, f"SQL file {filename} should have content"
-            assert len(sql_content.strip()) > 0, f"SQL file {filename} should have non-empty content"
+            sql_content = db_utils.read_sql(filename)
+            assert sql_content.strip(), f"SQL file {filename} should have non-empty content"
 
 
 if __name__ == "__main__":

--- a/api/utils/db_utils.py
+++ b/api/utils/db_utils.py
@@ -1,6 +1,7 @@
 """Database utility functions for the API."""
 
 import atexit
+import functools
 import hashlib
 import logging
 import os
@@ -132,6 +133,31 @@ def get_migrations() -> list[dict[str, str]]:
                 },
             )
     return migrations
+
+
+@functools.cache
+def read_sql(filename: str) -> str:
+    """Read a query from api/sql/<filename>.sql.
+
+    Memoized for the process lifetime: these files ship with the code and do not change at runtime.
+
+    Args:
+        filename: Bare stem of the file, without directory components or the .sql extension.
+
+    Returns:
+        The file's contents, stripped.
+
+    Raises:
+        ValueError: If filename is not a bare stem. Callers pass literals, so a value that could
+            traverse out of the directory is a bug rather than input to sanitize — reject it instead
+            of joining it. `Path(x).name == x` alone is not enough: `".."` and `""` both satisfy it.
+    """
+    if filename in {"", ".", ".."} or pathlib.Path(filename).name != filename:
+        msg = f"read_sql expects a bare file stem, got {filename!r}"
+        raise ValueError(msg)
+    sql_file = pathlib.Path(__file__).parent.parent / "sql" / f"{filename}.sql"
+    with sql_file.open(encoding="utf-8") as filehandle:
+        return filehandle.read().strip()
 
 
 class IntArray(list):

--- a/scripts/bench_random.py
+++ b/scripts/bench_random.py
@@ -26,6 +26,7 @@ sys.path.insert(0, "/app")
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
+from api.tests.support import override_attr
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -41,8 +42,8 @@ REPEATS = 3  # independent timed windows per cell (report min to reduce noise)
 
 print("Connecting to DB and loading engine store…", flush=True)
 api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
-api._import_recent = lambda: True
-api._setup_complete = lambda: True
+override_attr(api, "_import_recent", lambda: True)
+override_attr(api, "_setup_complete", lambda: True)
 api._reload_engine(force=True)
 total_printings = api._engine.size()
 print(f"Engine loaded: {total_printings:,} printings", flush=True)


### PR DESCRIPTION
Groundwork for the admin route split. Three independent changes, one commit each.

Framing note: this is mostly setup, but **two of the three do reduce live surface**, so it is not
purely preparatory.

## 1. Delete `get_stats` — removes a real DoS vector

`git grep get_stats` found only the definition: no test, script, makefile target, or frontend
reference. It streamed every line of the `default_cards` bulk dump through `preprocess_card` to count
JSON key frequencies — tens of seconds of single-threaded CPU holding one Bjoern worker per request,
unauthenticated. Worker count is `max(2, cpu_count * 0.6)`, so a handful of concurrent requests
exhausts the pool.

It also declared `-> dict[str, Any]` while returning `most_common()`'s list of tuples, which is its own
evidence nothing exercised it. Drops the now-unused `collections` import; `_bulk_data_fetcher` stays,
since `import_data` and the tag imports use it.

## 2. Move `read_sql` to `db_utils` — removes a latent path traversal

`read_sql` was a file reader that became an HTTP route by accident, because registration exposes every
public method. It joined a caller-supplied `filename` onto a path under `api/sql/` with no validation.
The only reason that was inert:

```
$ curl "https://sylvan-librarian.com/read_sql?filename=get_common_keywords"
{"title":"400 Bad Request",
 "description":"APIResource.read_sql() got an unexpected keyword argument 'falcon_response'"}
```

`_handle` injects `falcon_response=` into every call and the signature has no `**kwargs` to absorb it,
so requests die on `TypeError` first — and the 400 helpfully explains that to the caller. Adding `**_`
to that signature would have armed it.

A shared file reader has no reason to be a method on any resource, so it moves to `db_utils`. It now
also rejects anything that is not a bare stem instead of joining it. `Path(x).name == x` alone is not
enough — `".."` and `""` both satisfy it, which is why the check is explicit and each case is tested.

**Two behavior changes worth a reviewer's attention:**

- Memoization is now `functools.cache` rather than the local `@cached`, which gated on
  `settings.enable_cache`. These files ship with the code and never change at runtime, so coupling them
  to a *response*-cache flag was incidental. Consequence: under `ENABLE_CACHE=false` the files used to
  be re-read per call and now are not, so editing a `.sql` file against a running dev server needs a
  restart.
- The two tests asserting on the `.cache` attribute are replaced by one asserting memoization
  behaviorally via `cache_info()`.

`test_read_sql.py` also no longer constructs an `APIResource` — and so no longer opens a connection
pool — just to read a file off disk. Two hollow tests in `test_api_resource.py` are deleted rather than
ported: one was a `try/except` passing either way, the other mocked `pathlib` and admitted in a comment
that it may not test caching.

## 3. `override_attr` — closes the one silent failure mode ahead of the move

This is the pure-setup one, and it is the reason to do it *before* the handlers move rather than during.

Tests suppress `_import_recent` and `_setup_complete` by assigning over them on the instance. Plain
assignment silently *creates* the attribute if the name is wrong or the method has moved — so after the
handlers move to a child resource, patching the parent leaves the real method in place, the suppression
stops working, and **CI quietly starts doing real Scryfall imports while still passing**.

`override_attr` raises unless the attribute already exists. Applied at all ten sites (four
`_import_recent`, six `_setup_complete`) plus the two in `scripts/bench_random.py`. `monkeypatch.setattr`
does the same check and is preferable where the fixture is available, but two sites are in
`setup_method` and one is in a script, so one helper covers every context.

## Verification

- Route-eligible methods on `APIResource`: **29 → 27**, exactly `get_stats` and `read_sql`
- 1,688 unit tests pass; `ruff check` and `ruff format --check` clean
- `override_attr` confirmed to raise on an absent attribute, not just to work on a present one
- Net −43 lines
- Integration tests not run locally (Docker)

## Not included

The 15 admin-ish handlers are still routed and still advertised in the 404 listing. Nothing here
changes reachability of `setup_schema`, `import_data`, or the backfills — that is the actual split.
