### PR TITLE
Predict Compose's Declines, So the Model Stops Pricing a Plan That Will Refuse

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -363,6 +363,10 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                         + scan_units * RANGE_SCATTER_PER_PRINTING_NS
                         + matches * GATHER_PUSH_PER_MATCH_NS
                 }
+                // The fastpath will refuse this query, so there is no page term to charge. Infinity
+                // keeps the plan out of the argmin entirely — routing to a plan that returns `None`
+                // pays the detour and then runs something else anyway.
+                super::ComposePaging::Decline => return f64::INFINITY,
             };
             build + page + RANGE_FIXED_COST_NS // per-query setup
         }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5712,11 +5712,12 @@ fn printing_compose_fastpath<'a>(
     // The permutation-free gather's two decline gates, asked through the shared helper so that
     // `acquire_plan_features` can ask the SAME question when it costs this plan. See
     // `compose_gather_declines`.
-    if perm.is_none() && !walk_col {
-        if let Some(reason) = compose_gather_declines(filter, indexes, offsets, printings, cards, mode) {
-            note_paging_taken(reason);
-            return None;
-        }
+    if perm.is_none()
+        && !walk_col
+        && let Some(reason) = compose_gather_declines(filter, indexes, offsets, printings, cards, mode)
+    {
+        note_paging_taken(reason);
+        return None;
     }
     // Compose once, here (never in acquire) — that single build is the only synthesis, and it is paid
     // only because this plan won. The total is the popcount in the query's result space; the page is

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5709,54 +5709,12 @@ fn printing_compose_fastpath<'a>(
     // `COMPOSE_GATHER_MAX_CARD_FRACTION` gate must NOT apply to that branch: its premise ("broad ⇒ not
     // worth composing") is backwards here, where a broad predicate is the walk's *best* case.
     let walk_col = perm.is_none() && matches!(mode, Mode::Printing) && orderby_walk_available(sort_col);
-    // No permutation (rarity/usd) AND no orderby walk (card/artwork mode): before paying for the real
-    // build, check whether the gather is worth it at all using the same estimate
-    // `compose_printing_estimate` already computes cheaply in acquire (O(log n) partition points /
-    // plane popcounts, no scatter) — see `COMPOSE_GATHER_MAX_CARD_FRACTION`'s doc for why this needs
-    // its own threshold, not `MAX_NARROW_FRACTION`. The check must be in **mode space** (cards for
-    // `Card`, artworks for `Artwork`), not raw matching printings: a bare range's printing-space match
-    // count is a poor proxy for how many *candidates* `gather_composed_page` will actually visit (a
-    // card can have several qualifying printings). A plain `.min(domain)` cap is *not* enough to
-    // project it down, though — it saturates to exactly `domain` for every query whose printing-space
-    // count exceeds it (`cn<100`: 35,021 printings vs 31,508 cards, and `usd<50`: 80,527 vs 31,508
-    // both saturate to the *identical* 31,508, even though their true card counts are 17,616 vs 31,217
-    // — miles apart), which loses exactly the signal this check needs. A balls-into-bins estimate —
-    // `k` matching printings landing on `domain` cards, expected distinct cards touched
-    // `≈ domain·(1 − e^(−k/domain))` — doesn't saturate the same way and tracks the true count much
-    // better (checked against real totals: `cn<100` estimate 21,140 vs true 17,616; `usd<50` estimate
-    // 29,062 vs true 31,217; clearly separated, unlike the capped estimate's identical 31,508 for both).
+    // The permutation-free gather's two decline gates, asked through the shared helper so that
+    // `acquire_plan_features` can ask the SAME question when it costs this plan. See
+    // `compose_gather_declines`.
     if perm.is_none() && !walk_col {
-        let (printing_matches, _, _) = compose_printing_estimate(filter, indexes, offsets, printings.len());
-        // Artwork's true domain is n_artworks (>= n_cards), but getting it exactly means building
-        // artwork_base here — real O(n_cards) work paid just to maybe decline. `cards.len()` is a
-        // cheap, conservative stand-in (n_artworks is always >= it, so this only ever makes the
-        // fraction look *more* broad than reality — errs toward declining, same conservative lean
-        // `COMPOSE_GATHER_MAX_CARD_FRACTION` itself was calibrated with).
-        let domain = match mode {
-            Mode::Printing => printings.len(),
-            Mode::Card | Mode::Artwork => cards.len(),
-        };
-        let est = if matches!(mode, Mode::Printing) {
-            printing_matches as f64 // exact in printing space already, no projection needed
-        } else {
-            domain as f64 * (-(printing_matches as f64) / domain as f64).exp().mul_add(-1.0, 1.0)
-        };
-        if est > domain as f64 * *COMPOSE_GATHER_MAX_CARD_FRACTION {
-            note_paging_taken(PagingTaken::DeclineBroad);
-            return None;
-        }
-        // Small-total decline (mirrors the `Perm` branch's `total <= STREAM_MIN_MATCHES` below): in the
-        // permutation-free gather regime PrintingCompose has no paging edge over GatheredScan — it just
-        // composes the full printing bitmap and projects it back down, two O(n_cards) passes on top of
-        // the same gather. For a filter that narrows to few candidate cards the residual-eval saving is
-        // tiny while that build/projection dominates, so the candidate/narrowing path wins; decline to
-        // it. The SOUND card-space cardinality upper bound decides — exact for a collection leaf, unlike
-        // the balls-into-bins `est` above which overestimates a clustered predicate's distinct-card
-        // count (goblin: 501 cards but ~1471 `est`) and so can't make this call. This is what keeps a
-        // sparse `type:angel`/`type:goblin` card/usd (newly composable) from regressing onto this path:
-        // the collection compose leaves are a printing-mode orderby-walk win, not a card-mode gather win.
-        if (estimator::estimate_cardinality(filter, indexes, offsets).hi as usize) <= *STREAM_MIN_MATCHES {
-            note_paging_taken(PagingTaken::DeclineSparseEstimate);
+        if let Some(reason) = compose_gather_declines(filter, indexes, offsets, printings, cards, mode) {
+            note_paging_taken(reason);
             return None;
         }
     }
@@ -5878,6 +5836,10 @@ pub(crate) enum ComposePaging {
     /// No permutation and no orderby walk → the permutation-free bounded gather
     /// (`gather_composed_page`), which visits every match (offset-independent cost).
     Gather,
+    /// The fastpath will refuse this query — `compose_gather_declines`, or the `Perm` branch's
+    /// small-total bail. Costs infinity, which keeps the plan out of the argmin entirely: routing to
+    /// a plan that returns `None` pays the detour and then runs something else anyway.
+    Decline,
 }
 
 impl ComposePaging {
@@ -5899,6 +5861,11 @@ impl ComposePaging {
             ComposePaging::Perm => "Perm",
             ComposePaging::OrderbyWalk => "OrderbyWalk",
             ComposePaging::Gather => "Gather",
+            // No single `PagingTaken` counterpart on purpose: the executor distinguishes WHY it
+            // refused (`DeclineBroad` / `DeclineSparseEstimate` / `DeclineSparseExact`) while the
+            // model only predicts THAT it will. A comparison scoring these against each other has to
+            // treat any `Decline*` as matching this one.
+            ComposePaging::Decline => "Decline",
         }
     }
 }
@@ -7078,11 +7045,112 @@ fn declined_sibling_fastpath<'a>(
 /// — measured at 33x over-costed from the `PrintingRangeScan` acquire (~125 µs predicted against
 /// ~2.4 µs measured on `usd>20`/printing), which is enough to rank compose last and leave a 46x
 /// faster plan unused. See docs/issues/local-engine-plan-misselection.md.
+/// The permutation-free gather branch's two decline gates: `Some(reason)` if `printing_compose_fastpath`
+/// will refuse this query, `None` if it will run it.
+///
+/// Extracted so the COST MODEL can ask the same question. These conditions used to live inline in the
+/// fastpath, which meant `acquire_plan_features` had no way to know the plan it was costing would
+/// return `None` — so it priced a real gather, compose could win the argmin on that price, and
+/// dispatch then paid the detour and ran something else anyway. `compose_paging_with_total` now
+/// consults this and predicts `ComposePaging::Decline`, which costs infinity and keeps the plan out
+/// of the argmin entirely.
+///
+/// One function, two callers, so the prediction cannot drift from the behaviour by construction —
+/// and `paging_taken` (#797) measures whether it has.
+///
+/// No permutation (rarity/usd) AND no orderby walk (card/artwork mode): before paying for the real
+/// build, check whether the gather is worth it at all using the same estimate
+/// `compose_printing_estimate` already computes cheaply in acquire (O(log n) partition points /
+/// plane popcounts, no scatter) — see `COMPOSE_GATHER_MAX_CARD_FRACTION`'s doc for why this needs
+/// its own threshold, not `MAX_NARROW_FRACTION`. The check must be in **mode space** (cards for
+/// `Card`, artworks for `Artwork`), not raw matching printings: a bare range's printing-space match
+/// count is a poor proxy for how many *candidates* `gather_composed_page` will actually visit (a
+/// card can have several qualifying printings). A plain `.min(domain)` cap is *not* enough to
+/// project it down, though — it saturates to exactly `domain` for every query whose printing-space
+/// count exceeds it (`cn<100`: 35,021 printings vs 31,508 cards, and `usd<50`: 80,527 vs 31,508
+/// both saturate to the *identical* 31,508, even though their true card counts are 17,616 vs 31,217
+/// — miles apart), which loses exactly the signal this check needs. A balls-into-bins estimate —
+/// `k` matching printings landing on `domain` cards, expected distinct cards touched
+/// `≈ domain·(1 − e^(−k/domain))` — doesn't saturate the same way and tracks the true count much
+/// better (checked against real totals: `cn<100` estimate 21,140 vs true 17,616; `usd<50` estimate
+/// 29,062 vs true 31,217; clearly separated, unlike the capped estimate's identical 31,508 for both).
+fn compose_gather_declines(
+    filter: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    offsets: &Archived<Vec<u32>>,
+    printings: &[APrinting],
+    cards: &[AOracleCard],
+    mode: Mode,
+) -> Option<PagingTaken> {
+    let (printing_matches, _, _) = compose_printing_estimate(filter, indexes, offsets, printings.len());
+    // Artwork's true domain is n_artworks (>= n_cards), but getting it exactly means building
+    // artwork_base here — real O(n_cards) work paid just to maybe decline. `cards.len()` is a cheap,
+    // conservative stand-in (n_artworks is always >= it, so this only ever makes the fraction look
+    // *more* broad than reality — errs toward declining, the same conservative lean
+    // `COMPOSE_GATHER_MAX_CARD_FRACTION` itself was calibrated with).
+    let domain = match mode {
+        Mode::Printing => printings.len(),
+        Mode::Card | Mode::Artwork => cards.len(),
+    };
+    let est = if matches!(mode, Mode::Printing) {
+        printing_matches as f64 // exact in printing space already, no projection needed
+    } else {
+        domain as f64 * (-(printing_matches as f64) / domain as f64).exp().mul_add(-1.0, 1.0)
+    };
+    if est > domain as f64 * *COMPOSE_GATHER_MAX_CARD_FRACTION {
+        return Some(PagingTaken::DeclineBroad);
+    }
+    // Small-total decline (mirrors the `Perm` branch's `total <= STREAM_MIN_MATCHES`): in the
+    // permutation-free gather regime PrintingCompose has no paging edge over GatheredScan — it just
+    // composes the full printing bitmap and projects it back down, two O(n_cards) passes on top of the
+    // same gather. For a filter that narrows to few candidate cards the residual-eval saving is tiny
+    // while that build/projection dominates, so the candidate/narrowing path wins; decline to it. The
+    // SOUND card-space cardinality upper bound decides — exact for a collection leaf, unlike the
+    // balls-into-bins `est` above which overestimates a clustered predicate's distinct-card count
+    // (goblin: 501 cards but ~1471 `est`) and so cannot make this call. This is what keeps a sparse
+    // `type:angel`/`type:goblin` card/usd (newly composable) from regressing onto this path: the
+    // collection compose leaves are a printing-mode orderby-walk win, not a card-mode gather win.
+    if (estimator::estimate_cardinality(filter, indexes, offsets).hi as usize) <= *STREAM_MIN_MATCHES {
+        return Some(PagingTaken::DeclineSparseEstimate);
+    }
+    None
+}
+
+/// `compose_paging_with_total` without a result total, for the range branches: they cost a COMPETING
+/// compose and have no total for it, so they get the plain 3-way answer and cannot predict a decline.
 fn compose_paging_for(indexes: &Archived<CardIndexes>, n_cards: usize, mode: Mode, sort_col: SortCol, descending: bool) -> ComposePaging {
+    compose_paging_with_total(indexes, n_cards, mode, sort_col, descending, None, None)
+}
+
+/// Which paging branch `printing_compose_fastpath` will take — including whether it will refuse the
+/// query outright, which the caller that knows the estimated total can now predict.
+fn compose_paging_with_total(
+    indexes: &Archived<CardIndexes>,
+    n_cards: usize,
+    mode: Mode,
+    sort_col: SortCol,
+    descending: bool,
+    result_total: Option<usize>,
+    gather_declines: Option<PagingTaken>,
+) -> ComposePaging {
     if indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == n_cards) {
+        // Mirrors the fastpath's `Some(perm) => if total <= STREAM_MIN_MATCHES` bail. `result_total`
+        // is the acquire-time ESTIMATE where the fastpath has the exact count, so a query sitting
+        // right on the threshold can be classified either way — cheap by construction, since compose
+        // and its alternative are within noise of each other exactly there.
+        //
+        // A total of ZERO is different and must not be predicted as a decline. The fastpath returns at
+        // `total == 0 || page_offset >= total` BEFORE reaching the bail, and that return is
+        // `Some((total, vec![]))` — it SUCCEEDS, cheaply. Predicting Decline there makes `plan_cost`
+        // INFINITY and removes compose from the argmin for a query it would have answered immediately.
+        if result_total.is_some_and(|t| t > 0 && t <= *STREAM_MIN_MATCHES) {
+            return ComposePaging::Decline;
+        }
         ComposePaging::Perm
     } else if matches!(mode, Mode::Printing) && orderby_walk_available(sort_col) {
         ComposePaging::OrderbyWalk
+    } else if gather_declines.is_some() {
+        ComposePaging::Decline
     } else {
         ComposePaging::Gather
     }
@@ -7230,8 +7298,16 @@ fn acquire_plan_features(
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
-        // itself decides (permutation walk / #744 orderby walk / gather fallback).
-        feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
+        // itself decides, through the same helpers, including whether it will decline. Only this
+        // branch knows the estimated result total, so only it can predict the small-total bail. The
+        // gather gates cost an estimate each, so ask them only when the gather branch is the one that
+        // would run.
+        let no_perm = indexes.sort_perms.get(sort_col, descending).is_none_or(|p| p.len() != cards.len());
+        let gather_declines = (no_perm && !(matches!(mode, Mode::Printing) && orderby_walk_available(sort_col)))
+            .then(|| compose_gather_declines(filter, indexes, offsets, ctx.printings, cards, mode))
+            .flatten();
+        feats.compose_paging =
+            compose_paging_with_total(indexes, cards.len(), mode, sort_col, descending, Some(result_total), gather_declines);
         (feats, Prep::Range(CountSource::PrintingCompose))
     } else {
         let prep = prepare_candidates(ctx, params, filter, plane);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3346,6 +3346,11 @@ fn compose_paging_prediction_matches_the_branch_taken() {
     let offsets = [0usize, 40, 10_000];
 
     let (mut exercised, mut declined, mut empty) = (0usize, 0usize, 0usize);
+    // Predicted `Decline` where the fastpath actually RAN. Not a failure: acquire predicts the
+    // small-total bail from an ESTIMATED total where the fastpath has the exact one, so queries near
+    // `STREAM_MIN_MATCHES` can fall either side. Counted and printed so the rate stays visible --
+    // silently predicting Decline for plans that would have run removes them from the argmin.
+    let mut decline_predicted_but_ran = 0usize;
     // Perm / OrderbyWalk / Gather / GatherWalkDeclined. The fourth is not a strategy the model
     // predicts -- it is the one legal inexactness in the prediction, and it gets its own cell so
     // the allowance above cannot pass by never being exercised.
@@ -3413,6 +3418,11 @@ fn compose_paging_prediction_matches_the_branch_taken() {
                                 // fastpath found a walk available where acquire predicted none,
                                 // i.e. the two availability tests really had drifted.
                                 ComposePaging::Gather => &[PagingTaken::Gather],
+                                // The fastpath disagreed and ran. Legal (estimated vs exact total),
+                                // but every run-branch is a distinct disagreement worth counting.
+                                ComposePaging::Decline => {
+                                    &[PagingTaken::Perm, PagingTaken::OrderbyWalk, PagingTaken::Gather, PagingTaken::GatherWalkDeclined]
+                                }
                             };
                             assert!(
                                 legal.contains(&taken),
@@ -3424,6 +3434,7 @@ fn compose_paging_prediction_matches_the_branch_taken() {
                                 (ComposePaging::OrderbyWalk, PagingTaken::GatherWalkDeclined) => by_strategy[3] += 1,
                                 (ComposePaging::OrderbyWalk, _) => by_strategy[1] += 1,
                                 (ComposePaging::Gather, _) => by_strategy[2] += 1,
+                                (ComposePaging::Decline, _) => decline_predicted_but_ran += 1,
                             }
                         }
                     }
@@ -3435,7 +3446,8 @@ fn compose_paging_prediction_matches_the_branch_taken() {
     // that skipped the assertion, and all of them skipping would still pass.
     println!(
         "compose paging: {exercised} strategy runs checked \
-         ({} Perm, {} OrderbyWalk, {} Gather, {} walk-declined), {declined} declined, {empty} empty-page",
+         ({} Perm, {} OrderbyWalk, {} Gather, {} walk-declined), {declined} declined, {empty} empty-page, \
+         {decline_predicted_but_ran} predicted-decline-but-ran",
         by_strategy[0], by_strategy[1], by_strategy[2], by_strategy[3],
     );
     // Every cell, not just a total: the agreement is only interesting where the two decisions could

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -63,11 +63,16 @@ ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "usd",
 LIMITS = (10, 100, 175)
 OFFSETS = (0, 0, 0, 100)  # mostly first-page, which is what real traffic asks for
 MIN_FOR_QUARTILES = 8
-# The three paging strategies `ComposePaging` predicts. `paging_taken` reports five further labels —
-# `NotComposable`, `DeclineBroad`, `DeclineSparseEstimate`, `DeclineSparseExact` and `EmptyPage` —
-# all of them run-time outcomes reached BEFORE any strategy runs. The prediction is never exercised
-# there, so they are excluded rather than counted as disagreements.
-COMPOSE_STRATEGIES = ("Perm", "OrderbyWalk", "Gather")
+# The paging outcomes `ComposePaging` predicts. `Decline` joined the other three once acquire gained
+# the estimated result total and could ask `compose_gather_declines` the same question the fastpath
+# asks — before that, a decline was unpredictable by construction and excluded here.
+#
+# `NotComposable` and `EmptyPage` stay excluded: both are reached before any strategy runs and
+# neither is something the prediction claims.
+COMPOSE_STRATEGIES = ("Perm", "OrderbyWalk", "Gather", "Decline")
+# The executor records WHY it refused; the model only predicts THAT it will. Fold the three reasons
+# onto the single predicted label, or every correct decline scores as a disagreement.
+DECLINE_REASONS = ("DeclineBroad", "DeclineSparseEstimate", "DeclineSparseExact")
 # `GatherWalkDeclined` is a strategy outcome, so it IS counted — but it is not a disagreement. Acquire
 # never composes, so it can only test that an orderby walk is AVAILABLE, never that it will succeed;
 # the walk declines on the null-value tail or a page past the value structure and falls into the
@@ -218,8 +223,10 @@ def main() -> None:
             # acquire. Under any other branch it is the untouched `mk_plan_feats` default, so an
             # off-diagonal cell there means a competing compose was mispriced, not that a prediction
             # drifted -- different defect, different fix, and pooling them reports neither.
-            if p["plan"] == "PrintingCompose" and p["paging_taken"] in (*COMPOSE_STRATEGIES, WALK_DECLINED):
-                agr.paging[acq["count_source"], acq["compose_paging"], p["paging_taken"]] += 1
+            if p["plan"] == "PrintingCompose":
+                taken = "Decline" if p["paging_taken"] in DECLINE_REASONS else p["paging_taken"]
+                if taken in (*COMPOSE_STRATEGIES, WALK_DECLINED):
+                    agr.paging[acq["count_source"], acq["compose_paging"], taken] += 1
 
     report(agr, args.seconds)
 


### PR DESCRIPTION
Third of a stacked series. **Based on #805**, which is based on #804 — review those first.

#805 made the range branches predict compose's paging strategy correctly. This closes the rest.

## The model could not see a decline coming

`printing_compose_fastpath`'s two gather gates lived inline in the fastpath, so
`acquire_plan_features` had no way to know the plan it was costing would return `None`. It priced a
real gather, compose could win the argmin on that price, and dispatch then paid the detour and ran
something else anyway.

`compose_gather_declines` is those same two conditions, extracted verbatim — one function, two
callers, so the prediction cannot drift from the behaviour by construction. It returns
`Option<PagingTaken>` rather than a bool to preserve the executor's distinction between WHY it
refused, which #797's counter reports.

`compose_paging_with_total` adds `ComposePaging::Decline`, costing infinity so the plan leaves the
argmin entirely. Only the compose acquire branch knows the estimated result total, so only it can
predict the `Perm` branch's small-total bail; the range branches keep the plain 3-way answer.

## Measured

Predicted paging against the `paging_taken` counter, 492 compose-applicable queries:

    acquire                 main      #805     here
    card_range_popcount     100%        0%       0%
    printing_range_scan     100%        0%       0%
    printing_compose         20%       20%       0%
    overall                  43%       14%       0%

The `printing_compose` cell was 71 queries predicting `Gather` where the fastpath refused.

## A zero total is not a decline

The fastpath returns at `total == 0 || page_offset >= total` BEFORE the small-total bail, and that
return SUCCEEDS cheaply. Predicting Decline there would drop compose from the argmin for a query it
would have answered immediately, so the prediction carves it out explicitly.

## Both harnesses learn the new outcome

`bench_cost_model_agreement.py` excluded declines from its paging table because they were
unpredictable by construction. They are not any more, so it scores them — folding the three executor
reasons onto the single predicted label. **Without that fold every correct decline would read as a
disagreement and this PR would look like a regression.**

`compose_paging_prediction_matches_the_branch_taken` gains a `Decline` arm. Predicting a decline for
a query that then RUNS is legal — acquire estimates the total where the fastpath has it exactly, so
queries near `STREAM_MIN_MATCHES` fall either side — but it is counted and printed, since silently
predicting Decline for plans that would have run removes them from the argmin.

147 Rust tests pass.

## Stack

    A  #804  exact distinct-card counts
    B  #805  cost compose honestly from every acquire
    C1 this PR
    C2 correct the cost model's features against the executor's counters
    C3 refit both scan arms on the corrected features
    D  fit PrintingCompose, give it its own scan feature and rates