### PR TITLE
Engine: Collapse card_match_count and push_card_matches Onto One Body Each

### DIFF
--- a/card_engine/src/bench_card_match_unify.rs
+++ b/card_engine/src/bench_card_match_unify.rs
@@ -1,0 +1,500 @@
+//! Re-test of the measurement that put `card_match_count`/`push_card_matches` on #799's
+//! "what not to touch" list.
+//!
+//! `card_match_count` is split in two: an `existential_plane == None` arm that is a plain
+//! `match mode` over three specialized loops, and an `existential_plane == Some` arm that
+//! builds a `satisfies` closure and runs the same three shapes through it. Its doc explains
+//! the split as load-bearing:
+//!
+//! > A prior version of this function routed both cases through one closure-based
+//! > `satisfies` helper regardless of `existential_plane`; measured as a real (~15%)
+//! > regression on `banned:modern`/`restricted:vintage` (full-candidate-set scans,
+//! > unaffected by `existential_plane` in outcome but paying its indirection anyway) via
+//! > the broad survey, not the targeted benchmark
+//!
+//! Two reasons that number deserves a re-check. It was taken with the coarsest instrument
+//! available (end-to-end survey latency, which the doc itself flags), and it was taken at
+//! #676 (2026-07-13) — before #737 gave the artwork arms their skip-repped shortcut and
+//! before the group id moved to a columnar side array, both of which changed these loops.
+//!
+//! This bench isolates the kernel. `count_split` is today's shipped shape; `count_unified`
+//! is the deduplicated one — a single `satisfies` closure that folds the plane test in, one
+//! loop per mode instead of two. Both are compiled here rather than A/B'd across builds, so
+//! the same binary, same store, and same candidate order produce both numbers.
+//!
+//! What `count_unified` must NOT give up, or it would be measuring the wrong thing: the
+//! blind `all_match` shortcut (`Card` returns `start < end`, `Printing` returns
+//! `end - start`, no loop at all) is a real algorithmic shortcut, not duplication. It is
+//! only sound when there is no plane to check, so the unified version keeps it under an
+//! explicit `existential_plane.is_none()` guard. The `banned:modern` shape this bench is
+//! named for is exactly that case: legality planes (#679) make the narrowing tight, so
+//! `all_match` is true and the residual is empty.
+//!
+//!     cargo test --release bench_card_match_unify -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same file/rebuild contract as bench_verify_cost.rs).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, AOracleCard, APrinting, AStrings, BitPlanes, CardData, CmpOp, FilterExpr, Mmap, Mode, NumExpr,
+    NumField, PlaneExpr, ARCHIVE_HEADER_LEN, ARTWORK_GROUP_WORDS,
+};
+
+const ITERS: usize = 200;
+
+/// Which shape of the counting kernel to run.
+#[derive(Clone, Copy)]
+enum Variant {
+    /// Today's shipped `card_match_count`: plane check hoisted by duplicating the source.
+    Split,
+    /// One body, plane check as a runtime branch inside the shared closure.
+    Unified,
+    /// One body, plane check as a const generic — compiler-generated specializations.
+    Generic,
+    /// One body, const generic, AND slice iteration rather than indexing by `pid` — the form
+    /// `Split`'s no-plane arms use. `eval_plane_expr_for_printing` takes `&Archived<Printing>`,
+    /// not an index, so the plane path never needed `pid` either.
+    GenericIter,
+    /// `Split` again, measured independently. Its ratio against `Split` is the noise floor:
+    /// no column below is meaningful unless it clears this.
+    SplitControl,
+}
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// Today's shipped shape, copied verbatim from `card_match_count` so the comparison is
+/// against what actually runs rather than a paraphrase of it.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn count_split(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
+) -> u32 {
+    let Some((pe, planes)) = existential_plane else {
+        return match mode {
+            Mode::Card => {
+                if all_match {
+                    return u32::from(start < end);
+                }
+                for p in &printings[start..end] {
+                    if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
+                        return 1;
+                    }
+                }
+                0
+            }
+            Mode::Printing => {
+                if all_match {
+                    return (end - start) as u32;
+                }
+                let mut n = 0u32;
+                for p in &printings[start..end] {
+                    if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
+                        n += 1;
+                    }
+                }
+                n
+            }
+            Mode::Artwork => {
+                seen_words.fill(0);
+                for pid in start..end {
+                    let gid = u16::from(artwork_group_col[pid]) as usize;
+                    let (word, bit) = (gid / 64, 1u64 << (gid % 64));
+                    if seen_words[word] & bit != 0 {
+                        continue;
+                    }
+                    if !all_match && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                        continue;
+                    }
+                    seen_words[word] |= bit;
+                }
+                seen_words.iter().map(|w| w.count_ones()).sum()
+            }
+        };
+    };
+    let satisfies = |pid: usize| {
+        super::eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
+            && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
+    };
+    match mode {
+        Mode::Card => {
+            for pid in start..end {
+                if satisfies(pid) {
+                    return 1;
+                }
+            }
+            0
+        }
+        Mode::Printing => {
+            let mut n = 0u32;
+            for pid in start..end {
+                if satisfies(pid) {
+                    n += 1;
+                }
+            }
+            n
+        }
+        Mode::Artwork => {
+            seen_words.fill(0);
+            for pid in start..end {
+                let gid = u16::from(artwork_group_col[pid]) as usize;
+                let (word, bit) = (gid / 64, 1u64 << (gid % 64));
+                if seen_words[word] & bit != 0 || !satisfies(pid) {
+                    continue;
+                }
+                seen_words[word] |= bit;
+            }
+            seen_words.iter().map(|w| w.count_ones()).sum()
+        }
+    }
+}
+
+/// The deduplicated shape: one `satisfies` closure covering both plane cases, one loop per
+/// mode. The blind `all_match` shortcut is kept, guarded on there being no plane to check —
+/// dropping it would make this slower for reasons that have nothing to do with indirection.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn count_unified(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
+) -> u32 {
+    let satisfies = |pid: usize| {
+        existential_plane.is_none_or(|(pe, planes)| super::eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings))
+            && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
+    };
+    // Only sound with no plane: with one, every printing still needs its plane test.
+    let blind = all_match && existential_plane.is_none();
+    match mode {
+        Mode::Card => {
+            if blind {
+                return u32::from(start < end);
+            }
+            for pid in start..end {
+                if satisfies(pid) {
+                    return 1;
+                }
+            }
+            0
+        }
+        Mode::Printing => {
+            if blind {
+                return (end - start) as u32;
+            }
+            let mut n = 0u32;
+            for pid in start..end {
+                if satisfies(pid) {
+                    n += 1;
+                }
+            }
+            n
+        }
+        Mode::Artwork => {
+            seen_words.fill(0);
+            for pid in start..end {
+                let gid = u16::from(artwork_group_col[pid]) as usize;
+                let (word, bit) = (gid / 64, 1u64 << (gid % 64));
+                if seen_words[word] & bit != 0 || !satisfies(pid) {
+                    continue;
+                }
+                seen_words[word] |= bit;
+            }
+            seen_words.iter().map(|w| w.count_ones()).sum()
+        }
+    }
+}
+
+/// The third option, and the interesting one: the body is written **once**, but `HAS_PLANE` is a
+/// const generic, so each instantiation folds the plane test away at compile time. That is what the
+/// hand-written split achieves by duplicating the source — here the compiler duplicates it instead,
+/// from one copy the reader maintains. Callers dispatch once per query, not per printing.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn count_generic<const HAS_PLANE: bool>(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
+) -> u32 {
+    let satisfies = |pid: usize| {
+        (!HAS_PLANE
+            || {
+                let (pe, planes) = existential_plane.expect("HAS_PLANE implies Some");
+                super::eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
+            })
+            && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
+    };
+    // Folds to `all_match` in the false instantiation and to `false` in the true one.
+    let blind = all_match && !HAS_PLANE;
+    match mode {
+        Mode::Card => {
+            if blind {
+                return u32::from(start < end);
+            }
+            for pid in start..end {
+                if satisfies(pid) {
+                    return 1;
+                }
+            }
+            0
+        }
+        Mode::Printing => {
+            if blind {
+                return (end - start) as u32;
+            }
+            let mut n = 0u32;
+            for pid in start..end {
+                if satisfies(pid) {
+                    n += 1;
+                }
+            }
+            n
+        }
+        Mode::Artwork => {
+            seen_words.fill(0);
+            for pid in start..end {
+                let gid = u16::from(artwork_group_col[pid]) as usize;
+                let (word, bit) = (gid / 64, 1u64 << (gid % 64));
+                if seen_words[word] & bit != 0 || !satisfies(pid) {
+                    continue;
+                }
+                seen_words[word] |= bit;
+            }
+            seen_words.iter().map(|w| w.count_ones()).sum()
+        }
+    }
+}
+
+/// `count_generic`, but iterating `&printings[start..end]` instead of indexing `printings[pid]`.
+/// Isolates how much of the split's advantage is the *loop form* rather than the plane branch:
+/// only `Mode::Artwork` genuinely needs the index (for `artwork_group_col`), and it keeps one.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn count_generic_iter<const HAS_PLANE: bool>(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
+) -> u32 {
+    let satisfies = |p: &APrinting| {
+        (!HAS_PLANE
+            || {
+                let (pe, planes) = existential_plane.expect("HAS_PLANE implies Some");
+                super::eval_plane_expr_for_printing(pe, planes, cid, p, strings)
+            })
+            && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
+    };
+    let blind = all_match && !HAS_PLANE;
+    match mode {
+        Mode::Card => {
+            if blind {
+                return u32::from(start < end);
+            }
+            for p in &printings[start..end] {
+                if satisfies(p) {
+                    return 1;
+                }
+            }
+            0
+        }
+        Mode::Printing => {
+            if blind {
+                return (end - start) as u32;
+            }
+            let mut n = 0u32;
+            for p in &printings[start..end] {
+                if satisfies(p) {
+                    n += 1;
+                }
+            }
+            n
+        }
+        Mode::Artwork => {
+            seen_words.fill(0);
+            for pid in start..end {
+                let gid = u16::from(artwork_group_col[pid]) as usize;
+                let (word, bit) = (gid / 64, 1u64 << (gid % 64));
+                if seen_words[word] & bit != 0 || !satisfies(&printings[pid]) {
+                    continue;
+                }
+                seen_words[word] |= bit;
+            }
+            seen_words.iter().map(|w| w.count_ones()).sum()
+        }
+    }
+}
+
+fn best_ns(mut kernel: impl FnMut() -> u64) -> (u128, u64) {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    (best, out)
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_card_match_unify() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let (cards, printings, offsets) = (&data.cards, &data.printings, &data.offsets);
+    let strings = &data.strings;
+    let artwork_group_col = &data.indexes.artwork_group_col;
+    println!("\n{} printings, {} cards from {STORE_PATH}", printings.len(), cards.len());
+
+    // `banned:modern`'s shape is (all_match=true, residual=[]) — the legality planes make the
+    // narrowing tight, so every candidate takes the blind shortcut. The residual case is the
+    // other half of the space, where the closure is actually called per printing.
+    let cmc = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
+    let residual_leaf: [&FilterExpr; 1] = [&cmc];
+
+    // Full candidate set: every card, exactly the "full-candidate-set scan" the claim names.
+    //
+    // `existential_plane` and `all_match` go through `black_box` before the loop. This is what
+    // makes the comparison faithful rather than flattering: passing a literal `None` would let
+    // the optimizer constant-fold away exactly the per-printing branch the unified version adds,
+    // and measure a version that does not exist. In `run_query` both are computed once per query
+    // and are opaque runtime values at the call site, which is what this reproduces — the branch
+    // is loop-invariant and perfectly predicted, but it is really there.
+    let sweep_all = |mode: Mode, all_match: bool, residual: &[&FilterExpr], variant: Variant| -> u64 {
+        let no_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = black_box(None);
+        let all_match = black_box(all_match);
+        let mut seen = [0u64; ARTWORK_GROUP_WORDS];
+        let mut acc = 0u64;
+        for cid in 0..cards.len() {
+            let card = &cards[cid];
+            let start = u32::from(offsets[cid]) as usize;
+            let end = u32::from(offsets[cid + 1]) as usize;
+            let n = match variant {
+                // `SplitControl` is `Split`, measured separately to expose the noise floor.
+                Variant::Split | Variant::SplitControl => count_split(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
+                ),
+                Variant::Unified => count_unified(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
+                ),
+                // The dispatch a real caller would do: once per query, on the `Option`, not per
+                // printing. `false` here because this sweep is the no-plane case.
+                Variant::Generic => count_generic::<false>(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
+                ),
+                Variant::GenericIter => count_generic_iter::<false>(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
+                ),
+            };
+            acc += u64::from(n);
+        }
+        acc
+    };
+
+    println!("\n  {:<38} {:>10} {:>9} {:>9} {:>11} {:>9} {:>9}", "case (existential_plane = None)", "split ns", "unif/spl", "gen/spl", "gen+it/spl", "FLOOR", "rows");
+    let cases: &[(&str, Mode, bool, &[&FilterExpr])] = &[
+        ("Card,    all_match (banned:modern)", Mode::Card, true, &[]),
+        ("Printing, all_match", Mode::Printing, true, &[]),
+        ("Artwork,  all_match", Mode::Artwork, true, &[]),
+        ("Card,    residual cmc<3", Mode::Card, false, &residual_leaf),
+        ("Printing, residual cmc<3", Mode::Printing, false, &residual_leaf),
+        ("Artwork,  residual cmc<3", Mode::Artwork, false, &residual_leaf),
+    ];
+    for &(label, mode, all_match, residual) in cases {
+        // Agreement before timing: a dedupe that changes an answer is not a dedupe.
+        let a = sweep_all(mode, all_match, residual, Variant::Split);
+        let b = sweep_all(mode, all_match, residual, Variant::Unified);
+        let c = sweep_all(mode, all_match, residual, Variant::Generic);
+        let d = sweep_all(mode, all_match, residual, Variant::GenericIter);
+        assert_eq!(a, d, "{label}: const-generic+iter disagrees with split ({a} vs {d})");
+        assert_eq!(a, b, "{label}: split and unified disagree ({a} vs {b})");
+        assert_eq!(a, c, "{label}: split and const-generic disagree ({a} vs {c})");
+
+        // Each variant timed twice, in both relative orders. Whichever contender runs second
+        // inherits the other's cache and frequency state, so a one-order measurement cannot tell
+        // "slower function" apart from "ran second" — and at these magnitudes that confound is the
+        // same size as the effect. Best-over-both-orders removes it.
+        let mut best = [u128::MAX; 5];
+        let mut rows = 0;
+        for pass in 0..2 {
+            for i in 0..5 {
+                let all = [Variant::Split, Variant::Unified, Variant::Generic, Variant::GenericIter, Variant::SplitControl];
+                let v = all[if pass == 0 { i } else { 4 - i }];
+                let (ns, r) = best_ns(|| sweep_all(mode, all_match, residual, v));
+                let slot = match v {
+                    Variant::Split => 0,
+                    Variant::Unified => 1,
+                    Variant::Generic => 2,
+                    Variant::GenericIter => 3,
+                    Variant::SplitControl => 4,
+                };
+                best[slot] = best[slot].min(ns);
+                rows = r;
+            }
+        }
+        println!(
+            "  {label:<38} {:>10} {:>8.3}x {:>8.3}x {:>10.3}x {:>8.3}x {rows:>9}",
+            best[0],
+            best[1] as f64 / best[0] as f64,
+            best[2] as f64 / best[0] as f64,
+            best[3] as f64 / best[0] as f64,
+            best[4] as f64 / best[0] as f64,
+        );
+    }
+    println!("\n  ratio > 1 means slower than the shipped split. The claim under test is ~1.15x.");
+    println!("  Each variant is timed in both relative orders and the best taken, so a ratio here is");
+    println!("  the function's cost and not an artifact of which one ran second.");
+}

