### PR TITLE
Engine: Give the CSR Convention One Home

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -984,6 +984,80 @@ pub(crate) fn scan_oracle_words(idx: &Archived<OracleWordIndex>, needle: &str) -
     OracleWordScan { dense, sparse }
 }
 
+// ─── CSR tables ──────────────────────────────────────────────────────────────
+// Three indexes store an array-of-arrays as a CSR (compressed sparse row) pair —
+// oracle text → cards, artist → printings, flavor text → printings — flattened
+// into `offsets` (row boundaries, length n_rows + 1) plus a payload vec so each
+// archives as two contiguous zero-copy slices. Build and expand used to be
+// written out once per index; the convention lives here instead.
+
+/// A CSR row index. `u32` deliberately has no `Into<usize>` (usize may be 16-bit),
+/// so the widening is spelled once here rather than at every call site.
+trait CsrRow: Copy {
+    fn row(self) -> usize;
+}
+
+impl CsrRow for u16 {
+    fn row(self) -> usize {
+        self as usize
+    }
+}
+
+impl CsrRow for u32 {
+    fn row(self) -> usize {
+        self as usize
+    }
+}
+
+/// Concatenate the payload rows for `keys` and sort the result.
+///
+/// Each row is internally sorted (placement below walks store order), but rows are
+/// not ordered relative to each other (dense ids are first-seen order), so the
+/// concatenation needs one final sort — required both by `intersect_sorted` when
+/// And-combining with other candidate sets and by the query driver, which assumes
+/// candidates arrive in store order.
+fn expand_csr<K: CsrRow>(offsets: &AOffsets, values: &AOffsets, keys: &[K]) -> Vec<u32> {
+    let mut out: Vec<u32> = Vec::new();
+    for &k in keys {
+        let row = k.row();
+        let start = u32::from(offsets[row]) as usize;
+        let end = u32::from(offsets[row + 1]) as usize;
+        out.extend(values[start..end].iter().map(|x| u32::from(*x)));
+    }
+    out.sort_unstable();
+    out
+}
+
+/// Count → prefix-sum → place with a cursor. `row_of(i)` gives item `i`'s row, or
+/// `None` to omit it from the table entirely (an absent artist, a printing with no
+/// flavor text). Returns `(offsets, payload)`, the payload holding every included
+/// item index grouped by row and ascending within it.
+///
+/// `row_of` is called twice per item, once to count and once to place. Every caller
+/// is on the reload path, where this runs once over ~50k items, so a caller whose
+/// row lookup is a hash probe rather than a field read pays for the second probe
+/// there and nowhere else.
+fn build_csr(n_rows: usize, n_items: usize, row_of: impl Fn(usize) -> Option<usize>) -> (Vec<u32>, Vec<u32>) {
+    let mut offsets = vec![0u32; n_rows + 1];
+    for i in 0..n_items {
+        if let Some(row) = row_of(i) {
+            offsets[row + 1] += 1;
+        }
+    }
+    for i in 1..offsets.len() {
+        offsets[i] += offsets[i - 1];
+    }
+    let mut cursor = offsets.clone();
+    let mut payload = vec![0u32; offsets[n_rows] as usize];
+    for i in 0..n_items {
+        if let Some(row) = row_of(i) {
+            payload[cursor[row] as usize] = i as u32;
+            cursor[row] += 1;
+        }
+    }
+    (offsets, payload)
+}
+
 /// Oracle-text trigram index, deduplicated by distinct text.
 ///
 /// Distinct oracle cards still share text (~31.5k cards, ~28k distinct texts —
@@ -1085,19 +1159,9 @@ fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTe
     // CSR expansion table via counting sort: count cards per text, prefix-sum
     // the counts into row offsets, then place each card index in its row. Placement
     // walks cards in store order, so every row comes out sorted by card index.
