### PR TITLE
Follow Scryfall's Move to Gzipped JSONL Bulk Data

### DIFF
--- a/api/scryfall_bulk_data_fetcher.py
+++ b/api/scryfall_bulk_data_fetcher.py
@@ -1,12 +1,14 @@
 """Fetcher for Scryfall bulk data."""
 
 import io
+import itertools
 import logging
 import os
 import pathlib
 import secrets
 import time
-from collections.abc import Iterator
+import zlib
+from collections.abc import Iterable, Iterator
 from enum import StrEnum
 
 import orjson
@@ -33,9 +35,66 @@ _TMP_PRUNE_AGE_SECONDS = 15 * MINUTE
 # Log at most this many individual unparseable lines; beyond that only the final summary reports them.
 _MAX_UNPARSEABLE_LINE_LOGS = 5
 
+# Field on each /bulk-data record holding the dump URL. Scryfall served plain-JSON `download_uri`
+# until it moved the dumps to gzipped JSONL under this name; the old field no longer exists.
+_DOWNLOAD_URI_FIELD = "jsonl_download_uri"
+
+# Scryfall serves the dumps as `.jsonl.gz` with Content-Type: application/gzip and *no*
+# Content-Encoding header, so requests hands back raw gzip bytes rather than decompressing.
+_GZIP_MAGIC = b"\x1f\x8b"
+# zlib needs this window-bits offset to parse a gzip container rather than a raw deflate stream.
+_GZIP_WBITS = 16 + zlib.MAX_WBITS
+
 
 class BulkDataParseError(Exception):
     """Raised when a bulk data file yields implausibly little card data for its size."""
+
+
+class BulkDataFormatError(Exception):
+    """Raised when Scryfall's /bulk-data response does not have the shape we expect."""
+
+
+def _gunzip_if_needed(chunks: Iterable[bytes]) -> Iterator[bytes]:
+    """Decompress a byte stream if it is gzipped, else pass it through unchanged.
+
+    Sniffs the gzip magic bytes rather than trusting the URL suffix or headers, so this keeps
+    working whether Scryfall serves gzip as the payload (today) or as a Content-Encoding that
+    requests transparently decompresses for us.
+
+    Args:
+        chunks: Byte chunks as returned by requests' iter_content.
+
+    Yields:
+        Decompressed bytes, not aligned to any particular boundary.
+
+    Raises:
+        BulkDataFormatError: If a gzip stream ends mid-member, i.e. the download was truncated.
+    """
+    nonempty = (chunk for chunk in chunks if chunk)  # iter_content emits empty keep-alive chunks
+    first = next(nonempty, b"")
+    if not first:
+        return
+    if not first.startswith(_GZIP_MAGIC):
+        yield first
+        yield from nonempty
+        return
+
+    decompressor = zlib.decompressobj(_GZIP_WBITS)
+    for chunk in itertools.chain([first], nonempty):
+        pending = chunk
+        while pending:
+            if out := decompressor.decompress(pending):
+                yield out
+            if not decompressor.eof:
+                break
+            pending = decompressor.unused_data
+            if pending:
+                # Concatenated members are one logical stream; decode the next one too, or a
+                # multi-member dump would silently truncate to its first member.
+                decompressor = zlib.decompressobj(_GZIP_WBITS)
+    if not decompressor.eof:
+        msg = "Bulk data gzip stream ended mid-member; the download was truncated"
+        raise BulkDataFormatError(msg)
 
 
 class BulkDataKey(StrEnum):
@@ -110,14 +169,32 @@ class ScryfallBulkDataFetcher:
         return {BulkDataKey(r["type"]): r for r in records if r["type"] in known_types}
 
     def get_download_uri_for_key(self, data_key: BulkDataKey) -> str:
-        """Get the download URI for a given data key."""
-        return self.list_bulk_data()[data_key]["download_uri"]
+        """Get the download URI for a given data key.
+
+        Args:
+            data_key: Which bulk data dump to look up.
+
+        Returns:
+            The URL of the dump file.
+
+        Raises:
+            BulkDataFormatError: If the record lacks the download URI field, which means Scryfall
+                renamed or removed it again.
+        """
+        record = self.list_bulk_data()[data_key]
+        if _DOWNLOAD_URI_FIELD not in record:
+            msg = (
+                f"Scryfall bulk data record for {data_key} has no {_DOWNLOAD_URI_FIELD!r} field "
+                f"(present fields: {sorted(record)}); the /bulk-data schema has changed"
+            )
+            raise BulkDataFormatError(msg)
+        return record[_DOWNLOAD_URI_FIELD]
 
     def _cache_file_path_for_key(self, data_key: BulkDataKey) -> pathlib.Path:
         download_uri = self.get_download_uri_for_key(data_key)