--- a/card_engine/src/bench_card_match_unify.rs
+++ b/card_engine/src/bench_card_match_unify.rs
@@ -1,9 +1,9 @@
 //! Re-test of the measurement that put `card_match_count`/`push_card_matches` on #799's
 //! "what not to touch" list.
 //!
-//! `card_match_count` is split in two: an `existential_plane == None` arm that is a plain
+//! `card_match_count` *was* split in two: an `existential_plane == None` arm that was a plain
 //! `match mode` over three specialized loops, and an `existential_plane == Some` arm that
-//! builds a `satisfies` closure and runs the same three shapes through it. Its doc explains
+//! built a `satisfies` closure and ran the same three shapes through it. Its doc explained
 //! the split as load-bearing:
 //!
 //! > A prior version of this function routed both cases through one closure-based
@@ -42,8 +42,8 @@ use std::time::Instant;
 use rkyv::Archived;
 
 use super::{
-    archive_header, archive_payload, AOracleCard, APrinting, AStrings, BitPlanes, CardData, CmpOp, FilterExpr, Mmap, Mode, NumExpr,
-    NumField, PlaneExpr, ARCHIVE_HEADER_LEN, ARTWORK_GROUP_WORDS,
+    archive_header, archive_payload, AOracleCard, APrinting, AStrings, BitPlanes, Candidate, CardData, CmpOp, FilterExpr, MatchCtx, Mmap,
+    Mode, NumExpr, NumField, PlaneExpr, Prefer, SortCol, ARCHIVE_HEADER_LEN, ARTWORK_GROUP_WORDS,
 };
 
 const ITERS: usize = 200;
