### PR TITLE
Refactor: Register Routes From a Marker Instead of dir(self)

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -54,7 +54,7 @@ from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.generation_cache import GenerationCache
 from api.utils.http_utils import make_user_agent
 from api.utils.param_binding import ParamCoercionError, bind_params
-from api.utils.routing import iter_marked_routes, route
+from api.utils.routing import BoundRoute, iter_marked_routes, route
 from api.utils.timer import Timer
 from api.utils.type_conversions import _get_type_name
 from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
@@ -62,7 +62,7 @@ from card_engine import QueryEngine as _QueryEngine
 from card_engine import QueryError as _QueryError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator
+    from collections.abc import Iterable, Iterator
     from multiprocessing.sharedctypes import Synchronized
     from multiprocessing.synchronize import Event as EventType
     from multiprocessing.synchronize import RLock as LockType
@@ -548,14 +548,15 @@ def _max_positional_args(func: Any) -> float:  # noqa: ANN401
     return float(sum(1 for p in params if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)))
 
 
-def _build_routes_listing(action_map: dict[str, Callable]) -> dict[str, dict[str, Any]]:
+def _build_routes_listing(route_table: dict[str, BoundRoute]) -> dict[str, dict[str, Any]]:
     """Build the {route: {doc, args, kwargs}} listing served in 404 responses.
 
-    Depends only on `action_map`'s contents, which are fixed once APIResource.__init__ finishes —
+    Depends only on the route table's contents, which are fixed once APIResource.__init__ finishes —
     computed once there rather than on every 404 (inspect.signature() per route isn't free).
     """
     routes = {}
-    for endpoint_name, wrapped_func in action_map.items():
+    for endpoint_name, entry in route_table.items():
+        wrapped_func = entry.action
         # Get the original function from the wrapper
         original_func = wrapped_func.__wrapped__ if hasattr(wrapped_func, "__wrapped__") else wrapped_func
 
@@ -635,28 +636,26 @@ class APIResource:
         self._bulk_data_fetcher = ScryfallBulkDataFetcher()
         self._critical_css: str = _build_critical_css()
         self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
-        # Build the action map from methods marked with @route, scanning the class rather than this
-        # instance so nothing assigned below can become a route. Alongside it,
-        # _action_positional_capacity records how many positional path-segment args (beyond the
-        # action word) each action accepts, and _action_methods which HTTP methods it answers —
-        # both computed once here rather than per-request in _handle.
-        self.action_map: dict[str, Callable] = {}
-        self._action_positional_capacity: dict[str, float] = {}
-        self._action_methods: dict[str, frozenset[str]] = {}
+        # Build the route table from methods marked with @route, scanning the class rather than this
+        # instance so nothing assigned below can become a route. Each entry carries everything
+        # dispatch needs — the wrapped handler, how many positional path segments it absorbs, and
+        # what it declared — computed once here rather than per-request in _handle.
+        self.routes: dict[str, BoundRoute] = {}
         for attr_name, spec in iter_marked_routes(type(self)):
             handler = getattr(self, attr_name)
-            bound = bind_params(handler)
-            capacity = _max_positional_args(handler)
+            entry = BoundRoute(
+                action=bind_params(handler),
+                positional_capacity=_max_positional_args(handler),
+                spec=spec,
+            )
             for path in spec.paths:
-                if path in self.action_map:
-                    msg = f"Route path {path!r} is claimed by both {self.action_map[path].__name__} and {attr_name}"
+                if path in self.routes:
+                    msg = f"Route path {path!r} is claimed by both {self.routes[path].action.__name__} and {attr_name}"
                     raise RuntimeError(msg)
-                self.action_map[path] = bound
-                self._action_positional_capacity[path] = capacity
-                self._action_methods[path] = spec.methods
+                self.routes[path] = entry
 
-        # Static once action_map is fully populated — see _build_routes_listing.
-        self._not_found_routes = _build_routes_listing(self.action_map)
+        # Static once the route table is fully populated — see _build_routes_listing.
+        self._not_found_routes = _build_routes_listing(self.routes)
 
         self._cache_generation: Synchronized = cache_generation or multiprocessing.Value("i", 0)
         self._query_cache: GenerationCache = GenerationCache(
@@ -701,30 +700,29 @@ class APIResource:
             raise ValueError(msg)
         cursor.execute(f"set statement_timeout = {statement_timeout}")
 
-    def _resolve_action(self, path: str) -> tuple[Callable, list[str], str | None]:
-        """Map a request path to the action that answers it.
+    def _resolve_action(self, path: str) -> tuple[BoundRoute | None, list[str]]:
+        """Map a request path to the route that answers it.
 
         Args:
             path: Request path, already stripped of surrounding slashes and with dots replaced by
                 underscores.
 
         Returns:
-            The action to call, the positional path segments to pass it, and the action_map key that
-            matched. The key is None when nothing matched, so the caller knows there are no declared
-            methods to enforce.
+            The matching route and the positional path segments to pass it, or (None, []) when the
+            path identifies nothing.
         """
-        if path in self.action_map:
+        if path in self.routes:
             # Flat routes like "static/favicon_ico" register their full slash-containing path as
-            # the action_map key — check that exact match before treating "/" as an arg separator.
-            return self.action_map[path], [], path
+            # the route key — check that exact match before treating "/" as an arg separator.
+            return self.routes[path], []
 
         action_word, *action_args = path.split("/")
-        action = self.action_map.get(action_word)
-        # A matched action that can't absorb this many trailing segments (e.g. /robots.txt/x)
+        entry = self.routes.get(action_word)
+        # A matched route that can't absorb this many trailing segments (e.g. /robots.txt/x)
         # means the path doesn't identify anything — 404, not a 400 from a TypeError inside it.
-        if action is None or len(action_args) > self._action_positional_capacity.get(action_word, 0):
-            return self._raise_not_found, [], None
-        return action, action_args, action_word
+        if entry is None or len(action_args) > entry.positional_capacity:
+            return None, []
+        return entry, action_args
 
     def _handle(self, req: falcon.Request, resp: falcon.Response) -> None:
         """Handle a Falcon request and set the response.
@@ -748,12 +746,14 @@ class APIResource:
             id(resp),
         )
 
-        action, action_args, matched_key = self._resolve_action(path.replace(".", "_"))
-
-        # A route answers only the methods it declares. Checked after the path resolves, so a path
-        # that identifies nothing stays a 404 rather than reporting which methods it would accept.
-        if matched_key is not None and req.method not in self._action_methods[matched_key]:
-            raise falcon.HTTPMethodNotAllowed(allowed_methods=sorted(self._action_methods[matched_key]))
+        entry, action_args = self._resolve_action(path.replace(".", "_"))
+        action = self._raise_not_found
+        if entry is not None:
+            # A route answers only the methods it declares. Checked after the path resolves, so a
+            # path that identifies nothing stays a 404 rather than reporting what it would accept.
+            if req.method not in entry.spec.methods:
+                raise falcon.HTTPMethodNotAllowed(allowed_methods=sorted(entry.spec.methods))
+            action = entry.action
 
         res = None
         before = time.monotonic()

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -54,6 +54,7 @@ from api.utils import db_utils, error_monitoring, multiprocessing_utils
 from api.utils.generation_cache import GenerationCache
 from api.utils.http_utils import make_user_agent
 from api.utils.param_binding import ParamCoercionError, bind_params
