### PR TITLE
Engine: Project Printing Bits Into Card Space Once, Not Twice

### DIFF
--- a/card_engine/src/bench_compose_card_projection.rs
+++ b/card_engine/src/bench_compose_card_projection.rs
@@ -1,0 +1,144 @@
+//! Micro-benchmark: does `unique=card` PrintingCompose paging pay for its
+//! printing→card projection once or twice? Item 13 of
+//! docs/issues/00799-engine-simplicity-pass.md.
+//!
+//! `printing_compose_fastpath` projects the composed `pbits` into card space to popcount
+//! `Mode::Card`'s `total`. When the orderby has no card-space permutation (`usd`/`rarity`)
+//! and no printing-space walk applies (both true under `unique=card`), paging falls to
+//! `gather_composed_page`, which derived its candidate cards from the *same* projection
+//! over the *same* bits — a second full pass, discarded the first time.
+//!
+//! Two contenders over the identical `pbits`, both producing `(total, candidate_cards)`:
+//! - `derive_twice`: what shipped — project for the total, project again for the candidates.
+//! - `derive_once`: project once, popcount it, then extract ids from it.
+//!
+//! `printing_bits_to_card_bits` is O(n_printings/64) words scanned plus a set-bit
+//! extraction per surviving printing, so the saving tracks selectivity rather than being
+//! flat. The sweep below runs sparse → near-total to show that curve.
+//!
+//! `gather_composed_page` is timed alongside, not because it changes, but because a
+//! saving is only worth reporting next to the path it sits in: the last column is the
+//! share of the whole (derive + gather) card-mode paging cost that this removes.
+//!
+//!     cargo test --release bench_compose_card_projection -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same file/rebuild contract as bench_verify_cost.rs).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, bitmap_card_ids, compose_printing_bits, gather_composed_page, printing_bits_to_card_bits, AOffsets,
+    CardData, CmpOp, CollField, FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortCol, ARCHIVE_HEADER_LEN,
+};
+
+const ITERS: usize = 200;
+const LIMIT: usize = 175; // a Scryfall page
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// This bench's fixed query shape: `unique=card`, `orderby=usd` ascending. `usd` has no
+/// card-space sort permutation, and the printing-space orderby walk requires
+/// `Mode::Printing` — so card mode lands in `gather_composed_page`, the affected branch.
+fn card_params(page_offset: usize) -> QueryParams {
+    QueryParams { mode: Mode::Card, prefer: Prefer::Default, sort_col: SortCol::PriceUsd, descending: false, limit: LIMIT, page_offset }
+}
+
+fn best_ns(mut kernel: impl FnMut() -> usize) -> u128 {
+    let mut best = u128::MAX;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    best
+}
+
+fn popcount(bits: &[u64]) -> usize {
+    bits.iter().map(|w| w.count_ones() as usize).sum()
+}
+
+/// What shipped: the total's projection is thrown away, then rebuilt for the candidates.
+fn derive_twice(pbits: &[u64], offsets: &AOffsets, n_cards: usize) -> (usize, Vec<u32>) {
+    let total = popcount(&printing_bits_to_card_bits(pbits, offsets, n_cards));
+    let candidates = bitmap_card_ids(&printing_bits_to_card_bits(pbits, offsets, n_cards));
+    (total, candidates)
+}
+
+/// One projection, both consumers.
+fn derive_once(pbits: &[u64], offsets: &AOffsets, n_cards: usize) -> (usize, Vec<u32>) {
+    let card_bits = printing_bits_to_card_bits(pbits, offsets, n_cards);
+    (popcount(&card_bits), bitmap_card_ids(&card_bits))
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_compose_card_projection() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let n_printings = data.printings.len();
+    let n_cards = data.cards.len();
+    let offsets = &data.offsets;
+    let ctx = QueryCtx::from(data);
+    println!("\n{n_printings} printings, {n_cards} cards from {STORE_PATH}");
+
+    let coll = |field, value: &str, negate: bool| -> FilterExpr {
+        let leaf = FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value: value.to_string(), value_id: None };
+        if negate { FilterExpr::Not(Box::new(leaf)) } else { leaf }
+    };
+
+    // Same selectivity sweep as bench_compose_paging, so the two benches' rows line up:
+    // real composable collection leaves, sparse → near-total. Subtypes are title-case.
+    let filters: Vec<(&str, FilterExpr)> = vec![
+        ("type:Octopus (very sparse)", coll(CollField::Subtypes, "Octopus", false)),
+        ("type:Goblin (sparse)", coll(CollField::Subtypes, "Goblin", false)),
+        ("type:Human (mid)", coll(CollField::Subtypes, "Human", false)),
+        ("-type:Human (~85%)", coll(CollField::Subtypes, "Human", true)),
+        ("-type:Goblin (~98%)", coll(CollField::Subtypes, "Goblin", true)),
+        ("-type:Octopus (near-total)", coll(CollField::Subtypes, "Octopus", true)),
+    ];
+
+    println!(
+        "\n  {:<30} {:>6} {:>7} {:>10} {:>10} {:>9} {:>10} {:>8}",
+        "predicate", "sel%", "cards", "twice ns", "once ns", "saved ns", "gather ns", "saved %"
+    );
+    for (label, filter) in &filters {
+        let pbits = compose_printing_bits(filter, &data.indexes, offsets, &data.printings, n_printings);
+        let printing_total = popcount(&pbits);
+        if printing_total == 0 {
+            println!("  {label:<30}  (0 matches — skipped)");
+            continue;
+        }
+        let sel = 100.0 * printing_total as f64 / n_printings as f64;
+
+        // Agreement before timing: the projection is idempotent over the same bits, so the
+        // two derivations must produce the identical total and candidate list. A divergence
+        // here means the reuse is not sound, which is the whole thing being claimed.
+        let (twice_total, twice_cands) = derive_twice(&pbits, offsets, n_cards);
+        let (once_total, once_cands) = derive_once(&pbits, offsets, n_cards);
+        assert_eq!(twice_total, once_total, "{label}: totals differ");
+        assert_eq!(twice_cands, once_cands, "{label}: candidate cards differ");
+
+        let twice_ns = best_ns(|| derive_twice(&pbits, offsets, n_cards).1.len());
+        let once_ns = best_ns(|| derive_once(&pbits, offsets, n_cards).1.len());
+        let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards);
+        let gather_ns = best_ns(|| gather_composed_page(&ctx, &card_params(0), &pbits, Some(&card_bits)).len());
+
+        let saved = twice_ns.saturating_sub(once_ns);
+        let share = 100.0 * saved as f64 / (twice_ns + gather_ns) as f64;
+        println!(
+            "  {label:<30} {sel:>5.2} {:>7} {twice_ns:>10} {once_ns:>10} {saved:>9} {gather_ns:>10} {share:>7.1}%",
+            once_total,
+        );
+    }
+    println!();
+}

