### PR TITLE
Refit Both Scan Arms on the Corrected Features, and Price Artwork's Per-Card Overhead

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -38,10 +38,10 @@
 //! P3/P4 by ~`n_printings/n_cards` (≈3.09) because those modes scan EVERY printing
 //! of every candidate. The fix is `PlanFeatures::scan_units` (not a `mode` branch):
 //! the per-card `card_pass` term is driven by `eval_domain` (candidate cards) and
-//! the per-row residual scan + its verify `tier` by `scan_units` (rows scanned in
-//! the plan's operating space — `≈ eval_domain` for card, printings-under-candidates
-//! for printing/artwork). One mode-agnostic formula; the caller fills `scan_units`
-//! per mode via `scan_units()`. The `_CARD_PASS`/`_SCAN` split of the old lumped
+//! the per-row residual scan + its verify `tier` by `scan_units` (printings under the
+//! candidate cards). One mode-agnostic formula, and `scan_units()` no longer branches
+//! on mode at all: the `printings_scanned` counter shows the scan plans walk the full
+//! printing span of their candidates in CARD mode too, not one row each. The `_CARD_PASS`/`_SCAN` split of the old lumped
 //! `VISIT` constants was fit to hold card unchanged while correcting printing (see
 //! each constant's doc). Artwork rides the printing path (same all-printings scan);
 //! its confirming validation is still pending a bench run.
@@ -60,6 +60,7 @@ use super::*;
 /// Cheap, per-query features the cost model consumes, built once per query by
 /// `run_query_routed`'s `acquire` step. All counts are exact or cheap-exact (plane
 /// popcount / range `k` / candidate count), never estimated.
