### PR TITLE
The Measurement Toolkit and Design Notes Behind the Cost-Model Stack

### DIFF
--- a/docs/issues/local-engine-compose-membership-bittest.md
+++ b/docs/issues/local-engine-compose-membership-bittest.md
@@ -1,0 +1,72 @@
+# The materializing plans re-derive membership compose already computed exactly
+
+Worth ~**8x** on the highest-regret query class in the engine. Designed and measured, not implemented.
+
+## The waste
+
+`narrow_candidates_exact` ends with:
+
+```rust
+(Some(n.set), n.tight && !printing_space)
+```
+
+A printing-space narrowing is never reported as `residual_exact`, even when `n.tight`. That is correct
+as far as it goes — `into_card_space` projects "some printing matches", which does not imply "this
+printing matches", so card-space candidacy really is lossy. But `n.set` IS exact membership in printing
+space, and it is discarded.
+
+So `all_match_known` is false, and the materializing plans re-derive per printing what the narrowing
+already proved: `push_card_matches` and `card_match_count` evaluate the full residual for every printing
+they touch.
+
+Measured over 3,054 compose-acquired printing queries: **1,213 ms of match-loop time over 145 million
+printings scanned, 6.98 ns each**. An O(1) bit test is ~1 ns, so ~145 ms — **roughly 8x less**. This is
+the cell both the cost and regret matrices name as the top target
+([local-engine-cost-model-agreement.md](local-engine-cost-model-agreement.md)).
+
+There is in-tree precedent: `exec_card_range_popcount` threads `range_pbits` beside its card bitmap and
+membership-tests in O(1), for exactly this reason — "the shown printing must actually be in range, not
+just belong to a card that has some in-range printing".
+
+## It benefits all three distinct-ons
+
+The bitmap is printing-space truth, so any mode that walks printings under a candidate can use it:
+card mode breaking at the first match, artwork grouping printings, printing enumerating them. The
+current design pays a full residual evaluation in all three.
+
+## Two designs
+
+**A. Thread `member: Option<&[u64]>`** into `push_card_matches` / `card_match_count`, replacing
+`FilterExpr::residual_matches(...)` with `bitmap_contains(bits, pid)` where present. Two signatures,
+11 call sites, contained.
+
+**B. Rewrite the filter** into a printing-bitmap membership variant, the way `memoize_text_predicates`
+already rewrites `TextContains` into a memoized id-set. All 11 sites and all three modes then benefit
+with no signature change — but `FilterExpr` is matched exhaustively on purpose ("a new variant must get
+a considered cost here"), so it touches ~20 matches across filter.rs, estimator.rs, planes.rs and
+lib.rs, plus 39 in tests.rs.
+
+B is the better shape; A is the smaller change. Either way the plumbing is the same: capture the
+bitmap in `narrow_candidates_exact` when `n.tight && printing_space`, carry it on
+`PreparedCandidates`, and use it in the walk.
+
+## The correctness constraint that decides the gate
+
+The bitmap covers the NARROWED subexpression only. A plane is ANDed separately and is card-level truth,
+so:
+
+- **no plane, or a non-existential plane** — the bit test is complete. Every printing of a candidate
+  card satisfies a card-invariant plane, so membership plus card candidacy is the whole answer.
+- **existential plane (legality)** — NOT complete. "The card has some legal printing" does not mean this
+  printing is legal, which is the same carve-out `plane_true_for_mode` already encodes. The per-printing
+  plane check must still run.
+
+Gate the fast path on that distinction, exactly as `prepare_candidates` already does for
+`all_match_known`.
+
+## Verifying it
+
+This changes what rows come back if it is wrong, so measure rows, not timings. The row-diff harness used
+for the sparse-gather experiment captured totals and page rows over **127,640 compose-acquire queries**
+and compared them before/after; it found 0 differences there and would find these. Timings second:
+paired `bench_query_latency_ab.py`, interleaved.

--- a/docs/issues/local-engine-cost-model-agreement.md
+++ b/docs/issues/local-engine-cost-model-agreement.md
@@ -1,0 +1,543 @@
+# Cost-model: agreement 8/16 cells to 15/16, and why routing did not move
+
+`cost::plan_cost` was accurate enough to rank plans correctly most of the time while being badly
+wrong in absolute terms on several arms — a state that holds until something competes closely, and
+then mis-routes. This is the record of measuring that gap and closing most of it.
+
+Bar, set before the work: **every (plan, acquire) cell's measured/predicted median inside
+[0.8, 1.25]**, measured by [`scripts/bench_cost_model_agreement.py`](../../scripts/bench_cost_model_agreement.py).
+
+Measured baseline-to-branch on the same sampler (`92ecebf`, before any cost change, vs the branch tip):
+
+| | agreement cells in [0.8, 1.25] | n-weighted \|ln(median)\| | routing regret |
+| --- | --: | --: | --- |
+| uniform | **8/16 → 15/16** | **0.3501 → 0.1104** | no detectable difference |
+| realistic | **10/16 → 12/16** | 0.2432 → 0.2012 | no detectable difference |
+
+Routing, paired over ~1,870 queries per mode: realistic +0.018 µs CI [−0.316, +0.362]; uniform
+−0.517 µs CI [−1.323, +0.391]. **Both span zero.**
+
+### Absolute accuracy improved a lot; routing did not move at all
+
+This is the headline finding, and it is not a disappointment — it is the thing to know before doing
+more of this work. `cost.rs` said why in its own module docs and it took a long time to believe:
+
+> The per-card verify tier is added to BOTH the gather and stream per-card terms, so it largely
+> cancels in their argmin — cardinality and plan structure do the deciding.
+
+An argmin depends only on DIFFERENCES between plans. Most of what was wrong here was **common-mode**:
+shared by every plan that reads it, so fixing it improves every absolute number and changes no
+decision. Three successive reworkings of the per-card residual term (multiplicative → additive →
+floor) improved n-weighted agreement monotonically and moved routing by −0.003 µs, CI
+[−0.206, +0.214].
+
+**A mid-work claim of a 12x routing win was measured wrong** and is corrected here. That A/B compared
+the mode-split commit against the commit immediately before it, not against the baseline. The first
+cost commit zeroed compose's verify tier for all three modes, which *introduced* that regression; the
+mode-split commit fixed it. The pair nets to zero, which is what the baseline comparison above shows.
+
+Use [`scripts/bench_pairwise_ordering.py`](../../scripts/bench_pairwise_ordering.py) to target routing
+work: it reports, per plan pair, how often the order is right and what being wrong costs. Its own
+limitation, measured: pairwise regret OVERSTATES routing loss, because argmin is over all plans. On
+the worst pair, compose beat StreamedSelect in 708 mis-ordered cases but beat the best of all plans
+in only 189 — a third plan was usually the right answer regardless.
+
+### The measurement, which took three tries to get right
+
+The first two attempts at the routing number were both wrong, in opposite directions, and the
+failures are worth keeping:
+
+1. **Three seeds of `--sample 400`, unpaired.** Reported a 59% improvement and a 710 µs worst-case
+   regret. Both were noise: three repeats of the *identical* engine and seed gave max regret of
+   38 / 41 / 91 µs, and the mean swung 3x run to run (0.26 then 0.82). Regret is heavy-tailed — most
+   queries contribute exactly zero — so its mean converges far too slowly for this.
+2. **Interleaved blocks, still unpaired, still the old generator.** Correctly refused to claim the
+   noise was signal, and concluded "no detectable difference". That was also wrong, because the
+   generator drew thresholds from hardcoded value lists (`year:2019`–`2024` on a 1993–2026 corpus)
+   and never produced bounded ranges at all.
+3. **Paired, with corpus-drawn thresholds** ([`scripts/query_sampler.py`](../../scripts/query_sampler.py)).
+   Found a 12x difference the first two could not see.
+
+The harness was validated in both directions before being believed: on a **null** (same engine
+twice) it reports CI [−0.035, +0.389], spanning zero and symmetric per-query; on the **positive
+control** above the effect traces to its mechanism exactly — artwork saves 82.9 µs/query, card
+35.0, printing 0.7, which is precisely the printing/non-printing split the change makes.
+
+Use `--source distribution --out A.jsonl` then `--compare A.jsonl B.jsonl`. Never compare two
+headline means.
+
+## Features first, rates second
+
+The ordering is not stylistic. A feature that miscounts by 2.5x cannot be repaired by any rate, and
+a least-squares fit will bury the error in whichever coefficient correlates with it — so the fit
+comes out plausible and the model stays wrong. Executor counters (`cards_visited`,
+`printings_scanned`, `matches_pushed`, added in the preceding commit) exist to catch exactly this:
+each is checked against the feature meant to predict it before any rate is touched.
+
+### 1. CardRangePopcount costed the materializing alternatives as if the narrowing survived
+
+`range_narrowed` returns an enumerable printing list only below `MAX_NARROW_FRACTION`; past that it
+degrades to a printing-space bitmap, which cannot yield card ids, so `prep.card_ids()` falls back to
+`0..n_cards` and the scan walks the whole corpus. The branch charged `card_est` either way.
+
+| | model said | counters measured |
+| --- | --: | --: |
+| `eval_domain` | 12,450 | `cards_visited` **31,508** |
+| `scan_units` | 12,450 | `printings_scanned` **97,206** |
+| `matches` | 12,450 | `matches_pushed` 12,450 ✓ |
+
+Switching the branch on that predicate took `GatheredScan/card_range_popcount` from **3.20 to 1.01**.
+The sibling `PrintingRangeScan` branch already assumed the unnarrowed regime unconditionally, which
+is why *its* cells were passing at 0.99/0.92 all along — the two branches disagreed, and only one
+was right.
+
+### 2. The verify tier rode `scan_units`, but `card_pass` runs once per card
+
+Both scan arms charged `scan_units * (SCAN_PER_ROW + tier_ns)`. The loop calls `filter.card_pass`
+once per `cid`; only the cheaper printing-dependent residual is rechecked per row. Charging the full
+per-card verify cost on every row is invisible in card mode (`scan_units ≈ eval_domain`) and
+overcharges printing/artwork by the whole printings-per-card ratio.
+
+Moving it to `eval_domain` made `GatheredScan` mode-consistent — card/printing/artwork
+1.36/1.34/1.24, previously spread — which converted a mode-dependent error, unfixable by rates, into
+a uniform scale error that a refit could absorb.
+
+### 3. PrintingCompose charged a verify tier it never pays — in one mode of three
+
+Compose applicability means every leaf is index-composable in printing space, so `narrow_rec`
+returns `tight`, which is the `residual_exact` behind `all_match_known`. The branch passed
+`verify_cost_tier(filter)` regardless, on 100% of compose queries.
+
+But that reasoning only holds for **printing** mode, where the composed printing set is the answer
+outright. In card/artwork mode the same filter is inherently printing-*dependent* — the plan still
+has to choose which printing to show — so `card_pass` returns `Tri::PrintingDep`, not `Tri::True`.
+Measured match-loop ns per card, on rows the model called tier-free:
+
+| unique | P3 | P4 |
+| --- | --: | --: |
+| printing / compose | 5.0 | 8.1 |
+| card / compose | 28.2 | 24.0 |
+| artwork / compose | 25.6 | 29.0 |
+| card / plane (true `all_match` baseline) | 3.4 | 7.9 |
+
+Zeroing it in all three modes was the first attempt and over-corrected; splitting by mode is the fix.
+
+### 3b. A plan that will decline must not win the argmin
+
+Making the materializing plans correctly more expensive on card/artwork compose tipped the argmin to
+PrintingCompose, which then *declined at runtime* on sparse card-mode queries (`type:goblin`). The
+router paid the detour and ran something else anyway. `ComposePaging` gains a `Decline` variant.
+
+The three decline sites are not alike: the `Perm` branch's `total <= STREAM_MIN_MATCHES` is a
+**correctness** guard ("ordering ties differently"), while the gather branch's two are **cost**
+heuristics. Removing the cost gates and letting the model decide — the obvious next thought — was
+tried and made routing worse on all three seeds tested; `COMPOSE_GATHER_MAX_CARD_FRACTION`'s
+hand-calibrated 0.85 still beats `plan_cost` at that decision. Revisit once the compose arm agrees.
+
+### 4. StreamedSelect has no per-scanned-row cost at all
+
+P3 only *counts* matches: `card_match_count` is O(1) offset arithmetic under `all_match`, and the
+artwork-group count is a build-time constant. P4 must *push* every matching row, so `scan_units`
+genuinely drives it. Charging P3 per row put its printing/artwork bucket at 0.43 while card mode sat
+at 0.84; every fit, including an unregularised one, drove the rate to exactly 0.00.
+
+The term is gone. Its flat setup cost became an O(`n_cards`) rate instead, for the counts buffer the
+loop resizes and clears on every query. Re-tested after fix 3 landed (the earlier evidence predated
+it): adding the term back still makes agreement worse, 0.74 → 0.70.
+
+## Fitting the rates
+
+[`scripts/fit_cost_model.py`](../../scripts/fit_cost_model.py) regresses measured time on exactly the
+vector `plan_cost` consumes. Three choices were forced by measurement, each after the obvious
+alternative failed:
+
+- **Log-ratio objective, not relative error.** `sum (Xc/y - 1)²` is asymmetric — over-prediction is
+  unbounded, under-prediction saturates at 1 — so the minimiser shrinks every per-unit rate to zero
+  and keeps only the intercept. It did exactly that, and produced *worse* agreement than the
+  constants it replaced.
+- **Ridge-anchored to the previous values.** Several columns barely vary on one corpus: the P3 floor
+  is literally `n_cards` or 0, `page_span` is usually just `limit`. Unregularised, the fit traded
+  freely against the intercept and produced a 42 µs fixed cost.
+- **Weighted by sample frequency.** Deduplicating to one row per distinct shape fits a *different*
+  distribution than the bar scores — it gives a rare expensive shape the same say as a common cheap
+  one. That fit read 0.99 on shapes while the sampled distribution sat at 0.62–0.85.
+
+Coefficients are stable to <3% across independent seeds.
+
+## What is still wrong
+
+| cell | median | note |
+| --- | --: | --- |
+| `StreamedSelect/printing_compose` | 1.31 | p10 0.02 / p90 2.13 — heterogeneous, not a scale error |
+| `PrintingCompose/card_range_popcount` | 1.33 | |
+| `GatheredScan/plane` | 0.79 | marginal (bar is 0.80) |
+| `CardRangePopcount/card_range_popcount` | 0.78 | marginal |
+
+Two of the four miss by ≤0.02 and would move on almost any nudge; they are not worth a targeted
+constant, which would be fitting the bar rather than the machine.
+
+`StreamedSelect/printing_compose` is the real one, and it is **not** a rate problem: P3's error
+distribution is heavy-tailed enough that the log-LS objective no longer tracks its median. A refit
+lands at median 0.74 where the shipped constants give ~1.0, so refitting it actively hurts.
+
+It is also **not** the emission walk, which was the obvious suspect. With `emit_steps` counted and
+`ns_finish` timed separately, the walk behaves exactly as the inverse-selectivity argument predicts
+— `emit_steps` tracks `n_cards · page_span / matches` with a median ratio of 0.83 — but emission is
+only **~3% of P3's runtime** (median `ns_finish` 1.38 µs against `ns_loop` 51.21 µs). Neither plan
+can stop early, because both need an exact `total`: P4 pushes every match and P3 sums per-card
+counts over every candidate. Only the popcount plans escape that, by taking `total` from a bitmap.
+A walk term was tried and rejected on measurement (22% → 15% within 25%). The remaining error is in
+P3's match phase.
+
+## `verify_cost_tier` is fine; the CONJUNCTION model is what is missing
+
+The refit introduced `*_VERIFY_TIER_SCALE` (2.87 / 2.65) — a multiplier on `verify_cost_tier`'s
+output — and an earlier version of this document claimed that meant the tier constants were "1.7-5x
+low". **That was wrong**, and the correction is the useful part.
+
+`bench_verify_cost` (`cargo test --release bench_verify_cost -- --ignored --nocapture`) times the
+real `FilterExpr::matches()` path per node against the real archive. It is the right instrument, and
+it VALIDATES the constants:
+
+| constant | claims | measured |
+| --- | --: | --- |
+| `MASK_COMPARE_NS100` | 4.0 ns | 2.08–3.60 (median 2.8) |
+| `SET_LOOKUP_NS100` | 9.0 ns | 2.12–8.69 (median 5.3) |
+| `TEXT_SCAN_NS100` | 23.0 ns | **21.5** |
+| `REGEX_MACHINERY_NS100` | 50 ns | 45.8–47.5 |
+
+Each is at or slightly above measured per-node cost — deliberately conservative, not miscalibrated.
+The earlier "1.7-5x low" figure came from an end-to-end subtraction that swept up everything else a
+residual costs per card (tri-walk setup, the reused residual vec, the branch, the per-printing loop)
+and attributed it to the node. Two separate confounds, both since fixed: the multi-predicate version
+also let `max`-over-children inflate whichever class won the max, which is why its `SET_LOOKUP`
+estimate (5.2x) disagreed with the single-predicate one (2.6x).
+
+So the multiplier was wrong in FORM. There is no per-node error to scale away; there is an
+unmodelled fixed per-card overhead. `*_VERIFY_TIER_SCALE` is now
+`STREAM_RESIDUAL_WALK_NS` / `GATHER_RESIDUAL_WALK_NS`, added rather than multiplied. Fit on
+single-predicate queries, one additive constant per plan fits *both* cheap tiers (16.7 / 17.6 ns for
+P3, 10.8 / 11.4 for P4) where the multiplicative form needed a different factor per tier — that
+agreement is the evidence for the form.
+
+Scored honestly, it is a modest win and only on the axis that matters. Total |ln(median)| across
+cells: **n-weighted** (by query volume) 0.212 → 0.189 uniform and 0.256 → 0.236 realistic;
+**unweighted** it is marginally worse (0.169 → 0.178), because unweighted counts an n=416 cell the
+same as an n=75,044 one. The raw pass-count went 12/16 → 10/16 on that arbitrary boundary, which is
+why it is not the number to steer by.
+
+### The real gap: conjunctions
+
+`verify_cost_tier` takes `max` over an And's children. Neither `max` nor `sum` is right, because the
+walk sorts children cheapest-first and short-circuits:
+
+```
+cost(And) = c₁ + p₁·c₂ + p₁p₂·c₃ + …        (children in EVALUATION order, pᵢ = pass rate)
+```
+
+A cheap *selective* child means the expensive one almost never runs (cost → c₁); a cheap
+*non-selective* child means it always does (cost → c₁ + c₂). The spread is data-dependent, so no
+structural rule and no scalar can span it — which is exactly why the single-predicate calibration
+above is honest about single nodes and silent about conjunctions.
+
+Useful bounds fall straight out, and they are cheap:
+
+- **lower** = `min(children)` — cheapest-first ordering always pays at least the cheapest
+- **upper** = `sum(children)`
+- today's `max(children)` sits between them for no stated reason
+
+The bounds are also a cheap escape hatch: when `min` and `sum` are within a few percent there is no
+point estimating selectivity at all. Where they are far apart, `estimator::estimate_cardinality`
+already returns lo/hi per subtree (the compose decline gate uses it), so per-child pass rates are
+available without new machinery. `Or` is symmetric — it short-circuits on TRUE, so `reach *= (1 − p)`.
+
+**Blast radius.** `verify_cost_tier` is not cost-model private: it also orders And children for
+short-circuit evaluation (`children.sort_by_key(...)`, filter.rs) and gates `memoize_pays`. A
+selectivity-aware cost changes evaluation order, so validate ordering and memoize decisions
+separately from agreement — and note that text predicates mostly never reach the residual path at
+all (they are memoized through their indexes first), so `TEXT_SCAN_NS100`'s real consumers are those
+two callers, not the residual tier.
+
+There is still no counter for verify invocations or verify time. `residual_matches` runs millions of
+times per query, so it needs a feature gate rather than an unconditional increment — but
+`bench_verify_cost` measures the per-node cost directly and is the better instrument regardless.
+
+## Where the remaining error is, and that it is reachable
+
+[`scripts/bench_cost_error_attribution.py`](../../scripts/bench_cost_error_attribution.py) splits each
+cell's error three ways by substituting realized executor counters for estimated features (isolates
+cardinality error), refitting coefficients on those (isolates coefficient error), and calling what
+survives both the model's shape. Over 267,938 plan-rows realistic and 178,430 uniform:
+
+| plan / acquire | mean \|ln\| | median | features | coeffs | form floor |
+| --- | --: | --: | --: | --: | --: |
+| G / candidates | 0.305 | 0.251 | −0.002 | +0.029 | **0.330** |
+| G / printing_compose | 0.947 | 0.475 | +0.242 | −0.007 | **0.656** |
+| G / printing_range_scan | 0.982 | 0.188 | **+0.447** | +0.239 | 0.291 |
+| S / candidates | 0.316 | 0.109 | +0.019 | +0.036 | **0.427** |
+| S / printing_compose | 0.790 | 0.271 | +0.054 | +0.081 | **0.692** |
+
+Three conclusions:
+
+1. **Cardinality is now basically right** (±0.04) except `printing_range_scan`, the only
+   features-dominated cell, and `printing_compose`.
+2. **Coefficients are barely identifiable.** Refitting buys 0.02–0.14 while producing vectors that
+   bear no resemblance to the shipped ones (`GatheredScan` fixed 1154 vs 237, push 0.00 vs 3.30).
+   Wildly different vectors, near-identical error — not worth chasing.
+3. **The model's shape is the ceiling**, and it is worth ~0.33–0.69.
+
+Read the mean *and* the median. `printing_range_scan` has the worst mean (0.98) and one of the better
+medians (0.19): its problem is a tail. `printing_compose` has no tail flag and a median of 0.27–0.48,
+so its TYPICAL query is mis-costed — that is where the room is.
+
+### The floor is real shape error, not noise
+
+Grouping rows by IDENTICAL realized features, the spread that remains inside a group cannot be
+predicted from those features by any model. It is only **0.03–0.18** against floors of 0.33–0.69, so
+the floor is a wrong-FUNCTION problem, not noise.
+
+That argument needs the groups to hold DIFFERENT queries, not one query sampled repeatedly — otherwise
+the spread is just run-to-run timing noise and says nothing about whether the features suffice. Checked:
+14–42% of groups do, and splitting the spread by which kind of group it came from is what makes the
+number mean something:
+
+| cell | same query repeated | different queries, same features | form floor |
+| --- | --: | --: | --: |
+| G / candidates | 0.052 | **0.062** | 0.330 |
+| S / candidates | 0.044 | **0.030** | 0.427 |
+| S / printing_compose | 0.041 | **0.038** | ~0.68 |
+| **G / printing_compose** | 0.053 | **0.184** | 0.656 |
+
+For three of the four, different queries sharing realized features run in the same time as the same
+query repeated. Those features DO determine runtime, and the floor is reachable down to ~0.03–0.06 —
+81% for G/candidates, 93% for S/candidates.
+
+`GatheredScan/printing_compose` is the exception and the interesting one: 0.184 against a 0.053 noise
+floor. Different filters with identical counters take measurably different times, which is a MISSING
+FEATURE, not a wrong function. Its 0.656 floor splits roughly into 0.18 missing-feature and 0.47
+wrong-function. `StreamedSelect/printing_compose` shows no such signal (0.038), so whatever is missing
+is specific to P4 on compose acquires — and that is the one place the conjunction hypothesis below has
+direct evidence behind it rather than plausibility.
+
+One hypothesis has already been tried and REJECTED. Per-printing cost is flat on narrowed scans and
+roughly doubles on full-corpus sweeps (`candidates` 6.4 → 4.9 ns across a 1000x range, against
+`printing_compose` 5.3 → 9.9), which looked like scan locality. Adding a `scan_units × swept-fraction`
+column changed the floor by 0.000 on every cell — within a cell the fraction barely varies, so it
+carries no information the existing `scan_units` term lacks.
+
+The leading remaining candidate is the CONJUNCTION problem: `verify_cost_tier` takes `max` over an
+And's children, so two queries with the same `tier` can have very different true residual cost. That
+is a systematic, feature-level miss — precisely the "deterministic but unmodelled" signature above —
+and the fix shape is written up earlier in this document (`c₁ + p₁c₂ + p₁p₂c₃`, bounded by
+`min`/`sum`, with pass rates from `estimator::estimate_cardinality`).
+
+## Operating-space `matches`: reverted twice, then shipped on principle
+
+`candidate_feats` passes the candidate CARD count as `matches` in every mode, but the result total is
+in the plan's operating space. Measured `matches_pushed / matches`: **2.41 for printing**, 1.15 for
+artwork, 1.00 for card.
+
+Both are exactly summable from data already in hand — `scan_units` is the printing count under the
+candidates (offset deltas, computed one line above) and `indexes.artwork_groups` holds each card's
+distinct-artwork count. And the count is exact only when the narrowing is tight, which splits cleanly:
+
+| | `matches_pushed / matches` | log err |
+| --- | --: | --: |
+| `all_match_known` | **1.00** | 0.000 |
+| residual survives | 0.38–0.56 | 0.59–0.98 |
+
+Discounting the untight case by the measured pass rate (0.40 printing, 0.53 artwork — artwork higher
+because a group survives if ANY of its printings does) brings the feature to **1.00 tight and
+0.91–1.00 with a residual**, from 2.41-under.
+
+**SHIPPED on the third attempt**, carrying a measured routing regression of +0.298 µs,
+CI [+0.017, +0.574], deliberately. The feature is provably correct and the regression is a
+COMPENSATING error — rates and gates were fitted against a `matches` 2.4x too small in printing mode.
+An approximation kept as a hedge against a separate error only makes that error harder to find, and
+reverting this twice left the model looking healthier than it was. The compensator is identified:
+`matches` feeds `GATHER_PUSH_PER_MATCH`, `page_span`, and structurally P3's small-total floor gate
+`matches <= STREAM_MIN_MATCHES`, worth 25.5 µs when it fires — floor eligibility is now 81% card /
+73% printing / 77% artwork, printing lowest because its total is correctly larger. Refitting those
+three against the corrected feature is the outstanding work; a flat rate change will not do it, since
+`matches` moved for printing and artwork only.
+
+The two earlier reverts, and the reason each looked justified at the time: agreement got WORSE, 15/16 → 13/16
+cells and n-weighted |ln| 0.1104 → 0.1425. `GATHER_PUSH_PER_MATCH` (3.30) and
+`STREAM_EMIT_PER_MATCH` were fitted against the 2.4x-too-small `matches` and had absorbed the error;
+making the feature exact breaks that compensation. The attribution had already predicted it — on
+REALIZED features it fits `push` to 0.00 against a shipped 3.30.
+
+### Second attempt, after fixing the blocker — still reverted
+
+The blocker was real and is now fixed: `fit_cost_model.py` had drifted and is
+[synced and self-checking](../../scripts/fit_cost_model.py). With a trustworthy fitter, the feature was
+reapplied and four cost forms tried. None beats the baseline:
+
+| variant | uniform | realistic |
+| --- | --: | --: |
+| baseline, no matches fix | **0.1104** | 0.2012 |
+| + matches, flat `PUSH` 3.30 | 0.1500 | — |
+| + matches, flat `PUSH` 2.47 (swept) | 0.1225 | — |
+| + matches, hard shed split at `page_span + GATHER_PRUNE_CHUNK` | 0.1461 | — |
+| + matches, log-retained + swept rates | 0.1359 | **0.1833** |
+
+The log-retained form deserves recording, because the MECHANISM is real. `GatherSelect::absorb`
+tightens `cutoff` at every prune, so the i-th match survives with probability ≈ `k/i` and the expected
+number RETAINED across `n` matches is the harmonic sum ≈ `k · ln(n/k)`. Every match is appended and
+compared; only that many are kept, moved during compaction and quickselected. So the gather is
+genuinely sublinear in `matches`, and charging one flat rate over-costs exactly the high-match queries.
+
+**It earns nothing anyway.** Swept on an open geometric grid with `PUSH = 0` included, the optimum IS
+`PUSH = 0` and the retained term's gain is `+0.0000`: a pure flat per-match cost fits identically. Two
+earlier sweeps had to be redone because they read a grid BOUNDARY as an optimum — `ABSORB` at 1.5, then
+`PUSH` at 0.35. Always check the optimum is interior.
+
+Worse, the flat rate does not generalise: its optimum moved from **2.608** under limits 1–500 to
+**5.498** under limits 10–2560 on the same corpus. It is absorbing page-span-dependent cost that none of
+the three forms describes, so no single value is right. That is the reason for reverting, not the
+headline scores.
+
+Note also that `limit` is the ONLY thing separating a per-match cost from a per-retained-match one, since
+`retained` depends on `page_span` and the flat term does not. Sweeps for this need a wide geometric limit
+range (1,133 distinct `page_span` values here); the sampler's three limits leave the two collinear.
+
+The remaining gap after that is unnarrowed ARTWORK queries (16% of artwork candidate-acquire queries),
+where no corpus artwork total is stored and summing `artwork_groups` over every card is O(n_cards) in
+acquire. Storing one `u32` at build time closes it, for an `ARCHIVE_FORMAT_VERSION` bump; the error it
+leaves is ~1.15x on ~5% of queries, so it is genuinely marginal on its own.
+
+## The percentile view, and the two defects it found
+
+[`scripts/bench_cost_error_percentiles.py`](../../scripts/bench_cost_error_percentiles.py) prints
+estimate/real at p1/p10/p20/p50/p70/p90/p99 per plan. Every other view here reports a median, and a
+median is structurally blind to a tail — which is where two real defects were hiding.
+
+| plan | p10 | p50 | p90 | p99 | p90/p10 |
+| --- | --: | --: | --: | --: | --: |
+| GatheredScan | 0.42 | 0.95 | 1.86 | 5.77 | 4.5 |
+| StreamedSelect | 0.42 | 1.07 | **21.26** | **59.74** | 50.4 |
+| PrintingCompose | 0.64 | 0.96 | **inf** | **inf** | inf |
+| PlanePopcountOrder | 0.33 | 0.92 | 1.11 | 1.18 | 3.4 |
+| CardRangePopcount | 0.99 | **1.20** | 1.43 | **1.4** | 1.4 |
+| PrintingRangeScan | 0.28 | 0.86 | 1.49 | 2.27 | 5.3 |
+
+Read the SHAPE, not just p50. A tight spread (`CardRangePopcount`, 1.4) is a plain rate error worth
+recalibrating. A wide one means the error depends on something unmodelled. A healthy middle with a bad
+tail is a specific query class, not a general defect — and that is invisible to every other harness here.
+
+Three things came out of it, all now fixed:
+
+1. **`CardRangePopcount`, a uniform 1.20.** Only one of its five constants is not shared with
+   `PlanePopcountOrder` (which is slightly UNDER-costed, so the shared ones cannot move). Retuning that
+   one from 1.22 to 0.93 puts its whole p10–p90 inside the bar: 0.84 / 1.00 / 1.23.
+2. **`StreamedSelect`'s p90 of 21x** — the small-total floor charged on queries that return at
+   `total == 0` before reaching the gather. Zero-match queries take 0.62 µs and were estimated at
+   ~35 µs. Fixed; tail p90 21.3 → 8.5, and it produced this work's first cleanly-attributable routing
+   win, −0.166 µs CI [−0.341, −0.007].
+3. **`PrintingCompose`'s literal `inf`** — `ComposePaging::Decline` on 20% of rows that actually RUN.
+   The zero-total band (82% of them false) is fixed the same way, by mirroring an early return.
+
+**Two of the three are the same defect class**: the cost model mirrored a branch, but an EARLIER return
+reached first. Worth grepping for a third.
+
+**And the metrics disagree, informatively.** Fix 2 improved routing significantly while making the
+median-based agreement score slightly WORSE (0.1104 → 0.1273), because a per-cell median cannot see a
+56x error on 4% of rows. Agreement alone is not sufficient; use it with the percentile view and a paired
+routing A/B.
+
+## `build_artwork_base` was rebuilt on every artwork query
+
+Chasing compose's artwork arm (estimate/real 0.81, over-picked 38:1) found a constant ~11-12 µs
+shortfall — unchanged across prediction bands while the estimate grew 14x, and absent from printing and
+card. A fixed offset in one mode is not something a result-shaped term can absorb.
+
+The cause was `printing_compose_fastpath` calling `build_artwork_base` per query: an O(n_cards) prefix
+sum over `artwork_groups`, an input fixed at load. It was first PRICED (0.36 ns/card, which fixed the
+estimate to 1.00) and then DELETED — precomputed into the archive as a stored index and read as a slice.
+Deleting work beats modelling it, and the estimate stays at 1.00 without the term, which confirms the
+offset was that pass.
+
+It also unblocks two existing workarounds: the compose gather gate uses `cards.len()` as a conservative
+stand-in for the artwork domain "because getting it exactly means building artwork_base here", and
+`candidate_feats` falls back to the card count for unnarrowed artwork queries for want of a corpus
+artwork total. `artwork_base.last()` is that total, now free.
+
+## Sparse compose should gather, not decline — blocked on this arm
+
+Extracted to its own doc: **[local-engine-sparse-compose-gather.md](local-engine-sparse-compose-gather.md)**.
+
+One line, verified byte-identical over 127,640 queries, and blocked twice on routing (+0.445 µs, then
++0.377 µs after compose's artwork arm was corrected — which falsified the theory that mode-specific
+mispricing was the blocker). It is listed here because its prerequisite is this document's subject:
+the compose `Gather` arm cannot price the path, reading p10 0.14 on the population the change exposes.
+
+It is also the sharpest illustration of a trap worth remembering: **a declining plan accumulates no
+trials**, so those queries were absent from every measurement taken here. Enabling the path introduced
+a population nothing had ever measured.
+
+## The top target, found by both matrices agreeing — and what it exposed
+
+Both matrices independently named one cell, which is the strongest signal this work produced:
+
+- **cost matrix**: `StreamedSelect [printing_compose] / printing` at p50 **0.62**, p10 **0.09**,
+  p90/p10 spread **142** — the widest cell in the engine.
+- **regret matrix**: `StreamedSelect -> PrintingCompose` at **210 µs mean** over 124 queries, **21% of
+  all routing regret**.
+
+They are one defect: **97%** of that transition is that exact cell, and **70%** of all loss within the
+cell is that transition. P3 priced at 62% of its real cost wins the argmin, and compose — which was
+faster — loses.
+
+### The costing fix
+
+The compose acquire branch was passing verify tier `0` for printing mode, on the theory that compose
+applicability implies a `tight` narrowing and therefore `all_match_known`. It does not. Against a plane
+acquire, where the narrowing provably proves every candidate matches and P3's loop costs **5.11
+ns/card**, compose-printing costs **23–42 ns/card** and **5–11 ns per printing scanned**. That is a loop
+testing every printing, not the O(1) count `card_match_count` does under all_match.
+
+With the tier at 0 the arm charged neither the residual floor nor its gated per-row term, so tens of
+thousands of printings cost nothing. Charging it in every mode: p50 0.62 → **1.10**, spread 142 → 31.4,
+and routing **−0.695 µs, CI [−1.466, −0.079]** — the largest routing win in this work.
+
+The original evidence for the carve-out was `ns_loop / eval_domain` ≈ the all_match baseline. That
+denominator is the ESTIMATE, which over-counts by up to 2x here; against the measured `cards_visited`
+the ratio is 5–8x the baseline. **A feature error was hiding a costing error** — the fourth time on this
+branch.
+
+### The larger prize: P3 should not re-derive membership at all
+
+Costing the work correctly is not the same as the work being necessary, and here it is not.
+`into_card_space` drops tightness on projection — "some printing matches" does not imply every printing
+of that card matches. That is right for card mode and needlessly lossy for **printing** mode, where the
+plan operates in printing space and the composed `pbits` are already exact membership. P3 then
+re-derives it by evaluating the full residual per printing.
+
+Measured across 3,054 compose-acquired printing queries: **1,213 ms** of match-loop time over **145
+million printings scanned**, at 6.98 ns each. An O(1) bit test would be ~145 ms — roughly **8x less**,
+on the highest-regret query class in the engine.
+
+`exec_card_range_popcount` already solves exactly this: it threads `range_pbits` alongside the card
+bitmap so the shown printing can be membership-tested in O(1), for the same reason ("the shown printing
+must actually be in range, not just belong to a card that has some in-range printing"). The compose path
+needs the same treatment — carry printing-space membership through `PreparedCandidates` for
+printing-mode compose, and have the materializing executors bit-test instead of re-verifying.
+
+## Reproducing, and the rest of the toolkit
+
+```bash
+.venv/bin/python scripts/bench_regret_matrix.py --seconds 180          # what is worth fixing, by SHARE
+.venv/bin/python scripts/bench_cost_error_percentiles.py --seconds 180 # the shape of that cell's error
+.venv/bin/python scripts/bench_cost_error_attribution.py --seconds 400 # features / coefficients / shape
+.venv/bin/python scripts/bench_cost_model_agreement.py --seconds 300   # the bar
+.venv/bin/python scripts/fit_cost_model.py --seconds 300               # the rates (self-checks its mirror)
+.venv/bin/python scripts/bench_plan_misselection.py --source distribution --out A.jsonl
+.venv/bin/python scripts/bench_plan_misselection.py --compare A.jsonl B.jsonl   # the only real verdict
+```
+
+Which tool answers which question, how to read the two matrices, and the measurement traps this work
+paid for one at a time:
+**[reference-cost-model-measurement.md](reference-cost-model-measurement.md)**.
+
+Related: [plan mis-selection](local-engine-plan-misselection.md),
+[candidate materialization](local-engine-candidate-materialize.md).

--- a/docs/issues/local-engine-cost-model-stack-result.md
+++ b/docs/issues/local-engine-cost-model-stack-result.md
@@ -1,0 +1,72 @@
+# What the cost-model stack measured, end to end
+
+The eight PRs from #804 to #816 against `origin/main`, on the query distribution the work was
+targeted at. Recorded here because the individual PRs each report a component metric — agreement,
+feature-vs-counter ratios, paging-prediction rates — and none of them answers "did queries get
+faster".
+
+## The measurement
+
+`bench_query_latency_ab.py`, uniform weighting from
+[`query_sampler.py`](../../scripts/query_sampler.py), 120,000 sampled queries per side, 1 warmup and
+3 trials each, **interleaved A/B/A/B** across two reps with a separate store per side. Two reps
+because one number is not a measurement here: at `--sample 400` the same engine and seed has
+produced 0.26 and 0.82 µs on consecutive runs.
+
+Uniform rather than realistic on purpose. Realistic weighting is what users wait for, but it
+under-samples the tails where selectivity extremes live and where plan choice actually changes;
+uniform reaches them. The tradeoff is that the headline mean is not a traffic-weighted number.
+
+## Result
+
+    rep                     origin/main      stack        delta            95% CI
+    1                          85.8 us      81.8 us      -3.95 us   [-4.23, -3.65]
+    2                          87.8 us      83.9 us      -3.89 us   [-4.20, -3.62]
+
+    median ratio (stack/main)                              0.992 / 0.986
+
+The two reps agree to 0.06 µs, which is the part worth trusting. Earlier measurements in this work
+disagreed between reps by 3.5 µs and were read as signal before the disagreement was noticed.
+
+### By distinct-on
+
+    unique        rep1              rep2
+    printing     -9.78 us (-12.3%)  -10.90 us (-13.2%)
+    artwork      -1.93              -0.73
+    card         -0.09              -0.05
+
+### By cost band (banded on origin/main's time)
+
+    band            rep1 mean A -> B        rep2 mean A -> B
+    <10 us          7.1  ->  7.3  (+0.19)   7.2  ->  7.3  (+0.11)
+    10-50          25.2  -> 24.7  (-0.50)  25.3  -> 24.8  (-0.59)
+    50-200        102.8  -> 99.2  (-3.65) 103.6  -> 100.0 (-3.61)
+    200-1000      384.1  -> 370.7 (-13.4) 388.2  -> 376.0 (-12.3)
+    >=1000       1219.6  -> 968.4 (-251) 1226.0  -> 988.9 (-237)
+
+## Reading it honestly
+
+**The median ratio is below 1.** That matters more than the mean: it says the typical query got
+faster, not just that the tail did. An intermediate version of this work sat at 1.02-1.03 — a mean
+improvement carried entirely by expensive queries while ordinary ones were slightly worse.
+
+**Card mode is flat, and that is a fix, not a null.** It carried a reproducible +2% through every
+measurement of the earlier branch. The cause was `scan_units()`'s exact sum being O(candidates) —
+which printing/artwork already paid but card mode did not — so correcting the feature's VALUE also
+added ~14 µs of acquire to every broad card query (`border:black` 29.8 -> 15.5 µs once it took the
+O(1) projection instead).
+
+**The tail is where the routing work shows up.** The >=1000 µs band improves ~20%, and it is 0.5% of
+queries. A mean over the whole distribution understates that and a p99 overstates it, which is why
+the bands are here.
+
+**The <10 µs band is marginally worse** (+0.1 to +0.2 µs), consistently across reps. Small enough
+that it could be added planning work or could be noise at that scale; it was never attributed.
+
+## What this does not say
+
+- Not traffic-weighted. Uniform over-samples rare shapes by construction.
+- Not a claim about any single PR. The stack was measured at its tip; component PRs report their own
+  metrics and several were measured to be neutral end to end on their own.
+- Not a p99. Heavy-tailed distributions make percentile claims fragile at this sample size; the bands
+  above are the honest version of the same question.

--- a/docs/issues/local-engine-cost-model-stack-result.md
+++ b/docs/issues/local-engine-cost-model-stack-result.md
@@ -44,6 +44,40 @@ disagreed between reps by 3.5 µs and were read as signal before the disagreemen
     200-1000      384.1  -> 370.7 (-13.4) 388.2  -> 376.0 (-12.3)
     >=1000       1219.6  -> 968.4 (-251) 1226.0  -> 988.9 (-237)
 
+## Where the win actually comes from: 88% executor, 12% routing
+
+The stack is cost-model work, so the natural assumption is that the improvement comes from routing.
+It does not. Recording the picked plan alongside the routed time on both builds splits it cleanly --
+if both sides pick the same plan, any delta is that plan running faster; if the pick differs, it is
+routing:
+
+    group                        n    share   mean A -> B    total     of win
+    same plan (executor)     8,036      91%   82.5 -> 77.9   -37.0 ms     88%
+    different plan (routing)   777       9%  133.2 -> 126.9   -4.9 ms     12%
+
+The 88% is three executor changes that rode along in the same PRs:
+
+  - `artwork_base` precomputed at load instead of prefix-summed per artwork query (~11-12 us)
+  - #737's skip-repped shortcut extended to `card_match_count` (-17% on `r:common`)
+  - card mode's `scan_units` taking an O(1) projection instead of an O(candidates) sum (~14 us of
+    acquire on a broad card query)
+
+Routing touches only 9% of queries -- but where it fires it is worth MORE per query than the
+executor work is (-6.33 us against -4.61), and the two largest switches are precisely what the
+model changes were aimed at:
+
+    PrintingCompose   -> GatheredScan      n=483    -4.8 ms   (~10 us each)
+    PrintingRangeScan -> PrintingCompose   n= 31    -3.5 ms   (~113 us each)
+
+The second is 31 queries carrying 7% of the total win on its own.
+
+Worth being clear about the causation, though: all three executor wins were FOUND by the
+cost-model instrumentation. The `artwork_base` rebuild surfaced as an unmodelled ~11 us shortfall
+in compose's artwork arm; the skip-repped gap surfaced while pricing what that loop costs per card;
+the O(candidates) sum surfaced as a +2% card regression the feature audit then explained. The
+routing changes contributed 12% of the latency, and the measurement apparatus that produced them
+contributed the other 88% indirectly.
+
 ## Reading it honestly
 
 **The median ratio is below 1.** That matters more than the mean: it says the typical query got

