### PR TITLE
Chore: Ignore macOS Finder Cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ configs/postgres/conf/postgresql.conf
 docs/issues/security-*
 # Credential files (github.pat and friends) — .env and env.json are covered above.
 *.pat
+# macOS Finder writes .DS_Store into any directory it displays (view state: icon positions, sort
+# order, window size), and ._* AppleDouble files on non-Apple filesystems. Neither pattern has a
+# slash, so both match at every depth.
+.DS_Store
+._*


### PR DESCRIPTION
`.DS_Store` files turn up all over a checkout on macOS. Finder writes one into any directory it
displays — browsing the repo, a Quick Look, an Open/Save dialog — recording that folder's view state
(icon positions, list-vs-icon mode, window size, sort order). Nothing in the terminal creates them,
and there is no supported way to stop it for local volumes; `DSDontWriteNetworkStores` only covers
network shares. `._*` AppleDouble files appear the same way on non-Apple filesystems.

Neither pattern contains a slash, so **both match at every depth**, not just the repository root:

```
$ git check-ignore -v api/.DS_Store docs/.DS_Store .DS_Store
.gitignore:23:.DS_Store	api/.DS_Store
.gitignore:23:.DS_Store	docs/.DS_Store
.gitignore:23:.DS_Store	.DS_Store
```

`**/.DS_Store` would be equivalent, just redundant.

Nothing of either kind is tracked today (`git ls-files | grep -c DS_Store` → 0), so this changes no
file in the repo. It keeps them out of `git status`, where they crowd out real untracked files and
make it easy to sweep one into a commit with `git add -A`.