### PR TITLE
Refactor: Precompute Parameter Binding and Reject Bad Values

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -16,6 +16,13 @@ import threading
 import time
 import urllib.parse
 import uuid
+
+# Imported at runtime, not under TYPE_CHECKING, because route handlers annotate parameters with it and
+# ParamBinder resolves those annotations to real types at registration. Under TYPE_CHECKING the name is
+# absent at runtime and resolution fails, which is a startup error by design rather than a silent loss
+# of coercion. Ruff's TC003 wants it moved; the runtime-evaluated-decorators setting will make the noqa
+# unnecessary once handlers carry a route decorator.
+from collections.abc import Sequence  # noqa: TC003
 from datetime import timedelta
 from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any
@@ -46,14 +53,15 @@ from api.tag_import import import_oracle_tags as _import_oracle_tags
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.generation_cache import GenerationCache
 from api.utils.http_utils import make_user_agent
+from api.utils.param_binding import ParamCoercionError, bind_params
 from api.utils.timer import Timer
-from api.utils.type_conversions import _get_type_name, make_type_converting_wrapper
+from api.utils.type_conversions import _get_type_name
 from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
 from card_engine import QueryEngine as _QueryEngine
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Iterator
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
@@ -527,7 +535,7 @@ def _max_positional_args(func: Any) -> float:  # noqa: ANN401
     """Return how many positional args `func` accepts; inf if it takes *args.
 
     Computed once per registered action at APIResource.__init__ time (not per-request):
-    inspect.signature() follows a make_type_converting_wrapper wrapper's __wrapped__ link
+    inspect.signature() follows a bind_params wrapper's __wrapped__ link
     (set by functools.update_wrapper), so this sees the real underlying handler's signature.
     """
     try:
@@ -637,9 +645,9 @@ class APIResource:
                 continue
             method = getattr(self, method_name)
             if callable(method):
-                self.action_map[method_name] = make_type_converting_wrapper(method)
+                self.action_map[method_name] = bind_params(method)
                 self._action_positional_capacity[method_name] = _max_positional_args(method)
-        self.action_map["_root"] = make_type_converting_wrapper(self._root)
+        self.action_map["_root"] = bind_params(self._root)
         self._action_positional_capacity["_root"] = _max_positional_args(self._root)
 
         def redirect_to_root(**_: object) -> None:
@@ -746,6 +754,12 @@ class APIResource:
             params = {k: v for k, v in req.params.items() if k not in DISALLOWED_QUERY_ARGS}
             res = action(*action_args, falcon_response=resp, request_host=req.get_header("X-Proxy-Host") or req.host, **params)
             resp.media = res
+        except ParamCoercionError as oops:
+            # A value the client sent is not valid for the parameter it names. The message contains only
+            # the parameter name, the value the client already supplied, and — for enums — the accepted
+            # values, so it guides a fix without describing anything internal.
+            logger.info("Rejected %s: %s", path, oops)
+            raise falcon.HTTPBadRequest(title="Invalid Parameter", description=str(oops)) from oops
         except TypeError as oops:
             logger.error("Error handling request: %s", oops, exc_info=True)
             raise falcon.HTTPBadRequest(description=str(oops)) from oops
