### PR TITLE
Test: Share One APIResource Fixture Instead of Per-Class Setup

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -25,6 +25,29 @@ def engine_enabled_fixture() -> Generator[None]:
     settings.enable_engine = saved
 
 
+@pytest.fixture(name="stub_api_resource")
+def stub_api_resource_fixture() -> Generator[APIResource]:
+    """A fresh APIResource per test, readiness stubbed, connection pool closed afterward.
+
+    Function-scoped on purpose: it replaces per-class `setup_method` construction, and tests using it
+    mutate the instance (`_engine`, feature gates), so sharing one across a module would couple them.
+
+    Two things it deliberately does *not* do:
+
+    - It does not stub `_import_recent`. What keeps `__init__`'s own `import_data()` call on its fast
+      path is `last_import_time` being now — an override applied after construction would be too late
+      for that anyway. Tests that go on to exercise an import path override it themselves, where it is
+      visible: it guards a network fetch, and a silently ineffective override there means the suite
+      starts doing real Scryfall work while still passing.
+    - It does not set up a schema or touch the database. Tests needing that want the `api_resource`
+      fixture below instead.
+    """
+    api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+    override_attr(api, "_setup_complete", lambda: True)
+    yield api
+    api._conn_pool.close()
+
+
 @pytest.fixture(scope="module")
 def api_resource(postgres_container: None) -> Generator[APIResource]:
     """APIResource wired to the session-scoped postgres container, with the schema set up.

--- a/api/tests/test_card_ordering.py
+++ b/api/tests/test_card_ordering.py
@@ -1,31 +1,26 @@
 """Tests for CardOrdering SQL wiring."""
 
-import multiprocessing
-import time
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
-from api.tests.support import override_attr
 from api.utils.timer import Timer
 
-
-@pytest.fixture(name="api_resource")
-def api_resource_fixture() -> APIResource:
-    api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
-    override_attr(api, "_import_recent", lambda: True)
-    return api
+if TYPE_CHECKING:
+    from api.api_resource import APIResource
 
 
-def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
+def _compiled_sql(stub_api_resource: APIResource, ordering: CardOrdering) -> str:
     """Return the compiled SQL string via the SQL path directly."""
     parsed_query = parse_scryfall_query("cmc=1")
     with (
-        patch.object(api_resource, "_conn_pool") as mock_pool,
-        patch.object(api_resource, "_setup_complete", return_value=True),
+        patch.object(stub_api_resource, "_conn_pool") as mock_pool,
+        patch.object(stub_api_resource, "_setup_complete", return_value=True),
     ):
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = [{"total_cards_count": 0, "name": None}]
@@ -33,7 +28,7 @@ def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
         mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
         mock_pool.connection.return_value.__enter__.return_value = mock_conn
 
-        result = api_resource._search_sql(
+        result = stub_api_resource._search_sql(
             parsed_query=parsed_query,
             query="cmc=1",
             unique=UniqueOn.CARD,
@@ -58,7 +53,7 @@ def _compiled_sql(api_resource: APIResource, ordering: CardOrdering) -> str:
         (CardOrdering.USD, "price_usd"),
     ],
 )
-def test_orderby_column_in_compiled_sql(api_resource: APIResource, ordering: CardOrdering, expected_column: str) -> None:
+def test_orderby_column_in_compiled_sql(stub_api_resource: APIResource, ordering: CardOrdering, expected_column: str) -> None:
     """Every CardOrdering value should produce its mapped column in the compiled SQL."""
     needle = f", {expected_column} AS sort_value FROM magic.cards"
-    assert needle in _compiled_sql(api_resource, ordering)
+    assert needle in _compiled_sql(stub_api_resource, ordering)

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -2,33 +2,28 @@
 
 from __future__ import annotations
 
-import multiprocessing
-import time
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import falcon
 import pytest
 
-from api.api_resource import APIResource
 from api.settings import settings
 from api.tests.helpers import search_kwargs
 from api.tests.support import override_attr
 
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
-def _make_api() -> APIResource:
-    return APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+    from api.api_resource import APIResource
 
 
 class TestParsingErrorHandling:
     """Parsing errors in _search are surfaced as HTTPBadRequest."""
 
-    def setup_method(self) -> None:
-        self.api_resource = _make_api()
-        override_attr(self.api_resource, "_setup_complete", lambda: True)
-
-    def teardown_method(self) -> None:
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
 
     def test_incomplete_query_raises_bad_request(self) -> None:
         query = "cmc=2 and id="
@@ -61,14 +56,10 @@ class TestSearchRouting:
     covered in TestEngineFeatureGate.
     """
 
