### PR TITLE
Report Acquire Facts and Executor Counters From explain, and Measure Cost-Model Agreement

### DIFF
--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1348,12 +1348,12 @@ class TestExplain:
         # Card mode returns one row per matching card, so the pushes ARE the distinct-card total.
         assert gathered["matches_pushed"] <= acquire["n_cards"]
         # The phase split must account for the round, or a phase's cost is attributed to nothing.
-        # The three phases are disjoint sub-intervals of the round, so they can only sum to less
-        # than it -- the shortfall is the unmodelled remainder this instrumentation exists to size.
+        # The phases are disjoint sub-intervals of the round, so they can only sum to less than it --
+        # the shortfall is the unmodelled remainder this instrumentation exists to size.
         # NOT asserted individually as > 0: they are timings, and on a corpus this small
         # `prepare_candidates` really does complete inside the clock's granularity and report 0.
         assert gathered["ns_round_total"] >= gathered["ns_loop"]
-        phases = gathered["ns_prepare"] + gathered["ns_loop"] + gathered["ns_finish"]
+        phases = gathered["ns_prepare"] + gathered["ns_setup"] + gathered["ns_loop"] + gathered["ns_finish"]
         assert phases <= gathered["ns_round_total"], "phase split exceeds the round it came from"
 
         # `result_total` is ground truth for the analyzed run itself, which is the whole reason it

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1315,6 +1315,14 @@ class TestExplain:
             # num_trials recorded.
             assert row["trials_ns"] == [] or len(row["trials_ns"]) == 3
             assert all(t >= 0 for t in row["trials_ns"])
+            # A decline is reported as its own thing rather than as an absence: it produced no page,
+            # so it is not a trial, but it still cost wall time and named the gate that fired. The
+            # two are mutually exclusive because a decline is deterministic for one query and store.
+            assert not (row["trials_ns"] and row["declined_ns"]), f"{row['plan']} reported both trials and declines"
+            if row["declined_ns"]:
+                assert len(row["declined_ns"]) == 3
+                # Nothing executed, so a non-zero counter here would be another plan's.
+                assert (row["cards_visited"], row["matches_pushed"], row["ns_round_total"]) == (0, 0, 0)
         assert any(row["plan"] == "GatheredScan" and len(row["trials_ns"]) == 3 for row in analyzed["plans"])
 
     def test_explain_analyze_counters_track_the_features_that_predict_them(self, engine: QueryEngine) -> None:

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1258,13 +1258,31 @@ class TestExplain:
 
     def test_explain_ranks_applicable_plans_ascending(self, engine: QueryEngine) -> None:
         filters = parse_scryfall_query("t:creature")
-        rows = engine.explain(filters=filters, unique="card", orderby="edhrec", direction="asc", limit=50, offset=0)
+        result = engine.explain(filters=filters, unique="card", orderby="edhrec", direction="asc", limit=50, offset=0)
+        rows = result["plans"]
 
         assert rows, "GatheredScan is always applicable"
         assert {"plan", "predicted_ns"} <= rows[0].keys()
         predicted_ns = [row["predicted_ns"] for row in rows]
         assert predicted_ns == sorted(predicted_ns)
         assert any(row["plan"] == "GatheredScan" for row in rows)
+
+    def test_explain_reports_the_features_the_cost_model_consumes(self, engine: QueryEngine) -> None:
+        """The acquire vector is the point of the diagnostic.
+
+        A calibration fit regresses on exactly what `cost::plan_cost` reads, rather than on a
+        reconstruction of it that can drift.
+        """
+        filters = parse_scryfall_query("t:creature")
+        acquire = engine.explain(filters=filters, unique="card", orderby="edhrec", direction="asc", limit=50, offset=0)["acquire"]
+
+        assert acquire["count_source"], "every query is acquired through some branch"
+        # The cost model's own inputs, so a mis-counted feature is visible as itself.
+        assert {"eval_domain", "scan_units", "matches", "n_cards", "n_printings", "residual_tier_ns100"} <= acquire.keys()
+        assert acquire["limit"] == 50
+        assert acquire["offset"] == 0
+        assert acquire["n_cards"] > 0
+        assert acquire["eval_domain"] <= acquire["n_cards"], "candidates cannot exceed the card universe"
 
     def test_explain_analyze_matches_explain_and_times_every_plan(self, engine: QueryEngine) -> None:
         filters = parse_scryfall_query("t:creature")
@@ -1283,12 +1301,48 @@ class TestExplain:
 
         # Same plans, same order, same predicted_ns -- explain_analyze must never
         # diverge from explain (they share the engine's acquire_plan_features step).
-        assert [row["plan"] for row in analyzed] == [row["plan"] for row in explained]
-        assert [row["predicted_ns"] for row in analyzed] == [row["predicted_ns"] for row in explained]
-        for row in analyzed:
+        assert [row["plan"] for row in analyzed["plans"]] == [row["plan"] for row in explained["plans"]]
+        assert [row["predicted_ns"] for row in analyzed["plans"]] == [row["predicted_ns"] for row in explained["plans"]]
+        # The features must agree too, not just the predictions: they are the inputs those
+        # predictions are computed from, and a harness that reads one and times the other would be
+        # silently comparing two different queries.
+        assert analyzed["acquire"]["count_source"] == explained["acquire"]["count_source"]
+        for key in ("eval_domain", "scan_units", "matches"):
+            assert analyzed["acquire"][key] == explained["acquire"][key]
+        for row in analyzed["plans"]:
             # A structurally-applicable plan's fastpath can still decline at runtime
             # (empty trials_ns); otherwise warmups are discarded and exactly
             # num_trials recorded.
             assert row["trials_ns"] == [] or len(row["trials_ns"]) == 3
             assert all(t >= 0 for t in row["trials_ns"])
-        assert any(row["plan"] == "GatheredScan" and len(row["trials_ns"]) == 3 for row in analyzed)
+        assert any(row["plan"] == "GatheredScan" and len(row["trials_ns"]) == 3 for row in analyzed["plans"])
+
+    def test_explain_analyze_counters_track_the_features_that_predict_them(self, engine: QueryEngine) -> None:
+        """Each counter exists to check the feature that is supposed to predict it.
+
+        A mis-counted feature then shows up as itself rather than as a rate that will not calibrate.
+        `t:creature`/card narrows, so the plan that runs must visit candidates and push results, and
+        the phase split must account for the round it reports.
+        """
+        filters = parse_scryfall_query("t:creature")
+        result = engine.explain_analyze(
+            filters=filters,
+            unique="card",
+            prefer="GatheredScan",
+            orderby="edhrec",
+            direction="asc",
+            limit=50,
+            offset=0,
+            num_warmups=1,
+            num_trials=2,
+        )
+        acquire = result["acquire"]
+        gathered = next(row for row in result["plans"] if row["plan"] == "GatheredScan")
+        assert gathered["trials_ns"], "GatheredScan always runs"
+
+        assert gathered["cards_visited"] > 0
+        assert gathered["matches_pushed"] > 0
+        # Card mode returns one row per matching card, so the pushes ARE the distinct-card total.
+        assert gathered["matches_pushed"] <= acquire["n_cards"]
+        # The phase split must account for the round, or a phase's cost is attributed to nothing.
+        assert gathered["ns_round_total"] >= gathered["ns_loop"]

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1348,4 +1348,20 @@ class TestExplain:
         # Card mode returns one row per matching card, so the pushes ARE the distinct-card total.
         assert gathered["matches_pushed"] <= acquire["n_cards"]
         # The phase split must account for the round, or a phase's cost is attributed to nothing.
+        # The three phases are disjoint sub-intervals of the round, so they can only sum to less
+        # than it -- the shortfall is the unmodelled remainder this instrumentation exists to size.
+        # NOT asserted individually as > 0: they are timings, and on a corpus this small
+        # `prepare_candidates` really does complete inside the clock's granularity and report 0.
         assert gathered["ns_round_total"] >= gathered["ns_loop"]
+        phases = gathered["ns_prepare"] + gathered["ns_loop"] + gathered["ns_finish"]
+        assert phases <= gathered["ns_round_total"], "phase split exceeds the round it came from"
+
+        # `result_total` is ground truth for the analyzed run itself, which is the whole reason it
+        # exists: before it, a harness wanting the true cardinality made a SECOND `query()` call and
+        # ASSUMED the two agreed. Check the assumption once here, since every plan is supposed to
+        # return the same total for one query -- that is a correctness invariant, not a measurement.
+        expected_total, _ = _run(engine, "t:creature", unique="card", orderby="edhrec", limit=50)
+        for row in result["plans"]:
+            if not row["trials_ns"]:
+                continue  # declined at runtime, so it produced no total
+            assert row["result_total"] == expected_total, f"{row['plan']} disagrees with query()'s total"

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1328,7 +1328,10 @@ class TestExplain:
         result = engine.explain_analyze(
             filters=filters,
             unique="card",
-            prefer="GatheredScan",
+            # `prefer` is the PRINTING preference, not a plan selector -- `prefer_from_str` maps
+            # anything unrecognised to `Prefer::Default`. explain_analyze times every applicable plan
+            # regardless, so the plan under test is looked up by name from the results below.
+            prefer="default",
             orderby="edhrec",
             direction="asc",
             limit=50,

--- a/card_engine/src/bench_candidate_materialize.rs
+++ b/card_engine/src/bench_candidate_materialize.rs
@@ -1,0 +1,449 @@
+//! Three ways to turn selected postings rows into one sorted candidate list, as a
+//! function of how many candidates come back and how large the candidate space is.
+//!
+//! Context: `arith_tuple_narrow` (and any other arm that unions several postings
+//! rows) has sorted rows but no globally sorted output, because combination order
+//! is not card order. It currently concatenates the selected rows and sorts. Two
+//! alternatives cost nothing extra in information: a k-way merge, since every run
+//! is already sorted, and a bitmap scatter followed by reading the set bits back,
+//! which is sorted by construction.
+//!
+//! The three have different cost shapes, which is why this sweeps two axes:
+//!
+//! - `concat+sort` — O(c log c) in the candidate count, no dependence on the domain.
+//! - `merge` — O(c log k) in the count and the number of runs, no dependence on the
+//!   domain.
+//! - `bitmap+extract` — O(domain/64 + c): a fixed cost proportional to the *space*
+//!   plus a linear pass, so it wins broad results and loses as the domain grows
+//!   relative to the answer.
+//!
+//! Runs are disjoint (each card belongs to exactly one combination) and their ids
+//! are scattered through the domain rather than contiguous, which is the real
+//! situation: a combination's cards sit wherever they sit in store order.
+//!
+//! All three are asserted to produce the identical `Vec<u32>` before anything is
+//! timed.
+//!
+//!     cargo test --release bench_candidate_materialize -- --ignored --nocapture
+//!
+//! Needs no store — the inputs are synthetic so the domain can be varied.
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::hint::black_box;
+use std::time::Instant;
+
+const ITERS: usize = 60;
+
+/// Real corpus size, so one row of every table is the case the engine actually has.
+const REAL_DOMAIN: usize = 31_508;
+/// Distinct arith-tuple combinations over that corpus; the natural run count there.
+const REAL_RUNS: usize = 564;
+/// The engine's current sorted-vec/bitmap switch, for reference in the output.
+const BITS_PROMOTE_REF: usize = 4_096;
+/// Printing-space domain at the same corpus, the other space a narrowing arm can land in.
+const PRINTING_DOMAIN: usize = 97_206;
+
+fn time_ns(mut kernel: impl FnMut() -> usize) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+/// `runs` disjoint sorted id lists drawn from `0..domain`, holding `count` ids in
+/// total, each run's ids scattered rather than contiguous.
+fn make_runs(domain: usize, count: usize, runs: usize) -> Vec<Vec<u32>> {
+    assert!(count <= domain && runs >= 1);
+    // Deterministic LCG: reproducible without a dev-dependency.
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    // Pick `count` distinct ids by striding with a jitter, then sorting — cheaper
+    // than rejection sampling and still scattered.
+    let stride = domain / count.max(1);
+    let mut ids: Vec<u32> = (0..count)
+        .map(|i| {
+            let base = i * stride;
+            let j = if stride > 1 { (next() as usize) % stride } else { 0 };
+            (base + j).min(domain - 1) as u32
+        })
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    let mut out: Vec<Vec<u32>> = vec![Vec::new(); runs];
+    for id in ids {
+        out[(next() as usize) % runs].push(id);
+    }
+    for r in &mut out {
+        r.sort_unstable();
+    }
+    out
+}
+
+fn concat_sort(runs: &[Vec<u32>], total: usize) -> Vec<u32> {
+    let mut out: Vec<u32> = Vec::with_capacity(total);
+    for r in runs {
+        out.extend_from_slice(r);
+    }
+    out.sort_unstable();
+    out
+}
+
+/// k-way merge over the already-sorted runs. Heap entries are (value, run, pos).
+fn kway_merge(runs: &[Vec<u32>], total: usize) -> Vec<u32> {
+    let mut out: Vec<u32> = Vec::with_capacity(total);
+    let mut heap: BinaryHeap<Reverse<(u32, usize, usize)>> = BinaryHeap::with_capacity(runs.len());
+    for (i, r) in runs.iter().enumerate() {
+        if let Some(&v) = r.first() {
+            heap.push(Reverse((v, i, 0)));
+        }
+    }
+    while let Some(Reverse((v, i, p))) = heap.pop() {
+        out.push(v);
+        if let Some(&nv) = runs[i].get(p + 1) {
+            heap.push(Reverse((nv, i, p + 1)));
+        }
+    }
+    out
+}
+
+fn bitmap_extract(runs: &[Vec<u32>], total: usize, domain: usize) -> Vec<u32> {
+    let mut bits = vec![0u64; domain.div_ceil(64)];
+    for r in runs {
+        for &id in r {
+            bits[id as usize / 64] |= 1u64 << (id % 64);
+        }
+    }
+    let mut out: Vec<u32> = Vec::with_capacity(total);
+    for (w, &word) in bits.iter().enumerate() {
+        let mut word = word;
+        while word != 0 {
+            let b = word.trailing_zeros();
+            out.push((w * 64) as u32 + b);
+            word &= word - 1;
+        }
+    }
+    out
+}
+
+/// The scatter half alone — what the `CardBits` branch above `BITS_PROMOTE` already
+/// pays. Subtracting this from `bitmap_extract` prices the extract pass, which is the
+/// only thing lowering `BITS_PROMOTE` would save.
+fn bitmap_scatter(runs: &[Vec<u32>], domain: usize) -> Vec<u64> {
+    let mut bits = vec![0u64; domain.div_ceil(64)];
+    for r in runs {
+        for &id in r {
+            bits[id as usize / 64] |= 1u64 << (id % 64);
+        }
+    }
+    bits
+}
+
+// ─── Cost model ───────────────────────────────────────────────────────────────
+// Both plans' inputs are known before either structure is allocated: the caller's
+// first pass already sums the selected postings' lengths, and the rows are disjoint
+// (each card belongs to exactly one combination), so that sum is the exact candidate
+// count rather than an upper bound; the domain is `n_cards`. So the choice can be
+// modelled from two numbers already in hand, and only the winning structure ever
+// gets built. These constants are fit against axis A and B above, not assumed.
+
+/// `Vec::with_capacity` plus the run walk, before any comparison work.
+const SORT_FIXED_NS: f64 = 143.0;
+/// pdqsort on `u32`, per candidate — **linear**, not `c·log2 c`.
+///
+/// `sort_unstable` is a full pdqsort, so it is asymptotically `n log n`; this is not a
+/// claim otherwise. But over the three decades that matter here the measured per-element
+/// cost is flat — 5.09, 4.93, 4.92 and 5.06 ns at 1,024 / 4,096 / 16,384 / 31,508 (axis
+/// H) — where an `n log n` term fit to the same data predicts it rising from 3.6 to 5.4.
+/// So the log factor is not observable against per-element memory cost across this range,
+/// and a linear fit is both simpler and more accurate. Fit on the 64 and 1,024 rows of
+/// axis A, which brackets the crossover; it holds to ~6% out to 31,508.
+///
+/// This does NOT license extrapolating past the corpus sizes swept here. The log factor
+/// is real and will eventually show up; re-fit rather than trusting this beyond ~3M.
+const SORT_PER_CAND_NS: f64 = 4.95;
+/// The zeroed `vec![0u64; words]` allocation.
+const BITMAP_FIXED_NS: f64 = 200.0;
+/// Word scan on the extract pass. Fit beyond L1 (0.46–0.53 ns/word across axis B's
+/// 100k–3M domains); inside L1 the real rate is ~0.23, so this over-prices small
+/// domains, which biases the choice toward sort exactly where sort is already fine.
+const BITMAP_PER_WORD_NS: f64 = 0.50;
+/// One scatter store plus one `trailing_zeros` extraction per candidate.
+const BITMAP_PER_CAND_NS: f64 = 0.83;
+
+fn model_sort_ns(count: usize) -> f64 {
+    SORT_FIXED_NS + SORT_PER_CAND_NS * count as f64
+}
+
+/// Both plans are linear in the candidate count, so the crossover has a closed form:
+/// solving `model_sort_ns(c) == model_bitmap_ns(c, domain)` for `c` gives an *affine*
+/// function of the word count. Reported next to the measured crossover so the shape of
+/// the boundary is checked, not just its value at a few domains.
+fn model_crossover(domain: usize) -> f64 {
+    let words = domain.div_ceil(64) as f64;
+    (BITMAP_FIXED_NS - SORT_FIXED_NS + BITMAP_PER_WORD_NS * words) / (SORT_PER_CAND_NS - BITMAP_PER_CAND_NS)
+}
+
+fn model_bitmap_ns(count: usize, domain: usize) -> f64 {
+    BITMAP_FIXED_NS + BITMAP_PER_WORD_NS * domain.div_ceil(64) as f64 + BITMAP_PER_CAND_NS * count as f64
+}
+
+/// Candidate counts bracketing the crossover finely enough to locate it.
+const CROSSOVER_COUNTS: [usize; 12] = [16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512, 1_024];
+
+/// Fine sweep step for locating the crossover, as a percentage. The coarse
+/// `CROSSOVER_COUNTS` grid steps by ~1.5x, which cannot resolve whether the boundary
+/// collapses to a fixed domain:count ratio — that question needs steps finer than the
+/// ratio drift being tested for.
+const FINE_STEP_PCT: usize = 12;
+/// Consecutive bitmap wins required to call a crossover, so one noisy sample at these
+/// sub-microsecond sizes cannot declare it early.
+const FINE_CONFIRM_STEPS: usize = 2;
+/// Where the fine sweep starts; below this the bitmap has never won at any domain.
+const FINE_START: usize = 32;
+
+/// The measured crossover, located by a fine geometric sweep rather than read off the
+/// coarse grid. Returns the first count with `FINE_CONFIRM_STEPS` consecutive bitmap
+/// wins, or None if the bitmap never wins over the swept range.
+fn fine_crossover(domain: usize, runs_n: usize) -> Option<usize> {
+    let mut count = FINE_START;
+    let mut streak: Vec<usize> = Vec::new();
+    while count <= domain {
+        let runs = make_runs(domain, count, runs_n);
+        let total: usize = runs.iter().map(Vec::len).sum();
+        let sort_ns = time_ns(|| concat_sort(&runs, total).len());
+        let bitmap_ns = time_ns(|| bitmap_extract(&runs, total, domain).len());
+        if bitmap_ns < sort_ns {
+            streak.push(total);
+            if streak.len() >= FINE_CONFIRM_STEPS {
+                return streak.first().copied();
+            }
+        } else {
+            streak.clear();
+        }
+        count = (count * (100 + FINE_STEP_PCT) / 100).max(count + 1);
+    }
+    None
+}
+
+/// Measured vs modelled for one (domain, count) cell, plus the regret from following
+/// the model: how much worse the model's pick is than the better plan, measured.
+struct Cell {
+    count: usize,
+    sort_ns: f64,
+    bitmap_ns: f64,
+    model_picks_bitmap: bool,
+    regret_ns: f64,
+}
+
+fn cells(domain: usize, runs_n: usize) -> Vec<Cell> {
+    CROSSOVER_COUNTS
+        .iter()
+        .filter(|&&c| c <= domain)
+        .map(|&count| {
+            let runs = make_runs(domain, count, runs_n);
+            let total: usize = runs.iter().map(Vec::len).sum();
+            let sort_ns = time_ns(|| concat_sort(&runs, total).len());
+            let bitmap_ns = time_ns(|| bitmap_extract(&runs, total, domain).len());
+            let model_picks_bitmap = model_bitmap_ns(total, domain) < model_sort_ns(total);
+            let chosen = if model_picks_bitmap { bitmap_ns } else { sort_ns };
+            Cell { count: total, sort_ns, bitmap_ns, model_picks_bitmap, regret_ns: chosen - sort_ns.min(bitmap_ns) }
+        })
+        .collect()
+}
+
+/// First count at which the bitmap actually wins, and the first at which the model
+/// says it does. `None` means it never won over the swept range.
+fn crossovers(cells: &[Cell]) -> (Option<usize>, Option<usize>) {
+    (
+        cells.iter().find(|c| c.bitmap_ns < c.sort_ns).map(|c| c.count),
+        cells.iter().find(|c| c.model_picks_bitmap).map(|c| c.count),
+    )
+}
+
+fn row(domain: usize, count: usize, runs_n: usize, label: &str) {
+    let runs = make_runs(domain, count, runs_n);
+    let total: usize = runs.iter().map(Vec::len).sum();
+
+    let a = concat_sort(&runs, total);
+    let b = kway_merge(&runs, total);
+    let c = bitmap_extract(&runs, total, domain);
+    assert_eq!(a, b, "concat+sort vs merge disagree ({label})");
+    assert_eq!(a, c, "concat+sort vs bitmap disagree ({label})");
+
+    let t_s = time_ns(|| concat_sort(&runs, total).len());
+    let t_m = time_ns(|| kway_merge(&runs, total).len());
+    let t_b = time_ns(|| bitmap_extract(&runs, total, domain).len());
+    let best = t_s.min(t_m).min(t_b);
+    let win = if best == t_s {
+        "sort"
+    } else if best == t_m {
+        "merge"
+    } else {
+        "bitmap"
+    };
+    println!(
+        "{label:<26}{total:>8}{:>10.2}{:>10.2}{:>10.2}{win:>9}{:>8.2}x",
+        t_s / 1000.0,
+        t_m / 1000.0,
+        t_b / 1000.0,
+        [t_s, t_m, t_b].iter().copied().fold(f64::MIN, f64::max) / best,
+    );
+}
+
+fn header(axis: &str) {
+    println!("\n{axis:<26}{:>8}{:>10}{:>10}{:>10}{:>9}{:>8}", "cands", "sort µs", "merge µs", "bitmap µs", "best", "spread");
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic inputs, no store needed"]
+fn bench_candidate_materialize_contenders() {
+    println!(
+        "\nthree ways to a sorted candidate list. runs are disjoint and scattered;\n\
+         engine reference: domain {REAL_DOMAIN}, {REAL_RUNS} combinations, BITS_PROMOTE {BITS_PROMOTE_REF}"
+    );
+
+    // Axis 1: candidate count, at the real domain and run count.
+    header("A. count @ real domain");
+    for c in [16, 64, 256, 1_024, 4_096, 8_192, 16_384, 31_508] {
+        row(REAL_DOMAIN, c, REAL_RUNS, &format!("  {c} of {REAL_DOMAIN}"));
+    }
+
+    // Axis 2: domain, holding the answer size fixed. This is the axis that decides
+    // whether the bitmap's fixed cost is affordable.
+    header("B. domain @ 4,096 cands");
+    for d in [31_508, 100_000, 300_000, 1_000_000, 3_000_000] {
+        row(d, 4_096, REAL_RUNS, &format!("  domain {d}"));
+    }
+
+    // Axis 3: run count, which only the merge should care about.
+    header("C. runs @ 4,096 cands");
+    for k in [8, 64, 564, 2_048] {
+        row(REAL_DOMAIN, 4_096, k, &format!("  {k} runs"));
+    }
+}
+
+/// Can the plan be *modelled* from the count and domain the caller already has, rather
+/// than switched on a calibrated count threshold? The crossover is a function of both
+/// (axis B), so a single count constant is only right at one domain. This checks the
+/// model against measurement near the crossover, and prices being wrong.
+#[test]
+#[ignore = "micro-benchmark; synthetic inputs, no store needed"]
+fn bench_candidate_materialize_cost_model() {
+    println!(
+        "\nmodelled plan choice. sort = {SORT_FIXED_NS} + {SORT_PER_CAND_NS}·c ns;\n\
+         bitmap = {BITMAP_FIXED_NS} + {BITMAP_PER_WORD_NS}·⌈domain/64⌉ + {BITMAP_PER_CAND_NS}·c ns"
+    );
+
+    for (domain, name) in [(REAL_DOMAIN, "card space"), (PRINTING_DOMAIN, "printing space")] {
+        println!("\nD. residuals @ domain {domain} ({name}), {REAL_RUNS} runs");
+        println!("{:>8}{:>10}{:>10}{:>10}{:>10}{:>9}{:>11}", "cands", "sort µs", "model", "bmap µs", "model", "picks", "regret ns");
+        for c in cells(domain, REAL_RUNS) {
+            println!(
+                "{:>8}{:>10.2}{:>10.2}{:>10.2}{:>10.2}{:>9}{:>11}",
+                c.count,
+                c.sort_ns / 1000.0,
+                model_sort_ns(c.count) / 1000.0,
+                c.bitmap_ns / 1000.0,
+                model_bitmap_ns(c.count, domain) / 1000.0,
+                if c.model_picks_bitmap { "bitmap" } else { "sort" },
+                format!("{:.0}", c.regret_ns),
+            );
+        }
+    }
+
+    println!("\nE. crossover: where the bitmap starts winning, measured against modelled");
+    println!("{:>10}{:>8}{:>12}{:>12}{:>12}", "domain", "words", "measured", "modelled", "max regret");
+    for domain in [REAL_DOMAIN, PRINTING_DOMAIN, 300_000, 1_000_000, 3_000_000] {
+        let cs = cells(domain, REAL_RUNS);
+        let (measured, modelled) = crossovers(&cs);
+        let worst = cs.iter().map(|c| c.regret_ns).fold(0.0f64, f64::max);
+        let show = |v: Option<usize>| v.map_or("none ≤1024".to_string(), |c| c.to_string());
+        println!("{domain:>10}{:>8}{:>12}{:>12}{worst:>11.0}ns", domain.div_ceil(64), show(measured), show(modelled));
+    }
+
+    // Does the two-dimensional surface collapse to one number? Domain enters the bitmap
+    // linearly and the count enters it linearly too, so if the sort's log factor is weak
+    // enough over the range that matters, `domain/count` alone would decide — a far
+    // simpler rule than the model. Located with a fine sweep, since the answer being
+    // tested for is a drift smaller than the coarse grid's 1.5x steps.
+    println!("\nG. does it collapse to a domain:count ratio? ({FINE_STEP_PCT}% steps, {FINE_CONFIRM_STEPS} confirmations)");
+    println!("{:>10}{:>8}{:>12}{:>10}{:>12}{:>10}", "domain", "words", "crossover", "ratio", "modelled", "ratio");
+    for domain in [REAL_DOMAIN, PRINTING_DOMAIN, 300_000, 1_000_000, 3_000_000] {
+        let measured = fine_crossover(domain, REAL_RUNS);
+        let modelled = model_crossover(domain);
+        println!(
+            "{domain:>10}{:>8}{:>12}{:>10}{modelled:>12.0}{:>9.0}:1",
+            domain.div_ceil(64),
+            measured.map_or("none".to_string(), |c| c.to_string()),
+            measured.map_or("-".to_string(), |c| format!("{:.0}:1", domain as f64 / c as f64)),
+            domain as f64 / modelled,
+        );
+    }
+}
+
+/// Is the sort linear in the candidate count, or `n log n`? `sort_unstable` is a full
+/// pdqsort, so asymptotically it is the latter — but the model only has to be right over
+/// the corpus sizes this engine sees. Per-element cost flat across the sweep says the log
+/// factor is not observable here; per-element cost rising like `log2 c` says it is.
+#[test]
+#[ignore = "micro-benchmark; synthetic inputs, no store needed"]
+fn bench_candidate_materialize_sort_shape() {
+    println!("\nH. is concat+sort linear? @ domain {REAL_DOMAIN}, {REAL_RUNS} runs");
+    println!("{:>8}{:>10}{:>12}{:>14}{:>14}", "cands", "sort µs", "ns/elem", "if linear", "if n·log2 n");
+    // Reference point the two shapes are both anchored to, so they can only disagree
+    // about growth, not about scale.
+    const ANCHOR: usize = 1_024;
+    let anchor_runs = make_runs(REAL_DOMAIN, ANCHOR, REAL_RUNS);
+    let anchor_total: usize = anchor_runs.iter().map(Vec::len).sum();
+    let anchor_ns = time_ns(|| concat_sort(&anchor_runs, anchor_total).len());
+    let per_elem = anchor_ns / anchor_total as f64;
+    let per_elem_log = per_elem / (anchor_total as f64).log2();
+
+    for c in [ANCHOR, 4_096, 8_192, 16_384, 31_508] {
+        let runs = make_runs(REAL_DOMAIN, c, REAL_RUNS);
+        let total: usize = runs.iter().map(Vec::len).sum();
+        let ns = time_ns(|| concat_sort(&runs, total).len());
+        println!(
+            "{total:>8}{:>10.2}{:>12.2}{:>14.2}{:>14.2}",
+            ns / 1000.0,
+            ns / total as f64,
+            per_elem,
+            per_elem_log * (total as f64).log2(),
+        );
+    }
+}
+
+/// How much of the bitmap plan is the extract pass? That difference is what a lower
+/// `BITS_PROMOTE` would save, since the scatter is paid either way — the production-side
+/// half of the threshold question the issue doc leaves open.
+#[test]
+#[ignore = "micro-benchmark; synthetic inputs, no store needed"]
+fn bench_candidate_materialize_extract_split() {
+    println!("\nF. scatter against scatter+extract @ domain {REAL_DOMAIN}, {REAL_RUNS} runs");
+    println!("{:>8}{:>12}{:>12}{:>12}{:>10}", "cands", "scatter µs", "+extract", "extract µs", "sort µs");
+    for c in [64, 256, 1_024, 4_096, 16_384, 31_508] {
+        let runs = make_runs(REAL_DOMAIN, c, REAL_RUNS);
+        let total: usize = runs.iter().map(Vec::len).sum();
+        let t_scatter = time_ns(|| bitmap_scatter(&runs, REAL_DOMAIN).len());
+        let t_both = time_ns(|| bitmap_extract(&runs, total, REAL_DOMAIN).len());
+        let t_sort = time_ns(|| concat_sort(&runs, total).len());
+        println!(
+            "{total:>8}{:>12.2}{:>12.2}{:>12.2}{:>10.2}",
+            t_scatter / 1000.0,
+            t_both / 1000.0,
+            (t_both - t_scatter) / 1000.0,
+            t_sort / 1000.0,
+        );
+    }
+}

--- a/card_engine/src/bench_candidate_materialize.rs
+++ b/card_engine/src/bench_candidate_materialize.rs
@@ -33,6 +33,8 @@ use std::collections::BinaryHeap;
 use std::hint::black_box;
 use std::time::Instant;
 
+use super::cost::{MATERIALIZE_SORT_FIXED_NS as SORT_FIXED_NS, MATERIALIZE_SORT_PER_CAND_NS as SORT_PER_CAND_NS};
+
 const ITERS: usize = 60;
 
 /// Real corpus size, so one row of every table is the case the engine actually has.
@@ -157,10 +159,11 @@ fn bitmap_scatter(runs: &[Vec<u32>], domain: usize) -> Vec<u64> {
 // modelled from two numbers already in hand, and only the winning structure ever
 // gets built. These constants are fit against axis A and B above, not assumed.
 
-/// The sort model's constants are the ones `cost::materialize_cost` actually charges, imported
-/// rather than restated: this bench exists to check that model, and a private copy of its constants
-/// can drift out from under it without any test failing.
-use super::cost::{MATERIALIZE_SORT_FIXED_NS as SORT_FIXED_NS, MATERIALIZE_SORT_PER_CAND_NS as SORT_PER_CAND_NS};
+// The sort side's two constants are not defined here: `SORT_FIXED_NS` / `SORT_PER_CAND_NS` are
+// `cost::materialize_cost`'s own, imported at the top of the file rather than restated. This bench
+// exists to check that model, and a private copy of its constants can drift out from under it
+// without any test failing.
+
 /// The zeroed `vec![0u64; words]` allocation.
 const BITMAP_FIXED_NS: f64 = 200.0;
 /// Word scan on the extract pass. Fit beyond L1 (0.46–0.53 ns/word across axis B's
@@ -178,9 +181,19 @@ fn model_sort_ns(count: usize) -> f64 {
 /// solving `model_sort_ns(c) == model_bitmap_ns(c, domain)` for `c` gives an *affine*
 /// function of the word count. Reported next to the measured crossover so the shape of
 /// the boundary is checked, not just its value at a few domains.
+///
+/// The closed form only exists while the bitmap is cheaper PER CANDIDATE than the sort — that
+/// difference is the denominator. `SORT_PER_CAND_NS` is imported and flagged for a re-fit, so the
+/// tripwire below is live: re-fit it under `BITMAP_PER_CAND_NS` and there is no crossover at all
+/// (sort wins at every size), which this would otherwise print as a negative count.
 fn model_crossover(domain: usize) -> f64 {
+    let per_cand_gain = SORT_PER_CAND_NS - BITMAP_PER_CAND_NS;
+    debug_assert!(
+        per_cand_gain > 0.0,
+        "no crossover exists: sort is {SORT_PER_CAND_NS} ns/cand against the bitmap's {BITMAP_PER_CAND_NS}, so the bitmap never catches up",
+    );
     let words = domain.div_ceil(64) as f64;
-    (BITMAP_FIXED_NS - SORT_FIXED_NS + BITMAP_PER_WORD_NS * words) / (SORT_PER_CAND_NS - BITMAP_PER_CAND_NS)
+    (BITMAP_FIXED_NS - SORT_FIXED_NS + BITMAP_PER_WORD_NS * words) / per_cand_gain
 }
 
 fn model_bitmap_ns(count: usize, domain: usize) -> f64 {
@@ -206,19 +219,24 @@ const FINE_START: usize = 32;
 /// wins, or None if the bitmap never wins over the swept range.
 fn fine_crossover(domain: usize, runs_n: usize) -> Option<usize> {
     let mut count = FINE_START;
-    let mut streak: Vec<usize> = Vec::new();
+    // The first count of the current unbroken win streak, and its length. The crossover is the
+    // FIRST win of a confirmed streak, not the count that happened to confirm it.
+    let mut streak_start: Option<usize> = None;
+    let mut streak_len = 0usize;
     while count <= domain {
         let runs = make_runs(domain, count, runs_n);
         let total: usize = runs.iter().map(Vec::len).sum();
         let sort_ns = time_ns(|| concat_sort(&runs, total).len());
         let bitmap_ns = time_ns(|| bitmap_extract(&runs, total, domain).len());
         if bitmap_ns < sort_ns {
-            streak.push(total);
-            if streak.len() >= FINE_CONFIRM_STEPS {
-                return streak.first().copied();
+            streak_start = streak_start.or(Some(total));
+            streak_len += 1;
+            if streak_len >= FINE_CONFIRM_STEPS {
+                return streak_start;
             }
         } else {
-            streak.clear();
+            streak_start = None;
+            streak_len = 0;
         }
         count = (count * (100 + FINE_STEP_PCT) / 100).max(count + 1);
     }
@@ -385,6 +403,14 @@ fn bench_candidate_materialize_cost_model() {
 /// pdqsort, so asymptotically it is the latter — but the model only has to be right over
 /// the corpus sizes this engine sees. Per-element cost flat across the sweep says the log
 /// factor is not observable here; per-element cost rising like `log2 c` says it is.
+///
+/// Answer (minimum of 10 runs): faintly rising, far under `n log n`. 4.35 ns/elem at 1,024 to 5.08 at
+/// 31,508 — a 1.17x rise across 31x the size, where `n log n` demands 1.49x. Linear is the right
+/// model over this range, which is what `cost::MATERIALIZE_SORT_PER_CAND_NS` assumes.
+///
+/// **Run this more than once and take the minimum per column.** A single run on a machine doing
+/// anything else reads as flat ~5.0 at every size, which inverts the conclusion: the contention here
+/// is one-sided, so the max is contaminated while min and median agree to within 0.06 ns/elem.
 #[test]
 #[ignore = "micro-benchmark; synthetic inputs, no store needed"]
 fn bench_candidate_materialize_sort_shape() {

--- a/card_engine/src/bench_candidate_materialize.rs
+++ b/card_engine/src/bench_candidate_materialize.rs
@@ -60,7 +60,7 @@ fn time_ns(mut kernel: impl FnMut() -> usize) -> f64 {
 /// total, each run's ids scattered rather than contiguous.
 fn make_runs(domain: usize, count: usize, runs: usize) -> Vec<Vec<u32>> {
     assert!(count <= domain && runs >= 1);
-    // Deterministic LCG: reproducible without a dev-dependency.
+    // Deterministic xorshift64: reproducible without a dev-dependency.
     let mut state = 0x2545_F491_4F6C_DD1Du64;
     let mut next = move || {
         state ^= state << 13;
@@ -157,21 +157,10 @@ fn bitmap_scatter(runs: &[Vec<u32>], domain: usize) -> Vec<u64> {
 // modelled from two numbers already in hand, and only the winning structure ever
 // gets built. These constants are fit against axis A and B above, not assumed.
 
-/// `Vec::with_capacity` plus the run walk, before any comparison work.
-const SORT_FIXED_NS: f64 = 143.0;
-/// pdqsort on `u32`, per candidate — **linear**, not `c·log2 c`.
-///
-/// `sort_unstable` is a full pdqsort, so it is asymptotically `n log n`; this is not a
-/// claim otherwise. But over the three decades that matter here the measured per-element
-/// cost is flat — 5.09, 4.93, 4.92 and 5.06 ns at 1,024 / 4,096 / 16,384 / 31,508 (axis
-/// H) — where an `n log n` term fit to the same data predicts it rising from 3.6 to 5.4.
-/// So the log factor is not observable against per-element memory cost across this range,
-/// and a linear fit is both simpler and more accurate. Fit on the 64 and 1,024 rows of
-/// axis A, which brackets the crossover; it holds to ~6% out to 31,508.
-///
-/// This does NOT license extrapolating past the corpus sizes swept here. The log factor
-/// is real and will eventually show up; re-fit rather than trusting this beyond ~3M.
-const SORT_PER_CAND_NS: f64 = 4.95;
+/// The sort model's constants are the ones `cost::materialize_cost` actually charges, imported
+/// rather than restated: this bench exists to check that model, and a private copy of its constants
+/// can drift out from under it without any test failing.
+use super::cost::{MATERIALIZE_SORT_FIXED_NS as SORT_FIXED_NS, MATERIALIZE_SORT_PER_CAND_NS as SORT_PER_CAND_NS};
 /// The zeroed `vec![0u64; words]` allocation.
 const BITMAP_FIXED_NS: f64 = 200.0;
 /// Word scan on the extract pass. Fit beyond L1 (0.46–0.53 ns/word across axis B's

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -60,6 +60,7 @@ use super::*;
 /// Cheap, per-query features the cost model consumes, built once per query by
 /// `run_query_routed`'s `acquire` step. All counts are exact or cheap-exact (plane
 /// popcount / range `k` / candidate count), never estimated.
+#[derive(Clone)]
 pub(crate) struct PlanFeatures {
     /// Distinct cards in the corpus (card-space universe).
     pub n_cards: u32,

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -60,7 +60,6 @@ use super::*;
 /// Cheap, per-query features the cost model consumes, built once per query by
 /// `run_query_routed`'s `acquire` step. All counts are exact or cheap-exact (plane
 /// popcount / range `k` / candidate count), never estimated.
-#[derive(Clone)]
 pub(crate) struct PlanFeatures {
     /// Distinct cards in the corpus (card-space universe).
     pub n_cards: u32,
@@ -202,17 +201,24 @@ pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.22;
 /// `Vec::with_capacity` plus the run walk, before any comparison work
 /// (`bench_candidate_materialize`, axis A).
 pub(crate) const MATERIALIZE_SORT_FIXED_NS: f64 = 143.0;
-/// pdqsort on `u32`, per candidate — **linear**, not `c·log2 c`. `sort_unstable` is a full pdqsort
-/// so it is asymptotically `n log n`, but measured per-element cost is flat across the sizes this
-/// engine sees (4.39 ns at 1,024 rising only to 5.09 at 31,508, where an `n log n` fit predicts
-/// 4.39 → 6.57). Fit on the rows bracketing the crossover. Re-fit rather than extrapolating past
-/// ~3M cards, where the log factor does start to show.
+/// pdqsort on `u32`, per candidate — treated as **linear**, not `c·log2 c`. `sort_unstable` is a full
+/// pdqsort so it is asymptotically `n log n`, and the log factor is faintly visible over this range,
+/// but far too weak to model: per-element cost grows only 1.17x across a 31x size increase, where an
+/// `n log n` fit demands 1.49x.
 ///
-/// NOTE the per-element figures quoted above disagree with `bench_candidate_materialize`'s doc for
-/// the same axis-H measurement (it reports 5.09/4.93/4.92/5.06 at 1,024/4,096/16,384/31,508 against
-/// the 4.39 → 5.09 here). One of the two is stale; adjudicating it needs a re-run on a machine that
-/// is not clock-throttled, so it is flagged rather than silently reconciled. The VALUE is now shared
-/// with the bench either way, so only the prose can drift.
+/// Axis H, minimum of 10 runs (`bench_candidate_materialize_sort_shape`):
+///
+///     cands     1,024   4,096   8,192  16,384  31,508
+///     ns/elem    4.35    4.39    4.49    4.75    5.08
+///     n log n    4.35    4.83    5.11    5.40    6.50
+///
+/// Re-fit rather than extrapolating past ~3M cards, where the log factor does start to matter.
+///
+/// MEASUREMENT NOTE: take the MINIMUM across repeated runs, not a single run. Contention here is
+/// one-sided — across those 10 runs min and median agree to within 0.06 ns/elem at every point while
+/// the max reaches 5.73 — so one contaminated run reads as flat ~5.0 at every size and hides the
+/// trend completely. That artifact is what made an earlier draft of this doc quote figures that
+/// disagreed with the bench, and it is the reason to distrust any single-run number here.
 pub(crate) const MATERIALIZE_SORT_PER_CAND_NS: f64 = 4.95;
 
 /// Modelled cost of producing the candidate list a materializing plan consumes, in ns. `0.0` for

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -179,6 +179,58 @@ pub(crate) const RANGE_SCATTER_PER_PRINTING_NS: f64 = 0.36;
 /// compose's scatter but a cheaper op, which is exactly why a bare range routes here, not to compose.
 pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.22;
 
+// ─── Candidate materialization ──────────────────────────────────────────────
+// `plan_cost` prices only what happens AFTER the acquire step: `eval_domain` and `matches` are its
+// inputs, not its outputs. The acquire step is therefore unpriced, and it is where the model's error
+// lives — over 40 sampled queries the median `(measured - predicted) / acquire_ns` is 1.09, so
+// adding the MEASURED acquire time roughly closes the gap.
+//
+// `materialize_cost` below is NOT that term, and does not close that gap. It prices one component of
+// acquire — the candidate `collect` + `sort_unstable` — which measurement puts at a median 5% of
+// acquire (quartiles 2%–40%, n=167 candidate-acquired queries): the rest is index walks, the
+// narrowing recursion, `memoize_text_predicates` and feature building. Adding it to `predicted_ns`
+// measurably makes absolute accuracy slightly WORSE (73.1% -> 74.9% mean error), because it is a
+// small piece of a large omission and does not change which plans compare equal.
+//
+// So it is REPORTED BY `explain`, NOT ADDED TO `plan_cost`, for three reasons: it is validated as
+// too small to help; it is identical for the plans that actually compete (`StreamedSelect` and
+// `GatheredScan` call the same `prepare_candidates`), so it cannot change an argmin; and its real
+// purpose is to price the bitmap-versus-sort question in
+// docs/issues/local-engine-candidate-materialize.md, which is what it does measure exactly.
+
+/// `Vec::with_capacity` plus the run walk, before any comparison work
+/// (`bench_candidate_materialize`, axis A).
+const MATERIALIZE_SORT_FIXED_NS: f64 = 143.0;
+/// pdqsort on `u32`, per candidate — **linear**, not `c·log2 c`. `sort_unstable` is a full pdqsort
+/// so it is asymptotically `n log n`, but measured per-element cost is flat across the sizes this
+/// engine sees (4.39 ns at 1,024 rising only to 5.09 at 31,508, where an `n log n` fit predicts
+/// 4.39 → 6.57). Fit on the rows bracketing the crossover. Re-fit rather than extrapolating past
+/// ~3M cards, where the log factor does start to show.
+const MATERIALIZE_SORT_PER_CAND_NS: f64 = 4.95;
+
+/// Modelled cost of producing the candidate list a materializing plan consumes, in ns. `0.0` for
+/// plans that never build one — those walk or read a plane bitmap directly, and charging them this
+/// would invert exactly the comparison the term is meant to inform.
+///
+/// Prices today's behavior: a `collect` + `sort_unstable`. It does **not** model the bitmap
+/// alternative that doc proposes; if that ships, this needs the domain term as well.
+///
+/// The match below is deliberately NOT `PhysicalPlan::materializing()`, which means something
+/// else — "runnable off a materialized prep", and so includes `PlanePopcountOrder`, which reads
+/// the plane bitmap directly and builds no candidate list. Charging it here would invert exactly
+/// the plane-against-materializing comparison this term exists to inform.
+pub(crate) fn materialize_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
+    match plan {
+        PhysicalPlan::StreamedSelect | PhysicalPlan::GatheredScan => {
+            MATERIALIZE_SORT_FIXED_NS + MATERIALIZE_SORT_PER_CAND_NS * f64::from(f.eval_domain)
+        }
+        PhysicalPlan::PrintingRangeScan
+        | PhysicalPlan::PrintingCompose
+        | PhysicalPlan::PlanePopcountOrder
+        | PhysicalPlan::CardRangePopcount => 0.0,
+    }
+}
+
 // ─── P3: StreamedSelect ─────────────────────────────────────────────────────
 // Match phase walks eval_domain cards computing per-card counts, then either
 // walks the sort permutation to the page (broad) OR — when total <=

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -201,13 +201,19 @@ pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.22;
 
 /// `Vec::with_capacity` plus the run walk, before any comparison work
 /// (`bench_candidate_materialize`, axis A).
-const MATERIALIZE_SORT_FIXED_NS: f64 = 143.0;
+pub(crate) const MATERIALIZE_SORT_FIXED_NS: f64 = 143.0;
 /// pdqsort on `u32`, per candidate — **linear**, not `c·log2 c`. `sort_unstable` is a full pdqsort
 /// so it is asymptotically `n log n`, but measured per-element cost is flat across the sizes this
 /// engine sees (4.39 ns at 1,024 rising only to 5.09 at 31,508, where an `n log n` fit predicts
 /// 4.39 → 6.57). Fit on the rows bracketing the crossover. Re-fit rather than extrapolating past
 /// ~3M cards, where the log factor does start to show.
-const MATERIALIZE_SORT_PER_CAND_NS: f64 = 4.95;
+///
+/// NOTE the per-element figures quoted above disagree with `bench_candidate_materialize`'s doc for
+/// the same axis-H measurement (it reports 5.09/4.93/4.92/5.06 at 1,024/4,096/16,384/31,508 against
+/// the 4.39 → 5.09 here). One of the two is stale; adjudicating it needs a re-run on a machine that
+/// is not clock-throttled, so it is flagged rather than silently reconciled. The VALUE is now shared
+/// with the bench either way, so only the prose can drift.
+pub(crate) const MATERIALIZE_SORT_PER_CAND_NS: f64 = 4.95;
 
 /// Modelled cost of producing the candidate list a materializing plan consumes, in ns. `0.0` for
 /// plans that never build one — those walk or read a plane bitmap directly, and charging them this

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6500,7 +6500,12 @@ pub(crate) enum PagingTaken {
     /// strategy ran. Shared by both fastpaths — a compose that composed to nothing and a range whose
     /// `k` the offset overran are the same observation, and neither exercises a prediction.
     EmptyPage,
-    /// The structural check failed (not a composable expr, or the compose indexes are not built).
+    /// The structural check failed (not a composable expr, or the compose indexes are not built). A
+    /// TRIPWIRE, not an expected outcome, for the same reason `RangeNotBare` is:
+    /// `PhysicalPlan::PrintingCompose.applicable` IS `printing_compose_applicable`, which already
+    /// requires both halves of this test, and every caller of `printing_compose_fastpath` gates on
+    /// it first. So a plan `explain` ranked can only reach this if those two structural tests have
+    /// drifted apart.
     NotComposable,
     /// The `COMPOSE_GATHER_MAX_CARD_FRACTION` breadth gate.
     DeclineBroad,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5725,6 +5725,29 @@ pub(crate) enum ComposePaging {
     Gather,
 }
 
+impl ComposePaging {
+    /// The string `explain` reports under `"compose_paging"`. Byte-identical to what `Debug`
+    /// produced before this existed, so the Python surface did not move.
+    ///
+    /// Spelled out rather than left as `format!("{:?}", ..)` for the same reason `PagingTaken` and
+    /// `CountSource` are, and with a sharper edge than either: a consumer compares this label
+    /// against `PagingTaken`'s. `scripts/bench_cost_model_agreement.py` counts agreement as
+    /// `cells[(predicted, taken)]` with `predicted` from here and `taken` from
+    /// `PagingTaken::label()`, so the two must SPELL the three strategies the same way. While this
+    /// side was `Debug`-derived, renaming a variant here would have silently emptied that diagonal —
+    /// every agreed run reclassified as a disagreement — and `compose_paging_prediction_matches_the_branch_taken`
+    /// would not have noticed, because it compares enums rather than strings.
+    ///
+    /// `compose_paging_and_paging_taken_agree_on_strategy_names` is the test that pins the pairing.
+    fn label(self) -> &'static str {
+        match self {
+            ComposePaging::Perm => "Perm",
+            ComposePaging::OrderbyWalk => "OrderbyWalk",
+            ComposePaging::Gather => "Gather",
+        }
+    }
+}
+
 impl PhysicalPlan {
     /// All plans, argmin-ordered so ties resolve deterministically toward the
     /// cheaper-fixed-cost plan. The router filters this by `applicable`.
@@ -8204,7 +8227,9 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
     ] {
         d.set_item(k, v)?;
     }
-    d.set_item("compose_paging", format!("{:?}", g.compose_paging))?;
+    // `label()`, not `Debug` — a consumer compares this against `PagingTaken::label()`, so the two
+    // have to spell the shared strategy names identically. See `ComposePaging::label`.
+    d.set_item("compose_paging", g.compose_paging.label())?;
     Ok(d)
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4703,6 +4703,12 @@ fn aligned_page<'a>(
 /// selective range (the existing narrowing already wins, and restricting the walk to dense
 /// predicates keeps its worst case bounded), or an order-by without a card permutation (e.g. the
 /// range field itself — deferred).
+///
+/// Every exit records itself in `PAGING_TAKEN` (the `Range*` variants of [`PagingTaken`]), so a
+/// `None` from here reaches `explain_analyze` naming the gate rather than as a bare cost with no
+/// cause. Nothing predicts these the way `compose_paging` predicts the compose branch — the point
+/// is to size the declines, and to make `RangeNotBare`/`RangePermutationStale` visible if they ever
+/// fire, since neither should.
 fn printing_range_fastpath<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
@@ -4710,24 +4716,34 @@ fn printing_range_fastpath<'a>(
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
     let QueryCtx { cards, printings, indexes, .. } = *ctx;
     let QueryParams { sort_col, descending, limit, page_offset, .. } = *params;
-    let (idx, lo, hi) = bare_range_bounds(filter, indexes)?;
+    let Some((idx, lo, hi)) = bare_range_bounds(filter, indexes) else {
+        note_paging_taken(PagingTaken::RangeNotBare);
+        return None;
+    };
     let s = idx.partition_point(|p| u32::from(p.0) < lo);
     let e = idx.partition_point(|p| u32::from(p.0) < hi);
     let k = e - s;
     if !range_too_broad_to_narrow(k, idx.len()) {
+        note_paging_taken(PagingTaken::RangeSelective);
         return None; // selective: the existing narrowing path narrows tightly and wins
     }
     // total = matching printings = k (each priced printing in [lo, hi) is one row; NULL-valued
     // printings are absent from the index and don't match). Same value the count pass would sum.
     if k == 0 || page_offset >= k {
+        note_paging_taken(PagingTaken::EmptyPage);
         return Some((k, Vec::new()));
     }
     // Aligned: order by the range field itself. `usd` is the only range field that is also a sort
     // column, and only a price predicate makes `idx` the value-sorted permutation for that sort;
     // a non-price predicate ordered by usd has no aligned mapping (and no permutation) — bail.
     if matches!(sort_col, SortCol::PriceUsd) {
-        return is_price_leaf(filter)
-            .then(|| (k, aligned_page(idx, s, e, cards, printings, &indexes.printing_to_card, descending, page_offset, limit)));
+        if !is_price_leaf(filter) {
+            note_paging_taken(PagingTaken::RangeUnalignedPrice);
+            return None;
+        }
+        note_paging_taken(PagingTaken::RangeAligned);
+        let page = aligned_page(idx, s, e, cards, printings, &indexes.printing_to_card, descending, page_offset, limit);
+        return Some((k, page));
     }
     // The walk reproduces run_query_streamed's *stream* emission (per-card-contiguous), which the
     // general path only uses above STREAM_MIN_MATCHES; at or below it, run_query_streamed gathers
@@ -4737,12 +4753,18 @@ fn printing_range_fastpath<'a>(
     // index (broad needs k > index_len/4, so index_len < ~4096) -- never in production, where broad
     // means tens of thousands. aligned_page above matches the gathered path directly, so it's exempt.
     if k <= *STREAM_MIN_MATCHES {
+        note_paging_taken(PagingTaken::RangeSparse);
         return None;
     }
-    let perm = indexes.sort_perms.get(sort_col, descending)?;
+    let Some(perm) = indexes.sort_perms.get(sort_col, descending) else {
+        note_paging_taken(PagingTaken::RangeNoPermutation);
+        return None;
+    };
     if perm.len() != cards.len() {
+        note_paging_taken(PagingTaken::RangePermutationStale);
         return None;
     }
+    note_paging_taken(PagingTaken::RangeWalk);
     Some((k, walk_printing_page(ctx, params, filter, perm)))
 }
 
@@ -6383,8 +6405,11 @@ pub(crate) struct PhaseStats {
     /// harness wanting the true cardinality made a SECOND `query()` call, which is a different
     /// execution, so agreement with the analyzed run was assumed rather than observed.
     pub(crate) result_total: u64,
-    /// Which paging branch `printing_compose_fastpath` ACTUALLY took, against the `compose_paging`
-    /// the cost model predicted it would.
+    /// Which exit the printing-space fastpath that ran ACTUALLY took. For
+    /// `printing_compose_fastpath` that is a paging branch, checkable against the `compose_paging`
+    /// the cost model predicted; for `printing_range_fastpath` it is one of the `Range*` gates,
+    /// which predict nothing and exist to size the declines. The rest of this note is about the
+    /// compose half, which is the half with a prediction to falsify.
     ///
     /// `acquire_plan_features`' `PrintingCompose` branch sets `feats.compose_paging` by
     /// reimplementing a decision the fastpath makes independently -- it recomputes the permutation
@@ -6414,18 +6439,25 @@ pub(crate) struct PhaseStats {
     pub(crate) paging_taken: PagingTaken,
 }
 
-/// Which exit `printing_compose_fastpath` took, against the 3-way `ComposePaging` the cost model
-/// predicted. Every exit records itself, which is what lets `NotEntered` mean exactly one thing.
+/// Which exit a printing-space fastpath took: `printing_compose_fastpath` against the 3-way
+/// `ComposePaging` the cost model predicted, and `printing_range_fastpath` against nothing (the
+/// model predicts no strategy for it — see the `Range*` block). Every exit of both records itself,
+/// which is what lets `NotEntered` mean exactly one thing.
+///
+/// The name is compose-era and now undersells the type: only `Perm`/`OrderbyWalk`/`Gather` are
+/// about paging at all, and the rest name gates. Left alone deliberately — `paging_taken` is the
+/// wire key `scripts/bench_cost_model_agreement.py` and any later harness read, and renaming it
+/// would churn the compose narrative throughout this file for no diagnostic gain.
 ///
 /// An enum rather than a `&'static str` because the valid set is load-bearing in four places — the
-/// fastpath's record sites, `compose_paging_prediction_matches_the_branch_taken`'s legal-label
+/// fastpaths' record sites, `compose_paging_prediction_matches_the_branch_taken`'s legal-label
 /// tables, `scripts/bench_cost_model_agreement.py`'s strategy constants, and this doc. As strings
 /// those four drift silently; as variants the compiler settles three of them and a typo stops
 /// being expressible.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub(crate) enum PagingTaken {
-    /// The fastpath was never entered at all — every other plan, and a compose plan that
-    /// `run_query_with_plan` rejected before calling it. A compose that DID enter and declined
+    /// Neither fastpath was entered at all — every other plan, and a compose or range plan that
+    /// `run_query_with_plan` rejected before calling it. A fastpath that DID enter and declined
     /// always names the gate instead, so this never means "declined".
     ///
     /// `#[default]` so a cleared `PAGING_TAKEN` reads as "nothing recorded", which is what
@@ -6441,8 +6473,9 @@ pub(crate) enum PagingTaken {
     /// predicted `OrderbyWalk` and only under one; a bare `Gather` in that cell would mean the
     /// availability tests really had drifted.
     GatherWalkDeclined,
-    /// The composed total was 0 or the offset was past it, so the fastpath returned before any
-    /// strategy ran. The prediction is simply not exercised.
+    /// The total was 0 or the offset was past it, so the fastpath returned an empty page before any
+    /// strategy ran. Shared by both fastpaths — a compose that composed to nothing and a range whose
+    /// `k` the offset overran are the same observation, and neither exercises a prediction.
     EmptyPage,
     /// The structural check failed (not a composable expr, or the compose indexes are not built).
     NotComposable,
@@ -6452,6 +6485,46 @@ pub(crate) enum PagingTaken {
     /// the real total, respectively.
     DeclineSparseEstimate,
     DeclineSparseExact,
+
+    // ── printing_range_fastpath ─────────────────────────────────────────────
+    // Every exit of the range fastpath, for the same reason the compose ones exist: before these,
+    // a declining `PrintingRangeScan` reached `explain_analyze` with a non-empty `declined_ns` and
+    // a `NotEntered` label, i.e. "it cost something and we cannot say what for". Unlike compose
+    // there is nothing to check them AGAINST -- `PlanFeatures` carries no range-strategy prediction
+    // -- so these size the declines rather than falsify a prediction.
+    /// Ordered by the range field itself (a price predicate under a `usd` orderby), so the index IS
+    /// the sort permutation and the page is windowed straight out of it. One of the fastpath's two
+    /// success exits.
+    RangeAligned,
+    /// The general case: walked the card sort permutation, emitting per-card-contiguous runs. The
+    /// other success exit.
+    RangeWalk,
+    /// No bare range bounds — not a range predicate, or no index for its field. A TRIPWIRE, not an
+    /// expected outcome: `PhysicalPlan::PrintingRangeScan.applicable` already requires
+    /// `bare_range_bounds(..).is_some()`, so a plan `explain` ranked can only reach this if those
+    /// two structural tests have drifted apart.
+    RangeNotBare,
+    /// `range_too_broad_to_narrow` said no: the range is selective enough that the ordinary
+    /// narrowing beats the walk. The expected decline in production, and the cheapest — two binary
+    /// searches and a ratio.
+    RangeSelective,
+    /// A `usd` orderby whose predicate is not a price leaf, so the index is not the sort
+    /// permutation and there is no aligned mapping to window. Distinct from `RangeNoPermutation`
+    /// because the orderby DOES have an aligned representation in general — this query just cannot
+    /// use it — and a harness reading one label for both could not tell a missing permutation from
+    /// a mismatched one.
+    RangeUnalignedPrice,
+    /// `k <= STREAM_MIN_MATCHES`. The range analogue of `DeclineSparseExact`, and exact for the
+    /// same reason: `k` is the index's own count, not an estimate. Cheap either way — this gates
+    /// before the walk, where compose's namesake gates after a full compose.
+    RangeSparse,
+    /// No sort permutation for this (column, direction) pair, so there is nothing to walk.
+    RangeNoPermutation,
+    /// A permutation exists but its length disagrees with the corpus. Its own label rather than
+    /// folded into `RangeNoPermutation` because the two mean different things: that one is a query
+    /// the fastpath does not serve, this one is an index built against a different store. It should
+    /// never fire, and a non-zero count in the decline table is the finding.
+    RangePermutationStale,
 }
 
 /// Which acquire branch produced a query's cost features — the `count_source` `explain` reports.
@@ -6524,6 +6597,14 @@ impl PagingTaken {
             PagingTaken::DeclineBroad => "DeclineBroad",
             PagingTaken::DeclineSparseEstimate => "DeclineSparseEstimate",
             PagingTaken::DeclineSparseExact => "DeclineSparseExact",
+            PagingTaken::RangeAligned => "RangeAligned",
+            PagingTaken::RangeWalk => "RangeWalk",
+            PagingTaken::RangeNotBare => "RangeNotBare",
+            PagingTaken::RangeSelective => "RangeSelective",
+            PagingTaken::RangeUnalignedPrice => "RangeUnalignedPrice",
+            PagingTaken::RangeSparse => "RangeSparse",
+            PagingTaken::RangeNoPermutation => "RangeNoPermutation",
+            PagingTaken::RangePermutationStale => "RangePermutationStale",
         }
     }
 }
@@ -7281,7 +7362,9 @@ pub(crate) struct PlanTrial {
     /// `StreamedSelect` (`run_query_streamed`, which publishes from all three of its return paths).
     /// The four fast paths — `PrintingRangeScan`, `PrintingCompose`, `PlanePopcountOrder`,
     /// `CardRangePopcount` — are NOT instrumented and report zeros, except `paging_taken`, which
-    /// `printing_compose_fastpath` sets on its own.
+    /// the two printing-space fastpaths set on their own. `PlanePopcountOrder` and
+    /// `CardRangePopcount` write nothing at all and are the only plans for which a `NotEntered`
+    /// label is expected on a successful run.
     ///
     /// A consumer must not read all-zero counters as "this plan did no work": `explain_analyze`
     /// fills `ns_round_total` for every round it records, so `ns_round_total > 0 && ns_loop == 0` is
@@ -7293,10 +7376,12 @@ pub(crate) struct PlanTrial {
     /// - `declined_ns` non-empty — the plan entered and declined. Everything here is zero EXCEPT
     ///   `paging_taken`, which names the gate that fired. That is the whole point of recording
     ///   stats for a plan that produced nothing: without it a declining `PrintingCompose` is
-    ///   indistinguishable from one that was never tried, and the four decline labels
-    ///   (`NotComposable`, `DeclineBroad`, `DeclineSparseEstimate`, `DeclineSparseExact`) would be
-    ///   reachable only from Rust. The counters and phase timings stay zero because no executor
-    ///   ran — a decline is a gate, not a loop.
+    ///   indistinguishable from one that was never tried, and the decline labels — compose's
+    ///   `NotComposable`/`DeclineBroad`/`DeclineSparseEstimate`/`DeclineSparseExact` and the range
+    ///   fastpath's `RangeSelective`/`RangeSparse`/`RangeUnalignedPrice`/`RangeNoPermutation` (plus
+    ///   the two tripwires `RangeNotBare`/`RangePermutationStale`) — would be reachable only from
+    ///   Rust. The counters and phase timings stay zero because no executor ran — a decline is a
+    ///   gate, not a loop.
     pub(crate) phases: PhaseStats,
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5762,7 +5762,7 @@ impl PhysicalPlan {
 struct PreparedCandidates {
     candidate_cards: Option<Vec<u32>>,
     all_match_known: bool,
-    /// `Candidates::repr_label` of what the narrowing returned, before this struct flattened
+    /// `Candidates::repr` of what the narrowing returned, before this struct flattened
     /// it to `candidate_cards`. Diagnostic only (`explain`) — nothing in execution reads it,
     /// and it exists because a candidate *count* in some band does not imply the query paid
     /// a sort to get there: a plane AND'd with a range reaches the same count word-wise.
@@ -6406,6 +6406,11 @@ pub(crate) struct PhaseStats {
     ///
     /// The prediction is 3-way and this is 10-way, so they are not compared blindly — see
     /// `PagingTaken` for what each variant licenses.
+    ///
+    /// Reported here but NOT stored here: the live value lives in the `PAGING_TAKEN` thread-local
+    /// and `take_phase_stats` merges it in. It is the one field written by something other than an
+    /// executor, so sharing a slot with the counters meant every publisher had to remember not to
+    /// clobber it — see `PAGING_TAKEN`.
     pub(crate) paging_taken: PagingTaken,
 }
 
@@ -6423,7 +6428,7 @@ pub(crate) enum PagingTaken {
     /// `run_query_with_plan` rejected before calling it. A compose that DID enter and declined
     /// always names the gate instead, so this never means "declined".
     ///
-    /// `#[default]` so a zeroed `PhaseStats` reads as "nothing recorded", which is what
+    /// `#[default]` so a cleared `PAGING_TAKEN` reads as "nothing recorded", which is what
     /// `take_phase_stats` leaves behind and what an uninstrumented plan reports.
     #[default]
     NotEntered,
@@ -6529,22 +6534,45 @@ thread_local! {
     /// `explain_analyze` is the only caller that establishes it.
     ///
     /// Nothing clears this on the production path, deliberately: a `Cell` write per query to reset
-    /// state no production reader consults would be cost for nobody. The consequence is that a live
-    /// worker thread carries whatever its last query left here indefinitely, and because both
-    /// publishers use `..c.get()` to preserve `paging_taken` across a partial write, a stale label
-    /// from an unrelated earlier query is inherited rather than overwritten.
+    /// state no production reader consults would be cost for nobody. So a reader added outside
+    /// `explain_analyze` gets an arbitrary earlier query's numbers, not zeros and not the current
+    /// query's. Take first, then run, then read.
     ///
-    /// So a reader added outside `explain_analyze` gets an arbitrary earlier query's numbers, not
-    /// zeros and not the current query's. Take first, then run, then read.
+    /// Every publisher writes this slot WHOLE. That is what keeps the staleness above bounded to
+    /// "the last query on this thread" instead of compounding: an earlier draft had the publishers
+    /// write 8 of 10 fields and inherit the rest through `..c.get()`, which silently widened "this
+    /// run" to "this thread, ever" and was measured leaking a compose-only `paging_taken` into
+    /// `GatheredScan` on 49 of 600 queries. The two fields that made `..c.get()` necessary are now
+    /// owned elsewhere: `paging_taken` by `PAGING_TAKEN` below, `ns_round_total`/`result_total` by
+    /// `explain_analyze`, which fills them after the take.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
         cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
         ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
     }) };
-}
 
-thread_local! {
+    /// The compose fastpath's branch label, stored apart from `PHASE_STATS` because it is the one
+    /// field written by something that is not an executor, and on a path that runs in production.
+    ///
+    /// Two things fall out of the split, both of which the shared slot got wrong:
+    /// - a materializing publish can no longer wipe it, so the routed path's "compose declines,
+    ///   records its gate, falls through to a materializing plan" sequence is preserved by
+    ///   construction rather than by every publisher remembering to write `..c.get()`;
+    /// - `note_paging_taken` is a one-byte store instead of a read-modify-write of the whole
+    ///   ~80-byte `PhaseStats`, which matters because it is on the production compose path.
+    ///
+    /// `take_phase_stats` reassembles the two into one `PhaseStats`, so consumers see no seam.
+    static PAGING_TAKEN: std::cell::Cell<PagingTaken> = const { std::cell::Cell::new(PagingTaken::NotEntered) };
+
     /// `prepare_candidates`' time for the run in progress, handed to the executor that follows it —
     /// the two are separate calls in `run_query_with_plan`, and only the executor publishes stats.
+    ///
+    /// Unlike the two slots above this one is never cleared by `take_phase_stats`, because it is
+    /// not a stat: it is a value in flight between two calls, and the receiving executor consumes
+    /// it with `replace(0)`. That handoff is what keeps it from leaking, and it is an invariant
+    /// spanning three functions rather than anything the type system enforces — every
+    /// `timed_prepare_candidates` must be followed by an executor that publishes. The
+    /// `debug_assert` below pins it, because the failure is silent: an unconsumed value is read by
+    /// the NEXT participant and reported as its `ns_prepare`, which looks entirely plausible.
     static PENDING_PREPARE_NS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
@@ -6556,6 +6584,13 @@ fn timed_prepare_candidates(
     filter: &mut FilterExpr,
     plane: Option<&PlaneExpr>,
 ) -> PreparedCandidates {
+    // Nothing may be in flight here: the previous timed prepare's executor must already have
+    // consumed it. See PENDING_PREPARE_NS for why an unconsumed value is worse than a missing one.
+    debug_assert_eq!(
+        PENDING_PREPARE_NS.with(std::cell::Cell::get),
+        0,
+        "a previous timed_prepare_candidates was not consumed by an executor; its time would be reported as this run's",
+    );
     let t = std::time::Instant::now();
     let prep = prepare_candidates(ctx, params, filter, plane);
     PENDING_PREPARE_NS.with(|c| c.set(t.elapsed().as_nanos() as u64));
@@ -6565,18 +6600,19 @@ fn timed_prepare_candidates(
 /// Record which paging branch the compose fastpath took. Reporting only -- see
 /// `PhaseStats::paging_taken` for why the predicted branch is not enough.
 fn note_paging_taken(which: PagingTaken) {
-    PHASE_STATS.with(|c| {
-        let mut st = c.get();
-        st.paging_taken = which;
-        c.set(st);
-    });
+    PAGING_TAKEN.with(|c| c.set(which));
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a
 /// timed run, having cleared beforehand — see `PHASE_STATS` for why that order is the contract and
 /// why an unpaired read does NOT see zeros.
+///
+/// Both slots are taken together, so a caller cannot clear one and leave the other to leak into the
+/// next participant — which is the whole failure `plan_stats_never_leak_between_participants` pins.
 fn take_phase_stats() -> PhaseStats {
-    PHASE_STATS.with(|c| c.replace(PhaseStats::default()))
+    let mut stats = PHASE_STATS.with(|c| c.replace(PhaseStats::default()));
+    stats.paging_taken = PAGING_TAKEN.with(|c| c.replace(PagingTaken::NotEntered));
+    stats
 }
 
 /// P4 executor: the universal gathered per-card loop + `select_page`. Runs any
@@ -6649,6 +6685,9 @@ fn exec_gathered_scan<'a>(
     let t_end = std::time::Instant::now();
     let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
     PHASE_STATS.with(|c| {
+        // A WHOLE-struct set, deliberately: nothing here is inherited, so this executor cannot
+        // report a field an earlier query wrote. The compose fastpath's `paging_taken` survives
+        // regardless — it lives in `PAGING_TAKEN`, which this does not touch.
         c.set(PhaseStats {
             cards_visited: n_cards_visited,
             printings_scanned: n_printings_scanned,
@@ -6658,9 +6697,8 @@ fn exec_gathered_scan<'a>(
             ns_finish: (t_end - t_finish).as_nanos() as u64,
             ns_round_total: 0, // filled by explain_analyze, which owns the round timer
             ns_prepare: prep_ns,
-            // Keep whatever this run already recorded (e.g. the paging branch the fastpath took):
-            // a whole-struct set here would silently wipe it.
-            ..c.get()
+            result_total: 0,   // likewise: explain_analyze fills it from the value actually returned
+            paging_taken: PagingTaken::NotEntered, // owned by PAGING_TAKEN; take_phase_stats merges it in
         });
     });
     (total, page)
@@ -6928,9 +6966,11 @@ fn run_query_routed<'a>(
         // prepare_candidates yields for a True-residual plane query.
         (p, Prep::Plane) => exec_from_candidates(
             p, ctx, params, filter,
-            // `narrowed_repr` is diagnostic-only and this path is not reached via `explain`'s
-            // acquire (which reports `Prep::Plane` as "none"); the plane bitmap is the source.
-            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, narrowed_repr: NarrowedRepr::CardBits },
+            // `None`, matching what `Prep::narrowed_repr` reports for a plane acquire: the field
+            // means "what the residual NARROWING produced", and no narrowing ran here — the list
+            // came from the plane bitmap. Diagnostic-only and unread on this path, but `CardBits`
+            // here would be the one value that contradicts `explain`'s contract if it ever were.
+            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, narrowed_repr: NarrowedRepr::None },
             plane,
         ),
         (p, Prep::Candidates(prep)) => exec_from_candidates(p, ctx, params, filter, prep, plane),
@@ -7072,7 +7112,7 @@ pub(crate) struct AcquireFacts {
     /// `"candidates"` materializes a candidate list at all, so it is the first thing
     /// to check before treating a query as a test case for materialization work.
     pub(crate) count_source: CountSource,
-    /// `Candidates::repr_label` of what the narrowing produced — `cards`/`printings` mean a
+    /// `Candidates::repr` of what the narrowing produced — `cards`/`printings` mean a
     /// sorted vec was built (some site ran a `collect` + `sort_unstable`), `card_bits`/
     /// `printing_bits` mean it stayed word-wise. `none` means the residual narrowing produced
     /// nothing: either no candidate list at all (`range`/`plane` acquire), or a candidate
@@ -7081,7 +7121,7 @@ pub(crate) struct AcquireFacts {
     /// Needed because a candidate *count* in a given band does not imply a sort was paid to
     /// reach it: a plane AND'd with a range lands at the same count without sorting anything.
     ///
-    /// A top-of-narrowing proxy, not a per-site census — see `Candidates::repr_label`.
+    /// A top-of-narrowing proxy, not a per-site census — see `Candidates::repr`.
     pub(crate) narrowed_repr: NarrowedRepr,
     /// Raw per-sample wall time of the acquire step — narrowing and any
     /// materialization included. Not pre-reduced, same rationale as
@@ -7285,6 +7325,16 @@ const PARTICIPANT_SHUFFLE_SEED: u64 = 745_002;
 /// The shuffle is seeded from a fixed constant, so ordering stays reproducible for the same query
 /// while still decorrelating which participant follows which.
 ///
+/// What the shuffle gives up, and why `num_trials` has to carry it: rotation was *position-balanced*
+/// — over `n` rounds every participant occupied every slot exactly once — and an independent
+/// per-round shuffle is not. At `num_trials = 3` a participant can draw the warm tail of the round
+/// twice by chance, and since every consumer reduces `trials_ns` with `min`, that lower sample is
+/// the one that survives. The trade is still right, because the bias it removes was directional and
+/// unequal across acquire classes while this one is zero-mean and shrinks with rounds — but it
+/// shrinks only with rounds. Prefer enough trials for positions to average out
+/// (`scripts/bench_cost_model_agreement.py` uses 7); do not read a 2-3 trial run as a fair
+/// head-to-head between plans whose times are within ~10% of each other.
+///
 /// `trials_ns` is a fair head-to-head *between plans*, not a reproduction of a real
 /// query's wall time: each `run_query_with_plan` call re-runs its own
 /// `prepare_candidates`, whereas `run_query_routed` acquires the shared artifact
@@ -7316,9 +7366,10 @@ fn explain_analyze(
     let mut rng = rand::rngs::SmallRng::seed_from_u64(PARTICIPANT_SHUFFLE_SEED);
     let mut order: Vec<Participant> =
         (0..n).map(Participant::Plan).chain([Participant::Acquire, Participant::Routed]).collect();
-    // Every participant clears PHASE_STATS after itself, so this is only about the very first one:
-    // with `num_warmups == 0` it would otherwise publish over whatever an earlier query on this
-    // thread left behind (the publishers preserve unwritten fields via `..c.get()`).
+    // Every participant clears both stat slots after itself, so this is only about the very first
+    // one: with `num_warmups == 0` an uninstrumented plan would otherwise report whatever an
+    // earlier query on this thread left in `PAGING_TAKEN`, which nothing on the production path
+    // resets.
     take_phase_stats();
     for round in 0..(num_warmups + num_trials) {
         order.shuffle(&mut rng);
@@ -7626,7 +7677,8 @@ fn run_query_streamed<'a>(
                 ns_finish: (end - t_finish).as_nanos() as u64,
                 ns_round_total: 0,
                 ns_prepare: prep_ns,
-                ..c.get() // see the note at the other publisher
+                result_total: 0,                       // see the note at the other publisher
+                paging_taken: PagingTaken::NotEntered, // ditto: owned by PAGING_TAKEN
             });
         });
     };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2646,8 +2646,6 @@ impl Candidates {
         }
     }
 
-    /// The set as a bitmap over an n-element domain (scatters vec variants;
-    /// space is unchanged — callers pass the domain size of the set's space).
     /// Which representation the narrowing produced, for `explain` to report. A vec-shaped
     /// result means some site built a sorted vec — a `collect` + `sort_unstable` ran. A
     /// bits-shaped one means the narrowing stayed word-wise and never sorted.
@@ -2666,6 +2664,8 @@ impl Candidates {
         }
     }
 
+    /// The set as a bitmap over an n-element domain (scatters vec variants;
+    /// space is unchanged — callers pass the domain size of the set's space).
     fn into_bits(self, n: usize) -> Vec<u64> {
         match self {
             Candidates::Cards(v) | Candidates::Printings(v) => scatter_bits(v, n),
@@ -6329,9 +6329,6 @@ fn exec_streamed_select<'a>(
     run_query_streamed(ctx, params, filter, prep.all_match_known, perm, prep.card_ids(ctx), existential_plane)
 }
 
-/// P4 executor: the universal gathered per-card loop + `select_page`. Runs any
-/// query (printing-keyed orderbys, stores without permutations, or anything the
-/// other plans decline). Caller has run `prepare_candidates`.
 /// Per-query execution counters and coarse phase timings, for checking the cost model against what
 /// the executors actually do rather than against a fitted curve.
 ///
@@ -6419,6 +6416,9 @@ fn take_phase_stats() -> PhaseStats {
     PHASE_STATS.with(|c| c.replace(PhaseStats::default()))
 }
 
+/// P4 executor: the universal gathered per-card loop + `select_page`. Runs any
+/// query (printing-keyed orderbys, stores without permutations, or anything the
+/// other plans decline). Caller has run `prepare_candidates`.
 fn exec_gathered_scan<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
@@ -6874,6 +6874,12 @@ pub(crate) struct PlanEstimate {
     /// reported but deliberately NOT added to `predicted_ns`. `0.0` for plans that build no
     /// candidate list. See `cost.rs`'s "Candidate materialization" section for why it stays out
     /// of the routing decision.
+    /// Modelled `collect` + `sort_unstable` cost for this plan's candidate list.
+    ///
+    /// Charged on `eval_domain`, which is the candidate count only under a `Candidates` acquire.
+    /// Under `Prep::Range` the two materializing plans are estimated UNNARROWED
+    /// (`eval_domain = n_cards`), so this figure has no referent there -- do not pool range-acquired
+    /// rows with candidate-acquired ones when reading it.
     pub(crate) materialize_ns: f64,
     /// Whether this is the plan `run_query_routed` would run: the cheapest `predicted_ns`, which
     /// after the ascending sort is index 0. Reported explicitly so a caller never has to
@@ -6912,13 +6918,6 @@ pub(crate) struct AcquireFacts {
     ///
     /// A top-of-narrowing proxy, not a per-site census — see `Candidates::repr_label`.
     pub(crate) narrowed_repr: &'static str,
-    /// Candidate cards the walk would iterate (`PlanFeatures::eval_domain`). For a
-    /// `"candidates"` query this IS the materialized candidate count; compare it
-    /// against `n_cards` — equal means nothing narrowed.
-    pub(crate) eval_domain: u32,
-    pub(crate) n_cards: u32,
-    /// Result cardinality in the plan's operating space.
-    pub(crate) matches: u32,
     /// Raw per-sample wall time of the acquire step — narrowing and any
     /// materialization included. Not pre-reduced, same rationale as
     /// `PlanTrial::trials_ns`. `explain` reports a single sample; `explain_analyze`
@@ -6982,10 +6981,7 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
     let facts = AcquireFacts {
         count_source: prep.count_source(),
         narrowed_repr: prep.narrowed_repr(),
-        eval_domain: feats.eval_domain,
-        n_cards: feats.n_cards,
-        matches: feats.matches,
-        feats: feats.clone(),
+        feats, // moved: `eval_domain`/`n_cards`/`matches` live here and nowhere else
         acquire_ns: vec![acquire_ns],
         routed_ns: Vec::new(), // explain runs nothing
     };
@@ -6994,8 +6990,8 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
         .filter(|p| p.applicable(ctx, params, filter, plane))
         .map(|plan| PlanEstimate {
             plan,
-            predicted_ns: cost::plan_cost(plan, &feats),
-            materialize_ns: cost::materialize_cost(plan, &feats),
+            predicted_ns: cost::plan_cost(plan, &facts.feats),
+            materialize_ns: cost::materialize_cost(plan, &facts.feats),
             picked: false, // set below, once the ranking is known
         })
         .collect();
@@ -7097,6 +7093,12 @@ fn explain_analyze(
         let routed = run_query_routed(ctx, params, &mut routed_filter, plane);
         let routed_dt = t_routed.elapsed().as_nanos() as u64;
         drop(routed);
+        // The routed run dispatches into the same executors the plan loop below times, so it
+        // publishes into PHASE_STATS too. Clear it here or the first plan examined this round --
+        // `idx = round % n`, which is NOT the picked plan once `round > 0` -- reads the routed run's
+        // counters as its own whenever it publishes nothing itself. Measured before this line: 49 of
+        // 600 queries had GatheredScan reporting a `paging_taken` only the compose fastpath sets.
+        take_phase_stats();
         if round >= num_warmups {
             facts.acquire_ns.push(acq_dt);
             facts.routed_ns.push(routed_dt);
@@ -7316,7 +7318,6 @@ fn run_query_streamed<'a>(
     let t_match = std::time::Instant::now();
     for cid in card_ids {
         n_cards_visited += 1;
-        n_printings_scanned += (u32::from(offsets[cid as usize + 1]) - u32::from(offsets[cid as usize])) as u64;
         let card = &cards[cid as usize];
         // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True
         // when the narrowing already proved every candidate matches. Gated
@@ -7336,6 +7337,12 @@ fn run_query_streamed<'a>(
             };
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
+        // Counted HERE, below the `card_pass` continue above, because a card rejected there never has
+        // its printings touched. Counting at the top of the loop instead included them, so this plan
+        // and GatheredScan reported different `printings_scanned` for identical work whenever the
+        // narrowing was inexact -- and `scan_units` has one definition, so at most one could be the
+        // valid comparison.
+        n_printings_scanned += (end - start) as u64;
         // Every printing matches: card/printing counts are O(1) inside the
         // helper, and the artwork group count is a build-time constant.
         let c = if all_match && matches!(mode, Mode::Artwork) && have_group_counts {
@@ -7737,14 +7744,14 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
     let d = PyDict::new(py);
     d.set_item("count_source", f.count_source)?;
     d.set_item("narrowed_repr", f.narrowed_repr)?;
-    d.set_item("eval_domain", f.eval_domain)?;
-    d.set_item("n_cards", f.n_cards)?;
-    d.set_item("matches", f.matches)?;
     d.set_item("acquire_ns", f.acquire_ns.clone())?;
     d.set_item("routed_ns", f.routed_ns.clone())?;
     // The model's own inputs, so a calibration fit regresses on the same vector `plan_cost` reads.
     let g = &f.feats;
     for (k, v) in [
+        ("eval_domain", g.eval_domain),
+        ("n_cards", g.n_cards),
+        ("matches", g.matches),
         ("n_printings", g.n_printings),
         ("scan_units", g.scan_units),
         ("residual_tier_ns100", g.residual_tier_ns100),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6852,6 +6852,10 @@ pub(crate) struct PlanEstimate {
 /// leaves every `predicted_ns` untouched. That divergence is the point: it isolates
 /// the one term the cost model does not carry.
 pub(crate) struct AcquireFacts {
+    /// The full feature vector `cost::plan_cost` consumed for this query. Reported so a calibration
+    /// sweep can regress measured time on *exactly* the terms the model uses; fitting against
+    /// re-derived proxies instead means a feature error hides as a coefficient that will not settle.
+    pub(crate) feats: cost::PlanFeatures,
     /// Which of `Prep`'s three count sources this query's structure selected. Only
     /// `"candidates"` materializes a candidate list at all, so it is the first thing
     /// to check before treating a query as a test case for materialization work.
@@ -6940,6 +6944,7 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
         eval_domain: feats.eval_domain,
         n_cards: feats.n_cards,
         matches: feats.matches,
+        feats: feats.clone(),
         acquire_ns: vec![acquire_ns],
         routed_ns: Vec::new(), // explain runs nothing
     };
@@ -7690,6 +7695,22 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
     d.set_item("matches", f.matches)?;
     d.set_item("acquire_ns", f.acquire_ns.clone())?;
     d.set_item("routed_ns", f.routed_ns.clone())?;
+    // The model's own inputs, so a calibration fit regresses on the same vector `plan_cost` reads.
+    let g = &f.feats;
+    for (k, v) in [
+        ("n_printings", g.n_printings),
+        ("scan_units", g.scan_units),
+        ("residual_tier_ns100", g.residual_tier_ns100),
+        ("limit", g.limit),
+        ("offset", g.offset),
+        ("broadcast_printings", g.broadcast_printings),
+        ("scatter_printings", g.scatter_printings),
+        ("project_printings", g.project_printings),
+        ("popcount_words", g.popcount_words),
+    ] {
+        d.set_item(k, v)?;
+    }
+    d.set_item("compose_paging", format!("{:?}", g.compose_paging))?;
     Ok(d)
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7243,6 +7243,26 @@ pub(crate) struct PlanTrial {
     pub(crate) materialize_ns: f64,
     pub(crate) picked: bool,
     pub(crate) trials_ns: Vec<u64>,
+    /// Raw per-round wall time of the rounds where this plan ENTERED and then declined, producing
+    /// no page. Mutually exclusive with `trials_ns` in practice — a decline is deterministic for a
+    /// given query and store — so exactly one of the two is non-empty for a plan that participated.
+    ///
+    /// Separate from `trials_ns` rather than folded into it because the two answer different
+    /// questions and every consumer reduces `trials_ns` with `min` as "what this plan costs to run".
+    /// A decline is not a run: it produced nothing, and averaging it in would make a plan that bails
+    /// early look fast.
+    ///
+    /// Only the two printing-space fast paths can land here. `PhysicalPlan::applicable` is at least
+    /// as strong as the guard `run_query_with_plan` re-checks, so a plan `explain` ranked never
+    /// fails that guard — `None` from it is always a runtime decline, never a missed applicability
+    /// test. The other four either always produce a page or are not in the list.
+    ///
+    /// This is the cost of the decline itself, and it is not free: `PagingTaken::DeclineSparseExact`
+    /// fires AFTER `printing_compose_fastpath` has composed the printing bitmap, so those rounds pay
+    /// a full compose and throw it away before the general path runs the query again. The three
+    /// other declines gate before the compose and are cheap. `phases.paging_taken` is what tells the
+    /// two apart, which is why it is recorded for a declining plan even though nothing else is.
+    pub(crate) declined_ns: Vec<u64>,
     /// Execution counters and coarse phase timings from this plan's FASTEST recorded round — the
     /// same round `min(trials_ns)` names, so a phase share read against that total describes one
     /// execution rather than two. See `PhaseStats`: the counters check whether the cost arm's
@@ -7264,9 +7284,19 @@ pub(crate) struct PlanTrial {
     /// `printing_compose_fastpath` sets on its own.
     ///
     /// A consumer must not read all-zero counters as "this plan did no work": `explain_analyze`
-    /// always fills `ns_round_total`, so `ns_round_total > 0 && ns_loop == 0` is the uninstrumented
-    /// case, and only `ns_round_total == 0` means the plan never ran at all (which `trials_ns`
-    /// already says, being empty).
+    /// fills `ns_round_total` for every round it records, so `ns_round_total > 0 && ns_loop == 0` is
+    /// the uninstrumented case, and `ns_round_total == 0` means the plan completed no round.
+    ///
+    /// `ns_round_total == 0` has two sub-cases, and `declined_ns` is what separates them:
+    ///
+    /// - `declined_ns` empty — the plan never produced a page and never entered a fastpath either.
+    /// - `declined_ns` non-empty — the plan entered and declined. Everything here is zero EXCEPT
+    ///   `paging_taken`, which names the gate that fired. That is the whole point of recording
+    ///   stats for a plan that produced nothing: without it a declining `PrintingCompose` is
+    ///   indistinguishable from one that was never tried, and the four decline labels
+    ///   (`NotComposable`, `DeclineBroad`, `DeclineSparseEstimate`, `DeclineSparseExact`) would be
+    ///   reachable only from Rust. The counters and phase timings stay zero because no executor
+    ///   ran — a decline is a gate, not a loop.
     pub(crate) phases: PhaseStats,
 }
 
@@ -7362,6 +7392,10 @@ fn explain_analyze(
 
     let n = estimates.len();
     let mut trials_ns: Vec<Vec<u64>> = vec![Vec::with_capacity(num_trials); n];
+    // Rounds where a plan entered and declined instead of producing a page. Kept apart from
+    // `trials_ns` so `min(trials_ns)` never mixes "what running costs" with "what bailing costs" —
+    // see `PlanTrial::declined_ns`.
+    let mut declined_ns: Vec<Vec<u64>> = vec![Vec::new(); n];
     let mut phases: Vec<PhaseStats> = vec![PhaseStats::default(); n];
     let mut rng = rand::rngs::SmallRng::seed_from_u64(PARTICIPANT_SHUFFLE_SEED);
     let mut order: Vec<Participant> =
@@ -7417,6 +7451,14 @@ fn explain_analyze(
                             phases[i] = stats;
                         }
                         trials_ns[i].push(dt);
+                    } else {
+                        // Entered and declined. Nothing executed, so the counters and phase timings
+                        // stay at their default zeros — but the GATE is a real observation, and it
+                        // is the only place the four decline labels are visible from outside Rust.
+                        // Assigned rather than merged: everything else in `stats` is already zero
+                        // here, and leaving `ns_round_total` at 0 keeps "completed no round" true.
+                        phases[i].paging_taken = stats.paging_taken;
+                        declined_ns[i].push(dt);
                     }
                 }
             }
@@ -7427,13 +7469,15 @@ fn explain_analyze(
         estimates
         .into_iter()
         .zip(trials_ns)
+        .zip(declined_ns)
         .zip(phases)
-        .map(|((e, trials_ns), phases)| PlanTrial {
+        .map(|(((e, trials_ns), declined_ns), phases)| PlanTrial {
             plan: e.plan,
             predicted_ns: e.predicted_ns,
             materialize_ns: e.materialize_ns,
             picked: e.picked,
             trials_ns,
+            declined_ns,
             phases,
         })
         .collect();
@@ -8030,6 +8074,10 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     d.set_item("materialize_ns", t.materialize_ns)?;
     d.set_item("picked", t.picked)?;
     d.set_item("trials_ns", t.trials_ns.clone())?;
+    // Non-empty only for a plan that entered a fastpath and declined; `paging_taken` below names
+    // the gate. See `PlanTrial::declined_ns` — a decline is not a cheap run, and
+    // `DeclineSparseExact` in particular pays a full compose first.
+    d.set_item("declined_ns", t.declined_ns.clone())?;
     d.set_item("cards_visited", t.phases.cards_visited)?;
     d.set_item("printings_scanned", t.phases.printings_scanned)?;
     d.set_item("matches_pushed", t.phases.matches_pushed)?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2655,12 +2655,12 @@ impl Candidates {
     /// happen, and a bits-shaped arm can be extracted into a vec by `and_all`. Exact
     /// per-site accounting needs the shared materialization helper that
     /// docs/issues/local-engine-candidate-materialize.md proposes.
-    fn repr_label(&self) -> &'static str {
+    fn repr(&self) -> NarrowedRepr {
         match self {
-            Candidates::Cards(_) => "cards",
-            Candidates::Printings(_) => "printings",
-            Candidates::CardBits(_) => "card_bits",
-            Candidates::PrintingBits(_) => "printing_bits",
+            Candidates::Cards(_) => NarrowedRepr::Cards,
+            Candidates::Printings(_) => NarrowedRepr::Printings,
+            Candidates::CardBits(_) => NarrowedRepr::CardBits,
+            Candidates::PrintingBits(_) => NarrowedRepr::PrintingBits,
         }
     }
 
@@ -5522,7 +5522,7 @@ fn printing_compose_fastpath<'a>(
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, sort_col, descending, limit, page_offset, .. } = *params;
     if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
-        note_paging_taken("NotComposable");
+        note_paging_taken(PagingTaken::NotComposable);
         return None;
     }
     let perm = indexes.sort_perms.get(sort_col, descending).filter(|p| p.len() == cards.len());
@@ -5565,7 +5565,7 @@ fn printing_compose_fastpath<'a>(
             domain as f64 * (-(printing_matches as f64) / domain as f64).exp().mul_add(-1.0, 1.0)
         };
         if est > domain as f64 * *COMPOSE_GATHER_MAX_CARD_FRACTION {
-            note_paging_taken("DeclineBroad");
+            note_paging_taken(PagingTaken::DeclineBroad);
             return None;
         }
         // Small-total decline (mirrors the `Perm` branch's `total <= STREAM_MIN_MATCHES` below): in the
@@ -5579,7 +5579,7 @@ fn printing_compose_fastpath<'a>(
         // sparse `type:angel`/`type:goblin` card/usd (newly composable) from regressing onto this path:
         // the collection compose leaves are a printing-mode orderby-walk win, not a card-mode gather win.
         if (estimator::estimate_cardinality(filter, indexes, offsets).hi as usize) <= *STREAM_MIN_MATCHES {
-            note_paging_taken("DeclineSparseEstimate");
+            note_paging_taken(PagingTaken::DeclineSparseEstimate);
             return None;
         }
     }
@@ -5600,7 +5600,7 @@ fn printing_compose_fastpath<'a>(
         }
     };
     if total == 0 || page_offset >= total {
-        note_paging_taken("EmptyPage");
+        note_paging_taken(PagingTaken::EmptyPage);
         return Some((total, Vec::new()));
     }
     let page = match perm {
@@ -5609,10 +5609,10 @@ fn printing_compose_fastpath<'a>(
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
                 // one fires pre-compose off the estimator's upper bound, this one post-compose off
                 // the real total. A harness reading one label for both cannot tell which fired.
-                note_paging_taken("DeclineSparseExact");
+                note_paging_taken(PagingTaken::DeclineSparseExact);
                 return None; // sparse: the general path gathers + globally sorts, ordering ties differently
             }
-            note_paging_taken("Perm");
+            note_paging_taken(PagingTaken::Perm);
             walk_grouped_page(ctx, params, &pbits, perm)
         }
         // No permutation. #744: if the orderby has a printing-space value structure (usd/rarity,
@@ -5637,11 +5637,17 @@ fn printing_compose_fastpath<'a>(
             };
             match walked {
                 Some(rows) => {
-                    note_paging_taken("OrderbyWalk");
+                    note_paging_taken(PagingTaken::OrderbyWalk);
                     rows
                 }
                 None => {
-                    note_paging_taken("Gather");
+                    // Two different situations reach this gather, and `compose_paging` predicts
+                    // them differently, so they cannot share a label. `walk_col` false means no
+                    // walk was ever available and `Gather` was predicted — agreement. `walk_col`
+                    // true means a walk was available, was attempted, and declined (null-value
+                    // tail, or a page past the value structure), so `OrderbyWalk` was predicted
+                    // and this gather is the documented fallback — NOT a mispredicted branch.
+                    note_paging_taken(if walk_col { PagingTaken::GatherWalkDeclined } else { PagingTaken::Gather });
                     gather_composed_page(ctx, params, &pbits)
                 }
             }
@@ -5760,7 +5766,7 @@ struct PreparedCandidates {
     /// it to `candidate_cards`. Diagnostic only (`explain`) — nothing in execution reads it,
     /// and it exists because a candidate *count* in some band does not imply the query paid
     /// a sort to get there: a plane AND'd with a range reaches the same count word-wise.
-    narrowed_repr: &'static str,
+    narrowed_repr: NarrowedRepr,
 }
 
 impl PreparedCandidates {
@@ -5790,7 +5796,7 @@ enum Prep {
     /// Nothing is materialized — the fast paths walk; a materializing winner materializes for
     /// itself in dispatch. `Plane` carries no bitmap here because `run_query_routed` owns it
     /// locally (`plane_bits: Vec<u64>`), passed by reference into dispatch.
-    Range(&'static str),
+    Range(CountSource),
     /// True-residual plane (card): the exact match bitmap, owned by
     /// `run_query_routed`'s local `plane_bits` and passed by reference.
     /// `PlanePopcountOrder` reads it directly; P3/P4 read it as a candidate list.
@@ -5939,7 +5945,7 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     let (raw_candidates, residual_exact): (Option<Candidates>, bool) =
         narrow_candidates_exact(filter, indexes, offsets, cards);
     // Captured before the flattening below consumes it — see PreparedCandidates::narrowed_repr.
-    let narrowed_repr = raw_candidates.as_ref().map_or("none", Candidates::repr_label);
+    let narrowed_repr = raw_candidates.as_ref().map_or(NarrowedRepr::None, Candidates::repr);
     // A present plane is always exact (that's what compile_plane guarantees),
     // so the whole original query is exact iff the residual is too — either
     // because split_planes consumed all of it (bare True) or narrow_rec
@@ -6388,22 +6394,133 @@ pub(crate) struct PhaseStats {
     /// can assert, which `compose_paging_prediction_matches_the_branch_taken` now does (and
     /// `scripts/bench_cost_model_agreement.py` observes over the real corpus).
     ///
-    /// The prediction is 3-way and this is 7-way, so they are not compared blindly. Every exit from
-    /// the fastpath records itself, which is what lets `""` mean exactly one thing:
-    /// - `Perm` / `OrderbyWalk` / `Gather` — a strategy ran, and it must be the predicted one. These
-    ///   are the only labels comparable against `compose_paging`.
-    /// - `EmptyPage` — the composed total was 0 or the offset was past it, so the fastpath returned
-    ///   before any strategy ran. The prediction is simply not exercised.
-    /// - `NotComposable` — the structural check failed (not a composable expr, or the compose
-    ///   indexes are not built).
-    /// - `DeclineBroad` — the `COMPOSE_GATHER_MAX_CARD_FRACTION` breadth gate.
-    /// - `DeclineSparseEstimate` / `DeclineSparseExact` — the two sparse declines, pre-compose off
-    ///   the estimator's upper bound and post-compose off the real total respectively.
+    /// The two *availability* tests are identical by construction (`walk_col` against the
+    /// prediction's `matches!(mode, Mode::Printing) && orderby_walk_available(sort_col)`), so they
+    /// cannot disagree. What the prediction cannot see is one step further on: acquire never
+    /// composes, so it cannot know whether the walk it predicts will SUCCEED. The walk returns an
+    /// `Option` and declines at run time on the null-value tail or a page past the value structure,
+    /// falling into the gather. `compose_paging` is therefore an **upper bound** on `OrderbyWalk`,
+    /// exact in every other cell -- one-directional by construction, not drift between two
+    /// implementations. `GatherWalkDeclined` exists so that case is self-identifying rather than
+    /// arriving as a bare `Gather` indistinguishable from a genuine misprediction.
     ///
-    /// `""` therefore means the fastpath was never entered at all — every other plan, and a compose
-    /// plan that `run_query_with_plan` rejected before calling it. A declined compose always says
-    /// which gate declined it.
-    pub(crate) paging_taken: &'static str,
+    /// The prediction is 3-way and this is 10-way, so they are not compared blindly — see
+    /// `PagingTaken` for what each variant licenses.
+    pub(crate) paging_taken: PagingTaken,
+}
+
+/// Which exit `printing_compose_fastpath` took, against the 3-way `ComposePaging` the cost model
+/// predicted. Every exit records itself, which is what lets `NotEntered` mean exactly one thing.
+///
+/// An enum rather than a `&'static str` because the valid set is load-bearing in four places — the
+/// fastpath's record sites, `compose_paging_prediction_matches_the_branch_taken`'s legal-label
+/// tables, `scripts/bench_cost_model_agreement.py`'s strategy constants, and this doc. As strings
+/// those four drift silently; as variants the compiler settles three of them and a typo stops
+/// being expressible.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(crate) enum PagingTaken {
+    /// The fastpath was never entered at all — every other plan, and a compose plan that
+    /// `run_query_with_plan` rejected before calling it. A compose that DID enter and declined
+    /// always names the gate instead, so this never means "declined".
+    ///
+    /// `#[default]` so a zeroed `PhaseStats` reads as "nothing recorded", which is what
+    /// `take_phase_stats` leaves behind and what an uninstrumented plan reports.
+    #[default]
+    NotEntered,
+    /// A strategy ran, and it must be the predicted one. These three are the only variants
+    /// comparable against `compose_paging` as an equality.
+    Perm,
+    OrderbyWalk,
+    Gather,
+    /// A walk WAS available and was attempted, declined, and fell back to the gather. Legal under a
+    /// predicted `OrderbyWalk` and only under one; a bare `Gather` in that cell would mean the
+    /// availability tests really had drifted.
+    GatherWalkDeclined,
+    /// The composed total was 0 or the offset was past it, so the fastpath returned before any
+    /// strategy ran. The prediction is simply not exercised.
+    EmptyPage,
+    /// The structural check failed (not a composable expr, or the compose indexes are not built).
+    NotComposable,
+    /// The `COMPOSE_GATHER_MAX_CARD_FRACTION` breadth gate.
+    DeclineBroad,
+    /// The two sparse declines: pre-compose off the estimator's upper bound, and post-compose off
+    /// the real total, respectively.
+    DeclineSparseEstimate,
+    DeclineSparseExact,
+}
+
+/// Which acquire branch produced a query's cost features — the `count_source` `explain` reports.
+/// An enum for the same reason as `PagingTaken`: the three `Prep::Range` payloads are not
+/// interchangeable (reporting "range" for a compose once sent an investigation down a wrong path),
+/// and as strings nothing stopped a fourth from being invented at a call site.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum CountSource {
+    CardRangePopcount,
+    PrintingRangeScan,
+    PrintingCompose,
+    Plane,
+    Candidates,
+}
+
+impl CountSource {
+    /// Byte-identical to the strings this reported before it became an enum. Snake case, unlike
+    /// `PagingTaken`'s PascalCase — which is exactly why these are spelled out rather than derived
+    /// from `Debug`: the two label sets have different conventions and both are a wire format.
+    fn label(self) -> &'static str {
+        match self {
+            CountSource::CardRangePopcount => "card_range_popcount",
+            CountSource::PrintingRangeScan => "printing_range_scan",
+            CountSource::PrintingCompose => "printing_compose",
+            CountSource::Plane => "plane",
+            CountSource::Candidates => "candidates",
+        }
+    }
+}
+
+/// What the residual narrowing produced, before `PreparedCandidates` flattened it to
+/// `candidate_cards`. `Cards`/`Printings` mean a sorted vec was built (some site ran a `collect` +
+/// `sort_unstable`); the `Bits` pair mean it stayed word-wise and never sorted; `None` means the
+/// narrowing produced nothing at all.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum NarrowedRepr {
+    None,
+    Cards,
+    Printings,
+    CardBits,
+    PrintingBits,
+}
+
+impl NarrowedRepr {
+    /// Byte-identical to the strings this reported before it became an enum.
+    fn label(self) -> &'static str {
+        match self {
+            NarrowedRepr::None => "none",
+            NarrowedRepr::Cards => "cards",
+            NarrowedRepr::Printings => "printings",
+            NarrowedRepr::CardBits => "card_bits",
+            NarrowedRepr::PrintingBits => "printing_bits",
+        }
+    }
+}
+
+impl PagingTaken {
+    /// The string `explain_analyze` reports under `"paging_taken"`. Byte-identical to the labels
+    /// this reported before it became an enum, so the Python surface did not move — `NotEntered`
+    /// is still the empty string a consumer tests for.
+    fn label(self) -> &'static str {
+        match self {
+            PagingTaken::NotEntered => "",
+            PagingTaken::Perm => "Perm",
+            PagingTaken::OrderbyWalk => "OrderbyWalk",
+            PagingTaken::Gather => "Gather",
+            PagingTaken::GatherWalkDeclined => "GatherWalkDeclined",
+            PagingTaken::EmptyPage => "EmptyPage",
+            PagingTaken::NotComposable => "NotComposable",
+            PagingTaken::DeclineBroad => "DeclineBroad",
+            PagingTaken::DeclineSparseEstimate => "DeclineSparseEstimate",
+            PagingTaken::DeclineSparseExact => "DeclineSparseExact",
+        }
+    }
 }
 
 thread_local! {
@@ -6421,7 +6538,7 @@ thread_local! {
     /// zeros and not the current query's. Take first, then run, then read.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
         cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
-        ns_prepare: 0, result_total: 0, paging_taken: "",
+        ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
     }) };
 }
 
@@ -6447,7 +6564,7 @@ fn timed_prepare_candidates(
 
 /// Record which paging branch the compose fastpath took. Reporting only -- see
 /// `PhaseStats::paging_taken` for why the predicted branch is not enough.
-fn note_paging_taken(which: &'static str) {
+fn note_paging_taken(which: PagingTaken) {
     PHASE_STATS.with(|c| {
         let mut st = c.get();
         st.paging_taken = which;
@@ -6698,7 +6815,7 @@ fn acquire_plan_features(
         // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
         feats.scatter_printings = k;
         feats.project_printings = k;
-        (feats, Prep::Range("card_range_popcount"))
+        (feats, Prep::Range(CountSource::CardRangePopcount))
     } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
@@ -6706,7 +6823,7 @@ fn acquire_plan_features(
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
-        (feats, Prep::Range("printing_range_scan"))
+        (feats, Prep::Range(CountSource::PrintingRangeScan))
     } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, plane) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
@@ -6746,7 +6863,7 @@ fn acquire_plan_features(
         } else {
             ComposePaging::Gather
         };
-        (feats, Prep::Range("printing_compose"))
+        (feats, Prep::Range(CountSource::PrintingCompose))
     } else {
         let prep = prepare_candidates(ctx, params, filter, plane);
         let feats = candidate_feats(ctx, params, &prep, filter);
@@ -6813,7 +6930,7 @@ fn run_query_routed<'a>(
             p, ctx, params, filter,
             // `narrowed_repr` is diagnostic-only and this path is not reached via `explain`'s
             // acquire (which reports `Prep::Plane` as "none"); the plane bitmap is the source.
-            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, narrowed_repr: "card_bits" },
+            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, narrowed_repr: NarrowedRepr::CardBits },
             plane,
         ),
         (p, Prep::Candidates(prep)) => exec_from_candidates(p, ctx, params, filter, prep, plane),
@@ -6954,7 +7071,7 @@ pub(crate) struct AcquireFacts {
     /// Which of `Prep`'s three count sources this query's structure selected. Only
     /// `"candidates"` materializes a candidate list at all, so it is the first thing
     /// to check before treating a query as a test case for materialization work.
-    pub(crate) count_source: &'static str,
+    pub(crate) count_source: CountSource,
     /// `Candidates::repr_label` of what the narrowing produced — `cards`/`printings` mean a
     /// sorted vec was built (some site ran a `collect` + `sort_unstable`), `card_bits`/
     /// `printing_bits` mean it stayed word-wise. `none` means the residual narrowing produced
@@ -6965,7 +7082,7 @@ pub(crate) struct AcquireFacts {
     /// reach it: a plane AND'd with a range lands at the same count without sorting anything.
     ///
     /// A top-of-narrowing proxy, not a per-site census — see `Candidates::repr_label`.
-    pub(crate) narrowed_repr: &'static str,
+    pub(crate) narrowed_repr: NarrowedRepr,
     /// Raw per-sample wall time of the acquire step — narrowing and any
     /// materialization included. Not pre-reduced, same rationale as
     /// `PlanTrial::trials_ns`. `explain` reports a single sample; `explain_analyze`
@@ -6977,6 +7094,19 @@ pub(crate) struct AcquireFacts {
     /// text-predicate query this OVERSTATES what a warm repeated query spends in
     /// acquire, by that one-time cost — it is a fair number to compare across
     /// queries, not an end-to-end latency component.
+    ///
+    /// Do NOT subtract this from a materializing plan's `trials_ns` to isolate that plan's
+    /// execution from the narrowing. `PhaseStats::ns_prepare` does that job properly: it times
+    /// `prepare_candidates` INSIDE the plan's own run, so `ns_round_total - ns_prepare` is two
+    /// numbers from one execution, with no cross-run cache-state assumption to be wrong about.
+    /// Subtraction here would also be measuring the wrong quantity — `acquire_plan_features` is
+    /// `prepare_candidates` PLUS cost-feature construction (`mk_plan_feats`,
+    /// `compose_printing_estimate`, `verify_cost_tier`), and on a range or compose acquire it skips
+    /// `prepare_candidates` entirely.
+    ///
+    /// What it is good for is the thing nothing else measures: the router's own pre-dispatch
+    /// overhead. `run_query_with_plan` forces a plan and never runs the argmin, so no `trials_ns`
+    /// contains any of it.
     pub(crate) acquire_ns: Vec<u64>,
     /// Raw per-round wall time of `run_query_routed` — the whole real path: acquire, choose,
     /// dispatch, *and* the lazy re-materialize-and-re-choose a `Prep::Range` query can do at
@@ -6986,27 +7116,34 @@ pub(crate) struct AcquireFacts {
     /// per-plan `trials_ns` come from `run_query_with_plan`, which forces a plan and therefore
     /// bypasses that re-choose; so "the picked plan is slower than the best plan" does not by
     /// itself mean the engine runs the slow one. Compare against this: routed ≈ best means the
-    /// re-choose rescued it, routed ≈ picked means it did not. Same discipline as `trials_ns`
-    /// (fresh clone per round, warmups discarded), so the three are directly comparable.
+    /// re-choose rescued it, routed ≈ picked means it did not.
+    ///
+    /// That comparison is inherently cross-execution — there is no in-run equivalent, because a
+    /// forced-plan run skips the argmin by construction — so it is the one row that genuinely needs
+    /// to be measured on the same terms as `trials_ns`, and it is: same pristine clone per round,
+    /// same warmup discard, and drawn from the same shuffled participant pool rather than pinned
+    /// ahead of the plan loop. That last part is load-bearing rather than tidiness: this dispatches
+    /// into the picked plan's executor, so a fixed position ahead of the plans would pre-warm
+    /// exactly the plan whose selection the comparison is meant to question.
     pub(crate) routed_ns: Vec<u64>,
 }
 
 impl Prep {
     /// The `count_source` label `AcquireFacts` reports.
-    fn count_source(&self) -> &'static str {
+    fn count_source(&self) -> CountSource {
         match self {
-            Prep::Range(acquire) => acquire,
-            Prep::Plane => "plane",
-            Prep::Candidates(_) => "candidates",
+            Prep::Range(acquire) => *acquire,
+            Prep::Plane => CountSource::Plane,
+            Prep::Candidates(_) => CountSource::Candidates,
         }
     }
 
     /// The `narrowed_repr` label `AcquireFacts` reports. `Range` and `Plane` materialize no
     /// candidate list at all, so they have no narrowing representation to report.
-    fn narrowed_repr(&self) -> &'static str {
+    fn narrowed_repr(&self) -> NarrowedRepr {
         match self {
             Prep::Candidates(p) => p.narrowed_repr,
-            Prep::Range(_) | Prep::Plane => "none",
+            Prep::Range(_) | Prep::Plane => NarrowedRepr::None,
         }
     }
 }
@@ -7066,9 +7203,14 @@ pub(crate) struct PlanTrial {
     pub(crate) materialize_ns: f64,
     pub(crate) picked: bool,
     pub(crate) trials_ns: Vec<u64>,
-    /// Execution counters and coarse phase timings from the last recorded run of this plan. See
-    /// `PhaseStats`: the counters check whether the cost arm's FEATURES match what the loop did, and
-    /// the phase timings check whether its TERMS account for the whole executor.
+    /// Execution counters and coarse phase timings from this plan's FASTEST recorded round — the
+    /// same round `min(trials_ns)` names, so a phase share read against that total describes one
+    /// execution rather than two. See `PhaseStats`: the counters check whether the cost arm's
+    /// FEATURES match what the loop did, and the phase timings check whether its TERMS account for
+    /// the whole executor.
+    ///
+    /// (The counters are round-invariant — the same query visits the same cards every time — so
+    /// only the timings depend on which round is kept.)
     ///
     /// The three phases are contiguous and disjoint, so `ns_setup + ns_loop + ns_finish` can only
     /// be <= `ns_round_total`. The shortfall is real unmodelled work — `run_query_with_plan`'s own
@@ -7087,6 +7229,22 @@ pub(crate) struct PlanTrial {
     /// already says, being empty).
     pub(crate) phases: PhaseStats,
 }
+
+/// One timed unit inside an `explain_analyze` round. The acquire step and the routed path are
+/// participants rather than fixed preludes so the round's shuffle covers them too — see
+/// `explain_analyze`'s doc for why a pinned position biases the plans they pre-warm.
+#[derive(Clone, Copy)]
+enum Participant {
+    /// Index into `estimates` / `trials_ns` / `phases`.
+    Plan(usize),
+    Acquire,
+    Routed,
+}
+
+/// Fixed so a given query shuffles identically on every run. An A/B against another build has to
+/// compare the same execution order or the ordering drift swamps what is being measured — the same
+/// reason `bench_candidate_materialize` seeds its own generator rather than sampling entropy.
+const PARTICIPANT_SHUFFLE_SEED: u64 = 745_002;
 
 /// #745 primitive 2: actually run every applicable plan via `run_query_with_plan`,
 /// `num_warmups` discarded rounds then `num_trials` recorded rounds, returning the
@@ -7108,9 +7266,24 @@ pub(crate) struct PlanTrial {
 /// `plan_cost_model_matches_gold` already use (tests.rs), just via `Clone` instead
 /// of re-deriving from a `FuzzSpec`, since a real caller only has the bound tree.
 ///
-/// Rotates which plan runs first/last each round (`(i + round) % n`) rather than a
-/// fixed order, so no plan systematically benefits from whatever accumulates
-/// round-over-round (allocator state, cache residency).
+/// Each round runs `n + 2` participants in a freshly shuffled order: every applicable plan, plus
+/// the acquire step and the routed path. Shuffled rather than cyclically rotated, because a
+/// rotation only moves the cut point — the cyclic adjacency is fixed, so every participant keeps
+/// the same immediate predecessor round after round, and rotation balances only which one goes
+/// first.
+///
+/// That distinction matters here because two participants warm work the others then reuse, and each
+/// warms a *subset* of the plans it is meant to be compared against:
+/// - `run_query_routed` dispatches into the picked plan's executor, so pinning it ahead of the plan
+///   loop pre-warms exactly the plan whose selection `PlanTrial::picked` exists to question.
+/// - on a candidate acquire, `acquire_plan_features` calls the very `prepare_candidates` that
+///   `StreamedSelect` and `GatheredScan` are about to call, and that the four fast paths never do.
+///   (On a range or compose acquire it takes the cheap estimate branch and does not, so the bias is
+///   present for one acquire class and absent for another — it does not even wash out as a constant
+///   offset across a table keyed by acquire branch.)
+///
+/// The shuffle is seeded from a fixed constant, so ordering stays reproducible for the same query
+/// while still decorrelating which participant follows which.
 ///
 /// `trials_ns` is a fair head-to-head *between plans*, not a reproduction of a real
 /// query's wall time: each `run_query_with_plan` call re-runs its own
@@ -7125,64 +7298,76 @@ fn explain_analyze(
     num_warmups: usize,
     num_trials: usize,
 ) -> (AcquireFacts, Vec<PlanTrial>) {
+    use rand::SeedableRng as _;
+    use rand::seq::SliceRandom as _;
+
     // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
     // the timing loop below starts from `filter`'s untouched, pristine state.
     let (mut facts, estimates) = explain(ctx, params, &mut filter.clone(), plane);
     // explain()'s single sample was taken outside the loop below, so it sits in a
     // different cache/allocator state than the plan trials it would be compared
-    // against. Discard it and re-sample in-loop, one per round, on the same fresh
-    // clones and the same rotation the plans get.
+    // against. Discard it and re-sample in-loop, one per round, from the same fresh
+    // clones and the same shuffled position pool the plans draw from.
     facts.acquire_ns.clear();
 
     let n = estimates.len();
     let mut trials_ns: Vec<Vec<u64>> = vec![Vec::with_capacity(num_trials); n];
     let mut phases: Vec<PhaseStats> = vec![PhaseStats::default(); n];
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(PARTICIPANT_SHUFFLE_SEED);
+    let mut order: Vec<Participant> =
+        (0..n).map(Participant::Plan).chain([Participant::Acquire, Participant::Routed]).collect();
+    // Every participant clears PHASE_STATS after itself, so this is only about the very first one:
+    // with `num_warmups == 0` it would otherwise publish over whatever an earlier query on this
+    // thread left behind (the publishers preserve unwritten fields via `..c.get()`).
+    take_phase_stats();
     for round in 0..(num_warmups + num_trials) {
-        // The acquire step alone, on the same pristine-clone discipline as the plan
-        // trials. Subtracting this from a materializing plan's `trials_ns` isolates
-        // that plan's execution from the narrowing they both pay — the one term
-        // `predicted_ns` omits. Not identical to what `run_query_with_plan` pays
-        // internally (`acquire_plan_features` also builds cost features around its
-        // `prepare_candidates` call), so treat it as a close proxy, not an exact split.
-        let mut acquire_filter = filter.clone();
-        let t_acq = std::time::Instant::now();
-        let acquired = acquire_plan_features(ctx, params, &mut acquire_filter, plane);
-        let acq_dt = t_acq.elapsed().as_nanos() as u64;
-        drop(acquired);
-        // The real routed path, including the dispatch-time re-choose that `run_query_with_plan`
-        // cannot exercise. See AcquireFacts::routed_ns for why this row is the load-bearing one.
-        let mut routed_filter = filter.clone();
-        let t_routed = std::time::Instant::now();
-        let routed = run_query_routed(ctx, params, &mut routed_filter, plane);
-        let routed_dt = t_routed.elapsed().as_nanos() as u64;
-        drop(routed);
-        // The routed run dispatches into the same executors the plan loop below times, so it
-        // publishes into PHASE_STATS too. Clear it here or the first plan examined this round --
-        // `idx = round % n`, which is NOT the picked plan once `round > 0` -- reads the routed run's
-        // counters as its own whenever it publishes nothing itself. Measured before this line: 49 of
-        // 600 queries had GatheredScan reporting a `paging_taken` only the compose fastpath sets.
-        take_phase_stats();
-        if round >= num_warmups {
-            facts.acquire_ns.push(acq_dt);
-            facts.routed_ns.push(routed_dt);
-        }
-        for i in 0..n {
-            let idx = (i + round) % n;
-            let plan = estimates[idx].plan;
+        order.shuffle(&mut rng);
+        for &participant in &order {
             let mut round_filter = filter.clone();
+            // Bound rather than consumed, so the clock read below excludes every participant's own
+            // deallocation — otherwise the plans, which hold their result, would be measured on
+            // different terms from the two that discard it.
+            let (mut ran, mut acquired, mut routed) = (None, None, None);
             let t0 = std::time::Instant::now();
-            let ran = run_query_with_plan(plan, ctx, params, &mut round_filter, plane);
+            match participant {
+                Participant::Plan(i) => ran = run_query_with_plan(estimates[i].plan, ctx, params, &mut round_filter, plane),
+                Participant::Acquire => acquired = Some(acquire_plan_features(ctx, params, &mut round_filter, plane)),
+                Participant::Routed => routed = Some(run_query_routed(ctx, params, &mut round_filter, plane)),
+            }
             let dt = t0.elapsed().as_nanos() as u64;
-            // Read immediately: the next plan's run overwrites the thread-local.
+            drop((acquired, routed));
+            // Uniform, and read immediately: the next participant's run overwrites the thread-local.
+            // Routed and the plans dispatch into the same executors, so a participant that publishes
+            // nothing would otherwise read its predecessor's counters as its own. That is what the
+            // routed path needed a special-case clear for while it sat outside this loop — measured
+            // then: 49 of 600 queries had GatheredScan reporting a `paging_taken` only the compose
+            // fastpath sets.
             let mut stats = take_phase_stats();
-            stats.ns_round_total = dt;
-            stats.result_total = ran.as_ref().map_or(0, |(total, _)| *total as u64);
-            // A structurally-applicable plan's fastpath can still decline at runtime
-            // (e.g. PrintingCompose on a sparse total) — deterministic for this
-            // query/data, so a decliner simply never accumulates trials.
-            if ran.is_some() && round >= num_warmups {
-                trials_ns[idx].push(dt);
-                phases[idx] = stats;
+            if round < num_warmups {
+                continue;
+            }
+            match participant {
+                Participant::Acquire => facts.acquire_ns.push(dt),
+                Participant::Routed => facts.routed_ns.push(dt),
+                // A structurally-applicable plan's fastpath can still decline at runtime
+                // (e.g. PrintingCompose on a sparse total) — deterministic for this
+                // query/data, so a decliner simply never accumulates trials.
+                Participant::Plan(i) => {
+                    if let Some((total, _)) = &ran {
+                        stats.ns_round_total = dt;
+                        stats.result_total = *total as u64;
+                        // Keep the FASTEST recorded round's phases, not the last one's. Every
+                        // consumer reduces `trials_ns` with `min`, so carrying the last round's
+                        // split means the phase breakdown describes a different (and by
+                        // construction slower, often contended) execution than the total it gets
+                        // read next to. Cheaper than it looks: `ns_round_total` travels inside
+                        // `stats`, so the two always agree about which round they came from.
+                        if trials_ns[i].iter().all(|&prev| dt < prev) {
+                            phases[i] = stats;
+                        }
+                        trials_ns[i].push(dt);
+                    }
+                }
             }
         }
     }
@@ -7804,7 +7989,7 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     // Ground truth for this run, and which paging branch really ran. Both exist so a harness can
     // check the model against what happened rather than against a second, separate execution.
     d.set_item("result_total", t.phases.result_total)?;
-    d.set_item("paging_taken", t.phases.paging_taken)?;
+    d.set_item("paging_taken", t.phases.paging_taken.label())?;
     Ok(d)
 }
 
@@ -7812,8 +7997,8 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
 /// them under the `"acquire"` key.
 fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new(py);
-    d.set_item("count_source", f.count_source)?;
-    d.set_item("narrowed_repr", f.narrowed_repr)?;
+    d.set_item("count_source", f.count_source.label())?;
+    d.set_item("narrowed_repr", f.narrowed_repr.label())?;
     d.set_item("acquire_ns", f.acquire_ns.clone())?;
     d.set_item("routed_ns", f.routed_ns.clone())?;
     // The model's own inputs, so a calibration fit regresses on the same vector `plan_cost` reads.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2648,6 +2648,24 @@ impl Candidates {
 
     /// The set as a bitmap over an n-element domain (scatters vec variants;
     /// space is unchanged — callers pass the domain size of the set's space).
+    /// Which representation the narrowing produced, for `explain` to report. A vec-shaped
+    /// result means some site built a sorted vec — a `collect` + `sort_unstable` ran. A
+    /// bits-shaped one means the narrowing stayed word-wise and never sorted.
+    ///
+    /// Read at the *top* of the narrowing, so it is a proxy rather than a census of sort
+    /// events: `or_all` can scatter a vec-shaped arm into bits, hiding a sort that did
+    /// happen, and a bits-shaped arm can be extracted into a vec by `and_all`. Exact
+    /// per-site accounting needs the shared materialization helper that
+    /// docs/issues/local-engine-candidate-materialize.md proposes.
+    fn repr_label(&self) -> &'static str {
+        match self {
+            Candidates::Cards(_) => "cards",
+            Candidates::Printings(_) => "printings",
+            Candidates::CardBits(_) => "card_bits",
+            Candidates::PrintingBits(_) => "printing_bits",
+        }
+    }
+
     fn into_bits(self, n: usize) -> Vec<u64> {
         match self {
             Candidates::Cards(v) | Candidates::Printings(v) => scatter_bits(v, n),
@@ -5720,6 +5738,11 @@ impl PhysicalPlan {
 struct PreparedCandidates {
     candidate_cards: Option<Vec<u32>>,
     all_match_known: bool,
+    /// `Candidates::repr_label` of what the narrowing returned, before this struct flattened
+    /// it to `candidate_cards`. Diagnostic only (`explain`) — nothing in execution reads it,
+    /// and it exists because a candidate *count* in some band does not imply the query paid
+    /// a sort to get there: a plane AND'd with a range reaches the same count word-wise.
+    narrowed_repr: &'static str,
 }
 
 impl PreparedCandidates {
@@ -5739,12 +5762,17 @@ impl PreparedCandidates {
 /// any) the chosen executor reuses. One of three "count sources", picked by query
 /// structure — this is the engine's whole materialization story in one enum.
 enum Prep {
-    /// Bare printing range: features come from the range index's exact `k` (a
-    /// binary search, no scan). Nothing is materialized — `PrintingRangeScan`
-    /// walks; a materializing winner materializes for itself in dispatch. `Plane`
-    /// carries no bitmap here because `run_query_routed` owns it locally
-    /// (`plane_bits: Vec<u64>`), passed by reference into dispatch.
-    Range,
+    /// "Cheap estimate acquired, nothing materialized." Despite the name this is **not**
+    /// range-index-specific: it is shared by `CardRangePopcount` (#725), `PrintingRangeScan`
+    /// (#695) and `PrintingCompose` (#724), and a plane-composable printing-space query like
+    /// `type:merfolk` at `unique=printing` lands here via compose with no range in sight. The
+    /// payload names which acquire actually ran, so `explain` can report it instead of the
+    /// variant name — reporting "range" for a compose sent one investigation down a wrong path.
+    ///
+    /// Nothing is materialized — the fast paths walk; a materializing winner materializes for
+    /// itself in dispatch. `Plane` carries no bitmap here because `run_query_routed` owns it
+    /// locally (`plane_bits: Vec<u64>`), passed by reference into dispatch.
+    Range(&'static str),
     /// True-residual plane (card): the exact match bitmap, owned by
     /// `run_query_routed`'s local `plane_bits` and passed by reference.
     /// `PlanePopcountOrder` reads it directly; P3/P4 read it as a candidate list.
@@ -5892,6 +5920,8 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // directly instead of paying to materialize one of them first.
     let (raw_candidates, residual_exact): (Option<Candidates>, bool) =
         narrow_candidates_exact(filter, indexes, offsets, cards);
+    // Captured before the flattening below consumes it — see PreparedCandidates::narrowed_repr.
+    let narrowed_repr = raw_candidates.as_ref().map_or("none", Candidates::repr_label);
     // A present plane is always exact (that's what compile_plane guarantees),
     // so the whole original query is exact iff the residual is too — either
     // because split_planes consumed all of it (bare True) or narrow_rec
@@ -5978,7 +6008,7 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
         }
     }
 
-    PreparedCandidates { candidate_cards, all_match_known }
+    PreparedCandidates { candidate_cards, all_match_known, narrowed_repr }
 }
 
 // ─── Plan executors ─────────────────────────────────────────────────────────
@@ -6495,7 +6525,7 @@ fn acquire_plan_features(
         // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
         feats.scatter_printings = k;
         feats.project_printings = k;
-        (feats, Prep::Range)
+        (feats, Prep::Range("card_range_popcount"))
     } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
         // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
@@ -6503,7 +6533,7 @@ fn acquire_plan_features(
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
-        (feats, Prep::Range)
+        (feats, Prep::Range("printing_range_scan"))
     } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, plane) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
@@ -6543,7 +6573,7 @@ fn acquire_plan_features(
         } else {
             ComposePaging::Gather
         };
-        (feats, Prep::Range)
+        (feats, Prep::Range("printing_compose"))
     } else {
         let prep = prepare_candidates(ctx, params, filter, plane);
         let feats = candidate_feats(ctx, params, &prep, filter);
@@ -6608,7 +6638,9 @@ fn run_query_routed<'a>(
         // prepare_candidates yields for a True-residual plane query.
         (p, Prep::Plane) => exec_from_candidates(
             p, ctx, params, filter,
-            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true },
+            // `narrowed_repr` is diagnostic-only and this path is not reached via `explain`'s
+            // acquire (which reports `Prep::Plane` as "none"); the plane bitmap is the source.
+            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, narrowed_repr: "card_bits" },
             plane,
         ),
         (p, Prep::Candidates(prep)) => exec_from_candidates(p, ctx, params, filter, prep, plane),
@@ -6618,13 +6650,13 @@ fn run_query_routed<'a>(
         //   - CardRangePopcount builds its card bitmap from the (re-derived, ~free) range bounds now.
         //   - the printing-space fast paths walk (or, if they decline — sparse total — materialize).
         //   - a materializing plan (StreamedSelect/GatheredScan) that beat them narrows + runs.
-        (PhysicalPlan::CardRangePopcount, Prep::Range) => {
+        (PhysicalPlan::CardRangePopcount, Prep::Range(_)) => {
             let (idx, lo, hi) = bare_range_bounds(filter, ctx.indexes).expect("applicable ⇒ bare range");
             let (card_bits, range_pbits) =
                 build_card_range_bits(idx, lo, hi, ctx.indexes, ctx.cards.len(), ctx.printings.len());
             exec_card_range_popcount(ctx, params, &card_bits, &range_pbits)
         }
-        (plan, Prep::Range) => {
+        (plan, Prep::Range(_)) => {
             let fast_page = match plan {
                 PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
                 PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
@@ -6714,6 +6746,94 @@ fn run_query_with_plan<'a>(
 pub(crate) struct PlanEstimate {
     pub(crate) plan: PhysicalPlan,
     pub(crate) predicted_ns: f64,
+    /// `cost::materialize_cost` for this plan — the candidate-production term `plan_cost` omits,
+    /// reported but deliberately NOT added to `predicted_ns`. `0.0` for plans that build no
+    /// candidate list. See `cost.rs`'s "Candidate materialization" section for why it stays out
+    /// of the routing decision.
+    pub(crate) materialize_ns: f64,
+    /// Whether this is the plan `run_query_routed` would run: the cheapest `predicted_ns`, which
+    /// after the ascending sort is index 0. Reported explicitly so a caller never has to
+    /// reconstruct the argmin — doing that over only the plans that *ran* (dropping runtime
+    /// decliners) silently diverges from what the router picks.
+    ///
+    /// One documented exception it cannot capture: for a `Prep::Range` acquire the router may
+    /// re-materialize and re-choose at dispatch, so the executed plan can still differ. See the
+    /// free `explain` fn's doc.
+    pub(crate) picked: bool,
+}
+
+/// What the acquire step itself did, which is per-QUERY rather than per-plan: every
+/// plan in the same `explain` call shares one of these. `plan_cost` prices only what
+/// happens *after* acquire — `eval_domain` and `matches` are its inputs, not its
+/// outputs — so a change to how candidates get materialized moves `acquire_ns` and
+/// leaves every `predicted_ns` untouched. That divergence is the point: it isolates
+/// the one term the cost model does not carry.
+pub(crate) struct AcquireFacts {
+    /// Which of `Prep`'s three count sources this query's structure selected. Only
+    /// `"candidates"` materializes a candidate list at all, so it is the first thing
+    /// to check before treating a query as a test case for materialization work.
+    pub(crate) count_source: &'static str,
+    /// `Candidates::repr_label` of what the narrowing produced — `cards`/`printings` mean a
+    /// sorted vec was built (some site ran a `collect` + `sort_unstable`), `card_bits`/
+    /// `printing_bits` mean it stayed word-wise. `none` means the residual narrowing produced
+    /// nothing: either no candidate list at all (`range`/`plane` acquire), or a candidate
+    /// acquire whose list came from the plane bitmap alone. Both are "no sort happened".
+    ///
+    /// Needed because a candidate *count* in a given band does not imply a sort was paid to
+    /// reach it: a plane AND'd with a range lands at the same count without sorting anything.
+    ///
+    /// A top-of-narrowing proxy, not a per-site census — see `Candidates::repr_label`.
+    pub(crate) narrowed_repr: &'static str,
+    /// Candidate cards the walk would iterate (`PlanFeatures::eval_domain`). For a
+    /// `"candidates"` query this IS the materialized candidate count; compare it
+    /// against `n_cards` — equal means nothing narrowed.
+    pub(crate) eval_domain: u32,
+    pub(crate) n_cards: u32,
+    /// Result cardinality in the plan's operating space.
+    pub(crate) matches: u32,
+    /// Raw per-sample wall time of the acquire step — narrowing and any
+    /// materialization included. Not pre-reduced, same rationale as
+    /// `PlanTrial::trials_ns`. `explain` reports a single sample; `explain_analyze`
+    /// reports one per round.
+    ///
+    /// Every sample deliberately pays the one-time `memoize_text_predicates`
+    /// rewrite, because each is taken from a pristine filter clone (see
+    /// `explain_analyze`'s doc for why that fairness discipline matters). So for a
+    /// text-predicate query this OVERSTATES what a warm repeated query spends in
+    /// acquire, by that one-time cost — it is a fair number to compare across
+    /// queries, not an end-to-end latency component.
+    pub(crate) acquire_ns: Vec<u64>,
+    /// Raw per-round wall time of `run_query_routed` — the whole real path: acquire, choose,
+    /// dispatch, *and* the lazy re-materialize-and-re-choose a `Prep::Range` query can do at
+    /// dispatch. Empty from `explain`, which runs nothing.
+    ///
+    /// This is the row that decides whether a ranking error is a live defect. `explain_analyze`'s
+    /// per-plan `trials_ns` come from `run_query_with_plan`, which forces a plan and therefore
+    /// bypasses that re-choose; so "the picked plan is slower than the best plan" does not by
+    /// itself mean the engine runs the slow one. Compare against this: routed ≈ best means the
+    /// re-choose rescued it, routed ≈ picked means it did not. Same discipline as `trials_ns`
+    /// (fresh clone per round, warmups discarded), so the three are directly comparable.
+    pub(crate) routed_ns: Vec<u64>,
+}
+
+impl Prep {
+    /// The `count_source` label `AcquireFacts` reports.
+    fn count_source(&self) -> &'static str {
+        match self {
+            Prep::Range(acquire) => acquire,
+            Prep::Plane => "plane",
+            Prep::Candidates(_) => "candidates",
+        }
+    }
+
+    /// The `narrowed_repr` label `AcquireFacts` reports. `Range` and `Plane` materialize no
+    /// candidate list at all, so they have no narrowing representation to report.
+    fn narrowed_repr(&self) -> &'static str {
+        match self {
+            Prep::Candidates(p) => p.narrowed_repr,
+            Prep::Range(_) | Prep::Plane => "none",
+        }
+    }
 }
 
 /// #745 primitive 1: every applicable plan's predicted cost for this query, ranked
@@ -6727,15 +6847,36 @@ pub(crate) struct PlanEstimate {
 /// dispatch would compute if that plan actually won and got lazily re-costed
 /// against a materialized candidate list (see `acquire_plan_features`'s
 /// `PrintingRangeScan`/`PrintingCompose` branches).
-fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane: Option<&PlaneExpr>) -> Vec<PlanEstimate> {
-    let (feats, _prep, _plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane: Option<&PlaneExpr>) -> (AcquireFacts, Vec<PlanEstimate>) {
+    let t0 = std::time::Instant::now();
+    let (feats, prep, _plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    let acquire_ns = t0.elapsed().as_nanos() as u64;
+    let facts = AcquireFacts {
+        count_source: prep.count_source(),
+        narrowed_repr: prep.narrowed_repr(),
+        eval_domain: feats.eval_domain,
+        n_cards: feats.n_cards,
+        matches: feats.matches,
+        acquire_ns: vec![acquire_ns],
+        routed_ns: Vec::new(), // explain runs nothing
+    };
     let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
         .into_iter()
         .filter(|p| p.applicable(ctx, params, filter, plane))
-        .map(|plan| PlanEstimate { plan, predicted_ns: cost::plan_cost(plan, &feats) })
+        .map(|plan| PlanEstimate {
+            plan,
+            predicted_ns: cost::plan_cost(plan, &feats),
+            materialize_ns: cost::materialize_cost(plan, &feats),
+            picked: false, // set below, once the ranking is known
+        })
         .collect();
     estimates.sort_by(|a, b| a.predicted_ns.partial_cmp(&b.predicted_ns).expect("plan_cost is finite"));
-    estimates
+    // The router's argmin is index 0 after the sort. Marked here rather than left for the caller
+    // to re-derive, which is where a caller filtering out runtime decliners gets it wrong.
+    if let Some(first) = estimates.first_mut() {
+        first.picked = true;
+    }
+    (facts, estimates)
 }
 
 /// One applicable plan's `explain_analyze` (#745) result: the same predicted cost
@@ -6746,6 +6887,11 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
 pub(crate) struct PlanTrial {
     pub(crate) plan: PhysicalPlan,
     pub(crate) predicted_ns: f64,
+    /// Both carried through from `PlanEstimate` unchanged — see its fields. `picked` in particular
+    /// is the router's choice, which is NOT necessarily the fastest `trials_ns`: that difference is
+    /// the whole point of docs/issues/local-engine-plan-misselection.md.
+    pub(crate) materialize_ns: f64,
+    pub(crate) picked: bool,
     pub(crate) trials_ns: Vec<u64>,
 }
 
@@ -6785,14 +6931,41 @@ fn explain_analyze(
     plane: Option<&PlaneExpr>,
     num_warmups: usize,
     num_trials: usize,
-) -> Vec<PlanTrial> {
+) -> (AcquireFacts, Vec<PlanTrial>) {
     // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
     // the timing loop below starts from `filter`'s untouched, pristine state.
-    let estimates = explain(ctx, params, &mut filter.clone(), plane);
+    let (mut facts, estimates) = explain(ctx, params, &mut filter.clone(), plane);
+    // explain()'s single sample was taken outside the loop below, so it sits in a
+    // different cache/allocator state than the plan trials it would be compared
+    // against. Discard it and re-sample in-loop, one per round, on the same fresh
+    // clones and the same rotation the plans get.
+    facts.acquire_ns.clear();
 
     let n = estimates.len();
     let mut trials_ns: Vec<Vec<u64>> = vec![Vec::with_capacity(num_trials); n];
     for round in 0..(num_warmups + num_trials) {
+        // The acquire step alone, on the same pristine-clone discipline as the plan
+        // trials. Subtracting this from a materializing plan's `trials_ns` isolates
+        // that plan's execution from the narrowing they both pay — the one term
+        // `predicted_ns` omits. Not identical to what `run_query_with_plan` pays
+        // internally (`acquire_plan_features` also builds cost features around its
+        // `prepare_candidates` call), so treat it as a close proxy, not an exact split.
+        let mut acquire_filter = filter.clone();
+        let t_acq = std::time::Instant::now();
+        let acquired = acquire_plan_features(ctx, params, &mut acquire_filter, plane);
+        let acq_dt = t_acq.elapsed().as_nanos() as u64;
+        drop(acquired);
+        // The real routed path, including the dispatch-time re-choose that `run_query_with_plan`
+        // cannot exercise. See AcquireFacts::routed_ns for why this row is the load-bearing one.
+        let mut routed_filter = filter.clone();
+        let t_routed = std::time::Instant::now();
+        let routed = run_query_routed(ctx, params, &mut routed_filter, plane);
+        let routed_dt = t_routed.elapsed().as_nanos() as u64;
+        drop(routed);
+        if round >= num_warmups {
+            facts.acquire_ns.push(acq_dt);
+            facts.routed_ns.push(routed_dt);
+        }
         for i in 0..n {
             let idx = (i + round) % n;
             let plan = estimates[idx].plan;
@@ -6809,7 +6982,19 @@ fn explain_analyze(
         }
     }
 
-    estimates.into_iter().zip(trials_ns).map(|(e, trials_ns)| PlanTrial { plan: e.plan, predicted_ns: e.predicted_ns, trials_ns }).collect()
+    let trials =
+        estimates
+        .into_iter()
+        .zip(trials_ns)
+        .map(|(e, trials_ns)| PlanTrial {
+            plan: e.plan,
+            predicted_ns: e.predicted_ns,
+            materialize_ns: e.materialize_ns,
+            picked: e.picked,
+            trials_ns,
+        })
+        .collect();
+    (facts, trials)
 }
 
 /// #634 Step 2: popcount-skip order phase. Scoped to `unique=card` queries
@@ -7349,6 +7534,8 @@ fn plan_estimate_to_pydict<'py>(py: Python<'py>, e: &PlanEstimate) -> PyResult<B
     let d = PyDict::new(py);
     d.set_item("plan", format!("{:?}", e.plan))?;
     d.set_item("predicted_ns", e.predicted_ns)?;
+    d.set_item("materialize_ns", e.materialize_ns)?;
+    d.set_item("picked", e.picked)?;
     Ok(d)
 }
 
@@ -7356,7 +7543,23 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     let d = PyDict::new(py);
     d.set_item("plan", format!("{:?}", t.plan))?;
     d.set_item("predicted_ns", t.predicted_ns)?;
+    d.set_item("materialize_ns", t.materialize_ns)?;
+    d.set_item("picked", t.picked)?;
     d.set_item("trials_ns", t.trials_ns.clone())?;
+    Ok(d)
+}
+
+/// The acquire step's per-query facts, as both `explain` and `explain_analyze` report
+/// them under the `"acquire"` key.
+fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item("count_source", f.count_source)?;
+    d.set_item("narrowed_repr", f.narrowed_repr)?;
+    d.set_item("eval_domain", f.eval_domain)?;
+    d.set_item("n_cards", f.n_cards)?;
+    d.set_item("matches", f.matches)?;
+    d.set_item("acquire_ns", f.acquire_ns.clone())?;
+    d.set_item("routed_ns", f.routed_ns.clone())?;
     Ok(d)
 }
 
@@ -7853,7 +8056,7 @@ impl QueryEngine {
         direction: &str,
         limit: usize,
         offset: usize,
-    ) -> PyResult<Bound<'py, PyList>> {
+    ) -> PyResult<Bound<'py, PyDict>> {
         let mmap = self.get_mmap()?;
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
@@ -7872,10 +8075,13 @@ impl QueryEngine {
         // more per-card work. `explain_analyze` does take `prefer` and really runs the
         // plans, so its `trials_ns` reflect it even though its `predicted_ns` doesn't.
         let params = QueryParams::from_strs(unique, "default", orderby, direction, limit, offset);
-        let estimates = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
+        let (facts, estimates) = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
-        PyList::new(py, rows)
+        let out = PyDict::new(py);
+        out.set_item("acquire", acquire_facts_to_pydict(py, &facts)?)?;
+        out.set_item("plans", PyList::new(py, rows)?)?;
+        Ok(out)
     }
 
     /// #745 primitive 2: run every applicable plan `num_warmups + num_trials`
@@ -7898,7 +8104,7 @@ impl QueryEngine {
         offset: usize,
         num_warmups: usize,
         num_trials: usize,
-    ) -> PyResult<Bound<'py, PyList>> {
+    ) -> PyResult<Bound<'py, PyDict>> {
         let mmap = self.get_mmap()?;
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
@@ -7910,10 +8116,13 @@ impl QueryEngine {
         // conversion below stay on the GIL.
         let ctx = QueryCtx::from(data);
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let trials = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
+        let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;
-        PyList::new(py, rows)
+        let out = PyDict::new(py);
+        out.set_item("acquire", acquire_facts_to_pydict(py, &facts)?)?;
+        out.set_item("plans", PyList::new(py, rows)?)?;
+        Ok(out)
     }
 
     fn size(&self) -> PyResult<usize> {
@@ -8047,3 +8256,5 @@ mod bench_word_dict_scan;
 mod bench_card_dedup;
 #[cfg(test)]
 mod bench_compose_paging;
+#[cfg(test)]
+mod bench_candidate_materialize;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5522,6 +5522,7 @@ fn printing_compose_fastpath<'a>(
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, sort_col, descending, limit, page_offset, .. } = *params;
     if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
+        note_paging_taken("NotComposable");
         return None;
     }
     let perm = indexes.sort_perms.get(sort_col, descending).filter(|p| p.len() == cards.len());
@@ -5564,6 +5565,7 @@ fn printing_compose_fastpath<'a>(
             domain as f64 * (-(printing_matches as f64) / domain as f64).exp().mul_add(-1.0, 1.0)
         };
         if est > domain as f64 * *COMPOSE_GATHER_MAX_CARD_FRACTION {
+            note_paging_taken("DeclineBroad");
             return None;
         }
         // Small-total decline (mirrors the `Perm` branch's `total <= STREAM_MIN_MATCHES` below): in the
@@ -5577,6 +5579,7 @@ fn printing_compose_fastpath<'a>(
         // sparse `type:angel`/`type:goblin` card/usd (newly composable) from regressing onto this path:
         // the collection compose leaves are a printing-mode orderby-walk win, not a card-mode gather win.
         if (estimator::estimate_cardinality(filter, indexes, offsets).hi as usize) <= *STREAM_MIN_MATCHES {
+            note_paging_taken("DeclineSparseEstimate");
             return None;
         }
     }
@@ -5603,7 +5606,10 @@ fn printing_compose_fastpath<'a>(
     let page = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
-                note_paging_taken("DeclineSparse");
+                // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
+                // one fires pre-compose off the estimator's upper bound, this one post-compose off
+                // the real total. A harness reading one label for both cannot tell which fired.
+                note_paging_taken("DeclineSparseExact");
                 return None; // sparse: the general path gathers + globally sorts, ordering ties differently
             }
             note_paging_taken("Perm");
@@ -6363,17 +6369,45 @@ pub(crate) struct PhaseStats {
     /// Which paging branch `printing_compose_fastpath` ACTUALLY took, against the `compose_paging`
     /// the cost model predicted it would.
     ///
-    /// `compose_paging_with_total` reimplements a decision the fastpath makes independently -- it
-    /// recomputes the permutation lookup, the orderby-walk test and the decline conditions on its
-    /// own -- and nothing checked that the two agree. That is the same shape as the Python cost
-    /// mirror which silently drifted from `cost.rs` for two revisions. Reporting the real branch
-    /// turns the assumption into something a harness can assert.
+    /// `acquire_plan_features`' `PrintingCompose` branch sets `feats.compose_paging` by
+    /// reimplementing a decision the fastpath makes independently -- it recomputes the permutation
+    /// lookup and the `orderby_walk_available` test on its own -- and nothing checked that the two
+    /// agree. That is the same shape as the Python cost mirror which silently drifted from `cost.rs`
+    /// for two revisions. Reporting the real branch turns the assumption into something a harness
+    /// can assert, which `compose_paging_prediction_matches_the_branch_taken` now does (and
+    /// `scripts/bench_cost_model_agreement.py` observes over the real corpus).
     ///
-    /// `""` for every other plan, and for a compose run that never reached the paging step.
+    /// The prediction is 3-way and this is 7-way, so they are not compared blindly. Every exit from
+    /// the fastpath records itself, which is what lets `""` mean exactly one thing:
+    /// - `Perm` / `OrderbyWalk` / `Gather` — a strategy ran, and it must be the predicted one. These
+    ///   are the only labels comparable against `compose_paging`.
+    /// - `EmptyPage` — the composed total was 0 or the offset was past it, so the fastpath returned
+    ///   before any strategy ran. The prediction is simply not exercised.
+    /// - `NotComposable` — the structural check failed (not a composable expr, or the compose
+    ///   indexes are not built).
+    /// - `DeclineBroad` — the `COMPOSE_GATHER_MAX_CARD_FRACTION` breadth gate.
+    /// - `DeclineSparseEstimate` / `DeclineSparseExact` — the two sparse declines, pre-compose off
+    ///   the estimator's upper bound and post-compose off the real total respectively.
+    ///
+    /// `""` therefore means the fastpath was never entered at all — every other plan, and a compose
+    /// plan that `run_query_with_plan` rejected before calling it. A declined compose always says
+    /// which gate declined it.
     pub(crate) paging_taken: &'static str,
 }
 
 thread_local! {
+    /// Scratch slot the instrumented executors publish into. **Only meaningful between a
+    /// `take_phase_stats()` and the next publish** — that window is the whole contract, and
+    /// `explain_analyze` is the only caller that establishes it.
+    ///
+    /// Nothing clears this on the production path, deliberately: a `Cell` write per query to reset
+    /// state no production reader consults would be cost for nobody. The consequence is that a live
+    /// worker thread carries whatever its last query left here indefinitely, and because both
+    /// publishers use `..c.get()` to preserve `paging_taken` across a partial write, a stale label
+    /// from an unrelated earlier query is inherited rather than overwritten.
+    ///
+    /// So a reader added outside `explain_analyze` gets an arbitrary earlier query's numbers, not
+    /// zeros and not the current query's. Take first, then run, then read.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
         cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0, ns_prepare: 0,
         result_total: 0, paging_taken: "",
@@ -6411,7 +6445,8 @@ fn note_paging_taken(which: &'static str) {
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a
-/// timed run; anything else sees zeros.
+/// timed run, having cleared beforehand — see `PHASE_STATS` for why that order is the contract and
+/// why an unpaired read does NOT see zeros.
 fn take_phase_stats() -> PhaseStats {
     PHASE_STATS.with(|c| c.replace(PhaseStats::default()))
 }
@@ -6870,11 +6905,10 @@ fn run_query_with_plan<'a>(
 pub(crate) struct PlanEstimate {
     pub(crate) plan: PhysicalPlan,
     pub(crate) predicted_ns: f64,
-    /// `cost::materialize_cost` for this plan — the candidate-production term `plan_cost` omits,
-    /// reported but deliberately NOT added to `predicted_ns`. `0.0` for plans that build no
-    /// candidate list. See `cost.rs`'s "Candidate materialization" section for why it stays out
-    /// of the routing decision.
-    /// Modelled `collect` + `sort_unstable` cost for this plan's candidate list.
+    /// `cost::materialize_cost` for this plan: the modelled `collect` + `sort_unstable` cost of the
+    /// candidate list it consumes — the candidate-production term `plan_cost` omits. Reported but
+    /// deliberately NOT added to `predicted_ns`; `0.0` for plans that build no candidate list. See
+    /// `cost.rs`'s "Candidate materialization" section for why it stays out of the routing decision.
     ///
     /// Charged on `eval_domain`, which is the candidate count only under a `Candidates` acquire.
     /// Under `Prep::Range` the two materializing plans are estimated UNNARROWED
@@ -7018,10 +7052,20 @@ pub(crate) struct PlanTrial {
     pub(crate) materialize_ns: f64,
     pub(crate) picked: bool,
     pub(crate) trials_ns: Vec<u64>,
-    /// Execution counters and coarse phase timings from the last recorded run of this plan, when the
-    /// executor is instrumented (`GatheredScan` today). Zeros otherwise. See `PhaseStats`: the
-    /// counters check whether the cost arm's FEATURES match what the loop did, and the phase timings
-    /// check whether its TERMS account for the whole executor.
+    /// Execution counters and coarse phase timings from the last recorded run of this plan. See
+    /// `PhaseStats`: the counters check whether the cost arm's FEATURES match what the loop did, and
+    /// the phase timings check whether its TERMS account for the whole executor.
+    ///
+    /// Populated for the two materializing plans — `GatheredScan` (`exec_gathered_scan`) and
+    /// `StreamedSelect` (`run_query_streamed`, which publishes from all three of its return paths).
+    /// The four fast paths — `PrintingRangeScan`, `PrintingCompose`, `PlanePopcountOrder`,
+    /// `CardRangePopcount` — are NOT instrumented and report zeros, except `paging_taken`, which
+    /// `printing_compose_fastpath` sets on its own.
+    ///
+    /// A consumer must not read all-zero counters as "this plan did no work": `explain_analyze`
+    /// always fills `ns_round_total`, so `ns_round_total > 0 && ns_loop == 0` is the uninstrumented
+    /// case, and only `ns_round_total == 0` means the plan never ran at all (which `trials_ns`
+    /// already says, being empty).
     pub(crate) phases: PhaseStats,
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5597,13 +5597,16 @@ fn printing_compose_fastpath<'a>(
         }
     };
     if total == 0 || page_offset >= total {
+        note_paging_taken("EmptyPage");
         return Some((total, Vec::new()));
     }
     let page = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
+                note_paging_taken("DeclineSparse");
                 return None; // sparse: the general path gathers + globally sorts, ordering ties differently
             }
+            note_paging_taken("Perm");
             walk_grouped_page(ctx, params, &pbits, perm)
         }
         // No permutation. #744: if the orderby has a printing-space value structure (usd/rarity,
@@ -5626,7 +5629,16 @@ fn printing_compose_fastpath<'a>(
             } else {
                 None
             };
-            walked.unwrap_or_else(|| gather_composed_page(ctx, params, &pbits))
+            match walked {
+                Some(rows) => {
+                    note_paging_taken("OrderbyWalk");
+                    rows
+                }
+                None => {
+                    note_paging_taken("Gather");
+                    gather_composed_page(ctx, params, &pbits)
+                }
+            }
         }
     };
     Some((total, page))
@@ -6347,11 +6359,27 @@ pub(crate) struct PhaseStats {
     /// inferred. No cost term describes it, and on range-acquired queries it is where a third of the
     /// runtime was landing unaccounted.
     pub(crate) ns_prepare: u64,
+    /// The result total this run returned. `explain_analyze` had no ground truth at all before: a
+    /// harness wanting the true cardinality made a SECOND `query()` call, which is a different
+    /// execution, so agreement with the analyzed run was assumed rather than observed.
+    pub(crate) result_total: u64,
+    /// Which paging branch `printing_compose_fastpath` ACTUALLY took, against the `compose_paging`
+    /// the cost model predicted it would.
+    ///
+    /// `compose_paging_with_total` reimplements a decision the fastpath makes independently -- it
+    /// recomputes the permutation lookup, the orderby-walk test and the decline conditions on its
+    /// own -- and nothing checked that the two agree. That is the same shape as the Python cost
+    /// mirror which silently drifted from `cost.rs` for two revisions. Reporting the real branch
+    /// turns the assumption into something a harness can assert.
+    ///
+    /// `""` for every other plan, and for a compose run that never reached the paging step.
+    pub(crate) paging_taken: &'static str,
 }
 
 thread_local! {
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
         cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0, ns_prepare: 0,
+        result_total: 0, paging_taken: "",
     }) };
 }
 
@@ -6373,6 +6401,16 @@ fn timed_prepare_candidates(
     let prep = prepare_candidates(ctx, params, filter, plane);
     PENDING_PREPARE_NS.with(|c| c.set(t.elapsed().as_nanos() as u64));
     prep
+}
+
+/// Record which paging branch the compose fastpath took. Reporting only -- see
+/// `PhaseStats::paging_taken` for why the predicted branch is not enough.
+fn note_paging_taken(which: &'static str) {
+    PHASE_STATS.with(|c| {
+        let mut st = c.get();
+        st.paging_taken = which;
+        c.set(st);
+    });
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a
@@ -6454,6 +6492,9 @@ fn exec_gathered_scan<'a>(
             ns_finish,
             ns_round_total: 0, // filled by explain_analyze, which owns the round timer
             ns_prepare: prep_ns,
+            // Keep whatever this run already recorded (e.g. the paging branch the fastpath took):
+            // a whole-struct set here would silently wipe it.
+            ..c.get()
         });
     });
     (total, page)
@@ -7070,6 +7111,7 @@ fn explain_analyze(
             // Read immediately: the next plan's run overwrites the thread-local.
             let mut stats = take_phase_stats();
             stats.ns_round_total = dt;
+            stats.result_total = ran.as_ref().map_or(0, |(total, _)| *total as u64);
             // A structurally-applicable plan's fastpath can still decline at runtime
             // (e.g. PrintingCompose on a sparse total) — deterministic for this
             // query/data, so a decliner simply never accumulates trials.
@@ -7322,6 +7364,7 @@ fn run_query_streamed<'a>(
                 ns_finish,
                 ns_round_total: 0,
                 ns_prepare: prep_ns,
+                ..c.get() // see the note at the other publisher
             });
         });
     };
@@ -7681,6 +7724,10 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     d.set_item("ns_finish", t.phases.ns_finish)?;
     d.set_item("ns_round_total", t.phases.ns_round_total)?;
     d.set_item("ns_prepare", t.phases.ns_prepare)?;
+    // Ground truth for this run, and which paging branch really ran. Both exist so a harness can
+    // check the model against what happened rather than against a second, separate execution.
+    d.set_item("result_total", t.phases.result_total)?;
+    d.set_item("paging_taken", t.phases.paging_taken)?;
     Ok(d)
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6342,16 +6342,27 @@ fn exec_streamed_select<'a>(
 /// - are the FEATURE COUNTS right? `cards_visited` / `printings_scanned` / `matches_pushed` are the
 ///   real counts behind `eval_domain` / `scan_units` / `matches`. If a feature disagrees with its
 ///   counter, no rate constant can rescue the term.
-/// - is the WORK WHERE THE MODEL SAYS? `ns_loop` + `ns_finish` should account for the whole executor.
-///   Whatever is left over is work no term describes, and re-fitting cannot find it.
+/// - is the WORK WHERE THE MODEL SAYS? `ns_setup` + `ns_loop` + `ns_finish` should account for the
+///   whole executor. Whatever is left over is work no term describes, and re-fitting cannot find it.
 ///
 /// Counters are plain locals in the hot loop and only published here at the end, so the loop pays
-/// nothing; the three `Instant::now()` pairs are per query, not per card.
+/// nothing. The three phases are contiguous, so each boundary instant ends one and starts the next:
+/// four `Instant::now()` calls bound three phases, which is the same four clock reads the two
+/// phases cost before `ns_setup` was split out. Per query, not per card.
 #[derive(Default, Clone, Copy)]
 pub(crate) struct PhaseStats {
     pub(crate) cards_visited: u64,
     pub(crate) printings_scanned: u64,
     pub(crate) matches_pushed: u64,
+    /// Per-query scratch setup, before the match loop starts. Split out because it is neither
+    /// prepare nor match and it is NOT negligible: `run_query_streamed` zeroes an `n_cards`-long
+    /// counts buffer here (~126 kB on the real corpus) no matter how few candidates it is about to
+    /// visit, so on a selective query this can be most of the run. It used to fall outside every
+    /// timer and land silently in the unaccounted remainder.
+    ///
+    /// It is also the one phase here with an obvious cost term waiting for it: the dominant part
+    /// scales with `n_cards`, which `PlanFeatures` already carries.
+    pub(crate) ns_setup: u64,
     pub(crate) ns_loop: u64,
     pub(crate) ns_finish: u64,
     /// Wall time of the whole `run_query_with_plan` round these phases came from. Recorded so the
@@ -6409,8 +6420,8 @@ thread_local! {
     /// So a reader added outside `explain_analyze` gets an arbitrary earlier query's numbers, not
     /// zeros and not the current query's. Take first, then run, then read.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
-        cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0, ns_prepare: 0,
-        result_total: 0, paging_taken: "",
+        cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
+        ns_prepare: 0, result_total: 0, paging_taken: "",
     }) };
 }
 
@@ -6461,6 +6472,8 @@ fn exec_gathered_scan<'a>(
     prep: &PreparedCandidates,
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    // First of the three phase boundaries — everything down to the match loop is `ns_setup`.
+    let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let all_match_known = prep.all_match_known;
@@ -6484,7 +6497,8 @@ fn exec_gathered_scan<'a>(
     // Counters for the three features this plan's cost arm keys on, so they can be checked against
     // what the loop really does. Plain locals — no atomics, no branch — published once at the end.
     let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
-    let t_setup = std::time::Instant::now();
+    // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
+    let t_loop = std::time::Instant::now();
     for cid in card_ids {
         n_cards_visited += 1;
         let card = &cards[cid as usize];
@@ -6508,23 +6522,23 @@ fn exec_gathered_scan<'a>(
         n_matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
-    let ns_loop = t_setup.elapsed().as_nanos() as u64;
-
+    // Ends `ns_loop` and starts `ns_finish`.
     let t_finish = std::time::Instant::now();
     let (total, page_ids) = sel.finish(page_offset, limit);
     let page = page_ids
         .into_iter()
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
         .collect();
-    let ns_finish = t_finish.elapsed().as_nanos() as u64;
+    let t_end = std::time::Instant::now();
     let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
     PHASE_STATS.with(|c| {
         c.set(PhaseStats {
             cards_visited: n_cards_visited,
             printings_scanned: n_printings_scanned,
             matches_pushed: n_matches_pushed,
-            ns_loop, // includes setup: three small allocations, not worth its own timer
-            ns_finish,
+            ns_setup: (t_loop - t_start).as_nanos() as u64,
+            ns_loop: (t_finish - t_loop).as_nanos() as u64,
+            ns_finish: (t_end - t_finish).as_nanos() as u64,
             ns_round_total: 0, // filled by explain_analyze, which owns the round timer
             ns_prepare: prep_ns,
             // Keep whatever this run already recorded (e.g. the paging branch the fastpath took):
@@ -7056,6 +7070,11 @@ pub(crate) struct PlanTrial {
     /// `PhaseStats`: the counters check whether the cost arm's FEATURES match what the loop did, and
     /// the phase timings check whether its TERMS account for the whole executor.
     ///
+    /// The three phases are contiguous and disjoint, so `ns_setup + ns_loop + ns_finish` can only
+    /// be <= `ns_round_total`. The shortfall is real unmodelled work — `run_query_with_plan`'s own
+    /// dispatch and applicability checks sit outside all three — so treat it as a residual to size,
+    /// not as an invariant that should reach zero.
+    ///
     /// Populated for the two materializing plans — `GatheredScan` (`exec_gathered_scan`) and
     /// `StreamedSelect` (`run_query_streamed`, which publishes from all three of its return paths).
     /// The four fast paths — `PrintingRangeScan`, `PrintingCompose`, `PlanePopcountOrder`,
@@ -7334,6 +7353,9 @@ fn run_query_streamed<'a>(
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    // First of the three phase boundaries — everything down to the match loop is `ns_setup`, which
+    // for this executor is dominated by the `counts` zeroing below. See `PhaseStats::ns_setup`.
+    let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let artwork_groups = &indexes.artwork_groups;
@@ -7359,7 +7381,8 @@ fn run_query_streamed<'a>(
     // Same counters GatheredScan publishes, so the two plans' arms can be checked the same way.
     // Locals in the loop; published once at the end. See PhaseStats.
     let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
-    let t_match = std::time::Instant::now();
+    // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
+    let t_loop = std::time::Instant::now();
     for cid in card_ids {
         n_cards_visited += 1;
         let card = &cards[cid as usize];
@@ -7401,18 +7424,21 @@ fn run_query_streamed<'a>(
         total += c as usize;
         n_matches_pushed += c as u64;
     }
-    let ns_match = t_match.elapsed().as_nanos() as u64;
+    // Ends `ns_loop` and starts `ns_finish`.
+    let t_finish = std::time::Instant::now();
     // Publishing helper: the walk below has several early returns, and every one of them must leave
-    // the stats behind or the accounting silently attributes this plan's work to nothing.
-    let publish = |ns_finish: u64| {
+    // the stats behind or the accounting silently attributes this plan's work to nothing. Each takes
+    // the closing instant itself, so the emit phase is bounded without a second start marker.
+    let publish = |end: std::time::Instant| {
         let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
         PHASE_STATS.with(|c| {
             c.set(PhaseStats {
                 cards_visited: n_cards_visited,
                 printings_scanned: n_printings_scanned,
                 matches_pushed: n_matches_pushed,
-                ns_loop: ns_match,
-                ns_finish,
+                ns_setup: (t_loop - t_start).as_nanos() as u64,
+                ns_loop: (t_finish - t_loop).as_nanos() as u64,
+                ns_finish: (end - t_finish).as_nanos() as u64,
                 ns_round_total: 0,
                 ns_prepare: prep_ns,
                 ..c.get() // see the note at the other publisher
@@ -7420,10 +7446,9 @@ fn run_query_streamed<'a>(
         });
     };
     if total == 0 || page_offset >= total {
-        publish(0);
+        publish(std::time::Instant::now());
         return (total, Vec::new());
     }
-    let t_emit = std::time::Instant::now();
 
     // artwork-mode emission scratch (#629), reused across cards below. Pre-sized to
     // max_artwork_groups so the grouping loop needs no per-printing resize check.
@@ -7457,7 +7482,7 @@ fn run_query_streamed<'a>(
             .into_iter()
             .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
             .collect();
-        publish(t_emit.elapsed().as_nanos() as u64);
+        publish(std::time::Instant::now());
         return (total, page);
     }
 
@@ -7500,7 +7525,7 @@ fn run_query_streamed<'a>(
         }
         skip = 0;
     }
-    publish(t_emit.elapsed().as_nanos() as u64);
+    publish(std::time::Instant::now());
     (total, page)
     }) // COUNTS.with
 }
@@ -7771,6 +7796,7 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     d.set_item("cards_visited", t.phases.cards_visited)?;
     d.set_item("printings_scanned", t.phases.printings_scanned)?;
     d.set_item("matches_pushed", t.phases.matches_pushed)?;
+    d.set_item("ns_setup", t.phases.ns_setup)?;
     d.set_item("ns_loop", t.phases.ns_loop)?;
     d.set_item("ns_finish", t.phases.ns_finish)?;
     d.set_item("ns_round_total", t.phases.ns_round_total)?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6320,6 +6320,67 @@ fn exec_streamed_select<'a>(
 /// P4 executor: the universal gathered per-card loop + `select_page`. Runs any
 /// query (printing-keyed orderbys, stores without permutations, or anything the
 /// other plans decline). Caller has run `prepare_candidates`.
+/// Per-query execution counters and coarse phase timings, for checking the cost model against what
+/// the executors actually do rather than against a fitted curve.
+///
+/// Two distinct questions, and the model can fail either:
+/// - are the FEATURE COUNTS right? `cards_visited` / `printings_scanned` / `matches_pushed` are the
+///   real counts behind `eval_domain` / `scan_units` / `matches`. If a feature disagrees with its
+///   counter, no rate constant can rescue the term.
+/// - is the WORK WHERE THE MODEL SAYS? `ns_loop` + `ns_finish` should account for the whole executor.
+///   Whatever is left over is work no term describes, and re-fitting cannot find it.
+///
+/// Counters are plain locals in the hot loop and only published here at the end, so the loop pays
+/// nothing; the three `Instant::now()` pairs are per query, not per card.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct PhaseStats {
+    pub(crate) cards_visited: u64,
+    pub(crate) printings_scanned: u64,
+    pub(crate) matches_pushed: u64,
+    pub(crate) ns_loop: u64,
+    pub(crate) ns_finish: u64,
+    /// Wall time of the whole `run_query_with_plan` round these phases came from. Recorded so the
+    /// accounting compares like with like: `trials_ns` reports the MINIMUM across rounds, and
+    /// dividing phases from one round by the minimum of another silently reads as unmodelled work.
+    pub(crate) ns_round_total: u64,
+    /// Wall time of `prepare_candidates` for the two materializing plans, measured here rather than
+    /// inferred. No cost term describes it, and on range-acquired queries it is where a third of the
+    /// runtime was landing unaccounted.
+    pub(crate) ns_prepare: u64,
+}
+
+thread_local! {
+    static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
+        cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0, ns_prepare: 0,
+    }) };
+}
+
+thread_local! {
+    /// `prepare_candidates`' time for the run in progress, handed to the executor that follows it —
+    /// the two are separate calls in `run_query_with_plan`, and only the executor publishes stats.
+    static PENDING_PREPARE_NS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// `prepare_candidates`, timed. Only `run_query_with_plan`'s materializing arms use this; the routed
+/// path calls `prepare_candidates` directly, since its cost already shows up in `acquire_ns`.
+fn timed_prepare_candidates(
+    ctx: &QueryCtx,
+    params: &QueryParams,
+    filter: &mut FilterExpr,
+    plane: Option<&PlaneExpr>,
+) -> PreparedCandidates {
+    let t = std::time::Instant::now();
+    let prep = prepare_candidates(ctx, params, filter, plane);
+    PENDING_PREPARE_NS.with(|c| c.set(t.elapsed().as_nanos() as u64));
+    prep
+}
+
+/// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a
+/// timed run; anything else sees zeros.
+fn take_phase_stats() -> PhaseStats {
+    PHASE_STATS.with(|c| c.replace(PhaseStats::default()))
+}
+
 fn exec_gathered_scan<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
@@ -6347,7 +6408,12 @@ fn exec_gathered_scan<'a>(
     // the current card (reused buffer; see FilterExpr::card_pass).
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
+    // Counters for the three features this plan's cost arm keys on, so they can be checked against
+    // what the loop really does. Plain locals — no atomics, no branch — published once at the end.
+    let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    let t_setup = std::time::Instant::now();
     for cid in card_ids {
+        n_cards_visited += 1;
         let card = &cards[cid as usize];
         // #634 Step 1: all_match_known means the narrowing already proved
         // every candidate matches — card_pass would just re-derive Tri::True
@@ -6361,18 +6427,35 @@ fn exec_gathered_scan<'a>(
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
+        n_printings_scanned += (end - start) as u64;
         push_card_matches(
             card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
             sort_col, descending, strings, existential_plane, sel.buf(), &mut group_best, &mut touched,
         );
+        n_matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
+    let ns_loop = t_setup.elapsed().as_nanos() as u64;
 
+    let t_finish = std::time::Instant::now();
     let (total, page_ids) = sel.finish(page_offset, limit);
     let page = page_ids
         .into_iter()
         .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
         .collect();
+    let ns_finish = t_finish.elapsed().as_nanos() as u64;
+    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
+    PHASE_STATS.with(|c| {
+        c.set(PhaseStats {
+            cards_visited: n_cards_visited,
+            printings_scanned: n_printings_scanned,
+            matches_pushed: n_matches_pushed,
+            ns_loop, // includes setup: three small allocations, not worth its own timer
+            ns_finish,
+            ns_round_total: 0, // filled by explain_analyze, which owns the round timer
+            ns_prepare: prep_ns,
+        });
+    });
     (total, page)
 }
 
@@ -6728,12 +6811,12 @@ fn run_query_with_plan<'a>(
             if !streamed_select_applicable(cards, sort_col, descending, indexes) {
                 return None;
             }
-            let prep = prepare_candidates(ctx, params, filter, plane);
+            let prep = timed_prepare_candidates(ctx, params, filter, plane);
             Some(exec_streamed_select(ctx, params, filter, &prep, plane))
         }
         PhysicalPlan::GatheredScan => {
             debug_assert!(gathered_scan_applicable());
-            let prep = prepare_candidates(ctx, params, filter, plane);
+            let prep = timed_prepare_candidates(ctx, params, filter, plane);
             Some(exec_gathered_scan(ctx, params, filter, &prep, plane))
         }
     }
@@ -6893,6 +6976,11 @@ pub(crate) struct PlanTrial {
     pub(crate) materialize_ns: f64,
     pub(crate) picked: bool,
     pub(crate) trials_ns: Vec<u64>,
+    /// Execution counters and coarse phase timings from the last recorded run of this plan, when the
+    /// executor is instrumented (`GatheredScan` today). Zeros otherwise. See `PhaseStats`: the
+    /// counters check whether the cost arm's FEATURES match what the loop did, and the phase timings
+    /// check whether its TERMS account for the whole executor.
+    pub(crate) phases: PhaseStats,
 }
 
 /// #745 primitive 2: actually run every applicable plan via `run_query_with_plan`,
@@ -6943,6 +7031,7 @@ fn explain_analyze(
 
     let n = estimates.len();
     let mut trials_ns: Vec<Vec<u64>> = vec![Vec::with_capacity(num_trials); n];
+    let mut phases: Vec<PhaseStats> = vec![PhaseStats::default(); n];
     for round in 0..(num_warmups + num_trials) {
         // The acquire step alone, on the same pristine-clone discipline as the plan
         // trials. Subtracting this from a materializing plan's `trials_ns` isolates
@@ -6973,11 +7062,15 @@ fn explain_analyze(
             let t0 = std::time::Instant::now();
             let ran = run_query_with_plan(plan, ctx, params, &mut round_filter, plane);
             let dt = t0.elapsed().as_nanos() as u64;
+            // Read immediately: the next plan's run overwrites the thread-local.
+            let mut stats = take_phase_stats();
+            stats.ns_round_total = dt;
             // A structurally-applicable plan's fastpath can still decline at runtime
             // (e.g. PrintingCompose on a sparse total) — deterministic for this
             // query/data, so a decliner simply never accumulates trials.
             if ran.is_some() && round >= num_warmups {
                 trials_ns[idx].push(dt);
+                phases[idx] = stats;
             }
         }
     }
@@ -6986,12 +7079,14 @@ fn explain_analyze(
         estimates
         .into_iter()
         .zip(trials_ns)
-        .map(|(e, trials_ns)| PlanTrial {
+        .zip(phases)
+        .map(|((e, trials_ns), phases)| PlanTrial {
             plan: e.plan,
             predicted_ns: e.predicted_ns,
             materialize_ns: e.materialize_ns,
             picked: e.picked,
             trials_ns,
+            phases,
         })
         .collect();
     (facts, trials)
@@ -7168,7 +7263,13 @@ fn run_query_streamed<'a>(
     counts.resize(cards.len(), 0);
     let have_group_counts = artwork_groups.len() == cards.len();
     let mut total: usize = 0;
+    // Same counters GatheredScan publishes, so the two plans' arms can be checked the same way.
+    // Locals in the loop; published once at the end. See PhaseStats.
+    let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    let t_match = std::time::Instant::now();
     for cid in card_ids {
+        n_cards_visited += 1;
+        n_printings_scanned += (u32::from(offsets[cid as usize + 1]) - u32::from(offsets[cid as usize])) as u64;
         let card = &cards[cid as usize];
         // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True
         // when the narrowing already proved every candidate matches. Gated
@@ -7200,10 +7301,30 @@ fn run_query_streamed<'a>(
         };
         counts[cid as usize] = c;
         total += c as usize;
+        n_matches_pushed += c as u64;
     }
+    let ns_match = t_match.elapsed().as_nanos() as u64;
+    // Publishing helper: the walk below has several early returns, and every one of them must leave
+    // the stats behind or the accounting silently attributes this plan's work to nothing.
+    let publish = |ns_finish: u64| {
+        let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
+        PHASE_STATS.with(|c| {
+            c.set(PhaseStats {
+                cards_visited: n_cards_visited,
+                printings_scanned: n_printings_scanned,
+                matches_pushed: n_matches_pushed,
+                ns_loop: ns_match,
+                ns_finish,
+                ns_round_total: 0,
+                ns_prepare: prep_ns,
+            });
+        });
+    };
     if total == 0 || page_offset >= total {
+        publish(0);
         return (total, Vec::new());
     }
+    let t_emit = std::time::Instant::now();
 
     // artwork-mode emission scratch (#629), reused across cards below. Pre-sized to
     // max_artwork_groups so the grouping loop needs no per-printing resize check.
@@ -7237,6 +7358,7 @@ fn run_query_streamed<'a>(
             .into_iter()
             .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
             .collect();
+        publish(t_emit.elapsed().as_nanos() as u64);
         return (total, page);
     }
 
@@ -7279,6 +7401,7 @@ fn run_query_streamed<'a>(
         }
         skip = 0;
     }
+    publish(t_emit.elapsed().as_nanos() as u64);
     (total, page)
     }) // COUNTS.with
 }
@@ -7546,6 +7669,13 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     d.set_item("materialize_ns", t.materialize_ns)?;
     d.set_item("picked", t.picked)?;
     d.set_item("trials_ns", t.trials_ns.clone())?;
+    d.set_item("cards_visited", t.phases.cards_visited)?;
+    d.set_item("printings_scanned", t.phases.printings_scanned)?;
+    d.set_item("matches_pushed", t.phases.matches_pushed)?;
+    d.set_item("ns_loop", t.phases.ns_loop)?;
+    d.set_item("ns_finish", t.phases.ns_finish)?;
+    d.set_item("ns_round_total", t.phases.ns_round_total)?;
+    d.set_item("ns_prepare", t.phases.ns_prepare)?;
     Ok(d)
 }
 

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3603,6 +3603,15 @@ fn plan_stats_never_leak_between_participants() {
     /// Publish no counters whatsoever — see the doc's leak 1.
     const SILENT_PLANS: [PhysicalPlan; 3] =
         [PhysicalPlan::PrintingRangeScan, PhysicalPlan::PlanePopcountOrder, PhysicalPlan::CardRangePopcount];
+    /// The subset of `SILENT_PLANS` that writes NO field at all, `paging_taken` included, so
+    /// `NotEntered` there is still proof no label leaked in. `PrintingRangeScan` is silent for the
+    /// counters and phase timings but labels its own exits, so it is checked separately below —
+    /// against its own labels, which is a stronger statement than "inherited nothing".
+    const UNLABELLED_PLANS: [PhysicalPlan; 2] = [PhysicalPlan::PlanePopcountOrder, PhysicalPlan::CardRangePopcount];
+    /// What a `PrintingRangeScan` that produced a page must report. Both are success exits; every
+    /// other `Range*` variant means it declined, and a declining plan has empty `trials_ns` and is
+    /// skipped above.
+    const RANGE_SUCCESS: [PagingTaken; 2] = [PagingTaken::RangeAligned, PagingTaken::RangeWalk];
 
     let mut rng = rand::rngs::SmallRng::seed_from_u64(745_005);
     // Chosen for plan COVERAGE, not for query realism: the bare ranges are what make
@@ -3626,6 +3635,9 @@ fn plan_stats_never_leak_between_participants() {
     let ctx = QueryCtx::from(archived);
 
     let (mut silent_checked, mut materializing_checked, mut compose_labelled) = (0usize, 0usize, 0usize);
+    // Counted apart from `silent_checked` so the range fastpath's own success labels cannot go
+    // unexercised behind the two plans that legitimately report nothing.
+    let mut range_labelled = 0usize;
     for spec in &specs {
         for &(mode_label, mode) in &modes {
             for &(orderby, sort_col) in &sort_cols {
@@ -3653,14 +3665,31 @@ fn plan_stats_never_leak_between_participants() {
                             (p.ns_setup, p.ns_loop, p.ns_finish, p.ns_prepare), (0, 0, 0, 0),
                             "uninstrumented plan reported phase timings it never wrote: {case}",
                         );
-                        assert_eq!(p.paging_taken, PagingTaken::NotEntered, "uninstrumented plan inherited a paging label: {case}");
+                        // The label half splits: only the two plans that write nothing can be
+                        // checked as "still NotEntered". `PrintingRangeScan` labels its own exits,
+                        // so for it the equivalent — and stronger — statement is that the label is
+                        // one of ITS OWN success variants, not merely absent. A leaked compose
+                        // label would fail that just as surely.
+                        if UNLABELLED_PLANS.contains(&t.plan) {
+                            assert_eq!(
+                                p.paging_taken, PagingTaken::NotEntered,
+                                "uninstrumented plan inherited a paging label: {case}",
+                            );
+                        } else {
+                            assert!(
+                                RANGE_SUCCESS.contains(&p.paging_taken),
+                                "PrintingRangeScan produced a page but reported {:?}, not one of its success exits: {case}",
+                                p.paging_taken,
+                            );
+                            range_labelled += 1;
+                        }
                         silent_checked += 1;
                     } else if matches!(t.plan, PhysicalPlan::StreamedSelect | PhysicalPlan::GatheredScan) {
-                        // Leak 2: the field neither executor writes. Only `printing_compose_fastpath`
-                        // sets this, and it is not on either of their paths.
+                        // Leak 2: the field neither executor writes. Only the two printing-space
+                        // fastpaths set it, and neither is on either of their paths.
                         assert_eq!(
                             p.paging_taken, PagingTaken::NotEntered,
-                            "materializing plan inherited a paging label only the compose fastpath sets: {case}",
+                            "materializing plan inherited a paging label only a printing fastpath sets: {case}",
                         );
                         materializing_checked += 1;
                     } else if t.plan == PhysicalPlan::PrintingCompose {
@@ -3679,8 +3708,8 @@ fn plan_stats_never_leak_between_participants() {
     }
 
     println!(
-        "stat isolation: {silent_checked} uninstrumented-plan runs, {materializing_checked} materializing runs, \
-         {compose_labelled} compose runs carrying a real paging label"
+        "stat isolation: {silent_checked} uninstrumented-plan runs ({range_labelled} range-labelled), \
+         {materializing_checked} materializing runs, {compose_labelled} compose runs carrying a real paging label"
     );
     // Each guard covers a leak that would otherwise go unasserted, and the third is what supplies
     // the contaminant: without a labelled compose in the mix, leak 2 cannot be reproduced even with
@@ -3688,6 +3717,10 @@ fn plan_stats_never_leak_between_participants() {
     assert!(silent_checked > 0, "no uninstrumented plan ran; leak 1 is unchecked");
     assert!(materializing_checked > 0, "no materializing plan ran; leak 2 is unchecked");
     assert!(compose_labelled > 0, "no compose recorded a paging label; leak 2 has no contaminant to detect");
+    // The range fastpath is a second contaminant source AND the only plan here whose success is
+    // asserted against its own labels rather than against their absence. A sweep that never runs it
+    // successfully leaves both unexercised.
+    assert!(range_labelled > 0, "no PrintingRangeScan produced a page; its success labels are unchecked");
 }
 
 /// A plan that enters a fastpath and declines must say so through `explain_analyze`, not just
@@ -3708,8 +3741,14 @@ fn plan_stats_never_leak_between_participants() {
 ///
 /// Asserted here, in order: a declining plan reports EMPTY `trials_ns` (it produced nothing), a
 /// NON-EMPTY `declined_ns` (it still cost something), zero counters and zero phase timings (no
-/// executor ran, so anything else would be a leak), and — for compose specifically — a label naming
-/// the gate rather than the `NotEntered` default that would mean it was never tried.
+/// executor ran, so anything else would be a leak), and a label naming the gate rather than the
+/// `NotEntered` default that would mean it was never tried.
+///
+/// That last one now covers BOTH printing-space fastpaths. `PrintingRangeScan` used to decline as
+/// `NotEntered` — indistinguishable from never having been tried, and rendered as a blank gate
+/// column in `scripts/bench_cost_model_agreement.py`'s decline table. Its gates carry no prediction
+/// to falsify, unlike compose's, so the assertion is only that one fired; what they are for is
+/// sizing the declines and surfacing the two that should never fire at all.
 #[test]
 fn declining_plans_report_their_gate_through_explain_analyze() {
     use rand::SeedableRng;
@@ -3724,6 +3763,23 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
         PagingTaken::DeclineSparseEstimate,
         PagingTaken::DeclineSparseExact,
     ];
+    /// The same for the range fastpath. `RangeAligned`/`RangeWalk` are excluded because they are
+    /// its success exits — reaching one of those with an empty `trials_ns` would mean the fastpath
+    /// returned a page and `explain_analyze` recorded a decline anyway.
+    ///
+    /// `RangeNotBare` and `RangePermutationStale` are IN the list but should never be seen:
+    /// `PhysicalPlan::PrintingRangeScan.applicable` already requires bare range bounds, and a
+    /// permutation whose length disagrees with the corpus is a corrupt index. They are admitted
+    /// here rather than asserted against because this test's job is "a gate was named", and
+    /// `range_gate_counts` below prints the distribution so either one showing up is visible.
+    const RANGE_DECLINE_GATES: [PagingTaken; 6] = [
+        PagingTaken::RangeSelective,
+        PagingTaken::RangeSparse,
+        PagingTaken::RangeUnalignedPrice,
+        PagingTaken::RangeNoPermutation,
+        PagingTaken::RangeNotBare,
+        PagingTaken::RangePermutationStale,
+    ];
 
     let mut rng = rand::rngs::SmallRng::seed_from_u64(745_006);
     // The narrow keyword/border AND is the one that reliably declines -- same reasoning as the
@@ -3733,6 +3789,22 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
         FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
         fuzz_leaf_type(&mut rng),
         fuzz_leaf_price(&mut rng),
+        // The range fastpath's declines, which the sampled price leaf above does not reach: with
+        // this seed it draws a threshold that is broad enough to walk under every orderby in the
+        // list, so the sweep only ever saw the fastpath SUCCEED. Both of these are bare ranges, so
+        // `PrintingRangeScan` is applicable for all three of them and only the gate differs.
+        //
+        // Broad: passes `range_too_broad_to_narrow` and reaches the strategy choice, so it succeeds
+        // where a permutation exists and declines `RangeNoPermutation` where one does not.
+        FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }),
+        // Matches nothing, so the breadth gate turns it back first — `RangeSelective`, NOT
+        // `EmptyPage`: the broadness test runs before the `k == 0` check, which is why an empty
+        // range reads as "the narrowing wins" rather than as an empty page.
+        FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Gt, val: 100_000.0 }),
+        // A broad range that is NOT a price leaf, so under the `usd` orderby in `sort_cols` the
+        // index is not the sort permutation and there is no aligned mapping — `RangeUnalignedPrice`,
+        // the one gate that needs the predicate and the orderby to disagree.
+        FuzzSpec::Leaf(FuzzLeaf::Year { op: CmpOp::Gt, year: 1900 }),
         FuzzSpec::And(vec![
             FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: "fateseal".to_string() }),
             FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
@@ -3746,7 +3818,10 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let ctx = QueryCtx::from(archived);
 
-    let (mut declines_seen, mut compose_gates_seen) = (0usize, 0usize);
+    let (mut declines_seen, mut compose_gates_seen, mut range_gates_seen) = (0usize, 0usize, 0usize);
+    // Decline rounds that measured above zero. Counted rather than asserted per round — see the
+    // note at the accumulation site for why a zero is legitimate for the cheapest gates.
+    let mut nonzero_declines = 0usize;
     let mut by_gate = std::collections::BTreeMap::<String, usize>::new();
     for spec in &specs {
         for &(mode_label, mode) in &modes {
@@ -3767,7 +3842,14 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
                     // plan cannot both produce a page and bail across rounds of the same sweep.
                     assert!(t.trials_ns.is_empty(), "a plan reported both trials and declines: {case}");
                     assert_eq!(t.declined_ns.len(), NUM_TRIALS, "one decline sample per recorded round: {case}");
-                    assert!(t.declined_ns.iter().all(|&ns| ns > 0), "a decline still costs wall time: {case}");
+                    // NOT asserted per-round as `> 0`. The cheapest gates really do complete inside
+                    // the clock's granularity: `RangeSelective` on `usd>100000` is two binary
+                    // searches over an empty span, and in a release build it measures 0 ns. An
+                    // earlier draft asserted every round was non-zero and failed on exactly that
+                    // query — the assertion was wrong, not the timer. What is worth pinning is that
+                    // the timer is wired up AT ALL, which is a sweep-level claim; see
+                    // `nonzero_declines` below.
+                    nonzero_declines += t.declined_ns.iter().filter(|&&ns| ns > 0).count();
                     // No executor ran, so anything non-zero here came from somewhere else.
                     let p = &t.phases;
                     assert_eq!(
@@ -3779,16 +3861,33 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
                         "a declining plan reported timings or a total it never produced: {case}",
                     );
                     declines_seen += 1;
-                    // Only compose labels its gates; PrintingRangeScan has no equivalent, so it
-                    // legitimately declines as `NotEntered`.
-                    if t.plan == PhysicalPlan::PrintingCompose {
-                        assert!(
-                            DECLINE_GATES.contains(&p.paging_taken),
-                            "a declining compose reported {:?}, which does not name a gate: {case}",
-                            p.paging_taken,
-                        );
-                        *by_gate.entry(format!("{:?}", p.paging_taken)).or_default() += 1;
-                        compose_gates_seen += 1;
+                    // Both printing-space fastpaths label their gates, against their own legal
+                    // sets — a compose gate arriving on a range decline (or vice versa) is a leak,
+                    // and a shared "is not NotEntered" check would pass straight through it.
+                    // No other plan has a fastpath, so no other plan can reach here labelled.
+                    match t.plan {
+                        PhysicalPlan::PrintingCompose => {
+                            assert!(
+                                DECLINE_GATES.contains(&p.paging_taken),
+                                "a declining compose reported {:?}, which does not name a compose gate: {case}",
+                                p.paging_taken,
+                            );
+                            *by_gate.entry(format!("{:?}", p.paging_taken)).or_default() += 1;
+                            compose_gates_seen += 1;
+                        }
+                        PhysicalPlan::PrintingRangeScan => {
+                            assert!(
+                                RANGE_DECLINE_GATES.contains(&p.paging_taken),
+                                "a declining range scan reported {:?}, which does not name a range gate: {case}",
+                                p.paging_taken,
+                            );
+                            *by_gate.entry(format!("{:?}", p.paging_taken)).or_default() += 1;
+                            range_gates_seen += 1;
+                        }
+                        _ => assert_eq!(
+                            p.paging_taken, PagingTaken::NotEntered,
+                            "a plan with no fastpath declined carrying a label: {case}",
+                        ),
                     }
                 }
             }
@@ -3796,11 +3895,21 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
     }
 
     let gates: Vec<String> = by_gate.iter().map(|(g, n)| format!("{g} x{n}")).collect();
-    println!("declines through explain_analyze: {declines_seen} total, {compose_gates_seen} compose ({})", gates.join(", "));
-    // Both guards matter: the first says the wire field is reachable at all, the second says the
-    // labels ride along with it. Before `declined_ns` existed every one of these rows was dropped.
+    println!(
+        "declines through explain_analyze: {declines_seen} total, {compose_gates_seen} compose, \
+         {range_gates_seen} range ({})",
+        gates.join(", "),
+    );
+    // Each guard matters: the first says the wire field is reachable at all, the other two say the
+    // labels ride along with it. Before `declined_ns` existed every one of these rows was dropped,
+    // and before the `Range*` labels the third was reachable but blank.
     assert!(declines_seen > 0, "no plan declined; the whole assertion block above is unexercised");
     assert!(compose_gates_seen > 0, "no compose declined; the gate labels are still unreachable from outside Rust");
+    assert!(range_gates_seen > 0, "no range scan declined; its gate labels are still unreachable from outside Rust");
+    // `declined_ns` must be a real measurement somewhere, or it is a vector of zeros nothing would
+    // notice. Sweep-level because a single cheap gate legitimately reads 0 — the claim is that the
+    // timer runs, not that every gate is expensive enough to see.
+    assert!(nonzero_declines > 0, "every decline measured 0 ns; declined_ns is not timing anything");
 }
 
 /// #702 PR1 estimator accuracy report (NOT an assertion — a reporting tool).

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,7 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
-    acquire_plan_features, take_phase_stats,
+    acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -3066,16 +3066,11 @@ fn explain_reports_ranked_applicable_plans() {
             // The acquire facts every plan in this call shares. `eval_domain` is what a
             // caller filters on to decide whether a query exercises a given code path,
             // so it must be a real count in range, not a placeholder.
-            // The three `Prep::Range` labels are reported individually rather than as "range":
-            // that variant covers a bare range, a card-range popcount and a printing compose,
-            // and collapsing them made a compose look like a range index probe.
-            assert!(
-                matches!(
-                    facts.count_source,
-                    "plane" | "candidates" | "card_range_popcount" | "printing_range_scan" | "printing_compose"
-                ),
-                "unknown count_source {:?} ({mode_label}, {})", facts.count_source, fuzz_describe(spec),
-            );
+            //
+            // NOT asserted here any more: that `count_source` and `narrowed_repr` are drawn from
+            // their known sets. Both were `&'static str` and a "label is one of these five"
+            // `matches!` was the only thing keeping a typo'd or invented label out; as `CountSource`
+            // and `NarrowedRepr` the type says it, and the check would be a tautology.
             assert_eq!(facts.feats.n_cards, archived.cards.len() as u32, "n_cards must be the corpus size");
             assert!(
                 facts.feats.eval_domain <= facts.feats.n_cards,
@@ -3085,16 +3080,12 @@ fn explain_reports_ranked_applicable_plans() {
                 fuzz_describe(spec),
             );
             assert_eq!(facts.acquire_ns.len(), 1, "explain() reports exactly one acquire sample");
-            // `none` is legitimate for a candidate-acquired query — the residual narrowing can
+            // `None` is legitimate for a candidate-acquired query — the residual narrowing can
             // produce nothing and leave the plane bitmap as the whole candidate list, which is
-            // itself a "no sort happened" signal. What must hold is that the label is real, and
-            // that the two preps which materialize no candidate list never claim otherwise.
+            // itself a "no sort happened" signal. What must still hold, and what no type enforces,
+            // is that the two preps which materialize no candidate list never claim otherwise.
             assert!(
-                matches!(facts.narrowed_repr, "none" | "cards" | "printings" | "card_bits" | "printing_bits"),
-                "unknown narrowed_repr {:?} ({mode_label}, {})", facts.narrowed_repr, fuzz_describe(spec),
-            );
-            assert!(
-                facts.count_source == "candidates" || facts.narrowed_repr == "none",
+                facts.count_source == CountSource::Candidates || facts.narrowed_repr == NarrowedRepr::None,
                 "{:?}-acquired query reported narrowed_repr {:?} ({mode_label}, {})",
                 facts.count_source, facts.narrowed_repr, fuzz_describe(spec),
             );
@@ -3210,9 +3201,18 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
 /// mirror that silently drifted from `cost.rs` for two revisions. `PhaseStats::paging_taken` exists
 /// to make the agreement checkable; this is the check.
 ///
-/// The prediction is 3-way (`ComposePaging`) and `paging_taken` is 7-way, because a decline or an
-/// empty page reaches no strategy at all. Only the three strategy labels are comparable; the rest
-/// must still name the gate that fired, which is the other half of what this checks.
+/// The prediction is 3-way (`ComposePaging`) and `paging_taken` is 8-way, because a decline or an
+/// empty page reaches no strategy at all. Only the strategy labels are comparable; the rest must
+/// still name the gate that fired, which is the other half of what this checks.
+///
+/// Equality holds in every cell but one, and the exception is structural rather than a tolerance.
+/// Acquire never composes, so it can test only that an orderby walk is AVAILABLE, never that the
+/// walk will succeed: the walk declines at run time on the null-value tail or a page past the value
+/// structure and falls into the gather. So `OrderbyWalk` may legally come back as
+/// `GatherWalkDeclined`, and nothing else may be inexact — in particular a predicted `Gather` that
+/// took a walk is still a failure, since that direction can only mean the availability tests
+/// drifted. Checking equality in all three cells would be asserting something the engine cannot
+/// promise; over the real corpus this cell fires about once in 1,700 compose runs.
 ///
 /// Swept at two corpus sizes on purpose, because the two regimes are mutually exclusive and each
 /// leaves the other's assertion unexercised:
@@ -3229,6 +3229,13 @@ fn compose_paging_prediction_matches_the_branch_taken() {
 
     let mut rng = rand::rngs::SmallRng::seed_from_u64(745_003);
 
+    // ONLY the last two specs actually reach a compose acquire, and that is not obvious from
+    // reading them: `is_printing_composable` accepts `border==`, `set:`/`watermark:` and
+    // `CollectionCmp` at `Ge`, and nothing else. The colour/type/rarity leaves above are bitmask
+    // and numeric comparisons, so every one of their combinations acquires as `plane` or
+    // `candidates` and is skipped by the `count_source` guard below. They are kept because a spec
+    // that stops composing is exactly the regression this test should notice — but adding more of
+    // that shape does NOT widen coverage here. Add composable leaves.
     let specs = [
         FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]),
         fuzz_leaf_type(&mut rng),
@@ -3236,6 +3243,17 @@ fn compose_paging_prediction_matches_the_branch_taken() {
         fuzz_leaf_rarity(&mut rng),
         FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
         FuzzSpec::And(vec![fuzz_leaf_type(&mut rng), fuzz_leaf_rarity(&mut rng)]),
+        // Deliberately NARROW, and the only other spec here built from leaves `is_printing_composable`
+        // accepts (`border==`, and `CollectionCmp` at `Ge`). This is what reaches
+        // `GatherWalkDeclined`: the walk declines when the matches carrying an indexed value run out
+        // before `page_offset + limit` while unvalued matches remain, so the missing ingredient was
+        // never nulls -- the store already generates 16% null prices and 15% null rarity -- it was a
+        // match set small enough for the valued ones to fall short of one page. `fateseal` is the
+        // rare tail of `FUZZ_KEYWORDS` (weight 1 of 86), and ANDing a border narrows it ~6x further.
+        FuzzSpec::And(vec![
+            FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: "fateseal".to_string() }),
+            FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+        ]),
     ];
     // Every orderby, because which one is set is exactly what picks the branch: a card-space
     // permutation gives `Perm`, `usd`/`rarity` in printing mode give `OrderbyWalk` (#744), and
@@ -3252,7 +3270,10 @@ fn compose_paging_prediction_matches_the_branch_taken() {
     let offsets = [0usize, 40, 10_000];
 
     let (mut exercised, mut declined, mut empty) = (0usize, 0usize, 0usize);
-    let mut by_strategy = [0usize; 3]; // Perm / OrderbyWalk / Gather
+    // Perm / OrderbyWalk / Gather / GatherWalkDeclined. The fourth is not a strategy the model
+    // predicts -- it is the one legal inexactness in the prediction, and it gets its own cell so
+    // the allowance above cannot pass by never being exercised.
+    let mut by_strategy = [0usize; 4];
     for &n_cards in &CORPUS_SIZES {
         let data = fuzz_store_n(&mut rng, n_cards);
         let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
@@ -3272,7 +3293,7 @@ fn compose_paging_prediction_matches_the_branch_taken() {
                             // The prediction, on its own clone -- acquire mutates the filter it reads.
                             let mut acq_filter = filter.clone();
                             let (feats, prep, _bits) = acquire_plan_features(&ctx, &params, &mut acq_filter, pe.as_ref());
-                            if prep.count_source() != "printing_compose" {
+                            if prep.count_source() != CountSource::PrintingCompose {
                                 continue; // not a compose acquire; compose_paging has no referent
                             }
                             let predicted = feats.compose_paging;
@@ -3295,30 +3316,38 @@ fn compose_paging_prediction_matches_the_branch_taken() {
                             // decline sites returned without recording anything.
                             if ran.is_none() {
                                 assert!(
-                                    matches!(taken, "NotComposable" | "DeclineBroad" | "DeclineSparseEstimate" | "DeclineSparseExact"),
+                                    matches!(taken, PagingTaken::NotComposable | PagingTaken::DeclineBroad | PagingTaken::DeclineSparseEstimate | PagingTaken::DeclineSparseExact),
                                     "compose declined without recording which gate fired (got {taken:?}): {case}",
                                 );
                                 declined += 1;
                                 continue;
                             }
-                            if taken == "EmptyPage" {
+                            if taken == PagingTaken::EmptyPage {
                                 empty += 1;
                                 continue; // returned before any paging strategy ran
                             }
-                            let predicted_label = match predicted {
-                                ComposePaging::Perm => "Perm",
-                                ComposePaging::OrderbyWalk => "OrderbyWalk",
-                                ComposePaging::Gather => "Gather",
+                            // Not a blanket equality: the prediction is an upper bound on
+                            // `OrderbyWalk` and exact everywhere else -- see the doc above. Each
+                            // arm names the labels that are legal for it, so a wrong branch in the
+                            // OTHER direction (`Gather` predicted, walk taken) still fails.
+                            let legal: &[PagingTaken] = match predicted {
+                                ComposePaging::Perm => &[PagingTaken::Perm],
+                                ComposePaging::OrderbyWalk => &[PagingTaken::OrderbyWalk, PagingTaken::GatherWalkDeclined],
+                                // Bare `Gather` only. `GatherWalkDeclined` here would mean the
+                                // fastpath found a walk available where acquire predicted none,
+                                // i.e. the two availability tests really had drifted.
+                                ComposePaging::Gather => &[PagingTaken::Gather],
                             };
-                            assert_eq!(
-                                taken, predicted_label,
-                                "cost model predicted {predicted_label} but the fastpath took {taken}: {case}",
+                            assert!(
+                                legal.contains(&taken),
+                                "cost model predicted {predicted:?} (legal: {legal:?}) but the fastpath took {taken:?}: {case}",
                             );
                             exercised += 1;
-                            match predicted {
-                                ComposePaging::Perm => by_strategy[0] += 1,
-                                ComposePaging::OrderbyWalk => by_strategy[1] += 1,
-                                ComposePaging::Gather => by_strategy[2] += 1,
+                            match (predicted, taken) {
+                                (ComposePaging::Perm, _) => by_strategy[0] += 1,
+                                (ComposePaging::OrderbyWalk, PagingTaken::GatherWalkDeclined) => by_strategy[3] += 1,
+                                (ComposePaging::OrderbyWalk, _) => by_strategy[1] += 1,
+                                (ComposePaging::Gather, _) => by_strategy[2] += 1,
                             }
                         }
                     }
@@ -3329,17 +3358,303 @@ fn compose_paging_prediction_matches_the_branch_taken() {
     // Guard against the sweep silently covering nothing -- every `continue` above is a shape
     // that skipped the assertion, and all of them skipping would still pass.
     println!(
-        "compose paging: {exercised} strategy runs checked ({} Perm, {} OrderbyWalk, {} Gather), {declined} declined, {empty} empty-page",
-        by_strategy[0], by_strategy[1], by_strategy[2],
+        "compose paging: {exercised} strategy runs checked \
+         ({} Perm, {} OrderbyWalk, {} Gather, {} walk-declined), {declined} declined, {empty} empty-page",
+        by_strategy[0], by_strategy[1], by_strategy[2], by_strategy[3],
     );
-    // All three strategies, not just a count: the agreement is only interesting where the two
-    // decisions could differ, and a sweep that reaches one branch 64 times checks one branch. This
-    // caught the sweep exercising `Gather` zero times at a smaller corpus size.
-    for (i, strategy) in ["Perm", "OrderbyWalk", "Gather"].iter().enumerate() {
+    // Every cell, not just a total: the agreement is only interesting where the two decisions could
+    // differ, and a sweep that reaches one branch 64 times checks one branch. This caught the sweep
+    // exercising `Gather` zero times at a smaller corpus size. `GatherWalkDeclined` is in the list
+    // for the same reason and one more: it is the single cell where the prediction is allowed to be
+    // inexact, so a sweep that never reaches it turns that allowance into an unchecked hole.
+    for (i, strategy) in ["Perm", "OrderbyWalk", "Gather", "GatherWalkDeclined"].iter().enumerate() {
         assert!(by_strategy[i] > 0, "no compose query reached {strategy}; that branch is unchecked");
     }
     // And at least one decline, or the "every gate names itself" assertion never ran either.
     assert!(declined > 0, "no compose query declined; the decline-label assertion is unexercised");
+}
+
+/// The two materializing plans must report identical `cards_visited` and `printings_scanned`.
+///
+/// These are ONE counter under one name: `PhaseStats` has a single set of fields and both
+/// `exec_gathered_scan` and `run_query_streamed` publish into them, so a consumer reading
+/// `printings_scanned` off a `PlanTrial` cannot tell which executor produced it. `scan_units` has
+/// one definition too, and both plans' cost arms key on it — so if the executors count differently,
+/// at most one of them is the valid comparison, and the damage surfaces as a rate constant that
+/// will not calibrate rather than as anything that looks like a bug.
+///
+/// `printings_scanned` is the load-bearing half, and the reason is a one-line placement: both
+/// executors count it BELOW the `card_pass` continue, because a card rejected there never has its
+/// printings touched. Counting at the top of the loop instead is the exact defect this pins, and it
+/// is the shape a plausible "just count once at the top" cleanup would reintroduce silently.
+///
+/// Equality therefore rests on that continue firing identically in both loops — and the two
+/// `all_match` gates are NOT identical:
+///
+///     gathered:   all_match_known || card_pass(..)
+///     streamed:  (all_match_known && !Artwork) || card_pass(..)
+///
+/// In artwork mode with `all_match_known`, gathered short-circuits and never calls `card_pass`,
+/// while streamed calls it and could hit the `continue`. The counts stay equal only if
+/// `all_match_known` is honest, so the artwork/all-match cell checks the narrowing's own claim as
+/// well as the counters — which is why it is guarded for coverage separately below.
+///
+/// `matches_pushed` is deliberately NOT asserted: it equals `result_total` by construction in both
+/// executors (`GatherSelect::absorb` accumulates the identical `len() - before` the counter does),
+/// and plan-vs-plan agreement on `result_total` is already covered elsewhere.
+#[test]
+fn materializing_plans_agree_on_the_counters_they_share() {
+    use rand::SeedableRng;
+    // One size is enough here: unlike the compose sweep there are no mutually exclusive regimes,
+    // and what varies the `card_pass` continue is the predicate and the mode, not the corpus.
+    const CORPUS_SIZE: usize = 4_000;
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(745_004);
+    // Both narrowing kinds, and the second group is the load-bearing one. The plane/index leaves
+    // above it narrow EXACTLY -- every candidate they return passes `card_pass`, so the continue
+    // never fires and the two loops trivially agree. Only an inexact narrowing (an oracle-text
+    // trigram superset, an arithmetic comparison across a card and a printing field) hands the
+    // executors candidates that `card_pass` then rejects, which is the only condition under which
+    // `printings_scanned` can diverge at all. Verified: without the second group `saw_continue` is
+    // 0 across the whole sweep and both assertions pass without exercising anything.
+    let specs = [
+        fuzz_leaf_type(&mut rng),
+        fuzz_leaf_color(&mut rng),
+        fuzz_leaf_rarity(&mut rng),
+        FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]),
+        FuzzSpec::And(vec![fuzz_leaf_type(&mut rng), fuzz_leaf_rarity(&mut rng)]),
+        FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+        fuzz_leaf_text_contains(&mut rng, TextSearchField::OracleTextLower),
+        fuzz_leaf_text_contains(&mut rng, TextSearchField::NameLower),
+        fuzz_leaf_arith(&mut rng),
+        FuzzSpec::And(vec![fuzz_leaf_type(&mut rng), fuzz_leaf_text_contains(&mut rng, TextSearchField::OracleTextLower)]),
+    ];
+    // `usd`/`rarity` have no sort permutation, so StreamedSelect declines on them and the pair is
+    // skipped. Left in deliberately: which orderbys have permutations is not this test's business
+    // to encode, and `ran.is_none()` filters them without a second source of truth to drift.
+    let sort_cols = [
+        ("edhrec", SortCol::EdhrecRank), ("cmc", SortCol::Cmc), ("power", SortCol::Power),
+        ("toughness", SortCol::Toughness), ("name", SortCol::Name), ("cubecobra", SortCol::Cubecobra),
+        ("rarity", SortCol::Rarity), ("usd", SortCol::PriceUsd),
+    ];
+    let modes = [("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)];
+
+    let data = fuzz_store_n(&mut rng, CORPUS_SIZE);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ctx = QueryCtx::from(archived);
+
+    let (mut checked, mut artwork_all_match, mut saw_continue) = (0usize, 0usize, 0usize);
+    for spec in &specs {
+        for &(mode_label, mode) in &modes {
+            for &(orderby, sort_col) in &sort_cols {
+                let params = kernel_params(mode, sort_col, false, 60, 0);
+                let bound = fuzz_bound_filter(spec, archived);
+                let (pe, filter) = split_planes(
+                    bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+                );
+
+                // Each run gets a pristine clone -- `prepare_candidates` mutates the filter it is
+                // handed (`memoize_text_predicates`), and a shared one would let the second plan
+                // narrow a tree the first already rewrote.
+                let mut streamed_filter = filter.clone();
+                take_phase_stats();
+                let streamed_ran =
+                    run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref());
+                let streamed = take_phase_stats();
+                if streamed_ran.is_none() {
+                    continue; // no sort permutation for this orderby; nothing to compare against
+                }
+
+                let mut gathered_filter = filter.clone();
+                take_phase_stats();
+                let gathered_ran =
+                    run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref());
+                let gathered = take_phase_stats();
+                assert!(gathered_ran.is_some(), "GatheredScan is always applicable");
+
+                let case = format!("{mode_label}/{orderby} ({})", fuzz_describe(spec));
+                assert_eq!(
+                    streamed.cards_visited, gathered.cards_visited,
+                    "cards_visited disagrees (streamed {} vs gathered {}): {case}",
+                    streamed.cards_visited, gathered.cards_visited,
+                );
+                assert_eq!(
+                    streamed.printings_scanned, gathered.printings_scanned,
+                    "printings_scanned disagrees (streamed {} vs gathered {}): {case}",
+                    streamed.printings_scanned, gathered.printings_scanned,
+                );
+                checked += 1;
+
+                // Coverage bookkeeping, so the assertions above cannot pass by never meeting the
+                // cases that could break them. `all_match_known` is read from a third narrowing
+                // rather than inferred: nothing in `PhaseStats` reports it.
+                let mut prep_filter = filter.clone();
+                let prep = prepare_candidates(&ctx, &params, &mut prep_filter, pe.as_ref());
+                if prep.all_match_known && matches!(mode, Mode::Artwork) {
+                    artwork_all_match += 1;
+                }
+                // Did the `card_pass` continue actually fire? Only then do the two loops take
+                // different numbers of trips past the counter, which is the only way
+                // `printings_scanned` can come apart at all. Measured as "fewer printings scanned
+                // than the candidate set holds", not guessed from the counters alone.
+                let scannable: u64 = prep
+                    .card_ids(&ctx)
+                    .map(|cid| {
+                        let (s, e) = (ctx.offsets[cid as usize], ctx.offsets[cid as usize + 1]);
+                        u64::from(u32::from(e) - u32::from(s))
+                    })
+                    .sum();
+                if gathered.printings_scanned < scannable {
+                    saw_continue += 1;
+                }
+            }
+        }
+    }
+
+    println!(
+        "counter parity: {checked} query/plan pairs checked, {artwork_all_match} artwork+all_match_known, \
+         {saw_continue} with card_pass rejecting at least one candidate"
+    );
+    assert!(checked > 0, "no query ran both materializing plans; the parity assertions are unexercised");
+    // The one cell where the two `all_match` gates actually differ. Without it the sweep only ever
+    // compares two loops taking the identical branch, which is not a test of anything.
+    assert!(
+        artwork_all_match > 0,
+        "no artwork query had all_match_known; the one cell where the two all_match gates diverge is unchecked",
+    );
+    // And the continue must actually fire somewhere, or `printings_scanned` equality is trivial:
+    // with every candidate passing, both loops scan every printing and cannot disagree. This is
+    // what the inexact-narrowing specs are in the list for -- drop them and this drops to 0.
+    assert!(
+        saw_continue > 0,
+        "card_pass never rejected a candidate; printings_scanned agreed only because nothing was skipped",
+    );
+}
+
+/// No plan may report stats it did not write. Driven through `explain_analyze` on purpose — the
+/// invariant at risk lives in *its* loop, not in any executor.
+///
+/// `PHASE_STATS` is one thread-local slot every participant in a round publishes into, and
+/// `explain_analyze` separates them with a single `take_phase_stats()` after each. Nothing else
+/// enforces that separation, so deleting it corrupts the counters silently: the numbers stay
+/// plausible, every other test stays green, and the damage only appears later as a feature that
+/// disagrees with its counter for reasons no re-fit can find. This is the assertion that fails.
+///
+/// Two distinct leaks, and the second is the one actually observed:
+///
+/// 1. A participant that publishes NOTHING reads its predecessor's whole struct.
+///    `PrintingRangeScan`, `PlanePopcountOrder` and `CardRangePopcount` write no counters at all
+///    (they are bitmap/index operations with no per-card match loop), so without the clear they
+///    report whichever materializing plan ran before them.
+///
+/// 2. A participant that publishes PARTIALLY inherits the fields it does not write. Both executors
+///    set 8 of `PhaseStats`' 10 fields and carry the rest through `..c.get()` — deliberately, since
+///    a compose fastpath that declines records `paging_taken` and THEN falls through to a
+///    materializing plan whose publish must not wipe it. That `..c.get()` means "inherit from
+///    earlier in this run", and the clear is the only thing that keeps "this run" from widening to
+///    "this thread, ever". Measured before the clear existed: 49 of 600 queries had `GatheredScan`
+///    reporting a `paging_taken` only `printing_compose_fastpath` sets.
+///
+/// So a fully-instrumented, looping plan was the contaminated one — which is why asserting only
+/// that the silent fast paths report zeros would miss the real defect.
+///
+/// `result_total` is not checked: `explain_analyze` overwrites it after the take, so it is the one
+/// `..c.get()` field with no exposure. `paging_taken` is the whole of it.
+#[test]
+fn plan_stats_never_leak_between_participants() {
+    use rand::SeedableRng;
+    const CORPUS_SIZE: usize = 3_000;
+    const NUM_WARMUPS: usize = 1;
+    const NUM_TRIALS: usize = 3;
+    /// Publish no counters whatsoever — see the doc's leak 1.
+    const SILENT_PLANS: [PhysicalPlan; 3] =
+        [PhysicalPlan::PrintingRangeScan, PhysicalPlan::PlanePopcountOrder, PhysicalPlan::CardRangePopcount];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(745_005);
+    // Chosen for plan COVERAGE, not for query realism: the bare ranges are what make
+    // `PrintingRangeScan`/`CardRangePopcount` applicable, the plane leaves reach
+    // `PlanePopcountOrder` in card mode, and the border leaf is the one that composes -- and a
+    // compose is what puts a real `paging_taken` in the cell for leak 2 to inherit.
+    let specs = [
+        fuzz_leaf_price(&mut rng),
+        fuzz_leaf_year(&mut rng),
+        fuzz_leaf_collector_number(&mut rng),
+        fuzz_leaf_type(&mut rng),
+        fuzz_leaf_color(&mut rng),
+        FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+    ];
+    let modes = [("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)];
+    let sort_cols = [("edhrec", SortCol::EdhrecRank), ("usd", SortCol::PriceUsd), ("name", SortCol::Name)];
+
+    let data = fuzz_store_n(&mut rng, CORPUS_SIZE);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ctx = QueryCtx::from(archived);
+
+    let (mut silent_checked, mut materializing_checked, mut compose_labelled) = (0usize, 0usize, 0usize);
+    for spec in &specs {
+        for &(mode_label, mode) in &modes {
+            for &(orderby, sort_col) in &sort_cols {
+                let params = kernel_params(mode, sort_col, false, 60, 0);
+                let bound = fuzz_bound_filter(spec, archived);
+                let (pe, filter) = split_planes(
+                    bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+                );
+                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
+
+                for t in &trials {
+                    if t.trials_ns.is_empty() {
+                        continue; // declined at runtime, so nothing was recorded for it
+                    }
+                    let case = format!("{:?} {mode_label}/{orderby} ({})", t.plan, fuzz_describe(spec));
+                    let p = &t.phases;
+                    if SILENT_PLANS.contains(&t.plan) {
+                        // Leak 1. `ns_round_total` and `result_total` are excluded: `explain_analyze`
+                        // fills both itself after the take, so they are non-zero by design here.
+                        assert_eq!(
+                            (p.cards_visited, p.printings_scanned, p.matches_pushed), (0, 0, 0),
+                            "uninstrumented plan reported counters it never wrote: {case}",
+                        );
+                        assert_eq!(
+                            (p.ns_setup, p.ns_loop, p.ns_finish, p.ns_prepare), (0, 0, 0, 0),
+                            "uninstrumented plan reported phase timings it never wrote: {case}",
+                        );
+                        assert_eq!(p.paging_taken, PagingTaken::NotEntered, "uninstrumented plan inherited a paging label: {case}");
+                        silent_checked += 1;
+                    } else if matches!(t.plan, PhysicalPlan::StreamedSelect | PhysicalPlan::GatheredScan) {
+                        // Leak 2: the field neither executor writes. Only `printing_compose_fastpath`
+                        // sets this, and it is not on either of their paths.
+                        assert_eq!(
+                            p.paging_taken, PagingTaken::NotEntered,
+                            "materializing plan inherited a paging label only the compose fastpath sets: {case}",
+                        );
+                        materializing_checked += 1;
+                    } else if t.plan == PhysicalPlan::PrintingCompose {
+                        // The source of the label leak 2 would propagate. Asserting it is REAL is what
+                        // makes the check above meaningful: if compose never recorded anything, there
+                        // would be nothing for a broken clear to spread.
+                        assert_ne!(
+                            p.paging_taken, PagingTaken::NotEntered,
+                            "compose ran but recorded no paging branch, so leak 2 has no source: {case}",
+                        );
+                        compose_labelled += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    println!(
+        "stat isolation: {silent_checked} uninstrumented-plan runs, {materializing_checked} materializing runs, \
+         {compose_labelled} compose runs carrying a real paging label"
+    );
+    // Each guard covers a leak that would otherwise go unasserted, and the third is what supplies
+    // the contaminant: without a labelled compose in the mix, leak 2 cannot be reproduced even with
+    // the clear deleted.
+    assert!(silent_checked > 0, "no uninstrumented plan ran; leak 1 is unchecked");
+    assert!(materializing_checked > 0, "no materializing plan ran; leak 2 is unchecked");
+    assert!(compose_labelled > 0, "no compose recorded a paging label; leak 2 has no contaminant to detect");
 }
 
 /// #702 PR1 estimator accuracy report (NOT an assertion — a reporting tool).

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,7 +5,7 @@ use super::{
     assign_artwork_groups, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
-    range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, PlanEstimate, PlanTrial,
+    range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -3058,8 +3058,41 @@ fn explain_reports_ranked_applicable_plans() {
             let (pe, mut filter) = split_planes(
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
             );
-            let estimates: Vec<PlanEstimate> = explain(
+            let (facts, estimates): (AcquireFacts, Vec<PlanEstimate>) = explain(
                 &QueryCtx::from(archived), &explain_params(mode, 60), &mut filter, pe.as_ref(),
+            );
+
+            // The acquire facts every plan in this call shares. `eval_domain` is what a
+            // caller filters on to decide whether a query exercises a given code path,
+            // so it must be a real count in range, not a placeholder.
+            // The three `Prep::Range` labels are reported individually rather than as "range":
+            // that variant covers a bare range, a card-range popcount and a printing compose,
+            // and collapsing them made a compose look like a range index probe.
+            assert!(
+                matches!(
+                    facts.count_source,
+                    "plane" | "candidates" | "card_range_popcount" | "printing_range_scan" | "printing_compose"
+                ),
+                "unknown count_source {:?} ({mode_label}, {})", facts.count_source, fuzz_describe(spec),
+            );
+            assert_eq!(facts.n_cards, archived.cards.len() as u32, "n_cards must be the corpus size");
+            assert!(
+                facts.eval_domain <= facts.n_cards,
+                "eval_domain {} exceeds n_cards {} ({mode_label}, {})", facts.eval_domain, facts.n_cards, fuzz_describe(spec),
+            );
+            assert_eq!(facts.acquire_ns.len(), 1, "explain() reports exactly one acquire sample");
+            // `none` is legitimate for a candidate-acquired query — the residual narrowing can
+            // produce nothing and leave the plane bitmap as the whole candidate list, which is
+            // itself a "no sort happened" signal. What must hold is that the label is real, and
+            // that the two preps which materialize no candidate list never claim otherwise.
+            assert!(
+                matches!(facts.narrowed_repr, "none" | "cards" | "printings" | "card_bits" | "printing_bits"),
+                "unknown narrowed_repr {:?} ({mode_label}, {})", facts.narrowed_repr, fuzz_describe(spec),
+            );
+            assert!(
+                facts.count_source == "candidates" || facts.narrowed_repr == "none",
+                "{:?}-acquired query reported narrowed_repr {:?} ({mode_label}, {})",
+                facts.count_source, facts.narrowed_repr, fuzz_describe(spec),
             );
 
             assert!(!estimates.is_empty(), "GatheredScan is always applicable ({mode_label}, {})", fuzz_describe(spec));
@@ -3071,6 +3104,25 @@ fn explain_reports_ranked_applicable_plans() {
                 estimates.windows(2).all(|w| w[0].predicted_ns <= w[1].predicted_ns),
                 "explain() not sorted ascending ({mode_label}, {})", fuzz_describe(spec),
             );
+            // Exactly one plan is the router's pick, and it is the cheapest predicted — i.e. index
+            // 0 after the sort. A caller must never need to re-derive this.
+            assert_eq!(
+                estimates.iter().filter(|e| e.picked).count(), 1,
+                "exactly one plan must be marked picked ({mode_label}, {})", fuzz_describe(spec),
+            );
+            assert!(estimates[0].picked, "the picked plan must be index 0 ({mode_label}, {})", fuzz_describe(spec));
+            // The materialization term is REPORTED, never folded into predicted_ns — folding it in
+            // would change routing, which cost.rs's "Candidate materialization" section declines to
+            // do until the term is validated. Non-materializing plans must report exactly 0.
+            for e in &estimates {
+                assert!(e.materialize_ns >= 0.0 && e.materialize_ns.is_finite(), "bad materialize_ns for {:?}", e.plan);
+                let materializes = matches!(e.plan, PhysicalPlan::StreamedSelect | PhysicalPlan::GatheredScan);
+                assert_eq!(
+                    e.materialize_ns > 0.0, materializes,
+                    "{:?} materialize_ns {} contradicts whether it builds a candidate list",
+                    e.plan, e.materialize_ns,
+                );
+            }
             for e in &estimates {
                 assert!(e.predicted_ns.is_finite() && e.predicted_ns >= 0.0, "non-finite/negative predicted_ns for {:?}", e.plan);
             }
@@ -3102,20 +3154,36 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
     let (ref_pe, mut ref_filter) = split_planes(
         bound.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
     );
-    let reference: Vec<PlanEstimate> = explain(
+    let (ref_facts, reference): (AcquireFacts, Vec<PlanEstimate>) = explain(
         &QueryCtx::from(archived), &explain_params(Mode::Card, 60), &mut ref_filter, ref_pe.as_ref(),
     );
 
     let (pe, filter) = split_planes(bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
-    let trials: Vec<PlanTrial> = explain_analyze(
+    let (facts, trials): (AcquireFacts, Vec<PlanTrial>) = explain_analyze(
         &QueryCtx::from(archived), &QueryParams::from_strs("card", "default", "edhrec", "asc", 60, 0),
         &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS,
     );
+
+    // The acquire facts describe the query, not the round, so they must agree with
+    // what explain() alone reported — except acquire_ns, which is a measurement:
+    // explain() takes one sample, explain_analyze re-samples once per recorded round.
+    assert_eq!(facts.count_source, ref_facts.count_source, "count_source must match explain()'s");
+    assert_eq!(facts.eval_domain, ref_facts.eval_domain, "eval_domain must match explain()'s");
+    assert_eq!(facts.matches, ref_facts.matches, "matches must match explain()'s");
+    assert_eq!(facts.acquire_ns.len(), NUM_TRIALS, "explain_analyze records one acquire sample per trial round");
+    // The routed row is what distinguishes a ranking error from a live defect, so it must be
+    // present for every recorded round — and absent from explain(), which executes nothing.
+    assert_eq!(facts.routed_ns.len(), NUM_TRIALS, "explain_analyze records one routed sample per trial round");
+    assert!(ref_facts.routed_ns.is_empty(), "explain() runs no query, so it reports no routed timing");
 
     assert_eq!(trials.len(), reference.len(), "explain_analyze must cover exactly the plans explain() reports");
     for (t, r) in trials.iter().zip(&reference) {
         assert_eq!(t.plan, r.plan, "plan order must match explain()'s ranking");
         assert_eq!(t.predicted_ns, r.predicted_ns, "predicted_ns must be identical to explain()'s for {:?}", t.plan);
+        // Carried through, not recomputed — a caller comparing explain against explain_analyze must
+        // see the same term and the same pick, or the two primitives are not describing one query.
+        assert_eq!(t.materialize_ns, r.materialize_ns, "materialize_ns must match explain()'s for {:?}", t.plan);
+        assert_eq!(t.picked, r.picked, "picked must match explain()'s for {:?}", t.plan);
         // A structurally-applicable plan's fastpath can legitimately decline at
         // runtime (empty trials_ns); when it doesn't decline, it must have run
         // exactly NUM_TRIALS times (warmups are discarded, never recorded).

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3690,6 +3690,119 @@ fn plan_stats_never_leak_between_participants() {
     assert!(compose_labelled > 0, "no compose recorded a paging label; leak 2 has no contaminant to detect");
 }
 
+/// A plan that enters a fastpath and declines must say so through `explain_analyze`, not just
+/// through `run_query_with_plan`.
+///
+/// `compose_paging_prediction_matches_the_branch_taken` checks the decline labels by driving
+/// `run_query_with_plan` and reading the thread-local directly, which only Rust can do. Everything
+/// outside the crate — `scripts/bench_cost_model_agreement.py`, any future calibration harness —
+/// sees `explain_analyze`, and that used to drop the stats of any plan whose round returned `None`.
+/// So `NotComposable`, `DeclineBroad`, `DeclineSparseEstimate` and `DeclineSparseExact` were
+/// recorded, asserted in-crate, and then discarded before anyone outside could count them.
+///
+/// The distinction is worth a wire field rather than an inference because the four declines do not
+/// cost the same thing. Three gate BEFORE `printing_compose_fastpath` composes. `DeclineSparseExact`
+/// gates AFTER, off the real total, so it pays a full printing compose and throws it away before
+/// the general path answers the query again. `declined_ns` is what sizes that; `paging_taken` is
+/// what says which of the two happened.
+///
+/// Asserted here, in order: a declining plan reports EMPTY `trials_ns` (it produced nothing), a
+/// NON-EMPTY `declined_ns` (it still cost something), zero counters and zero phase timings (no
+/// executor ran, so anything else would be a leak), and — for compose specifically — a label naming
+/// the gate rather than the `NotEntered` default that would mean it was never tried.
+#[test]
+fn declining_plans_report_their_gate_through_explain_analyze() {
+    use rand::SeedableRng;
+    const CORPUS_SIZE: usize = 2_000;
+    const NUM_WARMUPS: usize = 1;
+    const NUM_TRIALS: usize = 2;
+    /// Gates that mean "entered the compose fastpath and turned back". `NotEntered` is excluded on
+    /// purpose: it is the value this test exists to prove a decline never reports.
+    const DECLINE_GATES: [PagingTaken; 4] = [
+        PagingTaken::NotComposable,
+        PagingTaken::DeclineBroad,
+        PagingTaken::DeclineSparseEstimate,
+        PagingTaken::DeclineSparseExact,
+    ];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(745_006);
+    // The narrow keyword/border AND is the one that reliably declines -- same reasoning as the
+    // compose sweep's last spec, where a small match set is what drives the sparse gates. The
+    // broader leaves are here so the sweep also covers plans that decline for other reasons.
+    let specs = [
+        FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+        fuzz_leaf_type(&mut rng),
+        fuzz_leaf_price(&mut rng),
+        FuzzSpec::And(vec![
+            FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: "fateseal".to_string() }),
+            FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+        ]),
+    ];
+    let modes = [("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)];
+    let sort_cols = [("edhrec", SortCol::EdhrecRank), ("usd", SortCol::PriceUsd), ("rarity", SortCol::Rarity)];
+
+    let data = fuzz_store_n(&mut rng, CORPUS_SIZE);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ctx = QueryCtx::from(archived);
+
+    let (mut declines_seen, mut compose_gates_seen) = (0usize, 0usize);
+    let mut by_gate = std::collections::BTreeMap::<String, usize>::new();
+    for spec in &specs {
+        for &(mode_label, mode) in &modes {
+            for &(orderby, sort_col) in &sort_cols {
+                let params = kernel_params(mode, sort_col, false, 60, 0);
+                let bound = fuzz_bound_filter(spec, archived);
+                let (pe, filter) = split_planes(
+                    bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+                );
+                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
+
+                for t in &trials {
+                    if t.declined_ns.is_empty() {
+                        continue;
+                    }
+                    let case = format!("{:?} {mode_label}/{orderby} ({})", t.plan, fuzz_describe(spec));
+                    // Mutually exclusive: a decline is deterministic for one query and store, so a
+                    // plan cannot both produce a page and bail across rounds of the same sweep.
+                    assert!(t.trials_ns.is_empty(), "a plan reported both trials and declines: {case}");
+                    assert_eq!(t.declined_ns.len(), NUM_TRIALS, "one decline sample per recorded round: {case}");
+                    assert!(t.declined_ns.iter().all(|&ns| ns > 0), "a decline still costs wall time: {case}");
+                    // No executor ran, so anything non-zero here came from somewhere else.
+                    let p = &t.phases;
+                    assert_eq!(
+                        (p.cards_visited, p.printings_scanned, p.matches_pushed), (0, 0, 0),
+                        "a declining plan reported counters no executor wrote: {case}",
+                    );
+                    assert_eq!(
+                        (p.ns_setup, p.ns_loop, p.ns_finish, p.ns_prepare, p.ns_round_total, p.result_total), (0, 0, 0, 0, 0, 0),
+                        "a declining plan reported timings or a total it never produced: {case}",
+                    );
+                    declines_seen += 1;
+                    // Only compose labels its gates; PrintingRangeScan has no equivalent, so it
+                    // legitimately declines as `NotEntered`.
+                    if t.plan == PhysicalPlan::PrintingCompose {
+                        assert!(
+                            DECLINE_GATES.contains(&p.paging_taken),
+                            "a declining compose reported {:?}, which does not name a gate: {case}",
+                            p.paging_taken,
+                        );
+                        *by_gate.entry(format!("{:?}", p.paging_taken)).or_default() += 1;
+                        compose_gates_seen += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    let gates: Vec<String> = by_gate.iter().map(|(g, n)| format!("{g} x{n}")).collect();
+    println!("declines through explain_analyze: {declines_seen} total, {compose_gates_seen} compose ({})", gates.join(", "));
+    // Both guards matter: the first says the wire field is reachable at all, the second says the
+    // labels ride along with it. Before `declined_ns` existed every one of these rows was dropped.
+    assert!(declines_seen > 0, "no plan declined; the whole assertion block above is unexercised");
+    assert!(compose_gates_seen > 0, "no compose declined; the gate labels are still unreachable from outside Rust");
+}
+
 /// #702 PR1 estimator accuracy report (NOT an assertion — a reporting tool).
 /// Runs a spread of fuzz queries against a corpus store, comparing the point
 /// estimate and bounds to the mode="card" reference count, and prints the

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3723,6 +3723,46 @@ fn plan_stats_never_leak_between_participants() {
     assert!(range_labelled > 0, "no PrintingRangeScan produced a page; its success labels are unchecked");
 }
 
+/// The predicted strategy and the taken strategy must SPELL themselves the same way.
+///
+/// These are two enums — `ComposePaging` (what the cost model predicted) and `PagingTaken` (what the
+/// fastpath did) — and Rust compares them nowhere: `compose_paging_prediction_matches_the_branch_taken`
+/// maps one to the other through an explicit table, so a rename on either side is invisible to it.
+///
+/// The comparison that DOES happen is in Python, on the strings.
+/// `scripts/bench_cost_model_agreement.py` counts agreement as `cells[(predicted, taken)]`, drawing
+/// `predicted` from `acquire["compose_paging"]` and `taken` from `plans[i]["paging_taken"]`. If the
+/// two labels drift apart, every agreed run is reclassified as a disagreement and the whole
+/// diagonal empties — a table full of alarming off-diagonal counts, with nothing wrong but a name.
+///
+/// This was a live hole until `ComposePaging::label()` existed: that side was `format!("{:?}", ..)`,
+/// so it followed a variant rename automatically while `PagingTaken::label()` did not.
+#[test]
+fn compose_paging_and_paging_taken_agree_on_strategy_names() {
+    // The three strategies that exist on BOTH sides, which is exactly the set the Python table
+    // compares. `PagingTaken`'s other variants are gates and outcomes with no predicted counterpart,
+    // and `GatherWalkDeclined` is deliberately spelled differently — it is the one cell where the
+    // prediction is allowed to be inexact, so it must NOT collide with `Gather`.
+    let paired = [
+        (ComposePaging::Perm, PagingTaken::Perm),
+        (ComposePaging::OrderbyWalk, PagingTaken::OrderbyWalk),
+        (ComposePaging::Gather, PagingTaken::Gather),
+    ];
+    for (predicted, taken) in paired {
+        assert_eq!(
+            predicted.label(), taken.label(),
+            "{predicted:?} and {taken:?} are the same strategy but spell it differently; \
+             bench_cost_model_agreement.py compares them as strings and its diagonal would empty",
+        );
+    }
+    // The fallback must stay distinguishable from the strategy it falls back to, or the walk-declined
+    // rate folds into the agreed count and the under-costing it measures disappears.
+    assert_ne!(
+        PagingTaken::GatherWalkDeclined.label(), PagingTaken::Gather.label(),
+        "a declined walk must not be reported as a plain gather",
+    );
+}
+
 /// A plan that enters a fastpath and declines must say so through `explain_analyze`, not just
 /// through `run_query_with_plan`.
 ///

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3075,10 +3075,13 @@ fn explain_reports_ranked_applicable_plans() {
                 ),
                 "unknown count_source {:?} ({mode_label}, {})", facts.count_source, fuzz_describe(spec),
             );
-            assert_eq!(facts.n_cards, archived.cards.len() as u32, "n_cards must be the corpus size");
+            assert_eq!(facts.feats.n_cards, archived.cards.len() as u32, "n_cards must be the corpus size");
             assert!(
-                facts.eval_domain <= facts.n_cards,
-                "eval_domain {} exceeds n_cards {} ({mode_label}, {})", facts.eval_domain, facts.n_cards, fuzz_describe(spec),
+                facts.feats.eval_domain <= facts.feats.n_cards,
+                "eval_domain {} exceeds n_cards {} ({mode_label}, {})",
+                facts.feats.eval_domain,
+                facts.feats.n_cards,
+                fuzz_describe(spec),
             );
             assert_eq!(facts.acquire_ns.len(), 1, "explain() reports exactly one acquire sample");
             // `none` is legitimate for a candidate-acquired query — the residual narrowing can
@@ -3168,8 +3171,8 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
     // what explain() alone reported — except acquire_ns, which is a measurement:
     // explain() takes one sample, explain_analyze re-samples once per recorded round.
     assert_eq!(facts.count_source, ref_facts.count_source, "count_source must match explain()'s");
-    assert_eq!(facts.eval_domain, ref_facts.eval_domain, "eval_domain must match explain()'s");
-    assert_eq!(facts.matches, ref_facts.matches, "matches must match explain()'s");
+    assert_eq!(facts.feats.eval_domain, ref_facts.feats.eval_domain, "eval_domain must match explain()'s");
+    assert_eq!(facts.feats.matches, ref_facts.feats.matches, "matches must match explain()'s");
     assert_eq!(facts.acquire_ns.len(), NUM_TRIALS, "explain_analyze records one acquire sample per trial round");
     // The routed row is what distinguishes a ranking error from a live defect, so it must be
     // present for every recorded round — and absent from explain(), which executes nothing.

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6,6 +6,7 @@ use super::{
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
+    acquire_plan_features, take_phase_stats,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -3199,6 +3200,146 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
         trials.iter().any(|t| t.plan == PhysicalPlan::GatheredScan && t.trials_ns.len() == NUM_TRIALS),
         "GatheredScan is always applicable and never declines",
     );
+}
+
+/// `feats.compose_paging` must name the branch `printing_compose_fastpath` really takes.
+///
+/// The two decisions are made independently: `acquire_plan_features` recomputes the permutation
+/// lookup, the `orderby_walk_available` test and the decline conditions on its own, and the fastpath
+/// decides again at run time. Nothing checked that they agree — the same shape as the Python cost
+/// mirror that silently drifted from `cost.rs` for two revisions. `PhaseStats::paging_taken` exists
+/// to make the agreement checkable; this is the check.
+///
+/// The prediction is 3-way (`ComposePaging`) and `paging_taken` is 7-way, because a decline or an
+/// empty page reaches no strategy at all. Only the three strategy labels are comparable; the rest
+/// must still name the gate that fired, which is the other half of what this checks.
+///
+/// Swept at two corpus sizes on purpose, because the two regimes are mutually exclusive and each
+/// leaves the other's assertion unexercised:
+/// - 8,000 cards reaches `Gather`, which needs a card/artwork compose on `rarity`/`usd` (the two
+///   orderbys with no permutation) to thread between the `COMPOSE_GATHER_MAX_CARD_FRACTION` breadth
+///   gate and the pre-compose sparse decline. At 2,000 that band is too narrow to land in.
+/// - 2,000 cards reaches the declines, which at 8,000 stop firing entirely.
+#[test]
+fn compose_paging_prediction_matches_the_branch_taken() {
+    use rand::SeedableRng;
+    // Both regimes, because they are mutually exclusive -- see the doc above. At 8,000 no query
+    // declines at all; at 2,000 `Gather` is unreachable. One size leaves half the test asleep.
+    const CORPUS_SIZES: [usize; 2] = [2_000, 8_000];
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(745_003);
+
+    let specs = [
+        FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]),
+        fuzz_leaf_type(&mut rng),
+        fuzz_leaf_color(&mut rng),
+        fuzz_leaf_rarity(&mut rng),
+        FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+        FuzzSpec::And(vec![fuzz_leaf_type(&mut rng), fuzz_leaf_rarity(&mut rng)]),
+    ];
+    // Every orderby, because which one is set is exactly what picks the branch: a card-space
+    // permutation gives `Perm`, `usd`/`rarity` in printing mode give `OrderbyWalk` (#744), and
+    // anything else falls through to `Gather`.
+    let sort_cols = [
+        ("edhrec", SortCol::EdhrecRank), ("cmc", SortCol::Cmc), ("power", SortCol::Power),
+        ("toughness", SortCol::Toughness), ("rarity", SortCol::Rarity), ("usd", SortCol::PriceUsd),
+        ("cubecobra", SortCol::Cubecobra), ("name", SortCol::Name),
+    ];
+    let modes = [("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)];
+    // Both, since the strategy branch keys off `sort_perms.get(sort_col, descending)`.
+    let directions = [false, true];
+    // A deep offset as well as the first page: `EmptyPage` is only reachable past the total.
+    let offsets = [0usize, 40, 10_000];
+
+    let (mut exercised, mut declined, mut empty) = (0usize, 0usize, 0usize);
+    let mut by_strategy = [0usize; 3]; // Perm / OrderbyWalk / Gather
+    for &n_cards in &CORPUS_SIZES {
+        let data = fuzz_store_n(&mut rng, n_cards);
+        let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+        let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+        let ctx = QueryCtx::from(archived);
+        for spec in &specs {
+            for &(mode_label, mode) in &modes {
+                for &(orderby, sort_col) in &sort_cols {
+                    for &descending in &directions {
+                        for &page_offset in &offsets {
+                            let params = kernel_params(mode, sort_col, descending, 60, page_offset);
+                            let bound = fuzz_bound_filter(spec, archived);
+                            let (pe, filter) = split_planes(
+                                bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+                            );
+
+                            // The prediction, on its own clone -- acquire mutates the filter it reads.
+                            let mut acq_filter = filter.clone();
+                            let (feats, prep, _bits) = acquire_plan_features(&ctx, &params, &mut acq_filter, pe.as_ref());
+                            if prep.count_source() != "printing_compose" {
+                                continue; // not a compose acquire; compose_paging has no referent
+                            }
+                            let predicted = feats.compose_paging;
+
+                            // The branch really taken, on a pristine clone. Clear first: an earlier
+                            // iteration's label survives in the cell otherwise (see PHASE_STATS).
+                            let mut run_filter = filter.clone();
+                            take_phase_stats();
+                            let ran = run_query_with_plan(PhysicalPlan::PrintingCompose, &ctx, &params, &mut run_filter, pe.as_ref());
+                            let taken = take_phase_stats().paging_taken;
+
+                            let case = format!(
+                                    "n={n_cards} {mode_label}/{orderby}/desc={descending}/offset={page_offset} ({})",
+                                fuzz_describe(spec),
+                            );
+                            // A decline reached no paging strategy, so there is nothing to compare
+                            // against `compose_paging`. But it must still say WHICH gate declined it:
+                            // `""` would mean the fastpath was never entered, and this call entered it.
+                            // That is the silent hole the labels close -- before them, three of the four
+                            // decline sites returned without recording anything.
+                            if ran.is_none() {
+                                assert!(
+                                    matches!(taken, "NotComposable" | "DeclineBroad" | "DeclineSparseEstimate" | "DeclineSparseExact"),
+                                    "compose declined without recording which gate fired (got {taken:?}): {case}",
+                                );
+                                declined += 1;
+                                continue;
+                            }
+                            if taken == "EmptyPage" {
+                                empty += 1;
+                                continue; // returned before any paging strategy ran
+                            }
+                            let predicted_label = match predicted {
+                                ComposePaging::Perm => "Perm",
+                                ComposePaging::OrderbyWalk => "OrderbyWalk",
+                                ComposePaging::Gather => "Gather",
+                            };
+                            assert_eq!(
+                                taken, predicted_label,
+                                "cost model predicted {predicted_label} but the fastpath took {taken}: {case}",
+                            );
+                            exercised += 1;
+                            match predicted {
+                                ComposePaging::Perm => by_strategy[0] += 1,
+                                ComposePaging::OrderbyWalk => by_strategy[1] += 1,
+                                ComposePaging::Gather => by_strategy[2] += 1,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Guard against the sweep silently covering nothing -- every `continue` above is a shape
+    // that skipped the assertion, and all of them skipping would still pass.
+    println!(
+        "compose paging: {exercised} strategy runs checked ({} Perm, {} OrderbyWalk, {} Gather), {declined} declined, {empty} empty-page",
+        by_strategy[0], by_strategy[1], by_strategy[2],
+    );
+    // All three strategies, not just a count: the agreement is only interesting where the two
+    // decisions could differ, and a sweep that reaches one branch 64 times checks one branch. This
+    // caught the sweep exercising `Gather` zero times at a smaller corpus size.
+    for (i, strategy) in ["Perm", "OrderbyWalk", "Gather"].iter().enumerate() {
+        assert!(by_strategy[i] > 0, "no compose query reached {strategy}; that branch is unchecked");
+    }
+    // And at least one decline, or the "every gate names itself" assertion never ran either.
+    assert!(declined > 0, "no compose query declined; the decline-label assertion is unexercised");
 }
 
 /// #702 PR1 estimator accuracy report (NOT an assertion — a reporting tool).

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3201,7 +3201,7 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
 /// mirror that silently drifted from `cost.rs` for two revisions. `PhaseStats::paging_taken` exists
 /// to make the agreement checkable; this is the check.
 ///
-/// The prediction is 3-way (`ComposePaging`) and `paging_taken` is 8-way, because a decline or an
+/// The prediction is 3-way (`ComposePaging`) and `paging_taken` is 10-way, because a decline or an
 /// empty page reaches no strategy at all. Only the strategy labels are comparable; the rest must
 /// still name the gate that fired, which is the other half of what this checks.
 ///
@@ -3399,9 +3399,13 @@ fn compose_paging_prediction_matches_the_branch_taken() {
 /// `all_match_known` is honest, so the artwork/all-match cell checks the narrowing's own claim as
 /// well as the counters — which is why it is guarded for coverage separately below.
 ///
-/// `matches_pushed` is deliberately NOT asserted: it equals `result_total` by construction in both
-/// executors (`GatherSelect::absorb` accumulates the identical `len() - before` the counter does),
-/// and plan-vs-plan agreement on `result_total` is already covered elsewhere.
+/// `matches_pushed` is asserted two ways: plan-vs-plan like the others, and against the total each
+/// run actually returned. The second is what carries it. Plan-vs-plan alone cannot catch both
+/// executors being wrong the same way, and "it equals the total by construction" is not something
+/// this file should take on faith across two functions — `GatherSelect::absorb` accumulates the
+/// identical `len() - before` the counter does, and in artwork mode that expression sits downstream
+/// of the group dedup, so a counter moved above it would still agree plan-to-plan while both
+/// disagreed with reality.
 #[test]
 fn materializing_plans_agree_on_the_counters_they_share() {
     use rand::SeedableRng;
@@ -3484,6 +3488,28 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                     "printings_scanned disagrees (streamed {} vs gathered {}): {case}",
                     streamed.printings_scanned, gathered.printings_scanned,
                 );
+                assert_eq!(
+                    streamed.matches_pushed, gathered.matches_pushed,
+                    "matches_pushed disagrees (streamed {} vs gathered {}): {case}",
+                    streamed.matches_pushed, gathered.matches_pushed,
+                );
+                // And anchored to the value the run really returned, in BOTH executors. The two
+                // above are plan-vs-plan only, which cannot catch the two of them being wrong the
+                // same way; this is the one counter with an independent ground truth available for
+                // free, since `run_query_with_plan` already hands back the total.
+                //
+                // It is also what makes the `matches_pushed` parity above more than a restatement:
+                // the counter and `GatherSelect::total` accumulate the identical `len() - before`,
+                // and in artwork mode that expression is downstream of the group dedup, so a
+                // counter placed outside it would diverge here rather than in some later re-fit.
+                assert_eq!(
+                    streamed.matches_pushed, streamed_ran.as_ref().expect("checked above").0 as u64,
+                    "StreamedSelect's matches_pushed must equal the total it returned: {case}",
+                );
+                assert_eq!(
+                    gathered.matches_pushed, gathered_ran.as_ref().expect("asserted above").0 as u64,
+                    "GatheredScan's matches_pushed must equal the total it returned: {case}",
+                );
                 checked += 1;
 
                 // Coverage bookkeeping, so the assertions above cannot pass by never meeting the
@@ -3543,24 +3569,31 @@ fn materializing_plans_agree_on_the_counters_they_share() {
 ///
 /// Two distinct leaks, and the second is the one actually observed:
 ///
-/// 1. A participant that publishes NOTHING reads its predecessor's whole struct.
-///    `PrintingRangeScan`, `PlanePopcountOrder` and `CardRangePopcount` write no counters at all
-///    (they are bitmap/index operations with no per-card match loop), so without the clear they
-///    report whichever materializing plan ran before them.
+/// 1. A participant that publishes NOTHING reads its predecessor's state. `PrintingRangeScan`,
+///    `PlanePopcountOrder` and `CardRangePopcount` write no counters at all (they are bitmap/index
+///    operations with no per-card match loop), so without the clear they report whichever
+///    materializing plan ran before them.
 ///
-/// 2. A participant that publishes PARTIALLY inherits the fields it does not write. Both executors
-///    set 8 of `PhaseStats`' 10 fields and carry the rest through `..c.get()` — deliberately, since
-///    a compose fastpath that declines records `paging_taken` and THEN falls through to a
-///    materializing plan whose publish must not wipe it. That `..c.get()` means "inherit from
-///    earlier in this run", and the clear is the only thing that keeps "this run" from widening to
-///    "this thread, ever". Measured before the clear existed: 49 of 600 queries had `GatheredScan`
-///    reporting a `paging_taken` only `printing_compose_fastpath` sets.
+/// 2. `paging_taken` crossing from the plan that recorded it to a later one. Only
+///    `printing_compose_fastpath` writes it, and it must survive a materializing publish within one
+///    run — the routed path's "compose declines, records its gate, falls through to a materializing
+///    plan" sequence depends on that. So its lifetime is deliberately wider than any single
+///    publisher, and the per-participant clear is the only thing bounding it to one run instead of
+///    "this thread, ever". Measured when that clear was absent: 49 of 600 queries had
+///    `GatheredScan` reporting a `paging_taken` only the compose fastpath sets.
 ///
 /// So a fully-instrumented, looping plan was the contaminated one — which is why asserting only
 /// that the silent fast paths report zeros would miss the real defect.
 ///
-/// `result_total` is not checked: `explain_analyze` overwrites it after the take, so it is the one
-/// `..c.get()` field with no exposure. `paging_taken` is the whole of it.
+/// The two leaks now fail in different ways, and both still need pinning. Leak 1 needs
+/// `take_phase_stats` to clear `PHASE_STATS`; leak 2 needs it to clear `PAGING_TAKEN`, which is a
+/// separate thread-local precisely so a publisher cannot clobber it — dropping either half of that
+/// take reproduces the corresponding leak. (An earlier draft stored both in one slot and had the
+/// executors preserve the label through `..c.get()`; that made every publisher responsible for not
+/// wiping a field it does not own, which is the arrangement leak 2 came out of.)
+///
+/// `result_total` is not checked: `explain_analyze` overwrites it after the take, so it has no
+/// exposure. `paging_taken` is the whole of it.
 #[test]
 fn plan_stats_never_leak_between_participants() {
     use rand::SeedableRng;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3797,6 +3797,12 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
     const NUM_TRIALS: usize = 2;
     /// Gates that mean "entered the compose fastpath and turned back". `NotEntered` is excluded on
     /// purpose: it is the value this test exists to prove a decline never reports.
+    ///
+    /// `NotComposable` is IN the list but should never be seen, exactly like the range fastpath's
+    /// two tripwires below: `PhysicalPlan::PrintingCompose.applicable` IS `printing_compose_applicable`,
+    /// the same structural test the fastpath re-checks. Admitted here rather than asserted against
+    /// for the same reason as those — this test's job is "a gate was named", and `by_gate` below
+    /// prints the distribution so its showing up is visible.
     const DECLINE_GATES: [PagingTaken; 4] = [
         PagingTaken::NotComposable,
         PagingTaken::DeclineBroad,

--- a/docs/issues/00801-engine-explain-analyze-shuffle-seed.md
+++ b/docs/issues/00801-engine-explain-analyze-shuffle-seed.md
@@ -1,0 +1,97 @@
+# Seed `explain_analyze`'s participant shuffle per query, not per call
+
+[#801](https://github.com/jbylund/sylvan_librarian/issues/801). Found in review of
+[#797](https://github.com/jbylund/sylvan_librarian/pull/797) and deliberately left out of it — that
+PR's scope is instrumentation, and this is a measurement-methodology change to the harness that
+consumes it.
+
+## The defect
+
+`explain_analyze` runs `n + 2` participants per round — every applicable plan, plus the acquire step
+and the routed path — in a shuffled order, seeded from a constant:
+
+```rust
+const PARTICIPANT_SHUFFLE_SEED: u64 = 745_002;
+// ...
+let mut rng = rand::rngs::SmallRng::seed_from_u64(PARTICIPANT_SHUFFLE_SEED);
+```
+
+The RNG is constructed inside the function. Every call with the same participant count `n` therefore
+draws the *identical sequence of permutations*, round for round, forever.
+
+For a single query that is the intended property, and it is load-bearing: an A/B of two builds has
+to compare the same execution order or ordering drift swamps the difference being measured.
+
+For a sweep it is a bias that does not average out. `scripts/bench_cost_model_agreement.py` pools
+thousands of queries into per-(plan, acquire branch) cells; every one of those samples reuses the
+same orderings, so drawing more queries does not help.
+
+## Why it is the same shape as the bug the shuffle fixed
+
+#797 replaced a cyclic rotation with a shuffle, and the argument was that rotation only moves the cut
+point — cyclic adjacency is fixed, so every participant keeps the same immediate predecessor round
+after round, and rotation balances only which one goes first.
+
+A per-call constant seed reintroduces that one level up. The bias attaches to **rank position** (the
+index into the cost-sorted `estimates`), not to plan identity — but rank correlates with plan
+identity, because the sort key is predicted cost and a given plan's cost arm puts it in similar
+positions across similar queries. So it survives into a table keyed by plan.
+
+`explain_analyze`'s doc says the residual is "zero-mean and shrinks with rounds." True within one
+query. The sweep is where the number is actually read, and there it shrinks with nothing.
+
+## Fix
+
+Mix a per-query value into the seed:
+
+```rust
+let mut rng = SmallRng::seed_from_u64(PARTICIPANT_SHUFFLE_SEED ^ query_shape_hash);
+```
+
+Same query and same build still produce the same order, so the A/B property is untouched; different
+queries decorrelate.
+
+The cheap source is already in hand at the construction site — `explain` has just returned
+`AcquireFacts`, whose `feats` is an all-integer `PlanFeatures` (`eval_domain`, `n_cards`, `matches`,
+`n_printings`, `scan_units`, `residual_tier_ns100`, `limit`, `offset`, the three compose build terms,
+`popcount_words`, and the `ComposePaging` enum). Hash that plus `QueryParams`' six small fields.
+
+Notably this avoids hashing `FilterExpr`, which derives only `Clone` today
+([filter.rs](../../card_engine/src/filter.rs)) — adding `Hash` to it would mean covering
+`regex::Regex`, which is not worth it for a seed.
+
+Two different queries that happen to produce an identical feature vector will collide and share an
+ordering. That is fine: they are the same query as far as this harness is concerned.
+
+## Rejected
+
+- **Reseed from entropy per call.** Loses the reproducibility the constant exists for, which is the
+  one property the current design gets right.
+- **Raise `num_trials`.** Does not touch it. The bias is common-mode across samples, not noise
+  within them — this is exactly the case where more data does not converge.
+- **A position-balanced design** (Latin square: each participant occupies each slot equally over
+  `n + 2` rounds). Strictly better statistically, and it is what the rotation was reaching for. It
+  needs `num_trials` to be a multiple of `n + 2`, which `explain_analyze` cannot assume — `n` varies
+  per query and `num_trials` is a caller argument. Worth revisiting only if the seed fix proves
+  insufficient.
+
+## Verification
+
+The claim to test is that ordering no longer contributes a fixed component, so the check is a
+comparison of *two sweeps* rather than an absolute number:
+
+1. Run `bench_cost_model_agreement.py` twice at the same budget with two different base seeds, on
+   today's code. Record the per-(plan, acquire) medians.
+2. Repeat after the change.
+3. The two sweeps should agree with each other *better* after than before. If they already agree
+   today, the bias is smaller than the run-to-run spread and this is not worth shipping — record
+   that and close it.
+
+Follow the usual discipline for this repo's benchmarks (idle machine, equal-length env values,
+canary queries); see [performance-pr-workflow](../workflows/performance-pr-workflow.md).
+
+## Caveat for held numbers
+
+Changing the seed derivation makes `trials_ns` collected before it incomparable with `trials_ns`
+collected after — the same caveat #797 already carries for the rotation-to-shuffle change. Any
+calibration fit in flight against pre-change numbers needs re-running.

--- a/docs/issues/local-engine-candidate-materialize.md
+++ b/docs/issues/local-engine-candidate-materialize.md
@@ -1,0 +1,90 @@
+# Materializing a sorted candidate list: bitmap beats sort, merge loses badly
+
+Any narrowing arm that unions several postings rows has sorted rows and no globally
+sorted output, because posting-row order is not card order. `arith_tuple_narrow` is
+the case that prompted this — it concatenates the selected rows and calls
+`sort_unstable`, with a comment naming exactly why the sort is needed. The same
+shape shows up anywhere disjoint sorted runs get combined.
+
+Two alternatives need no information the caller does not already have: a k-way
+merge (every run is already sorted), and a bitmap scatter followed by reading the
+set bits back (sorted by construction).
+
+Measured, all three asserted to produce the identical `Vec<u32>` first:
+
+    cargo test --release bench_candidate_materialize -- --ignored --nocapture
+
+`card_engine/src/bench_candidate_materialize.rs`. Synthetic inputs so the domain can
+be varied, runs disjoint and scattered through the domain rather than contiguous,
+which is the real situation.
+
+## The bitmap wins from about 64 candidates up
+
+Domain 31,508, 564 runs — the arith-tuple case:
+
+| candidates | concat+sort µs | merge µs | bitmap+extract µs | best |
+| ---------- | -------------: | -------: | ----------------: | ---- |
+| 16         | **0.25**       | 0.33     | 0.42              | sort |
+| 64         | **0.46**       | 1.00     | 0.46              | tie |
+| 256        | 1.50           | 3.58     | **0.79**          | bitmap 1.9x |
+| 1,024      | 5.25           | 16.08    | **1.42**          | bitmap 3.7x |
+| 4,096      | 21.12          | 79.58    | **3.50**          | bitmap 6.0x |
+| 16,384     | 80.83          | 381.00   | **13.54**         | bitmap 6.0x |
+| 31,508     | 159.88         | 798.25   | **26.04**         | bitmap 6.1x |
+
+## The k-way merge is the worst option at every size
+
+This is the surprise. The merge is 3x to 5x slower than the sort it was supposed to
+replace, and 30x slower than the bitmap at the top end. A `BinaryHeap` pays a
+`log k` sift with a data-dependent branch and a cache-unfriendly access pattern per
+element, where `sort_unstable` (pdqsort) on `u32` is close to optimal — branchless
+partitioning over a contiguous buffer. Being handed pre-sorted runs does not help
+enough to overcome that.
+
+Axis C confirms the merge is the only contender that cares about run count, and it
+is already losing: at 4,096 candidates it goes 43.5 µs at 8 runs to 82.0 at 2,048,
+while sort stays 17–21 and bitmap 3.0–4.4.
+
+**Do not build the merge.** That is the useful half of this finding.
+
+## The bitmap's edge is a function of domain/count, not of count
+
+The bitmap pays `domain/64` words regardless of the answer size, so its advantage
+erodes as the space grows relative to the result. Holding candidates at 4,096:
+
+| domain    | ratio  | concat+sort µs | bitmap+extract µs | best |
+| --------- | -----: | -------------: | ----------------: | ---- |
+| 31,508    | 7.7:1  | 18.12          | **3.17**          | bitmap 5.7x |
+| 100,000   | 24:1   | 18.29          | **3.33**          | bitmap 5.5x |
+| 300,000   | 73:1   | 18.29          | **5.83**          | bitmap 3.1x |
+| 1,000,000 | 244:1  | 18.25          | **11.38**         | bitmap 1.6x |
+| 3,000,000 | 732:1  | **18.17**      | 22.92             | sort 1.3x |
+
+Break-even sits near 600:1. The card corpus is 7.7:1 for a 4,096-card result and
+~31,508:1 only for a single-card result, so the engine is far inside the bitmap's
+range for anything but a handful of matches. Printing space (97,206) does not change
+that conclusion.
+
+## What to change
+
+The sorted-vec path only runs below `BITS_PROMOTE` (4,096) — above it the engine
+already hands back `CardBits`. So the band this affects is roughly 64 to 4,096
+candidates, where bitmap+extract is 1.9x to 6x faster for byte-identical output and
+the same sorted-`Cards` invariant. It is a drop-in.
+
+Keep concat+sort below ~64 candidates, where the bitmap's fixed domain scan costs
+more than sorting a handful of ids.
+
+## The larger question this raises, which is not answered here
+
+If a bitmap is cheaper to *build* than a sorted vec from 64 candidates up, and
+downstream can consume bitmaps (it does, above `BITS_PROMOTE`), then `BITS_PROMOTE`
+at 4,096 may be far too high — most of that band could stay a bitmap and never be
+extracted at all.
+
+This bench cannot settle that, because it measures only the *production* side. A
+31,508-bit map is 3,939 bytes that a consumer must scan; a 100-element `Vec<u32>` is
+400 bytes it can walk directly. That consumption asymmetry is what `BITS_PROMOTE`
+encodes, and moving the threshold needs the And/Or consumers measured on both
+representations at the same candidate counts. Worth doing separately — the
+production-side change above is worth making regardless of where the threshold lands.

--- a/docs/issues/local-engine-instrument-fast-paths.md
+++ b/docs/issues/local-engine-instrument-fast-paths.md
@@ -1,0 +1,99 @@
+# The four fast paths report features nobody can check
+
+`explain` reports a cost feature vector for all six plans. `explain_analyze` reports execution
+counters for two of them. The other four — `PrintingRangeScan`, `PrintingCompose`,
+`PlanePopcountOrder`, `CardRangePopcount` — return zeros, so every feature their cost arms key on is
+in exactly the state `matches` and `scan_units` were in before #797: reported, consumed by
+`plan_cost`, and unverified against anything the executor actually does.
+
+That is not a hypothetical gap. #797's headline finding was a compose-costing bug — the two range
+acquire branches price a competing `PrintingCompose` with the untouched `mk_plan_feats` default of
+`Gather`, so they cost an arm it never runs. The unchecked features are where the errors are.
+
+The reason it was not fixed there is that it is not four missing `+= 1`s. It needs three different
+counter vocabularies and one prerequisite.
+
+## The existing counters are the card-match-loop's vocabulary
+
+`cards_visited` / `printings_scanned` / `matches_pushed` describe one shape: iterate candidates,
+evaluate a filter per card, push per-printing matches. That is `exec_gathered_scan` and
+`run_query_streamed` and nothing else. None of the four fast paths has that loop — they are bitmap
+and index operations.
+
+So their zeros today are **zero-by-definition, not zero-by-omission**, and adding the same three
+counters would produce numbers that are either always 0 or unrelated to the feature they would be
+checked against. `scripts/bench_cost_model_agreement.py` already has to work around exactly this
+distinction for `ns_prepare` ("`== 0` because it has no such phase — which is not the same as
+spending 0% of its run there").
+
+## What each plan would actually need
+
+| plan | real cost driver | feature it should be checked against |
+| ---- | ---------------- | ------------------------------------ |
+| `CardRangePopcount` | words scanned in the scatter + skip | `popcount_words` |
+| `PlanePopcountOrder` | same | `popcount_words` |
+| `PrintingRangeScan` | index entries walked to the page | none that fits — see below |
+| `PrintingCompose` | four separate build passes | `broadcast_printings`, `scatter_printings`, `project_printings`, `popcount_words` |
+
+### The popcount pair is one site, and it is the cheap first step
+
+`exec_card_range_popcount` and `exec_plane_popcount_order_with_bitmap` both delegate to
+`run_query_streamed_popcount` (`card_engine/src/lib.rs`). One function, two plans. It does no filter
+evaluation at all — membership is the bitmap — and its work is a whole-bitmap popcount, a scatter
+through `inv_perm`, and a word-skip to the page. All three are word-counted, which is precisely what
+`popcount_words` already predicts.
+
+One counter at one site closes two of the four, against a feature that already exists. Do this first.
+
+### `PrintingRangeScan`'s `k` is not a scan
+
+`printing_range_fastpath` gets `k` from two `partition_point` binary searches. It never visits `k`
+printings — it gets the count in O(log n) and then walks only to the page, via `aligned_page` (a
+slice) or `walk_printing_page` (a permutation walk).
+
+So there is no counter that would validate `k`, because `k` is not a count of work. The honest
+instrumentation here is rows emitted by the page walk, which no current feature predicts. That makes
+this plan a cost-model question before it is an instrumentation question.
+
+## The prerequisite: features under a range acquire describe other plans
+
+This is the part that makes it more than a mechanical change. Under `Prep::Range`, the feature vector
+is deliberately set up to cost the *materializing alternatives*, not the plan that won:
+
+```rust
+// bare range branch — matches=k, eval_domain=n_cards, scan_units=n_printings
+let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
+```
+
+with the comment "P3/P4 estimated unnarrowed (their broad regime)". #797 already documents the same
+hazard for `materialize_ns`: "Under `Prep::Range` the two materializing plans are estimated
+UNNARROWED, so this figure has no referent there — do not pool range-acquired rows with
+candidate-acquired ones."
+
+A counter compared against `scan_units` on a range-acquired query would therefore be comparing a fast
+path's real work against a number that was never about it. **Per-acquire-branch feature semantics have
+to be settled before the counters mean anything**, or the new rows will read as enormous disagreements
+that are actually correct behaviour.
+
+## What to change
+
+1. Counter the word passes in `run_query_streamed_popcount`, reported against `popcount_words`. Two
+   plans, one site, existing feature.
+2. Decide what `scan_units` and `eval_domain` mean under a range or compose acquire — one definition
+   per acquire branch, documented — before adding counters that would be checked against them.
+3. Counter `PrintingCompose`'s four build passes separately. They are already four distinct features;
+   pooling them into one counter would lose the thing that makes them worth checking.
+4. Leave `PrintingRangeScan` last. It needs a cost term that describes its page walk before a counter
+   has anything to disagree with.
+
+`card_engine`'s `plan_stats_never_leak_between_participants` currently asserts the *opposite* contract
+— that these four report zeros. That is deliberate: it pins today's behaviour so that instrumenting
+them is a decision someone makes on purpose rather than a silent change in what a zero means. Expect
+to update it, one plan at a time, as each is instrumented.
+
+## What this does not cover
+
+Phase timings. The `ns_setup`/`ns_loop`/`ns_finish` split is also card-loop-shaped, and the fast paths
+have their own meaningful splits (compose build vs. page walk; scatter vs. skip vs. emit). Worth doing,
+but the counters are the higher-value half: a wrong feature count cannot be repaired by any rate
+constant, whereas an unattributed phase only widens the residual.

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -22,6 +22,11 @@ because the range-vs-plane contrast is the whole point of the row, and both cove
 materializing plans: no other plan has those phases at all, which is not the same as spending 0%
 of its run in them.
 
+Then what the fastpaths that DECLINED cost. Those rounds produce no page, so they have no
+measured/predicted ratio and appear in no other table -- but the work is real and no cost term
+describes it, and one gate (`DeclineSparseExact`) turns back only after composing the printing
+bitmap, paying a full compose it then discards. See `report_declines`.
+
 Finally, whether `PrintingCompose`'s predicted paging branch is the one that actually ran, split by
 acquire branch. Those two decisions are computed independently and nothing checked they agree until
 `paging_taken` existed; `card_engine`'s `compose_paging_prediction_matches_the_branch_taken` asserts
@@ -70,6 +75,10 @@ COMPOSE_STRATEGIES = ("Perm", "OrderbyWalk", "Gather")
 # Tracked separately because the rate is the interesting number: it is how often the engine pays a
 # walk attempt AND a full gather while being priced as a walk.
 WALK_DECLINED = "GatherWalkDeclined"
+# The one decline gate that fires AFTER `printing_compose_fastpath` has composed the printing
+# bitmap, off the real total rather than the estimator's bound -- so those rounds pay a full compose
+# and discard it. The other three gate before the compose and are cheap. See `report_declines`.
+POST_COMPOSE_GATE = "DeclineSparseExact"
 # The acquire branch that actually PREDICTS `compose_paging`. Every other branch leaves the
 # `mk_plan_feats` default of `Gather` untouched — see `report_paging` for why that is a different
 # defect rather than a prediction that missed.
@@ -166,6 +175,15 @@ def main() -> None:
             continue
         agr.sampled += 1
         for p in res["plans"]:
+            # A plan that entered a fastpath and turned back produces no page, so it has no
+            # measured/predicted ratio and falls out of every table below. It is not free, though,
+            # and until `declined_ns` existed it was invisible from here entirely: `explain_analyze`
+            # dropped the stats of any plan whose round returned nothing, so the four decline gates
+            # were recorded in Rust and discarded before this loop could count them. That made the
+            # compose table below a census of successful composes described as a census of composes.
+            if p["declined_ns"]:
+                agr.declines[p["plan"], p["paging_taken"]].append(min(p["declined_ns"]))
+                continue
             if not p["trials_ns"] or p["predicted_ns"] <= 0:
                 continue
             measured = min(p["trials_ns"])
@@ -199,6 +217,23 @@ def main() -> None:
     report(agr, args.seconds)
 
 
+def report_suppressed(groups: dict[tuple[str, str], list[float]]) -> None:
+    """The cells too thin to summarise, named and sized.
+
+    This harness's whole argument is that under-sampling hides the cells most likely to be wrong, so
+    dropping them silently is that same bias applied to the report itself -- the reason `skip_reasons`
+    counts exceptions by type rather than totalling them. Both numbers are needed: how many samples a
+    suppressed cell already has says whether more budget would surface it (n=6 of 8) or whether the
+    shape is genuinely rare in the sample space (n=1). Named, because a cell that is thin every run is
+    itself the finding.
+    """
+    thin = {f"{plan}/{key}": len(rs) for (plan, key), rs in groups.items() if len(rs) < MIN_FOR_QUARTILES}
+    if not thin:
+        return
+    listed = ", ".join(f"{name} n={n}" for name, n in sorted(thin.items(), key=lambda kv: (-kv[1], kv[0])))
+    print(f"  {len(thin)} cells suppressed (n < {MIN_FOR_QUARTILES}), {sum(thin.values())} samples: {listed}")
+
+
 def summarise(label: str, groups: dict[tuple[str, str], list[float]], col: str) -> None:
     """One table: median measured/predicted per cell, and how many cells clear the agreement bar."""
     cells: list[tuple[str, float]] = []
@@ -214,7 +249,10 @@ def summarise(label: str, groups: dict[tuple[str, str], list[float]], col: str) 
         cells.append((f"{plan}/{key}", med))
     passing = sum(1 for _, m in cells if AGREE_LO <= m <= AGREE_HI)
     print(f"  {label}")
-    print(f"  {passing}/{len(cells)} cells inside [{AGREE_LO}, {AGREE_HI}]")
+    # "of the cells reported", not "of the cells that exist" -- the suppressed line below carries the
+    # rest, and without it this ratio reads as coverage when it is nothing of the kind.
+    print(f"  {passing}/{len(cells)} reported cells inside [{AGREE_LO}, {AGREE_HI}]")
+    report_suppressed(groups)
 
 
 @dataclasses.dataclass
@@ -229,6 +267,9 @@ class Agreement:
     # says whether an off-diagonal cell is drift in a real prediction or a default that was never
     # one; see `report_paging`.
     paging: dict[tuple[str, str, str], int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
+    # (plan, gate) -> the ns each declining round cost. Declines produce no page and so appear in no
+    # other table; see `report_declines` for why the cost is worth its own row.
+    declines: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
     sampled: int = 0
     skipped: int = 0
     skip_reasons: dict[str, int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
@@ -290,6 +331,40 @@ def report_paging(agr: Agreement) -> None:
             print(f"    predicted {pred:<12} took {took:<12}{n:>7,}")
 
 
+def report_declines(agr: Agreement) -> None:
+    """What the fastpaths that turned back cost, per gate.
+
+    A decline produces no page, so it has no measured/predicted ratio and appears in no other table.
+    That is exactly why it needs one: the work is real, it is charged to the query, and no cost term
+    describes it. The router picked a plan, the plan bailed, and the general path then answered the
+    query from scratch -- so a declining round is pure overhead on top of whatever ran next.
+
+    The gates do not cost the same thing, which is the number this table exists to separate:
+
+    - `NotComposable`, `DeclineBroad`, `DeclineSparseEstimate` gate BEFORE the compose. Cheap; the
+      fastpath looked at an estimate and turned back.
+    - `DeclineSparseExact` gates AFTER, off the real total, so it has already composed the printing
+      bitmap and throws it away. That is a full compose paid for nothing.
+
+    A high `DeclineSparseExact` median against the same query's `PrintingCompose` predicted cost is
+    the actionable case: it means the pre-compose sparse estimate is not catching what the exact
+    total then rejects, and tightening the estimator would recover the whole of it.
+    """
+    if not agr.declines:
+        print("\nno plan declined; every fastpath that was tried produced a page")
+        return
+    total = sum(len(v) for v in agr.declines.values())
+    print(f"\nfastpath declines: {total:,} rounds that entered, turned back, and produced nothing")
+    print(f"{'plan':<20}{'gate':<24}{'n':>6}{'median µs':>12}{'p90 µs':>10}")
+    for (plan, gate), costs in sorted(agr.declines.items(), key=lambda kv: -len(kv[1])):
+        p90 = statistics.quantiles(costs, n=10)[8] if len(costs) >= MIN_FOR_QUARTILES else max(costs)
+        print(f"{plan:<20}{gate:<24}{len(costs):>6}{statistics.median(costs) / 1000:>12.1f}{p90 / 1000:>10.1f}")
+    post_compose = sum(len(v) for (_, gate), v in agr.declines.items() if gate == POST_COMPOSE_GATE)
+    if post_compose:
+        print(f"  {post_compose:,} of these ({post_compose / total:.0%}) are {POST_COMPOSE_GATE} -- composed, then discarded.")
+    print("  Declines appear in no other table: no page, so no measured/predicted ratio.")
+
+
 def report_phase_share(groups: dict[tuple[str, str], list[float]], caption: str) -> None:
     """One phase's share of the plan's whole run, per (plan, acquire branch)."""
     print(f"\n{'plan':<20}{'acquire':<22}{'n':>6}{'median share':>20}{'p90':>8}")
@@ -299,6 +374,7 @@ def report_phase_share(groups: dict[tuple[str, str], list[float]], caption: str)
         p90 = statistics.quantiles(fracs, n=10)[8]
         print(f"{plan:<20}{acquire:<22}{len(fracs):>6}{statistics.median(fracs):>19.0%}{p90:>8.0%}")
     print(f"  {caption}")
+    report_suppressed(groups)
 
 
 def report(agr: Agreement, seconds: float) -> None:
@@ -315,6 +391,7 @@ def report(agr: Agreement, seconds: float) -> None:
     print("  scales with the corpus rather than with the answer, and no cost arm carries it either.")
     print("  Both tables cover only the two materializing plans; no other plan has these phases.")
     report_paging(agr)
+    report_declines(agr)
 
 
 if __name__ == "__main__":

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -1,0 +1,184 @@
+"""How well does `cost::plan_cost` agree with measured plan time, across the whole query space?
+
+Not a mis-selection check — this asks whether each plan's cost ARM is right, per acquire branch, per
+`unique`, per `orderby`. A plan can be picked correctly for a long time while its arm is badly wrong,
+and only diverge once something competes closely with it.
+
+Sampling is deliberately unbiased where the existing generator is not:
+
+- `unique` is drawn evenly across card / printing / artwork, not 75/20/5. Distinct-on changes which
+  plans are even applicable and what `scan_units` means, so under-sampling two thirds of it hides
+  exactly the cells most likely to be wrong.
+- `orderby` is drawn across every column the engine supports, since the permutation's existence is
+  what gates `StreamedSelect` and `PlanePopcountOrder`.
+- range thresholds are sampled from each field's real value distribution rather than a hand-picked
+  list, so selectivity is spread instead of clustered at round numbers.
+
+Reports measured/predicted per (plan, acquire branch), plus what fraction of the time is
+`prepare_candidates` — which no cost term currently describes and which is 21-33% of a range-acquired
+query against 7-10% of a plane-acquired one.
+
+    .venv/bin/python scripts/bench_cost_model_agreement.py --seconds 120
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import math
+import pathlib
+import random
+import statistics
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+# Every distinct-on the engine supports, evenly weighted — see the module docstring.
+UNIQUES = ("card", "printing", "artwork")
+# Every orderby `orderby_to_col` maps. Which ones have a sort permutation decides plan applicability.
+ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "usd", "name")
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)  # mostly first-page, which is what real traffic asks for
+MIN_FOR_QUARTILES = 8
+# The agreement bar this work is aiming at: every (plan, acquire) cell's median inside it.
+AGREE_LO, AGREE_HI = 0.8, 1.25
+
+# Predicate templates, one per engine path, so no single family dominates the sample the way a
+# weighted-dimension generator does. A query is one or two of these joined.
+PREDICATES: dict[str, list[str]] = {
+    "plane_color": ["c:w", "c:u", "c:b", "c:r", "c:g", "c:wu", "c:br", "id:g", "id:wu"],
+    "plane_type": ["t:creature", "t:instant", "t:artifact", "t:land", "t:enchantment", "t:sorcery"],
+    "legality": ["f:modern", "f:commander", "f:legacy", "f:pauper", "f:standard", "f:vintage"],
+    "text": ["o:flying", "o:draw", "o:destroy", "o:trample", "o:counter", "o:sacrifice"],
+    "collection": ["is:reprint", "border:black", "border:borderless", "frame:showcase", "watermark:set"],
+    "arith": ["pow>2", "tou<4", "power+toughness<6", "cmc>=4", "loyalty>=3"],
+}
+# Range fields with a real index, and the value ranges to sample thresholds from.
+RANGE_FIELDS: dict[str, tuple[float, float, bool]] = {
+    "usd": (0.05, 400.0, True),  # log-sampled: prices span four orders of magnitude
+    "cn": (1, 500, False),
+    "year": (1993, 2026, False),
+}
+RANGE_OPS = (">", ">=", "<", "<=", ":")
+
+
+def sample_range(rng: random.Random) -> str:
+    """One range predicate with the threshold drawn from the field's own distribution."""
+    field, (lo, hi, log_scale) = rng.choice(list(RANGE_FIELDS.items()))
+    value = f"{math.exp(rng.uniform(math.log(lo), math.log(hi))):.2f}" if log_scale else str(rng.randint(int(lo), int(hi)))
+    op = rng.choice(RANGE_OPS)
+    return f"{field}{op}{value}"
+
+
+def sample_query(rng: random.Random) -> str:
+    """One or two predicates, each family equally likely — ranges included as their own family."""
+    families = [*PREDICATES.keys(), "range"]
+    n = rng.choice((1, 1, 2))
+    parts, used = [], set()
+    for _ in range(n):
+        fam = rng.choice(families)
+        if fam in used:
+            continue
+        used.add(fam)
+        parts.append(sample_range(rng) if fam == "range" else rng.choice(PREDICATES[fam]))
+    return " ".join(parts)
+
+
+def main() -> None:
+    """Sample until the budget runs out, then report agreement per plan and acquire branch."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=120.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".agreement.store"))
+    rng = random.Random(args.seed)
+
+    agr = Agreement()
+
+    deadline = time.monotonic() + args.seconds
+    while time.monotonic() < deadline:
+        q, unique = sample_query(rng), rng.choice(UNIQUES)
+        kw = {
+            "filters": None,
+            "unique": unique,
+            "orderby": rng.choice(ORDERBYS),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": rng.choice(LIMITS),
+            "offset": rng.choice(OFFSETS),
+        }
+        try:
+            kw["filters"] = parse_scryfall_query(q)
+            acq = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001 - a rejected query is a skipped sample
+            agr.skipped += 1
+            continue
+        agr.sampled += 1
+        for p in res["plans"]:
+            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+                continue
+            measured = min(p["trials_ns"])
+            agr.ratios[p["plan"], acq["count_source"]].append(measured / p["predicted_ns"])
+            agr.by_unique[p["plan"], unique].append(measured / p["predicted_ns"])
+            if p["ns_round_total"]:
+                agr.prep_frac[p["plan"]].append(p["ns_prepare"] / p["ns_round_total"])
+
+    report(agr, args.seconds)
+
+
+def summarise(label: str, groups: dict[tuple[str, str], list[float]], col: str) -> None:
+    """One table: median measured/predicted per cell, and how many cells clear the agreement bar."""
+    cells: list[tuple[str, float]] = []
+    print(f"\n{'plan':<20}{col:<22}{'n':>5}{'median':>9}{'p10':>8}{'p90':>8}{'within 25%':>12}")
+    for (plan, key), rs in sorted(groups.items(), key=lambda kv: (kv[0][0], -len(kv[1]))):
+        if len(rs) < MIN_FOR_QUARTILES:
+            continue
+        ds = statistics.quantiles(rs, n=10)
+        near = sum(1 for r in rs if AGREE_LO <= r <= AGREE_HI) / len(rs)
+        med = statistics.median(rs)
+        verdict = "" if AGREE_LO <= med <= AGREE_HI else "  FAIL"
+        print(f"{plan:<20}{key:<22}{len(rs):>5}{med:>9.2f}{ds[0]:>8.2f}{ds[8]:>8.2f}{near:>11.0%}{verdict}")
+        cells.append((f"{plan}/{key}", med))
+    passing = sum(1 for _, m in cells if AGREE_LO <= m <= AGREE_HI)
+    print(f"  {label}")
+    print(f"  {passing}/{len(cells)} cells inside [{AGREE_LO}, {AGREE_HI}]")
+
+
+@dataclasses.dataclass
+class Agreement:
+    """Everything the sweep accumulates, keyed for the three tables the report prints."""
+
+    ratios: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
+    by_unique: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
+    prep_frac: dict[str, list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
+    sampled: int = 0
+    skipped: int = 0
+
+
+def report(agr: Agreement, seconds: float) -> None:
+    """Agreement per acquire branch and per distinct-on, then the unpriced prepare share."""
+    print(f"\n{agr.sampled:,} queries sampled ({agr.skipped:,} skipped) in {seconds:.0f}s")
+    summarise("measured/predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
+    summarise("the same, split by distinct-on rather than acquire.", agr.by_unique, "unique")
+
+    print(f"\n{'plan':<20}{'n':>6}{'median prep share':>20}{'p90':>8}")
+    for plan, fracs in sorted(agr.prep_frac.items()):
+        if len(fracs) < MIN_FOR_QUARTILES:
+            continue
+        print(f"{plan:<20}{len(fracs):>6}{statistics.median(fracs):>19.0%}{statistics.quantiles(fracs, n=10)[8]:>8.0%}")
+    print("  prepare_candidates as a share of the plan's run.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -16,7 +16,13 @@ Sampling is deliberately unbiased where the existing generator is not:
 
 Reports measured/predicted per (plan, acquire branch), plus what fraction of the time is
 `prepare_candidates` — which no cost term currently describes and which is 21-33% of a range-acquired
-query against 7-10% of a plane-acquired one.
+query against 7-10% of a plane-acquired one. That share is keyed by acquire branch as well as plan,
+because the range-vs-plane contrast is the whole point of the row.
+
+Finally, whether `PrintingCompose`'s predicted paging branch is the one that actually ran. Those two
+decisions are computed independently and nothing checked they agree until `paging_taken` existed;
+`card_engine`'s `compose_paging_prediction_matches_the_branch_taken` asserts it on a fuzz store, and
+this observes it over the real corpus, which reaches shapes the fuzz store does not.
 
     .venv/bin/python scripts/bench_cost_model_agreement.py --seconds 120
 """
@@ -48,6 +54,10 @@ ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "usd",
 LIMITS = (10, 100, 175)
 OFFSETS = (0, 0, 0, 100)  # mostly first-page, which is what real traffic asks for
 MIN_FOR_QUARTILES = 8
+# The three paging strategies `ComposePaging` predicts. `paging_taken` also reports `EmptyPage` and
+# `DeclineSparse`, which are run-time outcomes reached BEFORE any strategy runs — for those the
+# prediction is never exercised, so they are excluded rather than counted as disagreements.
+COMPOSE_STRATEGIES = ("Perm", "OrderbyWalk", "Gather")
 # The agreement bar this work is aiming at: every (plan, acquire) cell's median inside it.
 AGREE_LO, AGREE_HI = 0.8, 1.25
 
@@ -136,8 +146,19 @@ def main() -> None:
             measured = min(p["trials_ns"])
             agr.ratios[p["plan"], acq["count_source"]].append(measured / p["predicted_ns"])
             agr.by_unique[p["plan"], unique].append(measured / p["predicted_ns"])
+            # Keyed by acquire branch as well as plan: the whole point of this row is that the
+            # prepare share differs by HOW the query was acquired, so collapsing to the plan alone
+            # averages a range-acquired query together with a plane-acquired one and reports a
+            # number that describes neither.
             if p["ns_round_total"]:
-                agr.prep_frac[p["plan"]].append(p["ns_prepare"] / p["ns_round_total"])
+                agr.prep_frac[p["plan"], acq["count_source"]].append(p["ns_prepare"] / p["ns_round_total"])
+            # Did the compose fastpath take the branch the cost model predicted? The two decisions
+            # are computed independently, and nothing checked they agree until now -- the same shape
+            # as the Python cost mirror that drifted from cost.rs for two revisions.
+            # `card_engine`'s `compose_paging_prediction_matches_the_branch_taken` asserts this on a
+            # fuzz store; here it is observed over the real corpus, which reaches far more shapes.
+            if p["plan"] == "PrintingCompose" and p["paging_taken"] in COMPOSE_STRATEGIES:
+                agr.paging[acq["compose_paging"], p["paging_taken"]] += 1
 
     report(agr, args.seconds)
 
@@ -166,10 +187,32 @@ class Agreement:
 
     ratios: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
     by_unique: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
-    prep_frac: dict[str, list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
+    prep_frac: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
+    # (predicted ComposePaging, paging_taken) -> count. Off-diagonal cells are real drift between
+    # the cost model's branch prediction and the branch the fastpath ran.
+    paging: dict[tuple[str, str], int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
     sampled: int = 0
     skipped: int = 0
     skip_reasons: dict[str, int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
+
+
+def report_paging(agr: Agreement) -> None:
+    """Predicted compose paging branch against the branch that actually ran."""
+    if not agr.paging:
+        print("\nno PrintingCompose run reached a paging strategy; nothing to check")
+        return
+    total = sum(agr.paging.values())
+    wrong = {(pred, took): n for (pred, took), n in agr.paging.items() if pred != took}
+    print(f"\ncompose paging: predicted vs taken over {total:,} runs")
+    for strategy in COMPOSE_STRATEGIES:
+        n = agr.paging.get((strategy, strategy), 0)
+        print(f"  {strategy:<14}{n:>7,} agreed")
+    if wrong:
+        print(f"  {sum(wrong.values()):,} DISAGREEMENTS -- the cost model priced a branch that did not run:")
+        for (pred, took), n in sorted(wrong.items(), key=lambda kv: -kv[1]):
+            print(f"    predicted {pred:<12} took {took:<12}{n:>7,}")
+    else:
+        print("  0 disagreements.")
 
 
 def report(agr: Agreement, seconds: float) -> None:
@@ -181,12 +224,15 @@ def report(agr: Agreement, seconds: float) -> None:
     summarise("measured/predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
     summarise("the same, split by distinct-on rather than acquire.", agr.by_unique, "unique")
 
-    print(f"\n{'plan':<20}{'n':>6}{'median prep share':>20}{'p90':>8}")
-    for plan, fracs in sorted(agr.prep_frac.items()):
+    print(f"\n{'plan':<20}{'acquire':<22}{'n':>6}{'median prep share':>20}{'p90':>8}")
+    for (plan, acquire), fracs in sorted(agr.prep_frac.items(), key=lambda kv: (kv[0][0], -len(kv[1]))):
         if len(fracs) < MIN_FOR_QUARTILES:
             continue
-        print(f"{plan:<20}{len(fracs):>6}{statistics.median(fracs):>19.0%}{statistics.quantiles(fracs, n=10)[8]:>8.0%}")
-    print("  prepare_candidates as a share of the plan's run.")
+        p90 = statistics.quantiles(fracs, n=10)[8]
+        print(f"{plan:<20}{acquire:<22}{len(fracs):>6}{statistics.median(fracs):>19.0%}{p90:>8.0%}")
+    print("  prepare_candidates as a share of the plan's run — the term no cost arm carries.")
+    print("  Only the two materializing plans call it; every other plan is absent, not zero.")
+    report_paging(agr)
 
 
 if __name__ == "__main__":

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -63,6 +63,13 @@ MIN_FOR_QUARTILES = 8
 # all of them run-time outcomes reached BEFORE any strategy runs. The prediction is never exercised
 # there, so they are excluded rather than counted as disagreements.
 COMPOSE_STRATEGIES = ("Perm", "OrderbyWalk", "Gather")
+# `GatherWalkDeclined` is a strategy outcome, so it IS counted — but it is not a disagreement. Acquire
+# never composes, so it can only test that an orderby walk is AVAILABLE, never that it will succeed;
+# the walk declines on the null-value tail or a page past the value structure and falls into the
+# gather. `compose_paging` is therefore an upper bound on `OrderbyWalk` and exact everywhere else.
+# Tracked separately because the rate is the interesting number: it is how often the engine pays a
+# walk attempt AND a full gather while being priced as a walk.
+WALK_DECLINED = "GatherWalkDeclined"
 # The acquire branch that actually PREDICTS `compose_paging`. Every other branch leaves the
 # `mk_plan_feats` default of `Gather` untouched — see `report_paging` for why that is a different
 # defect rather than a prediction that missed.
@@ -142,8 +149,13 @@ def main() -> None:
         }
         try:
             kw["filters"] = parse_scryfall_query(q)
-            acq = engine.explain(**kw)["acquire"]
+            # `explain_analyze` runs `explain` internally and returns the same `acquire` dict, so a
+            # separate `engine.explain(**kw)` call here would be a second full acquire per sample for
+            # fields we already have. This loop is budgeted in wall-clock seconds, so dropping it buys
+            # samples directly. (`acquire_ns` is the one field that differs -- re-sampled per round
+            # rather than once -- and nothing below reads it.)
             res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+            acq = res["acquire"]
         except Exception as exc:  # noqa: BLE001 - a rejected query is a skipped sample
             # Counted BY TYPE, not just totalled. This harness's whole argument is that sampling bias
             # hides the cells most likely to be wrong -- and a bare skip counter is that same bias: if
@@ -165,11 +177,11 @@ def main() -> None:
             # number that describes neither. Restricted to the plans that HAVE a prepare phase --
             # `ns_round_total` alone admits every plan that ran, and the uninstrumented ones would
             # then contribute a run of 0.0 that reads as "spends no time preparing".
+            #
+            # The setup phase rides the same guard: also instrumented for both materializing plans,
+            # and for `StreamedSelect` it is an O(n_cards) counts zeroing that no cost term carries.
             if p["ns_round_total"] and p["plan"] in MATERIALIZING_PLANS:
                 agr.prep_frac[p["plan"], acq["count_source"]].append(p["ns_prepare"] / p["ns_round_total"])
-            # The setup phase, on the same footing. Instrumented for both materializing plans, and
-            # for `StreamedSelect` it is an O(n_cards) counts zeroing that no cost term carries.
-            if p["ns_round_total"] and p["plan"] in MATERIALIZING_PLANS:
                 agr.setup_frac[p["plan"], acq["count_source"]].append(p["ns_setup"] / p["ns_round_total"])
             # Did the compose fastpath take the branch the cost model predicted? The two decisions
             # are computed independently, and nothing checked they agree until now -- the same shape
@@ -181,7 +193,7 @@ def main() -> None:
             # acquire. Under any other branch it is the untouched `mk_plan_feats` default, so an
             # off-diagonal cell there means a competing compose was mispriced, not that a prediction
             # drifted -- different defect, different fix, and pooling them reports neither.
-            if p["plan"] == "PrintingCompose" and p["paging_taken"] in COMPOSE_STRATEGIES:
+            if p["plan"] == "PrintingCompose" and p["paging_taken"] in (*COMPOSE_STRATEGIES, WALK_DECLINED):
                 agr.paging[acq["count_source"], acq["compose_paging"], p["paging_taken"]] += 1
 
     report(agr, args.seconds)
@@ -232,6 +244,14 @@ def report_paging(agr: Agreement) -> None:
     decides again at run time. An off-diagonal cell is drift between two independent implementations
     of one decision, and the fix is to share it.
 
+    With one cell excepted, and it is excepted on structure rather than tolerance. The two
+    *availability* tests are identical by construction and cannot disagree; what acquire cannot see is
+    whether the walk it predicts will SUCCEED, since knowing that means composing, which acquire
+    deliberately never does. A walk that declines falls into the gather and reports
+    `GatherWalkDeclined`, so `compose_paging` is an upper bound on `OrderbyWalk` and exact elsewhere.
+    That cell gets its own line rather than being pooled either way — it is not drift, but it is not
+    free either: those runs pay the walk attempt and the gather while priced as a walk.
+
     Under any other acquire nothing predicted anything — `compose_paging` is the `mk_plan_feats`
     default of `Gather`, which `cost.rs` nonetheless prices a COMPETING `PrintingCompose` with. An
     off-diagonal cell there means the competitor was costed with an arm it never runs, and the fix is
@@ -249,6 +269,13 @@ def report_paging(agr: Agreement) -> None:
         print(f"\ncompose paging under {acquire} acquire: {subject}, {total:,} runs")
         for strategy in COMPOSE_STRATEGIES:
             print(f"  {strategy:<14}{cells.get((strategy, strategy), 0):>7,} agreed")
+        # Structural, not drift: a predicted walk that declined into the gather. Reported on its own
+        # line with a rate, because that rate is the size of a real (small) under-costing — those runs
+        # pay the walk attempt AND the gather while priced as a walk — and folding it into either the
+        # agreed count or the disagreement count would hide it.
+        declined = cells.pop(("OrderbyWalk", WALK_DECLINED), 0)
+        if declined:
+            print(f"  {'walk declined':<14}{declined:>7,} ({declined / total:.1%}) predicted OrderbyWalk, fell back to gather")
         wrong = {key: n for key, n in cells.items() if key[0] != key[1]}
         if not wrong:
             print("  0 disagreements.")

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -14,15 +14,19 @@ Sampling is deliberately unbiased where the existing generator is not:
 - range thresholds are sampled from each field's real value distribution rather than a hand-picked
   list, so selectivity is spread instead of clustered at round numbers.
 
-Reports measured/predicted per (plan, acquire branch), plus what fraction of the time is
-`prepare_candidates` — which no cost term currently describes and which is 21-33% of a range-acquired
-query against 7-10% of a plane-acquired one. That share is keyed by acquire branch as well as plan,
-because the range-vs-plane contrast is the whole point of the row.
+Reports measured/predicted per (plan, acquire branch), plus the two phases no cost term describes:
+`prepare_candidates` — 21-33% of a range-acquired query against 7-10% of a plane-acquired one — and
+the per-query scratch setup, which for `StreamedSelect` is an O(`n_cards`) counts zeroing that grows
+with the corpus rather than with the answer. Both shares are keyed by acquire branch as well as plan,
+because the range-vs-plane contrast is the whole point of the row, and both cover only the two
+materializing plans: no other plan has those phases at all, which is not the same as spending 0%
+of its run in them.
 
-Finally, whether `PrintingCompose`'s predicted paging branch is the one that actually ran. Those two
-decisions are computed independently and nothing checked they agree until `paging_taken` existed;
-`card_engine`'s `compose_paging_prediction_matches_the_branch_taken` asserts it on a fuzz store, and
-this observes it over the real corpus, which reaches shapes the fuzz store does not.
+Finally, whether `PrintingCompose`'s predicted paging branch is the one that actually ran, split by
+acquire branch. Those two decisions are computed independently and nothing checked they agree until
+`paging_taken` existed; `card_engine`'s `compose_paging_prediction_matches_the_branch_taken` asserts
+it on a fuzz store, and this observes it over the real corpus, which reaches shapes the fuzz store
+does not. The split matters because only a compose acquire predicts anything — see `report_paging`.
 
     .venv/bin/python scripts/bench_cost_model_agreement.py --seconds 120
 """
@@ -54,10 +58,19 @@ ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "usd",
 LIMITS = (10, 100, 175)
 OFFSETS = (0, 0, 0, 100)  # mostly first-page, which is what real traffic asks for
 MIN_FOR_QUARTILES = 8
-# The three paging strategies `ComposePaging` predicts. `paging_taken` also reports `EmptyPage` and
-# `DeclineSparse`, which are run-time outcomes reached BEFORE any strategy runs — for those the
-# prediction is never exercised, so they are excluded rather than counted as disagreements.
+# The three paging strategies `ComposePaging` predicts. `paging_taken` reports five further labels —
+# `NotComposable`, `DeclineBroad`, `DeclineSparseEstimate`, `DeclineSparseExact` and `EmptyPage` —
+# all of them run-time outcomes reached BEFORE any strategy runs. The prediction is never exercised
+# there, so they are excluded rather than counted as disagreements.
 COMPOSE_STRATEGIES = ("Perm", "OrderbyWalk", "Gather")
+# The acquire branch that actually PREDICTS `compose_paging`. Every other branch leaves the
+# `mk_plan_feats` default of `Gather` untouched — see `report_paging` for why that is a different
+# defect rather than a prediction that missed.
+COMPOSE_ACQUIRE = "printing_compose"
+# The only plans that call `prepare_candidates`, and so the only ones with a prepare phase at all.
+# Every other plan reports `ns_prepare == 0` because it has no such phase — which is not the same
+# as spending 0% of its run there, and pooling the two says the wrong thing.
+MATERIALIZING_PLANS = ("StreamedSelect", "GatheredScan")
 # The agreement bar this work is aiming at: every (plan, acquire) cell's median inside it.
 AGREE_LO, AGREE_HI = 0.8, 1.25
 
@@ -149,16 +162,27 @@ def main() -> None:
             # Keyed by acquire branch as well as plan: the whole point of this row is that the
             # prepare share differs by HOW the query was acquired, so collapsing to the plan alone
             # averages a range-acquired query together with a plane-acquired one and reports a
-            # number that describes neither.
-            if p["ns_round_total"]:
+            # number that describes neither. Restricted to the plans that HAVE a prepare phase --
+            # `ns_round_total` alone admits every plan that ran, and the uninstrumented ones would
+            # then contribute a run of 0.0 that reads as "spends no time preparing".
+            if p["ns_round_total"] and p["plan"] in MATERIALIZING_PLANS:
                 agr.prep_frac[p["plan"], acq["count_source"]].append(p["ns_prepare"] / p["ns_round_total"])
+            # The setup phase, on the same footing. Instrumented for both materializing plans, and
+            # for `StreamedSelect` it is an O(n_cards) counts zeroing that no cost term carries.
+            if p["ns_round_total"] and p["plan"] in MATERIALIZING_PLANS:
+                agr.setup_frac[p["plan"], acq["count_source"]].append(p["ns_setup"] / p["ns_round_total"])
             # Did the compose fastpath take the branch the cost model predicted? The two decisions
             # are computed independently, and nothing checked they agree until now -- the same shape
             # as the Python cost mirror that drifted from cost.rs for two revisions.
             # `card_engine`'s `compose_paging_prediction_matches_the_branch_taken` asserts this on a
             # fuzz store; here it is observed over the real corpus, which reaches far more shapes.
+            #
+            # Keyed by acquire branch, because `compose_paging` is only a PREDICTION under a compose
+            # acquire. Under any other branch it is the untouched `mk_plan_feats` default, so an
+            # off-diagonal cell there means a competing compose was mispriced, not that a prediction
+            # drifted -- different defect, different fix, and pooling them reports neither.
             if p["plan"] == "PrintingCompose" and p["paging_taken"] in COMPOSE_STRATEGIES:
-                agr.paging[acq["compose_paging"], p["paging_taken"]] += 1
+                agr.paging[acq["count_source"], acq["compose_paging"], p["paging_taken"]] += 1
 
     report(agr, args.seconds)
 
@@ -188,35 +212,70 @@ class Agreement:
     ratios: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
     by_unique: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
     prep_frac: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
-    # (predicted ComposePaging, paging_taken) -> count. Off-diagonal cells are real drift between
-    # the cost model's branch prediction and the branch the fastpath ran.
-    paging: dict[tuple[str, str], int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
+    setup_frac: dict[tuple[str, str], list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
+    # (acquire branch, predicted ComposePaging, paging_taken) -> count. The acquire branch is what
+    # says whether an off-diagonal cell is drift in a real prediction or a default that was never
+    # one; see `report_paging`.
+    paging: dict[tuple[str, str, str], int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
     sampled: int = 0
     skipped: int = 0
     skip_reasons: dict[str, int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
 
 
 def report_paging(agr: Agreement) -> None:
-    """Predicted compose paging branch against the branch that actually ran."""
+    """Predicted compose paging branch against the branch that ran, split by acquire branch.
+
+    Split because the two halves are different defects with different fixes.
+
+    Under a `printing_compose` acquire the prediction is genuinely computed: `acquire_plan_features`
+    re-derives the permutation lookup and the orderby-walk test that `printing_compose_fastpath` then
+    decides again at run time. An off-diagonal cell is drift between two independent implementations
+    of one decision, and the fix is to share it.
+
+    Under any other acquire nothing predicted anything — `compose_paging` is the `mk_plan_feats`
+    default of `Gather`, which `cost.rs` nonetheless prices a COMPETING `PrintingCompose` with. An
+    off-diagonal cell there means the competitor was costed with an arm it never runs, and the fix is
+    to give that branch a result total. Pooling the two averages a cell that is wrong by
+    construction into one that is mostly right, and describes neither.
+    """
     if not agr.paging:
         print("\nno PrintingCompose run reached a paging strategy; nothing to check")
         return
-    total = sum(agr.paging.values())
-    wrong = {(pred, took): n for (pred, took), n in agr.paging.items() if pred != took}
-    print(f"\ncompose paging: predicted vs taken over {total:,} runs")
-    for strategy in COMPOSE_STRATEGIES:
-        n = agr.paging.get((strategy, strategy), 0)
-        print(f"  {strategy:<14}{n:>7,} agreed")
-    if wrong:
-        print(f"  {sum(wrong.values()):,} DISAGREEMENTS -- the cost model priced a branch that did not run:")
+    for acquire in sorted({branch for branch, _, _ in agr.paging}):
+        cells = {(pred, took): n for (branch, pred, took), n in agr.paging.items() if branch == acquire}
+        total = sum(cells.values())
+        is_prediction = acquire == COMPOSE_ACQUIRE
+        subject = "predicted vs taken" if is_prediction else "default Gather vs taken (NO prediction made here)"
+        print(f"\ncompose paging under {acquire} acquire: {subject}, {total:,} runs")
+        for strategy in COMPOSE_STRATEGIES:
+            print(f"  {strategy:<14}{cells.get((strategy, strategy), 0):>7,} agreed")
+        wrong = {key: n for key, n in cells.items() if key[0] != key[1]}
+        if not wrong:
+            print("  0 disagreements.")
+            continue
+        verdict = (
+            "two implementations of one decision have drifted"
+            if is_prediction
+            else "a competing compose was priced with an arm it never runs"
+        )
+        print(f"  {sum(wrong.values()):,} ({sum(wrong.values()) / total:.0%}) DISAGREEMENTS -- {verdict}:")
         for (pred, took), n in sorted(wrong.items(), key=lambda kv: -kv[1]):
             print(f"    predicted {pred:<12} took {took:<12}{n:>7,}")
-    else:
-        print("  0 disagreements.")
+
+
+def report_phase_share(groups: dict[tuple[str, str], list[float]], caption: str) -> None:
+    """One phase's share of the plan's whole run, per (plan, acquire branch)."""
+    print(f"\n{'plan':<20}{'acquire':<22}{'n':>6}{'median share':>20}{'p90':>8}")
+    for (plan, acquire), fracs in sorted(groups.items(), key=lambda kv: (kv[0][0], -len(kv[1]))):
+        if len(fracs) < MIN_FOR_QUARTILES:
+            continue
+        p90 = statistics.quantiles(fracs, n=10)[8]
+        print(f"{plan:<20}{acquire:<22}{len(fracs):>6}{statistics.median(fracs):>19.0%}{p90:>8.0%}")
+    print(f"  {caption}")
 
 
 def report(agr: Agreement, seconds: float) -> None:
-    """Agreement per acquire branch and per distinct-on, then the unpriced prepare share."""
+    """Agreement per acquire branch and per distinct-on, then the two unpriced phase shares."""
     print(f"\n{agr.sampled:,} queries sampled ({agr.skipped:,} skipped) in {seconds:.0f}s")
     if agr.skip_reasons:
         breakdown = ", ".join(f"{name} x{n:,}" for name, n in sorted(agr.skip_reasons.items(), key=lambda kv: -kv[1]))
@@ -224,14 +283,10 @@ def report(agr: Agreement, seconds: float) -> None:
     summarise("measured/predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
     summarise("the same, split by distinct-on rather than acquire.", agr.by_unique, "unique")
 
-    print(f"\n{'plan':<20}{'acquire':<22}{'n':>6}{'median prep share':>20}{'p90':>8}")
-    for (plan, acquire), fracs in sorted(agr.prep_frac.items(), key=lambda kv: (kv[0][0], -len(kv[1]))):
-        if len(fracs) < MIN_FOR_QUARTILES:
-            continue
-        p90 = statistics.quantiles(fracs, n=10)[8]
-        print(f"{plan:<20}{acquire:<22}{len(fracs):>6}{statistics.median(fracs):>19.0%}{p90:>8.0%}")
-    print("  prepare_candidates as a share of the plan's run — the term no cost arm carries.")
-    print("  Only the two materializing plans call it; every other plan is absent, not zero.")
+    report_phase_share(agr.prep_frac, "prepare_candidates as a share of the plan's run — the term no cost arm carries.")
+    report_phase_share(agr.setup_frac, "per-query scratch setup — StreamedSelect's is an O(n_cards) counts zeroing, so it")
+    print("  scales with the corpus rather than with the answer, and no cost arm carries it either.")
+    print("  Both tables cover only the two materializing plans; no other plan has these phases.")
     report_paging(agr)
 
 

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -79,12 +79,13 @@ WALK_DECLINED = "GatherWalkDeclined"
 # bitmap, off the real total rather than the estimator's bound -- so those rounds pay a full compose
 # and discard it. The other three gate before the compose and are cheap. See `report_declines`.
 POST_COMPOSE_GATE = "DeclineSparseExact"
-# Range-fastpath gates that should be unreachable, so a non-zero count is a defect rather than a
-# measurement. `RangeNotBare` contradicts `PrintingRangeScan.applicable`, which already requires bare
-# range bounds; `RangePermutationStale` means a sort permutation was built against a different store.
-# Called out on their own line because in the decline table they would otherwise read as two more
-# cheap rows -- their cost is not the point, their existence is.
-IMPOSSIBLE_GATES = ("RangeNotBare", "RangePermutationStale")
+# Gates that should be unreachable, so a non-zero count is a defect rather than a measurement.
+# `RangeNotBare` contradicts `PrintingRangeScan.applicable`, which already requires bare range
+# bounds; `NotComposable` contradicts `PrintingCompose.applicable`, which IS the same structural
+# test the compose fastpath re-checks; `RangePermutationStale` means a sort permutation was built
+# against a different store. Called out on their own line because in the decline table they would
+# otherwise read as three more cheap rows -- their cost is not the point, their existence is.
+IMPOSSIBLE_GATES = ("RangeNotBare", "NotComposable", "RangePermutationStale")
 # The acquire branch that actually PREDICTS `compose_paging`. Every other branch leaves the
 # `mk_plan_feats` default of `Gather` untouched — see `report_paging` for why that is a different
 # defect rather than a prediction that missed.
@@ -349,10 +350,13 @@ def report_declines(agr: Agreement) -> None:
     the number this table exists to separate:
 
     `PrintingCompose` --
-    - `NotComposable`, `DeclineBroad`, `DeclineSparseEstimate` gate BEFORE the compose. Cheap; the
-      fastpath looked at an estimate and turned back.
+    - `DeclineBroad` and `DeclineSparseEstimate` gate BEFORE the compose. Cheap; the fastpath looked
+      at an estimate and turned back.
     - `DeclineSparseExact` gates AFTER, off the real total, so it has already composed the printing
       bitmap and throws it away. That is a full compose paid for nothing.
+    - `NotComposable` should never appear at all: `PrintingCompose.applicable` IS the structural
+      test the fastpath re-checks, so reaching it means the two have drifted. Its existence is the
+      finding, not the timing next to it -- see `IMPOSSIBLE_GATES`.
 
     `PrintingRangeScan` -- all four of its real gates are cheap (two binary searches and a lookup),
     so the interesting number here is the COUNT, not the median:
@@ -364,7 +368,8 @@ def report_declines(agr: Agreement) -> None:
     - `RangeSparse` needs 1000 < k <= 1024 and so is near-unreachable outside a tiny index.
     - `RangeNotBare` and `RangePermutationStale` should never appear at all -- the first contradicts
       `PrintingRangeScan.applicable`, the second means an index built against a different store. A
-      non-zero count in either row is the finding, not the timing next to it.
+      non-zero count in either row is the finding, not the timing next to it. Same class as compose's
+      `NotComposable` above; all three are in `IMPOSSIBLE_GATES`.
 
     A high `DeclineSparseExact` median against the same query's `PrintingCompose` predicted cost is
     the actionable case: it means the pre-compose sparse estimate is not catching what the exact

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -79,6 +79,12 @@ WALK_DECLINED = "GatherWalkDeclined"
 # bitmap, off the real total rather than the estimator's bound -- so those rounds pay a full compose
 # and discard it. The other three gate before the compose and are cheap. See `report_declines`.
 POST_COMPOSE_GATE = "DeclineSparseExact"
+# Range-fastpath gates that should be unreachable, so a non-zero count is a defect rather than a
+# measurement. `RangeNotBare` contradicts `PrintingRangeScan.applicable`, which already requires bare
+# range bounds; `RangePermutationStale` means a sort permutation was built against a different store.
+# Called out on their own line because in the decline table they would otherwise read as two more
+# cheap rows -- their cost is not the point, their existence is.
+IMPOSSIBLE_GATES = ("RangeNotBare", "RangePermutationStale")
 # The acquire branch that actually PREDICTS `compose_paging`. Every other branch leaves the
 # `mk_plan_feats` default of `Gather` untouched — see `report_paging` for why that is a different
 # defect rather than a prediction that missed.
@@ -339,12 +345,26 @@ def report_declines(agr: Agreement) -> None:
     describes it. The router picked a plan, the plan bailed, and the general path then answered the
     query from scratch -- so a declining round is pure overhead on top of whatever ran next.
 
-    The gates do not cost the same thing, which is the number this table exists to separate:
+    Both printing-space fastpaths name their gate. The gates do not cost the same thing, which is
+    the number this table exists to separate:
 
+    `PrintingCompose` --
     - `NotComposable`, `DeclineBroad`, `DeclineSparseEstimate` gate BEFORE the compose. Cheap; the
       fastpath looked at an estimate and turned back.
     - `DeclineSparseExact` gates AFTER, off the real total, so it has already composed the printing
       bitmap and throws it away. That is a full compose paid for nothing.
+
+    `PrintingRangeScan` -- all four of its real gates are cheap (two binary searches and a lookup),
+    so the interesting number here is the COUNT, not the median:
+    - `RangeSelective` is the expected one: the range is narrow enough that the ordinary narrowing
+      wins. A large count is fine.
+    - `RangeNoPermutation` and `RangeUnalignedPrice` are orderby/predicate mismatches. A large count
+      means the router keeps ranking a plan that structurally cannot serve those queries, which is a
+      costing question rather than a fastpath one.
+    - `RangeSparse` needs 1000 < k <= 1024 and so is near-unreachable outside a tiny index.
+    - `RangeNotBare` and `RangePermutationStale` should never appear at all -- the first contradicts
+      `PrintingRangeScan.applicable`, the second means an index built against a different store. A
+      non-zero count in either row is the finding, not the timing next to it.
 
     A high `DeclineSparseExact` median against the same query's `PrintingCompose` predicted cost is
     the actionable case: it means the pre-compose sparse estimate is not catching what the exact
@@ -362,6 +382,10 @@ def report_declines(agr: Agreement) -> None:
     post_compose = sum(len(v) for (_, gate), v in agr.declines.items() if gate == POST_COMPOSE_GATE)
     if post_compose:
         print(f"  {post_compose:,} of these ({post_compose / total:.0%}) are {POST_COMPOSE_GATE} -- composed, then discarded.")
+    impossible = {gate: len(v) for (_, gate), v in agr.declines.items() if gate in IMPOSSIBLE_GATES}
+    if impossible:
+        named = ", ".join(f"{gate} x{n:,}" for gate, n in sorted(impossible.items()))
+        print(f"  DEFECT: {named} -- see IMPOSSIBLE_GATES; these gates are supposed to be unreachable.")
     print("  Declines appear in no other table: no page, so no measured/predicted ratio.")
 
 

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -121,8 +121,13 @@ def main() -> None:
             kw["filters"] = parse_scryfall_query(q)
             acq = engine.explain(**kw)["acquire"]
             res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
-        except Exception:  # noqa: BLE001 - a rejected query is a skipped sample
+        except Exception as exc:  # noqa: BLE001 - a rejected query is a skipped sample
+            # Counted BY TYPE, not just totalled. This harness's whole argument is that sampling bias
+            # hides the cells most likely to be wrong -- and a bare skip counter is that same bias: if
+            # explain_analyze started raising for every artwork query, the table below would look
+            # healthy over two thirds of the intended space with nothing to say so.
             agr.skipped += 1
+            agr.skip_reasons[type(exc).__name__] += 1
             continue
         agr.sampled += 1
         for p in res["plans"]:
@@ -164,11 +169,15 @@ class Agreement:
     prep_frac: dict[str, list[float]] = dataclasses.field(default_factory=lambda: collections.defaultdict(list))
     sampled: int = 0
     skipped: int = 0
+    skip_reasons: dict[str, int] = dataclasses.field(default_factory=lambda: collections.defaultdict(int))
 
 
 def report(agr: Agreement, seconds: float) -> None:
     """Agreement per acquire branch and per distinct-on, then the unpriced prepare share."""
     print(f"\n{agr.sampled:,} queries sampled ({agr.skipped:,} skipped) in {seconds:.0f}s")
+    if agr.skip_reasons:
+        breakdown = ", ".join(f"{name} x{n:,}" for name, n in sorted(agr.skip_reasons.items(), key=lambda kv: -kv[1]))
+        print(f"  skipped by reason: {breakdown}")
     summarise("measured/predicted by acquire branch. 1.00 is agreement; >1 under-costed.", agr.ratios, "acquire")
     summarise("the same, split by distinct-on rather than acquire.", agr.by_unique, "unique")
 


### PR DESCRIPTION
## Summary

Behavior-neutral instrumentation: `explain` reports the feature vector `cost::plan_cost` actually
consumes, and `explain_analyze` reports per-plan executor counters and phase timings. Plus
`bench_cost_model_agreement.py`, the first consumer.

Nothing about routing, costing or results changes. This is visibility — and it already found a
selected plan that is priced at 795 ns, spends 9.4 µs producing nothing, and hands the query back.

## Why this first

The cost model can only be improved against measurements, and today there is no way to see inside a
query from outside the engine. Two consequences, both hit while doing the follow-on work:

- **A cost error is invisible until it becomes a latency error.** A plan whose arm is 2x wrong is
  picked correctly right up until something competes closely, and then it is a mystery. With the
  feature vector exposed, the arm can be checked directly against the counter that realizes it.
- **Cross-version comparison is a black box.** Benchmarking a branch against `main` currently yields
  total wall time and nothing else, so a 2% regression cannot be attributed to acquire, prepare, the
  match loop, or emit. Landing the instrumentation on `main` is what makes every later change
  measurable, which is why it goes first rather than riding along with a behavior change.

## What is exposed

`explain`'s `acquire` gains the model's own inputs — `eval_domain`, `scan_units`, `matches`,
`n_cards`/`n_printings`, `residual_tier_ns100`, the compose build terms
(`broadcast_printings`/`scatter_printings`/`project_printings`/`popcount_words`), `compose_paging`,
and the acquire branch (`count_source`). A calibration fit can then regress on exactly the vector the
engine reads instead of a reconstruction of it.

`explain_analyze`'s per-plan entries gain `cards_visited`, `printings_scanned`, `matches_pushed`, the
phase split `ns_prepare` / `ns_setup` / `ns_loop` / `ns_finish` against `ns_round_total`, and the two
ground-truth fields `result_total` and `paging_taken`, plus `materialize_ns` and `routed_ns`. The
counters are what let a FEATURE be checked rather than inferred: `matches` is supposed to predict
`matches_pushed`, `scan_units` to predict `printings_scanned`. Where they disagree, no coefficient
can repair it.

A plan that entered a fastpath and turned back reports `declined_ns` instead of `trials_ns` — raw
per-round wall time, kept in its own field because every consumer reduces `trials_ns` with `min` as
"what this plan costs to run", and a decline is not a run. Its counters and phase timings stay zero
(no executor ran) but `paging_taken` names the gate, which is the only thing that distinguishes a
cheap turn-back from an expensive one. `PhysicalPlan::applicable` is at least as strong as the guard
`run_query_with_plan` re-checks, so `None` from a ranked plan is always a runtime decline and never
a missed applicability test — that is what makes the field well-defined.

`ns_setup` is split from the match loop rather than folded into it because it is neither small nor
modelled: `run_query_streamed` zeroes an `n_cards`-long counts buffer (~126 kB on the real corpus)
regardless of how few candidates it is about to visit. Under a `printing_compose` acquire that is 0%
of the run at the median and **65% at p90** — the selective case, previously landing in the
unaccounted remainder. It is also the one phase with an obvious cost term waiting for it, since the
dominant part scales with `n_cards`, which `PlanFeatures` already carries. The phases are contiguous,
so four `Instant::now()` calls bound all three: no clock reads were added to split it out.

## The response shape, before and after

Both blocks are real output, same query (`t:creature`, `unique=card`, `orderby=edhrec`,
`num_warmups=1, num_trials=3`) against the real corpus — the "before" produced by checking out
`origin/main`'s `card_engine/src` and rebuilding the extension, not hand-written.

**Before** — a bare list, three fields per plan:

```json
[
  { "plan": "PlanePopcountOrder", "predicted_ns": 12048.362500000001,
    "trials_ns": [511917, 513208, 499000] },
  { "plan": "StreamedSelect",     "predicted_ns": 54182.7,
    "trials_ns": [1118750, 1147667, 1145000] },
  { "plan": "GatheredScan",       "predicted_ns": 112805.5,
    "trials_ns": [2556791, 2521959, 2670292] }
]
```

You can see the ranking and you can see the wall time. You cannot see *why* either number is what it
is, and there is nowhere to put a query-level fact, which is why the top level had to become a dict.

**After** — `{"acquire": ..., "plans": [...]}`:

```json
{
  "acquire": {
    "count_source": "plane",
    "narrowed_repr": "none",
    "acquire_ns": [17000, 15625, 16709],
    "routed_ns": [465000, 453917, 456916],
    "eval_domain": 17317,
    "n_cards": 31508,
    "matches": 17317,
    "n_printings": 97206,
    "scan_units": 17317,
    "residual_tier_ns100": 0,
    "limit": 50,
    "offset": 0,
    "broadcast_printings": 0,
    "scatter_printings": 0,
    "project_printings": 0,
    "popcount_words": 0,
    "compose_paging": "Gather"
  },
  "plans": [
    {
      "plan": "PlanePopcountOrder", "predicted_ns": 12048.362500000001,
      "materialize_ns": 0.0, "picked": true,
      "trials_ns": [456000, 493625, 472166],
      "cards_visited": 0, "printings_scanned": 0, "matches_pushed": 0,
      "ns_setup": 0, "ns_loop": 0, "ns_finish": 0, "ns_prepare": 0,
      "ns_round_total": 456000, "result_total": 17317, "paging_taken": ""
    },
    {
      "plan": "StreamedSelect", "predicted_ns": 54182.7,
      "materialize_ns": 85862.15000000001, "picked": false,
      "trials_ns": [1157417, 1121625, 1109417],
      "cards_visited": 17317, "printings_scanned": 45976, "matches_pushed": 17317,
      "ns_setup": 95666, "ns_loop": 896667, "ns_finish": 11250, "ns_prepare": 105208,
      "ns_round_total": 1109417, "result_total": 17317, "paging_taken": ""
    },
    {
      "plan": "GatheredScan", "predicted_ns": 112805.5,
      "materialize_ns": 85862.15000000001, "picked": false,
      "trials_ns": [2504875, 2319625, 2466416],
      "cards_visited": 17317, "printings_scanned": 45976, "matches_pushed": 17317,
      "ns_setup": 334, "ns_loop": 2196958, "ns_finish": 16042, "ns_prepare": 105292,
      "ns_round_total": 2319625, "result_total": 17317, "paging_taken": ""
    }
  ]
}
```

`explain` returns the same two keys; its `plans` entries stop at `predicted_ns`/`materialize_ns`/
`picked`, and its `acquire.routed_ns` is empty because it runs nothing.

Both blocks predate `declined_ns` and are left exactly as captured rather than re-measured: they are
a matched pair taken on one machine in one state, and replacing only the "after" half would turn a
shape comparison into a fabricated speedup. No plan declines on this query, so the field would read
`[]` throughout anyway — it is shown with real content under "What it already found" below.

Four things this one response makes checkable that the old one did not:

- **`predicted_ns` is byte-identical across the two builds** (`12048.362500000001`, `54182.7`,
  `112805.5`). Costing did not move.
- **The counters agree across executors.** `StreamedSelect` and `GatheredScan` both report
  `17317 / 45976 / 17317`. They are one counter under one name and `scan_units` has one definition,
  so a disagreement would mean at most one is the valid comparison —
  `materializing_plans_agree_on_the_counters_they_share` is what pins it.
- **A feature can be checked against what happened.** `matches: 17317` predicts
  `matches_pushed: 17317` exactly here; `scan_units: 17317` against `printings_scanned: 45976` is a
  2.65x under-count, visible as itself rather than as a coefficient that will not settle.
- **The winner is 38x cheaper than predicted, and the phase split says where.** `PlanePopcountOrder`
  predicts 12 µs and runs in 456 µs. It is a fast path, so its counters are zeros *by definition* —
  and `ns_round_total: 456000` with `ns_loop: 0` is exactly the "uninstrumented, not idle" signal
  documented on `PlanTrial::phases`. Closing that is
  `docs/issues/local-engine-instrument-fast-paths.md`.

Note `ns_prepare` ≈ 105 µs against a `StreamedSelect` round of 1109 µs — ~9.5% of the run, in a term
`plan_cost` does not carry at all. That is the gap this instrumentation exists to size.

## What it already found

`paging_taken` exists because `compose_paging` is a prediction — `acquire_plan_features` re-derives
the permutation lookup and the orderby-walk test that `printing_compose_fastpath` then decides again
at run time, and nothing checked the two agree. They now can be. Over 120s of the real corpus
(31,858 queries), split by acquire branch:

    acquire              strategy runs    disagreements    walk-declined
    printing_compose             4,398             0    0%              1
    card_range_popcount            635           635  100%              0
    printing_range_scan            958           958  100%              3

`walk-declined` is broken out rather than pooled into either column — it is the one cell where the
prediction is allowed to be inexact, so counting it as agreement would hide it and counting it as
drift would misname it.

**The two range rows are the defect.** Both cost a *competing* `PrintingCompose` with the untouched
`mk_plan_feats` default of `Gather`, so they price an arm it never runs — `Gather` is
O(`eval_domain`), `Perm` is O(`page_span`/selectivity). The fix is to hand those branches a result
total, not to reconcile two predictions. Not done here: this PR reports.

**The single `printing_compose` walk-declined row is not drift**, and tracing it is what produced
`GatherWalkDeclined`. The two *availability* tests are byte-identical by construction, so they cannot
disagree; what acquire cannot see is one step further on, because it never composes and so cannot
know whether the walk it predicts will *succeed*. The walk declines on the null-value tail or a page
past the value structure and falls into the gather. So `compose_paging` is an **upper bound on
`OrderbyWalk`** and exact in every other cell — one-directional, structural. That gather now reports
`GatherWalkDeclined` rather than a bare `Gather` indistinguishable from a real misprediction, and the
harness reports its rate on its own line: those runs pay a walk attempt *and* a gather while priced
as a walk, which is a real (small) under-costing worth its own follow-up.

This supersedes b83769e's commit-message table, which put the compose-acquired branch at 20% wrong.
That 20% was entirely `predicted Gather -> actual Decline` rows. Pooling the three acquire branches
into one number was hiding a cell that is wrong by construction inside one that is right.

### The declines are 21% of compose entries, and one gate is expensive

The table above counts only composes that reached a paging strategy — which is every compose the
harness could see, because `explain_analyze` dropped the stats of any plan whose round produced no
page. So the four decline gates were recorded in Rust, asserted in-crate, and discarded before
anything outside the crate could count them: a census of *successful* composes presented as a census
of composes. `declined_ns` closes that, and the missing fifth of the picture is not uniform:

    plan               gate                       n   median µs   p90 µs
    PrintingCompose    DeclineSparseExact       959        12.2     15.2
    PrintingRangeScan  (no gate label)          679         0.0      0.0
    PrintingCompose    DeclineBroad             397         0.2      0.3
    PrintingCompose    DeclineSparseEstimate    236         0.0      0.1

**The blank gate column in row 2 is a defect this PR then fixed, not a current finding.** That table
was captured before `printing_range_fastpath` labelled its exits; at the time only the compose
fastpath named a gate, so a declining `PrintingRangeScan` arrived as `NotEntered` — indistinguishable
from never having been tried — and rendered as an empty cell. Every exit of both fastpaths now
records itself, so those 679 rounds resolve into `RangeSelective`/`RangeSparse`/`RangeUnalignedPrice`/
`RangeNoPermutation`. The table is left as captured rather than re-measured for the same reason the
before/after JSON above is: it is one machine in one state, and refreshing half of it would make the
comparison worse, not better. The counts and costs in the other three rows are unaffected — the
labelling change adds no work to any path.

Two of those exits — `RangeNotBare` and `RangePermutationStale` — are tripwires rather than expected
outcomes: the first contradicts `PrintingRangeScan.applicable`, which already requires bare range
bounds, and the second means a permutation built against a different store. Compose's
`NotComposable` is the same class, since `PrintingCompose.applicable` *is* the structural test the
fastpath re-checks. All three sit in `bench_cost_model_agreement.py`'s `IMPOSSIBLE_GATES`, so a
non-zero count prints as a `DEFECT:` line rather than as three more cheap rows. None of them fires
today.

Three of the four compose gates gate *before* the compose and cost nothing, which is the design
working. `DeclineSparseExact` gates *after*, off the real total rather than the estimator's bound, so
it has already composed the printing bitmap and throws it away. The pre-compose sparse gate catches
236 while **959 get past it** to pay a full compose and discard it — a 4:1 miss rate on a gate whose
entire job is catching those.

This is not confined to plans the router rejected. A real response, `cn:312` at `unique=card`:

```json
{
  "plan": "PrintingCompose", "predicted_ns": 795.54, "picked": true,
  "trials_ns": [], "declined_ns": [9541, 9375, 9417],
  "cards_visited": 0, "ns_loop": 0, "ns_round_total": 0,
  "result_total": 0, "paging_taken": "DeclineSparseExact"
}
```

The router **picked** this plan, priced it at 795 ns, and it spent 9.4 µs producing nothing before
the general path ran the query anyway — a 12x under-cost on a selected plan, paid on every such
query. That is precisely the "cost error invisible until it becomes a latency error" this PR opens
with, and it was invisible until `declined_ns` existed.

The fix is estimator tightening rather than a new cost term — the gate exists and fires, it just
fires too late — so it is its own follow-up. Not done here: this PR reports.

## Measurement discipline

`explain_analyze` runs `n + 2` participants per round — every applicable plan, plus the acquire step
and the routed path — in a **seeded-shuffled order**, rather than rotating the plans and pinning the
other two ahead of them.

Pinning them was biased, and specifically so: each pre-warms a *subset* of the plans it is meant to be
compared against. `run_query_routed` dispatches into the picked plan's executor, so a fixed slot ahead
of the plan loop pre-warmed exactly the plan whose selection `picked` exists to question. And on a
candidate acquire, `acquire_plan_features` calls the very `prepare_candidates` that `StreamedSelect`
and `GatheredScan` are about to call and the four fast paths never do — so the bias was present for
one acquire class and absent for another, not even washing out as a constant offset.

Shuffled rather than rotated because a rotation only moves the cut point: cyclic adjacency is fixed,
so every participant keeps the same immediate predecessor round after round. Seeded from a constant,
so ordering stays reproducible for an A/B against another build.

What the shuffle gives up, stated because the trade is not free in both directions: rotation was
*position-balanced* — over `n` rounds every participant sat in every slot exactly once — and an
independent per-round shuffle is not. At `num_trials = 3` a participant can draw the warm tail of the
round twice by chance, and since every consumer reduces `trials_ns` with `min`, that lower sample is
the one that survives. The trade is still right — the bias removed was directional and unequal across
acquire classes, this one is zero-mean — but it shrinks only with rounds, so `num_trials` is now
load-bearing. `bench_cost_model_agreement.py` uses 7; a 2-3 trial run is not a fair head-to-head
between plans within ~10% of each other.

**"Zero-mean and shrinks with rounds" is true within one query and not across a sweep**, which is
[#801](https://github.com/jbylund/sylvan_librarian/issues/801)
([doc](docs/issues/00801-engine-explain-analyze-shuffle-seed.md)), found in review of this PR and
deliberately left out of it. The RNG is constructed inside `explain_analyze` from a constant, so
every call with the same participant count draws the identical sequence of permutations. The
resulting bias attaches to rank position, which correlates with plan identity, so it survives into a
table keyed by plan and *does not* average out over more queries — it is common-mode across samples
rather than noise within them. That applies to every table in this PR produced by
`bench_cost_model_agreement.py`: the paging-agreement counts and the decline census are ordering-
sensitive in their timings, though not in their counts, which is what the findings above turn on.
The fix is to mix a per-query value into the seed; it is a methodology change to the harness, and
landing the instrumentation first is what makes it measurable at all.

**Caveat for anyone holding earlier numbers from this branch: `trials_ns` collected before the shuffle
is not comparable to `trials_ns` collected after it.**

## Correctness

Instrumentation must change nothing observable.

- **648 query shapes** (18 predicates x 3 distinct-ons x 4 orderbys x 3 pages), branch vs `main`:
  **0 total mismatches, 0 first-page mismatches.**
- `cargo test`: 145 pass debug, 144 release. 2,228 Python unit tests, 159 engine unit tests.
- `paging_taken` lives in its own `PAGING_TAKEN` thread-local rather than sharing a slot with the
  counters. It is the one field written by something that is not an executor, and sharing forced both
  publishers to write 8 of 10 fields and inherit the rest through `..c.get()` — making every
  publisher responsible for not wiping a field it does not own, which is the arrangement the 49-of-600
  leak came out of. Both executors now write `PhaseStats` whole and can inherit nothing;
  `take_phase_stats` reassembles the two and consumers see no seam. `note_paging_taken` also drops
  from a read-modify-write of the whole ~80-byte struct to a one-byte store, which matters because it
  runs on the production compose path.
- `PENDING_PREPARE_NS` is a value in flight between two calls rather than a stat, so nothing clears
  it — the receiving executor consumes it with `replace(0)`. That invariant spans three functions and
  the failure is silent (an unconsumed value is read by the *next* participant and reported as its
  `ns_prepare`), so `timed_prepare_candidates` asserts it in debug.
- The diagnostic labels (`paging_taken`, `count_source`, `narrowed_repr`) are enums with explicit
  `label()` methods, verified byte-identical against the built extension — the Python surface did not
  move, including `PagingTaken::NotEntered -> ""`. Two "the label is one of these five" assertions
  became tautologies and were deleted.
- Counters are published through a single helper because the walk has several early returns, and each
  one has to leave the stats behind or the phase accounting silently attributes work to nothing.
- `ns_setup + ns_loop + ns_finish` is asserted as a sum bounded by the round, not as an equality:
  `run_query_with_plan`'s dispatch and the applicability checks sit outside all three, so the
  shortfall is a residual to size rather than an invariant that should reach zero.

### Regression tests, each verified against the failure it exists to catch

- `materializing_plans_agree_on_the_counters_they_share` — the two executors publish into one
  `PhaseStats` under one set of names, and `scan_units` has one definition, so if they count
  differently at most one is the valid comparison. Reverting the counter-placement fix fails at
  `streamed 15133 vs gathered 1254`. Its first draft passed vacuously (plane/index specs narrow
  exactly, so `card_pass` never rejected anything); inexact narrowings fixed that, and "the continue
  fired somewhere" is now itself asserted. `matches_pushed` is additionally anchored to the total each
  run actually returned, in both executors — plan-vs-plan alone cannot catch the two being wrong the
  same way, and in artwork mode the counter sits downstream of the group dedup, so a counter moved
  above it would still agree plan-to-plan while both disagreed with reality.
- `plan_stats_never_leak_between_participants` — driven through `explain_analyze`, because the
  invariant lives in *its* loop. Two leaks, and dropping either half of `take_phase_stats` reproduces
  the corresponding one: an uninstrumented plan reads its predecessor's `PHASE_STATS`, and — the leak
  actually observed at 49 of 600 — `paging_taken` crosses from the plan that recorded it to a later
  one. The second is structural: only `printing_compose_fastpath` writes that label, and it must
  survive a materializing publish *within* one run, since the routed path's "compose declines,
  records its gate, falls through to a materializing plan" sequence depends on it. Its lifetime is
  therefore deliberately wider than any single publisher, and the per-participant clear is the only
  thing bounding it to one run instead of "this thread, ever".
- `declining_plans_report_their_gate_through_explain_analyze` — a decline must reach the wire, not
  just the thread-local. Asserts empty `trials_ns` against non-empty `declined_ns`, zero counters and
  zero timings (no executor ran, so anything else is a leak), and a compose label that names a gate
  rather than the `NotEntered` default meaning "never tried". Its sweep reaches both
  `DeclineSparseEstimate` and `DeclineSparseExact`; before `declined_ns` every row it checks was
  discarded by `explain_analyze` before a caller could see it.
- `compose_paging_prediction_matches_the_branch_taken` now asserts per-arm legal labels, which is
  *stricter* than the equality it replaced: a bare `Gather` under a predicted `OrderbyWalk` is now a
  failure. Its sweep reached the walk-declined cell zero times until a narrow composable spec was
  added — only 2 of its 7 specs are printing-composable at all, now noted in the list.

## Performance

No measurable difference, and the measurement says so rather than the intent.

    order                          origin/main    branch
    branch first                       197.9 ms   185.7 ms   branch -6.2%
    origin/main first                  199.2 ms   205.8 ms   branch +3.3%

The two orderings disagree in sign — whichever build runs first is faster — so ordering drift of
about +/-5% dominates and no real difference is resolvable at this scale. Reported both ways rather
than picking the flattering one.

The production-path cost is ~5 clock reads and a thread-local write per query on the two materializing
plans. Deliberately not feature-gated: `explain_analyze` is a `#[pyo3]` method on the shipped
extension, so gating the instrumentation out of release builds would return zeros in exactly the build
worth diagnosing.

## Also included

`bench_cost_model_agreement.py` reports measured/predicted per (plan, acquire branch), sampling
`unique` evenly across card/printing/artwork rather than the 75/20/5 of real traffic — distinct-on
changes which plans are applicable and what `scan_units` means, so under-sampling two thirds of it
hides exactly the cells most likely to be wrong. Its `prepare_candidates` and setup shares cover only
the two materializing plans, because no other plan has those phases at all — which is not the same as
spending 0% of its run in them, and pooling the two says the wrong thing.

It also names the cells it suppresses. Dropping `n < 8` cells silently, and then reporting
`passing/total` over the survivors as if it were coverage, is the same under-sampling bias the script
argues against applied to its own report — so suppressed cells are listed with their sample counts
("n=6 of 8" and "n=1" call for different responses) and the ratio says "reported cells". Measured
honestly: at the default budget nothing is suppressed at all (31,858 samples, smallest cell n=359),
so this is a guard against short runs rather than a live defect.

`bench_candidate_materialize.rs` and `docs/issues/local-engine-candidate-materialize.md` cover the
materialization term `explain` now reports (bitmap beats sort from ~64 candidates; **do not build the
k-way merge** — it loses at every size).

`docs/issues/local-engine-instrument-fast-paths.md` writes up the gap this PR does not close: the four
fast paths report features nothing checks. It needs three different counter vocabularies, not four
missing increments, and one prerequisite — per-acquire-branch feature semantics. The cheap first step
is `run_query_streamed_popcount`, one site covering two plans against a `popcount_words` feature that
already exists.

`docs/issues/00801-engine-explain-analyze-shuffle-seed.md` records the shuffle-seed bias described
under *Measurement discipline* — the one review finding from this PR held back rather than fixed in
it, since it changes how the harness measures rather than what the engine reports.