--- a/docs/issues/local-engine-eur-tix-range-index.md
+++ b/docs/issues/local-engine-eur-tix-range-index.md
@@ -1,0 +1,70 @@
+# `eur` and `tix` have no range index, and pay 170–550x for it
+
+`usd>150` routes in **1.3 µs**. `eur>150`, the same shape at the same selectivity, takes **710.8 µs**.
+`tix>10` takes **782.2 µs**. The difference is not the cost model — it is that only `price_usd` has a
+`PrintingRangeIndex`, so `eur` and `tix` predicates never narrow and fall through to a scan.
+
+Found while scoping the acceptance test for
+[local-engine-range-cardinality-estimate.md](local-engine-range-cardinality-estimate.md): those two
+dimensions showed estimate errors up to 106x, which turned out to be a symptom of routing elsewhere
+entirely rather than a bad estimate.
+
+## Measured
+
+All `unique=card`, `orderby=edhrec`, `limit=100`, via `explain_analyze`'s `routed_ns`.
+
+| query | acquire | est | true | routed | usd equivalent | ratio |
+| ----- | ------- | --: | ---: | -----: | -------------: | ----: |
+| `eur>150` | candidates | 31,508 | 338 | **710.8 µs** | `usd>150` 1.3 µs | **546x** |
+| `tix>10` | candidates | 31,508 | 298 | **782.2 µs** | `usd>150` 1.3 µs | 602x |
+| `eur>20` | candidates | 31,508 | 1,123 | 655.6 µs | `usd>20` 3.8 µs | 172x |
+| `tix>1` | candidates | 31,508 | 2,961 | 720.6 µs | `usd>20` 3.8 µs | 190x |
+| `eur<1` | candidates | 31,508 | 26,391 | 438.2 µs | `usd<1` 82.5 µs | 5.3x |
+| `tix<0.5` | candidates | 31,508 | 26,651 | 452.0 µs | `usd<1` 82.5 µs | 5.5x |
+
+The gap is worst where the range is selective — exactly where an index earns most — and never below
+5x even for a range covering most of the corpus.
+
+`eur>150` is also mis-selected on top of that (`StreamedSelect` where `GatheredScan` is 29.5 µs
+faster), which is the unnarrowed `matches = 31,508` feeding the plan choice. That is a second-order
+effect; the 546x is the finding.
+
+## Mechanism
+
+Three fields have a `PrintingRangeIndex`:
+
+```rust
+released_at:      PrintingRangeIndex,   // printing space
+price_usd:        PrintingRangeIndex,   // printing space (integer cents)
+collector_number: PrintingRangeIndex,   // printing space (extracted int)
+```
+
+And `resolve_numeric_range_leaf` maps only two numeric fields onto them — `PriceUsd` and
+`CollectorNumberInt`. `PriceEur` and `PriceTix` hit the `_ => None` arm, so `bare_range_bounds`
+returns `None`, no range acquire applies, and the query lands on the general candidates path where
+`matches`/`eval_domain` are the unnarrowed card count.
+
+## Fix
+
+Add `price_eur` and `price_tix` as `PrintingRangeIndex`es and map them in
+`resolve_numeric_range_leaf`, alongside `price_usd`. Both columns already exist on the printing row
+(`price_eur`, `price_tix` in the corpus), and `price_usd` already demonstrates the integer-cents
+handling those two need — `snap_to_nearest_cent(v * PRICE_CENTS_PER_DOLLAR)`.
+
+**Cost:** roughly 1.1 MB of archive. The index is (value, printing id) pairs over printings that
+carry the column — `eur` has 81,523 and `tix` 54,896, so ~652 KB and ~439 KB at 8 bytes each. That
+is real against a 75 MB store but small against the 546x it buys.
+
+**The omission was deliberate** — `eur` and `tix` were lower priority than `usd` and left out of the
+range indexes on purpose. So this is a prioritisation question, not a bug: the measurements above are
+what that trade actually costs, now that it can be priced.
+
+## Acceptance
+
+`scripts/bench_range_estimate_scan.py` currently excludes `eur` and `tix` for exactly this reason.
+When they gain an index, add them back to `SCANS` and they should behave like `usd`:
+`count_source: card_range_popcount` at `unique=card`, `printing_range_scan` at `unique=printing`, and
+an estimate within 1% of true once the boundary table from the sibling doc lands.
+
+The runtime check is simpler: `eur>150` and `tix>10` should drop from ~700 µs to low single-digit µs,
+matching their `usd` counterparts.

