### PR TITLE
Exact Distinct-Card Counts for Range Acquires, Replacing the k.min(n_cards) Proxy

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2073,6 +2073,134 @@ fn build_printing_to_card(offsets: &[u32]) -> Vec<u32> {
 
 type PrintingRangeIndex = Vec<(u32, u32)>;
 
+/// Exact distinct-CARD counts alongside a `PrintingRangeIndex`, so a range acquire can report the
+/// real answer instead of estimating it.
+///
+/// The index is printing-space and value-sorted, but `unique=card` costing needs distinct *cards*,
+/// and the two differ by the local printing:card ratio — measured 1.0 to 4.3 across the corpus, worst
+/// where reprint density is highest. `CardRangePopcount`'s acquire has stood in `k.min(n_cards)` (the
+/// in-range printing count clamped), which over-estimates a median 1.49x and up to 4.33x. See
+/// docs/issues/local-engine-range-cardinality-estimate.md for the estimators that were tried and why
+/// none of them work: distinct-card counts do not compose by arithmetic, because one card spans many
+/// values, so nothing derived from a coarser summary is exact.
+///
+/// The trick that makes an exact table affordable is that these dimensions have far fewer distinct
+/// VALUES than printings — 914 release dates against 97,206 printings, 4,133 usd prices. Printings
+/// sharing a value are contiguous, so any threshold, present in the data or not, bisects to a value
+/// boundary; there is no interpolation to do. One entry per distinct value is enough, and all three
+/// counts come out of a single build pass.
+///
+/// None of the three derives from the others — each was measured failing:
+/// - `suf[i] != total - pre[i]`: a card with printings on both sides of the cut is in both.
+/// - `val[i] != pre[i+1] - pre[i]`: that counts cards whose FIRST printing is at this value, not
+///   cards present at it (10 against a true 54 at `usd:2.99`).
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct RangeCardCounts {
+    /// Each distinct value in the index, ascending. Parallel to the three count vectors.
+    values: Vec<u32>,
+    /// Distinct cards among printings with value < `values[i]`. Serves `<` and `<=`.
+    below: Vec<u32>,
+    /// Distinct cards among printings with value >= `values[i]`. Serves `>` and `>=`.
+    at_or_above: Vec<u32>,
+    /// Distinct cards among printings with value == `values[i]`. Serves `Eq`, which cannot be had by
+    /// subtracting neighbouring `below` entries.
+    at: Vec<u32>,
+}
+
+impl ArchivedRangeCardCounts {
+    /// Exact distinct cards for the half-open value range `[lo, hi)`, or `None` when the shape is one
+    /// this table cannot answer.
+    ///
+    /// Answerable: `[0, hi)` and `[lo, MAX)` — every op except `Eq` produces one of those — plus a
+    /// range covering exactly one distinct value, which is what `Eq` produces. A range spanning
+    /// several values (only `year:Y`, which covers a whole calendar year of release dates) returns
+    /// `None`; distinct counts do not subtract, so the neighbouring entries cannot be combined.
+    fn distinct_cards(&self, lo: u32, hi: u32) -> Option<u32> {
+        if self.values.is_empty() || hi <= lo {
+            return None;
+        }
+        let pos = |v: u32| self.values.partition_point(|x| u32::from(*x) < v);
+        let (i, j) = (pos(lo), pos(hi));
+        if j <= i {
+            return Some(0); // no indexed value falls in the range
+        }
+        let first = u32::from(self.values[0]);
+        let last_covers_end = j == self.values.len();
+        match (lo <= first, last_covers_end) {
+            (true, true) => Some(u32::from(self.at_or_above[0])), // whole index
+            (true, false) => Some(u32::from(self.below[j])),      // `<` / `<=`
+            (false, true) => Some(u32::from(self.at_or_above[i])), // `>` / `>=`
+            // Interior range: exact only when it holds a single distinct value, which is `Eq`.
+            (false, false) if j == i + 1 => Some(u32::from(self.at[i])),
+            _ => None,
+        }
+    }
+}
+
+/// Build the three count vectors for one range index. O(n) over the index plus one card-seen bitmap
+/// per direction, so two passes; the index is already value-sorted, which is what makes the value
+/// boundaries a simple adjacent-difference scan.
+fn build_range_card_counts(idx: &PrintingRangeIndex, printing_to_card: &[u32], n_cards: usize) -> RangeCardCounts {
+    let mut out = RangeCardCounts::default();
+    if idx.is_empty() {
+        return out;
+    }
+    // Boundary positions: 0, then every position where the value changes.
+    let mut starts: Vec<usize> = vec![0];
+    starts.extend((1..idx.len()).filter(|&i| idx[i].0 != idx[i - 1].0));
+    out.values = starts.iter().map(|&i| idx[i].0).collect();
+
+    let words = n_cards.div_ceil(64);
+    let mut seen = vec![0u64; words];
+    let mut distinct = 0u32;
+    // Forward: `below[i]` is the running distinct count before this value's block begins.
+    for (b, &start) in starts.iter().enumerate() {
+        out.below.push(distinct);
+        let end = starts.get(b + 1).copied().unwrap_or(idx.len());
+        for &(_, pid) in &idx[start..end] {
+            let cid = printing_to_card[pid as usize] as usize;
+            let (w, bit) = (cid >> 6, 1u64 << (cid & 63));
+            if seen[w] & bit == 0 {
+                seen[w] |= bit;
+                distinct += 1;
+            }
+        }
+    }
+    // Backward for `at_or_above`, and per-block for `at` — both need their own fresh bitmap, since a
+    // card counted in one block must still count in another.
+    seen.fill(0);
+    distinct = 0;
+    out.at_or_above = vec![0; starts.len()];
+    out.at = vec![0; starts.len()];
+    // One scratch bitmap reused across blocks, cleared by walking back over the cards this block
+    // actually touched — a `fill(0)` per block would be O(n_cards) each, and there are as many
+    // blocks as distinct values.
+    let mut block = vec![0u64; words];
+    let mut touched: Vec<usize> = Vec::new();
+    for (b, &start) in starts.iter().enumerate().rev() {
+        let end = starts.get(b + 1).copied().unwrap_or(idx.len());
+        touched.clear();
+        for &(_, pid) in &idx[start..end] {
+            let cid = printing_to_card[pid as usize] as usize;
+            let (w, bit) = (cid >> 6, 1u64 << (cid & 63));
+            if seen[w] & bit == 0 {
+                seen[w] |= bit;
+                distinct += 1;
+            }
+            if block[w] & bit == 0 {
+                block[w] |= bit;
+                touched.push(cid);
+            }
+        }
+        out.at_or_above[b] = distinct;
+        out.at[b] = touched.len() as u32;
+        for &cid in &touched {
+            block[cid >> 6] &= !(1u64 << (cid & 63));
+        }
+    }
+    out
+}
+
 /// One-shot env override for the guard statics below: reads
 /// `CARD_ENGINE_<NAME>` once (each static is a LazyLock), falling back to the
 /// measured default when the var is unset or unparseable. Production leaves
@@ -2428,6 +2556,12 @@ struct CardIndexes {
     released_at:    PrintingRangeIndex,       // printing space
     price_usd:      PrintingRangeIndex,       // printing space (integer cents, already order-preserving)
     collector_number: PrintingRangeIndex,     // printing space (extracted int)
+    // Exact distinct-CARD counts per distinct value of each range index above, so a card-space
+    // range acquire reports the truth instead of the `k.min(n_cards)` proxy (which over-estimates a
+    // median 1.49x). ~159 KB for all three; see RangeCardCounts.
+    released_at_cards:      RangeCardCounts,
+    price_usd_cards:        RangeCardCounts,
+    collector_number_cards: RangeCardCounts,
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     artwork_group_col: Vec<u16>,               // printing space: pid -> artwork_group_id (columnar; lets the gather skip read gid without touching the wide struct)
@@ -4461,6 +4595,27 @@ fn resolve_numeric_range_leaf<'i>(
         (NumExpr::Field(NumField::CollectorNumberInt), NumExpr::Const(v)) => Some((&indexes.collector_number, op, *v)),
         (NumExpr::Const(v), NumExpr::Field(NumField::CollectorNumberInt)) => Some((&indexes.collector_number, flip_op(op), *v)),
         _ => None,
+    }
+}
+
+/// The exact card-count table paired with a range index, or `None` if that index has none.
+///
+/// Matched by pointer identity because `bare_range_bounds` hands back one of the three index
+/// references itself, not a discriminant — and all three live in the same archived struct, so the
+/// comparison is exact rather than heuristic. Threading a dimension tag through
+/// `resolve_numeric_range_leaf` instead would touch every caller for no more safety.
+fn range_card_counts_for<'i>(
+    indexes: &'i Archived<CardIndexes>,
+    idx: &Archived<PrintingRangeIndex>,
+) -> Option<&'i ArchivedRangeCardCounts> {
+    if std::ptr::eq(idx, &indexes.released_at) {
+        Some(&indexes.released_at_cards)
+    } else if std::ptr::eq(idx, &indexes.price_usd) {
+        Some(&indexes.price_usd_cards)
+    } else if std::ptr::eq(idx, &indexes.collector_number) {
+        Some(&indexes.collector_number_cards)
+    } else {
+        None
     }
 }
 
