### PR TITLE
Rescue Unmerged Tooling and the #754 Design Note From a Feature Branch

### DIFF
--- a/docs/issues/00754-engine-plane-compose-and-not-arm.md
+++ b/docs/issues/00754-engine-plane-compose-and-not-arm.md
@@ -1,0 +1,162 @@
+# Engine: Plane-Subtree Compose Leaf + General `Not(composable)` Arm
+
+**Status: proposed**, filed as [#754](https://github.com/jbylund/sylvan_librarian/issues/754). Found while auditing the broad-survey slow
+tail after the survey-driven compose chain landed (#746 set/watermark, #749 probe, #750 arith-tuple,
+#751 orderby-walk, #753 collection leaves). This is the natural next step in
+[#731](done/00731-engine-compose-universal-evaluator.md)'s leaf-source table: the two things that keep
+the current #1–#2 slowest survey queries (both `Not(Or(...))`) off the fast path. It is also a
+**consolidation** step — see "Consolidation" below — folding the per-leaf negation and null logic those
+earlier PRs each added locally into one general arm, rather than a sixth special case.
+
+## Measured problem
+
+Broad survey (`scripts/survey_queries.py --count 400 --wild 120 --seed 42`, 97,206-printing corpus,
+branch = composite of the five PRs above + main). The two slowest queries in the whole survey are now
+`Not(Or(...))` shapes, essentially unchanged from `main`:
+
+| query | unique/orderby | min ms | total |
+|---|---|---:|---:|
+| `border:black -(name:ancient or pow=5)` | artwork/rarity | 0.935 | 18,824 |
+| `id:gw -(color:gw or set:mom)` | printing/edhrec | 0.677 | 38,411 |
+
+The second is fully addressable here. The first is **not** (its inner `Or` contains `name:ancient`,
+text — see Scope). A broader family of `color`/`type` boolean combinations sits behind the same two
+gaps.
+
+## Where the cost is — two independent gaps
+
+1. **No general `Not(composable)` compose arm.** `is_printing_composable`
+   ([lib.rs:4636](../../card_engine/src/lib.rs#L4636)) has only *leaf-specific* `Not` arms — `-set:`
+   (:4651), `-type:`/`-kw:`/… (:4667), `-range` (:4692). A `Not` wrapping an `Or`/`And` falls through
+   to `_ => false` (:4695). So `-(color:gw or set:mom)` can't compose even though each concept is
+   individually expressible. `narrow_rec`'s `Not` arm is no help either: it requires a *tight* child
+   (`tight_narrow_space`), and an `Or` of mixed leaves isn't tight → it bails → full `GatheredScan`.
+
+2. **Color/identity/type aren't compose leaves at all** — even though they're already card-space
+   `BitPlanes` (#630, `indexes.planes`) with a compiler (`compile_plane`) and evaluator
+   (`eval_planes`) that `estimator.rs:257-259` already uses to turn a plane-expressible subtree into a
+   card-space bitmap. `set:mom` composes (#746); `color:gw` does not.
+
+## Proposed approach
+
+### 1. General null-guarded `Not(inner)` compose arm
+
+```
+Not(inner) if is_printing_composable(inner) && null_safe(inner)  =>  complement(compose(inner))
+```
+
+De Morgan in bitmap space: `Not(Or(a,b))` = `complement(bits(a) ∪ bits(b))`. The complement is a
+bitwise-NOT over `n_printings/64` words (~1,519 words, ~1.5µs) — cheap.
+
+### 2. Plane-subtree compose leaf
+
+For any plane-expressible subtree (`compile_plane(leaf, &indexes.planes, …)` returns `Some`):
+`eval_planes` → card-space bitmap → **`broadcast_card_bits_to_printings`**
+([lib.rs:4802](../../card_engine/src/lib.rs#L4802), the bitmap variant). One arm covers `color`,
+`id`/`identity`, `type:` card-types, devotion, and rarity **combinations** in a single broadcast — not
+one leaf at a time. Broadcast the **plane**, not postings: color has no `TagIndex` to begin with
+(u8 mask → transposed plane), so an id-list broadcast would first have to materialize a list from the
+plane bitmap — pointless. (Postings-backed fields — subtypes/keywords/set, from #753/#746 — keep their
+id-list broadcast; the primitive follows the source representation, neither is universally better.)
+
+### 3. `null_safe(inner)` predicate — the load-bearing correctness gate, and one source of truth
+
+Complement is exact **only** through a child that is both *tight* and *null-safe*. Recurses through
+`And`/`Or`; every leaf must be non-nullable (or known-mask-complemented):
+
+- **Safe (non-nullable):** `set_code`, `color`/`identity`/`type` (colorless/typeless = empty mask, a
+  real value — never NULL), collection containment (a collection is never NULL), `border`, `rarity`,
+  plane-backed `legality`.
+- **Not safe as bare complement:** `watermark` (nullable — already excluded from `-set`'s sibling arm
+  at :4649 for exactly this reason), and a range over a nullable date/year (needs the known-mask, per
+  [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md)).
+
+`null_safe` must be the **single source of truth** for this decision. Today the "is this complement
+sound?" judgment is scattered across the three leaf-specific `Not` arms as ad-hoc local guards
+(#748's `-watermark` exclusion, #741's date known-mask, #753's "collections are never NULL"). This PR
+centralizes all of it into `null_safe`, and the existing guards are re-expressed *through* it, not
+duplicated beside it — the same single-source-of-truth discipline `bare_range_bounds` /
+`is_arith_tuple_route` / `collection_compose_index` already follow.
+
+This is a **design-time** correctness check: a wrong `null_safe`/tightness claim returns wrong *rows*,
+not just slow ones, and only a differential test with a null-valued fixture catches it — no benchmark
+will. Mark any loose leaf loose and let it stay off the complement path; never complement a loose set
+(it would *exclude* real matches).
+
+## Consolidation — delete, don't layer
+
+This is not purely additive. #754 **supersedes** three per-leaf `Not` arms shipped incrementally:
+
+- #741 (merged): `-range` (`Not(NumericCmp/DateCmp/YearCmp)`, lib.rs:4692)
+- #748: `-set:` (`set_code_negated_leaf_bits`, lib.rs:4651)
+- #753: `-type:`/`-kw:`/`-collection` (lib.rs:4667)
+
+Each is `Not(exact leaf) → complement` hand-written per leaf — exactly the special cases the general
+arm in §1 generalizes. **The three arms must be deleted and replaced by the single general arm, not
+left beside it.** Layering the general arm on top would leave redundant, drifting dispatch. A
+differential test must confirm the negated forms those PRs measured (`-set:dmu`, `-type:goblin`,
+`-usd<c`) still return identical rows through the general path.
+
+Forward note (not required here, but the reason to resist a sixth ad-hoc case): the compose-leaf
+concept is now threaded through three parallel functions — `is_printing_composable` /
+`compose_printing_bits` / `compose_printing_estimate` — for every leaf kind (border, rarity, legality,
+range, set/watermark, collection, and now plane-subtree). #753 already introduced
+`collection_compose_index` as a shared table to stop those three from drifting. With a 7th kind, the
+trajectory points at [#731](done/00731-engine-compose-universal-evaluator.md)'s "universal evaluator":
+one leaf-source dispatch (a leaf → `(bitmap, exactness, null-mask)` contract) that the three functions
+become thin projections over. Do **not** add a 7th ad-hoc triple here if that small abstraction is in
+reach; if it isn't, at minimum route plane-subtree and `null_safe` through shared helpers so nothing is
+written twice.
+
+## Expected cost (sizing, not a promise)
+
+`id:gw -(color:gw or set:mom)`: `color:gw` and `set:mom` are both sparse. Build ≈ `eval_planes`
+(~sub-µs over ~492 card words) + `set:mom` scatter (tiny) + `broadcast_card_bits_to_printings` of
+`id:gw` (`id=gw` ≈ 1,534 printings × 1.5ns ≈ **2–3µs**, measured cardinality from
+`benchmarks/bitplanes/corpus.jsonl`) + complement (~1.5µs). The union is sparse, so its complement is
+near-total → **the best case** for #751's orderby-range-index walk. Projected: **~677µs → low tens of
+µs** (~20–30×). No new paging needed — the A-vs-B paging question was already resolved in #753 (the
+orderby walk wins for near-total; a linear-sweep alternative is redundant with `GatheredScan`).
+
+## Scope / non-goals
+
+- **`border:black -(name:ancient or pow=5)` (the #1 slowest) is out of scope.** `name:ancient` is text
+  → `compile_plane` returns `None` on the whole `Or` → it stays declined. Text composability is the
+  separate, harder text-search track (#734/#735/#736 already landed the regex/memmem half). `pow=5`
+  alone *could* become a broadcast leaf (card-space numeric via the #750 arith-tuple index +
+  `broadcast_card_ids_to_printings`, ~5µs for its 3,300 printings), but the `name:` leaf blocks this
+  query regardless, so defer it as a possible follow-on, not part of this work.
+- **Any mixed `Or` with a non-plane, non-postings (i.e. text) leaf** declines — `compile_plane`/
+  `is_printing_composable` return `None`/false. Expected; `is:permanent or oracle:destroy or …`
+  (survey #3) stays blocked on `oracle:`.
+- **`plane_expr_is_existential`** (estimator.rs:251) — verify it isn't a trap for the broadcast path
+  (planes are card-space, so it should be inert here) with a differential test, don't assume.
+
+## Acceptance
+
+- `id:gw -(color:gw or set:mom)` printing/edhrec: ~677µs → single-digit-to-low-tens-of-µs, `total`
+  parity (38,411) exact.
+- A `color`/`type`-`Or` family (e.g. `color:gw or type:goblin`, `-(type:instant or type:sorcery)`):
+  measurable improvement, `total` parity.
+- **Differential test** mirroring `collection_compose_leaves` / `orderby_walk_matches_gather_composed`:
+  the composed `Not(Or(...))` / plane-subtree path returns row-for-row identical results to the
+  `GatheredScan` reference, **including a fixture with a null-valued field** (empty color identity, a
+  no-watermark printing) to exercise the `null_safe` gate — both polarities.
+- **Regression guard for the consolidation:** the negated forms #741/#748/#753 measured (`-usd<c`,
+  `-set:dmu`, `-type:goblin`) must still return identical rows and stay fast through the new general
+  arm — proof the deleted per-leaf arms lost nothing.
+- **Controls that must stay declined and flat:** any `Or` containing a text leaf (falls to the general
+  path); `-watermark:` (stays non-composable); every already-fast query.
+- Broad survey re-run: 0 parity failures, the #2 query drops out of the tail, nothing regresses.
+
+## Related
+
+- [done/00731-engine-compose-universal-evaluator.md](done/00731-engine-compose-universal-evaluator.md)
+  — the parent leaf-source table this widens, and the consolidation target.
+- [00753-engine-collection-compose-leaves.md](done/00753-engine-collection-compose-leaves.md) and #746 — the
+  postings-broadcast primitive and the `-set`/`-collection` `Not`-arm precedents this generalizes and
+  supersedes.
+- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) — the
+  nullable-`Not` trap the `null_safe` gate must respect, and the third `Not` arm being folded in.
+- #630 (`BitPlanes`), `compile_plane`/`eval_planes` — the plane machinery being broadcast.
+- `docs/workflows/performance-pr-workflow.md` — the process this doc will follow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,11 @@ ignore = [
     "COM812", # trailing comma - enforced by ruff format
     "S311",   # random is fine for non-cryptographic use in this codebase
 ]
-per-file-ignores = {"**/tests/**/*.py" = ["ANN001", "ANN201", "ANN401", "ARG001", "D101", "D102", "D103", "PLR2004", "PT004", "PT006", "S101"], "conftest.py" = ["ANN001", "ANN201", "ANN401", "ARG001", "D101", "D102", "D103", "PLR2004", "PT004", "PT006", "S101"], "api_worker.py" = ["PLC0415"], "**/scripts/**/*.py" = ["T201", "S603", "S607", "PTH123"]}
+# The per-file entries for analyze_labels / art_distance / bench_search / fit_artwork_score /
+# fit_prefer_score / gen_labeller cover scripts rescued from an unmerged branch as-is: preserved
+# rather than reviewed, so their existing lint debt is scoped rather than fixed blind in code nobody
+# has read. Drop those entries when someone picks the work up properly.
+per-file-ignores = {"**/tests/**/*.py" = ["ANN001", "ANN201", "ANN401", "ARG001", "D101", "D102", "D103", "PLR2004", "PT004", "PT006", "S101"], "conftest.py" = ["ANN001", "ANN201", "ANN401", "ARG001", "D101", "D102", "D103", "PLR2004", "PT004", "PT006", "S101"], "api_worker.py" = ["PLC0415"], "**/scripts/**/*.py" = ["T201", "S603", "S607", "PTH123"], "**/scripts/analyze_labels.py" = ["D103", "PLR2004", "EXE001", "S108", "S310", "PLR0915", "ARG001"], "**/scripts/art_distance.py" = ["D103", "PLR2004", "EXE001", "S108", "S310", "PLR0915", "ARG001"], "**/scripts/bench_search.py" = ["D103", "PLR2004", "EXE001", "S108", "S310", "PLR0915", "ARG001"], "**/scripts/fit_artwork_score.py" = ["D103", "PLR2004", "EXE001", "S108", "S310", "PLR0915", "ARG001"], "**/scripts/fit_prefer_score.py" = ["D103", "PLR2004", "EXE001", "S108", "S310", "PLR0915", "ARG001"], "**/scripts/gen_labeller.py" = ["D103", "PLR2004", "EXE001", "S108", "S310", "PLR0915", "ARG001"]}
 
 
 [tool.ruff.lint.pydocstyle]

--- a/scripts/analyze_labels.py
+++ b/scripts/analyze_labels.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Score candidate artwork features against collected preference labels.
+
+Takes the JSONL exported by the labelling page (scripts/gen_labeller.py) and asks,
+for each candidate feature, how often it agrees with the human verdict. Rejoins the
+labelled scryfall_ids against magic.cards, so the labelling page never has to know
+or display any feature value.
+
+The headline question for `art-only` labels: **does reprint count predict artwork
+preference better than chance?** `illustration_count` is the only component of
+prefer_score that refers to the artwork at all, so if it does not predict these
+verdicts then the scoring function is effectively blind to artwork and needs a new
+feature rather than a re-weighting. See
+docs/issues/local-prefer-score-label-harness.md.
+
+Usage:
+    python scripts/analyze_labels.py ~/Downloads/prefer-score-labels.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+DB_CONTAINER = "sylvan_blue-postgres-1"
+DB_USER = "foouser"
+DB_NAME = "magic"
+
+# Two-sided binomial significance threshold for "better than a coin flip".
+ALPHA = 0.05
+
+# Features fetched per labelled printing. Each is a candidate predictor of which
+# artwork a human prefers; `prefer_score` is the current model's overall answer.
+FEATURE_SQL = """
+SELECT c.scryfall_id::text AS sid,
+       c.prefer_score,
+       (SELECT count(*) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL
+           AND o.card_name = c.card_name)                                AS reprints_same_name,
+       (SELECT count(DISTINCT o.card_set_code) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL) AS distinct_sets,
+       -- days since epoch, so it compares numerically like the other features
+       (SELECT min(o.released_at) - DATE '1970-01-01' FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL) AS art_first_seen
+FROM magic.cards c
+WHERE c.scryfall_id::text IN ({ids})
+"""
+
+# name -> (higher value means preferred?, human-readable hypothesis)
+CANDIDATES = {
+    "prefer_score": (True, "the current scoring function, overall"),
+    "reprints_same_name": (True, "more-reprinted art is preferred (today's illustration_count)"),
+    "distinct_sets": (True, "art appearing in more distinct sets is preferred"),
+    "art_first_seen": (False, "the ORIGINAL art is preferred (earlier first appearance)"),
+}
+
+
+def run_query(sql: str) -> list[dict[str, str]]:
+    proc = subprocess.run(
+        ["docker", "exec", "-i", DB_CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-v", "ON_ERROR_STOP=1", "--csv", "-f", "-"],
+        input=sql,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"psql failed:\n{proc.stderr}")
+    return list(csv.DictReader(io.StringIO(proc.stdout)))
+
+
+def binomial_two_sided_p(wins: int, n: int) -> float:
+    """Exact two-sided binomial test against p=0.5, no scipy dependency."""
+    if n == 0:
+        return 1.0
+    k = min(wins, n - wins)
+    tail = sum(math.comb(n, i) for i in range(k + 1)) / 2**n
+    return min(1.0, 2 * tail)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("labels", type=Path, help="JSONL exported from the labelling page")
+    args = ap.parse_args()
+
+    labels = [json.loads(line) for line in args.labels.read_text().splitlines() if line.strip()]
+    if not labels:
+        sys.exit("no labels in file")
+
+    decided = [x for x in labels if x["verdict"] in ("left", "right")]
+    other = len(labels) - len(decided)
+    print(f"{len(labels)} labels: {len(decided)} decided, {other} no-preference/can't-tell ({100 * other / len(labels):.0f}%)")
+    by_mode: dict[str, int] = {}
+    for x in labels:
+        by_mode[x["mode"]] = by_mode.get(x["mode"], 0) + 1
+    print(f"  by mode: {by_mode}")
+    if not decided:
+        sys.exit("\nNo decided labels yet — nothing to score.")
+
+    sids = {s for x in decided for s in (x["left_sid"], x["right_sid"])}
+    rows = run_query(FEATURE_SQL.format(ids=",".join(f"'{s}'" for s in sorted(sids))))
+    feats = {r["sid"]: r for r in rows}
+    missing = sids - feats.keys()
+    if missing:
+        print(f"  warning: {len(missing)} labelled printings not found in the DB (stale labels?)")
+
+    print(f"\nAgreement with {len(decided)} decided labels (chance = 50%):\n")
+    print(f"  {'feature':22s} {'agree':>7s} {'n':>5s} {'p':>8s}   hypothesis")
+    for name, (higher_is_better, hypothesis) in CANDIDATES.items():
+        agree = n = 0
+        for x in decided:
+            chosen, rejected = x["chosen_sid"], (x["right_sid"] if x["verdict"] == "left" else x["left_sid"])
+            if chosen not in feats or rejected not in feats:
+                continue
+            a, b = feats[chosen].get(name), feats[rejected].get(name)
+            if a in (None, "") or b in (None, ""):
+                continue
+            a, b = float(a), float(b)
+            if a == b:
+                continue  # feature cannot discriminate this pair; not a miss
+            n += 1
+            agree += (a > b) if higher_is_better else (a < b)
+        if n == 0:
+            print(f"  {name:22s} {'—':>7s} {0:5d} {'—':>8s}   {hypothesis} (never discriminates)")
+            continue
+        pct = 100 * agree / n
+        p = binomial_two_sided_p(agree, n)
+        flag = "  *" if p < ALPHA else ""
+        print(f"  {name:22s} {pct:6.1f}% {n:5d} {p:8.3f}{flag}   {hypothesis}")
+
+    print(
+        f"\n  * = differs from chance at p < {ALPHA}. Pairs where a feature ties are excluded from its"
+        "\n  own row, so `n` differs per feature — a feature that ties constantly is weak evidence"
+        "\n  even at high agreement."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/art_distance.py
+++ b/scripts/art_distance.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Perceptual distance between two printings' artwork, for filtering the label pool.
+
+Scryfall assigns distinct illustration_ids to printings whose art is the same
+composition with a recolour or effect treatment (observed: Arashin War Beast
+frf/123 vs ugin/123). Attribute-level filters cannot see that, so "art-only" pairs
+sometimes show what a human reads as one picture — a wasted click.
+
+The metric, deliberately the simple one: crop to the art window, convert to
+grayscale, blur by downscaling hard, normalise brightness, and take the mean
+absolute pixel difference. Small distance means "looks the same". Runs on `dwebp`
+plus the standard library — no image-library dependency.
+
+Two design notes that matter more than the algorithm choice:
+
+  * **Crop to the art before comparing.** Card frames carry the title, text box,
+    set symbol and collector line, all of which differ between printings of the
+    same art. Uncropped, that text dominates the distance and the filter inverts:
+    identical art in two different sets scores as "different".
+  * **Normalise brightness, and use grayscale.** The failure case this exists for
+    is a recolour of one composition, so colour and exposure differences are
+    exactly what should be ignored.
+
+Calibrate rather than guess the threshold: run --calibrate against a labelled
+JSONL and see where the "other" verdicts sit in the distance distribution.
+
+Usage:
+    python scripts/art_distance.py --pair frf/123 ugin/123
+    python scripts/art_distance.py --calibrate ~/Downloads/prefer-score-labels.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+CDN_BASE = "https://d1hot9ps2xugbc.cloudfront.net/img"
+# Smallest CDN size: enough for a blurred comparison and cheap to fetch in bulk.
+FETCH_WIDTH = 280
+
+# Fractional art window of a card face, as (left, top, right, bottom). Generous
+# and frame-agnostic: modern frames put art at roughly y 0.11-0.46 and older ones
+# slightly lower, so this covers the art in both while excluding the title bar,
+# the text box, and the collector line. Pairs always share a frame version (the
+# labelling pool holds it constant), so a single window is consistent within a pair.
+ART_BOX = (0.09, 0.12, 0.91, 0.46)
+
+# Downscale target after cropping. This IS the blur — 16x16 keeps composition and
+# discards brushwork, which is the level of detail the comparison should work at.
+GRID = 16
+
+# Mean absolute grayscale difference, 0-255, below which two arts are treated as
+# the same picture. Provisional until --calibrate says otherwise.
+SAME_ART_THRESHOLD = 12.0
+
+
+def fetch(set_code: str, collector: str, cache: Path) -> Path:
+    """Download one card face, cached by set/collector."""
+    dst = cache / f"{set_code}_{collector}.webp".replace("/", "_")
+    if not dst.exists():
+        # Collector numbers contain non-ASCII (e.g. "86★"), which urllib refuses to
+        # send raw; quote the path segments so those printings are not silently skipped.
+        url = f"{CDN_BASE}/{urllib.parse.quote(set_code)}/{urllib.parse.quote(collector)}/1/{FETCH_WIDTH}.webp"
+        try:
+            with urllib.request.urlopen(url, timeout=20) as r, dst.open("wb") as f:
+                f.write(r.read())
+        except Exception as exc:
+            msg = f"{url}: {exc}"
+            raise FileNotFoundError(msg) from exc
+    return dst
+
+
+def read_ppm(path: Path) -> tuple[int, int, bytes]:
+    """Parse a binary P6 PPM (what `dwebp -ppm` emits)."""
+    data = path.read_bytes()
+    fields: list[bytes] = []
+    i = 0
+    while len(fields) < 4:  # magic, width, height, maxval
+        while data[i : i + 1].isspace():
+            i += 1
+        if data[i : i + 1] == b"#":
+            i = data.index(b"\n", i) + 1
+            continue
+        j = i
+        while not data[j : j + 1].isspace():
+            j += 1
+        fields.append(data[i:j])
+        i = j
+    return int(fields[1]), int(fields[2]), data[i + 1 :]
+
+
+def fingerprint(webp: Path) -> list[float]:
+    """Cropped, grayscale, downscaled, brightness-normalised GRID x GRID cells."""
+    with tempfile.NamedTemporaryFile(suffix=".ppm", delete=False) as tmp:
+        ppm = Path(tmp.name)
+    try:
+        subprocess.run(["dwebp", "-quiet", "-ppm", "-o", str(ppm), str(webp)], check=True, capture_output=True)
+        w, h, px = read_ppm(ppm)
+    finally:
+        ppm.unlink(missing_ok=True)
+
+    x0, y0, x1, y1 = (int(ART_BOX[0] * w), int(ART_BOX[1] * h), int(ART_BOX[2] * w), int(ART_BOX[3] * h))
+    cw, ch = x1 - x0, y1 - y0
+    cells = []
+    for gy in range(GRID):
+        for gx in range(GRID):
+            # Average every pixel in this cell: downscaling as blur.
+            sx0, sx1 = x0 + cw * gx // GRID, x0 + cw * (gx + 1) // GRID
+            sy0, sy1 = y0 + ch * gy // GRID, y0 + ch * (gy + 1) // GRID
+            total = count = 0
+            for y in range(sy0, max(sy0 + 1, sy1)):
+                row = 3 * y * w
+                for x in range(sx0, max(sx0 + 1, sx1)):
+                    o = row + 3 * x
+                    # Rec. 601 luma; the recolour case should compare on structure.
+                    total += 0.299 * px[o] + 0.587 * px[o + 1] + 0.114 * px[o + 2]
+                    count += 1
+            cells.append(total / count)
+    # Brightness-normalise so an exposure or tint shift is not read as difference.
+    mean = sum(cells) / len(cells)
+    return [c - mean for c in cells]
+
+
+def distance(a: list[float], b: list[float]) -> float:
+    return sum(abs(x - y) for x, y in zip(a, b, strict=True)) / len(a)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--pair", nargs=2, metavar=("SET/CN", "SET/CN"), help="compare two printings")
+    g.add_argument(
+        "--calibrate", type=Path, metavar="LABELS.jsonl", help="score every labelled pair and show where 'other' verdicts sit"
+    )
+    ap.add_argument("--cache", type=Path, default=Path(tempfile.gettempdir()) / "art-cache")
+    args = ap.parse_args()
+    args.cache.mkdir(parents=True, exist_ok=True)
+
+    if args.pair:
+        fps = []
+        for spec in args.pair:
+            set_code, collector = spec.split("/", 1)
+            fps.append(fingerprint(fetch(set_code, collector, args.cache)))
+        d = distance(*fps)
+        verdict = "SAME art" if d < SAME_ART_THRESHOLD else "different art"
+        print(f"distance {d:.2f}  ->  {verdict}  (threshold {SAME_ART_THRESHOLD})")
+        return
+
+    # --calibrate: the labelled batch tells us where to put the threshold. Pairs the
+    # human called "other" are candidate near-duplicates; if they cluster at low
+    # distance, that low region is what the filter should exclude.
+    labels = [json.loads(x) for x in args.calibrate.read_text().splitlines() if x.strip()]
+    sids = sorted({s for d in labels for s in (d["left_sid"], d["right_sid"])})
+    sql = (
+        "SELECT scryfall_id::text AS sid, card_set_code || '/' || collector_number AS loc "
+        f"FROM magic.cards WHERE scryfall_id::text IN ({','.join(repr(s) for s in sids)})"
+    )
+    out = subprocess.run(
+        [
+            "docker",
+            "exec",
+            "-i",
+            "sylvan_blue-postgres-1",
+            "psql",
+            "-U",
+            "foouser",
+            "-d",
+            "magic",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-At",
+            "-F",
+            "\t",
+            "-f",
+            "-",
+        ],
+        input=sql,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    loc = dict(line.split("\t") for line in out.stdout.splitlines() if "\t" in line)
+
+    fps: dict[str, list[float]] = {}
+    rows = []
+    for i, lab in enumerate(labels, 1):
+        try:
+            for sid in (lab["left_sid"], lab["right_sid"]):
+                if sid not in fps:
+                    set_code, collector = loc[sid].split("/", 1)
+                    fps[sid] = fingerprint(fetch(set_code, collector, args.cache))
+            rows.append((distance(fps[lab["left_sid"]], fps[lab["right_sid"]]), lab["verdict"], lab["card"]))
+        except (FileNotFoundError, KeyError, subprocess.CalledProcessError) as exc:
+            print(f"  skip {lab['card']}: {exc}", file=sys.stderr)
+        if i % 25 == 0:
+            print(f"  ...{i}/{len(labels)}", file=sys.stderr)
+
+    decided = [d for d, v, _ in rows if v in ("left", "right")]
+    other = [d for d, v, _ in rows if v == "other"]
+    print(f"\n{len(rows)} pairs scored: {len(decided)} decided, {len(other)} 'other'\n")
+    print(f"  {'distance band':>16s} {'decided':>9s} {'other':>7s}  {'% other':>8s}")
+    bands = [(0, 4), (4, 8), (8, 12), (12, 16), (16, 24), (24, 1000)]
+    for lo, hi in bands:
+        nd = sum(1 for d in decided if lo <= d < hi)
+        no = sum(1 for d in other if lo <= d < hi)
+        pct = f"{100 * no / (nd + no):.0f}%" if nd + no else "—"
+        label = f"{lo}-{hi}" if hi < 1000 else f"{lo}+"
+        print(f"  {label:>16s} {nd:9d} {no:7d}  {pct:>8s}")
+    if decided:
+        print(f"\n  median distance, decided : {sorted(decided)[len(decided) // 2]:.1f}")
+    if other:
+        print(f"  median distance, 'other' : {sorted(other)[len(other) // 2]:.1f}")
+    print(
+        "\n  A filter is worth adding if 'other' concentrates in the low bands: those are\n"
+        "  pairs the labeller could not distinguish, and excluding them raises the yield\n"
+        "  of every future click. If 'other' is spread evenly, the high rate is genuine\n"
+        "  indifference between visibly different arts and no image filter will fix it."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_autocomplete.js
+++ b/scripts/bench_autocomplete.js
@@ -1,0 +1,594 @@
+#!/usr/bin/env node
+/**
+ * Benchmark: autoCompleteQuery filter+sort vs partitioned Map with early termination.
+ *
+ * Run with:  node scripts/bench_autocomplete.js
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Live fixture: fetched from https://sylvan-librarian.com/get_common_card_types
+// 381 types, alphabetically sorted by type_name.
+// ---------------------------------------------------------------------------
+
+const CARD_TYPES = [
+  { t: 'Adventure', n: 310 },
+  { t: 'Advisor', n: 406 },
+  { t: 'Aetherborn', n: 62 },
+  { t: 'Ajani', n: 59 },
+  { t: 'Alien', n: 99 },
+  { t: 'Ally', n: 398 },
+  { t: 'Aminatou', n: 7 },
+  { t: 'Angel', n: 1050 },
+  { t: 'Angrath', n: 11 },
+  { t: 'Antelope', n: 23 },
+  { t: 'Ape', n: 110 },
+  { t: 'Arcane', n: 184 },
+  { t: 'Archer', n: 275 },
+  { t: 'Archon', n: 76 },
+  { t: 'Arlinn', n: 19 },
+  { t: 'Artifact', n: 10947 },
+  { t: 'Artificer', n: 752 },
+  { t: 'Ashiok', n: 16 },
+  { t: 'Assassin', n: 392 },
+  { t: 'Assembly-Worker', n: 36 },
+  { t: 'Astartes', n: 46 },
+  { t: 'Atog', n: 24 },
+  { t: 'Aura', n: 3246 },
+  { t: 'Aurochs', n: 6 },
+  { t: 'Avatar', n: 571 },
+  { t: 'Azra', n: 16 },
+  { t: 'Background', n: 70 },
+  { t: 'Badger', n: 20 },
+  { t: 'Bahamut', n: 6 },
+  { t: 'Barbarian', n: 125 },
+  { t: 'Bard', n: 127 },
+  { t: 'Basic', n: 4196 },
+  { t: 'Basilisk', n: 40 },
+  { t: 'Basri', n: 7 },
+  { t: 'Bat', n: 98 },
+  { t: 'Bear', n: 147 },
+  { t: 'Beast', n: 1207 },
+  { t: 'Beholder', n: 16 },
+  { t: 'Berserker', n: 350 },
+  { t: 'Bird', n: 1042 },
+  { t: 'Bison', n: 8 },
+  { t: 'Boar', n: 135 },
+  { t: 'Bobblehead', n: 21 },
+  { t: 'Bolas', n: 30 },
+  { t: 'Book', n: 169 },
+  { t: 'Bringer', n: 6 },
+  { t: 'Brushwagg', n: 7 },
+  { t: 'Calix', n: 5 },
+  { t: 'Camel', n: 9 },
+  { t: 'Carrier', n: 22 },
+  { t: 'Cartouche', n: 13 },
+  { t: 'Case', n: 24 },
+  { t: 'Cat', n: 919 },
+  { t: 'Cave', n: 44 },
+  { t: 'Centaur', n: 148 },
+  { t: 'Chandra', n: 81 },
+  { t: 'Chimera', n: 39 },
+  { t: 'Citizen', n: 200 },
+  { t: 'Class', n: 69 },
+  { t: 'Cleric', n: 1572 },
+  { t: 'Clown', n: 6 },
+  { t: 'Clue', n: 42 },
+  { t: 'Cockatrice', n: 16 },
+  { t: 'Construct', n: 632 },
+  { t: 'Crab', n: 94 },
+  { t: 'Creature', n: 45967 },
+  { t: 'Crocodile', n: 60 },
+  { t: 'Curse', n: 102 },
+  { t: 'Cyberman', n: 16 },
+  { t: 'Cyclops', n: 69 },
+  { t: 'Dack', n: 6 },
+  { t: 'Dalek', n: 16 },
+  { t: 'Daretti', n: 13 },
+  { t: 'Dauthi', n: 25 },
+  { t: 'Davriel', n: 6 },
+  { t: 'Demigod', n: 37 },
+  { t: 'Demon', n: 684 },
+  { t: 'Desert', n: 103 },
+  { t: 'Detective', n: 181 },
+  { t: 'Devil', n: 148 },
+  { t: 'Dihada', n: 6 },
+  { t: 'Dinosaur', n: 623 },
+  { t: 'Djinn', n: 179 },
+  { t: 'Doctor', n: 120 },
+  { t: 'Dog', n: 315 },
+  { t: 'Domri', n: 15 },
+  { t: 'Dovin', n: 10 },
+  { t: 'Dragon', n: 1499 },
+  { t: 'Drake', n: 249 },
+  { t: 'Dreadnought', n: 7 },
+  { t: 'Drix', n: 5 },
+  { t: 'Drone', n: 111 },
+  { t: 'Druid', n: 1140 },
+  { t: 'Dryad', n: 158 },
+  { t: 'Dwarf', n: 309 },
+  { t: 'Efreet', n: 74 },
+  { t: 'Egg', n: 28 },
+  { t: 'Elder', n: 277 },
+  { t: 'Eldrazi', n: 473 },
+  { t: 'Elemental', n: 1772 },
+  { t: 'Elephant', n: 197 },
+  { t: 'Elf', n: 2096 },
+  { t: 'Elk', n: 102 },
+  { t: 'Ellywick', n: 5 },
+  { t: 'Elspeth', n: 42 },
+  { t: 'Enchantment', n: 9913 },
+  { t: 'Equipment', n: 1644 },
+  { t: 'Eternal', n: 5 },
+  { t: 'Eye', n: 23 },
+  { t: 'Faerie', n: 420 },
+  { t: 'Fish', n: 124 },
+  { t: 'Flagbearer', n: 5 },
+  { t: 'Food', n: 33 },
+  { t: 'Forest', n: 1180 },
+  { t: 'Fox', n: 105 },
+  { t: 'Fractal', n: 11 },
+  { t: 'Freyalise', n: 8 },
+  { t: 'Frog', n: 181 },
+  { t: 'Fungus', n: 188 },
+  { t: 'Gamma', n: 32 },
+  { t: 'Gargoyle', n: 83 },
+  { t: 'Garruk', n: 37 },
+  { t: 'Gate', n: 180 },
+  { t: 'Giant', n: 629 },
+  { t: 'Gideon', n: 34 },
+  { t: 'Gith', n: 5 },
+  { t: 'Glimmer', n: 35 },
+  { t: 'Gnome', n: 65 },
+  { t: 'Goat', n: 27 },
+  { t: 'Goblin', n: 1506 },
+  { t: 'God', n: 277 },
+  { t: 'Golem', n: 434 },
+  { t: 'Gorgon', n: 51 },
+  { t: 'Gremlin', n: 26 },
+  { t: 'Griffin', n: 101 },
+  { t: 'Grist', n: 12 },
+  { t: 'Hag', n: 16 },
+  { t: 'Halfling', n: 162 },
+  { t: 'Harpy', n: 20 },
+  { t: 'Hellion', n: 45 },
+  { t: 'Hero', n: 491 },
+  { t: 'Hippo', n: 21 },
+  { t: 'Hippogriff', n: 17 },
+  { t: 'Homarid', n: 16 },
+  { t: 'Homunculus', n: 72 },
+  { t: 'Horror', n: 934 },
+  { t: 'Horse', n: 142 },
+  { t: 'Huatli', n: 11 },
+  { t: 'Human', n: 10567 },
+  { t: 'Hydra', n: 234 },
+  { t: 'Hyena', n: 7 },
+  { t: 'Illusion', n: 258 },
+  { t: 'Imp', n: 131 },
+  { t: 'Incarnation', n: 150 },
+  { t: 'Infinity', n: 7 },
+  { t: 'Inhuman', n: 12 },
+  { t: 'Inquisitor', n: 6 },
+  { t: 'Insect', n: 608 },
+  { t: 'Instant', n: 10724 },
+  { t: 'Island', n: 1127 },
+  { t: 'Jace', n: 76 },
+  { t: 'Jackal', n: 55 },
+  { t: 'Jaya', n: 15 },
+  { t: 'Jellyfish', n: 74 },
+  { t: 'Juggernaut', n: 68 },
+  { t: 'Kaito', n: 24 },
+  { t: 'Karn', n: 29 },
+  { t: 'Kasmina', n: 11 },
+  { t: 'Kavu', n: 111 },
+  { t: 'Kaya', n: 34 },
+  { t: 'Kindred', n: 183 },
+  { t: 'Kiora', n: 11 },
+  { t: 'Kirin', n: 23 },
+  { t: 'Kithkin', n: 156 },
+  { t: 'Knight', n: 1329 },
+  { t: 'Kobold', n: 26 },
+  { t: 'Kor', n: 207 },
+  { t: 'Koth', n: 9 },
+  { t: 'Kraken', n: 118 },
+  { t: 'Kree', n: 14 },
+  { t: 'Lair', n: 12 },
+  { t: 'Lamia', n: 7 },
+  { t: 'Land', n: 11551 },
+  { t: 'Leech', n: 32 },
+  { t: 'Legendary', n: 13532 },
+  { t: 'Lemur', n: 7 },
+  { t: 'Lesson', n: 120 },
+  { t: 'Leviathan', n: 92 },
+  { t: 'Lhurgoyf', n: 67 },
+  { t: 'Licid', n: 14 },
+  { t: 'Liliana', n: 84 },
+  { t: 'Lizard', n: 339 },
+  { t: 'Locus', n: 8 },
+  { t: 'Lolth', n: 6 },
+  { t: 'Lord', n: 168 },
+  { t: 'Lukka', n: 17 },
+  { t: 'Manticore', n: 22 },
+  { t: 'Masticore', n: 22 },
+  { t: 'Mercenary', n: 195 },
+  { t: 'Merfolk', n: 796 },
+  { t: 'Metathran', n: 14 },
+  { t: 'Mine', n: 26 },
+  { t: 'Minion', n: 112 },
+  { t: 'Minotaur', n: 210 },
+  { t: 'Minsc', n: 7 },
+  { t: 'Mite', n: 7 },
+  { t: 'Mole', n: 21 },
+  { t: 'Monger', n: 7 },
+  { t: 'Mongoose', n: 8 },
+  { t: 'Monk', n: 364 },
+  { t: 'Monkey', n: 40 },
+  { t: 'Moogle', n: 16 },
+  { t: 'Moonfolk', n: 54 },
+  { t: 'Mordenkainen', n: 5 },
+  { t: 'Mount', n: 68 },
+  { t: 'Mountain', n: 1139 },
+  { t: 'Mouse', n: 45 },
+  { t: 'Mutant', n: 464 },
+  { t: 'Myr', n: 127 },
+  { t: 'Mystic', n: 11 },
+  { t: 'Nahiri', n: 27 },
+  { t: 'Narset', n: 18 },
+  { t: 'Necron', n: 48 },
+  { t: 'Nephilim', n: 10 },
+  { t: 'Nightmare', n: 239 },
+  { t: 'Nightstalker', n: 22 },
+  { t: 'Ninja', n: 317 },
+  { t: 'Nissa', n: 50 },
+  { t: 'Nixilis', n: 25 },
+  { t: 'Noble', n: 584 },
+  { t: 'Noggle', n: 9 },
+  { t: 'Nomad', n: 70 },
+  { t: 'Nymph', n: 58 },
+  { t: 'Octopus', n: 100 },
+  { t: 'Ogre', n: 284 },
+  { t: 'Oko', n: 15 },
+  { t: 'Omen', n: 32 },
+  { t: 'Ooze', n: 188 },
+  { t: 'Orc', n: 269 },
+  { t: 'Orgg', n: 10 },
+  { t: 'Otter', n: 51 },
+  { t: 'Ouphe', n: 35 },
+  { t: 'Ox', n: 55 },
+  { t: 'Pangolin', n: 7 },
+  { t: 'Peasant', n: 88 },
+  { t: 'Pegasus', n: 73 },
+  { t: 'Performer', n: 17 },
+  { t: 'Pest', n: 11 },
+  { t: 'Phelddagrif', n: 6 },
+  { t: 'Phoenix', n: 105 },
+  { t: 'Phyrexian', n: 1234 },
+  { t: 'Pilot', n: 91 },
+  { t: 'Pirate', n: 456 },
+  { t: 'Plains', n: 1109 },
+  { t: 'Plan', n: 12 },
+  { t: 'Planeswalker', n: 1379 },
+  { t: 'Planet', n: 25 },
+  { t: 'Plant', n: 238 },
+  { t: 'Possum', n: 6 },
+  { t: 'Power-Plant', n: 26 },
+  { t: 'Praetor', n: 101 },
+  { t: 'Processor', n: 16 },
+  { t: 'Quintorius', n: 6 },
+  { t: 'Rabbit', n: 78 },
+  { t: 'Raccoon', n: 39 },
+  { t: 'Ral', n: 28 },
+  { t: 'Ranger', n: 176 },
+  { t: 'Rat', n: 337 },
+  { t: 'Rebel', n: 161 },
+  { t: 'Rhino', n: 135 },
+  { t: 'Robot', n: 198 },
+  { t: 'Rogue', n: 1367 },
+  { t: 'Room', n: 59 },
+  { t: 'Rowan', n: 12 },
+  { t: 'Rune', n: 5 },
+  { t: 'Saga', n: 439 },
+  { t: 'Saheeli', n: 18 },
+  { t: 'Salamander', n: 37 },
+  { t: 'Samurai', n: 153 },
+  { t: 'Samut', n: 7 },
+  { t: 'Sarkhan', n: 23 },
+  { t: 'Satyr', n: 70 },
+  { t: 'Scarecrow', n: 81 },
+  { t: 'Scientist', n: 123 },
+  { t: 'Scorpion', n: 39 },
+  { t: 'Scout', n: 675 },
+  { t: 'Seal', n: 5 },
+  { t: 'Serpent', n: 146 },
+  { t: 'Shade', n: 84 },
+  { t: 'Shaman', n: 1420 },
+  { t: 'Shapeshifter', n: 486 },
+  { t: 'Shark', n: 45 },
+  { t: 'Sheep', n: 15 },
+  { t: 'Shrine', n: 35 },
+  { t: 'Siren', n: 46 },
+  { t: 'Skeleton', n: 245 },
+  { t: 'Skrull', n: 5 },
+  { t: 'Slith', n: 17 },
+  { t: 'Sliver', n: 328 },
+  { t: 'Sloth', n: 13 },
+  { t: 'Slug', n: 22 },
+  { t: 'Snake', n: 481 },
+  { t: 'Snow', n: 262 },
+  { t: 'Soldier', n: 2327 },
+  { t: 'Soltari', n: 22 },
+  { t: 'Sorcerer', n: 127 },
+  { t: 'Sorcery', n: 10624 },
+  { t: 'Sorin', n: 38 },
+  { t: 'Spacecraft', n: 58 },
+  { t: 'Specter', n: 92 },
+  { t: 'Spellshaper', n: 94 },
+  { t: 'Sphere', n: 23 },
+  { t: 'Sphinx', n: 258 },
+  { t: 'Spider', n: 376 },
+  { t: 'Spike', n: 24 },
+  { t: 'Spirit', n: 1694 },
+  { t: 'Spy', n: 30 },
+  { t: 'Squid', n: 20 },
+  { t: 'Squirrel', n: 75 },
+  { t: 'Starfish', n: 11 },
+  { t: 'Stone', n: 7 },
+  { t: 'Surrakar', n: 8 },
+  { t: 'Survivor', n: 29 },
+  { t: 'Swamp', n: 1129 },
+  { t: 'Symbiote', n: 30 },
+  { t: 'Synth', n: 14 },
+  { t: 'Tamiyo', n: 27 },
+  { t: 'Teferi', n: 46 },
+  { t: 'Teyo', n: 7 },
+  { t: 'Tezzeret', n: 30 },
+  { t: 'Thalakos', n: 7 },
+  { t: 'Thopter', n: 91 },
+  { t: 'Thrull', n: 60 },
+  { t: 'Tibalt', n: 14 },
+  { t: 'Tiefling', n: 35 },
+  { t: 'Time', n: 168 },
+  { t: 'Tower', n: 26 },
+  { t: 'Town', n: 20 },
+  { t: 'Toy', n: 24 },
+  { t: 'Trap', n: 43 },
+  { t: 'Treasure', n: 12 },
+  { t: 'Treefolk', n: 279 },
+  { t: 'Trilobite', n: 7 },
+  { t: 'Troll', n: 147 },
+  { t: 'Turtle', n: 213 },
+  { t: 'Tyranid', n: 76 },
+  { t: 'Tyvar', n: 11 },
+  { t: 'Ugin', n: 24 },
+  { t: 'Unicorn', n: 97 },
+  { t: "Urza'S", n: 95 },
+  { t: 'Utrom', n: 13 },
+  { t: 'Vampire', n: 1301 },
+  { t: 'Vedalken', n: 175 },
+  { t: 'Vehicle', n: 500 },
+  { t: 'Villain', n: 321 },
+  { t: 'Vivien', n: 31 },
+  { t: 'Volver', n: 6 },
+  { t: 'Vraska', n: 28 },
+  { t: 'Wall', n: 514 },
+  { t: 'Warlock', n: 430 },
+  { t: 'Warrior', n: 2907 },
+  { t: 'Weasel', n: 5 },
+  { t: 'Weird', n: 31 },
+  { t: 'Werewolf', n: 189 },
+  { t: 'Whale', n: 34 },
+  { t: 'Will', n: 14 },
+  { t: 'Wizard', n: 3107 },
+  { t: 'Wolf', n: 220 },
+  { t: 'Wolverine', n: 14 },
+  { t: 'Wombat', n: 5 },
+  { t: 'World', n: 42 },
+  { t: 'Worm', n: 26 },
+  { t: 'Wraith', n: 79 },
+  { t: 'Wrenn', n: 18 },
+  { t: 'Wurm', n: 290 },
+  { t: 'Yanggu', n: 7 },
+  { t: 'Yanling', n: 6 },
+  { t: 'Yeti', n: 29 },
+  { t: 'Zariel', n: 5 },
+  { t: 'Zombie', n: 1649 },
+  { t: 'Zubera', n: 7 },
+];
+
+// ---------------------------------------------------------------------------
+// Old implementation: filter + sort on every call
+// ---------------------------------------------------------------------------
+
+function filterSortMatch(types, prefix) {
+  return types.filter(type => type.t.toLowerCase().startsWith(prefix)).sort((a, b) => b.n - a.n)[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// New implementation: build once, look up in O(1) + early-termination scan
+// ---------------------------------------------------------------------------
+
+function buildTypeMap(types) {
+  const map = new Map();
+  for (const type of types) {
+    const tl = type.t.toLowerCase();
+    const letter = tl[0];
+    if (!map.has(letter)) map.set(letter, []);
+    map.get(letter).push({ n: type.n, tl });
+  }
+  for (const bucket of map.values()) {
+    bucket.sort((a, b) => a.tl.localeCompare(b.tl));
+  }
+  return map;
+}
+
+function buildTypeMapOld(types) {
+  const map = new Map();
+  for (const type of types) {
+    const letter = type.t[0].toLowerCase();
+    if (!map.has(letter)) map.set(letter, []);
+    map.get(letter).push(type);
+  }
+  for (const bucket of map.values()) {
+    bucket.sort((a, b) => a.t.toLowerCase().localeCompare(b.t.toLowerCase()));
+  }
+  return map;
+}
+
+function findBestMatch(typeMap, prefix) {
+  const p = prefix.toLowerCase();
+  const bucket = typeMap.get(p[0]) ?? [];
+  let bestMatch = null;
+  for (const type of bucket) {
+    if (type.tl.slice(0, p.length) > p) break;
+    if (type.tl.startsWith(p)) {
+      if (!bestMatch || type.n > bestMatch.n) bestMatch = type;
+    }
+  }
+  return bestMatch;
+}
+
+function findBestMatchOld(typeMap, prefix) {
+  const bucket = typeMap.get(prefix[0]) ?? [];
+  let bestMatch = null;
+  for (const type of bucket) {
+    const typeLower = type.t.toLowerCase();
+    if (typeLower.slice(0, prefix.length) > prefix) break;
+    if (typeLower.startsWith(prefix)) {
+      if (!bestMatch || type.n > bestMatch.n) bestMatch = type;
+    }
+  }
+  return bestMatch;
+}
+
+// ---------------------------------------------------------------------------
+// Representative prefixes (24, matching the scenario from the issue doc)
+// Covers short/long, small/large buckets, matches and no-matches.
+// ---------------------------------------------------------------------------
+
+const PREFIXES = [
+  // Large-bucket 's' entries (bucket has 51 types)
+  'sh',
+  'sk',
+  'sl',
+  'sn',
+  'so',
+  'sp',
+  'sq',
+  'st',
+  // Common short prefixes with multiple matches
+  'dr',
+  'cr',
+  'wa',
+  'wi',
+  // Single-match prefixes
+  'hy',
+  'zu',
+  'qu',
+  // Long prefixes (should terminate early)
+  'shapeshifter',
+  'planeswalker',
+  'legendary',
+  // Exact full names
+  'zombie',
+  'dragon',
+  'wizard',
+  // No-match prefixes (whole scan of bucket, no result)
+  'zz',
+  'xx',
+  'jj',
+];
+
+// ---------------------------------------------------------------------------
+// Correctness check
+// ---------------------------------------------------------------------------
+
+const typeMap = buildTypeMap(CARD_TYPES);
+const typeMapOld = buildTypeMapOld(CARD_TYPES);
+
+let allMatch = true;
+for (const prefix of PREFIXES) {
+  const expected = filterSortMatch(CARD_TYPES, prefix);
+  for (const [label, fn, map] of [
+    ['map+precomputed', findBestMatch, typeMap],
+    ['map+old', findBestMatchOld, typeMapOld],
+  ]) {
+    const actual = fn(map, prefix);
+    const actualTl = actual === null ? null : (actual.tl ?? actual.t.toLowerCase());
+    const expectedTl = expected === null ? null : expected.t.toLowerCase();
+    const match = actualTl === expectedTl;
+    if (!match) {
+      console.error(
+        `MISMATCH [${label}] for "${prefix}": filter+sort=${JSON.stringify(expected?.t)} got=${JSON.stringify(actual?.t)}`
+      );
+      allMatch = false;
+    }
+  }
+}
+if (allMatch) {
+  console.log('✓  All three implementations produce identical results for all prefixes.\n');
+} else {
+  console.log('✗  Output mismatch — see above.\n');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark harness
+// ---------------------------------------------------------------------------
+
+function bench(label, fn, iterations) {
+  // Warm up
+  for (let i = 0; i < 1000; i++) fn(PREFIXES[i % PREFIXES.length]);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    fn(PREFIXES[i % PREFIXES.length]);
+  }
+  const elapsed = performance.now() - start;
+  const usPerCall = (elapsed * 1000) / iterations;
+  return { label, elapsed, usPerCall };
+}
+
+const ITERS = 100_000;
+
+console.log(
+  `Dataset: ${CARD_TYPES.length} types, ${PREFIXES.length} prefixes, ${ITERS.toLocaleString()} iterations each\n`
+);
+
+const results = [
+  bench('filter+sort', prefix => filterSortMatch(CARD_TYPES, prefix), ITERS),
+  bench('map (per-call tl)', prefix => findBestMatchOld(typeMapOld, prefix), ITERS),
+  bench('map (precomp tl)', prefix => findBestMatch(typeMap, prefix), ITERS),
+];
+
+const baseline = results[0].usPerCall;
+const col1 = 20;
+const col2 = 12;
+const col3 = 15;
+const col4 = 10;
+
+const header = `${'Approach'.padEnd(col1)} ${'Total (ms)'.padStart(col2)} ${'Per call (µs)'.padStart(col3)} ${'vs baseline'.padStart(col4)}`;
+const sep = '-'.repeat(header.length);
+console.log(header);
+console.log(sep);
+for (const r of results) {
+  const speedup = r === results[0] ? '—' : `${(baseline / r.usPerCall).toFixed(1)}×`;
+  console.log(
+    `${r.label.padEnd(col1)} ${r.elapsed.toFixed(1).padStart(col2)} ${r.usPerCall.toFixed(2).padStart(col3)} ${speedup.padStart(col4)}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-bucket stats
+// ---------------------------------------------------------------------------
+
+console.log('\nBucket sizes (first character → entry count):');
+const bucketSizes = [...typeMap.entries()]
+  .map(([ch, bucket]) => ({ ch, size: bucket.length }))
+  .sort((a, b) => b.size - a.size);
+for (const { ch, size } of bucketSizes) {
+  const bar = '█'.repeat(Math.round(size / 2));
+  console.log(`  ${ch}  ${String(size).padStart(3)}  ${bar}`);
+}
+const avg = CARD_TYPES.length / typeMap.size;
+console.log(`\n  Total: ${CARD_TYPES.length} types across ${typeMap.size} buckets (avg ${avg.toFixed(1)} per bucket)`);

--- a/scripts/bench_catalog_map.js
+++ b/scripts/bench_catalog_map.js
@@ -1,0 +1,1172 @@
+#!/usr/bin/env node
+/**
+ * Benchmark: CatalogMap (bucket scan) vs FanoutCatalogMap (prefix trie + binary search).
+ *
+ * Run with:  node --expose-gc scripts/bench_catalog_map.js
+ * (--expose-gc enables accurate heap measurements; omit to skip memory section)
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Implementations (copied from api/static/app.js — browser file, not a module)
+// ---------------------------------------------------------------------------
+
+class CatalogMap {
+  constructor(mapping) {
+    this._map = new Map();
+    for (const [v, n] of Object.entries(mapping)) {
+      const letter = v[0].toLowerCase();
+      if (!this._map.has(letter)) this._map.set(letter, []);
+      this._map.get(letter).push({ v, n });
+    }
+    for (const bucket of this._map.values()) {
+      bucket.sort((a, b) => a.v.localeCompare(b.v));
+    }
+  }
+
+  get bool() {
+    return this._map.size > 0;
+  }
+  get size() {
+    let n = 0;
+    for (const b of this._map.values()) n += b.length;
+    return n;
+  }
+
+  getBestMatch(prefix) {
+    const bucket = this._map.get(prefix[0]) ?? [];
+    let best = null;
+    for (const entry of bucket) {
+      const lower = entry.v.toLowerCase();
+      if (lower.slice(0, prefix.length) > prefix) break;
+      if (lower.startsWith(prefix) && (!best || entry.n > best.n)) best = entry;
+    }
+    return best?.v ?? null;
+  }
+}
+
+class FanoutCatalogMap {
+  constructor(mapping) {
+    this._words = Object.entries(mapping)
+      .map(([v, n]) => ({ v, n, lower: v.toLowerCase() }))
+      .sort((a, b) => a.lower.localeCompare(b.lower));
+
+    this._d1 = {};
+    this._d2 = {};
+
+    const words = this._words;
+    let i = 0;
+    while (i < words.length) {
+      const c1 = words[i].lower[0];
+      const d1start = i;
+      while (i < words.length && words[i].lower[0] === c1) i++;
+      const d1end = i;
+      this._d1[c1] = { start: d1start, end: d1end, best: this._bestInRange(d1start, d1end) };
+
+      let j = d1start;
+      while (j < d1end) {
+        const c2 = words[j].lower[1] ?? '';
+        const key = c1 + c2;
+        const d2start = j;
+        while (j < d1end && (words[j].lower[1] ?? '') === c2) j++;
+        const d2end = j;
+        this._d2[key] = { start: d2start, end: d2end, best: this._bestInRange(d2start, d2end) };
+      }
+    }
+  }
+
+  _bestInRange(start, end) {
+    let best = null;
+    for (let i = start; i < end; i++) {
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+
+  _lowerBound(prefix, start, end) {
+    let lo = start,
+      hi = end;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this._words[mid].lower < prefix) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  get bool() {
+    return this._words.length > 0;
+  }
+  get size() {
+    return this._words.length;
+  }
+
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    const c1 = prefix[0];
+    const node1 = this._d1[c1];
+    if (!node1) return null;
+    if (prefix.length === 1) return node1.best;
+
+    const key = prefix.slice(0, 2);
+    const node2 = this._d2[key];
+    if (!node2) return null;
+    if (prefix.length === 2) return node2.best;
+
+    const { start, end } = node2;
+    const pos = this._lowerBound(prefix, start, end);
+    let best = null;
+    for (let i = pos; i < end; i++) {
+      if (!this._words[i].lower.startsWith(prefix)) break;
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+}
+
+class FlatSortedMap {
+  constructor(mapping) {
+    this._words = Object.entries(mapping)
+      .map(([v, n]) => ({ v, n, lower: v.toLowerCase() }))
+      .sort((a, b) => a.lower.localeCompare(b.lower));
+  }
+
+  get bool() {
+    return this._words.length > 0;
+  }
+  get size() {
+    return this._words.length;
+  }
+
+  _lowerBound(prefix) {
+    let lo = 0,
+      hi = this._words.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this._words[mid].lower < prefix) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    const pos = this._lowerBound(prefix);
+    let best = null;
+    for (let i = pos; i < this._words.length; i++) {
+      if (!this._words[i].lower.startsWith(prefix)) break;
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+}
+
+// ci(str, pos) — returns char index 0-25 for a-z, or -1 for anything else.
+function ci(str, pos) {
+  if (pos >= str.length) return -1;
+  const c = str.charCodeAt(pos) - 97;
+  return c >= 0 && c < 26 ? c : -1;
+}
+
+const A = 26;
+const A2 = 26 * 26; //    676
+const A3 = 26 * 26 * 26; // 17,576
+
+class FanoutD2Array {
+  constructor(mapping) {
+    this._words = Object.entries(mapping)
+      .map(([v, n]) => ({ v, n, lower: v.toLowerCase() }))
+      .sort((a, b) => a.lower.localeCompare(b.lower));
+
+    this._d1s = new Int32Array(A).fill(-1);
+    this._d1e = new Int32Array(A).fill(-1);
+    this._d1b = new Array(A).fill(null);
+    this._d2s = new Int32Array(A2).fill(-1);
+    this._d2e = new Int32Array(A2).fill(-1);
+    this._d2b = new Array(A2).fill(null);
+
+    const words = this._words;
+    let i = 0;
+    while (i < words.length) {
+      const i1 = ci(words[i].lower, 0);
+      if (i1 < 0) {
+        i++;
+        continue;
+      }
+      const d1s = i;
+      while (i < words.length && ci(words[i].lower, 0) === i1) i++;
+      const d1e = i;
+      this._d1s[i1] = d1s;
+      this._d1e[i1] = d1e;
+      this._d1b[i1] = this._bestInRange(d1s, d1e);
+
+      let j = d1s;
+      while (j < d1e) {
+        const i2 = ci(words[j].lower, 1);
+        if (i2 < 0) {
+          j++;
+          continue;
+        }
+        const d2idx = i1 * A + i2;
+        const d2s = j;
+        while (j < d1e && ci(words[j].lower, 1) === i2) j++;
+        const d2e = j;
+        this._d2s[d2idx] = d2s;
+        this._d2e[d2idx] = d2e;
+        this._d2b[d2idx] = this._bestInRange(d2s, d2e);
+      }
+    }
+  }
+
+  _bestInRange(start, end) {
+    let best = null;
+    for (let i = start; i < end; i++) {
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+
+  _lowerBound(prefix, start, end) {
+    let lo = start,
+      hi = end;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this._words[mid].lower < prefix) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  get bool() {
+    return this._words.length > 0;
+  }
+  get size() {
+    return this._words.length;
+  }
+
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    const i1 = ci(prefix, 0);
+    if (i1 < 0 || this._d1s[i1] < 0) return null;
+    if (prefix.length === 1) return this._d1b[i1];
+
+    const i2 = ci(prefix, 1);
+    if (i2 < 0) return null;
+    const d2idx = i1 * A + i2;
+    if (this._d2s[d2idx] < 0) return null;
+    if (prefix.length === 2) return this._d2b[d2idx];
+
+    const start = this._d2s[d2idx],
+      end = this._d2e[d2idx];
+    const pos = this._lowerBound(prefix, start, end);
+    let best = null;
+    for (let i = pos; i < end; i++) {
+      if (!this._words[i].lower.startsWith(prefix)) break;
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+}
+
+class FanoutD3Array extends FanoutD2Array {
+  constructor(mapping) {
+    super(mapping);
+    this._d3s = new Int32Array(A3).fill(-1);
+    this._d3e = new Int32Array(A3).fill(-1);
+    this._d3b = new Array(A3).fill(null);
+
+    const words = this._words;
+    for (let i1 = 0; i1 < A; i1++) {
+      for (let i2 = 0; i2 < A; i2++) {
+        const d2idx = i1 * A + i2;
+        const d2s = this._d2s[d2idx];
+        if (d2s < 0) continue;
+        const d2e = this._d2e[d2idx];
+        let j = d2s;
+        while (j < d2e) {
+          const i3 = ci(words[j].lower, 2);
+          if (i3 < 0) {
+            j++;
+            continue;
+          }
+          const d3idx = i1 * A2 + i2 * A + i3;
+          const d3s = j;
+          while (j < d2e && ci(words[j].lower, 2) === i3) j++;
+          const d3e = j;
+          this._d3s[d3idx] = d3s;
+          this._d3e[d3idx] = d3e;
+          this._d3b[d3idx] = this._bestInRange(d3s, d3e);
+        }
+      }
+    }
+  }
+
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    const i1 = ci(prefix, 0);
+    if (i1 < 0 || this._d1s[i1] < 0) return null;
+    if (prefix.length === 1) return this._d1b[i1];
+
+    const i2 = ci(prefix, 1);
+    if (i2 < 0) return null;
+    const d2idx = i1 * A + i2;
+    if (this._d2s[d2idx] < 0) return null;
+    if (prefix.length === 2) return this._d2b[d2idx];
+
+    const i3 = ci(prefix, 2);
+    if (i3 < 0) return null;
+    const d3idx = i1 * A2 + i2 * A + i3;
+    if (this._d3s[d3idx] < 0) return null;
+    if (prefix.length === 3) return this._d3b[d3idx];
+
+    const start = this._d3s[d3idx],
+      end = this._d3e[d3idx];
+    const pos = this._lowerBound(prefix, start, end);
+    let best = null;
+    for (let i = pos; i < end; i++) {
+      if (!this._words[i].lower.startsWith(prefix)) break;
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+}
+
+class SparseTrieD3 {
+  constructor(mapping) {
+    this._words = Object.entries(mapping)
+      .map(([v, n]) => ({ v, n, lower: v.toLowerCase() }))
+      .sort((a, b) => a.lower.localeCompare(b.lower));
+
+    // Sparse object trie: only allocates nodes that exist in the data.
+    // Each node stores just the best word string — no start/end indices.
+    // Sort by frequency descending so first-write-wins gives the best word.
+    this._d1 = {};
+    this._d2 = {};
+    this._d3 = {};
+    const byFreq = [...this._words].sort((a, b) => b.n - a.n);
+    for (const w of byFreq) {
+      const l = w.lower;
+      if (l.length >= 1 && !(l[0] in this._d1)) this._d1[l[0]] = w.v;
+      if (l.length >= 2 && !(l[0] + l[1] in this._d2)) this._d2[l[0] + l[1]] = w.v;
+      if (l.length >= 3 && !(l[0] + l[1] + l[2] in this._d3)) this._d3[l[0] + l[1] + l[2]] = w.v;
+    }
+  }
+
+  _lowerBound(prefix) {
+    let lo = 0,
+      hi = this._words.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this._words[mid].lower < prefix) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  get bool() {
+    return this._words.length > 0;
+  }
+  get size() {
+    return this._words.length;
+  }
+
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    if (prefix.length === 1) return this._d1[prefix] ?? null;
+    if (prefix.length === 2) return this._d2[prefix] ?? null;
+    if (prefix.length === 3) return this._d3[prefix] ?? null;
+
+    // Length 4+: binary search the full sorted array.
+    const pos = this._lowerBound(prefix);
+    let best = null;
+    for (let i = pos; i < this._words.length; i++) {
+      if (!this._words[i].lower.startsWith(prefix)) break;
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+}
+
+// Flat map from prefix string → best answer, for all prefixes up to maxDepth.
+// O(1) lookup for short prefixes; binary search fallback for longer ones.
+class PrefixMap {
+  constructor(mapping, maxDepth = 5) {
+    this._maxDepth = maxDepth;
+    this._words = Object.entries(mapping)
+      .map(([v, n]) => ({ v, n, lower: v.toLowerCase() }))
+      .sort((a, b) => a.lower.localeCompare(b.lower));
+    this._map = {};
+    const byFreq = [...this._words].sort((a, b) => b.n - a.n);
+    for (const w of byFreq) {
+      const l = w.lower;
+      for (let d = 1; d <= maxDepth && d <= l.length; d++) {
+        const key = l.slice(0, d);
+        if (!(key in this._map)) this._map[key] = w.v;
+      }
+    }
+  }
+
+  _lowerBound(prefix) {
+    let lo = 0,
+      hi = this._words.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this._words[mid].lower < prefix) lo = mid + 1;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  get bool() {
+    return this._words.length > 0;
+  }
+  get size() {
+    return this._words.length;
+  }
+
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    if (prefix.length <= this._maxDepth) return this._map[prefix] ?? null;
+    const pos = this._lowerBound(prefix);
+    let best = null;
+    for (let i = pos; i < this._words.length; i++) {
+      if (!this._words[i].lower.startsWith(prefix)) break;
+      if (!best || this._words[i].n > best.n) best = this._words[i];
+    }
+    return best?.v ?? null;
+  }
+}
+
+class FanoutCatalogMapScan extends FanoutCatalogMap {
+  getBestMatch(prefix) {
+    if (!prefix) return null;
+    const c1 = prefix[0];
+    const node1 = this._d1[c1];
+    if (!node1) return null;
+    if (prefix.length === 1) return node1.best;
+
+    const key = prefix.slice(0, 2);
+    const node2 = this._d2[key];
+    if (!node2) return null;
+    if (prefix.length === 2) return node2.best;
+
+    // Skip binary search — scan the full depth-2 range directly.
+    const { start, end } = node2;
+    let best = null;
+    for (let i = start; i < end; i++) {
+      const w = this._words[i];
+      if (w.lower > prefix && !w.lower.startsWith(prefix)) break;
+      if (w.lower.startsWith(prefix) && (!best || w.n > best.n)) best = w;
+    }
+    return best?.v ?? null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Real fixture — 381 types from https://sylvan-librarian.com/get_common_card_types
+// Mapping shape: { TypeName: count }
+// ---------------------------------------------------------------------------
+
+const REAL_MAPPING = {
+  Adventure: 310,
+  Advisor: 406,
+  Aetherborn: 62,
+  Ajani: 59,
+  Alien: 99,
+  Ally: 398,
+  Aminatou: 7,
+  Angel: 1050,
+  Angrath: 11,
+  Antelope: 23,
+  Ape: 110,
+  Arcane: 184,
+  Archer: 275,
+  Archon: 76,
+  Arlinn: 19,
+  Artifact: 10947,
+  Artificer: 752,
+  Ashiok: 16,
+  Assassin: 392,
+  'Assembly-Worker': 36,
+  Astartes: 46,
+  Atog: 24,
+  Aura: 3246,
+  Aurochs: 6,
+  Avatar: 571,
+  Azra: 16,
+  Background: 70,
+  Badger: 20,
+  Bahamut: 6,
+  Barbarian: 125,
+  Bard: 127,
+  Basic: 4196,
+  Basilisk: 40,
+  Basri: 7,
+  Bat: 98,
+  Bear: 147,
+  Beast: 1207,
+  Beholder: 16,
+  Berserker: 350,
+  Bird: 1042,
+  Bison: 8,
+  Boar: 135,
+  Bobblehead: 21,
+  Bolas: 30,
+  Book: 169,
+  Bringer: 6,
+  Brushwagg: 7,
+  Calix: 5,
+  Camel: 9,
+  Carrier: 22,
+  Cartouche: 13,
+  Case: 24,
+  Cat: 919,
+  Cave: 44,
+  Centaur: 148,
+  Chandra: 81,
+  Chimera: 39,
+  Citizen: 200,
+  Class: 69,
+  Cleric: 1572,
+  Clown: 6,
+  Clue: 42,
+  Cockatrice: 16,
+  Construct: 632,
+  Crab: 94,
+  Creature: 45967,
+  Crocodile: 60,
+  Curse: 102,
+  Cyberman: 16,
+  Cyclops: 69,
+  Dack: 6,
+  Dalek: 16,
+  Daretti: 13,
+  Dauthi: 25,
+  Davriel: 6,
+  Demigod: 37,
+  Demon: 684,
+  Desert: 103,
+  Detective: 181,
+  Devil: 148,
+  Dihada: 6,
+  Dinosaur: 623,
+  Djinn: 179,
+  Doctor: 120,
+  Dog: 315,
+  Domri: 15,
+  Dovin: 10,
+  Dragon: 1499,
+  Drake: 249,
+  Dreadnought: 7,
+  Drix: 5,
+  Drone: 111,
+  Druid: 1140,
+  Dryad: 158,
+  Dwarf: 309,
+  Efreet: 74,
+  Egg: 28,
+  Elder: 277,
+  Eldrazi: 473,
+  Elemental: 1772,
+  Elephant: 197,
+  Elf: 2096,
+  Elk: 102,
+  Ellywick: 5,
+  Elspeth: 42,
+  Enchantment: 9913,
+  Equipment: 1644,
+  Eternal: 5,
+  Eye: 23,
+  Faerie: 420,
+  Fish: 124,
+  Flagbearer: 5,
+  Food: 33,
+  Forest: 1180,
+  Fox: 105,
+  Fractal: 11,
+  Freyalise: 8,
+  Frog: 181,
+  Fungus: 188,
+  Gamma: 32,
+  Gargoyle: 83,
+  Garruk: 37,
+  Gate: 180,
+  Giant: 629,
+  Gideon: 34,
+  Gith: 5,
+  Glimmer: 35,
+  Gnome: 65,
+  Goat: 27,
+  Goblin: 1506,
+  God: 277,
+  Golem: 434,
+  Gorgon: 51,
+  Gremlin: 26,
+  Griffin: 101,
+  Grist: 12,
+  Hag: 16,
+  Halfling: 162,
+  Harpy: 20,
+  Hellion: 45,
+  Hero: 491,
+  Hippo: 21,
+  Hippogriff: 17,
+  Homarid: 16,
+  Homunculus: 72,
+  Horror: 934,
+  Horse: 142,
+  Huatli: 11,
+  Human: 10567,
+  Hydra: 234,
+  Hyena: 7,
+  Illusion: 258,
+  Imp: 131,
+  Incarnation: 150,
+  Infinity: 7,
+  Inhuman: 12,
+  Inquisitor: 6,
+  Insect: 608,
+  Instant: 10724,
+  Island: 1127,
+  Jace: 76,
+  Jackal: 55,
+  Jaya: 15,
+  Jellyfish: 74,
+  Juggernaut: 68,
+  Kaito: 24,
+  Karn: 29,
+  Kasmina: 11,
+  Kavu: 111,
+  Kaya: 34,
+  Kindred: 183,
+  Kiora: 11,
+  Kirin: 23,
+  Kithkin: 156,
+  Knight: 1329,
+  Kobold: 26,
+  Kor: 207,
+  Koth: 9,
+  Kraken: 118,
+  Kree: 14,
+  Lair: 12,
+  Lamia: 7,
+  Land: 11551,
+  Leech: 32,
+  Legendary: 13532,
+  Lemur: 7,
+  Lesson: 120,
+  Leviathan: 92,
+  Lhurgoyf: 67,
+  Licid: 14,
+  Liliana: 84,
+  Lizard: 339,
+  Locus: 8,
+  Lolth: 6,
+  Lord: 168,
+  Lukka: 17,
+  Manticore: 22,
+  Masticore: 22,
+  Mercenary: 195,
+  Merfolk: 796,
+  Metathran: 14,
+  Mine: 26,
+  Minion: 112,
+  Minotaur: 210,
+  Minsc: 7,
+  Mite: 7,
+  Mole: 21,
+  Monger: 7,
+  Mongoose: 8,
+  Monk: 364,
+  Monkey: 40,
+  Moogle: 16,
+  Moonfolk: 54,
+  Mordenkainen: 5,
+  Mount: 68,
+  Mountain: 1139,
+  Mouse: 45,
+  Mutant: 464,
+  Myr: 127,
+  Mystic: 11,
+  Nahiri: 27,
+  Narset: 18,
+  Necron: 48,
+  Nephilim: 10,
+  Nightmare: 239,
+  Nightstalker: 22,
+  Ninja: 317,
+  Nissa: 50,
+  Nixilis: 25,
+  Noble: 584,
+  Noggle: 9,
+  Nomad: 70,
+  Nymph: 58,
+  Octopus: 100,
+  Ogre: 284,
+  Oko: 15,
+  Omen: 32,
+  Ooze: 188,
+  Orc: 269,
+  Orgg: 10,
+  Otter: 51,
+  Ouphe: 35,
+  Ox: 55,
+  Pangolin: 7,
+  Peasant: 88,
+  Pegasus: 73,
+  Performer: 17,
+  Pest: 11,
+  Phelddagrif: 6,
+  Phoenix: 105,
+  Phyrexian: 1234,
+  Pilot: 91,
+  Pirate: 456,
+  Plains: 1109,
+  Plan: 12,
+  Planeswalker: 1379,
+  Planet: 25,
+  Plant: 238,
+  Possum: 6,
+  'Power-Plant': 26,
+  Praetor: 101,
+  Processor: 16,
+  Quintorius: 6,
+  Rabbit: 78,
+  Raccoon: 39,
+  Ral: 28,
+  Ranger: 176,
+  Rat: 337,
+  Rebel: 161,
+  Rhino: 135,
+  Robot: 198,
+  Rogue: 1367,
+  Room: 59,
+  Rowan: 12,
+  Rune: 5,
+  Saga: 439,
+  Saheeli: 18,
+  Salamander: 37,
+  Samurai: 153,
+  Samut: 7,
+  Sarkhan: 23,
+  Satyr: 70,
+  Scarecrow: 81,
+  Scientist: 123,
+  Scorpion: 39,
+  Scout: 675,
+  Seal: 5,
+  Serpent: 146,
+  Shade: 84,
+  Shaman: 1420,
+  Shapeshifter: 486,
+  Shark: 45,
+  Sheep: 15,
+  Shrine: 35,
+  Siren: 46,
+  Skeleton: 245,
+  Skrull: 5,
+  Slith: 17,
+  Sliver: 328,
+  Sloth: 13,
+  Slug: 22,
+  Snake: 481,
+  Snow: 262,
+  Soldier: 2327,
+  Soltari: 22,
+  Sorcerer: 127,
+  Sorcery: 10624,
+  Sorin: 38,
+  Spacecraft: 58,
+  Specter: 92,
+  Spellshaper: 94,
+  Sphere: 23,
+  Sphinx: 258,
+  Spider: 376,
+  Spike: 24,
+  Spirit: 1694,
+  Spy: 30,
+  Squid: 20,
+  Squirrel: 75,
+  Starfish: 11,
+  Stone: 7,
+  Surrakar: 8,
+  Survivor: 29,
+  Swamp: 1129,
+  Symbiote: 30,
+  Synth: 14,
+  Tamiyo: 27,
+  Teferi: 46,
+  Teyo: 7,
+  Tezzeret: 30,
+  Thalakos: 7,
+  Thopter: 91,
+  Thrull: 60,
+  Tibalt: 14,
+  Tiefling: 35,
+  Time: 168,
+  Tower: 26,
+  Town: 20,
+  Toy: 24,
+  Trap: 43,
+  Treasure: 12,
+  Treefolk: 279,
+  Trilobite: 7,
+  Troll: 147,
+  Turtle: 213,
+  Tyranid: 76,
+  Tyvar: 11,
+  Ugin: 24,
+  Unicorn: 97,
+  "Urza'S": 95,
+  Utrom: 13,
+  Vampire: 1301,
+  Vedalken: 175,
+  Vehicle: 500,
+  Villain: 321,
+  Vivien: 31,
+  Volver: 6,
+  Vraska: 28,
+  Wall: 514,
+  Warlock: 430,
+  Warrior: 2907,
+  Weasel: 5,
+  Weird: 31,
+  Werewolf: 189,
+  Whale: 34,
+  Will: 14,
+  Wizard: 3107,
+  Wolf: 220,
+  Wolverine: 14,
+  Wombat: 5,
+  World: 42,
+  Worm: 26,
+  Wraith: 79,
+  Wrenn: 18,
+  Wurm: 290,
+  Yanggu: 7,
+  Yanling: 6,
+  Yeti: 29,
+  Zariel: 5,
+  Zombie: 1649,
+  Zubera: 7,
+};
+
+// ---------------------------------------------------------------------------
+// Synthetic dataset generator — scales the real dataset by repeating it with
+// modified names to produce N unique entries with realistic frequency skew.
+// ---------------------------------------------------------------------------
+
+function syntheticMapping(n) {
+  const base = Object.entries(REAL_MAPPING);
+  const result = {};
+  const suffixes = 'abcdefghijklmnopqrstuvwxyz';
+  let count = 0;
+  for (let i = 0; count < n; i++) {
+    const [t, freq] = base[i % base.length];
+    const suffix = suffixes[Math.floor(i / base.length) % 26] + suffixes[Math.floor(i / (base.length * 26)) % 26];
+    const word = t + suffix;
+    if (!(word in result)) count++;
+    result[word] = Math.max(1, freq + i);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Prefixes — cover length 1 (O(1) for FanoutCatalogMap), length 2 (O(1)),
+// length 3+ (binary search path), and no-match cases.
+// ---------------------------------------------------------------------------
+
+const PREFIXES = [
+  // Length 1 — O(1) in FanoutCatalogMap, full bucket scan in CatalogMap
+  's',
+  'c',
+  'w',
+  // Length 2 — O(1) in FanoutCatalogMap, partial bucket scan in CatalogMap
+  'sh',
+  'sk',
+  'sl',
+  'sn',
+  'so',
+  'sp',
+  'st',
+  'dr',
+  'cr',
+  'wa',
+  'wi',
+  // Length 3+ — binary search path in FanoutCatalogMap
+  'sha',
+  'spi',
+  'war',
+  'cre',
+  'wiz',
+  // Long / exact
+  'shapeshifter',
+  'planeswalker',
+  'legendary',
+  'zombie',
+  'dragon',
+  // No-match
+  'zz',
+  'xx',
+  'jj',
+];
+
+const PREFIX_GROUPS = [
+  { label: 'length 1  (trie stored best)', prefixes: ['s', 'c', 'w'] },
+  {
+    label: 'length 2  (trie stored best)',
+    prefixes: ['sh', 'sk', 'sl', 'sn', 'so', 'sp', 'st', 'dr', 'cr', 'wa', 'wi'],
+  },
+  { label: 'length 3  (binary search path)', prefixes: ['sha', 'spi', 'war', 'cre', 'wiz'] },
+  { label: 'length 6+ (exact/long)', prefixes: ['shapeshifter', 'planeswalker', 'legendary', 'zombie', 'dragon'] },
+  { label: 'no match', prefixes: ['zz', 'xx', 'jj'] },
+];
+
+// ---------------------------------------------------------------------------
+// Correctness check (real dataset only, filter+sort as ground truth)
+// ---------------------------------------------------------------------------
+
+function filterSortMatch(mapping, prefix) {
+  let best = null;
+  for (const [v, n] of Object.entries(mapping)) {
+    if (v.toLowerCase().startsWith(prefix) && (!best || n > best.n)) best = { v, n };
+  }
+  return best?.v ?? null;
+}
+
+const catReal = new CatalogMap(REAL_MAPPING);
+const fanReal = new FanoutCatalogMap(REAL_MAPPING);
+const fanScanReal = new FanoutCatalogMapScan(REAL_MAPPING);
+const flatReal = new FlatSortedMap(REAL_MAPPING);
+const fd2Real = new FanoutD2Array(REAL_MAPPING);
+const fd3Real = new FanoutD3Array(REAL_MAPPING);
+const st3Real = new SparseTrieD3(REAL_MAPPING);
+
+let allMatch = true;
+for (const prefix of PREFIXES) {
+  const expected = filterSortMatch(REAL_MAPPING, prefix);
+  for (const [label, actual] of [
+    ['CatalogMap', catReal.getBestMatch(prefix)],
+    ['FanoutCatalogMap', fanReal.getBestMatch(prefix)],
+    ['FanoutCatalogMapScan', fanScanReal.getBestMatch(prefix)],
+    ['FlatSortedMap', flatReal.getBestMatch(prefix)],
+    ['FanoutD2Array', fd2Real.getBestMatch(prefix)],
+    ['FanoutD3Array', fd3Real.getBestMatch(prefix)],
+    ['SparseTrieD3', st3Real.getBestMatch(prefix)],
+  ]) {
+    const match = (actual?.toLowerCase() ?? null) === (expected?.toLowerCase() ?? null);
+    if (!match) {
+      console.error(
+        `MISMATCH [${label}] prefix="${prefix}": expected=${JSON.stringify(expected)} got=${JSON.stringify(actual)}`
+      );
+      allMatch = false;
+    }
+  }
+}
+if (allMatch) {
+  console.log('✓  All seven implementations produce identical results for all prefixes.\n');
+} else {
+  console.log('✗  Output mismatch — see above.\n');
+  process.exit(1);
+}
+
+// Count unique prefix nodes at each depth for a given mapping.
+function prefixNodeCounts(mapping, maxDepth = 6) {
+  const counts = new Array(maxDepth).fill(0);
+  const seen = Array.from({ length: maxDepth }, () => new Set());
+  for (const v of Object.keys(mapping)) {
+    const lower = v.toLowerCase();
+    for (let d = 0; d < maxDepth && d < lower.length; d++) {
+      seen[d].add(lower.slice(0, d + 1));
+    }
+  }
+  for (let d = 0; d < maxDepth; d++) counts[d] = seen[d].size;
+  return counts;
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark harness
+// ---------------------------------------------------------------------------
+
+function bench(label, fn, iters, prefixes = PREFIXES) {
+  for (let i = 0; i < 500; i++) fn(prefixes[i % prefixes.length]);
+  const start = performance.now();
+  for (let i = 0; i < iters; i++) fn(prefixes[i % prefixes.length]);
+  const elapsed = performance.now() - start;
+  return { label, elapsed, nsPerCall: (elapsed * 1e6) / iters };
+}
+
+function benchConstruct(label, fn, iters) {
+  fn(); // warm up
+  const start = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  const elapsed = performance.now() - start;
+  return { label, elapsed, usPerCall: (elapsed * 1000) / iters };
+}
+
+// Iterations scale inversely with dataset size to keep total runtime reasonable.
+function lookupIters(size) {
+  if (size <= 1_000) return 500_000;
+  if (size <= 10_000) return 50_000;
+  return 5_000;
+}
+function constructIters(size) {
+  if (size <= 1_000) return 1_000;
+  if (size <= 10_000) return 100;
+  return 10;
+}
+
+const col = [28, 14, 16, 12];
+const header = `${''.padEnd(col[0])} ${'Total (ms)'.padStart(col[1])} ${'Per call (ns)'.padStart(col[2])} ${'vs CatalogMap'.padStart(col[3])}`;
+const sep = '-'.repeat(header.length);
+
+function printResults(results) {
+  const baseline = results[0].nsPerCall ?? results[0].usPerCall;
+  console.log(header);
+  console.log(sep);
+  for (const r of results) {
+    const val = r.nsPerCall ?? r.usPerCall;
+    const speedup = r === results[0] ? '—' : `${(baseline / val).toFixed(2)}×`;
+    const unit = r.nsPerCall != null ? r.nsPerCall.toFixed(1) : r.usPerCall.toFixed(1);
+    console.log(
+      `${r.label.padEnd(col[0])} ${r.elapsed.toFixed(1).padStart(col[1])} ${unit.padStart(col[2])} ${speedup.padStart(col[3])}`
+    );
+  }
+  console.log();
+}
+
+// ---------------------------------------------------------------------------
+// Run at multiple scales
+// ---------------------------------------------------------------------------
+
+function fmtBytes(n) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+// Returns exact byte sizes of each internal typed array/array in a structure,
+// using .byteLength for Int32Arrays and length*8 (pointer size) for JS Arrays.
+function trieBytes(instance) {
+  let total = 0;
+  for (const key of Object.keys(instance)) {
+    const v = instance[key];
+    if (v instanceof Int32Array) total += v.byteLength;
+    else if (Array.isArray(v)) total += v.length * 8; // 8-byte pointer per slot
+  }
+  // Exclude _words — shared cost across all implementations.
+  const wordsBytes = instance._words ? instance._words.length * 8 : 0;
+  return total - wordsBytes;
+}
+
+const scales = [
+  { name: 'real (381 entries)', mapping: REAL_MAPPING },
+  { name: '10K synthetic', mapping: syntheticMapping(10_000) },
+  { name: '100K synthetic', mapping: syntheticMapping(100_000) },
+];
+
+for (const { name, mapping } of scales) {
+  const cat = new CatalogMap(mapping);
+  const fan = new FanoutCatalogMap(mapping);
+  const fanScan = new FanoutCatalogMapScan(mapping);
+  const size = Object.keys(mapping).length;
+
+  console.log(`=== ${name} (${size.toLocaleString()} entries) ===`);
+
+  const flat = new FlatSortedMap(mapping);
+  const fd2 = new FanoutD2Array(mapping);
+  const fd3 = new FanoutD3Array(mapping);
+  const st3 = new SparseTrieD3(mapping);
+  const pm3 = new PrefixMap(mapping, 3);
+  const pm5 = new PrefixMap(mapping, 5);
+  const liters = lookupIters(size);
+
+  console.log(`Lookup — all prefixes mixed (${liters.toLocaleString()} iters, ${PREFIXES.length} prefixes):`);
+  printResults([
+    bench('  FanoutCatalogMap (obj d2)', prefix => fan.getBestMatch(prefix), liters),
+    bench('  FanoutD2Array (arr d2)', prefix => fd2.getBestMatch(prefix), liters),
+    bench('  FanoutD3Array (arr d3)', prefix => fd3.getBestMatch(prefix), liters),
+    bench('  SparseTrieD3', prefix => st3.getBestMatch(prefix), liters),
+    bench('  PrefixMap (d3)', prefix => pm3.getBestMatch(prefix), liters),
+    bench('  PrefixMap (d5)', prefix => pm5.getBestMatch(prefix), liters),
+    bench('  FlatSortedMap (baseline)', prefix => flat.getBestMatch(prefix), liters),
+  ]);
+
+  console.log(`Lookup — by prefix length (${liters.toLocaleString()} iters each):`);
+  for (const { label, prefixes } of PREFIX_GROUPS) {
+    console.log(`  [${label}]`);
+    printResults([
+      bench('    FanoutCatalogMap (obj d2)', prefix => fan.getBestMatch(prefix), liters, prefixes),
+      bench('    FanoutD2Array (arr d2)', prefix => fd2.getBestMatch(prefix), liters, prefixes),
+      bench('    FanoutD3Array (arr d3)', prefix => fd3.getBestMatch(prefix), liters, prefixes),
+      bench('    SparseTrieD3', prefix => st3.getBestMatch(prefix), liters, prefixes),
+      bench('    PrefixMap (d3)', prefix => pm3.getBestMatch(prefix), liters, prefixes),
+      bench('    PrefixMap (d5)', prefix => pm5.getBestMatch(prefix), liters, prefixes),
+      bench('    FlatSortedMap (baseline)', prefix => flat.getBestMatch(prefix), liters, prefixes),
+    ]);
+  }
+
+  const citers = constructIters(size);
+  console.log(`Construction (${citers.toLocaleString()} iterations):`);
+  const constructResults = [
+    benchConstruct('  CatalogMap', () => new CatalogMap(mapping), citers),
+    benchConstruct('  FanoutCatalogMap', () => new FanoutCatalogMap(mapping), citers),
+  ];
+  for (const r of constructResults) {
+    r.nsPerCall = undefined;
+  }
+  const baselineUs = constructResults[0].usPerCall;
+  console.log(header.replace('Per call (ns)', 'Per call (µs)'));
+  console.log(sep);
+  for (const r of constructResults) {
+    const speedup = r === constructResults[0] ? '—' : `${(baselineUs / r.usPerCall).toFixed(2)}×`;
+    console.log(
+      `${r.label.padEnd(col[0])} ${r.elapsed.toFixed(1).padStart(col[1])} ${r.usPerCall.toFixed(1).padStart(col[2])} ${speedup.padStart(col[3])}`
+    );
+  }
+  console.log();
+
+  console.log('Trie overhead (excl. shared _words array):');
+  // FanoutCatalogMap uses plain objects — count populated nodes × ~80 bytes each (V8 object overhead).
+  const fanD1Nodes = Object.keys(fan._d1).length;
+  const fanD2Nodes = Object.keys(fan._d2).length;
+  const fanObjBytes = (fanD1Nodes + fanD2Nodes) * 80;
+  console.log(
+    `  FanoutCatalogMap (obj d2)     ${fmtBytes(fanObjBytes).padStart(10)}  (${fanD1Nodes} d1 + ${fanD2Nodes} d2 nodes × ~80 B)`
+  );
+  for (const [label, instance] of [
+    ['FanoutD2Array (arr d2)', fd2],
+    ['FanoutD3Array (arr d3)', fd3],
+  ]) {
+    const bytes = trieBytes(instance);
+    console.log(`  ${label.padEnd(28)} ${fmtBytes(bytes).padStart(10)}`);
+  }
+  // SparseTrieD3 uses plain objects — estimate from key count × ~60 bytes/entry.
+  const st3d1 = Object.keys(st3._d1).length;
+  const st3d2 = Object.keys(st3._d2).length;
+  const st3d3 = Object.keys(st3._d3).length;
+  const st3Bytes = (st3d1 + st3d2 + st3d3) * 60;
+  console.log(
+    `  SparseTrieD3                 ${fmtBytes(st3Bytes).padStart(10)}  (${st3d1} d1 + ${st3d2} d2 + ${st3d3} d3 nodes × ~60 B)`
+  );
+
+  // Show prefix node counts at each depth to estimate cost of deeper coverage.
+  const nodeCounts = prefixNodeCounts(mapping, 6);
+  const incr = nodeCounts.map((c, i) => (i === 0 ? c : c - nodeCounts[i - 1]));
+  console.log(`  Unique prefix nodes by depth:`);
+  for (let d = 0; d < 6; d++) {
+    const cumBytes = nodeCounts[d] * 60;
+    const incrNote = d === 0 ? '' : `  (+${incr[d]} new at d${d + 1})`;
+    console.log(
+      `    d${d + 1}: ${String(nodeCounts[d]).padStart(6)} nodes  ${fmtBytes(cumBytes).padStart(9)} cumulative${incrNote}`
+    );
+  }
+
+  // PrefixMap — flat {prefix→best} hash: each entry ~60 B (key string + value string + object slot).
+  const pm3Keys = Object.keys(pm3._map).length;
+  const pm5Keys = Object.keys(pm5._map).length;
+  console.log(`  PrefixMap (d3)               ${fmtBytes(pm3Keys * 60).padStart(10)}  (${pm3Keys} keys × ~60 B)`);
+  console.log(`  PrefixMap (d5)               ${fmtBytes(pm5Keys * 60).padStart(10)}  (${pm5Keys} keys × ~60 B)`);
+  console.log();
+}

--- a/scripts/bench_escape_html.js
+++ b/scripts/bench_escape_html.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Benchmark: DOM-based escapeHtml vs single-pass regex escapeHtml.
+ *
+ * Run with:  node scripts/bench_escape_html.js
+ */
+
+'use strict';
+
+const { JSDOM } = require('jsdom');
+
+const { document } = new JSDOM('').window;
+
+// --- Implementations ---
+
+function escapeHtmlDom(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+function escapeHtmlRegex(text) {
+  if (text == null) return '';
+  return String(text).replace(/[&<>"]/g, c =>
+    c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&quot;'
+  );
+}
+
+// --- Test data representative of MTG card fields ---
+
+const samples = [
+  // Card names
+  'Lightning Bolt',
+  "Urza's Saga",
+  "Jace, the Mind's Sculptor",
+  'Lim-Dûl the Necromancer',
+
+  // Oracle text with HTML-special characters
+  "Destroy target creature. It can't be regenerated.",
+  'Deal 3 damage to any target.',
+  'When ~ enters the battlefield, draw a card.',
+  'Creatures you control get +1/+1 until end of turn.',
+  "Counter target spell unless its controller pays {2}. If they don't, they discard a card.",
+
+  // Edge cases
+  '',
+  'no special chars here just plain text',
+  '<<< double angle brackets >>>',
+  // NOTE: the DOM approach (textContent → innerHTML) does NOT escape " in text nodes —
+  // that's valid HTML text content, but unsafe when the result is placed inside a
+  // double-quoted attribute (alt="...").  The regex approach correctly escapes " as &quot;.
+  // We benchmark them separately below but don't include this in the must-match set.
+
+  // Image URLs (no special chars — exercises the fast-exit path)
+  'https://d1hot9ps2xugbc.cloudfront.net/img/neo/123/1/388.webp',
+
+  // Long oracle text
+  `Flying\n\nWhen ${Array(40).fill('Flying').join(' ')} enters the battlefield, each opponent loses 3 life and you gain 3 life. If a creature dealt damage this way would die this turn, exile it instead.`,
+];
+
+// --- Correctness check ---
+
+let allMatch = true;
+for (const s of samples) {
+  const a = escapeHtmlDom(s);
+  const b = escapeHtmlRegex(s);
+  if (a !== b) {
+    console.error(`MISMATCH for: ${JSON.stringify(s)}`);
+    console.error(`  DOM:   ${JSON.stringify(a)}`);
+    console.error(`  Regex: ${JSON.stringify(b)}`);
+    allMatch = false;
+  }
+}
+if (allMatch) {
+  console.log('✓  Both implementations produce identical output for all test strings.\n');
+} else {
+  console.log('✗  Output mismatch — see above.\n');
+  process.exit(1);
+}
+
+// --- Benchmark harness ---
+
+function bench(label, fn, iterations) {
+  // Warm up
+  for (let i = 0; i < 1000; i++) fn(samples[i % samples.length]);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    fn(samples[i % samples.length]);
+  }
+  const elapsed = performance.now() - start;
+  const nsPerCall = (elapsed * 1e6) / iterations;
+  console.log(
+    `  ${label.padEnd(16)} ${elapsed.toFixed(1).padStart(8)} ms  |  ${nsPerCall.toFixed(0).padStart(6)} ns/call`
+  );
+}
+
+// Simulate a full render: ~14 escapeHtml calls per card × 100 cards = 1400 calls
+function benchRender(label, fn, iterations) {
+  const callsPerRender = 14 * 100; // 1400
+
+  // Warm up
+  for (let i = 0; i < 1000; i++) fn(samples[i % samples.length]);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    for (let j = 0; j < callsPerRender; j++) {
+      fn(samples[j % samples.length]);
+    }
+  }
+  const elapsed = performance.now() - start;
+  const msPerRender = elapsed / iterations;
+  console.log(`  ${label.padEnd(16)} ${msPerRender.toFixed(2).padStart(8)} ms/render  (${iterations} renders)`);
+}
+
+const ITERS = 500_000;
+const RENDER_ITERS = 500;
+
+console.log(`Per-call (${ITERS.toLocaleString()} iterations):`);
+bench('DOM', escapeHtmlDom, ITERS);
+bench('Regex', escapeHtmlRegex, ITERS);
+
+console.log(`\nSimulated render (1,400 escapeHtml calls per render, ${RENDER_ITERS} renders):`);
+benchRender('DOM', escapeHtmlDom, RENDER_ITERS);
+benchRender('Regex', escapeHtmlRegex, RENDER_ITERS);

--- a/scripts/bench_search.py
+++ b/scripts/bench_search.py
@@ -1,0 +1,127 @@
+"""Benchmark engine vs SQL search paths.
+
+Run inside the API container so both DB and card_engine are available:
+
+    docker exec sylvan_blue-apiservice-1 python3 /app/scripts/bench_search.py
+
+The script loads the engine from the DB (same path as production), then
+times both engine.query() and _search_sql() for each query/unique combination
+and prints a comparison table.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import sys
+import time
+
+sys.path.insert(0, "/app")
+
+from api.api_resource import APIResource
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.utils.timer import Timer
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+
+QUERIES: list[tuple[str, str, CardOrdering]] = [
+    ("name:soldier", "name:soldier", CardOrdering.EDHREC),
+    ("t:merfolk and name:tide", "t:merfolk+tide", CardOrdering.EDHREC),
+    ("cmc>3", "cmc>3", CardOrdering.CMC),
+    ("format:legacy", "format:legacy", CardOrdering.EDHREC),
+]
+
+UNIQUES = [UniqueOn.CARD, UniqueOn.PRINTING, UniqueOn.ARTWORK]
+
+ENGINE_WARMUP = 20  # iterations to discard before timing
+ENGINE_WINDOW = 5.0  # seconds to run the timed loop
+SQL_RUNS = 15  # total SQL calls per cell
+SQL_DISCARD = 3  # discard this many from the front
+
+# ─── Setup ────────────────────────────────────────────────────────────────────
+
+print("Connecting to DB and loading engine store…", flush=True)
+api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+api.admin._import_recent = lambda: True  # prevent import_data() from running
+api._setup_complete = lambda: True
+
+api._reload_engine(force=True)
+print(f"Engine loaded: {api._engine.size():,} cards\n", flush=True)
+
+# ─── Benchmark helpers ────────────────────────────────────────────────────────
+
+
+def bench_engine(q_str: str, unique: UniqueOn, orderby: CardOrdering) -> float:
+    """Return average µs per engine.query() call."""
+    q = parse_scryfall_query(q_str)
+    for _ in range(ENGINE_WARMUP):
+        api._engine.query(
+            filters=q,
+            unique=str(unique),
+            prefer=str(PreferOrder.DEFAULT),
+            orderby=str(orderby),
+            direction=str(SortDirection.ASC),
+            limit=100,
+        )
+    n = 0
+    t0 = time.monotonic()
+    deadline = t0 + ENGINE_WINDOW
+    while time.monotonic() < deadline:
+        api._engine.query(
+            filters=q,
+            unique=str(unique),
+            prefer=str(PreferOrder.DEFAULT),
+            orderby=str(orderby),
+            direction=str(SortDirection.ASC),
+            limit=100,
+        )
+        n += 1
+    return (time.monotonic() - t0) / n * 1_000  # ms
+
+
+def bench_sql(q_str: str, unique: UniqueOn, orderby: CardOrdering) -> float:
+    """Return average ms per _search_sql() call with cache cleared before each."""
+    parsed = parse_scryfall_query(q_str)
+    where_clause, base_params = generate_sql_query(parsed)
+    query_explanation = parsed.to_human_explanation()
+    times = []
+    for _ in range(SQL_RUNS):
+        api._query_cache.clear()
+        t0 = time.monotonic()
+        api._search_sql(
+            where_clause=where_clause,
+            params=dict(base_params),
+            query_explanation=query_explanation,
+            query=q_str,
+            unique=unique,
+            prefer=PreferOrder.DEFAULT,
+            orderby=orderby,
+            direction=SortDirection.ASC,
+            limit=100,
+            timer=Timer(),
+        )
+        times.append((time.monotonic() - t0) * 1_000)
+    return sum(times[SQL_DISCARD:]) / len(times[SQL_DISCARD:])
+
+
+# ─── Run ──────────────────────────────────────────────────────────────────────
+
+header = f"{'query':<22} {'unique':<10} {'engine ms':>10} {'sql ms':>9}  winner"
+print(header)
+print("-" * len(header))
+
+prev_label = ""
+for q_str, label, orderby in QUERIES:
+    for unique in UNIQUES:
+        eng_ms = bench_engine(q_str, unique, orderby)
+        sql_ms = bench_sql(q_str, unique, orderby)
+
+        winner = f"engine {sql_ms / eng_ms:.0f}x" if eng_ms < sql_ms else f"sql    {eng_ms / sql_ms:.0f}x"
+
+        if label != prev_label and prev_label:
+            print()
+        print(f"{label:<22} {unique!s:<10} {eng_ms:>10.2f} {sql_ms:>9.1f}  {winner}")
+        prev_label = label
+
+print(f"\nEngine: {ENGINE_WARMUP} warmup + {ENGINE_WINDOW:.0f}s timed window")
+print(f"SQL:    {SQL_RUNS} runs, first {SQL_DISCARD} discarded, _query_cache cleared each call")

--- a/scripts/bench_search.sh
+++ b/scripts/bench_search.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Benchmark engine vs SQL search paths.
+#
+# Finds a running sylvan apiservice container and runs the benchmark inside it
+# so both the DB connection and card_engine module are available.
+#
+# Usage:
+#   ./scripts/bench_search.sh              # auto-pick blue or green container
+#   ./scripts/bench_search.sh sylvan_blue  # pick a specific project
+
+set -euo pipefail
+
+PROJECT="${1:-}"
+
+if [[ -n "$PROJECT" ]]; then
+    CONTAINER=$(docker ps --format '{{.Names}}' | grep "${PROJECT}-apiservice" | head -1)
+else
+    CONTAINER=$(docker ps --format '{{.Names}}' | grep "apiservice" | head -1)
+fi
+
+if [[ -z "$CONTAINER" ]]; then
+    echo "No running apiservice container found." >&2
+    exit 1
+fi
+
+echo "Running benchmark in: $CONTAINER"
+echo ""
+
+docker exec -i "$CONTAINER" python3 - << 'PYEOF'
+"""Benchmark: engine vs SQL search paths."""
+from __future__ import annotations
+
+import math, multiprocessing, sys, time
+sys.path.insert(0, "/app")
+
+from api.api_resource import APIResource
+from api.enums import CardOrdering, PreferOrder, SortDirection, UniqueOn
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.utils.timer import Timer
+
+QUERIES = [
+    ("name:soldier",                                    CardOrdering.EDHREC),
+    ("t:merfolk and name:tide",                       CardOrdering.EDHREC),
+    ("id:g",                                          CardOrdering.EDHREC),
+    ("t:creature",                                    CardOrdering.EDHREC),
+    ("cmc>3",                                         CardOrdering.CMC),
+    ("cmc>6",                                         CardOrdering.CMC),
+    ("format:legacy",                                 CardOrdering.EDHREC),
+    ("(t:bird color:blue) or (t:beast color:green)",  CardOrdering.EDHREC),
+    ("(name:forest) or (name:mountain)",              CardOrdering.EDHREC),
+    ("power+toughness>8",                               CardOrdering.EDHREC),
+    ("power>4",                                         CardOrdering.EDHREC),
+]
+UNIQUES = [UniqueOn.CARD, UniqueOn.PRINTING, UniqueOn.ARTWORK]
+
+ENGINE_WARMUP = 20
+ENGINE_WINDOW = 5.0  # seconds
+SQL_RUNS      = 15
+SQL_DISCARD   = 3
+
+print("Connecting to DB and loading engine store…", flush=True)
+api = APIResource(last_import_time=multiprocessing.Value("d", time.time(), lock=True))
+api._import_recent = lambda: True
+api._setup_complete = lambda: True
+api._reload_engine()
+print(f"Engine loaded: {api._engine.size():,} cards\n", flush=True)
+
+
+def bench_engine(q_str, unique, orderby):
+    q = parse_scryfall_query(q_str)
+    kw = dict(unique=str(unique), prefer=str(PreferOrder.DEFAULT),
+              orderby=str(orderby), direction=str(SortDirection.ASC), limit=100)
+    for _ in range(ENGINE_WARMUP):
+        api._engine.query(filters=q, **kw)
+    n, t0 = 0, time.monotonic()
+    while time.monotonic() < t0 + ENGINE_WINDOW:
+        api._engine.query(filters=q, **kw)
+        n += 1
+    return (time.monotonic() - t0) / n * 1_000  # ms
+
+
+def bench_sql(q_str, unique, orderby):
+    parsed = parse_scryfall_query(q_str)
+    wc, base_params = generate_sql_query(parsed)
+    qe = parsed.to_human_explanation()
+    kw = dict(where_clause=wc, query_explanation=qe, query=q_str, unique=unique,
+              prefer=PreferOrder.DEFAULT, orderby=orderby,
+              direction=SortDirection.ASC, limit=100)
+    times = []
+    for _ in range(SQL_RUNS):
+        api._query_cache.clear()
+        t0 = time.monotonic()
+        api._search_sql(params=dict(base_params), timer=Timer(), **kw)
+        times.append((time.monotonic() - t0) * 1_000)
+    return sum(times[SQL_DISCARD:]) / len(times[SQL_DISCARD:])
+
+
+def gmean(values):
+    return math.exp(sum(math.log(v) for v in values) / len(values))
+
+
+hdr = f"{'query':<28} {'unique':<10} {'engine ms':>10} {'sql ms':>9}  winner"
+print(hdr)
+print("-" * len(hdr))
+
+prev = ""
+all_eng, all_sql = [], []
+for q_str, orderby in QUERIES:
+    for unique in UNIQUES:
+        eng = bench_engine(q_str, unique, orderby)
+        sql = bench_sql(q_str, unique, orderby)
+        all_eng.append(eng)
+        all_sql.append(sql)
+        winner = f"engine {sql/eng:.0f}x" if eng < sql else f"sql    {eng/sql:.0f}x"
+        if q_str != prev and prev:
+            print()
+        print(f"{q_str:<28} {str(unique):<10} {eng:>10.2f} {sql:>9.1f}  {winner}")
+        prev = q_str
+
+ge, gs = gmean(all_eng), gmean(all_sql)
+winner = f"engine {gs/ge:.1f}x" if ge < gs else f"sql    {ge/gs:.1f}x"
+print(f"\n{'geometric mean':<22} {'':10} {ge:>10.2f} {gs:>9.1f}  {winner}")
+
+print(f"\nEngine: {ENGINE_WARMUP} warmup + {ENGINE_WINDOW:.0f}s timed window")
+print(f"SQL:    {SQL_RUNS} runs, first {SQL_DISCARD} discarded, _query_cache cleared each call")
+PYEOF

--- a/scripts/fit_artwork_score.py
+++ b/scripts/fit_artwork_score.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Fit artwork-preference weights from labels and compare models by cross-validation.
+
+Reads both label formats produced so far:
+
+  v1 pairwise  {left_sid, right_sid, verdict: left|right|other}
+  v2 grid      {shown: [{sid, art}], chosen_sid, verdict: pick|other}
+
+A grid pick expands to N-1 pairwise observations (chosen beats each other shown), so
+a 10-artwork card yields 9 observations from one keypress.
+
+Only ARTWORK-level features are fitted, on purpose. The v2 labeller showed nothing but
+the cropped art, so the verdict cannot have been influenced by border, frame, finish or
+rarity -- those were invisible. Fitting them would be attributing to the printing what
+was judged about the picture. (v1 showed whole cards, so its labels are weaker in
+exactly that respect.)
+
+Features, all oriented so LARGER IS PREFERRED, which is what lets every weight be
+constrained non-negative -- the declared-signs approach from
+docs/issues/local-prefer-score-label-harness.md.
+
+  art_age            decades since this artwork first appeared
+  art_pop            log1p(printings of this artwork under this card name)
+  artist_prominence  log1p(total printings of the artist's OTHER work)
+  artist_reuse       log(printings per artwork for the artist's OTHER work)
+
+Both artist features are leave-one-out: this artwork's own printings are subtracted
+before aggregating, or they would partly re-encode art_pop and steal its credit
+invisibly. Prominence and reuse are used rather than (illustrations, printings) because
+those two correlate at 0.986 -- collinear enough that their individual coefficients
+would be noise. Prominence/reuse correlate at 0.697.
+
+Usage:
+    python scripts/fit_artwork_score.py labels1.jsonl labels2.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import random
+import subprocess
+import sys
+from pathlib import Path
+
+DB_CONTAINER, DB_USER, DB_NAME = "sylvan_blue-postgres-1", "foouser", "magic"
+
+FOLDS = 5
+SPLIT_SEED = 20260725
+LEARNING_RATE = 0.08
+ITERATIONS = 3000
+L2 = 1e-3
+# Reference year for artwork age. Keep in step with the corpus, not with wall-clock.
+NOW_YEAR = 2026
+
+FEATURES = ("art_age", "art_pop", "artist_prominence", "artist_reuse")
+
+FEATURE_SQL = """
+WITH illus AS (   -- per artwork: printings and debut
+    SELECT illustration_id, card_name, count(*) AS n_print, min(released_at) AS first_seen
+    FROM magic.cards
+    WHERE raw_card_blob ->> 'lang' = 'en' AND illustration_id IS NOT NULL
+    GROUP BY illustration_id, card_name
+),
+art_one AS (      -- one row per artwork, with its artist
+    SELECT DISTINCT ON (illustration_id) illustration_id, raw_card_blob ->> 'artist' AS artist
+    FROM magic.cards
+    WHERE raw_card_blob ->> 'lang' = 'en' AND illustration_id IS NOT NULL
+    ORDER BY illustration_id
+),
+artist_tot AS (   -- artist-level aggregates over all their artworks
+    SELECT a.artist,
+           count(*) AS n_illus,
+           sum(i.n_print) AS n_print_total
+    FROM art_one a JOIN illus i USING (illustration_id)
+    GROUP BY a.artist
+)
+SELECT c.scryfall_id::text AS sid,
+       c.prefer_score,
+       i.n_print,
+       extract(year from i.first_seen) AS first_year,
+       t.n_illus,
+       t.n_print_total
+FROM magic.cards c
+JOIN illus i ON i.illustration_id = c.illustration_id AND i.card_name = c.card_name
+JOIN art_one a ON a.illustration_id = c.illustration_id
+JOIN artist_tot t ON t.artist = a.artist
+WHERE c.scryfall_id::text IN ({ids})
+"""
+
+
+def run_query(sql: str) -> list[dict[str, str]]:
+    proc = subprocess.run(
+        ["docker", "exec", "-i", DB_CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-v", "ON_ERROR_STOP=1", "--csv", "-f", "-"],
+        input=sql,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"psql failed:\n{proc.stderr}")
+    return list(csv.DictReader(io.StringIO(proc.stdout)))
+
+
+def expand(paths: list[Path]) -> tuple[list[tuple[str, str, str]], dict[str, int]]:
+    """Both formats -> (chosen_sid, rejected_sid, provenance) triples."""
+    pairs: list[tuple[str, str, str]] = []
+    stats = {"v1_records": 0, "v2_records": 0, "other": 0}
+    for p in paths:
+        for line in p.read_text().splitlines():
+            if not line.strip():
+                continue
+            r = json.loads(line)
+            if "shown" in r:  # v2 grid
+                stats["v2_records"] += 1
+                if r["verdict"] != "pick":
+                    stats["other"] += 1
+                    continue
+                for s in r["shown"]:
+                    if s["sid"] != r["chosen_sid"]:
+                        pairs.append((r["chosen_sid"], s["sid"], "v2"))
+            else:  # v1 pairwise
+                stats["v1_records"] += 1
+                if r["verdict"] not in ("left", "right"):
+                    stats["other"] += 1
+                    continue
+                rejected = r["right_sid"] if r["verdict"] == "left" else r["left_sid"]
+                pairs.append((r["chosen_sid"], rejected, "v1"))
+    return pairs, stats
+
+
+def to_vector(row: dict[str, str]) -> list[float] | None:
+    try:
+        n_print = float(row["n_print"])
+        first_year = float(row["first_year"])
+        n_illus = float(row["n_illus"])
+        tot = float(row["n_print_total"])
+    except (ValueError, TypeError):
+        return None
+    # Leave-one-out: remove this artwork's own contribution to the artist totals.
+    other_print = max(0.0, tot - n_print)
+    other_illus = max(0.0, n_illus - 1.0)
+    reuse = (other_print / other_illus) if other_illus > 0 else 0.0
+    return [
+        (NOW_YEAR - first_year) / 10.0,  # art_age, decades
+        math.log1p(n_print),  # art_pop
+        math.log1p(other_print),  # artist_prominence (LOO)
+        math.log1p(reuse),  # artist_reuse (LOO)
+    ]
+
+
+def softplus(x: float) -> float:
+    return math.log1p(math.exp(x)) if x < 30 else x
+
+
+def sigmoid(x: float) -> float:
+    return 0.0 if x < -30 else 1.0 if x > 30 else 1.0 / (1.0 + math.exp(-x))
+
+
+def fit(deltas: list[list[float]], k: int) -> list[float]:
+    """Non-negative-constrained logistic fit via w = softplus(theta)."""
+    theta = [0.0] * k
+    for _ in range(ITERATIONS):
+        w = [softplus(t) for t in theta]
+        grad = [0.0] * k
+        for d in deltas:
+            g = 1.0 - sigmoid(sum(wi * di for wi, di in zip(w, d, strict=True)))
+            for j, dj in enumerate(d):
+                grad[j] += g * dj
+        n = max(1, len(deltas))
+        for j in range(k):
+            theta[j] += LEARNING_RATE * (grad[j] / n) * sigmoid(theta[j]) - LEARNING_RATE * L2 * theta[j]
+    return [softplus(t) for t in theta]
+
+
+def agree(deltas: list[list[float]], w: list[float]) -> tuple[int, int]:
+    hit = n = 0
+    for d in deltas:
+        z = sum(wi * di for wi, di in zip(w, d, strict=True))
+        if z == 0:
+            continue
+        n += 1
+        hit += z > 0
+    return hit, n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("labels", type=Path, nargs="+")
+    ap.add_argument(
+        "--only",
+        choices=("v1", "v2", "both"),
+        default="both",
+        help="restrict to one label generation (v2 labels saw only the art crop)",
+    )
+    args = ap.parse_args()
+
+    pairs, stats = expand(args.labels)
+    if args.only != "both":
+        pairs = [p for p in pairs if p[2] == args.only]
+    print(
+        f"{stats['v1_records']} v1 + {stats['v2_records']} v2 records, "
+        f"{stats['other']} no-preference -> {len(pairs)} pairwise observations"
+        + (f" (filtered to {args.only})" if args.only != "both" else "")
+    )
+
+    sids = sorted({s for a, b, _ in pairs for s in (a, b)})
+    rows = {r["sid"]: r for r in run_query(FEATURE_SQL.format(ids=",".join(repr(s) for s in sids)))}
+
+    deltas, base, prov = [], [], []
+    for chosen, rejected, src in pairs:
+        rc, rr = rows.get(chosen), rows.get(rejected)
+        if not rc or not rr:
+            continue
+        vc, vr = to_vector(rc), to_vector(rr)
+        if vc is None or vr is None:
+            continue
+        deltas.append([a - b for a, b in zip(vc, vr, strict=True)])
+        base.append((float(rc["prefer_score"]), float(rr["prefer_score"])))
+        prov.append(src)
+    print(f"usable after feature lookup: {len(deltas)}  (v1 {prov.count('v1')} / v2 {prov.count('v2')})\n")
+
+    idx = list(range(len(deltas)))
+    random.Random(SPLIT_SEED).shuffle(idx)
+    folds = [idx[i::FOLDS] for i in range(FOLDS)]
+
+    def cv(keep: tuple[str, ...]) -> tuple[int, int, list[float]]:
+        ks = [FEATURES.index(f) for f in keep]
+        sub = [[d[j] for j in ks] for d in deltas]
+        hit = n = 0
+        for f in range(FOLDS):
+            te = folds[f]
+            tr = [i for g, fold in enumerate(folds) if g != f for i in fold]
+            w = fit([sub[i] for i in tr], len(ks))
+            h, c = agree([sub[i] for i in te], w)
+            hit += h
+            n += c
+        return hit, n, fit(sub, len(ks))
+
+    models: tuple[tuple[str, ...], ...] = (
+        ("art_age",),
+        ("art_pop",),
+        ("artist_prominence",),
+        ("artist_reuse",),
+        ("art_age", "art_pop"),
+        ("art_age", "artist_prominence"),
+        ("art_age", "art_pop", "artist_prominence", "artist_reuse"),
+    )
+    print(f"{FOLDS}-fold CV, out-of-fold agreement (chance = 50%):\n")
+    print(f"  {'model':46s} {'agree':>7s} {'n':>5s} {'95% band':>9s}")
+    best = None
+    for keep in models:
+        hit, n, w = cv(keep)
+        if not n:
+            continue
+        pct, band = 100 * hit / n, 1.96 * math.sqrt(0.25 / n) * 100
+        label = " + ".join(keep)
+        print(f"  {label:46s} {pct:6.1f}% {n:5d} {'±' + f'{band:.0f}':>9s}")
+        if best is None or pct > best[0]:
+            best = (pct, keep, w)
+
+    hit = n = 0
+    for c, r in base:
+        if c != r:
+            n += 1
+            hit += c > r
+    if n:
+        band = 1.96 * math.sqrt(0.25 / n) * 100
+        print(f"  {'current prefer_score (baseline)':46s} {100 * hit / n:6.1f}% {n:5d} {'±' + f'{band:.0f}':>9s}")
+
+    if best:
+        pct, keep, w = best
+        scale = max(w) or 1.0
+        print(f"\nbest model: {' + '.join(keep)}  ({pct:.1f}%)")
+        print("  relative weights (only ratios are identified):")
+        for name, wk in sorted(zip(keep, w, strict=True), key=lambda kv: -kv[1]):
+            print(f"    {name:20s} {wk / scale:6.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fit_prefer_score.py
+++ b/scripts/fit_prefer_score.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Fit prefer-score weights to preference labels, then measure the change.
+
+Two phases:
+
+  fit     Learn weights from pairwise labels and report held-out agreement against
+          the current prefer_score on the same held-out pairs. This is the only
+          number that says whether the new score is better.
+  impact  Score every printing under both weightings and count how many cards
+          change their representative printing. Agreement says "right where we have
+          labels"; impact says "how much else moved".
+
+Method, per docs/issues/local-prefer-score-label-harness.md:
+
+  * Bradley-Terry with covariates == logistic regression on feature differences,
+    fit within-card: P(a beats b) = sigmoid(w . (x_a - x_b)).
+  * **Signs are declared, not learned.** The maintainer already knows which frame
+    or border they prefer; what is unknown is the magnitudes. Constraining signs
+    removes the degeneracy (a deterministic answer on a one-dimension pair would
+    otherwise drive its coefficient to infinity), shrinks the search space, and
+    guarantees the fit can never contradict a known preference.
+  * Constraints are imposed by reparameterisation, w_k = softplus(theta_k), so the
+    problem stays unconstrained and plain gradient descent suffices. No numpy.
+
+Usage:
+    python scripts/fit_prefer_score.py fit ~/Downloads/prefer-score-labels.jsonl
+    python scripts/fit_prefer_score.py impact ~/Downloads/prefer-score-labels.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import math
+import random
+import subprocess
+import sys
+from pathlib import Path
+
+DB_CONTAINER, DB_USER, DB_NAME = "sylvan_blue-postgres-1", "foouser", "magic"
+
+# Fraction of labels held out. 70/30 mirrors the cost-model calibration in
+# card_engine/src/tests.rs, whose comment names the hazard: "the 22-query trap".
+TEST_FRACTION = 0.30
+SPLIT_SEED = 20260725
+
+# Plain gradient descent on the logistic likelihood. Few parameters, few hundred
+# observations, so nothing cleverer is warranted.
+LEARNING_RATE = 0.05
+ITERATIONS = 4000
+# Ridge penalty, in the reparameterised space. Small: with signs declared the fit is
+# already well-posed, so this only discourages a runaway magnitude.
+L2 = 1e-3
+
+# Every feature is defined so that LARGER IS PREFERRED, which is what lets all
+# weights be constrained non-negative. That encodes the declared signs.
+#   art_pop      reprint count of this artwork, log-shaped like today's term
+#   art_spread   distinct sets the artwork appears in, log-shaped
+#   art_age      years since the artwork first appeared (older art preferred)
+#   nonfoil      a nonfoil version of this printing is obtainable
+#   rarity_low   commons/uncommons preferred, as today's rarity term asserts
+#   highres      a high-resolution scan exists
+FEATURES = ("art_pop", "art_spread", "art_age", "nonfoil", "rarity_low", "highres")
+
+FEATURE_SQL = """
+SELECT c.scryfall_id::text AS sid,
+       c.prefer_score,
+       (SELECT count(*) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL
+           AND o.card_name = c.card_name)                                           AS n_reprints,
+       (SELECT count(DISTINCT o.card_set_code) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL) AS n_sets,
+       (SELECT min(o.released_at) FROM magic.cards o
+         WHERE o.illustration_id = c.illustration_id AND o.illustration_id IS NOT NULL) AS art_first,
+       COALESCE((c.raw_card_blob -> 'finishes') ? 'nonfoil', false)                  AS nonfoil,
+       c.card_rarity_int                                                             AS rarity,
+       ((c.raw_card_blob ->> 'image_status') = 'highres_scan')                        AS highres
+FROM magic.cards c
+WHERE {where}
+"""
+
+
+def run_query(sql: str) -> list[dict[str, str]]:
+    proc = subprocess.run(
+        ["docker", "exec", "-i", DB_CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-v", "ON_ERROR_STOP=1", "--csv", "-f", "-"],
+        input=sql,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"psql failed:\n{proc.stderr}")
+    return list(csv.DictReader(io.StringIO(proc.stdout)))
+
+
+def to_vector(row: dict[str, str]) -> list[float] | None:
+    """Feature vector, oriented so larger is preferred for every entry."""
+    try:
+        n_reprints = float(row["n_reprints"] or 0)
+        n_sets = float(row["n_sets"] or 0)
+        rarity = float(row["rarity"]) if row["rarity"] not in (None, "") else 2.0
+    except ValueError:
+        return None
+    if not row["art_first"]:
+        return None
+    year = int(row["art_first"][:4])
+    return [
+        math.log1p(n_reprints),  # art_pop
+        math.log1p(n_sets),  # art_spread
+        (2026 - year) / 10.0,  # art_age, decades old
+        1.0 if row["nonfoil"] == "t" else 0.0,  # nonfoil
+        (3.0 - rarity) / 3.0,  # rarity_low: common=1.0, mythic=0.0
+        1.0 if row["highres"] == "t" else 0.0,  # highres
+    ]
+
+
+def softplus(x: float) -> float:
+    return math.log1p(math.exp(x)) if x < 30 else x
+
+
+def sigmoid(x: float) -> float:
+    if x < -30:
+        return 0.0
+    if x > 30:
+        return 1.0
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def fit(deltas: list[list[float]]) -> list[float]:
+    """Maximise sum log sigmoid(w . delta) with w = softplus(theta) >= 0.
+
+    Every delta is oriented chosen-minus-rejected, so a correct model gives every
+    observation a positive score.
+    """
+    theta = [0.0] * len(FEATURES)
+    for _ in range(ITERATIONS):
+        grad = [0.0] * len(FEATURES)
+        w = [softplus(t) for t in theta]
+        for d in deltas:
+            z = sum(wk * dk for wk, dk in zip(w, d, strict=True))
+            # d/dz of log sigmoid(z) is 1 - sigmoid(z)
+            g = 1.0 - sigmoid(z)
+            for k, dk in enumerate(d):
+                grad[k] += g * dk
+        for k in range(len(FEATURES)):
+            dw_dtheta = sigmoid(theta[k])  # derivative of softplus
+            theta[k] += LEARNING_RATE * (grad[k] / max(1, len(deltas))) * dw_dtheta
+            theta[k] -= LEARNING_RATE * L2 * theta[k]
+    return [softplus(t) for t in theta]
+
+
+def agreement(deltas: list[list[float]], w: list[float]) -> tuple[int, int]:
+    """How many oriented deltas the weighting scores positively."""
+    hit = n = 0
+    for d in deltas:
+        z = sum(wk * dk for wk, dk in zip(w, d, strict=True))
+        if z == 0:
+            continue  # cannot discriminate; not a miss
+        n += 1
+        hit += z > 0
+    return hit, n
+
+
+def load_labelled(labels_path: Path) -> tuple[list[list[float]], list[tuple[float, float]]]:
+    """Oriented feature deltas plus (chosen, rejected) current prefer_score pairs."""
+    labels = [json.loads(x) for x in labels_path.read_text().splitlines() if x.strip()]
+    decided = [x for x in labels if x["verdict"] in ("left", "right")]
+    print(f"{len(labels)} labels, {len(decided)} decided ({100 * (len(labels) - len(decided)) / len(labels):.0f}% no-preference)")
+
+    sids = sorted({s for x in decided for s in (x["left_sid"], x["right_sid"])})
+    where = f"c.scryfall_id::text IN ({','.join(repr(s) for s in sids)})"
+    rows = {r["sid"]: r for r in run_query(FEATURE_SQL.format(where=where))}
+
+    deltas, baseline = [], []
+    for x in decided:
+        chosen = x["chosen_sid"]
+        rejected = x["right_sid"] if x["verdict"] == "left" else x["left_sid"]
+        rc, rr = rows.get(chosen), rows.get(rejected)
+        if not rc or not rr:
+            continue
+        vc, vr = to_vector(rc), to_vector(rr)
+        if vc is None or vr is None:
+            continue
+        deltas.append([a - b for a, b in zip(vc, vr, strict=True)])
+        baseline.append((float(rc["prefer_score"]), float(rr["prefer_score"])))
+    return deltas, baseline
+
+
+def cmd_fit(labels_path: Path) -> None:
+    deltas, baseline = load_labelled(labels_path)
+    idx = list(range(len(deltas)))
+    random.Random(SPLIT_SEED).shuffle(idx)
+    cut = int(len(idx) * (1 - TEST_FRACTION))
+    train, test = idx[:cut], idx[cut:]
+    print(f"usable pairs: {len(deltas)}  ->  {len(train)} train / {len(test)} held out\n")
+
+    w = fit([deltas[i] for i in train])
+    scale = max(w) or 1.0
+    print("fitted weights (relative; only ratios are identified):")
+    for name, wk in sorted(zip(FEATURES, w, strict=True), key=lambda kv: -kv[1]):
+        print(f"  {name:12s} {wk / scale:6.3f}")
+
+    print("\nagreement:")
+    print(f"  {'':22s} {'train':>14s} {'HELD OUT':>14s}")
+    for label, weights in (("fitted", w),):
+        th, tn = agreement([deltas[i] for i in train], weights)
+        hh, hn = agreement([deltas[i] for i in test], weights)
+        print(f"  {label:22s} {f'{100 * th / tn:.1f}% ({tn})':>14s} {f'{100 * hh / hn:.1f}% ({hn})':>14s}")
+    # Baseline: the current prefer_score on the identical pairs.
+    for label, subset in (("current prefer_score", train), ("", test)):
+        hit = n = 0
+        for i in subset:
+            c, r = baseline[i]
+            if c == r:
+                continue
+            n += 1
+            hit += c > r
+        if label:
+            cur_train = (hit, n)
+        else:
+            cur_test = (hit, n)
+    print(
+        f"  {'current prefer_score':22s} "
+        f"{f'{100 * cur_train[0] / cur_train[1]:.1f}% ({cur_train[1]})':>14s} "
+        f"{f'{100 * cur_test[0] / cur_test[1]:.1f}% ({cur_test[1]})':>14s}"
+    )
+
+    n = cur_test[1]
+    margin = 1.96 * math.sqrt(0.25 / n) * 100 if n else 0
+    print(
+        f"\n  Held-out n is {n}, so the 95% band on any single figure is about "
+        f"+/-{margin:.0f} points.\n  Treat held-out differences smaller than that as unproven."
+    )
+    Path("/tmp/fitted_weights.json").write_text(json.dumps(dict(zip(FEATURES, w, strict=True)), indent=1))
+    print("  weights -> /tmp/fitted_weights.json")
+
+
+def cmd_impact(labels_path: Path) -> None:
+    """How many cards change representative printing under the fitted weights."""
+    weights_path = Path("/tmp/fitted_weights.json")
+    if not weights_path.exists():
+        sys.exit("run `fit` first (writes /tmp/fitted_weights.json)")
+    w = [json.loads(weights_path.read_text())[f] for f in FEATURES]
+
+    print("scoring the whole corpus under both weightings (English, non-promo)...")
+    where = "c.raw_card_blob ->> 'lang' = 'en' AND NOT COALESCE((c.raw_card_blob ->> 'promo')::bool, false)"
+    rows = run_query(FEATURE_SQL.format(where=where) + " AND c.card_name IS NOT NULL")
+
+    by_card: dict[str, list[tuple[float, float, str]]] = {}
+    skipped = 0
+    {r["sid"]: r for r in rows}
+    # Card name is not in FEATURE_SQL's projection, so fetch the mapping separately.
+    names = {
+        r["sid"]: r["card_name"]
+        for r in run_query(f"SELECT scryfall_id::text AS sid, card_name FROM magic.cards WHERE {where.replace('c.', '')}")
+    }
+    for r in rows:
+        v = to_vector(r)
+        if v is None or r["sid"] not in names:
+            skipped += 1
+            continue
+        new = sum(wk * vk for wk, vk in zip(w, v, strict=True))
+        by_card.setdefault(names[r["sid"]], []).append((float(r["prefer_score"]), new, r["sid"]))
+
+    changed = multi = 0
+    for printings in by_card.values():
+        if len(printings) < 2:
+            continue
+        multi += 1
+        old_pick = max(printings, key=lambda t: t[0])[2]
+        new_pick = max(printings, key=lambda t: t[1])[2]
+        changed += old_pick != new_pick
+    print(f"\n  multi-printing cards : {multi}")
+    print(f"  representative changes: {changed}  ({100 * changed / multi:.1f}%)")
+    if skipped:
+        print(f"  skipped (no art date): {skipped} printings")
+    print(
+        "\n  A large number here is not automatically bad -- it is the blast radius, and it\n"
+        "  needs eyeballing against the sampled changes before the weights are trusted."
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("cmd", choices=("fit", "impact"))
+    ap.add_argument("labels", type=Path)
+    args = ap.parse_args()
+    (cmd_fit if args.cmd == "fit" else cmd_impact)(args.labels)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_labeller.py
+++ b/scripts/gen_labeller.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Generate a self-contained artwork-preference labelling page.
+
+Emits a single HTML file with the queue embedded, so it needs no server and no CORS
+workaround — open it directly. Verdicts accumulate in localStorage as you go and are
+exported as JSONL with one button.
+
+Background: docs/issues/local-prefer-score-label-harness.md.
+
+Shows every distinct artwork for one card at once; you click the best, or "no
+preference". A pick-best-of-N is the argmax in a single click AND decomposes into
+N-1 pairwise observations for fitting (chosen beats each other shown), so it yields
+strictly more data per click than asking one pair at a time.
+
+Three design rules:
+
+  * **Show only the artwork**, via Scryfall's own `art_crop`. The judgment is about
+    art, so frame, title and text box are noise. Cropping a full card scan ourselves
+    needs per-frame geometry and got it wrong; the publisher's crop is exact.
+  * **Never display a scored feature** (reprint count, first-appearance date,
+    prefer_score). Those are the model's inputs; showing them would make the label
+    partly a function of them, and any later fit would learn a rule inferred from the
+    same numbers it is fitting. Emitted labels carry scryfall_ids, so analysis
+    rejoins against magic.cards for whatever it needs.
+  * **Randomise tile order** per card, so position bias cannot look like preference.
+
+Usage:
+    python scripts/gen_labeller.py --limit 150 -o /tmp/labeller.html
+    python scripts/gen_labeller.py --limit 150 --seed 2 \
+        --exclude ~/Downloads/prefer-score-labels.jsonl -o /tmp/batch2.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import random
+import subprocess
+import sys
+from pathlib import Path
+
+DB_CONTAINER, DB_USER, DB_NAME = "sylvan_blue-postgres-1", "foouser", "magic"
+
+# Artwork images come from Scryfall's own `art_crop` (stored per printing in
+# raw_card_blob.image_uris), NOT from this project's card CDN. Cropping a full card
+# scan ourselves needs the art window's geometry, which differs by frame version --
+# a single fractional box cut roughly the bottom third off 2015-frame art while
+# fitting older frames. art_crop is the publisher's crop, correct for every frame,
+# and populated for 100% of English printings (94,718/94,718). Typical size 626x457.
+#
+# This is the one place the tooling hits cards.scryfall.io rather than the project
+# CDN. Acceptable for a dev labelling tool loading a few hundred images; do not point
+# production at it.
+ART_CROP_JSON = "raw_card_blob -> 'image_uris' ->> 'art_crop'"
+
+# Basic lands have hundreds of artworks and no meaningful "best" one.
+EXCLUDED_CARDS = ("Mountain", "Island", "Plains", "Forest", "Swamp", "Wastes")
+
+# Sets whose printings are a *treatment* of an existing artwork rather than new art.
+# Scryfall assigns them their own illustration_id, so they surface as a duplicate
+# "artwork". `dbl` (Innistrad: Double Feature) reprints 530 cards in black and white.
+# prefer_score already singles this set out -- its `artwork_set` component scores dbl 0
+# against everything else's 20 -- so excluding it here is consistent with that.
+EXCLUDED_SETS = ("dbl",)
+
+# Perceptual backstop for treatment variants that are not covered by a set or promo
+# flag. Distances measured with the fingerprint below: black-and-white vs colour of one
+# artwork 6.9, a promo recolour 19.3, genuinely different artworks 34.1. A threshold of
+# 15 removes grayscale and near-identical treatments while leaving real pairs alone --
+# of 183 previously labelled pairs only 3 fell below 16.
+DEDUP_THRESHOLD = 15.0
+# Decode size for the comparison. Small on purpose: the blur IS the comparison, and it
+# keeps a 375-artwork batch to a few seconds rather than minutes.
+DEDUP_DECODE = 64
+DEDUP_GRID = 16
+
+# Candidate "off style" art tags, from the community tagger vocabulary reachable via
+# `art:`. These are curated descriptions OF THE PICTURE, which is why they are preferred
+# over an era/year term: a term on year permanently penalises all future art, whereas a
+# style tag generalises -- a new anime-styled card gets tagged and scores low, a new
+# card in the core style does not.
+#
+# Measured on 155 labelled artwork pairs: where exactly one side carried one of these,
+# the UNTAGGED artwork was chosen 19 out of 19 times (p ~ 4e-6). Strong, but 19
+# observations cannot pin the magnitude, support per tag is 2-6, and `anime` never
+# appeared at all -- hence this stratified sampler.
+#
+# This list is a hypothesis, not a conclusion. Analysis should scan all 10,807 art tags
+# for predictive ones rather than trusting the selection here.
+STYLE_TAGS = (
+    "anime",
+    "comic-style",
+    "line-art",
+    "rulebook-style",
+    "word-art-title",
+    "marvel-universe",
+    "fallout-universe",
+    "warhammer-universe",
+)
+
+# Cards with more distinct artworks than this are skipped: past roughly a dozen
+# tiles the choice stops being a judgment and starts being a search.
+MAX_ARTWORKS = 12
+# Cards with fewer than this have no choice to make.
+MIN_ARTWORKS = 2
+
+STYLE_ELIGIBLE_SQL = """
+WITH rep AS (
+    SELECT DISTINCT ON (card_name, illustration_id) card_name, illustration_id,
+           (SELECT string_agg(t, ',') FROM jsonb_object_keys(COALESCE(card_art_tags, '{{}}'::jsonb)) t
+            WHERE t IN {tags}) AS style_tags
+    FROM magic.cards
+    WHERE raw_card_blob ->> 'lang' = 'en'
+      AND illustration_id IS NOT NULL
+      AND card_name NOT IN {excluded}
+      AND card_set_code NOT IN {excluded_sets}
+      AND NOT COALESCE((raw_card_blob ->> 'promo')::bool, false)
+      AND raw_card_blob -> 'image_uris' ->> 'art_crop' IS NOT NULL
+      {exclude_cards}
+    ORDER BY card_name, illustration_id, prefer_score DESC NULLS LAST
+)
+SELECT card_name, string_agg(DISTINCT style_tags, ',') AS tags
+FROM rep GROUP BY card_name
+-- must contain BOTH a tagged and an untagged artwork, or the pair teaches nothing
+HAVING bool_or(style_tags IS NOT NULL) AND bool_or(style_tags IS NULL)
+   AND count(*) BETWEEN {min_art} AND {max_art}
+"""
+
+QUERY = """
+WITH src AS (
+    SELECT card_name, scryfall_id::text AS sid, illustration_id::text AS art,
+           raw_card_blob -> 'image_uris' ->> 'art_crop' AS art_url, prefer_score
+    FROM magic.cards
+    WHERE raw_card_blob ->> 'lang' = 'en'
+      AND card_name NOT IN {excluded}
+      AND illustration_id IS NOT NULL
+      AND raw_card_blob -> 'image_uris' ->> 'art_crop' IS NOT NULL
+      AND card_set_code NOT IN {excluded_sets}
+      -- Promos are excluded because Scryfall gives a promo whose art is the base art
+      -- with a recolour/effect treatment its own illustration_id, so it would appear
+      -- as a separate "artwork" that reads as a duplicate. Observed with Arashin War
+      -- Beast: frf/123 vs ugin/123. Costs ~12% of the pool.
+      AND NOT COALESCE((raw_card_blob ->> 'promo')::bool, false)
+      {exclude_cards}
+),
+rep AS (   -- one representative printing per distinct artwork
+    SELECT DISTINCT ON (card_name, art) *
+    FROM src
+    ORDER BY card_name, art, prefer_score DESC NULLS LAST, sid
+),
+counted AS (
+    SELECT card_name, count(*) AS n_art FROM rep GROUP BY card_name
+    HAVING count(*) BETWEEN {min_art} AND {max_art}
+),
+picked AS (   -- seeded card selection; the seed must reach the SQL or every batch
+              -- returns the same alphabetically-first cards
+    SELECT card_name FROM counted
+    {restrict}
+    ORDER BY md5(card_name || '{seed}')
+    LIMIT {limit}
+)
+SELECT r.card_name, r.sid, r.art, r.art_url
+FROM rep r JOIN picked p USING (card_name)
+ORDER BY r.card_name, r.art
+"""
+
+
+def run_query(sql: str) -> list[dict[str, str]]:
+    """Run SQL in the postgres container; parse CSV (card names contain commas).
+
+    ON_ERROR_STOP is essential: psql exits 0 on SQL errors by default, which makes
+    the returncode meaningless and turns a broken query into silent empty results.
+    """
+    proc = subprocess.run(
+        ["docker", "exec", "-i", DB_CONTAINER, "psql", "-U", DB_USER, "-d", DB_NAME, "-v", "ON_ERROR_STOP=1", "--csv", "-f", "-"],
+        input=sql,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(f"psql failed:\n{proc.stderr}")
+    rows = list(csv.DictReader(io.StringIO(proc.stdout)))
+    if not rows:
+        sys.exit("query returned no rows")
+    return rows
+
+
+def sql_list(values: tuple[str, ...]) -> str:
+    """SQL IN-list. Python's repr of a 1-tuple is ('x',), which is a syntax error."""
+    return "(" + ", ".join("'" + v.replace("'", "''") + "'" for v in values) + ")"
+
+
+def already_labelled(paths: list[Path]) -> set[str]:
+    seen: set[str] = set()
+    for p in paths:
+        for line in p.read_text().splitlines():
+            if line.strip():
+                seen.add(json.loads(line)["card"])
+    return seen
+
+
+def pick_style_cards(limit: int, seed: int, clause: str) -> list[str]:
+    """Cards having both a style-tagged and an untagged artwork, stratified by tag.
+
+    Stratified rather than random so no candidate tag is left untested: `anime` has 577
+    tagged artworks yet appeared in zero labelled pairs under random sampling.
+    """
+    rows = run_query(
+        STYLE_ELIGIBLE_SQL.format(
+            tags=sql_list(STYLE_TAGS),
+            excluded=sql_list(EXCLUDED_CARDS),
+            excluded_sets=sql_list(EXCLUDED_SETS),
+            exclude_cards=clause,
+            min_art=MIN_ARTWORKS,
+            max_art=MAX_ARTWORKS,
+        )
+    )
+    by_tag: dict[str, list[str]] = {t: [] for t in STYLE_TAGS}
+    for r in rows:
+        for t in set((r["tags"] or "").split(",")):
+            if t in by_tag:
+                by_tag[t].append(r["card_name"])
+    rng = random.Random(seed)
+    for cards in by_tag.values():
+        rng.shuffle(cards)
+    # Round-robin across tags so the scarcest tag still gets its share.
+    chosen: list[str] = []
+    seen: set[str] = set()
+    i = 0
+    while len(chosen) < limit and any(len(v) > i for v in by_tag.values()):
+        for t in STYLE_TAGS:
+            if len(chosen) >= limit:
+                break
+            if len(by_tag[t]) > i and by_tag[t][i] not in seen:
+                seen.add(by_tag[t][i])
+                chosen.append(by_tag[t][i])
+        i += 1
+    print("  stratified by tag: " + ", ".join(f"{t}={sum(1 for c in chosen if c in set(by_tag[t]))}" for t in STYLE_TAGS))
+    return chosen
+
+
+def build_cards(limit: int, seed: int, exclude: set[str], mode: str) -> list[dict[str, object]]:
+    clause = ""
+    if exclude:
+        quoted = ",".join("'" + c.replace("'", "''") + "'" for c in sorted(exclude))
+        clause = f"AND card_name NOT IN ({quoted})"
+    restrict = ""
+    if mode == "style":
+        names = pick_style_cards(limit, seed, clause)
+        if not names:
+            sys.exit("no eligible style-tag cards")
+        restrict = f"WHERE card_name IN ({','.join(chr(39) + n.replace(chr(39), chr(39) * 2) + chr(39) for n in names)})"
+    rows = run_query(
+        QUERY.format(
+            excluded=sql_list(EXCLUDED_CARDS),
+            excluded_sets=sql_list(EXCLUDED_SETS),
+            exclude_cards=clause,
+            min_art=MIN_ARTWORKS,
+            max_art=MAX_ARTWORKS,
+            seed=seed,
+            limit=limit,
+            restrict=restrict,
+        )
+    )
+
+    grouped: dict[str, list[dict[str, str]]] = {}
+    for r in rows:
+        grouped.setdefault(r["card_name"], []).append(
+            {
+                "sid": r["sid"],
+                "art": r["art"],
+                "img": r["art_url"],
+            }
+        )
+    rng = random.Random(seed)
+    cards = []
+    for name, tiles in grouped.items():
+        rng.shuffle(tiles)  # position bias must not read as preference
+        cards.append({"card": name, "tiles": tiles})
+    rng.shuffle(cards)
+    return cards
+
+
+PAGE = """<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Artwork preference labeller</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { margin:0; font:15px/1.4 system-ui, sans-serif; display:flex; flex-direction:column;
+         min-height:100vh; }
+  header { display:flex; align-items:baseline; gap:1rem; padding:.6rem 1rem;
+           border-bottom:1px solid color-mix(in srgb, currentColor 20%, transparent); }
+  h1 { font-size:1rem; margin:0; font-weight:600; }
+  #card { font-weight:600; }
+  #progress { margin-left:auto; opacity:.7; font-variant-numeric:tabular-nums; }
+  main { flex:1; padding:1rem; display:grid; gap:.75rem; align-content:start;
+         grid-template-columns:repeat(auto-fit, minmax(260px, 1fr)); }
+  .tile { border:3px solid transparent; border-radius:10px; padding:0; background:none;
+          cursor:pointer; overflow:hidden; position:relative; }
+  .tile:hover, .tile:focus-visible { border-color:#4f8cff; outline:none; }
+  .crop { position:relative; border-radius:6px; overflow:hidden; }
+  .crop img { width:100%; display:block; }
+  .num { position:absolute; left:.35rem; top:.35rem; background:#000a; color:#fff;
+         font:12px/1 monospace; padding:.2rem .35rem; border-radius:4px; }
+  footer { display:flex; gap:.75rem; align-items:center; justify-content:center; padding:.75rem;
+           border-top:1px solid color-mix(in srgb, currentColor 20%, transparent); flex-wrap:wrap; }
+  button.act { font:inherit; padding:.5rem .9rem; border-radius:8px; cursor:pointer; background:none;
+               border:1px solid color-mix(in srgb, currentColor 35%, transparent); }
+  .key { font:12px monospace; opacity:.6; }
+  #done { display:none; padding:2rem; text-align:center; }
+</style></head><body>
+<header>
+  <h1>Pick the best artwork</h1><span id="card"></span><span id="progress"></span>
+</header>
+<main id="stage"></main>
+<div id="done"><p><strong>Queue finished.</strong> Download your labels below.</p></div>
+<footer>
+  <button class="act" id="otherBtn">No preference <span class="key">(space)</span></button>
+  <button class="act" id="undoBtn">Undo <span class="key">(u)</span></button>
+  <button class="act" id="dlBtn">Download labels (JSONL)</button>
+  <button class="act" id="resetBtn">Reset</button>
+</footer>
+<script>
+const ALL_CARDS = __CARDS__;
+const KEY = 'prefer-score-labels-v2';
+let labels = JSON.parse(localStorage.getItem(KEY) || '[]');
+const $ = id => document.getElementById(id);
+
+// Resume by CARD, not by count. The queue gets regenerated (new seed, new exclusions,
+// bug fixes), and a count-based resume would then point into a reshuffled queue --
+// skipping cards never seen and re-showing ones already done. Every label record is
+// self-describing (card name + chosen/shown sids), so filtering the queue against
+// what is already labelled makes restarts and regenerations safe.
+const done = new Set(labels.map(l => l.card));
+const CARDS = ALL_CARDS.filter(c => !done.has(c.card));
+const CARRIED = labels.length;
+const at = () => labels.length - CARRIED;
+
+function preload(i) {
+  (CARDS[i]?.tiles || []).forEach(t => { const im = new Image(); im.src = t.img; });
+}
+
+function render() {
+  const i = at();
+  $('progress').textContent = CARRIED
+      ? `${i} / ${CARDS.length} left  (${CARRIED} already done)`
+      : `${i} / ${CARDS.length}`;
+  if (i >= CARDS.length) { $('stage').style.display='none'; $('done').style.display='block'; $('card').textContent=''; return; }
+  $('stage').style.display='grid'; $('done').style.display='none';
+  const c = CARDS[i];
+  $('card').textContent = c.card;
+  $('stage').innerHTML = c.tiles.map((t, k) => `
+    <button class="tile" data-k="${k}">
+      <div class="crop"><img src="${t.img}" alt="artwork ${k+1}"><span class="num">${k+1}</span></div>
+    </button>`).join('');
+  for (const b of $('stage').querySelectorAll('.tile')) b.onclick = () => record(+b.dataset.k);
+  preload(i + 1);
+}
+
+function record(k) {
+  const i = at();
+  if (i >= CARDS.length) return;
+  const c = CARDS[i];
+  labels.push({
+    card: c.card,
+    mode: 'artworks',
+    verdict: k === null ? 'other' : 'pick',
+    chosen_sid: k === null ? null : c.tiles[k].sid,
+    chosen_art: k === null ? null : c.tiles[k].art,
+    shown: c.tiles.map(t => ({sid: t.sid, art: t.art})),
+    labeled_at: new Date().toISOString(),
+  });
+  localStorage.setItem(KEY, JSON.stringify(labels));
+  render();
+}
+
+$('otherBtn').onclick = () => record(null);
+$('undoBtn').onclick = () => {
+  if (labels.length <= CARRIED) return;   // never undo into a previous session's labels
+  labels.pop(); localStorage.setItem(KEY, JSON.stringify(labels)); render();
+};
+$('resetBtn').onclick = () => { if (confirm('Discard all labels in this browser?')) { labels=[]; localStorage.removeItem(KEY); render(); } };
+$('dlBtn').onclick = () => {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([labels.map(l=>JSON.stringify(l)).join('\\n')+'\\n'], {type:'application/x-ndjson'}));
+  a.download = 'prefer-score-labels.jsonl'; a.click();
+};
+addEventListener('keydown', e => {
+  const c = CARDS[at()]; if (!c) return;
+  if (e.key === ' ') { e.preventDefault(); record(null); }
+  else if (e.key === 'u') $('undoBtn').click();
+  else if (/^[1-9]$/.test(e.key) && +e.key <= c.tiles.length) record(+e.key - 1);
+  else if (e.key === 'ArrowLeft') record(0);
+  else if (e.key === 'ArrowRight') record(c.tiles.length - 1);
+});
+render();
+</script></body></html>
+"""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--mode",
+        choices=("artworks", "style"),
+        default="artworks",
+        help="artworks: any card with 2+ distinct artworks. "
+        "style: only cards having BOTH a style-tagged and an untagged artwork, "
+        "stratified across candidate tags so none stays untested.",
+    )
+    ap.add_argument("--limit", type=int, default=150, help="number of cards to queue")
+    ap.add_argument("--seed", type=int, default=0, help="selection seed; reaches the SQL, so a new seed means new cards")
+    ap.add_argument(
+        "--exclude", type=Path, nargs="*", default=[], help="previous label JSONL files whose cards should not reappear"
+    )
+    ap.add_argument("-o", "--out", type=Path, default=Path("/tmp/labeller.html"))
+    args = ap.parse_args()
+
+    skip = already_labelled(args.exclude) if args.exclude else set()
+    cards = build_cards(args.limit, args.seed, skip, args.mode)
+    args.out.write_text(PAGE.replace("__CARDS__", json.dumps(cards, separators=(",", ":"))))
+    tiles = sum(len(c["tiles"]) for c in cards)
+    print(
+        f"[{args.mode}] {len(cards)} cards / {tiles} artworks -> {args.out}"
+        + (f"  (skipped {len(skip)} already-labelled)" if skip else "")
+    )
+    print(f"open {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Independent of the cost-model stack (#804–#816). Off `main` directly.

Eleven files that exist on **exactly one unmerged feature branch** and nowhere else. They were swept
into `b511254` — a commit whose message is entirely about `query_sampler.py` — by an over-broad
`git add`. If that branch is abandoned they go with it, and none of it is cost-model work.

## Three clusters, one design note

**Artwork-preference labelling pipeline** (~1,386 lines) — a coherent workflow for learning which
printing represents a card, i.e. the `prefer_score` the engine sorts and dedupes on:

    gen_labeller.py      self-contained HTML labelling page (no server, no CORS workaround)
    art_distance.py      perceptual distance, to keep recolour/effect variants out of the pool
    analyze_labels.py    scores candidate features against collected human verdicts
    fit_artwork_score.py fits artwork-preference weights, cross-validated
    fit_prefer_score.py  fits prefer-score weights, measured against held-out agreement

**Engine-vs-SQL benchmark** — `bench_search.py` + `bench_search.sh`, run inside the API container so
both paths are available.

**Frontend micro-benches** — `bench_autocomplete.js`, `bench_catalog_map.js`, `bench_escape_html.js`.

**`docs/issues/00754-...md`** — the plane-subtree compose leaf and general `Not(composable)` arm.
GitHub #754 is **open**, and `CLAUDE.md` makes `docs/issues/` the primary source of truth with the
GitHub issue as a secondary triage layer — so the depth lives in this file and nowhere else. It
existed only on unmerged engine branches.

## What this PR is not

Preservation, not review. Nothing here was run, tested, or linted as part of this change, and the
commits say so individually. The `.js` files in particular are covered by `make lint` under prettier
and may want formatting before anyone treats them as live.

Split into four commits so any cluster can be taken on its own or dropped.

The prefer-score work is worth a second look given recent engine changes: #815 makes cross-card row
order independent of `prefer_score`, so the two now interact less than they used to — but
`prefer_score` still decides *which printing* represents a card, which is what these scripts fit.