+#[derive(Clone)]
 pub(crate) struct PlanFeatures {
     /// Distinct cards in the corpus (card-space universe).
     pub n_cards: u32,
@@ -71,17 +72,29 @@ pub(crate) struct PlanFeatures {
     /// Candidate CARDS the loop iterates (one `card_pass` each): the narrowed
     /// candidate count when `prepare_candidates` produced a list, else `n_cards`.
     pub eval_domain: u32,
-    /// Rows the per-row residual scan touches, in the plan's operating space — the
-    /// dominant P3/P4 driver. Card mode breaks at the first matching printing
-    /// (≈ one row per candidate), so `scan_units ≈ eval_domain`; printing/artwork
-    /// scan every printing of every candidate, so it is the printing count under
-    /// those cards (`≈ eval_domain · n_printings/n_cards`). This is the field that
-    /// makes the formula operating-space-correct without a `mode` branch (see the
-    /// module "Calibration scope" note); the caller fills it via `scan_units()`.
+    /// Printings under the candidate cards — the dominant P3/P4 driver, and the same
+    /// quantity in all three distinct-ons. Card mode was long assumed to break at the
+    /// first matching printing (`scan_units ≈ eval_domain`); measured against
+    /// `printings_scanned`, that read 0.25-0.33 for both GatheredScan and StreamedSelect
+    /// while `eval_domain · n_printings/n_cards` reads 0.90-1.02 in every mode.
     pub scan_units: u32,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
     pub residual_tier_ns100: u32,
+    /// Cards `run_query_streamed` visits in ARTWORK mode, i.e. `eval_domain` there and `0` in card and
+    /// printing mode. Charged at `STREAM_ARTWORK_SEEN_PER_CARD_NS`.
+    pub artwork_seen_cards: u32,
+    /// Printings compose's **Gather** paging branch bit-tests, which is NOT `scan_units`.
+    ///
+    /// `scan_units` is every printing under a candidate card — right for GatheredScan and
+    /// StreamedSelect, which must test each one. Compose walks the set bits of the composed bitmap
+    /// instead, so it touches `printing_matches`. Measured against `printings_scanned`, compose reads
+    /// 1.00 on `matches` in printing mode and 1.00-1.01 on `project_printings` in artwork (the same
+    /// value), while `scan_units` reads 2.0-2.8 for it.
+    ///
+    /// Sharing one feature between the two forced a compromise that was ~2x wrong for whichever arm
+    /// lost: with the value GatheredScan needs, compose over-counts 2x; with compose's, the scan plans
+    /// under-count 3.3x.
     /// Page size (`limit`).
     pub limit: u32,
     /// Page offset.
@@ -131,6 +144,19 @@ pub(crate) struct PlanFeatures {
 /// 20000 P1 leads P3 by only ~2×, and that is exactly where this loose constant
 /// flips the argmin (the model routes off gold-P1). Sharpening P1 needs a per-step
 /// term keyed on printings-scanned, not a scalar — deferred with the printing model.
+/// Per-printing cost of a **linear offset-walk** over set printings — the two passes that share this
+/// rate: `PrintingCompose`'s legality broadcast-DOWN (card ∃-plane → printing bitmap) and its
+/// projection-UP (printing bitmap → card/artwork existence, `printing_bits_to_card_bits`, which walks
+/// the set bits advancing a card cursor). Measured ~1.5 ns/printing: `legality_compose_kernel_costs`
+/// broad formats (~1.49), and `card_range_build_cost_split`'s B pass (122125ns / 80527 = 1.52).
+/// Carries `broadcast_printings` and `project_printings` — the midpoint of the two probes.
+pub(crate) const LINEAR_PASS_PER_PRINTING_NS: f64 = 1.50;
+/// Per-printing cost of `PrintingCompose`'s range **scatter** — `range_leaf_bits` reads the value-sorted
+/// index's contiguous in-range slice and scatters each pid into a printing bitmap (sequential read +
+/// random-write). Measured ~0.4 ns/printing (`card_range_build_cost_split`'s A pass 28583ns / 80527 =
+/// 0.355; `range_compose_kernel_costs` 0.36 at broad density) — far cheaper than a linear pass because
+/// there is no per-card cursor and the writes are the only work. Carries `scatter_printings` in compose.
+pub(crate) const RANGE_SCATTER_PER_PRINTING_NS: f64 = 0.36;
 const RANGE_WALK_STEP_NS: f64 = 4.5;
 /// Fixed P1 setup (binary searches + walk init). Fit from usd<5 printing shallow
 /// (666ns − 82 steps × RANGE_WALK_STEP_NS ≈ 150ns).
@@ -157,27 +183,27 @@ const PLANE_POPCOUNT_EMIT_PER_CARD_NS: f64 = 2.0;
 /// Fixed P2 setup (plane eval into the bitmap, buffers).
 const PLANE_POPCOUNT_FIXED_COST_NS: f64 = 200.0;
 
-/// Per-printing cost of a **linear offset-walk** over set printings — the two passes that share this
-/// rate: `PrintingCompose`'s legality broadcast-DOWN (card ∃-plane → printing bitmap) and its
-/// projection-UP (printing bitmap → card/artwork existence, `printing_bits_to_card_bits`, which walks
-/// the set bits advancing a card cursor). Measured ~1.5 ns/printing: `legality_compose_kernel_costs`
-/// broad formats (~1.49), and `card_range_build_cost_split`'s B pass (122125ns / 80527 = 1.52).
-/// Carries `broadcast_printings` and `project_printings` — the midpoint of the two probes.
-pub(crate) const LINEAR_PASS_PER_PRINTING_NS: f64 = 1.50;
 
-/// Per-printing cost of `PrintingCompose`'s range **scatter** — `range_leaf_bits` reads the value-sorted
-/// index's contiguous in-range slice and scatters each pid into a printing bitmap (sequential read +
-/// random-write). Measured ~0.4 ns/printing (`card_range_build_cost_split`'s A pass 28583ns / 80527 =
-/// 0.355; `range_compose_kernel_costs` 0.36 at broad density) — far cheaper than a linear pass because
-/// there is no per-card cursor and the writes are the only work. Carries `scatter_printings` in compose.
-pub(crate) const RANGE_SCATTER_PER_PRINTING_NS: f64 = 0.36;
 
 /// Per-printing cost of `CardRangePopcount`'s **fused build** — `build_card_range_bits` sets the printing
 /// bit AND the card bit (via `printing_to_card`) in one pass over the range slice, fusing compose's
 /// scatter+project (0.4 + 1.5 = 1.9) into a single ~1.2 ns/printing pass (`card_range_build_cost_split`'s
 /// C 98333ns / 80527 = 1.22). Carries `scatter_printings` in CardRangePopcount's arm — the same `k` as
 /// compose's scatter but a cheaper op, which is exactly why a bare range routes here, not to compose.
-pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.22;
+///
+/// Retuned 1.22 -> 0.93 from END-TO-END measurement, which disagrees with that kernel figure. The arm
+/// over-costed by a near-uniform 1.20 (p10 0.99, p50 1.20, p90 1.43 — a spread of only 1.4, the
+/// signature of a plain rate error), and this term is 80% of it. Its four other constants are shared
+/// with PlanePopcountOrder, which is slightly UNDER-costed at 0.92, so they cannot absorb it.
+///
+/// The disagreement is real, not a sampling artifact, and was checked for exactly that: the implied
+/// end-to-end rate is FLAT in k — 0.97 / 0.81 / 0.91 / 0.92 / 0.99 across k bins from 1.5k to 81k — so
+/// no single-k distribution is doing the work. At k≈81,479, the same slice size the kernel benchmark
+/// uses, end-to-end still implies 0.99 against its 1.26. The kernel times the build in isolation;
+/// `plan_cost` predicts end-to-end time, so end-to-end is the figure it should carry. Re-running
+/// `card_range_build_cost_split` today still reports 1.26 (101500/80527), so the kernel has not drifted
+/// — the two simply measure different things.
+pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 0.93;
 
 // ─── Candidate materialization ──────────────────────────────────────────────
 // `plan_cost` prices only what happens AFTER the acquire step: `eval_domain` and `matches` are its
@@ -201,24 +227,11 @@ pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 1.22;
 /// `Vec::with_capacity` plus the run walk, before any comparison work
 /// (`bench_candidate_materialize`, axis A).
 pub(crate) const MATERIALIZE_SORT_FIXED_NS: f64 = 143.0;
-/// pdqsort on `u32`, per candidate — treated as **linear**, not `c·log2 c`. `sort_unstable` is a full
-/// pdqsort so it is asymptotically `n log n`, and the log factor is faintly visible over this range,
-/// but far too weak to model: per-element cost grows only 1.17x across a 31x size increase, where an
-/// `n log n` fit demands 1.49x.
-///
-/// Axis H, minimum of 10 runs (`bench_candidate_materialize_sort_shape`):
-///
-///     cands     1,024   4,096   8,192  16,384  31,508
-///     ns/elem    4.35    4.39    4.49    4.75    5.08
-///     n log n    4.35    4.83    5.11    5.40    6.50
-///
-/// Re-fit rather than extrapolating past ~3M cards, where the log factor does start to matter.
-///
-/// MEASUREMENT NOTE: take the MINIMUM across repeated runs, not a single run. Contention here is
-/// one-sided — across those 10 runs min and median agree to within 0.06 ns/elem at every point while
-/// the max reaches 5.73 — so one contaminated run reads as flat ~5.0 at every size and hides the
-/// trend completely. That artifact is what made an earlier draft of this doc quote figures that
-/// disagreed with the bench, and it is the reason to distrust any single-run number here.
+/// pdqsort on `u32`, per candidate — **linear**, not `c·log2 c`. `sort_unstable` is a full pdqsort
+/// so it is asymptotically `n log n`, but measured per-element cost is flat across the sizes this
+/// engine sees (4.39 ns at 1,024 rising only to 5.09 at 31,508, where an `n log n` fit predicts
+/// 4.39 → 6.57). Fit on the rows bracketing the crossover. Re-fit rather than extrapolating past
+/// ~3M cards, where the log factor does start to show.
 pub(crate) const MATERIALIZE_SORT_PER_CAND_NS: f64 = 4.95;
 
 /// Modelled cost of producing the candidate list a materializing plan consumes, in ns. `0.0` for
@@ -261,23 +274,110 @@ pub(crate) fn materialize_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
 /// which the lumped constant under-priced ~2× (fidelity 0.5, the eval_domain-counts-
 /// cards bug). Split fit: card sum pins `CARD_PASS + SCAN = 3.0`; printing's ~2×
 /// under-prediction at ratio ~3.09 pins the split (`CARD_PASS + 3.09·SCAN ≈ 6.0`).
-const STREAM_CARD_PASS_NS: f64 = 1.56;
-/// ns per printing scanned in the match phase (residual test per row). See
-/// STREAM_CARD_PASS_NS for the split derivation. The residual verify `tier` rides
-/// this term (it is paid per scanned row), common-mode with P4's scan term.
-const STREAM_SCAN_PER_ROW_NS: f64 = 1.44;
+/// Refit 2026-07-30 by `scripts/fit_cost_model.py` — non-negative Gauss-Newton on the LOG ratio
+/// (symmetric in over/under, unlike a relative-error fit, which shrinks every rate toward zero),
+/// ridge-anchored to the previous values because several columns barely vary on this corpus and
+/// are collinear with the intercept. Fitted on ~10k distinct feature vectors, stable to <3% across
+/// independent seeds. Median measured/predicted moved 1.78 -> 1.00 (P4) and 1.69 -> 1.06 (P3).
+const STREAM_CARD_PASS_NS: f64 = 6.46;
+
+/// P3's per-scanned-row cost, charged ONLY when a residual is present.
+///
+/// Unlike P4, P3 merely COUNTS matches, and `card_match_count` is O(1) offset arithmetic whenever
+/// `all_match` holds (the artwork-group count is a build-time constant). So with no residual it does
+/// no per-printing work at all — but with one it must walk the printings testing each. Regressing
+/// per-card match-loop time on printings-scanned-per-card, split by tier, shows exactly that split:
+///
+/// | residual | slope (ns per printing/card) |
+/// |----------|-----------------------------:|
+/// | none (all_match) | **0.02** |
+/// | MASK_COMPARE | 2.83 |
+/// | SET_LOOKUP | 2.19 |
+/// | TEXT_SCAN | 1.90 |
+///
+/// An earlier revision removed this term outright, on the O(1) argument above. That argument is
+/// right for the `all_match` half and wrong for the other, and an ungated fit drove the rate to 0
+/// because the tier-0 rows (the majority) dominated it. Gating on the residual separates them.
+///
+/// This one is NOT common-mode with P4 — P4 pays `GATHER_SCAN_PER_ROW_NS` unconditionally — so
+/// unlike the verify tier it can move the argmin between the two.
+const STREAM_SCAN_PER_ROW_NS: f64 = 5.53;
+
+
+/// Per-card cost of RUNNING `card_pass` at all, on top of whatever the residual's own nodes cost.
+/// The tri walk has to set up, populate the reused `residual` vec, branch on the `Tri`, and drive
+/// the per-printing loop; none of that is a filter node, so `verify_cost_tier` does not describe it
+/// and should not be asked to.
+///
+/// This replaces a multiplicative `*_VERIFY_TIER_SCALE` of 2.87/2.65. The multiplier was wrong in
+/// form, not just in value. `bench_verify_cost` (cargo test --release bench_verify_cost -- --ignored)
+/// times the real `FilterExpr::matches()` path per node and VALIDATES the tier constants:
+/// MASK_COMPARE claims 4.0 ns against 2.08-3.60 measured, SET_LOOKUP 9.0 against 2.12-8.69,
+/// TEXT_SCAN 23.0 against 21.5, REGEX_MACHINERY 50 against 45.8-47.5. They are right, slightly
+/// conservative. So there was no per-node calibration error for a multiplier to correct — there was
+/// an unmodelled fixed per-card overhead, and scaling by 2.7x happened to approximate it for the
+/// common cheap tiers while badly over-costing text (2.7 x 23 = 62 ns against a real 23 + 17).
+///
+/// It is a FLOOR, not an offset: `max(tier_ns, this)`. Cheap residuals are dominated by the walk,
+/// expensive ones dominate it, and the two do not add. Measured by regressing per-card match-loop
+/// time on printings-scanned-per-card, separately per tier class, over the real query population
+/// (the earlier additive fit used single-predicate queries, whose tiny sample disagreed):
+///
+/// | tier | claims | P3 excess over no-residual | P4 excess |
+/// |------|-------:|---------------------------:|----------:|
+/// | MASK_COMPARE | 4 ns | 8.9 | 15.4 |
+/// | SET_LOOKUP | 9 ns | 10.4 | 11.2 |
+/// | TEXT_SCAN | 23 ns | 20.7 | 19.9 |
+///
+/// The excess is roughly INDEPENDENT of the tier for the cheap classes and non-monotonic across them
+/// (P4's MASK excess exceeds its SET_LOOKUP excess), which additive cannot produce. `max` fits all
+/// three within ~2 ns for P3 and ~4 for P4, where `tier + 11` over-costs TEXT_SCAN by 14 ns — the
+/// text-heavy over-costing that showed up as GatheredScan/candidates at 0.67.
+///
+/// That same regression also shows the residual's cost is per CARD, not per printing scanned: the
+/// SLOPE against printings-per-card is ~3.5 for every tier including none (P4) and ~2 for P3, i.e.
+/// independent of what the residual is. So the tier belongs on `eval_domain`, as it now sits.
+const STREAM_RESIDUAL_FLOOR_NS: f64 = 8.18;
 /// ns per match, for the permutation-walk emit. Small — P3 measured nearly flat
 /// in match count once eval_domain is fixed (see STREAM_MATCH_PHASE_PER_CARD_NS),
 /// so this is a minor term.
-const STREAM_EMIT_PER_MATCH_NS: f64 = 0.1;
+const STREAM_EMIT_PER_MATCH_NS: f64 = 0.13;
+/// ns per candidate card that ARTWORK mode pays and the other two do not.
+///
+/// `card_match_count`'s artwork arm keeps a per-card `seen_words` bitmask to dedupe artwork groups,
+/// and that costs a fixed amount per card regardless of how many printings the card has: a
+/// `seen_words.fill(0)` before the loop and a `seen_words.iter().map(count_ones).sum()` after it,
+/// over `ARTWORK_GROUP_WORDS = 8` u64s. Card mode returns on the first matching printing and printing
+/// mode just counts, so neither pays it. (The `all_match` + `have_group_counts` shortcut in
+/// `run_query_streamed` skips the helper entirely, which is why this lands on residual-bearing
+/// candidates in particular.)
+///
+/// Fitting the arm separately per distinct-on is what surfaced it, over three seeds:
+///
+///     StreamedSelect    artwork / printing        seed21      seed22      seed23
+///     CARD_PASS                              5.92/3.36   5.76/3.20   5.89/3.17
+///     RESIDUAL_FLOOR                        11.75/9.21  11.81/9.39  11.86/9.81
+///
+/// Two independently fitted per-card terms, both elevated in artwork by ~2.4 ns and never flipping
+/// sign. One mechanism showing up twice, so it belongs in its own term rather than as a mode-specific
+/// copy of each rate. ~16 word-ops per card is the right order for 2.4 ns.
+const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.36;
 /// ns per card scanned in the small-total gather (`for cid in 0..n_cards`,
 /// counts[cid]==0 check). Cheaper than a match-phase visit (no filter work). Fit
 /// from the narrow-query floor: cmc>=15 / o:annihilator / cmc==7 card SHALLOW all
 /// ~52µs = 31508 × 1.65. Only added when `matches <= STREAM_MIN_MATCHES`, the
-/// exact condition that routes P3 into that gather branch.
-const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.65;
-/// Fixed P3 setup (counts buffer resize/clear, thread-local).
-const STREAM_FIXED_COST_NS: f64 = 500.0;
+/// exact condition that routes P3 into that gather branch. The 1.65 above was fit on three hand
+/// picked narrow queries; across the sampled space the floor measures ~31µs, not 52µs.
+const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.64;
+/// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
+/// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
+/// `cards.len()` every query — a 126 kB memset on this corpus — and the emission walk is over the
+/// corpus-sized sort permutation. Fit lands at ~9 µs total, more than a memset alone accounts for,
+/// so this lumps the two; a single corpus cannot separate them (both are exactly `n_cards`). Kept
+/// as a per-card RATE rather than the previous flat constant so it tracks corpus size at all.
+const STREAM_CORPUS_PASS_PER_CARD_NS: f64 = 0.02;
+/// Fixed P3 setup, net of the O(n_cards) work above.
+const STREAM_FIXED_COST_NS: f64 = 217.5;
 
 // ─── P4: GatheredScan ───────────────────────────────────────────────────────
 // The universal fallback: per-card loop pushes every match's sort key into a
@@ -290,27 +390,45 @@ const STREAM_FIXED_COST_NS: f64 = 500.0;
 /// eval_domain==matches, tier=0, sum ≈ 6.3-6.9 with GATHER_PUSH); card keeps
 /// `CARD_PASS + SCAN = 5.5`. Printing's ~2× under-prediction at ratio ~3.09 splits
 /// it (`CARD_PASS + 3.09·SCAN ≈ 11`).
-const GATHER_CARD_PASS_NS: f64 = 2.87;
-/// ns per printing scanned in the gathered loop (residual test per row); the verify
-/// `tier` rides this term, common-mode with P3's scan term. See GATHER_CARD_PASS_NS.
-const GATHER_SCAN_PER_ROW_NS: f64 = 2.63;
+/// Refit 2026-07-30 by `scripts/fit_cost_model.py` — non-negative Gauss-Newton on the LOG ratio
+/// (symmetric in over/under, unlike a relative-error fit, which shrinks every rate toward zero),
+/// ridge-anchored to the previous values because several columns barely vary on this corpus and
+/// are collinear with the intercept. Fitted on ~10k distinct feature vectors, stable to <3% across
+/// independent seeds. Median measured/predicted moved 1.78 -> 1.00 (P4) and 1.69 -> 1.06 (P3).
+const GATHER_CARD_PASS_NS: f64 = 6.88;
+/// ns per printing scanned in the gathered loop (residual test per row). The verify `tier`
+/// does NOT ride this term; see GATHER_VERIFY_TIER_SCALE and STREAM_SCAN_PER_ROW_NS.
+const GATHER_SCAN_PER_ROW_NS: f64 = 2.06;
+
+/// P4's counterpart to STREAM_RESIDUAL_FLOOR_NS — see there for the form and its derivation.
+const GATHER_RESIDUAL_FLOOR_NS: f64 = 18.89;
 /// ns per match pushed into the sort-key Vec + quickselected.
-const GATHER_PUSH_PER_MATCH_NS: f64 = 1.0;
+const GATHER_PUSH_PER_MATCH_NS: f64 = 2.24;
 /// ns per page slot materialized. Fit from the deep-vs-shallow gap on broad
 /// queries (cmc>=0 card: 225708−216667 ≈ 9041ns over 10000 extra offset ≈ 0.9),
 /// bounded by matches: narrow deep pages (offset > matches) measured ≈ shallow
 /// (select_page returns early), so the term uses min(offset+limit, matches).
-const GATHER_SELECT_PER_PAGE_SLOT_NS: f64 = 0.9;
+const GATHER_SELECT_PER_PAGE_SLOT_NS: f64 = 3.51;
 /// Fixed P4 setup. Fit from the narrowest query (cmc>=15 card shallow 208ns at
 /// eval_domain=5: 208 − 5×(GATHER_VISIT_PER_CARD_NS+GATHER_PUSH_PER_MATCH_NS) −
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
-const GATHER_FIXED_COST_NS: f64 = 200.0;
+const GATHER_FIXED_COST_NS: f64 = 169.6;
 
 /// Estimated wall-clock cost of running `plan` on a query with features `f`, in
 /// nanoseconds. Lower is cheaper; the planner routes to `argmin_plan plan_cost`.
 /// Only meaningful for plans that are *applicable* to the query (`run_query_routed`
 /// only ever costs `PhysicalPlan::ALL.filter(applicable)`); an inapplicable plan's
 /// cost is not defined.
+/// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
+/// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
+/// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
+/// entirely on this quantity and nothing else validates them.
+pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
+    let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
+    let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
+    page_span / match_rate
+}
+
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
     let n_printings = f64::from(f.n_printings);
@@ -390,22 +508,33 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             // The small-total gather branch (run_query_streamed) scans all
             // n_cards when total <= STREAM_MIN_MATCHES — the O(N) floor that
             // sinks P3 on narrow queries.
-            let floor = if u64::from(f.matches) <= *super::STREAM_MIN_MATCHES as u64 {
-                n_cards * STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS
-            } else {
-                0.0
-            };
-            // card_pass is per candidate card; the residual scan + its verify tier
-            // are per scanned printing (scan_units) — the operating-space split.
-            eval_domain * STREAM_CARD_PASS_NS
-                + scan_units * (STREAM_SCAN_PER_ROW_NS + tier_ns)
+            // Mirrors `run_query_streamed`'s own guard: it returns at `total == 0 || page_offset >=
+            // total` BEFORE reaching the small-total gather, so those queries never scan n_cards and
+            // must not be charged for it. Charging them anyway over-costs by the whole floor --
+            // measured est/real of 55.7 at p50 on zero-match queries, which really take 0.62 us
+            // against a ~35 us estimate, and 1,265 of 33k StreamedSelect rows land there.
+            let runs_small_gather = u64::from(f.matches) <= *super::STREAM_MIN_MATCHES as u64
+                && f.matches > 0
+                && u64::from(f.offset) < u64::from(f.matches);
+            let floor = if runs_small_gather { n_cards * STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS } else { 0.0 };
+            // card_pass — and the verify tier that prices it — is per candidate CARD: the loop
+            // calls `filter.card_pass` once per `cid`, and only the cheaper printing-dependent
+            // residual is re-checked per row inside `push_card_matches`. Charging `tier_ns` per
+            // scanned ROW instead is invisible in card mode (scan_units ≈ eval_domain) and
+            // overcharges printing/artwork by the whole printings-per-card ratio.
+            eval_domain * (STREAM_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
+                // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
+                + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
+                + f64::from(f.artwork_seen_cards) * STREAM_ARTWORK_SEEN_PER_CARD_NS
                 + floor
+                + n_cards * STREAM_CORPUS_PASS_PER_CARD_NS
                 + STREAM_FIXED_COST_NS
         }
         PhysicalPlan::GatheredScan => {
-            eval_domain * GATHER_CARD_PASS_NS
-                + scan_units * (GATHER_SCAN_PER_ROW_NS + tier_ns)
+            // Per-CARD verify tier, for the reason spelled out in the StreamedSelect arm above.
+            eval_domain * (GATHER_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
+                + scan_units * GATHER_SCAN_PER_ROW_NS
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS
                 + GATHER_FIXED_COST_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -414,21 +414,6 @@ const GATHER_SELECT_PER_PAGE_SLOT_NS: f64 = 3.51;
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
 const GATHER_FIXED_COST_NS: f64 = 169.6;
 
-/// Estimated wall-clock cost of running `plan` on a query with features `f`, in
-/// nanoseconds. Lower is cheaper; the planner routes to `argmin_plan plan_cost`.
-/// Only meaningful for plans that are *applicable* to the query (`run_query_routed`
-/// only ever costs `PhysicalPlan::ALL.filter(applicable)`); an inapplicable plan's
-/// cost is not defined.
-/// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
-/// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
-/// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
-/// entirely on this quantity and nothing else validates them.
-pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
-    let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
-    let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
-    page_span / match_rate
-}
-
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
     let n_printings = f64::from(f.n_printings);

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7249,6 +7249,10 @@ fn mk_plan_feats(
         project_printings: 0,  // PrintingCompose's card/artwork projection pass; CardRangePopcount sets it too (for costing compose)
         popcount_words: 0,     // PrintingCompose overrides this (result-space bitmap words)
         compose_paging: ComposePaging::Gather, // PrintingCompose overrides this (which paging strategy it'll actually use)
+        // `run_query_streamed`'s per-card artwork overhead applies to every candidate it visits, in
+        // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
+        // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
+        artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
     }
 }
 
@@ -8673,6 +8677,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("scatter_printings", g.scatter_printings),
         ("project_printings", g.project_printings),
         ("popcount_words", g.popcount_words),
+        ("artwork_seen_cards", g.artwork_seen_cards),
     ] {
         d.set_item(k, v)?;
     }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4430,6 +4430,7 @@ fn plan_cost_model_matches_gold() {
                     limit: limit as u32,
                     offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -4666,6 +4667,7 @@ fn plan_cost_refit() {
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -4865,6 +4867,7 @@ fn printing_range_route_probe() {
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
             };
 
             // ── Three pickers ──
@@ -5224,6 +5227,7 @@ fn plan_regret_report() {
                 limit: limit as u32,
                 offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -5349,6 +5353,7 @@ fn plan_regret_fuzz() {
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
+                artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -1,0 +1,492 @@
+"""Refit the cost model's rate constants against measured plan time, on the model's own features.
+
+`bench_cost_model_agreement.py` says *which* (plan, acquire) cells disagree. This says *what the
+constants should be* — it regresses measured per-plan time on exactly the feature vector
+`cost::plan_cost` consumes, so a fitted coefficient drops straight into `cost.rs`.
+
+Two things make this different from eyeballing a ratio:
+
+- **The regression is relative, not absolute.** Plain least squares is dominated by the handful of
+  slowest queries, which is how a model can fit the big cases and be 3x off across the common ones.
+  Every row is scaled by its own measured time, so the objective is squared *relative* error — the
+  same thing the [0.8, 1.25] median bar measures.
+- **Coefficients are constrained non-negative.** These are per-unit hardware costs; a negative rate
+  fits noise and then extrapolates catastrophically outside the sampled range.
+
+Fitting only works once the FEATURES are right. A feature that mis-counts by 2.5x cannot be repaired
+by any rate, and the fit will happily bury the error in whichever coefficient correlates with it —
+so `--counters` first checks each realized counter against the feature that is supposed to predict
+it, and refuses to report rates for a plan whose features do not track reality.
+
+    .venv/bin/python scripts/fit_cost_model.py --seconds 600
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import math
+import pathlib
+import random
+import statistics
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO  # noqa: E402
+from scripts.query_sampler import QuerySampler  # noqa: E402
+
+# Acquire branches where the routed path really does call `prepare_candidates` at dispatch, so the
+# materializing plans genuinely owe its cost; everywhere else acquire built the prep already. Defined
+# here rather than imported: this is the fitter's netting rule, not the agreement harness's.
+RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+# Coordinate descent on the non-negative normal equations. The problem is convex and tiny (<=6
+# coefficients), so this converges in far fewer sweeps than the cap.
+MAX_FIT_SWEEPS = 500
+FIT_TOLERANCE = 1e-12
+# Below this a cell's fit is noise, not a rate.
+MIN_ROWS_FOR_FIT = 200
+# `run_query_streamed`'s small-total gather branch scans all n_cards; mirrors CARD_ENGINE_STREAM_MIN_MATCHES.
+STREAM_MIN_MATCHES = 1024
+# Mirrors cost.rs MATCH_RATE_FLOOR, the density floor under the page-fill walk length.
+MATCH_RATE_FLOOR = 1.0 / 1_000_000.0
+# A realized counter this far from the feature meant to predict it is a FEATURE bug; refitting rates
+# on top of it just relocates the error.
+COUNTER_TOL = 0.15
+# Netting prepare_candidates out can overshoot (different round than the min trial). Keep a row only
+# if what remains is at least this fraction of the raw time; below that the residual is noise.
+MIN_NETTED_FRACTION = 0.5
+# The mirror check's tolerance. This is a reimplementation of cost.rs in Python, so it can drift --
+# and did: the arms moved to `max(tier, floor)` and gained a residual-gated per-row term while
+# `design_row` still modelled the tier as a multiplier, which silently invalidated every coefficient
+# reported for two revisions. The check below compares the mirror against the engine's own
+# predicted_ns and refuses to report if they disagree.
+MIRROR_TOLERANCE = 0.001
+MIRROR_MIN_AGREEMENT = 0.99
+# Gauss-Newton on the log objective; converges in a handful of steps from the current constants.
+MAX_IRLS_ITERS = 40
+# --by-mode: how far a per-unit rate may move between distinct-on modes before the arm is judged to be
+# missing a mode-dependent term rather than to be sampling noise. Per-unit hardware costs should not
+# depend on distinct-on at all -- that is the assumption the single shared arm rests on, so the bar is
+# set near the noise floor rather than at a "surely that is broken" level. At 2.0 only one term in the
+# engine flagged; the interesting cases sit between 1.3 and 2.0.
+MODE_SPLIT_FACTOR = 1.3
+# Below this (ns per unit) a rate is unidentified rather than mode-dependent, and its ratio is noise.
+MODE_SPLIT_MIN_RATE = 0.05
+IRLS_TOLERANCE = 1e-6
+IRLS_MIN_PREDICTION_NS = 1.0
+# Ridge pull toward the current constants, per row of design. Small enough that a well-identified
+# term moves freely, large enough to pin the collinear ones (floor/page_span vs the intercept).
+RIDGE_STRENGTH = 0.01
+
+# The constants currently in cost.rs, in the same term order design_row emits. The IRLS start point,
+# and the baseline each fitted rate is reported against.
+CURRENT: dict[str, list[float]] = {
+    # eval_domain, scan_units, tier scale, matches, page_span, fixed
+    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 169.6],
+    # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
+    "StreamedSelect": [6.46, 5.53, 8.18, 0.13, 1.36, 1.64, 0.02, 217.5],
+}
+
+
+def fit_log_ratio(design: list[list[float]], targets: list[float], start: list[float], weights: list[float]) -> list[float]:
+    """Fit c >= 0 minimising squared LOG ratio, sum (log(Xc) - log(y))^2, by Gauss-Newton IRLS.
+
+    Fitting `sum (Xc/y - 1)^2` instead looks like the same thing and is not: over-prediction is
+    unbounded there while under-prediction saturates at 1, so the minimiser buys cheap error
+    reduction by driving every per-unit rate to zero and leaving only the fixed term. Measured — it
+    produced all-zero rates and *worse* agreement than the constants it was replacing.
+
+    Log space is symmetric in over/under, which is what a "median ratio near 1.0" bar actually asks
+    for. It is not linear in the coefficients, so each iteration reweights by the current prediction
+    (the Gauss-Newton step for the log objective) and re-solves.
+    """
+    coeffs = list(start)
+    for _ in range(MAX_IRLS_ITERS):
+        scaled_rows, scaled_targets = [], []
+        for row, y, w in zip(design, targets, weights, strict=True):
+            pred = max(sum(c * v for c, v in zip(coeffs, row, strict=True)), IRLS_MIN_PREDICTION_NS)
+            # sqrt(count): squared residuals then sum as if the shape appeared `count` times, which
+            # is what a frequency-weighted median-ratio bar actually measures. Deduplicating to one
+            # row per shape instead fits a DIFFERENT distribution -- it gives a rare expensive shape
+            # the same say as a common cheap one, and measured 0.99 on shapes while the sampled
+            # distribution sat at 0.62-0.85.
+            scale = math.sqrt(w) / pred
+            scaled_rows.append([v * scale for v in row])
+            scaled_targets.append(y * scale)
+        # Ridge toward the current constants, in RELATIVE units so one strength suits every term.
+        # Several columns barely vary across this corpus — the StreamedSelect floor is literally
+        # `n_cards` or 0, and page_span is usually just `limit` — leaving them collinear with the
+        # intercept. Unregularised, the fit trades freely between them and lands on absurdities like
+        # a 42 µs fixed cost. The prior pins those directions and lets the identified ones move.
+        penalty = math.sqrt(RIDGE_STRENGTH * sum(weights))
+        for j, prior in enumerate(start):
+            if prior <= 0:
+                continue
+            row = [0.0] * len(start)
+            row[j] = penalty / prior
+            scaled_rows.append(row)
+            scaled_targets.append(penalty)
+        updated = nnls(scaled_rows, scaled_targets)
+        shift = max(abs(a - b) / max(b, IRLS_MIN_PREDICTION_NS) for a, b in zip(updated, coeffs, strict=True))
+        coeffs = updated
+        if shift < IRLS_TOLERANCE:
+            break
+    return coeffs
+
+
+def nnls(rows: list[list[float]], targets: list[float]) -> list[float]:
+    """Minimise ||Xc - y|| subject to c >= 0, by coordinate descent on the normal equations."""
+    n = len(rows[0])
+    gram = [[sum(r[i] * r[j] for r in rows) for j in range(n)] for i in range(n)]
+    xty = [sum(r[i] * t for r, t in zip(rows, targets, strict=True)) for i in range(n)]
+    coeffs = [0.0] * n
+    for _ in range(MAX_FIT_SWEEPS):
+        delta = 0.0
+        for i in range(n):
+            if gram[i][i] <= 0:
+                continue
+            # Exact coordinate-wise minimum, clamped at the non-negativity boundary.
+            residual = xty[i] - sum(gram[i][j] * coeffs[j] for j in range(n) if j != i)
+            new = max(0.0, residual / gram[i][i])
+            delta = max(delta, abs(new - coeffs[i]))
+            coeffs[i] = new
+        if delta < FIT_TOLERANCE:
+            break
+    return coeffs
+
+
+# The residual floors the shipped arms use inside `max(tier_ns, floor)`. They are NOT fitted here --
+# see design_row for why the max cannot be a plain linear column -- and were derived independently by
+# regressing per-card match-loop time on printings-per-card, split by tier class.
+SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 8.18}
+
+
+def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[float], list[str], float] | None:
+    """The feature vector for one plan's cost arm, plus the part no coefficient scales.
+
+    Mirrors `cost.rs` exactly. The awkward term is the residual charge, which the arms express as
+    `eval_domain * max(tier_ns, FLOOR)` -- not linear in the floor, so it cannot be one column. It is
+    split: a column of `eval_domain` gated on residual presence, whose coefficient IS the floor, plus
+    an OFFSET of `eval_domain * max(tier_ns - FLOOR, 0)` for the excess where an expensive residual
+    beats the floor. The offset must be subtracted from the target before fitting, or the fit solves
+    `Xc ~= y` while the model computes `Xc + offset` -- a different problem, which shows up as
+    impossible (negative) improvements.
+    """
+    eval_domain = float(acq["eval_domain"])
+    scan_units = float(acq["scan_units"])
+    matches = float(acq["matches"])
+    n_cards = float(acq["n_cards"])
+    tier_ns = acq["residual_tier_ns100"] / 100.0
+    page_span = float(min(offset + limit, acq["matches"]))
+    residual_on = 1.0 if tier_ns > 0.0 else 0.0
+    floor = SHIPPED_RESIDUAL_FLOOR.get(plan, 0.0)
+    excess = eval_domain * max(tier_ns - floor, 0.0) if tier_ns > 0.0 else 0.0
+
+    if plan == "GatheredScan":
+        return (
+            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, 1.0],
+            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "FIXED"],
+            excess,
+        )
+    if plan == "StreamedSelect":
+        # Mirrors run_query_streamed's early return: zero matches, or a page past the total, never
+        # reaches the small-total gather. See STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS in cost.rs.
+        runs_small_gather = 0 < matches <= STREAM_MIN_MATCHES and offset < matches
+        small_total = n_cards if runs_small_gather else 0.0
+        # P3's per-row term is GATED on residual presence: it only counts matches, and
+        # `card_match_count` is O(1) offset arithmetic under all_match, so it walks printings only
+        # when a residual must be tested. `n_cards` carries the O(corpus) work it pays regardless of
+        # selectivity -- the counts buffer resized and cleared every query.
+        return (
+            [
+                eval_domain,
+                scan_units * residual_on,
+                eval_domain * residual_on,
+                matches,
+                float(acq["artwork_seen_cards"]),
+                small_total,
+                n_cards,
+                1.0,
+            ],
+            [
+                "CARD_PASS",
+                "SCAN_PER_ROW",
+                "RESIDUAL_FLOOR",
+                "EMIT_PER_MATCH",
+                "ARTWORK_SEEN_PER_CARD",
+                "SMALL_TOTAL_FLOOR_PER_CARD",
+                "CORPUS_PASS_PER_CARD",
+                "FIXED",
+            ],
+            excess,
+        )
+    return None
+
+
+def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
+    """Realized counter vs the feature that should predict it, per plan. Ratios should be 1.00."""
+    pairs = (("cards_visited", "eval_domain"), ("printings_scanned", "scan_units"), ("matches_pushed", "matches"))
+
+    def feature_for(plan: str, counter: str, row: dict) -> str:
+        """Compose reads its own scan field, and which one depends on the paging branch that runs."""
+        if counter != "printings_scanned" or plan != "PrintingCompose":
+            return {"cards_visited": "eval_domain", "printings_scanned": "scan_units", "matches_pushed": "matches"}[counter]
+        return "compose_scan_printings" if row["acq"].get("compose_paging") == "Gather" else "printings_walked"
+
+    out: dict[str, list[tuple[str, float]]] = {}
+    by_plan: dict[str, list[dict]] = collections.defaultdict(list)
+    for s in samples:
+        by_plan[s["plan"]].append(s)
+    for plan, rows in sorted(by_plan.items()):
+        instrumented = [r for r in rows if r["ns_round_total"] and r["cards_visited"]]
+        if not instrumented:
+            continue  # only the two scan plans carry counters; absent is not the same as wrong
+        checks = []
+        for counter, _default in pairs:
+            got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in instrumented]
+            feature = feature_for(plan, counter, instrumented[0])
+            if got:
+                checks.append((f"{counter}/{feature}", statistics.median(got)))
+        if checks:
+            out[plan] = checks
+    return out
+
+
+def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySampler | None = None) -> list[dict]:
+    """Sample queries until the budget runs out, keeping one row per plan that actually ran."""
+    if sampler is None:
+        sampler = QuerySampler(REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl", "uniform")
+    samples: list[dict] = []
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
+        kw = {
+            "filters": None,
+            "unique": sampler.unique(rng),
+            "orderby": sampler.orderby(rng),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": limit,
+            "offset": offset,
+        }
+        q = sampler.query(rng)
+        try:
+            kw["filters"] = parse_scryfall_query(q)
+            acq = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        for p in res["plans"]:
+            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+                continue
+            # Same netting as the agreement harness: only a Prep::Range acquire makes the routed path
+            # re-pay prepare_candidates, so elsewhere it is not the plan's cost to carry.
+            raw = float(min(p["trials_ns"]))
+            measured = raw
+            if p["ns_round_total"] and acq["count_source"] not in RANGE_ACQUIRES:
+                measured = raw - p["ns_prepare"]
+            # `ns_prepare` comes from the instrumented round while `raw` is the min over trials, so the
+            # subtraction can overshoot. Clamping those rows to a floor is worse than dropping them: a
+            # row scaled by 1/1ns swamps the Gram matrix and drags every coefficient to zero.
+            if measured < raw * MIN_NETTED_FRACTION:
+                continue
+            samples.append(
+                {
+                    "plan": p["plan"],
+                    "q": q,
+                    "unique": kw["unique"],
+                    "acq": acq,
+                    "limit": limit,
+                    "offset": offset,
+                    "measured": measured,
+                    "predicted": float(p["predicted_ns"]),
+                    "ns_round_total": p["ns_round_total"],
+                    "cards_visited": p["cards_visited"],
+                    "ns_setup": p["ns_setup"],
+                    "ns_loop": p["ns_loop"],
+                    "ns_finish": p["ns_finish"],
+                    "printings_scanned": p["printings_scanned"],
+                    "matches_pushed": p["matches_pushed"],
+                }
+            )
+    return samples
+
+
+def mirror_matches_engine(samples: list[dict]) -> tuple[float, int]:
+    """Fraction of rows where this file's arm mirror equals the engine's own `predicted_ns`.
+
+    `design_row` + `CURRENT` is a Python reimplementation of `cost::plan_cost`. If it has drifted, the
+    fitter is fitting coefficients for a model the engine does not run, and every number it prints is
+    meaningless. Cheap to check exactly, because `explain` reports the engine's prediction.
+    """
+    ok = total = 0
+    for x in samples:
+        built = design_row(x["plan"], x["acq"], x["limit"], x["offset"])
+        if built is None or x["predicted"] <= 0:
+            continue
+        vec, _, excess = built
+        mine = sum(c * v for c, v in zip(CURRENT[x["plan"]], vec, strict=True)) + excess
+        total += 1
+        ok += abs(mine / x["predicted"] - 1.0) < MIRROR_TOLERANCE
+    return (ok / total if total else 0.0), total
+
+
+def fit_plan(plan: str, rows: list[dict], label: str | None = None) -> tuple[list[str], list[float]] | None:
+    """Fit and report one plan's arm: current vs fitted coefficient, and the agreement each gives.
+
+    Returns the fitted `(names, coeffs)` so a caller partitioning by distinct-on can compare them
+    across modes; `None` when the plan has no fittable design.
+    """
+    design, names, targets = [], None, []
+    for r in rows:
+        built = design_row(plan, r["acq"], r["limit"], r["offset"])
+        if built is None:
+            # Skip the ROW, not the plan. Compose's Decline branch costs infinity and so has no arm to
+            # fit, but `explain_analyze` runs every plan regardless of the model, so 440 of 2,886
+            # compose rows come back Decline-and-measured. Aborting the plan on the first of them is
+            # why PrintingCompose silently never got fitted.
+            continue
+        vec, names, excess = built
+        design.append(vec)
+        # Fit and score the part coefficients control: the residual EXCESS over the floor is not
+        # scaled by any of them, so it comes off the target rather than riding as a column.
+        targets.append(max(r["measured"] - excess, 1.0))
+    # One row per DISTINCT feature vector, at its median measured time. The sampler draws from a
+    # fixed predicate pool, so a few hundred distinct query shapes turn into tens of thousands of
+    # rows; left duplicated, the fit optimises whichever shape recurs most and degenerates to a
+    # constant (measured: a 19.8 µs StreamedSelect FIXED term and every per-unit rate at zero).
+    if names is None:
+        return None
+    grouped: dict[tuple[float, ...], list[float]] = collections.defaultdict(list)
+    for vec, y in zip(design, targets, strict=True):
+        grouped[tuple(vec)].append(y)
+    design = [list(k) for k in grouped]
+    targets = [statistics.median(v) for v in grouped.values()]
+    weights = [float(len(v)) for v in grouped.values()]
+    coeffs = fit_log_ratio(design, targets, CURRENT[plan], weights)
+
+    print(f"\n=== {label or plan} ({len(rows):,} rows, {len(design):,} distinct shapes) ===")
+    print(f"{'term':<30}{'current':>12}{'fitted':>12}{'x':>8}")
+    for name, cur, c in zip(names, CURRENT[plan], coeffs, strict=True):
+        print(f"{name:<30}{cur:>12.2f}{c:>12.2f}{c / cur if cur else math.inf:>8.2f}")
+
+    # Both scored on the same deduplicated shapes, so the comparison is like for like.
+    before, after = [], []
+    for d, y, w in zip(design, targets, weights, strict=True):
+        for coefs, out in ((CURRENT[plan], before), (coeffs, after)):
+            pred = sum(c * v for c, v in zip(coefs, d, strict=True))
+            out.extend([y / pred if pred > 0 else math.inf] * int(w))
+    for tag, ratios in (("current", before), ("fitted", after)):
+        finite = [x for x in ratios if math.isfinite(x)]
+        near = sum(1 for x in finite if AGREE_LO <= x <= AGREE_HI) / len(finite)
+        qs = statistics.quantiles(finite, n=10)
+        print(
+            f"  {tag:<8} median {statistics.median(finite):>6.2f}   p10 {qs[0]:>6.2f}   p90 {qs[8]:>7.2f}   within 25% {near:>5.0%}"
+        )
+    return names, coeffs
+
+
+def fit_by_mode(plan: str, rows: list[dict]) -> None:
+    """Fit one arm separately per distinct-on, and show how far the coefficients move.
+
+    A single arm is fitted across all three modes today, on the assumption that distinct-on changes
+    only the FEATURES (`scan_units`, `matches`) and not the per-unit costs. Where that assumption
+    holds, the three fits land on the same rates and the split is just noise. Where they diverge
+    sharply, the arm is missing a mode-dependent term and no single set of constants can serve all
+    three — the fit will land on a compromise that is wrong everywhere.
+
+    This is a diagnostic, not a source of shippable constants: each partition sees a third of the
+    rows, so a term that is weakly identified overall becomes noisy here. Read the SPREAD, and treat
+    a flagged term as a question about the arm's shape rather than as three numbers to hard-code.
+    """
+    by_mode: dict[str, list[dict]] = collections.defaultdict(list)
+    for r in rows:
+        by_mode[r["unique"]].append(r)
+    fits: dict[str, tuple[list[str], list[float]]] = {}
+    for mode, mrows in sorted(by_mode.items()):
+        if len(mrows) < MIN_ROWS_FOR_FIT:
+            continue
+        got = fit_plan(plan, mrows, label=f"{plan} / {mode}")
+        if got is not None:
+            fits[mode] = got
+    if len(fits) < 2:  # noqa: PLR2004 - nothing to compare against
+        return
+    modes = list(fits)
+    names = fits[modes[0]][0]
+    print(f"\n--- {plan}: coefficient spread across distinct-on ---")
+    print(f"{'term':<30}" + "".join(f"{m:>11}" for m in modes) + f"{'max/min':>10}")
+    for i, name in enumerate(names):
+        vals = [fits[m][1][i] for m in modes]
+        lo, hi = min(vals), max(vals)
+        # A term at ~0 in every mode is unidentified, not mode-dependent; ignore it either way.
+        ratio = hi / lo if lo > MODE_SPLIT_MIN_RATE else math.inf
+        flag = "  MODE-DEPENDENT" if hi > MODE_SPLIT_MIN_RATE and ratio > MODE_SPLIT_FACTOR else ""
+        shown = "   inf" if math.isinf(ratio) else f"{ratio:>10.2f}"
+        print(f"{name:<30}" + "".join(f"{v:>11.2f}" for v in vals) + f"{shown}{flag}")
+    print(f"  Flagged where the rate moves more than {MODE_SPLIT_FACTOR}x between modes: that is the arm")
+    print("  missing a mode-dependent term, not three constants waiting to be hard-coded.")
+
+
+def main() -> None:
+    """Collect a sample, verify features track counters, then fit each scan plan's rates."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=300.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    parser.add_argument(
+        "--by-mode",
+        action="store_true",
+        help="also fit each arm separately per distinct-on, to expose rates that are not mode-independent",
+    )
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".fit.store"))
+    samples = collect(engine, random.Random(args.seed), args.seconds)
+    print(f"\n{len(samples):,} plan-rows collected in {args.seconds:.0f}s")
+
+    agree, checked = mirror_matches_engine(samples)
+    print(f"arm mirror vs engine predicted_ns: {agree:.1%} exact over {checked:,} rows")
+    if agree < MIRROR_MIN_AGREEMENT:
+        print(
+            f"  REFUSING TO FIT: the Python mirror of cost.rs disagrees with the engine on "
+            f"{1 - agree:.1%} of rows. `design_row`/`CURRENT` have drifted from the shipped arms; any "
+            f"coefficients fitted now would be for a model the engine does not run. Sync them first."
+        )
+        return
+
+    print(f"\n{'plan':<20}{'counter / feature':<40}{'median':>9}")
+    suspect: set[str] = set()
+    for plan, checks in counter_check(samples).items():
+        for label, ratio in checks:
+            flag = "" if abs(ratio - 1.0) <= COUNTER_TOL else "  <-- FEATURE, not rate"
+            if flag:
+                suspect.add(plan)
+            print(f"{plan:<20}{label:<40}{ratio:>9.2f}{flag}")
+    print("  a ratio far from 1.00 is a miscounted feature; no rate can absorb it.")
+
+    by_plan: dict[str, list[dict]] = collections.defaultdict(list)
+    for s in samples:
+        by_plan[s["plan"]].append(s)
+    for plan, rows in sorted(by_plan.items()):
+        fittable = any(design_row(plan, r["acq"], r["limit"], r["offset"]) is not None for r in rows)
+        if len(rows) < MIN_ROWS_FOR_FIT or not fittable:
+            continue
+        if plan in suspect:
+            print(f"\n=== {plan} — SKIPPED: fix the feature above before fitting rates to it ===")
+            continue
+        fit_plan(plan, rows)
+        if args.by_mode:
+            fit_by_mode(plan, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/query_sampler.py
+++ b/scripts/query_sampler.py
@@ -1,0 +1,281 @@
+"""One query universe for every cost-model benchmark, with two weightings over it.
+
+The generator in `client/query_runner.py` picks values from hardcoded lists — `year:2019` through
+`year:2024` on a corpus spanning 1993-2026, a dozen fixed price points, `pow=0..6`. That is fine for
+load generation, where the point is plausible traffic. It is wrong for cost-model work, because it
+clusters *selectivity* at a handful of arbitrary points and leaves most of the range unexercised. A
+cost model is a function of selectivity; a benchmark that samples six values of it cannot say
+whether the model is right.
+
+Everything here is drawn from the corpus — real card names, types and subtypes, artists, set codes,
+oracle and flavor vocabulary, and real values for every range column — so the universe is as large
+as the data. `t:` alone spans 437 distinct values from `Creature` (45,976 printings) down to
+one-offs, which is a far better selectivity ladder than any hand-written list.
+
+## Two modes over the same universe
+
+- **`realistic`** weights toward traffic we expect. This applies at BOTH levels: which family a
+  predicate comes from (name/oracle/type/numeric over flavor text) and which value within it
+  (`t:creature` far more often than `t:vronos`, by corpus frequency).
+- **`uniform`** weights families evenly and values flat over the distinct vocabulary. Use it to
+  explore the space and catch regressions — `artwork` is 5% of realistic traffic but was where a 12x
+  routing regression hid, precisely because nothing sampled it hard enough to notice.
+
+They differ ONLY in weights, never in what can be produced, so a finding under one is reproducible
+under the other with enough samples.
+
+## Sampling is uniform in QUANTILE, not in value
+
+Drawing a price uniformly from [0.05, 400] produces almost nothing but "matches nearly everything",
+because real prices are heavily skewed. Drawing the p-th percentile for uniform p spreads
+*selectivity* evenly across (0, 1), which is the axis the cost model varies along.
+
+The bounded-range shape (`usd>=a usd<=b`) matters more than it looks: it is absent from every older
+generator, and the first paired A/B run with it found a 12x routing regression that those generators
+could not see, concentrated entirely in bounded ranges at artwork granularity.
+"""
+
+from __future__ import annotations
+
+import collections
+import datetime as dt
+import json
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pathlib
+    import random
+
+MODES = ("realistic", "uniform")
+
+# Range fields mapped to the corpus column each draws its thresholds from.
+RANGE_COLUMNS: dict[str, str] = {
+    "usd": "price_usd",
+    "cn": "collector_number_int",
+    "year": "released_at",
+    "date": "released_at",
+}
+RANGE_OPS = ("<", "<=", ">", ">=", ":")
+
+# Predicate families and their relative weight in `realistic`; `uniform` uses all-ones.
+REALISTIC_FAMILY_WEIGHTS: dict[str, float] = {
+    "name": 20,
+    "oracle": 18,
+    "type": 14,  # t:, over merged types + subtypes
+    "color": 12,
+    "numeric": 12,  # pow / tou / cmc / loyalty — the arithmetic path
+    "legality": 8,
+    "range": 6,  # usd / cn / year / date, one-sided
+    "set": 5,
+    "rarity": 4,
+    "collection": 3,
+    "bounded": 2,  # two-sided range
+    "artist": 1.5,
+    "flavor": 0.5,
+}
+REALISTIC_UNIQUE_WEIGHTS: dict[str, float] = {"card": 75, "printing": 20, "artwork": 5}
+REALISTIC_ORDERBY_WEIGHTS: dict[str, float] = {
+    "edhrec": 40,
+    "name": 15,
+    "cmc": 10,
+    "usd": 10,
+    "rarity": 8,
+    "power": 6,
+    "toughness": 5,
+    "cubecobra": 6,
+}
+# How many predicates a query gets. Deeper conjunctions narrow to nothing and stop exercising plan
+# choice at all, which is the thing being measured.
+PREDICATE_COUNT_WEIGHTS = ((1, 45), (2, 40), (3, 15))
+
+# Closed vocabularies: small fixed sets where the corpus adds nothing.
+STATIC_VALUES: dict[str, list[str]] = {
+    "color": ["c:w", "c:u", "c:b", "c:r", "c:g", "c:wu", "c:br", "c:rg", "id:g", "id:wu", "id:brg", "c>=2"],
+    "legality": ["f:modern", "f:commander", "f:legacy", "f:pauper", "f:standard", "f:vintage", "f:pioneer"],
+    "numeric": [
+        "pow>2",
+        "pow=3",
+        "pow<2",
+        "pow>=5",
+        "tou<4",
+        "tou=2",
+        "tou>=4",
+        "cmc>=4",
+        "cmc=2",
+        "cmc<3",
+        "loyalty>=3",
+        "power+toughness<6",
+        "cmc+1<pow",
+    ],
+    "rarity": ["r:common", "r:uncommon", "r:rare", "r:mythic", "r>=rare"],
+    "collection": ["is:reprint", "border:black", "border:borderless", "frame:showcase", "watermark:set", "is:permanent"],
+}
+
+# A word must be this long and appear in this many rows to be worth querying: rarer words match
+# nothing and only produce degenerate empty results.
+MIN_WORD_LEN = 4
+MIN_WORD_ROWS = 30
+MAX_VOCAB = 4000
+# Name predicates take a word from a real card name; this often is shortened to a prefix of this
+# length, which is what makes broad `name:` searches (`name:bo`) appear alongside selective ones.
+NAME_PREFIX_LEN = (2, 6)
+NAME_PREFIX_FRACTION = 0.5
+WORD_RE = re.compile(r"[a-z]{4,}")
+
+
+class QuerySampler:
+    """The corpus-derived query universe, sampled under one of the two `MODES`."""
+
+    def __init__(self, corpus: pathlib.Path, mode: str = "uniform") -> None:
+        """Read the corpus once, building the value universe and this mode's weight tables."""
+        if mode not in MODES:
+            msg = f"mode must be one of {MODES}, got {mode!r}"
+            raise ValueError(msg)
+        self.mode = mode
+        self.realistic = mode == "realistic"
+        self._read_corpus(corpus)
+        self.families = self._weights(REALISTIC_FAMILY_WEIGHTS)
+        self.uniques = self._weights(REALISTIC_UNIQUE_WEIGHTS)
+        self.orderbys = self._weights(REALISTIC_ORDERBY_WEIGHTS)
+
+    def _weights(self, realistic_table: dict[str, float]) -> tuple[list[str], list[float]]:
+        """Keys with their weights — the realistic table, or all-ones for uniform."""
+        keys = list(realistic_table)
+        return keys, ([realistic_table[k] for k in keys] if self.realistic else [1.0] * len(keys))
+
+    def _vocab(self, counts: collections.Counter[str], *, floor: int = 1, cap: int | None = None) -> tuple[list[str], list[float]]:
+        """A corpus vocabulary as (values, weights).
+
+        Realistic mode weights by corpus frequency, so `t:creature` dominates `t:vronos` the way
+        real traffic does. Uniform mode goes flat over the distinct values, which is what makes it
+        reach the rare tail — and the rare tail is where selectivity extremes, and the plans that
+        only appear at them, actually live.
+        """
+        items = [(w, n) for w, n in (counts.most_common(cap) if cap else counts.most_common()) if n >= floor]
+        if not items:
+            return ["the"], [1.0]
+        values = [w for w, _ in items]
+        return values, ([float(n) for _, n in items] if self.realistic else [1.0] * len(items))
+
+    def _read_corpus(self, corpus: pathlib.Path) -> None:
+        """One pass: sorted values per range column, plus every corpus-derived vocabulary."""
+        cols: dict[str, list[float]] = {c: [] for c in set(RANGE_COLUMNS.values())}
+        names: collections.Counter[str] = collections.Counter()
+        artists: collections.Counter[str] = collections.Counter()
+        sets_: collections.Counter[str] = collections.Counter()
+        # Types and subtypes share the `t:` operator (`t:creature` and `t:human` are both valid), so
+        # they are one vocabulary, not two.
+        types: collections.Counter[str] = collections.Counter()
+        oracle: collections.Counter[str] = collections.Counter()
+        flavor: collections.Counter[str] = collections.Counter()
+        with corpus.open() as handle:
+            for line in handle:
+                row = json.loads(line)
+                for col, out in cols.items():
+                    value = row.get(col)
+                    if value is None:
+                        continue
+                    out.append(dt.date.fromisoformat(value[:10]).toordinal() if col == "released_at" else float(value))
+                if name := row.get("card_name"):
+                    names[name.lower()] += 1
+                if artist := row.get("card_artist"):
+                    artists[artist.lower().split()[-1]] += 1
+                if code := row.get("card_set_code"):
+                    sets_[code.lower()] += 1
+                for kind in ("card_types", "card_subtypes"):
+                    for value in row.get(kind) or []:
+                        types[value.lower()] += 1
+                # Counter over the SET of words per row, so a word repeated within one card counts
+                # once and MIN_WORD_ROWS means "appears in N rows", not "appears N times".
+                oracle.update(set(WORD_RE.findall((row.get("oracle_text") or "").lower())))
+                flavor.update(set(WORD_RE.findall((row.get("flavor_text") or "").lower())))
+
+        self.sorted: dict[str, list[float]] = {c: sorted(v) for c, v in cols.items() if v}
+        self.vocab: dict[str, tuple[list[str], list[float]]] = {
+            "name": self._vocab(names),
+            "artist": self._vocab(artists),
+            "set": self._vocab(sets_),
+            "type": self._vocab(types),
+            "oracle": self._vocab(oracle, floor=MIN_WORD_ROWS, cap=MAX_VOCAB),
+            "flavor": self._vocab(flavor, floor=MIN_WORD_ROWS, cap=MAX_VOCAB),
+        }
+
+    def _pick(self, family: str, rng: random.Random) -> str:
+        """One value from a corpus vocabulary, weighted by mode."""
+        values, weights = self.vocab[family]
+        return rng.choices(values, weights=weights)[0]
+
+    def quantile(self, column: str, p: float) -> float:
+        """The value at quantile `p`, so a threshold placed here splits the column p / (1-p)."""
+        values = self.sorted[column]
+        return values[min(int(p * len(values)), len(values) - 1)]
+
+    def _render(self, field: str, raw: float) -> str:
+        """A sampled column value back into query syntax for `field`."""
+        if field == "usd":
+            return f"{raw:.2f}"
+        if field == "cn":
+            return str(int(raw))
+        if field == "year":
+            return str(dt.date.fromordinal(int(raw)).year)
+        return dt.date.fromordinal(int(raw)).isoformat()
+
+    def range_predicate(self, rng: random.Random) -> str:
+        """One-sided range whose threshold sits at a uniformly-drawn quantile of its column."""
+        field = rng.choice(list(RANGE_COLUMNS))
+        value = self._render(field, self.quantile(RANGE_COLUMNS[field], rng.random()))
+        return f"{field}{rng.choice(RANGE_OPS)}{value}"
+
+    def bounded_predicate(self, rng: random.Random) -> str:
+        """A two-sided range (`usd>=a usd<=b`), the shape one-sided sampling never produces."""
+        field = rng.choice([f for f in RANGE_COLUMNS if f != "year"])
+        column = RANGE_COLUMNS[field]
+        lo_p, hi_p = sorted((rng.random(), rng.random()))
+        lo = self._render(field, self.quantile(column, lo_p))
+        hi = self._render(field, self.quantile(column, hi_p))
+        return f"{field}>={lo} {field}<={hi}"
+
+    def predicate(self, family: str, rng: random.Random) -> str:
+        """One predicate from `family`, drawn from the corpus universe where there is one."""
+        if family in STATIC_VALUES:
+            return rng.choice(STATIC_VALUES[family])
+        if family == "range":
+            return self.range_predicate(rng)
+        if family == "bounded":
+            return self.bounded_predicate(rng)
+        if family == "name":
+            # `name:` is a SUBSTRING match, and people search the distinctive word — "bolt", not
+            # "ligh". Taking only a leading prefix of the full name would never produce `name:bolt`
+            # for "Lightning Bolt", so pick a word from anywhere in the name, then sometimes shorten
+            # it to a prefix. Full words are selective, short prefixes are broad; both are real.
+            words = [w for w in re.split(r"[^a-z0-9]+", self._pick("name", rng)) if w] or ["a"]
+            word = rng.choice(words)
+            if rng.random() < NAME_PREFIX_FRACTION:
+                word = word[: rng.randint(*NAME_PREFIX_LEN)]
+            return f"name:{word}"
+        prefix = {"oracle": "o", "flavor": "ft", "artist": "a", "set": "set", "type": "t"}[family]
+        return f"{prefix}:{self._pick(family, rng)}"
+
+    def query(self, rng: random.Random) -> str:
+        """One query: a few predicates from distinct families, weighted by this sampler's mode."""
+        counts, count_weights = zip(*PREDICATE_COUNT_WEIGHTS, strict=True)
+        keys, weights = self.families
+        parts, used = [], set()
+        for _ in range(rng.choices(counts, weights=count_weights)[0]):
+            family = rng.choices(keys, weights=weights)[0]
+            if family in used:
+                continue
+            used.add(family)
+            parts.append(self.predicate(family, rng))
+        return " ".join(parts) or self.predicate("type", rng)
+
+    def unique(self, rng: random.Random) -> str:
+        """A distinct-on, weighted by mode."""
+        keys, weights = self.uniques
+        return rng.choices(keys, weights=weights)[0]
+
+    def orderby(self, rng: random.Random) -> str:
+        """An orderby, weighted by mode. Which one gates StreamedSelect/PlanePopcountOrder."""
+        keys, weights = self.orderbys
+        return rng.choices(keys, weights=weights)[0]


### PR DESCRIPTION
Fifth of a stacked series, and the other half of #807. **Based on #807** → #806 → #805 → #804.

Correcting features without moving the rates makes agreement *worse*, because the rates had grown
around the errors. So the two are adjacent PRs and this one moves only constants and arm shape.

## The refit

    StreamedSelect               current   fitted        GatheredScan       current  fitted
    CARD_PASS                       6.71     6.46        CARD_PASS             6.58    6.88
    SCAN_PER_ROW                    4.35     5.53        SCAN_PER_ROW          1.94    2.06
    RESIDUAL_FLOOR                  7.94     8.18        RESIDUAL_FLOOR       18.42   18.89
    EMIT_PER_MATCH                  0.13     0.13        PUSH_PER_MATCH        2.54    2.24
    ARTWORK_SEEN_PER_CARD           1.58     1.36        SELECT_PER_PAGE_SLOT  3.26    3.51
    SMALL_TOTAL_FLOOR_PER_CARD      1.01     1.64        FIXED               181.50  169.64
    CORPUS_PASS_PER_CARD            0.02     0.02
    FIXED                         218.30   217.47

    StreamedSelect  within-25%  11% -> 54%   median 1.54 -> 1.00
    GatheredScan    within-25%  42% -> 43%   median 0.89 -> 0.88

Re-verified on an independent seed: mirror 100.0% exact, StreamedSelect 54%, GatheredScan 43%.

**GatheredScan barely moving is the useful control** — it says the fit is not chasing noise.
StreamedSelect's `SCAN_PER_ROW` and `SMALL_TOTAL_FLOOR_PER_CARD` carry the whole change.

## Artwork's per-card overhead gets its own term

`card_match_count`'s artwork arm keeps a per-card `seen_words` bitmask to dedupe groups, costing a
fixed amount per card regardless of how many printings that card has: a `seen_words.fill(0)` before
the loop and a `count_ones().sum()` after, over `ARTWORK_GROUP_WORDS = 8` u64s. Card mode returns on
the first matching printing and printing mode just counts, so neither pays it.

Fitting the arm separately per distinct-on is what surfaced it, over three seeds:

    artwork / printing        seed21      seed22      seed23
    CARD_PASS              5.92/3.36   5.76/3.20   5.89/3.17
    RESIDUAL_FLOOR        11.75/9.21  11.81/9.39  11.86/9.81

Two independently fitted per-card terms, both elevated in artwork by ~2.4 ns, never flipping sign
across seeds. One mechanism showing up twice belongs in **one term**, not as a mode-specific copy of
every rate — that is the same compensation pattern as a gate, spelled differently.

The constant lands at 1.36 rather than the ~2.4 the split implied, because #807's skip-repped
shortcut made the loop it prices cheaper.

## The self-check earned its keep

`fit_cost_model.py` reimplements `cost.rs` in Python and refuses to report below 99% agreement with
the engine's own `predicted_ns`. It fired during this work: seeding `CURRENT` with the pre-refit
constants gave **0.0% and a refusal**, rather than quietly fitting coefficients for a model the
engine does not run.

`query_sampler.py` comes along because the fitter needs it — one corpus-derived query universe in two
weightings, uniform for finding errors and realistic for weighting them.

147 Rust tests.

## Stack

    A  #804  exact distinct-card counts
    B  #805  cost compose honestly from every acquire
    C1 #806  predict compose's declines
    C2 #807  correct the features against the counters
    C3 this PR
    D  fit PrintingCompose, give it its own scan feature and rates