@@ -6954,7 +7109,13 @@ fn acquire_plan_features(
         // alternatives are costed with the range's verify tier (a `0` would under-cost them).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        let card_est = k.min(n_cards);
+        // Exact distinct cards from the per-value table when it can answer this shape — every op but
+        // `Eq` is one-sided, and `Eq` is a single value, so the only fallback is `year:Y`, which spans
+        // a whole year of release dates. The `k.min(n_cards)` proxy it falls back to over-estimates a
+        // median 1.49x (docs/issues/local-engine-range-cardinality-estimate.md).
+        let card_est = range_card_counts_for(indexes, idx)
+            .and_then(|counts| counts.distinct_cards(lo, hi))
+            .unwrap_or_else(|| k.min(n_cards));
         let mut feats = mk_plan_feats(ctx, params, card_est, card_est, card_est, verify_cost_tier(filter));
         // `k` rides `scatter_printings`: this plan's arm charges it as its FUSED one-pass build
         // (`CARD_RANGE_BUILD_PER_PRINTING_NS`), while a competing PrintingCompose costed off these shared
@@ -8038,7 +8199,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // current calendar date (20260723) and 20260724 were both already consumed by
 // earlier same-window archive changes (#737 columnar artwork_group_id, #741
 // watermark postings), so this takes the next distinct value — see the doc above.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260725;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260730;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -8518,6 +8679,16 @@ impl QueryEngine {
         // feed CardIndexes.artwork_groups below. Must run before printings is
         // borrowed by the builders in the CardIndexes literal.
         let artwork_group_counts = assign_artwork_groups(&mut printings, &offsets);
+        // The range indexes and their exact card-count tables come out here rather than inside the
+        // literal below, because the tables need `printing_to_card` — which the literal also wants,
+        // so it is derived once and moved in.
+        let printing_to_card = build_printing_to_card(&offsets);
+        let released_at_idx = build_range_index(&printings, |p| p.released_at_int);
+        let price_usd_idx = build_range_index(&printings, |p| p.price_usd);
+        let collector_number_idx = build_range_index(&printings, |p| p.collector_number_int.map(u32::from));
+        let released_at_cards = build_range_card_counts(&released_at_idx, &printing_to_card, cards.len());
+        let price_usd_cards = build_range_card_counts(&price_usd_idx, &printing_to_card, cards.len());
+        let collector_number_cards = build_range_card_counts(&collector_number_idx, &printing_to_card, cards.len());
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
@@ -8553,9 +8724,12 @@ impl QueryEngine {
                 }
                 idx
             },
