### PR TITLE
Refactor: Move Critical-CSS Extraction Into Its Own Module

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -35,7 +35,6 @@ import orjson
 import psycopg
 import psycopg_pool
 import requests
-import tinycss2
 from cachebox import LRUCache, TTLCache
 from cachebox import cached as cachebox_cached
 from psycopg import Connection, Cursor
@@ -51,6 +50,7 @@ from api.settings import settings
 from api.tag_import import import_art_tags as _import_art_tags
 from api.tag_import import import_oracle_tags as _import_oracle_tags
 from api.utils import db_utils, error_monitoring, multiprocessing_utils
+from api.utils.css_utils import build_critical_css
 from api.utils.generation_cache import GenerationCache
 from api.utils.http_utils import make_user_agent
 from api.utils.param_binding import ParamCoercionError, bind_params
@@ -90,92 +90,6 @@ FALLBACK_SITE_NAME = "MTG Search"
 # Placeholder written into index.html/card.html wherever the site name belongs, so the substitution
 # below can't accidentally match unrelated copy that happens to contain "MTG Search".
 _SITE_NAME_PLACEHOLDER = "%%%SITENAME%%%"
-
-# Selectors extracted from styles.css and inlined in the HTML <style> block to prevent
-# layout shift on pages with server-side rendered results. Excludes hover/focus states,
-# animations, and modal styles (not visible on initial paint).
-_CRITICAL_SELECTORS = frozenset(
-    {
-        '[data-theme="light"]',
-        '[data-theme="dark"]',
-        "*",
-        "html",
-        "body",
-        ".container",
-        ".spacer",
-        ".spacer-30",
-        ".spacer-20",
-        ".header",
-        ".theme-toggle",
-        ".header h1",
-        ".header p",
-        ".search-container",
-        ".search-box",
-        ".search-input",
-        ".help-icon",
-        ".order-controls",
-        ".dropdown-label",
-        ".order-dropdown",
-        ".order-toggle",
-        ".arrow-up",
-        # Results grid — needed for SSR search result pages
-        ".results-container",
-        ".card-item",
-        ".card-image",
-        ".card-name-mana-row",
-        ".card-name",
-        ".card-mana",
-        ".ms-cost",
-        ".mana-symbol",
-        ".card-type",
-        ".card-text",
-        ".card-set-power-row",
-        ".card-set",
-        ".card-power-toughness",
-        ".results-count",
-        "#statusMessage",
-        # Footer — margin-top:auto positions it; missing this causes it to jump on styles load
-        ".footer",
-        ".footer-legal",  # also matches the comma rule .footer-legal, .footer-attribution, .footer-links
-        ".footer-attribution a",
-        ".footer-links a",
-    }
-)
-
-
-def _selector_is_critical(selector: str) -> bool:
-    """Return True if any part of a (possibly comma-separated) selector is critical."""
-    return any(part.strip() in _CRITICAL_SELECTORS for part in selector.split(","))
-
-
-def _build_critical_css() -> str:
-    """Extract and minify critical selectors from styles.css at startup."""
-    styles_path = _STATIC_DIR / "styles.css"
-    rules = tinycss2.parse_stylesheet(styles_path.read_text(), skip_comments=True, skip_whitespace=True)
-    parts: list[str] = []
-    for rule in rules:
-        if isinstance(rule, tinycss2.ast.QualifiedRule):
-            selector = tinycss2.serialize(rule.prelude).strip()
-            if _selector_is_critical(selector):
-                parts.append(tinycss2.serialize([rule]))
-        elif isinstance(rule, tinycss2.ast.AtRule) and rule.at_keyword == "media" and rule.content is not None:
-            inner = tinycss2.parse_rule_list(rule.content, skip_comments=True, skip_whitespace=True)
-            critical_inner = [
-                r
-                for r in inner
-                if isinstance(r, tinycss2.ast.QualifiedRule) and _selector_is_critical(tinycss2.serialize(r.prelude).strip())
-            ]
-            if critical_inner:
-                condition = tinycss2.serialize(rule.prelude).strip()
-                inner_css = tinycss2.serialize(critical_inner)
-                parts.append(f"@media {condition}{{{inner_css}}}")
-    raw = "".join(parts)
-    # Minify: collapse whitespace around punctuation and strip excess spaces
-    raw = re.sub(r"/\*.*?\*/", "", raw, flags=re.DOTALL)
-    raw = re.sub(r"\s+", " ", raw)
-    raw = re.sub(r"\s*([{};:,>])\s*", r"\1", raw)
-    raw = re.sub(r";\}", "}", raw)
-    return raw.strip()
 
 
 _STATIC_DIR = pathlib.Path(__file__).parent / "static"