@@ -421,6 +421,19 @@ fn bench_card_match_unify() {
     let sweep_all = |mode: Mode, all_match: bool, residual: &[&FilterExpr], variant: Variant| -> u64 {
         let no_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = black_box(None);
         let all_match = black_box(all_match);
+        // What a real caller builds once per query. The count path ignores prefer/sort_col/
+        // descending; they are here because `MatchCtx` also serves `push_card_matches`. The
+        // black_box'd `no_plane` goes in as-is, so the dispatch stays opaque to the optimizer.
+        let mctx = MatchCtx {
+            printings,
+            artwork_group_col,
+            strings,
+            mode,
+            prefer: Prefer::Default,
+            sort_col: SortCol::EdhrecRank,
+            descending: false,
+            existential_plane: no_plane,
+        };
         let mut seen = [0u64; ARTWORK_GROUP_WORDS];
         let mut acc = 0u64;
         for cid in 0..cards.len() {
@@ -444,7 +457,9 @@ fn bench_card_match_unify() {
                     card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
                 ),
                 Variant::Shipped => super::card_match_count(
-                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
+                    mctx,
+                    Candidate { card, cid: cid as u32, start, end, all_match, residual, residual_is_or: false },
+                    &mut seen,
                 ),
             };
             acc += u64::from(n);

--- a/card_engine/src/bench_card_match_unify.rs
+++ b/card_engine/src/bench_card_match_unify.rs
@@ -17,7 +17,9 @@
 //! #676 (2026-07-13) — before #737 gave the artwork arms their skip-repped shortcut and
 //! before the group id moved to a columnar side array, both of which changed these loops.
 //!
-//! This bench isolates the kernel. `count_split` is today's shipped shape; `count_unified`
+//! This bench isolates the kernel. `count_split` preserves the **historical** duplicated shape
+//! (it was the shipped one when this bench was written, and is kept as the baseline now that the
+//! collapse has landed); `Variant::Shipped` calls the real `card_match_count`. `count_unified`
 //! is the deduplicated one — a single `satisfies` closure that folds the plane test in, one
 //! loop per mode instead of two. Both are compiled here rather than A/B'd across builds, so
 //! the same binary, same store, and same candidate order produce both numbers.
@@ -59,6 +61,9 @@ enum Variant {
     /// `Split`'s no-plane arms use. `eval_plane_expr_for_printing` takes `&Archived<Printing>`,
     /// not an index, so the plane path never needed `pid` either.
     GenericIter,
+    /// The **shipped** `card_match_count`, whatever shape it currently has. This is the column
+    /// that matters for a PR: the others are hypotheses, this one is production.
+    Shipped,
     /// `Split` again, measured independently. Its ratio against `Split` is the noise floor:
     /// no column below is meaningful unless it clears this.
     SplitControl,
@@ -438,13 +443,16 @@ fn bench_card_match_unify() {
                 Variant::GenericIter => count_generic_iter::<false>(
                     card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
                 ),
+                Variant::Shipped => super::card_match_count(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, mode, strings, no_plane, &mut seen,
+                ),
             };
             acc += u64::from(n);
         }
         acc
     };
 
-    println!("\n  {:<38} {:>10} {:>9} {:>9} {:>11} {:>9} {:>9}", "case (existential_plane = None)", "split ns", "unif/spl", "gen/spl", "gen+it/spl", "FLOOR", "rows");
+    println!("\n  {:<38} {:>9} {:>9} {:>9} {:>11} {:>9} {:>8} {:>8}", "case (existential_plane = None)", "old ns", "unif/old", "gen/old", "gen+it/old", "SHIPPED", "FLOOR", "rows");
     let cases: &[(&str, Mode, bool, &[&FilterExpr])] = &[
         ("Card,    all_match (banned:modern)", Mode::Card, true, &[]),
         ("Printing, all_match", Mode::Printing, true, &[]),
@@ -460,6 +468,8 @@ fn bench_card_match_unify() {
         let c = sweep_all(mode, all_match, residual, Variant::Generic);
         let d = sweep_all(mode, all_match, residual, Variant::GenericIter);
         assert_eq!(a, d, "{label}: const-generic+iter disagrees with split ({a} vs {d})");
+        let e = sweep_all(mode, all_match, residual, Variant::Shipped);
+        assert_eq!(a, e, "{label}: SHIPPED card_match_count disagrees with the historical split ({a} vs {e})");
         assert_eq!(a, b, "{label}: split and unified disagree ({a} vs {b})");
         assert_eq!(a, c, "{label}: split and const-generic disagree ({a} vs {c})");
 
@@ -467,31 +477,35 @@ fn bench_card_match_unify() {
         // inherits the other's cache and frequency state, so a one-order measurement cannot tell
         // "slower function" apart from "ran second" — and at these magnitudes that confound is the
         // same size as the effect. Best-over-both-orders removes it.
-        let mut best = [u128::MAX; 5];
+        let mut best = [u128::MAX; 6];
         let mut rows = 0;
         for pass in 0..2 {
-            for i in 0..5 {
-                let all = [Variant::Split, Variant::Unified, Variant::Generic, Variant::GenericIter, Variant::SplitControl];
-                let v = all[if pass == 0 { i } else { 4 - i }];
+            for i in 0..6 {
+                let all = [
+                    Variant::Split, Variant::Unified, Variant::Generic, Variant::GenericIter, Variant::Shipped, Variant::SplitControl,
+                ];
+                let v = all[if pass == 0 { i } else { 5 - i }];
                 let (ns, r) = best_ns(|| sweep_all(mode, all_match, residual, v));
                 let slot = match v {
                     Variant::Split => 0,
                     Variant::Unified => 1,
                     Variant::Generic => 2,
                     Variant::GenericIter => 3,
-                    Variant::SplitControl => 4,
+                    Variant::Shipped => 4,
+                    Variant::SplitControl => 5,
                 };
                 best[slot] = best[slot].min(ns);
                 rows = r;
             }
         }
         println!(
-            "  {label:<38} {:>10} {:>8.3}x {:>8.3}x {:>10.3}x {:>8.3}x {rows:>9}",
+            "  {label:<38} {:>9} {:>8.3}x {:>8.3}x {:>10.3}x {:>8.3}x {:>7.3}x {rows:>8}",
             best[0],
             best[1] as f64 / best[0] as f64,
             best[2] as f64 / best[0] as f64,
             best[3] as f64 / best[0] as f64,
             best[4] as f64 / best[0] as f64,
+            best[5] as f64 / best[0] as f64,
         );
     }
     println!("\n  ratio > 1 means slower than the shipped split. The claim under test is ~1.15x.");

--- a/card_engine/src/bench_push_card_matches.rs
+++ b/card_engine/src/bench_push_card_matches.rs
@@ -28,12 +28,34 @@ use std::time::Instant;
 use rkyv::Archived;
 
 use super::{
-    archive_header, archive_payload, prefer_score, sort_key_bits, AOracleCard, APrinting, AStrings, BitPlanes, CardData, CmpOp, FilterExpr,
-    Match, Mmap, Mode, NumExpr, NumField, PlaneExpr, Prefer, SortCol, ARCHIVE_HEADER_LEN,
+    archive_header, archive_payload, prefer_score, sort_key_bits, AOracleCard, APrinting, AStrings, BitPlanes, Candidate, CardData, CmpOp,
+    FilterExpr, Match, MatchCtx, Mmap, Mode, NumExpr, NumField, PlaneExpr, Prefer, SortCol, ARCHIVE_HEADER_LEN,
 };
 
 const ITERS: usize = 120;
 const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// The `MatchCtx` a real caller builds once per query, for the two sweeps below. `Mode::Card`,
+/// `SortCol::EdhrecRank` and `descending: false` are fixed for this bench — only `prefer` varies
+/// across cases, and `existential_plane` arrives already `black_box`ed by the caller.
+fn shipped_ctx<'a>(
+    printings: &'a [APrinting],
+    artwork_group_col: &'a Archived<Vec<u16>>,
+    strings: &'a AStrings,
+    prefer: Prefer,
+    existential_plane: Option<(&'a PlaneExpr, &'a Archived<BitPlanes>)>,
+) -> MatchCtx<'a> {
+    MatchCtx {
+        printings,
+        artwork_group_col,
+        strings,
+        mode: Mode::Card,
+        prefer,
+        sort_col: SortCol::EdhrecRank,
+        descending: false,
+        existential_plane,
+    }
+}
 
 /// The historical Card arm: three blocks, plane hoisted by duplicating the source. Printing and
 /// artwork modes are omitted — the collapse did not touch them, so there is nothing to compare.
@@ -147,11 +169,12 @@ fn bench_push_card_matches() {
     let residual_leaf: [&FilterExpr; 1] = [&cmc];
 
     // As in bench_card_match_unify: the plane `Option` and `all_match` go through `black_box`, or
-    // the optimizer folds away the branch the const generic exists to remove and every variant
-    // measures as free.
+    // the optimizer folds away the branch the `PlaneTest` dispatch exists to remove and every
+    // variant measures as free.
     let sweep = |prefer: Prefer, all_match: bool, residual: &[&FilterExpr], which: Which| -> usize {
         let no_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = black_box(None);
         let all_match = black_box(all_match);
+        let mctx = shipped_ctx(printings, artwork_group_col, strings, prefer, no_plane);
         let mut out: Vec<Match> = Vec::with_capacity(cards.len());
         let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
         let mut touched: Vec<u16> = Vec::new();
@@ -165,8 +188,11 @@ fn bench_push_card_matches() {
                     no_plane, &mut out,
                 ),
                 Which::Shipped => super::push_card_matches(
-                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, Mode::Card, prefer,
-                    SortCol::EdhrecRank, false, strings, no_plane, &mut out, &mut group_best, &mut touched,
+                    mctx,
+                    Candidate { card, cid: cid as u32, start, end, all_match, residual, residual_is_or: false },
+                    &mut out,
+                    &mut group_best,
+                    &mut touched,
                 ),
             }
         }
@@ -176,6 +202,7 @@ fn bench_push_card_matches() {
     // The emitted rows themselves, for the agreement check below.
     let rows = |prefer: Prefer, all_match: bool, residual: &[&FilterExpr], which: Which| -> Vec<Match> {
         let no_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = black_box(None);
+        let mctx = shipped_ctx(printings, artwork_group_col, strings, prefer, no_plane);
         let mut out: Vec<Match> = Vec::new();
         let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
         let mut touched: Vec<u16> = Vec::new();
@@ -189,8 +216,11 @@ fn bench_push_card_matches() {
                     no_plane, &mut out,
                 ),
                 Which::Shipped => super::push_card_matches(
-                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, Mode::Card, prefer,
-                    SortCol::EdhrecRank, false, strings, no_plane, &mut out, &mut group_best, &mut touched,
+                    mctx,
+                    Candidate { card, cid: cid as u32, start, end, all_match, residual, residual_is_or: false },
+                    &mut out,
+                    &mut group_best,
+                    &mut touched,
                 ),
             }
         }

--- a/card_engine/src/bench_push_card_matches.rs
+++ b/card_engine/src/bench_push_card_matches.rs
@@ -1,0 +1,239 @@
+//! Evidence for collapsing `push_card_matches`' Card arm (#799 follow-up to
+//! `bench_card_match_unify`).
+//!
+//! That arm used to be three blocks: one `if let Some(..) = existential_plane` block holding
+//! both prefer cases behind a `satisfies` closure, then a no-plane default-prefer block, then a
+//! no-plane custom-prefer block. The plane distinction is now a `const HAS_PLANE: bool`, so the
+//! body is written once; the *prefer* distinction stays, because it is algorithmic — printings
+//! are stored default-prefer-descending, so default prefer takes the first satisfying printing
+//! and stops, while a custom prefer must score every one.
+//!
+//! `push_old` preserves the historical three-block shape verbatim. The shipped
+//! `push_card_matches` is measured against it, with an old-vs-old control column for the noise
+//! floor — without which none of these ratios can be read (see `bench_card_match_unify`, where
+//! the floor on one row ran to ±12%).
+//!
+//! Emission, unlike counting, produces a `Vec<Match>`, so agreement here is checked on the
+//! actual emitted tuples — sort key, cid and chosen pid — not just a count. Picking a
+//! *different but equally valid* representative printing would change the rows a user sees, and
+//! `Match` equality is what catches that.
+//!
+//!     cargo test --release bench_push_card_matches -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store (same file/rebuild contract as bench_verify_cost.rs).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, prefer_score, sort_key_bits, AOracleCard, APrinting, AStrings, BitPlanes, CardData, CmpOp, FilterExpr,
+    Match, Mmap, Mode, NumExpr, NumField, PlaneExpr, Prefer, SortCol, ARCHIVE_HEADER_LEN,
+};
+
+const ITERS: usize = 120;
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// The historical Card arm: three blocks, plane hoisted by duplicating the source. Printing and
+/// artwork modes are omitted — the collapse did not touch them, so there is nothing to compare.
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn push_old(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    out: &mut Vec<Match>,
+) {
+    let chosen: Option<u32> = if let Some((pe, planes)) = existential_plane {
+        let satisfies = |pid: usize| {
+            super::eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
+                && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
+        };
+        if matches!(prefer, Prefer::Default) {
+            (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
+        } else {
+            let mut chosen: Option<(u32, f64)> = None;
+            for pid in start..end {
+                if !satisfies(pid) {
+                    continue;
+                }
+                let score = prefer_score(card, &printings[pid], prefer);
+                if chosen.is_none_or(|(_, s)| score > s) {
+                    chosen = Some((pid as u32, score));
+                }
+            }
+            chosen.map(|(pid, _)| pid)
+        }
+    } else if matches!(prefer, Prefer::Default) {
+        let mut found: Option<u32> = None;
+        for pid in start..end {
+            if all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
+                found = Some(pid as u32);
+                break;
+            }
+        }
+        found
+    } else {
+        let mut chosen: Option<(u32, f64)> = None;
+        for pid in start..end {
+            let p = &printings[pid];
+            if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
+                continue;
+            }
+            let score = prefer_score(card, p, prefer);
+            if chosen.is_none_or(|(_, s)| score > s) {
+                chosen = Some((pid as u32, score));
+            }
+        }
+        chosen.map(|(pid, _)| pid)
+    };
+    if let Some(pid) = chosen {
+        out.push((sort_key_bits(card, &printings[pid as usize], sort_col, descending), cid, pid));
+    }
+}
+
+/// Which shape to run. `OldControl` is `Old` again, measured separately: its ratio against `Old`
+/// is the noise floor, and nothing else in the table is readable without it.
+#[derive(Clone, Copy)]
+enum Which {
+    Old,
+    Shipped,
+    OldControl,
+}
+
+fn best_ns(mut kernel: impl FnMut() -> usize) -> (u128, usize) {
+    let mut best = u128::MAX;
+    let mut n = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        n = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    (best, n)
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_push_card_matches() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let (cards, printings, offsets) = (&data.cards, &data.printings, &data.offsets);
+    let strings = &data.strings;
+    let artwork_group_col = &data.indexes.artwork_group_col;
+    let max_groups = usize::from(u16::from(data.indexes.max_artwork_groups));
+    println!("\n{} printings, {} cards from {STORE_PATH}", printings.len(), cards.len());
+
+    let cmc = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Lt, rhs: NumExpr::Const(3.0) };
+    let residual_leaf: [&FilterExpr; 1] = [&cmc];
+
+    // As in bench_card_match_unify: the plane `Option` and `all_match` go through `black_box`, or
+    // the optimizer folds away the branch the const generic exists to remove and every variant
+    // measures as free.
+    let sweep = |prefer: Prefer, all_match: bool, residual: &[&FilterExpr], which: Which| -> usize {
+        let no_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = black_box(None);
+        let all_match = black_box(all_match);
+        let mut out: Vec<Match> = Vec::with_capacity(cards.len());
+        let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
+        let mut touched: Vec<u16> = Vec::new();
+        for cid in 0..cards.len() {
+            let card = &cards[cid];
+            let start = u32::from(offsets[cid]) as usize;
+            let end = u32::from(offsets[cid + 1]) as usize;
+            match which {
+                Which::Old | Which::OldControl => push_old(
+                    card, cid as u32, printings, start, end, all_match, residual, false, prefer, SortCol::EdhrecRank, false, strings,
+                    no_plane, &mut out,
+                ),
+                Which::Shipped => super::push_card_matches(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, Mode::Card, prefer,
+                    SortCol::EdhrecRank, false, strings, no_plane, &mut out, &mut group_best, &mut touched,
+                ),
+            }
+        }
+        out.len()
+    };
+
+    // The emitted rows themselves, for the agreement check below.
+    let rows = |prefer: Prefer, all_match: bool, residual: &[&FilterExpr], which: Which| -> Vec<Match> {
+        let no_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)> = black_box(None);
+        let mut out: Vec<Match> = Vec::new();
+        let mut group_best: Vec<Option<(u32, f64)>> = vec![None; max_groups];
+        let mut touched: Vec<u16> = Vec::new();
+        for cid in 0..cards.len() {
+            let card = &cards[cid];
+            let start = u32::from(offsets[cid]) as usize;
+            let end = u32::from(offsets[cid + 1]) as usize;
+            match which {
+                Which::Old | Which::OldControl => push_old(
+                    card, cid as u32, printings, start, end, all_match, residual, false, prefer, SortCol::EdhrecRank, false, strings,
+                    no_plane, &mut out,
+                ),
+                Which::Shipped => super::push_card_matches(
+                    card, cid as u32, printings, artwork_group_col, start, end, all_match, residual, false, Mode::Card, prefer,
+                    SortCol::EdhrecRank, false, strings, no_plane, &mut out, &mut group_best, &mut touched,
+                ),
+            }
+        }
+        out
+    };
+
+    println!("\n  {:<40} {:>10} {:>10} {:>9} {:>8} {:>8}", "case (Mode::Card, no plane)", "old ns", "shipped ns", "ship/old", "FLOOR", "rows");
+    let cases: &[(&str, Prefer, bool, &[&FilterExpr])] = &[
+        ("prefer=default, all_match", Prefer::Default, true, &[]),
+        ("prefer=default, residual cmc<3", Prefer::Default, false, &residual_leaf),
+        ("prefer=usd_high, all_match", Prefer::UsdHigh, true, &[]),
+        ("prefer=usd_high, residual cmc<3", Prefer::UsdHigh, false, &residual_leaf),
+        ("prefer=oldest, residual cmc<3", Prefer::Oldest, false, &residual_leaf),
+    ];
+    for &(label, prefer, all_match, residual) in cases {
+        // Agreement on the emitted tuples, not just the count: a different-but-valid
+        // representative printing would change what a user sees and must fail here.
+        let a = rows(prefer, all_match, residual, Which::Old);
+        let b = rows(prefer, all_match, residual, Which::Shipped);
+        assert_eq!(a, b, "{label}: SHIPPED push_card_matches emits different rows than the historical shape");
+
+        let mut best = [u128::MAX; 3];
+        let mut n = 0;
+        for pass in 0..2 {
+            for i in 0..3 {
+                let w = [Which::Old, Which::Shipped, Which::OldControl][if pass == 0 { i } else { 2 - i }];
+                let (ns, got) = best_ns(|| sweep(prefer, all_match, residual, w));
+                let slot = match w {
+                    Which::Old => 0,
+                    Which::Shipped => 1,
+                    Which::OldControl => 2,
+                };
+                best[slot] = best[slot].min(ns);
+                n = got;
+            }
+        }
+        println!(
+            "  {label:<40} {:>10} {:>10} {:>8.3}x {:>7.3}x {n:>8}",
+            best[0],
+            best[1],
+            best[1] as f64 / best[0] as f64,
+            best[2] as f64 / best[0] as f64,
+        );
+    }
+    println!("\n  ship/old > 1 means the collapsed version is slower. Read it against FLOOR (old vs old).");
+}

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4272,6 +4272,100 @@ enum Mode { Card, Artwork, Printing }
 /// silently under-count in production instead of failing loudly on reload.
 const ARTWORK_GROUP_WORDS: usize = 8;
 
