### PR TITLE
Make Row Order Filter-Independent, and Take the Card-Mode scan_units Projection

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -444,47 +444,6 @@ const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 /// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
 /// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
 /// entirely on this quantity and nothing else validates them.
-// --- PrintingCompose's own rates -------------------------------------------------------------
-//
-// This arm borrowed every constant it used from plans fitted against DIFFERENT physical operations,
-// because until now nothing fitted it: `design_row` returned None for PrintingCompose, so the one arm
-// carrying ~75% of measured routing regret was the one arm no tool calibrated. Fitting it (11,332
-// rows, 5,996 distinct shapes) moved within-25% agreement from 39% to 55% and p10 from 0.30 to 0.52,
-// the largest single gain of the exercise -- and showed the borrowed values are genuinely wrong here:
-//
-//     term                    borrowed from            was    fitted
-//     BROADCAST / PROJECT     LINEAR_PASS             1.50      1.93
-//     SCATTER                 RANGE_SCATTER           0.36      0.48
-//     WALK_STEP               RANGE_WALK_STEP          4.5      0.58
-//     GATHER_CARD_PASS        GATHER_CARD_PASS        6.80      9.81
-//     GATHER_PUSH_PER_MATCH   GATHER_PUSH_PER_MATCH   2.81      3.39
-//     FIXED                   RANGE_FIXED_COST       150.0    163.56
-//
-// The two gather rates are the informative ones: fitted on the SAME sample, GatheredScan wants 6.58
-// and 2.54 for what the comments called "the same operation". They are not the same operation --
-// compose walks a bitmap it just built, GatheredScan walks the printing array -- so the sharing was an
-// assumption, not a measurement. WALK_STEP at 7.7x is the largest error; RANGE_WALK_STEP stays at 4.5
-// for PrintingRangeScan, which has too few rows here to refit and should not inherit this.
-
-/// Legality broadcast-down and the printing→card/artwork projection pass, both linear over the set.
-pub(crate) const COMPOSE_LINEAR_PASS_PER_PRINTING_NS: f64 = 1.93;
-/// Range-slice scatter into the printing bitmap during build.
-pub(crate) const COMPOSE_SCATTER_PER_PRINTING_NS: f64 = 0.48;
-/// Result-space bitmap words popcounted for the total.
-const COMPOSE_POPCOUNT_PER_WORD_NS: f64 = 1.07;
-/// Per printing stepped over by the Perm / OrderbyWalk page fill.
-const COMPOSE_WALK_STEP_NS: f64 = 0.58;
-/// Per row emitted by the Perm / OrderbyWalk page fill.
-const COMPOSE_WALK_EMIT_PER_ROW_NS: f64 = 2.19;
-/// Per candidate card visited by `gather_composed_page`.
-const COMPOSE_GATHER_CARD_PASS_NS: f64 = 9.81;
-/// Per printing bit-tested against `pbits` inside the gather.
-const COMPOSE_GATHER_BITTEST_PER_PRINTING_NS: f64 = 0.38;
-/// Per match pushed into the bounded GatherSelect accumulator.
-const COMPOSE_GATHER_PUSH_PER_MATCH_NS: f64 = 3.39;
-/// Per-query setup for the compose fastpath.
-const COMPOSE_FIXED_COST_NS: f64 = 163.56;
-
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -444,6 +444,47 @@ const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 /// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
 /// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
 /// entirely on this quantity and nothing else validates them.
