### PR TITLE
Engine: Assert the Arith-Tuple Domain Stays Collapsed

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1499,11 +1499,41 @@ struct ArithTupleIndex {
     n_cards: u32,
 }
 
+/// Distinct-combination budget for the tuple key, as a multiple of sqrt(cards).
+///
+/// The tuple route only beats a per-card scan while these four fields collapse the corpus
+/// hard, and nothing else in the code checks that. Distinct combinations grow sub-linearly
+/// in card count — measured 74, 109, 155, 210, 270, 350, 453 and 564 at 250 up to 31,508
+/// cards, so `keys / sqrt(cards)` peaks at 4.9 and falls to 3.2 as the corpus fills in the
+/// design space. That makes sqrt a deliberately loose envelope: real growth saturates
+/// toward the number of stat lines Magic prints while the bound keeps rising, so headroom
+/// widens over time rather than narrowing. A ratio of keys to cards would be the wrong
+/// shape — it is naturally ~0.30 at 250 cards and 0.018 at full corpus, so any bound
+/// calibrated on production data would fire on every small fixture.
+const ARITH_TUPLE_KEYS_PER_SQRT_CARD: usize = 10;
+
+/// Additive slack for small corpora, where a few hundred cards can legitimately be nearly
+/// all-distinct before the design space starts repeating itself.
+const ARITH_TUPLE_KEYS_SLACK: usize = 32;
+
+/// Below this the keys-to-cards relationship says nothing useful, so the budget is not
+/// checked at all. Above it the largest test fixtures still exercise the assertion.
+const ARITH_TUPLE_GUARD_MIN_CARDS: usize = 4_096;
+
+/// The `keys` ceiling this corpus size is allowed to produce, per
+/// `ARITH_TUPLE_KEYS_PER_SQRT_CARD`. Separate from the assertion so tests can assert
+/// against the same arithmetic instead of restating it.
+fn arith_tuple_key_budget(n_cards: usize) -> usize {
+    ARITH_TUPLE_KEYS_PER_SQRT_CARD * n_cards.isqrt() + ARITH_TUPLE_KEYS_SLACK
+}
+
 /// Intern each card's (cmc,power,toughness,loyalty) into a dense combination id and
 /// accumulate card postings under it. Cards are visited in ascending index order, so
 /// every postings row is naturally sorted. The id space is the number of distinct
 /// combinations (~564), far below any width concern — EdhrEc is excluded from the key
-/// precisely because it would blow this up to ~card-count distinct values (#743).
+/// precisely because it would blow this up to ~card-count distinct values (#743), and the
+/// `debug_assert` below is what makes that a test failure rather than a silent regression
+/// to a per-card scan with extra indirection.
 fn build_arith_tuple_index(cards: &[OracleCard]) -> ArithTupleIndex {
     let mut interner: HashMap<ArithTupleKey, usize> = HashMap::new();
     let mut keys: Vec<ArithTupleKey> = Vec::new();
@@ -1522,6 +1552,14 @@ fn build_arith_tuple_index(cards: &[OracleCard]) -> ArithTupleIndex {
         });
         postings[id].push(i as u32);
     }
+    debug_assert!(
+        cards.len() < ARITH_TUPLE_GUARD_MIN_CARDS || keys.len() <= arith_tuple_key_budget(cards.len()),
+        "arith tuple domain blew up: {} distinct combinations over {} cards, budget {} — is a \
+         high-cardinality field in ArithTupleKey?",
+        keys.len(),
+        cards.len(),
+        arith_tuple_key_budget(cards.len()),
+    );
     ArithTupleIndex { keys, postings, n_cards: cards.len() as u32 }
 }
 

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -9356,3 +9356,48 @@ fn regex_required_factors_extracts_only_guaranteed() {
     // a min≥1 repetition of a literal is still guaranteed
     assert_eq!(f("(?i)aaa+"), vec!["aaa".to_string()]);
 }