+/// The existential-plane conjunct as a *type*, so each instantiation of the match bodies below
+/// folds it away instead of testing an `Option` once per printing. That distinction measured ~4%
+/// on Card+residual against a 1.000-1.002x noise floor (`bench_card_match_unify`, #799).
+///
+/// This replaces a `const HAS_PLANE: bool` that travelled *alongside* the `Option` it described:
+/// nothing stopped the two from disagreeing, and the shared body leaned on an
+/// `.expect("HAS_PLANE implies Some")` to assert they did not. [`NoPlane`] carries no plane and
+/// [`WithPlane`] cannot be constructed without one, so the invariant is the type's now and the
+/// `expect` is gone.
+trait PlaneTest: Copy {
+    /// Whether [`holds`](PlaneTest::holds) can ever return false. Gates the blind `all_match`
+    /// shortcut, which is only sound when there is no plane to satisfy on the *same* printing.
+    const HAS_PLANE: bool;
+
+    /// Does this printing satisfy the folded existential leaf? Trivially true when absent.
+    fn holds(self, cid: u32, printing: &APrinting, strings: &AStrings) -> bool;
+}
+
+/// No folded existential plane — the overwhelmingly common case (every query without a promoted
+/// legality leaf). A ZST, so it costs nothing to pass and `holds` inlines to `true`.
+#[derive(Clone, Copy)]
+struct NoPlane;
+
+impl PlaneTest for NoPlane {
+    const HAS_PLANE: bool = false;
+
+    #[inline(always)]
+    fn holds(self, _cid: u32, _printing: &APrinting, _strings: &AStrings) -> bool {
+        true
+    }
+}
+
+/// A folded existential plane and the bit planes to evaluate it against.
+#[derive(Clone, Copy)]
+struct WithPlane<'a>(&'a PlaneExpr, &'a Archived<BitPlanes>);
+
+impl PlaneTest for WithPlane<'_> {
+    const HAS_PLANE: bool = true;
+
+    #[inline(always)]
+    fn holds(self, cid: u32, printing: &APrinting, strings: &AStrings) -> bool {
+        eval_plane_expr_for_printing(self.0, self.1, cid, printing, strings)
+    }
+}
+
+/// What a match call needs that does not vary across candidates: the store slices its
+/// per-printing loops read, the request knobs that pick their shape, and the folded existential
+/// plane. Built once outside the candidate loop at all four call sites.
+///
+/// Same grouping argument as [`QueryCtx`]/[`QueryParams`] one layer up, applied one layer down:
+/// [`card_match_count`] and [`push_card_matches`] took 13 and 18 positional args, of which only
+/// [`Candidate`]'s seven and the scratch buffers actually differ between calls. As there, not
+/// every callee reads every field — `card_match_count` ignores `prefer`/`sort_col`/`descending`,
+/// since counting needs no representative printing and no sort key.
+///
+/// **Passed by value, and that is load-bearing — do not "tidy" it to `&MatchCtx`.** This and
+/// [`Candidate`] are `Copy` bundles of what used to be positional args, and taking either by
+/// reference costs real time: `bench_push_card_matches`' `prefer=usd_high, all_match` shape ran
+/// 314 μs with both behind `&`, 293 μs with `Candidate` by value, and 261 μs with both by value
+/// (best of three runs each, same machine). Reference form apparently gives the inliner an
+/// address to keep rather than fields to scalarize. Re-run that bench if you change how these
+/// are passed.
+#[derive(Clone, Copy)]
+struct MatchCtx<'a> {
+    printings: &'a [APrinting],
+    artwork_group_col: &'a Archived<Vec<u16>>,
+    strings: &'a AStrings,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    /// `Some` iff `mode` is `Card` and the plane driving `all_match` touched a legality leaf —
+    /// see [`push_card_matches`]' doc for why the chosen printing must then satisfy the plane and
+    /// the residual *together*. Inspected in exactly one place: the dispatch wrappers, which turn
+    /// it into a [`PlaneTest`] type once, outside the printing loop.
+    existential_plane: Option<(&'a PlaneExpr, &'a Archived<BitPlanes>)>,
+}
+
+/// One card under test, together with what the card pass already concluded about it. The part of
+/// a match call that genuinely changes per candidate. Built fresh each iteration and passed by
+/// value — see [`MatchCtx`] for why the `&` form is slower.
+#[derive(Clone, Copy)]
+struct Candidate<'a> {
+    card: &'a AOracleCard,
+    cid: u32,
+    /// Half-open range of this card's printings in [`MatchCtx::printings`].
+    start: usize,
+    end: usize,
+    /// The card pass proved every printing matches, so the residual need not be re-tested.
+    all_match: bool,
+    residual: &'a [&'a FilterExpr],
+    residual_is_or: bool,
+}
+
 /// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
 /// passing printings for Printing mode, distinct illustrations with a passing
 /// printing for Artwork mode. `seen_words` is a reused scratch buffer: a
@@ -4289,38 +4383,16 @@ const ARTWORK_GROUP_WORDS: usize = 8;
 // only ever `Some` for `Mode::Card` (see its computation in `run_query`), so
 // `Mode::Printing`/`Artwork` below are unaffected -- their planes, if any,
 // were never folded to begin with when existential (`unique_is_card`).
-#[allow(clippy::too_many_arguments)]
 #[inline(always)]