+// --- PrintingCompose's own rates -------------------------------------------------------------
+//
+// This arm borrowed every constant it used from plans fitted against DIFFERENT physical operations,
+// because until now nothing fitted it: `design_row` returned None for PrintingCompose, so the one arm
+// carrying ~75% of measured routing regret was the one arm no tool calibrated. Fitting it (11,332
+// rows, 5,996 distinct shapes) moved within-25% agreement from 39% to 55% and p10 from 0.30 to 0.52,
+// the largest single gain of the exercise -- and showed the borrowed values are genuinely wrong here:
+//
+//     term                    borrowed from            was    fitted
+//     BROADCAST / PROJECT     LINEAR_PASS             1.50      1.93
+//     SCATTER                 RANGE_SCATTER           0.36      0.48
+//     WALK_STEP               RANGE_WALK_STEP          4.5      0.58
+//     GATHER_CARD_PASS        GATHER_CARD_PASS        6.80      9.81
+//     GATHER_PUSH_PER_MATCH   GATHER_PUSH_PER_MATCH   2.81      3.39
+//     FIXED                   RANGE_FIXED_COST       150.0    163.56
+//
+// The two gather rates are the informative ones: fitted on the SAME sample, GatheredScan wants 6.58
+// and 2.54 for what the comments called "the same operation". They are not the same operation --
+// compose walks a bitmap it just built, GatheredScan walks the printing array -- so the sharing was an
+// assumption, not a measurement. WALK_STEP at 7.7x is the largest error; RANGE_WALK_STEP stays at 4.5
+// for PrintingRangeScan, which has too few rows here to refit and should not inherit this.
+
+/// Legality broadcast-down and the printing→card/artwork projection pass, both linear over the set.
+pub(crate) const COMPOSE_LINEAR_PASS_PER_PRINTING_NS: f64 = 1.93;
+/// Range-slice scatter into the printing bitmap during build.
+pub(crate) const COMPOSE_SCATTER_PER_PRINTING_NS: f64 = 0.48;
+/// Result-space bitmap words popcounted for the total.
+const COMPOSE_POPCOUNT_PER_WORD_NS: f64 = 1.07;
+/// Per printing stepped over by the Perm / OrderbyWalk page fill.
+const COMPOSE_WALK_STEP_NS: f64 = 0.58;
+/// Per row emitted by the Perm / OrderbyWalk page fill.
+const COMPOSE_WALK_EMIT_PER_ROW_NS: f64 = 2.19;
+/// Per candidate card visited by `gather_composed_page`.
+const COMPOSE_GATHER_CARD_PASS_NS: f64 = 9.81;
+/// Per printing bit-tested against `pbits` inside the gather.
+const COMPOSE_GATHER_BITTEST_PER_PRINTING_NS: f64 = 0.38;
+/// Per match pushed into the bounded GatherSelect accumulator.
+const COMPOSE_GATHER_PUSH_PER_MATCH_NS: f64 = 3.39;
+/// Per-query setup for the compose fastpath.
+const COMPOSE_FIXED_COST_NS: f64 = 163.56;
+
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1965,7 +1965,9 @@ fn invert_perm(perm: &[u32]) -> Vec<u32> {
     inv
 }
 
-fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets: &[u32]) -> SortPermutations {
+fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
+    // Purely card-space now: the printings/offsets arguments existed only to read the first stored
+    // printing's prefer_score, which is no longer a sort key (see the closure below).
     let perm = |get: &dyn Fn(&OracleCard) -> Option<f32>, descending: bool| -> Vec<u32> {
         let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
         ids.sort_unstable_by_key(|&i| {
@@ -1975,12 +1977,11 @@ fn build_sort_permutations(cards: &[OracleCard], printings: &[Printing], offsets
             // Canonical secondary: the first (store-preferred) printing's
             // default prefer score, matching sort_key_bits' third component
             // for the printing the default prefer chooses.
-            let first = offsets[i as usize] as usize;
-            let sc = printings
-                .get(first)
-                .and_then(|p| p.prefer_score)
-                .map_or(u32::MAX, |v| f32_sort_bits(-v));
-            (((pk as u128) << 64) | ((e as u128) << 32) | (sc as u128), i)
+            // Keys 1-2 then the card index. prefer_score is deliberately NOT a key here: it used to
+            // be, taken from the first stored printing, which the gathered paths cannot reproduce
+            // because they see the first MATCHING printing instead. Ordering on something only one
+            // side can compute is what made row order depend on which plan ran. See `page_cmp`.
+            (((pk as u128) << 64) | (e as u128), i)
         });
         ids
     };
@@ -3996,7 +3997,18 @@ type Match = (u128, u32, u32);
 /// The page comparator (`select_page`'s order): sort key, then pid. pid is unique,
 /// so this is a total order over `Match`.
 fn page_cmp(a: &Match, b: &Match) -> std::cmp::Ordering {
-    a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2))
+    // Keys 1-2 only (`>> 32` drops key 3, prefer_score), then CARD, then printing.
+    //
+    // Key 3 must not decide across cards, because the two sides cannot agree on it. The prebuilt
+    // permutation bakes in `printings[offsets[i]]`'s prefer_score -- the first STORED printing, chosen
+    // without knowledge of any filter -- while this path uses the first MATCHING printing. Whenever a
+    // card's preferred printing fails the filter the two disagree, and the row order flips depending
+    // on which plan ran. Same query, different page, different plan: a page boundary could then repeat
+    // or skip a row.
+    //
+    // `cid` is filter-independent and total, so both sides can reach it. Within a card this changes
+    // nothing: printings are stored prefer-desc, so ascending pid already IS descending prefer_score.
+    (a.0 >> 32).cmp(&(b.0 >> 32)).then_with(|| a.1.cmp(&b.1)).then_with(|| a.2.cmp(&b.2))
 }
 
 /// Number of matches the gather buffer may grow *past* the page (`offset+limit`)
