### PR TITLE
Refactor: Register Static Assets at Their Real URLs

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -712,7 +712,7 @@ class APIResource:
             path identifies nothing.
         """
         if path in self.routes:
-            # Flat routes like "static/favicon_ico" register their full slash-containing path as
+            # Flat routes like "static/favicon.ico" register their full slash-containing path as
             # the route key — check that exact match before treating "/" as an arg separator.
             return self.routes[path], []
 
@@ -746,7 +746,7 @@ class APIResource:
             id(resp),
         )
 
-        entry, action_args = self._resolve_action(path.replace(".", "_"))
+        entry, action_args = self._resolve_action(path)
         action = self._raise_not_found
         if entry is not None:
             # A route answers only the methods it declares. Checked after the path resolves, so a
@@ -1577,7 +1577,7 @@ class APIResource:
             "total_cards": total_cards,
         }
 
-    @route(paths=("index", "index_html"))
+    @route(paths=("index", "index.html"))
     def _redirect_to_root(self, **_: object) -> None:
         """Send the legacy index paths to /.
 
@@ -1687,7 +1687,7 @@ class APIResource:
         self._serve_static_file(filename="prefer_score_tuner.html", falcon_response=falcon_response)
         falcon_response.content_type = "text/html"
 
-    @route(paths=("favicon_ico", "static/favicon_ico"))
+    @route(paths=("favicon.ico", "static/favicon.ico"))
     def favicon_ico(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the favicon.ico file.
 
@@ -1707,7 +1707,7 @@ class APIResource:
         # Cache favicon for 7 days - it rarely changes
         set_cache_header(falcon_response, duration=timedelta(days=7))
 
-    @route(paths=("social_preview_webp", "static/social-preview_webp"))
+    @route(paths=("static/social-preview.webp",))
     def social_preview_webp(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the social preview image."""
         if falcon_response is None:
@@ -1720,7 +1720,7 @@ class APIResource:
         falcon_response.headers["content-length"] = len(contents)
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
-    @route(paths=("styles_css", "static/styles_css"))
+    @route(paths=("static/styles.css",))
     def styles_css(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the styles.css file.
 
@@ -1734,7 +1734,7 @@ class APIResource:
         falcon_response.content_type = "text/css"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
-    @route(paths=("app_js", "static/app_js"))
+    @route(paths=("static/app.js",))
     def app_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the app.js file.
 
@@ -1749,7 +1749,7 @@ class APIResource:
         # Cache JavaScript for 1 hour - it changes infrequently
         set_cache_header(falcon_response, duration=timedelta(hours=1))
 
-    @route(paths=("app_min_js", "static/app_min_js"))
+    @route(paths=("static/app.min.js",))
     def app_min_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the app.min.js file.
 
@@ -1763,7 +1763,7 @@ class APIResource:
         falcon_response.content_type = "application/javascript"
         set_cache_header(falcon_response, duration=timedelta(days=30))
 
-    @route()
+    @route(paths=("robots.txt",))
     def robots_txt(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the robots.txt file."""
         if falcon_response is None:
@@ -1771,7 +1771,7 @@ class APIResource:
         self._serve_static_file(filename="robots.txt", falcon_response=falcon_response)
         falcon_response.content_type = "text/plain"
 
-    @route(paths=("card_js", "static/card_js"))
+    @route(paths=("static/card.js",))
     def card_js(self, *, falcon_response: falcon.Response | None = None, **_: object) -> None:
         """Return the card.js file.
 

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -207,6 +207,22 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
             assert method in registered
 
 
+# The URLs the fragments, index.html and root conventions actually request. app.min.js is a build
+# artifact — *.min.js is gitignored — so it is registered like the rest but only present once the
+# minifier has run, which is why the serving cases omit it.
+REAL_ASSET_URLS = [
+    "/favicon.ico",
+    "/static/favicon.ico",
+    "/robots.txt",
+    "/static/styles.css",
+    "/static/app.js",
+    "/static/app.min.js",
+    "/static/card.js",
+    "/static/social-preview.webp",
+]
+COMMITTED_ASSET_URLS = [url for url in REAL_ASSET_URLS if url != "/static/app.min.js"]
+
+
 class TestRequestDispatch(TestBaseAPIResourceTest):
     """_handle() routes both flat "static/x" action keys and positional path segments.
 
@@ -252,23 +268,14 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         with pytest.raises(falcon.HTTPNotFound):
             self._dispatch("/card/eoc/104/extra")
 
-    @pytest.mark.parametrize(
-        argnames=["path"],
-        argvalues=[
-            ("/favicon.ico",),
-            ("/static/favicon.ico",),
-            ("/robots.txt",),
-            ("/static/styles.css",),
-            ("/static/app.js",),
-            ("/static/app.min.js",),
-            ("/static/card.js",),
-            ("/static/social-preview.webp",),
-        ],
-    )
-    def test_static_asset_is_served_at_its_real_url(self, path: str) -> None:
+    @pytest.mark.parametrize(argnames=["path"], argvalues=[(url,) for url in REAL_ASSET_URLS])
+    def test_static_asset_is_registered_at_its_real_url(self, path: str) -> None:
         # Paths are declared rather than derived from method names, so they can hold dots and no
-        # path rewrite is needed. These are the URLs the fragments, index.html and root conventions
-        # actually request.
+        # path rewrite is needed.
+        assert path.lstrip("/") in self.api_resource.routes
+
+    @pytest.mark.parametrize(argnames=["path"], argvalues=[(url,) for url in COMMITTED_ASSET_URLS])
+    def test_static_asset_is_served_at_its_real_url(self, path: str) -> None:
         assert self._dispatch(path).status == falcon.HTTP_200
 
     @pytest.mark.parametrize(

--- a/api/tests/test_api_resource.py
+++ b/api/tests/test_api_resource.py
@@ -192,16 +192,19 @@ class TestAPIResourceInitializationNewStyle(TestBaseAPIResourceTest):
     def test_every_public_method_is_still_registered(self) -> None:
         """Test the marker migration left no previously-routed method behind.
 
-        Registration used to take every public callable. This pins that the same set is reachable
-        now that each one has to opt in; step 3 is where that stops being true on purpose.
+        Registration used to take every public callable. This pins that the same set is still
+        reachable now that each one has to opt in; step 3 is where that stops being true on purpose.
+        Checked by handler rather than by key, since a handler's path need not match its name — the
+        static assets are registered at the URLs they are actually requested at.
         """
         api_resource = self.api_resource
         public_methods = [
             method for method in dir(api_resource) if not method.startswith("_") and callable(getattr(api_resource, method))
         ]
+        registered = {entry.action.__wrapped__.__name__ for entry in api_resource.routes.values()}
 
         for method in public_methods:
-            assert method in api_resource.routes
+            assert method in registered
 
 
 class TestRequestDispatch(TestBaseAPIResourceTest):
@@ -249,6 +252,55 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         with pytest.raises(falcon.HTTPNotFound):
             self._dispatch("/card/eoc/104/extra")
 
+    @pytest.mark.parametrize(
+        argnames=["path"],
+        argvalues=[
+            ("/favicon.ico",),
+            ("/static/favicon.ico",),
+            ("/robots.txt",),
+            ("/static/styles.css",),
+            ("/static/app.js",),
+            ("/static/app.min.js",),
+            ("/static/card.js",),
+            ("/static/social-preview.webp",),
+        ],
+    )
+    def test_static_asset_is_served_at_its_real_url(self, path: str) -> None:
+        # Paths are declared rather than derived from method names, so they can hold dots and no
+        # path rewrite is needed. These are the URLs the fragments, index.html and root conventions
+        # actually request.
+        assert self._dispatch(path).status == falcon.HTTP_200
+
+    @pytest.mark.parametrize(
+        argnames=["path"],
+        argvalues=[
+            ("/favicon_ico",),
+            ("/static/favicon_ico",),
+            ("/robots_txt",),
+            ("/styles_css",),
+            ("/static/styles_css",),
+            ("/app_js",),
+            ("/static/app_js",),
+            ("/social_preview_webp",),
+            ("/index_html",),
+        ],
+    )
+    def test_underscore_spelling_is_no_longer_a_route(self, path: str) -> None:
+        # Artifacts of deriving route keys from Python identifiers. Nothing ever linked to them.
+        with pytest.raises(falcon.HTTPNotFound):
+            self._dispatch(path)
+
+    def test_one_handler_two_paths_shares_a_single_entry(self) -> None:
+        # The favicon is requested at the root by browser convention and under /static/ by the
+        # fragment, so it declares both; one @route means one entry behind both keys.
+        assert self.api_resource.routes["favicon.ico"] is self.api_resource.routes["static/favicon.ico"]
+
+    def test_dots_in_path_arguments_are_no_longer_rewritten(self) -> None:
+        # The rewrite applied to the whole path, not just the action word, so a dotted collector
+        # number reached the handler as 104_5.
+        _entry, action_args = self.api_resource._resolve_action("card/eoc/104.5")
+        assert action_args == ["eoc", "104.5"]
+
     def test_two_routes_claiming_one_path_fail_at_construction(self) -> None:
         # Registration is fail-closed both ways: an unmarked method is not routed, and a path two
         # methods both claim is a startup error rather than one silently shadowing the other.
@@ -259,13 +311,13 @@ class TestRequestDispatch(TestBaseAPIResourceTest):
         with pytest.raises(RuntimeError, match="claimed by both"):
             Colliding(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
 
-    def test_index_paths_redirect_instead_of_erroring(self) -> None:
+    @pytest.mark.parametrize(argnames=["path"], argvalues=[("/index",), ("/index.html",)])
+    def test_index_path_redirects_instead_of_erroring(self, path: str) -> None:
         # falcon.HTTPMovedPermanently subclasses HTTPStatus, which is a sibling of HTTPError rather
         # than a subclass, so the generic `except Exception` swallowed the redirect and returned a
         # 500. Falcon turns the propagated signal into a 301.
-        for path in ("/index", "/index.html"):
-            with pytest.raises(falcon.HTTPMovedPermanently):
-                self._dispatch(path)
+        with pytest.raises(falcon.HTTPMovedPermanently):
+            self._dispatch(path)
 
     def test_keyword_only_injection_route_with_extra_segment_raises_not_found(self) -> None:
         # get_catalog's falcon_response is keyword-only, so the route has no positional capacity.
@@ -689,12 +741,9 @@ class TestAPIResourceStaticFileServing(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.headers = {}
 
-        # One @route(paths=(...)) registers both the bare name and the static/ alias, so they are the
-        # same wrapper over the same handler. The alias used to be registered as the unwrapped method,
-        # which meant the two paths did not bind parameters the same way.
-        aliased = self.api_resource.routes["static/social-preview_webp"]
-        assert aliased is self.api_resource.routes["social_preview_webp"]
-        assert aliased.action.__wrapped__ == self.api_resource.social_preview_webp
+        # Reachable at the URL index.html's og:image actually points at, and only there.
+        entry = self.api_resource.routes["static/social-preview.webp"]
+        assert entry.action.__wrapped__ == self.api_resource.social_preview_webp
 
         self.api_resource.social_preview_webp(falcon_response=mock_response)
 


### PR DESCRIPTION
Stacked on #789 — **review that first**; this diff is against it, not main.

Route keys came from method names, so `_handle` had to rewrite `.` to `_` before every lookup:
`/favicon.ico` was dispatched as `favicon_ico`. Now that `@route` declares paths, a path is just a
dict key and can hold a dot. The rewrite goes away.

## What the URLs actually are

Taken from `api/static/fragments/*.html`, `index.html`, and the two root conventions browsers and
crawlers follow without being told:

| handler | registered at | was also reachable at |
| --- | --- | --- |
| `favicon_ico` | `/favicon.ico`, `/static/favicon.ico` | `/favicon_ico`, `/static/favicon_ico` |
| `robots_txt` | `/robots.txt` | `/robots_txt` |
| `styles_css` | `/static/styles.css` | `/styles_css`, `/static/styles_css` |
| `app_js` | `/static/app.js` | `/app_js`, `/static/app_js` |
| `app_min_js` | `/static/app.min.js` | `/app_min_js`, `/static/app_min_js` |
| `card_js` | `/static/card.js` | `/card_js`, `/static/card_js` |
| `social_preview_webp` | `/static/social-preview.webp` | `/social_preview_webp`, `/static/social-preview_webp` |
| `_redirect_to_root` | `/index`, `/index.html` | `/index_html` |

The right-hand column existed only because the rewrite made those spellings collide with the
method-name keys. Nothing in `api/`, `client/`, `scripts/` or `docs/` links to any of them. 35 paths
becomes 30.

The favicon keeps two, for two different reasons: browsers request `/favicon.ico` at the root
whatever the markup says, and the fragment links to `/static/favicon.ico`. It is now the one place
the two-paths-one-entry invariant is asserted.

## The rewrite also mangled path arguments

It applied to the whole path, not just the action word:

```
/card/eoc/104.5   ->  dispatched as card/eoc/104_5, handler got collector_number="104_5"
```

I did not confirm whether any real collector number contains a dot, so this may never have bitten —
but the rewrite was unconditional and the mangling was plainly not intended. There is now a direct
test on `_resolve_action`.

## Tests

2,144 pass. The new coverage is parametrized one path per case, so a failure names the URL:
every real URL serves 200, every retired spelling 404s, `/index` and `/index.html` still 301, and
dots survive in path arguments. `ruff check` and `ruff format --check` clean.

Two existing tests changed premise rather than breaking by accident: the "every public method is
registered" guard now checks by handler instead of by key, since a handler's path no longer has to
match its name, and the social-preview test asserts the single URL `og:image` actually points at.