### PR TITLE
Give PrintingCompose Its Own Scan Feature and Its Own Rates, and Fit It at Last

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -95,6 +95,16 @@ pub(crate) struct PlanFeatures {
     /// Sharing one feature between the two forced a compromise that was ~2x wrong for whichever arm
     /// lost: with the value GatheredScan needs, compose over-counts 2x; with compose's, the scan plans
     /// under-count 3.3x.
+    /// Printings compose's **Gather** paging branch bit-tests, which is NOT `scan_units`.
+    ///
+    /// `scan_units` is every printing under a candidate card -- right for GatheredScan and
+    /// StreamedSelect, which must test each one. Compose walks the set bits of the bitmap it just
+    /// built, so it touches `printing_matches`. Measured against `printings_scanned`, compose reads
+    /// 1.00 on `matches` in printing mode and 1.00-1.01 on `project_printings` in artwork (the same
+    /// value), while `scan_units` reads 2.0-2.8 for it.
+    ///
+    /// Sharing one feature between the two forced a compromise ~2x wrong for whichever arm lost.
+    pub compose_scan_printings: u32,
     /// Page size (`limit`).
     pub limit: u32,
     /// Page offset.
@@ -132,31 +142,6 @@ pub(crate) struct PlanFeatures {
 // dominated by how far the walk must go to fill the page, which is
 // (offset+limit) matches at density `match_rate` printings.
 
-/// ns per permutation step walked. Fit from usd<5 printing shallow/deep
-/// (match_rate=0.734): (88708−666)ns over (13706−82) steps ≈ 6.5; year>=2020
-/// printing gave ≈3.5. The per-step cost is noisy (printing clustering along the
-/// sort order), so this is a representative middle value.
-///
-/// CAUTION: `printing_range_route_probe` measures P1 fidelity swinging 0.10×–2.24×
-/// against this single constant — a walk step in printing mode scans a whole card's
-/// printings, whose count varies by query. The earlier claim that exactness "matters
-/// little because P1 wins by 1-2 orders of magnitude" is FALSE at depth: at offset
-/// 20000 P1 leads P3 by only ~2×, and that is exactly where this loose constant
-/// flips the argmin (the model routes off gold-P1). Sharpening P1 needs a per-step
-/// term keyed on printings-scanned, not a scalar — deferred with the printing model.
-/// Per-printing cost of a **linear offset-walk** over set printings — the two passes that share this
-/// rate: `PrintingCompose`'s legality broadcast-DOWN (card ∃-plane → printing bitmap) and its
-/// projection-UP (printing bitmap → card/artwork existence, `printing_bits_to_card_bits`, which walks
-/// the set bits advancing a card cursor). Measured ~1.5 ns/printing: `legality_compose_kernel_costs`
-/// broad formats (~1.49), and `card_range_build_cost_split`'s B pass (122125ns / 80527 = 1.52).
-/// Carries `broadcast_printings` and `project_printings` — the midpoint of the two probes.
-pub(crate) const LINEAR_PASS_PER_PRINTING_NS: f64 = 1.50;
-/// Per-printing cost of `PrintingCompose`'s range **scatter** — `range_leaf_bits` reads the value-sorted
-/// index's contiguous in-range slice and scatters each pid into a printing bitmap (sequential read +
-/// random-write). Measured ~0.4 ns/printing (`card_range_build_cost_split`'s A pass 28583ns / 80527 =
-/// 0.355; `range_compose_kernel_costs` 0.36 at broad density) — far cheaper than a linear pass because
-/// there is no per-card cursor and the writes are the only work. Carries `scatter_printings` in compose.
-pub(crate) const RANGE_SCATTER_PER_PRINTING_NS: f64 = 0.36;
 const RANGE_WALK_STEP_NS: f64 = 4.5;
 /// Fixed P1 setup (binary searches + walk init). Fit from usd<5 printing shallow
 /// (666ns − 82 steps × RANGE_WALK_STEP_NS ≈ 150ns).
@@ -414,6 +399,57 @@ const GATHER_SELECT_PER_PAGE_SLOT_NS: f64 = 3.51;
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
 const GATHER_FIXED_COST_NS: f64 = 169.6;
 
+// --- PrintingCompose's own rates -------------------------------------------------------------
+//
+// This arm borrowed every constant it used from plans fitted against DIFFERENT physical operations,
+// because until now nothing fitted it: `design_row` returned None for PrintingCompose, so the one arm
+// carrying ~75% of measured routing regret was the one arm no tool calibrated. Fitting it (11,332
+// rows, 5,996 distinct shapes) moved within-25% agreement from 39% to 55% and p10 from 0.30 to 0.52,
+// the largest single gain of the exercise -- and showed the borrowed values are genuinely wrong here:
+//
+//     term                    borrowed from            was    fitted
+//     BROADCAST / PROJECT     LINEAR_PASS             1.50      1.93
+//     SCATTER                 RANGE_SCATTER           0.36      0.48
+//     WALK_STEP               RANGE_WALK_STEP          4.5      0.58
+//     GATHER_CARD_PASS        GATHER_CARD_PASS        6.80      9.81
+//     GATHER_PUSH_PER_MATCH   GATHER_PUSH_PER_MATCH   2.81      3.39
+//     FIXED                   RANGE_FIXED_COST       150.0    163.56
+//
+// The two gather rates are the informative ones: fitted on the SAME sample, GatheredScan wants 6.58
+// and 2.54 for what the comments called "the same operation". They are not the same operation --
+// compose walks a bitmap it just built, GatheredScan walks the printing array -- so the sharing was an
+// assumption, not a measurement. WALK_STEP at 7.7x is the largest error; RANGE_WALK_STEP stays at 4.5
+// for PrintingRangeScan, which has too few rows here to refit and should not inherit this.
+
+/// Legality broadcast-down and the printing→card/artwork projection pass, both linear over the set.
+pub(crate) const COMPOSE_LINEAR_PASS_PER_PRINTING_NS: f64 = 1.93;
+/// Range-slice scatter into the printing bitmap during build.
+pub(crate) const COMPOSE_SCATTER_PER_PRINTING_NS: f64 = 0.48;
+/// Result-space bitmap words popcounted for the total.
+const COMPOSE_POPCOUNT_PER_WORD_NS: f64 = 1.07;
+/// Per printing stepped over by the Perm / OrderbyWalk page fill.
+const COMPOSE_WALK_STEP_NS: f64 = 0.58;
+/// Per row emitted by the Perm / OrderbyWalk page fill.
+const COMPOSE_WALK_EMIT_PER_ROW_NS: f64 = 2.19;
+/// Per candidate card visited by `gather_composed_page`.
+const COMPOSE_GATHER_CARD_PASS_NS: f64 = 9.81;
+/// Per printing bit-tested against `pbits` inside the gather.
+const COMPOSE_GATHER_BITTEST_PER_PRINTING_NS: f64 = 0.38;
+/// Per match pushed into the bounded GatherSelect accumulator.
+const COMPOSE_GATHER_PUSH_PER_MATCH_NS: f64 = 3.39;
+/// Per-query setup for the compose fastpath.
+const COMPOSE_FIXED_COST_NS: f64 = 163.56;
+
+/// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
+/// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
+/// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
+/// entirely on this quantity and nothing else validates them.
+pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
+    let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
+    let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
+    page_span / match_rate
+}
+
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
     let n_printings = f64::from(f.n_printings);
@@ -440,10 +476,10 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
         // `compose_has_perm`'s doc) — the permutation walk and the permutation-free gather fallback
         // have different cost shapes, so this must not just assume the walk.
         PhysicalPlan::PrintingCompose => {
-            let build = f64::from(f.broadcast_printings) * LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
-                + f64::from(f.scatter_printings) * RANGE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
-                + f64::from(f.project_printings) * LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
-                + f64::from(f.popcount_words) * PLANE_POPCOUNT_PER_WORD_NS; // popcount the result-space bitmap for the total (printing/card/artwork words)
+            let build = f64::from(f.broadcast_printings) * COMPOSE_LINEAR_PASS_PER_PRINTING_NS  // legality broadcast-down into the printing bitmap (border/rarity read a plane → 0)
+                + f64::from(f.scatter_printings) * COMPOSE_SCATTER_PER_PRINTING_NS  // range-slice scatter into the printing bitmap (cheap: no card cursor)
+                + f64::from(f.project_printings) * COMPOSE_LINEAR_PASS_PER_PRINTING_NS  // second pass: project printing→card/artwork (0 for printing mode) — the pass CardRangePopcount fuses away
+                + f64::from(f.popcount_words) * COMPOSE_POPCOUNT_PER_WORD_NS; // popcount the result-space bitmap for the total (printing/card/artwork words)
             let page = match f.compose_paging {
                 // Perm (forward grouped walk) and OrderbyWalk (#744 value-index/plane walk) share the
                 // offset-dependent walk shape: fill the page in ~page_span/selectivity steps, then emit
@@ -451,8 +487,8 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // which is exactly why the COMPOSE_GATHER breadth gate is bypassed for it — broad is its
                 // best case, not its worst.
                 super::ComposePaging::Perm | super::ComposePaging::OrderbyWalk => {
-                    printings_walked * RANGE_WALK_STEP_NS  // walk to fill the page
-                        + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS  // emit one page of rows
+                    printings_walked * COMPOSE_WALK_STEP_NS  // walk to fill the page
+                        + limit * COMPOSE_WALK_EMIT_PER_ROW_NS  // emit one page of rows
                 }
                 // gather_composed_page: visits every candidate (eval_domain, same rate GatheredScan's
                 // own permutation-free walk pays per card), tests `pbits` membership per printing
@@ -462,16 +498,16 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // same per-match rate GatheredScan pays for the same operation). Offset-independent —
                 // unlike the walk above, it costs the same regardless of how deep the page is.
                 super::ComposePaging::Gather => {
-                    eval_domain * GATHER_CARD_PASS_NS
-                        + scan_units * RANGE_SCATTER_PER_PRINTING_NS
-                        + matches * GATHER_PUSH_PER_MATCH_NS
+                    eval_domain * COMPOSE_GATHER_CARD_PASS_NS
+                        + f64::from(f.compose_scan_printings) * COMPOSE_GATHER_BITTEST_PER_PRINTING_NS
+                        + matches * COMPOSE_GATHER_PUSH_PER_MATCH_NS
                 }
                 // The fastpath will refuse this query, so there is no page term to charge. Infinity
                 // keeps the plan out of the argmin entirely — routing to a plan that returns `None`
                 // pays the detour and then runs something else anyway.
                 super::ComposePaging::Decline => return f64::INFINITY,
             };
-            build + page + RANGE_FIXED_COST_NS // per-query setup
+            build + page + COMPOSE_FIXED_COST_NS // per-query setup
         }
         // #634 plane popcount-skip order walk (precomputed bitmap ⇒ no synth):
         PhysicalPlan::PlanePopcountOrder => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7253,6 +7253,7 @@ fn mk_plan_feats(
         // artwork mode only — so it rides `eval_domain` there and vanishes elsewhere. See
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
+        compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
     }
 }
 
