### PR TITLE
Fix: Keep POSTGRES_MEM_LIMIT With the Config It Was Generated For

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -324,6 +324,14 @@ NOT_FOUND = 404
 MIN_IMPORT_INTERVAL = 300
 IMPORT_LOCK_TIMEOUT = 2
 MIN_IMPORT_CARDS = 90_000
+# Cards per bulk_upsert call during an import. The whole batch becomes ONE bind parameter: a JSON
+# array that Postgres must receive, cast to jsonb, expand with jsonb_array_elements, and join against
+# magic.cards. So this value sets the server-side peak for the statement, and the corpus grows over
+# time — a size that fit once does not stay fitting. Lowered from 6000 to 3000 after backends were
+# lost mid-statement during import; the extra round trips are not measurable against the import's
+# total, and it halves the logged parameter too (see log_parameter_max_length in the pg config).
+_UPSERT_PAGE_SIZE = 3_000
+
 # Rows per batch streamed into the engine during a reload. The reload's memory
 # floor is the Rust-side build (~305 MB), so the batch only needs to be small
 # relative to that: ~2k rows ≈ 18 MB of dicts. Smaller adds round trips for no
@@ -2497,7 +2505,7 @@ class APIResource:
     def _upsert_cards(
         self,
         cards: Iterable[dict[str, Any]],
-        page_size: int = 6000,
+        page_size: int = _UPSERT_PAGE_SIZE,
     ) -> dict[str, Any]:
         """Preprocess and upsert an iterable of raw card dicts into magic.cards.
 

--- a/api/db/bulk_upsert.py
+++ b/api/db/bulk_upsert.py
@@ -101,6 +101,31 @@ def _dedupe_rows(rows: list[dict[str, Any]], key_cols: list[str]) -> list[dict[s
     return list(unique.values())
 
 
+def _quiet_statement_logging(cur: psycopg.Cursor) -> None:
+    """Suppress duration and plan logging for the statement this cursor is about to run.
+
+    The upsert passes a whole batch as one JSON array parameter, and no truncation setting can make
+    that readable in the log:
+
+    - `log_parameter_max_length` caps the `DETAIL: Parameters:` line, but `log_min_duration_statement`
+      still logs the statement text itself, which is ~12 KB of per-column CASE expressions.
+    - `auto_explain.log_parameter_max_length` caps auto_explain's own parameters line, but with
+      `log_verbose` on, the planner folds the parameter into a Const and EXPLAIN prints the expression
+      tree — so the entire array reappears inside `Function Call: jsonb_array_elements(...)`.
+
+    Both are SUSET, so a non-superuser role cannot set them. A failed SET would abort the surrounding
+    transaction and take the upsert with it, so this checks first rather than catching: on a managed
+    Postgres where the app role is not superuser, logging stays as configured and the upsert still runs.
+    """
+    cur.execute("SELECT current_setting('is_superuser') = 'on' AS ok")
+    row = cur.fetchone()
+    if not (row and row["ok"]):
+        return
+    # SET LOCAL: reverts at commit, so this never leaks to another statement on a pooled connection.
+    cur.execute("SET LOCAL log_min_duration_statement = -1")
+    cur.execute("SET LOCAL auto_explain.log_min_duration = -1")
+
+
 def bulk_upsert(  # noqa: PLR0913, PLR0917
     conn: psycopg.Connection,
     table: str,
@@ -208,6 +233,7 @@ def bulk_upsert(  # noqa: PLR0913, PLR0917
     )
 
     with conn.cursor(row_factory=dict_row) as cur:
+        _quiet_statement_logging(cur)
         cur.execute(stmt, [orjson.dumps(rows).decode()])
         counts = {"inserted": 0, "updated": 0, "unchanged": 0}
         for row in cur.fetchall():

--- a/configs/postgres/conf/postgresql.conf.template
+++ b/configs/postgres/conf/postgresql.conf.template
@@ -888,6 +888,10 @@ auto_explain.log_triggers = on
 auto_explain.log_verbose = on
 auto_explain.log_nested_statements = on
 auto_explain.sample_rate = 1
+# Separate from the core log_parameter_max_length above and defaulting to -1, so capping that one
+# alone leaves auto_explain still dumping every bind parameter in full. The bulk-upsert path sends one
+# JSON array per batch as a single parameter, which is what made import logs unreadable.
+auto_explain.log_parameter_max_length = 1024
 
 # --- Query ID tracking ---
 compute_query_id = on

--- a/configs/postgres/conf/postgresql.conf.template
+++ b/configs/postgres/conf/postgresql.conf.template
@@ -815,6 +815,13 @@ log_statement = 'none'
 log_min_messages = notice
 log_min_error_statement = notice
 log_min_duration_statement = 15
+# Truncate logged bind parameters. The bulk-upsert path passes one JSON array per batch as a single
+# parameter — thousands of cards, tens of MB — and every such statement exceeds the 15ms threshold
+# above, so an untruncated -1 logs the whole payload for each batch. That costs the backend the memory
+# to format it, at the moment a bulk load already has memory pressure, and stderr goes to Docker's
+# json-file driver, which has no size cap here.
+log_parameter_max_length = 1024
+log_parameter_max_length_on_error = 1024
 log_connections = off
 log_disconnections = off
 log_duration = off

--- a/makefile
+++ b/makefile
@@ -89,7 +89,7 @@ configs/postgres/conf/postgresql.conf: configs/postgres/conf/postgresql.conf.tem
 	$(PYTHON) scripts/gen_postgres_conf.py \
 		--template $< \
 		--output $@ \
-		--env-output envs
+		--env-output .env
 
 help: # @doc show this help and exit
 	@$(PYTHON) ./scripts/show_makefile_help.py $(mkfile_path)

--- a/scripts/gen_postgres_conf.py
+++ b/scripts/gen_postgres_conf.py
@@ -87,6 +87,19 @@ def compute_pg_mem_limit_bytes(total_bytes: int) -> int:
     return raw["shared_buffers"] + raw["maintenance_work_mem"] + 256 * 1024 * 1024
 
 
+def _is_gitignored(path: Path) -> bool:
+    """Return True if git ignores path, False if tracked or if git cannot be consulted."""
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--quiet", str(path)],
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        return True  # No git available; nothing useful to warn about.
+    return result.returncode == 0
+
+
 def update_env_file(env_path: Path, key: str, value: str) -> None:
     """Update or append key=value in an env file, leaving all other lines untouched."""
     line = f"{key}={value}\n"
@@ -111,7 +124,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--template", required=True, help="path to postgresql.conf.template")
     parser.add_argument("--output", required=True, help="path to write postgresql.conf")
-    parser.add_argument("--env-output", help="directory of env files to update with POSTGRES_MEM_LIMIT (e.g. envs/)")
+    parser.add_argument(
+        "--env-output",
+        help=(
+            "path of the per-host env file to update with POSTGRES_MEM_LIMIT (e.g. .env). Must be a "
+            "gitignored file: the limit is derived from THIS host's memory and has to travel with the "
+            "postgresql.conf generated alongside it."
+        ),
+    )
     args = parser.parse_args()
 
     total_bytes = get_available_memory_bytes()
@@ -128,11 +148,17 @@ def main() -> None:
     if args.env_output:
         limit_mb = compute_pg_mem_limit_bytes(total_bytes) // (1024 * 1024)
         limit_str = f"{limit_mb}m"
-        env_dir = Path(args.env_output)
-        for env_file in sorted(env_dir.iterdir()):
-            if env_file.is_file():
-                update_env_file(env_file, "POSTGRES_MEM_LIMIT", limit_str)
-                print(f"  POSTGRES_MEM_LIMIT: {limit_str} -> {env_file}")
+        # One per-host file, not the tracked envs/ directory. POSTGRES_MEM_LIMIT has to agree with the
+        # shared_buffers in the postgresql.conf generated just above, and both are derived from this
+        # host's memory. Written into a tracked file, the next git checkout reverts it while the
+        # untracked conf survives — and make then considers the conf up to date and never regenerates,
+        # so the compose default silently applies to a conf that needs more. Compose reads .env before
+        # envs/<stack>, so this still wins for every stack.
+        env_file = Path(args.env_output)
+        update_env_file(env_file, "POSTGRES_MEM_LIMIT", limit_str)
+        print(f"  POSTGRES_MEM_LIMIT: {limit_str} -> {env_file}")
+        if not _is_gitignored(env_file):
+            print(f"  WARNING: {env_file} is tracked by git; a checkout will revert this value.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Backends were being lost mid-statement during import:

```
psycopg.OperationalError: consuming input failed: server closed the connection unexpectedly
```

Not an application error — Postgres is being killed. The container limit and `postgresql.conf` disagree
about how much memory it has.

## The drift

`gen_postgres_conf.py` sizes `shared_buffers` / `maintenance_work_mem` from the host's memory and
computes a matching `POSTGRES_MEM_LIMIT` — but wrote it into `envs/`, which is **tracked**, while
`postgresql.conf` is **untracked**. So:

1. A checkout reverts the limit; the untracked conf survives.
2. `make` then sees the conf as up to date and **never regenerates** —
   `make: 'configs/postgres/conf/postgresql.conf' is up to date.`
3. Compose falls back to `${POSTGRES_MEM_LIMIT:-3g}` against a conf sized for something else.

`git log -S POSTGRES_MEM_LIMIT -- envs/` shows it was never committed at all, so the fallback has
always been in effect.

On a 64 GB host that means `shared_buffers = 3209MB` inside a **3072MB** cgroup, with `memswap_limit`
equal to the limit so there is no swap to absorb it. Shared buffers are charged to the cgroup as pages
are *touched*, so an idle DB is fine and a bulk load is not. The generator's own budget wants **4748MB**
— a 1676MB shortfall. Growth in the corpus is why it started happening more often.

**The limit is host-derived, not a constant.** Below roughly 32 GB the generated limit is *smaller*
than the old `3g` default, so hosts differ in which direction the fallback was wrong:

| host RAM | shared_buffers | generated limit | vs old 3g default |
| --- | --- | --- | --- |
| 8 GB | 409 MB | 829 MB | far too generous |
| 16 GB | 819 MB | 1402 MB | too generous |
| 32 GB | 1638 MB | 2549 MB | slightly too generous |
| 64 GB | 3276 MB | 4843 MB | **too small — OOM** |

So this is not "raise the limit"; it is "stop the limit and the conf from disagreeing."

## Fix

`POSTGRES_MEM_LIMIT` now goes to `.env` — gitignored, per-host, and read by compose *before*
`envs/<stack>`, so it still applies to every stack. The script warns if pointed at a tracked file, since
that is the failure it exists to prevent.

Verified on this host: regenerating writes `POSTGRES_MEM_LIMIT=4748m`, and `docker compose config`
renders `4978638848` bytes for the postgres service — exactly 4748m, against `shared_buffers = 3209MB`.
1539MB of headroom where there was a 137MB deficit.

## Also here

- **`log_parameter_max_length` (and `_on_error`) = 1024.** The bulk-upsert path sends one JSON array per
  batch as a single bind parameter, and every such statement exceeds `log_min_duration_statement = 15`
  (ms), so the untruncated `-1` default logged the whole payload — tens of MB per batch. That costs the
  backend the memory to format it exactly when a bulk load is already under pressure, and `stderr` goes
  to a Docker `json-file` driver with no size cap configured.
- **`_UPSERT_PAGE_SIZE = 3000`**, down from a bare `6000` default, now a named constant. The page size
  sets the server-side peak for the statement, since the whole batch becomes one `jsonb` value to parse,
  expand with `jsonb_array_elements`, and join against `magic.cards`. It halves the logged parameter too.

2,071 tests pass; `ruff check` and `ruff format --check` clean.

## After merging

`make postgres-config` needs to run on each host to populate `.env` — the conf will not regenerate on
its own, since make still considers the existing one up to date. On a host smaller than ~32 GB this will
*lower* the limit from the 3g fallback.

## Found but not fixed here

`apiservice` has `shm_size: 3000M` against its own `memory: 2813m`, both hardcoded. `/dev/shm` is
charged to the container's cgroup, so an engine store that grows into that tmpfs can OOM the API
container — the same class of contradiction, 187MB over. Left alone because picking the right number
needs to know how large the store actually gets, rather than guessing.