@@ -1796,6 +1810,7 @@ class APIResource:
 
     def get_catalog(
         self,
+        *,
         falcon_response: falcon.Response | None = None,
         **_: object,
     ) -> dict[str, dict[str, int]]:

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -192,8 +192,8 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
     inside the handler rather than being recognized as "no route matches this" beforehand.
     """
 
-    def _dispatch(self, path: str) -> falcon.Response:
-        req = falcon.Request(falcon.testing.create_environ(path=path))
+    def _dispatch(self, path: str, query_string: str = "") -> falcon.Response:
+        req = falcon.Request(falcon.testing.create_environ(path=path, query_string=query_string))
         resp = falcon.Response()
         self.api_resource._handle(req, resp)
         return resp
@@ -224,6 +224,30 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         # should 404 rather than reach the handler.
         with pytest.raises(falcon.HTTPNotFound):
             self._dispatch("/card/eoc/104/extra")
+
+    def test_keyword_only_injection_route_with_extra_segment_raises_not_found(self) -> None:
+        # get_catalog's falcon_response is keyword-only, so the route has no positional capacity.
+        # While it was positional the segment was absorbed and then silently overwritten by the
+        # injected response, so a path identifying nothing still returned 200.
+        assert self.api_resource._action_positional_capacity["get_catalog"] == 0
+        with pytest.raises(falcon.HTTPNotFound):
+            self._dispatch("/get_catalog/foo")
+
+    def test_unconvertible_enum_query_value_is_rejected(self) -> None:
+        # orderby is annotated CardOrdering. The raw string used to reach the handler unconverted;
+        # binding now rejects it before the handler runs.
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self._dispatch("/search", query_string="q=bolt&orderby=nonsense")
+        assert exc_info.value.title == "Invalid Parameter"
+        assert "orderby" in exc_info.value.description
+        assert "edhrec" in exc_info.value.description  # the message names what the enum accepts
+
+    def test_unconvertible_int_query_value_is_rejected(self) -> None:
+        # Not enum-specific: any declared type that a raw string cannot satisfy is a 400 now.
+        with pytest.raises(falcon.HTTPBadRequest) as exc_info:
+            self._dispatch("/search", query_string="q=bolt&limit=abc")
+        assert exc_info.value.title == "Invalid Parameter"
+        assert "limit" in exc_info.value.description
 
     def test_positional_capacity_computed_at_init_not_per_request(self) -> None:
         assert self.api_resource._action_positional_capacity["get_pid"] == 0

--- a/api/tests/test_param_binding.py
+++ b/api/tests/test_param_binding.py
@@ -1,0 +1,243 @@
+"""Tests for binding raw request parameters to typed handler arguments."""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+import types
+
+# Sequence is imported at runtime, not under TYPE_CHECKING, for the same reason api_resource needs it
+# that way: annotations are resolved to real types at construction. Exercised by
+# test_unresolvable_annotation_is_a_startup_error.
+from collections.abc import Sequence  # noqa: TC003
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.utils.param_binding import (
+    ParamBinder,
+    ParamCoercionError,
+    UnresolvableAnnotationError,
+    bind_params,
+)
+
+
+def handler(  # noqa: PLR0913 - one parameter per annotation shape the real handlers use
+    set_code: str = "",
+    *,
+    limit: int = 100,
+    ratio: float = 1.0,
+    verbose: bool = False,
+    orderby: CardOrdering = CardOrdering.EDHREC,
+    prefer: PreferOrder = PreferOrder.DEFAULT,
+    direction: SortDirection = SortDirection.ASC,
+    unique: UniqueOn = UniqueOn.CARD,
+    q: str | None = None,
+    fields: Sequence[str] | None = None,
+    injected: object = None,
+) -> dict[str, object]:
+    """Stand-in for a route handler, covering every annotation shape the real ones use."""
+    return {
+        "set_code": set_code,
+        "limit": limit,
+        "ratio": ratio,
+        "verbose": verbose,
+        "orderby": orderby,
+        "prefer": prefer,
+        "direction": direction,
+        "unique": unique,
+        "q": q,
+        "fields": fields,
+        "injected": injected,
+    }
+
+
+scalar_testcases = {
+    "int_from_digits": {"param": "limit", "raw": "7", "expected": 7},
+    "float_from_decimal": {"param": "ratio", "raw": "2.5", "expected": 2.5},
+    "bool_true_word": {"param": "verbose", "raw": "true", "expected": True},
+    "bool_on": {"param": "verbose", "raw": "on", "expected": True},
+    "bool_anything_else_is_false": {"param": "verbose", "raw": "maybe", "expected": False},
+    "str_passes_through": {"param": "q", "raw": "lightning bolt", "expected": "lightning bolt"},
+    "optional_str_is_not_none": {"param": "q", "raw": "", "expected": ""},
+    "enum_by_value": {"param": "orderby", "raw": "cmc", "expected": CardOrdering.CMC},
+    "enum_other_field": {"param": "unique", "raw": "printing", "expected": UniqueOn.PRINTING},
+    "sequence_splits_on_comma": {"param": "fields", "raw": "name,cmc", "expected": ["name", "cmc"]},
+    "sequence_strips_and_drops_empties": {"param": "fields", "raw": " name , , cmc ", "expected": ["name", "cmc"]},
+}
+
+rejected_testcases = {
+    "int_from_letters": {"param": "limit", "raw": "abc"},
+    "float_from_letters": {"param": "ratio", "raw": "abc"},
+    "enum_unknown_value": {"param": "orderby", "raw": "nonsense"},
+    "enum_wrong_case": {"param": "unique", "raw": "CARD"},
+    "no_converter_for_annotation": {"param": "injected", "raw": "a string"},
+}
+
+
+class TestCoercion:
+    """Raw strings become the types a handler declares."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(scalar_testcases.values()))),
+        argvalues=[[v for _, v in sorted(scalar_testcases[name].items())] for name in sorted(scalar_testcases)],
+        ids=sorted(scalar_testcases),
+    )
+    def test_converts_by_annotation(self, expected: object, param: str, raw: str) -> None:
+        """Test each annotation shape converts a raw string to the declared type."""
+        bound = ParamBinder(handler).bind((), {param: raw})
+        assert bound[param] == expected
+
+    def test_defaults_come_from_the_signature(self) -> None:
+        """Test parameters absent from the request are filled from their defaults."""
+        bound = ParamBinder(handler).bind((), {})
+        assert bound["limit"] == 100
+        assert bound["orderby"] is CardOrdering.EDHREC
+        assert bound["q"] is None
+
+    def test_non_string_values_pass_through_unconverted(self) -> None:
+        """Test an injected object reaches the handler untouched.
+
+        This is how falcon_response is supplied, so converting or rejecting it would break every
+        handler that writes to the response.
+        """
+        sentinel = object()
+        bound = ParamBinder(handler).bind((), {"injected": sentinel})
+        assert bound["injected"] is sentinel
+
+    def test_already_typed_values_are_not_reconverted(self) -> None:
+        """Test an internal caller passing real types gets them back unchanged."""
+        bound = ParamBinder(handler).bind((), {"limit": 7, "orderby": CardOrdering.CMC})
+        assert bound["limit"] == 7
+        assert bound["orderby"] is CardOrdering.CMC
+
+    def test_positional_arguments_map_onto_positional_parameters(self) -> None:
+        """Test path segments bind to positional parameters in declaration order."""
+        bound = ParamBinder(handler).bind(("eoc",), {})
+        assert bound["set_code"] == "eoc"
+
+
+class TestRejection:
+    """Values that cannot be converted are refused rather than passed through raw."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(rejected_testcases.values()))),
+        argvalues=[[v for _, v in sorted(rejected_testcases[name].items())] for name in sorted(rejected_testcases)],
+        ids=sorted(rejected_testcases),
+    )
+    def test_unconvertible_value_raises(self, param: str, raw: str) -> None:
+        """Test an unconvertible string raises instead of reaching the handler as a string."""
+        with pytest.raises(ParamCoercionError) as exc_info:
+            ParamBinder(handler).bind((), {param: raw})
+        assert exc_info.value.param == param
+        assert exc_info.value.value == raw
+
+    def test_enum_error_lists_accepted_values(self) -> None:
+        """Test the message enumerates what the enum accepts, so a client can correct the request."""
+        with pytest.raises(ParamCoercionError) as exc_info:
+            ParamBinder(handler).bind((), {"orderby": "nonsense"})
+        assert exc_info.value.allowed == tuple(member.value for member in CardOrdering)
+        assert "cmc" in str(exc_info.value)
+
+    def test_unknown_string_parameters_are_tolerated(self) -> None:
+        """Test query noise is dropped rather than rejected.
+
+        Deliberate for now: rejecting unknown parameters would break links carrying utm_* and similar,
+        and per-route strictness needs a route decorator to declare it.
+        """
+        bound = ParamBinder(handler).bind((), {"utm_source": "twitter", "limt": "5"})
+        assert "utm_source" not in bound
+        assert "limt" not in bound
+        assert bound["limit"] == 100
+
+    def test_unknown_non_string_values_still_reach_the_handler(self) -> None:
+        """Test undeclared non-strings pass through, so a handler without **kwargs raises TypeError.
+
+        The previous implementation behaved this way and it is load-bearing: a path-traversal helper was
+        inert only because injected keywords it did not declare raised TypeError before it ran.
+        """
+        sentinel = object()
+        bound = ParamBinder(handler).bind((), {"undeclared": sentinel})
+        assert bound["undeclared"] is sentinel
+
+    def test_too_many_positional_arguments_raises(self) -> None:
+        """Test extra path segments are refused rather than silently ignored."""
+        with pytest.raises(TypeError, match="positional arguments"):
+            ParamBinder(handler).bind(("eoc", "104", "extra"), {})
+
+    def test_positional_and_keyword_for_one_parameter_raises(self) -> None:
+        """Test a path segment colliding with an injected keyword is an error.
+
+        The previous implementation let the keyword win silently, so a request to a path that identified
+        nothing still returned 200.
+        """
+        with pytest.raises(TypeError, match="multiple values"):
+            ParamBinder(handler).bind(("eoc",), {"set_code": "blb"})
+
+
+class TestAnnotationResolution:
+    """Annotations are resolved to real types once, at construction."""
+
+    def test_unresolvable_annotation_is_a_startup_error(self) -> None:
+        """Test an annotation hidden behind TYPE_CHECKING fails at construction, not per request.
+
+        Ruff's TC rules move typing-only imports into `if TYPE_CHECKING:`, which leaves the name absent
+        at runtime. Resolution has to fail loudly: a binder that skipped the parameter would reject
+        every request supplying it, which is a much worse way to discover the problem.
+        """
+        module = types.ModuleType("_param_binding_type_checking_probe")
+        source = textwrap.dedent("""
+            from __future__ import annotations
+            from typing import TYPE_CHECKING
+            if TYPE_CHECKING:
+                from collections.abc import Sequence
+            def probe(*, fields: Sequence[str] | None = None) -> None: ...
+        """)
+        exec(source, module.__dict__)  # noqa: S102 - fixture module built to exercise annotation resolution
+        sys.modules[module.__name__] = module
+        try:
+            with pytest.raises(UnresolvableAnnotationError, match="imported at runtime"):
+                ParamBinder(module.probe)
+        finally:
+            del sys.modules[module.__name__]
+
+    def test_callable_without_annotations_binds_without_converting(self) -> None:
+        """Test a non-function callable is accepted rather than rejected at registration.
+
+        Registration walks class attributes, so it meets whatever is there — including a MagicMock left
+        by a test that patched a handler during construction. `get_type_hints` raises TypeError on those
+        where `inspect.signature` tolerated them, so this is a regression guard, not a hypothetical.
+        """
+        mock_handler = MagicMock()
+        bound = ParamBinder(mock_handler).bind((), {"anything": "a string", "obj": object()})
+        assert "anything" not in bound  # no annotations, so no converter, so treated as unknown
+        assert "obj" in bound  # non-strings still pass through
+
+    def test_binder_is_built_once_not_per_call(self) -> None:
+        """Test the wrapper reuses one binder, since per-call introspection was the cost being removed."""
+        wrapped = bind_params(handler)
+        assert wrapped.binder is wrapped.binder
+        assert isinstance(wrapped.binder, ParamBinder)
+
+
+class TestBindParams:
+    """The wrapper is a drop-in for the function it replaces."""
+
+    def test_wrapper_converts_then_delegates(self) -> None:
+        """Test the wrapped callable accepts raw strings and the handler receives typed values."""
+        result = bind_params(handler)(limit="7", orderby="cmc", fields="name,cmc")
+        assert result["limit"] == 7
+        assert result["orderby"] is CardOrdering.CMC
+        assert result["fields"] == ["name", "cmc"]
+
+    def test_wrapper_preserves_handler_metadata(self) -> None:
+        """Test functools.update_wrapper is applied, so registration can still read __name__."""
+        wrapped = bind_params(handler)
+        assert wrapped.__name__ == handler.__name__
+        assert wrapped.__doc__ == handler.__doc__
+
+    def test_handler_itself_is_left_unwrapped(self) -> None:
+        """Test the original stays plain, so internal callers and direct tests are unaffected."""
+        assert bind_params(handler).__wrapped__ is handler
+        assert handler(limit=7)["limit"] == 7

--- a/api/tests/test_param_binding.py
+++ b/api/tests/test_param_binding.py
@@ -16,6 +16,7 @@ import pytest
 
 from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
 from api.utils.param_binding import (
+    MAX_ECHOED_VALUE_LEN,
     ParamBinder,
     ParamCoercionError,
     UnresolvableAnnotationError,
@@ -139,6 +140,19 @@ class TestRejection:
             ParamBinder(handler).bind((), {"orderby": "nonsense"})
         assert exc_info.value.allowed == tuple(member.value for member in CardOrdering)
         assert "cmc" in str(exc_info.value)
+
+    def test_long_values_are_truncated_in_the_message(self) -> None:
+        """Test an oversized value does not become an oversized 400 body and log line.
+
+        The message is both reflected to the client and logged at INFO, so it is bounded; the full
+        value stays on the attribute for internal callers.
+        """
+        raw = "x" * 5000
+        with pytest.raises(ParamCoercionError) as exc_info:
+            ParamBinder(handler).bind((), {"limit": raw})
+        assert exc_info.value.value == raw
+        assert len(str(exc_info.value)) < 2 * MAX_ECHOED_VALUE_LEN
+        assert str(exc_info.value).endswith("…' (expected int)")
 
     def test_unknown_string_parameters_are_tolerated(self) -> None:
         """Test query noise is dropped rather than rejected.

