### PR TITLE
Engine: Peel the Not Instead of Nesting a Helper

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4662,37 +4662,33 @@ fn bare_range_bounds<'i>(
     filter: &FilterExpr,
     indexes: &'i Archived<CardIndexes>,
 ) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
-    // The direct and `Not` arms are the same three-way leaf dispatch, differing only in
-    // whether the leaf's op is taken as written or negated. `map_op` is that difference,
-    // so the grammar is written once and the two arms cannot drift apart.
-    fn leaf<'i>(
-        filter: &FilterExpr,
-        indexes: &'i Archived<CardIndexes>,
-        map_op: impl Fn(CmpOp) -> CmpOp,
-    ) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
-        match filter {
-            FilterExpr::NumericCmp { lhs, op, rhs } => {
-                let (idx, op, value) = resolve_numeric_range_leaf(lhs, map_op(*op), rhs, indexes)?;
-                match int_range_bounds(op, value)? {
-                    None => Some((idx, 0, 0)),
-                    Some((lo, hi)) => Some((idx, lo, hi)),
-                }
-            }
-            FilterExpr::DateCmp { op, value } => {
-                let (lo, hi) = date_range_bounds(map_op(*op), *value)?;
-                Some((&indexes.released_at, lo, hi))
-            }
-            FilterExpr::YearCmp { op, year } => {
-                let (lo, hi) = year_range_bounds(map_op(*op), *year)?;
-                Some((&indexes.released_at, lo, hi))
-            }
-            _ => None,
-        }
-    }
-
+    // The direct and `Not` cases are the same three-way leaf dispatch, differing only in
+    // whether the leaf's op is taken as written or negated. Peel the `Not` into that one
+    // difference up front and the grammar below is written once, for both.
+    //
+    // Peeling exactly one level is what makes `Not(Not(x))` decline: the second `Not` is
+    // then matched as a leaf, and it is not one.
+    let (filter, map_op): (&FilterExpr, fn(CmpOp) -> CmpOp) = match filter {
+        FilterExpr::Not(inner) => (inner.as_ref(), negate_op),
+        _ => (filter, |op| op),
+    };
     match filter {
-        FilterExpr::Not(inner) => leaf(inner.as_ref(), indexes, negate_op),
-        _ => leaf(filter, indexes, |op| op),
+        FilterExpr::NumericCmp { lhs, op, rhs } => {
+            let (idx, op, value) = resolve_numeric_range_leaf(lhs, map_op(*op), rhs, indexes)?;
+            match int_range_bounds(op, value)? {
+                None => Some((idx, 0, 0)),
+                Some((lo, hi)) => Some((idx, lo, hi)),
+            }
+        }
+        FilterExpr::DateCmp { op, value } => {
+            let (lo, hi) = date_range_bounds(map_op(*op), *value)?;
+            Some((&indexes.released_at, lo, hi))
+        }
+        FilterExpr::YearCmp { op, year } => {
+            let (lo, hi) = year_range_bounds(map_op(*op), *year)?;
+            Some((&indexes.released_at, lo, hi))
+        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Optional follow-up to #809, stacked on it — take it or drop it, #809 stands either way.

#809 writes the leaf grammar once by moving it into an inner `fn leaf` parameterized by
`map_op`. That works, but a nested `fn` cannot inherit the outer generics, so it has to
restate the whole signature — both parameters and the return type — which is most of the
+18 that commit adds:

```rust
fn leaf<'i>(
    filter: &FilterExpr,
    indexes: &'i Archived<CardIndexes>,
    map_op: impl Fn(CmpOp) -> CmpOp,
) -> Option<(&'i Archived<PrintingRangeIndex>, u32, u32)> {
```

The difference between the two cases is one op mapping, and it can be bound directly:

```rust
let (filter, map_op): (&FilterExpr, fn(CmpOp) -> CmpOp) = match filter {
    FilterExpr::Not(inner) => (inner.as_ref(), negate_op),
    _ => (filter, |op| op),
};
match filter {
    // the same four arms, unchanged
}
```

Net **-4 lines** against #809, one flat match instead of a helper plus a dispatch, and no
second signature to keep in step with the first. A non-capturing `|op| op` coerces to the
`fn` pointer, so nothing monomorphizes into two copies of `leaf` either.

## Why `Not(Not(x))` still declines

Exactly one level is peeled, so a second `Not` reaches the leaf match and falls through its
catch-all — the same reason as #809, but visible in the shape of the code rather than in an
inner function's fallthrough. #809's test commit asserts this directly, and that assertion
fails if the peel is made recursive.

## Testing

- `cargo test` (debug): 147 passed
- `cargo clippy --all-targets`: clean
- Behavior is unchanged, so #809's three added assertions (negated arm, negated equality,
  double negation) cover this as-is.
