### PR TITLE
Engine: Keep the Intersection Chain Ascending, and Stop Repopcounting best

### DIFF
--- a/card_engine/src/bench_and_best.rs
+++ b/card_engine/src/bench_and_best.rs
@@ -1,0 +1,174 @@
+//! Micro-benchmark for the And arm's `best` bookkeeping — item 14 of
+//! docs/issues/00799-engine-simplicity-pass.md.
+//!
+//! `narrow_rec`'s And arm reads `best` (the smallest set accumulated so far) at the top
+//! of every child iteration, to decide whether the driver is already selective enough to
+//! skip a costlier child. It used to recompute that from scratch:
+//!
+//! ```ignore
+//! let best = card_sets.iter().chain(printing_sets.iter()).map(|n| n.set.len()).min();
+//! ```
+//!
+//! `Candidates::len()` is O(1) for the vec variants but popcounts the **whole** bitmap for
+//! `CardBits`/`PrintingBits`, so with `c` accumulated bitmap children the loop is
+//! O(c² × words) for a value that only ever shrinks. The fix maintains the running minimum
+//! as sets are pushed, reusing the length the broad-child check (`len > domain - domain/4`)
+//! already computes — one popcount per child instead of `c²/2` of them.
+//!
+//! Both contenders below pay that broad-child `len()` call, because both variants of the
+//! shipped code do; the only difference is the recomputed `min` over the accumulated sets.
+//! They are asserted to agree on the final value before either is timed.
+//!
+//! What to expect: nothing at all for vec-shaped children (`len()` is `Vec::len`), and a
+//! cost that grows quadratically in the number of *bitmap* children. Real Ands are 2-6
+//! children wide, so this is a small absolute number — a bitmap popcount over the printing
+//! space is ~1,520 words. The configs below bracket the realistic range and go a little
+//! past it to show the shape.
+//!
+//! Synthetic bitmaps over the real corpus dimensions (31,508 cards / 97,206 printings):
+//! popcount cost depends on the word count, not on which bits are set, so there is nothing
+//! a corpus-derived set would add.
+//!
+//!     cargo test --release bench_and_best -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::RngExt;
+
+use crate::{Candidates, Narrowed};
+
+/// Real corpus dimensions (blue, 2026-07): the domains the two bitmap variants are sized to.
+const N_CARDS: usize = 31_508;
+const N_PRINTINGS: usize = 97_206;
+/// Best-of rounds per contender, matching `bench_intersect_order`.
+const ITERS: usize = 300;
+/// Calls inside one timed window. `Instant` on this machine quantizes to ~41.7 ns, which is
+/// the same order as the whole kernel for the small configs — timing one call at a time
+/// reports nothing but that quantum. Times below are per call, `best / REPS`.
+const REPS: usize = 200;
+/// Child counts to sweep. Real Ands are 2-6 children; 8 and 12 show the curve's shape.
+const CHILD_COUNTS: &[usize] = &[2, 3, 4, 6, 8, 12];
+
+fn time_ns(sets: &[Narrowed], kernel: impl Fn(&[Narrowed]) -> usize) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        for _ in 0..REPS {
+            // Opaque input per call, so the repetition loop cannot be hoisted out of.
+            out = black_box(kernel(black_box(sets)));
+        }
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64 / REPS as f64
+}
+
+/// The shipped-before order: `min` over every set accumulated so far, recomputed at the top
+/// of each child iteration, plus the one `len()` the broad-child check pays after the child
+/// narrows. `sets[..i]` stands in for the accumulated `card_sets`/`printing_sets` — the
+/// chained iteration order does not matter to a `min`, and neither vec is mutated inside the
+/// timed region, so this isolates the popcounts and nothing else.
+fn best_recomputed(sets: &[Narrowed]) -> usize {
+    let mut running = usize::MAX;
+    for i in 0..sets.len() {
+        let best = sets[..i].iter().map(|n| n.set.len()).min();
+        black_box(best);
+        let len = sets[i].set.len(); // the broad-child check, paid by both contenders
+        running = best.unwrap_or(usize::MAX).min(len);
+    }
+    running
+}
+
+/// The shipped-after order: one `len()` per child, folded into a running minimum.
+fn best_maintained(sets: &[Narrowed]) -> usize {
+    let mut best: Option<usize> = None;
+    for n in sets {
+        black_box(best);
+        let len = n.set.len();
+        best = Some(best.map_or(len, |b| b.min(len)));
+    }
+    best.unwrap_or(usize::MAX)
+}
+
+/// A bitmap over `domain` bits with roughly `fill` of them set. Density is irrelevant to
+/// popcount cost; it varies only so the `min` has something non-degenerate to choose from.
+fn random_bits(rng: &mut rand::rngs::SmallRng, domain: usize, fill: f64) -> Vec<u64> {
+    let mut bits = vec![0u64; domain.div_ceil(64)];
+    let target = (domain as f64 * fill) as usize;
+    for _ in 0..target {
+        let id = rng.random::<u64>() as usize % domain;
+        bits[id >> 6] |= 1u64 << (id & 63);
+    }
+    bits
+}
+
+fn random_sorted_list(rng: &mut rand::rngs::SmallRng, domain: usize, size: usize) -> Vec<u32> {
+    let mut set = std::collections::HashSet::with_capacity(size);
+    while set.len() < size {
+        set.insert((rng.random::<u64>() as usize % domain) as u32);
+    }
+    let mut v: Vec<u32> = set.into_iter().collect();
+    v.sort_unstable();
+    v
+}
+
+/// Set shapes an And can accumulate. Each child's `len()` is O(words) for the two bitmap
+/// shapes and O(1) for the vec ones, which is the entire spread this benchmark measures.
+#[derive(Clone, Copy)]
+enum Shape {
+    CardBits,
+    PrintingBits,
+    /// Alternating bitmap / vec children — the common real mix, where a plane-backed child
+    /// (legality, rarity, colors) sits next to a posting-backed one (a range or a text word).
+    Mixed,
+    Vecs,
+}
+
+fn build(rng: &mut rand::rngs::SmallRng, shape: Shape, k: usize) -> Vec<Narrowed> {
+    (0..k)
+        .map(|i| {
+            // Descending fill so the running minimum actually moves as children are pushed,
+            // which is the case the recomputed `min` is least favorable in (it never gets to
+            // short-circuit — not that `min` does anyway, but it keeps the two honest).
+            let fill = 0.3 / (i + 1) as f64;
+            let set = match (shape, i % 2) {
+                (Shape::CardBits, _) | (Shape::Mixed, 0) => Candidates::CardBits(random_bits(rng, N_CARDS, fill)),
+                (Shape::PrintingBits, _) => Candidates::PrintingBits(random_bits(rng, N_PRINTINGS, fill)),
+                (Shape::Vecs, _) | (Shape::Mixed, _) => {
+                    Candidates::Cards(random_sorted_list(rng, N_CARDS, (N_CARDS as f64 * fill) as usize))
+                }
+            };
+            Narrowed { set, tight: true }
+        })
+        .collect()
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic data, no external deps"]
+fn bench_and_best() {
+    let mut rng: rand::rngs::SmallRng = rand::make_rng();
+
+    println!("\nN_CARDS={N_CARDS} ({} words), N_PRINTINGS={N_PRINTINGS} ({} words), ITERS={ITERS} (best-of)", N_CARDS.div_ceil(64), N_PRINTINGS.div_ceil(64));
+    println!("{:>14} {:>4} {:>14} {:>14} {:>9}", "children", "k", "recomputed", "maintained", "speedup");
+
+    for &(name, shape) in &[
+        ("card bits", Shape::CardBits),
+        ("printing bits", Shape::PrintingBits),
+        ("mixed", Shape::Mixed),
+        ("vecs", Shape::Vecs),
+    ] {
+        for &k in CHILD_COUNTS {
+            let sets = build(&mut rng, shape, k);
+
+            // Agreement before timing: both are the same `min`, computed in a different order.
+            let expect = best_recomputed(&sets);
+            assert_eq!(expect, best_maintained(&sets), "{name} k={k}: contenders disagree on best");
+
+            let recomputed = time_ns(&sets, best_recomputed);
+            let maintained = time_ns(&sets, best_maintained);
+            println!("{name:>14} {k:>4} {recomputed:>11.1} ns {maintained:>11.1} ns {:>8.2}x", recomputed / maintained);
+        }
+    }
+}

--- a/card_engine/src/bench_intersect_order.rs
+++ b/card_engine/src/bench_intersect_order.rs
@@ -1,0 +1,127 @@
+//! Micro-benchmark for the operand *order* of a sorted-merge intersection chain —
+//! item 12 of docs/issues/00799-engine-simplicity-pass.md.
+//!
+//! `and_all` and `intersect_operands` both sort their operands by ascending length,
+//! then seed the working set with `swap_remove(0)`. That returns the shortest operand,
+//! as intended, but moves the **longest** into slot 0, so the remaining chain runs
+//! roughly longest-first. Both call sites carry a comment saying ascending.
+//!
+//! The result is identical either way (intersection is commutative and associative),
+//! so this measures only the cost of the order. Two contenders:
+//! - `chain_swap_remove`: reproduces the shipped order — `swap_remove(0)` for the seed,
+//!   then iterate the mutated vec, which now begins with the longest operand.
+//! - `chain_ascending`: `into_iter()`, so the chain stays ascending.
+//!
+//! What to expect, and why the honest answer is "bounded": each merge step costs
+//! O(|result| + |operand|), and `sum(|operand|)` is order-invariant. Order only moves
+//! the `sum(|result|)` term, and `|result|` starts at the shortest operand's length and
+//! only shrinks. So the ceiling on the win is roughly `(k - 1) x |shortest|`, which is
+//! small next to `sum(|operand|)` whenever the operands are much larger than the
+//! shortest one. Configs below are chosen to bracket that: a wide spread (where the
+//! shortest is a small share of the total) and a narrow one (where it is not).
+//!
+//! Synthetic sorted id lists over a 31,500-id universe — this corpus's card count —
+//! following `bench_posting_intersect`'s reasoning: the question is a cost curve
+//! across operand-size mixes, not the behavior of one specific query.
+//!
+//!     cargo test --release bench_intersect_order -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::RngExt;
+
+use crate::intersect_sorted;
+
+/// Card-space universe: this corpus's card count.
+const UNIVERSE: usize = 31_500;
+/// Best-of rounds per contender, matching `bench_posting_intersect`.
+const ITERS: usize = 300;
+
+fn time_ns(mut kernel: impl FnMut() -> Vec<u32>) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = Vec::new();
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out.len());
+    best as f64
+}
+
+fn random_sorted_list(rng: &mut rand::rngs::SmallRng, size: usize) -> Vec<u32> {
+    let mut set = std::collections::HashSet::with_capacity(size);
+    while set.len() < size {
+        set.insert((rng.random::<u64>() as usize % UNIVERSE) as u32);
+    }
+    let mut v: Vec<u32> = set.into_iter().collect();
+    v.sort_unstable();
+    v
+}
+
+/// Merge `sorted[0]` against `sorted[i]` for each `i` in `order`, keeping the shipped
+/// early exit. `sorted` is ascending by length, so `sorted[0]` is the seed either way —
+/// only `order` differs between the contenders, which is the entire point: no operand is
+/// cloned and no sort runs inside the timed region, so the measurement is the order and
+/// nothing else.
+fn chain(sorted: &[Vec<u32>], order: &[usize]) -> Vec<u32> {
+    let mut result = sorted[0].clone();
+    for &i in order {
+        if result.is_empty() {
+            break;
+        }
+        result = intersect_sorted(&result, &sorted[i]);
+    }
+    result
+}
+
+/// What `swap_remove(0)` leaves behind. It returns `sorted[0]` (the shortest — the seed
+/// the comment intends) but moves `sorted[k - 1]` into slot 0, so the chain visits the
+/// **longest** operand first and the genuinely ascending middle afterwards.
+fn swap_remove_order(k: usize) -> Vec<usize> {
+    let mut order = vec![k - 1];
+    order.extend(1..k - 1);
+    order
+}
+
+/// Ascending throughout: `1, 2, …, k - 1`.
+fn ascending_order(k: usize) -> Vec<usize> {
+    (1..k).collect()
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic data, no external deps"]
+fn bench_intersect_order() {
+    let mut rng: rand::rngs::SmallRng = rand::make_rng();
+
+    // Operand-size mixes. The first group spreads sizes widely (the shortest is a
+    // small share of the total, so order should barely matter); the last two keep the
+    // operands close in size, where the moved `sum(|result|)` term is a larger share.
+    let configs: &[(&str, &[usize])] = &[
+        ("3 wide", &[200, 4_000, 20_000]),
+        ("4 wide", &[200, 2_000, 8_000, 20_000]),
+        ("6 wide", &[150, 800, 2_000, 6_000, 12_000, 24_000]),
+        ("3 narrow", &[4_000, 5_000, 6_000]),
+        ("6 narrow", &[4_000, 4_400, 4_800, 5_200, 5_600, 6_000]),
+    ];
+
+    println!("\nUNIVERSE={UNIVERSE}, ITERS={ITERS} (best-of), times in ns");
+    println!("{:>10} {:>6} {:>14} {:>14} {:>9} {:>7}", "config", "k", "swap_remove", "ascending", "speedup", "rows");
+
+    for &(name, sizes) in configs {
+        let mut sorted: Vec<Vec<u32>> = sizes.iter().map(|&s| random_sorted_list(&mut rng, s)).collect();
+        sorted.sort_unstable_by_key(Vec::len);
+        let k = sorted.len();
+        let (swap_ord, asc_ord) = (swap_remove_order(k), ascending_order(k));
+
+        // Agreement before timing: the whole premise is that order cannot change the
+        // result, so a divergence here means the benchmark is wrong, not the ordering.
+        let expect = chain(&sorted, &swap_ord);
+        assert_eq!(expect, chain(&sorted, &asc_ord), "{name}: operand order changed the result");
+
+        let swap = time_ns(|| chain(&sorted, &swap_ord));
+        let asc = time_ns(|| chain(&sorted, &asc_ord));
+        println!("{:>10} {:>6} {:>14.0} {:>14.0} {:>8.2}x {:>7}", name, k, swap, asc, swap / asc, expect.len());
+    }
+}

--- a/card_engine/src/bench_narrow_alloc.rs
+++ b/card_engine/src/bench_narrow_alloc.rs
@@ -1,0 +1,361 @@
+//! Micro-benchmarks for the three narrowing allocations of items 15 and 16 in
+//! docs/issues/00799-engine-simplicity-pass.md. Each is a same-output rewrite, so every
+//! contender is asserted result-identical before anything is timed.
+//!
+//! **A. `and_all`'s bitmap seed (item 15).** `bit_sets.split_first().map(|(first, rest)| {
+//! let mut acc = first.clone(); … })` clones a whole bitmap out of an owned
+//! `Vec<Vec<u64>>`. `into_iter()` takes it instead. One allocation plus one memcpy of
+//! `words_per_plane` words, against a chain that then does `(k-1) × words` of AND — so the
+//! expected win is real but bounded, and shrinks as `k` grows.
+//!
+//! **B. The oracle-word sparse expansion (item 16).** For a needle matching `w` sparse
+//! dictionary words, `sparse_text_ids` folds `union_sorted` once per word, rebuilding the
+//! accumulator every time — quadratic in `w`. Concatenating then `sort_unstable` + `dedup`
+//! is linearithmic, and item 16 proposed it as a straight improvement. It is not: this
+//! section is why the fold still ships. The fold wins by 2-5x for `w` ≤ 7, which is 98.8%
+//! of the needle population (the sweep below measures that distribution), and sort+dedup
+//! only pulls ahead past `w` ≈ 24. Both contenders and the crossover are kept here rather
+//! than deleted, because a threshold could serve both regimes if the needle mix ever shifts
+//! — docs/issues/local-engine-sparse-union-threshold.md.
+//!
+//! **C. The regex-factor fold (item 16).** `acc.map_or(cand.clone(), |prev|
+//! intersect_sorted(&prev, &cand))`. Note this is worse than "clones on the first factor":
+//! `map_or` takes its default **by value**, so `cand.clone()` is evaluated on every factor
+//! and thrown away on all but the first. A `match` clones on none of them. Driven by
+//! trigram candidate sets for the literal factors of real regexes.
+//!
+//!     cargo test --release bench_narrow_alloc -- --ignored --nocapture
+//!
+//! B and C need benchmarks/verify-order/real.store (see bench_verify_cost.rs's module doc
+//! for the one-time build command); A is synthetic and always runs.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rkyv::Archived;
+
+use rand::RngExt;
+
+use super::{
+    and_bits_into, archive_header, archive_payload, intersect_sorted, regex_required_factors, scan_oracle_words, trigram_candidates,
+    union_sorted, CardData, Mmap, OracleWordIndex, ARCHIVE_HEADER_LEN,
+};
+
+/// Real corpus dimensions (blue, 2026-07).
+const N_CARDS: usize = 31_508;
+const N_PRINTINGS: usize = 97_206;
+/// Best-of rounds per contender, matching `bench_intersect_order`.
+const ITERS: usize = 300;
+/// Inputs consumed inside one timed window, for the consuming kernels (see `time_ns_owned`).
+/// Kept small so the pool stays cache-resident: 32 printing-space bitmap chains of k=6 is
+/// ~2.3 MB, already past L2 on this machine, and larger pools only measure the memory system.
+const POOL: usize = 32;
+/// Calls inside one timed window, for the borrowing kernels (see `time_ns`).
+const REPS: usize = 200;
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// Best-of timing for a kernel that **consumes** its input — which is the whole point here:
+/// one contender takes ownership where the other clones. The input therefore cannot be
+/// reused across calls, and rebuilding it costs more than the kernel does, so a pool of
+/// `POOL` inputs is built outside the timed window and one timed window drains it. Times
+/// reported are per call, `best / POOL`. Both contenders drain an identically-shaped pool,
+/// so whatever cache pressure the pool adds, it adds to both.
+fn time_ns_owned<I, O>(mut make: impl FnMut() -> I, mut kernel: impl FnMut(I) -> O) -> f64 {
+    let mut best = u128::MAX;
+    for _ in 0..ITERS {
+        let pool: Vec<I> = (0..POOL).map(|_| make()).collect();
+        let t0 = Instant::now();
+        for input in pool {
+            black_box(kernel(black_box(input)));
+        }
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    best as f64 / POOL as f64
+}
+
+/// Best-of timing for a kernel that only borrows. `REPS` calls per timed window, for the
+/// same reason `POOL` exists above: `Instant` quantizes to ~41.7 ns on this machine, the
+/// same order as the smallest kernels here. Times reported are per call.
+fn time_ns(mut kernel: impl FnMut() -> usize) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        for _ in 0..REPS {
+            out = black_box(kernel());
+        }
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64 / REPS as f64
+}
+
+// ---------------------------------------------------------------- A: and_all bitmap seed
+
+/// What `and_all` did: borrow the first bitmap and clone it as the accumulator.
+fn bits_chain_clone(bit_sets: Vec<Vec<u64>>) -> Option<Vec<u64>> {
+    bit_sets.split_first().map(|(first, rest)| {
+        let mut acc = first.clone();
+        for b in rest {
+            and_bits_into(&mut acc, b);
+        }
+        acc
+    })
+}
+
+/// What it does now: take the first bitmap by value.
+fn bits_chain_into_iter(bit_sets: Vec<Vec<u64>>) -> Option<Vec<u64>> {
+    let mut it = bit_sets.into_iter();
+    it.next().map(|mut acc| {
+        for b in it {
+            and_bits_into(&mut acc, &b);
+        }
+        acc
+    })
+}
+
+fn random_bits(rng: &mut rand::rngs::SmallRng, domain: usize, fill: f64) -> Vec<u64> {
+    let mut bits = vec![0u64; domain.div_ceil(64)];
+    for _ in 0..(domain as f64 * fill) as usize {
+        let id = rng.random::<u64>() as usize % domain;
+        bits[id >> 6] |= 1u64 << (id & 63);
+    }
+    bits
+}
+
+fn bench_and_all_seed() {
+    let mut rng: rand::rngs::SmallRng = rand::make_rng();
+    println!("\nA. and_all's bitmap seed — clone vs into_iter (ITERS={ITERS} best-of)");
+    println!("{:>16} {:>4} {:>13} {:>13} {:>9}", "domain", "k", "clone", "into_iter", "speedup");
+
+    for &(space, domain) in &[("card", N_CARDS), ("printing", N_PRINTINGS)] {
+        for k in [2usize, 3, 4, 6] {
+            let base: Vec<Vec<u64>> = (0..k).map(|_| random_bits(&mut rng, domain, 0.2)).collect();
+
+            let expect = bits_chain_clone(base.clone());
+            assert_eq!(expect, bits_chain_into_iter(base.clone()), "{space} k={k}: contenders disagree");
+
+            let clone = time_ns_owned(|| base.clone(), bits_chain_clone);
+            let into_iter = time_ns_owned(|| base.clone(), bits_chain_into_iter);
+            let words = domain.div_ceil(64);
+            println!("{:>10} ({words:>4}w) {k:>4} {clone:>10.0} ns {into_iter:>10.0} ns {:>8.2}x", space, clone / into_iter);
+        }
+    }
+}
+
+// ------------------------------------------------------- B: oracle-word sparse expansion
+
+/// The old fold: `union_sorted` once per matched dictionary word.
+fn sparse_ids_fold(words: &Archived<OracleWordIndex>, sparse: &[u32]) -> Vec<u32> {
+    let mut ids: Vec<u32> = Vec::new();
+    for &s in sparse {
+        let start = u32::from(words.sparse_offsets[s as usize]) as usize;
+        let end = u32::from(words.sparse_offsets[s as usize + 1]) as usize;
+        let row: Vec<u32> = words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))).collect();
+        ids = union_sorted(ids, row);
+    }
+    ids
+}
+
+/// The replacement: concatenate, then sort and dedup once.
+fn sparse_ids_sort(words: &Archived<OracleWordIndex>, sparse: &[u32]) -> Vec<u32> {
+    let mut ids: Vec<u32> = Vec::new();
+    for &s in sparse {
+        let start = u32::from(words.sparse_offsets[s as usize]) as usize;
+        let end = u32::from(words.sparse_offsets[s as usize + 1]) as usize;
+        ids.extend(words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))));
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+/// Needles spanning the real distribution of "how many sparse dictionary words does this
+/// hit": a bare handful (`hexproof`), a few dozen (`sacrifice`, `equip`), and the long tail
+/// of a short common fragment that appears inside many longer words (`counter`, `creature`).
+/// Only sparse-tier hits matter here — a needle whose matches are all dense skips this code
+/// path entirely, so those are reported with w=0 and excluded from the comparison.
+const NEEDLES: &[&str] = &["hexproof", "sacrifice", "equip", "counter", "creature", "damage", "target", "land", "enchant"];
+
+/// Total sparse postings behind a set of matched dictionary words — the input size the fold
+/// is quadratic in.
+fn sparse_posting_count(words: &Archived<OracleWordIndex>, sparse: &[u32]) -> usize {
+    sparse
+        .iter()
+        .map(|&s| {
+            let start = u32::from(words.sparse_offsets[s as usize]) as usize;
+            let end = u32::from(words.sparse_offsets[s as usize + 1]) as usize;
+            end - start
+        })
+        .sum()
+}
+
+/// How bad can the fold's quadratic term get on this corpus? Every eligible dictionary word
+/// is itself a legal needle (`o:sacrifice` is the ordinary way to reach this path), and a
+/// needle that is a substring of many dictionary words matches at least as many words as any
+/// of them do. So sweeping the dictionary bounds the realistic `w` from below, and the top
+/// of that sweep is the case worth timing.
+fn worst_case_needles(words: &Archived<OracleWordIndex>, n: usize) -> Vec<String> {
+    let mut ranked: Vec<(usize, usize, String)> = words
+        .sparse_words
+        .iter()
+        .filter(|w| w.len() > 3)
+        .map(|w| {
+            let needle = w.as_str().to_string();
+            let scan = scan_oracle_words(words, &needle);
+            (scan.sparse.len(), sparse_posting_count(words, &scan.sparse), needle)
+        })
+        .collect();
+    // Both tails matter: total postings is the fold's quadratic *size* term, matched words is
+    // its *step count*, and the two do not peak on the same needles.
+    ranked.sort_unstable_by_key(|r| std::cmp::Reverse(r.1));
+    let by_postings: Vec<String> = ranked.iter().take(n).map(|r| r.2.clone()).collect();
+    ranked.sort_unstable_by_key(|r| std::cmp::Reverse(r.0));
+    println!(
+        "  dictionary sweep: {} eligible sparse words; worst needle by words matched = {} ({} words), by postings = {}",
+        ranked.len(),
+        ranked.first().map_or("", |r| r.2.as_str()),
+        ranked.first().map_or(0, |r| r.0),
+        by_postings.first().map_or("", String::as_str),
+    );
+    // Which regime a needle lands in is what decides the two contenders, so report how the
+    // needle population is distributed across it.
+    let buckets = [1usize, 2, 4, 8, 16, 32];
+    let hist: Vec<String> = buckets
+        .iter()
+        .enumerate()
+        .map(|(i, &lo)| {
+            let hi = buckets.get(i + 1).copied().unwrap_or(usize::MAX);
+            let n = ranked.iter().filter(|r| r.0 >= lo && r.0 < hi).count();
+            format!("{lo}-{}: {n} ({:.1}%)", if hi == usize::MAX { "max".to_string() } else { (hi - 1).to_string() }, 100.0 * n as f64 / ranked.len() as f64)
+        })
+        .collect();
+    println!("  words matched per needle — {}", hist.join(", "));
+    let mut out = by_postings;
+    out.extend(ranked.iter().take(n).map(|r| r.2.clone()));
+    out.sort_unstable();
+    out.dedup();
+    out.retain(|w| !NEEDLES.contains(&w.as_str()));
+    out
+}
+
+fn bench_sparse_expansion(data: &Archived<CardData>) {
+    let words = &data.indexes.oracle_trigram.words;
+    println!("\nB. oracle-word sparse expansion — union_sorted fold vs sort+dedup (ITERS={ITERS} best-of)");
+    let worst = worst_case_needles(words, 5);
+    let needles: Vec<&str> = NEEDLES.iter().copied().chain(worst.iter().map(String::as_str)).collect();
+    println!("{:>12} {:>6} {:>10} {:>7} {:>13} {:>13} {:>9}", "needle", "words", "postings", "ids", "fold", "sort+dedup", "speedup");
+
+    for needle in needles {
+        let scan = scan_oracle_words(words, needle);
+        let sparse = scan.sparse;
+        let postings = sparse_posting_count(words, &sparse);
+
+        let expect = sparse_ids_fold(words, &sparse);
+        assert_eq!(expect, sparse_ids_sort(words, &sparse), "{needle}: contenders disagree");
+        if sparse.is_empty() {
+            println!("{needle:>12} {:>6} {postings:>10} {:>7}   (all-dense or absent — this path not taken)", 0, 0);
+            continue;
+        }
+
+        let fold = time_ns(|| sparse_ids_fold(words, &sparse).len());
+        let sorted = time_ns(|| sparse_ids_sort(words, &sparse).len());
+        println!(
+            "{needle:>12} {:>6} {postings:>10} {:>7} {fold:>10.0} ns {sorted:>10.0} ns {:>8.2}x",
+            sparse.len(),
+            expect.len(),
+            fold / sorted
+        );
+    }
+}
+
+// ------------------------------------------------------------------- C: regex-factor fold
+
+/// The old fold. `map_or`'s default is evaluated eagerly, so the clone happens on **every**
+/// factor, not only the first.
+fn factors_map_or(cands: Vec<Vec<u32>>) -> Option<Vec<u32>> {
+    let mut acc: Option<Vec<u32>> = None;
+    for cand in cands {
+        acc = Some(acc.map_or(cand.clone(), |prev| intersect_sorted(&prev, &cand)));
+    }
+    acc
+}
+
+/// The replacement: the first factor's candidates are moved into the accumulator.
+fn factors_match(cands: Vec<Vec<u32>>) -> Option<Vec<u32>> {
+    let mut acc: Option<Vec<u32>> = None;
+    for cand in cands {
+        acc = Some(match acc {
+            None => cand,
+            Some(prev) => intersect_sorted(&prev, &cand),
+        });
+    }
+    acc
+}
+
+/// Real regexes over the two fields that carry trigram indexes, chosen for factor counts of
+/// one (where the whole fold *is* the clone) through three.
+const REGEXES: &[(&str, bool)] = &[
+    (r"destroy target creature", false),
+    (r"draw (a|two) cards?", false),
+    (r"counter target spell", false),
+    (r"whenever .* enters the battlefield", false),
+    (r"goblin", true),
+    (r"^ancient .*dragon$", true),
+];
+
+fn bench_regex_factors(data: &Archived<CardData>) {
+    println!("\nC. regex-factor fold — map_or(cand.clone()) vs match (ITERS={ITERS} best-of)");
+    println!("{:>34} {:>3} {:>7} {:>13} {:>13} {:>9}", "regex", "f", "ids", "map_or", "match", "speedup");
+
+    for &(pattern, is_name) in REGEXES {
+        let factors = regex_required_factors(pattern);
+        let cands: Vec<Vec<u32>> = factors
+            .iter()
+            .filter_map(|f| {
+                if is_name {
+                    trigram_candidates(&data.indexes.name_trigram, f)
+                } else {
+                    trigram_candidates(&data.indexes.oracle_trigram.trigrams, f)
+                }
+            })
+            .collect();
+        if cands.is_empty() {
+            println!("{pattern:>34} {:>3}   (no trigram-indexable factor — full scan path)", factors.len());
+            continue;
+        }
+
+        let expect = factors_map_or(cands.clone());
+        assert_eq!(expect, factors_match(cands.clone()), "{pattern}: contenders disagree");
+
+        let map_or = time_ns_owned(|| cands.clone(), factors_map_or);
+        let matched = time_ns_owned(|| cands.clone(), factors_match);
+        println!(
+            "{pattern:>34} {:>3} {:>7} {map_or:>10.0} ns {matched:>10.0} ns {:>8.2}x",
+            cands.len(),
+            expect.as_ref().map_or(0, Vec::len),
+            map_or / matched
+        );
+    }
+}
+
+#[test]
+#[ignore = "micro-benchmark; B and C need benchmarks/verify-order/real.store (see module docs)"]
+fn bench_narrow_alloc() {
+    bench_and_all_seed();
+
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP B and C: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as get_mmap() in lib.rs — re-validated against the header below.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP B and C: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+
+    bench_sparse_expansion(data);
+    bench_regex_factors(data);
+}

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3325,19 +3325,21 @@ fn narrow_rec(
             let words = &indexes.oracle_trigram.words;
             let scan = scan_oracle_words(words, word);
             let wpp = words_per_plane(n_cards);
-            // Concatenate then sort+dedup, rather than folding `union_sorted` once per
-            // matched dictionary word: the fold rebuilt the whole accumulator on every
-            // word, quadratic in total postings for a needle hitting many words. Same
-            // output — `union_sorted` dedups on equal, and so does this.
+            // Folds `union_sorted` once per matched dictionary word, so it is quadratic in
+            // total postings — but only in the *step count*, and the needle population does
+            // not reach the regime where that matters: 98.8% of eligible dictionary words
+            // match at most 7 words, where the fold beats concatenate-then-sort+dedup by
+            // 2-5x (bench_narrow_alloc.rs, section B). Sort+dedup only pulls ahead past
+            // ~20-30 matched words, which 0.2% of needles reach — see
+            // docs/issues/local-engine-sparse-union-threshold.md before rewriting this.
             let sparse_text_ids = |sparse: &[u32]| -> Vec<u32> {
                 let mut ids: Vec<u32> = Vec::new();
                 for &s in sparse {
                     let start = u32::from(words.sparse_offsets[s as usize]) as usize;
                     let end = u32::from(words.sparse_offsets[s as usize + 1]) as usize;
-                    ids.extend(words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))));
+                    let row: Vec<u32> = words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))).collect();
+                    ids = union_sorted(ids, row);
                 }