+from api.utils.routing import iter_marked_routes, route
 from api.utils.timer import Timer
 from api.utils.type_conversions import _get_type_name
 from card_engine import ENGINE_COLUMNS as _ENGINE_COLUMNS_FROM_MODULE
@@ -634,38 +635,25 @@ class APIResource:
         self._bulk_data_fetcher = ScryfallBulkDataFetcher()
         self._critical_css: str = _build_critical_css()
         self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
-        # Create action map with type-converting wrappers for all public methods. Alongside it,
+        # Build the action map from methods marked with @route, scanning the class rather than this
+        # instance so nothing assigned below can become a route. Alongside it,
         # _action_positional_capacity records how many positional path-segment args (beyond the
-        # action word) each action accepts, computed once here rather than per-request in
-        # _handle — see _max_positional_args.
-        self.action_map = {}
+        # action word) each action accepts, and _action_methods which HTTP methods it answers —
+        # both computed once here rather than per-request in _handle.
+        self.action_map: dict[str, Callable] = {}
         self._action_positional_capacity: dict[str, float] = {}
-        for method_name in dir(self):
-            if method_name.startswith("_"):
-                continue
-            method = getattr(self, method_name)
-            if callable(method):
-                self.action_map[method_name] = bind_params(method)
-                self._action_positional_capacity[method_name] = _max_positional_args(method)
-        self.action_map["_root"] = bind_params(self._root)
-        self._action_positional_capacity["_root"] = _max_positional_args(self._root)
-
-        def redirect_to_root(**_: object) -> None:
-            msg = "/"
-            raise falcon.HTTPMovedPermanently(msg)
-
-        self.action_map["index"] = redirect_to_root
-        self.action_map["index_html"] = redirect_to_root
-        self._action_positional_capacity["index"] = _max_positional_args(redirect_to_root)
-        self._action_positional_capacity["index_html"] = _max_positional_args(redirect_to_root)
-
-        # add static file serving actions
-        self.action_map["static/app_js"] = self.app_js
-        self.action_map["static/app_min_js"] = self.app_min_js
-        self.action_map["static/card_js"] = self.card_js
-        self.action_map["static/favicon_ico"] = self.favicon_ico
-        self.action_map["static/social-preview_webp"] = self.social_preview_webp
-        self.action_map["static/styles_css"] = self.styles_css
+        self._action_methods: dict[str, frozenset[str]] = {}
+        for attr_name, spec in iter_marked_routes(type(self)):
+            handler = getattr(self, attr_name)
+            bound = bind_params(handler)
+            capacity = _max_positional_args(handler)
+            for path in spec.paths:
+                if path in self.action_map:
+                    msg = f"Route path {path!r} is claimed by both {self.action_map[path].__name__} and {attr_name}"
+                    raise RuntimeError(msg)
+                self.action_map[path] = bound
+                self._action_positional_capacity[path] = capacity
+                self._action_methods[path] = spec.methods
 
         # Static once action_map is fully populated — see _build_routes_listing.
         self._not_found_routes = _build_routes_listing(self.action_map)
@@ -713,6 +701,31 @@ class APIResource:
             raise ValueError(msg)
         cursor.execute(f"set statement_timeout = {statement_timeout}")
 
+    def _resolve_action(self, path: str) -> tuple[Callable, list[str], str | None]:
+        """Map a request path to the action that answers it.
+
+        Args:
+            path: Request path, already stripped of surrounding slashes and with dots replaced by
+                underscores.
+
+        Returns:
+            The action to call, the positional path segments to pass it, and the action_map key that
+            matched. The key is None when nothing matched, so the caller knows there are no declared
+            methods to enforce.
+        """
+        if path in self.action_map:
+            # Flat routes like "static/favicon_ico" register their full slash-containing path as
+            # the action_map key — check that exact match before treating "/" as an arg separator.
+            return self.action_map[path], [], path
+
+        action_word, *action_args = path.split("/")
+        action = self.action_map.get(action_word)
+        # A matched action that can't absorb this many trailing segments (e.g. /robots.txt/x)
+        # means the path doesn't identify anything — 404, not a 400 from a TypeError inside it.
+        if action is None or len(action_args) > self._action_positional_capacity.get(action_word, 0):
+            return self._raise_not_found, [], None
+        return action, action_args, action_word
+
     def _handle(self, req: falcon.Request, resp: falcon.Response) -> None:
         """Handle a Falcon request and set the response.
 
@@ -735,19 +748,13 @@ class APIResource:
             id(resp),
         )
 
-        path = path.replace(".", "_")
-        if path in self.action_map:
-            # Flat routes like "static/favicon_ico" register their full slash-containing path as
-            # the action_map key — check that exact match before treating "/" as an arg separator.
-            action = self.action_map[path]
-            action_args: list[str] = []
-        else:
-            action_word, *action_args = path.split("/")
-            action = self.action_map.get(action_word, self._raise_not_found)
-            # A matched action that can't absorb this many trailing segments (e.g. /robots.txt/x)
-            # means the path doesn't identify anything — 404, not a 400 from a TypeError inside it.
-            if len(action_args) > self._action_positional_capacity.get(action_word, 0):
-                action, action_args = self._raise_not_found, []
+        action, action_args, matched_key = self._resolve_action(path.replace(".", "_"))
+
+        # A route answers only the methods it declares. Checked after the path resolves, so a path
+        # that identifies nothing stays a 404 rather than reporting which methods it would accept.
+        if matched_key is not None and req.method not in self._action_methods[matched_key]:
+            raise falcon.HTTPMethodNotAllowed(allowed_methods=sorted(self._action_methods[matched_key]))
+
         res = None
         before = time.monotonic()
         try:
@@ -765,6 +772,13 @@ class APIResource:
             raise falcon.HTTPBadRequest(description=str(oops)) from oops
         except falcon.HTTPError as oops:
             logger.error("Error handling request for %s: %s", path, oops, exc_info=True)
+            raise
+        except falcon.HTTPStatus:
+            # Not an error, so deliberately not folded into the HTTPError branch above and its
+            # error-level traceback. HTTPStatus is Falcon's "return this status as-is" signal — how a
+            # redirect and a 304 are expressed — and it is a sibling of HTTPError, not a subclass. It
+            # only has to reach Falcon, which the generic handler below would otherwise prevent by
+            # turning it into a 500.
             raise
         except Exception as oops:
             logger.error("Error handling request: %s", oops, exc_info=True)
@@ -872,6 +886,7 @@ class APIResource:
 
         return copy.deepcopy(result)
 
+    @route()
     def get_pid(self, *, falcon_response: falcon.Response | None = None, **_: object) -> int:
         """Just return the pid of the process which served this request.
 
