### PR TITLE
Consolidate the Measurement Toolkit Into Four Layers, and Add the Missing One

### DIFF
--- a/docs/issues/local-benchmark-toolkit-audit.md
+++ b/docs/issues/local-benchmark-toolkit-audit.md
@@ -88,15 +88,33 @@ draw queries from one universe, `query_sampler.py`."* Two of seven do.
 | harness | source | verdict |
 | --- | --- | --- |
 | `fit_cost_model`, `bench_cost_error_attribution` | `QuerySampler` | correct |
-| `bench_plan_misselection` | `client.query_runner.random_query` | **wrong universe** |
+| `bench_plan_misselection` | wild corpus (default) / `random_query` (opt-in) | **fixed** — see below |
 | `bench_plane_popcount_cost` | `random_query` | **wrong universe** |
 | `census_candidate_materialize` | `random_query` + wild corpus | wild slice is deliberate |
 | `bench_cost_model_agreement` | private `sample_query` | hardcoded predicate lists |
 | `bench_card_range_estimate` | private `random_range_query` | range-only is deliberate, values are not |
 
-`bench_plan_misselection` is the one that matters most — it produces the headline routing-regret
-number, from the generator `query_sampler` was written to replace. Switching it will move that
-number, so the switch needs a before/after recorded, not a silent edit.
+An earlier draft of this doc called `bench_plan_misselection` the worst case, on the grounds that
+the headline regret number came from `random_query`. That was wrong. Its default source is
+`--source wild-operators`, the real Scryfall traffic slice, which is the *right* universe for a
+regret number — regret is what users actually lose. Only the opt-in `--source random` used the load
+generator.
+
+That opt-in path now draws from `QuerySampler`. Same synthetic role, corpus-derived values,
+quantile-placed thresholds, and a real spread of distinct-on and orderby instead of a fixed
+`edhrec`. It changes what the source can find, measured at `--sample 150 --seed 0`:
+
+| | `random_query` | `QuerySampler` |
+| --- | --- | --- |
+| multi-plan queries | 150 | 103 |
+| mis-selected | 2 (1%) | 5 (5%) |
+| mean regret | 0.66 µs | 3.32 µs |
+| max regret | 72.0 µs | 162.1 µs |
+
+Five times the mis-selection rate over a smaller denominator, because the sampler produces more
+selective queries where fewer plans apply. The mis-selections it surfaces are shapes the old
+generator could not emit — `c:r usd>=0.47 usd<=0.63` and `cn>=13 cn<=108 name:of`, both bounded
+ranges, the shape `query_sampler`'s header singles out as missing from every older generator.
 
 ## Per-script disposition
 
@@ -150,10 +168,11 @@ spent on scripts that may not survive.
 
 ## Sequence
 
-1. Extract `load_engine` from `bench_bitplanes` into `costbench` (20 importers, mechanical).
-2. Add the shape filter to `QuerySampler`; port `bench_card_range_estimate` and
-   `bench_cost_model_agreement` off their private generators onto it.
-3. Switch `bench_plan_misselection` to `QuerySampler`, recording the before/after regret delta.
-4. Correct the reference doc's "one universe" claim.
-5. Harvest curated `CONFIGS` into fixtures, then delete the 25 closed/unreferenced scripts.
-6. Revisit the range-acquire cluster and the two agreement/percentile merges.
+1. ~~Extract `load_engine` from `bench_bitplanes` into `costbench`~~ — done, 35 call sites.
+2. ~~Add the shape filter to `QuerySampler`~~ — done, as `Shape`, with unit tests.
+3. ~~Switch `bench_plan_misselection`'s `random` source~~ — done, delta recorded above.
+4. ~~Correct the reference doc's "one universe" claim~~ — done.
+5. Port `bench_card_range_estimate` and `bench_cost_model_agreement` off their private range
+   generators onto `Shape(families={"range"}, predicates=1, ...)`.
+6. Harvest curated `CONFIGS` into fixtures, then delete the 25 closed/unreferenced scripts.
+7. Revisit the range-acquire cluster and the two agreement/percentile merges.