-            released_at:    build_range_index(&printings, |p| p.released_at_int),
-            price_usd:      build_range_index(&printings, |p| p.price_usd),
-            collector_number: build_range_index(&printings, |p| p.collector_number_int.map(u32::from)),
+            released_at:    released_at_idx,
+            price_usd:      price_usd_idx,
+            collector_number: collector_number_idx,
+            released_at_cards,
+            price_usd_cards,
+            collector_number_cards,
             sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
             max_artwork_groups: artwork_group_counts.iter().copied().max().unwrap_or(0),
             artwork_groups: artwork_group_counts,
@@ -8563,7 +8737,7 @@ impl QueryEngine {
             // production spot where assign_artwork_groups (above) has just filled it. Archived with
             // the store, so it is never recomputed post-load and cannot drift from the struct field.
             artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
-            printing_to_card: build_printing_to_card(&offsets),
+            printing_to_card,
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             border_printing: build_border_printing_planes(&printings, &strings),
             rarity_printing: build_rarity_printing_planes(&printings),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7,6 +7,7 @@ use super::{
     build_artist_index, build_range_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
+    RangeCardCounts, build_range_card_counts,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -2365,6 +2366,15 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.released_at = build_range_index(&data.printings, |p| p.released_at_int);
     data.indexes.price_usd = build_range_index(&data.printings, |p| p.price_usd);
     data.indexes.collector_number = build_range_index(&data.printings, |p| p.collector_number_int.map(u32::from));
+    // The exact card-count tables ride on those indexes and must be rebuilt with them — leaving them
+    // at their empty defaults would make every range acquire silently fall back to the `k.min(n_cards)`
+    // proxy here while production used the table, so the fuzz differential would stop covering the
+    // path it is meant to cover.
+    let p2c = build_printing_to_card(&data.offsets);
+    let n_cards = data.cards.len();
+    data.indexes.released_at_cards = build_range_card_counts(&data.indexes.released_at, &p2c, n_cards);
+    data.indexes.price_usd_cards = build_range_card_counts(&data.indexes.price_usd, &p2c, n_cards);
+    data.indexes.collector_number_cards = build_range_card_counts(&data.indexes.collector_number, &p2c, n_cards);
     data.indexes.border_printing = build_border_printing_planes(&data.printings, &data.strings);
     data.indexes.rarity_printing = build_rarity_printing_planes(&data.printings);
     data
@@ -3031,6 +3041,72 @@ fn force_plan_differential_agreement() {
             ran[plan_idx(plan)] > 0,
             "plan {plan:?} was never exercised by the differential corpus — add coverage",
         );
+    }
+}
+
+/// The per-value card-count table must be EXACT, not close: every one-sided cut and every single
+/// value, on all three range indexes, checked against a brute-force distinct count over the store.
+///
+/// Exhaustive over the distinct values rather than sampled. There are only a few thousand per
+/// dimension — the same property that makes the table affordable — and this investigation's errors
+/// clustered at the ends of ranges, exactly where a sampled check would have missed them.
+#[test]
+fn range_card_counts_are_exact() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_730);
+    let data = fuzz_store_n(&mut rng, 2_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let indexes = &archived.indexes;
+    let p2c = &indexes.printing_to_card;
+
+    for (name, idx, counts) in [
+        ("released_at", &indexes.released_at, &indexes.released_at_cards),
+        ("price_usd", &indexes.price_usd, &indexes.price_usd_cards),
+        ("collector_number", &indexes.collector_number, &indexes.collector_number_cards),
+    ] {
+        if idx.is_empty() {
+            continue;
+        }
+        assert_eq!(counts.values.len(), counts.below.len(), "{name}: parallel vectors");
+        assert_eq!(counts.values.len(), counts.at_or_above.len(), "{name}: parallel vectors");
+        assert_eq!(counts.values.len(), counts.at.len(), "{name}: parallel vectors");
+
+        // Brute force: distinct cards among printings whose value satisfies the predicate.
+        let distinct = |keep: &dyn Fn(u32) -> bool| -> u32 {
+            let mut seen = std::collections::HashSet::new();
+            for entry in idx.iter() {
+                if keep(u32::from(entry.0)) {
+                    seen.insert(u32::from(p2c[u32::from(entry.1) as usize]));
+                }
+            }
+            seen.len() as u32
+        };
+
+        for (i, value) in counts.values.iter().enumerate() {
+            let v = u32::from(*value);
+            assert_eq!(u32::from(counts.below[i]), distinct(&|x| x < v), "{name}: below[{i}] at {v}");
+            assert_eq!(u32::from(counts.at_or_above[i]), distinct(&|x| x >= v), "{name}: at_or_above[{i}] at {v}");
+            assert_eq!(u32::from(counts.at[i]), distinct(&|x| x == v), "{name}: at[{i}] at {v}");
+            // And through the lookup the acquire actually calls, for all three answerable shapes.
+            assert_eq!(counts.distinct_cards(0, v), Some(distinct(&|x| x < v)), "{name}: lookup `< {v}`");
+            assert_eq!(counts.distinct_cards(v, u32::MAX), Some(distinct(&|x| x >= v)), "{name}: lookup `>= {v}`");
+            assert_eq!(counts.distinct_cards(v, v + 1), Some(distinct(&|x| x == v)), "{name}: lookup `== {v}`");
+        }
+
+        // A range spanning several distinct values is the one shape the table declines, rather than
+        // answering it wrongly by subtracting neighbouring entries. It has to be genuinely interior:
+        // a multi-value range starting at the minimum is a prefix and IS answerable, which is what
+        // `below` is for.
+        if counts.values.len() >= 4 {
+            let (lo, hi) = (u32::from(counts.values[1]), u32::from(counts.values[3]));
+            assert_eq!(counts.distinct_cards(lo, hi), None, "{name}: multi-value interior must decline");
+            let span = u32::from(counts.values[2]);
+            assert!(
+                counts.distinct_cards(0, span).is_some(),
+                "{name}: a multi-value range from the bottom is a prefix and must still answer",
+            );
+        }
     }
 }
 