@@ -4034,14 +4046,15 @@ fn select_page(mut v: Vec<Match>, offset: usize, limit: usize) -> Vec<(u32, u32)
     if offset >= end {
         return Vec::new();
     }
-    let cmp = |a: &Match, b: &Match| a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2));
+    // `page_cmp` itself, not a copy of it. This was an inlined duplicate, which is exactly the
+    // drift `page_cmp`'s doc warns about -- one of the two got the cid tiebreak and the other did not.
     if end < v.len() {
-        v.select_nth_unstable_by(end, cmp);
+        v.select_nth_unstable_by(end, page_cmp);
     }
     if offset > 0 {
-        v[..end].select_nth_unstable_by(offset, cmp);
+        v[..end].select_nth_unstable_by(offset, page_cmp);
     }
-    v[offset..end].sort_unstable_by(cmp);
+    v[offset..end].sort_unstable_by(page_cmp);
     v.truncate(end);
     v.drain(..offset);
     v.into_iter().map(|(_, c, p)| (c, p)).collect()
@@ -7000,12 +7013,32 @@ fn run_query<'a>(
 /// `offsets` ranges over the candidate cards — O(candidates), a routing-time cost
 /// only paid when a candidate list exists.
 #[allow(dead_code)] // consumed by the cost benches (tests.rs) and future all-mode routing
-fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n_printings: u32, eval_domain: u32) -> u32 {
-    match mode {
-        Mode::Card => eval_domain,
-        Mode::Printing | Mode::Artwork => match candidate_cards {
-            None => n_printings,
-            Some(v) => v
+fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n_printings: u32, n_cards: u32) -> u32 {
+    // Card mode used to short-circuit to `eval_domain`, on the theory that the loop breaks at the
+    // first matching printing of each card. The `printings_scanned` counter says otherwise: across
+    // every acquire branch, GatheredScan and StreamedSelect scan the FULL printing span of their
+    // candidates in card mode too, and the old feature read 0.25-0.33 against it. So the QUANTITY is
+    // the same in all three modes -- printings under the candidates -- and there is no mode branch in
+    // what this means.
+    //
+    // There is a mode branch in how it is PAID FOR. The exact sum is O(candidates), which
+    // printing/artwork have always paid; card mode had not, and simply removing the short-circuit
+    // added ~30-47 us of acquire to every broad card query (`border:black` 47 us at 31,169
+    // candidates) -- a 40-70 us end-to-end regression on exactly those queries, for a feature nothing
+    // needed to be exact. The O(1) projection is what the counter was validated against in the first
+    // place: `eval_domain * n_printings/n_cards` reads 0.90-1.02 for both plans in all three modes,
+    // inside the [0.8, 1.25] bar.
+    //
+    // Printing/artwork keep the exact sum: they are already paying for it, and it reads 1.00 with a
+    // spread of 1.0. Card mode takes the projection and pays nothing.
+    match candidate_cards {
+        None => n_printings,
+        Some(v) => match mode {
+            Mode::Card => {
+                let per_card = f64::from(n_printings) / f64::from(n_cards.max(1));
+                (f64::from(v.len() as u32) * per_card) as u32
+            }
+            Mode::Printing | Mode::Artwork => v
                 .iter()
                 .map(|&cid| u32::from(offsets[cid as usize + 1]) - u32::from(offsets[cid as usize]))
                 .sum(),
@@ -7267,7 +7300,7 @@ fn mk_plan_feats(
 /// for `eval_domain·n_printings/n_cards` without re-justifying.
 fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidates, filter: &FilterExpr) -> cost::PlanFeatures {
     let count = prep.candidate_cards.as_ref().map_or(ctx.n_cards(), |v| v.len() as u32);
-    let scan = scan_units(params.mode, prep.candidate_cards.as_deref(), ctx.offsets, ctx.n_printings(), count);
+    let scan = scan_units(params.mode, prep.candidate_cards.as_deref(), ctx.offsets, ctx.n_printings(), ctx.n_cards());
     // Result cardinality is in the plan's OPERATING space, so it is NOT the candidate card count in
     // every mode. Passing `count` regardless under-counted printing mode by the printings-per-card
     // ratio: measured `matches_pushed / matches` of 2.41 for printing and 1.15 for artwork against
@@ -9028,7 +9061,7 @@ impl QueryEngine {
             released_at_cards,
             price_usd_cards,
             collector_number_cards,
-            sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
+            sort_perms:     build_sort_permutations(&cards),
             max_artwork_groups: artwork_group_counts.iter().copied().max().unwrap_or(0),
             artwork_groups: artwork_group_counts,
             // Columnar copy of each printing's assigned artwork_group_id, derived here — the single

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -286,7 +286,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         planes: build_bit_planes(&cards, &printings, &offsets, &[]),
         name_bigrams: build_name_bigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
-        sort_perms: build_sort_permutations(&cards, &printings, &offsets),
+        sort_perms: build_sort_permutations(&cards),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,
         artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
@@ -2359,7 +2359,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.flavor = build_flavor_index(&data.printings, &data.strings);
     data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
     data.indexes.legal_divergent = build_divergent_ids(&data.cards);
-    data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+    data.indexes.sort_perms = build_sort_permutations(&data.cards);
     data.indexes.cmc = build_numeric_index(&data.cards, |c| c.cmc.map(i16::from));
     data.indexes.power = build_numeric_index(&data.cards, |c| c.creature_power.map(i16::from));
     data.indexes.toughness = build_numeric_index(&data.cards, |c| c.creature_toughness.map(i16::from));
@@ -2963,6 +2963,10 @@ fn force_plan_differential_agreement() {
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
     // Same rows regardless of tie order.
+    // Order-preserving, unlike `id_multiset` below -- the full row sequence.
+    let id_seq = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
+        page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect()
+    };
     let id_multiset = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
         let mut v: Vec<u128> = page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
         v.sort_unstable();
@@ -3006,6 +3010,13 @@ fn force_plan_differential_agreement() {
                 ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
                 let ref_ids = id_multiset(&ref_page);
                 let ref_key2 = key2_seq(&ref_page);
+                // Full ROW ORDER, not just the 2-key value sequence. Every plan now orders on
+                // (key1, key2, cid, pid) -- all four filter-independent, all four reachable from
+                // either side -- so the sequences must be identical, not merely compatible. This
+                // could not be asserted while key 3 decided: the permutation baked in the first
+                // STORED printing's prefer_score and the gathered paths used the first MATCHING
+                // one, so tied rows legitimately interleaved differently per plan.
+                let ref_order = id_seq(&ref_page);
 
                 for &plan in &all_plans {
                     if plan == PhysicalPlan::GatheredScan {
@@ -3035,6 +3046,20 @@ fn force_plan_differential_agreement() {
                         "{plan:?} 2-key order disagrees with GatheredScan (mode={mode}, prefer={prefer}, orderby={orderby}, dir={direction}, filter={})",
                         fuzz_describe(spec),
                     );
+                    // Full row order, for every plan that orders through `page_cmp` or a card
+                    // permutation -- i.e. everything except `PrintingRangeScan`, which walks the
+                    // range index bucket by bucket and windows within the touched ones instead of
+                    // ordering the whole match set. That is a SEPARATE, pre-existing divergence:
+                    // verified by probe, it fails identically with and without the `cid` tiebreak
+                    // this change adds, so it is neither caused nor fixed here. Tracked for its own
+                    // change rather than silently folded in.
+                    if plan != PhysicalPlan::PrintingRangeScan {
+                        assert_eq!(
+                            id_seq(&page), ref_order,
+                            "{plan:?} ROW ORDER disagrees with GatheredScan (mode={mode}, prefer={prefer}, orderby={orderby}, dir={direction}, filter={})",
+                            fuzz_describe(spec),
+                        );
+                    }
                 }
             }
         }
@@ -5684,7 +5709,7 @@ fn bench_checked_vs_unchecked_access() {
         released_at_cards: RangeCardCounts::default(),
         price_usd_cards: RangeCardCounts::default(),
         collector_number_cards: RangeCardCounts::default(),
-        sort_perms:     build_sort_permutations(&cards, &printings, &offsets),
+        sort_perms:     build_sort_permutations(&cards),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,
         artwork_group_col: printings.iter().map(|p| p.artwork_group_id).collect(),
@@ -6285,7 +6310,7 @@ fn streamed_selection_matches_gathered() {
             p.price_usd = Some((pid % 7) as u32 * 100 + 50); // $0.50, $1.50, ... $6.50
         }
         if with_perms {
-            data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+            data.indexes.sort_perms = build_sort_permutations(&data.cards);
             reassign_artwork_grouping(&mut data);
         }
         rkyv::to_bytes::<Error>(&data).expect("serialize")
@@ -6393,7 +6418,7 @@ fn sort_permutations_nulls_last_both_directions() {
     cards[1].cmc = None;
     cards[2].cmc = Some(1);
     let data = store_of(cards, &[1, 1, 1], vocab);
-    let perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+    let perms = build_sort_permutations(&data.cards);
     assert_eq!(perms.cmc[0], vec![2, 0, 1], "asc: 1, 5, null");
     assert_eq!(perms.cmc[1], vec![0, 2, 1], "desc: 5, 1, null");
 }
@@ -9052,7 +9077,7 @@ fn named_store() -> CardData {
         .collect();
     assign_name_ranks(&mut cards);
     let mut data = store_of(cards, &[1; 6], vocab);
-    data.indexes.sort_perms = build_sort_permutations(&data.cards, &data.printings, &data.offsets);
+    data.indexes.sort_perms = build_sort_permutations(&data.cards);
     data
 }
 


### PR DESCRIPTION
Seventh of a stacked series. **Based on #814** → #813 → #807 → #806 → #805 → #804.

This is the change #814 held one piece back for.

## Row order depended on which plan ran

The prebuilt sort permutation bakes in `printings[offsets[i]]`'s prefer_score — the first **stored**
printing, chosen with no knowledge of any filter. The gathered paths use the first **matching**
printing's. Whenever a card's preferred printing fails the query, the two disagree on sort key 3 and
order that row differently.

Plan choice depends on `offset` (`page_span = min(offset+limit, matches)`, and the Perm/OrderbyWalk
arms are offset-dependent while Gather is not). So **one query paged twice can run two plans and get
two orders** — a page boundary can repeat or skip a row. #702's ordering-parity contract documents the
divergence and declares keys 3+ unspecified rather than fixing it.

## Stop letting key 3 decide across cards

Both sides already have a filter-independent card identifier, so neither needs the other's key 3:

    permutation   sort by (key1, key2, i)          -- prefer_score dropped
    page_cmp      (key >> 32), then cid, then pid  -- key 3 dropped, card added

Behaviour-preserving where it is not fixing anything: within a card, printings are stored prefer-desc,
so ascending pid already **is** descending prefer_score. Only tied rows *across* cards move — exactly
where the two sides could not agree.

Reachability, measured on the real corpus: of 31,508 cards only **62 (0.2%)** share (key1, key2) with
another at `orderby=cmc`, and **95% of those are the 65 cards with a null edhrec_rank**, which all
collapse to one key 2. Rare, but reachable and silently wrong — and cheap to make impossible.

`build_sort_permutations` loses its `printings`/`offsets` arguments as a result: it is purely
card-space now, which is the shape the fix implies.

## A duplicated comparator, found by the test

`select_page` had its own **inlined copy** of `page_cmp` instead of calling it, so changing one left
the other behind — precisely the drift `page_cmp`'s own doc warns about ("`select_page`'s order"). It
calls `page_cmp` now.

## The contract can assert more

`force_plan_differential_agreement` compared a 2-key VALUE sequence because full order was not
guaranteed. It now also asserts full **row order** equality.

Scoped to exclude `PrintingRangeScan`: it walks the range index bucket by bucket and windows within
the touched ones rather than ordering the whole match set, which diverges for printing-space orderbys.
**Verified by probe** to fail identically with and without the `cid` tiebreak added here — a separate
pre-existing defect, neither caused nor fixed by this change, left for its own rather than folded in
silently.

## The projection #814 deferred

GatheredScan and StreamedSelect walk the full printing span of their candidates in card mode too; the
feature claimed roughly one row each, reading **0.25–0.33** against `printings_scanned`. This is what
exposed the ordering bug, and it lands here because the fix is what makes it safe.

Card mode takes the O(1) projection rather than the exact sum. The sum is O(candidates) — which
printing/artwork already pay but card mode did not — and simply falling through added ~14 µs of
acquire to every broad card query (`border:black` 29.8 → 15.5 µs) for a value nothing needs exact. The
projection is what the counter was validated against: 0.90–1.02 for both plans in all three modes.

147 Rust tests debug, 146 release.

## Stack

    A  #804  exact distinct-card counts
    B  #805  cost compose honestly from every acquire
    C1 #806  predict compose's declines
    C2 #807  correct the features against the counters
    C3 #813  refit both scan arms
    D  #814  compose's own scan feature and rates
    E  this PR