### PR TITLE
Engine: Write bare_range_bounds' Leaf Grammar Once

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4662,41 +4662,37 @@ fn bare_range_bounds<'i>(
     filter: &FilterExpr,
     indexes: &'i Archived<CardIndexes>,
 ) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
-    match filter {
-        FilterExpr::NumericCmp { lhs, op, rhs } => {
-            let (idx, op, value) = resolve_numeric_range_leaf(lhs, *op, rhs, indexes)?;
-            match int_range_bounds(op, value)? {
-                None => Some((idx, 0, 0)),
-                Some((lo, hi)) => Some((idx, lo, hi)),
-            }
-        }
-        FilterExpr::DateCmp { op, value } => {
-            let (lo, hi) = date_range_bounds(*op, *value)?;
-            Some((&indexes.released_at, lo, hi))
-        }
-        FilterExpr::YearCmp { op, year } => {
-            let (lo, hi) = year_range_bounds(*op, *year)?;
-            Some((&indexes.released_at, lo, hi))
-        }
-        FilterExpr::Not(inner) => match inner.as_ref() {
+    // The direct and `Not` arms are the same three-way leaf dispatch, differing only in
+    // whether the leaf's op is taken as written or negated. `map_op` is that difference,
+    // so the grammar is written once and the two arms cannot drift apart.
+    fn leaf<'i>(
+        filter: &FilterExpr,
+        indexes: &'i Archived<CardIndexes>,
+        map_op: impl Fn(CmpOp) -> CmpOp,
+    ) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
+        match filter {
             FilterExpr::NumericCmp { lhs, op, rhs } => {
-                let (idx, op, value) = resolve_numeric_range_leaf(lhs, negate_op(*op), rhs, indexes)?;
+                let (idx, op, value) = resolve_numeric_range_leaf(lhs, map_op(*op), rhs, indexes)?;
                 match int_range_bounds(op, value)? {
                     None => Some((idx, 0, 0)),
                     Some((lo, hi)) => Some((idx, lo, hi)),
                 }
             }
             FilterExpr::DateCmp { op, value } => {
-                let (lo, hi) = date_range_bounds(negate_op(*op), *value)?;
+                let (lo, hi) = date_range_bounds(map_op(*op), *value)?;
                 Some((&indexes.released_at, lo, hi))
             }
             FilterExpr::YearCmp { op, year } => {
-                let (lo, hi) = year_range_bounds(negate_op(*op), *year)?;
+                let (lo, hi) = year_range_bounds(map_op(*op), *year)?;
                 Some((&indexes.released_at, lo, hi))
             }
             _ => None,
-        },
-        _ => None,
+        }
+    }
+
+    match filter {
+        FilterExpr::Not(inner) => leaf(inner.as_ref(), indexes, negate_op),
+        _ => leaf(filter, indexes, |op| op),
     }
 }
 

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -9708,6 +9708,15 @@ fn bare_range_bounds_recognizes_leaves_and_rejects_rest() {
     assert!(bounds(&FilterExpr::And(vec![usd_cmp(CmpOp::Lt, 50.0)])).is_none());
     let cmc_lt = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
     assert!(bounds(&cmc_lt).is_none());
+    // The negated arm takes the same leaf grammar with the op negated: -usd<50 is usd>=50's
+    // bounds outright, no complement. Ne is the shape that doesn't reduce, from either side --
+    // written as Ne above, and reached as negate_op(Eq) here.
+    let not_usd_lt = FilterExpr::Not(Box::new(usd_cmp(CmpOp::Lt, 50.0)));
+    assert_eq!(bounds(&not_usd_lt), Some((5000, u32::MAX)));
+    assert!(bounds(&FilterExpr::Not(Box::new(usd_cmp(CmpOp::Eq, 50.0)))).is_none());
+    // One Not deep and no further: the inner Not is not a leaf, so a double negation falls
+    // through the leaf catch-all rather than cancelling to the bare comparison.
+    assert!(bounds(&FilterExpr::Not(Box::new(not_usd_lt))).is_none());
 }
 
 /// #724 de-risk: does `popcount` + a printing walk over a *precomputed* border plane beat today's


### PR DESCRIPTION
Item 2 of #799. The direct arm and the `Not` arm were the same three-way
NumericCmp/DateCmp/YearCmp dispatch, differing only in `op` versus
`negate_op(op)` — 30 lines to say one thing twice, with nothing checking that the
copies stayed in step. An inner `leaf` helper takes that difference as a
`map_op: impl Fn(CmpOp) -> CmpOp` parameter, and the outer match becomes two lines.

Same shapes accepted and rejected: `Not(Not(x))` still returns `None` (the inner
`Not` falls through `leaf`'s catch-all exactly as it fell through the old nested
match's), and a non-leaf at the top still returns `None` through the same arm.

Landable independently of item 1, which will resolve its `Range` leaf through this.

Item 2 of #799.

## Testing

- `cargo test` (debug): 146 passed
- `cargo clippy --all-targets`: clean

No performance table: pure restructuring of a dispatch that runs once per query at plan time.