@@ -7370,6 +7371,7 @@ fn acquire_plan_features(
         // `project` pass — so the fused op wins the argmin and a bare range doesn't mis-route to compose.
         feats.scatter_printings = k;
         feats.project_printings = k;
+        feats.compose_scan_printings = k;
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::CardRangePopcount))
     } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
@@ -7378,6 +7380,7 @@ fn acquire_plan_features(
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
         let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
+        feats.compose_scan_printings = k;
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
         // Also for costing that competing compose: `eval_domain`/`scan_units` above are the
         // unnarrowed universe (right for P3/P4, which is what they are there for), so leaving
@@ -7446,6 +7449,7 @@ fn acquire_plan_features(
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
+        feats.compose_scan_printings = printing_matches as u32;
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
         // itself decides, through the same helpers, including whether it will decline. Only this
         // branch knows the estimated result total, so only it can predict the small-total bail. The
@@ -8678,6 +8682,10 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("project_printings", g.project_printings),
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
+        ("compose_scan_printings", g.compose_scan_printings),
+        // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk
+        // paging branches are priced entirely on it and nothing else can check them.
+        ("printings_walked", cost::printings_walked(g) as u32),
     ] {
         d.set_item(k, v)?;
     }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4431,6 +4431,7 @@ fn plan_cost_model_matches_gold() {
                     offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                compose_scan_printings: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -4543,8 +4544,8 @@ fn cost_terms(plan: PhysicalPlan, f: &super::cost::PlanFeatures) -> (Vec<f64>, f
         // scatter + project) are hand-set offsets, not refit params.
         PhysicalPlan::PrintingCompose => (
             vec![f64::from(f.popcount_words), page_span / match_rate, limit, 1.0],
-            (f64::from(f.broadcast_printings) + f64::from(f.project_printings)) * super::cost::LINEAR_PASS_PER_PRINTING_NS
-                + f64::from(f.scatter_printings) * super::cost::RANGE_SCATTER_PER_PRINTING_NS,
+            (f64::from(f.broadcast_printings) + f64::from(f.project_printings)) * super::cost::COMPOSE_LINEAR_PASS_PER_PRINTING_NS
+                + f64::from(f.scatter_printings) * super::cost::COMPOSE_SCATTER_PER_PRINTING_NS,
         ),
         // [PERM_SCATTER, POPCOUNT(card words), EMIT, FIXED].
         PhysicalPlan::PlanePopcountOrder => (vec![matches, n_cards / 64.0, limit, 1.0], 0.0),
@@ -4668,6 +4669,7 @@ fn plan_cost_refit() {
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                compose_scan_printings: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -4868,6 +4870,7 @@ fn printing_range_route_probe() {
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                compose_scan_printings: 0,
             };
 
             // ── Three pickers ──
@@ -5228,6 +5231,7 @@ fn plan_regret_report() {
                 offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                compose_scan_printings: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -5354,6 +5358,7 @@ fn plan_regret_fuzz() {
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
+                compose_scan_printings: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -41,8 +41,7 @@ from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO  # noqa: E402
 from scripts.query_sampler import QuerySampler  # noqa: E402
 
 # Acquire branches where the routed path really does call `prepare_candidates` at dispatch, so the
-# materializing plans genuinely owe its cost; everywhere else acquire built the prep already. Defined
-# here rather than imported: this is the fitter's netting rule, not the agreement harness's.
+# materializing plans genuinely owe its cost; everywhere else acquire built the prep already.
 RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
 NUM_WARMUPS = 2
 NUM_TRIALS = 7
@@ -94,6 +93,11 @@ CURRENT: dict[str, list[float]] = {
     "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     "StreamedSelect": [6.46, 5.53, 8.18, 0.13, 1.36, 1.64, 0.02, 217.5],
+    # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
+    # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
+    # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
+    # with the other arm's is information about the shared constant, not a number to paste blindly.
+    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 9.81, 0.38, 3.39, 163.56],
 }
 
 
@@ -228,6 +232,46 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "FIXED",
             ],
             excess,
+        )
+    if plan == "PrintingCompose":
+        # The arm no tool has ever fitted, while the regret matrix puts 75% of all lost time on it.
+        # `build` is common to every paging branch; the page term is whichever branch will run, so a
+        # row contributes to exactly one of the two page columns and zero to the other. Decline costs
+        # infinity and never reaches a measurement, so those rows are absent by construction.
+        paging = acq.get("compose_paging", "Gather")
+        if paging == "Decline":
+            return None
+        gather = paging == "Gather"
+        # Recomputed rather than read from the exposed u32, which is truncated for display. The
+        # mirror has to match cost.rs bit for bit or its self-check fails on small walks.
+        match_rate = max(matches / max(float(acq["n_printings"]), 1.0), MATCH_RATE_FLOOR)
+        walk = (page_span / match_rate) if not gather else 0.0
+        return (
+            [
+                float(acq["broadcast_printings"]),
+                float(acq["scatter_printings"]),
+                float(acq["project_printings"]),
+                float(acq["popcount_words"]),
+                walk,
+                limit if not gather else 0.0,
+                eval_domain if gather else 0.0,
+                float(acq["compose_scan_printings"]) if gather else 0.0,
+                matches if gather else 0.0,
+                1.0,
+            ],
+            [
+                "BROADCAST_PER_PRINTING",
+                "SCATTER_PER_PRINTING",
+                "PROJECT_PER_PRINTING",
+                "POPCOUNT_PER_WORD",
+                "WALK_STEP",
+                "WALK_EMIT_PER_ROW",
+                "GATHER_CARD_PASS",
+                "GATHER_BITTEST_PER_PRINTING",
+                "GATHER_PUSH_PER_MATCH",
+                "FIXED",
+            ],
+            0.0,  # no residual-floor term in this arm, so nothing comes off the target
         )
     return None
 


### PR DESCRIPTION
Sixth of a stacked series. **Based on #813** → #807 → #806 → #805 → #804.

PrintingCompose carries roughly **75% of measured routing regret** and was the one arm no tool had
ever calibrated: `design_row` returned `None` for it, so every constant it used was borrowed from a
plan fitted against a *different physical operation*.

## Its scan feature was never its own

`scan_units` is every printing under a candidate card — right for GatheredScan and StreamedSelect,
which must test each one. Compose walks the set bits of the bitmap it just built, so it touches
`printing_matches`. Against `printings_scanned`, compose reads 1.00 on `matches` in printing mode and
1.00–1.01 on `project_printings` in artwork (the same value), while `scan_units` reads **2.0–2.8** for
it. One feature cannot serve both.

## The borrowed rates were measurably wrong

    term                    borrowed from            was    fitted
    BROADCAST / PROJECT     LINEAR_PASS             1.50      1.93
    SCATTER                 RANGE_SCATTER           0.36      0.48
    WALK_STEP               RANGE_WALK_STEP          4.5      0.58
    GATHER_CARD_PASS        GATHER_CARD_PASS        6.88      9.81
    GATHER_PUSH_PER_MATCH   GATHER_PUSH_PER_MATCH   2.24      3.39
    FIXED                   RANGE_FIXED_COST       150.0    163.56

The two gather rates are the informative ones: fitted on one sample, GatheredScan wants 6.88 and 2.24
for what the comments called "the same operation". **They are not the same operation** — compose walks
a bitmap it just built, GatheredScan walks the printing array — so the sharing was an assumption,
never a measurement. `WALK_STEP` at 7.7x is the largest single error.

`RANGE_WALK_STEP` stays 4.5 for PrintingRangeScan, which has too few rows here to refit and must not
inherit compose's 0.58. `LINEAR_PASS_PER_PRINTING_NS` and `RANGE_SCATTER_PER_PRINTING_NS` had no other
consumer and are deleted.

## Measured

`bench_cost_model_agreement.py`, same seed either side:

    cell                              before          after
    [printing_compose]           1.15 /  28%    0.96 /  49%
    [printing_range_scan]        1.09 /  48%    0.94 /  60%
    [card_range_popcount]        1.39 /  27%    1.26 /  48%
    / artwork                    1.28 /  28%    1.01 /  67%
    / card                       1.30 /  29%    1.12 /  45%
    / printing                   0.95 /  34%    0.88 /  38%
    unique cells inside the bar         6/12          10/12

`printings_walked` is exposed as well: the Perm/OrderbyWalk paging branches are priced entirely on
that quantity and nothing outside the engine could check them.

## Deliberately not in this PR

The `scan_units()` card-mode projection. GatheredScan and StreamedSelect walk the full printing span
of their candidates in card mode too, where the feature claims roughly one row each — **0.25–0.33
against `printings_scanned`**. It belongs with this work, but it shifts plan choice enough to expose a
pre-existing hazard: tie order is *unspecified across plans* (the #702 ordering-parity contract says
so in as many words), so a page-to-page plan flip can duplicate or skip a row.

That is a live bug on `main` today, independent of this PR. It lands next, together with the fix.

147 Rust tests.

## Stack

    A  #804  exact distinct-card counts
    B  #805  cost compose honestly from every acquire
    C1 #806  predict compose's declines
    C2 #807  correct the features against the counters
    C3 #813  refit both scan arms
    D  this PR
    E  stable tie order + the card-mode scan_units projection