@@ -634,7 +548,7 @@ class APIResource:
         Sets up the database connection pool and action mapping for the API.
         """
         self._bulk_data_fetcher = ScryfallBulkDataFetcher()
-        self._critical_css: str = _build_critical_css()
+        self._critical_css: str = build_critical_css(_STATIC_DIR / "styles.css")
         self._conn_pool: psycopg_pool.ConnectionPool = db_utils.make_pool()
         # Build the route table from methods marked with @route, scanning the class rather than this
         # instance so nothing assigned below can become a route. Each entry carries everything

--- a/api/tests/test_css_utils.py
+++ b/api/tests/test_css_utils.py
@@ -1,0 +1,90 @@
+"""Tests for extracting the critical subset of a stylesheet."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from api.utils.css_utils import build_critical_css
+
+STYLES_PATH = pathlib.Path(__file__).parent.parent / "static" / "styles.css"
+
+selection_testcases = {
+    "critical_rule_is_kept": {"css": "body{color:red}", "expected": "body{color:red}"},
+    "uncritical_rule_is_dropped": {"css": ".tooltip{color:red}", "expected": ""},
+    "comma_rule_kept_via_any_part": {
+        "css": ".footer-legal,.tooltip{color:red}",
+        "expected": ".footer-legal,.tooltip{color:red}",
+    },
+    "hover_state_is_dropped": {"css": ".card-item:hover{color:red}", "expected": ""},
+    "id_selector_is_kept": {"css": "#statusMessage{color:red}", "expected": "#statusMessage{color:red}"},
+    "attribute_selector_is_kept": {
+        "css": '[data-theme="dark"]{color:red}',
+        "expected": '[data-theme="dark"]{color:red}',
+    },
+}
+
+
+class TestSelection:
+    """Only allowlisted selectors survive."""
+
+    @pytest.mark.parametrize(
+        argnames=sorted(next(iter(selection_testcases.values()))),
+        argvalues=[[v for _, v in sorted(selection_testcases[name].items())] for name in sorted(selection_testcases)],
+        ids=sorted(selection_testcases),
+    )
+    def test_rule_selection(self, css: str, expected: str, tmp_path: pathlib.Path) -> None:
+        """Test each selector shape is kept or dropped as the allowlist dictates."""
+        stylesheet = tmp_path / "styles.css"
+        stylesheet.write_text(css)
+        assert build_critical_css(stylesheet) == expected
+
+    def test_empty_stylesheet_yields_empty_string(self, tmp_path: pathlib.Path) -> None:
+        """Test nothing critical produces nothing, rather than stray punctuation."""
+        stylesheet = tmp_path / "styles.css"
+        stylesheet.write_text(".tooltip{color:red}\n.modal{color:blue}\n")
+        assert build_critical_css(stylesheet) == ""
+
+
+class TestMediaQueries:
+    """@media blocks are descended into and rebuilt around their critical rules."""
+
+    def test_media_block_keeps_only_its_critical_rules(self, tmp_path: pathlib.Path) -> None:
+        """Test a responsive override of a critical rule survives, without its uncritical siblings.
+
+        Dropping the whole at-rule would lose the override; keeping it whole would inline rules that
+        do not affect the initial paint.
+        """
+        stylesheet = tmp_path / "styles.css"
+        stylesheet.write_text("@media (max-width:600px){body{color:red}.tooltip{color:blue}}")
+        assert build_critical_css(stylesheet) == "@media (max-width:600px){body{color:red}}"
+
+    def test_media_block_with_nothing_critical_is_dropped_entirely(self, tmp_path: pathlib.Path) -> None:
+        """Test an at-rule whose rules are all uncritical leaves no empty wrapper behind."""
+        stylesheet = tmp_path / "styles.css"
+        stylesheet.write_text("@media (max-width:600px){.tooltip{color:blue}}")
+        assert build_critical_css(stylesheet) == ""
+
+
+class TestMinification:
+    """Output is inlined into every page, so it carries no avoidable bytes."""
+
+    def test_comments_and_whitespace_are_stripped(self, tmp_path: pathlib.Path) -> None:
+        """Test the result has no comments and no padding around punctuation."""
+        stylesheet = tmp_path / "styles.css"
+        stylesheet.write_text("/* a comment */\nbody {\n    color: red;\n    margin: 0;\n}\n")
+        result = build_critical_css(stylesheet)
+        assert result == "body{color:red;margin:0}"
+        assert "/*" not in result
+
+    def test_real_stylesheet_extracts_a_nonempty_subset(self) -> None:
+        """Test the shipped stylesheet still yields critical CSS, and less than the whole file.
+
+        A selector rename in styles.css that silently emptied this would reintroduce the layout
+        shift inlining exists to prevent.
+        """
+        result = build_critical_css(STYLES_PATH)
+        assert result
+        assert len(result) < len(STYLES_PATH.read_text())
+        assert "body{" in result