+
+/// The arith-tuple key budget is a tripwire for adding a high-cardinality field to
+/// `ArithTupleKey`, which would silently turn the 564-combination scan back into a per-card
+/// scan with extra indirection. Assert both halves: a realistic corpus sits well inside the
+/// budget, and a deliberately near-unique key space blows through it.
+///
+/// `debug_assert` only fires in debug builds, so the panicking half is gated — release runs
+/// skip it rather than failing.
+#[test]
+fn arith_tuple_key_budget_bounds_the_domain() {
+    use rand::SeedableRng;
+    const N: usize = 8_000;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(11);
+    let data = fuzz_store_n(&mut rng, N);
+    let keys = data.indexes.arith_tuple.keys.len();
+    let budget = super::arith_tuple_key_budget(N);
+    assert!(
+        keys <= budget,
+        "corpus-shaped fixture should sit inside the budget: {keys} keys over {N} cards, budget {budget}"
+    );
+    // The guard is only useful if it has real headroom over reality, not if it barely clears.
+    assert!(keys * 2 <= budget, "want >=2x headroom, got {keys} keys against budget {budget}");
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "arith tuple domain blew up")]
+fn arith_tuple_key_budget_catches_a_blown_domain() {
+    // Give every card a distinct cmc/power pair, which is what adding something like
+    // edhrec_rank to the key would effectively do.
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = (0..ARITH_TUPLE_BLOWUP_CARDS)
+        .map(|i| {
+            let mut c = stub_card(i as u128, TYPE_CREATURE, &[], &mut vocab);
+            c.cmc = Some((i % 251) as u8);
+            c.creature_power = Some((i / 251) as i8);
+            c
+        })
+        .collect();
+    let _ = super::build_arith_tuple_index(&cards);
+}
+
+/// Above `ARITH_TUPLE_GUARD_MIN_CARDS`, and large enough that an all-distinct key space
+/// clears `10*sqrt(n)+32` by a wide margin.
+const ARITH_TUPLE_BLOWUP_CARDS: usize = 6_000;


### PR DESCRIPTION
The arith-tuple index (#750) only beats a per-card scan while `(cmc, power, toughness, loyalty)`
collapses the corpus hard. Nothing in the code checked that, so adding a high-cardinality field to
`ArithTupleKey` would have quietly turned the narrowing into a slower scan with an extra index to
build. This asserts the collapse at build time.

## The bound

`keys <= 10 * sqrt(cards) + 32`, checked only above 4,096 cards.

`sqrt` rather than a ratio, and deliberately loose. Distinct combinations grow sub-linearly in card
count — measured 74, 109, 155, 210, 270, 350, 453 and 564 at 250 up to 31,508 cards — so
`keys / sqrt(cards)` peaks at 4.9 and falls to 3.2 as the corpus fills in the design space. Real
growth saturates toward the number of stat lines Magic prints while the bound keeps rising, so
headroom widens over time rather than narrowing. At the current corpus the budget is 1,802 against
564 observed.

A keys-to-cards ratio would be the wrong shape: it is naturally ~0.30 at 250 cards and 0.018 at full
corpus, so any bound calibrated on production data fires on every small fixture. Hence the 4,096
floor as well — below it the relationship says nothing useful, and above it the largest test
fixtures still exercise the assertion.

## Tests

- `arith_tuple_key_budget_bounds_the_domain` — the real corpus stays inside budget.
- `arith_tuple_key_budget_catches_a_blown_domain` — `should_panic`, so the guard is shown to fire
  rather than merely to exist.

Full engine suite passes in a debug build (141 passed), which is what CI runs; a release-only run
would skip the `debug_assert` tripwires elsewhere in the file.

## One thing to weigh in review

The check is a hard `assert!` on the store-build path, so it fires in release too. That is the
intent — a blown domain means the index is worse than the scan it replaced, and shipping it silently
is worse than refusing to load — but it does mean a future high-cardinality field in
`ArithTupleKey` fails at reload rather than degrading. Say so if you would rather it were a
`debug_assert!` plus a metric.

The 4.9 and 3.2 figures come from a growth-curve measurement over the corpus in publication order;
that artifact lives on the blog branch (`benchmarks/arith-tuple-postings/tuple-growth.csv`) and is
not included here.