--- a/docs/issues/local-engine-range-scan-row-order.md
+++ b/docs/issues/local-engine-range-scan-row-order.md
@@ -1,0 +1,78 @@
+# PrintingRangeScan orders tied rows differently from every other plan
+
+`force_plan_differential_agreement` asserts full row-order equality across plans — except for
+`PrintingRangeScan`, which is excluded. This is that exclusion.
+
+## What differs
+
+Every other plan orders its whole match set through `page_cmp`, or walks a card permutation whose
+order `page_cmp` reproduces. `PrintingRangeScan` does neither. `printing_range_fastpath` walks the
+range index bucket by bucket, counts past the buckets that fall before the page, and sorts only the
+*touched* buckets:
+
+```
+collected.extend((bs..be).map(|t| u32::from(idx[t].1)));   // one value-bucket
+...
+select_page(matches, page_offset - first_touched, limit)   // window within what was collected
+```
+
+That is the whole point of the plan — it is O(page) rather than O(matches), and never materializes
+the rows it skips. But it means the global order is *implied* by the index walk rather than produced
+by a comparator, and the two only agree if bucket order and `page_cmp` order agree on every key the
+comparator reads.
+
+They do not, for printing-space orderbys. A `usd` bucket is one price; within it the index has its
+own arrangement, while `page_cmp` continues on to `edhrec_rank`, then card, then printing. Rows tied
+on price come out in different orders depending on which plan answered.
+
+## It is not the key-3 divergence
+
+Worth stating explicitly, because the two look alike and were found together.
+
+The key-3 problem — the permutation baking in the first STORED printing's `prefer_score` while the
+gathered paths use the first MATCHING one — was fixed by dropping key 3 from cross-card comparison
+entirely. This one survived that fix. Probed directly: with the `cid` tiebreak removed from
+`page_cmp`, `PrintingRangeScan`/`usd` fails *identically*. Neither caused by that change nor repaired
+by it.
+
+## Why it was invisible until now
+
+The ordering contract used to compare a 2-key VALUE sequence, which is blind to this by construction:
+tied rows share their `(key1, key2)` value, so any interleaving of them produces the same sequence.
+Only once the contract could assert full row order did the divergence have anywhere to show up.
+
+## Blast radius
+
+Same shape as the key-3 bug: a query paged twice can run two plans, because plan choice depends on
+`offset`. If one page is answered by `PrintingRangeScan` and the next by a gathered plan, a row tied
+on the sort column can repeat or be skipped at the boundary.
+
+Narrower than key 3 was, though. It needs a *printing-space* orderby (`usd`, `rarity` — the columns
+with no card permutation), a tie on that column, and a page boundary landing inside the tie. Price
+ties are common in the corpus, so this is not exotic.
+
+## Options, none costed yet
+
+1. **Give the fastpath the same total order.** Sort each touched bucket by `page_cmp` — it already
+   does — and make the *bucket* boundaries agree with `page_cmp`'s key 1. If a bucket is exactly one
+   distinct value of key 1, that holds, and the remaining question is only whether rows spanning a
+   bucket edge are windowed correctly.
+2. **Widen the buckets to a full key-1 tie group.** Guarantees the plan sees every row it needs to
+   order, at the cost of collecting more than the page when a value is very common.
+3. **Decline the plan when the page boundary lands inside a tie.** Cheap to detect from the index,
+   and falls back to a plan that is already correct — but gives up the fast path exactly where prices
+   cluster, which is where it is most valuable.
+4. **Leave it and narrow the contract instead**, documenting that printing-space orderbys have
+   unstable tie order. Honest, but it keeps a user-visible paging defect.
+
+(1) looks most likely to be both correct and free; it needs someone to check the bucket-edge
+windowing rather than assume it.
+
+## Reproducing
+
+`force_plan_differential_agreement` with the `PrintingRangeScan` exclusion removed:
+
+```
+PrintingRangeScan ROW ORDER disagrees with GatheredScan
+(mode=printing, prefer=default, orderby=usd, dir=asc, filter=usd<100000)
+```

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -1,0 +1,100 @@
+# Sparse compose should gather, not decline
+
+`printing_compose_fastpath` throws away a completed compose on every sparse permutation query and
+makes the router redo the same work with a full scan. It does not have to. The replacement is
+**verified byte-identical over 127,640 queries** and is one line.
+
+It is nonetheless **blocked**, twice measured, and the blocker is not the change itself — it is that
+`plan_cost` cannot price the path the change routes to. Written up separately from
+[the cost-model work](local-engine-cost-model-agreement.md) because it is one shippable idea with a
+clean acceptance test, waiting on a prerequisite that lives elsewhere.
+
+## The change
+
+```rust
+Some(perm) => {
+    if total <= *STREAM_MIN_MATCHES {
+        return None; // sparse: the general path gathers + globally sorts, ordering ties differently
+    }
+    walk_grouped_page(ctx, params, &pbits, perm)
+}
+```
+
+becomes `gather_composed_page(ctx, params, &pbits)` in place of the `return None`.
+
+**Why the stated reason does not apply.** The decline exists because `walk_grouped_page` orders ties
+differently from the general path. `gather_composed_page` does not: it pages through the same bounded
+`GatherSelect` with the same comparator. That is exactly why the permutation-free branch immediately
+below needs no small-total decline of its own, and its comment says so —
+
+> the gather fallback pages via the bounded GatherSelect, whose tie-break matches the general path
+> exactly (same GatherSelect, same comparator) — so no separate small-total decline is needed.
+
+**Why it is cheap precisely here.** `gather_composed_page` walks `bitmap_card_ids` of the composed
+set — only cards holding a matching printing — so it is O(total), and `total <= STREAM_MIN_MATCHES`
+is the condition. Add one O(n_printings/64) projection. Declining instead discards the finished
+compose and pays `prepare_candidates` plus a full candidate scan to recompute it.
+
+## Correctness: verified, not asserted
+
+The suite passing is not evidence here, because the claim is about returned ROWS on a path the suite
+may not cover. Rows were captured before and after and compared directly:
+
+| | |
+| --- | --- |
+| compose-acquire queries compared | **127,640** |
+| identical result totals | **100.0000%** |
+| identical rows, in order | **100.0000%** |
+| differences | **0** |
+
+## Why it is blocked
+
+Those queries previously declined. **A declining plan accumulates no trials**, so they were absent
+from every cost measurement ever taken here. Enabling the path introduces a population nothing had
+measured — and the compose arm handles it badly:
+
+| | p10 | p50 |
+| --- | --: | --: |
+| `PrintingCompose` estimate/real, before | 0.64 | 0.93 |
+| after enabling the gather | **0.14** | 0.74 |
+| after adding an explicit `n_printings/64` projection term | 0.23 | 0.77 |
+
+All three `Gather` terms scale with the RESULT, while the projection runs whatever the result size, so
+a sparse query predicts almost nothing. Under-costed compose is then over-picked, and routing gets
+worse — twice:
+
+| attempt | routing regret |
+| --- | --- |
+| first | **+0.445 µs**, 95% CI [+0.129, +0.829], 187 worse / 145 better |
+| retried after compose's artwork arm was corrected | **+0.377 µs**, CI [+0.123, +0.709] |
+
+The retry matters because it **falsified the obvious theory**. The change makes compose cheaper in
+every mode, which is right for printing (under-picked 10:1) and wrong for artwork (over-picked 38:1).
+Artwork is now priced correctly and the retry still loses by nearly as much, so mode-specific
+mispricing was not the blocker, or not the only one.
+
+## Two traps, both paid for
+
+- **An A/B on this change can be inert.** The first latency comparison measured "no difference" —
+  because the cost model still returned `INFINITY` for those queries, so the router never picked
+  compose and the engine change did nothing at all. Change both halves before measuring anything.
+- **Removing the infinities exposes a pre-existing p99 of 178x OVER-cost** in the compose arm, which
+  was always there and hidden behind `inf`. The arm is wrong in both directions on this population.
+
+## Prerequisite
+
+Price the compose `Gather` path. This is not a one-term tweak: the arm is under by ~4-7x at p10 and
+over by 178x at p99 on the population the change exposes. Progress on the compose arm generally is
+tracked in [the cost-model doc](local-engine-cost-model-agreement.md); this change should be retried
+whenever that cell reads sanely.
+
+## Acceptance
+
+1. `PrintingCompose` estimate/real p10 ≥ 0.6 on the sparse-gather population, from
+   `scripts/bench_cost_error_percentiles.py --mode uniform`.
+2. Paired routing not worse: `scripts/bench_plan_misselection.py --compare`, CI including or below
+   zero.
+3. Rows still identical — re-run the before/after row capture; it should stay at 0 differences.
+
+The rows check is cheap and should be repeated rather than trusted from this document, since the
+comparator or the paging strategy may have moved since.

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -18,6 +18,10 @@ Pick by question:
 | Where does routing actually lose time? | [`bench_regret_matrix.py`](../../scripts/bench_regret_matrix.py) |
 | Did a change help end to end? | [`bench_plan_misselection.py`](../../scripts/bench_plan_misselection.py) `--compare`, or [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py) vs `main` |
 