--- a/api/utils/param_binding.py
+++ b/api/utils/param_binding.py
@@ -1,0 +1,264 @@
+"""Bind raw request parameters to a handler's typed keyword arguments.
+
+Replaces the per-call introspection in `type_conversions.make_type_converting_wrapper`. A `ParamBinder`
+resolves a handler's annotations **once**, at construction, into a fixed plan of
+`(name, converter, default)`; binding a request then walks that plan with no signature inspection, no
+converter table rebuilt per parameter, and no logging per converted value.
+
+Two behavioral differences from the function it replaces, both deliberate:
+
+- A string that cannot be converted raises `ParamCoercionError` instead of being passed through as the
+  raw string. A handler annotated `orderby: CardOrdering` can no longer receive `'nonsense'`.
+- Annotations are resolved to real types with `typing.get_type_hints`, so a `str | None` parameter
+  works. The old path required the annotation to already be a *string* — it called `.split("|")` on it
+  — and raised `AttributeError` on a real `UnionType`. An annotation that cannot be resolved is a
+  startup error, not a silently unconverted parameter.
+
+Everything else matches the old calling convention exactly, including the parts that are load-bearing
+elsewhere: positional arguments map onto positional parameter names, explicit keyword arguments override
+those, non-string values pass through untouched, and unknown names are tolerated (see `bind`).
+"""
+
+from __future__ import annotations
+
+import enum
+import functools
+import inspect
+import logging
+import types
+import typing
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class UnresolvableAnnotationError(TypeError):
+    """A handler annotates a parameter with a name that does not exist at runtime.
+
+    Almost always means the annotation's import sits under `if TYPE_CHECKING:` — which ruff's TC rules
+    encourage — while this module needs the real type to build a converter. The fix is to import it at
+    runtime in the handler's module, as `api_resource` does for `Sequence`.
+
+    Deliberately fatal at construction rather than degrading: a binder that quietly skipped the
+    parameter would reject every request supplying it, which is a far worse way to find out.
+    """
+
+
+def _resolve_hints(func: Callable[..., Any]) -> dict[str, Any]:
+    """Resolve func's annotations to real types.
+
+    Args:
+        func: The handler whose annotations to resolve.
+
+    Returns:
+        Parameter name to resolved type. Empty for callables that carry no annotations at all, such as
+        a MagicMock standing in for a handler: registration walks attributes, so it meets whatever is
+        on the class, and refusing those would make patching a handler during construction impossible.
+
+    Raises:
+        UnresolvableAnnotationError: An annotation names something absent at runtime.
+    """
+    try:
+        return typing.get_type_hints(func)
+    except TypeError:
+        # Not a module, class, method, or function — nothing to resolve, so nothing to convert.
+        return {}
+    except NameError as oops:
+        msg = (
+            f"{getattr(func, '__qualname__', func)}: {oops}. Route handler annotations are resolved at "
+            f"registration, so the name must be imported at runtime rather than under TYPE_CHECKING."
+        )
+        raise UnresolvableAnnotationError(msg) from oops
+
+
+# Scalars a query string can name directly. Enums are handled structurally rather than listed, so a new
+# enum needs no edit here — which the old converter table did require.
+_SCALAR_CONVERTERS: dict[Any, Callable[[str], Any]] = {
+    str: lambda x: x,
+    int: int,
+    float: float,
+    bool: lambda x: x.lower() in ("true", "1", "yes", "on", "t"),
+}
+
+
+def _convert_to_str_list(raw: str) -> list[str]:
+    """Split a comma-separated query value, dropping empty parts."""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+class ParamCoercionError(ValueError):
+    """A request parameter's value is not valid for the type its handler declares.
+
+    Carries the parameter name and, for enums, the accepted values, so a caller can build a useful 4xx
+    without the handler restating its own signature. Deliberately not a Falcon error: this module has no
+    framework dependency, and internal callers should see a plain exception.
+    """
+
+    def __init__(self, param: str, value: str, expected: str, allowed: tuple[str, ...] = ()) -> None:
+        """Record which parameter rejected which value, and what it would have accepted.
+
+        Args:
+            param: Parameter name as the handler declares it.
+            value: The raw string that could not be converted.
+            expected: Human-readable name of the declared type.
+            allowed: Accepted values, for enums.
+        """
+        self.param = param
+        self.value = value
+        self.expected = expected
+        self.allowed = allowed
+        detail = f" (expected one of: {', '.join(allowed)})" if allowed else f" (expected {expected})"
+        super().__init__(f"Invalid value for {param!r}: {value!r}{detail}")
+
+
+def _unwrap_optional(hint: Any) -> Any:  # noqa: ANN401
+    """Return the single non-None member of an Optional hint, else the hint unchanged.
+
+    A query string never carries None, so `str | None` converts exactly like `str`. Unions with more
+    than one real member are left alone; they get no converter.
+    """
+    if typing.get_origin(hint) in (typing.Union, types.UnionType):
+        members = [m for m in typing.get_args(hint) if m is not type(None)]
+        if len(members) == 1:
+            return members[0]
+    return hint
+
+
+def _converter_for(hint: Any) -> Callable[[str], Any] | None:  # noqa: ANN401
+    """Return a converter for an annotation, or None if strings cannot be converted to it.
+
+    None is not an error. `falcon_response: falcon.Response | None` is injected as an object and never
+    arrives as a string; making that an import-time failure would reject every handler that accepts a
+    response. A string arriving for such a parameter is reported at bind time instead.
+    """
+    hint = _unwrap_optional(hint)
+    if isinstance(hint, type) and issubclass(hint, enum.Enum):
+        return hint
+    if hint in _SCALAR_CONVERTERS:
+        return _SCALAR_CONVERTERS[hint]
+    if typing.get_origin(hint) in (list, tuple, Sequence):
+        args = typing.get_args(hint)
+        if args and args[0] is str:
+            return _convert_to_str_list
+    return None
+
+
+class ParamBinder:
+    """A fixed plan for turning one handler's raw parameters into typed keyword arguments."""
+
+    __slots__ = ("_func_name", "_known", "_plan", "_positional_names")
+
+    def __init__(self, func: Callable[..., Any]) -> None:
+        """Resolve func's annotations and precompute its binding plan.
+
+        Args:
+            func: The handler. Annotations are resolved against its module globals.
+        """
+        sig = inspect.signature(func)
+        hints = _resolve_hints(func)
+
+        plan: list[tuple[str, Callable[[str], Any] | None, str, bool, Any]] = []
+        positional: list[str] = []
+        for name, param in sig.parameters.items():
+            if name == "self" or param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if param.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD):
+                positional.append(name)
+            hint = hints.get(name, param.annotation)
+            has_default = param.default is not inspect.Parameter.empty
+            plan.append((name, _converter_for(hint), _describe(hint), has_default, param.default))
+
+        self._func_name = getattr(func, "__qualname__", repr(func))
+        self._plan = tuple(plan)
+        self._positional_names = tuple(positional)
+        self._known = frozenset(name for name, *_ in plan)
+
+    def bind(self, args: Sequence[Any], kwargs: Mapping[str, Any]) -> dict[str, Any]:
+        """Map positional and raw keyword arguments onto typed keyword arguments.
+
+        Args:
+            args: Positional values, mapped onto positional parameter names in declaration order.
+            kwargs: Keyword values. String values are converted; anything else passes through.
+
+        Returns:
+            Keyword arguments ready to splat into the handler.
+
+        Raises:
+            TypeError: More positional values than the handler has positional parameters, or a
+                positional value collides with a keyword for the same parameter.
+            ParamCoercionError: A string value is not valid for its parameter's declared type.
+        """
+        if len(args) > len(self._positional_names):
+            msg = f"{self._func_name}() takes {len(self._positional_names)} positional arguments but {len(args)} were given"
+            raise TypeError(msg)
+        supplied: dict[str, Any] = dict(zip(self._positional_names, args, strict=False))
+        # The previous implementation let a keyword silently overwrite a colliding positional, which
+        # meant a stray path segment landing on an injected parameter was discarded and the request
+        # still succeeded. Report it instead; a path that does not identify anything should not 200.
+        collisions = supplied.keys() & kwargs.keys()
+        if collisions:
+            msg = f"{self._func_name}() got multiple values for {', '.join(sorted(collisions))}"
+            raise TypeError(msg)
+        supplied.update(kwargs)
+
+        bound: dict[str, Any] = {}
+        for name, converter, expected, has_default, default in self._plan:
+            if name in supplied:
+                value = supplied[name]
+                if type(value) is str:
+                    if converter is None:
+                        raise ParamCoercionError(name, value, expected)
+                    try:
+                        bound[name] = converter(value)
+                    except (ValueError, TypeError) as oops:
+                        raise ParamCoercionError(name, value, expected, _allowed_values(converter)) from oops
+                else:
+                    bound[name] = value
+            elif has_default:
+                bound[name] = default
+
+        # Names the handler does not declare. Non-strings pass through so injected keywords still reach
+        # handlers that accept them via **kwargs — and still raise TypeError for handlers that do not,
+        # which is the existing behavior. Unknown *strings* are query noise and are dropped; per-route
+        # strictness needs a route decorator to declare it and is not available yet.
+        for name, value in supplied.items():
+            if name not in self._known and type(value) is not str:
+                bound[name] = value
+        return bound
+
+
+def _describe(hint: Any) -> str:  # noqa: ANN401
+    """Render an annotation for an error message."""
+    hint = _unwrap_optional(hint)
+    return getattr(hint, "__name__", None) or str(hint)
+
+
+def _allowed_values(converter: Callable[[str], Any]) -> tuple[str, ...]:
+    """Return an enum converter's accepted values, or () for anything else."""
+    if isinstance(converter, type) and issubclass(converter, enum.Enum):
+        return tuple(str(member.value) for member in converter)
+    return ()
+
+
+def bind_params(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap func so callers may pass raw strings, converted per its annotations.
+
+    A drop-in replacement for `type_conversions.make_type_converting_wrapper`. The returned callable
+    holds the precomputed binder; `func` itself is untouched, so internal callers and direct tests are
+    unaffected.
+
+    Args:
+        func: The handler to wrap.
+
+    Returns:
+        A callable with func's metadata that converts arguments before delegating.
+    """
+    binder = ParamBinder(func)
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        return func(**binder.bind(args, kwargs))
+
+    wrapped = functools.update_wrapper(wrapper, func)
+    wrapped.binder = binder  # type: ignore[attr-defined]  # exposed for tests and registration
+    return wrapped

--- a/api/utils/param_binding.py
+++ b/api/utils/param_binding.py
@@ -24,13 +24,10 @@ from __future__ import annotations
 import enum
 import functools
 import inspect
-import logging
 import types
 import typing
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
-
-logger = logging.getLogger(__name__)
 
 
 class UnresolvableAnnotationError(TypeError):
@@ -87,6 +84,12 @@ def _convert_to_str_list(raw: str) -> list[str]:
     return [part.strip() for part in raw.split(",") if part.strip()]
 
 
+# Longest client-supplied value echoed back in an error message. The message reaches both the 400 body
+# and an INFO log record, so an unbounded value lets one request amplify into a large response and a
+# large log line. Long enough to show a plausible mistake in full, short enough to be harmless.
+MAX_ECHOED_VALUE_LEN = 80
+
+
 class ParamCoercionError(ValueError):
     """A request parameter's value is not valid for the type its handler declares.
 
@@ -108,8 +111,17 @@ class ParamCoercionError(ValueError):
         self.value = value
         self.expected = expected
         self.allowed = allowed
-        detail = f" (expected one of: {', '.join(allowed)})" if allowed else f" (expected {expected})"
-        super().__init__(f"Invalid value for {param!r}: {value!r}{detail}")
+        detail = f" (expected {expected})"
+        if allowed:
+            detail = f" (expected one of: {', '.join(allowed)})"
+
+        # `value` is kept whole on the attribute for internal callers; only the rendered message, which
+        # is what gets reflected and logged, is bounded.
+        shown = value
+        if len(shown) > MAX_ECHOED_VALUE_LEN:
+            shown = shown[:MAX_ECHOED_VALUE_LEN] + "…"
+
+        super().__init__(f"Invalid value for {param!r}: {shown!r}{detail}")
 
 
 def _unwrap_optional(hint: Any) -> Any:  # noqa: ANN401

--- a/docs/issues/local-api-resource-routing-redesign.md
+++ b/docs/issues/local-api-resource-routing-redesign.md
@@ -1,0 +1,177 @@
+# Reworking APIResource's Routing and Parameter Handling
+
+A plan, in independently shippable steps, for replacing `APIResource`'s hand-rolled routing and
+parameter coercion. Each step stands alone; none requires the next.
+
+The prompt for this was the admin route split, whose exposure analysis and fix design are tracked out
+of tree per [the `security-` convention](./README.md#unfixed-security-findings). This doc is only the
+architecture and the order of operations — it is deliberately written so it would read the same had
+nothing prompted it.
+
+## Current mechanics
+
+Falcon's router is **entirely unused**. `api/api_worker.py` installs one sink —
+`api.add_sink(sink._handle, prefix="/")` — and `_handle` does its own dispatch against an
+`action_map` built in `APIResource.__init__` by walking `dir(self)` and taking every public callable.
+Path segments beyond the action word are passed positionally, bounded by a precomputed
+`_action_positional_capacity`. Query parameters are coerced by `make_type_converting_wrapper`, which
+reads the handler's signature and converts each string via `_convert_string_to_type`.
+
+Two properties of that design are worth keeping, and shape everything below:
+
+- **Handlers are plain functions with typed keyword params.** Tests call them directly
+  (`api._search(query="name:opt")`) with no request/response objects, and internal callers use them as
+  ordinary methods — `__init__` calls `setup_schema()`, `_run_import_under_lock` calls
+  `backfill_prefer_scores()`. Falcon's native `on_get(self, req, resp)` convention would break both.
+- **Coercion and defaults come from the signature.** No schema to keep in sync, no per-handler parsing.
+
+## Measured problems
+
+Numbers taken 2026-07-27 on a 64 GB dev machine, against the 520-query engine corpus in
+`benchmarks/survey/` for the comparison baselines.
+
+### Coercion is the whole overhead
+
+| | |
+| --- | ---: |
+| plain call, no coercion | 0.1 μs |
+| coercion, logging suppressed | 4.4 μs |
+| coercion, INFO logging on (production level) | **20.9 μs** |
+| engine query, p50 | 61 μs |
+
+Per parameter, per request, `_convert_string_to_type` rebuilds a 10-entry `converter_map`, splits the
+annotation string on `|`, and emits a `logger.info` per successful conversion. `search` has nine
+parameters, so a p50 search spends ~21 μs coercing before it spends 61 μs answering, and ~16 μs of
+that is log formatting at the `logging.INFO` level `api_worker.py` sets.
+
+### Coercion is fail-open in four ways
+
+| input | current behavior |
+| --- | --- |
+| unconvertible enum (`orderby=nonsense`) | logs, passes the **raw string** to a handler annotated `CardOrdering` |
+| unconvertible int (`limit=abc`) | logs, passes the raw string |
+| unknown parameter (`?limt=5`) | silently dropped, no error |
+| wrong type from an internal caller | passed straight through |
+
+The clean 400s a black-box probe sees for bad input come from downstream checks like
+`_validate_limit`, not from this layer.
+
+### Coercion depends on a module-level import in the caller's file
+
+`_convert_string_to_type` does `param_type.__name__` and then `param_type.split("|")`, so it only works
+when annotations are **strings**:
+
+```python
+_convert_string_to_type("x", "str | None")   # -> 'x'
+_convert_string_to_type("x", str | None)     # -> AttributeError: 'types.UnionType' has no '__name__'
+```
+
+`api/api_resource.py` has `from __future__ import annotations`, which is the only reason this works. A
+new resource module without that import would 500 on the first request to any handler with an
+`X | None` parameter — and creating a new resource module is exactly what the admin split does.
+
+### Registration is fail-open and self-advertising
+
+`dir(self)` plus `callable()` means a method is routed unless someone remembers a leading underscore,
+which overloads `_` to mean both "private in Python" and "not HTTP-reachable" — so
+`setup_schema`, called from `__init__` and from tests, cannot be hidden without lying about its Python
+visibility. Because `_build_routes_listing` iterates the same `action_map`, anything registered is also
+published: a request to any unknown path returns all 37 route names.
+
+Scanning the *instance* also means any new public attribute can change the route table. A child
+resource stored as `self.admin` escapes registration only because it has no `__call__`.
+
+### The routing layer is not where the cost is
+
+| path | current dict dispatch | Falcon `CompiledRouter` |
+| --- | ---: | ---: |
+| `/search` (static) | 91 ns | 146 ns |
+| `/static/app_js` (nested static) | 88 ns | 256 ns |
+| `/card/eoc/104` (templated) | 232 ns | 254 ns |
+
+Falcon's router is genuinely slower than a bare dict — by tens to a couple hundred nanoseconds. Against
+a 20,900 ns coercion path and a 61,000 ns query, that is noise: adopting it spends ~100 ns to save
+~19,900 ns. Worth stating explicitly so the cheap layer does not attract the optimization effort.
+
+## Design decisions
+
+**Take Falcon's router, not its responder convention.** `add_route` gives URI templates with converters
+(`{limit:int}`), per-method responders, and 405s for unmapped methods — retiring the positional-split
+scheme that a previous dispatch rewrite broke. Register an adapter rather than an `on_get`, and handlers
+stay plain typed functions.
+
+**One decorator marks; it does not wrap.**
+
+```python
+@route(methods=("GET",), advertise=True, ignore_unknown_params=True)
+def search(self, *, query: str | None = None, limit: int = 100) -> dict[str, Any]: ...
+```
+
+It attaches a spec and returns the function unchanged. Wrapping would put a fail-open coercer between
+internal callers and handlers — `limit=[1,2,3]` from `_run_import_under_lock` would sail through instead
+of raising — and would add a frame to every traceback for no benefit. The existing code already gets
+this right by putting the wrapper in `action_map` while `self.method` stays plain; a wrapping decorator
+would be a regression.
+
+**Marking flips the default to fail-closed** while keeping declaration at the definition site, so adding
+a route stays one line. It frees `_` to mean only "private in Python", and gives `methods` and
+`advertise` a home. Registration scans `type(self)` for the marker, not `dir(self)`, so instance
+attributes can never become routes.
+
+**Resolve annotations and build a coercion plan once, at import.** `typing.get_type_hints()` gives real
+types instead of strings, which fixes the union crash and makes a precomputed plan possible:
+
+```python
+plan = ((name, converter, default), ...)     # built once
+for name, convert, default in plan:          # per request: no introspection, no dict rebuild
+    kwargs[name] = convert(params[name]) if name in params else default
+```
+
+An annotation with no converter becomes an **import-time** error rather than a silent pass-through.
+
+**Unconvertible values are a 400. Unknown parameters are per-route.** These are different failures: a
+bad `orderby` is a client sending a value the API does not accept, while an extra `utm_source` is a
+client sending something irrelevant. Strict is the default; public routes opt into
+`ignore_unknown_params=True` so tracking parameters and cache-busters keep working on `/search`.
+`DISALLOWED_QUERY_ARGS` then disappears — injected names like `falcon_response` are not *rejected*, they
+are simply never sourced from the query string.
+
+**Handlers stop needing `**_: object`.** Worth naming as a goal rather than a side effect: a path
+traversal in `read_sql` was inert *only because* it lacked `**_`, so injected kwargs raised `TypeError`
+first. Making that a designed property is most of the value here.
+
+## Sequencing
+
+Ordered so that each step is shippable, and so the steps with a measurable story come before the ones
+that move code.
+
+1. **Rewrite coercion.** Precomputed plan, annotations resolved at import, 400 on unconvertible, per-route
+   unknown-parameter policy, drop the per-conversion log line. Self-contained, has the only performance
+   story, and fixes a latent crash that the next step would otherwise trip over. No routes move.
+2. **Add `@route` and explicit registration.** Pure refactor: same routes, same paths, existing tests
+   untouched. Retires `dir(self)`, frees `_` to mean only "private in Python", and makes each route
+   declare which HTTP methods it accepts.
+3. **Move the admin handlers to a child resource.** The closure analysis for this — which methods and
+   handles are shared, which move — lives in the out-of-tree doc. Mounting is a loop over a child's
+   marked methods; resist extracting a `Router` abstraction until a second mount point exists.
+4. **Delist.** `advertise=False` for the child, and make the public listing opt-in so forgetting a flag
+   under-advertises rather than over-advertises.
+5. **Auth at the mount.** One check where dispatch enters the child, rather than a decorator on every
+   handler that someone forgets on the next one.
+
+## Out of scope
+
+**This does not decompose the god object.** `APIResource` will still own SQL generation, engine dispatch,
+import orchestration, static file serving, and HTML rendering after all five steps. Step 3 moves 22
+methods out, which helps, but routing hygiene is not architecture and nobody should expect the latter
+from this plan.
+
+## Open questions
+
+- Does `mount()` need to exist as a concept, or is it five lines at the one call site? Prefer the loop
+  until a second mount point argues otherwise.
+- Should the 404 route listing survive at all? It is useful for discovery and it is also the most
+  convenient enumeration of the surface. Opt-in advertising makes it defensible either way, but it is a
+  flag that has to be right.
+- `prefer_score_tuner` serves a static HTML page that adjusts **server-global** scoring weights. That
+  makes it a mutation with a UI rather than a developer tool. Delete instead of moving it?


### PR DESCRIPTION
Step 1 of the plan in `docs/issues/local-api-resource-routing-redesign.md` (#786). **No routes move and
registration is unchanged** — this is only how a request's raw strings become a handler's typed
arguments.

## Performance

`make_type_converting_wrapper` did the work per call: rebuilt a 10-entry converter table for *every
parameter*, split the annotation string on `|`, walked `inspect.signature`, and emitted a `logger.info`
per successful conversion. `search` has nine parameters.

| | |
| --- | ---: |
| old, INFO logging on (production level) | 20.9 μs |
| **new, precomputed plan** | **1.4 μs** |
| engine query, p50 | 61 μs |

**14× faster** — from 33% of a p50 query down to 2.3%. `ParamBinder` resolves annotations once at
construction into a fixed `(name, converter, default)` plan; binding walks the plan.

## Three fail-open behaviours fixed

**Unconvertible values were passed through as raw strings.** A handler annotated `orderby: CardOrdering`
could receive `'nonsense'`; the clean 400s a black-box probe sees came from downstream checks like
`_validate_limit`, not from coercion. Now:

```
/search?q=bolt&orderby=nonsense  -> 400  Invalid value for 'orderby': 'nonsense'
                                          (expected one of: cmc, cubecobra, edhrec, name, power, rarity, toughness, usd)
/search?q=bolt&limit=abc         -> 400  Invalid value for 'limit': 'abc' (expected int)
/search?q=bolt&unique=CARD       -> 400  Invalid value for 'unique': 'CARD' (expected one of: card, printing, artwork)
```

The message names only the parameter and the value the client already sent, so it guides a fix without
describing anything internal.

**Annotations are resolved to real types.** The old path required them to *already be strings* — it
called `.split("|")` — and raised `AttributeError: 'types.UnionType' has no '__name__'` on a real union.
It worked only because `api_resource.py` has `from __future__ import annotations`. A new resource module
without that import would have 500'd on the first request to any handler with an `X | None` parameter,
and creating such a module is exactly what a later step does.

**An unresolvable name is now a startup error.** Previously that parameter silently lost its converter
and then rejected every request supplying it — a miserable way to find out.

## The ruff interaction

That last fix needs `Sequence` imported at runtime in `api_resource.py` rather than under
`TYPE_CHECKING`, with a `# noqa: TC003`. Ruff documents `runtime-evaluated-decorators` for precisely
this situation (it exists for Pydantic/SQLAlchemy); it applies once handlers carry a route decorator, at
which point the noqa goes away. Only `Sequence` was needed — it resolves all 26 handlers.

## Behaviour changes to be aware of

- **`?orderby=nonsense` was a 200, now a 400.** Same for a non-numeric `limit` and a wrong-case enum.
  This is the point of the change, but it is a real API change.
- **`/get_catalog/foo` was a 200, now a 404.** A path segment colliding with an injected keyword used to
  be silently discarded, because the keyword overwrote it. `get_catalog`'s `falcon_response` is now
  keyword-only, matching the other twelve handlers — its being positional is what made the route's
  positional capacity wrong in the first place.
- **Unknown query parameters are still tolerated**, deliberately. Rejecting them would break links
  carrying `utm_*`, and per-route strictness needs a route decorator to declare it. Step 2.

## Tests

31 new tests. Beyond the coercion and rejection tables, two are regression guards for things that bit me
while writing this:

- `test_unresolvable_annotation_is_a_startup_error` builds a throwaway module with `Sequence` under
  `TYPE_CHECKING` and asserts construction raises. The guard is exercised, not just written.
- `test_callable_without_annotations_binds_without_converting` covers a `MagicMock` handler.
  `get_type_hints` raises `TypeError` where `inspect.signature` tolerated it, and registration walks
  class attributes — so two `test_upsert_cards` tests that patch `import_data` during construction
  failed until `_resolve_hints` handled it. That failure is why `TypeError` and `NameError` are treated
  differently: one is a callable with nothing to resolve, the other is a real mistake.

2,105 tests pass; `ruff check` and `ruff format --check` clean.

## Not in this change

`type_conversions.py` stays — still used for `_get_type_name` by the route listing, still covered by its
own tests. Dropping it and taking over its module name is a later change, so this diff shows the new
implementation against the old rather than replacing it in place.