-        suffix = download_uri.rpartition("/")[-1]
-        cache_file_path = self.cache_directory / data_key / suffix
-        return cache_file_path.with_suffix(".json.zstd")
+        remote_name = download_uri.rpartition("/")[-1]
+        # We store decompressed-then-zstd-recompressed content, so drop any upstream .gz suffix.
+        return self.cache_directory / data_key / f"{remote_name.removesuffix('.gz')}.zstd"
 
     def _ensure_cached(self, data_key: BulkDataKey, cache_file_path: pathlib.Path) -> None:
         """Download and cache the bulk data file if not already present.
@@ -147,7 +224,7 @@ class ScryfallBulkDataFetcher:
         try:
             with self._get(download_uri, stream=True, timeout=60) as response:
                 with tmp_path.open("wb") as f, cctx.stream_writer(f) as compressor:
-                    for chunk in response.iter_content(chunk_size=65536):
+                    for chunk in _gunzip_if_needed(response.iter_content(chunk_size=65536)):
                         compressor.write(chunk)
             tmp_path.rename(cache_file_path)
         except Exception:
@@ -158,11 +235,12 @@ class ScryfallBulkDataFetcher:
     def stream_data_for_key(self, data_key: BulkDataKey) -> Iterator[dict]:
         """Yield card dicts one at a time without loading the full file into memory.
 
-        Reads the cached .json.zstd file line-by-line; downloads and caches first if needed.
-        Each line that starts with '{' is treated as one card JSON object (trailing comma stripped).
-        Unparseable lines are logged and skipped, but if a non-trivially-sized file ends up with
-        less than _PARSE_COVERAGE_THRESHOLD of its content parsed into cards (e.g. the dump is no
-        longer one-object-per-line), BulkDataParseError is raised instead of silently under-yielding.
+        Reads the cached .zstd file line-by-line; downloads and caches first if needed. The dumps
+        are JSONL, so every non-blank line must be one JSON object. Lines that are not — malformed
+        JSON, or valid JSON of some other type such as a whole array on one line — are logged and
+        skipped. But if a non-trivially-sized file ends up with less than _PARSE_COVERAGE_THRESHOLD
+        of its content parsed into cards (e.g. the dump is no longer one-object-per-line),
+        BulkDataParseError is raised instead of silently under-yielding.
 
         Note: the coverage check runs after the last line is read, so it only fires for consumers
         that iterate to exhaustion. A consumer that stops early (break, islice, etc.) gets no
@@ -185,12 +263,16 @@ class ScryfallBulkDataFetcher:
             ):
                 for raw_line in text_reader:
                     total_chars += len(raw_line)
-                    stripped = raw_line.strip().rstrip(",")
-                    if not stripped.startswith("{"):
+                    stripped = raw_line.strip()
+                    if not stripped:
                         continue
                     try:
                         card = orjson.loads(stripped)
                     except orjson.JSONDecodeError:
+                        card = None
+                    # A non-dict line means the layout is not JSONL; skipping keeps the yielded
+                    # type honest and lets the coverage check below turn it into a hard failure.
+                    if not isinstance(card, dict):
                         skipped_lines += 1
                         if skipped_lines <= _MAX_UNPARSEABLE_LINE_LOGS:
                             logger.warning("Skipping unparseable line: %.120s", stripped)

--- a/api/tests/test_scryfall_bulk_data_fetcher.py
+++ b/api/tests/test_scryfall_bulk_data_fetcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import logging
 import os
 import time