+The end-to-end answer for the whole cost-model stack is recorded in
+[local-engine-cost-model-stack-result.md](local-engine-cost-model-stack-result.md) — including the
+bands, because a mean over this distribution understates the tail and a p99 overstates it.
+
 All of them draw queries from one universe, [`query_sampler.py`](../../scripts/query_sampler.py), in
 one of two weightings. Diagnostics default to `uniform` because their job is to FIND errors and
 uniform reaches the rare tails; latency defaults to `realistic` because there the question is what

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -1,0 +1,93 @@
+# Measuring the cost model: which tool answers which question
+
+Seven harnesses, built while doing the work in
+[local-engine-cost-model-agreement.md](local-engine-cost-model-agreement.md). They exist because each
+answers a question the others structurally cannot, and reaching for the wrong one wastes days — three
+successive reworkings of one term improved the metric being watched and moved routing by
+`-0.003 µs, CI [-0.206, +0.214]`.
+
+Pick by question:
+
+| question | tool |
+| --- | --- |
+| Is this plan's absolute cost right? | [`bench_cost_model_agreement.py`](../../scripts/bench_cost_model_agreement.py) |
+| What SHAPE is the error — uniform, or a tail? | [`bench_cost_error_percentiles.py`](../../scripts/bench_cost_error_percentiles.py) |
+| Is it the features, the coefficients, or the arm's shape? | [`bench_cost_error_attribution.py`](../../scripts/bench_cost_error_attribution.py) |
+| What should the constants be? | [`fit_cost_model.py`](../../scripts/fit_cost_model.py) |
+| Does the model ORDER two plans correctly? | [`bench_pairwise_ordering.py`](../../scripts/bench_pairwise_ordering.py) |
+| Where does routing actually lose time? | [`bench_regret_matrix.py`](../../scripts/bench_regret_matrix.py) |
+| Did a change help end to end? | [`bench_plan_misselection.py`](../../scripts/bench_plan_misselection.py) `--compare`, or [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py) vs `main` |
+
+All of them draw queries from one universe, [`query_sampler.py`](../../scripts/query_sampler.py), in
+one of two weightings. Diagnostics default to `uniform` because their job is to FIND errors and
+uniform reaches the rare tails; latency defaults to `realistic` because there the question is what
+users wait for. Both matter: artwork is 5% of realistic traffic and carries **50% of all routing
+regret**.
+
+## The two matrices, and why both
+
+They disagree, and the disagreement is the point. An estimate can be off 100x on a plan that never
+wins anyway, and right to 5% where the margin decides every query.
+
+### The cost matrix — estimate/real at p1/p10/p20/p50/p70/p90/p99
+
+Sliced by plan, by `plan / distinct-on`, by `plan [acquire]`, and by all three. **Read the shape, not
+p50:**
+
+- **tight spread** (p90/p10 ≈ 1) → a plain rate error, recalibrate. `CardRangePopcount` was a uniform
+  1.20 with spread 1.4; one constant fixed it to 1.00.
+- **wide spread** → the error depends on something unmodelled; a constant will not help.
+- **healthy middle, bad tail** → a specific query class, not a general defect. `printing_range_scan`
+  has the worst mean in the engine (0.98) and one of the better medians (0.19).
+
+**Always read mean AND median.** They diverge sharply, and the mean invites being read as "typical"
+when it is a tail.
+
+**Slice by distinct-on.** Errors CANCEL when pooled, and the cancellation hid the largest routing
+defect in the engine: compose reads 0.81 on artwork and 1.15 on printing, pooling to "roughly fine",
+while those two drove OPPOSITE routing errors.
+
+### The regret matrix — where being wrong costs time
+
+Regret is `routed_ns - best_measured_ns`, so a correct pick contributes 0. Measured against
+`routed_ns`, not the picked plan's own trial, because those differ exactly when the picked plan
+DECLINES and dispatch re-chooses among materializing plans only.
+
+Regret is mostly zeros, so **read SHARE** — the fraction of all lost time a slice accounts for, which
+is frequency times severity and is what ranks work. It found compose carrying **75%** of all lost
+time, and one transition (`StreamedSelect -> PrintingCompose`) losing a mean of 190 µs over 150
+queries.
+
+**Split compose-like regret by DIRECTION before acting.** "75% of lost time" is compatible with two
+opposite fixes, and here it was both at once: over-picked 38:1 in artwork, under-picked 10:1 in
+printing. A change that made compose uniformly cheaper was therefore right for one mode and wrong for
+the other, and lost overall.
+
+## Traps, each one paid for
+
+- **Never compare two headline means.** Regret and latency are heavy-tailed. Write per-query rows with
+  `--out` and use `--compare`, which pairs over the same queries and gives a bootstrap CI. At
+  `--sample 400` the same engine and seed produced 0.26 and 0.82 µs on two runs.
+- **Interleave A/B/A/B.** All-of-A-then-all-of-B maps machine drift onto the comparison. A sequential
+  run showed a ~3% median slowdown spread evenly across acquire branches the change never touched.
+- **A grid optimum on the boundary is not an optimum.** Two sweeps had to be redone for this. Use
+  geometric grids open at both ends, and check the optimum is interior.
+- **Fixing a feature can make agreement worse**, because coefficients were compensating. Expect it,
+  and refit in the same change.
+- **Verify the fitter mirrors the engine.** `fit_cost_model.py` reimplements `cost.rs` in Python and
+  had silently drifted for two revisions; it now checks itself against `predicted_ns` and refuses to
+  fit below 99% agreement.
+- **A plan that DECLINES accumulates no trials**, so it is absent from every measurement here. Enabling
+  a declining path introduces a population nothing has ever measured.
+- **Agreement is not sufficient.** One fix improved routing significantly (`-0.166 µs`,
+  CI `[-0.341, -0.007]`) while making median agreement WORSE — a per-cell median cannot see a 56x error
+  on 4% of rows.
+
+## A working order
+
+1. **Regret matrix** — what is worth fixing at all, by SHARE, and in which direction.
+2. **Cost matrix** — the shape of that cell's error, sliced by distinct-on.
+3. **Attribution** — features, coefficients, or the arm's shape. Do not skip: a miscounted feature
+   cannot be repaired by any rate, and a fit will bury it in whichever term correlates.
+4. **Fix**, features before rates.
+5. **Paired A/B** — the only thing that says whether it worked.

