### PR TITLE
Cost Compose Honestly From Every Acquire, and Retry Its Sibling on Decline

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7027,6 +7027,67 @@ fn exec_from_candidates<'a>(
     }
 }
 
+/// When a `Prep::Range` fast path declines at runtime, try its non-materializing sibling before
+/// paying `prepare_candidates`.
+///
+/// `run_query_routed`'s fallback re-chooses with `materializing_only = true`, and
+/// `PhysicalPlan::materializing()` excludes every fast path — so the sibling was unreachable even
+/// when it was applicable, would not decline, and was an order of magnitude cheaper. Measured on
+/// `usd>20` at `unique=printing`: `PrintingRangeScan` declines, the materializing fallback runs in
+/// ~105 µs, and `PrintingCompose` answers the same query in 2.3 µs.
+///
+/// Gated on the (now-fixed) cost model rather than tried unconditionally: only run the sibling when
+/// it prices below the cheapest materializing plan, so this can never make a query slower than the
+/// fallback it replaces on the model's own terms. Both paths are correct for any query either is
+/// applicable to — `force_plan_differential_agreement` holds every plan to identical results — so
+/// this changes only which correct plan runs.
+fn declined_sibling_fastpath<'a>(
+    declined: PhysicalPlan,
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
+    filter: &FilterExpr,
+    plane: Option<&PlaneExpr>,
+    feats: &cost::PlanFeatures,
+    choose: &impl Fn(&FilterExpr, &cost::PlanFeatures, bool) -> PhysicalPlan,
+) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    let sibling = match declined {
+        PhysicalPlan::PrintingRangeScan => PhysicalPlan::PrintingCompose,
+        PhysicalPlan::PrintingCompose => PhysicalPlan::PrintingRangeScan,
+        _ => return None, // a materializing plan won the estimate; it has no fast-path sibling
+    };
+    if !sibling.applicable(ctx, params, filter, plane) {
+        return None;
+    }
+    if cost::plan_cost(sibling, feats) >= cost::plan_cost(choose(filter, feats, true), feats) {
+        return None;
+    }
+    match sibling {
+        PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
+        PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
+        _ => unreachable!("sibling is one of the two printing-space fast paths"),
+    }
+}
+
+/// Which paging strategy `printing_compose_fastpath` would run for this query, decided the same
+/// way the fastpath itself decides.
+///
+/// Every acquire branch that costs `PrintingCompose` as a competitor needs this, not just compose's
+/// own: `mk_plan_feats` defaults it to `Gather`, and `Gather` is the one branch of compose's cost
+/// whose page term is `O(eval_domain)`. A branch that leaves the default while also setting
+/// `eval_domain` to the unnarrowed universe charges a walk-shaped compose for a full-corpus gather
+/// — measured at 33x over-costed from the `PrintingRangeScan` acquire (~125 µs predicted against
+/// ~2.4 µs measured on `usd>20`/printing), which is enough to rank compose last and leave a 46x
+/// faster plan unused. See docs/issues/local-engine-plan-misselection.md.
+fn compose_paging_for(indexes: &Archived<CardIndexes>, n_cards: usize, mode: Mode, sort_col: SortCol, descending: bool) -> ComposePaging {
+    if indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == n_cards) {
+        ComposePaging::Perm
+    } else if matches!(mode, Mode::Printing) && orderby_walk_available(sort_col) {
+        ComposePaging::OrderbyWalk
+    } else {
+        ComposePaging::Gather
+    }
+}
+
 /// Cost features: the query-invariant fields filled once; the four that vary by
 /// count source passed in. Collapses each acquire branch's 8-field literal to one call.
 fn mk_plan_feats(
@@ -7123,6 +7184,7 @@ fn acquire_plan_features(
         // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
         feats.scatter_printings = k;
         feats.project_printings = k;
+        feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::CardRangePopcount))
     } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
         // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