--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -103,13 +103,13 @@ fn bench_compose_paging() {
                     .map_or(0, |p| p.len())
             };
             let run_b = || {
-                gather_composed_page(&ctx, &bench_params(offset), &pbits)
+                gather_composed_page(&ctx, &bench_params(offset), &pbits, None)
                     .len()
             };
             // Cross-check identical page (offset 0 only — A declines into the null-price tail at deep
             // offsets, where only B is defined; that decline is itself the finding for those rows).
             let a_page = walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset);
-            let b_page = gather_composed_page(&ctx, &bench_params(offset), &pbits);
+            let b_page = gather_composed_page(&ctx, &bench_params(offset), &pbits, None);
             if let Some(a_page) = &a_page {
                 let a_ids: Vec<u128> = a_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
                 let b_ids: Vec<u128> = b_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5775,9 +5775,13 @@ fn printing_compose_fastpath<'a>(
     // only because this plan won. The total is the popcount in the query's result space; the page is
     // the one grouped walk at the mode's granularity, using the composed bits as exact membership.
     let pbits = compose_printing_bits(filter, indexes, offsets, printings, printings.len());
+    // Card mode's total *is* the popcount of the card-space projection, and the permutation-free
+    // `gather_composed_page` below derives its candidate cards from that same projection over
+    // those same bits. Built once here and threaded through, instead of twice.
+    let card_bits = matches!(mode, Mode::Card).then(|| printing_bits_to_card_bits(&pbits, offsets, cards.len()));
     let total: usize = match mode {
         Mode::Printing => pbits.iter().map(|w| w.count_ones() as usize).sum(),
-        Mode::Card => printing_bits_to_card_bits(&pbits, offsets, cards.len()).iter().map(|w| w.count_ones() as usize).sum(),
+        Mode::Card => card_bits.as_ref().expect("card mode built card_bits above").iter().map(|w| w.count_ones() as usize).sum(),
         Mode::Artwork => {
             // Read straight off the archive. This used to prefix-sum `artwork_groups` here on every
             // artwork query -- an O(n_cards) pass for a value that cannot change after load.
@@ -5838,7 +5842,7 @@ fn printing_compose_fastpath<'a>(
                     // tail, or a page past the value structure), so `OrderbyWalk` was predicted
                     // and this gather is the documented fallback — NOT a mispredicted branch.
                     note_paging_taken(if walk_col { PagingTaken::GatherWalkDeclined } else { PagingTaken::Gather });
-                    gather_composed_page(ctx, params, &pbits)
+                    gather_composed_page(ctx, params, &pbits, card_bits.as_deref())
                 }
             }
         }