-    def setup_method(self) -> None:
-        self.api_resource = _make_api()
-        override_attr(self.api_resource, "_setup_complete", lambda: True)
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
         self.api_resource._engine = MagicMock()
-
-    def teardown_method(self) -> None:
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
 
     def test_routes_to_sql_when_engine_empty(self) -> None:
         self.api_resource._engine.size.return_value = 0
@@ -135,12 +126,9 @@ class TestSearchRouting:
 class TestSearchSqlDirect:
     """_search_sql result structure and count-row extraction."""
 
-    def setup_method(self) -> None:
-        self.api_resource = _make_api()
-
-    def teardown_method(self) -> None:
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
 
     def _mock_run_query(self, cards: list[dict], total: int) -> dict:
         return {
@@ -169,13 +157,10 @@ class TestSearchSqlDirect:
 class TestSearchEngineDirect:
     """_search_engine forwards engine.query results verbatim."""
 
-    def setup_method(self) -> None:
-        self.api_resource = _make_api()
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
         self.api_resource._engine = MagicMock()
-
-    def teardown_method(self) -> None:
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
 
     def test_total_cards_and_cards_forwarded(self) -> None:
         mock_cards = [{"name": "Lightning Bolt"}, {"name": "Counterspell"}]
@@ -194,13 +179,9 @@ class TestSearchEngineDirect:
 class TestResultFieldSelection:
     """`fields=` validation on `_search`, independent of which backend serves the request."""
 
-    def setup_method(self) -> None:
-        self.api_resource = _make_api()
-        override_attr(self.api_resource, "_setup_complete", lambda: True)
-
-    def teardown_method(self) -> None:
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
 
     def test_unknown_field_raises_bad_request(self) -> None:
         with pytest.raises(falcon.HTTPBadRequest) as exc_info:
@@ -226,14 +207,10 @@ class TestResultFieldSelection:
 class TestResultFieldRouting:
     """The fields resolved by _search are threaded to whichever backend serves the request."""
 
-    def setup_method(self) -> None:
-        self.api_resource = _make_api()
-        override_attr(self.api_resource, "_setup_complete", lambda: True)
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> None:
+        self.api_resource = stub_api_resource
         self.api_resource._engine = MagicMock()
-
-    def teardown_method(self) -> None:
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
 
     def test_fields_passed_to_sql_path(self) -> None:
         self.api_resource._engine.size.return_value = 0
@@ -253,18 +230,13 @@ class TestResultFieldRouting:
 class TestEngineFeatureGate:
     """ENABLE_ENGINE gates the engine path: off (default) means the engine is inert."""
 
-    def setup_method(self) -> None:
-        self.api_resource = APIResource(
-            last_import_time=multiprocessing.Value("d", time.time(), lock=True),
-        )
-        override_attr(self.api_resource, "_setup_complete", lambda: True)
+    @pytest.fixture(autouse=True)
+    def _api(self, stub_api_resource: APIResource) -> Generator[None]:
+        self.api_resource = stub_api_resource
         self.api_resource._engine = MagicMock()
-        self._saved_enable_engine = settings.enable_engine
-
-    def teardown_method(self) -> None:
-        settings.enable_engine = self._saved_enable_engine
-        if hasattr(self, "api_resource") and self.api_resource:
-            self.api_resource._conn_pool.close()
+        saved_enable_engine = settings.enable_engine
+        yield
+        settings.enable_engine = saved_enable_engine
 
     def _mock_result(self) -> dict:
         return {

--- a/api/tests/test_prefer_order.py
+++ b/api/tests/test_prefer_order.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 from api.api_resource import APIResource
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.parsing import parse_scryfall_query
-from api.tests.support import override_attr
 from api.utils.timer import Timer
 
 
@@ -16,15 +15,19 @@ class TestPreferOrder(unittest.TestCase):
     """Test cases for prefer order parameter."""
 
     def setUp(self) -> None:
-        """Set up test fixtures."""
+        """Set up test fixtures.
+
+        A unittest.TestCase cannot consume the `stub_api_resource` fixture, so this constructs its own.
+        `last_import_time` being now is what keeps __init__'s import_data() on its fast path; nothing
+        here calls an import path afterwards, so no suppression override is needed.
+        """
         self.api_resource = APIResource(
             last_import_time=multiprocessing.Value("d", time.time(), lock=True),
         )
 
-        def always_true() -> bool:
-            return True
-
-        override_attr(self.api_resource, "_import_recent", always_true)
+    def tearDown(self) -> None:
+        """Close the connection pool this test case opened."""
+        self.api_resource._conn_pool.close()
 
     def _search_sql(self, query: str, prefer: PreferOrder) -> dict:
         """Run _search_sql directly, bypassing engine dispatch."""


### PR DESCRIPTION
Stacked on #783 — **base is `admin-split-step-0`, not `main`.** Review #783 first.

Follow-up to the `override_attr` discussion there: the repetition worth removing turned out not to be
the override calls but the construct-an-`APIResource`-and-neuter-it boilerplate around them.

## What moved

A `stub_api_resource` fixture in `api/tests/conftest.py` owns construction, the readiness stub, and
pool teardown. Six classes in `test_parsing_errors.py` and a local fixture in `test_card_ordering.py`
now use it.

Function-scoped deliberately, matching what `setup_method` already did — these tests mutate the
instance (`_engine`, feature gates), so one per module would couple them. No isolation or performance
change.

## What deliberately stayed explicit

The fixture does **not** stub `_import_recent`. Suppression stays visible at sites that go on to
exercise an import path, since that is the one where a silently ineffective override means the suite
does real Scryfall work while passing.

Investigating which sites those actually are turned up something: **two of the overrides were doing
nothing.** Neither `test_card_ordering` nor `test_prefer_order` calls an import path after
construction, so their `_import_recent` overrides were vestigial — presumably added believing they
would suppress `__init__`'s own `import_data()` call, but that runs *during* construction, before any
override could apply. What actually keeps it on the fast path is `last_import_time` being now. Those
two are dropped rather than carried into the fixture.

## Scope of the change

Concretely, scoped to what was touched rather than as a ratio against the whole suite:

- **`test_parsing_errors.py`**: six classes lose their per-class `setup_method`/`teardown_method`
  pairs — seven of each, down to zero. 355 → 327 lines.
- **`test_card_ordering.py`**: local fixture deleted, tests take `stub_api_resource`.
- **`test_prefer_order.py`**: gains the `tearDown` it was missing.
- **`conftest.py`**: one new fixture.

Net −78/+71. Everything else in `api/tests` is untouched.

Three findings that no line count captures, and which are worth more than the deduplication:

- **`test_card_ordering.py` defined a local fixture named `api_resource`**, shadowing the
  module-scoped one in `conftest.py` that wires up a real database. Anyone adding a DB-backed test to
  that file would have silently got the stub instead.
- **`TestPreferOrder` never closed its connection pool.** Every other class did; it was the one that
  did not. It is a `unittest.TestCase`, so it cannot consume the fixture and keeps its own
  construction, but it now has a `tearDown`.
- **Two `_import_recent` overrides had never done anything** (above).

2,074 tests pass, `ruff check` and `ruff format --check` clean. The 3 warnings are unchanged from the
base branch — they come from `test_integration_testcontainers.py`'s pre-existing class-scoped fixture,
which I checked by running the base branch rather than assuming.

## Left alone

`test_api_resource.py` has 10 `APIResource(` constructions, and `test_upsert_cards.py` and the
`test_import_*.py` files have their own. They pass different arguments — schema events, pre-mocked
pools — and are not the uniform pattern this fixture replaces. Worth a separate pass if the duplication
keeps bothering you; folding them in here would have made the diff much harder to check.