-                ids.sort_unstable();
-                ids.dedup();
                 ids
             };
             match (scan.dense.as_slice(), scan.sparse.as_slice()) {
@@ -9437,6 +9439,10 @@ mod bench_iter_dispatch;
 mod bench_posting_intersect;
 #[cfg(test)]
 mod bench_intersect_order;
+#[cfg(test)]
+mod bench_and_best;
+#[cfg(test)]
+mod bench_narrow_alloc;
 #[cfg(test)]
 mod bench_word_dict_scan;
 #[cfg(test)]

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1345,20 +1345,25 @@ fn intersect_operands(ops: Vec<TriOperand>) -> Vec<u32> {
         // every window happens to be a hot trigram (uncommon — a longer
         // needle usually has at least one rarer window, which is what lets
         // the sparse-seeded path below narrow well).
-        let mut acc = planes.swap_remove(0);
-        for p in &planes {
-            for (a, b) in acc.iter_mut().zip(p) {
+        let mut planes = planes.into_iter();
+        let mut acc = planes.next().expect("postings empty implies at least one plane");
+        for p in planes {
+            for (a, b) in acc.iter_mut().zip(&p) {
                 *a &= *b;
             }
         }
         return bitmap_card_ids(&acc);
     }
     postings.sort_by_key(Vec::len);
-    let mut result = postings.swap_remove(0);
+    // Ascending, and it stays ascending: `swap_remove(0)` seeded from the shortest as
+    // intended but left the *longest* at slot 0, so the merge chain below ran in
+    // descending-ish order — the expensive direction for an O(|a| + |b|) merge.
+    let mut postings = postings.into_iter();
+    let mut result = postings.next().expect("checked non-empty above");
     for p in &planes {
         result.retain(|&id| (p[(id >> 6) as usize] >> (id & 63)) & 1 != 0);
     }
-    for p in &postings {
+    for p in postings {
         if result.is_empty() {
             break;
         }
@@ -2852,10 +2857,14 @@ fn and_all(mut sets: Vec<Narrowed>) -> Option<Narrowed> {
     // word-wise, then combine by retaining the vec against the bitmap — the
     // sparse side never gets scattered, and the result stays a vec whenever
     // any input was one.
-    let vec_result = (!vecs.is_empty()).then(|| {
-        vecs.sort_unstable_by_key(Vec::len);
-        let mut result = vecs.swap_remove(0);
-        for v in vecs {
+    vecs.sort_unstable_by_key(Vec::len);
+    let mut vec_iter = vecs.into_iter();
+    // `next()` takes the shortest and leaves the rest ascending. `swap_remove(0)` also
+    // returned the shortest, but moved the *longest* into slot 0, so the merge chain then
+    // ran longest-first — the expensive direction for an O(|a| + |b|) merge, and the
+    // opposite of what the comment above says.
+    let vec_result = vec_iter.next().map(|mut result| {
+        for v in vec_iter {
             if result.is_empty() {
                 break;
             }
@@ -2863,10 +2872,10 @@ fn and_all(mut sets: Vec<Narrowed>) -> Option<Narrowed> {
         }
         result
     });
-    let bits_result = bit_sets.split_first().map(|(first, rest)| {
-        let mut acc = first.clone();
-        for b in rest {
-            and_bits_into(&mut acc, b);
+    let mut bit_iter = bit_sets.into_iter();
+    let bits_result = bit_iter.next().map(|mut acc| {
+        for b in bit_iter {
+            and_bits_into(&mut acc, &b);
         }
         acc
     });
@@ -3316,14 +3325,19 @@ fn narrow_rec(
             let words = &indexes.oracle_trigram.words;
             let scan = scan_oracle_words(words, word);
             let wpp = words_per_plane(n_cards);
+            // Concatenate then sort+dedup, rather than folding `union_sorted` once per
+            // matched dictionary word: the fold rebuilt the whole accumulator on every
+            // word, quadratic in total postings for a needle hitting many words. Same
+            // output — `union_sorted` dedups on equal, and so does this.
             let sparse_text_ids = |sparse: &[u32]| -> Vec<u32> {
                 let mut ids: Vec<u32> = Vec::new();
                 for &s in sparse {
                     let start = u32::from(words.sparse_offsets[s as usize]) as usize;
                     let end = u32::from(words.sparse_offsets[s as usize + 1]) as usize;
-                    let row: Vec<u32> = words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))).collect();
-                    ids = union_sorted(ids, row);
+                    ids.extend(words.sparse_postings[start..end].iter().map(|x| u32::from(u16::from(*x))));
                 }
+                ids.sort_unstable();
+                ids.dedup();
                 ids
             };
             match (scan.dense.as_slice(), scan.sparse.as_slice()) {
@@ -3399,7 +3413,12 @@ fn narrow_rec(
                     trigram_candidates(&indexes.oracle_trigram.trigrams, f)
                 };
                 let Some(cand) = cand else { continue }; // factor not trigram-indexable: skip, keep the rest
-                acc = Some(acc.map_or(cand.clone(), |prev| intersect_sorted(&prev, &cand)));
+                // A `match`, not `map_or`: the first factor takes ownership of its
+                // candidates instead of cloning the whole vec to hand `map_or` a default.
+                acc = Some(match acc {
+                    None => cand,
+                    Some(prev) => intersect_sorted(&prev, &cand),
+                });
             }
             let acc = acc?; // no factor produced candidates ⇒ general path (full scan)
             let ids = if is_name { acc } else { expand_text_ids(&indexes.oracle_trigram, &acc) };
@@ -3734,8 +3753,11 @@ fn narrow_rec(
             // satisfy the skipped children, and a complement taken over a
             // falsely-tight set would drop real matches of the negation.
             let mut every_child_included = true;
+            // Smallest set pushed so far, maintained as they are pushed. Recomputing it
+            // per child meant popcounting every accumulated bitmap again on every
+            // iteration — O(children² × words) for a value that only ever shrinks.
+            let mut best: Option<usize> = None;
             for (rank, probe, c) in ranked {
-                let best = card_sets.iter().chain(printing_sets.iter()).map(|n| n.set.len()).min();
                 // A driver this selective already bounds the candidate set the
                 // residual re-verifies, so a costlier (rank>0) child usually
                 // narrows nothing the driver's verification doesn't already do
@@ -3766,10 +3788,12 @@ fn narrow_rec(
                     // intersection; skipping it is advisory-sound and avoids
                     // paying its projection/materialization for ~nothing.
                     let domain = if n.set.is_printing_space() { n_printings } else { n_cards };
-                    if n.set.len() > domain - domain / 4 {
+                    let len = n.set.len();
+                    if len > domain - domain / 4 {
                         every_child_included = false;
                         continue;
                     }
+                    best = Some(best.map_or(len, |b| b.min(len)));
                     if n.set.is_printing_space() { printing_sets.push(n) } else { card_sets.push(n) }
                 } else {
                     every_child_included = false;
@@ -9411,6 +9435,8 @@ mod bench_text_search;
 mod bench_iter_dispatch;
 #[cfg(test)]
 mod bench_posting_intersect;
+#[cfg(test)]
+mod bench_intersect_order;
 #[cfg(test)]
 mod bench_word_dict_scan;
 #[cfg(test)]

--- a/docs/issues/00799-engine-simplicity-pass.md
+++ b/docs/issues/00799-engine-simplicity-pass.md
@@ -210,20 +210,33 @@ projection over the same `pbits` again. Pass the card bits (or the derived candi
 loop, and `Candidates::len()` popcounts an entire bitmap. That is O(children² × words). Track the
 running minimum as sets are pushed.
 
+Measured (`bench_and_best.rs`, #811): 1.5x at two bitmap children, 2.5x at four, 3.5x at six —
+50 ns to 1.9 μs per And node at realistic widths, and nothing at all when every child is
+vec-shaped, since `Vec::len` was never the problem.
+
 ### 15. `and_all` clones a whole bitmap for nothing
 
 [2719-2725](../../card_engine/src/lib.rs#L2719):
 `bit_sets.split_first().map(|(first, rest)| { let mut acc = first.clone(); … })` — on an owned
 `Vec<Vec<u64>>`. `into_iter()` takes ownership instead.
 
+Measured (`bench_narrow_alloc.rs` section A, #811): 1.06-1.45x, i.e. 60-130 ns per `and_all` that
+sees bitmaps. Biggest at two printing-space operands (414 → 286 ns), shrinking as the AND chain
+grows and the saved memcpy becomes a smaller share.
+
 ### 16. Two avoidable allocations in narrowing
 
-- The oracle-word sparse expansion chains `union_sorted` once per matched dictionary word
+- ~~The oracle-word sparse expansion chains `union_sorted` once per matched dictionary word
   ([3172-3181](../../card_engine/src/lib.rs#L3172)) — quadratic in total postings for a needle that
-  hits many words. Collect, then `sort_unstable` + `dedup`: linearithmic and shorter.
-- The regex-factor arm clones the candidate vec on the first factor:
-  `acc.map_or(cand.clone(), …)` ([3255](../../card_engine/src/lib.rs#L3255)). A plain `match`
-  avoids it.
+  hits many words. Collect, then `sort_unstable` + `dedup`: linearithmic and shorter.~~
+  **Measured and rejected** (#811): the fold beats sort+dedup by 2-5x for the 98.8% of needles
+  that match ≤ 7 dictionary words, and only loses past ~24. Kept as a threshold proposal in
+  [local-engine-sparse-union-threshold.md](local-engine-sparse-union-threshold.md);
+  `bench_narrow_alloc.rs` section B holds the numbers.
+- The regex-factor arm clones the candidate vec — `acc.map_or(cand.clone(), …)`
+  ([3255](../../card_engine/src/lib.rs#L3255)). Note `map_or` takes its default **by value**, so
+  this clones on *every* factor, not just the first. A plain `match` avoids it: 2-3x on
+  single-factor regexes, 1.05-1.08x on multi-factor ones (`bench_narrow_alloc.rs` section C).
 
 ## Batch E — comment density
 

--- a/docs/issues/local-engine-sparse-union-threshold.md
+++ b/docs/issues/local-engine-sparse-union-threshold.md
@@ -1,0 +1,82 @@
+# Pick the oracle-word sparse union by matched-word count
+
+The oracle-word index's sparse expansion unions one posting row per matched dictionary word.
+Two strategies are possible and each wins a different regime; today the engine ships one of them
+unconditionally, and it is the right one for ~99% of needles. This doc records the measured
+crossover in case the other regime ever becomes worth serving.
+
+Spun out of #811 (item 16 of [00799](00799-engine-simplicity-pass.md)), where the rewrite was
+proposed as a pure simplification, measured as a regression, and reverted.
+
+## The two strategies
+
+`narrow_rec`'s `TextContains { field: OracleTextLower }` arm, `sparse_text_ids`:
+
+- **Fold** (shipped): `ids = union_sorted(ids, row)` once per matched word. Each step is an
+  O(|ids| + |row|) merge that reallocates the accumulator, so total work is quadratic in the
+  *number of matched words* `w` — the classic repeated-merge shape.
+- **Concatenate + sort**: `extend` every row, then one `sort_unstable` + `dedup`. Linearithmic in
+  total postings, one growth-amortized allocation.
+
+Same output either way: `union_sorted` dedups on equal, and so does `dedup`.
+
+## Measurement
+
+`cargo test --release bench_narrow_alloc -- --ignored --nocapture`, section B — real dictionary
+from `benchmarks/verify-order/real.store`, best-of-300, times per call.
+
+| needle | words matched | postings | fold | sort+dedup | fold ÷ sort |
+|---|---|---|---|---|---|
+| hexproof | 1 | 297 | 45 ns | 184 ns | 0.24× |
+| sacrifice | 2 | 585 | 447 ns | 2219 ns | 0.20× |
+| creature | 3 | 1086 | 1085 ns | 4555 ns | 0.24× |
+| equip | 4 | 1748 | 1859 ns | 7898 ns | 0.24× |
+| block | 7 | 2959 | 8554 ns | 13401 ns | 0.64× |
+| enchant | 8 | 4202 | 8985 ns | 20791 ns | 0.43× |
+| land | 18 | 1940 | 7600 ns | 8397 ns | 0.91× |
+| king | 19 | 1393 | 8246 ns | 5856 ns | 1.41× |
+| lock | 22 | 3102 | 25880 ns | 14059 ns | 1.84× |
+| less | 23 | 3158 | 13912 ns | 15208 ns | 0.91× |
+| fire | 34 | 126 | 2207 ns | 535 ns | 4.12× |
+| ring | 38 | 1188 | 13142 ns | 5146 ns | 2.55× |
+
+The crossover is governed by `w`, not by total postings — `fire` matches 34 words holding only 126
+postings between them and still favors sort+dedup by 4×, while `enchant` matches 8 words holding
+4,202 postings and favors the fold by 2.3×. Around `w` = 18-23 the two are within noise of each
+other in either direction, depending on whether a long row lands early in the fold (which inflates
+the accumulator for every later step) or late.
+
+## Why the fold ships
+
+Sweeping every eligible sparse dictionary word as its own needle (each is a legal query — `o:ring`
+is how a user reaches this path), 6,246 needles:
+
+| words matched | needles | share |
+|---|---|---|
+| 1 | 4,892 | 78.3% |
+| 2-3 | 988 | 15.8% |
+| 4-7 | 291 | 4.7% |
+| 8-15 | 61 | 1.0% |
+| 16-31 | 12 | 0.2% |
+| 32+ | 2 | 0.0% |
+
+98.8% of needles land at `w` ≤ 7, where the fold wins by 2-5×. Fourteen needles reach `w` ≥ 16.
+Switching unconditionally costs up to 11.8 μs on `o:enchant` to save up to 8 μs on `o:ring`.
+
+## The proposal, if it is ever worth it
+
+Branch on `sparse.len()`: fold below a threshold, concatenate + sort above it. From the table the
+threshold belongs around 24 — above the ambiguous 18-23 band, below the clear wins at 34+.
+
+Worth doing only if the needle mix shifts (a UI that generates wide fragment needles, or a
+tokenizer change that grows the dictionary's substring overlap). As of this measurement it buys a
+few microseconds on 0.2% of an already-microsecond path, in exchange for a tuned constant on a code
+path whose current form is one loop. `bench_narrow_alloc.rs` section B already benches both
+contenders and reports the needle distribution, so re-deciding is a single command.
+
+## Acceptance
+
+- `bench_narrow_alloc.rs` section B shows no regression at `w` ≤ 7 against the fold's numbers above.
+- The `w` ≥ 32 rows (`fire`, `ring`) improve by at least 2×.
+- The threshold is a named constant with the measured band in its comment, per the project's
+  measured-constant convention (`STREAM_MIN_MATCHES`, `MAX_NARROW_FRACTION`).


### PR DESCRIPTION
Batch D of #799, the narrowing-path items. Same results throughout; the differential tests
(force_plan_differential_agreement, fuzz_row_identity_matches_reference) and the full debug
suite pass unchanged. Every item here now has its own kernel micro-benchmark, and one of
them measured badly enough to be dropped.

**Operand order (item 12).** `and_all` and `intersect_operands` both sort operands
by ascending length and then seed with `swap_remove(0)`. That returns the shortest,
as the comment says — but it moves the *longest* into slot 0, so the rest of the
chain runs longest-first. `into_iter()` is both the fix and the simpler phrasing.

`bench_intersect_order.rs` measures the order alone: operands are pre-sorted and
the chain is driven by a precomputed index order, so nothing is cloned or sorted
inside the timed region. Best-of-300, 31,500-id universe, times in μs:

| operand mix        | k | swap_remove (μs) | ascending (μs) | speedup | rows |
|--------------------|---|------------------|----------------|---------|------|
| 200/4k/20k         | 3 |               40 |             38 |   1.06x |   13 |
| 200/2k/8k/20k      | 4 |               49 |             32 |   1.52x |    2 |
| 150/800/2k/6k/12k/24k | 6 |            43 |            3.4 |  12.72x |    0 |
| 4k/5k/6k           | 3 |               25 |             26 |   0.97x |  105 |
| 4k/4.4k/…/6k       | 6 |               46 |             47 |   0.97x |    1 |

Honestly: the win needs a *spread* of operand sizes, which is the common shape for
an And of one selective posting against a broad one. Where the operands are all
about the same size it is a 3% wash, reproducibly on the wrong side of even —
close sizes barely move the sum(|result|) term that order controls, and what is
left is allocation-size noise. The large multiples are the early exit doing the
work: ascending order reaches an empty result in two merges, and the existing
`if result.is_empty() { break }` then skips four large ones.

**`best` recomputed per child (item 14).** `narrow_rec`'s And arm recomputed
`min(len)` over every accumulated set on every iteration, and `Candidates::len`
popcounts a whole bitmap — O(children² × words) for a value that only shrinks. Now
maintained as sets are pushed, reusing the length the broad-child check already
computes.

`bench_and_best.rs` times the two orderings of that bookkeeping over child sets at the
real corpus dimensions (31,508 cards → 493-word bitmaps, 97,206 printings → 1,519-word
bitmaps). Both contenders pay the broad-child `len()` call, since both versions of the
shipped code do. Best-of-300, ns per call:

| children | k=2 | k=3 | k=4 | k=6 | k=8 | k=12 |
|----------|-----|-----|-----|-----|-----|------|
| card bits | 1.55x | 2.00x | 2.50x | 3.50x | 4.51x | 6.50x |
| printing bits | 1.50x | 2.00x | 2.50x | 3.52x | 4.52x | 6.64x |
| alternating bits/vecs | 2.00x | 2.00x | 3.00x | 4.00x | 4.73x | 7.02x |
| all vecs | 1.66x | 2.26x | 3.20x | 4.73x | 6.55x | 8.53x |

Real Ands are 2-6 children wide, so this is 50 ns (two card-space bitmaps, 143 → 93 ns)
to 1.9 μs (six printing-space bitmaps, 2702 → 767 ns) per And node. The multiples grow
quadratically past that but nothing generates a twelve-child And today; those rows are
there to show the shape. The all-vec row is the honest caveat — the ratios look identical
but the absolute numbers are 27 ns → 3 ns, because `Vec::len` was never the problem. The
win is entirely in avoided popcounts, so it only appears when plane-backed children are
in the And.

**`and_all`'s bitmap clone (item 15).** It cloned the first bitmap out of an owned
`Vec<Vec<u64>>`; `into_iter` takes it. `bench_narrow_alloc.rs` section A, best-of-300 over
a pool of pre-built inputs (both contenders consume their input, so it cannot be reused):
1.06-1.45x, or 60-130 ns per `and_all` that sees bitmaps. Biggest at two printing-space
operands (414 → 286 ns) and shrinking from there, exactly as the ratio of one saved memcpy
to a growing AND chain predicts.

**The regex-factor clone (item 16).** `acc.map_or(cand.clone(), |prev| intersect_sorted(…))`.
`map_or` takes its default **by value**, so that clone ran on *every* factor, not just the
first as the issue doc claimed; a `match` clones on none. `bench_narrow_alloc.rs` section C,
against real trigram candidate sets: 2.1-3.0x on single-factor regexes where the fold is
nothing but the clone (`destroy target creature`: 47 → 16 ns), and 1.05-1.08x on
multi-factor ones where `intersect_sorted` dominates (`draw (a|two) cards?`: 15.5 → 14.4 μs).

**The sparse expansion (item 16, dropped).** The other half of item 16 proposed replacing
the oracle-word sparse expansion's `union_sorted` fold — quadratic in the number of matched
dictionary words — with concatenate-then-`sort_unstable`+`dedup`. It is asymptotically
better and measurably worse. `bench_narrow_alloc.rs` section B, real dictionary from
`benchmarks/verify-order/real.store`:

| needle | words matched | postings | fold | sort+dedup | fold ÷ sort |
|--------|---------------|----------|------|------------|-------------|
| hexproof | 1 | 297 | 45 ns | 184 ns | 0.24x |
| sacrifice | 2 | 585 | 447 ns | 2219 ns | 0.20x |
| creature | 3 | 1086 | 1085 ns | 4555 ns | 0.24x |
| equip | 4 | 1748 | 1859 ns | 7898 ns | 0.24x |
| enchant | 8 | 4202 | 8985 ns | 20791 ns | 0.43x |
| land | 18 | 1940 | 7600 ns | 8397 ns | 0.91x |
| lock | 22 | 3102 | 25880 ns | 14059 ns | 1.84x |
| ring | 38 | 1188 | 13142 ns | 5146 ns | 2.55x |

The crossover is governed by the matched-word count, not by total postings (`fire` matches
34 words holding 126 postings between them and still favors sort+dedup 4x). Sweeping all
6,246 eligible sparse dictionary words as needles — each is a legal query, `o:ring` is how
a user reaches this path — 78.3% match one word, 98.8% match at most seven, and 0.2% reach
sixteen or more. So switching unconditionally spends 11.8 μs on `o:enchant` to save 8 μs on
`o:ring`. The fold stays, with a comment saying why; the benchmark keeps both contenders
and prints the needle distribution, and docs/issues/local-engine-sparse-union-threshold.md
records the threshold version for if that distribution ever shifts.

Batch D of #799.

## Testing

- `cargo test` (debug): 147 passed
- `cargo clippy --all-targets`: clean
- `cargo test --release bench_intersect_order bench_and_best bench_narrow_alloc -- --ignored --nocapture`
  for the tables above; each bench asserts its contenders agree before timing any of them.
  Both new benches use an inner repetition loop — `Instant` quantizes to ~41.7 ns on this
  machine, the same order as the smallest kernels here, so one call per timed window measures
  the quantum and nothing else.

Kernel micro-benchmarks rather than query A/Bs, per the project's usual practice for
sub-microsecond representation-level effects — and specifically because an end-to-end delta
would also fold in the router's plan choice.