@@ -6472,12 +6476,25 @@ fn gather_composed_page<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     pbits: &[u64],
+    card_bits: Option<&[u64]>,
 ) -> Vec<(&'a AOracleCard, &'a APrinting)> {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
-    let candidate_cards = bitmap_card_ids(&printing_bits_to_card_bits(pbits, offsets, cards.len()));
+    // `card_bits` is `pbits` already projected into card space. `Mode::Card` computes that
+    // projection for its `total` and hands it over rather than have this function repeat it
+    // over the same bits; printing/artwork totals need no card projection, so those pass
+    // `None` and it is built here as before.
+    let projected: Vec<u64>;
+    let card_bits = match card_bits {
+        Some(bits) => bits,
+        None => {
+            projected = printing_bits_to_card_bits(pbits, offsets, cards.len());
+            &projected
+        }
+    };
+    let candidate_cards = bitmap_card_ids(card_bits);
     let n = match mode {
         Mode::Artwork => usize::from(max_artwork_groups),
         Mode::Card => 1,
@@ -9449,5 +9466,7 @@ mod bench_word_dict_scan;
 mod bench_card_dedup;
 #[cfg(test)]
 mod bench_compose_paging;
+#[cfg(test)]
+mod bench_compose_card_projection;
 #[cfg(test)]
 mod bench_candidate_materialize;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7276,7 +7276,7 @@ fn orderby_walk_matches_gather_composed() {
                 for &offset in &[0usize, 50, 200] {
                     let limit = 100usize;
                     let gather = super::gather_composed_page(
-                        &QueryCtx::from(archived), &kernel_params(Mode::Printing, sort_col, descending, limit, offset), &pbits,
+                        &QueryCtx::from(archived), &kernel_params(Mode::Printing, sort_col, descending, limit, offset), &pbits, None,
                     );
                     let walk = match sort_col {
                         SortCol::PriceUsd => super::walk_range_orderby_page(


### PR DESCRIPTION
Item 13 of #799. Under `unique=card`, `printing_compose_fastpath` projects the
composed `pbits` into card space to popcount its `total`, then throws the
projection away. When the orderby has no card-space permutation (`usd`/`rarity`)
paging falls to `gather_composed_page`, which derived its candidate cards from the
same projection over the same bits — a second full pass. The projection is now
built once and threaded through; printing and artwork modes never had a card
projection to reuse, so they pass `None` and build it there as before.

`bench_compose_card_projection.rs` measures the derivation both ways over
benchmarks/verify-order/real.store (97,206 printings, 31,508 cards), asserting the
two agree on total and candidate list before timing either. Best-of-200:

| predicate            | sel%  | cards  | twice (μs) | once (μs) | saved (μs) | gather (μs) | saved % |
|----------------------|-------|--------|-----------|----------|-----------|------------|---------|
| type:Octopus         |  0.10 |     45 |        19 |      9.5 |       9.3 |        0.9 |   47.0% |
| type:Goblin          |  1.55 |    501 |        29 |       15 |        14 |        5.7 |   41.1% |
| type:Human           | 10.87 |  4,249 |        41 |       21 |        20 |         28 |   28.5% |
| -type:Human          | 89.13 | 27,259 |       279 |      147 |       131 |        170 |   29.3% |
| -type:Goblin         | 98.45 | 31,007 |       303 |      166 |       138 |        197 |   27.5% |
| -type:Octopus        | 99.90 | 31,463 |       304 |      160 |       144 |        186 |   29.4% |

The derivation halves, as a pass done twice should. The last column is what that is
worth in context: 27-47% of the entire card-mode (derive + gather) paging cost. On a
broad predicate the path drops from ~489 μs to ~345 μs, 1.42x.

That contradicts the issue doc's premise. It filed this batch under "each of these
is below the noise floor of end-to-end query timing" — 144 μs is not, and a query
A/B would have seen it. The doc was wrong about the magnitude, not about the fix.

**The cost model was already right.** `cost.rs` charges `project_printings` once,
described as "second pass: project printing->card/artwork" — one projection. The
executor was paying two, so `plan_cost` *under*-predicted PrintingCompose in exactly
this regime by a full projection pass. This brings the executor in line with what the
model already claimed rather than requiring a re-calibration, and it removes a source
of the router under-charging a plan it then picks.

`compose_paging_prediction_matches_the_branch_taken` still passes, so the predicted
paging branch is unchanged — this makes the predicted branch cheaper, it does not
move which branch runs.

Item 13 of #799.

## Testing

- `cargo test` (debug, what CI runs): 147 passed
- `cargo clippy --all-targets`: clean
- `cargo test --release bench_compose_card_projection -- --ignored --nocapture` for the table above, three runs, stable to within a few percent

## What I did not measure

The cost-model claim above is established by reading `cost.rs` (one `project_printings` term) against the executor (two projections), not by running `scripts/bench_cost_model_agreement.py`. That script is the right instrument to watch the Gather-branch measured/predicted ratio move toward 1.0, but it needs `card_engine` built into the venv, and I did not want to install into your shared `.venv` as a side effect. Worth a run if you want the ratio on the record.

Per the plan-pinned reasoning in #812: this is an executor change, and the routing half of acceptance is safe by direction — it makes PrintingCompose strictly cheaper, so the router cannot start avoiding it, and `compose_paging_prediction_matches_the_branch_taken` confirms the predicted branch is unchanged.