--- a/api/utils/css_utils.py
+++ b/api/utils/css_utils.py
@@ -1,0 +1,133 @@
+"""Extract the critical subset of a stylesheet for inlining into a page's <style> block.
+
+Critical CSS is the rules needed to paint the page correctly before the external stylesheet loads.
+Inlining them prevents the layout shift that would otherwise be visible on server-side rendered
+result pages, where content is on screen before styles.css arrives.
+
+Membership is an explicit allowlist rather than anything inferred: what is above the fold depends on
+the markup, not on the stylesheet, so it cannot be derived from the CSS alone. Hover and focus states,
+animations, and modal styles are deliberately excluded — none of them affect the initial paint, and
+every rule inlined is bytes added to the HTML of every request.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import tinycss2
+
+if TYPE_CHECKING:
+    import pathlib
+
+# Selectors inlined into the HTML <style> block. A rule is included when any comma-separated part of
+# its selector appears here, so a shared rule like `.footer-legal, .footer-attribution` is pulled in
+# by whichever part is listed.
+_CRITICAL_SELECTORS = frozenset(
+    {
+        '[data-theme="light"]',
+        '[data-theme="dark"]',
+        "*",
+        "html",
+        "body",
+        ".container",
+        ".spacer",
+        ".spacer-30",
+        ".spacer-20",
+        ".header",
+        ".theme-toggle",
+        ".header h1",
+        ".header p",
+        ".search-container",
+        ".search-box",
+        ".search-input",
+        ".help-icon",
+        ".order-controls",
+        ".dropdown-label",
+        ".order-dropdown",
+        ".order-toggle",
+        ".arrow-up",
+        # Results grid — needed for SSR search result pages
+        ".results-container",
+        ".card-item",
+        ".card-image",
+        ".card-name-mana-row",
+        ".card-name",
+        ".card-mana",
+        ".ms-cost",
+        ".mana-symbol",
+        ".card-type",
+        ".card-text",
+        ".card-set-power-row",
+        ".card-set",
+        ".card-power-toughness",
+        ".results-count",
+        "#statusMessage",
+        # Footer — margin-top:auto positions it; missing this causes it to jump on styles load
+        ".footer",
+        ".footer-legal",  # also matches the comma rule .footer-legal, .footer-attribution, .footer-links
+        ".footer-attribution a",
+        ".footer-links a",
+    }
+)
+
+
+def _selector_is_critical(selector: str) -> bool:
+    """Return True if any part of a (possibly comma-separated) selector is critical.
+
+    Args:
+        selector: A serialized selector, which may list several comma-separated parts.
+
+    Returns:
+        Whether the rule this selector belongs to should be inlined.
+    """
+    return any(part.strip() in _CRITICAL_SELECTORS for part in selector.split(","))
+
+
+def _minify(css: str) -> str:
+    """Strip comments and collapse whitespace, since this is inlined into every page.
+
+    Args:
+        css: Serialized CSS.
+
+    Returns:
+        The same rules with comments and avoidable whitespace removed.
+    """
+    css = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+    css = re.sub(r"\s+", " ", css)
+    css = re.sub(r"\s*([{};:,>])\s*", r"\1", css)
+    css = re.sub(r";\}", "}", css)
+    return css.strip()
+
+
+def build_critical_css(styles_path: pathlib.Path) -> str:
+    """Extract and minify the critical rules from a stylesheet.
+
+    `@media` blocks are descended into and rebuilt around whichever of their rules are critical, so a
+    responsive override of a critical rule is kept rather than dropped with its wrapper.
+
+    Args:
+        styles_path: The stylesheet to read.
+
+    Returns:
+        Minified CSS ready to inline in a <style> block, empty if nothing matched.
+    """
+    rules = tinycss2.parse_stylesheet(styles_path.read_text(), skip_comments=True, skip_whitespace=True)
+    parts: list[str] = []
+    for rule in rules:
+        if isinstance(rule, tinycss2.ast.QualifiedRule):
+            selector = tinycss2.serialize(rule.prelude).strip()
+            if _selector_is_critical(selector):
+                parts.append(tinycss2.serialize([rule]))
+        elif isinstance(rule, tinycss2.ast.AtRule) and rule.at_keyword == "media" and rule.content is not None:
+            inner = tinycss2.parse_rule_list(rule.content, skip_comments=True, skip_whitespace=True)
+            critical_inner = [
+                r
+                for r in inner
+                if isinstance(r, tinycss2.ast.QualifiedRule) and _selector_is_critical(tinycss2.serialize(r.prelude).strip())
+            ]
+            if critical_inner:
+                condition = tinycss2.serialize(rule.prelude).strip()
+                inner_css = tinycss2.serialize(critical_inner)
+                parts.append(f"@media {condition}{{{inner_css}}}")
+    return _minify("".join(parts))

--- a/docs/issues/local-api-resource-routing-redesign.md
+++ b/docs/issues/local-api-resource-routing-redesign.md
@@ -8,14 +8,40 @@ of tree per [the `security-` convention](./README.md#unfixed-security-findings).
 architecture and the order of operations — it is deliberately written so it would read the same had
 nothing prompted it.
 
+## Status
+
+Steps 1 and 2 have shipped. The problems and decisions below are kept as written — they are the
+reasoning the shipped work rests on — but read them as the state of the code *before* those PRs.
+
+| step | status |
+| --- | --- |
+| 1. Rewrite coercion | shipped — #787 |
+| 2. `@route` and explicit registration | shipped — #789, with #791 following on |
+| 3. Move the admin handlers to a child resource | not started |
+| 4. Delist | not started |
+| 5. Auth at the mount | not started |
+
+Three things this doc commits to that the shipped code deliberately does **not** do:
+
+- **Falcon's router was not adopted.** See [Design decisions](#design-decisions), which has been
+  revised to record why the hand-rolled dispatch stayed.
+- **`DISALLOWED_QUERY_ARGS` still exists**, and handlers still declare `**_: object` — 27 of 28 do.
+  Both retire with per-route unknown-parameter enforcement, which step 2 declared but did not enforce.
+- **Nothing reads `advertise` or `ignore_unknown_params` yet.** They are on every `RouteSpec`; all 30
+  routes are still published in the 404 listing. Steps 4 and the unknown-parameter work consume them.
+
 ## Current mechanics
 
 Falcon's router is **entirely unused**. `api/api_worker.py` installs one sink —
-`api.add_sink(sink._handle, prefix="/")` — and `_handle` does its own dispatch against an
-`action_map` built in `APIResource.__init__` by walking `dir(self)` and taking every public callable.
-Path segments beyond the action word are passed positionally, bounded by a precomputed
-`_action_positional_capacity`. Query parameters are coerced by `make_type_converting_wrapper`, which
-reads the handler's signature and converts each string via `_convert_string_to_type`.
+`api.add_sink(sink._handle, prefix="/")` — and `_handle` does its own dispatch against a route table
+built in `APIResource.__init__`. Path segments beyond the action word are passed positionally, bounded
+by a precomputed positional capacity.
+
+Before step 2 that table came from walking `dir(self)` and taking every public callable; it is now
+built from methods carrying an `@route` marker, scanned off the class. Before step 1, query parameters
+were coerced by `make_type_converting_wrapper`, which read the handler's signature per call and
+converted each string via `_convert_string_to_type`; a `ParamBinder` now resolves each handler's
+annotations once at registration and binds against a fixed plan.
 
 Two properties of that design are worth keeping, and shape everything below:
 
@@ -46,15 +72,17 @@ that is log formatting at the `logging.INFO` level `api_worker.py` sets.
 
 ### Coercion is fail-open in four ways
 
-| input | current behavior |
-| --- | --- |
-| unconvertible enum (`orderby=nonsense`) | logs, passes the **raw string** to a handler annotated `CardOrdering` |
-| unconvertible int (`limit=abc`) | logs, passes the raw string |
-| unknown parameter (`?limt=5`) | silently dropped, no error |
-| wrong type from an internal caller | passed straight through |
+| input | behavior before step 1 | now |
+| --- | --- | --- |
+| unconvertible enum (`orderby=nonsense`) | logs, passes the **raw string** to a handler annotated `CardOrdering` | 400 |
+| unconvertible int (`limit=abc`) | logs, passes the raw string | 400 |
+| unknown parameter (`?limt=5`) | silently dropped, no error | **still dropped** |
+| wrong type from an internal caller | passed straight through | raises |
 
-The clean 400s a black-box probe sees for bad input come from downstream checks like
-`_validate_limit`, not from this layer.
+The clean 400s a black-box probe saw for bad input came from downstream checks like
+`_validate_limit`, not from this layer. Unknown parameters are the one row left: rejecting them needs
+a per-route opt-out so that `utm_*` and cache-busters keep working on public URLs, which is what
+`ignore_unknown_params` is for.
 
 ### Coercion depends on a module-level import in the caller's file
 
@@ -75,11 +103,15 @@ new resource module without that import would 500 on the first request to any ha
 `dir(self)` plus `callable()` means a method is routed unless someone remembers a leading underscore,
 which overloads `_` to mean both "private in Python" and "not HTTP-reachable" — so
 `setup_schema`, called from `__init__` and from tests, cannot be hidden without lying about its Python
-visibility. Because `_build_routes_listing` iterates the same `action_map`, anything registered is also
-published: a request to any unknown path returns all 37 route names.
+visibility. Because `_build_routes_listing` iterates the same table, anything registered is also
+published: a request to any unknown path returns every route name.
 
 Scanning the *instance* also means any new public attribute can change the route table. A child
 resource stored as `self.admin` escapes registration only because it has no `__call__`.
+
+Step 2 fixed the registration half: routes are marked, the scan is over the class, and a path claimed
+twice is a startup error. The self-advertising half is unchanged — all 30 routes are still listed, and
+`advertise` exists but is read by nothing until step 4.
 
 ### The routing layer is not where the cost is
 
@@ -95,10 +127,17 @@ a 20,900 ns coercion path and a 61,000 ns query, that is noise: adopting it spen
 
 ## Design decisions
 
-**Take Falcon's router, not its responder convention.** `add_route` gives URI templates with converters
-(`{limit:int}`), per-method responders, and 405s for unmapped methods — retiring the positional-split
-scheme that a previous dispatch rewrite broke. Register an adapter rather than an `on_get`, and handlers
-stay plain typed functions.
+**~~Take Falcon's router, not its responder convention.~~ Superseded — the dict dispatch stayed.**
+The argument was that `add_route` gives URI templates with converters (`{limit:int}`), per-method
+responders, and 405s for unmapped methods, retiring the positional-split scheme that a previous
+dispatch rewrite broke. Step 2 got the part that mattered — per-route declared methods and 405s — from
+the `@route` marker directly, in about ten lines of `_handle`, without adopting the router. What is
+left unclaimed is URI templates: the positional-split scheme and its precomputed capacity are still
+there.
+
+Adopting the router now would be a swap with no remaining behavioural payoff, against the measurement
+above showing it is the slower of the two. Revisit only if templated paths start carrying real
+structure — typed segments, or a path that the split cannot express.
 
 **One decorator marks; it does not wrap.**
 
@@ -145,15 +184,20 @@ first. Making that a designed property is most of the value here.
 Ordered so that each step is shippable, and so the steps with a measurable story come before the ones
 that move code.
 
-1. **Rewrite coercion.** Precomputed plan, annotations resolved at import, 400 on unconvertible, per-route
-   unknown-parameter policy, drop the per-conversion log line. Self-contained, has the only performance
-   story, and fixes a latent crash that the next step would otherwise trip over. No routes move.
-2. **Add `@route` and explicit registration.** Pure refactor: same routes, same paths, existing tests
-   untouched. Retires `dir(self)`, frees `_` to mean only "private in Python", and makes each route
-   declare which HTTP methods it accepts.
-3. **Move the admin handlers to a child resource.** The closure analysis for this — which methods and
-   handles are shared, which move — lives in the out-of-tree doc. Mounting is a loop over a child's
-   marked methods; resist extracting a `Router` abstraction until a second mount point exists.
+1. **Rewrite coercion.** *(shipped, #787)* Precomputed plan, annotations resolved at import, 400 on
+   unconvertible, drop the per-conversion log line. Self-contained, has the only performance story,
+   and fixes a latent crash that the next step would otherwise trip over. No routes move. The
+   per-route unknown-parameter policy slipped out of this step and is still unshipped — declaring it
+   needs the marker from step 2.
+2. **Add `@route` and explicit registration.** *(shipped, #789)* Pure refactor: same routes, same
+   paths, existing tests untouched. Retires `dir(self)`, frees `_` to mean only "private in Python",
+   and makes each route declare which HTTP methods it accepts. #791 followed on, registering the
+   static assets at the URLs they are actually requested at now that paths are declared rather than
+   derived from method names.
+3. **Move the admin handlers to a child resource.** *(next)* The closure analysis for this — which
+   methods and handles are shared, which move — lives in the out-of-tree doc. Mounting is a loop over
+   a child's marked methods; resist extracting a `Router` abstraction until a second mount point
+   exists.
 4. **Delist.** `advertise=False` for the child, and make the public listing opt-in so forgetting a flag
    under-advertises rather than over-advertises.
 5. **Auth at the mount.** One check where dispatch enters the child, rather than a decorator on every


### PR DESCRIPTION
Not on the plan — cleanup noticed while working through it.

## The extraction

`_CRITICAL_SELECTORS`, `_selector_is_critical` and `_build_critical_css` lived in `api_resource.py`,
which routes requests, generates SQL, orchestrates imports and renders HTML. They share nothing with
any of that except the path to the static directory, so `build_critical_css` now takes the stylesheet
path as an argument instead of reaching for a module global — which is also what makes it testable
against an arbitrary stylesheet rather than only the shipped one.

`api_resource.py` loses 88 lines and the `tinycss2` import.

**Output is byte-identical.** Checked against `main` in a throwaway worktree, not assumed:

| | length | sha256 |
| --- | ---: | --- |
| `main` `_build_critical_css()` | 8300 | `ca2285b7abd046a5…` |
| `build_critical_css(styles.css)` | 8300 | `ca2285b7abd046a5…` |

## Tests

There were none before, which is the more interesting half: the selector allowlist is coupled to
`styles.css` by nothing but convention, so a class rename could have quietly emptied the critical set
and reintroduced the layout shift inlining exists to prevent.

11 tests: which selector shapes are kept or dropped (comma rules, hover states, id and attribute
selectors), that an `@media` block is rebuilt around only its critical rules and dropped entirely when
none of them qualify, that minification strips comments and padding, and that the real stylesheet
still yields a non-empty subset smaller than the whole file.

## Plan doc update

`docs/issues/local-api-resource-routing-redesign.md` described steps 1 and 2 in the present tense as
work not yet done. Now: a status table, the fail-open table showing which rows closed and that
unknown parameters are the one left, and a note that registration is fixed while self-advertising is
not.

The **Falcon-router decision is marked superseded**. The plan committed to adopting `add_route`; step
2 instead took the part that mattered — per-route declared methods and 405s — straight from the
`@route` marker, and left the dict dispatch alone. Adopting the router now would be a swap with no
behavioural payoff against a measurement, already in the doc, showing it is the slower of the two. The
doc also now records what stayed unclaimed: `DISALLOWED_QUERY_ARGS` still exists, 27 of 28 handlers
still declare `**_: object`, and nothing reads `advertise` or `ignore_unknown_params` yet.

2,173 tests pass; `ruff check` and `ruff format --check` clean.