--- a/scripts/bench_card_range_estimate.py
+++ b/scripts/bench_card_range_estimate.py
@@ -1,0 +1,280 @@
+"""Why is every plan costed off the `CardRangePopcount` acquire under-costed 2.0-2.6x?
+
+That branch feeds `matches`/`eval_domain`/`scan_units` from `card_est = k.min(n_cards)`, where `k` is
+the number of in-range *printings* standing in for a card count — a proxy its own comment flags. Two
+things get measured here, because the proxy alone cannot be the cause:
+
+1. **Estimate accuracy** — `card_est` against the query's real total. It over-estimates, which
+   *over*-costs, the opposite sign to the observed error. So correcting it alone makes the
+   under-costing worse; establishing that ordering is the point of measuring it.
+2. **The materialization split** — `acquire.prep_ns` times `prepare_candidates` directly. This
+   acquire materializes nothing, so a materializing plan's `trials_ns` pays a full
+   `prepare_candidates` that `acquire_ns` never saw. Netting the *measured* prep separates "the model
+   omits candidate production" from "the plan arm's own rates are wrong". Modelled proxies were tried
+   and rejected (`cost::materialize_cost` prices a concat+sort; these branches extract from a bitmap).
+
+Generates range queries exclusively, at `unique=card`, because that is the only shape this acquire
+fires for (`card_range_popcount_applicable` requires `Mode::Card`) and the general `random_query()`
+emits it roughly once in 150,000.
+
+    .venv/bin/python scripts/bench_card_range_estimate.py --seconds 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import dataclasses
+import math
+import pathlib
+import random
+import statistics
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+TARGET_SOURCE = "card_range_popcount"
+MATERIALIZING = ("StreamedSelect", "GatheredScan")
+LIMIT = 100
+NUM_WARMUPS = 3
+NUM_TRIALS = 9
+# Rows of the sorted table to show at each end before eliding the middle.
+SHOW_HEAD = 8
+SHOW_TAIL = 4
+# statistics.quantiles needs at least this many samples for deciles.
+MIN_FOR_DECILES = 10
+# cost.rs's CARD_RANGE_BUILD_PER_PRINTING_NS: the fused scatter+project pass an exact distinct-card
+# count would need, measured at 98333ns/80527 printings.
+BUILD_PER_PRINTING_NS = 1.22
+
+# Every field `bare_range_bounds` resolves to a range index: the three price columns and collector
+# number have their own, `year:`/`date:` both map onto `released_at`. Values span each field's real
+# distribution so the sweep covers selectivities from a handful of cards to nearly the whole corpus.
+RANGE_FIELDS: dict[str, list[str]] = {
+    "usd": ["0.1", "0.25", "1", "2", "5", "10", "20", "50", "100", "200", "500"],
+    "eur": ["0.1", "0.5", "1", "3", "8", "20", "60", "150"],
+    "tix": ["0.05", "0.1", "0.5", "1", "3", "10", "30"],
+    "cn": ["5", "20", "50", "100", "200", "300", "500"],
+    "year": ["1994", "1999", "2004", "2009", "2014", "2018", "2021", "2023", "2025"],
+    "date": ["1995-01-01", "2005-06-01", "2015-03-01", "2020-09-01", "2024-01-01"],
+}
+RANGE_OPS = [">", ">=", "<", "<="]
+DATE_FIELDS = ("year", "date")
+
+
+def random_range_query(rng: random.Random) -> str:
+    """One bare range predicate — the only filter shape this acquire branch fires for."""
+    field = rng.choice(list(RANGE_FIELDS))
+    # `year:2023` is a bounded range on released_at (bare_range_bounds handles YearCmp/DateCmp), so
+    # it belongs in the sweep; `:` on a price column is equality and mostly yields empty results.
+    ops = [*RANGE_OPS, ":"] if field in DATE_FIELDS else RANGE_OPS
+    return f"{field}{rng.choice(ops)}{rng.choice(RANGE_FIELDS[field])}"
+
+
+def main() -> None:
+    """Sweep range queries, checking both the estimate and the measured materialization split."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=60.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".misselect.store"))
+    rng = random.Random(args.seed)
+
+    samples = Samples()
+    seen: set[str] = set()
+    generated = other_source = 0
+    deadline = time.monotonic() + args.seconds
+    while time.monotonic() < deadline:
+        q = random_range_query(rng)
+        generated += 1
+        if q in seen:
+            continue
+        seen.add(q)
+        try:
+            filters = parse_scryfall_query(q)
+            kw = {"filters": filters, "unique": "card", "orderby": "edhrec", "direction": "asc", "limit": LIMIT, "offset": 0}
+            quick = engine.explain(**kw)
+            if quick["acquire"]["count_source"] != TARGET_SOURCE:
+                other_source += 1
+                continue
+            total = engine.query(prefer="default", **{**kw, "limit": 1})[0]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001, S112 - a query bind rejects is a sample skip
+            continue
+        samples.record(q, quick, res, total)
+
+    if not samples.est_rows:
+        print(f"no {TARGET_SOURCE} samples in the budget ({generated:,} generated, {other_source:,} other acquire)")
+        return
+
+    report(samples.est_rows, samples.arm_rows, args.seconds, generated, other_source)
+    score_estimators(samples.est_rows, samples.n_cards, engine.size(), [r[0] for r in samples.k_rows])
+    by_slice_size(samples.k_rows, samples.picks)
+
+
+def score_estimators(est_rows: list[tuple[float, int, int, str]], n_cards: int, n_printings: int, k_seen: list[int]) -> None:
+    """Score replacements for `card_est` against the real total, before changing the engine.
+
+    `card_est = k.min(n_cards)` uses an in-range PRINTING count as a card count. The obvious cheap
+    correction scales by the corpus-wide card:printing ratio, which costs one multiply and keeps the
+    branch's O(1) promise (counting distinct cards in the slice is the O(k) build it defers to
+    dispatch on purpose). Scored on |log ratio| so over- and under-estimates are penalised alike.
+    """
+    if not n_cards or not n_printings:
+        return
+    ratio = n_cards / n_printings
+    # `est == k` whenever the clamp did not bite, which is the only regime a rescale can change.
+    rows = [(est, total) for _, est, total, _ in est_rows if total > 0]
+    if not rows:
+        return
+
+    def score(name: str, f) -> tuple[float, float, str]:  # noqa: ANN001 - local scoring helper
+        errs = [abs(math.log(max(f(est), 1) / total)) for est, total in rows]
+        ratios = sorted(max(f(est), 1) / total for est, total in rows)
+        return statistics.median(errs), statistics.median(ratios), name
+
+    # Balls into bins: if `k` printings were an exchangeable draw from `n_printings` spread over
+    # `n_cards` cards, the expected number of distinct cards is the classic occupancy result. Two
+    # parameterisations, since neither is obviously the right one for a value-sorted index slice.
+    prints_per_card = n_printings / n_cards
+
+    def occupancy_exp(est: int) -> int:
+        return min(round(n_cards * (1.0 - math.exp(-est / n_cards))), n_cards)
+
+    def occupancy_pow(est: int) -> int:
+        return min(round(n_cards * (1.0 - (1.0 - min(est / n_printings, 1.0)) ** prints_per_card)), n_cards)
+
+    scored = [
+        score("k.min(n_cards) (current)", lambda est: min(est, n_cards)),
+        score("k * n_cards/n_printings", lambda est: min(round(est * ratio), n_cards)),
+        score("k * 0.5", lambda est: min(round(est * 0.5), n_cards)),
+        score("k * 0.75", lambda est: min(round(est * 0.75), n_cards)),
+        score("occupancy 1-exp(-k/n_cards)", occupancy_exp),
+        score("occupancy, per-card prints", occupancy_pow),
+    ]
+    print(f"\nreplacements for card_est (n={len(rows)}, card:printing = {ratio:.3f})")
+    print(f"{'estimator':<28}{'median |log err|':>18}{'median est/real':>17}")
+    for err, med, name in sorted(scored):
+        print(f"{name:<28}{err:>18.3f}{med:>17.2f}")
+    print("  lower |log err| is better; median est/real near 1.00 means unbiased.")
+
+    # Would an EXACT count be affordable instead? It needs one O(k) pass scattering each in-range
+    # printing to its card bit (the `printing_to_card` direct lookup) plus a popcount — which is
+    # exactly `build_card_range_bits`, measured at CARD_RANGE_BUILD_PER_PRINTING_NS in cost.rs. The
+    # branch defers that to dispatch today, but CardRangePopcount pays it anyway when it wins, so
+    # the marginal cost is only incurred when a materializing plan wins instead.
+    ks = sorted(k for k in k_seen if k > 0)
+    if not ks:
+        return
+    words = n_cards / 64.0
+    print(f"\ncost of an exact count instead (k printings x {BUILD_PER_PRINTING_NS} ns + {words:.0f} words)")
+    print(f"{'k percentile':<16}{'k':>10}{'exact-count µs':>17}")
+    for label, kv in (("median", ks[len(ks) // 2]), ("p90", ks[int(len(ks) * 0.9)]), ("max", ks[-1])):
+        print(f"{label:<16}{kv:>10,}{(kv * BUILD_PER_PRINTING_NS + words) / 1000:>17.1f}")
+    print("  compare against the whole query: these range queries route at ~4-100 µs today.")
+
+
+@dataclasses.dataclass
+class Samples:
+    """Everything the report needs, accumulated one query at a time."""
+
+    est_rows: list[tuple[float, int, int, str]] = dataclasses.field(default_factory=list)
+    k_rows: list[tuple[int, float, int, str]] = dataclasses.field(default_factory=list)
+    arm_rows: list[tuple[str, float, float, str]] = dataclasses.field(default_factory=list)
+    picks: collections.Counter[str] = dataclasses.field(default_factory=collections.Counter)
+    n_cards: int = 0
+
+    def record(self, q: str, quick: dict, res: dict, total: int) -> None:
+        """Fold one sampled query in. `matches` is clamped at n_cards here, so k comes from range_k."""
+        acq = quick["acquire"]
+        est = acq["matches"]
+        self.n_cards = acq["n_cards"]
+        self.est_rows.append((est / max(total, 1), est, total, q))
+        self.k_rows.append((acq["range_k"], est / max(total, 1), total, q))
+        self.picks[next((p["plan"] for p in quick["plans"] if p["picked"]), "?")] += 1
+        prep = min(res["acquire"]["prep_ns"])
+        for p in res["plans"]:
+            if p["plan"] not in MATERIALIZING or not p["trials_ns"] or p["predicted_ns"] <= 0:
+                continue
+            meas = max(min(p["trials_ns"]), 1)
+            self.arm_rows.append((p["plan"], meas / p["predicted_ns"], max(meas - prep, 1) / p["predicted_ns"], q))
+
+
+def by_slice_size(k_rows: list[tuple[int, float, int, str]], picks: collections.Counter[str]) -> None:
+    """Is the estimate's error selectivity-dependent, and is it worst where an exact count is cheap?
+
+    If the two are inversely related there is no need to always build the bitmap: take the exact count
+    below some `k` where it is cheap, and trust the estimate above it where it is already accurate.
+    """
+    print(f"\n{'k (printings)':<16}{'n':>5}{'median est/real':>17}{'build µs':>10}")
+    buckets = (
+        (0, 1_000, "< 1k"),
+        (1_000, 5_000, "1k-5k"),
+        (5_000, 20_000, "5k-20k"),
+        (20_000, 60_000, "20k-60k"),
+        (60_000, 1 << 30, "60k+"),
+    )
+    for lo, hi, label in buckets:
+        grp = [r for r in k_rows if lo <= r[0] < hi]
+        if not grp:
+            continue
+        med_k = statistics.median(r[0] for r in grp)
+        print(f"{label:<16}{len(grp):>5}{statistics.median(r[1] for r in grp):>17.2f}{med_k * BUILD_PER_PRINTING_NS / 1000:>10.1f}")
+    print("  est/real near 1.00 means the proxy is already fine there; build µs is what an exact")
+    print("  count would cost at that slice size.")
+
+    total = sum(picks.values())
+    print(f"\nrouter's pick on these queries (n={total:,}) — a plan that does not want a card bitmap")
+    print("pays for one built unconditionally in acquire:")
+    for plan, n in picks.most_common():
+        print(f"  {plan:<22}{n:>5}{n / max(total, 1):>7.0%}")
+
+
+def report(
+    est_rows: list[tuple[float, int, int, str]],
+    arm_rows: list[tuple[str, float, float, str]],
+    seconds: float,
+    generated: int,
+    other_source: int,
+) -> None:
+    """Estimate accuracy, then the arm error with measured candidate production netted out."""
+    print(f"\n{len(est_rows):,} {TARGET_SOURCE} queries in {seconds:.0f}s ({generated:,} generated, {other_source:,} other)")
+
+    ratios = [r[0] for r in est_rows]
+    print(f"\ncard_est / real total: median {statistics.median(ratios):.2f}  min {min(ratios):.2f}  max {max(ratios):.2f}")
+    print("  >1 means the acquire OVER-estimates, which over-costs — the opposite sign to the arm error below.")
+
+    print(f"\n{'plan':<18}{'n':>5}{'raw median':>12}{'prep-netted':>13}{'p10':>8}{'p90':>8}")
+    for plan in MATERIALIZING:
+        grp = [r for r in arm_rows if r[0] == plan]
+        if not grp:
+            continue
+        nets = sorted(r[2] for r in grp)
+        ds = statistics.quantiles(nets, n=10) if len(nets) >= MIN_FOR_DECILES else [float("nan")] * 9
+        print(
+            f"{plan:<18}{len(grp):>5}{statistics.median(r[1] for r in grp):>12.2f}"
+            f"{statistics.median(nets):>13.2f}{ds[0]:>8.2f}{ds[8]:>8.2f}"
+        )
+    print("  raw >1 = under-costed. If prep-netted lands near 1 the gap was unpriced candidate")
+    print("  production; if it stays high the plan arm's own rates are wrong at this operating point.")
+
+    est_rows.sort()
+    print(f"\n{'est/real':>9}{'estimate':>10}{'real':>8}  query")
+    for ratio, est, total, q in est_rows[:SHOW_HEAD]:
+        print(f"{ratio:>9.2f}{est:>10,}{total:>8,}  {q[:40]}")
+    if len(est_rows) > SHOW_HEAD:
+        print("  ...")
+        for ratio, est, total, q in est_rows[-SHOW_TAIL:]:
+            print(f"{ratio:>9.2f}{est:>10,}{total:>8,}  {q[:40]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_cost_error_attribution.py
+++ b/scripts/bench_cost_error_attribution.py
@@ -1,0 +1,264 @@
+"""When a cost estimate is wrong, WHICH of the three possible causes is it?
+
+Agreement tells you a cell is off. It does not tell you what to fix, and the three candidates need
+completely different work:
+
+1. **Features** — the cardinality/domain estimates fed to the model are wrong. No coefficient can
+   repair this, and a fit will quietly bury the error in whichever term correlates with it.
+2. **Model form** — the arm is not the right shape. No coefficients fit, however you choose them.
+3. **Coefficients** — the shape is right and the rates are stale or mis-fit.
+
+They are separable because the executors publish what they REALLY did. Substituting realized counters
+for estimated features isolates (1); refitting coefficients on those realized features isolates (3);
+whatever error survives both is (2), the floor imposed by the arm's shape.
+
+    err_shipped   = |ln(measured / predict(shipped coeffs, ESTIMATED features))|   <- what agreement sees
+    err_features  = |ln(measured / predict(shipped coeffs, REALIZED features))|
+    err_best      = |ln(measured / predict(FITTED coeffs,  REALIZED features))|
+
+    feature-error share      = err_shipped  - err_features
+    coefficient-error share  = err_features - err_best
+    model-form floor         = err_best
+
+Scoped to GatheredScan and StreamedSelect: they are the two plans with full executor counters, and
+they take the large majority of queries. `cards_visited` and `matches_pushed` are exact
+(verified 1.00 against their features on the candidates branch). `printings_scanned` is deliberately
+NOT substituted -- it counts the printing SPAN of each visited card, not rows examined, so in card
+mode where the loop breaks at the first match it overstates real work. Substituting it would
+manufacture a feature error that is really a counter definition. That makes the feature share here a
+LOWER bound, which is the safe direction.
+
+    .venv/bin/python scripts/bench_cost_error_attribution.py --seconds 600 --mode realistic
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import math
+import pathlib
+import random
+import statistics
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.fit_cost_model as fitmod  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.fit_cost_model import collect, fit_log_ratio  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+# Mirrors cost.rs. Kept in the order each arm's design_row emits, so a fitted vector prints against
+# the shipped one term by term.
+SHIPPED: dict[str, dict[str, float]] = {
+    "GatheredScan": {
+        "card_pass": 5.77,
+        "scan_per_row": 1.72,
+        "residual_floor": 15.0,
+        "push": 3.30,
+        "page_slot": 2.79,
+        "fixed": 237.0,
+    },
+    "StreamedSelect": {
+        "card_pass": 3.29,
+        "scan_per_row": 2.13,
+        "residual_floor": 9.0,
+        "emit": 0.12,
+        "small_total_floor": 0.81,
+        "corpus_pass": 0.288,
+        "fixed": 233.0,
+    },
+}
+STREAM_MIN_MATCHES = 1024
+# The attribution needs the TRUE best fit, so the ridge that anchors `fit_log_ratio` to the shipped
+# values for shipping purposes is switched off here. Left on, it holds coefficients near where they
+# already are and the error it cannot remove gets misattributed to the model's shape.
+UNANCHORED_RIDGE = 0.0
+MIN_ROWS_PER_CELL = 200
+
+
+@dataclasses.dataclass(frozen=True)
+class Feats:
+    """The handful of feature values an arm reads, bundled so `terms` stays a two-argument call."""
+
+    eval_domain: float
+    scan_units: float
+    matches: float
+    n_cards: float
+    tier_ns: float
+    page_span: float
+
+
+def terms(plan: str, f: Feats) -> list[float]:
+    """The arm's design row: one entry per coefficient, in SHIPPED order. Mirrors cost.rs exactly."""
+    residual_on = 1.0 if f.tier_ns > 0.0 else 0.0
+    if plan == "GatheredScan":
+        # eval_domain*(card_pass + max(tier,floor) if residual) + scan_units*scan_per_row
+        #   + matches*push + page_span*page_slot + fixed.
+        # Where the tier EXCEEDS the floor its excess is not scaled by any coefficient, so it rides
+        # `fixed_offset` rather than a fitted column.
+        return [f.eval_domain, f.scan_units, f.eval_domain * residual_on, f.matches, f.page_span, 1.0]
+    floor_on = f.n_cards if f.matches <= STREAM_MIN_MATCHES else 0.0
+    return [f.eval_domain, f.scan_units * residual_on, f.eval_domain * residual_on, f.matches, floor_on, f.n_cards, 1.0]
+
+
+def fixed_offset(plan: str, eval_domain: float, tier_ns: float) -> float:
+    """The part of the residual charge the coefficients do not scale: the tier where it beats the floor."""
+    if tier_ns <= 0.0:
+        return 0.0
+    floor = SHIPPED[plan]["residual_floor"]
+    return eval_domain * max(tier_ns - floor, 0.0)
+
+
+def predict(coeffs: list[float], row: list[float], offset: float) -> float:
+    """A prediction from a coefficient vector, plus the unscaled tier offset."""
+    return sum(c * v for c, v in zip(coeffs, row, strict=True)) + offset
+
+
+def rows_for(samples: list[dict], plan: str, *, realized: bool) -> tuple[list[list[float]], list[float], list[float]]:
+    """Design rows, targets and tier offsets for one plan, on estimated or realized features."""
+    design, targets, offsets = [], [], []
+    for s in samples:
+        if s["plan"] != plan or not s["ns_round_total"] or not s["cards_visited"]:
+            continue
+        a = s["acq"]
+        tier = a["residual_tier_ns100"] / 100.0
+        # Realized: substitute the two EXACT counters. scan_units is left alone on purpose -- see the
+        # module docstring on why printings_scanned is not a drop-in for it.
+        eval_domain = float(s["cards_visited"] if realized else a["eval_domain"])
+        matches = float(s["matches_pushed"] if realized else a["matches"])
+        design.append(
+            terms(
+                plan,
+                Feats(
+                    eval_domain=eval_domain,
+                    scan_units=float(a["scan_units"]),
+                    matches=matches,
+                    n_cards=float(a["n_cards"]),
+                    tier_ns=tier,
+                    page_span=float(min(s["offset"] + s["limit"], matches)),
+                ),
+            )
+        )
+        targets.append(s["measured"])
+        offsets.append(fixed_offset(plan, eval_domain, tier))
+    return design, targets, offsets
+
+
+def err_median(design: list[list[float]], targets: list[float], offsets: list[float], coeffs: list[float]) -> float:
+    """MEDIAN |ln(measured/predicted)| — what a TYPICAL query sees.
+
+    Reported alongside the mean because the two diverge sharply here and only the mean is usable for
+    the attribution. `GatheredScan/printing_compose` reads 0.95 mean against ~0.15 median: most
+    queries are close and a tail is 10x+ out. A mean of 0.95 invites reading "2.6x typical", which is
+    wrong. Use the mean to compare the three stages, the median to judge the typical query, and the
+    gap between them to spot a cell whose problem is its tail rather than its centre.
+    """
+    out = []
+    for row, y, off in zip(design, targets, offsets, strict=True):
+        p = predict(coeffs, row, off)
+        if p > 0 and y > 0:
+            out.append(abs(math.log(y / p)))
+    return statistics.median(out) if out else math.nan
+
+
+def err(design: list[list[float]], targets: list[float], offsets: list[float], coeffs: list[float]) -> float:
+    """MEAN |ln(measured/predicted)|.
+
+    Mean, not median, on purpose: `fit_log_ratio` minimises squared log error, so scoring with the
+    mean makes the three stages monotone by construction -- each can only reduce error or hold. Scored
+    on the median, a refit that improves the bulk while worsening the middle produces a NEGATIVE
+    coefficient share, which is meaningless as an attribution (observed on StreamedSelect/plane).
+    """
+    out = []
+    for row, y, off in zip(design, targets, offsets, strict=True):
+        p = predict(coeffs, row, off)
+        if p > 0 and y > 0:
+            out.append(abs(math.log(y / p)))
+    return statistics.fmean(out) if out else math.nan
+
+
+def attribute(samples: list[dict], plan: str, cell: str) -> dict | None:
+    """Split one cell's error into feature, coefficient and model-form parts."""
+    subset = [s for s in samples if s["acq"]["count_source"] == cell] if cell else samples
+    est = rows_for(subset, plan, realized=False)
+    real = rows_for(subset, plan, realized=True)
+    if len(est[0]) < MIN_ROWS_PER_CELL:
+        return None
+    shipped = list(SHIPPED[plan].values())
+    order = [k for k in SHIPPED[plan] if k != "residual_floor"]
+    # `terms` emits the residual column third, where the shipped floor already sits, so the shipped
+    # vector is already in emitted order.
+    emitted = list(shipped)
+    e_ship = err(*est, emitted)
+    e_ship_med = err_median(*est, emitted)
+    e_feat = err(*real, emitted)
+    # `fit_log_ratio` knows nothing about `fixed_offset`, so it must be fitted against the target with
+    # that offset REMOVED -- otherwise the fit solves `Xc ~= y` while the metric scores `Xc + offset`,
+    # which is a different problem and shows up as a negative (impossible) coefficient share.
+    net = [max(y - off, 1.0) for y, off in zip(real[1], real[2], strict=True)]
+    saved, fitmod.RIDGE_STRENGTH = fitmod.RIDGE_STRENGTH, UNANCHORED_RIDGE
+    try:
+        fitted = fit_log_ratio(real[0], net, emitted, [1.0] * len(net))
+    finally:
+        fitmod.RIDGE_STRENGTH = saved
+    e_best = err(*real, fitted)
+    return {
+        "n": len(est[0]),
+        "shipped": e_ship,
+        "shipped_median": e_ship_med,
+        "features": e_feat,
+        "best": e_best,
+        "fitted": fitted,
+        "emitted": emitted,
+        "order": ["card_pass", "scan_units", "residual", *order[2:]],
+    }
+
+
+def main() -> None:
+    """Collect a large sample, then attribute each cell's error to features / coefficients / form."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=600.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--mode", choices=MODES, default="uniform", help="diagnostic: uniform reaches the rare tails where model error hides"
+    )
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".attrib.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    samples = collect(engine, random.Random(args.seed), args.seconds, sampler)
+    print(f"\n{len(samples):,} plan-rows, mode={args.mode}")
+
+    cells = ["", *sorted({s["acq"]["count_source"] for s in samples})]
+    for plan in ("GatheredScan", "StreamedSelect"):
+        print(f"\n=== {plan} ===")
+        print(f"  {'acquire':<22}{'n':>7}{'mean':>8}{'median':>8}{'FEATURES':>10}{'COEFFS':>9}{'form floor':>12}  dominant")
+        for cell in cells:
+            a = attribute(samples, plan, cell)
+            if a is None:
+                continue
+            feat, coef = a["shipped"] - a["features"], a["features"] - a["best"]
+            parts = {"features": max(feat, 0.0), "coefficients": max(coef, 0.0), "model form": a["best"]}
+            tail = "  TAIL" if a["shipped"] > 2.5 * a["shipped_median"] else ""
+            print(
+                f"  {(cell or 'ALL'):<22}{a['n']:>7}{a['shipped']:>8.3f}{a['shipped_median']:>8.3f}"
+                f"{feat:>+10.3f}{coef:>+9.3f}{a['best']:>12.3f}  {max(parts, key=parts.get)}{tail}"
+            )
+        a = attribute(samples, plan, "")
+        if a:
+            print(
+                "  fitted vs shipped: "
+                + "  ".join(f"{n}={f:.2f}/{s:.2f}" for n, f, s in zip(a["order"], a["fitted"], a["emitted"], strict=True))
+            )
+    print("\n  mean |ln| drives the attribution (monotone by construction); median is the TYPICAL query.")
+    print("  TAIL marks a cell whose mean far exceeds its median -- its problem is outliers, not its centre.")
+    print("  FEATURES/COEFFS are error REMOVED by fixing that cause (bigger = more of the problem).")
+    print("  'form floor' is what survives exact features AND refitted coefficients: the arm's shape.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_cost_error_percentiles.py
+++ b/scripts/bench_cost_error_percentiles.py
@@ -1,0 +1,140 @@
+"""The full estimate/real distribution per plan, at fixed percentiles.
+
+Every other view here reports a median, which hides the shape. A plan can have a perfect median while
+over-costing a fifth of queries by 10x, and the fix for that is nothing like the fix for a uniform
+shift. This prints p1/p10/p20/p50/p70/p90/p99 so the shape is visible: a flat row is a uniform scale
+error (recalibrate a rate), a steep row is a missing feature or wrong shape, and a row that is fine
+in the middle with a bad tail is a specific query class rather than a general defect.
+
+Ratio is **estimate / real**, so **>1 means OVER-costed** — the reciprocal of the measured/predicted
+convention the agreement harness uses. Stated here because mixing them up inverts every conclusion.
+
+Covers all six plans, not just the two carrying executor counters, since it needs only `predicted_ns`
+and `trials_ns`.
+
+    .venv/bin/python scripts/bench_cost_error_percentiles.py --seconds 180
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import pathlib
+import random
+import sys
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.bench_cost_model_agreement import RANGE_ACQUIRES  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+PERCENTILES = (1, 10, 20, 50, 70, 90, 99)
+MIN_ROWS = 40
+
+
+def percentile(sorted_vals: list[float], pct: int) -> float:
+    """Nearest-rank percentile; no interpolation, so every printed number is a real observation."""
+    if not sorted_vals:
+        return float("nan")
+    idx = min(round(pct / 100.0 * len(sorted_vals) + 0.5) - 1, len(sorted_vals) - 1)
+    return sorted_vals[max(idx, 0)]
+
+
+def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
+    """One row per (query, plan) that ran, with the plan's own cost isolated the usual way."""
+    rows: list[dict] = []
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
+        kw = {
+            "filters": None,
+            "unique": sampler.unique(rng),
+            "orderby": sampler.orderby(rng),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": limit,
+            "offset": offset,
+        }
+        try:
+            kw["filters"] = parse_scryfall_query(sampler.query(rng))
+            acq = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        for p in res["plans"]:
+            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+                continue
+            # Only a Prep::Range acquire makes the routed path re-pay prepare_candidates, so elsewhere
+            # it is not this plan's cost to carry. Same netting as every other harness here.
+            real = float(min(p["trials_ns"]))
+            if p["ns_round_total"] and acq["count_source"] not in RANGE_ACQUIRES:
+                netted = real - p["ns_prepare"]
+                if netted < real * 0.5:
+                    continue  # netting overshot; the residual is noise, not a measurement
+                real = netted
+            rows.append(
+                {
+                    "plan": p["plan"],
+                    "acquire": acq["count_source"],
+                    "unique": kw["unique"],
+                    "ratio": p["predicted_ns"] / real,
+                }
+            )
+    return rows
+
+
+def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 40) -> None:
+    """Percentile table for one grouping of the rows."""
+    groups: dict[object, list[float]] = collections.defaultdict(list)
+    for r in rows:
+        groups[key(r)].append(r["ratio"])
+    head = "".join(f"{f'p{p}':>8}" for p in PERCENTILES)
+    print(f"\n{label:<38}{'n':>7}{head}{'p90/p10':>9}")
+    for name, vals in sorted(groups.items(), key=lambda kv: -len(kv[1]))[:limit]:
+        if len(vals) < MIN_ROWS:
+            continue
+        vals.sort()
+        cells = "".join(f"{percentile(vals, p):>8.2f}" for p in PERCENTILES)
+        spread = percentile(vals, 90) / percentile(vals, 10) if percentile(vals, 10) > 0 else float("inf")
+        print(f"{name!s:<38}{len(vals):>7}{cells}{spread:>9.1f}")
+
+
+def main() -> None:
+    """Sample, then print the estimate/real distribution per plan and per (plan, acquire)."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=60.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--mode", choices=MODES, default="uniform")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".pctile.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = collect(engine, sampler, random.Random(args.seed), args.seconds)
+    print(f"\n{len(rows):,} plan-rows, mode={args.mode}.  ratio = ESTIMATE / REAL, so >1 is OVER-costed.")
+    table(rows, lambda r: r["plan"], "plan")
+    # distinct-on splits errors that cancel when pooled, and the cancellation hides real defects: the
+    # compose arm reads 0.79 (too cheap) on artwork and 1.15 on printing, which pools to "roughly fine"
+    # while the two drive OPPOSITE routing errors -- compose over-picked 38:1 in artwork, under-picked
+    # 10:1 in printing. Per (plan, unique) is the smallest slice that shows it.
+    table(rows, lambda r: f"{r['plan']} / {r['unique']}", "plan / distinct-on", limit=24)
+    table(rows, lambda r: f"{r['plan']} [{r['acquire']}]", "plan [acquire]")
+    table(rows, lambda r: f"{r['plan']} [{r['acquire']}] / {r['unique']}", "plan [acquire] / distinct-on", limit=20)
+    print("\n  p90/p10 is the spread: ~1 means a uniform scale error (recalibrate), large means the")
+    print("  error depends on something unmodelled. Nearest-rank percentiles, so each is a real query.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_cost_model_agreement.py
+++ b/scripts/bench_cost_model_agreement.py
@@ -95,6 +95,11 @@ IMPOSSIBLE_GATES = ("RangeNotBare", "NotComposable", "RangePermutationStale")
 # `mk_plan_feats` default of `Gather` untouched — see `report_paging` for why that is a different
 # defect rather than a prediction that missed.
 COMPOSE_ACQUIRE = "printing_compose"
+# Acquire branches where the routed path really does call `prepare_candidates` at dispatch, so the
+# materializing plans genuinely owe its cost; everywhere else acquire built the prep already. Every
+# harness that nets prepare out of a plan's measured time needs the same rule, so it lives here once
+# rather than as a copy per script.
+RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", COMPOSE_ACQUIRE})
 # The only plans that call `prepare_candidates`, and so the only ones with a prepare phase at all.
 # Every other plan reports `ns_prepare == 0` because it has no such phase — which is not the same
 # as spending 0% of its run there, and pooling the two says the wrong thing.

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -1,0 +1,191 @@
+"""Do the cost model's FEATURES match what the executor actually does? Per cell, against counters.
+
+First link in the chain the rest of this toolkit walks:
+
+    cardinality estimate -> cost model -> coefficients -> plan choice
+
+Everything else here measures the far end. `bench_cost_model_agreement.py` and
+`bench_cost_error_percentiles.py` compare *predicted time* to *real time*, which conflates all four
+links; `fit_cost_model.py` fits coefficients and can only do so honestly once the features are right.
+This tool isolates the first link by comparing each feature to the executor counter that realizes it,
+so a mis-counted feature is visible as itself rather than as a rate that will not calibrate.
+
+Why it earns a place: the compose branch handed the PRINTING count to `result_total` in artwork mode,
+where it is consumed as a per-result push count. `matches_pushed` is deduped, so the feature read a
+median 1.95x the truth. That survived 154k paired A/B queries, both percentile matrices and a
+coefficient fit, because a 2x feature error is absorbed by whatever rate correlates with it and shows
+up only as spread. Sliced here it is a single cell reading 1.95 with everything else near 1.0.
+
+Ratio is **feature / counter**, so **>1 means the feature OVER-counts** the work done.
+
+Read the same way as `bench_cost_error_percentiles.py`: a tight row off 1.0 is a systematic bias worth
+fixing outright, a wide row means the feature is right on average but driven by something unmodelled,
+and slicing by distinct-on matters because a feature can be exact in one mode and 2x off in another
+while the pooled median looks fine.
+
+    .venv/bin/python scripts/bench_feature_accuracy.py --seconds 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import math
+import pathlib
+import random
+import sys
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+NUM_WARMUPS = 1
+NUM_TRIALS = 2  # counters are deterministic; trials exist only to make the plan run
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+PERCENTILES = (10, 50, 90)
+MIN_ROWS = 30
+# A cell's median must land inside this to be considered calibrated, matching the agreement bar in
+# bench_cost_model_agreement.py so the two tools grade on the same scale.
+AGREE_LO, AGREE_HI = 0.8, 1.25
+# Below this the counter is too small for a ratio to mean anything -- a feature of 3 against a counter
+# of 1 is a 3x "error" that costs nanoseconds.
+MIN_COUNTER = 100
+
+# feature name on the shared acquire vector -> the executor counter that realizes it.
+PAIRS = (
+    ("matches", "matches_pushed"),
+    ("eval_domain", "cards_visited"),
+    ("scan_units", "printings_scanned"),
+)
+
+
+def scan_feature(plan: str, paging: str) -> str:
+    """Which feature the ARM actually charges its printing scan on.
+
+    One shared vector costs every plan, but they do not all read the same field, and comparing a
+    counter to a feature the arm never touches manufactures a defect. Compose walks the set bits of
+    its composed bitmap (`compose_scan_printings`) when it pages by Gather, and stops at
+    `page_offset + limit` when it pages by walking (`printings_walked`); only the materializing scan
+    plans read `scan_units`.
+    """
+    if plan != "PrintingCompose":
+        return "scan_units"
+    return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+
+
+def percentile(sorted_vals: list[float], pct: int) -> float:
+    """Nearest-rank percentile; every printed number is a real observation."""
+    if not sorted_vals:
+        return float("nan")
+    idx = min(round(pct / 100.0 * len(sorted_vals) + 0.5) - 1, len(sorted_vals) - 1)
+    return sorted_vals[max(idx, 0)]
+
+
+def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
+    """One row per (query, plan, feature) where the plan reported the matching counter."""
+    rows: list[dict] = []
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        kw = {
+            "filters": None,
+            "unique": sampler.unique(rng),
+            "orderby": sampler.orderby(rng),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": rng.choice(LIMITS),
+            "offset": rng.choice(OFFSETS),
+        }
+        try:
+            kw["filters"] = parse_scryfall_query(sampler.query(rng))
+            acq = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        for plan in res["plans"]:
+            if not plan["trials_ns"]:
+                continue  # declined: it ran nothing, so there is no counter to check against
+            paging = acq.get("compose_paging", "-")
+            for feat, counter in PAIRS:
+                if feat == "scan_units":
+                    feat = scan_feature(plan["plan"], paging)  # noqa: PLW2901 - the arm decides which field it reads
+                got = plan.get(counter)
+                if got is None or got < MIN_COUNTER:
+                    continue
+                rows.append(
+                    {
+                        "feature": feat,
+                        "plan": plan["plan"],
+                        "acquire": acq["count_source"],
+                        "unique": kw["unique"],
+                        # Compose's arm reads `scan_units` ONLY in its Gather branch; Perm/OrderbyWalk
+                        # stop at page_offset+limit and never scan the candidates. A ratio measured on
+                        # those is comparing the feature to work the arm never charges for.
+                        "paging": acq.get("compose_paging", "-"),
+                        "ratio": acq[feat] / got,
+                    }
+                )
+    return rows
+
+
+def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 30) -> None:
+    """Feature/counter percentiles for one grouping, worst-calibrated cells first."""
+    groups: dict[object, list[float]] = collections.defaultdict(list)
+    for r in rows:
+        groups[key(r)].append(r["ratio"])
+    head = "".join(f"{f'p{p}':>8}" for p in PERCENTILES)
+    print(f"\n{label:<52}{'n':>7}{head}{'spread':>8}   verdict")
+    scored = []
+    for name, vals in groups.items():
+        if len(vals) < MIN_ROWS:
+            continue
+        vals.sort()
+        scored.append((abs(math.log(max(percentile(vals, 50), 1e-9))), name, vals))
+    for _, name, vals in sorted(scored, reverse=True)[:limit]:
+        med = percentile(vals, 50)
+        cells = "".join(f"{percentile(vals, p):>8.2f}" for p in PERCENTILES)
+        lo = percentile(vals, 10)
+        spread = percentile(vals, 90) / lo if lo > 0 else float("inf")
+        verdict = "" if AGREE_LO <= med <= AGREE_HI else ("  OVER-COUNTS" if med > AGREE_HI else "  UNDER-COUNTS")
+        print(f"{name!s:<52}{len(vals):>7}{cells}{spread:>8.1f}{verdict}")
+
+
+def main() -> None:
+    """Sample, then show which features disagree with the counters that realize them."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=60.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--mode", choices=MODES, default="uniform")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".featacc.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = collect(engine, sampler, random.Random(args.seed), args.seconds)
+    print(f"\n{len(rows):,} feature-rows, mode={args.mode}.  ratio = FEATURE / COUNTER, so >1 is OVER-counted.")
+    table(rows, lambda r: r["feature"], "feature (pooled -- hides per-cell errors that cancel)")
+    table(rows, lambda r: f"{r['feature']} [{r['acquire']}]", "feature [acquire]")
+    # The slice that catches mode-dependent features. A count taken in printing space is exact in
+    # printing mode and ~2x off in artwork mode; pooled across modes it reads as mild spread.
+    table(rows, lambda r: f"{r['feature']} [{r['acquire']}] / {r['unique']}", "feature [acquire] / distinct-on")
+    # One shared feature vector costs every plan, but the plans do different work: `scan_units` feeds
+    # StreamedSelect, GatheredScan and compose's Gather branch alike. If they disagree here, no single
+    # value of the feature is right for all of them and the fix is per-arm, not per-mode.
+    table(rows, lambda r: f"{r['feature']} <{r['plan']}> / {r['unique']}", "feature <plan> / distinct-on")
+    # Compose only pays `scan_units` when it pages by Gather, so judge the feature on those rows.
+    compose = [r for r in rows if r["plan"] == "PrintingCompose"]
+    table(compose, lambda r: f"{r['feature']} <compose {r['paging']}> / {r['unique']}", "compose only: feature by PAGING branch")
+    print(f"\n  Cells outside [{AGREE_LO}, {AGREE_HI}] are flagged. A feature error cannot be fixed by any")
+    print("  rate: fit_cost_model.py will bury it in whichever coefficient correlates with it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_pairwise_ordering.py
+++ b/scripts/bench_pairwise_ordering.py
@@ -1,0 +1,157 @@
+"""Does the cost model ORDER each pair of plans correctly? The quantity routing actually depends on.
+
+`bench_cost_model_agreement.py` scores each plan's absolute cost. That is the wrong target for plan
+selection, and the gap is not academic: three successive reworkings of the per-card residual term
+improved absolute agreement (n-weighted |ln| 0.212 -> 0.166) and moved routing by a measured
+-0.003 us, CI [-0.206, +0.214]. `cost.rs` explains why in its own module docs -- the verify tier is
+added to BOTH materializing plans, so it largely cancels in their argmin.
+
+An argmin depends only on DIFFERENCES between plans. A term shared by every plan can be arbitrarily
+wrong without changing a single routing decision; a small error in a term that differs between two
+plans can flip many. So this measures, per plan PAIR:
+
+- how often the model orders the pair correctly (`sign(pred_a - pred_b) == sign(meas_a - meas_b)`)
+- what it costs when wrong, in microseconds of avoidable time
+- how well the model's predicted GAP tracks the measured gap
+
+Read it to decide what to fix next. A pair that is ordered correctly 99% of the time needs no work on
+its relative costs however wrong both absolute numbers are; a pair near 50% is where routing is
+actually being lost.
+
+    .venv/bin/python scripts/bench_pairwise_ordering.py --seconds 300 --mode realistic
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import itertools
+import pathlib
+import random
+import statistics
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.bench_cost_model_agreement import RANGE_ACQUIRES  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+# A gap smaller than this is inside measurement noise, so calling the order "wrong" says nothing.
+TIE_FLOOR_US = 1.0
+MIN_PAIRS_TO_REPORT = 30
+
+
+def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
+    """One row per (query, plan) that ran, carrying a query id so pairs can be reconstructed."""
+    rows: list[dict] = []
+    deadline = time.monotonic() + seconds
+    qid = 0
+    while time.monotonic() < deadline:
+        limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
+        kw = {
+            "filters": None,
+            "unique": sampler.unique(rng),
+            "orderby": sampler.orderby(rng),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": limit,
+            "offset": offset,
+        }
+        try:
+            kw["filters"] = parse_scryfall_query(sampler.query(rng))
+            acq = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        qid += 1
+        for p in res["plans"]:
+            if not p["trials_ns"] or p["predicted_ns"] <= 0:
+                continue
+            # Same netting as the agreement harness: only a Prep::Range acquire makes the routed path
+            # re-pay prepare_candidates, so elsewhere it is not the plan's cost to carry.
+            measured = float(min(p["trials_ns"]))
+            if p["ns_round_total"] and acq["count_source"] not in RANGE_ACQUIRES:
+                measured = max(measured - p["ns_prepare"], 1.0)
+            rows.append(
+                {
+                    "qid": qid,
+                    "plan": p["plan"],
+                    "acquire": acq["count_source"],
+                    "measured_us": measured / 1000.0,
+                    "predicted_us": p["predicted_ns"] / 1000.0,
+                }
+            )
+    return rows
+
+
+def report(rows: list[dict], by_acquire: bool) -> None:
+    """Per plan pair: ordering accuracy, regret when wrong, and how well the gap is predicted."""
+    per_query: dict[int, list[dict]] = collections.defaultdict(list)
+    for r in rows:
+        per_query[r["qid"]].append(r)
+
+    stats: dict[tuple[str, ...], dict] = collections.defaultdict(
+        lambda: {"n": 0, "right": 0, "ties": 0, "regret": [], "gap_ratio": []}
+    )
+    for plans in per_query.values():
+        for a, b in itertools.combinations(sorted(plans, key=lambda p: p["plan"]), 2):
+            key = (a["plan"], b["plan"]) + ((a["acquire"],) if by_acquire else ())
+            s = stats[key]
+            meas_gap = a["measured_us"] - b["measured_us"]
+            pred_gap = a["predicted_us"] - b["predicted_us"]
+            if abs(meas_gap) < TIE_FLOOR_US:
+                s["ties"] += 1
+                continue
+            s["n"] += 1
+            if (meas_gap > 0) == (pred_gap > 0):
+                s["right"] += 1
+            else:
+                # Picking the model's winner costs the whole measured gap.
+                s["regret"].append(abs(meas_gap))
+            if abs(pred_gap) > 0:
+                s["gap_ratio"].append(meas_gap / pred_gap)
+
+    label = "pair / acquire" if by_acquire else "plan pair"
+    print(f"\n{label:<52}{'n':>7}{'ordered right':>15}{'mean regret':>13}{'gap meas/pred':>15}")
+    ranked = sorted(stats.items(), key=lambda kv: -sum(kv[1]["regret"]))
+    for key, s in ranked:
+        if s["n"] < MIN_PAIRS_TO_REPORT:
+            continue
+        name = f"{key[0]} vs {key[1]}" + (f"  [{key[2]}]" if by_acquire else "")
+        regret = sum(s["regret"]) / s["n"]
+        gap = statistics.median(s["gap_ratio"]) if s["gap_ratio"] else float("nan")
+        print(f"{name:<52}{s['n']:>7}{s['right'] / s['n']:>14.0%}{regret:>12.2f}µs{gap:>15.2f}")
+    print(f"  ties (|measured gap| < {TIE_FLOOR_US:g}µs) excluded; ranked by TOTAL regret contributed.")
+    print("  'gap meas/pred' is the ratio of measured to predicted GAP — 1.00 means the model sizes")
+    print("  the difference right, which is what argmin needs. Absolute per-plan accuracy is not.")
+
+
+def main() -> None:
+    """Sample, then report pairwise ordering overall and split by acquire branch."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=300.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--mode", choices=MODES, default="uniform", help="diagnostic: uniform reaches the rare tails where ordering errors hide"
+    )
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".pairwise.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = collect(engine, sampler, random.Random(args.seed), args.seconds)
+    print(f"\n{len(rows):,} plan-rows over {len({r['qid'] for r in rows}):,} queries, mode={args.mode}")
+    report(rows, by_acquire=False)
+    report(rows, by_acquire=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_plane_popcount_cost.py
+++ b/scripts/bench_plane_popcount_cost.py
@@ -1,0 +1,147 @@
+"""Why is `PlanePopcountOrder` under-costed? Residual against every term the model could be missing.
+
+Its cost arm is `matches·0.65 + (n_cards/64)·1.0 + limit·2.0 + 200` ns — no term for evaluating the
+plane itself, and no dependence on how many plane leaves the expression has. A corpus sweep put it
+at a median 1.54-1.61x under-costed with a p90 of 6.16, so something real looked unpriced.
+
+That turned out to be the harness, not the engine: `run_query_with_plan` re-evaluates the plane,
+which the routed path does once in acquire and reuses. Netting acquire for every plan clears it
+(2.10 raw -> 0.69 net). Kept because the leaf-count breakdown below is what diagnosed it.
+
+Sampling is time-budgeted rather than count-budgeted (`--seconds`), because the plan only fires on
+plane-acquired queries — roughly one generated query in seven. Cheap `explain` calls filter for
+those first; only hits pay for `explain_analyze`.
+
+    .venv/bin/python scripts/bench_plane_popcount_cost.py --seconds 120
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import statistics
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from client.query_runner import random_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+TARGET_PLAN = "PlanePopcountOrder"
+NUM_WARMUPS = 3
+NUM_TRIALS = 11
+# Leaf-ish tokens in the query text, as a cheap proxy for how many planes get ANDed/ORed together —
+# the model has no term for this, so it is the first candidate explanation for the residual.
+LEAF_RE = re.compile(r"[a-z]+[:<>=]", re.I)
+# Model constants mirrored from cost.rs, so the residual can be attributed to a term rather than
+# just observed. Any drift here shows up as a constant offset in the residual column.
+SCATTER_PER_MATCH_NS = 0.65
+PER_WORD_NS = 1.0
+EMIT_PER_CARD_NS = 2.0
+FIXED_NS = 200.0
+LIMIT = 100
+
+
+def predicted_ns(matches: int, n_cards: int) -> float:
+    """The model's own arithmetic, re-derived so its terms can be inspected separately."""
+    return matches * SCATTER_PER_MATCH_NS + (n_cards / 64.0) * PER_WORD_NS + LIMIT * EMIT_PER_CARD_NS + FIXED_NS
+
+
+def main() -> None:
+    """Sample plane-acquired queries until the time budget is spent, then attribute the residual."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=120.0, help="wall-clock budget for sampling")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".misselect.store"))
+
+    rows: list[tuple[float, int, int, float, float, str]] = []
+    seen: set[str] = set()
+    generated = filtered = 0
+    deadline = time.monotonic() + args.seconds
+    while time.monotonic() < deadline:
+        q = random_query()
+        generated += 1
+        if q in seen:
+            continue
+        seen.add(q)
+        try:
+            filters = parse_scryfall_query(q)
+            # Cheap filter: one acquire, no plan executions.
+            quick = engine.explain(filters=filters, unique="card", orderby="edhrec", direction="asc", limit=LIMIT, offset=0)
+        except Exception:  # noqa: BLE001, S112 - a query bind rejects is a sample skip
+            continue
+        if not any(p["plan"] == TARGET_PLAN for p in quick["plans"]):
+            continue
+        filtered += 1
+        try:
+            res = engine.explain_analyze(
+                filters=filters,
+                unique="card",
+                orderby="edhrec",
+                direction="asc",
+                limit=LIMIT,
+                offset=0,
+                num_warmups=NUM_WARMUPS,
+                num_trials=NUM_TRIALS,
+            )
+        except Exception:  # noqa: BLE001, S112
+            continue
+        plan = next((p for p in res["plans"] if p["plan"] == TARGET_PLAN and p["trials_ns"]), None)
+        if plan is None:
+            continue
+        a = res["acquire"]
+        meas = min(plan["trials_ns"])
+        rows.append((meas / plan["predicted_ns"], a["matches"], len(LEAF_RE.findall(q)), meas, plan["predicted_ns"], q))
+
+    if not rows:
+        print("no plane-acquired samples in the budget")
+        return
+
+    report(rows, generated, filtered, args.seconds)
+
+
+def report(rows: list[tuple[float, int, int, float, float, str]], generated: int, filtered: int, seconds: float) -> None:
+    """Ratio summary, then the residual broken down by plane-leaf count and by match count."""
+    ratios = [r[0] for r in rows]
+    print(f"\n{len(rows):,} {TARGET_PLAN} samples ({generated:,} generated, {filtered:,} plane-acquired) in {seconds:.0f}s")
+    qs = statistics.quantiles(ratios, n=10)
+    print(
+        f"ratio measured/predicted: median {statistics.median(ratios):.2f}  p10 {qs[0]:.2f}  p90 {qs[8]:.2f}  max {max(ratios):.2f}"
+    )
+
+    # Is the residual a fixed underestimate, or does it scale with match count or leaf count? A
+    # constant residual means the fixed term is too low; one that scales means a missing rate.
+    print(f"\n{'leaves':>7}{'n':>6}{'median ratio':>14}{'median resid ns':>17}{'resid/match ns':>16}")
+    for leaves in sorted({r[2] for r in rows}):
+        grp = [r for r in rows if r[2] == leaves]
+        resid = [r[3] - r[4] for r in grp]
+        per_match = [(r[3] - r[4]) / max(r[1], 1) for r in grp]
+        print(
+            f"{leaves:>7}{len(grp):>6}{statistics.median(r[0] for r in grp):>14.2f}"
+            f"{statistics.median(resid):>17.0f}{statistics.median(per_match):>16.2f}"
+        )
+
+    print(f"\n{'matches':>9}{'n':>6}{'median ratio':>14}{'median resid ns':>17}")
+    buckets = ((0, 1, "0"), (1, 100, "1-99"), (100, 1_000, "100-999"), (1_000, 10_000, "1k-10k"), (10_000, 1 << 30, "10k+"))
+    for lo, hi, label in buckets:
+        grp = [r for r in rows if lo <= r[1] < hi]
+        if not grp:
+            continue
+        resid = [r[3] - r[4] for r in grp]
+        print(f"{label:>9}{len(grp):>6}{statistics.median(r[0] for r in grp):>14.2f}{statistics.median(resid):>17.0f}")
+
+    rows.sort(reverse=True)
+    print(f"\n{'ratio':>7}{'matches':>9}{'leaves':>7}{'meas ns':>10}{'pred ns':>10}  query")
+    for ratio, matches, leaves, meas, pred, q in rows[:12]:
+        print(f"{ratio:>7.2f}{matches:>9}{leaves:>7}{meas:>10.0f}{pred:>10.0f}  {q[:42]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_query_latency_ab.py
+++ b/scripts/bench_query_latency_ab.py
@@ -1,0 +1,181 @@
+"""Paired end-to-end query latency between two engine builds. The only A/B that works against main.
+
+`bench_plan_misselection.py` measures routing regret, but it reads `explain_analyze` fields and a
+response shape that this branch introduced — main returns a bare list where the branch returns
+`{"acquire": ..., "plans": [...]}`, and the per-plan `picked` / `ns_prepare` / `ns_round_total`
+fields do not exist there at all. So it cannot be pointed at main.
+
+`query()` is present and identically shaped in both, and it measures the thing users actually wait
+for. Same discipline as the regret A/B: write per-query rows with `--out`, then `--compare` two files
+PAIRED over the same query list, with a bootstrap CI on the difference. Latency is heavy-tailed
+(broad scans cost thousands of times a name lookup), so comparing two headline means is hopeless —
+pairing removes query-sampling variance and the interval says whether what remains is real.
+
+    # once per build:
+    .venv/bin/python scripts/bench_query_latency_ab.py --sample 2000 --out A.jsonl
+    .venv/bin/python scripts/bench_query_latency_ab.py --compare A.jsonl B.jsonl
+
+INTERLEAVE THE BUILDS. Run A, then B, then A, then B, and compare like against like. Measuring all
+of A and then all of B maps any drift in machine state -- thermal, background load, page cache --
+straight onto the comparison. Measured: a sequential main-then-branch run showed a ~3% median
+slowdown spread EVENLY across acquire branches the change never touched, while the branch it did
+touch was absolutely faster. A uniform effect on untouched code paths is drift, not signal, and the
+mean's confidence interval spanned zero throughout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import math
+import pathlib
+import random
+import statistics
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+BOOTSTRAP_RESAMPLES = 10_000
+BOOTSTRAP_CI = 0.95
+# Below this, per-query differences are timer noise rather than a real change.
+NOISE_FLOOR_US = 1.0
+
+
+@dataclasses.dataclass(frozen=True)
+class Budget:
+    """How many queries to measure, and how hard.
+
+    Fewer trials buys more DISTINCT queries per unit of CPU, and for a PAIRED comparison that is the
+    better trade -- pairing already removes per-query variance, so breadth beats depth.
+    """
+
+    sample: int
+    warmups: int = NUM_WARMUPS
+    trials: int = NUM_TRIALS
+
+
+def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget) -> list[dict]:
+    """Min-of-trials wall time for `query()` on each sampled query."""
+    rows: list[dict] = []
+    for _ in range(budget.sample):
+        limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
+        kw = {
+            "unique": sampler.unique(rng),
+            "orderby": sampler.orderby(rng),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": limit,
+            "offset": offset,
+        }
+        q = sampler.query(rng)
+        try:
+            filters = parse_scryfall_query(q)
+            for _ in range(budget.warmups):
+                engine.query(filters=filters, prefer="default", **kw)
+            best = math.inf
+            for _ in range(budget.trials):
+                t0 = time.perf_counter_ns()
+                engine.query(filters=filters, prefer="default", **kw)
+                best = min(best, time.perf_counter_ns() - t0)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        rows.append(
+            {
+                "q": q,
+                **{k: kw[k] for k in ("unique", "orderby", "direction")},
+                "limit": limit,
+                "offset": offset,
+                "us": best / 1000.0,
+            }
+        )
+    return rows
+
+
+def paired_bootstrap(deltas: list[float]) -> tuple[float, float]:
+    """Central `BOOTSTRAP_CI` interval for the mean of `deltas`, by resampling with replacement."""
+    rng = random.Random(0)  # fixed: the interval should not wobble between reads of the same data
+    n = len(deltas)
+    means = sorted(sum(deltas[rng.randrange(n)] for _ in range(n)) / n for _ in range(BOOTSTRAP_RESAMPLES))
+    tail = (1.0 - BOOTSTRAP_CI) / 2.0
+    return means[int(tail * BOOTSTRAP_RESAMPLES)], means[int((1.0 - tail) * BOOTSTRAP_RESAMPLES) - 1]
+
+
+def compare(path_a: pathlib.Path, path_b: pathlib.Path) -> None:
+    """Paired latency comparison over the queries both runs recorded."""
+
+    def rows(path: pathlib.Path) -> dict[tuple, float]:
+        out = {}
+        for line in path.open():
+            r = json.loads(line)
+            out[(r["q"], r["unique"], r["orderby"], r["direction"], r["limit"], r["offset"])] = r["us"]
+        return out
+
+    a, b = rows(path_a), rows(path_b)
+    shared = sorted(set(a) & set(b))
+    if not shared:
+        print("no queries in common -- both runs need the same --mode/--sample/--seed")
+        return
+    deltas = [b[k] - a[k] for k in shared]
+    lo, hi = paired_bootstrap(deltas)
+    mean_a = sum(a[k] for k in shared) / len(shared)
+    mean_b = sum(b[k] for k in shared) / len(shared)
+    # The mean is dominated by the slowest queries; the median ratio says what a typical query sees.
+    ratios = sorted(b[k] / a[k] for k in shared if a[k] > 0)
+    worse = sum(1 for d in deltas if d > NOISE_FLOOR_US)
+    better = sum(1 for d in deltas if d < -NOISE_FLOOR_US)
+
+    print(f"\npaired over {len(shared):,} queries in common ({len(a):,} / {len(b):,} recorded)")
+    print(f"  A mean latency  {mean_a:>9.1f} µs   median {statistics.median(a[k] for k in shared):>8.1f} µs   ({path_a.name})")
+    print(f"  B mean latency  {mean_b:>9.1f} µs   median {statistics.median(b[k] for k in shared):>8.1f} µs   ({path_b.name})")
+    print(f"  B - A           {mean_b - mean_a:>9.1f} µs   {BOOTSTRAP_CI:.0%} CI [{lo:+.1f}, {hi:+.1f}]")
+    print(
+        f"  per-query ratio B/A: median {statistics.median(ratios):.3f}   p10 {ratios[len(ratios) // 10]:.3f}   p90 {ratios[len(ratios) * 9 // 10]:.3f}"
+    )
+    print(f"  slower on {worse:,}, faster on {better:,}, within ±{NOISE_FLOOR_US:g}µs on {len(shared) - worse - better:,}")
+    verdict = "NO DETECTABLE DIFFERENCE (interval spans zero)" if lo <= 0.0 <= hi else ("B is SLOWER" if lo > 0 else "B is FASTER")
+    print(f"  verdict: {verdict}")
+
+
+def main() -> None:
+    """Either measure one build to a file, or compare two such files."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--sample", type=int, default=2000)
+    # Fewer trials buys more DISTINCT queries per unit of CPU. For a paired comparison that is the
+    # better trade: pairing already removes per-query variance, so breadth beats depth.
+    parser.add_argument("--warmups", type=int, default=NUM_WARMUPS)
+    parser.add_argument("--trials", type=int, default=NUM_TRIALS)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--mode", choices=MODES, default="realistic", help="latency asks what users wait for, so traffic-weighted")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    parser.add_argument("--out", type=pathlib.Path, help="write per-query latencies as JSONL")
+    parser.add_argument("--compare", nargs=2, type=pathlib.Path, metavar=("A.jsonl", "B.jsonl"))
+    args = parser.parse_args()
+
+    if args.compare:
+        compare(*args.compare)
+        return
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".latency.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = measure(engine, sampler, random.Random(args.seed), Budget(args.sample, args.warmups, args.trials))
+    print(f"measured {len(rows):,} queries, mode={args.mode}")
+    if args.out:
+        with args.out.open("w") as handle:
+            for row in rows:
+                handle.write(json.dumps(row) + "\n")
+        print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -1,0 +1,146 @@
+"""Where routing loss actually concentrates: the regret distribution, sliced several ways.
+
+The companion to `bench_cost_error_percentiles.py`. That one says where the ESTIMATE is wrong; this
+says where being wrong COSTS something. They disagree often enough to matter — an estimate can be off
+by 100x on a plan that never wins anyway, and correct to 5% on one where the margin decides every
+query.
+
+Regret is `routed_ns - best_measured_ns`: what the router gave up against the best plan that ran, so a
+correct pick contributes exactly 0. It is measured against `routed_ns` rather than the picked plan's
+own trial because those differ in the case that matters most — when the picked plan DECLINES at
+runtime, dispatch re-chooses among materializing plans only, and a non-materializing fast path that
+would have won is never reconsidered.
+
+Regret is mostly zeros, so a median is useless here: read the SHARE column, which is what fraction of
+all lost time a slice accounts for. That ranks the work. p90/p99/max show whether a slice loses a
+little constantly or a lot rarely.
+
+    .venv/bin/python scripts/bench_regret_matrix.py --seconds 180
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import pathlib
+import random
+import statistics
+import sys
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+from scripts.query_sampler import MODES, QuerySampler  # noqa: E402
+
+NUM_WARMUPS = 2
+NUM_TRIALS = 7
+LIMITS = (10, 100, 175)
+OFFSETS = (0, 0, 0, 100)
+# Below this a "miss" costs nothing and only inflates the rate.
+NOISE_FLOOR_US = 1.0
+MIN_ROWS = 30
+PERCENTILES = (90, 99)
+
+
+def percentile(vals: list[float], pct: int) -> float:
+    """Nearest-rank percentile, so each printed number is a real query."""
+    idx = min(round(pct / 100.0 * len(vals) + 0.5) - 1, len(vals) - 1)
+    return vals[max(idx, 0)]
+
+
+def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
+    """One row per multi-plan query: what it lost, and everything to slice that by."""
+    rows: list[dict] = []
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        unique = sampler.unique(rng)
+        kw = {
+            "filters": None,
+            "unique": unique,
+            "orderby": sampler.orderby(rng),
+            "direction": rng.choice(("asc", "desc")),
+            "limit": rng.choice(LIMITS),
+            "offset": rng.choice(OFFSETS),
+        }
+        try:
+            kw["filters"] = parse_scryfall_query(sampler.query(rng))
+            acq = engine.explain(**kw)["acquire"]
+            res = engine.explain_analyze(prefer="default", num_warmups=NUM_WARMUPS, num_trials=NUM_TRIALS, **kw)
+        except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
+            continue
+        ran = [p for p in res["plans"] if p["trials_ns"]]
+        if len(ran) < 2:  # noqa: PLR2004 - one applicable plan means there is nothing to get wrong
+            continue
+        picked = next((p for p in res["plans"] if p["picked"]), None)
+        declined = picked is not None and not picked["trials_ns"]
+        best = min(ran, key=lambda p: min(p["trials_ns"]))
+        # routed_ns lives on explain_analyze's acquire; `explain` runs nothing and leaves it empty.
+        routed = res["acquire"]["routed_ns"]
+        if not routed:
+            continue
+        routed_us = min(routed) / 1000.0
+        rows.append(
+            {
+                "lost": max(routed_us - min(best["trials_ns"]) / 1000.0, 0.0),
+                "acquire": acq["count_source"],
+                "unique": unique,
+                "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
+                "best": best["plan"],
+            }
+        )
+    return rows
+
+
+def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 12) -> None:
+    """One slice of the regret distribution, ranked by share of all lost time."""
+    groups: dict[object, list[float]] = collections.defaultdict(list)
+    for r in rows:
+        groups[key(r)].append(r["lost"])
+    grand = sum(r["lost"] for r in rows) or 1.0
+    head = "".join(f"{f'p{p}':>9}" for p in PERCENTILES)
+    print(f"\n{label:<44}{'n':>7}{'miss%':>7}{'mean':>8}{head}{'max':>10}{'SHARE':>8}")
+    ranked = sorted(groups.items(), key=lambda kv: -sum(kv[1]))
+    for name, vals in ranked[:limit]:
+        if len(vals) < MIN_ROWS:
+            continue
+        vals.sort()
+        total = sum(vals)
+        cells = "".join(f"{percentile(vals, p):>9.2f}" for p in PERCENTILES)
+        miss = sum(1 for v in vals if v > NOISE_FLOOR_US) / len(vals)
+        print(f"{name!s:<44}{len(vals):>7}{miss:>6.0%}{statistics.fmean(vals):>8.2f}{cells}{vals[-1]:>10.1f}{total / grand:>7.0%}")
+
+
+def main() -> None:
+    """Sample, then show where routing loss concentrates by acquire, mode, and transition."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=60.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--mode", choices=MODES, default="uniform")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".regret.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = collect(engine, sampler, random.Random(args.seed), args.seconds)
+    total = sum(r["lost"] for r in rows)
+    print(
+        f"\n{len(rows):,} multi-plan queries, mode={args.mode}.  total regret {total / 1000:.1f} ms, mean {total / max(len(rows), 1):.2f} µs"
+    )
+    table(rows, lambda r: r["acquire"], "acquire")
+    table(rows, lambda r: r["unique"], "unique")
+    table(rows, lambda r: f"{r['acquire']} / {r['unique']}", "acquire / unique")
+    table(rows, lambda r: f"{r['picked']} -> {r['best']}", "picked -> best (only when they differ)")
+    print("\n  SHARE is the fraction of ALL lost time, which is what ranks the work: frequency times")
+    print("  severity. miss% counts queries losing more than 1µs. Regret is mostly zeros, so no median.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/census_candidate_materialize.py
+++ b/scripts/census_candidate_materialize.py
@@ -1,0 +1,211 @@
+"""Census: which real queries would a change to candidate materialization actually touch?
+
+Step 1 of docs/issues/local-engine-candidate-materialize.md. Six engine sites turn selected
+index rows into a sorted candidate list via `collect` + `sort_unstable`; replacing that with
+a bitmap scatter pays off from roughly `n_cards / 460` candidates up. This asks how many
+queries land in that band before any engine code changes.
+
+Uses `explain`, not `explain_analyze`: one acquire per query, so 14k queries is seconds, and
+`acquire.count_source` + `acquire.eval_domain` is all the filtering needs. Feed the shortlist
+this prints to `explain_analyze` for real timings.
+
+    .venv/bin/python scripts/census_candidate_materialize.py --wild
+    .venv/bin/python scripts/census_candidate_materialize.py --random 5000 --out /tmp/shortlist.csv
+
+**Reads card-space counts only.** `eval_domain` is candidate CARDS the walk iterates, so for
+the three printing-space sites (`range_narrowed`, `expand_artist_ids`, `expand_flavor_ids`)
+this sees the post-projection card count, not the printing count those sites sort. Their band
+is wider (crossover ~194 against ~81), so this census under-counts them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import json
+import pathlib
+import random
+import re
+import sys
+from typing import TYPE_CHECKING
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from client.query_runner import random_query  # noqa: E402
+from scripts.bench_bitplanes import load_engine  # noqa: E402
+
+if TYPE_CHECKING:
+    import card_engine
+
+# Crossover ratio from bench_candidate_materialize's axis G: the bitmap wins once
+# `count * 460 > domain`, flat to +/-13% across a 95x range of domain. Divided into the live
+# corpus size rather than hardcoded as a count, so this tracks the corpus instead of drifting.
+CROSSOVER_RATIO = 460
+# Mirror of the engine's BITS_PROMOTE (card_engine/src/lib.rs). At or above it a narrowing
+# already returns a bitmap, so those queries are unaffected by the production-side change.
+BITS_PROMOTE = 4_096
+# The wild corpus records Scryfall's `unique` spellings; the engine's `mode_from_unique`
+# falls through to Card for anything it does not recognize, so an unmapped value would be
+# silently mis-measured rather than rejected. Map explicitly.
+UNIQUE_FROM_SCRYFALL = {
+    "card": "card",
+    "cards": "card",
+    "art": "artwork",
+    "artwork": "artwork",
+    "prints": "printing",
+    "printing": "printing",
+}
+# Engine-supported orderby values (client/query_runner.py's list), so a corpus row carrying
+# an orderby the engine does not know cannot quietly change which plan is measured.
+ORDERBY_VALUES = frozenset(
+    {"edhrec", "cubecobra", "cmc", "power", "toughness", "rarity", "name", "released", "set", "color", "usd", "artist", "review"}
+)
+DEFAULT_ORDERBY = "edhrec"
+# random_query() emits shapes, not unique/orderby; sample those the way real traffic
+# distributes (client/query_runner.py's own weights).
+RANDOM_UNIQUE_WEIGHTS = {"card": 75, "printing": 20, "artwork": 5}
+# Same rule build_wild_corpus.py uses to split its own census, so the partition here is
+# comparable to the counts in benchmarks/wild-queries/README.md (3,566 with operators against
+# 10,907 bare name lookups). The corpus is 75% name lookups — largely bot/tooling deep links —
+# which narrow to a single card by construction, so aggregating the two halves measures
+# mostly bots and says nothing about search.
+OP_RE = re.compile(r"[a-z]+[:<>=]", re.I)
+
+
+# Representations that mean a sorted vec was built, so a `collect` + `sort_unstable` ran. The
+# bits-shaped and `none` labels mean the narrowing stayed word-wise or came from the plane
+# bitmap, and no sort happened — those queries are in the band but cannot be affected.
+SORTED_REPRS = frozenset({"cards", "printings"})
+
+
+def band_of(eval_domain: int, n_cards: int, crossover: int, narrowed_repr: str) -> str:
+    """Which materialization band a query falls in, counting only queries that actually sort."""
+    if eval_domain >= n_cards:
+        return "unnarrowed"
+    if eval_domain >= BITS_PROMOTE:
+        return "already_bitmap"
+    if eval_domain >= crossover:
+        # In the band by count, but the change can only touch it if a sort produced the list.
+        return "AFFECTED" if narrowed_repr in SORTED_REPRS else f"band_no_sort_{narrowed_repr}"
+    return "below_crossover"
+
+
+def wild_queries(path: pathlib.Path, *, with_operators: bool) -> list[tuple[str, str, str, int]]:
+    """(query, unique, orderby, weight) from the Common Crawl wild-query corpus.
+
+    `with_operators` selects one half of the partition: operator-bearing queries (the actual
+    search workload) or bare name lookups (bot deep links). Never both — see OP_RE.
+    """
+    out = []
+    for line in path.open():
+        row = json.loads(line)
+        unique = UNIQUE_FROM_SCRYFALL.get(row.get("unique", "card"))
+        if unique is None or bool(OP_RE.search(row["q"])) != with_operators:
+            continue
+        order = row.get("order", DEFAULT_ORDERBY)
+        out.append((row["q"], unique, order if order in ORDERBY_VALUES else DEFAULT_ORDERBY, int(row.get("weight", 1))))
+    return out
+
+
+def random_queries(n: int, seed: int) -> list[tuple[str, str, str, int]]:
+    """(query, unique, orderby, weight=1) from the random generator, for shape coverage."""
+    rng = random.Random(seed)
+    uniques = list(RANDOM_UNIQUE_WEIGHTS)
+    weights = [RANDOM_UNIQUE_WEIGHTS[u] for u in uniques]
+    return [(random_query(), rng.choices(uniques, weights=weights)[0], DEFAULT_ORDERBY, 1) for _ in range(n)]
+
+
+def census_one(
+    engine: card_engine.QueryEngine, name: str, queries: list[tuple[str, str, str, int]], limit: int
+) -> list[tuple[str, str, str, str, int, int]]:
+    """Explain every query, print the band distribution, and return the affected-band rows."""
+    # Counted both weighted by occurrence (production share) and unweighted (distinct-query
+    # share) — a rare-but-heavy query and a common-but-light one are different findings.
+    bands: collections.Counter[str] = collections.Counter()
+    weighted: collections.Counter[str] = collections.Counter()
+    by_source: collections.Counter[str] = collections.Counter()
+    affected: list[tuple[str, str, str, str, int, int]] = []
+    rejected = 0
+    n_cards = 0
+
+    for q, unique, orderby, weight in queries:
+        try:
+            filters = parse_scryfall_query(q)
+            res = engine.explain(filters=filters, unique=unique, orderby=orderby, direction="asc", limit=limit, offset=0)
+        except Exception:  # noqa: BLE001 - a query the parser or bind rejects is a census skip, not an error
+            rejected += 1
+            continue
+        acq = res["acquire"]
+        n_cards = acq["n_cards"]
+        crossover = max(1, n_cards // CROSSOVER_RATIO)
+        by_source[acq["count_source"]] += weight
+        band = (
+            band_of(acq["eval_domain"], n_cards, crossover, acq["narrowed_repr"])
+            if acq["count_source"] == "candidates"
+            else f"prep_{acq['count_source']}"
+        )
+        bands[band] += 1
+        weighted[band] += weight
+        if band == "AFFECTED":
+            affected.append((name, q, unique, orderby, acq["eval_domain"], weight))
+
+    crossover = max(1, n_cards // CROSSOVER_RATIO)
+    total, total_w = sum(bands.values()) or 1, sum(weighted.values()) or 1
+    print(f"\n{name}: {sum(bands.values()):,} queries explained ({rejected:,} rejected), corpus {n_cards:,} cards")
+    print(f"  affected band: {crossover:,} <= eval_domain < {BITS_PROMOTE:,} (crossover = n_cards / {CROSSOVER_RATIO})")
+    print(f"  {'band':<18}{'queries':>10}{'share':>9}{'weighted':>12}{'share':>9}")
+    for band, n in sorted(bands.items(), key=lambda kv: -kv[1]):
+        w = weighted[band]
+        print(f"  {band:<18}{n:>10,}{n / total:>8.1%}{w:>12,}{w / total_w:>8.1%}")
+    print(f"  count_source: {', '.join(f'{k}={v:,}' for k, v in by_source.most_common())}")
+    return affected
+
+
+def main() -> None:
+    """Run the census over the requested corpora and print the band distribution."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--corpus",
+        type=pathlib.Path,
+        default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl",
+        help="card rows to build the store from",
+    )
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None, help="engine archive path (default: alongside --corpus)")
+    parser.add_argument("--wild", action="store_true", help="census the Common Crawl wild-query corpus")
+    parser.add_argument("--random", type=int, default=0, metavar="N", help="also census N generated queries")
+    parser.add_argument("--seed", type=int, default=0, help="seed for --random")
+    parser.add_argument("--out", type=pathlib.Path, default=None, help="CSV shortlist of affected-band queries")
+    parser.add_argument("--limit", type=int, default=100, help="page size to explain at")
+    args = parser.parse_args()
+
+    if not args.wild and not args.random:
+        parser.error("nothing to census: pass --wild and/or --random N")
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".census.store"))
+
+    sources: list[tuple[str, list[tuple[str, str, str, int]]]] = []
+    if args.wild:
+        corpus = REPO_ROOT / "benchmarks/wild-queries/wild-corpus.jsonl"
+        sources.append(("wild-operators", wild_queries(corpus, with_operators=True)))
+        sources.append(("wild-namelookup", wild_queries(corpus, with_operators=False)))
+    if args.random:
+        sources.append(("random", random_queries(args.random, args.seed)))
+
+    affected: list[tuple[str, str, str, str, int, int]] = []
+    for name, queries in sources:
+        affected += census_one(engine, name, queries, args.limit)
+
+    if args.out and affected:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        with args.out.open("w", newline="") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["source", "query", "unique", "orderby", "eval_domain", "weight"])
+            writer.writerows(sorted(affected, key=lambda r: -r[4]))
+        print(f"\nwrote {len(affected):,} affected-band queries to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -37,12 +37,9 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
 from scripts.bench_bitplanes import load_engine  # noqa: E402
-from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO  # noqa: E402
+from scripts.bench_cost_model_agreement import AGREE_HI, AGREE_LO, RANGE_ACQUIRES  # noqa: E402
 from scripts.query_sampler import QuerySampler  # noqa: E402
 
-# Acquire branches where the routed path really does call `prepare_candidates` at dispatch, so the
-# materializing plans genuinely owe its cost; everywhere else acquire built the prep already.
-RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
 NUM_WARMUPS = 2
 NUM_TRIALS = 7
 LIMITS = (10, 100, 175)

--- a/scripts/study_range_slice_layouts.py
+++ b/scripts/study_range_slice_layouts.py
@@ -1,0 +1,285 @@
+"""Which summary structure estimates distinct cards in a range slice, and at what size?
+
+Companion to `study_range_slice_cardinality.py`, which established that no closed-form estimator
+works (the duplication factor moves in opposite directions by dimension and direction) and that a
+build-time table beats all of them. This one settles the table's *shape*, separately for the two
+query populations, because they turn out to need different structures:
+
+- **one-sided** (`usd>x`, `year<x`): needs only prefix and suffix arrays, which is LINEAR in the cut
+  count, so a fine layout is affordable. A trapezoid — bucket widths doubling in from each edge,
+  capped, uniform across the middle — is the right shape, because one-sided slice boundaries are
+  edge-anchored by construction and a boundary near a cut interpolates over a tiny interval.
+- **bounded** (`x<usd<y`, `year:2023`): distinct counts do not subtract, so prefix/suffix cannot
+  answer these at all. Needs a table of `[cut_i, cut_j)` counts, which is QUADRATIC if stored in
+  full; a band (only `j - i <= w`) brings it back to linear at the cost of a fallback for wide ranges.
+
+Also scores a Postgres-style most-common-values split, since heavy-hitter separation is the standard
+fix for exactly this kind of skew.
+
+    .venv/bin/python scripts/study_range_slice_layouts.py
+
+Reuses the corpus extraction cache from `study_range_slice_cardinality.py`.
+"""
+
+from __future__ import annotations
+
+import bisect
+import collections
+import dataclasses
+import math
+import statistics
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.study_range_slice_cardinality import load  # noqa: E402
+
+MIN_SLICE = 16
+MIN_FOR_DECILES = 10
+# Band width for the bounded-range table, in buckets. 32 is where coverage stopped being the
+# limiting factor at the layouts below — past it the residual error is sub-bucket ranges, which no
+# band width reaches.
+BAND = 32
+# Most-common-value list sizes, as card counts. Postgres defaults to 100 values; this sweeps well
+# past that because the duplication here is far less concentrated than a typical column's.
+MCV_SIZES = (0, 200, 1000, 3000)
+
+
+def trapezoid(n: int, cap_frac: float) -> list[int]:
+    """Cut positions, widths doubling in from each edge, capped, then uniform across the middle."""
+    cap = max(int(n * cap_frac), 1)
+    cuts = {0, n}
+    width, x = 1, 0
+    while x < n // 2:
+        x += min(width, cap)
+        cuts.add(min(x, n))
+        cuts.add(max(n - x, 0))
+        width *= 2
+    return sorted(c for c in cuts if 0 <= c <= n)
+
+
+def equidepth(n: int, buckets: int) -> list[int]:
+    """Evenly spaced cut positions — percentile markers, the conventional layout."""
+    return [round(n * i / buckets) for i in range(buckets + 1)]
+
+
+def prefix_suffix(cards: list[int], cuts: list[int]) -> tuple[list[int], list[int]]:
+    """Distinct cards in [0, cut) and in [cut, n). Two arrays, linear in the cut count."""
+    pre, seen, last = [], set(), 0
+    for c in cuts:
+        seen.update(cards[last:c])
+        last = c
+        pre.append(len(seen))
+    suf, seen, last = [], set(), len(cards)
+    for c in reversed(cuts):
+        seen.update(cards[c:last])
+        last = c
+        suf.append(len(seen))
+    return pre, list(reversed(suf))
+
+
+def banded(cards: list[int], cuts: list[int], band: int) -> dict[tuple[int, int], int]:
+    """Exact distinct counts for [cut_i, cut_j) where j - i <= band."""
+    out = {}
+    for i in range(len(cuts) - 1):
+        seen: set[int] = set()
+        for j in range(i + 1, min(i + band, len(cuts) - 1) + 1):
+            seen.update(cards[cuts[j - 1] : cuts[j]])
+            out[i, j] = len(seen)
+    return out
+
+
+def _frac(cuts: list[int], x: int) -> tuple[int, float]:
+    i = min(max(bisect.bisect_right(cuts, x) - 1, 0), len(cuts) - 2)
+    width = cuts[i + 1] - cuts[i]
+    return i, (x - cuts[i]) / width if width else 0.0
+
+
+def est_one_sided(cuts: list[int], table: list[int], boundary: int) -> float:
+    """Linear interpolation in index position — the position the binary search already computed."""
+    i, f = _frac(cuts, boundary)
+    return max(table[i] + (table[i + 1] - table[i]) * f, 1.0)
+
+
+@dataclasses.dataclass
+class Summary:
+    """Everything stored for one dimension: cut positions, the two linear arrays, the banded table."""
+
+    cuts: list[int]
+    pre: list[int]
+    suf: list[int]
+    bnd: dict[tuple[int, int], int]
+    band: int
+    total: int
+
+
+def est_bounded(s: Summary, lo: int, hi: int) -> float:
+    """Estimate distinct cards in [lo, hi), bilinear on BOTH endpoints.
+
+    Interpolating only the right endpoint snaps the left edge to a cut, silently widening every
+    slice by up to a bucket — worth stating, because that bug cost an 8x error before it was caught.
+
+    Outside the band the fallback is `pre[j] + suf[i] - total`, the inclusion-exclusion size of
+    `[0, cut_j) ∩ [cut_i, n)`. That is an upper BOUND, not an estimate: it also counts cards
+    straddling the range with no printing inside it. Substituting the total distinct count there
+    instead — an easy mistake — inflates the bounded error roughly 2x.
+    """
+    cuts, pre, suf, bnd, band, total = s.cuts, s.pre, s.suf, s.bnd, s.band, s.total
+    i, fi = _frac(cuts, lo)
+    j, fj = _frac(cuts, hi)
+    top = len(cuts) - 1
+
+    def at(ii: int, jj: int) -> float:
+        ii = min(ii, top - 1)
+        jj = max(min(jj, top), ii + 1)
+        if jj - ii <= band and (ii, jj) in bnd:
+            return float(bnd[ii, jj])
+        return max(min(pre[min(jj, len(pre) - 1)] + suf[ii] - total, pre[min(jj, len(pre) - 1)]), 1.0)
+
+    j0 = max(j, i + 1)
+    low = at(i, j0) + (at(i, j0 + 1) - at(i, j0)) * fj
+    high = at(i + 1, j0) + (at(i + 1, j0 + 1) - at(i + 1, j0)) * fj
+    return max(low + (high - low) * fi, 1.0)
+
+
+def realistic_bounded(dim: str) -> list[tuple[float, float]]:
+    """Bounded ranges shaped like real queries.
+
+    Calendar years, set-sized collector blocks and price bands — rather than uniformly random
+    intervals, which over-represent mid-index slices no user would ever type.
+    """
+    if dim == "date":
+        return [(y * 10000, (y + 1) * 10000) for y in range(1993, 2027)]
+    if dim == "cn":
+        return [(s, s + 50) for s in range(0, 600, 50)]
+    bands = [0.1, 0.25, 0.5, 1, 2, 3, 5, 8, 12, 20, 35, 60, 100, 200, 400]
+    return [(bands[i], bands[i + 1]) for i in range(len(bands) - 1)]
+
+
+def stats(errs: list[float]) -> tuple[float, float, float]:
+    """Median, p90, max of |log ratio| — over- and under-estimates penalised alike."""
+    p90 = statistics.quantiles(errs, n=10)[8] if len(errs) >= MIN_FOR_DECILES else float("nan")
+    return statistics.median(errs), p90, max(errs)
+
+
+def study_one_sided(dims: dict[str, list[tuple[float, int]]]) -> None:
+    """Layout comparison for one-sided ranges, on linear prefix/suffix storage."""
+    print(f"\none-sided ranges — prefix/suffix arrays, {'2 x cuts'} entries (linear)")
+    print(f"{'layout':<28}{'cuts':>6}{'bytes':>9}{'median':>10}{'p90':>9}{'max':>9}")
+    layouts = (
+        ("equi-depth 32", lambda n: equidepth(n, 32)),
+        ("equi-depth 256", lambda n: equidepth(n, 256)),
+        ("trapezoid cap n/64", lambda n: trapezoid(n, 1 / 64)),
+        ("trapezoid cap n/256", lambda n: trapezoid(n, 1 / 256)),
+        ("trapezoid cap n/1024", lambda n: trapezoid(n, 1 / 1024)),
+    )
+    for label, mk in layouts:
+        errs, nbytes, ncuts = [], 0, 0
+        for rows in dims.values():
+            vals = [v for v, _ in rows]
+            cards = [c for _, c in rows]
+            n = len(rows)
+            cuts = mk(n)
+            pre, suf = prefix_suffix(cards, cuts)
+            nbytes += 2 * len(cuts) * 4
+            ncuts = len(cuts)
+            for q in [i / 400 for i in range(1, 400)]:
+                b = bisect.bisect_left(vals, vals[int(n * q)])
+                for lo, hi, tbl in ((0, b, pre), (b, n, suf)):
+                    if hi - lo < MIN_SLICE:
+                        continue
+                    errs.append(abs(math.log(est_one_sided(cuts, tbl, b) / len(set(cards[lo:hi])))))
+        med, p90, mx = stats(errs)
+        print(f"{label:<28}{ncuts:>6}{nbytes:>9,}{med:>10.4f}{p90:>9.4f}{mx:>9.3f}")
+
+
+def study_exact_per_value(dims: dict[str, list[tuple[float, int]]]) -> None:
+    """Store the true count at every distinct-value boundary: one-sided ranges stop being estimated.
+
+    The range dimensions have far fewer distinct VALUES than printings — 914 dates against 97,206
+    printings — and printings sharing a value are contiguous in the value-sorted index. So any query
+    threshold, present in the data or not, bisects to a value boundary: there is no between-buckets
+    case to interpolate. Storing the exact prefix and suffix distinct-card counts at those boundaries
+    answers every one-sided range by lookup.
+
+    This supersedes every closed form and every bucket layout above for one-sided ranges. They were
+    all modelling a distribution over ~100k printings when the domain is ~1-4k values — the same
+    collapse the arith-tuple index (#750) exploits.
+    """
+    print("\nexact per distinct value — one-sided ranges answered by lookup, not estimate")
+    print(f"{'dim':<7}{'boundaries':>12}{'bytes':>9}{'max |log err|':>16}")
+    total = 0
+    for dim, rows in dims.items():
+        vals = [v for v, _ in rows]
+        cards = [c for _, c in rows]
+        n = len(rows)
+        bounds = [0, *[i for i in range(1, n) if vals[i] != vals[i - 1]], n]
+        pre, suf = prefix_suffix(cards, bounds)
+        total += 2 * len(bounds) * 4
+        errs = []
+        for q in [i / 400 for i in range(1, 400)]:
+            b = bisect.bisect_left(vals, vals[int(n * q)])
+            idx = bisect.bisect_left(bounds, b)
+            for lo, hi, tbl in ((0, b, pre), (b, n, suf)):
+                if hi - lo < MIN_SLICE:
+                    continue
+                errs.append(abs(math.log(max(tbl[idx], 1) / len(set(cards[lo:hi])))))
+        print(f"{dim:<7}{len(bounds):>12,}{2 * len(bounds) * 4:>9,}{max(errs):>16.2e}")
+    print(f"  {total:,} bytes total, zero error. Bounded ranges are NOT covered: distinct counts do")
+    print("  not subtract, and the prefix/suffix bracket is a median 4.35x wide (worst 285x on cn).")
+
+
+def study_bounded(dims: dict[str, list[tuple[float, int]]]) -> None:
+    """Banded table plus an MCV split, on realistic bounded ranges."""
+    print(f"\nbounded ranges — trapezoid cap n/256 + banded table (band {BAND}), realistic intervals")
+    print(f"{'most-common-values':<22}{'residual dup':>14}{'median':>9}{'p90':>8}{'max':>8}")
+    for mcv in MCV_SIZES:
+        errs, resid = [], []
+        for dim, rows in dims.items():
+            vals = [v for v, _ in rows]
+            cards = [c for _, c in rows]
+            counts = collections.Counter(cards)
+            heavy = {c for c, _ in counts.most_common(mcv)} if mcv else set()
+            pos: dict[int, list[int]] = collections.defaultdict(list)
+            for i, c in enumerate(cards):
+                if c in heavy:
+                    pos[c].append(i)
+            light = [(i, c) for i, c in enumerate(cards) if c not in heavy]
+            lpos = [i for i, _ in light]
+            lcards = [c for _, c in light]
+            if not lcards:
+                continue
+            resid.append(len(lcards) / len(set(lcards)))
+            cuts = trapezoid(len(lcards), 1 / 256)
+            pre, suf = prefix_suffix(lcards, cuts)
+            summary = Summary(cuts, pre, suf, banded(lcards, cuts, BAND), BAND, len(set(lcards)))
+            for v0, v1 in realistic_bounded(dim):
+                a, b = bisect.bisect_left(vals, v0), bisect.bisect_left(vals, v1)
+                if b - a < MIN_SLICE:
+                    continue
+                exact = len(set(cards[a:b]))
+                hv = sum(1 for c in heavy if pos[c] and bisect.bisect_left(pos[c], a) < bisect.bisect_left(pos[c], b))
+                la, lb = bisect.bisect_left(lpos, a), bisect.bisect_left(lpos, b)
+                est = hv + est_bounded(summary, la, lb)
+                errs.append(abs(math.log(max(est, 1.0) / exact)))
+        med, p90, mx = stats(errs)
+        label = "none (histogram only)" if not mcv else f"top {mcv:,} cards"
+        print(f"{label:<22}{statistics.mean(resid):>14.2f}{med:>9.3f}{p90:>8.3f}{mx:>8.3f}")
+    print("  MCV separates heavy hitters the way Postgres does for value-frequency skew. Duplication")
+    print("  here is far less concentrated than a typical column's — 3,000 cards carry only ~54% of")
+    print("  it — yet the split still more than halves the worst case, so it earns its space.")
+
+
+def main() -> None:
+    """Run both studies."""
+    dims = load()
+    dims.pop("_n_cards", None)
+    study_one_sided(dims)
+    study_exact_per_value(dims)
+    study_bounded(dims)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Eighth and last. **Based on #815** → #814 → #813 → #807 → #806 → #805 → #804.

No engine change. This is what makes the other seven reproducible, and what records why they were
done in that order.

## Six harnesses, each answering what the others structurally cannot

| question | tool |
| --- | --- |
| Is this plan's absolute cost right? | `bench_cost_model_agreement.py` *(already on main)* |
| What SHAPE is the error — uniform, or a tail? | `bench_cost_error_percentiles.py` |
| Features, coefficients, or the arm's shape? | `bench_cost_error_attribution.py` |
| Do the FEATURES match what the executor did? | `bench_feature_accuracy.py` |
| Does the model ORDER two plans correctly? | `bench_pairwise_ordering.py` |
| Where does routing actually lose time? | `bench_regret_matrix.py` |
| Did a change help end to end? | `bench_query_latency_ab.py` |

Reaching for the wrong one wastes days: three successive reworkings of one term improved the metric
being watched and moved routing by `-0.003 µs, CI [-0.206, +0.214]`.

`bench_feature_accuracy.py` earned its place fastest. Comparing each feature to the counter that
realizes it — sliced by acquire, plan and distinct-on — found **four errors that had survived every
other tool**, including a printing count consumed as a deduped result count at 1.95x. Pooled, all
three features read a median 1.00; every error lived in a slice.

## Design notes

`local-engine-cost-model-agreement.md` is the record behind the whole stack, including the
experiments that were tried and **rejected** — a scan-locality term (gain 0.000), sparse-gather
(twice, +0.377 µs), a log-retained gather form. Those are the expensive part to rediscover.

`reference-cost-model-measurement.md` is the toolkit's own doc: which tool answers which question,
the traps each has already cost someone, and a working order.

`local-engine-compose-membership-bittest.md` is designed and deliberately unbuilt — an ~8x on the top
regret class.

**`local-engine-range-scan-row-order.md` is new here**: the divergence #815 isolated but did not fix.
`PrintingRangeScan` walks the range index bucket by bucket and windows within the touched ones, so its
global order is *implied by the walk* rather than produced by a comparator — and the two disagree for
printing-space orderbys. Probed to fail identically with and without #815's `cid` tiebreak, so it is
genuinely separate from the key-3 bug fixed there. Four options written down, none costed, with a note
on which looks most likely to be free.

## One shared constant

`RANGE_ACQUIRES` — which acquire branches make the routed path re-pay `prepare_candidates`, so a
harness knows whether to net it out — now lives in `bench_cost_model_agreement.py` and is imported by
the three consumers that need it, rather than copied into each.

Every harness was smoke-tested against this branch. They were written against a tree with different
instrumentation and **two would not have imported** — worth catching before they are the thing someone
reaches for.

## Stack

    A  #804  exact distinct-card counts
    B  #805  cost compose honestly from every acquire
    C1 #806  predict compose's declines
    C2 #807  correct the features against the counters
    C3 #813  refit both scan arms
    D  #814  compose's own scan feature and rates
    E  #815  filter-independent row order + card-mode scan_units
    F  this PR