--- a/docs/issues/local-benchmark-toolkit-audit.md
+++ b/docs/issues/local-benchmark-toolkit-audit.md
@@ -1,0 +1,159 @@
+# Benchmark toolkit audit: 42 scripts, and what shape targeting would collapse
+
+`scripts/` holds 65 Python files, 42 of them `bench_*` / `study_*` / `census_*`. This is a keep /
+merge / delete pass over all 42, plus the one API change that makes most of the deletions possible.
+
+Companion to [reference-cost-model-measurement.md](reference-cost-model-measurement.md) (which tool
+answers which question) and [the performance PR workflow](../workflows/performance-pr-workflow.md)
+(when in a PR's life to reach for each).
+
+## Method, and its one blind spot
+
+Classified by where a script is referenced from: a doc outside `docs/issues/done/` means live; only
+`done/` means the investigation that spawned it has shipped; neither means unreferenced.
+
+**That signal is unreliable for anything recent.** `bench_plane_popcount_cost.py` and
+`census_candidate_materialize.py` both landed 2026-08-02 in #816 and have no doc reference yet —
+and `bench_plane_popcount_cost` has an active worktree against it. New is not dead. Dates were
+checked for every zero-reference script before recommending anything.
+
+| bucket | n |
+| --- | --- |
+| Live — referenced from an open doc | 14 |
+| Closed — referenced only from `done/` | 20 |
+| Unreferenced, ≥3 weeks old | 6 |
+| Unreferenced, landed this week | 2 |
+| **total** | **42** |
+
+(`survey_queries.py`, `query_sampler.py`, `costbench.py` and `build_wild_corpus.py` are shared
+infrastructure rather than benchmarks, and are outside this count.)
+
+## The structural finding: targeting belongs in the sampler
+
+Roughly 20 of these scripts exist because they need **one query shape**: a bare range under
+`unique=printing`, a compose leaf, a negated range, a two-sided bound. Each hand-rolls a `CONFIGS`
+list or a private generator, then re-implements the same measurement loop around it.
+
+`query_sampler.py` already has the hard part. `predicate(family, rng)` is public, there are 13
+families, and thresholds are drawn at a uniformly-sampled **quantile of the real column**. What it
+lacks is any way to constrain a draw. `query()` always takes 1–3 predicates from the full weighted
+table; `unique()` and `orderby()` always draw from theirs.
+
+A shape filter — restrict families, pin the predicate count, restrict distinct-on and orderby —
+would let a targeted benchmark be a flag rather than a file:
+
+```python
+Shape(families={"range"}, predicates=1, unique={"printing"}, orderby={"edhrec"})
+```
+
+### What that does and does not replace
+
+It replaces the **generated** half. `bench_printing_range`'s `target` group is exactly the shape
+above; `bench_range_bits`' is the same under `unique=card`.
+
+It does **not** replace the curated half, and that half is the science:
+
+- **Selectivity anchors.** `subtype=Human` is in `bench_collection_eq_gt` because Human is the most
+  common subtype at 10,567 postings — chosen so a full scan costs something real.
+- **Matched algebraic pairs.** `-usd<0.25 usd<5` against `usd>=0.25 usd<5` in
+  `bench_negated_range_narrowing`. A sampler cannot generate a pair that must come out equal.
+- **Controls chosen to be unaffected.** The `control` groups are picked by knowing what the change
+  touches. That is a human judgement about the diff.
+- **Negation.** No family produces `-set:dmu`. Several benchmarks turn on exactly that.
+
+So the realistic outcome is not deletion but compression: a targeted benchmark becomes a short
+curated `CONFIGS` plus a shape spec, sharing one runner. Call it ~110 lines down to ~30.
+
+### Where it pays most
+
+Three **cost-model** harnesses hand-roll a range generator, and all three sample selectivity in a way
+that cannot answer the question they were built to ask:
+
+| harness | how it picks a range threshold |
+| --- | --- |
+| `bench_card_range_estimate` | `rng.choice(...)` over a hardcoded value list |
+| `bench_cost_model_agreement` | log-uniform over hardcoded bounds — `usd (0.05, 400)`, `cn (1, 500)` |
+| `query_sampler` | uniformly-drawn **quantile of the actual column** |
+
+`query_sampler.py`'s own docstring makes the case against the first two: a cost model is a function
+of selectivity, and a benchmark that samples a handful of arbitrary points cannot say whether the
+model is right. Shape targeting is what lets those two adopt it without losing their range-only
+focus.
+
+## The query-universe defect, separately
+
+[reference-cost-model-measurement.md](reference-cost-model-measurement.md) states that *"All of them
+draw queries from one universe, `query_sampler.py`."* Two of seven do.
+
+| harness | source | verdict |
+| --- | --- | --- |
+| `fit_cost_model`, `bench_cost_error_attribution` | `QuerySampler` | correct |
+| `bench_plan_misselection` | `client.query_runner.random_query` | **wrong universe** |
+| `bench_plane_popcount_cost` | `random_query` | **wrong universe** |
+| `census_candidate_materialize` | `random_query` + wild corpus | wild slice is deliberate |
+| `bench_cost_model_agreement` | private `sample_query` | hardcoded predicate lists |
+| `bench_card_range_estimate` | private `random_range_query` | range-only is deliberate, values are not |
+
+`bench_plan_misselection` is the one that matters most — it produces the headline routing-regret
+number, from the generator `query_sampler` was written to replace. Switching it will move that
+number, so the switch needs a before/after recorded, not a silent edit.
+
+## Per-script disposition
+
+**Keep — the cost-model toolkit (10).** Each answers a structurally distinct question; see the
+reference doc's table. Two merges are defensible:
+
+- `bench_cost_model_agreement` (441 lines) reports an absolute measured/predicted median.
+  `bench_cost_error_percentiles` (97 lines) reports the same ratio at nine percentiles — the median
+  is one of its columns. The agreement harness's paging/decline/phase-share reports are the part
+  that is genuinely its own; those should move rather than be lost.
+- `bench_plan_misselection`'s argmin check overlaps `bench_regret_matrix`'s transition slice.
+
+**Keep — the other four live ones.** `bench_verify_order`, plus the range-acquire cluster below.
+
+`bench_bitplanes` is classified closed (all four references are in `done/`) but **must not be
+deleted**: `load_engine` lives in it and 20 scripts import it from there. Extract that into
+`costbench` first, then the remaining 200 lines can be judged on their own.
+
+**Delete — closed investigations (19).** Referenced only from `docs/issues/done/`, and the workflow
+doc already treats the targeted set as disposable per-investigation work:
+
+`bench_arith_tuple_postings`, `bench_border_planes`, `bench_collection_compose`,
+`bench_collection_eq_gt`, `bench_compose_orderby_range_walk`, `bench_compose_permutation_fallback`,
+`bench_cost_guards`, `bench_guard_validation`, `bench_legality_banned_restricted`,
+`bench_legality_divergent`, `bench_memo_crossover`, `bench_negated_range_narrowing`,
+`bench_oracle_word_index`, `bench_permuted_order`, `bench_printing_planes`, `bench_printing_range`,
+`bench_produces_planes`, `bench_rarity_planes`, `bench_tag_postings_compose`.
+
+Git history is the archive; a closed benchmark is recoverable and a stale one is a trap. Before
+deleting any, harvest its curated `CONFIGS` — the selectivity anchors and control groups are the
+expensive part and should survive as shape-spec fixtures.
+
+**Delete — unreferenced and old (6).** `bench_devotion`, `bench_name_order`, `bench_random`,
+`bench_range_bits`, `bench_price_range_targeted`, `bench_text_memo`. All ≥3 weeks old with no doc
+reference in either state.
+
+**Leave alone — too new to judge (2).** `bench_plane_popcount_cost` (active worktree),
+`census_candidate_materialize`. Both from #816 this week. Revisit once their work lands.
+
+**Range-acquire cluster (4) — merge candidate.** `bench_card_range_estimate`,
+`bench_range_estimate_scan`, `study_range_slice_cardinality`, `study_range_slice_layouts` all probe
+the same acquire. Three are live. Worth one pass to see whether they are one tool with three
+reports.
+
+## Net
+
+42 → about 17, and the reduction comes mostly from deleting finished work rather than from clever
+sharing. That ordering matters: **triage before consolidation.** Two of the three harnesses queued
+for a query-source fix turned out to be unreferenced, and fixing them first would have been work
+spent on scripts that may not survive.
+
+## Sequence
+
+1. Extract `load_engine` from `bench_bitplanes` into `costbench` (20 importers, mechanical).
+2. Add the shape filter to `QuerySampler`; port `bench_card_range_estimate` and
+   `bench_cost_model_agreement` off their private generators onto it.
+3. Switch `bench_plan_misselection` to `QuerySampler`, recording the before/after regret delta.
+4. Correct the reference doc's "one universe" claim.
+5. Harvest curated `CONFIGS` into fixtures, then delete the 25 closed/unreferenced scripts.
+6. Revisit the range-acquire cluster and the two agreement/percentile merges.

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -1,22 +1,39 @@
 # Measuring the cost model: which tool answers which question
 
-Seven harnesses, built while doing the work in
+Eight harnesses, built while doing the work in
 [local-engine-cost-model-agreement.md](local-engine-cost-model-agreement.md). They exist because each
 answers a question the others structurally cannot, and reaching for the wrong one wastes days — three
 successive reworkings of one term improved the metric being watched and moved routing by
 `-0.003 µs, CI [-0.206, +0.214]`.
 
+This is the tool-picking reference. For *when in a PR's life* to reach for each one, see
+[the performance PR workflow](../workflows/performance-pr-workflow.md), which organizes the same
+tools into four layers: features, plan costs, plan execution, end-user latency.
+
 Pick by question:
 
 | question | tool |
 | --- | --- |
+| Do the FEATURES match what the executor did? | [`bench_feature_accuracy.py`](../../scripts/bench_feature_accuracy.py) |
 | Is this plan's absolute cost right? | [`bench_cost_model_agreement.py`](../../scripts/bench_cost_model_agreement.py) |
 | What SHAPE is the error — uniform, or a tail? | [`bench_cost_error_percentiles.py`](../../scripts/bench_cost_error_percentiles.py) |
 | Is it the features, the coefficients, or the arm's shape? | [`bench_cost_error_attribution.py`](../../scripts/bench_cost_error_attribution.py) |
 | What should the constants be? | [`fit_cost_model.py`](../../scripts/fit_cost_model.py) |
 | Does the model ORDER two plans correctly? | [`bench_pairwise_ordering.py`](../../scripts/bench_pairwise_ordering.py) |
 | Where does routing actually lose time? | [`bench_regret_matrix.py`](../../scripts/bench_regret_matrix.py) |
-| Did a change help end to end? | [`bench_plan_misselection.py`](../../scripts/bench_plan_misselection.py) `--compare`, or [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py) vs `main` |
+| Did this PLAN's executor get faster, picked or not? | [`bench_plan_execution_ab.py`](../../scripts/bench_plan_execution_ab.py) `--compare` |
+| Did a change help end to end? | [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py) vs `main` |
+
+All of them are built on [`scripts/costbench.py`](../../scripts/costbench.py), which owns the
+sampling loop, the nearest-rank percentiles, the paired-bootstrap comparison, and — the one that
+matters for comparing numbers ACROSS these tools — the single definition of a plan's own cost,
+`plan_self_ns`: min-of-trials, less `ns_prepare`, except under a range acquire, dropping the row when
+the subtraction overshoots. Three harnesses used to disagree about that rule, one of them netting
+`acquire_ns` (a different participant entirely), so their columns were never comparable.
+
+`costbench.predicted_ns` is the other shared screen: `cost::plan_cost` returns `f64::INFINITY` for a
+declining compose, which no `predicted_ns <= 0` guard catches, and any ratio built from it silently
+poisons the percentile cell it lands in.
 
 The end-to-end answer for the whole cost-model stack is recorded in
 [local-engine-cost-model-stack-result.md](local-engine-cost-model-stack-result.md) — including the
@@ -74,6 +91,18 @@ the other, and lost overall.
   `--sample 400` the same engine and seed produced 0.26 and 0.82 µs on two runs.
 - **Interleave A/B/A/B.** All-of-A-then-all-of-B maps machine drift onto the comparison. A sequential
   run showed a ~3% median slowdown spread evenly across acquire branches the change never touched.
+- **A cross-process A/B needs far more trials than a within-call comparison, and breadth is not a
+  substitute.** `min` over the trials is a floor estimator whose distance above the floor depends on
+  the interference that run saw, and that error is common-mode across every query in a run — so
+  pairing and a wide sample do not cancel it. Both A/B harnesses false-positived on same-build,
+  same-seed pairs at 7 trials: the plan-execution one called every plan "SLOWER" by 4–9% with
+  "faster on 0"; the latency one called `-1.0 µs, CI [-1.6, -0.5]` over 388 paired queries. Both are
+  clean at 30. Prefix-min convergence, absolute, is much gentler — 0.4–1.4% above the floor at k=7,
+  converged by k=30 — which is why the within-call diagnostics keep the cheaper default. The table
+  is in [`costbench.py`](../../scripts/costbench.py).
+- **Run the canary.** Compare a build against ITSELF before believing any cross-build number.
+  `bench_plan_execution_ab.py` also keeps acquire as a CONTROL and prints an adjusted column when it
+  moves; if that fires, raise `--trials` before reading anything else.
 - **A grid optimum on the boundary is not an optimum.** Two sweeps had to be redone for this. Use
   geometric grids open at both ends, and check the optimum is interior.
 - **Fixing a feature can make agreement worse**, because coefficients were compensating. Expect it,
@@ -82,7 +111,10 @@ the other, and lost overall.
   had silently drifted for two revisions; it now checks itself against `predicted_ns` and refuses to
   fit below 99% agreement.
 - **A plan that DECLINES accumulates no trials**, so it is absent from every measurement here. Enabling
-  a declining path introduces a population nothing has ever measured.
+  a declining path introduces a population nothing has ever measured. The decline is not free —
+  `DeclineSparseExact` fires after a full compose — and its cost is in `declined_ns`, which
+  `bench_cost_model_agreement.py` reports in its own section rather than in the measured/predicted
+  table.
 - **Agreement is not sufficient.** One fix improved routing significantly (`-0.166 µs`,
   CI `[-0.341, -0.007]`) while making median agreement WORSE — a per-cell median cannot see a 56x error
   on 4% of rows.

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -39,11 +39,19 @@ The end-to-end answer for the whole cost-model stack is recorded in
 [local-engine-cost-model-stack-result.md](local-engine-cost-model-stack-result.md) — including the
 bands, because a mean over this distribution understates the tail and a p99 overstates it.
 
-All of them draw queries from one universe, [`query_sampler.py`](../../scripts/query_sampler.py), in
+Most of them draw queries from one universe, [`query_sampler.py`](../../scripts/query_sampler.py), in
 one of two weightings. Diagnostics default to `uniform` because their job is to FIND errors and
 uniform reaches the rare tails; latency defaults to `realistic` because there the question is what
 users wait for. Both matter: artwork is 5% of realistic traffic and carries **50% of all routing
 regret**.
+
+Constrain the draw with `Shape` rather than writing a generator — `Shape(families={"range"},
+predicates=1, unique={"printing"})` gives a bare printing-space range while keeping corpus-derived
+values and quantile-placed thresholds. Two harnesses still hand-roll a range generator off hardcoded
+values (`bench_card_range_estimate`, `bench_cost_model_agreement`) and should move; see
+[local-benchmark-toolkit-audit.md](local-benchmark-toolkit-audit.md). Two draw from real traffic on
+purpose: `bench_plan_misselection --source wild-operators` and `census_candidate_materialize`, where
+the question is what users actually lose.
 
 ## The two matrices, and why both
 

--- a/docs/workflows/performance-pr-workflow.md
+++ b/docs/workflows/performance-pr-workflow.md
@@ -1,0 +1,209 @@
+# Performance PR Workflow: Design Doc to Merge
+
+Applies to changes justified by "queries get faster" or "memory footprint shrinks" — engine
+kernel work, index/bitplane additions, SQL generation changes. Correctness-only fixes don't need
+a benchmark story; see [differential property tests](https://github.com/jbylund/sylvan_librarian/pull/641)
+for how those are verified instead.
+
+## 1. Write the design doc
+
+Start (or refine) a doc at `docs/issues/<name>.md`. These are local working notes — untracked,
+not shipped in the PR diff — so write freely. Shape follows the
+[performance issue template](../../.github/ISSUE_TEMPLATE/performance.md):
+
+- **Measured problem** — numbers, and the protocol used to get them (warmup/window, corpus, build, machine)
+- **Where the cost is** — mechanism, not symptom
+- **Proposed approach** — design, expected cost, alternatives considered
+- **Acceptance** — which benchmark proves it, which queries must improve, what must not regress, and
+  — for executor work — **which physical plan** is being changed, since that decides whether the
+  broad screen can see the change at all (step 2's plan-pinned block)
+
+If the design claims a predicate is exact/tight, check that claim against the existing composition
+invariants *before* writing any code, not after: `Not` only narrows through tight children, and
+`And`/`Or` of same-space tight sets is assumed to stay tight. A predicate that's only exact in
+isolation (true for a lone leaf, false once ANDed with another predicate over the same
+non-card-invariant domain — a shared-witness problem) is a silent correctness bug if it's marked
+tight anyway, not just a missed optimization. This is a design-time review, not something a
+benchmark will surface — a wrong exactness claim produces wrong *results*, not just slow ones, and
+a differential test only catches it if someone thinks to write the specific case that breaks it.
+
+Recent examples: `local-engine-legality-bitplanes.md`, `00630-engine-card-bitplanes.md` (both closed out under
+`docs/issues/done/` once merged).
+
+## 2. Build the test sets: broad screen, plan-pinned, targeted set, and kernel micro-benchmarks
+
+Three rungs, and which one answers the question depends on what changed. The broad screen measures
+**what a user gets** — the cost-based router picks a plan and the number includes that choice. A
+plan-pinned run measures **one executor**. A kernel benchmark measures **one subroutine**. Reaching
+for the wrong rung is the most common way a real win reads as noise; see the plan-pinned block for
+why that is a router-era problem this doc predates.
+
+**Broad regression screen** — `scripts/survey_queries.py`. This is the one to reach for by
+default; it composes `client/query_runner.py`'s hand-tuned dimension weights (30+ query types,
+no exact-name bias) with a slice of real `scryfall.com/search` traffic from
+`benchmarks/wild-queries/wild-corpus.jsonl`. Exact-name lookups (`!"Sol Ring"`) dominate that wild
+corpus by raw frequency, so they're deliberately capped at `WILD_NAME_LOOKUP_FRACTION = 1/6` of
+the wild slots (see PR #646) rather than sampled proportionally — if a future edit to that file
+removes the cap, the survey silently reverts to being name-search-heavy, so check for it before
+trusting a survey run as a general screen.
+
+```bash
+.venv/bin/python scripts/survey_queries.py --out benchmarks/survey/baseline-main.csv \
+    --count 400 --wild 120 --seed 42
+```
+
+`client/query_runner.py` itself is the live load-testing loop this reuses weights from — don't
+invoke it directly for a one-shot baseline CSV.
+
+**Targeted set** — a fixed `CONFIGS` list scoped to the feature area, following the pattern in
+`scripts/bench_bitplanes.py`: named groups of queries that exercise the changed code path, plus a
+handful of `control` queries picked to be unaffected (they must not regress). Corpus is exported
+once from the blue DB, not regenerated per run:
+
+```bash
+COLS=$(.venv/bin/python -c "import card_engine; print(', '.join(card_engine.ENGINE_COLUMNS))")
+docker exec sylvan_blue-postgres-1 psql -U foouser -d magic -X -At \
+    -c "SELECT row_to_json(t) FROM (SELECT $COLS FROM magic.cards) t" > benchmarks/<feature>/corpus.jsonl
+```
+
+Check whether a corpus already under `benchmarks/` covers this schema before re-exporting —
+`ENGINE_COLUMNS` changes rarely, so an existing export (e.g. `benchmarks/bitplanes/corpus.jsonl`)
+is usually still valid and saves standing up Docker/the blue DB at all.
+
+If the change isn't engine/bitplane-shaped, write a small new script on this pattern rather than
+stretching `survey_queries.py` to cover area-specific cases it wasn't built for.
+
+**Plan-pinned measurement** — for any change to a *plan's executor* rather than to the cost model.
+This is the rung that did not exist when the rest of this doc was written: with a cost-based router
+in front of six physical plans, an end-to-end latency delta is the sum of two independent effects,
+and the survey cannot tell them apart.
+
+- The executor got faster **but the router never picks it**, so the survey moves by 0% and the win
+  looks like it never happened.
+- The change moved a `cost::plan_cost` input, so the router picks *differently* — the survey moves,
+  and none of the delta is the executor's. The same query can be served by a different plan
+  before and after, which also silently breaks the `total`-row parity check's usefulness as a
+  "same work, less time" argument.
+
+`explain_analyze` ([`card_engine/src/lib.rs`](../../card_engine/src/lib.rs)) is the fix, and it is
+already built: it drives `run_query_with_plan` for **every applicable plan**, `num_warmups` discarded
+rounds then `num_trials` recorded ones, and returns raw per-trial nanoseconds next to each plan's
+predicted cost. Pin the plan under test, compare it to itself across builds, and report the routing
+change as a separate line item.
+
+Two scripts already drive it — prefer extending one over writing a third:
+
+```bash
+# per-(plan, acquire branch) measured vs. predicted, plus the phases no cost term describes
+.venv/bin/python scripts/bench_cost_model_agreement.py --seconds 120
+# does argmin(predicted) match argmin(measured)? reports regret, in time, over multi-plan queries
+.venv/bin/python scripts/bench_plan_misselection.py --source wild-operators --sample 200
+```
+
+Three properties of `trials_ns` that decide whether a number means anything:
+
+- It is a fair head-to-head **between plans**, not a reproduction of a real query's wall time. Each
+  forced run re-runs its own `prepare_candidates`, where `run_query_routed` acquires the shared
+  artifact once. Never compare a `trials_ns` figure against a `query()` latency.
+- Participants are shuffled per round from a fixed seed, not rotated, so ordering is reproducible but
+  **not position-balanced**. Since every consumer reduces with `min`, a participant can draw the warm
+  tail twice at low trial counts. Use ≥ 7 trials (what `bench_cost_model_agreement.py` uses); do not
+  read a 2–3 trial run as a head-to-head between plans within ~10% of each other.
+- A plan can return `None` — declined on its applicability predicate or, for the fastpaths,
+  structurally. A decline still costs real time (`DeclineSparseExact` composes the printing bitmap
+  before turning back) and produces no page, so it appears in no measured/predicted table. If the
+  change touches a fastpath's gate, the decline cost is part of the result, not an absence of one.
+
+**Acceptance for an executor change therefore has two halves**, and a PR that reports only the first
+has not shown the change helps anyone: the pinned plan is faster, *and* the router still routes to it
+(or the cost model was updated in the same PR so that it now does). An executor win the router
+declines to use is a latent win, and the PR body should say so plainly rather than quoting a survey
+delta that came from somewhere else.
+
+**Kernel micro-benchmarks** — for representation-level questions neither of the above can resolve:
+which of two algorithms/data structures wins for a specific sub-routine, or *why* a broad-survey
+regression happened once you know one exists. End-to-end query timing can't isolate sub-microsecond
+effects; a kernel benchmark runs the two contenders directly against each other over real data,
+nothing else in the loop. Follow the existing pattern (`bench_mana.rs`, `bench_verify_cost.rs`,
+`bench_text_search.rs`, `bench_posting_intersect.rs`, `bench_iter_dispatch.rs`,
+`bench_word_dict_scan.rs`): a `#[cfg(test)] mod bench_<name>;` in `lib.rs`, an `#[ignore]`d test
+function reading `benchmarks/verify-order/real.store` (rebuild it if the archive layout changed
+since it was last built — see any of those files' module doc for the one-time command), asserting
+every contender agrees on real data before timing any of them, run via
+`cargo test --release bench_<name> -- --ignored --nocapture`. This is what actually diagnosed and
+fixed the regression in #663 (`bench_word_dict_scan.rs` comparing `match_indices` vs `memchr::memmem`
+over the real dictionary blob) — reach for it whenever the broad/targeted scripts show something
+regressed but not *why*, not only when scoping a brand-new representation up front.
+
+## 3. Baseline on main
+
+Run both scripts against a `main` build before touching anything. Save CSVs under
+`benchmarks/<feature>/`, named by branch or commit sha (e.g. `baseline-main-d3c5e58.csv`). The
+`benchmarks/` tree is untracked working data — never committed, just local scratch for the
+duration of the PR. A `git worktree add <path> main` alongside the working branch is the clean way
+to get a `main` build without disturbing uncommitted work.
+
+If the change touches archive layout (`CardIndexes`, any new/changed index struct), also capture a
+memory baseline: build with `--features alloc-counter` and read `QueryEngine.mem_stats()` after
+loading the same corpus (`archive_bytes`, `indexes_rkyv_bytes`, `reload_peak` are the ones worth
+tracking). The issue template's "Measured problem" section already asks for "archive bytes, RSS"
+alongside query timings — this is easy to skip since the query-latency scripts don't touch it at
+all, but a change can shrink or grow the archive independently of what happens to query speed (#663
+turned out to shrink it 14%, discovered only after the PR was already up because nobody had asked).
+
+## 4. Implement, with correctness first
+
+Add/extend unit and differential tests before chasing speed. For engine changes, a `total`
+row-count column doubling as a parity check (identical across builds) is the cheap way to catch a
+change that's fast because it's wrong. Self-review the diff before re-measuring — don't loop
+performance tuning on top of a design you haven't re-read.
+
+## 5. Re-measure and loop
+
+Re-run the same two scripts against the branch build, same corpus and seed. Compare:
+
+- Broad screen: percentiles (p50/75/90/95/99/max), a "top improvements" table, and — importantly —
+  every remaining regression, not just the ones that look bad in aggregate.
+- Targeted set: per-query before/after/speedup plus a geometric mean.
+- Plan-pinned, if the change touched an executor: the target plan's `trials_ns` before/after, **and**
+  separately whether the routed pick changed on those same queries. A broad-screen delta that
+  disagrees with the pinned delta is not a contradiction to explain away — it means routing moved,
+  and the two numbers are measuring different things.
+- Memory, if step 3 captured a baseline: re-run `mem_stats()` against the branch build, same corpus.
+
+Fix regressions, look for further wins, repeat until the branch is in good shape. This is the slow
+part — budget for several iterations, not one measurement. When a regression shows up but its cause
+isn't obvious from either script's output, that's the point to reach for a kernel micro-benchmark
+(see step 2) rather than guessing and re-measuring blind.
+
+## 6. Open the PR
+
+Use `.github/PULL_REQUEST_TEMPLATE.md`'s Performance section: a `Benchmark | Before | After |
+Change` table, geometric mean, and which corpus was used — or, if step 3 captured a memory
+baseline, the template's own note to swap that table for a before/after memory profile instead
+(or alongside it, if both moved). Link the design doc's issue number if
+one was filed.
+
+Report before/after in the **most natural unit for the magnitude** — if the numbers are
+sub-millisecond, use μs, not `0.088 ms` (leading-zero decimals bury the scale and misread at a
+glance). Every before/after table (in the PR body and the docs) must, without exception:
+
+- Put the unit **in the column header** (`off µs` / `Before (μs)`), never in a caption or repeated
+  per cell — a reader scanning the table sees the numbers, not the prose around it.
+- Use the **same unit on both sides** of a comparison, picked from the smaller value. (`Change`/speedup
+  is a ratio, so it's unitless.)
+- Include a **`rows`/`total` parity column** (identical across builds — the cheap correctness check)
+  and, when several queries move, a **geometric-mean speedup** over the impacted rows so the summary
+  is one honest number rather than a cherry-picked max.
+
+Examples of this workflow end-to-end: PR #663 (oracle word index — a kernel micro-benchmark
+diagnosed and fixed a broad-survey regression the other two tools could only detect, and a memory
+baseline turned up an unplanned 14% archive shrink), #659 (numeric-range bitplanes), #658
+(exactness propagation), #654 (legality bitplanes), #646 (name-sort permutation — the PR that
+added the wild corpus's exact-name cap described above), #639 (bigram index, broad-screen
+percentile table).
+
+## Related
+
+`docs/issues/local-query-benchmark-suite.md` proposes formalizing corpus generation further (a
+`--generate-corpus` flag) — unimplemented; the manual export in step 2 is the current state.

--- a/docs/workflows/performance-pr-workflow.md
+++ b/docs/workflows/performance-pr-workflow.md
@@ -1,209 +1,159 @@
 # Performance PR Workflow: Design Doc to Merge
 
-Applies to changes justified by "queries get faster" or "memory footprint shrinks" — engine
-kernel work, index/bitplane additions, SQL generation changes. Correctness-only fixes don't need
+Applies to changes justified by "queries get faster" or "memory footprint shrinks" — engine kernel
+work, index/bitplane additions, cost-model changes, SQL generation. Correctness-only fixes don't need
 a benchmark story; see [differential property tests](https://github.com/jbylund/sylvan_librarian/pull/641)
 for how those are verified instead.
 
 ## 1. Write the design doc
 
-Start (or refine) a doc at `docs/issues/<name>.md`. These are local working notes — untracked,
-not shipped in the PR diff — so write freely. Shape follows the
-[performance issue template](../../.github/ISSUE_TEMPLATE/performance.md):
+Start (or refine) a doc at `docs/issues/<name>.md`, shaped by the
+[performance issue template](../../.github/ISSUE_TEMPLATE/performance.md): measured problem (with the
+protocol that produced the numbers), where the cost is, proposed approach, and acceptance.
 
-- **Measured problem** — numbers, and the protocol used to get them (warmup/window, corpus, build, machine)
-- **Where the cost is** — mechanism, not symptom
-- **Proposed approach** — design, expected cost, alternatives considered
-- **Acceptance** — which benchmark proves it, which queries must improve, what must not regress, and
-  — for executor work — **which physical plan** is being changed, since that decides whether the
-  broad screen can see the change at all (step 2's plan-pinned block)
+**These docs are tracked and this repo is public.** Everything under `docs/issues/` is committed —
+the sole exception is `docs/issues/security-*`, which is gitignored. Read
+[docs/issues/README.md](../../docs/issues/README.md) before writing anything you would not publish.
 
-If the design claims a predicate is exact/tight, check that claim against the existing composition
-invariants *before* writing any code, not after: `Not` only narrows through tight children, and
-`And`/`Or` of same-space tight sets is assumed to stay tight. A predicate that's only exact in
-isolation (true for a lone leaf, false once ANDed with another predicate over the same
-non-card-invariant domain — a shared-witness problem) is a silent correctness bug if it's marked
-tight anyway, not just a missed optimization. This is a design-time review, not something a
-benchmark will surface — a wrong exactness claim produces wrong *results*, not just slow ones, and
-a differential test only catches it if someone thinks to write the specific case that breaks it.
+For acceptance, name **which of the four measurement layers below** proves the change, and for
+executor work name **which physical plan** you are changing. That decides whether an end-to-end
+measurement can see it at all.
 
-Recent examples: `local-engine-legality-bitplanes.md`, `00630-engine-card-bitplanes.md` (both closed out under
-`docs/issues/done/` once merged).
+If the design claims a predicate is exact/tight, check that against the composition invariants
+*before* writing code: `Not` only narrows through tight children, and `And`/`Or` of same-space tight
+sets is assumed to stay tight. A predicate exact in isolation but not once ANDed with another over
+the same non-card-invariant domain is a silent correctness bug, not a missed optimization — it
+produces wrong *results*, and no benchmark will surface it.
 
-## 2. Build the test sets: broad screen, plan-pinned, targeted set, and kernel micro-benchmarks
+## 2. The four measurement layers
 
-Three rungs, and which one answers the question depends on what changed. The broad screen measures
-**what a user gets** — the cost-based router picks a plan and the number includes that choice. A
-plan-pinned run measures **one executor**. A kernel benchmark measures **one subroutine**. Reaching
-for the wrong rung is the most common way a real win reads as noise; see the plan-pinned block for
-why that is a router-era problem this doc predates.
+With a cost-based router in front of six physical plans, "the query got faster" is four separate
+questions, and a number from one layer cannot answer another. Reaching for the wrong layer is the
+most common way a real win reads as noise.
 
-**Broad regression screen** — `scripts/survey_queries.py`. This is the one to reach for by
-default; it composes `client/query_runner.py`'s hand-tuned dimension weights (30+ query types,
-no exact-name bias) with a slice of real `scryfall.com/search` traffic from
-`benchmarks/wild-queries/wild-corpus.jsonl`. Exact-name lookups (`!"Sol Ring"`) dominate that wild
-corpus by raw frequency, so they're deliberately capped at `WILD_NAME_LOOKUP_FRACTION = 1/6` of
-the wild slots (see PR #646) rather than sampled proportionally — if a future edit to that file
-removes the cap, the survey silently reverts to being name-search-heavy, so check for it before
-trusting a survey run as a general screen.
+| # | question | tool |
+| --- | --- | --- |
+| 1 | Are the model's **features** right — do the estimates match what the executor did? | [`bench_feature_accuracy.py`](../../scripts/bench_feature_accuracy.py) |
+| 2 | Are the **plan costs** right — does predicted match measured? | [`bench_cost_error_percentiles.py`](../../scripts/bench_cost_error_percentiles.py) |
+| 3 | Did a **plan's execution** get faster, whether or not the router picks it? | [`bench_plan_execution_ab.py`](../../scripts/bench_plan_execution_ab.py) |
+| 4 | Did the **end user** get a faster answer? | [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py), [`survey_queries.py`](../../scripts/survey_queries.py) |
 
-```bash
-.venv/bin/python scripts/survey_queries.py --out benchmarks/survey/baseline-main.csv \
-    --count 400 --wild 120 --seed 42
-```
+Layers 1 and 2 are diagnosis; 3 and 4 are acceptance. All of them share one core,
+[`scripts/costbench.py`](../../scripts/costbench.py) — the sampling loop, the nearest-rank
+percentiles, and the single definition of "what this plan costs to run" (`plan_self_ns`). Use it for
+anything new rather than starting a twelfth private copy.
 
-`client/query_runner.py` itself is the live load-testing loop this reuses weights from — don't
-invoke it directly for a one-shot baseline CSV.
+For diagnosing *which* of features / model shape / coefficients is at fault once layer 1 or 2 shows
+an error, and for the regret and pairwise-ordering views, see
+[reference-cost-model-measurement.md](../../docs/issues/reference-cost-model-measurement.md). That is
+the tool-picking reference; this doc is the process.
 
-**Targeted set** — a fixed `CONFIGS` list scoped to the feature area, following the pattern in
-`scripts/bench_bitplanes.py`: named groups of queries that exercise the changed code path, plus a
-handful of `control` queries picked to be unaffected (they must not regress). Corpus is exported
-once from the blue DB, not regenerated per run:
+### Layers 1 and 2: read the shape, not the median
 
-```bash
-COLS=$(.venv/bin/python -c "import card_engine; print(', '.join(card_engine.ENGINE_COLUMNS))")
-docker exec sylvan_blue-postgres-1 psql -U foouser -d magic -X -At \
-    -c "SELECT row_to_json(t) FROM (SELECT $COLS FROM magic.cards) t" > benchmarks/<feature>/corpus.jsonl
-```
+Both print nearest-rank percentiles from p0 to p100, sliced by plan, by distinct-on, by acquire
+branch, and by orderby. **Slice before you conclude** — errors cancel when pooled, and the
+cancellation has hidden the largest routing defect in the engine: compose read 0.81 on artwork and
+1.15 on printing, pooling to "roughly fine" while the two drove opposite routing errors.
 
-Check whether a corpus already under `benchmarks/` covers this schema before re-exporting —
-`ENGINE_COLUMNS` changes rarely, so an existing export (e.g. `benchmarks/bitplanes/corpus.jsonl`)
-is usually still valid and saves standing up Docker/the blue DB at all.
+p0 and p100 are the real min and max. They earn their columns because estimates of zero cards and of
+every card are both common, and they are exactly where an arm's shape breaks down — a recent run read
+p99 = 7.1 and p100 = 232 on the same cell.
 
-If the change isn't engine/bitplane-shaped, write a small new script on this pattern rather than
-stretching `survey_queries.py` to cover area-specific cases it wasn't built for.
+### Layer 3: did the executor get faster
 
-**Plan-pinned measurement** — for any change to a *plan's executor* rather than to the cost model.
-This is the rung that did not exist when the rest of this doc was written: with a cost-based router
-in front of six physical plans, an end-to-end latency delta is the sum of two independent effects,
-and the survey cannot tell them apart.
+The layer end-to-end latency cannot answer, because a `query()` delta is the sum of two independent
+effects: how fast the executor is, and which executor got picked. An executor change lands in one of
+three places, and only this layer separates them:
 
-- The executor got faster **but the router never picks it**, so the survey moves by 0% and the win
-  looks like it never happened.
-- The change moved a `cost::plan_cost` input, so the router picks *differently* — the survey moves,
-  and none of the delta is the executor's. The same query can be served by a different plan
-  before and after, which also silently breaks the `total`-row parity check's usefulness as a
-  "same work, less time" argument.
-
-`explain_analyze` ([`card_engine/src/lib.rs`](../../card_engine/src/lib.rs)) is the fix, and it is
-already built: it drives `run_query_with_plan` for **every applicable plan**, `num_warmups` discarded
-rounds then `num_trials` recorded ones, and returns raw per-trial nanoseconds next to each plan's
-predicted cost. Pin the plan under test, compare it to itself across builds, and report the routing
-change as a separate line item.
-
-Two scripts already drive it — prefer extending one over writing a third:
+- Faster **and still picked** — a real win, visible end to end.
+- Faster **but never picked** — a latent win. Layer 4 moves 0%, and a PR quoting only the survey
+  concludes, wrongly, that nothing happened.
+- A `cost::plan_cost` input moved, so the router picks **differently** — layer 4 moves, and none of
+  the delta is the executor's.
 
 ```bash
-# per-(plan, acquire branch) measured vs. predicted, plus the phases no cost term describes
-.venv/bin/python scripts/bench_cost_model_agreement.py --seconds 120
-# does argmin(predicted) match argmin(measured)? reports regret, in time, over multi-plan queries
-.venv/bin/python scripts/bench_plan_misselection.py --source wild-operators --sample 200
+# once per build, same corpus, mode and seed on both sides
+.venv/bin/python scripts/bench_plan_execution_ab.py --sample 600 --out /tmp/main.jsonl
+.venv/bin/python scripts/bench_plan_execution_ab.py --compare /tmp/main.jsonl /tmp/branch.jsonl
 ```
 
-Three properties of `trials_ns` that decide whether a number means anything:
+It pairs per (query, plan), reports acquire and the routed path alongside the plans, excludes pairs
+whose `result_total` disagrees, and says separately whether routing moved.
 
-- It is a fair head-to-head **between plans**, not a reproduction of a real query's wall time. Each
-  forced run re-runs its own `prepare_candidates`, where `run_query_routed` acquires the shared
-  artifact once. Never compare a `trials_ns` figure against a `query()` latency.
-- Participants are shuffled per round from a fixed seed, not rotated, so ordering is reproducible but
-  **not position-balanced**. Since every consumer reduces with `min`, a participant can draw the warm
-  tail twice at low trial counts. Use ≥ 7 trials (what `bench_cost_model_agreement.py` uses); do not
-  read a 2–3 trial run as a head-to-head between plans within ~10% of each other.
-- A plan can return `None` — declined on its applicability predicate or, for the fastpaths,
-  structurally. A decline still costs real time (`DeclineSparseExact` composes the printing bitmap
-  before turning back) and produces no page, so it appears in no measured/predicted table. If the
-  change touches a fastpath's gate, the decline cost is part of the result, not an absence of one.
+### Kernel micro-benchmarks: below all four layers
 
-**Acceptance for an executor change therefore has two halves**, and a PR that reports only the first
-has not shown the change helps anyone: the pinned plan is faster, *and* the router still routes to it
-(or the cost model was updated in the same PR so that it now does). An executor win the router
-declines to use is a latent win, and the PR body should say so plainly rather than quoting a survey
-delta that came from somewhere else.
-
-**Kernel micro-benchmarks** — for representation-level questions neither of the above can resolve:
-which of two algorithms/data structures wins for a specific sub-routine, or *why* a broad-survey
-regression happened once you know one exists. End-to-end query timing can't isolate sub-microsecond
-effects; a kernel benchmark runs the two contenders directly against each other over real data,
-nothing else in the loop. Follow the existing pattern (`bench_mana.rs`, `bench_verify_cost.rs`,
-`bench_text_search.rs`, `bench_posting_intersect.rs`, `bench_iter_dispatch.rs`,
-`bench_word_dict_scan.rs`): a `#[cfg(test)] mod bench_<name>;` in `lib.rs`, an `#[ignore]`d test
-function reading `benchmarks/verify-order/real.store` (rebuild it if the archive layout changed
-since it was last built — see any of those files' module doc for the one-time command), asserting
-every contender agrees on real data before timing any of them, run via
-`cargo test --release bench_<name> -- --ignored --nocapture`. This is what actually diagnosed and
-fixed the regression in #663 (`bench_word_dict_scan.rs` comparing `match_indices` vs `memchr::memmem`
-over the real dictionary blob) — reach for it whenever the broad/targeted scripts show something
-regressed but not *why*, not only when scoping a brand-new representation up front.
+For representation-level questions no query-level measurement can resolve — which of two algorithms
+wins for one subroutine, or *why* a layer-4 regression happened once you know one exists. Follow the
+existing pattern (`bench_mana.rs`, `bench_word_dict_scan.rs`, `bench_posting_intersect.rs` and the
+six others in `card_engine/src/`): a `#[cfg(test)] mod bench_<name>;`, an `#[ignore]`d test over
+`benchmarks/verify-order/real.store` that asserts every contender agrees on real data before timing
+any of them, run with `cargo test --release bench_<name> -- --ignored --nocapture`. This is what
+diagnosed and fixed the regression in #663.
 
 ## 3. Baseline on main
 
-Run both scripts against a `main` build before touching anything. Save CSVs under
-`benchmarks/<feature>/`, named by branch or commit sha (e.g. `baseline-main-d3c5e58.csv`). The
-`benchmarks/` tree is untracked working data — never committed, just local scratch for the
-duration of the PR. A `git worktree add <path> main` alongside the working branch is the clean way
-to get a `main` build without disturbing uncommitted work.
+Record a baseline with `--out` from a `main` build before touching anything —
+`git worktree add <path> main` is the clean way to get one without disturbing your branch. The
+`benchmarks/` tree is local scratch: untracked, though **not** gitignored, so don't `git add -A`.
 
-If the change touches archive layout (`CardIndexes`, any new/changed index struct), also capture a
-memory baseline: build with `--features alloc-counter` and read `QueryEngine.mem_stats()` after
-loading the same corpus (`archive_bytes`, `indexes_rkyv_bytes`, `reload_peak` are the ones worth
-tracking). The issue template's "Measured problem" section already asks for "archive bytes, RSS"
-alongside query timings — this is easy to skip since the query-latency scripts don't touch it at
-all, but a change can shrink or grow the archive independently of what happens to query speed (#663
-turned out to shrink it 14%, discovered only after the PR was already up because nobody had asked).
+If the change touches archive layout, also capture memory: build with `--features alloc-counter` and
+read `QueryEngine.mem_stats()` after loading the same corpus (`archive_bytes`, `indexes_rkyv_bytes`,
+`reload_peak`). Easy to skip, since none of the four layers touches it — and #663 turned out to
+shrink the archive 14%, discovered only after the PR was up because nobody had asked.
 
 ## 4. Implement, with correctness first
 
-Add/extend unit and differential tests before chasing speed. For engine changes, a `total`
-row-count column doubling as a parity check (identical across builds) is the cheap way to catch a
-change that's fast because it's wrong. Self-review the diff before re-measuring — don't loop
-performance tuning on top of a design you haven't re-read.
+Add unit and differential tests before chasing speed. `result_total` doubling as a parity check
+(identical across builds) is the cheap way to catch a change that is fast because it is wrong;
+layer 3 enforces it for you. Self-review the diff before re-measuring.
 
-## 5. Re-measure and loop
+## 5. Re-measure — and run the canary first
 
-Re-run the same two scripts against the branch build, same corpus and seed. Compare:
+Re-run the same layers against the branch build, same corpus and seed.
 
-- Broad screen: percentiles (p50/75/90/95/99/max), a "top improvements" table, and — importantly —
-  every remaining regression, not just the ones that look bad in aggregate.
-- Targeted set: per-query before/after/speedup plus a geometric mean.
-- Plan-pinned, if the change touched an executor: the target plan's `trials_ns` before/after, **and**
-  separately whether the routed pick changed on those same queries. A broad-screen delta that
-  disagrees with the pinned delta is not a contradiction to explain away — it means routing moved,
-  and the two numbers are measuring different things.
-- Memory, if step 3 captured a baseline: re-run `mem_stats()` against the branch build, same corpus.
+**Before trusting any cross-build number, compare a build against ITSELF.** Same commit, same seed,
+two runs. It should report no detectable difference. Both A/B harnesses failed that canary at the
+toolkit's default 7 trials:
 
-Fix regressions, look for further wins, repeat until the branch is in good shape. This is the slow
-part — budget for several iterations, not one measurement. When a regression shows up but its cause
-isn't obvious from either script's output, that's the point to reach for a kernel micro-benchmark
-(see step 2) rather than guessing and re-measuring blind.
+| harness, same build and seed | at 2w/7t | at 6w/30t |
+| --- | --- | --- |
+| `bench_plan_execution_ab.py` | every plan, acquire and routed "SLOWER" by 4–9%, "faster on 0" | no detectable difference |
+| `bench_query_latency_ab.py` | "B is FASTER", −1.0 µs, CI [−1.6, −0.5] | +0.5 µs, CI [−1.0, +2.9] |
+
+The cause is not the machine. `min` over the trials is a floor estimator, and how far above the floor
+it lands depends on the interference that run saw. **That error is common-mode across every query in
+a run, so pairing and a wider sample do not cancel it** — the latency canary above had 388 paired
+queries and still called it. Depth is what fixes it, which is why both A/B tools default to 30 trials
+while the within-call diagnostics stay at 7 (see `costbench.py` for the convergence table).
+
+`bench_plan_execution_ab.py` also treats acquire as a **control**: most executor changes don't touch
+it, so if it moves, the two runs are not comparable and the tool says so and prints an adjusted
+column. Raise `--trials` before believing anything it flags.
+
+Interleaving A/B/A/B and quiescing the machine are still worth doing against genuine long-run
+thermal drift. They were not what these two canaries needed.
+
+Never compare two headline means. Latency and regret are heavy-tailed enough that the same engine and
+seed have produced 0.26 and 0.82 µs on consecutive runs. Pair over identical observations and report
+the bootstrap interval.
 
 ## 6. Open the PR
 
-Use `.github/PULL_REQUEST_TEMPLATE.md`'s Performance section: a `Benchmark | Before | After |
-Change` table, geometric mean, and which corpus was used — or, if step 3 captured a memory
-baseline, the template's own note to swap that table for a before/after memory profile instead
-(or alongside it, if both moved). Link the design doc's issue number if
-one was filed.
+Use `.github/PULL_REQUEST_TEMPLATE.md`'s Performance section. For an executor change, state
+acceptance as both halves: **the plan is faster, and the router still routes to it.** A win the
+router declines to use is a latent win — say so plainly rather than quoting a layer-4 delta that came
+from somewhere else.
 
-Report before/after in the **most natural unit for the magnitude** — if the numbers are
-sub-millisecond, use μs, not `0.088 ms` (leading-zero decimals bury the scale and misread at a
-glance). Every before/after table (in the PR body and the docs) must, without exception:
+Every before/after table, without exception:
 
-- Put the unit **in the column header** (`off µs` / `Before (μs)`), never in a caption or repeated
-  per cell — a reader scanning the table sees the numbers, not the prose around it.
-- Use the **same unit on both sides** of a comparison, picked from the smaller value. (`Change`/speedup
-  is a ratio, so it's unitless.)
-- Include a **`rows`/`total` parity column** (identical across builds — the cheap correctness check)
-  and, when several queries move, a **geometric-mean speedup** over the impacted rows so the summary
-  is one honest number rather than a cherry-picked max.
+- Unit **in the column header** (`Before (µs)`), never in a caption or repeated per cell.
+- **Same unit on both sides**, picked from the smaller value, at the natural magnitude — `88 µs`,
+  not `0.088 ms`. (Ratios are unitless.)
+- A **`rows`/`total` parity column**, identical across builds.
+- A **geometric mean** over the impacted rows when several queries move, so the summary is one honest
+  number rather than a cherry-picked max.
 
-Examples of this workflow end-to-end: PR #663 (oracle word index — a kernel micro-benchmark
-diagnosed and fixed a broad-survey regression the other two tools could only detect, and a memory
-baseline turned up an unplanned 14% archive shrink), #659 (numeric-range bitplanes), #658
-(exactness propagation), #654 (legality bitplanes), #646 (name-sort permutation — the PR that
-added the wild corpus's exact-name cap described above), #639 (bigram index, broad-screen
-percentile table).
-
-## Related
-
-`docs/issues/local-query-benchmark-suite.md` proposes formalizing corpus generation further (a
-`--generate-corpus` flag) — unimplemented; the manual export in step 2 is the current state.
+Examples end to end: #663 (oracle word index — a kernel benchmark diagnosed a regression the
+query-level tools could only detect, plus an unplanned 14% archive shrink), #659 (numeric-range
+bitplanes), #658 (exactness propagation), #654 (legality bitplanes), #646 (name-sort permutation),
+#639 (bigram index).

--- a/scripts/bench_arith_tuple_postings.py
+++ b/scripts/bench_arith_tuple_postings.py
@@ -25,7 +25,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_bitplanes.py
+++ b/scripts/bench_bitplanes.py
@@ -23,17 +23,20 @@ from __future__ import annotations
 
 import argparse
 import csv
-import json
 import pathlib
 import subprocess
 import sys
 import time
+from typing import TYPE_CHECKING
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-import card_engine  # noqa: E402
 from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
+
+if TYPE_CHECKING:
+    import card_engine
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # Groups map to the #630 phases; "control" rows are selective queries that must not regress.
@@ -109,28 +112,6 @@ CONFIGS: list[tuple[str, str, str, str, str]] = [
 ]
 
 WARMUP = 20
-BATCH_SIZE = 2000
-
-
-def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> card_engine.QueryEngine:
-    """Build a fresh engine store from the corpus JSONL via the staged reload API."""
-    engine = card_engine.QueryEngine(str(shm_path))
-    if not engine.reload_begin():
-        msg = "reload_begin returned False (stale archive published concurrently?)"
-        raise RuntimeError(msg)
-    t0 = time.monotonic()
-    batch: list[dict] = []
-    with corpus.open() as fh:
-        for line in fh:
-            batch.append(json.loads(line))
-            if len(batch) == BATCH_SIZE:
-                engine.add_batch(batch)
-                batch.clear()
-    if batch:
-        engine.add_batch(batch)
-    engine.reload_commit()
-    print(f"Engine loaded: {engine.size():,} printings in {time.monotonic() - t0:.1f}s", flush=True)
-    return engine
 
 
 def bench_one(engine: card_engine.QueryEngine, config: tuple[str, str, str, str], window: float) -> tuple[int, int, float, float]:

--- a/scripts/bench_border_planes.py
+++ b/scripts/bench_border_planes.py
@@ -30,7 +30,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_card_range_estimate.py
+++ b/scripts/bench_card_range_estimate.py
@@ -38,6 +38,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts import costbench  # noqa: E402
 from scripts.costbench import load_engine  # noqa: E402
+from scripts.query_sampler import QuerySampler, Shape  # noqa: E402
 
 TARGET_SOURCE = "card_range_popcount"
 MATERIALIZING = ("StreamedSelect", "GatheredScan")
@@ -53,28 +54,13 @@ MIN_FOR_DECILES = 10
 # count would need, measured at 98333ns/80527 printings.
 BUILD_PER_PRINTING_NS = 1.22
 
-# Every field `bare_range_bounds` resolves to a range index: the three price columns and collector
-# number have their own, `year:`/`date:` both map onto `released_at`. Values span each field's real
-# distribution so the sweep covers selectivities from a handful of cards to nearly the whole corpus.
-RANGE_FIELDS: dict[str, list[str]] = {
-    "usd": ["0.1", "0.25", "1", "2", "5", "10", "20", "50", "100", "200", "500"],
-    "eur": ["0.1", "0.5", "1", "3", "8", "20", "60", "150"],
-    "tix": ["0.05", "0.1", "0.5", "1", "3", "10", "30"],
-    "cn": ["5", "20", "50", "100", "200", "300", "500"],
-    "year": ["1994", "1999", "2004", "2009", "2014", "2018", "2021", "2023", "2025"],
-    "date": ["1995-01-01", "2005-06-01", "2015-03-01", "2020-09-01", "2024-01-01"],
-}
-RANGE_OPS = [">", ">=", "<", "<="]
-DATE_FIELDS = ("year", "date")
-
-
-def random_range_query(rng: random.Random) -> str:
-    """One bare range predicate — the only filter shape this acquire branch fires for."""
-    field = rng.choice(list(RANGE_FIELDS))
-    # `year:2023` is a bounded range on released_at (bare_range_bounds handles YearCmp/DateCmp), so
-    # it belongs in the sweep; `:` on a price column is equality and mostly yields empty results.
-    ops = [*RANGE_OPS, ":"] if field in DATE_FIELDS else RANGE_OPS
-    return f"{field}{rng.choice(ops)}{rng.choice(RANGE_FIELDS[field])}"
+#: One bare range at `unique=card` — the only filter shape this acquire branch fires for.
+#: Replaces a private generator that drew thresholds from a hardcoded list per field (eleven `usd`
+#: values, nine `year`s). Those clustered selectivity at a dozen arbitrary points, which is exactly
+#: what a cardinality-estimate sweep must not do: the estimate is a function of selectivity, so a
+#: sweep that samples a dozen values of it cannot describe the error curve between them.
+#: `QuerySampler` places each threshold at a uniformly-drawn quantile of the real column instead.
+RANGE_SHAPE = Shape(families=frozenset({"range"}), predicates=1, unique=frozenset({"card"}))
 
 
 def main() -> None:
@@ -87,6 +73,7 @@ def main() -> None:
     args = parser.parse_args()
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".misselect.store"))
+    sampler = QuerySampler(args.corpus, "uniform")
     rng = random.Random(args.seed)
 
     samples = Samples()
@@ -94,7 +81,7 @@ def main() -> None:
     generated = other_source = 0
     deadline = time.monotonic() + args.seconds
     while time.monotonic() < deadline:
-        q = random_range_query(rng)
+        q = sampler.query(rng, RANGE_SHAPE)
         generated += 1
         if q in seen:
             continue

--- a/scripts/bench_card_range_estimate.py
+++ b/scripts/bench_card_range_estimate.py
@@ -37,7 +37,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 TARGET_SOURCE = "card_range_popcount"
 MATERIALIZING = ("StreamedSelect", "GatheredScan")

--- a/scripts/bench_card_range_estimate.py
+++ b/scripts/bench_card_range_estimate.py
@@ -36,6 +36,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 
 TARGET_SOURCE = "card_range_popcount"
@@ -193,19 +194,33 @@ class Samples:
     n_cards: int = 0
 
     def record(self, q: str, quick: dict, res: dict, total: int) -> None:
-        """Fold one sampled query in. `matches` is clamped at n_cards here, so k comes from range_k."""
+        """Fold one sampled query in.
+
+        Both quantities this reads used to be spelled as acquire keys the engine has never published
+        — `acquire.range_k` and `acquire.prep_ns` — so the harness raised `KeyError` on its first
+        recorded query. They are read from what the engine does expose now:
+
+        - `k` comes from `matches`, which for this acquire IS `card_est = k.min(n_cards)`. It is
+          clamped, so every slice at or above `n_cards` collapses into the last bucket and
+          `by_slice_size` cannot separate them. Recovering the unclamped probe would mean exporting
+          `probe_range_k` from the engine; the buckets below the clamp are unaffected.
+        - prep is per-PLAN `ns_prepare`, not a single acquire-wide number. That is the more accurate
+          reading anyway: each forced round pays its own `prepare_candidates`, so netting one shared
+          value across two plans was already the wrong subtraction.
+        """
         acq = quick["acquire"]
         est = acq["matches"]
         self.n_cards = acq["n_cards"]
         self.est_rows.append((est / max(total, 1), est, total, q))
-        self.k_rows.append((acq["range_k"], est / max(total, 1), total, q))
+        self.k_rows.append((est, est / max(total, 1), total, q))
         self.picks[next((p["plan"] for p in quick["plans"] if p["picked"]), "?")] += 1
-        prep = min(res["acquire"]["prep_ns"])
         for p in res["plans"]:
-            if p["plan"] not in MATERIALIZING or not p["trials_ns"] or p["predicted_ns"] <= 0:
+            predicted = costbench.predicted_ns(p)
+            if p["plan"] not in MATERIALIZING or not p["trials_ns"] or predicted is None:
                 continue
             meas = max(min(p["trials_ns"]), 1)
-            self.arm_rows.append((p["plan"], meas / p["predicted_ns"], max(meas - prep, 1) / p["predicted_ns"], q))
+            netted = max(meas - p["ns_prepare"], 1)
+            self.arm_rows.append((p["plan"], meas / predicted, netted / predicted, q))
 
 
 def by_slice_size(k_rows: list[tuple[int, float, int, str]], picks: collections.Counter[str]) -> None:

--- a/scripts/bench_collection_compose.py
+++ b/scripts/bench_collection_compose.py
@@ -28,7 +28,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # `total` doubles as the parity check (identical across builds for every row).

--- a/scripts/bench_compose_orderby_range_walk.py
+++ b/scripts/bench_compose_orderby_range_walk.py
@@ -32,7 +32,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # `total` doubles as the parity check (identical across builds for every row).
@@ -52,14 +53,12 @@ CONFIGS: list[tuple[str, str, str, str, str]] = [
     # that the "pick the sparser side" branch leaves the majority-illegal case alone.
     ("pioneer_printing", "f:pioneer", "printing", "usd", "default"),
     ("pioneer_printing", "f:pioneer", "printing", "rarity", "default"),
-
     # ── Controls: unique=card / artwork (out of scope — prefer-dependent representative). Hold flat. ──
     ("commander_card", "f:commander", "card", "usd", "default"),
     ("commander_card", "f:commander", "card", "rarity", "default"),
     ("commander_artwork", "f:commander", "artwork", "usd", "default"),
     ("commander_artwork", "f:commander", "artwork", "rarity", "default"),
     ("legacy_card", "f:legacy", "card", "usd", "default"),
-
     # ── Controls: already-fast printing-mode paths. Hold flat. ──
     # Permutation orderby (edhrec) → walk_grouped_page, unaffected by either change.
     ("commander_printing_perm", "f:commander", "printing", "edhrec", "default"),
@@ -69,7 +68,6 @@ CONFIGS: list[tuple[str, str, str, str, str]] = [
     ("border_printing", "border:black", "printing", "rarity", "default"),
     # Bare usd range, printing/rarity — permutation-free gather fallback (#740), no legality build.
     ("bare_usd_printing", "usd<50", "printing", "rarity", "default"),
-
     # ── Controls: plane-only card path (split_planes + card popcount). Hold flat. ──
     ("plane_card", "f:modern", "card", "usd", "default"),
     ("plane_card", "f:commander", "card", "edhrec", "default"),

--- a/scripts/bench_compose_permutation_fallback.py
+++ b/scripts/bench_compose_permutation_fallback.py
@@ -26,7 +26,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # `edhrec` rows are controls (already fast via a real permutation; must not regress). `rarity`/`usd`

--- a/scripts/bench_cost_error_attribution.py
+++ b/scripts/bench_cost_error_attribution.py
@@ -45,7 +45,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 import scripts.fit_cost_model as fitmod  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.fit_cost_model import collect, fit_log_ratio  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 

--- a/scripts/bench_cost_error_percentiles.py
+++ b/scripts/bench_cost_error_percentiles.py
@@ -31,7 +31,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
 # This harness pools finer than most (four nested slices), so it holds out for a thicker cell than

--- a/scripts/bench_cost_error_percentiles.py
+++ b/scripts/bench_cost_error_percentiles.py
@@ -2,9 +2,13 @@
 
 Every other view here reports a median, which hides the shape. A plan can have a perfect median while
 over-costing a fifth of queries by 10x, and the fix for that is nothing like the fix for a uniform
-shift. This prints p1/p10/p20/p50/p70/p90/p99 so the shape is visible: a flat row is a uniform scale
+shift. This prints the whole percentile row so the shape is visible: a flat row is a uniform scale
 error (recalibrate a rate), a steep row is a missing feature or wrong shape, and a row that is fine
 in the middle with a bad tail is a specific query class rather than a general defect.
+
+p0 and p100 are the real min and max, and they are not decoration. Estimates of zero cards and of
+every card are both common, and they are exactly where a cost arm's shape breaks down — a p1/p99 view
+clips the two cases most likely to be wrong.
 
 Ratio is **estimate / real**, so **>1 means OVER-costed** — the reciprocal of the measured/predicted
 convention the agreement harness uses. Stated here because mixing them up inverts every conclusion.
@@ -18,100 +22,46 @@ and `trials_ns`.
 from __future__ import annotations
 
 import argparse
-import collections
+import functools
 import pathlib
 import random
 import sys
-import time
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
-from scripts.bench_cost_model_agreement import RANGE_ACQUIRES  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
-NUM_WARMUPS = 2
-NUM_TRIALS = 7
-LIMITS = (10, 100, 175)
-OFFSETS = (0, 0, 0, 100)
-PERCENTILES = (1, 10, 20, 50, 70, 90, 99)
+# This harness pools finer than most (four nested slices), so it holds out for a thicker cell than
+# the shared default before it will print a percentile row.
 MIN_ROWS = 40
 
 
-def percentile(sorted_vals: list[float], pct: int) -> float:
-    """Nearest-rank percentile; no interpolation, so every printed number is a real observation."""
-    if not sorted_vals:
-        return float("nan")
-    idx = min(round(pct / 100.0 * len(sorted_vals) + 0.5) - 1, len(sorted_vals) - 1)
-    return sorted_vals[max(idx, 0)]
-
-
 def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
-    """One row per (query, plan) that ran, with the plan's own cost isolated the usual way."""
+    """One row per (query, plan) that ran, with the plan's own cost isolated the shared way."""
     rows: list[dict] = []
-    deadline = time.monotonic() + seconds
-    while time.monotonic() < deadline:
-        limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
-        kw = {
-            "filters": None,
-            "unique": sampler.unique(rng),
-            "orderby": sampler.orderby(rng),
-            "direction": rng.choice(("asc", "desc")),
-            "limit": limit,
-            "offset": offset,
-        }
-        try:
-            kw["filters"] = parse_scryfall_query(sampler.query(rng))
-            acq = engine.explain(**kw)["acquire"]
-            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
-        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
-            continue
-        for p in res["plans"]:
-            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+    for sample in costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds)):
+        for p in sample.plans:
+            real = costbench.plan_self_ns(p, sample.acquire)
+            predicted = costbench.predicted_ns(p)
+            if real is None or predicted is None:
                 continue
-            # Only a Prep::Range acquire makes the routed path re-pay prepare_candidates, so elsewhere
-            # it is not this plan's cost to carry. Same netting as every other harness here.
-            real = float(min(p["trials_ns"]))
-            if p["ns_round_total"] and acq["count_source"] not in RANGE_ACQUIRES:
-                netted = real - p["ns_prepare"]
-                if netted < real * 0.5:
-                    continue  # netting overshot; the residual is noise, not a measurement
-                real = netted
             rows.append(
                 {
                     "plan": p["plan"],
-                    "acquire": acq["count_source"],
-                    "unique": kw["unique"],
-                    "ratio": p["predicted_ns"] / real,
+                    "acquire": sample.acquire["count_source"],
+                    "unique": sample.kw["unique"],
+                    "orderby": sample.kw["orderby"],
+                    "ratio": predicted / real,
                 }
             )
     return rows
 
 
-def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 40) -> None:
-    """Percentile table for one grouping of the rows."""
-    groups: dict[object, list[float]] = collections.defaultdict(list)
-    for r in rows:
-        groups[key(r)].append(r["ratio"])
-    head = "".join(f"{f'p{p}':>8}" for p in PERCENTILES)
-    print(f"\n{label:<38}{'n':>7}{head}{'p90/p10':>9}")
-    for name, vals in sorted(groups.items(), key=lambda kv: -len(kv[1]))[:limit]:
-        if len(vals) < MIN_ROWS:
-            continue
-        vals.sort()
-        cells = "".join(f"{percentile(vals, p):>8.2f}" for p in PERCENTILES)
-        spread = percentile(vals, 90) / percentile(vals, 10) if percentile(vals, 10) > 0 else float("inf")
-        print(f"{name!s:<38}{len(vals):>7}{cells}{spread:>9.1f}")
-
-
 def main() -> None:
-    """Sample, then print the estimate/real distribution per plan and per (plan, acquire)."""
+    """Sample, then print the estimate/real distribution sliced four ways."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--seconds", type=float, default=60.0)
     parser.add_argument("--seed", type=int, default=0)
@@ -124,16 +74,23 @@ def main() -> None:
     sampler = QuerySampler(args.corpus, args.mode)
     rows = collect(engine, sampler, random.Random(args.seed), args.seconds)
     print(f"\n{len(rows):,} plan-rows, mode={args.mode}.  ratio = ESTIMATE / REAL, so >1 is OVER-costed.")
-    table(rows, lambda r: r["plan"], "plan")
+
+    table = functools.partial(costbench.percentile_table, rows, min_rows=MIN_ROWS)
+    table(lambda r: r["plan"], "plan")
     # distinct-on splits errors that cancel when pooled, and the cancellation hides real defects: the
     # compose arm reads 0.79 (too cheap) on artwork and 1.15 on printing, which pools to "roughly fine"
     # while the two drive OPPOSITE routing errors -- compose over-picked 38:1 in artwork, under-picked
     # 10:1 in printing. Per (plan, unique) is the smallest slice that shows it.
-    table(rows, lambda r: f"{r['plan']} / {r['unique']}", "plan / distinct-on", limit=24)
-    table(rows, lambda r: f"{r['plan']} [{r['acquire']}]", "plan [acquire]")
-    table(rows, lambda r: f"{r['plan']} [{r['acquire']}] / {r['unique']}", "plan [acquire] / distinct-on", limit=20)
+    table(lambda r: f"{r['plan']} / {r['unique']}", "plan / distinct-on", limit=24)
+    # Sort column decides which paging strategy the compose arm reaches for (Perm vs OrderbyWalk vs
+    # Gather), and those have different shapes, so an arm can calibrate on one order and not another.
+    # The sampler has always varied orderby; this is the slice that reads it back.
+    table(lambda r: f"{r['plan']} / {r['orderby']}", "plan / orderby", limit=24)
+    table(lambda r: f"{r['plan']} [{r['acquire']}]", "plan [acquire]")
+    table(lambda r: f"{r['plan']} [{r['acquire']}] / {r['unique']}", "plan [acquire] / distinct-on", limit=20)
     print("\n  p90/p10 is the spread: ~1 means a uniform scale error (recalibrate), large means the")
     print("  error depends on something unmodelled. Nearest-rank percentiles, so each is a real query.")
+    print("  p0/p100 are the real min and max -- the zero-card and all-cards estimates a p1/p99 view clips.")
 
 
 if __name__ == "__main__":

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -52,6 +52,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 
 NUM_WARMUPS = 2
@@ -96,10 +97,10 @@ IMPOSSIBLE_GATES = ("RangeNotBare", "NotComposable", "RangePermutationStale")
 # defect rather than a prediction that missed.
 COMPOSE_ACQUIRE = "printing_compose"
 # Acquire branches where the routed path really does call `prepare_candidates` at dispatch, so the
-# materializing plans genuinely owe its cost; everywhere else acquire built the prep already. Every
-# harness that nets prepare out of a plan's measured time needs the same rule, so it lives here once
-# rather than as a copy per script.
-RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", COMPOSE_ACQUIRE})
+# materializing plans genuinely owe its cost; everywhere else acquire built the prep already. Now
+# owned by `costbench` alongside the netting rule that reads it — re-exported here because this
+# module's own report still slices on it, and because other harnesses imported it from here.
+RANGE_ACQUIRES = costbench.RANGE_ACQUIRES
 # The only plans that call `prepare_candidates`, and so the only ones with a prepare phase at all.
 # Every other plan reports `ns_prepare == 0` because it has no such phase — which is not the same
 # as spending 0% of its run there, and pooling the two says the wrong thing.
@@ -201,11 +202,12 @@ def main() -> None:
             if p["declined_ns"]:
                 agr.declines[p["plan"], p["paging_taken"]].append(min(p["declined_ns"]))
                 continue
-            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+            predicted = costbench.predicted_ns(p)
+            if not p["trials_ns"] or predicted is None:
                 continue
             measured = min(p["trials_ns"])
-            agr.ratios[p["plan"], acq["count_source"]].append(measured / p["predicted_ns"])
-            agr.by_unique[p["plan"], unique].append(measured / p["predicted_ns"])
+            agr.ratios[p["plan"], acq["count_source"]].append(measured / predicted)
+            agr.by_unique[p["plan"], unique].append(measured / predicted)
             # Keyed by acquire branch as well as plan: the whole point of this row is that the
             # prepare share differs by HOW the query was acquired, so collapsing to the plan alone
             # averages a range-acquired query together with a plane-acquired one and reports a

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -53,7 +53,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 NUM_WARMUPS = 2
 NUM_TRIALS = 7

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -4,15 +4,19 @@ Not a mis-selection check — this asks whether each plan's cost ARM is right, p
 `unique`, per `orderby`. A plan can be picked correctly for a long time while its arm is badly wrong,
 and only diverge once something competes closely with it.
 
-Sampling is deliberately unbiased where the existing generator is not:
+Sampling comes from `query_sampler.QuerySampler` in `uniform` mode, which is deliberately unbiased
+in the three ways this measurement needs. It used to come from private tables here that aimed at the
+same properties and reached two of the three:
 
 - `unique` is drawn evenly across card / printing / artwork, not 75/20/5. Distinct-on changes which
   plans are even applicable and what `scan_units` means, so under-sampling two thirds of it hides
   exactly the cells most likely to be wrong.
 - `orderby` is drawn across every column the engine supports, since the permutation's existence is
   what gates `StreamedSelect` and `PlanePopcountOrder`.
-- range thresholds are sampled from each field's real value distribution rather than a hand-picked
-  list, so selectivity is spread instead of clustered at round numbers.
+- range thresholds sit at a uniformly-drawn QUANTILE of the real column. The private table sampled
+  log-uniformly between hardcoded bounds (`usd` 0.05-400, `cn` 1-500), which spreads the *value* and
+  not the *selectivity* — and selectivity is the axis a cost model varies along. The shared sampler
+  also reaches `eur`/`tix` and two-sided bounds, neither of which the private table produced.
 
 Reports measured/predicted per (plan, acquire branch), plus the two phases no cost term describes:
 `prepare_candidates` — 21-33% of a range-acquired query against 7-10% of a plane-acquired one — and
@@ -41,7 +45,6 @@ from __future__ import annotations
 import argparse
 import collections
 import dataclasses
-import math
 import pathlib
 import random
 import statistics
@@ -54,13 +57,12 @@ sys.path.insert(0, str(REPO_ROOT))
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts import costbench  # noqa: E402
 from scripts.costbench import load_engine  # noqa: E402
+from scripts.query_sampler import QuerySampler  # noqa: E402
 
 NUM_WARMUPS = 2
 NUM_TRIALS = 7
 # Every distinct-on the engine supports, evenly weighted — see the module docstring.
-UNIQUES = ("card", "printing", "artwork")
 # Every orderby `orderby_to_col` maps. Which ones have a sort permutation decides plan applicability.
-ORDERBYS = ("edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "usd", "name")
 LIMITS = (10, 100, 175)
 OFFSETS = (0, 0, 0, 100)  # mostly first-page, which is what real traffic asks for
 MIN_FOR_QUARTILES = 8
@@ -110,43 +112,7 @@ AGREE_LO, AGREE_HI = 0.8, 1.25
 
 # Predicate templates, one per engine path, so no single family dominates the sample the way a
 # weighted-dimension generator does. A query is one or two of these joined.
-PREDICATES: dict[str, list[str]] = {
-    "plane_color": ["c:w", "c:u", "c:b", "c:r", "c:g", "c:wu", "c:br", "id:g", "id:wu"],
-    "plane_type": ["t:creature", "t:instant", "t:artifact", "t:land", "t:enchantment", "t:sorcery"],
-    "legality": ["f:modern", "f:commander", "f:legacy", "f:pauper", "f:standard", "f:vintage"],
-    "text": ["o:flying", "o:draw", "o:destroy", "o:trample", "o:counter", "o:sacrifice"],
-    "collection": ["is:reprint", "border:black", "border:borderless", "frame:showcase", "watermark:set"],
-    "arith": ["pow>2", "tou<4", "power+toughness<6", "cmc>=4", "loyalty>=3"],
-}
 # Range fields with a real index, and the value ranges to sample thresholds from.
-RANGE_FIELDS: dict[str, tuple[float, float, bool]] = {
-    "usd": (0.05, 400.0, True),  # log-sampled: prices span four orders of magnitude
-    "cn": (1, 500, False),
-    "year": (1993, 2026, False),
-}
-RANGE_OPS = (">", ">=", "<", "<=", ":")
-
-
-def sample_range(rng: random.Random) -> str:
-    """One range predicate with the threshold drawn from the field's own distribution."""
-    field, (lo, hi, log_scale) = rng.choice(list(RANGE_FIELDS.items()))
-    value = f"{math.exp(rng.uniform(math.log(lo), math.log(hi))):.2f}" if log_scale else str(rng.randint(int(lo), int(hi)))
-    op = rng.choice(RANGE_OPS)
-    return f"{field}{op}{value}"
-
-
-def sample_query(rng: random.Random) -> str:
-    """One or two predicates, each family equally likely — ranges included as their own family."""
-    families = [*PREDICATES.keys(), "range"]
-    n = rng.choice((1, 1, 2))
-    parts, used = [], set()
-    for _ in range(n):
-        fam = rng.choice(families)
-        if fam in used:
-            continue
-        used.add(fam)
-        parts.append(sample_range(rng) if fam == "range" else rng.choice(PREDICATES[fam]))
-    return " ".join(parts)
 
 
 def main() -> None:
@@ -159,17 +125,18 @@ def main() -> None:
     args = parser.parse_args()
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".agreement.store"))
+    sampler = QuerySampler(args.corpus, "uniform")
     rng = random.Random(args.seed)
 
     agr = Agreement()
 
     deadline = time.monotonic() + args.seconds
     while time.monotonic() < deadline:
-        q, unique = sample_query(rng), rng.choice(UNIQUES)
+        q, unique = sampler.query(rng), sampler.unique(rng)
         kw = {
             "filters": None,
             "unique": unique,
-            "orderby": rng.choice(ORDERBYS),
+            "orderby": sampler.orderby(rng),
             "direction": rng.choice(("asc", "desc")),
             "limit": rng.choice(LIMITS),
             "offset": rng.choice(OFFSETS),

--- a/scripts/bench_devotion.py
+++ b/scripts/bench_devotion.py
@@ -20,7 +20,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query) — unique=card, orderby=edhrec, prefer=default throughout.
 CONFIGS: list[tuple[str, str]] = [

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -41,7 +41,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
 # Deliberately below the shared (2, 7) default, and the one place in the toolkit where that is

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -29,12 +29,9 @@ while the pooled median looks fine.
 from __future__ import annotations
 
 import argparse
-import collections
-import math
 import pathlib
 import random
 import sys
-import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -43,16 +40,16 @@ if TYPE_CHECKING:
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
+# Deliberately below the shared (2, 7) default, and the one place in the toolkit where that is
+# justified: the counters this harness reads are deterministic for a given query, so the trials exist
+# only to make each plan run once. Extra rounds buy nothing and cost sample breadth.
 NUM_WARMUPS = 1
-NUM_TRIALS = 2  # counters are deterministic; trials exist only to make the plan run
-LIMITS = (10, 100, 175)
-OFFSETS = (0, 0, 0, 100)
-PERCENTILES = (10, 50, 90)
-MIN_ROWS = 30
+NUM_TRIALS = 2
+MIN_ROWS = costbench.MIN_ROWS
 # A cell's median must land inside this to be considered calibrated, matching the agreement bar in
 # bench_cost_model_agreement.py so the two tools grade on the same scale.
 AGREE_LO, AGREE_HI = 0.8, 1.25
@@ -82,37 +79,19 @@ def scan_feature(plan: str, paging: str) -> str:
     return "compose_scan_printings" if paging == "Gather" else "printings_walked"
 
 
-def percentile(sorted_vals: list[float], pct: int) -> float:
-    """Nearest-rank percentile; every printed number is a real observation."""
-    if not sorted_vals:
-        return float("nan")
-    idx = min(round(pct / 100.0 * len(sorted_vals) + 0.5) - 1, len(sorted_vals) - 1)
-    return sorted_vals[max(idx, 0)]
+percentile = costbench.percentile
 
 
 def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
     """One row per (query, plan, feature) where the plan reported the matching counter."""
     rows: list[dict] = []
-    deadline = time.monotonic() + seconds
-    while time.monotonic() < deadline:
-        kw = {
-            "filters": None,
-            "unique": sampler.unique(rng),
-            "orderby": sampler.orderby(rng),
-            "direction": rng.choice(("asc", "desc")),
-            "limit": rng.choice(LIMITS),
-            "offset": rng.choice(OFFSETS),
-        }
-        try:
-            kw["filters"] = parse_scryfall_query(sampler.query(rng))
-            acq = engine.explain(**kw)["acquire"]
-            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
-        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
-            continue
-        for plan in res["plans"]:
+    budget = costbench.Budget(seconds=seconds, warmups=NUM_WARMUPS, trials=NUM_TRIALS)
+    for sample in costbench.iter_samples(engine, sampler, rng, budget):
+        acq = sample.acquire
+        for plan in sample.plans:
             if not plan["trials_ns"]:
                 continue  # declined: it ran nothing, so there is no counter to check against
-            paging = acq.get("compose_paging", "-")
+            paging = acq["compose_paging"]
             for feat, counter in PAIRS:
                 if feat == "scan_units":
                     feat = scan_feature(plan["plan"], paging)  # noqa: PLW2901 - the arm decides which field it reads
@@ -124,37 +103,36 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
                         "feature": feat,
                         "plan": plan["plan"],
                         "acquire": acq["count_source"],
-                        "unique": kw["unique"],
+                        "unique": sample.kw["unique"],
                         # Compose's arm reads `scan_units` ONLY in its Gather branch; Perm/OrderbyWalk
                         # stop at page_offset+limit and never scan the candidates. A ratio measured on
                         # those is comparing the feature to work the arm never charges for.
-                        "paging": acq.get("compose_paging", "-"),
+                        "paging": paging,
                         "ratio": acq[feat] / got,
                     }
                 )
     return rows
 
 
+def verdict(sorted_vals: list[float]) -> str:
+    """Flag a cell whose median feature/counter ratio sits outside the agreement band."""
+    med = costbench.percentile(sorted_vals, 50)
+    if AGREE_LO <= med <= AGREE_HI:
+        return ""
+    return "  OVER-COUNTS" if med > AGREE_HI else "  UNDER-COUNTS"
+
+
 def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 30) -> None:
     """Feature/counter percentiles for one grouping, worst-calibrated cells first."""
-    groups: dict[object, list[float]] = collections.defaultdict(list)
-    for r in rows:
-        groups[key(r)].append(r["ratio"])
-    head = "".join(f"{f'p{p}':>8}" for p in PERCENTILES)
-    print(f"\n{label:<52}{'n':>7}{head}{'spread':>8}   verdict")
-    scored = []
-    for name, vals in groups.items():
-        if len(vals) < MIN_ROWS:
-            continue
-        vals.sort()
-        scored.append((abs(math.log(max(percentile(vals, 50), 1e-9))), name, vals))
-    for _, name, vals in sorted(scored, reverse=True)[:limit]:
-        med = percentile(vals, 50)
-        cells = "".join(f"{percentile(vals, p):>8.2f}" for p in PERCENTILES)
-        lo = percentile(vals, 10)
-        spread = percentile(vals, 90) / lo if lo > 0 else float("inf")
-        verdict = "" if AGREE_LO <= med <= AGREE_HI else ("  OVER-COUNTS" if med > AGREE_HI else "  UNDER-COUNTS")
-        print(f"{name!s:<52}{len(vals):>7}{cells}{spread:>8.1f}{verdict}")
+    costbench.percentile_table(
+        rows,
+        key,
+        label,
+        rank=costbench.BY_MISCALIBRATION,
+        limit=limit,
+        min_rows=MIN_ROWS,
+        annotate=verdict,
+    )
 
 
 def main() -> None:

--- a/scripts/bench_guard_validation.py
+++ b/scripts/bench_guard_validation.py
@@ -159,7 +159,7 @@ def cmd_worker(args: argparse.Namespace) -> None:
 
 def cmd_run(args: argparse.Namespace) -> None:
     """Build the store + frozen query set, then run interleaved old/new reps."""
-    from scripts.bench_bitplanes import load_engine  # noqa: PLC0415 — heavy loader, workers don't need it
+    from scripts.costbench import load_engine  # noqa: PLC0415 — heavy loader, workers don't need it
 
     store = OUTDIR / "real.store"
     queries = OUTDIR / "validation-queries.json"

--- a/scripts/bench_memo_crossover.py
+++ b/scripts/bench_memo_crossover.py
@@ -23,7 +23,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 NEEDLES = ["deathtouch", "vigilance", "trample", "sacrifice", "draw", "target"]
 CMC_STEPS = [0, 1, 2, 3, 4, 5, 6, 8]

--- a/scripts/bench_name_order.py
+++ b/scripts/bench_name_order.py
@@ -24,7 +24,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # Each config row is (group, query, unique, orderby, prefer).
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_negated_range_narrowing.py
+++ b/scripts/bench_negated_range_narrowing.py
@@ -26,7 +26,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_oracle_word_index.py
+++ b/scripts/bench_oracle_word_index.py
@@ -28,7 +28,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_pairwise_ordering.py
+++ b/scripts/bench_pairwise_ordering.py
@@ -35,7 +35,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
 # A gap smaller than this is inside measurement noise, so calling the order "wrong" says nothing.

--- a/scripts/bench_pairwise_ordering.py
+++ b/scripts/bench_pairwise_ordering.py
@@ -30,20 +30,14 @@ import pathlib
 import random
 import statistics
 import sys
-import time
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
-from scripts.bench_cost_model_agreement import RANGE_ACQUIRES  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
-NUM_WARMUPS = 2
-NUM_TRIALS = 7
-LIMITS = (10, 100, 175)
-OFFSETS = (0, 0, 0, 100)
 # A gap smaller than this is inside measurement noise, so calling the order "wrong" says nothing.
 TIE_FLOOR_US = 1.0
 MIN_PAIRS_TO_REPORT = 30
@@ -52,40 +46,19 @@ MIN_PAIRS_TO_REPORT = 30
 def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
     """One row per (query, plan) that ran, carrying a query id so pairs can be reconstructed."""
     rows: list[dict] = []
-    deadline = time.monotonic() + seconds
-    qid = 0
-    while time.monotonic() < deadline:
-        limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
-        kw = {
-            "filters": None,
-            "unique": sampler.unique(rng),
-            "orderby": sampler.orderby(rng),
-            "direction": rng.choice(("asc", "desc")),
-            "limit": limit,
-            "offset": offset,
-        }
-        try:
-            kw["filters"] = parse_scryfall_query(sampler.query(rng))
-            acq = engine.explain(**kw)["acquire"]
-            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
-        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
-            continue
-        qid += 1
-        for p in res["plans"]:
-            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+    for qid, sample in enumerate(costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds))):
+        for p in sample.plans:
+            measured = costbench.plan_self_ns(p, sample.acquire)
+            predicted = costbench.predicted_ns(p)
+            if measured is None or predicted is None:
                 continue
-            # Same netting as the agreement harness: only a Prep::Range acquire makes the routed path
-            # re-pay prepare_candidates, so elsewhere it is not the plan's cost to carry.
-            measured = float(min(p["trials_ns"]))
-            if p["ns_round_total"] and acq["count_source"] not in RANGE_ACQUIRES:
-                measured = max(measured - p["ns_prepare"], 1.0)
             rows.append(
                 {
                     "qid": qid,
                     "plan": p["plan"],
-                    "acquire": acq["count_source"],
+                    "acquire": sample.acquire["count_source"],
                     "measured_us": measured / 1000.0,
-                    "predicted_us": p["predicted_ns"] / 1000.0,
+                    "predicted_us": predicted / 1000.0,
                 }
             )
     return rows

--- a/scripts/bench_plan_execution_ab.py
+++ b/scripts/bench_plan_execution_ab.py
@@ -1,0 +1,295 @@
+"""Did this branch make a PLAN faster? Paired per-plan execution time between two builds.
+
+The layer the rest of the toolkit does not cover. Every other harness reads `trials_ns` as a RATIO
+against `predicted_ns` — they ask whether the cost model is right, not whether the executor got
+faster. `bench_query_latency_ab.py` asks the end-user question, but a `query()` delta is the sum of
+two independent effects: how fast the executor is, and which executor the router picked. So an
+executor change lands in one of three places, and only this harness separates them:
+
+- The plan got faster **and the router still picks it** — a real win, visible end to end.
+- The plan got faster **and the router never picks it** — a latent win. End-to-end latency moves 0%,
+  and a PR that only quotes the survey concludes, wrongly, that nothing happened.
+- A `cost::plan_cost` input moved, so the router picks **differently**. End-to-end latency moves and
+  none of the delta is the executor's. `result_total` will usually still match, so the parity check
+  does not catch it.
+
+What is compared, per (query, plan):
+
+- `exec_us` — `costbench.plan_self_ns`, the plan's own run with its re-paid `prepare_candidates`
+  netted back out. The toolkit's single definition, so this is comparable to the other harnesses.
+- `acquire_us` / `routed_us` — the acquire step and the whole routed path, both timed by
+  `explain_analyze` as shuffled participants rather than as preludes, so they are on the same footing
+  as the plans.
+- `picked` — whether the router chose this plan. Reported as a separate routing-shift line, because
+  an executor win the router declines to use is a different claim from a win it uses.
+- `result_total` — the row-count parity check. Rows whose totals disagree across builds are not
+  compared; a plan that got faster by returning different rows is not faster.
+
+Usage — same corpus, mode and seed on both sides, or nothing pairs:
+
+    # on main
+    .venv/bin/python scripts/bench_plan_execution_ab.py --sample 600 --out /tmp/main.jsonl
+    # on the branch
+    .venv/bin/python scripts/bench_plan_execution_ab.py --sample 600 --out /tmp/branch.jsonl
+    .venv/bin/python scripts/bench_plan_execution_ab.py --compare /tmp/main.jsonl /tmp/branch.jsonl
+
+    # or narrow to the plan under test
+    .venv/bin/python scripts/bench_plan_execution_ab.py --compare A.jsonl B.jsonl --plan PrintingCompose
+
+## Why this harness runs more trials than the rest of the toolkit
+
+`min` over the trials is a FLOOR estimator, and at a low trial count it is a noisy one. Its error
+depends on how much interference that particular run happened to see, so two runs of the same build
+land at different distances above the same true floor — and since every participant in a run shares
+those conditions, the error is common-mode and reads as a uniform slowdown rather than as noise.
+
+Measured, same build and same seed, only the trial count changed:
+
+| median µs           | 2w/7t A → B     | 6w/30t A → B     |
+| ------------------- | --------------- | ---------------- |
+| StreamedSelect      | 54.65 → 56.96   | 54.38 → 54.37    |
+| GatheredScan        | 40.29 → 42.98   | 39.96 → 39.79    |
+| acquire             |  2.67 →  2.92   |  2.67 →  2.62    |
+
+At 2w/7t all four measurements reported "B is SLOWER" with every interval excluding zero and "faster
+on 0". At 6w/30t all four report no detectable difference. The floors themselves only moved 0.5-2.6%,
+so this is not `min` finding a lower value — it is the run-to-run SPREAD collapsing from 4-9% to
+under 0.5% on the plans. Hence the defaults below.
+
+Interleaving A/B/A/B and quiescing the machine are still worth doing, and are the answer to genuine
+thermal drift over a long run. They were not the answer to the above.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import pathlib
+import random
+import statistics
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import costbench  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+# Identity of one measured (query, plan) observation. Everything here must match across builds for
+# the pair to be comparable -- the plan included, since the same query measures every applicable one.
+PAIR_KEY = ("q", "unique", "orderby", "direction", "limit", "offset", "plan")
+# A plan must appear this many times in BOTH runs before its own comparison is printed. Below it the
+# bootstrap interval is wider than anything the change could have done.
+MIN_PAIRS_PER_PLAN = 20
+# Well above the shared costbench (2, 7). Seven trials is enough to RANK plans inside one
+# `explain_analyze` call, where every participant shares the same conditions; it is not enough to
+# compare a plan against ITSELF in a second process, where each run's floor estimate carries its own
+# error. See the module docstring for the measurement that fixes these numbers.
+AB_WARMUPS = 6
+AB_TRIALS = 30
+# Acquire disagreeing between two runs by more than this means the two are not comparable. Most
+# executor changes do not touch acquire, so its movement estimates the residual common-mode error
+# left after the trial count above.
+DRIFT_WARN_FRACTION = 0.02
+
+
+def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: costbench.Budget) -> list[dict]:
+    """One row per (query, plan) that produced a page, plus the acquire and routed times."""
+    rows: list[dict] = []
+    for sample in costbench.iter_samples(engine, sampler, rng, budget):
+        acq = sample.res["acquire"]
+        # Both are per-round participant timings from the same shuffled loop as the plans.
+        acquire_us = min(acq["acquire_ns"]) / 1000.0 if acq["acquire_ns"] else None
+        routed_us = min(acq["routed_ns"]) / 1000.0 if acq["routed_ns"] else None
+        for p in sample.plans:
+            exec_ns = costbench.plan_self_ns(p, sample.acquire)
+            if exec_ns is None:
+                continue
+            rows.append(
+                {
+                    "q": sample.q,
+                    **{k: sample.kw[k] for k in ("unique", "orderby", "direction", "limit", "offset")},
+                    "plan": p["plan"],
+                    "exec_us": exec_ns / 1000.0,
+                    "acquire_us": acquire_us,
+                    "routed_us": routed_us,
+                    "picked": p["picked"],
+                    "result_total": p["result_total"],
+                    "count_source": sample.acquire["count_source"],
+                }
+            )
+    return rows
+
+
+def read_run(path: pathlib.Path) -> dict[tuple, dict]:
+    """Read a recorded run back, keyed by the identity a pair needs to share."""
+    import json  # noqa: PLC0415 - only the compare path needs it
+
+    out: dict[tuple, dict] = {}
+    for line in path.open():
+        r = json.loads(line)
+        out[tuple(r[k] for k in PAIR_KEY)] = r
+    return out
+
+
+def report_parity(a: dict[tuple, dict], b: dict[tuple, dict], shared: list[tuple]) -> list[tuple]:
+    """Drop pairs whose row counts disagree, and say how many. Returns the pairs worth comparing."""
+    mismatched = [k for k in shared if a[k]["result_total"] != b[k]["result_total"]]
+    if mismatched:
+        print(f"\n  !! {len(mismatched):,} of {len(shared):,} pairs returned DIFFERENT row counts and were excluded.")
+        print("     A plan that got faster by returning different rows is not faster. Sample:")
+        for k in mismatched[:3]:
+            print(f"       {k[6]:<20} {a[k]['result_total']:>9,} -> {b[k]['result_total']:>9,}   {k[0][:60]}")
+    return [k for k in shared if a[k]["result_total"] == b[k]["result_total"]]
+
+
+def median_ratio(a: dict[tuple, dict], b: dict[tuple, dict], keys: list[tuple], field: str) -> float | None:
+    """Median per-observation B/A for one field, or None if nothing usable paired."""
+    ratios = sorted(b[k][field] / a[k][field] for k in keys if a[k].get(field) and b[k].get(field))
+    return statistics.median(ratios) if ratios else None
+
+
+def report_drift(a: dict[tuple, dict], b: dict[tuple, dict], shared: list[tuple], by_plan: dict[str, list[tuple]]) -> None:
+    """Use acquire as a CONTROL, and refuse to let two incomparable runs read as a result.
+
+    The backstop for what `AB_WARMUPS`/`AB_TRIALS` mostly fixes. Each run's `min`-of-trials sits some
+    distance above the true floor, and that distance depends on the interference that run saw, so two
+    runs of the SAME build can disagree. The error is common-mode — every participant in a run shares
+    the conditions — which is exactly what makes acquire a usable control: most executor changes do
+    not touch it, so its movement estimates what is left.
+
+    At the old (2, 7) this fired hard: plans +4.2% and +6.7%, acquire +9.4%, every interval excluding
+    zero on a same-build pair, and the adjusted column below correctly read "no change". At (6, 30)
+    the same pair agrees to within 0.5% and this never fires. If it fires now, the two runs are not
+    comparable — raise `--trials` before believing anything above.
+    """
+    acquire_drift = median_ratio(a, b, shared, "acquire_us")
+    if acquire_drift is None or abs(acquire_drift - 1.0) < DRIFT_WARN_FRACTION:
+        return
+    print(f"\n  !! CONTROL MOVED — acquire disagrees by {acquire_drift - 1.0:+.1%} between these two runs.")
+    print("     If this change did not touch the acquire path, these two runs are not comparable and")
+    print(f"     every per-plan delta above carries the same error. Raise --trials (default {AB_TRIALS}) first;")
+    print("     that is what usually closes it. Until then read the adjusted column, not the raw one.")
+    print(f"\n  {'plan':<24}{'raw B/A':>10}{'÷ acquire':>12}   adjusted reading")
+    for plan, keys in sorted(by_plan.items(), key=lambda kv: -len(kv[1])):
+        raw = median_ratio(a, b, keys, "exec_us")
+        if raw is None or len(keys) < MIN_PAIRS_PER_PLAN:
+            continue
+        adjusted = raw / acquire_drift
+        verdict = (
+            "no change once the control is removed"
+            if abs(adjusted - 1.0) < DRIFT_WARN_FRACTION
+            else (f"{adjusted - 1.0:+.1%} after adjustment")
+        )
+        print(f"  {plan:<24}{raw:>10.3f}{adjusted:>12.3f}   {verdict}")
+
+
+def report_routing(a: dict[tuple, dict], b: dict[tuple, dict], shared: list[tuple]) -> None:
+    """Whether the router's choice moved — the second half of acceptance for an executor change."""
+    gained: collections.Counter[str] = collections.Counter()
+    lost: collections.Counter[str] = collections.Counter()
+    for k in shared:
+        if a[k]["picked"] == b[k]["picked"]:
+            continue
+        (gained if b[k]["picked"] else lost)[k[6]] += 1
+    if not gained and not lost:
+        print("\nrouting: unchanged on every paired query — an execution delta here is the whole story.")
+        return
+    print("\nrouting CHANGED — the end-to-end delta is not purely this executor's:")
+    for plan in sorted(set(gained) | set(lost)):
+        print(f"  {plan:<24}picked on {gained[plan]:>5,} more, {lost[plan]:>5,} fewer")
+
+
+def compare(path_a: pathlib.Path, path_b: pathlib.Path, only_plan: str | None) -> None:
+    """Paired per-plan execution comparison over the observations both runs recorded."""
+    a, b = read_run(path_a), read_run(path_b)
+    shared = sorted(set(a) & set(b))
+    if only_plan:
+        shared = [k for k in shared if k[6] == only_plan]
+    if not shared:
+        print("no (query, plan) observations in common -- both runs need the same --mode/--sample/--seed")
+        return
+    shared = report_parity(a, b, shared)
+    if not shared:
+        return
+
+    by_plan: dict[str, list[tuple]] = collections.defaultdict(list)
+    for k in shared:
+        by_plan[k[6]].append(k)
+
+    print(f"\nEXECUTION, per plan   (A={path_a.name}  B={path_b.name})")
+    for plan, keys in sorted(by_plan.items(), key=lambda kv: -len(kv[1])):
+        if len(keys) < MIN_PAIRS_PER_PLAN:
+            continue
+        print(f"\n── {plan}  ({len(keys):,} paired queries)")
+        costbench.report_paired(
+            {k: a[k]["exec_us"] for k in keys},
+            {k: b[k]["exec_us"] for k in keys},
+            unit="µs",
+            label_a=path_a.name,
+            label_b=path_b.name,
+        )
+
+    # Acquire and routed are per-QUERY, not per-plan: `explain_analyze` times each once per round and
+    # every plan row on that query carries the same copy. Key them by the query alone, or a query with
+    # four applicable plans votes four times and narrows the interval on strength it does not have.
+    for field, caption in (
+        ("acquire_us", "ACQUIRE (the shared prep, per query)"),
+        ("routed_us", "ROUTED (what a user actually waits for)"),
+    ):
+        av = {k[:6]: a[k][field] for k in shared if a[k][field] is not None}
+        bv = {k[:6]: b[k][field] for k in shared if b[k][field] is not None}
+        if paired := set(av) & set(bv):
+            print(f"\n── {caption}  ({len(paired):,} paired queries)")
+            costbench.report_paired(
+                {q: av[q] for q in paired},
+                {q: bv[q] for q in paired},
+                unit="µs",
+                label_a=path_a.name,
+                label_b=path_b.name,
+            )
+
+    report_drift(a, b, shared, by_plan)
+    report_routing(a, b, shared)
+    print("\n  Acceptance for an executor change is BOTH halves: the pinned plan is faster, AND the")
+    print("  router still routes to it. A win the router declines to use is a latent win — say so.")
+
+
+def main() -> None:
+    """Either measure one build to a file, or compare two such files."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--sample", type=int, default=600, help="queries to measure; every applicable plan is timed on each")
+    parser.add_argument("--warmups", type=int, default=AB_WARMUPS)
+    parser.add_argument(
+        "--trials", type=int, default=AB_TRIALS, help="a cross-process A/B needs a converged floor; see the module docstring"
+    )
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--mode", choices=MODES, default="realistic", help="executor work should be weighted like real traffic")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    parser.add_argument("--out", type=pathlib.Path, help="write per-(query, plan) rows as JSONL")
+    parser.add_argument("--compare", nargs=2, type=pathlib.Path, metavar=("A.jsonl", "B.jsonl"))
+    parser.add_argument("--plan", help="restrict --compare to one plan, e.g. PrintingCompose")
+    args = parser.parse_args()
+
+    if args.compare:
+        compare(*args.compare, args.plan)
+        return
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".planexec.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    budget = costbench.Budget(sample=args.sample, warmups=args.warmups, trials=args.trials)
+    rows = measure(engine, sampler, random.Random(args.seed), budget)
+    per_plan = collections.Counter(r["plan"] for r in rows)
+    print(f"\nmeasured {len(rows):,} (query, plan) observations, mode={args.mode}")
+    for plan, n in per_plan.most_common():
+        print(f"  {plan:<24}{n:>7,}")
+    if args.out:
+        costbench.write_rows(args.out, rows)
+    else:
+        print("\n  no --out given, so nothing was recorded. Pass --out to make this run comparable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_plan_execution_ab.py
+++ b/scripts/bench_plan_execution_ab.py
@@ -73,7 +73,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
 # Identity of one measured (query, plan) observation. Everything here must match across builds for

--- a/scripts/bench_plan_misselection.py
+++ b/scripts/bench_plan_misselection.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from api.parsing import parse_scryfall_query  # noqa: E402
 from client.query_runner import random_query  # noqa: E402
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 if TYPE_CHECKING:
     import card_engine

--- a/scripts/bench_plan_misselection.py
+++ b/scripts/bench_plan_misselection.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from client.query_runner import random_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 
 if TYPE_CHECKING:
@@ -51,13 +52,13 @@ ORDERBY_VALUES = frozenset(
 )
 DEFAULT_ORDERBY = "edhrec"
 RANDOM_UNIQUE_WEIGHTS = {"card": 75, "printing": 20, "artwork": 5}
-# Enough rounds that a bimodal plan shows both modes (00648's measurement-traps section) while
-# keeping a 200-query sweep to a couple of minutes.
+# Above the shared costbench default, with a reason: enough rounds that a bimodal plan shows both
+# modes (00648's measurement-traps section) while keeping a 200-query sweep to a couple of minutes.
 NUM_WARMUPS = 3
 NUM_TRIALS = 15
 # Regret below this is inside run-to-run noise at these sizes; counted but reported separately
 # so a "miss" that costs nothing does not inflate the headline rate.
-NOISE_FLOOR_US = 1.0
+NOISE_FLOOR_US = costbench.NOISE_FLOOR_US
 # Fewer plans than this and there is no choice to get wrong.
 MIN_PLANS_TO_CHOOSE = 2
 # statistics.quantiles needs more than this many samples to say anything.
@@ -119,18 +120,23 @@ def calibration(engine: card_engine.QueryEngine, queries: list[tuple[str, str, s
         except Exception:  # noqa: BLE001, S112 - a query bind rejects is a sample skip, not an error
             continue
         for p in res["plans"]:
-            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+            predicted = costbench.predicted_ns(p)
+            if not p["trials_ns"] or predicted is None:
                 continue
             # A plan can measure 0 ns when it is faster than the clock's resolution; clamp so the
             # log-scale ordering below stays defined without dropping the sample.
             meas = max(min(p["trials_ns"]), 1)
-            r = meas / p["predicted_ns"]
+            r = meas / predicted
             ratios[p["plan"]].append(r)
-            # A plan that materializes pays acquire inside its trial; net it out. Clamped at a
-            # nanosecond so a plan whose whole cost was acquire cannot divide by zero.
-            net = max(meas - min(res["acquire"]["acquire_ns"]), 1.0) if p["materialize_ns"] > 0 else float(meas)
-            nets[p["plan"]].append(net / p["predicted_ns"])
-            by_source[p["plan"], res["acquire"]["count_source"]].append(net / p["predicted_ns"])
+            # `costbench.plan_self_ns` is the toolkit's one definition of a plan's own cost. This
+            # harness previously netted `acquire_ns`, which times a DIFFERENT participant, so its
+            # `net` column was not comparable to the same column in the percentile and pairwise
+            # harnesses. It nets `ns_prepare` now, and drops the row when the subtraction overshoots.
+            self_ns = costbench.plan_self_ns(p, res["acquire"])
+            if self_ns is None:
+                continue
+            nets[p["plan"]].append(self_ns / predicted)
+            by_source[p["plan"], res["acquire"]["count_source"]].append(self_ns / predicted)
             # Track the furthest from 1 in log terms, either direction.
             if abs(math.log(r)) > abs(math.log(worst[p["plan"]][0])):
                 worst[p["plan"]] = (r, f"{q} [{unique}]")

--- a/scripts/bench_plan_misselection.py
+++ b/scripts/bench_plan_misselection.py
@@ -29,9 +29,9 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from client.query_runner import random_query  # noqa: E402
 from scripts import costbench  # noqa: E402
 from scripts.costbench import load_engine  # noqa: E402
+from scripts.query_sampler import QuerySampler  # noqa: E402
 
 if TYPE_CHECKING:
     import card_engine
@@ -51,7 +51,6 @@ ORDERBY_VALUES = frozenset(
     {"edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "name", "released", "set", "color", "usd", "artist", "review"}
 )
 DEFAULT_ORDERBY = "edhrec"
-RANDOM_UNIQUE_WEIGHTS = {"card": 75, "printing": 20, "artwork": 5}
 # Above the shared costbench default, with a reason: enough rounds that a bimodal plan shows both
 # modes (00648's measurement-traps section) while keeping a 200-query sweep to a couple of minutes.
 NUM_WARMUPS = 3
@@ -68,13 +67,23 @@ MIN_FOR_QUARTILES = 4
 LIVE_DEFECT_FLOOR_US = 5.0
 
 
-def load_queries(source: str, sample: int, seed: int) -> list[tuple[str, str, str]]:
-    """(query, unique, orderby) triples from the requested source, sampled deterministically."""
+def load_queries(source: str, sample: int, seed: int, corpus: pathlib.Path) -> list[tuple[str, str, str]]:
+    """(query, unique, orderby) triples from the requested source, sampled deterministically.
+
+    `wild-operators` is the default and stays the wild corpus: real Scryfall traffic is the right
+    universe for a REGRET number, because regret is what users actually lose.
+
+    `random` used `client.query_runner.random_query`, which is a load generator — it picks values
+    off hardcoded lists (`year:2019`..`year:2024` on a corpus spanning 1993-2026, a dozen fixed
+    prices) and so clusters selectivity at a handful of arbitrary points. Routing is decided by
+    selectivity, so that source could barely produce a mis-selection to measure. It draws from
+    `QuerySampler` now: same synthetic role, but corpus-derived values, quantile-placed thresholds,
+    and a real spread of distinct-on and orderby instead of a fixed `edhrec`.
+    """
     rng = random.Random(seed)
     if source == "random":
-        uniques = list(RANDOM_UNIQUE_WEIGHTS)
-        weights = [RANDOM_UNIQUE_WEIGHTS[u] for u in uniques]
-        return [(random_query(), rng.choices(uniques, weights=weights)[0], DEFAULT_ORDERBY) for _ in range(sample)]
+        sampler = QuerySampler(corpus, "uniform")
+        return [(sampler.query(rng), sampler.unique(rng), sampler.orderby(rng)) for _ in range(sample)]
 
     rows = []
     for line in (REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl").open():
@@ -177,7 +186,7 @@ def main() -> None:
     args = parser.parse_args()
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".misselect.store"))
-    queries = load_queries(args.source, args.sample, args.seed)
+    queries = load_queries(args.source, args.sample, args.seed, args.corpus)
     if args.calibration:
         calibration(engine, queries, args.trials)
         return

--- a/scripts/bench_plan_misselection.py
+++ b/scripts/bench_plan_misselection.py
@@ -51,6 +51,8 @@ ORDERBY_VALUES = frozenset(
     {"edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "name", "released", "set", "color", "usd", "artist", "review"}
 )
 DEFAULT_ORDERBY = "edhrec"
+# Overridable so the harness runs from a git worktree, which has no benchmarks/ tree of its own.
+WILD_CORPUS = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
 # Above the shared costbench default, with a reason: enough rounds that a bimodal plan shows both
 # modes (00648's measurement-traps section) while keeping a 200-query sweep to a couple of minutes.
 NUM_WARMUPS = 3
@@ -67,7 +69,9 @@ MIN_FOR_QUARTILES = 4
 LIVE_DEFECT_FLOOR_US = 5.0
 
 
-def load_queries(source: str, sample: int, seed: int, corpus: pathlib.Path) -> list[tuple[str, str, str]]:
+def load_queries(
+    source: str, sample: int, seed: int, corpus: pathlib.Path, wild_corpus: pathlib.Path
+) -> list[tuple[str, str, str]]:
     """(query, unique, orderby) triples from the requested source, sampled deterministically.
 
     `wild-operators` is the default and stays the wild corpus: real Scryfall traffic is the right
@@ -86,7 +90,7 @@ def load_queries(source: str, sample: int, seed: int, corpus: pathlib.Path) -> l
         return [(sampler.query(rng), sampler.unique(rng), sampler.orderby(rng)) for _ in range(sample)]
 
     rows = []
-    for line in (REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl").open():
+    for line in wild_corpus.open():
         row = json.loads(line)
         unique = UNIQUE_FROM_SCRYFALL.get(row.get("unique", "card"))
         if unique is None or not OP_RE.search(row["q"]):
@@ -182,11 +186,14 @@ def main() -> None:
     parser.add_argument("--trials", type=int, default=NUM_TRIALS, help="timed rounds per plan; lower for large sweeps")
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument(
+        "--wild-corpus", type=pathlib.Path, default=WILD_CORPUS, help="real-traffic corpus for --source wild-operators"
+    )
     parser.add_argument("--shm-path", type=pathlib.Path, default=None)
     args = parser.parse_args()
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".misselect.store"))
-    queries = load_queries(args.source, args.sample, args.seed, args.corpus)
+    queries = load_queries(args.source, args.sample, args.seed, args.corpus, args.wild_corpus)
     if args.calibration:
         calibration(engine, queries, args.trials)
         return

--- a/scripts/bench_plane_popcount_cost.py
+++ b/scripts/bench_plane_popcount_cost.py
@@ -29,7 +29,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from client.query_runner import random_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 TARGET_PLAN = "PlanePopcountOrder"
 NUM_WARMUPS = 3

--- a/scripts/bench_price_range_targeted.py
+++ b/scripts/bench_price_range_targeted.py
@@ -22,7 +22,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 # usd/cn/year/date across card/printing/artwork are what the two commits in this PR target.

--- a/scripts/bench_printing_planes.py
+++ b/scripts/bench_printing_planes.py
@@ -30,7 +30,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 if TYPE_CHECKING:
     import card_engine

--- a/scripts/bench_printing_range.py
+++ b/scripts/bench_printing_range.py
@@ -24,7 +24,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import WARMUP, load_engine  # noqa: E402
+from scripts.bench_bitplanes import WARMUP  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 if TYPE_CHECKING:
     import card_engine

--- a/scripts/bench_produces_planes.py
+++ b/scripts/bench_produces_planes.py
@@ -27,7 +27,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_query_latency_ab.py
+++ b/scripts/bench_query_latency_ab.py
@@ -1,4 +1,4 @@
-"""Paired end-to-end query latency between two engine builds. The only A/B that works against main.
+"""Paired end-to-end query latency between two engine builds. The A/B that works against ANY build.
 
 `bench_plan_misselection.py` measures routing regret, but it reads `explain_analyze` fields and a
 response shape that this branch introduced — main returns a bare list where the branch returns
@@ -10,6 +10,17 @@ for. Same discipline as the regret A/B: write per-query rows with `--out`, then 
 PAIRED over the same query list, with a bootstrap CI on the difference. Latency is heavy-tailed
 (broad scans cost thousands of times a name lookup), so comparing two headline means is hopeless —
 pairing removes query-sampling variance and the interval says whether what remains is real.
+
+For the executor-level question underneath this one — did a specific PLAN get faster, whether or not
+the router picks it — see `bench_plan_execution_ab.py`.
+
+**Pairing does not remove the other variance, and breadth does not substitute for depth.** `min` over
+the trials is a floor estimator, and how far above the floor it lands depends on the interference
+that run saw. That error is common-mode across every query in a run, so averaging it over more
+queries does NOT cancel it. Measured on a same-build, same-seed pair at the old (2, 7) defaults, 388
+queries paired: `B - A = -1.0 µs, 95% CI [-1.6, -0.5]`, verdict "B is FASTER", faster on 110 and
+slower on 35 — with nothing changed. The same pair at (6, 30): `+0.5 µs, CI [-1.0, +2.9]`, no
+detectable difference. Hence the defaults below; lower them only if you can show the canary is clean.
 
     # once per build:
     .venv/bin/python scripts/bench_query_latency_ab.py --sample 2000 --out A.jsonl
@@ -42,8 +53,12 @@ from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
-NUM_WARMUPS = 2
-NUM_TRIALS = 7
+# Well above the shared costbench (2, 7), which is calibrated for comparisons INSIDE one
+# `explain_analyze` call where every participant shares the same conditions. This is a
+# cross-process comparison, where each run's floor estimate carries its own error -- see the module
+# docstring for the same-build canary that fixes these numbers.
+NUM_WARMUPS = 6
+NUM_TRIALS = 30
 LIMITS = (10, 100, 175)
 OFFSETS = (0, 0, 0, 100)
 BOOTSTRAP_RESAMPLES = 10_000
@@ -56,8 +71,10 @@ NOISE_FLOOR_US = 1.0
 class Budget:
     """How many queries to measure, and how hard.
 
-    Fewer trials buys more DISTINCT queries per unit of CPU, and for a PAIRED comparison that is the
-    better trade -- pairing already removes per-query variance, so breadth beats depth.
+    Breadth and depth defend against DIFFERENT variance, and only one of them is optional. Pairing
+    plus a wide sample removes query-to-query variance. Neither touches the floor-estimation error,
+    which is common-mode within a run and therefore survives any amount of averaging over queries.
+    Buy depth first, then spend what is left on breadth.
     """
 
     sample: int
@@ -149,11 +166,15 @@ def compare(path_a: pathlib.Path, path_b: pathlib.Path) -> None:
 def main() -> None:
     """Either measure one build to a file, or compare two such files."""
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("--sample", type=int, default=2000)
-    # Fewer trials buys more DISTINCT queries per unit of CPU. For a paired comparison that is the
-    # better trade: pairing already removes per-query variance, so breadth beats depth.
+    # Was 2000 when a run was 9 rounds deep; at 36 that would be 4x the wall time. Depth comes first
+    # (breadth cannot cancel a common-mode error), and the same-build canary was already clean at 400.
+    parser.add_argument("--sample", type=int, default=800)
+    # Lowering these to buy more distinct queries is the trade this harness used to make, and it is
+    # the wrong one: breadth cannot cancel an error that is common-mode within a run.
     parser.add_argument("--warmups", type=int, default=NUM_WARMUPS)
-    parser.add_argument("--trials", type=int, default=NUM_TRIALS)
+    parser.add_argument(
+        "--trials", type=int, default=NUM_TRIALS, help="a cross-process A/B needs a converged floor; see the module docstring"
+    )
     parser.add_argument("--seed", type=int, default=1)
     parser.add_argument("--mode", choices=MODES, default="realistic", help="latency asks what users wait for, so traffic-weighted")
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")

--- a/scripts/bench_query_latency_ab.py
+++ b/scripts/bench_query_latency_ab.py
@@ -50,7 +50,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
 # Well above the shared costbench (2, 7), which is calibrated for comparisons INSIDE one

--- a/scripts/bench_range_bits.py
+++ b/scripts/bench_range_bits.py
@@ -28,7 +28,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 if TYPE_CHECKING:
     import card_engine

--- a/scripts/bench_range_estimate_scan.py
+++ b/scripts/bench_range_estimate_scan.py
@@ -35,7 +35,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # Thresholds per dimension, spanning each field's real distribution from a handful of cards to
 # nearly the whole corpus. Deliberately the same shapes the investigation swept.

--- a/scripts/bench_rarity_planes.py
+++ b/scripts/bench_rarity_planes.py
@@ -27,7 +27,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -26,7 +26,6 @@ import pathlib
 import random
 import statistics
 import sys
-import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -35,62 +34,47 @@ if TYPE_CHECKING:
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
-NUM_WARMUPS = 2
-NUM_TRIALS = 7
-LIMITS = (10, 100, 175)
-OFFSETS = (0, 0, 0, 100)
 # Below this a "miss" costs nothing and only inflates the rate.
-NOISE_FLOOR_US = 1.0
-MIN_ROWS = 30
+NOISE_FLOOR_US = costbench.NOISE_FLOOR_US
+MIN_ROWS = costbench.MIN_ROWS
+# Regret is mostly zeros, so the low percentiles carry no information and the shared p0..p100 row
+# would be six columns of 0.00. Only the tail says anything here.
 PERCENTILES = (90, 99)
 
 
-def percentile(vals: list[float], pct: int) -> float:
-    """Nearest-rank percentile, so each printed number is a real query."""
-    idx = min(round(pct / 100.0 * len(vals) + 0.5) - 1, len(vals) - 1)
-    return vals[max(idx, 0)]
+percentile = costbench.percentile
 
 
 def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
-    """One row per multi-plan query: what it lost, and everything to slice that by."""
+    """One row per multi-plan query: what it lost, and everything to slice that by.
+
+    Deliberately does NOT use `costbench.plan_self_ns`. That nets `ns_prepare` back out to make a
+    plan comparable to the cost model's per-plan prediction; regret compares against `routed_ns`,
+    a whole real execution with the prep included. Netting one side of that subtraction and not the
+    other would invent time that was never saved.
+    """
     rows: list[dict] = []
-    deadline = time.monotonic() + seconds
-    while time.monotonic() < deadline:
-        unique = sampler.unique(rng)
-        kw = {
-            "filters": None,
-            "unique": unique,
-            "orderby": sampler.orderby(rng),
-            "direction": rng.choice(("asc", "desc")),
-            "limit": rng.choice(LIMITS),
-            "offset": rng.choice(OFFSETS),
-        }
-        try:
-            kw["filters"] = parse_scryfall_query(sampler.query(rng))
-            acq = engine.explain(**kw)["acquire"]
-            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
-        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
-            continue
-        ran = [p for p in res["plans"] if p["trials_ns"]]
+    for sample in costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds)):
+        ran = [p for p in sample.plans if p["trials_ns"]]
         if len(ran) < 2:  # noqa: PLR2004 - one applicable plan means there is nothing to get wrong
             continue
-        picked = next((p for p in res["plans"] if p["picked"]), None)
+        picked = next((p for p in sample.plans if p["picked"]), None)
         declined = picked is not None and not picked["trials_ns"]
         best = min(ran, key=lambda p: min(p["trials_ns"]))
         # routed_ns lives on explain_analyze's acquire; `explain` runs nothing and leaves it empty.
-        routed = res["acquire"]["routed_ns"]
+        routed = sample.res["acquire"]["routed_ns"]
         if not routed:
             continue
         routed_us = min(routed) / 1000.0
         rows.append(
             {
                 "lost": max(routed_us - min(best["trials_ns"]) / 1000.0, 0.0),
-                "acquire": acq["count_source"],
-                "unique": unique,
+                "acquire": sample.acquire["count_source"],
+                "unique": sample.kw["unique"],
                 "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
                 "best": best["plan"],
             }

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -35,7 +35,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
 
 # Below this a "miss" costs nothing and only inflates the rate.

--- a/scripts/bench_tag_postings_compose.py
+++ b/scripts/bench_tag_postings_compose.py
@@ -26,7 +26,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query, unique, orderby, prefer) — direction=asc, limit=100, offset=0 throughout.
 CONFIGS: list[tuple[str, str, str, str, str]] = [

--- a/scripts/bench_text_memo.py
+++ b/scripts/bench_text_memo.py
@@ -21,7 +21,8 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.bench_bitplanes import bench_one, load_engine  # noqa: E402
+from scripts.bench_bitplanes import bench_one  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # (group, query) — unique=card, orderby=edhrec, prefer=default throughout.
 CONFIGS: list[tuple[str, str]] = [

--- a/scripts/bench_verify_order.py
+++ b/scripts/bench_verify_order.py
@@ -194,7 +194,7 @@ def cmd_worker(args: argparse.Namespace) -> None:
 
 def cmd_run(args: argparse.Namespace) -> None:
     """Build the store + frozen spec set, then run interleaved old/new reps."""
-    from scripts.bench_bitplanes import load_engine  # noqa: PLC0415 — heavy loader, workers don't need it
+    from scripts.costbench import load_engine  # noqa: PLC0415 — heavy loader, workers don't need it
 
     store = OUTDIR / "real.store"
     queries = OUTDIR / "specs.json"

--- a/scripts/census_candidate_materialize.py
+++ b/scripts/census_candidate_materialize.py
@@ -35,7 +35,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from client.query_runner import random_query  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 if TYPE_CHECKING:
     import card_engine

--- a/scripts/census_candidate_materialize.py
+++ b/scripts/census_candidate_materialize.py
@@ -64,6 +64,8 @@ ORDERBY_VALUES = frozenset(
     {"edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "name", "released", "set", "color", "usd", "artist", "review"}
 )
 DEFAULT_ORDERBY = "edhrec"
+# Overridable so the harness runs from a git worktree, which has no benchmarks/ tree of its own.
+WILD_CORPUS = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
 # random_query() emits shapes, not unique/orderby; sample those the way real traffic
 # distributes (client/query_runner.py's own weights).
 RANDOM_UNIQUE_WEIGHTS = {"card": 75, "printing": 20, "artwork": 5}
@@ -174,6 +176,7 @@ def main() -> None:
         help="card rows to build the store from",
     )
     parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --corpus)")
+    parser.add_argument("--wild-corpus", type=pathlib.Path, default=WILD_CORPUS, help="real-traffic corpus read by --wild")
     parser.add_argument("--wild", action="store_true", help="census the Common Crawl wild-query corpus")
     parser.add_argument("--random", type=int, default=0, metavar="N", help="also census N generated queries")
     parser.add_argument("--seed", type=int, default=0, help="seed for --random")
@@ -188,7 +191,7 @@ def main() -> None:
 
     sources: list[tuple[str, list[tuple[str, str, str, int]]]] = []
     if args.wild:
-        corpus = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
+        corpus = args.wild_corpus
         sources.append(("wild-operators", wild_queries(corpus, with_operators=True)))
         sources.append(("wild-namelookup", wild_queries(corpus, with_operators=False)))
     if args.random:

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -1,0 +1,387 @@
+"""Shared measurement core for the `explain_analyze` harnesses.
+
+Eleven benchmarks drive `QueryEngine.explain_analyze` and, before this module, each one carried its
+own copy of the same four things: the sampling loop, a nearest-rank `percentile`, a percentile-table
+renderer, and the rule for turning a plan's raw `trials_ns` into "what this plan costs to run". The
+copies had drifted, and the drift was not cosmetic:
+
+- Three different netting rules. Two subtracted `ns_prepare`, disagreeing on what to do when the
+  subtraction overshot; a third subtracted `acquire_ns`, which times a DIFFERENT participant. A
+  number netted one way is not comparable to a number netted another, which quietly undercut the
+  cross-harness working order in `docs/issues/reference-cost-model-measurement.md`.
+- Five different `(warmups, trials)` settings across nine files, with no stated reason for the
+  differences beyond what each author needed that day.
+- One `percentile` copy had lost its empty-input guard and raised `IndexError` on an empty slice
+  where the other two returned `nan`.
+
+So the point of this module is not line count. It is that every harness answers "how long did this
+plan take" the same way, and a fix to that answer lands everywhere at once.
+
+The schema this module reads is asserted, not assumed -- see `require_schema`. `explain_analyze`'s
+response shape has changed before, and a harness that reads a key the engine stopped publishing
+should say so rather than `KeyError` a hundred queries in.
+"""
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import json
+import math
+import random
+import statistics
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Callable, Iterator
+
+    from scripts.query_sampler import QuerySampler
+
+# ── measurement defaults ──────────────────────────────────────────────────────────────────────
+# The (2, 7) pair six of the nine harnesses had already converged on. Seven is the floor for reading
+# `trials_ns` as a head-to-head: participants are shuffled per round from a fixed seed rather than
+# rotated, so at 2-3 trials a plan can draw the warm tail twice. See docs/issues/00801-*.
+#
+# These defaults are for comparisons made INSIDE one `explain_analyze` call -- plan against plan,
+# measured against predicted -- where every participant ran in the same rounds under the same
+# conditions, so the floor-estimation error is common-mode and largely cancels. Prefix-min of
+# `trials_ns` against min-of-60, median over queries, measured in one process:
+#
+#     k=          2      3      5      7     10     15     20     30     45     60
+#     GatheredScan    1.029  1.024  1.017  1.014  1.013  1.004  1.002  1.000  1.000  1.000
+#     StreamedSelect  1.010  1.007  1.005  1.004  1.003  1.001  1.001  1.000  1.000  1.000
+#
+# So at k=7 an absolute measurement sits 0.4-1.4% above the true floor -- far below the errors these
+# harnesses hunt (2x feature miscounts, 100x cost tails), and not worth 4x the runtime.
+#
+# A CROSS-PROCESS comparison is a different regime and must not use these. There each run carries its
+# own floor error, and it does NOT average out over queries because it is common-mode within the run.
+# `bench_plan_execution_ab.py` and `bench_query_latency_ab.py` both false-positived on same-build,
+# same-seed pairs at (2, 7) and both come out clean at (6, 30); each states its own numbers.
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+# Page shapes to sample. Mostly first-page, which is what real traffic asks for.
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+
+# Nearest-rank percentiles reported by `percentile_table`. 0 and 100 are the real min and max, and
+# they earn their place here: estimates of zero cards and of every card are both common, and a p1/p99
+# view clips exactly the cases where a cost arm is most likely to be shaped wrong.
+PERCENTILES = (0, 1, 10, 20, 50, 70, 90, 99, 100)
+# Cells thinner than this are noise; a percentile over a handful of samples says nothing.
+MIN_ROWS = 30
+# Below this, a per-query difference is timer jitter rather than a real change.
+NOISE_FLOOR_US = 1.0
+
+# Acquire sources whose routed path re-pays `prepare_candidates`, so a plan's `trials_ns` is NOT
+# double-counting it and must not be netted. Everywhere else the prep is shared and the plan is
+# charged for a copy it would not pay under the router.
+RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
+# If netting `ns_prepare` removes more than this fraction of the measured round, the subtraction has
+# overshot and the residual is noise rather than a smaller measurement. Drop the row instead of
+# reporting a number built out of two nearly-equal quantities.
+NETTING_RESIDUAL_FLOOR = 0.5
+
+BOOTSTRAP_RESAMPLES = 10_000
+BOOTSTRAP_CI = 0.95
+
+# ── the explain_analyze contract ──────────────────────────────────────────────────────────────
+# Asserted once per run against the first response, so a shape change is a named error rather than a
+# KeyError deep in a collection loop. Keep in sync with `plan_trial_to_pydict` /
+# `acquire_facts_to_pydict` in card_engine/src/lib.rs.
+PLAN_KEYS = frozenset(
+    {
+        "plan",
+        "predicted_ns",
+        "materialize_ns",
+        "picked",
+        "trials_ns",
+        "declined_ns",
+        "cards_visited",
+        "printings_scanned",
+        "matches_pushed",
+        "ns_setup",
+        "ns_loop",
+        "ns_finish",
+        "ns_round_total",
+        "ns_prepare",
+        "result_total",
+        "paging_taken",
+    }
+)
+ACQUIRE_KEYS = frozenset({"count_source", "narrowed_repr", "acquire_ns", "routed_ns", "compose_paging"})
+
+
+def require_schema(res: dict) -> None:
+    """Fail loudly if `explain_analyze` is not publishing what the harnesses read.
+
+    Raises:
+        RuntimeError: naming the missing keys, so a shape change reads as itself.
+    """
+    missing = {"acquire": sorted(ACQUIRE_KEYS - set(res.get("acquire", {})))}
+    for plan in res.get("plans", []):
+        if gap := sorted(PLAN_KEYS - set(plan)):
+            missing[plan.get("plan", "?")] = gap
+    if named := {k: v for k, v in missing.items() if v}:
+        msg = f"explain_analyze response is missing keys this harness reads: {named}"
+        raise RuntimeError(msg)
+
+
+# ── sampling ──────────────────────────────────────────────────────────────────────────────────
+
+
+@dataclasses.dataclass(frozen=True)
+class Budget:
+    """How much to measure, and how hard.
+
+    Exactly one of `seconds` or `sample` bounds the run. Fewer trials buys more DISTINCT queries per
+    unit of CPU; for a PAIRED comparison that is the better trade, since pairing already removes
+    per-query variance and breadth beats depth.
+    """
+
+    seconds: float | None = None
+    sample: int | None = None
+    warmups: int = NUM_WARMUPS
+    trials: int = NUM_TRIALS
+
+    def __post_init__(self) -> None:
+        """Reject a budget with no bound, or with two that could disagree."""
+        if (self.seconds is None) == (self.sample is None):
+            msg = "Budget takes exactly one of seconds= or sample="
+            raise ValueError(msg)
+
+
+@dataclasses.dataclass(frozen=True)
+class Sample:
+    """One measured query: what was asked, and both views of the answer."""
+
+    q: str
+    kw: dict
+    acquire: dict
+    """`explain`'s acquire facts -- the cheap pass, with the feature vector and no timings."""
+    res: dict
+    """The full `explain_analyze` response: `plans` plus its own `acquire` carrying `routed_ns`."""
+
+    @property
+    def plans(self) -> list[dict]:
+        """The per-plan trials, in the router's predicted-cost order."""
+        return self.res["plans"]
+
+    def key(self) -> tuple:
+        """Identity for pairing this query across two builds."""
+        return (self.q, self.kw["unique"], self.kw["orderby"], self.kw["direction"], self.kw["limit"], self.kw["offset"])
+
+
+def sample_kwargs(sampler: QuerySampler, rng: random.Random) -> dict:
+    """One query shape: distinct-on, order, direction and page, weighted by the sampler's mode."""
+    return {
+        "filters": None,
+        "unique": sampler.unique(rng),
+        "orderby": sampler.orderby(rng),
+        "direction": rng.choice(("asc", "desc")),
+        "limit": rng.choice(LIMITS),
+        "offset": rng.choice(OFFSETS),
+    }
+
+
+def iter_samples(engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget) -> Iterator[Sample]:
+    """Yield measured queries until the budget runs out, skipping any the parser rejects.
+
+    The schema is checked against the first response that comes back, so a run against a build whose
+    `explain_analyze` has moved on fails immediately instead of part way through.
+    """
+    # Imported here, not at module scope, so `costbench` stays importable (and unit-testable)
+    # without the `api` package on the path. The cost is one import per process.
+    from api.parsing import parse_scryfall_query  # noqa: PLC0415
+
+    checked = False
+    deadline = time.monotonic() + budget.seconds if budget.seconds is not None else math.inf
+    taken = 0
+    while time.monotonic() < deadline and (budget.sample is None or taken < budget.sample):
+        taken += 1
+        kw = sample_kwargs(sampler, rng)
+        q = sampler.query(rng)
+        try:
+            kw["filters"] = parse_scryfall_query(q)
+            acquire = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=budget.warmups, num_trials=budget.trials, **kw)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        if not checked:
+            require_schema(res)
+            checked = True
+        yield Sample(q=q, kw=kw, acquire=acquire, res=res)
+
+
+# ── the one netting rule ──────────────────────────────────────────────────────────────────────
+
+
+def predicted_ns(plan: dict) -> float | None:
+    """The model's cost for this plan, or None when it did not give one.
+
+    `cost::plan_cost` returns `f64::INFINITY` for `ComposePaging::Decline` — that is "never pick me",
+    not a prediction. It arrives in Python as `inf`, and the `predicted_ns <= 0` guard every harness
+    used does not catch it, so any ratio built from such a row is `inf` and poisons whichever
+    percentile cell it lands in. Visible as `inf` in `PrintingCompose`'s p90/p99/p100 before this
+    existed; the old p1..p99 tables hid it wherever those rows stayed under a tenth of the cell.
+    """
+    p = plan["predicted_ns"]
+    return p if math.isfinite(p) and p > 0 else None
+
+
+def plan_self_ns(plan: dict, acquire: dict) -> float | None:
+    """What this plan costs to RUN, in nanoseconds -- the single definition every harness uses.
+
+    `min` over the trials, because the question is what the plan costs when nothing interferes, and
+    the distribution's upper tail is machine noise rather than the plan.
+
+    Materializing plans re-run `prepare_candidates` inside their own forced round, where the router
+    would have acquired the artifact once and shared it. That prep is published per plan as
+    `ns_prepare`, so it can be netted back out -- except under a range-style acquire, where the
+    routed path re-pays it too and it IS the plan's cost.
+
+    Returns:
+        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or
+        if netting overshot far enough that the residual is noise.
+    """
+    if not plan["trials_ns"]:
+        return None
+    real = float(min(plan["trials_ns"]))
+    if plan["ns_round_total"] and acquire["count_source"] not in RANGE_ACQUIRES:
+        netted = real - plan["ns_prepare"]
+        if netted < real * NETTING_RESIDUAL_FLOOR:
+            return None
+        real = netted
+    return real
+
+
+# ── statistics and tables ─────────────────────────────────────────────────────────────────────
+
+
+def percentile(sorted_vals: list[float], pct: int) -> float:
+    """Nearest-rank percentile; no interpolation, so every printed number is a real observation."""
+    if not sorted_vals:
+        return float("nan")
+    idx = min(round(pct / 100.0 * len(sorted_vals) + 0.5) - 1, len(sorted_vals) - 1)
+    return sorted_vals[max(idx, 0)]
+
+
+def spread(sorted_vals: list[float]) -> float:
+    """p90/p10 -- flat means a uniform rate error, wide means something unmodelled."""
+    lo = percentile(sorted_vals, 10)
+    return percentile(sorted_vals, 90) / lo if lo > 0 else float("inf")
+
+
+#: Ranking strategies for `percentile_table`, by what puts the interesting cell first.
+BY_COUNT = ("n", lambda vals: -len(vals))
+BY_MISCALIBRATION = ("worst-calibrated", lambda vals: -abs(math.log(max(percentile(sorted(vals), 50), 1e-9))))
+BY_TOTAL = ("share of total", lambda vals: -sum(vals))
+
+
+def percentile_table(  # noqa: PLR0913 - a table renderer's arguments ARE its output format
+    rows: list[dict],
+    key: Callable[[dict], object],
+    label: str,
+    *,
+    value: str = "ratio",
+    rank: tuple[str, Callable[[list[float]], float]] = BY_COUNT,
+    limit: int = 40,
+    min_rows: int = MIN_ROWS,
+    annotate: Callable[[list[float]], str] | None = None,
+) -> None:
+    """Print one grouping of `rows` as a nearest-rank percentile table.
+
+    Args:
+        rows: collected rows, each carrying `value` and whatever `key` reads.
+        key: the slice -- what goes in the leftmost column.
+        label: header for that column.
+        value: which field to build the distribution from.
+        rank: one of `BY_COUNT` / `BY_MISCALIBRATION` / `BY_TOTAL`, deciding row order.
+        limit: how many cells to print.
+        min_rows: cells thinner than this are dropped as noise.
+        annotate: optional trailing column, given the sorted values.
+    """
+    groups: dict[object, list[float]] = collections.defaultdict(list)
+    for r in rows:
+        groups[key(r)].append(r[value])
+    kept = {name: sorted(vals) for name, vals in groups.items() if len(vals) >= min_rows}
+    if not kept:
+        print(f"\n{label}: no cell reached {min_rows} samples")
+        return
+    head = "".join(f"{f'p{p}':>8}" for p in PERCENTILES)
+    print(f"\n{label:<44}{'n':>7}{head}{'p90/p10':>9}   [{rank[0]} first]")
+    for name, vals in sorted(kept.items(), key=lambda kv: rank[1](kv[1]))[:limit]:
+        cells = "".join(f"{percentile(vals, p):>8.2f}" for p in PERCENTILES)
+        tail = annotate(vals) if annotate else ""
+        print(f"{name!s:<44}{len(vals):>7}{cells}{spread(vals):>9.1f}{tail}")
+
+
+def paired_bootstrap(deltas: list[float]) -> tuple[float, float]:
+    """Central `BOOTSTRAP_CI` interval for the mean of `deltas`, by resampling with replacement."""
+    rng = random.Random(0)  # fixed: the interval should not wobble between reads of the same data
+    n = len(deltas)
+    means = sorted(sum(deltas[rng.randrange(n)] for _ in range(n)) / n for _ in range(BOOTSTRAP_RESAMPLES))
+    tail = (1.0 - BOOTSTRAP_CI) / 2.0
+    return means[int(tail * BOOTSTRAP_RESAMPLES)], means[int((1.0 - tail) * BOOTSTRAP_RESAMPLES) - 1]
+
+
+# ── paired A/B across two builds ──────────────────────────────────────────────────────────────
+
+
+def write_rows(path: pathlib.Path, rows: list[dict]) -> None:
+    """Write per-observation rows as JSONL, for a later `--compare`."""
+    with path.open("w") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+    print(f"wrote {len(rows):,} rows to {path}")
+
+
+def read_keyed(path: pathlib.Path, key_fields: tuple[str, ...], value: str) -> dict[tuple, float]:
+    """Read a JSONL run back as {identity: value}, for pairing against another run."""
+    out: dict[tuple, float] = {}
+    for line in path.open():
+        r = json.loads(line)
+        out[tuple(r[k] for k in key_fields)] = r[value]
+    return out
+
+
+def report_paired(  # noqa: PLR0913 - a print function's arguments ARE its output
+    a: dict[tuple, float],
+    b: dict[tuple, float],
+    *,
+    unit: str,
+    label_a: str,
+    label_b: str,
+    noise_floor: float = NOISE_FLOOR_US,
+) -> None:
+    """Compare two runs over the observations they have in common.
+
+    Never compares two headline means: those are heavy-tailed enough that the same engine and seed
+    have produced 0.26 and 0.82 µs on consecutive runs. Pairing over identical observations removes
+    the sampling variance, and the bootstrap interval says whether what remains is real.
+    """
+    shared = sorted(set(a) & set(b))
+    if not shared:
+        print("no observations in common -- both runs need the same --mode/--sample/--seed")
+        return
+    deltas = [b[k] - a[k] for k in shared]
+    lo, hi = paired_bootstrap(deltas)
+    mean_a = statistics.fmean(a[k] for k in shared)
+    mean_b = statistics.fmean(b[k] for k in shared)
+    ratios = sorted(b[k] / a[k] for k in shared if a[k] > 0)
+    worse = sum(1 for d in deltas if d > noise_floor)
+    better = sum(1 for d in deltas if d < -noise_floor)
+
+    print(f"\npaired over {len(shared):,} observations in common ({len(a):,} / {len(b):,} recorded)")
+    print(f"  A  {mean_a:>10.2f} {unit}   median {statistics.median(a[k] for k in shared):>9.2f} {unit}   ({label_a})")
+    print(f"  B  {mean_b:>10.2f} {unit}   median {statistics.median(b[k] for k in shared):>9.2f} {unit}   ({label_b})")
+    print(f"  B - A {mean_b - mean_a:>+9.2f} {unit}   {BOOTSTRAP_CI:.0%} CI [{lo:+.2f}, {hi:+.2f}]")
+    if ratios:
+        print(
+            f"  per-observation B/A: median {statistics.median(ratios):.3f}   p10 {ratios[len(ratios) // 10]:.3f}   p90 {ratios[len(ratios) * 9 // 10]:.3f}"
+        )
+    print(f"  slower on {worse:,}, faster on {better:,}, within ±{noise_floor:g}{unit} on {len(shared) - worse - better:,}")
+    verdict = "NO DETECTABLE DIFFERENCE (interval spans zero)" if lo <= 0.0 <= hi else ("B is SLOWER" if lo > 0 else "B is FASTER")
+    print(f"  verdict: {verdict}")

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -39,6 +39,42 @@ if TYPE_CHECKING:
 
     from scripts.query_sampler import QuerySampler
 
+# ── engine loading ────────────────────────────────────────────────────────────────────────────
+# Rows per `add_batch` during a staged reload. Large enough that the per-call overhead disappears,
+# small enough that the batch list stays cheap to hold.
+BATCH_SIZE = 2000
+
+
+def load_engine(corpus: pathlib.Path, shm_path: pathlib.Path) -> object:
+    """Build a fresh engine store from the corpus JSONL via the staged reload API.
+
+    Lived in `bench_bitplanes.py` until 35 call sites were importing it out of a targeted benchmark
+    whose own investigation had closed. Nothing about it is bitplane-specific.
+
+    Raises:
+        RuntimeError: if `reload_begin` refuses, which means another process published concurrently.
+    """
+    import card_engine  # noqa: PLC0415 - keeps `costbench` importable without the built extension
+
+    engine = card_engine.QueryEngine(str(shm_path))
+    if not engine.reload_begin():
+        msg = "reload_begin returned False (stale archive published concurrently?)"
+        raise RuntimeError(msg)
+    t0 = time.monotonic()
+    batch: list[dict] = []
+    with corpus.open() as fh:
+        for line in fh:
+            batch.append(json.loads(line))
+            if len(batch) == BATCH_SIZE:
+                engine.add_batch(batch)
+                batch.clear()
+    if batch:
+        engine.add_batch(batch)
+    engine.reload_commit()
+    print(f"Engine loaded: {engine.size():,} printings in {time.monotonic() - t0:.1f}s", flush=True)
+    return engine
+
+
 # ── measurement defaults ──────────────────────────────────────────────────────────────────────
 # The (2, 7) pair six of the nine harnesses had already converged on. Seven is the floor for reading
 # `trials_ns` as a head-to-head: participants are shuffled per round from a fixed seed rather than

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -36,8 +36,9 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
-from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO, RANGE_ACQUIRES  # noqa: E402
+from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO  # noqa: E402
 from scripts.query_sampler import QuerySampler  # noqa: E402
 
 NUM_WARMUPS = 2
@@ -59,7 +60,8 @@ MATCH_RATE_FLOOR = 1.0 / 1_000_000.0
 COUNTER_TOL = 0.15
 # Netting prepare_candidates out can overshoot (different round than the min trial). Keep a row only
 # if what remains is at least this fraction of the raw time; below that the residual is noise.
-MIN_NETTED_FRACTION = 0.5
+# Now enforced inside `costbench.plan_self_ns`, which every harness shares.
+MIN_NETTED_FRACTION = costbench.NETTING_RESIDUAL_FLOOR
 # The mirror check's tolerance. This is a reimplementation of cost.rs in Python, so it can drift --
 # and did: the arms moved to `max(tier, floor)` and gained a residual-gated per-row term while
 # `design_row` still modelled the tier as a multiplier, which silently invalidated every coefficient
@@ -326,18 +328,13 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
         except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
             continue
         for p in res["plans"]:
-            if not p["trials_ns"] or p["predicted_ns"] <= 0:
-                continue
-            # Same netting as the agreement harness: only a Prep::Range acquire makes the routed path
-            # re-pay prepare_candidates, so elsewhere it is not the plan's cost to carry.
-            raw = float(min(p["trials_ns"]))
-            measured = raw
-            if p["ns_round_total"] and acq["count_source"] not in RANGE_ACQUIRES:
-                measured = raw - p["ns_prepare"]
-            # `ns_prepare` comes from the instrumented round while `raw` is the min over trials, so the
-            # subtraction can overshoot. Clamping those rows to a floor is worse than dropping them: a
-            # row scaled by 1/1ns swamps the Gram matrix and drags every coefficient to zero.
-            if measured < raw * MIN_NETTED_FRACTION:
+            # `costbench.plan_self_ns` is this rule, now shared: net `ns_prepare` except under a
+            # range acquire, and DROP the row when the subtraction overshoots. Dropping beats
+            # clamping here in particular -- a row scaled by 1/1ns swamps the Gram matrix and drags
+            # every coefficient to zero. `predicted_ns` screens the infinite cost a declining
+            # compose reports, which no `<= 0` guard catches.
+            measured = costbench.plan_self_ns(p, acq)
+            if not p["trials_ns"] or costbench.predicted_ns(p) is None or measured is None:
                 continue
             samples.append(
                 {

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -37,8 +37,8 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts import costbench  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
 from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 from scripts.query_sampler import QuerySampler  # noqa: E402
 
 NUM_WARMUPS = 2

--- a/scripts/query_sampler.py
+++ b/scripts/query_sampler.py
@@ -38,6 +38,7 @@ could not see, concentrated entirely in bounded ranges at artwork granularity.
 from __future__ import annotations
 
 import collections
+import dataclasses
 import datetime as dt
 import json
 import re
@@ -88,6 +89,9 @@ REALISTIC_ORDERBY_WEIGHTS: dict[str, float] = {
 # How many predicates a query gets. Deeper conjunctions narrow to nothing and stop exercising plan
 # choice at all, which is the thing being measured.
 PREDICATE_COUNT_WEIGHTS = ((1, 45), (2, 40), (3, 15))
+# Attempts per requested predicate before `query()` gives up trying to land another distinct family.
+# Only reachable under a `Shape` whose family pool is small relative to the requested count.
+MAX_FAMILY_DRAWS = 8
 
 # Closed vocabularies: small fixed sets where the corpus adds nothing.
 STATIC_VALUES: dict[str, list[str]] = {
@@ -122,6 +126,52 @@ MAX_VOCAB = 4000
 NAME_PREFIX_LEN = (2, 6)
 NAME_PREFIX_FRACTION = 0.5
 WORD_RE = re.compile(r"[a-z]{4,}")
+
+
+@dataclasses.dataclass(frozen=True)
+class Shape:
+    """A constraint on what `query()` / `unique()` / `orderby()` may draw.
+
+    Targeted benchmarks exist because they need ONE query shape — a bare range under
+    `unique=printing`, a compose leaf, a two-sided bound — and before this they each hand-rolled a
+    generator to get it. Those generators picked values off hardcoded lists, which is precisely what
+    this module's header argues against: a cost model is a function of selectivity, and a benchmark
+    that samples six values of it cannot say whether the model is right. A shape narrows WHICH
+    predicates appear without giving up corpus-derived values or quantile-placed thresholds.
+
+    Every field is a restriction on the default weighted draw; `None` means "no restriction", and
+    the mode's weights still apply across whatever survives.
+
+    Note what this deliberately cannot express: matched algebraic pairs (`-usd<c usd<d` against its
+    direct equivalent), controls chosen by knowing what a diff touches, negation, or a value picked
+    because it has a known posting count. Those are human judgements and belong in a curated list.
+
+        Shape(families={"range"}, predicates=1, unique={"printing"})  # bare printing-space range
+    """
+
+    families: frozenset[str] | None = None
+    predicates: int | None = None
+    unique: frozenset[str] | None = None
+    orderby: frozenset[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject a shape that can never produce a query, rather than looping forever later."""
+        for field, known in (
+            ("families", set(REALISTIC_FAMILY_WEIGHTS)),
+            ("unique", set(REALISTIC_UNIQUE_WEIGHTS)),
+            ("orderby", set(REALISTIC_ORDERBY_WEIGHTS)),
+        ):
+            value = getattr(self, field)
+            if value is not None and (unknown := set(value) - known):
+                msg = f"Shape.{field} has unknown {sorted(unknown)}; known are {sorted(known)}"
+                raise ValueError(msg)
+        if self.predicates is not None and self.predicates < 1:
+            msg = f"Shape.predicates must be >= 1, got {self.predicates}"
+            raise ValueError(msg)
+
+
+#: No restriction — what every caller got before `Shape` existed.
+ANY_SHAPE = Shape()
 
 
 class QuerySampler:
@@ -257,12 +307,33 @@ class QuerySampler:
         prefix = {"oracle": "o", "flavor": "ft", "artist": "a", "set": "set", "type": "t"}[family]
         return f"{prefix}:{self._pick(family, rng)}"
 
-    def query(self, rng: random.Random) -> str:
-        """One query: a few predicates from distinct families, weighted by this sampler's mode."""
-        counts, count_weights = zip(*PREDICATE_COUNT_WEIGHTS, strict=True)
-        keys, weights = self.families
+    @staticmethod
+    def _restrict(table: tuple[list[str], list[float]], allowed: frozenset[str] | None) -> tuple[list[str], list[float]]:
+        """Drop keys a shape excludes, keeping the mode's relative weights over what is left."""
+        keys, weights = table
+        if allowed is None:
+            return keys, weights
+        kept = [(k, w) for k, w in zip(keys, weights, strict=True) if k in allowed]
+        return [k for k, _ in kept], [w for _, w in kept]
+
+    def query(self, rng: random.Random, shape: Shape = ANY_SHAPE) -> str:
+        """One query: a few predicates from distinct families, weighted by this sampler's mode.
+
+        A `shape` narrows the family pool and can pin the predicate count. Because families are
+        drawn without replacement, a pinned count larger than the pool yields the pool.
+        """
+        keys, weights = self._restrict(self.families, shape.families)
+        if shape.predicates is None:
+            counts, count_weights = zip(*PREDICATE_COUNT_WEIGHTS, strict=True)
+            n = rng.choices(counts, weights=count_weights)[0]
+        else:
+            n = shape.predicates
         parts, used = [], set()
-        for _ in range(rng.choices(counts, weights=count_weights)[0]):
+        # Sample until `n` DISTINCT families land, rather than skipping duplicates as the unshaped
+        # path does -- with a narrow pool a skip would silently return fewer predicates than asked.
+        for _ in range(n * MAX_FAMILY_DRAWS):
+            if len(parts) == n or len(used) == len(keys):
+                break
             family = rng.choices(keys, weights=weights)[0]
             if family in used:
                 continue
@@ -270,12 +341,12 @@ class QuerySampler:
             parts.append(self.predicate(family, rng))
         return " ".join(parts) or self.predicate("type", rng)
 
-    def unique(self, rng: random.Random) -> str:
-        """A distinct-on, weighted by mode."""
-        keys, weights = self.uniques
+    def unique(self, rng: random.Random, shape: Shape = ANY_SHAPE) -> str:
+        """A distinct-on, weighted by mode and narrowed by `shape`."""
+        keys, weights = self._restrict(self.uniques, shape.unique)
         return rng.choices(keys, weights=weights)[0]
 
-    def orderby(self, rng: random.Random) -> str:
+    def orderby(self, rng: random.Random, shape: Shape = ANY_SHAPE) -> str:
         """An orderby, weighted by mode. Which one gates StreamedSelect/PlanePopcountOrder."""
-        keys, weights = self.orderbys
+        keys, weights = self._restrict(self.orderbys, shape.orderby)
         return rng.choices(keys, weights=weights)[0]

--- a/scripts/query_sampler.py
+++ b/scripts/query_sampler.py
@@ -50,13 +50,21 @@ if TYPE_CHECKING:
 
 MODES = ("realistic", "uniform")
 
-# Range fields mapped to the corpus column each draws its thresholds from.
+# Range fields mapped to the corpus column each draws its thresholds from. `eur`/`tix` are sparser
+# than `usd` (not every printing is priced in every currency), which is the point: they exercise a
+# different density of the same index, and there is live work on exactly that
+# (local-engine-eur-tix-range-index.md). Rows missing a column are skipped when the corpus is read,
+# so a sparse column still yields quantiles over the values that exist.
 RANGE_COLUMNS: dict[str, str] = {
     "usd": "price_usd",
+    "eur": "price_eur",
+    "tix": "price_tix",
     "cn": "collector_number_int",
     "year": "released_at",
     "date": "released_at",
 }
+# Rendered to two decimal places; everything else in RANGE_COLUMNS is an integer or a date.
+PRICE_FIELDS = frozenset({"usd", "eur", "tix"})
 RANGE_OPS = ("<", "<=", ">", ">=", ":")
 
 # Predicate families and their relative weight in `realistic`; `uniform` uses all-ones.
@@ -185,6 +193,13 @@ class QuerySampler:
         self.mode = mode
         self.realistic = mode == "realistic"
         self._read_corpus(corpus)
+        # Only range fields whose column actually carried values in this corpus. `eur`/`tix` are
+        # sparse and an export can omit them entirely; sampling a field with no quantiles to draw
+        # from would raise deep inside `range_predicate` instead of simply not being offered.
+        self.range_fields = [f for f, col in RANGE_COLUMNS.items() if col in self.sorted]
+        if not self.range_fields:
+            msg = f"corpus {corpus} has no usable range column; need one of {sorted(set(RANGE_COLUMNS.values()))}"
+            raise ValueError(msg)
         self.families = self._weights(REALISTIC_FAMILY_WEIGHTS)
         self.uniques = self._weights(REALISTIC_UNIQUE_WEIGHTS)
         self.orderbys = self._weights(REALISTIC_ORDERBY_WEIGHTS)
@@ -263,7 +278,7 @@ class QuerySampler:
 
     def _render(self, field: str, raw: float) -> str:
         """A sampled column value back into query syntax for `field`."""
-        if field == "usd":
+        if field in PRICE_FIELDS:
             return f"{raw:.2f}"
         if field == "cn":
             return str(int(raw))
@@ -273,13 +288,13 @@ class QuerySampler:
 
     def range_predicate(self, rng: random.Random) -> str:
         """One-sided range whose threshold sits at a uniformly-drawn quantile of its column."""
-        field = rng.choice(list(RANGE_COLUMNS))
+        field = rng.choice(self.range_fields)
         value = self._render(field, self.quantile(RANGE_COLUMNS[field], rng.random()))
         return f"{field}{rng.choice(RANGE_OPS)}{value}"
 
     def bounded_predicate(self, rng: random.Random) -> str:
         """A two-sided range (`usd>=a usd<=b`), the shape one-sided sampling never produces."""
-        field = rng.choice([f for f in RANGE_COLUMNS if f != "year"])
+        field = rng.choice([f for f in self.range_fields if f != "year"])
         column = RANGE_COLUMNS[field]
         lo_p, hi_p = sorted((rng.random(), rng.random()))
         lo = self._render(field, self.quantile(column, lo_p))

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -36,7 +36,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from client.query_runner import _DIM_NAMES, _DIM_VALUES, _DIM_WEIGHTS  # noqa: E402
-from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
 
 # tix/eur are excluded from the survey (issue #638, priority low): they are not
 # part of our real search traffic, and they have no index, so they'd dominate

--- a/scripts/survey_queries.py
+++ b/scripts/survey_queries.py
@@ -69,6 +69,7 @@ WARMUP = 3
 WINDOW_S = 0.3
 MAX_ITERS = 1000
 
+# Overridable so the survey runs from a git worktree, which has no benchmarks/ tree of its own.
 WILD_CORPUS = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
 # Fraction of the wild sample drawn from bare name lookups. They dominate the
 # wild corpus by weight but are a single engine code path, so they get one
@@ -83,7 +84,7 @@ _WILD_UNIQUE = {"card": "card", "prints": "printing", "art": "artwork"}
 _ENGINE_ORDERS = {"cmc", "power", "rarity", "toughness", "usd", "cubecobra", "edhrec", "name"}
 
 
-def sample_wild(rng: random.Random, count: int) -> list[dict]:
+def sample_wild(rng: random.Random, count: int, wild_corpus: pathlib.Path = WILD_CORPUS) -> list[dict]:
     """Sample `count` wild queries, weight-proportionally without replacement.
 
     Name lookups get WILD_NAME_LOOKUP_FRACTION of the slots; operator queries
@@ -92,7 +93,7 @@ def sample_wild(rng: random.Random, count: int) -> list[dict]:
     """
     ops: list[dict] = []
     names: list[dict] = []
-    with WILD_CORPUS.open() as fh:
+    with wild_corpus.open() as fh:
         for line in fh:
             row = json.loads(line)
             (ops if _OP_RE.search(row["q"]) else names).append(row)
@@ -269,13 +270,16 @@ def main() -> None:
     parser.add_argument("--out", type=pathlib.Path, required=True, help="CSV output path")
     parser.add_argument("--count", type=int, default=400, help="number of queries to generate")
     parser.add_argument("--wild", type=int, default=120, help="number of wild-corpus queries to sample")
+    parser.add_argument(
+        "--wild-corpus", type=pathlib.Path, default=WILD_CORPUS, help="real-traffic corpus the --wild slots draw from"
+    )
     parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
 
     rng = random.Random(args.seed)
     specs = generate(rng, args.count)
     if args.wild:
-        specs.extend(sample_wild(rng, args.wild))
+        specs.extend(sample_wild(rng, args.wild, args.wild_corpus))
     args.out.parent.mkdir(parents=True, exist_ok=True)
     engine = load_engine(args.corpus, args.out.with_suffix(".store"))
 

--- a/scripts/tests/test_query_sampler_shape.py
+++ b/scripts/tests/test_query_sampler_shape.py
@@ -6,13 +6,16 @@ Runs against a tiny synthetic corpus rather than the 239MB benchmark one, so the
 from __future__ import annotations
 
 import json
-import pathlib
 import random
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
 from scripts.query_sampler import ANY_SHAPE, MODES, QuerySampler, Shape
+
+if TYPE_CHECKING:
+    import pathlib
 
 # Enough rows that every corpus-derived vocabulary is non-empty and the range columns have spread.
 CORPUS_ROWS = 60

--- a/scripts/tests/test_query_sampler_shape.py
+++ b/scripts/tests/test_query_sampler_shape.py
@@ -113,14 +113,18 @@ def test_default_shape_matches_the_old_unshaped_behaviour(sampler: QuerySampler)
     assert [sampler.query(random.Random(i)) for i in range(50)] == [sampler.query(random.Random(i), ANY_SHAPE) for i in range(50)]
 
 
+impossible_shapes = {
+    "unknown_family": {"kwargs": {"families": frozenset({"nope"})}, "needle": "families"},
+    "scryfall_spelling_of_unique": {"kwargs": {"unique": frozenset({"cards"})}, "needle": "unique"},
+    "orderby_the_engine_has_no_column_for": {"kwargs": {"orderby": frozenset({"released"})}, "needle": "orderby"},
+    "zero_predicates": {"kwargs": {"predicates": 0}, "needle": "predicates"},
+}
+
+
 @pytest.mark.parametrize(
-    ("kwargs", "needle"),
-    [
-        ({"families": frozenset({"nope"})}, "families"),
-        ({"unique": frozenset({"cards"})}, "unique"),
-        ({"orderby": frozenset({"released"})}, "orderby"),
-        ({"predicates": 0}, "predicates"),
-    ],
+    argnames=sorted(next(iter(impossible_shapes.values()))),
+    argvalues=[[v for _, v in sorted(impossible_shapes[name].items())] for name in sorted(impossible_shapes)],
+    ids=sorted(impossible_shapes),
 )
 def test_impossible_shapes_are_rejected_at_construction(kwargs: dict, needle: str) -> None:
     """A typo should fail where it is written, not loop or silently sample the wrong thing."""
@@ -132,3 +136,55 @@ def test_every_mode_accepts_a_shape(corpus: pathlib.Path) -> None:
     for mode in MODES:
         s = QuerySampler(corpus, mode)
         assert s.query(random.Random(0), Shape(families=frozenset({"type"}), predicates=1)).startswith("t:")
+
+
+def test_sparse_range_columns_are_offered_when_present(tmp_path: pathlib.Path) -> None:
+    """`eur`/`tix` join the range family when the corpus carries them."""
+    path = tmp_path / "priced.jsonl"
+    with path.open("w") as handle:
+        for i in range(CORPUS_ROWS):
+            handle.write(
+                json.dumps(
+                    {
+                        "card_name": f"Card {i}",
+                        "card_types": ["Creature"],
+                        "oracle_text": "draw cards target creature",
+                        "price_usd": 1.0 + i,
+                        "price_eur": 0.9 + i,
+                        "price_tix": 0.05 * i,
+                        "collector_number_int": i + 1,
+                        "released_at": f"{2000 + i % 20}-01-01",
+                    }
+                )
+                + "\n"
+            )
+    s = QuerySampler(path, "uniform")
+    assert {"usd", "eur", "tix"} <= set(s.range_fields)
+    rng = random.Random(0)
+    drawn = {
+        s.query(rng, Shape(families=frozenset({"range"}), predicates=1)).split(">")[0].split("<")[0].split(":")[0]
+        for _ in range(400)
+    }
+    assert {"eur", "tix"} & drawn, f"expected eur/tix to appear, saw {drawn}"
+
+
+def test_absent_range_columns_are_not_offered(sampler: QuerySampler) -> None:
+    """The module fixture has no eur/tix, so they must not be sampled rather than raising."""
+    assert "eur" not in sampler.range_fields
+    assert "tix" not in sampler.range_fields
+    rng = random.Random(0)
+    for _ in range(DRAWS):
+        sampler.query(rng, Shape(families=frozenset({"range", "bounded"}), predicates=1))
+
+
+def test_prices_render_to_two_decimals(tmp_path: pathlib.Path) -> None:
+    """eur/tix are prices and must not render like a collector number."""
+    path = tmp_path / "eur.jsonl"
+    with path.open("w") as handle:
+        for i in range(CORPUS_ROWS):
+            handle.write(json.dumps({"card_name": f"C{i}", "card_types": ["Creature"], "price_eur": 1.5 + i * 0.37}) + "\n")
+    s = QuerySampler(path, "uniform")
+    rng = random.Random(0)
+    for _ in range(50):
+        q = s.query(rng, Shape(families=frozenset({"range"}), predicates=1))
+        assert re.fullmatch(r"eur(<=|>=|<|>|:)\d+\.\d{2}", q), q

--- a/scripts/tests/test_query_sampler_shape.py
+++ b/scripts/tests/test_query_sampler_shape.py
@@ -1,0 +1,131 @@
+"""`Shape` narrows what the sampler draws without changing where values come from.
+
+Runs against a tiny synthetic corpus rather than the 239MB benchmark one, so these stay unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import random
+import re
+
+import pytest
+
+from scripts.query_sampler import ANY_SHAPE, MODES, QuerySampler, Shape
+
+# Enough rows that every corpus-derived vocabulary is non-empty and the range columns have spread.
+CORPUS_ROWS = 60
+# Draws per assertion. Large enough that a family excluded by a shape would almost surely appear if
+# the restriction were not applied, small enough to stay fast.
+DRAWS = 300
+
+
+@pytest.fixture(scope="module")
+def corpus(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
+    """A small synthetic corpus with every column the sampler reads."""
+    path = tmp_path_factory.mktemp("sampler") / "corpus.jsonl"
+    with path.open("w") as handle:
+        for i in range(CORPUS_ROWS):
+            handle.write(
+                json.dumps(
+                    {
+                        "card_name": f"Test Card {i}",
+                        "card_artist": f"Alice Painter{i}",
+                        "card_set_code": f"s{i % 7}",
+                        "card_types": ["Creature"],
+                        "card_subtypes": ["Human", "Wizard"][: 1 + i % 2],
+                        "oracle_text": f"draw cards target creature gains flying number{i}",
+                        "flavor_text": f"words about wizards and dragons here {i}",
+                        "price_usd": round(0.05 + i * 3.1, 2),
+                        "collector_number_int": i + 1,
+                        "released_at": f"{1995 + i % 30}-06-15",
+                    }
+                )
+                + "\n"
+            )
+    return path
+
+
+@pytest.fixture(scope="module")
+def sampler(corpus: pathlib.Path) -> QuerySampler:
+    return QuerySampler(corpus, "uniform")
+
+
+def test_unshaped_draw_reaches_many_families(sampler: QuerySampler) -> None:
+    """Baseline: without a shape the pool is wide, so the restriction tests below mean something."""
+    seen = {sampler.query(random.Random(i), ANY_SHAPE) for i in range(DRAWS)}
+    assert len(seen) > DRAWS // 4
+
+
+def test_families_restriction_excludes_everything_else(sampler: QuerySampler) -> None:
+    """A range-only shape yields only range predicates, never a type or oracle one."""
+    rng = random.Random(0)
+    for _ in range(DRAWS):
+        q = sampler.query(rng, Shape(families=frozenset({"range"}), predicates=1))
+        assert re.fullmatch(r"(usd|cn|year|date)(<=|>=|<|>|:)\S+", q), q
+
+
+def test_predicate_count_is_pinned(sampler: QuerySampler) -> None:
+    """`predicates=1` means exactly one, which is what "bare range" plans require."""
+    rng = random.Random(1)
+    for _ in range(DRAWS):
+        q = sampler.query(rng, Shape(families=frozenset({"range"}), predicates=1))
+        assert " " not in q, q
+
+
+def test_pinned_count_larger_than_pool_yields_the_pool(sampler: QuerySampler) -> None:
+    """Families are drawn without replacement, so a count above the pool size cannot be met."""
+    rng = random.Random(2)
+    shape = Shape(families=frozenset({"range", "bounded"}), predicates=5)
+    for _ in range(50):
+        q = sampler.query(rng, shape)
+        # `bounded` renders as two clauses (`usd>=a usd<=b`), so count fields, not tokens.
+        assert len(re.findall(r"(?:usd|cn|year|date)(?:<=|>=|<|>|:)", q)) <= 4, q
+
+
+def test_unique_and_orderby_are_restricted(sampler: QuerySampler) -> None:
+    rng = random.Random(3)
+    shape = Shape(unique=frozenset({"printing"}), orderby=frozenset({"usd", "cmc"}))
+    for _ in range(DRAWS):
+        assert sampler.unique(rng, shape) == "printing"
+        assert sampler.orderby(rng, shape) in {"usd", "cmc"}
+
+
+def test_shape_preserves_relative_weights_within_the_pool(corpus: pathlib.Path) -> None:
+    """Restricting must not flatten the mode's weights over what survives.
+
+    `realistic` weights name (20) far above flavor (0.5); a shape allowing only those two should
+    still show that ratio rather than a coin flip.
+    """
+    realistic = QuerySampler(corpus, "realistic")
+    rng = random.Random(4)
+    shape = Shape(families=frozenset({"name", "flavor"}), predicates=1)
+    names = sum(sampler_q.startswith("name:") for sampler_q in (realistic.query(rng, shape) for _ in range(DRAWS)))
+    assert names > DRAWS * 0.8, f"expected name to dominate flavor 40:1, got {names}/{DRAWS}"
+
+
+def test_default_shape_matches_the_old_unshaped_behaviour(sampler: QuerySampler) -> None:
+    """The default argument must reproduce the pre-Shape stream exactly, seed for seed."""
+    assert [sampler.query(random.Random(i)) for i in range(50)] == [sampler.query(random.Random(i), ANY_SHAPE) for i in range(50)]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "needle"),
+    [
+        ({"families": frozenset({"nope"})}, "families"),
+        ({"unique": frozenset({"cards"})}, "unique"),
+        ({"orderby": frozenset({"released"})}, "orderby"),
+        ({"predicates": 0}, "predicates"),
+    ],
+)
+def test_impossible_shapes_are_rejected_at_construction(kwargs: dict, needle: str) -> None:
+    """A typo should fail where it is written, not loop or silently sample the wrong thing."""
+    with pytest.raises(ValueError, match=needle):
+        Shape(**kwargs)
+
+
+def test_every_mode_accepts_a_shape(corpus: pathlib.Path) -> None:
+    for mode in MODES:
+        s = QuerySampler(corpus, mode)
+        assert s.query(random.Random(0), Shape(families=frozenset({"type"}), predicates=1)).startswith("t:")


### PR DESCRIPTION
Eleven scripts drive `explain_analyze`, and each carried its own copy of the sampling loop, a
nearest-rank `percentile`, a table renderer, and the rule for turning `trials_ns` into "what this
plan costs". The copies had drifted in ways that were not cosmetic, so this adds
`scripts/costbench.py` to own them once.

Three harnesses disagreed about netting. Two subtracted `ns_prepare` and disagreed on the overshoot
case; `bench_plan_misselection.py` subtracted `acquire_ns`, a different participant entirely, so its
`net` column was never comparable to the same column elsewhere. All of them now call
`costbench.plan_self_ns`: min-of-trials less `ns_prepare`, except under a range acquire, dropping the
row when the subtraction overshoots — the rule `fit_cost_model.py` had already argued for.
**`bench_plan_misselection.py`'s numbers move as a result.**

## Two defects fell out of the consolidation

- `cost::plan_cost` returns `f64::INFINITY` for a declining compose. Every harness guarded with
  `predicted_ns <= 0`, which does not catch it, so those rows reached the percentile tables as `inf`.
  `PrintingCompose` read `inf` at p90/p99/p100; screened out it reads 2.19 / 199.96 / 234.23, over
  ~200 fewer rows.
- `bench_card_range_estimate.py` read `acquire.range_k` and `acquire.prep_ns`, neither of which the
  engine has ever published, so it raised `KeyError` on its first recorded query. Prep is per-plan
  `ns_prepare`; `k` comes from `matches`, clamped, which is noted where it matters.

## The missing layer

`bench_plan_execution_ab.py` answers what nothing covered: did a **plan's executor** get faster,
whether or not the router picks it. Every other harness reads `trials_ns` as a ratio against
predicted; `bench_query_latency_ab.py` measures `query()`, which sums executor speed and routing
choice. This pairs per (query, plan), excludes pairs whose `result_total` disagrees, and reports any
routing shift separately.

## Both A/B harnesses were reporting false positives

Comparing a build against **itself**, same seed, at the toolkit's (2 warmup, 7 trial) default:

| harness, same build and seed | at 2w/7t | at 6w/30t |
| --- | --- | --- |
| `bench_plan_execution_ab.py` | every plan, acquire and routed "SLOWER" by 4–9%, every interval excluding zero, "faster on 0" | no detectable difference |
| `bench_query_latency_ab.py` | "B is FASTER", −1.0 µs, 95% CI [−1.6, −0.5], over 388 paired queries | +0.5 µs, CI [−1.0, +2.9] |

`min` over the trials is a floor estimator whose distance above the floor depends on the interference
that run saw, and that error is **common-mode across every query in a run** — so pairing and a wide
sample do not cancel it. The latency canary had 388 paired queries and still called it. Depth is the
fix; both harnesses default to (6, 30) now. `bench_query_latency_ab.py`'s docstring argued the
opposite ("breadth beats depth"), and its `--sample` drops 2000 → 800 so the extra depth does not
quadruple wall time.

The within-call diagnostics keep (2, 7). Prefix-min of `trials_ns` against min-of-60, measured inside
one process, puts k=7 only 0.4–1.4% above the floor and converged by k=30 — far below the errors
those tools hunt. The table is recorded in `costbench.py`.

`bench_plan_execution_ab.py` additionally keeps acquire as a **control**, since most executor changes
do not touch it, and prints an adjusted column when it moves.

## Also

Percentile tables gain p0 and p100 — the zero-card and all-cards estimates a p1/p99 view clips — and
a `plan / orderby` slice the sampler had always populated and no table read back.

The workflow doc is rewritten around the four layers and corrected: it claimed `docs/issues/` is
untracked and told the reader to "write freely", in a tracked directory in a public repo where only
`security-*` is gitignored.

## Verification

`ruff check` clean on every touched file, 1554 unit tests pass, and all six touched harnesses plus
the new one were run against the real engine.