-    let mut offsets: Vec<u32> = vec![0; n_texts + 1];
-    for &t in &text_id_of_card {
-        offsets[t as usize + 1] += 1;
-    }
-    for i in 1..offsets.len() {
-        offsets[i] += offsets[i - 1];
-    }
-    let mut cursor: Vec<u32> = offsets.clone();
-    let mut card_indices: Vec<u32> = vec![0; cards.len()];
-    for (card_idx, &t) in text_id_of_card.iter().enumerate() {
-        card_indices[cursor[t as usize] as usize] = card_idx as u32;
-        cursor[t as usize] += 1;
-    }
+    // Every card has a text id, so no row is ever omitted and `card_indices` ends up
+    // exactly `cards.len()` long.
+    let (offsets, card_indices) = build_csr(n_texts, text_id_of_card.len(), |i| Some(text_id_of_card[i] as usize));
 
     // Word dictionary split: #639's crossover, reused verbatim with domain =
     // n_texts (matching SortedTrigramIndex's oracle instance) to decide
@@ -1145,21 +1209,8 @@ fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTe
 }
 
 /// Expand surviving dense text ids to card indices via the CSR table.
-///
-/// Each row is internally sorted (placement above walks store order), but rows are
-/// not ordered relative to each other (dense ids are first-seen order), so the
-/// concatenation needs one final sort — required both by intersect_sorted() when
-/// And-combining with other candidate sets and by the query driver, which
-/// assumes candidates arrive in store order.
 fn expand_text_ids(idx: &Archived<OracleTextIndex>, text_ids: &[u32]) -> Vec<u32> {
-    let mut out: Vec<u32> = Vec::new();
-    for &t in text_ids {
-        let start = u32::from(idx.offsets[t as usize]) as usize;
-        let end = u32::from(idx.offsets[t as usize + 1]) as usize;
-        out.extend(idx.card_indices[start..end].iter().map(|x| u32::from(*x)));
-    }
-    out.sort_unstable();
-    out
+    expand_csr(&idx.offsets, &idx.card_indices, text_ids)
 }
 
 // ─── Name bigram index (#639 short-name narrowing) ──────────────────────────
@@ -1662,37 +1713,16 @@ fn build_thresholded_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn
 }
 
 fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
-    let mut offsets = vec![0u32; n_artists + 1];
-    for p in printings {
-        if p.card_artist_vid != ARTIST_NONE {
-            offsets[p.card_artist_vid as usize + 1] += 1;
-        }
-    }
-    for i in 1..offsets.len() {
-        offsets[i] += offsets[i - 1];
-    }
-    let mut cursor = offsets.clone();
-    let mut out = vec![0u32; offsets[n_artists] as usize];
-    for (i, p) in printings.iter().enumerate() {
-        if p.card_artist_vid != ARTIST_NONE {
-            let a = p.card_artist_vid as usize;
-            out[cursor[a] as usize] = i as u32;
-            cursor[a] += 1;
-        }
-    }
+    let (offsets, out) = build_csr(n_artists, printings.len(), |i| {
+        let vid = printings[i].card_artist_vid;
+        (vid != ARTIST_NONE).then_some(vid as usize)
+    });
     ArtistIndex { offsets, printings: out }
 }
 
 /// Expand matching artist vocab ids to sorted printing ids via the CSR table.
 fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32> {
-    let mut out: Vec<u32> = Vec::new();
-    for &a in artist_ids {
-        let start = u32::from(idx.offsets[a as usize]) as usize;
-        let end = u32::from(idx.offsets[a as usize + 1]) as usize;
-        out.extend(idx.printings[start..end].iter().map(|x| u32::from(*x)));
-    }
-    out.sort_unstable();
-    out
+    expand_csr(&idx.offsets, &idx.printings, artist_ids)
 }
 
 // ─── Flavor-text index ────────────────────────────────────────────────────────