@@ -5576,6 +5652,10 @@ fn bench_checked_vs_unchecked_access() {
         released_at:    Vec::new(),
         price_usd:      Vec::new(),
         collector_number: Vec::new(),
+        // Empty to match the empty range indexes above; fuzz_store_n rebuilds all six together.
+        released_at_cards: RangeCardCounts::default(),
+        price_usd_cards: RangeCardCounts::default(),
+        collector_number_cards: RangeCardCounts::default(),
         sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,

--- a/docs/issues/local-engine-range-cardinality-estimate.md
+++ b/docs/issues/local-engine-range-cardinality-estimate.md
@@ -1,0 +1,241 @@
+# Estimating distinct cards in a range slice
+
+`CardRangePopcount`'s acquire feeds `matches`/`eval_domain`/`scan_units` from
+`card_est = k.min(n_cards)`, where `k` counts in-range **printings** and stands in for a card count —
+a proxy the branch's own comment flags. Measured against the true total on realistic ranges:
+
+| estimator | p10 | p50 | p75 | p90 | p99 | max |
+| --------- | --: | --: | --: | --: | --: | --: |
+| `min(k, n_cards)` (current) | 1.14 | **1.49** | 1.65 | **1.82** | **4.33** | 4.33 |
+
+Not a tail problem — the median is 1.49x and p10 is already 1.14, so it over-estimates nearly
+everywhere, because printings outnumber cards.
+
+Split out of [local-engine-plan-misselection.md](local-engine-plan-misselection.md), which found the
+proxy while investigating why every plan costed off that acquire is under-costed 2.0–2.6x.
+
+## Nothing here ships alone
+
+The proxy over-costs ~1.48x; the plan arms under-cost ~1.5x at this operating point. The two errors
+point in opposite directions and **partially cancel**, which is why routing mostly survives them.
+Correcting the estimate without re-fitting the arms pushes the arm error from 1.6x to ~2.4x.
+
+The arm half belongs to the sibling doc, and cannot be fixed by re-fitting rates globally: the same
+two plans are over-costed (0.57) off `candidates` acquires and under-costed (2.56) off this one, and
+`STREAM_*`/`GATHER_*` are shared constants. This doc owns the estimate half only.
+
+## The surviving candidates
+
+### 1. Build the card bitmap in acquire — exact, no storage
+
+`CardRangePopcount` already calls `build_card_range_bits` at dispatch, re-deriving the bounds to do
+so, and it wins **138 of 142** sampled range queries. `StreamedSelect`/`GatheredScan` would take
+`bitmap_card_ids` over their own `range_narrowed` → `into_cards`. Only `PrintingCompose` has no use
+for a card bitmap, and it wins **zero**.
+
+So promoting the build into the acquire branch and carrying it in `Prep` — the pattern `Prep::Plane`
+already uses for the plane bitmap — is a reordering of work already done. Its popcount is the exact
+`matches`/`eval_domain`, and it deletes a duplicate bounds derivation.
+
+| | |
+| --- | --- |
+| accuracy | **exact** |
+| memory | **none** — no archive data |
+| query time | 0 in the 97% case (the winner builds it anyway); 47 µs median, 106 µs p90 when a plan wins that does not want it |
+| risk | moves an O(k) build across the acquire/dispatch boundary; the both-fast-paths-decline case (`usd>50`) needs a test |
+
+That 47 µs is why the storage options below still matter — it is the cost when the artifact goes
+unused. Measured from `acquire.range_k`: median slice 38,245 printings at
+`CARD_RANGE_BUILD_PER_PRINTING_NS` = 1.22.
+
+### 2. One boundary table, three counts — exact for every shape here, 159 KB
+
+The dimensions have far fewer distinct **values** than printings: 914 dates against 97,206 printings,
+4,133 usd. Printings sharing a value are contiguous in the value-sorted index, so *any* threshold —
+present in the data or not — bisects to a value boundary. There is no between-buckets case to
+interpolate.
+
+Store three counts per boundary, all produced by one build pass and served by the one binary search
+the acquire already performs to get `k`:
+
+| column | distinct cards in | serves |
+| ------ | ----------------- | ------ |
+| `pre[i]` | `[0, boundary_i)` | `<`, `<=` |
+| `suf[i]` | `[boundary_i, n)` | `>`, `>=` |
+| `val[i]` | `[boundary_i, boundary_{i+1})` | `Eq` |
+
+| dim | boundaries | pre+suf | val | total |
+| --- | ---------: | ------: | --: | ----: |
+| date | 915 | 7,320 | 3,656 | 10,976 |
+| tix | 1,208 | 9,664 | 4,828 | 14,492 |
+| cn | 3,205 | 25,640 | 12,816 | 38,456 |
+| eur | 3,925 | 31,400 | 15,696 | 47,096 |
+| usd | 4,134 | 33,072 | 16,532 | 49,604 |
+| **total** | | 107,096 | 53,528 | **160,624** |
+
+Plus ~34 per-year counts on `date` for `year:Y`, which is a bounded range spanning many values.
+
+| | |
+| --- | --- |
+| accuracy | **exact** for every shape that reaches this acquire |
+| memory | ~159 KB of archive data — needs an `ARCHIVE_FORMAT_VERSION` bump |
+| query time | O(1) — the binary search already paid to get `k`, plus one array read |
+| risk | low; no tuning parameter, and it tracks corpus growth one value at a time |
+
+**`val[i]` cannot be derived from `pre`.** `count(usd<=2.99) − count(usd<2.99)` looks like it should give
+the `Eq` answer and does not: it is 10 against a true 54, because 44 of those cards also have a cheaper
+printing and were already counted below the boundary. Subtraction yields cards whose *first* appearance
+is at that value, not cards present at it. Distinct-card counts do not subtract over a multiset — one
+card spans many prices — which is the same reason prefix/suffix cannot answer a bounded range, and the
+reason the arith-tuple index escapes it (each card has exactly one tuple).
+
+### 3. prev-array + wavelet tree — exact for arbitrary ranges, 1.06 MB
+
+Kept for completeness; **probably not needed** — see the next section.
+
+The general problem is **range distinct count** (colored range counting). Let `prev[i]` be the index
+of the previous printing of the same card, or −1. Then
+
+    distinct cards in [a, b)  ==  #{ i in [a, b) : prev[i] < a }
+
+because each card in the window has exactly one occurrence that is its first there, and only that one
+points back outside it. A wavelet tree over `prev` answers that dominance count in O(log n), and the
+tree encodes `prev`, so the array need not be stored. Verified exact on 2,583 windows across all five
+dimensions — bounded, one-sided and random. Space is 1.06 MB, 134–252 KB per dimension.
+
+No maintained Rust crate exposes the operation. [`qwt`](https://docs.rs/qwt/) has rank/select/access
+only. [`sucds`](https://github.com/kampersanda/sucds) and [`vers`](https://github.com/Cydhra/vers) —
+both Apache-2.0, both actively maintained — expose `quantile(range, k)`, the inverse, which would have
+to be binary-searched at roughly 17x the work. [`wavelet-matrix`](https://github.com/sekineh/wavelet-matrix-rs)
+has exactly `count_lt(pos_range, value)` and is MIT (declared in `Cargo.toml`; there is no LICENSE
+file, which is why GitHub's API reports none) but was last touched in 2022. Vendoring the ~200 lines
+that path needs — `prefix_rank_op`, the struct, and a rank-capable bitvector the engine can supply
+itself — is viable under an MIT attribution header if it is ever wanted.
+
+## Which shapes actually reach this acquire
+
+This narrows the problem sharply, and was established late. `bare_range_bounds` matches only
+`NumericCmp`, `DateCmp`, `YearCmp` and `Not` of those — **not `And`**. So a two-sided conjunction like
+`cn>=441 cn<=447` never reaches this acquire; it goes through the general candidates route, where the
+estimate is not `card_est` at all. It was treated as the motivating bounded case for several turns and
+is not one.
+
+Of the ops that do reach it, every one except `Eq` is one-sided: `Lt`/`Le` give `(0, x)`, `Gt`/`Ge`
+give `(x, MAX)`. The complete bounded set is:
+
+| shape | range | answered exactly by |
+| ----- | ----- | ------------------- |
+| `usd:5`, `cn:441` | `[v, v+1)` — a single distinct value | a per-value distinct count, one entry |
+| `date:2023-01-01` | `[d, d+1)` — a single distinct value | the same array |
+| `year:2023` | `[y·10⁴, (y+1)·10⁴)` — one calendar year | a per-year count on `date`, ~34 entries |
+
+So candidate (2) plus two small arrays is exact for every shape that reaches this acquire, with no
+wavelet, no banded table, no MCV and no dependency.
+
+**`Not` introduces no new shapes**, checked: it applies `negate_op` and reuses the same bounds
+functions. `-usd>20` becomes `Le` → `(0, 21)`; `-usd<5` becomes `Ge` → `(5, MAX)`. And negating `Eq`
+gives `Ne`, which returns `None` and never narrows — so `Not` cannot produce a bounded range at all,
+making it strictly easier than the positive case. (`-usd!=5` inverts to `Eq`, a single value, which the
+per-value array covers.)
+
+The engine's documented negation hazards are a different category and do not apply here:
+`range_narrowed`'s note that price bounds are widened for float rounding, so "a Not would complement
+away the boundary printings", is about the **tightness of the candidate set** — which cards come back.
+These arrays feed only the cost estimate, so an error there would degrade routing, not results.
+
+## Plan
+
+1. **The boundary table (candidate 2).** ~159 KB, O(1), no dependency, no tuning parameter — three
+   columns built in one pass, exact for every shape that reaches this acquire. Add the ~34 per-year
+   counts on `date` in the same change; after it the proxy is gone.
+2. **Re-ask the arm question.** With exact features, part of the arms' ~1.5x under-costing may
+   disappear — it may be the model charging `card_est`-shaped terms for true-card-shaped work. Re-fit
+   only afterwards, and only against prep-netted measurements.
+
+Candidate (1), the prep artifact, is complementary and independent: it removes the proxy for the
+`CardRangePopcount` branch by reordering work already done, at no storage cost. Candidate (3) is parked
+unless two-sided conjunctions are ever routed to the range index.
+
+**Fallback if 107 KB is somehow unaffordable:** a trapezoid histogram — bucket widths doubling in from
+each edge, capped, uniform between — over prefix/suffix arrays reaches 1.19x worst case at 3.4 KB, or
+1.06x at 42 KB. Dominated by (2) on every axis except size, and for `date` not even that, since 1,048
+cuts exceeds the 915 possible answers.
+
+## What was tried and rejected
+
+All measured; recorded so the next attempt does not repeat them.
+
+| approach | result | why it fails |
+| -------- | ------ | ------------ |
+| rescale `card_est` by the card:printing ratio | worse than current | scored on a **clamped** input; the ranking was an artifact |
+| `k / prints-per-card` per dimension | 0.126 median, worst of three below k=5k | duplication is not constant in `k` |
+| occupancy (balls into bins) | 0.161 median | wins `usd<` at every slice size, loses `usd>` at every one |
+| equi-depth histogram | 0.005 median, **3.7 max** | the median hid a 150x tail on sub-bucket slices |
+| more buckets | fixes the mid-band, not small-k | still 1.409 at 256 buckets and 658 KB |
+| point sampling, even or random | 1.32–1.45 | needs collisions; ~2.5 printings per card means a sparse sample never collides |
+| cluster sampling in runs | 0.615 | 2x better than point sampling, still 5x worse than a free constant |
+| per-card `(first, last)` intervals | 0.390 median | exact for 3 of 4 cases; `year:2015` has 5,919 spanners against 1,642 real matches, and the fraction actually inside swings 11–69% |
+| banded table + MCV 3,000 | p90 1.07x, p99 1.46x | works, but ~760 KB and the MCV lookup costs 6,000 probes as written (~12 KB scanned as bitmaps) — dominated by (3) |
+
+One cause runs through the failures: **duplication is non-local and predicate-dependent**. A card's
+printings are spread across the value range, so no window or sample recovers them; and whether a
+predicate selects whole cards (`usd>x` — expensive cards are uniformly expensive) or one printing each
+(`usd<x` — every card has a cheapest printing) flips the duplication factor from ~3 to ~1 at the same
+slice size.
+
+## Measurement traps worth keeping
+
+Four wrong answers here came from the same habit, so the note is itself the finding:
+
+- **Pooled medians hide the structure that matters.** The 2x–50x compose spread was two populations;
+  the estimator ranking flipped by slice size; the "k-regime" split was really a direction split; the
+  histogram's 0.005 median concealed a 150x tail. Quote per-cell breakdowns.
+- **Scaling a clamped value.** `card_est` is `k.min(n_cards)`, so scaling it on a broad range scales
+  31,508, not `k`. That inverted an entire estimator ranking until `acquire.range_k` exposed real `k`.
+- **Interpolate both endpoints.** Doing only the right one snaps the left edge to a cut and widens
+  every bounded slice by up to a bucket — an 8x median error.
+- **The out-of-band fallback must be the inclusion-exclusion bound** `pre[j] + suf[i] - total`.
+  Substituting the total distinct count inflates bounded error ~2x, and did, which made MCV look
+  useless on a first pass.
+
+## Acceptance criteria
+
+`scripts/bench_range_estimate_scan.py` is the test. It sweeps thresholds across each dimension in both
+directions and reports `acquire.matches / true total` per point — scans rather than a pooled median,
+because every pooled figure in this investigation hid structure that only showed up per cell.
+
+**Target:** every `unique=card` cell within 1% of true. Baseline today, 0 of 8 cells passing:
+
+| cell | n | median | worst |
+| ---- | -: | -----: | ----: |
+| `usd<x` | 6 | 1.047 | 1.707 |
+| `usd>x` | 6 | 1.975 | 2.691 |
+| `cn<x` | 3 | 1.643 | 1.789 |
+| `cn>x` | 3 | 1.437 | 1.976 |
+| `year<x` | 4 | 1.993 | 2.527 |
+| `year>x` | 4 | 1.371 | 2.020 |
+| `date<x` | 3 | 2.159 | 2.183 |
+| `date>x` | 3 | 1.357 | 1.865 |
+
+**Control — `PrintingRangeScan` needs no change, confirmed.** All eight cells at `unique=printing`
+already read 1.000 across 26 scan points: that branch sets `matches = k`, the in-range printing count,
+and in printing mode that *is* the result cardinality. Those rows must stay at 1.000.
+
+**Out of scope:** `eur` and `tix`, which have no range index and never reach this acquire — a separate
+and much larger defect, see [local-engine-eur-tix-range-index.md](local-engine-eur-tix-range-index.md).
+
+Routing is deliberately **not** an acceptance criterion for this change alone. Correcting the estimate
+lowers predicted cost for the materializing plans, which are already over-picked, so routing should
+regress until the arm fix lands with it — hence the stacked-PR plan of merging both together.
+
+## Reproducing
+
+    .venv/bin/python scripts/bench_card_range_estimate.py --seconds 60   # engine-side, live store
+    .venv/bin/python scripts/study_range_slice_cardinality.py            # offline: closed forms
+    .venv/bin/python scripts/study_range_slice_layouts.py                # offline: table shapes
+
+The offline studies read `benchmarks/bitplanes/corpus.jsonl` directly and cache the extraction, which
+lets them enumerate thousands of thresholds instead of the ~142 distinct range queries the engine-side
+generator can produce. Bounded ranges are scored on realistic intervals — calendar years, set-sized
+collector blocks, price bands — rather than uniformly random ones. n=84 there, thin for a tail claim,
+and the interval boundaries were chosen by hand.

--- a/scripts/bench_range_estimate_scan.py
+++ b/scripts/bench_range_estimate_scan.py
@@ -1,0 +1,106 @@
+"""Acceptance test for the range-cardinality estimate: scan each dimension, compare estimate to truth.
+
+`docs/issues/local-engine-range-cardinality-estimate.md` proposes replacing `card_est = k.min(n_cards)`
+with a three-column boundary table (prefix / suffix / per-value distinct-card counts), which should be
+**exact**. This is the test that says whether it worked.
+
+It sweeps thresholds across each range dimension in both directions and reports
+`acquire.matches / true total` at every point. Run it before and after the change:
+
+- **before** — `unique=card` shows the proxy's error, a median around 1.49x
+- **after** — every `unique=card` row should read 1.000
+
+Scoped to the dimensions that actually reach this acquire. `eur` and `tix` have no range index, so
+they route elsewhere and are excluded -- see SCANS.
+
+`unique=printing` is included as a control that should *already* be exact: that acquire branch
+(`printing_range_scan`) sets `matches = k`, the in-range printing count, and for printing mode the
+result cardinality IS the printing count. If those rows are not already 1.000, that assumption is
+wrong and the branch needs wiring too.
+
+    .venv/bin/python scripts/bench_range_estimate_scan.py
+
+Scans rather than a pooled median on purpose: every pooled figure in this investigation hid structure
+that only showed up per-cell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+# Thresholds per dimension, spanning each field's real distribution from a handful of cards to
+# nearly the whole corpus. Deliberately the same shapes the investigation swept.
+SCANS: dict[str, list[str]] = {
+    "usd": ["0.25", "1", "5", "20", "50", "200"],
+    "cn": ["20", "100", "300"],
+    "year": ["1999", "2009", "2018", "2023"],
+    "date": ["2005-06-01", "2015-03-01", "2022-01-01"],
+    # `eur` and `tix` are deliberately absent: only `price_usd` has a PrintingRangeIndex, and
+    # `resolve_numeric_range_leaf` maps only PriceUsd, so those predicates never reach
+    # `bare_range_bounds`. They fall through to the general candidates path, where `matches` is the
+    # unnarrowed card count -- measured at up to 106x off, which is a missing index rather than a
+    # bad estimate and is out of scope here. Add them if either ever gets an index.
+}
+DIRECTIONS = ("<", ">")
+# An estimate this close to truth counts as exact; the target for the boundary table is 1.000.
+EXACT_TOL = 0.01
+
+
+def main() -> None:
+    """Sweep every dimension and direction, printing estimate/true per point and a per-cell summary."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    parser.add_argument("--unique", default="card,printing", help="comma-separated modes to scan")
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".estimate-scan.store"))
+
+    for unique in args.unique.split(","):
+        print(f"\n=== unique={unique} ===")
+        print(f"{'query':<16}{'acquire':>20}{'estimate':>10}{'true':>9}{'est/true':>10}")
+        cells: dict[str, list[float]] = {}
+        for dim, thresholds in SCANS.items():
+            for direction in DIRECTIONS:
+                ratios = []
+                for t in thresholds:
+                    q = f"{dim}{direction}{t}"
+                    try:
+                        filters = parse_scryfall_query(q)
+                        kw = {"filters": filters, "unique": unique, "orderby": "edhrec", "direction": "asc", "offset": 0}
+                        acq = engine.explain(limit=100, **kw)["acquire"]
+                        true = engine.query(prefer="default", limit=1, **kw)[0]
+                    except Exception as exc:  # noqa: BLE001 - a rejected query is a skipped scan point
+                        print(f"{q:<16}{'skipped':>20}  {exc}")
+                        continue
+                    if true == 0:
+                        continue
+                    ratio = acq["matches"] / true
+                    ratios.append(ratio)
+                    flag = "" if abs(ratio - 1.0) <= EXACT_TOL else "  <-- off"
+                    print(f"{q:<16}{acq['count_source']:>20}{acq['matches']:>10,}{true:>9,}{ratio:>10.3f}{flag}")
+                if ratios:
+                    cells[f"{dim}{direction}x"] = ratios
+
+        print(f"\n{'cell':<12}{'n':>4}{'median':>9}{'worst':>9}{'all exact?':>12}")
+        worst_overall = 0.0
+        for cell, ratios in cells.items():
+            worst = max(abs(r - 1.0) for r in ratios)
+            worst_overall = max(worst_overall, worst)
+            verdict = "yes" if worst <= EXACT_TOL else "NO"
+            print(f"{cell:<12}{len(ratios):>4}{statistics.median(ratios):>9.3f}{max(ratios):>9.3f}{verdict:>12}")
+        status = "PASS" if worst_overall <= EXACT_TOL else "FAIL"
+        print(f"\n{unique}: worst deviation {worst_overall:.3f} — {status} (target: every cell within {EXACT_TOL:.0%})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/study_range_slice_cardinality.py
+++ b/scripts/study_range_slice_cardinality.py
@@ -1,0 +1,140 @@
+"""Offline study of the range-slice card-count estimate, straight from the corpus.
+
+Answers three things the engine-side sweep could not, because it can enumerate thousands of
+thresholds instead of the 142 the query generator produces, and can simulate sampling without an
+engine hook:
+
+1. Does the printing:card ratio in a slice differ by DIMENSION (price / collector number / date)?
+2. Can a correction curve on the balls-into-bins estimate fit the k-dependence?
+3. How accurate is sampling s printings from the slice and extrapolating distinct cards?
+
+Extraction is cached, since parsing the 239 MB corpus takes a while.
+"""
+
+import bisect
+import collections
+import json
+import math
+import pathlib
+import pickle
+import statistics
+
+CORPUS = pathlib.Path("/Users/joseph.bylund/scratch/sylvan_librarian/benchmarks/bitplanes/corpus.jsonl")
+# Cache the extraction beside the corpus, not in scripts/ -- it is a ~10 MB derived artifact and
+# benchmarks/ is already gitignored, so it never risks being committed.
+CACHE = CORPUS.with_suffix(".slice-study.cache.pkl")
+# Sample sizes to score the sampling estimator at, as printing counts.
+SAMPLE_SIZES = (64, 256, 1024, 4096)
+# Slices below this are too small for the ratio to mean anything.
+MIN_SLICE = 16
+# statistics.quantiles needs at least this many samples for deciles.
+MIN_FOR_DECILES = 10
+# "Close enough" band for the hit-rate columns.
+NEAR_LO, NEAR_HI = 0.8, 1.2
+# Estimators are compared against exact counts, so a per-dimension divisor needs the dimension's own
+# printings-per-card — computed here rather than assumed corpus-wide, since tix indexes far fewer.
+
+
+def load() -> dict[str, list[tuple[float, int]]]:
+    """Per dimension, the (value, card_index) pairs sorted by value — the range index's own shape."""
+    if CACHE.exists():
+        with CACHE.open("rb") as fh:
+            return pickle.load(fh)  # noqa: S301 - our own cache
+
+    card_of: dict[str, int] = {}
+    dims: dict[str, list[tuple[float, int]]] = {d: [] for d in ("usd", "eur", "tix", "cn", "date")}
+    with CORPUS.open() as fh:
+        for line in fh:
+            r = json.loads(line)
+            cid = card_of.setdefault(r["oracle_id"], len(card_of))
+            for dim, key in (("usd", "price_usd"), ("eur", "price_eur"), ("tix", "price_tix")):
+                v = r.get(key)
+                if v is not None:
+                    dims[dim].append((float(v), cid))
+            cn = r.get("collector_number_int")
+            if cn is not None:
+                dims["cn"].append((float(cn), cid))
+            d = r.get("released_at")
+            if d:
+                y, m, dd = d.split("-")[:3]
+                dims["date"].append((int(y) * 10000 + int(m) * 100 + int(dd), cid))
+    for v in dims.values():
+        v.sort()
+    dims["_n_cards"] = len(card_of)  # type: ignore[assignment]
+    with CACHE.open("wb") as fh:
+        pickle.dump(dims, fh)
+    return dims
+
+
+def main() -> None:
+    """Enumerate slices per dimension and score the estimators against exact distinct-card counts."""
+    dims = load()
+    n_cards = dims.pop("_n_cards")  # type: ignore[arg-type]
+    n_printings = sum(len(v) for v in dims.values())
+    print(f"{n_cards:,} cards, {n_printings:,} indexed printings across {len(dims)} dimensions")
+
+    per_dim: dict[str, list[tuple[int, int]]] = collections.defaultdict(list)  # (k, exact distinct)
+    sampling: dict[int, list[float]] = collections.defaultdict(list)
+
+    for dim, rows in dims.items():
+        vals = [v for v, _ in rows]
+        cards = [c for _, c in rows]
+        n = len(rows)
+        # Sweep one-sided slices at many quantiles, both directions — the shapes `bare_range_bounds`
+        # produces for `usd>x` / `usd<x` / `year<x`.
+        for q in [i / 60 for i in range(1, 60)]:
+            cut = vals[int(n * q)]
+            for lo, hi in ((bisect.bisect_left(vals, cut), n), (0, bisect.bisect_left(vals, cut))):
+                k = hi - lo
+                if k < MIN_SLICE:
+                    continue
+                exact = len(set(cards[lo:hi]))
+                per_dim[dim].append((k, exact))
+                # Sampling: s evenly spaced printings from the slice, extrapolated by the classic
+                # occupancy inversion — d distinct in s draws implies m cards where
+                # d = m(1 - (1 - 1/m)^s); solved by bisection on m.
+                for s in SAMPLE_SIZES:
+                    if s >= k:
+                        continue
+                    step = k / s
+                    seen = {cards[lo + min(int(i * step), k - 1)] for i in range(s)}
+                    d = len(seen)
+                    est = invert_occupancy(d, s, n_cards)
+                    sampling[s].append(est / exact)
+
+    print(f"\n{'dimension':<10}{'n slices':>10}{'median k/cards':>16}{'p10':>8}{'p90':>8}")
+    for dim, rows in per_dim.items():
+        ratios = sorted(k / ex for k, ex in rows)
+        ds = statistics.quantiles(ratios, n=10)
+        print(f"{dim:<10}{len(rows):>10}{statistics.median(ratios):>16.2f}{ds[0]:>8.2f}{ds[8]:>8.2f}")
+    print("  k/cards is how many in-range printings each distinct card contributes — the factor the")
+    print("  current estimator ignores by using k directly.")
+
+    print(f"\n{'sample size':<14}{'n':>8}{'median est/exact':>18}{'p10':>8}{'p90':>8}{'within 20%':>12}")
+    for s in SAMPLE_SIZES:
+        rs = sorted(sampling[s])
+        if len(rs) < MIN_FOR_DECILES:
+            continue
+        ds = statistics.quantiles(rs, n=10)
+        near = sum(1 for r in rs if NEAR_LO <= r <= NEAR_HI) / len(rs)
+        print(f"{s:<14}{len(rs):>8}{statistics.median(rs):>18.2f}{ds[0]:>8.2f}{ds[8]:>8.2f}{near:>11.0%}")
+    print("  sampling cost is s printing_to_card lookups, independent of k.")
+
+
+def invert_occupancy(d: int, s: int, n_cards: int) -> float:
+    """Cards implied by seeing `d` distinct in `s` draws, under uniform occupancy."""
+    if d >= s:
+        return float(d) * (1.0 + 0.0)  # every draw distinct: the slice looks card-disjoint
+    lo, hi = float(d), float(n_cards)
+    for _ in range(60):
+        mid = (lo + hi) / 2
+        expected = mid * (1.0 - math.exp(-s / mid))
+        if expected < d:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
First of four stacked PRs breaking up the cost-model work. This one stands alone: it replaces one
estimate with a stored exact answer.

## The estimate

`CardRangePopcount`'s acquire used `card_est = k.min(n_cards)` — an in-range PRINTING count clamped
to the card count — for the distinct CARDS a range matches. Against truth it over-estimates a median
**1.49x and up to 4.33x**, because printings outnumber cards by a ratio that varies 1.0–4.3 with
local reprint density. No constant absorbs that: it is a per-query property of where the range falls.

## The table

`RangeCardCounts` stores the answer. Three u32 columns per distinct value of each range index:

    below[i]        distinct cards with value <  values[i]     ->  <, <=
    at_or_above[i]  distinct cards with value >= values[i]     ->  >, >=
    at[i]           distinct cards with value == values[i]     ->  Eq

Exactness is affordable because these dimensions have far fewer distinct VALUES than printings — 914
release dates against 97,206 printings, 4,133 usd prices — and printings sharing a value are
contiguous, so any threshold bisects to a value boundary with nothing to interpolate. **~159 KB** for
all three indexes.

None of the three columns derives from the others, and each shortcut was checked failing:
`suf != total - pre` (a card with printings on either side of the cut belongs to both), and
`at != pre[i+1] - pre[i]` (that counts cards whose FIRST printing is at this value, not cards present
at it — 10 against a true 54 at `usd:2.99`).

## Correctness

`range_card_counts_are_exact` checks all three columns, plus the lookup the acquire actually calls,
against a brute-force distinct count at EVERY distinct value of all three indexes. Exhaustive rather
than sampled on purpose: this investigation's errors clustered at range ends, where sampling would
have missed them.

It also pins the one shape the table declines rather than answering wrongly — a genuinely interior
multi-value range. A multi-value range from the minimum IS a prefix and must still answer, which the
test asserts separately after I got exactly that wrong once.

147 Rust tests pass.

## Measured

`scripts/bench_range_estimate_scan.py` goes from **0 of 8 cells passing (worst 2.691x) to 8 of 8 at
exactly 1.000**. The `unique=printing` control stays at 1.000, confirming `PrintingRangeScan` needed
no change.

## Known gap

`year:Y` spans a whole calendar year — several distinct release-date values — so the lookup returns
None and the proxy still serves it. A per-year array (~34 entries) is the follow-up. Every other
range op is one-sided or a single value.

## Stack

    A  this PR                      exact distinct-card counts
    B  compose paging               cost compose honestly from every acquire
    C  cost-model feature fixes     + refit both scan arms
    D  compose's own arm            fit PrintingCompose, give it its own rates

Each is based on the one above it.