@@ -883,6 +898,7 @@ class APIResource:
         set_no_store_header(falcon_response)
         return os.getpid()
 
+    @route()
     def setup_schema(self, *_: object, **__: object) -> None:
         """Set up the database schema and apply migrations as needed."""
         if self._schema_setup_event.is_set():
@@ -1127,6 +1143,7 @@ class APIResource:
     @cached(
         cache=TTLCache(maxsize=1, global_ttl=MIN_IMPORT_INTERVAL),
     )
+    @route()
     def import_data(self, **_: object) -> None:
         """Import data from Scryfall and insert into the database."""
         before = time.monotonic()
@@ -1180,6 +1197,7 @@ class APIResource:
                 )
         return resolved
 
+    @route()
     def search(  # noqa: PLR0913
         self,
         *,
@@ -1559,6 +1577,17 @@ class APIResource:
             "total_cards": total_cards,
         }
 
+    @route(paths=("index", "index_html"))
+    def _redirect_to_root(self, **_: object) -> None:
+        """Send the legacy index paths to /.
+
+        Raises:
+            falcon.HTTPMovedPermanently: Always; these paths exist only to redirect.
+        """
+        msg = "/"
+        raise falcon.HTTPMovedPermanently(msg)
+
+    @route()
     def _root(  # noqa: PLR0913
         self,
         *,
@@ -1646,6 +1675,7 @@ class APIResource:
         falcon_response.text = html_content
         falcon_response.content_type = "text/html"
 
+    @route()
     def prefer_score_tuner(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the prefer score tuner page.
 
@@ -1657,6 +1687,7 @@ class APIResource:
         self._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
         falcon_response.content_type = "text/html"
 
+    @route(paths=("favicon_ico", "static/favicon_ico"))
     def favicon_ico(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the favicon.ico file.
 
@@ -1676,6 +1707,7 @@ class APIResource:
         # Cache favicon for 7 days - it rarely changes
         set_cache_header(falcon_response, duration=timedelta(days=7))
 
+    @route(paths=("social_preview_webp", "static/social-preview_webp"))
     def social_preview_webp(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the social preview image."""
         if falcon_response is None:
@@ -1688,6 +1720,7 @@ class APIResource:
         falcon_response.headers["content-length"] = len(contents)
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
+    @route(paths=("styles_css", "static/styles_css"))
     def styles_css(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the styles.css file.
 
@@ -1701,6 +1734,7 @@ class APIResource:
         falcon_response.content_type = "text/css"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
+    @route(paths=("app_js", "static/app_js"))
     def app_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the app.js file.
 
@@ -1715,6 +1749,7 @@ class APIResource:
         # Cache JavaScript for 1 hour - it changes infrequently
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
+    @route(paths=("app_min_js", "static/app_min_js"))
     def app_min_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the app.min.js file.
 
@@ -1728,6 +1763,7 @@ class APIResource:
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
+    @route()
     def robots_txt(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the robots.txt file."""
         if falcon_response is None:
@@ -1735,6 +1771,7 @@ class APIResource:
         self._serve_static_file(filename="robots.txt", falcon_response=falcon_response)
         falcon_response.content_type = "text/plain"
 
+    @route(paths=("card_js", "static/card_js"))
     def card_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the card.js file.
 
@@ -1748,6 +1785,7 @@ class APIResource:
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
+    @route()
     def card(
         self,
         set_code: str = "",
@@ -1798,6 +1836,7 @@ class APIResource:
             falcon_response.status = falcon.HTTP_500
             falcon_response.text = f"Error reading file {filename}: {e}"
 
+    @route()
     def get_migrations(self, **_: object) -> list[dict[str, str]]:
         """Get the migrations from the filesystem.
 
@@ -1808,6 +1847,7 @@ class APIResource:
         """
         return db_utils.get_migrations()
 
+    @route()
     def get_catalog(
         self,
         *,
@@ -1837,12 +1877,14 @@ class APIResource:
             "keywords": dict(sorted(keyword_catalog.items())),
         }
 
+    @route()
     def get_common_keywords(self, **_: object) -> list[dict[str, Any]]:
         """Get the common keywords from the database."""
         return self._run_query(
             query=db_utils.read_sql("get_common_keywords"),
         )["result"]
 
+    @route()
     def backfill_prefer_scores(self, **_: object) -> dict[str, Any]:
         """Backfill prefer_score and prefer_score_components for all cards.
 
@@ -1977,6 +2019,7 @@ class APIResource:
 
         return total_updated
 
+    @route()
     def backfill_cubecobra_scores(self, **_: object) -> dict[str, Any]:
         """Backfill cubecobra_score for all cards.
 
@@ -2017,6 +2060,7 @@ class APIResource:
             "weights": weights,
         }
 
+    @route()
     def ingest_cubecobra(self, **_: object) -> dict[str, Any]:
         """Fetch card data from CubeCobra and store it in magic.cards.
 
@@ -2200,6 +2244,7 @@ class APIResource:
             "message": f"Successfully updated {updated_count} printings with is:{is_tag}",
         }
 
+    @route()
     def discover_is_tags_from_syntax(self, **_: object) -> list[str]:
         """Discover all available is: tags from Scryfall syntax documentation.
 
@@ -2230,14 +2275,17 @@ class APIResource:
         logger.info("Discovered %d unique is: tags from Scryfall syntax", len(unique_is_tags))
         return unique_is_tags
 
+    @route()
     def import_oracle_tags(self, **_: object) -> dict[str, Any]:
         """Import oracle tags from Scryfall bulk data into oracle_tags, oracle_tag_relationships, and card_oracle_tags."""
         return _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
 
+    @route()
     def import_art_tags(self, **_: object) -> dict[str, Any]:
         """Import art tags from Scryfall bulk data into art_tags, art_tag_relationships, and card_art_tags."""
         return _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
 
+    @route()
     def import_all_is_tags(self, **_: object) -> dict[str, Any]:
         """Discover and import all is: tags from Scryfall syntax documentation.
 
@@ -2319,6 +2367,7 @@ class APIResource:
 
         return result
 
+    @route()
     def import_card_by_name(
         self,
         *,
@@ -2359,6 +2408,7 @@ class APIResource:
         # Use import_cards_by_search with exact name query
         return self.import_cards_by_search(search_query=f'!"{card_name}"')
 
+    @route()
     def import_cards_by_search(
         self,
         *,
@@ -2588,6 +2638,7 @@ class APIResource:
         with self._cache_generation.get_lock():
             self._cache_generation.value += 1
 
+    @route()
     def random_search(
         self,
         *,

--- a/api/middlewares/caching_middleware.py
+++ b/api/middlewares/caching_middleware.py
@@ -33,6 +33,12 @@ CacheKey = bytes
 # X-Cache describes this request's cache outcome, so a stored "miss" must never be replayed.
 _UNCACHEABLE_HEADER_PREFIXES: tuple[str, ...] = ("access-control-", "x-cache")
 
+# Only the safe, idempotent methods are cached, and the method is part of the key. Both are needed:
+# a route answers only the methods it declares, so a response is method-dependent, and a POST that a
+# route refuses would otherwise store a 405 that the next GET to the same URL would be served.
+# Responses to POST/PUT/DELETE are not replayable in the first place.
+CACHEABLE_METHODS = frozenset({"GET", "HEAD"})
+
 
 def cacheable_headers(headers: Mapping[str, str]) -> list[tuple[str, str]]:
     """Return the subset of headers safe to replay on a cache hit for a different request."""
@@ -89,6 +95,7 @@ class CachingMiddleware:
         host = host.strip().lower() if isinstance(host, str) and host else None
         return orjson.dumps(
             (
+                req.method,
                 req.relative_uri,
                 tuple(sorted(req.params.items())),
                 tuple(sorted({k: req.headers.get(k) for k in cached_headers}.items())),
@@ -104,6 +111,8 @@ class CachingMiddleware:
             resp: The response object to populate if cache hit.
         """
         if not settings.enable_cache:
+            return
+        if req.method not in CACHEABLE_METHODS:
             return
 
         cache_key = self._cache_key(req)
@@ -141,6 +150,8 @@ class CachingMiddleware:
             req_succeeded: Whether the request was successful (unused).
         """
         if not settings.enable_cache:
+            return
+        if req.method not in CACHEABLE_METHODS:
             return
 
         del resource, req_succeeded

--- a/api/middlewares/tests/test_caching_middleware.py
+++ b/api/middlewares/tests/test_caching_middleware.py
@@ -13,8 +13,9 @@ from api.middlewares.caching_middleware import CachedResponse, CachingMiddleware
 class TestCachingMiddleware:
     """Tests for caching middleware."""
 
-    def _make_req(self, path: str = "/search", uri: str = "/search?q=lightning+bolt") -> MagicMock:
+    def _make_req(self, path: str = "/search", uri: str = "/search?q=lightning+bolt", method: str = "GET") -> MagicMock:
         req = MagicMock()
+        req.method = method
         req.path = path
         req.relative_uri = uri
         req.params = {"q": "lightning bolt"}
@@ -30,9 +31,10 @@ class TestCachingMiddleware:
         resp.render_body.return_value = b"rendered body"
         return resp
 
-    def _cache_key(self, host: str | None = None) -> bytes:
+    def _cache_key(self, host: str | None = None, method: str = "GET") -> bytes:
         return orjson.dumps(
             (
+                method,
                 "/search?q=lightning+bolt",
                 (("q", "lightning bolt"),),
                 (("ACCEPT-ENCODING", None),),
@@ -236,3 +238,50 @@ class TestCachingMiddleware:
 
         assert cache[self._cache_key()] is cached
         resp.render_body.assert_not_called()
+
+    @pytest.mark.parametrize(argnames=["method"], argvalues=[("POST",), ("PUT",), ("PATCH",), ("DELETE",)])
+    def test_unsafe_method_response_is_not_cached(self, method: str) -> None:
+        """Responses to methods that are not safe and idempotent must never be stored."""
+        cache = {}
+        middleware = CachingMiddleware(cache=cache)
+        req = self._make_req(method=method)
+        resp = self._make_resp("200 OK")
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            middleware.process_response(req, resp, None, True)
+
+        assert cache == {}
+
+    @pytest.mark.parametrize(argnames=["method"], argvalues=[("POST",), ("PUT",), ("PATCH",), ("DELETE",)])
+    def test_unsafe_method_does_not_consult_the_cache(self, method: str) -> None:
+        """An unsafe method must not be served a stored response, whatever is in the cache."""
+        cached = CachedResponse(status="200 OK", headers={}, body=b"cached body", result_count=0, total_cards=0)
+        cache = {self._cache_key(): cached, self._cache_key(method=method): cached}
+
+        middleware = CachingMiddleware(cache=cache)
+        req = self._make_req(method=method)
+        resp = MagicMock()
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            middleware.process_request(req, resp)
+
+        assert req.context.get("cache_hit") is None
+        assert resp.complete is not True
+
+    def test_method_is_part_of_the_cache_key(self) -> None:
+        """The same URL under two methods must not share an entry.
+
+        A route answers only the methods it declares, so its response depends on the method: a
+        refused POST returns a 405 that must never be replayed to a GET of the same URL.
+        """
+        cache = {}
+        middleware = CachingMiddleware(cache=cache)
+
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            middleware.process_response(self._make_req(method="GET"), self._make_resp(), None, True)
+            middleware.process_response(self._make_req(method="HEAD"), self._make_resp(), None, True)
+
+        assert sorted(cache) == sorted([self._cache_key(method="GET"), self._cache_key(method="HEAD")])

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -25,6 +25,7 @@ from api.api_resource import (
     hostname_to_site_name,
 )
 from api.enums import ResponseShape
+from api.middlewares.caching_middleware import CachingMiddleware
 from api.settings import settings
 from api.utils.routing import BoundRoute, RouteSpec, route
 
@@ -1174,3 +1175,45 @@ class TestCardSiteNameInjection(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestMethodAwareCaching(TestBaseAPIResourceTest):
+    """A refused method must not poison the cache for a method the route does answer.
+
+    Before routes declared their methods, every method reached the same handler and returned the
+    same response, so a cache key without the method was harmless. Declaring methods makes a
+    response method-dependent: a POST to a GET-only route now 405s, and that 405 would be stored
+    under the key a subsequent GET looks up.
+    """
+
+    def _client(self) -> falcon.testing.TestClient:
+        app = falcon.App(middleware=[CachingMiddleware()])
+        app.add_sink(self.api_resource._handle, prefix="/")
+        return falcon.testing.TestClient(app)
+
+    @contextmanager
+    def _cache_enabled(self) -> Generator[None]:
+        with patch("api.middlewares.caching_middleware.settings") as mock_settings:
+            mock_settings.enable_cache = True
+            yield
+
+    def test_refused_post_does_not_poison_a_later_get(self) -> None:
+        client = self._client()
+        with self._cache_enabled():
+            assert client.simulate_post("/get_pid").status == falcon.HTTP_405
+            after = client.simulate_get("/get_pid")
+
+        assert after.status == falcon.HTTP_200
+        assert after.headers.get("X-Cache") == "miss"
+
+    def test_get_is_still_cached_across_requests(self) -> None:
+        # /robots.txt rather than /get_pid: get_pid sets Cache-Control: no-store, which is also why
+        # it makes a good poisoning case — the 405 is raised before the handler can set that header.
+        client = self._client()
+        with self._cache_enabled():
+            first = client.simulate_get("/robots.txt")
+            second = client.simulate_get("/robots.txt")
+
+        assert first.headers.get("X-Cache") == "miss"
+        assert second.headers.get("X-Cache") == "hit"
+        assert second.status == falcon.HTTP_200

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -26,7 +26,25 @@ from api.api_resource import (
 )
 from api.enums import ResponseShape
 from api.settings import settings
-from api.utils.routing import route
+from api.utils.routing import BoundRoute, RouteSpec, route
+
+
+def make_bound_route(action: object, *, path: str = "search", positional_capacity: float = 0.0) -> BoundRoute:
+    """Build a route table entry around a stub handler, for tests that patch the table wholesale.
+
+    Args:
+        action: The stub to dispatch to.
+        path: Path the stub claims.
+        positional_capacity: How many trailing path segments it absorbs.
+
+    Returns:
+        An entry shaped like the ones __init__ builds.
+    """
+    return BoundRoute(
+        action=action,
+        positional_capacity=positional_capacity,
+        spec=RouteSpec(paths=(path,), methods=frozenset({"GET", "HEAD"}), advertise=True, ignore_unknown_params=False),
+    )
 
 
 def create_test_card(  # noqa: PLR0913, PLR0917
@@ -152,9 +170,9 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
         assert api_resource._conn_pool == self.mock_conn_pool
 
         # Check that action map is populated
-        assert "get_pid" in api_resource.action_map
-        assert "search" in api_resource.action_map
-        assert "index" in api_resource.action_map
+        assert "get_pid" in api_resource.routes
+        assert "search" in api_resource.routes
+        assert "index" in api_resource.routes
 
         # Check that caches are initialized
         assert hasattr(api_resource, "_query_cache")
@@ -170,15 +188,19 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
 
         assert api_resource._import_guard == custom_guard
 
-    def test_action_map_includes_all_public_methods(self) -> None:
-        """Test that action_map includes all public methods."""
+    def test_every_public_method_is_still_registered(self) -> None:
+        """Test the marker migration left no previously-routed method behind.
+
+        Registration used to take every public callable. This pins that the same set is reachable
+        now that each one has to opt in; step 3 is where that stops being true on purpose.
+        """
         api_resource = self.api_resource
         public_methods = [
             method for method in dir(api_resource) if not method.startswith("_") and callable(getattr(api_resource, method))
         ]
 
         for method in public_methods:
-            assert method in api_resource.action_map
+            assert method in api_resource.routes
 
 
 class TestRequestDispatch(TestBaseAPIResourceTest):
@@ -248,7 +270,7 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         # get_catalog's falcon_response is keyword-only, so the route has no positional capacity.
         # While it was positional the segment was absorbed and then silently overwritten by the
         # injected response, so a path identifying nothing still returned 200.
-        assert self.api_resource._action_positional_capacity["get_catalog"] == 0
+        assert self.api_resource.routes["get_catalog"].positional_capacity == 0
         with pytest.raises(falcon.HTTPNotFound):
             self._dispatch("/get_catalog/foo")
 
@@ -269,8 +291,8 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         assert "limit" in exc_info.value.description
 
     def test_positional_capacity_computed_at_init_not_per_request(self) -> None:
-        assert self.api_resource._action_positional_capacity["get_pid"] == 0
-        assert self.api_resource._action_positional_capacity["card"] == 2
+        assert self.api_resource.routes["get_pid"].positional_capacity == 0
+        assert self.api_resource.routes["card"].positional_capacity == 2
 
     def test_not_found_routes_precomputed_not_rebuilt_per_request(self) -> None:
         # _not_found_routes is built once in __init__ (see _build_routes_listing) from the fixed
@@ -400,7 +422,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
             raise TypeError(msg)
 
         # Patch the action_map directly to include our mock
-        with patch.object(self.api_resource, "action_map", {"search": mock_action_that_raises_type_error}):
+        with patch.object(self.api_resource, "routes", {"search": make_bound_route(mock_action_that_raises_type_error)}):
             with pytest.raises(falcon.HTTPBadRequest):
                 self.api_resource._handle(mock_req, mock_resp)
 
@@ -418,7 +440,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
             raise Exception(msg)
 
         # Mock search method to raise a general exception
-        with patch.object(self.api_resource, "action_map", {"search": raise_error}):
+        with patch.object(self.api_resource, "routes", {"search": make_bound_route(raise_error)}):
             with patch("api.api_resource.error_monitoring.error_handler") as mock_error_handler:
                 with pytest.raises(falcon.HTTPInternalServerError):
                     self.api_resource._handle(mock_req, mock_resp)
@@ -446,7 +468,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
             msg = f"Test error touching {db_password}"
             raise RuntimeError(msg)
 
-        with patch.object(self.api_resource, "action_map", {"search": raise_error}):
+        with patch.object(self.api_resource, "routes", {"search": make_bound_route(raise_error)}):
             with patch("api.api_resource.error_monitoring.error_handler"):
                 with pytest.raises(falcon.HTTPInternalServerError) as excinfo:
                     self.api_resource._handle(mock_req, mock_resp)
@@ -669,9 +691,9 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         # One @route(paths=(...)) registers both the bare name and the static/ alias, so they are the
         # same wrapper over the same handler. The alias used to be registered as the unwrapped method,
         # which meant the two paths did not bind parameters the same way.
-        aliased = self.api_resource.action_map["static/social-preview_webp"]
-        assert aliased is self.api_resource.action_map["social_preview_webp"]
-        assert aliased.__wrapped__ == self.api_resource.social_preview_webp
+        aliased = self.api_resource.routes["static/social-preview_webp"]
+        assert aliased is self.api_resource.routes["social_preview_webp"]
+        assert aliased.action.__wrapped__ == self.api_resource.social_preview_webp
 
         self.api_resource.social_preview_webp(falcon_response=mock_response)
 

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -26,6 +26,7 @@ from api.api_resource import (
 )
 from api.enums import ResponseShape
 from api.settings import settings
+from api.utils.routing import route
 
 
 def create_test_card(  # noqa: PLR0913, PLR0917
@@ -225,6 +226,24 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         with pytest.raises(falcon.HTTPNotFound):
             self._dispatch("/card/eoc/104/extra")
 
+    def test_two_routes_claiming_one_path_fail_at_construction(self) -> None:
+        # Registration is fail-closed both ways: an unmarked method is not routed, and a path two
+        # methods both claim is a startup error rather than one silently shadowing the other.
+        class Colliding(APIResource):
+            @route(paths=("search",))
+            def shadows_search(self, **_: object) -> None: ...
+
+        with pytest.raises(RuntimeError, match="claimed by both"):
+            Colliding(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+
+    def test_index_paths_redirect_instead_of_erroring(self) -> None:
+        # falcon.HTTPMovedPermanently subclasses HTTPStatus, which is a sibling of HTTPError rather
+        # than a subclass, so the generic `except Exception` swallowed the redirect and returned a
+        # 500. Falcon turns the propagated signal into a 301.
+        for path in ("/index", "/index.html"):
+            with pytest.raises(falcon.HTTPMovedPermanently):
+                self._dispatch(path)
+
     def test_keyword_only_injection_route_with_extra_segment_raises_not_found(self) -> None:
         # get_catalog's falcon_response is keyword-only, so the route has no positional capacity.
         # While it was positional the segment was absorbed and then silently overwritten by the
@@ -312,6 +331,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
     def test_handle_returns_early_if_response_complete(self) -> None:
         """Test _handle returns early if response is already complete."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.path = mock_req.relative_uri = "/test"
         mock_resp = MagicMock()
         mock_resp.complete = True
@@ -323,6 +343,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
     def test_handle_processes_valid_paths(self) -> None:
         """Test _handle processes valid paths correctly."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.uri = mock_req.path = mock_req.relative_uri = "/get_pid"
         mock_req.params = {}
         mock_resp = MagicMock()
@@ -337,6 +358,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
     def test_handle_raises_not_found_for_invalid_paths(self) -> None:
         """Test _handle raises HTTPNotFound for invalid paths."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.uri = mock_req.path = mock_req.relative_uri = "/nonexistent"
         mock_req.params = {}
         mock_resp = MagicMock()
@@ -348,6 +370,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
     def test_disallowed_query_params_do_not_cause_type_error(self) -> None:
         """Query params named after internal kwargs must be stripped before dispatch."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.path = mock_req.relative_uri = "/"
         mock_req.params = {"falcon_response": "injected", "request_host": "evil.com"}
         mock_req.host = "localhost"
@@ -363,6 +386,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
     def test_handle_handles_type_errors(self) -> None:
         """Test _handle handles TypeError exceptions."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.uri = mock_req.path = mock_req.relative_uri = "/search"
         mock_req.params = {"invalid_param": "value"}
         mock_resp = MagicMock()
@@ -383,6 +407,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
     def test_handle_handles_general_exceptions(self) -> None:
         """Test _handle handles general exceptions."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.uri = mock_req.path = mock_req.relative_uri = "/search"
         mock_req.params = {}
         mock_resp = MagicMock()
@@ -409,6 +434,7 @@ class TestAPIResourceRequestHandling(unittest.TestCase):
         regression, which is why it is asserted on the response rather than on the validation.
         """
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.uri = mock_req.path = mock_req.relative_uri = "/search"
         mock_req.params = {}
         mock_resp = MagicMock()
@@ -479,6 +505,7 @@ class TestSearchResponseShape(TestBaseAPIResourceTest):
     def test_handle_converts_shape_query_param(self) -> None:
         """The string 'columnar' from the query string is converted to the enum."""
         mock_req = MagicMock()
+        mock_req.method = "GET"
         mock_req.uri = mock_req.path = mock_req.relative_uri = "/search"
         mock_req.params = {"q": "test", "shape": "columnar"}
         mock_req.get_header.return_value = None
@@ -639,7 +666,13 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.headers = {}
 
-        assert self.api_resource.action_map["static/social-preview_webp"] == self.api_resource.social_preview_webp
+        # One @route(paths=(...)) registers both the bare name and the static/ alias, so they are the
+        # same wrapper over the same handler. The alias used to be registered as the unwrapped method,
+        # which meant the two paths did not bind parameters the same way.
+        aliased = self.api_resource.action_map["static/social-preview_webp"]
+        assert aliased is self.api_resource.action_map["social_preview_webp"]
+        assert aliased.__wrapped__ == self.api_resource.social_preview_webp
+
         self.api_resource.social_preview_webp(falcon_response=mock_response)
 
         expected_contents = (pathlib.Path(__file__).parent.parent / "static" / "social-preview.webp").read_bytes()

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -1200,11 +1200,21 @@ class TestMethodAwareCaching(TestBaseAPIResourceTest):
     def test_refused_post_does_not_poison_a_later_get(self) -> None:
         client = self._client()
         with self._cache_enabled():
-            assert client.simulate_post("/get_pid").status == falcon.HTTP_405
+            refused = client.simulate_post("/get_pid")
             after = client.simulate_get("/get_pid")
 
+        assert refused.status == falcon.HTTP_405
         assert after.status == falcon.HTTP_200
         assert after.headers.get("X-Cache") == "miss"
+
+        # The two properties this case depends on, asserted so that changing either one fails here
+        # rather than leaving the test passing for a reason it was not written to check.
+        # 1. The 405 is raised before the handler runs, so it carries none of get_pid's cache
+        #    headers and was therefore storable — that is what made poisoning possible at all.
+        assert "no-store" not in (refused.headers.get("Cache-Control") or "")
+        # 2. get_pid itself opts out of caching, so the route being poisoned is one that could
+        #    never have populated that key through its own successful response.
+        assert "no-store" in (after.headers.get("Cache-Control") or "")
 
     def test_get_is_still_cached_across_requests(self) -> None:
         # /robots.txt rather than /get_pid: get_pid sets Cache-Control: no-store, which is also why

--- a/api/tests/test_routing.py
+++ b/api/tests/test_routing.py
@@ -1,0 +1,145 @@
+"""Tests for marking methods as HTTP routes and collecting the marked ones off a class."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.utils.routing import RouteSpec, iter_marked_routes, route
+
+method_testcases = {
+    "get_implies_head": {"declared": ("GET",), "expected": {"GET", "HEAD"}},
+    "head_not_implied_without_get": {"declared": ("POST",), "expected": {"POST"}},
+    "lowercase_is_normalized": {"declared": ("post", "put"), "expected": {"POST", "PUT"}},
+    "get_alongside_others_still_implies_head": {"declared": ("GET", "POST"), "expected": {"GET", "HEAD", "POST"}},
+}
+
+
+class TestMarking:
+    """The decorator attaches a spec and leaves the function alone."""
+
+    def test_returns_the_function_unchanged(self) -> None:
+        """Test @route marks rather than wraps.
+
+        Wrapping would put the request-facing coercer between internal callers and the handler, and
+        would add a frame to every traceback.
+        """
+
+        def handler() -> None: ...
+
+        assert route()(handler) is handler
+
+    def test_default_path_is_the_function_name(self) -> None:
+        """Test a route declares no path in the common case."""
+
+        @route()
+        def search() -> None: ...
+
+        assert search._route_spec.paths == ("search",)
+
+    def test_explicit_paths_replace_the_default(self) -> None:
+        """Test a handler reachable under a static/ alias declares both of its paths."""
+
+        @route(paths=("app_js", "static/app_js"))
+        def app_js() -> None: ...
+
+        assert app_js._route_spec.paths == ("app_js", "static/app_js")
+
+    def test_flags_default_to_advertised_and_lenient(self) -> None:
+        """Test the not-yet-enforced flags carry the defaults the plan calls for."""
+
+        @route()
+        def handler() -> None: ...
+
+        assert handler._route_spec.advertise is True
+        assert handler._route_spec.ignore_unknown_params is False
+
+
+class TestDeclaredMethods:
+    """GET implies HEAD; nothing else is inferred."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(method_testcases.values()))),
+        argvalues=[[v for _, v in sorted(method_testcases[name].items())] for name in sorted(method_testcases)],
+        ids=sorted(method_testcases),
+    )
+    def test_declared_methods_resolve_to_accepted_set(self, declared: tuple[str, ...], expected: set[str]) -> None:
+        """Test each declared-method shape resolves to the set the route accepts."""
+
+        @route(methods=declared)
+        def handler() -> None: ...
+
+        assert handler._route_spec.methods == frozenset(expected)
+
+
+class TestCollection:
+    """Registration scans the class for markers, not the instance for callables."""
+
+    def test_collects_only_marked_methods(self) -> None:
+        """Test an unmarked public method is not a route, which is the fail-closed default."""
+
+        class Resource:
+            @route()
+            def marked(self) -> None: ...
+
+            def unmarked(self) -> None: ...
+
+        assert set(dict(iter_marked_routes(Resource))) == {"marked"}
+
+    def test_underscore_no_longer_means_unroutable(self) -> None:
+        """Test a marked private method is a route.
+
+        The point of marking: `_` goes back to meaning only "private in Python", so `setup_schema`
+        can stop being HTTP-reachable without being renamed, and `_root` can be a route.
+        """
+
+        class Resource:
+            @route()
+            def _root(self) -> None: ...
+
+            def _helper(self) -> None: ...
+
+        assert set(dict(iter_marked_routes(Resource))) == {"_root"}
+
+    def test_instance_attributes_cannot_become_routes(self) -> None:
+        """Test a marked callable assigned in __init__ is not registered.
+
+        Scanning `dir(self)` meant any new public attribute could change the route table; a child
+        resource escaped only because it had no __call__.
+        """
+
+        @route()
+        def escaped() -> None: ...
+
+        class Resource:
+            def __init__(self) -> None:
+                self.child = escaped
+
+        assert dict(iter_marked_routes(type(Resource()))) == {}
+
+    def test_inherited_routes_are_collected(self) -> None:
+        """Test a subclass answers its base's routes, which is how a child resource will mount."""
+
+        class Base:
+            @route()
+            def inherited(self) -> None: ...
+
+        class Child(Base):
+            @route()
+            def own(self) -> None: ...
+
+        assert set(dict(iter_marked_routes(Child))) == {"inherited", "own"}
+
+    def test_yields_specs_alongside_names(self) -> None:
+        """Test the collector hands back the spec, so registration needs no second lookup."""
+
+        class Resource:
+            @route(paths=("a", "b"), methods=("POST",))
+            def handler(self) -> None: ...
+
+        collected = list(iter_marked_routes(Resource))
+        assert len(collected) == 1
+        name, spec = collected[0]
+        assert name == "handler"
+        assert isinstance(spec, RouteSpec)
+        assert spec.paths == ("a", "b")
+        assert spec.methods == frozenset({"POST"})

--- a/api/tests/test_type_conversion.py
+++ b/api/tests/test_type_conversion.py
@@ -120,11 +120,11 @@ class TestTypeConversion:
             )
 
             # Check that import_oracle_tags is wrapped
-            assert "import_oracle_tags" in api_resource.action_map
+            assert "import_oracle_tags" in api_resource.routes
 
             # The wrapped function should be different from the original
             original_method = api_resource.import_oracle_tags
-            wrapped_method = api_resource.action_map["import_oracle_tags"]
+            wrapped_method = api_resource.routes["import_oracle_tags"].action
 
             # They should not be the same function object
             assert wrapped_method is not original_method

--- a/api/utils/routing.py
+++ b/api/utils/routing.py
@@ -51,6 +51,26 @@ class RouteSpec:
     ignore_unknown_params: bool
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class BoundRoute:
+    """A route as registered on a live resource: what to call, and what it declared.
+
+    One entry per path, so everything dispatch needs is reached through a single lookup. These were
+    three dicts keyed by the same string, which could disagree — and did: the `static/` aliases had an
+    entry in one and not the others.
+
+    Attributes:
+        action: The wrapped handler to invoke, with request parameters bound to typed arguments.
+        positional_capacity: How many path segments beyond the action word the handler accepts.
+        spec: What the handler declared via @route. Carried whole rather than copied field by field,
+            so the flags later steps read arrive without another change here.
+    """
+
+    action: Callable[..., Any]
+    positional_capacity: float
+    spec: RouteSpec
+
+
 def route(
     *,
     methods: Sequence[str] = ("GET",),

--- a/api/utils/routing.py
+++ b/api/utils/routing.py
@@ -1,0 +1,109 @@
+"""Mark a method as an HTTP route, and collect the marked ones off a class.
+
+The decorator attaches a `RouteSpec` and returns the function unchanged. It deliberately does not
+wrap: wrapping would put the request-facing coercer between internal callers and the handler —
+`_run_import_under_lock` calling `backfill_prefer_scores()` would be routed through it — and would add
+a frame to every traceback for no benefit. `APIResource` already keeps that separation by putting the
+wrapper in `action_map` while `self.method` stays plain, and a wrapping decorator would undo it.
+
+Marking flips registration from fail-open to fail-closed. Scanning `dir(self)` for public callables
+meant a method was reachable over HTTP unless someone remembered a leading underscore, which
+overloaded `_` to mean both "private in Python" and "not HTTP-reachable" — so `setup_schema`, called
+from `__init__` and from tests, could not be hidden without lying about its Python visibility. A
+marker separates the two. Scanning the *class* rather than the instance additionally means nothing
+assigned in `__init__` can become a route.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
+
+# Attribute the marker is stored under. Named rather than inlined because registration reads it off
+# arbitrary class attributes, where a typo would silently unregister every route rather than fail.
+ROUTE_SPEC_ATTR = "_route_spec"
+
+# Declaring GET implies HEAD: a HEAD response is a GET's headers without its body, and uptime checks
+# and `curl -I` rely on it. Callers never list it themselves.
+GET_IMPLIES = frozenset({"HEAD"})
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RouteSpec:
+    """How one handler is reachable over HTTP.
+
+    Attributes:
+        paths: Action-map keys this handler answers to. Defaults to the method's own name, and is
+            given explicitly where a handler also answers under a `static/` path.
+        methods: Accepted HTTP methods, upper-cased, with HEAD added wherever GET is present.
+        advertise: Whether the route belongs in the public route listing. Declared here but not yet
+            read — the listing becomes opt-in when the admin handlers move to a child resource.
+        ignore_unknown_params: Whether unrecognized query parameters are tolerated. Declared here but
+            not yet read — they are still tolerated on every route.
+    """
+
+    paths: tuple[str, ...]
+    methods: frozenset[str]
+    advertise: bool
+    ignore_unknown_params: bool
+
+
+def route(
+    *,
+    methods: Sequence[str] = ("GET",),
+    paths: Sequence[str] | None = None,
+    advertise: bool = True,
+    ignore_unknown_params: bool = False,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Mark a method as reachable over HTTP.
+
+    Args:
+        methods: Accepted HTTP methods. Declaring GET additionally accepts HEAD.
+        paths: Action-map keys to answer to. Defaults to the method's own name.
+        advertise: Whether the route belongs in the public route listing.
+        ignore_unknown_params: Whether unrecognized query parameters are tolerated.
+
+    Returns:
+        A decorator that attaches the spec and returns the function unchanged.
+    """
+
+    def mark(func: Callable[..., Any]) -> Callable[..., Any]:
+        allowed = frozenset(method.upper() for method in methods)
+        if "GET" in allowed:
+            allowed |= GET_IMPLIES
+
+        declared_paths = (func.__name__,)
+        if paths is not None:
+            declared_paths = tuple(paths)
+
+        spec = RouteSpec(
+            paths=declared_paths,
+            methods=allowed,
+            advertise=advertise,
+            ignore_unknown_params=ignore_unknown_params,
+        )
+        setattr(func, ROUTE_SPEC_ATTR, spec)
+        return func
+
+    return mark
+
+
+def iter_marked_routes(cls: type) -> Iterator[tuple[str, RouteSpec]]:
+    """Yield the marked methods of a resource class, in a stable order.
+
+    Scans the class, not an instance, so an attribute assigned in `__init__` — a child resource, a
+    cache, a session — can never become a route by virtue of being callable.
+
+    Args:
+        cls: The resource class to scan.
+
+    Yields:
+        Attribute name and the spec its function carries, ordered by attribute name.
+    """
+    for name in dir(cls):
+        spec = getattr(getattr(cls, name, None), ROUTE_SPEC_ATTR, None)
+        if isinstance(spec, RouteSpec):
+            yield name, spec


### PR DESCRIPTION
Step 2 of the plan in `docs/issues/local-api-resource-routing-redesign.md` (#786), following #787.
**The route table does not change** — the same 35 paths, none added or removed. This is only how a
method becomes a route.

## Registration was fail-open

`dir(self)` plus `callable()` meant a method was reachable over HTTP unless someone remembered a
leading underscore. That overloads `_` to mean both "private in Python" and "not HTTP-reachable", so
`setup_schema` — called from `__init__` and from tests — could not be hidden without lying about its
Python visibility. Scanning the *instance* also meant any public attribute assigned in `__init__`
could change the route table; a child resource stored as `self.admin` would escape only by having no
`__call__`.

`@route` marks a method, and registration scans the class for the marker:

```python
@route()
def search(self, *, q: str | None = None, limit: int = 100) -> dict[str, Any]: ...

@route(paths=("app_js", "static/app_js"))
def app_js(self, *, falcon_response: falcon.Response | None = None) -> None: ...
```

**It marks; it does not wrap.** Wrapping would put the request-facing coercer between internal
callers and the handler — `_run_import_under_lock` calling `backfill_prefer_scores()` would be routed
through it — and would add a frame to every traceback for no benefit. `APIResource` already keeps
that separation by putting the wrapper in `action_map` while `self.method` stays plain.

Freeing `_` is what lets `_root` and the index redirect become ordinary marked methods rather than
special cases assembled in `__init__`.

## Registration is now uniform, which it was not

The six `static/` aliases were registered as raw bound methods:

| | `/app_js` | `/static/app_js` |
| --- | --- | --- |
| before | bound via `bind_params` | raw method, **no** parameter binding |
| before | positional capacity recorded | **no** capacity entry at all |
| after | identical wrapper | identical wrapper |

Both paths now resolve to the same object, because one `@route(paths=(...))` registers both.

## Declared methods

Each route declares what it answers; anything else is a 405. Declaring `GET` also accepts `HEAD`,
since a HEAD response is a GET's headers without its body and uptime checks rely on it. A path that
matches nothing is still a 404, checked first, so a nonexistent path does not report which methods it
would have taken.

```
POST /get_pid      -> 405  Allow: GET, HEAD
GET  /nonexistent  -> 404  (not 405)
```

## /index and /index.html returned 500

Falcon's redirect classes derive from `HTTPStatus`, which is a *sibling* of `HTTPError` rather than a
subclass — `HTTPError` means "render an error body", `HTTPStatus` means "return this status as-is".
`_handle`'s generic `except Exception` therefore converted the redirect before Falcon could act on
it, and the redirect had never worked. Confirmed against `main`, not inferred:

| sink behavior | result |
| --- | --- |
| lets `HTTPStatus` propagate | `301`, `Location: /` |
| `main`'s `except` chain | `500`, no `Location` |

Caught and re-raised separately from `HTTPError` rather than folded in with it: a 301 is not an
error, and the `HTTPError` branch logs at error level with a full traceback.

## Behaviour changes to be aware of

- **Non-GET requests are now 405s.** Nothing in the frontend or `client/` sends anything but GET, and
  nothing reads `req.method`, but any route accepted every method before.
- **`OPTIONS` is a 405.** `CORSMiddleware` sets `Access-Control-Allow-Origin: *` on every response
  and simple GETs do not preflight, so nothing exercises it. Called out because it is a real change.
- **`/index` and `/index.html` are 301s instead of 500s.**

## Tests

15 new. `api/tests/test_routing.py` covers marking and collection, including the two properties the
change exists for: an unmarked public method is not a route, and a marked callable assigned in
`__init__` is not a route either. Two more in `test_api_resource.py` cover the duplicate-path startup
error and the index redirect.

The `_handle` mock requests grew a `method` attribute, and the one test asserting
`action_map["static/social-preview_webp"] is the raw method` now asserts the alias and its
bare-name twin are the same wrapper — it was pinning the inconsistency described above.

2,124 tests pass; `ruff check` and `ruff format --check` clean.

## Not in this change

`advertise` and `ignore_unknown_params` are declared on `RouteSpec` and nothing reads them yet;
steps 3 and 4 consume them, and unknown query parameters are still tolerated everywhere.

A class-level route registry was considered and deferred. `@route` cannot reach its class — the class
object does not exist while the class body runs — so a registry cannot replace the per-function
marker, only cache it, via `__init_subclass__` or a metaclass. Scanning the class costs 9.5 μs for 88
attributes, once per construction. Step 3 is the point to revisit, when mounting a child resource
becomes a second caller that wants the same thing.