-fn card_match_count(
-    card: &AOracleCard,
-    cid: u32,
-    printings: &[APrinting],
-    artwork_group_col: &Archived<Vec<u16>>,
-    start: usize,
-    end: usize,
-    all_match: bool,
-    residual: &[&FilterExpr],
-    residual_is_or: bool,
-    mode: Mode,
-    strings: &AStrings,
-    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
-    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
-) -> u32 {
-    // The plane test is a *const* parameter, not a runtime branch, so each instantiation
-    // folds it away and the per-printing loops below are branch-free on it. This dispatch is
-    // the only place the `Option` is inspected, and it sits outside the printing loop; every
-    // caller has it loop-invariant across candidates, so it costs one predicted branch per
-    // candidate at worst and is usually unswitched out of the candidate loop entirely.
-    if existential_plane.is_some() {
-        card_match_count_impl::<true>(
-            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, strings, existential_plane,
-            seen_words,
-        )
-    } else {
-        card_match_count_impl::<false>(
-            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, strings, existential_plane,
-            seen_words,
-        )
+fn card_match_count(ctx: MatchCtx, cand: Candidate, seen_words: &mut [u64; ARTWORK_GROUP_WORDS]) -> u32 {
+    // The plane test becomes a *type* here, not a runtime branch, so each instantiation folds it
+    // away and the per-printing loops below are branch-free on it. This is the only place the
+    // `Option` is inspected, and it sits outside the printing loop; every caller has it
+    // loop-invariant across candidates, so it costs one predicted branch per candidate at worst
+    // and is usually unswitched out of the candidate loop entirely.
+    match ctx.existential_plane {
+        Some((pe, planes)) => card_match_count_impl(ctx, cand, WithPlane(pe, planes), seen_words),
+        None => card_match_count_impl(ctx, cand, NoPlane, seen_words),
     }
 }
 
@@ -4332,8 +4404,9 @@ fn card_match_count(
 /// worth ~15% on `banned:modern`. `bench_card_match_unify` (#799) showed otherwise, and the
 /// two things that actually cost anything are both preserved here rather than duplicated:
 ///
-///   - `HAS_PLANE` is a const generic, not a runtime `Option` test inside `satisfies`. That
-///     distinction measured ~4% on Card+residual against a 1.000-1.002x noise floor.
+///   - The plane test arrives as a [`PlaneTest`] type, not a runtime `Option` test inside
+///     `satisfies`. That distinction measured ~4% on Card+residual against a 1.000-1.002x
+///     noise floor.
 ///   - The loops iterate `&printings[start..end]` rather than indexing `printings[pid]`,
 ///     worth another ~5%. Only `Mode::Artwork` needs the index at all, for
 ///     `artwork_group_col`; `eval_plane_expr_for_printing` takes `&Archived<Printing>`, so
@@ -4343,43 +4416,25 @@ fn card_match_count(
 /// if you touch it, and re-run that bench — it carries a split-vs-split floor column without
 /// which its ratios cannot be read, and a `black_box` on the plane `Option` without which the
 /// optimizer folds away the very branch under test.
-#[allow(clippy::too_many_arguments)]
 // needless_range_loop: Artwork's `pid` indexes `artwork_group_col` alongside the printing itself,
 // so a bare slice iterator would lose the id it needs.
 #[allow(clippy::needless_range_loop)]
 #[inline(always)]
-fn card_match_count_impl<const HAS_PLANE: bool>(
-    card: &AOracleCard,
-    cid: u32,
-    printings: &[APrinting],
-    artwork_group_col: &Archived<Vec<u16>>,
-    start: usize,
-    end: usize,
-    all_match: bool,
-    residual: &[&FilterExpr],
-    residual_is_or: bool,
-    mode: Mode,
-    strings: &AStrings,
-    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
-    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
-) -> u32 {
+fn card_match_count_impl<P: PlaneTest>(ctx: MatchCtx, cand: Candidate, plane: P, seen_words: &mut [u64; ARTWORK_GROUP_WORDS]) -> u32 {
+    let MatchCtx { printings, artwork_group_col, strings, mode, .. } = ctx;
+    let Candidate { card, cid, start, end, all_match, residual, residual_is_or } = cand;
     // Both the residual and, when present, the plane must hold for the *same* printing
     // (#676's review: `all_match`/`residual` alone only prove some printing satisfies the
     // residual; the plane alone only proves its existential leaf holds for some possibly
-    // different printing). `HAS_PLANE` is const, so the plane conjunct disappears entirely
-    // from the `false` instantiation rather than being tested per printing.
+    // different printing). `NoPlane::holds` is `true`, so the plane conjunct disappears
+    // entirely from that instantiation rather than being tested per printing.
     let satisfies = |p: &APrinting| {
-        (!HAS_PLANE
-            || {
-                let (pe, planes) = existential_plane.expect("HAS_PLANE implies Some");
-                eval_plane_expr_for_printing(pe, planes, cid, p, strings)
-            })
-            && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
+        plane.holds(cid, p, strings) && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
     };
     // The blind shortcut: with every printing matching AND no plane to check, the answer is
     // the range's shape and no printing needs visiting. Folds to `all_match` in the no-plane
     // instantiation and to `false` in the other, where it is never sound.
-    let blind = all_match && !HAS_PLANE;
+    let blind = all_match && !P::HAS_PLANE;
     match mode {
         Mode::Card => {
             if blind {
@@ -4429,7 +4484,7 @@ fn card_match_count_impl<const HAS_PLANE: bool>(
 /// Emit this card's matches as (sort key, cid, pid) tuples — the per-card body
 /// of the gathered path, shared by the streamed path for page cards.
 ///
-/// `existential_plane`: `Some((plane, planes))` iff `mode` is `Card` and the
+/// [`MatchCtx::existential_plane`]: `Some((plane, planes))` iff `mode` is `Card` and the
 /// plane driving `all_match` touched a legality leaf
 /// (docs/issues/00667-engine-legality-divergent-carveout.md "Row selection for
 /// unique=card") — `all_match`/`residual` there only prove *some* printing
@@ -4442,44 +4497,23 @@ fn card_match_count_impl<const HAS_PLANE: bool>(
 /// case) keeps today's behavior exactly: `Mode`s other than `Card` never hit
 /// this (their planes are never folded this way, see `unique_is_card`), and a
 /// card-invariant `all_match` needs no check (every printing already agrees).
-#[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn push_card_matches(
-    card: &AOracleCard,
-    cid: u32,
-    printings: &[APrinting],
-    artwork_group_col: &Archived<Vec<u16>>,
-    start: usize,
-    end: usize,
-    all_match: bool,
-    residual: &[&FilterExpr],
-    residual_is_or: bool,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    strings: &AStrings,
-    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    ctx: MatchCtx,
+    cand: Candidate,
     out: &mut Vec<Match>,
     group_best: &mut [Option<(u32, f64)>],
     touched: &mut Vec<u16>,
 ) {
-    // Same const-generic dispatch as `card_match_count` — see its doc for the measurements.
-    // `existential_plane` is `Some` only for `Mode::Card`, so only that arm below reads it.
-    if existential_plane.is_some() {
-        push_card_matches_impl::<true>(
-            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, prefer, sort_col,
-            descending, strings, existential_plane, out, group_best, touched,
-        );
-    } else {
-        push_card_matches_impl::<false>(
-            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, prefer, sort_col,
-            descending, strings, existential_plane, out, group_best, touched,
-        );
+    // Same dispatch as `card_match_count` — see its doc for the measurements. The plane is `Some`
+    // only for `Mode::Card`, so only that arm below consults it.
+    match ctx.existential_plane {
+        Some((pe, planes)) => push_card_matches_impl(ctx, cand, WithPlane(pe, planes), out, group_best, touched),
+        None => push_card_matches_impl(ctx, cand, NoPlane, out, group_best, touched),
     }
 }
 
-/// `push_card_matches`' body, once. `HAS_PLANE` folds the existential-plane conjunct in or out
+/// `push_card_matches`' body, once. [`PlaneTest`] folds the existential-plane conjunct in or out
 /// at compile time, exactly as in `card_match_count` and for the same measured reasons.
 ///
 /// The Card arm used to be three blocks — plane×(default-prefer, custom-prefer) in one, then
@@ -4487,31 +4521,20 @@ fn push_card_matches(
 /// prefer: default-prefer takes the first satisfying printing (they are stored prefer-desc, so
 /// first *is* best) while a custom prefer must score them all. That distinction is algorithmic
 /// and stays; the plane one is now the compiler's job.
-#[allow(clippy::too_many_arguments)]
 // needless_range_loop: Artwork's `pid` indexes `artwork_group_col`, and every arm pushes `pid`
 // into the emitted match tuple, so the loops need the absolute index.
 #[allow(clippy::needless_range_loop)]
 #[inline(always)]
-fn push_card_matches_impl<const HAS_PLANE: bool>(
-    card: &AOracleCard,
-    cid: u32,
-    printings: &[APrinting],
-    artwork_group_col: &Archived<Vec<u16>>,
-    start: usize,
-    end: usize,
-    all_match: bool,
-    residual: &[&FilterExpr],
-    residual_is_or: bool,
-    mode: Mode,
-    prefer: Prefer,
-    sort_col: SortCol,
-    descending: bool,
-    strings: &AStrings,
-    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+fn push_card_matches_impl<P: PlaneTest>(
+    ctx: MatchCtx,
+    cand: Candidate,
+    plane: P,
     out: &mut Vec<Match>,
     group_best: &mut [Option<(u32, f64)>],
     touched: &mut Vec<u16>,
 ) {
+    let MatchCtx { printings, artwork_group_col, strings, mode, prefer, sort_col, descending, .. } = ctx;
+    let Candidate { card, cid, start, end, all_match, residual, residual_is_or } = cand;
     match mode {
         Mode::Card => {
             // Printings are stored in descending default-prefer order, so for the default
@@ -4525,12 +4548,7 @@ fn push_card_matches_impl<const HAS_PLANE: bool>(
             // "Row selection for unique=card"). Checking only the plane could pick a printing
             // that is legal but fails the residual, or vice versa.
             let satisfies = |p: &APrinting| {
-                (!HAS_PLANE
-                    || {
-                        let (pe, planes) = existential_plane.expect("HAS_PLANE implies Some");
-                        eval_plane_expr_for_printing(pe, planes, cid, p, strings)
-                    })
-                    && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
+                plane.holds(cid, p, strings) && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
             };
             let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
                 printings[start..end].iter().position(satisfies).map(|i| (start + i) as u32)
@@ -6986,6 +7004,18 @@ fn exec_gathered_scan<'a>(
     // the current card (reused buffer; see FilterExpr::card_pass).
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
+    // Everything the match call needs that is fixed for the whole scan, bundled once here so the
+    // loop below passes only what actually varies per candidate. See `MatchCtx`.
+    let mctx = MatchCtx {
+        printings,
+        artwork_group_col: &indexes.artwork_group_col,
+        strings,
+        mode,
+        prefer,
+        sort_col,
+        descending,
+        existential_plane,
+    };
     // Counters for the three features this plan's cost arm keys on, so they can be checked against
     // what the loop really does. Plain locals — no atomics, no branch — published once at the end.
     let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
@@ -7007,10 +7037,8 @@ fn exec_gathered_scan<'a>(
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
         n_printings_scanned += (end - start) as u64;
-        push_card_matches(
-            card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
-            sort_col, descending, strings, existential_plane, sel.buf(), &mut group_best, &mut touched,
-        );
+        let cand = Candidate { card, cid, start, end, all_match, residual: &residual, residual_is_or };
+        push_card_matches(mctx, cand, sel.buf(), &mut group_best, &mut touched);
         n_matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
@@ -8294,6 +8322,9 @@ fn run_query_streamed<'a>(
     let artwork_groups = &indexes.artwork_groups;
     let artwork_group_col = &indexes.artwork_group_col;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
+    // Fixed for the whole query; the three match calls below vary only by `Candidate` and which
+    // scratch buffer they emit into. See `MatchCtx`.
+    let mctx = MatchCtx { printings, artwork_group_col, strings, mode, prefer, sort_col, descending, existential_plane };
     let mut residual: Vec<&FilterExpr> = Vec::new();
     let mut residual_is_or = false;
     let mut seen_words = [0u64; ARTWORK_GROUP_WORDS]; // #629: artwork-mode match-count scratch
@@ -8348,11 +8379,8 @@ fn run_query_streamed<'a>(
         let c = if all_match && matches!(mode, Mode::Artwork) && have_group_counts {
             u32::from(u16::from(artwork_groups[cid as usize]))
         } else {
-            card_match_count(
-                card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, strings,
-                existential_plane,
-                &mut seen_words,
-            )
+            let cand = Candidate { card, cid, start, end, all_match, residual: &residual, residual_is_or };
+            card_match_count(mctx, cand, &mut seen_words)
         };
         counts[cid as usize] = c;
         total += c as usize;
@@ -8407,10 +8435,8 @@ fn run_query_streamed<'a>(
                 };
             let start = u32::from(offsets[cid as usize]) as usize;
             let end   = u32::from(offsets[cid as usize + 1]) as usize;
-            push_card_matches(
-                card, cid, printings, artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
-                sort_col, descending, strings, existential_plane, &mut best, &mut group_best, &mut touched,
-            );
+            let cand = Candidate { card, cid, start, end, all_match, residual: &residual, residual_is_or };
+            push_card_matches(mctx, cand, &mut best, &mut group_best, &mut touched);
         }
         let page = select_page(best, page_offset, limit)
             .into_iter()
@@ -8446,10 +8472,8 @@ fn run_query_streamed<'a>(
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         scratch.clear();
-        push_card_matches(
-            card, cid, printings, artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
-            sort_col, descending, strings, existential_plane, &mut scratch, &mut group_best, &mut touched,
-        );
+        let cand = Candidate { card, cid, start, end, all_match, residual: &residual, residual_is_or };
+        push_card_matches(mctx, cand, &mut scratch, &mut group_best, &mut touched);
         scratch.sort_unstable_by(page_cmp);
         for m in scratch.iter().skip(skip) {
             page.push((&cards[m.1 as usize], &printings[m.2 as usize]));

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4290,9 +4290,6 @@ const ARTWORK_GROUP_WORDS: usize = 8;
 // `Mode::Printing`/`Artwork` below are unaffected -- their planes, if any,
 // were never folded to begin with when existential (`unique_is_card`).
 #[allow(clippy::too_many_arguments)]
-// needless_range_loop: `pid` is the printing's absolute id, used for `artwork_group_id`
-// lookups alongside the residual test — a slice iterator would lose the id.
-#[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn card_match_count(
     card: &AOracleCard,
@@ -4309,134 +4306,117 @@ fn card_match_count(
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
 ) -> u32 {
-    // No existential plane: identical code shape to before #676's
-    // existential_plane parameter existed at all -- no closure, no extra
-    // branch inside the hot loop. This is the overwhelmingly common case
-    // (every query without a promoted legality leaf), and it's called once
-    // per *candidate*, not once per emitted row, so its cost is on the
-    // critical path for every non-Step-2 query.
-    //
-    // This comment used to justify the split with "a real (~15%) regression on
-    // `banned:modern`/`restricted:vintage`", measured via the broad survey.
-    // `bench_card_match_unify` re-measured it at the kernel (#799 follow-up).
-    // Every part of that claim turned out to be wrong, including the verdict.
-    //
-    // The named workload pays nothing: `banned:modern` measures at the noise
-    // floor. #676 recorded the note at 16:36; #679 gave banned:/restricted:
-    // exact legality planes at 18:09 the same day, making those queries tight
-    // -- `all_match` true, empty residual -- so they take the blind shortcut
-    // below and never reach a per-printing closure at all. The cited
-    // measurement was invalidated 93 minutes after it was written down.
-    //
-    // The split IS faster than a naive dedupe, but for two separable reasons,
-    // roughly half each, and neither requires duplicated source. Against a
-    // split-vs-split noise floor of 1.000-1.002x on Card+residual:
-    //
-    //   runtime `existential_plane` branch + `printings[pid]`   1.086-1.103x
-    //   `const HAS_PLANE: bool`            + `printings[pid]`   1.051-1.059x
-    //   `const HAS_PLANE: bool`            + slice iteration    0.980-0.997x
-    //
-    // So ~4% was the per-printing plane branch, and ~5% was indexing by `pid`
-    // instead of iterating `&printings[start..end]`. The second one is pure
-    // accident: `eval_plane_expr_for_printing` takes `&Archived<Printing>`,
-    // not an index, so even the plane path never needed `pid` -- only
-    // `Mode::Artwork` does, for `artwork_group_col`.
-    //
-    // A single body with `const HAS_PLANE: bool` and slice iteration
-    // benchmarks at parity or slightly better than what is written here, so
-    // the duplication below is NOT load-bearing and this function is no longer
-    // on #799's do-not-touch list. It is still written out twice only because
-    // nobody has done the collapse yet. If you do it: keep the const generic
-    // (a runtime branch costs the 4%), keep slice iteration, keep the blind
-    // `all_match` shortcut, and re-run the bench -- including its
-    // split-vs-split floor column, without which none of these numbers can be
-    // read, and its `black_box` on the plane `Option`, without which the
-    // optimizer folds away the branch under test and reports every variant as
-    // free.
-    let Some((pe, planes)) = existential_plane else {
-        return match mode {
-            Mode::Card => {
-                if all_match {
-                    return u32::from(start < end);
-                }
-                for p in &printings[start..end] {
-                    if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
-                        return 1;
-                    }
-                }
-                0
-            }
-            Mode::Printing => {
-                if all_match {
-                    return (end - start) as u32;
-                }
-                let mut n = 0u32;
-                for p in &printings[start..end] {
-                    if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
-                        n += 1;
-                    }
-                }
-                n
-            }
-            Mode::Artwork => {
-                // #737's skip-repped shortcut, which landed in the gather loop but not here. Read the
-                // group id FIRST -- from the columnar array, so an already-counted group never touches
-                // the wide APrinting struct -- and skip before the residual. This loop only COUNTS
-                // distinct groups, so once a bit is set no later printing of that group can change the
-                // answer and testing the residual again is pure waste. Strictly safer than the
-                // gather's version, which had to assume prefer-desc ordering to pick a representative;
-                // counting needs no ordering assumption and so has no custom-prefer carve-out.
-                seen_words.fill(0);
-                for pid in start..end {
-                    let gid = u16::from(artwork_group_col[pid]) as usize;
-                    let (word, bit) = (gid / 64, 1u64 << (gid % 64));
-                    if seen_words[word] & bit != 0 {
-                        continue;
-                    }
-                    if !all_match
-                        && !FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or)
-                    {
-                        continue;
-                    }
-                    seen_words[word] |= bit;
-                }
-                seen_words.iter().map(|w| w.count_ones()).sum()
-            }
-        };
-    };
+    // The plane test is a *const* parameter, not a runtime branch, so each instantiation
+    // folds it away and the per-printing loops below are branch-free on it. This dispatch is
+    // the only place the `Option` is inspected, and it sits outside the printing loop; every
+    // caller has it loop-invariant across candidates, so it costs one predicted branch per
+    // candidate at worst and is usually unswitched out of the candidate loop entirely.
+    if existential_plane.is_some() {
+        card_match_count_impl::<true>(
+            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, strings, existential_plane,
+            seen_words,
+        )
+    } else {
+        card_match_count_impl::<false>(
+            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, strings, existential_plane,
+            seen_words,
+        )
+    }
+}
 
-    // Existential plane present (Mode::Card only -- see this function's
-    // doc): the blind all_match shortcut never applies, and both the
-    // residual and the plane must hold for the same printing.
-    let satisfies =
-        |pid: usize| eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
-            && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or));
+/// `card_match_count`'s body, once, with `HAS_PLANE` deciding at compile time whether the
+/// existential plane participates.
+///
+/// This used to be written out twice — a no-plane arm of three specialized mode loops, then a
+/// closure-based arm of the same three shapes — with a comment claiming the duplication was
+/// worth ~15% on `banned:modern`. `bench_card_match_unify` (#799) showed otherwise, and the
+/// two things that actually cost anything are both preserved here rather than duplicated:
+///
+///   - `HAS_PLANE` is a const generic, not a runtime `Option` test inside `satisfies`. That
+///     distinction measured ~4% on Card+residual against a 1.000-1.002x noise floor.
+///   - The loops iterate `&printings[start..end]` rather than indexing `printings[pid]`,
+///     worth another ~5%. Only `Mode::Artwork` needs the index at all, for
+///     `artwork_group_col`; `eval_plane_expr_for_printing` takes `&Archived<Printing>`, so
+///     even the plane path never did.
+///
+/// Collapsed, this benchmarks at 0.980-0.997x of the duplicated version. Keep both properties
+/// if you touch it, and re-run that bench — it carries a split-vs-split floor column without
+/// which its ratios cannot be read, and a `black_box` on the plane `Option` without which the
+/// optimizer folds away the very branch under test.
+#[allow(clippy::too_many_arguments)]
+// needless_range_loop: Artwork's `pid` indexes `artwork_group_col` alongside the printing itself,
+// so a bare slice iterator would lose the id it needs.
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn card_match_count_impl<const HAS_PLANE: bool>(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
+) -> u32 {
+    // Both the residual and, when present, the plane must hold for the *same* printing
+    // (#676's review: `all_match`/`residual` alone only prove some printing satisfies the
+    // residual; the plane alone only proves its existential leaf holds for some possibly
+    // different printing). `HAS_PLANE` is const, so the plane conjunct disappears entirely
+    // from the `false` instantiation rather than being tested per printing.
+    let satisfies = |p: &APrinting| {
+        (!HAS_PLANE
+            || {
+                let (pe, planes) = existential_plane.expect("HAS_PLANE implies Some");
+                eval_plane_expr_for_printing(pe, planes, cid, p, strings)
+            })
+            && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
+    };
+    // The blind shortcut: with every printing matching AND no plane to check, the answer is
+    // the range's shape and no printing needs visiting. Folds to `all_match` in the no-plane
+    // instantiation and to `false` in the other, where it is never sound.
+    let blind = all_match && !HAS_PLANE;
     match mode {
         Mode::Card => {
-            for pid in start..end {
-                if satisfies(pid) {
+            if blind {
+                return u32::from(start < end);
+            }
+            for p in &printings[start..end] {
+                if satisfies(p) {
                     return 1;
                 }
             }
             0
         }
         Mode::Printing => {
+            if blind {
+                return (end - start) as u32;
+            }
             let mut n = 0u32;
-            for pid in start..end {
-                if satisfies(pid) {
+            for p in &printings[start..end] {
+                if satisfies(p) {
                     n += 1;
                 }
             }
             n
         }
         Mode::Artwork => {
-            // Same skip-repped shortcut as the no-plane arm above, and it matters more here:
-            // `satisfies` evaluates a plane expression per printing on top of the residual.
+            // #737's skip-repped shortcut. Read the group id FIRST -- from the columnar array, so
+            // an already-counted group never touches the wide APrinting struct -- and skip before
+            // the residual. This loop only COUNTS distinct groups, so once a bit is set no later
+            // printing of that group can change the answer and re-testing is pure waste. Counting
+            // needs no ordering assumption, so unlike the gather's version there is no
+            // custom-prefer carve-out. It matters more under `HAS_PLANE`, where `satisfies` also
+            // evaluates a plane expression per printing.
             seen_words.fill(0);
             for pid in start..end {
                 let gid = u16::from(artwork_group_col[pid]) as usize;
                 let (word, bit) = (gid / 64, 1u64 << (gid % 64));
-                if seen_words[word] & bit != 0 || !satisfies(pid) {
+                if seen_words[word] & bit != 0 || !satisfies(&printings[pid]) {
                     continue;
                 }
                 seen_words[word] |= bit;
@@ -4463,9 +4443,6 @@ fn card_match_count(
 /// this (their planes are never folded this way, see `unique_is_card`), and a
 /// card-invariant `all_match` needs no check (every printing already agrees).
 #[allow(clippy::too_many_arguments)]
-// needless_range_loop: `pid` is the printing's identity, not a cursor — it is pushed into
-// the emitted match tuple (`pid as u32`), so the loop needs the absolute index.
-#[allow(clippy::needless_range_loop)]
 #[inline(always)]
 fn push_card_matches(
     card: &AOracleCard,
@@ -4487,56 +4464,81 @@ fn push_card_matches(
     group_best: &mut [Option<(u32, f64)>],
     touched: &mut Vec<u16>,
 ) {
+    // Same const-generic dispatch as `card_match_count` — see its doc for the measurements.
+    // `existential_plane` is `Some` only for `Mode::Card`, so only that arm below reads it.
+    if existential_plane.is_some() {
+        push_card_matches_impl::<true>(
+            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, prefer, sort_col,
+            descending, strings, existential_plane, out, group_best, touched,
+        );
+    } else {
+        push_card_matches_impl::<false>(
+            card, cid, printings, artwork_group_col, start, end, all_match, residual, residual_is_or, mode, prefer, sort_col,
+            descending, strings, existential_plane, out, group_best, touched,
+        );
+    }
+}
+
+/// `push_card_matches`' body, once. `HAS_PLANE` folds the existential-plane conjunct in or out
+/// at compile time, exactly as in `card_match_count` and for the same measured reasons.
+///
+/// The Card arm used to be three blocks — plane×(default-prefer, custom-prefer) in one, then
+/// no-plane default-prefer, then no-plane custom-prefer — where the only real distinction is
+/// prefer: default-prefer takes the first satisfying printing (they are stored prefer-desc, so
+/// first *is* best) while a custom prefer must score them all. That distinction is algorithmic
+/// and stays; the plane one is now the compiler's job.
+#[allow(clippy::too_many_arguments)]
+// needless_range_loop: Artwork's `pid` indexes `artwork_group_col`, and every arm pushes `pid`
+// into the emitted match tuple, so the loops need the absolute index.
+#[allow(clippy::needless_range_loop)]
+#[inline(always)]
+fn push_card_matches_impl<const HAS_PLANE: bool>(
+    card: &AOracleCard,
+    cid: u32,
+    printings: &[APrinting],
+    artwork_group_col: &Archived<Vec<u16>>,
+    start: usize,
+    end: usize,
+    all_match: bool,
+    residual: &[&FilterExpr],
+    residual_is_or: bool,
+    mode: Mode,
+    prefer: Prefer,
+    sort_col: SortCol,
+    descending: bool,
+    strings: &AStrings,
+    existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
+    out: &mut Vec<Match>,
+    group_best: &mut [Option<(u32, f64)>],
+    touched: &mut Vec<u16>,
+) {
     match mode {
         Mode::Card => {
-            // Printings are stored in descending default-prefer order, so
-            // for the default prefer the first matching printing IS the
-            // chosen one — O(1) when the card pass already said True.
+            // Printings are stored in descending default-prefer order, so for the default
+            // prefer the first satisfying printing IS the chosen one — O(1) when the card pass
+            // already said True. A custom prefer has to score every printing.
             //
-            // #676 review: when `existential_plane` is `Some`, the residual
-            // check is still required, not replaced -- a legality leaf folded
-            // into `plane` alongside a genuinely printing-dependent residual
-            // (DateCmp, ArtistMatch, ...) needs a printing satisfying *both*
-            // at once (docs/issues/00667-engine-legality-divergent-carveout.md "Row
-            // selection for unique=card"); checking only the plane could pick
-            // a printing that's legal but fails the residual, or vice versa.
-            // Kept as two separate closures (not one closure branching on
-            // `existential_plane` every call) for the same reason
-            // `card_match_count` is split this way — see its doc.
-            let chosen: Option<u32> = if let Some((pe, planes)) = existential_plane {
-                let satisfies = |pid: usize| {
-                    eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
-                        && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
-                };
-                if matches!(prefer, Prefer::Default) {
-                    (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
-                } else {
-                    let mut chosen: Option<(u32, f64)> = None;
-                    for pid in start..end {
-                        if !satisfies(pid) {
-                            continue;
-                        }
-                        let score = prefer_score(card, &printings[pid], prefer);
-                        if chosen.is_none_or(|(_, s)| score > s) {
-                            chosen = Some((pid as u32, score));
-                        }
-                    }
-                    chosen.map(|(pid, _)| pid)
-                }
-            } else if matches!(prefer, Prefer::Default) {
-                let mut found: Option<u32> = None;
-                for pid in start..end {
-                    if all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or) {
-                        found = Some(pid as u32);
-                        break;
-                    }
-                }
-                found
+            // #676 review: when a plane is present the residual check is still required, not
+            // replaced — a legality leaf folded into `plane` alongside a genuinely
+            // printing-dependent residual (DateCmp, ArtistMatch, ...) needs one printing
+            // satisfying *both* at once (docs/issues/00667-engine-legality-divergent-carveout.md
+            // "Row selection for unique=card"). Checking only the plane could pick a printing
+            // that is legal but fails the residual, or vice versa.
+            let satisfies = |p: &APrinting| {
+                (!HAS_PLANE
+                    || {
+                        let (pe, planes) = existential_plane.expect("HAS_PLANE implies Some");
+                        eval_plane_expr_for_printing(pe, planes, cid, p, strings)
+                    })
+                    && (all_match || FilterExpr::residual_matches(card, p, strings, residual, residual_is_or))
+            };
+            let chosen: Option<u32> = if matches!(prefer, Prefer::Default) {
+                printings[start..end].iter().position(satisfies).map(|i| (start + i) as u32)
             } else {
                 let mut chosen: Option<(u32, f64)> = None;
                 for pid in start..end {
                     let p = &printings[pid];
-                    if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
+                    if !satisfies(p) {
                         continue;
                     }
                     let score = prefer_score(card, p, prefer);
@@ -9498,6 +9500,8 @@ mod bench_word_dict_scan;
 mod bench_card_dedup;
 #[cfg(test)]
 mod bench_card_match_unify;
+#[cfg(test)]
+mod bench_push_card_matches;
 #[cfg(test)]
 mod bench_compose_paging;
 #[cfg(test)]

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4314,13 +4314,45 @@ fn card_match_count(
     // branch inside the hot loop. This is the overwhelmingly common case
     // (every query without a promoted legality leaf), and it's called once
     // per *candidate*, not once per emitted row, so its cost is on the
-    // critical path for every non-Step-2 query. A prior version of this
-    // function routed both cases through one closure-based `satisfies`
-    // helper regardless of `existential_plane`; measured as a real (~15%)
-    // regression on `banned:modern`/`restricted:vintage` (full-candidate-set
-    // scans, unaffected by `existential_plane` in outcome but paying its
-    // indirection anyway) via the broad survey, not the targeted benchmark --
-    // isolating the fast path here restores it.
+    // critical path for every non-Step-2 query.
+    //
+    // This comment used to justify the split with "a real (~15%) regression on
+    // `banned:modern`/`restricted:vintage`", measured via the broad survey.
+    // `bench_card_match_unify` re-measured it at the kernel (#799 follow-up).
+    // Every part of that claim turned out to be wrong, including the verdict.
+    //
+    // The named workload pays nothing: `banned:modern` measures at the noise
+    // floor. #676 recorded the note at 16:36; #679 gave banned:/restricted:
+    // exact legality planes at 18:09 the same day, making those queries tight
+    // -- `all_match` true, empty residual -- so they take the blind shortcut
+    // below and never reach a per-printing closure at all. The cited
+    // measurement was invalidated 93 minutes after it was written down.
+    //
+    // The split IS faster than a naive dedupe, but for two separable reasons,
+    // roughly half each, and neither requires duplicated source. Against a
+    // split-vs-split noise floor of 1.000-1.002x on Card+residual:
+    //
+    //   runtime `existential_plane` branch + `printings[pid]`   1.086-1.103x
+    //   `const HAS_PLANE: bool`            + `printings[pid]`   1.051-1.059x
+    //   `const HAS_PLANE: bool`            + slice iteration    0.980-0.997x
+    //
+    // So ~4% was the per-printing plane branch, and ~5% was indexing by `pid`
+    // instead of iterating `&printings[start..end]`. The second one is pure
+    // accident: `eval_plane_expr_for_printing` takes `&Archived<Printing>`,
+    // not an index, so even the plane path never needed `pid` -- only
+    // `Mode::Artwork` does, for `artwork_group_col`.
+    //
+    // A single body with `const HAS_PLANE: bool` and slice iteration
+    // benchmarks at parity or slightly better than what is written here, so
+    // the duplication below is NOT load-bearing and this function is no longer
+    // on #799's do-not-touch list. It is still written out twice only because
+    // nobody has done the collapse yet. If you do it: keep the const generic
+    // (a runtime branch costs the 4%), keep slice iteration, keep the blind
+    // `all_match` shortcut, and re-run the bench -- including its
+    // split-vs-split floor column, without which none of these numbers can be
+    // read, and its `black_box` on the plane `Option`, without which the
+    // optimizer folds away the branch under test and reports every variant as
+    // free.
     let Some((pe, planes)) = existential_plane else {
         return match mode {
             Mode::Card => {
@@ -9464,6 +9496,8 @@ mod bench_narrow_alloc;
 mod bench_word_dict_scan;
 #[cfg(test)]
 mod bench_card_dedup;
+#[cfg(test)]
+mod bench_card_match_unify;
 #[cfg(test)]
 mod bench_compose_paging;
 #[cfg(test)]

--- a/docs/issues/00799-engine-simplicity-pass.md
+++ b/docs/issues/00799-engine-simplicity-pass.md
@@ -282,10 +282,33 @@ classifier doc).
 
 - **`card_match_count` / `push_card_matches`** ([4115](../../card_engine/src/lib.rs#L4115),
   [4239](../../card_engine/src/lib.rs#L4239)). The mode × `existential_plane` matrix is the most
-  duplicated code in the engine and the most obvious refactor target. Both carry measurements
-  showing the unified-closure version regressed ~15% on `banned:modern`-shaped scans. Leave them,
-  and keep their comments — this is exactly the "don't 'fix' this" case the density rule above
-  exempts.
+  duplicated code in the engine and the most obvious refactor target. **This entry is withdrawn** —
+  the ~15%-on-`banned:modern` figure it cited does not survive re-measurement, and neither does the
+  verdict. `card_engine/src/bench_card_match_unify.rs` re-tested it at the kernel; the code comment
+  now carries the numbers. Summary, against a split-vs-split noise floor of 1.000-1.002× on
+  Card+residual:
+
+  | one body, no duplicated source                        | Card + residual |
+  |-------------------------------------------------------|-----------------|
+  | runtime `existential_plane` branch + `printings[pid]` | 1.086-1.103×    |
+  | `const HAS_PLANE: bool` + `printings[pid]`            | 1.051-1.059×    |
+  | `const HAS_PLANE: bool` + slice iteration             | 0.980-0.997×    |
+
+  So the split's advantage was two separable things: ~4% the per-printing plane branch, ~5% indexing
+  by `pid` rather than iterating `&printings[start..end]`. The latter is accidental —
+  `eval_plane_expr_for_printing` takes `&Archived<Printing>`, so even the plane path never needed the
+  index; only `Mode::Artwork` does. With both addressed, one body reaches parity, so **the
+  duplication is not load-bearing** and the collapse is available whenever someone wants it.
+
+  `banned:modern` specifically measures at the floor under every variant: #679 gave
+  banned:/restricted: exact legality planes 93 minutes after #676 recorded the note, making those
+  queries tight and routing them to the blind `all_match` shortcut.
+
+  **Two methodology notes the bench encodes, both of which produced wrong answers first:** passing
+  `existential_plane: None` as a literal lets the optimizer fold away the branch under test and
+  reports every variant as free — it has to go through `black_box`. And without a split-vs-split
+  floor column, none of these ratios can be read: the floor on Card+`all_match` runs to ±12%, which
+  is wider than any real effect in the table.
 - **`ArchivedSortPermutations::get` / `get_inv`** ([1912](../../card_engine/src/lib.rs#L1912)) —
   near-identical, but the duplication is forced by the archived struct's field layout. Not worth a
   macro.

--- a/docs/issues/00799-engine-simplicity-pass.md
+++ b/docs/issues/00799-engine-simplicity-pass.md
@@ -298,7 +298,16 @@ classifier doc).
   by `pid` rather than iterating `&printings[start..end]`. The latter is accidental —
   `eval_plane_expr_for_printing` takes `&Archived<Printing>`, so even the plane path never needed the
   index; only `Mode::Artwork` does. With both addressed, one body reaches parity, so **the
-  duplication is not load-bearing** and the collapse is available whenever someone wants it.
+  duplication is not load-bearing**.
+
+  **Collapsed.** Both functions now have one body plus a `const HAS_PLANE: bool` dispatch wrapper,
+  so every call site is unchanged. `bench_card_match_unify`'s `SHIPPED` column tracks its
+  old-vs-old floor in every row, and `bench_push_card_matches` compares emitted `Match` tuples
+  (not just counts — picking a different-but-valid representative printing would change what a
+  user sees) and finds custom-prefer emission 11-13% *faster* collapsed, outside the floor.
+  `push_card_matches` keeps its prefer split, which is algorithmic rather than duplication:
+  printings are stored default-prefer-descending, so default prefer takes the first satisfying
+  printing and stops while a custom prefer must score them all.
 
   `banned:modern` specifically measures at the floor under every variant: #679 gave
   banned:/restricted: exact legality planes 93 minutes after #676 recorded the note, making those


### PR DESCRIPTION
`card_match_count` and `push_card_matches` each wrote their mode × `existential_plane`
matrix out twice. A comment justified that with "a real (~15%) regression on
`banned:modern`/`restricted:vintage`", measured — as the comment itself admitted —
"via the broad survey, not the targeted benchmark", and #799 repeated the figure and
put both functions on its do-not-touch list.

This re-measures the claim at the kernel, finds it wrong in every part including the
verdict, does the collapse it was blocking, and then pays off the collapse's own cost.

## The claim does not survive

`bench_card_match_unify` compiles four shapes of the same counting loop into one
binary, asserts they agree on every count before timing anything, times each in both
relative orders, and carries a split-vs-split control column that measures the noise
floor directly.

**The named workload pays nothing.** `banned:modern` sits at the floor under every
variant. #676 recorded the note at 16:36; #679 gave banned:/restricted: exact legality
planes at 18:09 the same day, making those queries tight — `all_match` true, empty
residual — so they take the blind shortcut and never reach a per-printing closure. The
cited measurement was invalidated 93 minutes after it was written, and stood for three
weeks as the reason not to touch the function.

**The duplication was worth something, but not what it claimed, and not irreplaceably.**
Against a split-vs-split floor of 1.000-1.002x on Card+residual:

| one body, no duplicated source                        | Card + residual |
|-------------------------------------------------------|-----------------|
| runtime `existential_plane` branch + `printings[pid]` | 1.086-1.103x    |
| `const HAS_PLANE: bool` + `printings[pid]`            | 1.051-1.059x    |
| `const HAS_PLANE: bool` + slice iteration             | 0.980-0.997x    |

So ~4% was the per-printing plane branch and ~5% was indexing by `pid` rather than
iterating `&printings[start..end]`. The second is accidental —
`eval_plane_expr_for_printing` takes `&Archived<Printing>`, so even the plane path never
needed the index; only `Mode::Artwork` does, for `artwork_group_col`. Address both and
one body beats the duplicated version.

## The collapse

Each function has one body plus a dispatch wrapper, so every call site is unchanged and
the per-printing loops stay branch-free on the plane. The wrapper inspects the `Option`
once, outside the printing loop, where it is loop-invariant across candidates at all four
call sites.

`push_card_matches` keeps its *prefer* split. That one is algorithmic rather than
duplication: printings are stored default-prefer-descending, so default prefer takes the
first satisfying printing and stops, while a custom prefer has to score them all.

## Paying off the collapse's cost

Collapsed naively, the dispatch is not free in *source*: each function's 13- and
18-parameter signature ends up written twice, and each wrapper lists every argument twice
more. That was ~60 lines of scaffolding bought with ~45 lines of deduplicated loop body,
and the reason the collapse alone left lib.rs longer rather than shorter.

Two structs remove it, on the same grouping argument `QueryCtx`/`QueryParams` make one
layer up. `MatchCtx` holds what does not vary across candidates (store slices,
mode/prefer/sort_col/descending, the folded plane), built once outside the candidate loop
at all four call sites; `Candidate` holds what does (card, cid, printing range,
`all_match`, residual).

- `card_match_count`: 13 args → 3
- `push_card_matches`: 18 args → 5
- both `#[allow(clippy::too_many_arguments)]` withdrawn (11 → 9 file-wide)

**The plane invariant becomes the type's.** `const HAS_PLANE: bool` travelled *alongside*
the `Option` it described: nothing stopped the two disagreeing, and the shared body leaned
on an `.expect("HAS_PLANE implies Some")` to assert they did not. A `PlaneTest` trait
replaces it — `NoPlane`, a ZST whose `holds` is `true`, and
`WithPlane(&PlaneExpr, &Archived<BitPlanes>)`. `NoPlane` carries no plane and `WithPlane`
cannot be built without one, so the wrapper's `match` is the only place the two
representations meet and the `expect` is gone.

**Both structs are passed by value, and that is load-bearing.** Taking either behind `&`
costs real time — on `prefer=usd_high, all_match`, shipped, best of three runs each:

| form                        | shipped |
|-----------------------------|---------|
| `&MatchCtx` + `&Candidate`  |  314 μs |
| `&MatchCtx` + `Candidate`   |  293 μs |
| `MatchCtx` + `Candidate`    |  261 μs |

The reference form apparently gives the inliner an address to hold rather than fields to
scalarize. This is documented on `MatchCtx` with the numbers, because "tidying" it back to
a reference would silently cost 20% on that shape.

## Evidence on the shipped code

`bench_card_match_unify` gains a `SHIPPED` column calling the real `card_match_count`,
measured against its preserved copy of the historical duplicated shape. Across three runs
of all six shapes, SHIPPED deviates from parity by at most 2.8%, against an old-vs-old
floor that deviates by up to 4.3% — no measurable change.

`bench_push_card_matches` is new and compares emitted `Match` tuples rather than counts,
because picking a different-but-equally-valid representative printing would change the
rows a user sees and a count would not catch it. Over 31,508 cards, three runs:

| case (Mode::Card, no plane)      | old (μs) | shipped (μs) | ship/old    | floor      |
|----------------------------------|----------|--------------|-------------|------------|
| prefer=default, all_match        |    89-92 |        85-94 | 0.93-1.02x  | 1.00-1.11x |
| prefer=default, residual cmc<3   |  451-456 |      425-435 | 0.94-0.95x  | 0.99-1.01x |
| prefer=usd_high, all_match       |  273-278 |      261-268 | 0.94-0.96x  | 1.01-1.03x |
| prefer=usd_high, residual cmc<3  |  679-685 |      676-677 | 0.99-1.00x  | 1.00-1.00x |
| prefer=oldest, residual cmc<3    |  637-649 |      636-643 | 0.99-1.00x  | 1.00-1.00x |

Two rows sit outside their floor on the fast side: custom-prefer emission with `all_match`
(~5%) and default-prefer with a residual (~5%). I have no verified mechanism for either —
the logic is equivalent, so they are codegen effects — and they should be read as "no
regression, plus something unexplained" rather than speedups to rely on.

## Three methodology notes the benches encode

Each produced a wrong answer first, so each is written into the module docs or onto the
type it concerns.

Passing `existential_plane: None` as a literal lets the optimizer constant-fold away the
branch under test and reports every variant as free; the `Option` has to go through
`black_box`.

Without a split-vs-split floor column none of these ratios can be read — the floor on one
row runs to ±12%.

And cross-build absolute comparison is not safe here even with identical source on both
sides. The by-reference first cut lost the collapse's custom-prefer win, so pre-refactor
HEAD was benched to establish whose it was (it is real there: 0.893/0.925/0.905x). By
value, absolute shipped time is same-or-better than that HEAD on all five shapes — 85 vs
94, 425 vs 455, 261 vs 285, 676 vs 677, 636 vs 640 μs. But the *untouched* `push_old`
control also moved between those builds, 318 → 273 μs on one shape, so part of that
improvement is whole-binary codegen rather than the change; by the in-binary `ship/old`
ratio the same shape reads 0.91 → 0.95. No regression on either reading, which is the
claim — but only the in-binary ratio is a controlled one.

## On line count

lib.rs is +236/-174 against `main`. Split by content that is **code -16, comment +67,
blank +11**: the executable code is net negative, which is what removing duplication
should look like, and the growth is documentation — the `PlaneTest`, `MatchCtx` and
`Candidate` docs plus the by-value measurement above. Comment density is worth a separate
pass; it is not what this PR is trading.

(For the record, since the earlier revisions of this description got it wrong: the collapse
commit alone was +161/-157 on lib.rs, but the PR including the bench module declarations
was +163/-125 — code +16 — before the argument bundling turned that around.)

## Testing

- `cargo test` (debug, what CI runs): 147 passed, including `force_plan_differential_agreement` and `fuzz_row_identity_matches_reference`
- `cargo clippy --all-targets`: clean
- `cargo test --release bench_card_match_unify -- --ignored --nocapture` and `bench_push_card_matches`, three runs each, plus three runs of each at pre-refactor HEAD for the cross-build control above

## Not included

C8's group-best extraction — the block `push_card_matches` shares with `walk_grouped_page`
and `gather_composed_page`. Different mechanism, no plane branch involved, and #799 excludes
`push_card_matches`' copy from that extraction anyway.