@@ -14,7 +15,9 @@ import requests
 import zstandard as zstd
 
 from api.scryfall_bulk_data_fetcher import (
+    _DOWNLOAD_URI_FIELD,
     _MAX_UNPARSEABLE_LINE_LOGS,
+    BulkDataFormatError,
     BulkDataKey,
     BulkDataParseError,
     ScryfallBulkDataFetcher,
@@ -23,8 +26,10 @@ from api.scryfall_bulk_data_fetcher import (
 if TYPE_CHECKING:
     import pathlib
 
-_FAKE_URI = "https://data.scryfall.io/default-cards/default-cards-test.json"
-_FAKE_BULK_DATA = {BulkDataKey.DEFAULT_CARDS: {"download_uri": _FAKE_URI}}
+_FAKE_URI = "https://data.scryfall.io/default-cards/default-cards-test.jsonl.gz"
+_FAKE_BULK_DATA = {BulkDataKey.DEFAULT_CARDS: {"jsonl_download_uri": _FAKE_URI}}
+# What _cache_file_path_for_key derives from _FAKE_URI: .gz stripped, .zstd appended.
+_FAKE_CACHE_NAME = "default-cards-test.jsonl.zstd"
 
 
 def _make_fetcher(cache_directory: pathlib.Path) -> ScryfallBulkDataFetcher:
@@ -35,20 +40,15 @@ def _make_fetcher(cache_directory: pathlib.Path) -> ScryfallBulkDataFetcher:
 
 
 def _write_cache_file(cache_dir: pathlib.Path, raw_json: bytes) -> pathlib.Path:
-    cache_file = cache_dir / "default_cards" / "default-cards-test.json.zstd"
+    cache_file = cache_dir / "default_cards" / _FAKE_CACHE_NAME
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_bytes(zstd.compress(raw_json))
     return cache_file
 
 
-def _scryfall_json(cards: list[dict]) -> bytes:
-    """Produce a Scryfall-style newline-delimited JSON array."""
-    lines = ["[\n"]
-    for i, card in enumerate(cards):
-        comma = "," if i < len(cards) - 1 else ""
-        lines.append(orjson.dumps(card).decode() + comma + "\n")
-    lines.append("]\n")
-    return "".join(lines).encode()
+def _scryfall_jsonl(cards: list[dict]) -> bytes:
+    """Produce a Scryfall-style JSONL dump: one compact JSON object per line."""
+    return b"".join(orjson.dumps(card) + b"\n" for card in cards)
 
 
 def _mock_streaming_response(chunks: list[bytes] | object) -> MagicMock:
@@ -67,7 +67,7 @@ class TestStreamDataForKeyHappyPath:
 
     def test_streams_all_cards_from_cache(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         cards = [{"id": "c1", "name": "Lightning Bolt"}, {"id": "c2", "name": "Counterspell"}]
-        _write_cache_file(tmp_path, _scryfall_json(cards))
+        _write_cache_file(tmp_path, _scryfall_jsonl(cards))
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
@@ -77,7 +77,7 @@ class TestStreamDataForKeyHappyPath:
         assert result[1] == {"id": "c2", "name": "Counterspell"}
 
     def test_single_card_file(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
-        _write_cache_file(tmp_path, _scryfall_json([{"id": "only", "name": "Dark Ritual"}]))
+        _write_cache_file(tmp_path, _scryfall_jsonl([{"id": "only", "name": "Dark Ritual"}]))
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
@@ -85,8 +85,8 @@ class TestStreamDataForKeyHappyPath:
         assert len(result) == 1
         assert result[0]["name"] == "Dark Ritual"
 
-    def test_empty_array_yields_nothing(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
-        _write_cache_file(tmp_path, _scryfall_json([]))
+    def test_empty_file_yields_nothing(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        _write_cache_file(tmp_path, _scryfall_jsonl([]))
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
@@ -99,31 +99,11 @@ class TestStreamDataForKeyLineParsing:
     def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
         return _make_fetcher(tmp_path)
 
-    def test_skips_opening_and_closing_bracket_lines(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
-        """[ and ] delimiter lines must not be parsed as cards."""
-        raw = b'[\n{"id":"c1","name":"A"}\n]\n'
-        _write_cache_file(tmp_path, raw)
-
-        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
-            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
-
-        assert result == [{"id": "c1", "name": "A"}]
-
-    def test_strips_trailing_comma_from_card_lines(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
-        """Trailing commas on all-but-last card lines must be stripped before parsing."""
-        raw = b'[\n{"id":"c1","name":"A"},\n{"id":"c2","name":"B"},\n{"id":"c3","name":"C"}\n]\n'
-        _write_cache_file(tmp_path, raw)
-
-        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
-            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
-
-        assert [r["name"] for r in result] == ["A", "B", "C"]
-
     def test_skips_malformed_lines_and_logs_warning(
         self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Malformed JSON lines are skipped; a WARNING is emitted and parsing continues."""
-        raw = b'[\n{"id":"good1","name":"Good"},\n{bad json here},\n{"id":"good2","name":"Also Good"}\n]\n'
+        raw = b'{"id":"good1","name":"Good"}\n{bad json here}\n{"id":"good2","name":"Also Good"}\n'
         _write_cache_file(tmp_path, raw)
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), caplog.at_level(logging.WARNING):
@@ -132,14 +112,32 @@ class TestStreamDataForKeyLineParsing:
         assert [r["name"] for r in result] == ["Good", "Also Good"]
         assert any("Skipping unparseable" in r.message for r in caplog.records)
 
-    def test_ignores_blank_lines(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
-        raw = b'[\n\n{"id":"c1","name":"A"}\n\n]\n'
+    def test_skips_valid_json_that_is_not_an_object(
+        self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Lines that parse but aren't objects must not be yielded, or callers get a non-dict card."""
+        raw = b'{"id":"c1","name":"A"}\n[{"id":"nested"}]\n"a bare string"\n42\n'
         _write_cache_file(tmp_path, raw)
 
-        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), caplog.at_level(logging.WARNING):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
-        assert len(result) == 1
+        assert result == [{"id": "c1", "name": "A"}]
+        assert all(isinstance(card, dict) for card in result)
+        assert sum("Skipping unparseable" in r.message for r in caplog.records) == 3
+
+    def test_ignores_blank_lines(
+        self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Blank lines are structural whitespace, not unparseable content, so they log nothing."""
+        raw = b'\n{"id":"c1","name":"A"}\n\n'
+        _write_cache_file(tmp_path, raw)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), caplog.at_level(logging.WARNING):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == [{"id": "c1", "name": "A"}]
+        assert not [r for r in caplog.records if "Skipping unparseable" in r.message]
 
 
 class TestStreamDataForKeyCacheMiss:
@@ -149,13 +147,13 @@ class TestStreamDataForKeyCacheMiss:
 
     def test_downloads_and_caches_on_miss(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """When no cache file exists, the file is downloaded and written as zstd-compressed cache."""
-        raw_json = _scryfall_json([{"id": "dl-1", "name": "Downloaded Card"}])
+        raw_json = _scryfall_jsonl([{"id": "dl-1", "name": "Downloaded Card"}])
         fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
-        cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
+        cache_file = tmp_path / "default_cards" / _FAKE_CACHE_NAME
         assert cache_file.exists(), "cache file should have been written"
         # Use ZstdDecompressor so we can bound output size via max_output_size.
         dctx = zstd.ZstdDecompressor()
@@ -165,7 +163,7 @@ class TestStreamDataForKeyCacheMiss:
 
     def test_second_call_does_not_re_download(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """Once the cache file exists, subsequent calls must not make HTTP requests."""
-        _write_cache_file(tmp_path, _scryfall_json([{"id": "c1", "name": "Cached"}]))
+        _write_cache_file(tmp_path, _scryfall_jsonl([{"id": "c1", "name": "Cached"}]))
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
@@ -179,11 +177,11 @@ class TestStreamDataForKeyCacheMiss:
         stale.parent.mkdir(parents=True, exist_ok=True)
         stale.write_bytes(b"stale data")
 
-        raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
+        raw_json = _scryfall_jsonl([{"id": "new", "name": "New Card"}])
         uri = "https://data.scryfall.io/default-cards/default-cards-new.json"
         fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
-        bulk_data = {BulkDataKey.DEFAULT_CARDS: {"download_uri": uri}}
+        bulk_data = {BulkDataKey.DEFAULT_CARDS: {"jsonl_download_uri": uri}}
         with patch.object(fetcher, "list_bulk_data", return_value=bulk_data):
             list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
@@ -195,7 +193,7 @@ class TestStreamDataForKeyCacheMiss:
         fresh_tmp.parent.mkdir(parents=True, exist_ok=True)
         fresh_tmp.write_bytes(b"in-flight download")
 
-        raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
+        raw_json = _scryfall_jsonl([{"id": "new", "name": "New Card"}])
         fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
@@ -211,7 +209,7 @@ class TestStreamDataForKeyCacheMiss:
         two_hours_ago = time.time() - 2 * 60 * 60
         os.utime(old_tmp, (two_hours_ago, two_hours_ago))
 
-        raw_json = _scryfall_json([{"id": "new", "name": "New Card"}])
+        raw_json = _scryfall_jsonl([{"id": "new", "name": "New Card"}])
         fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
@@ -226,7 +224,7 @@ class TestStreamDataForKeyCacheMiss:
 
         def _chunks() -> object:
             seen_names.extend(p.name for p in cache_dir.iterdir())
-            yield _scryfall_json([{"id": "c1", "name": "A"}])
+            yield _scryfall_jsonl([{"id": "c1", "name": "A"}])
 
         fetcher.session.get.return_value = _mock_streaming_response(_chunks())
 
@@ -262,15 +260,15 @@ class TestScryfallApiSession:
         response = MagicMock()
         response.json.return_value = {
             "data": [
-                {"type": "default_cards", "download_uri": _FAKE_URI},
-                {"type": "future_type", "download_uri": "https://data.scryfall.io/future/whatever.json"},
+                {"type": "default_cards", "jsonl_download_uri": _FAKE_URI},
+                {"type": "future_type", "jsonl_download_uri": "https://data.scryfall.io/future/whatever.json"},
             ],
         }
         fetcher.session.get.return_value = response
 
         result = fetcher.list_bulk_data()
 
-        assert result == {BulkDataKey.DEFAULT_CARDS: {"type": "default_cards", "download_uri": _FAKE_URI}}
+        assert result == {BulkDataKey.DEFAULT_CARDS: {"type": "default_cards", "jsonl_download_uri": _FAKE_URI}}
 
 
 class TestStreamDataForKeyCorruptCache:
@@ -280,7 +278,7 @@ class TestStreamDataForKeyCorruptCache:
 
     def test_corrupt_cache_file_is_deleted_and_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """A cache file that fails zstd decompression is deleted so the next call can re-download."""
-        cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
+        cache_file = tmp_path / "default_cards" / _FAKE_CACHE_NAME
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_bytes(b"this is not a zstd stream")
 
@@ -301,11 +299,11 @@ class TestStreamDataForKeyCorruptCache:
 
     def test_call_after_corruption_re_downloads(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """After a corrupt cache file is deleted, the next call downloads a fresh copy and succeeds."""
-        cache_file = tmp_path / "default_cards" / "default-cards-test.json.zstd"
+        cache_file = tmp_path / "default_cards" / _FAKE_CACHE_NAME
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_bytes(b"this is not a zstd stream")
 
-        raw_json = _scryfall_json([{"id": "c1", "name": "Recovered"}])
+        raw_json = _scryfall_jsonl([{"id": "c1", "name": "Recovered"}])
         fetcher.session.get.return_value = _mock_streaming_response([raw_json])
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
@@ -329,8 +327,8 @@ class TestStreamDataForKeyParseCoverage:
     def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
         return _make_fetcher(tmp_path)
 
-    def test_minified_single_line_array_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
-        """A large dump minified onto one line yields zero cards and must raise, not silently return nothing."""
+    def test_whole_array_on_one_line_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A dump that reverts to a single-line JSON array parses as a list, yields no cards, and must raise."""
         cards = [_padded_card(i) for i in range(1200)]  # ~1.2MB as a single line
         _write_cache_file(tmp_path, orjson.dumps(cards) + b"\n")
 
@@ -339,9 +337,8 @@ class TestStreamDataForKeyParseCoverage:
 
     def test_mostly_unparseable_large_file_raises(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """A large file whose content is mostly garbage lines raises even though some cards parsed."""
-        good_lines = [orjson.dumps(_padded_card(i)).decode() for i in range(400)]
-        garbage_lines = ["{not valid json " + "y" * 1000 for _ in range(800)]
-        raw = ("[\n" + ",\n".join(good_lines + garbage_lines) + "\n]\n").encode()
+        raw = _scryfall_jsonl([_padded_card(i) for i in range(400)])
+        raw += b"".join(b"{not valid json " + b"y" * 1000 + b"\n" for _ in range(800))
         _write_cache_file(tmp_path, raw)
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), pytest.raises(BulkDataParseError):
@@ -351,9 +348,8 @@ class TestStreamDataForKeyParseCoverage:
         self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path
     ) -> None:
         """Garbage below the threshold is skipped with warnings, as for small files."""
-        good_lines = [orjson.dumps(_padded_card(i)).decode() for i in range(1000)]
-        garbage_lines = ["{not valid json " + "y" * 1000 for _ in range(100)]
-        raw = ("[\n" + ",\n".join(good_lines + garbage_lines) + "\n]\n").encode()
+        raw = _scryfall_jsonl([_padded_card(i) for i in range(1000)])
+        raw += b"".join(b"{not valid json " + b"y" * 1000 + b"\n" for _ in range(100))
         _write_cache_file(tmp_path, raw)
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
@@ -365,9 +361,8 @@ class TestStreamDataForKeyParseCoverage:
         self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Per-line warnings stop after the cap; a single summary line reports the total."""
-        good_lines = [orjson.dumps(_padded_card(i)).decode() for i in range(1000)]
-        garbage_lines = ["{not valid json " + "y" * 1000 for _ in range(100)]
-        raw = ("[\n" + ",\n".join(good_lines + garbage_lines) + "\n]\n").encode()
+        raw = _scryfall_jsonl([_padded_card(i) for i in range(1000)])
+        raw += b"".join(b"{not valid json " + b"y" * 1000 + b"\n" for _ in range(100))
         _write_cache_file(tmp_path, raw)
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), caplog.at_level(logging.WARNING):
@@ -381,9 +376,125 @@ class TestStreamDataForKeyParseCoverage:
 
     def test_small_files_are_exempt_from_coverage_check(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
         """Files below the minimum size never trigger the coverage check, even at 0% coverage."""
-        _write_cache_file(tmp_path, b"[\n{bad json}\n]\n")
+        _write_cache_file(tmp_path, b"{bad json}\n")
 
         with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
             result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
 
         assert result == []
+
+
+class TestGzippedJsonlBulkData:
+    """Scryfall serves gzipped JSONL dumps via `jsonl_download_uri`, with no Content-Encoding header."""
+
+    @pytest.fixture
+    def fetcher(self, tmp_path: pathlib.Path) -> ScryfallBulkDataFetcher:
+        return _make_fetcher(tmp_path)
+
+    def test_cache_path_strips_gz_and_appends_zstd(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """The upstream .gz suffix is dropped, since we store zstd-recompressed plaintext."""
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            path = fetcher._cache_file_path_for_key(BulkDataKey.DEFAULT_CARDS)
+
+        assert path == tmp_path / "default_cards" / "default-cards-test.jsonl.zstd"
+
+    def test_gzipped_jsonl_download_is_decompressed_and_streamed(
+        self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path
+    ) -> None:
+        """A gzip payload must be gunzipped before zstd-caching, not stored as opaque bytes."""
+        cards = [{"id": "c1", "name": "Lightning Bolt"}, {"id": "c2", "name": "Counterspell"}]
+        fetcher.session.get.return_value = _mock_streaming_response([gzip.compress(_scryfall_jsonl(cards))])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == cards
+        dctx = zstd.ZstdDecompressor()
+        cached = dctx.decompress((tmp_path / "default_cards" / _FAKE_CACHE_NAME).read_bytes(), max_output_size=1 << 20)
+        assert cached.startswith(b'{"id":"c1"'), "cache must hold plaintext JSONL, not gzip bytes"
+
+    def test_gzip_split_across_chunks(self, fetcher: ScryfallBulkDataFetcher) -> None:
+        """Decompression must work when gzip members are split arbitrarily across iter_content chunks."""
+        cards = [{"id": f"c{i}", "name": f"Card {i}"} for i in range(50)]
+        blob = gzip.compress(_scryfall_jsonl(cards))
+        chunk_size = 7  # deliberately tiny, so members split mid-header and mid-trailer
+        chunks = [blob[i : i + chunk_size] for i in range(0, len(blob), chunk_size)]
+        fetcher.session.get.return_value = _mock_streaming_response(chunks)
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == cards
+
+    def test_concatenated_gzip_members_are_all_read(self, fetcher: ScryfallBulkDataFetcher) -> None:
+        """Multi-member gzip is one logical stream; every member must be decompressed."""
+        first = [{"id": "a", "name": "A"}]
+        second = [{"id": "b", "name": "B"}]
+        blob = gzip.compress(_scryfall_jsonl(first)) + gzip.compress(_scryfall_jsonl(second))
+        fetcher.session.get.return_value = _mock_streaming_response([blob])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == first + second
+
+    def test_truncated_gzip_raises_and_leaves_no_cache_file(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """A download cut off mid-member must fail loudly rather than cache a partial dump."""
+        blob = gzip.compress(_scryfall_jsonl([{"id": f"c{i}", "name": f"Card {i}"} for i in range(50)]))
+        fetcher.session.get.return_value = _mock_streaming_response([blob[: len(blob) // 2]])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA), pytest.raises(BulkDataFormatError):
+            list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert list((tmp_path / "default_cards").iterdir()) == [], "no cache or tmp file should survive"
+
+    def test_uncompressed_payload_still_passes_through(self, fetcher: ScryfallBulkDataFetcher) -> None:
+        """If the body is already plaintext (e.g. requests decoded a Content-Encoding), pass it through."""
+        cards = [{"id": "c1", "name": "Plain"}]
+        fetcher.session.get.return_value = _mock_streaming_response([_scryfall_jsonl(cards)])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == cards
+
+    def test_empty_leading_chunks_are_tolerated(self, fetcher: ScryfallBulkDataFetcher) -> None:
+        """iter_content can emit empty keep-alive chunks before the real body."""
+        cards = [{"id": "c1", "name": "Keepalive"}]
+        fetcher.session.get.return_value = _mock_streaming_response([b"", b"", gzip.compress(_scryfall_jsonl(cards))])
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert result == cards
+
+    def test_large_jsonl_file_passes_coverage_check(self, fetcher: ScryfallBulkDataFetcher, tmp_path: pathlib.Path) -> None:
+        """JSONL yields ~100% parse coverage, so a big real-shaped dump must not trip BulkDataParseError."""
+        cards = [_padded_card(i) for i in range(1200)]  # ~1.2MB, past _PARSE_COVERAGE_MIN_CHARS
+        _write_cache_file(tmp_path, _scryfall_jsonl(cards))
+
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            result = list(fetcher.stream_data_for_key(BulkDataKey.DEFAULT_CARDS))
+
+        assert len(result) == 1200
+
+
+class TestBulkDataSchemaDrift:
+    """A renamed or removed download-URI field must name the problem, not surface as a bare KeyError."""
+
+    def test_missing_download_uri_field_raises_with_diagnostics(self, tmp_path: pathlib.Path) -> None:
+        fetcher = _make_fetcher(tmp_path)
+        # The exact shape that broke production: the record exists, the URI field does not.
+        stale_schema = {BulkDataKey.DEFAULT_CARDS: {"type": "default_cards", "download_uri": _FAKE_URI}}
+
+        with patch.object(fetcher, "list_bulk_data", return_value=stale_schema), pytest.raises(BulkDataFormatError) as exc:
+            fetcher.get_download_uri_for_key(BulkDataKey.DEFAULT_CARDS)
+
+        message = str(exc.value)
+        assert _DOWNLOAD_URI_FIELD in message
+        assert "download_uri" in message, "the message should list the fields that were present"
+
+    def test_download_uri_read_from_jsonl_field(self, tmp_path: pathlib.Path) -> None:
+        fetcher = _make_fetcher(tmp_path)
+        with patch.object(fetcher, "list_bulk_data", return_value=_FAKE_BULK_DATA):
+            assert fetcher.get_download_uri_for_key(BulkDataKey.DEFAULT_CARDS) == _FAKE_URI

--- a/docs/changelog/2026-08-02-scryfall-jsonl-bulk-data.md
+++ b/docs/changelog/2026-08-02-scryfall-jsonl-bulk-data.md
@@ -1,0 +1,49 @@
+# Scryfall's gzipped-JSONL bulk data
+
+Card imports were failing outright with `KeyError: 'download_uri'` from
+`get_download_uri_for_key`. Scryfall changed `/bulk-data`: each record's `download_uri` is now
+`jsonl_download_uri` (and `size` is now `compressed_size`), and the dumps moved from a
+pretty-printed JSON array to gzipped JSONL.
+
+The rename was the visible half. The second break was behind it: the new URLs are `.jsonl.gz`
+served as `Content-Type: application/gzip` with **no** `Content-Encoding` header, so requests does
+not transparently decompress and `iter_content()` yields raw gzip bytes. Fixing only the field name
+would have re-wrapped gzip in zstd, then hit `UnicodeDecodeError` on read — which deletes the cache
+and re-raises, so every import would re-download 77 MB and fail again.
+
+Changes to `api/scryfall_bulk_data_fetcher.py`:
+
+- Read the URI from `jsonl_download_uri`, hoisted into `_DOWNLOAD_URI_FIELD`. A missing field now
+  raises `BulkDataFormatError` naming the field and listing the fields that *were* present, so the
+  next upstream rename reads as a schema change rather than a bare `KeyError`.
+- New `_gunzip_if_needed()` decompresses the download stream before it is zstd-cached. It sniffs the
+  gzip magic bytes instead of trusting the URL suffix or headers, so it keeps working if Scryfall
+  later serves gzip as a `Content-Encoding` that requests decodes for us. It decodes concatenated
+  gzip members (otherwise a multi-member dump would silently truncate to its first member) and
+  raises on a stream ending mid-member rather than caching a partial dump.
+- Cache paths are now `<name>.jsonl.zstd`, not the `<name>.jsonl.json.zstd` that chaining
+  `with_suffix` onto a `.jsonl.gz` name would have produced.
+
+The legacy JSON-array tolerance is gone, since the dumps are JSONL only: no more `[`/`]` line
+skipping or trailing-comma stripping. An `isinstance(card, dict)` guard replaces the old
+`startswith("{")` check — stricter as well as simpler, because it stops a minified single-line array
+from being yielded as a `list` where callers expect a `dict`, and it feeds the existing parse
+coverage check so a future format change fails loudly instead of under-yielding.
+
+Verified against live Scryfall — all seven dumps stream to exhaustion, every record a dict:
+
+| dump | records |
+|---|---:|
+| `all_cards` | 538,597 |
+| `default_cards` | 116,490 |
+| `unique_artwork` | 53,950 |
+| `oracle_cards` | 38,485 |
+| `rulings` | 77,998 |
+| `art_tags` | 11,431 |
+| `oracle_tags` | 4,509 |
+
+`rulings` matches `wc -l` on the raw gunzipped file exactly. The `default_cards` import path runs
+clean through `preprocess_card` (116,490 cards → 99,407 rows) and the cache file holds plaintext
+JSONL. New tests cover the gzip transport (split chunks, concatenated members, truncation, empty
+keep-alive chunks, plaintext passthrough), the cache-path suffix, non-object JSONL lines, and the
+schema-drift diagnostic. Unit suite 2,129 passed.


### PR DESCRIPTION
Card imports were failing outright with `KeyError: 'download_uri'` from `get_download_uri_for_key`. Scryfall changed `/bulk-data`: each record's `download_uri` is now `jsonl_download_uri` (and `size` is now `compressed_size`), and the dumps moved from a pretty-printed JSON array to gzipped JSONL.

The rename was the visible half. The second break was behind it: the new URLs are `.jsonl.gz` served as `Content-Type: application/gzip` with **no** `Content-Encoding` header, so requests does not transparently decompress and `iter_content()` yields raw gzip bytes. Fixing only the field name would have re-wrapped gzip in zstd, then hit `UnicodeDecodeError` on read — which deletes the cache and re-raises, so every import would re-download 77 MB and fail again.

## Changes

`api/scryfall_bulk_data_fetcher.py`:

- Read the URI from `jsonl_download_uri`, hoisted into `_DOWNLOAD_URI_FIELD`. A missing field now raises `BulkDataFormatError` naming the field and listing the fields that *were* present, so the next upstream rename reads as a schema change rather than a bare `KeyError`.
- New `_gunzip_if_needed()` decompresses the download stream before it is zstd-cached. It sniffs the gzip magic bytes instead of trusting the URL suffix or headers, so it keeps working if Scryfall later serves gzip as a `Content-Encoding` that requests decodes for us. It decodes concatenated gzip members (otherwise a multi-member dump would silently truncate to its first member) and raises on a stream ending mid-member rather than caching a partial dump.
- Cache paths are now `<name>.jsonl.zstd`, not the `<name>.jsonl.json.zstd` that chaining `with_suffix` onto a `.jsonl.gz` name would have produced.

The legacy JSON-array tolerance is gone, since the dumps are JSONL only: no more `[`/`]` line skipping or trailing-comma stripping. An `isinstance(card, dict)` guard replaces the old `startswith("{")` check — stricter as well as simpler, because it stops a minified single-line array from being yielded as a `list` where callers expect a `dict`, and it feeds the existing parse-coverage check so a future format change fails loudly instead of under-yielding.

## Verification

Against live Scryfall, all seven dumps stream to exhaustion with every record a dict:

| dump | records |
|---|---:|
| `all_cards` | 538,597 |
| `default_cards` | 116,490 |
| `unique_artwork` | 53,950 |
| `rulings` | 77,998 |
| `oracle_cards` | 38,485 |
| `art_tags` | 11,431 |
| `oracle_tags` | 4,509 |

`rulings` matches `wc -l` on the raw gunzipped file exactly. The `default_cards` import path runs clean through `preprocess_card` (116,490 cards → 99,407 rows) and the cache file holds plaintext JSONL.

New tests cover the gzip transport (split chunks, concatenated members, truncation, empty keep-alive chunks, plaintext passthrough), the cache-path suffix, non-object JSONL lines, and the schema-drift diagnostic. Unit suite 2,129 passed; lint clean.

Not addressed here: `preprocess_card` dropping 116,490 cards to 99,407 rows is pre-existing filtering, unrelated to this break.