@@ -1774,37 +1804,24 @@ pub(crate) struct FlavorIndex {
 }
 
 fn build_flavor_index(printings: &[Printing], strings: &[String]) -> FlavorIndex {
+    // Assign dense ids in first-seen printing order; `build_csr` does its own counting
+    // pass, so this one only needs to establish the numbering and how many rows there are.
     let mut dense_of: HashMap<u32, u32> = HashMap::new();
     let mut gids: Vec<u32> = Vec::new();
-    let mut counts: Vec<u32> = Vec::new();
     for p in printings {
         let gid = p.flavor_text_lower_id;
         if gid == NONE_STR {
             continue;
         }
-        let d = *dense_of.entry(gid).or_insert_with(|| {
+        dense_of.entry(gid).or_insert_with(|| {
             gids.push(gid);
-            counts.push(0);
             (gids.len() - 1) as u32
         });
-        counts[d as usize] += 1;
     }
-    let n = gids.len();
-    let mut offsets = vec![0u32; n + 1];
-    for i in 0..n {
-        offsets[i + 1] = offsets[i] + counts[i];
-    }
-    let mut cursor = offsets.clone();
-    let mut out = vec![0u32; offsets[n] as usize];
-    for (i, p) in printings.iter().enumerate() {
-        let gid = p.flavor_text_lower_id;
-        if gid == NONE_STR {
-            continue;
-        }
-        let d = dense_of[&gid] as usize;
-        out[cursor[d] as usize] = i as u32;
-        cursor[d] += 1;
-    }
+    let (offsets, out) = build_csr(gids.len(), printings.len(), |i| {
+        let gid = printings[i].flavor_text_lower_id;
+        (gid != NONE_STR).then(|| dense_of[&gid] as usize)
+    });
     let fingerprints = gids
         .iter()
         .map(|&g| {
@@ -1849,14 +1866,7 @@ pub(crate) fn flavor_match_sets(
 
 /// Expand matched dense flavor text ids to sorted printing ids via the CSR.
 fn expand_flavor_ids(idx: &Archived<FlavorIndex>, dense_ids: &[u32]) -> Vec<u32> {
-    let mut out: Vec<u32> = Vec::new();
-    for &d in dense_ids {
-        let start = u32::from(idx.offsets[d as usize]) as usize;
-        let end = u32::from(idx.offsets[d as usize + 1]) as usize;
-        out.extend(idx.printings[start..end].iter().map(|x| u32::from(*x)));
-    }
-    out.sort_unstable();
-    out
+    expand_csr(&idx.offsets, &idx.printings, dense_ids)
 }
 
 // ─── Sort permutations (streamed selection) ──────────────────────────────────

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -991,38 +991,22 @@ pub(crate) fn scan_oracle_words(idx: &Archived<OracleWordIndex>, needle: &str) -
 // archives as two contiguous zero-copy slices. Build and expand used to be
 // written out once per index; the convention lives here instead.
 
-/// A CSR row index. `u32` deliberately has no `Into<usize>` (usize may be 16-bit),
-/// so the widening is spelled once here rather than at every call site.
-trait CsrRow: Copy {
-    fn row(self) -> usize;
-}
-
-impl CsrRow for u16 {
-    fn row(self) -> usize {
-        self as usize
-    }
-}
-
-impl CsrRow for u32 {
-    fn row(self) -> usize {
-        self as usize
-    }
-}
-
-/// Concatenate the payload rows for `keys` and sort the result.
+/// Concatenate the `payload` rows named by `rows` and sort the result. Row ids are
+/// `u16` or `u32` depending on the index, so callers widen at the call site — `u32`
+/// deliberately has no `Into<usize>` (usize may be 16-bit) and a trait to hide three
+/// `as usize` casts costs more than it saves.
 ///
 /// Each row is internally sorted (placement below walks store order), but rows are
 /// not ordered relative to each other (dense ids are first-seen order), so the
 /// concatenation needs one final sort — required both by `intersect_sorted` when
 /// And-combining with other candidate sets and by the query driver, which assumes
 /// candidates arrive in store order.
-fn expand_csr<K: CsrRow>(offsets: &AOffsets, values: &AOffsets, keys: &[K]) -> Vec<u32> {
+fn expand_csr(offsets: &AOffsets, payload: &AOffsets, rows: impl IntoIterator<Item = usize>) -> Vec<u32> {
     let mut out: Vec<u32> = Vec::new();
-    for &k in keys {
-        let row = k.row();
+    for row in rows {
         let start = u32::from(offsets[row]) as usize;
         let end = u32::from(offsets[row + 1]) as usize;
-        out.extend(values[start..end].iter().map(|x| u32::from(*x)));
+        out.extend(payload[start..end].iter().map(|x| u32::from(*x)));
     }
     out.sort_unstable();
     out
@@ -1033,14 +1017,14 @@ fn expand_csr<K: CsrRow>(offsets: &AOffsets, values: &AOffsets, keys: &[K]) -> V
 /// flavor text). Returns `(offsets, payload)`, the payload holding every included
 /// item index grouped by row and ascending within it.
 ///
-/// `row_of` is called twice per item, once to count and once to place. Every caller
-/// is on the reload path, where this runs once over ~50k items, so a caller whose
-/// row lookup is a hash probe rather than a field read pays for the second probe
-/// there and nowhere else.
+/// `row_of` is called twice per item, once to count and once to place, so it should be
+/// a field read rather than a hash probe — every caller runs on the reload path over
+/// ~50k items, and one that has to look its row up materializes the rows first.
 fn build_csr(n_rows: usize, n_items: usize, row_of: impl Fn(usize) -> Option<usize>) -> (Vec<u32>, Vec<u32>) {
     let mut offsets = vec![0u32; n_rows + 1];
     for i in 0..n_items {
         if let Some(row) = row_of(i) {
+            debug_assert!(row < n_rows, "build_csr: row_of({i}) = {row}, out of range for {n_rows} rows");
             offsets[row + 1] += 1;
         }
     }
@@ -1210,7 +1194,7 @@ fn build_oracle_text_index(cards: &[OracleCard], strings: &[String]) -> OracleTe
 
 /// Expand surviving dense text ids to card indices via the CSR table.
 fn expand_text_ids(idx: &Archived<OracleTextIndex>, text_ids: &[u32]) -> Vec<u32> {
-    expand_csr(&idx.offsets, &idx.card_indices, text_ids)
+    expand_csr(&idx.offsets, &idx.card_indices, text_ids.iter().map(|&t| t as usize))
 }
 
 // ─── Name bigram index (#639 short-name narrowing) ──────────────────────────
@@ -1722,7 +1706,7 @@ fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
 
 /// Expand matching artist vocab ids to sorted printing ids via the CSR table.
 fn expand_artist_ids(idx: &Archived<ArtistIndex>, artist_ids: &[u16]) -> Vec<u32> {
-    expand_csr(&idx.offsets, &idx.printings, artist_ids)
+    expand_csr(&idx.offsets, &idx.printings, artist_ids.iter().map(|&a| a as usize))
 }
 
 // ─── Flavor-text index ────────────────────────────────────────────────────────
@@ -1804,23 +1788,31 @@ pub(crate) struct FlavorIndex {
 }
 
 fn build_flavor_index(printings: &[Printing], strings: &[String]) -> FlavorIndex {
-    // Assign dense ids in first-seen printing order; `build_csr` does its own counting
-    // pass, so this one only needs to establish the numbering and how many rows there are.
+    /// Row of a printing carrying no flavor text — omitted from the CSR table entirely.
+    const NO_ROW: u32 = u32::MAX;
+
+    // Assign dense ids in first-seen printing order, recording each printing's row as we
+    // go. Flavor is the one caller whose row is a hash lookup rather than a field read,
+    // and `build_csr` asks twice; materializing the rows here keeps this at one probe per
+    // printing, against two before the CSR helpers existed.
     let mut dense_of: HashMap<u32, u32> = HashMap::new();
     let mut gids: Vec<u32> = Vec::new();
+    let mut row_of_printing: Vec<u32> = Vec::with_capacity(printings.len());
     for p in printings {
         let gid = p.flavor_text_lower_id;
         if gid == NONE_STR {
+            row_of_printing.push(NO_ROW);
             continue;
         }
-        dense_of.entry(gid).or_insert_with(|| {
+        let dense = *dense_of.entry(gid).or_insert_with(|| {
             gids.push(gid);
             (gids.len() - 1) as u32
         });
+        row_of_printing.push(dense);
     }
     let (offsets, out) = build_csr(gids.len(), printings.len(), |i| {
-        let gid = printings[i].flavor_text_lower_id;
-        (gid != NONE_STR).then(|| dense_of[&gid] as usize)
+        let row = row_of_printing[i];
+        (row != NO_ROW).then_some(row as usize)
     });
     let fingerprints = gids
         .iter()
@@ -1866,7 +1858,7 @@ pub(crate) fn flavor_match_sets(
 
 /// Expand matched dense flavor text ids to sorted printing ids via the CSR.
 fn expand_flavor_ids(idx: &Archived<FlavorIndex>, dense_ids: &[u32]) -> Vec<u32> {
-    expand_csr(&idx.offsets, &idx.printings, dense_ids)
+    expand_csr(&idx.offsets, &idx.printings, dense_ids.iter().map(|&d| d as usize))
 }
 
 // ─── Sort permutations (streamed selection) ──────────────────────────────────


### PR DESCRIPTION
Item 10 of #799. Three indexes store an array-of-arrays as a CSR pair — oracle
text to cards, artist to printings, flavor text to printings — and both halves of
the convention were written out once per index: three byte-identical
expand-and-sort bodies, and three count/prefix-sum/place-with-a-cursor builds.
Six hand-written copies of two algorithms become two documented functions.

`expand_csr` takes the offsets, the payload, and the rows to concatenate, as
`impl IntoIterator<Item = usize>` — row ids are `u16` or `u32` depending on the
index, and the three callers widen at the call site. `u32` deliberately has no
`Into<usize>` (usize may be 16-bit), which is worth writing down but is not worth
a trait: an earlier revision had one, and 17 lines of trait plus impls to hide
three `as usize` casts is the wrong trade.

`build_csr` takes `row_of(i) -> Option<usize>`, where `None` omits an item
(an absent artist, a printing with no flavor text). It calls `row_of` twice, once
to count and once to place, so every caller's row lookup is a field read. Two of
the three were already field reads; `build_flavor_index` now records each
printing's row in the pass that assigns the dense ids, which makes it one too —
and takes that function from two hash probes per printing to one, better than the
code this PR replaces. The cost is a transient ~200 KB vec over ~50k printings,
on the reload path.

Doing so also retires `build_flavor_index`'s `counts` vec: its first pass existed
to assign dense ids *and* count, and only the numbering is still needed.

`build_csr` carries a `debug_assert!` that `row_of` stays in range. Out of range
otherwise panics with a bare index-out-of-bounds on an anonymous vec; the
tripwire names the caller's contract. Load path only, so it is free at query time
and in release.

Same output, so no archive layout change and no ARCHIVE_FORMAT_VERSION bump: both
builds prefix-sum identically and place in ascending item order, which is what
made the three copies interchangeable in the first place.

Net +2 lines rather than the ~60 removed the issue estimated — the two helpers
carry the doc comments that six copies had between them. The duplication is what
went away, not the line count.

## Testing

- `cargo test` (debug): 147 passed, 30 ignored
- `cargo clippy --all-targets`: clean

## On item 11 (the three interners)

The issue doc pairs this with item 11 — `Interner` (u32), `VocabInterner` (u16), `ManaVocabInterner` (u8), described as "~90 lines for one algorithm with three id types". I implemented it and then dropped it, because it does not pay:

- The region went **90 → 105 lines**. A generic `HashCons<Id>` holding the algorithm is only ~38 lines, but each width then needs its own `intern` shim to re-export it at the return type its callers expect — `u32` infallible, `u16` returning `PyResult`, `u8` taking `&str` — and those shims cost what the shared algorithm saves.
- Naming the generic method `intern` directly is not an option: an inherent `impl Interner<u32>` and a generic `impl<Id> Interner<Id>` both defining `intern` compiles but makes every call site ambiguous (E0034).
- Doing it without shims means changing return types at call sites, which reaches **78 sites in `tests.rs`** — the file today's in-flight engine branches churn hardest. Trading a real merge conflict for a line-count wash is the wrong side of that deal.

The CSR half has no such problem: callers invoke the helper directly, so nothing outside the two new functions changes shape.

No performance table: reload-path only, and the one caller whose row lookup is a
hash probe comes out ahead of where it started.

## Follow-up

Review follow-ups landed as #819: the interner-style trait dropped from
`expand_csr`, flavor's probe count, the `debug_assert`, and `values` → `payload`.

Still open, deliberately not in this PR: a direct unit test for the two helpers
covering `n_rows == 0`, an all-`None` `row_of`, and an empty interior row (a real
case — an artist vid with no printings), asserting monotonic offsets and
ascending payload within each row. The three builders exercise the helpers
end-to-end at nine sites in `tests.rs`, but nothing targets those edges on
purpose.