@@ -7131,6 +7193,11 @@ fn acquire_plan_features(
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
+        // Also for costing that competing compose: `eval_domain`/`scan_units` above are the
+        // unnarrowed universe (right for P3/P4, which is what they are there for), so leaving
+        // `compose_paging` at its `Gather` default charged compose a full-corpus gather it would
+        // never run. Compose's page term only reads `eval_domain` in the Gather branch.
+        feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::PrintingRangeScan))
     } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, plane) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
@@ -7164,13 +7231,7 @@ fn acquire_plan_features(
         feats.popcount_words = popcount_words as u32;
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
         // itself decides (permutation walk / #744 orderby walk / gather fallback).
-        feats.compose_paging = if indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len()) {
-            ComposePaging::Perm
-        } else if matches!(mode, Mode::Printing) && orderby_walk_available(sort_col) {
-            ComposePaging::OrderbyWalk
-        } else {
-            ComposePaging::Gather
-        };
+        feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::PrintingCompose))
     } else {
         let prep = prepare_candidates(ctx, params, filter, plane);
@@ -7262,7 +7323,7 @@ fn run_query_routed<'a>(
                 PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
                 _ => None, // a materializing plan won the estimate — materialize + run it below
             };
-            match fast_page {
+            match fast_page.or_else(|| declined_sibling_fastpath(plan, ctx, params, filter, plane, &feats, &choose)) {
                 Some(page) => page,
                 None => {
                     let prep = prepare_candidates(ctx, params, filter, plane);

--- a/docs/issues/local-engine-plan-misselection.md
+++ b/docs/issues/local-engine-plan-misselection.md
@@ -1,0 +1,171 @@
+# The decline fallback never reconsidered a non-materializing plan, at up to 260 µs (fixed)
+
+When a `Prep::Range`-acquired query's chosen fast path declines at runtime, dispatch re-chooses
+among **materializing plans only** — so `PrintingCompose`, which is applicable and often 30–70x
+faster, is never reconsidered. Measured worst case: a bare `year:` or `usd:` range at
+`unique=printing` paying 266 µs where compose needs 2–4 µs.
+
+Everything else the router does is fine. Across 249 wild-operator queries the mean regret is
+0.14 µs and the worst is 14.1 µs.
+
+## The mechanism
+
+[`run_query_routed`'s `Prep::Range` dispatch arm](../../card_engine/src/lib.rs) runs the chosen
+fast path, and on `None`:
+
+```rust
+let prep = prepare_candidates(ctx, params, filter, plane);
+let feats = candidate_feats(ctx, params, &prep, filter);
+let plan = choose(filter, &feats, true);   // materializing_only = true
+```
+
+`PhysicalPlan::materializing()` excludes `PrintingRangeScan`, `PrintingCompose` and
+`CardRangePopcount`. So the fallback can only land on `StreamedSelect` or `GatheredScan`, even when
+the *other* non-materializing fast path was applicable, would not have declined, and is an order of
+magnitude cheaper.
+
+`usd>20` at `unique=printing`, from `explain_analyze`:
+
+| plan | predicted | measured |
+| ---- | --------: | -------: |
+| PrintingRangeScan | 15.0 µs | **declined** ← picked |
+| PrintingCompose | 129.6 µs | **2.4 µs** |
+| StreamedSelect | 578.7 µs | 109.1 µs |
+| GatheredScan | 738.1 µs | 130.7 µs |
+
+`routed_ns` is 111.0 µs — it tracks `StreamedSelect`, confirming the fallback took a materializing
+plan while a 2.4 µs option sat unused. `usd>5` is worse: routed 267.7 µs against compose's 3.8 µs.
+
+Note the cost model also over-predicts `PrintingCompose` badly here (129.6 predicted against 2.4
+measured, ratio 0.02), so even a fallback that *could* pick compose would rank it last. Both need
+fixing, but the exclusion is the hard blocker.
+
+## Sizing
+
+`bench_plan_misselection.py` scores regret as `routed_ns − best measured plan` — what the engine
+actually pays against the best available.
+
+| source | multi-plan | mean regret | max regret | regret >5 µs |
+| ------ | ---------: | ----------: | ---------: | -----------: |
+| wild-operators | 249 | 0.14 µs | 14.1 µs | 2 |
+| random | 250 | 1.79 µs | **265.0 µs** | 5 |
+
+The 100 µs-class misses are all the decline fallback on bare ranges at `unique=printing`
+(`year:2022`, `year:2024`, `year:2019`, `usd>20`, `usd>5`). Below that sits a 13–33 µs
+`StreamedSelect`/`GatheredScan` cluster on candidate acquires, a separate and much smaller problem.
+
+Neither corpus is authoritative — the wild one samples linked URLs (bot-dominated, per its own
+README), the generated one a domain-informed guess at the search surface. Read them as a range.
+
+## Scanning for mis-*costing* rather than mis-selection
+
+`--calibration` reports each plan's measured/predicted ratio across the corpus. This is the more
+useful scan: a plan costed 30x wrong is picked correctly right up until it competes closely with
+something, so mis-costing is the leading indicator and mis-selection only the symptom.
+
+200 generated queries. `net` subtracts the measured acquire from materializing plans, because
+`measured` includes acquire and `predicted` does not.
+
+| plan | n | raw ratio | net | p25 | p75 | worst |
+| ---- | --: | --------: | --: | --: | --: | ----: |
+| GatheredScan | 200 | 6.47 | **0.84** | 1.89 | 27.66 | 0.01 |
+| PlanePopcountOrder | 36 | 2.44 | **2.44** | 1.01 | 5.02 | 8.69 |
+| StreamedSelect | 200 | 0.69 | **0.58** | 0.18 | 0.90 | 0.00 |
+| PrintingCompose | 9 | 0.47 | **0.47** | 0.11 | 0.92 | 0.02 |
+| CardRangePopcount | 1 | 0.72 | 0.72 | – | – | 0.72 |
+
+Ratio >1 means under-costed (the model thinks it is cheaper than it is, so it gets over-picked); <1
+over-costed and under-picked.
+
+**Netting acquire inverts the headline.** Raw, `GatheredScan` looks under-costed by 6.5x — which
+would be the single biggest cost-model defect in the engine. Net of acquire it is 0.84, i.e. fine:
+the whole apparent error was the unpriced acquire step, which `GatheredScan` pays like every
+materializing plan. Anyone reading the raw column alone would go and "fix" a calibrated arm.
+
+What survives netting is two arms:
+
+- `PlanePopcountOrder` under-costed a median 2.4x, worst 8.7x. It materializes nothing, so raw and
+  net agree — this one is real and unexplained.
+- `PrintingCompose` over-costed a median 2x and up to **50x** (`set:mkm set:neo`, ratio 0.02). This
+  is the same defect the decline fallback runs into: compose is ranked last, so even a fallback that
+  *could* choose it would not.
+
+## Why this stayed hidden through three earlier passes
+
+Each produced a confidently wrong answer, and each is now closed off.
+
+**Scoring the picked plan instead of the routed path.** The harness required the picked plan to have
+*run*, so every decline was skipped — which is exactly the failing case. Regret is now
+`routed − best`. This is what raised the worst case from 94 µs to 265 µs.
+
+**Reconstructing the pick.** Before `PlanEstimate::picked` existed, the harness derived the router's
+choice as `argmin(predicted)` over plans that ran, inventing a 12% mis-selection rate out of a real
+1% and a tidy causal story that was entirely artifact.
+
+**A mislabelled acquire.** `explain` reported `count_source: "range"` for compose-acquired queries,
+because `Prep::Range` is a misnomer covering three acquires. One pass went at the wrong branch.
+
+Also worth keeping: `routed ≈ forced-picked` on non-declining queries, which validates that forcing
+a plan does not distort timing.
+
+## Both fixed
+
+**Root cause of the 2x–50x spread: two populations, not one miscalibrated constant.** Compose is
+~1.5x over-costed generally, and was **33x** over-costed only when costed off the
+`PrintingRangeScan` acquire. That branch sets `eval_domain = n_cards` and `scan_units = n_printings`
+(correct for costing P3/P4, which is what its comment says it is for) and left `compose_paging` at
+`mk_plan_feats`' `Gather` default — and `Gather` is the one branch of compose's cost whose page term
+is `O(eval_domain)`. So compose was charged a full-corpus gather it would never run:
+31,508 × 2.87 + 97,206 × 0.36 ≈ 125 µs against 2.4 µs measured. `CardRangePopcount` escaped it only
+because its `eval_domain` is the small card estimate.
+
+`compose_paging_for` is now shared by every branch that costs compose, not just compose's own.
+
+**The exclusion needed fixing too, and the cost fix was its prerequisite.** Correcting the cost
+alone left `routed` at 106.5 µs, because `PrintingRangeScan` (15.0) still ranked ahead of compose
+(16.3), still declined, and the fallback still could not reach compose. `declined_sibling_fastpath`
+now tries the declining plan's non-materializing sibling first, gated on the model so it can never
+be slower than the fallback it replaces on the model's own terms.
+
+| measurement | before | after |
+| ----------- | -----: | ----: |
+| `usd>20` printing, routed | 111.0 µs | **2.4 µs** |
+| `usd>5` printing, routed | 267.7 µs | **4.2 µs** |
+| random sweep, max regret | 265.0 µs | **61.3 µs** |
+| random sweep, mean regret | 1.79 µs | 1.46 µs |
+| compose ratio from `printing_range_scan` | 0.03 | **0.55** |
+
+The 100 µs-class decline-fallback category is gone. `usd>50`, where *both* fast paths decline, still
+correctly falls through to materializing.
+
+## What is left
+
+The remaining 26–34 µs misses are the pre-existing `StreamedSelect`/`GatheredScan` discrimination
+and a `PrintingCompose → StreamedSelect` pair (`type:aura`, `type:wizard`) — a separate problem from
+this one, and small enough to leave alone until something shows it matters.
+
+Two calibration findings from the 2,500-query scan remain unaddressed, both pre-existing:
+
+- `PlanePopcountOrder` under-costed a median 1.61x, p90 6.16 (n=157). It materializes nothing, so
+  netting acquire is a no-op — this one is real and unexplained.
+- `StreamedSelect`/`GatheredScan` costed off the `card_range_popcount` acquire are under-costed
+  ~2.4x (n=13). Thin sample; re-measure before acting.
+
+## What to do
+
+1. Re-measure `PlanePopcountOrder`'s 1.61x under-costing on a larger sample and find the term it is
+   missing. It is the largest remaining calibration gap and it is not explained by acquire.
+2. Leave the 26–34 µs `StreamedSelect`/`GatheredScan` cluster alone until something shows it matters.
+3. `PrintingCompose` is still ~1.5x over-costed generally (0.69 from its own acquire). Harmless at
+   that size, and tightening it risks the ranking that now works.
+
+## Method notes
+
+- `min` of 15 trials after 3 warmups, per plan, plans rotated each round so none benefits
+  systematically from accumulated allocator or cache state (`explain_analyze`'s discipline).
+- Every plan runs from a fresh `filter.clone()`, so each pays the one-time
+  `memoize_text_predicates` cost identically — a fair head-to-head, not real query latency.
+- Queries where the best measured plan *is* the picked plan are excluded from the table: `routed −
+  best` there is routing overhead plus noise, not a wrong choice.
+- Run-to-run, misses under ~5 µs flip; only the larger ones are stable. Quote those.
+- Store built from `benchmarks/bitplanes/corpus.jsonl` (31,508 cards, 97,206 printings).

--- a/scripts/bench_plan_misselection.py
+++ b/scripts/bench_plan_misselection.py
@@ -1,0 +1,267 @@
+"""How often does the router pick a plan slower than the best one available, and by how much?
+
+`explain` ranks every applicable plan by `cost::plan_cost` and `run_query_routed` takes the
+argmin. `explain_analyze` then runs each plan for real. Comparing `argmin(predicted)` against
+`argmin(measured)` prices the cost model's ranking errors directly — not its absolute accuracy,
+which is a separate and much more forgiving question.
+
+    .venv/bin/python scripts/bench_plan_misselection.py --source wild-operators --sample 200
+
+Only multi-plan queries count: with one applicable plan there is nothing to mis-select. Regret
+is `measured(picked) - measured(best)`, so a correct pick contributes 0 and the mean is over
+all multi-plan queries, not only the misses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import math
+import pathlib
+import random
+import re
+import statistics
+import sys
+from typing import TYPE_CHECKING
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from client.query_runner import random_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+if TYPE_CHECKING:
+    import card_engine
+
+# Same operator test build_wild_corpus.py uses to split its census: the corpus is 75% bare
+# name lookups (bot deep links), which resolve to one card and are never multi-plan.
+OP_RE = re.compile(r"[a-z]+[:<>=]", re.I)
+UNIQUE_FROM_SCRYFALL = {
+    "card": "card",
+    "cards": "card",
+    "art": "artwork",
+    "artwork": "artwork",
+    "prints": "printing",
+    "printing": "printing",
+}
+ORDERBY_VALUES = frozenset(
+    {"edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "name", "released", "set", "color", "usd", "artist", "review"}
+)
+DEFAULT_ORDERBY = "edhrec"
+RANDOM_UNIQUE_WEIGHTS = {"card": 75, "printing": 20, "artwork": 5}
+# Enough rounds that a bimodal plan shows both modes (00648's measurement-traps section) while
+# keeping a 200-query sweep to a couple of minutes.
+NUM_WARMUPS = 3
+NUM_TRIALS = 15
+# Regret below this is inside run-to-run noise at these sizes; counted but reported separately
+# so a "miss" that costs nothing does not inflate the headline rate.
+NOISE_FLOOR_US = 1.0
+# Fewer plans than this and there is no choice to get wrong.
+MIN_PLANS_TO_CHOOSE = 2
+# statistics.quantiles needs more than this many samples to say anything.
+MIN_FOR_QUARTILES = 4
+# Only misses at least this costly are classified live-or-rescued; below it the routed,
+# picked and best timings all sit inside each other's noise and the comparison says nothing.
+LIVE_DEFECT_FLOOR_US = 5.0
+
+
+def load_queries(source: str, sample: int, seed: int) -> list[tuple[str, str, str]]:
+    """(query, unique, orderby) triples from the requested source, sampled deterministically."""
+    rng = random.Random(seed)
+    if source == "random":
+        uniques = list(RANDOM_UNIQUE_WEIGHTS)
+        weights = [RANDOM_UNIQUE_WEIGHTS[u] for u in uniques]
+        return [(random_query(), rng.choices(uniques, weights=weights)[0], DEFAULT_ORDERBY) for _ in range(sample)]
+
+    rows = []
+    for line in (REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl").open():
+        row = json.loads(line)
+        unique = UNIQUE_FROM_SCRYFALL.get(row.get("unique", "card"))
+        if unique is None or not OP_RE.search(row["q"]):
+            continue
+        order = row.get("order", DEFAULT_ORDERBY)
+        rows.append((row["q"], unique, order if order in ORDERBY_VALUES else DEFAULT_ORDERBY))
+    rng.shuffle(rows)
+    return rows[:sample]
+
+
+def calibration(engine: card_engine.QueryEngine, queries: list[tuple[str, str, str]], trials: int = NUM_TRIALS) -> None:
+    """Per-plan measured/predicted ratio across the corpus — which cost arms are wrong, and how.
+
+    Mis-COSTING is the leading indicator; mis-selection is only where it happens to bite. A plan
+    costed 30x wrong is picked correctly right up until it competes closely with something, so this
+    scan finds problems before they cost a query anything.
+
+    Ratio > 1 means the plan is cheaper in the model than in reality (under-costed, so over-picked);
+    < 1 means over-costed and under-picked.
+    """
+    # Two ratios, because `measured` includes the acquire step and `predicted` does not — that
+    # unpriced term (docs/issues/local-engine-candidate-materialize.md) would otherwise be read as
+    # the plan arm being wrong. `net` subtracts the measured acquire, isolating the arm itself.
+    ratios: collections.defaultdict[str, list[float]] = collections.defaultdict(list)
+    nets: collections.defaultdict[str, list[float]] = collections.defaultdict(list)
+    by_source: collections.defaultdict[tuple[str, str], list[float]] = collections.defaultdict(list)
+    worst: collections.defaultdict[str, tuple[float, str]] = collections.defaultdict(lambda: (1.0, ""))
+    for q, unique, orderby in queries:
+        try:
+            res = engine.explain_analyze(
+                filters=parse_scryfall_query(q),
+                unique=unique,
+                orderby=orderby,
+                direction="asc",
+                limit=100,
+                offset=0,
+                num_warmups=NUM_WARMUPS,
+                num_trials=trials,
+            )
+        except Exception:  # noqa: BLE001, S112 - a query bind rejects is a sample skip, not an error
+            continue
+        for p in res["plans"]:
+            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+                continue
+            # A plan can measure 0 ns when it is faster than the clock's resolution; clamp so the
+            # log-scale ordering below stays defined without dropping the sample.
+            meas = max(min(p["trials_ns"]), 1)
+            r = meas / p["predicted_ns"]
+            ratios[p["plan"]].append(r)
+            # A plan that materializes pays acquire inside its trial; net it out. Clamped at a
+            # nanosecond so a plan whose whole cost was acquire cannot divide by zero.
+            net = max(meas - min(res["acquire"]["acquire_ns"]), 1.0) if p["materialize_ns"] > 0 else float(meas)
+            nets[p["plan"]].append(net / p["predicted_ns"])
+            by_source[p["plan"], res["acquire"]["count_source"]].append(net / p["predicted_ns"])
+            # Track the furthest from 1 in log terms, either direction.
+            if abs(math.log(r)) > abs(math.log(worst[p["plan"]][0])):
+                worst[p["plan"]] = (r, f"{q} [{unique}]")
+
+    print(f"\n{'plan':<20}{'n':>5}{'median':>9}{'net':>8}{'p25':>8}{'p75':>8}{'worst':>9}  worst query")
+    for plan, rs in sorted(ratios.items(), key=lambda kv: abs(math.log(statistics.median(kv[1]))), reverse=True):
+        qs = statistics.quantiles(rs, n=4) if len(rs) >= MIN_FOR_QUARTILES else [float("nan")] * 3
+        w, wq = worst[plan]
+        print(
+            f"{plan:<20}{len(rs):>5}{statistics.median(rs):>9.2f}{statistics.median(nets[plan]):>8.2f}"
+            f"{qs[0]:>8.2f}{qs[2]:>8.2f}{w:>9.2f}  {wq[:38]}"
+        )
+    print("\nratio = measured / predicted; net subtracts the measured acquire from materializing plans.")
+    print(">1 under-costed (over-picked), <1 over-costed (under-picked).")
+
+    # Which acquire branch built the features matters: a plan costed off another plan's acquire can
+    # be charged for work it would never do, because the feature fields it needs were left at their
+    # defaults. A plan whose ratio is fine on its own acquire and wrong on others is that bug.
+    print(f"\n{'plan':<20}{'acquire branch':<22}{'n':>5}{'net median':>12}{'p10':>8}{'p90':>8}")
+    for (plan, src), rs in sorted(by_source.items(), key=lambda kv: (kv[0][0], -len(kv[1]))):
+        if len(rs) < MIN_FOR_QUARTILES:
+            print(f"{plan:<20}{src:<22}{len(rs):>5}{statistics.median(rs):>12.2f}{'':>8}{'':>8}")
+            continue
+        ds = statistics.quantiles(rs, n=10)
+        print(f"{plan:<20}{src:<22}{len(rs):>5}{statistics.median(rs):>12.2f}{ds[0]:>8.2f}{ds[8]:>8.2f}")
+
+
+def main() -> None:
+    """Sweep the sample, print every mis-selection, and summarize the rate and regret."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--calibration", action="store_true", help="per-plan cost-model accuracy instead of the miss table")
+    parser.add_argument("--source", choices=("wild-operators", "random"), default="wild-operators")
+    parser.add_argument("--sample", type=int, default=200)
+    parser.add_argument("--trials", type=int, default=NUM_TRIALS, help="timed rounds per plan; lower for large sweeps")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".misselect.store"))
+    queries = load_queries(args.source, args.sample, args.seed)
+    if args.calibration:
+        calibration(engine, queries, args.trials)
+        return
+
+    pairs: collections.Counter[str] = collections.Counter()
+    regret: list[float] = []
+    misses: list[tuple[float, str, str, str, float, str]] = []
+    live_count: list[str] = []
+    multi = skipped = declined = 0
+
+    for q, unique, orderby in queries:
+        try:
+            res = engine.explain_analyze(
+                filters=parse_scryfall_query(q),
+                unique=unique,
+                orderby=orderby,
+                direction="asc",
+                limit=100,
+                offset=0,
+                num_warmups=NUM_WARMUPS,
+                num_trials=NUM_TRIALS,
+            )
+        except Exception:  # noqa: BLE001 - a query bind rejects is a sample skip, not an error
+            skipped += 1
+            continue
+        ran = [p for p in res["plans"] if p["trials_ns"]]
+        if len(ran) < MIN_PLANS_TO_CHOOSE:
+            continue
+        # Regret is measured against `routed_ns` — what the engine actually pays — not against the
+        # picked plan's own trial. Those differ in the case that matters most: when the picked plan
+        # declines at runtime, dispatch re-chooses among MATERIALIZING plans only, so a
+        # non-materializing fast path that would have won is never reconsidered. Scoring the picked
+        # plan's trial skips those queries entirely, which is how the worst misses stayed hidden.
+        picked = [p for p in res["plans"] if p["picked"]]
+        pick = picked[0] if picked else None
+        pick_declined = pick is not None and not pick["trials_ns"]
+        declined += pick_declined
+        multi += 1
+        best = min(ran, key=lambda p: min(p["trials_ns"]))
+        routed = min(res["acquire"]["routed_ns"]) / 1000
+        lost = routed - min(best["trials_ns"]) / 1000
+        regret.append(lost)
+        same_plan = pick is not None and pick["plan"] == best["plan"] and not pick_declined
+        if lost >= NOISE_FLOOR_US and not same_plan:
+            pick_name = f"{pick['plan']}{'(declined)' if pick_declined else ''}" if pick else "?"
+            pairs[f"{pick_name} -> {best['plan']}"] += 1
+            if lost >= LIVE_DEFECT_FLOOR_US:
+                live_count.append(q)
+            misses.append((lost, res["acquire"]["count_source"], pick_name, best["plan"], routed, q))
+
+    print_misses(misses)
+    counts = {"sampled": len(queries), "multi": multi, "skipped": skipped, "declined": declined}
+    print_summary(args.source, counts, misses, regret, pairs, live=len(live_count))
+
+
+def print_misses(misses: list[tuple[float, str, str, str, float, str]]) -> None:
+    """The per-miss table, worst regret first. `live?` is blank below the classification floor."""
+    misses.sort(reverse=True)
+    print(f"\n{'lost µs':>9}{'routed':>9}{'src':>19}{'picked':>26}{'best':>20}  query")
+    for lost, src, pick_name, best_name, routed, q in misses:
+        print(f"{lost:>9.1f}{routed:>9.1f}{src:>19}{pick_name:>26}{best_name:>20}  {q[:34]}")
+
+
+def print_summary(  # noqa: PLR0913 - a print function's arguments ARE its output; bundling them
+    # into a struct would add a type whose only purpose is to satisfy this rule.
+    source: str,
+    counts: dict[str, int],
+    misses: list[tuple[float, str, str, str, float, str]],
+    regret: list[float],
+    pairs: collections.Counter[str],
+    *,
+    live: int,
+) -> None:
+    """Rates and totals. Regret is routed-minus-best, so it is what the engine actually pays."""
+    real = sum(1 for lost, *_ in misses if lost >= NOISE_FLOOR_US)
+    print(
+        f"\n{source}: {counts['multi']:,} multi-plan queries of {counts['sampled']:,} sampled "
+        f"({counts['skipped']:,} skipped, {counts['declined']:,} picked-plan declined)"
+    )
+    print(
+        f"mis-selected: {len(misses):,} ({len(misses) / max(counts['multi'], 1):.0%}), of which {real:,} cost >{NOISE_FLOOR_US:g} µs"
+    )
+    if regret:
+        print(f"regret over all multi-plan queries: mean {statistics.mean(regret):.2f} µs, max {max(regret):.1f} µs")
+    print(
+        f"regret >{LIVE_DEFECT_FLOOR_US:g} µs on {live:,} queries; {counts['declined']:,} had their picked plan decline at runtime"
+    )
+    for pair, n in pairs.most_common():
+        print(f"  {pair}: {n}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Second of four stacked PRs. **Based on #804**, not on `main` — review that one first.

Two compounding defects made a bare printing-space range 46–64x slower than it had to be. Found by
scanning `explain_analyze` for mis-COSTED plans rather than mis-selected ones: a plan costed 30x wrong
is picked correctly right up until it competes closely.

## Compose was charged a gather it would never run

`mk_plan_feats` defaults `compose_paging` to `Gather`, expecting `PrintingCompose`'s own acquire
branch to override it. Every other branch that costs compose as a COMPETITOR left the default — and
`Gather` is the one branch of compose's cost whose page term is `O(eval_domain)`. The
`PrintingRangeScan` branch also sets `eval_domain = n_cards` and `scan_units = n_printings`, correct
for costing P3/P4 and badly wrong for compose, so compose was charged
`31,508 x 2.87 + 97,206 x 0.36 ~ 125 us` against 2.4 us measured.

A 2,500-query calibration sweep separates the populations cleanly: compose costed off its own acquire
reads 0.64 (n=65) and off `card_range_popcount` 0.66 (n=34), but off `printing_range_scan` it is 0.03
(n=6). `CardRangePopcount` escaped only because its `eval_domain` is the small card estimate.

`compose_paging_for` is now shared by all three branches. On `main` that function's body already
existed, inlined in the compose branch — so this is factoring one decision out of three copies, not
adding a fourth.

## The decline fallback could not reach it

Fixing the cost alone left the query at 106.5 us: `PrintingRangeScan` (15.0) still ranked ahead of
compose (16.3), still declined, and the fallback re-chooses with `materializing_only = true` — and
`materializing()` excludes every fast path, so the sibling was unreachable however cheap it was.
`declined_sibling_fastpath` tries it first, gated on the model so it can never be slower than the
fallback it replaces on the model's own terms. Both plans are correct for any query either is
applicable to, which `force_plan_differential_agreement` already holds them to.

## Now verified, which it could not be when written

This change asserted the range branches were pricing compose with the wrong paging arm, with no way
to confirm the fix. `paging_taken` (merged in #797) compares the PREDICTED branch against the one the
fastpath really took. Over 492 compose-applicable queries:

    acquire                 before        after
    card_range_popcount     55 / 55       0 / 55      100% wrong -> 0%
    printing_range_scan     88 / 88       0 / 88      100% wrong -> 0%
    printing_compose        71 / 349      71 / 349    unchanged
    overall                 43%           14%

`Gather` is O(eval_domain) and `Perm` is O(page_span/selectivity) — different shapes, not nearby
numbers — so every range-acquired query was pricing a competing compose off the wrong arm.

The residual 14% is one cell: `printing_compose` predicting `Gather` where the fastpath takes
`DeclineBroad`. Predicting a decline needs the result total, which `compose_paging_for` is not given.
That is a later change and not in this PR.

## Measured

    usd>20  unique=printing, routed   111.0 us -> 2.4 us
    usd>5   unique=printing, routed   267.7 us -> 4.2 us
    random sweep, max regret          265.0 us -> 61.3 us
    compose ratio from range acquire  0.03 -> 0.55

`usd>50`, where both fast paths decline, still correctly falls through to materializing. The
100 us-class decline-fallback category is gone; the remaining 26–34 us misses are a separate
StreamedSelect/GatheredScan discrimination.

147 Rust tests pass.

## Stack

    A  #804  exact distinct-card counts
    B  this PR
    C  cost-model feature fixes + refit both scan arms
    D  fit PrintingCompose, give it its own rates