### PR TITLE
Engine: Count the Printings the Match Kernels Actually Look At

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -40,8 +40,7 @@
 //! the per-card `card_pass` term is driven by `eval_domain` (candidate cards) and
 //! the per-row residual scan + its verify `tier` by `scan_units` (printings under the
 //! candidate cards). One mode-agnostic formula, and `scan_units()` no longer branches
-//! on mode at all: the `printings_scanned` counter shows the scan plans walk the full
-//! printing span of their candidates in CARD mode too, not one row each. The `_CARD_PASS`/`_SCAN` split of the old lumped
+//! on mode at all. The `_CARD_PASS`/`_SCAN` split of the old lumped
 //! `VISIT` constants was fit to hold card unchanged while correcting printing (see
 //! each constant's doc). Artwork rides the printing path (same all-printings scan);
 //! its confirming validation is still pending a bench run.
@@ -54,6 +53,27 @@
 //! rare). The `_CARD_PASS`/`_SCAN`/`PUSH` split is a physical prior resolving what
 //! data alone cannot. Model sits at ~1.4× absolute (slow bucket), ordering-correct
 //! (argmin==gold 87/88) — the identifiable ceiling for this workload.
+//!
+//! ## What the span counter could and could not show (2026-08-02)
+//!
+//! The paragraph above used to justify the mode-agnostic `scan_units` by asserting that "the
+//! `printings_scanned` counter shows the scan plans walk the full printing span of their candidates in
+//! CARD mode too, not one row each". That inference does not hold, and the sentence is now deleted
+//! rather than merely qualified: the counter (since renamed `printing_span`) was computed by the
+//! CALLER as `end - start` per surviving card, before the match kernel ran, so it reported the span
+//! whatever the kernel then did. It could not distinguish the two cases it was being cited for.
+//!
+//! The kernels do stop early in card mode. `card_match_count` returns from `all_match` without reading
+//! a printing at all, and both it and `push_card_matches` return at the FIRST qualifying printing
+//! under `Prefer::Default`. `printings_examined`, reported by the kernels themselves, is the quantity
+//! `scan_units` predicts, and grading against it is what `bench_feature_accuracy.py` now does.
+//!
+//! The mode-agnostic span estimate nonetheless survives that correction, for a reason the original
+//! note did not give: under an INEXACT narrowing most candidate cards do not match, and a
+//! non-matching card is ruled out only after its whole span is walked. So the span is a good proxy in
+//! card mode generally (`scan_units [candidates] / card` grades p50 1.00 against `printings_examined`)
+//! and wrong specifically where the narrowing is EXACT — the plane acquire, where `all_match` holds
+//! and `prefer` then decides everything. That case is handled in `acquire_plan_features`.
 
 use super::*;
 
@@ -73,10 +93,17 @@ pub(crate) struct PlanFeatures {
     /// candidate count when `prepare_candidates` produced a list, else `n_cards`.
     pub eval_domain: u32,
     /// Printings under the candidate cards — the dominant P3/P4 driver, and the same
-    /// quantity in all three distinct-ons. Card mode was long assumed to break at the
-    /// first matching printing (`scan_units ≈ eval_domain`); measured against
-    /// `printings_scanned`, that read 0.25-0.33 for both GatheredScan and StreamedSelect
-    /// while `eval_domain · n_printings/n_cards` reads 0.90-1.02 in every mode.
+    /// quantity in all three distinct-ons.
+    ///
+    /// Card mode DOES break at the first matching printing, so the `0.25-0.33` this note used to cite
+    /// against `printings_scanned` was the counter's artifact, not the feature's error — see the module
+    /// header. Graded against `printings_examined` the span estimate reads p50 1.00 in card mode
+    /// anyway, because an inexact narrowing makes non-matching candidates walk their whole span.
+    ///
+    /// `prefer` is the one thing this cannot see: it decides whether the kernels may break early at
+    /// all, and `PlanFeatures` does not carry it. That is invisible under an inexact narrowing (the
+    /// non-matching cards dominate either way) and decisive under an exact one, which is why the plane
+    /// branch of `acquire_plan_features` sets this field itself rather than taking the span estimate.
     pub scan_units: u32,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
@@ -88,22 +115,13 @@ pub(crate) struct PlanFeatures {
     ///
     /// `scan_units` is every printing under a candidate card — right for GatheredScan and
     /// StreamedSelect, which must test each one. Compose walks the set bits of the composed bitmap
-    /// instead, so it touches `printing_matches`. Measured against `printings_scanned`, compose reads
+    /// instead, so it touches `printing_matches`. Measured against `printing_span`, compose reads
     /// 1.00 on `matches` in printing mode and 1.00-1.01 on `project_printings` in artwork (the same
     /// value), while `scan_units` reads 2.0-2.8 for it.
     ///
     /// Sharing one feature between the two forced a compromise that was ~2x wrong for whichever arm
     /// lost: with the value GatheredScan needs, compose over-counts 2x; with compose's, the scan plans
     /// under-count 3.3x.
-    /// Printings compose's **Gather** paging branch bit-tests, which is NOT `scan_units`.
-    ///
-    /// `scan_units` is every printing under a candidate card -- right for GatheredScan and
-    /// StreamedSelect, which must test each one. Compose walks the set bits of the bitmap it just
-    /// built, so it touches `printing_matches`. Measured against `printings_scanned`, compose reads
-    /// 1.00 on `matches` in printing mode and 1.00-1.01 on `project_printings` in artwork (the same
-    /// value), while `scan_units` reads 2.0-2.8 for it.
-    ///
-    /// Sharing one feature between the two forced a compromise ~2x wrong for whichever arm lost.
     pub compose_scan_printings: u32,
     /// Page size (`limit`).
     pub limit: u32,
@@ -264,7 +282,17 @@ pub(crate) fn materialize_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
 /// ridge-anchored to the previous values because several columns barely vary on this corpus and
 /// are collinear with the intercept. Fitted on ~10k distinct feature vectors, stable to <3% across
 /// independent seeds. Median measured/predicted moved 1.78 -> 1.00 (P4) and 1.69 -> 1.06 (P3).
-const STREAM_CARD_PASS_NS: f64 = 6.46;
+///
+/// Refit again 2026-08-02, and this is the first fit of P3 that was allowed to happen: every earlier
+/// run of `fit_cost_model.py` REFUSED to fit this plan, because its `counter_check` graded
+/// `scan_units` against the printing SPAN, and P3's `all_match` rows disagree with the span by ~3x
+/// over a term this arm multiplies by zero (`if tier_ns > 0.0`). With `printings_examined` reported
+/// by the match kernels and the zero-weight rows excluded, all six counter checks read 1.00 and the
+/// fit ran: median predicted/measured 0.63 -> 0.92 and within-25% 19% -> 58% over 29,084 rows /
+/// 9,867 distinct shapes. P3 had been under-costed ~1.6x, which biases the router toward picking it.
+/// P4 and compose were re-fit in the same run and NOT changed: P4's fitted values reproduce these
+/// within 8% with no agreement gain, and compose's fit makes its median worse (0.95 -> 0.86).
+const STREAM_CARD_PASS_NS: f64 = 5.05;
 
 /// P3's per-scanned-row cost, charged ONLY when a residual is present.
 ///
@@ -286,7 +314,7 @@ const STREAM_CARD_PASS_NS: f64 = 6.46;
 ///
 /// This one is NOT common-mode with P4 — P4 pays `GATHER_SCAN_PER_ROW_NS` unconditionally — so
 /// unlike the verify tier it can move the argmin between the two.
-const STREAM_SCAN_PER_ROW_NS: f64 = 5.53;
+const STREAM_SCAN_PER_ROW_NS: f64 = 5.97;
 
 
 /// Per-card cost of RUNNING `card_pass` at all, on top of whatever the residual's own nodes cost.
@@ -322,11 +350,11 @@ const STREAM_SCAN_PER_ROW_NS: f64 = 5.53;
 /// That same regression also shows the residual's cost is per CARD, not per printing scanned: the
 /// SLOPE against printings-per-card is ~3.5 for every tier including none (P4) and ~2 for P3, i.e.
 /// independent of what the residual is. So the tier belongs on `eval_domain`, as it now sits.
-const STREAM_RESIDUAL_FLOOR_NS: f64 = 8.18;
+const STREAM_RESIDUAL_FLOOR_NS: f64 = 6.58;
 /// ns per match, for the permutation-walk emit. Small — P3 measured nearly flat
 /// in match count once eval_domain is fixed (see STREAM_MATCH_PHASE_PER_CARD_NS),
 /// so this is a minor term.
-const STREAM_EMIT_PER_MATCH_NS: f64 = 0.13;
+const STREAM_EMIT_PER_MATCH_NS: f64 = 0.12;
 /// ns per candidate card that ARTWORK mode pays and the other two do not.
 ///
 /// `card_match_count`'s artwork arm keeps a per-card `seen_words` bitmask to dedupe artwork groups,
@@ -346,14 +374,14 @@ const STREAM_EMIT_PER_MATCH_NS: f64 = 0.13;
 /// Two independently fitted per-card terms, both elevated in artwork by ~2.4 ns and never flipping
 /// sign. One mechanism showing up twice, so it belongs in its own term rather than as a mode-specific
 /// copy of each rate. ~16 word-ops per card is the right order for 2.4 ns.
-const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.36;
+const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.21;
 /// ns per card scanned in the small-total gather (`for cid in 0..n_cards`,
 /// counts[cid]==0 check). Cheaper than a match-phase visit (no filter work). Fit
 /// from the narrow-query floor: cmc>=15 / o:annihilator / cmc==7 card SHALLOW all
 /// ~52µs = 31508 × 1.65. Only added when `matches <= STREAM_MIN_MATCHES`, the
 /// exact condition that routes P3 into that gather branch. The 1.65 above was fit on three hand
 /// picked narrow queries; across the sampled space the floor measures ~31µs, not 52µs.
-const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.64;
+const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
 /// `cards.len()` every query — a 126 kB memset on this corpus — and the emission walk is over the
@@ -362,7 +390,7 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.64;
 /// as a per-card RATE rather than the previous flat constant so it tracks corpus size at all.
 const STREAM_CORPUS_PASS_PER_CARD_NS: f64 = 0.02;
 /// Fixed P3 setup, net of the O(n_cards) work above.
-const STREAM_FIXED_COST_NS: f64 = 217.5;
+const STREAM_FIXED_COST_NS: f64 = 217.0;
 
 // ─── P4: GatheredScan ───────────────────────────────────────────────────────
 // The universal fallback: per-card loop pushes every match's sort key into a
@@ -442,7 +470,7 @@ const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 
 /// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
 /// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
-/// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
+/// against the `printing_span` counter -- the Perm and OrderbyWalk paging branches are priced
 /// entirely on this quantity and nothing else validates them.
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4272,12 +4272,22 @@ enum Mode { Card, Artwork, Printing }
 /// silently under-count in production instead of failing loudly on reload.
 const ARTWORK_GROUP_WORDS: usize = 8;
 
-/// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
+/// Matches this card contributes, and how many printings it had to look at to know:
+/// `(matches, examined)`. 0/1 matches for Card mode (existence, short-circuit),
 /// passing printings for Printing mode, distinct illustrations with a passing
 /// printing for Artwork mode. `seen_words` is a reused scratch buffer: a
 /// fixed-size bitmask indexed by each printing's dense `artwork_group_id`
 /// (#629), one bit per group, `word = gid / 64` -- zeroed in full every card
 /// (cheap: ARTWORK_GROUP_WORDS is tiny), never resized.
+///
+/// `examined` is the number of times the per-printing loop body ran, which is the quantity
+/// `PlanFeatures::scan_units` claims to predict. It is NOT `end - start`: every Card-mode path here
+/// short-circuits, and the two `all_match` arms return without touching a printing at all. The
+/// `printing_span` counter used to be incremented as the full span by the CALLER, before this
+/// function ran, so it reported what a full scan would have cost rather than what happened -- and
+/// `cost.rs`'s "the `printing_span` counter shows the scan plans walk the full printing span of
+/// their candidates in CARD mode too, not one row each" was inferred from exactly that. Returning the
+/// truth from the only place that knows it is what makes the claim checkable.
 // #676 review: a legality leaf promoted into `plane` alongside a genuinely
 // printing-dependent residual (DateCmp, ArtistMatch, ...) needs *both*
 // checked against the *same* printing -- `all_match`/`residual_matches` alone
@@ -4308,7 +4318,7 @@ fn card_match_count(
     strings: &AStrings,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
-) -> u32 {
+) -> (u32, u32) {
     // No existential plane: identical code shape to before #676's
     // existential_plane parameter existed at all -- no closure, no extra
     // branch inside the hot loop. This is the overwhelmingly common case
@@ -4325,18 +4335,20 @@ fn card_match_count(
         return match mode {
             Mode::Card => {
                 if all_match {
-                    return u32::from(start < end);
+                    // Existence is settled by the span being non-empty; no printing is read.
+                    return (u32::from(start < end), 0);
                 }
-                for p in &printings[start..end] {
+                for (i, p) in printings[start..end].iter().enumerate() {
                     if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
-                        return 1;
+                        return (1, i as u32 + 1); // stopped here: i+1 printings looked at
                     }
                 }
-                0
+                (0, (end - start) as u32) // no match: the whole span was ruled out
             }
             Mode::Printing => {
                 if all_match {
-                    return (end - start) as u32;
+                    // The count is the span itself, arithmetic only -- no printing is read.
+                    return ((end - start) as u32, 0);
                 }
                 let mut n = 0u32;
                 for p in &printings[start..end] {
@@ -4344,7 +4356,7 @@ fn card_match_count(
                         n += 1;
                     }
                 }
-                n
+                (n, (end - start) as u32)
             }
             Mode::Artwork => {
                 // #737's skip-repped shortcut, which landed in the gather loop but not here. Read the
@@ -4368,7 +4380,8 @@ fn card_match_count(
                     }
                     seen_words[word] |= bit;
                 }
-                seen_words.iter().map(|w| w.count_ones()).sum()
+                // Artwork never short-circuits: a later printing can always rep an unseen group.
+                (seen_words.iter().map(|w| w.count_ones()).sum(), (end - start) as u32)
             }
         };
     };
@@ -4383,10 +4396,10 @@ fn card_match_count(
         Mode::Card => {
             for pid in start..end {
                 if satisfies(pid) {
-                    return 1;
+                    return (1, (pid - start) as u32 + 1);
                 }
             }
-            0
+            (0, (end - start) as u32)
         }
         Mode::Printing => {
             let mut n = 0u32;
@@ -4395,7 +4408,7 @@ fn card_match_count(
                     n += 1;
                 }
             }
-            n
+            (n, (end - start) as u32)
         }
         Mode::Artwork => {
             // Same skip-repped shortcut as the no-plane arm above, and it matters more here:
@@ -4409,13 +4422,20 @@ fn card_match_count(
                 }
                 seen_words[word] |= bit;
             }
-            seen_words.iter().map(|w| w.count_ones()).sum()
+            (seen_words.iter().map(|w| w.count_ones()).sum(), (end - start) as u32)
         }
     }
 }
 
 /// Emit this card's matches as (sort key, cid, pid) tuples — the per-card body
 /// of the gathered path, shared by the streamed path for page cards.
+///
+/// Returns how many printings the loop body ran on, the same `examined` quantity
+/// `card_match_count` reports and for the same reason: `scan_units` claims to predict it, and the
+/// span the caller used to add in its place is not it. Card mode with the default prefer stops at the
+/// first qualifying printing (one, not the span); a custom prefer must score every printing, so there
+/// the span IS the truth. That difference is invisible to a caller-side `end - start`, and it is
+/// exactly the difference the cost model needs to see.
 ///
 /// `existential_plane`: `Some((plane, planes))` iff `mode` is `Card` and the
 /// plane driving `all_match` touched a legality leaf
@@ -4454,7 +4474,7 @@ fn push_card_matches(
     out: &mut Vec<Match>,
     group_best: &mut [Option<(u32, f64)>],
     touched: &mut Vec<u16>,
-) {
+) -> u32 {
     match mode {
         Mode::Card => {
             // Printings are stored in descending default-prefer order, so
@@ -4471,13 +4491,19 @@ fn push_card_matches(
             // Kept as two separate closures (not one closure branching on
             // `existential_plane` every call) for the same reason
             // `card_match_count` is split this way — see its doc.
-            let chosen: Option<u32> = if let Some((pe, planes)) = existential_plane {
+            // `examined` rides alongside `chosen` rather than being counted in a separate local: on
+            // the two default-prefer paths the chosen printing IS the one the loop stopped at, so its
+            // offset from `start` is the count and no per-iteration bookkeeping is needed. The custom-
+            // prefer paths score every printing and so examine the whole span, unconditionally.
+            let span = (end - start) as u32;
+            let (chosen, examined): (Option<u32>, u32) = if let Some((pe, planes)) = existential_plane {
                 let satisfies = |pid: usize| {
                     eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
                         && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
                 };
                 if matches!(prefer, Prefer::Default) {
-                    (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
+                    let found = (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32);
+                    (found, found.map_or(span, |pid| pid - start as u32 + 1))
                 } else {
                     let mut chosen: Option<(u32, f64)> = None;
                     for pid in start..end {
@@ -4489,7 +4515,7 @@ fn push_card_matches(
                             chosen = Some((pid as u32, score));
                         }
                     }
-                    chosen.map(|(pid, _)| pid)
+                    (chosen.map(|(pid, _)| pid), span)
                 }
             } else if matches!(prefer, Prefer::Default) {
                 let mut found: Option<u32> = None;
@@ -4499,7 +4525,7 @@ fn push_card_matches(
                         break;
                     }
                 }
-                found
+                (found, found.map_or(span, |pid| pid - start as u32 + 1))
             } else {
                 let mut chosen: Option<(u32, f64)> = None;
                 for pid in start..end {
@@ -4512,11 +4538,12 @@ fn push_card_matches(
                         chosen = Some((pid as u32, score));
                     }
                 }
-                chosen.map(|(pid, _)| pid)
+                (chosen.map(|(pid, _)| pid), span)
             };
             if let Some(pid) = chosen {
                 out.push((sort_key_bits(card, &printings[pid as usize], sort_col, descending), cid, pid));
             }
+            examined
         }
         Mode::Printing => {
             for pid in start..end {
@@ -4524,6 +4551,8 @@ fn push_card_matches(
                 if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
                 out.push((sort_key_bits(card, p, sort_col, descending), cid, pid as u32));
             }
+            // Every printing is a candidate row: no ordering lets this stop early.
+            (end - start) as u32
         }
         Mode::Artwork => {
             // Within-range order is prefer-score-desc (not illustration), so
@@ -4581,6 +4610,8 @@ fn push_card_matches(
                 let (bp, _) = group_best[gid as usize].take().unwrap();
                 out.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
             }
+            // Both grouping loops run to `end`: a later printing can always rep a group not yet seen.
+            (end - start) as u32
         }
     }
 }
@@ -6586,7 +6617,7 @@ fn exec_streamed_select<'a>(
 /// the executors actually do rather than against a fitted curve.
 ///
 /// Two distinct questions, and the model can fail either:
-/// - are the FEATURE COUNTS right? `cards_visited` / `printings_scanned` / `matches_pushed` are the
+/// - are the FEATURE COUNTS right? `cards_visited` / `printing_span` / `matches_pushed` are the
 ///   real counts behind `eval_domain` / `scan_units` / `matches`. If a feature disagrees with its
 ///   counter, no rate constant can rescue the term.
 /// - is the WORK WHERE THE MODEL SAYS? `ns_setup` + `ns_loop` + `ns_finish` should account for the
@@ -6599,7 +6630,21 @@ fn exec_streamed_select<'a>(
 #[derive(Default, Clone, Copy)]
 pub(crate) struct PhaseStats {
     pub(crate) cards_visited: u64,
-    pub(crate) printings_scanned: u64,
+    /// The printings under the candidate cards — what a full scan of them WOULD cost. A span,
+    /// computed as `end - start` per surviving card, kept because it is the right comparison for
+    /// `scan_units` in printing and artwork mode, where the loops really do traverse the span.
+    ///
+    /// It is the WRONG comparison in card mode, and reading it as though it were the work done is how
+    /// `cost.rs` came to assert that "the scan plans walk the full printing span of their candidates
+    /// in CARD mode too, not one row each". They do not: see `card_match_count` and
+    /// `push_card_matches`, both of which stop at the first qualifying printing under the default
+    /// prefer. Compare against `printings_examined` for what actually ran.
+    pub(crate) printing_span: u64,
+    /// The printings the per-card body actually ran on — the quantity `scan_units` claims to predict.
+    /// Reported by the two match kernels, which are the only code that knows where they stopped.
+    /// Legitimately 0 for a whole query: both `all_match` arms of `card_match_count` answer from the
+    /// span arithmetic alone, and the stored artwork group count answers without a printing either.
+    pub(crate) printings_examined: u64,
     pub(crate) matches_pushed: u64,
     /// Per-query scratch setup, before the match loop starts. Split out because it is neither
     /// prepare nor match and it is NOT negligible: `run_query_streamed` zeroes an `n_cards`-long
@@ -6851,7 +6896,7 @@ thread_local! {
     /// owned elsewhere: `paging_taken` by `PAGING_TAKEN` below, `ns_round_total`/`result_total` by
     /// `explain_analyze`, which fills them after the take.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
-        cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
+        cards_visited: 0, printing_span: 0, printings_examined: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
         ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
     }) };
 
@@ -6954,7 +6999,11 @@ fn exec_gathered_scan<'a>(
     let mut residual_is_or = false;
     // Counters for the three features this plan's cost arm keys on, so they can be checked against
     // what the loop really does. Plain locals — no atomics, no branch — published once at the end.
-    let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    let (mut n_cards_visited, mut n_printing_span, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    // The printings the per-card body actually ran on, which is NOT `n_printing_span` (the span).
+    // See `push_card_matches`; the two are published side by side so the gap is readable rather than
+    // inferred.
+    let mut n_printings_examined = 0u64;
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -6972,11 +7021,11 @@ fn exec_gathered_scan<'a>(
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
-        n_printings_scanned += (end - start) as u64;
-        push_card_matches(
+        n_printing_span += (end - start) as u64;
+        n_printings_examined += u64::from(push_card_matches(
             card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
             sort_col, descending, strings, existential_plane, sel.buf(), &mut group_best, &mut touched,
-        );
+        ));
         n_matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
@@ -6995,7 +7044,8 @@ fn exec_gathered_scan<'a>(
         // regardless — it lives in `PAGING_TAKEN`, which this does not touch.
         c.set(PhaseStats {
             cards_visited: n_cards_visited,
-            printings_scanned: n_printings_scanned,
+            printing_span: n_printing_span,
+            printings_examined: n_printings_examined,
             matches_pushed: n_matches_pushed,
             ns_setup: (t_loop - t_start).as_nanos() as u64,
             ns_loop: (t_finish - t_loop).as_nanos() as u64,
@@ -7037,7 +7087,7 @@ fn run_query<'a>(
 /// only paid when a candidate list exists. Called from `candidate_feats`.
 fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n_printings: u32, n_cards: u32) -> u32 {
     // Card mode used to short-circuit to `eval_domain`, on the theory that the loop breaks at the
-    // first matching printing of each card. The `printings_scanned` counter says otherwise: across
+    // first matching printing of each card. The `printing_span` counter says otherwise: across
     // every acquire branch, GatheredScan and StreamedSelect scan the FULL printing span of their
     // candidates in card mode too, and the old feature read 0.25-0.33 against it. So the QUANTITY is
     // the same in all three modes -- printings under the candidates -- and there is no mode branch in
@@ -7375,9 +7425,13 @@ fn acquire_plan_features(
     plane: Option<&PlaneExpr>,
 ) -> (cost::PlanFeatures, Prep, Vec<u64>) {
     let QueryCtx { cards, offsets, indexes, .. } = *ctx;
-    let QueryParams { mode, sort_col, descending, .. } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, .. } = *params;
     let n_cards = ctx.n_cards();
     let n_printings = ctx.n_printings();
+    // Mean printings per card, the factor between "one printing of each candidate" and "all of them".
+    // Both the plane branch and the compose branch's `scan_all` need it; `.max(1.0)` guards a corpus
+    // with more cards than printings, which cannot happen but costs nothing to exclude.
+    let printings_per_card = (f64::from(n_printings) / f64::from(n_cards)).max(1.0);
 
     // Scratch for the plane bitmap (`Prep::Plane` only). A fresh `Vec` allocates
     // just once, on the plane branch's `eval_planes`; non-plane queries leave it
@@ -7385,11 +7439,44 @@ fn acquire_plan_features(
     let mut plane_bits: Vec<u64> = Vec::new();
 
     let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, plane) {
-        // The ONE plane eval; its popcount IS the exact count. scan_units == count
-        // (Mode::Card breaks at first match); True residual ⇒ tier 0.
+        // The ONE plane eval; its popcount IS the exact count. True residual ⇒ tier 0.
         eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
-        (mk_plan_feats(ctx, params, count, count, count, 0), Prep::Plane)
+        // `scan_units` costs the MATERIALIZING alternatives to this plan (PlanePopcountOrder itself
+        // popcounts a bitmap and scans nothing), and here alone it depends on `prefer`.
+        //
+        // A True residual means `all_match`, so `push_card_matches` takes its first-match branch: under
+        // `Prefer::Default` printings are stored prefer-desc, the first printing IS the pick, and the
+        // loop breaks after one — `scan_units == count`. Under any other prefer the same loop must
+        // score every printing of the card to find the max, so it examines the full span.
+        //
+        // Measured against `printings_examined` over 4,136 plane-acquire rows: the old unconditional
+        // `count` graded 1.00 at p90-p100 (the default-prefer population) and 0.16-0.35 at p10-p50 (the
+        // other four prefers) — one value cannot be right for both, and the 3.09x between them is
+        // exactly `printings_per_card`. This is the only feature in the vector that reads `prefer`;
+        // everywhere else the span-shaped estimate already covers both regimes, because an inexact
+        // narrowing makes non-matching candidates burn their whole span regardless of prefer.
+        //
+        // The custom-prefer side takes the EXACT span rather than `count * printings_per_card`. The
+        // corpus mean puts the cell's median at 1.00 but leaves a 3.09x over-count tail (measured p90
+        // 3.05, p99 3.09) on plane sets whose cards are single-printing, and a mean cannot fix a
+        // spread. One pass over the set bits is exact and is paid only here — `Prefer::Default`, ~85%
+        // of traffic by `REALISTIC_PREFER_WEIGHTS`, returns before reaching it.
+        let scan_units = if matches!(prefer, Prefer::Default) {
+            count
+        } else {
+            let mut span = 0u64;
+            for (w, word) in plane_bits.iter().enumerate() {
+                let mut bits = *word;
+                while bits != 0 {
+                    let cid = w * 64 + bits.trailing_zeros() as usize;
+                    span += u64::from(u32::from(offsets[cid + 1]) - u32::from(offsets[cid]));
+                    bits &= bits - 1;
+                }
+            }
+            span.min(u64::from(n_printings)) as u32
+        };
+        (mk_plan_feats(ctx, params, count, count, scan_units, 0), Prep::Plane)
     } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, plane) {
         // Exact in-range printing count `k` from the index partition points (two binary searches, no
         // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
@@ -7473,7 +7560,6 @@ fn acquire_plan_features(
         // `eval_domain` and scanned 0.14x the claimed `scan_units`. Over-costing both plans inflates
         // the predicted GAP between them (P4 carries the larger per-row rates), which is what routing
         // reads -- measured as a GatheredScan-vs-StreamedSelect gap ratio of 0.32 on this acquire.
-        let printings_per_card = (f64::from(n_printings) / f64::from(n_cards)).max(1.0);
         let scan_all = |cards: usize| ((cards as f64) * printings_per_card) as usize;
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
             Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
@@ -7491,7 +7577,7 @@ fn acquire_plan_features(
                 // pushes 34,285, not the 68,687 printings it scans. Handing over the printing count
                 // over-charged every materializing alternative by ~2x on this acquire. The printing
                 // count stays where it belongs -- `project` (the printing->artwork pass) and
-                // `scan_units` both walk printings, as `printings_scanned` confirms.
+                // `scan_units` both walk printings, as `printing_span` confirms.
                 let n_artworks = u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize;
                 let rt = artwork_estimate(printing_matches, est_cards, n_cards as usize, n_artworks);
                 // The bitmap `printing_bits_to_artwork_bits` popcounts is n_artworks bits wide, not
@@ -8279,7 +8365,12 @@ fn run_query_streamed<'a>(
     let mut total: usize = 0;
     // Same counters GatheredScan publishes, so the two plans' arms can be checked the same way.
     // Locals in the loop; published once at the end. See PhaseStats.
-    let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    let (mut n_cards_visited, mut n_printing_span, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    // See the same local in the gathered loop. This plan only COUNTS here (the page is emitted
+    // below), and counting short-circuits harder than emitting does: both `all_match` arms of
+    // `card_match_count` answer without reading a printing at all, so this can legitimately be 0
+    // where `n_printing_span` is the full corpus span.
+    let mut n_printings_examined = 0u64;
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -8305,20 +8396,23 @@ fn run_query_streamed<'a>(
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         // Counted HERE, below the `card_pass` continue above, because a card rejected there never has
         // its printings touched. Counting at the top of the loop instead included them, so this plan
-        // and GatheredScan reported different `printings_scanned` for identical work whenever the
+        // and GatheredScan reported different `printing_span` for identical work whenever the
         // narrowing was inexact -- and `scan_units` has one definition, so at most one could be the
         // valid comparison.
-        n_printings_scanned += (end - start) as u64;
+        n_printing_span += (end - start) as u64;
         // Every printing matches: card/printing counts are O(1) inside the
         // helper, and the artwork group count is a build-time constant.
         let c = if all_match && matches!(mode, Mode::Artwork) && have_group_counts {
+            // A stored per-card group count: answered without looking at one printing.
             u32::from(u16::from(artwork_groups[cid as usize]))
         } else {
-            card_match_count(
+            let (c, examined) = card_match_count(
                 card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, strings,
                 existential_plane,
                 &mut seen_words,
-            )
+            );
+            n_printings_examined += u64::from(examined);
+            c
         };
         counts[cid as usize] = c;
         total += c as usize;
@@ -8334,7 +8428,8 @@ fn run_query_streamed<'a>(
         PHASE_STATS.with(|c| {
             c.set(PhaseStats {
                 cards_visited: n_cards_visited,
-                printings_scanned: n_printings_scanned,
+                printing_span: n_printing_span,
+                printings_examined: n_printings_examined,
                 matches_pushed: n_matches_pushed,
                 ns_setup: (t_loop - t_start).as_nanos() as u64,
                 ns_loop: (t_finish - t_loop).as_nanos() as u64,
@@ -8698,7 +8793,8 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     // `DeclineSparseExact` in particular pays a full compose first.
     d.set_item("declined_ns", t.declined_ns.clone())?;
     d.set_item("cards_visited", t.phases.cards_visited)?;
-    d.set_item("printings_scanned", t.phases.printings_scanned)?;
+    d.set_item("printing_span", t.phases.printing_span)?;
+    d.set_item("printings_examined", t.phases.printings_examined)?;
     d.set_item("matches_pushed", t.phases.matches_pushed)?;
     d.set_item("ns_setup", t.phases.ns_setup)?;
     d.set_item("ns_loop", t.phases.ns_loop)?;
@@ -9250,12 +9346,14 @@ impl QueryEngine {
     /// lazily re-materialize and re-choose on exact features at dispatch — so the
     /// executed plan can differ from `result[0]`. See the free `explain` fn's doc.
         #[allow(clippy::too_many_arguments)] // the PyO3 keyword surface; the free `explain` fn it calls takes 4
-    #[pyo3(signature = (*, filters, unique="card", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
     fn explain<'py>(
         &self,
         py: Python<'py>,
         filters: &Bound<PyAny>,
         unique: &str,
+        prefer: &str,
         orderby: &str,
         direction: &str,
         limit: usize,
@@ -9266,19 +9364,19 @@ impl QueryEngine {
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
 
-        // This method's signature has never taken `prefer` (it predates #757), and
-        // substituting the default here is behavior-preserving *for what explain
-        // reports*: `cost::plan_cost`/`PlanFeatures` don't read `prefer` at all, so
-        // both the argmin and every `predicted_ns` are prefer-blind regardless of what
-        // is passed. That is a gap in the cost model, not a property of execution —
-        // `prefer` genuinely changes the work done (it picks each card's representative
-        // printing, and `Prefer::Default` specifically lets `gather_composed_page`
-        // early-break on the first set printing instead of scoring every printing of
-        // the card, and `run_query_streamed_popcount` likewise). So an `explain` for a
-        // non-default `prefer` predicts the same numbers while the real query would do
-        // more per-card work. `explain_analyze` does take `prefer` and really runs the
-        // plans, so its `trials_ns` reflect it even though its `predicted_ns` doesn't.
-        let params = QueryParams::from_strs(unique, "default", orderby, direction, limit, offset);
+        // `prefer` is accepted and passed through, but note what it does NOT yet change:
+        // `cost::plan_cost`/`PlanFeatures` still don't read it, so the argmin and every
+        // `predicted_ns` remain prefer-blind. That is a real gap, now measurable rather
+        // than merely asserted — `prefer` genuinely changes the work done, since it picks
+        // each card's representative printing and `Prefer::Default` alone lets the match
+        // kernels early-break on the first qualifying printing instead of scoring every
+        // printing of the card. Measured over the plane acquire (exact narrowing, so the
+        // early break is the whole per-card cost), `scan_units` grades 1.00 against
+        // `printings_examined` under `default` and 0.32 under each of the other four — one
+        // feature value cannot be right for both. Taking the parameter is what lets a
+        // prefer-aware feature be graded here at all; until one exists, an `explain` for a
+        // non-default `prefer` still predicts the default's numbers.
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
         let (facts, estimates) = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3491,16 +3491,16 @@ fn compose_paging_prediction_matches_the_branch_taken() {
     assert!(declined > 0, "no compose query declined; the decline-label assertion is unexercised");
 }
 
-/// The two materializing plans must report identical `cards_visited` and `printings_scanned`.
+/// The two materializing plans must report identical `cards_visited` and `printing_span`.
 ///
 /// These are ONE counter under one name: `PhaseStats` has a single set of fields and both
 /// `exec_gathered_scan` and `run_query_streamed` publish into them, so a consumer reading
-/// `printings_scanned` off a `PlanTrial` cannot tell which executor produced it. `scan_units` has
+/// `printing_span` off a `PlanTrial` cannot tell which executor produced it. `scan_units` has
 /// one definition too, and both plans' cost arms key on it — so if the executors count differently,
 /// at most one of them is the valid comparison, and the damage surfaces as a rate constant that
 /// will not calibrate rather than as anything that looks like a bug.
 ///
-/// `printings_scanned` is the load-bearing half, and the reason is a one-line placement: both
+/// `printing_span` is the load-bearing half, and the reason is a one-line placement: both
 /// executors count it BELOW the `card_pass` continue, because a card rejected there never has its
 /// printings touched. Counting at the top of the loop instead is the exact defect this pins, and it
 /// is the shape a plausible "just count once at the top" cleanup would reintroduce silently.
@@ -3515,6 +3515,12 @@ fn compose_paging_prediction_matches_the_branch_taken() {
 /// while streamed calls it and could hit the `continue`. The counts stay equal only if
 /// `all_match_known` is honest, so the artwork/all-match cell checks the narrowing's own claim as
 /// well as the counters — which is why it is guarded for coverage separately below.
+///
+/// `printings_examined` is deliberately NOT in this set, and must not be added: the two executors do
+/// genuinely different work there, which is the whole reason it exists as a second counter. Streamed
+/// only COUNTS, so both `all_match` arms of `card_match_count` answer from span arithmetic and examine
+/// zero printings; gathered must EMIT, so it reads the one printing it picks. Asserting equality would
+/// pin the very conflation `printing_span` already suffered from — see `PhaseStats`.
 ///
 /// `matches_pushed` is asserted two ways: plan-vs-plan like the others, and against the total each
 /// run actually returned. The second is what carries it. Plan-vs-plan alone cannot catch both
@@ -3536,7 +3542,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
     // never fires and the two loops trivially agree. Only an inexact narrowing (an oracle-text
     // trigram superset, an arithmetic comparison across a card and a printing field) hands the
     // executors candidates that `card_pass` then rejects, which is the only condition under which
-    // `printings_scanned` can diverge at all. Verified: without the second group `saw_continue` is
+    // `printing_span` can diverge at all. Verified: without the second group `saw_continue` is
     // 0 across the whole sweep and both assertions pass without exercising anything.
     let specs = [
         fuzz_leaf_type(&mut rng),
@@ -3601,9 +3607,9 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                     streamed.cards_visited, gathered.cards_visited,
                 );
                 assert_eq!(
-                    streamed.printings_scanned, gathered.printings_scanned,
-                    "printings_scanned disagrees (streamed {} vs gathered {}): {case}",
-                    streamed.printings_scanned, gathered.printings_scanned,
+                    streamed.printing_span, gathered.printing_span,
+                    "printing_span disagrees (streamed {} vs gathered {}): {case}",
+                    streamed.printing_span, gathered.printing_span,
                 );
                 assert_eq!(
                     streamed.matches_pushed, gathered.matches_pushed,
@@ -3639,7 +3645,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                 }
                 // Did the `card_pass` continue actually fire? Only then do the two loops take
                 // different numbers of trips past the counter, which is the only way
-                // `printings_scanned` can come apart at all. Measured as "fewer printings scanned
+                // `printing_span` can come apart at all. Measured as "fewer printings scanned
                 // than the candidate set holds", not guessed from the counters alone.
                 let scannable: u64 = prep
                     .card_ids(&ctx)
@@ -3648,7 +3654,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                         u64::from(u32::from(e) - u32::from(s))
                     })
                     .sum();
-                if gathered.printings_scanned < scannable {
+                if gathered.printing_span < scannable {
                     saw_continue += 1;
                 }
             }
@@ -3666,12 +3672,12 @@ fn materializing_plans_agree_on_the_counters_they_share() {
         artwork_all_match > 0,
         "no artwork query had all_match_known; the one cell where the two all_match gates diverge is unchecked",
     );
-    // And the continue must actually fire somewhere, or `printings_scanned` equality is trivial:
+    // And the continue must actually fire somewhere, or `printing_span` equality is trivial:
     // with every candidate passing, both loops scan every printing and cannot disagree. This is
     // what the inexact-narrowing specs are in the list for -- drop them and this drops to 0.
     assert!(
         saw_continue > 0,
-        "card_pass never rejected a candidate; printings_scanned agreed only because nothing was skipped",
+        "card_pass never rejected a candidate; printing_span agreed only because nothing was skipped",
     );
 }
 
@@ -3775,7 +3781,7 @@ fn plan_stats_never_leak_between_participants() {
                         // Leak 1. `ns_round_total` and `result_total` are excluded: `explain_analyze`
                         // fills both itself after the take, so they are non-zero by design here.
                         assert_eq!(
-                            (p.cards_visited, p.printings_scanned, p.matches_pushed), (0, 0, 0),
+                            (p.cards_visited, p.printing_span, p.printings_examined, p.matches_pushed), (0, 0, 0, 0),
                             "uninstrumented plan reported counters it never wrote: {case}",
                         );
                         assert_eq!(
@@ -4016,7 +4022,7 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
                     // No executor ran, so anything non-zero here came from somewhere else.
                     let p = &t.phases;
                     assert_eq!(
-                        (p.cards_visited, p.printings_scanned, p.matches_pushed), (0, 0, 0),
+                        (p.cards_visited, p.printing_span, p.printings_examined, p.matches_pushed), (0, 0, 0, 0),
                         "a declining plan reported counters no executor wrote: {case}",
                     );
                     assert_eq!(

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -768,6 +768,17 @@ class QuerySampler:
         """An orderby, weighted by mode. Which one gates StreamedSelect/PlanePopcountOrder."""
         return self._choose(self._restrict(self.orderbys, shape.orderby), rng)
 
+    def prefer(self, rng: random.Random) -> str:
+        """A printing-preference, weighted by mode.
+
+        Exposed alongside `unique`/`orderby` because it is not merely a result-shaping knob: the
+        card- and artwork-mode match kernels may stop at the first qualifying printing under
+        `default` (printings are stored in prefer-desc order, so the first match IS the pick) and
+        must score every printing under any other value. A harness that pins this to `default`
+        measures only the short-circuiting path.
+        """
+        return self._choose(self.prefers, rng)
+
     def params(self, rng: random.Random, shape: Shape = ANY_SHAPE) -> dict[str, str | int]:
         """Every result-shaping parameter at once: unique, orderby, prefer, direction, offset."""
         return {

--- a/scripts/bench_cost_error_attribution.py
+++ b/scripts/bench_cost_error_attribution.py
@@ -22,11 +22,14 @@ whatever error survives both is (2), the floor imposed by the arm's shape.
 
 Scoped to GatheredScan and StreamedSelect: they are the two plans with full executor counters, and
 they take the large majority of queries. `cards_visited` and `matches_pushed` are exact
-(verified 1.00 against their features on the candidates branch). `printings_scanned` is deliberately
-NOT substituted -- it counts the printing SPAN of each visited card, not rows examined, so in card
-mode where the loop breaks at the first match it overstates real work. Substituting it would
-manufacture a feature error that is really a counter definition. That makes the feature share here a
-LOWER bound, which is the safe direction.
+(verified 1.00 against their features on the candidates branch).
+
+`scan_units` is now substituted too, from `printings_examined`. It used to be left alone because the
+only counter available was `printing_span` (then named `printings_scanned`), which counts the printing
+SPAN of each visited card rather than rows examined -- so in card mode, where the kernels break at the
+first qualifying printing, it overstates real work and substituting it would have manufactured a
+feature error that was really a counter definition. `printings_examined` is reported by the match
+kernels themselves, so the feature share here is no longer a LOWER bound.
 
     .venv/bin/python scripts/bench_cost_error_attribution.py --seconds 600 --mode realistic
 """
@@ -124,16 +127,18 @@ def rows_for(samples: list[dict], plan: str, *, realized: bool) -> tuple[list[li
             continue
         a = s["acq"]
         tier = a["residual_tier_ns100"] / 100.0
-        # Realized: substitute the two EXACT counters. scan_units is left alone on purpose -- see the
-        # module docstring on why printings_scanned is not a drop-in for it.
+        # Realized: substitute all three counters. `printings_examined` is the match kernels' own
+        # report of rows touched, so unlike the `printing_span` it replaces it IS a drop-in for
+        # `scan_units` -- see the module docstring.
         eval_domain = float(s["cards_visited"] if realized else a["eval_domain"])
         matches = float(s["matches_pushed"] if realized else a["matches"])
+        scan_units = float(s["printings_examined"] if realized else a["scan_units"])
         design.append(
             terms(
                 plan,
                 Feats(
                     eval_domain=eval_domain,
-                    scan_units=float(a["scan_units"]),
+                    scan_units=scan_units,
                     matches=matches,
                     n_cards=float(a["n_cards"]),
                     tier_ns=tier,

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -29,6 +29,7 @@ while the pooled median looks fine.
 from __future__ import annotations
 
 import argparse
+import math
 import pathlib
 import random
 import sys
@@ -58,25 +59,47 @@ AGREE_LO, AGREE_HI = 0.8, 1.25
 MIN_COUNTER = 100
 
 # feature name on the shared acquire vector -> the executor counter that realizes it.
+#
+# `scan_units` is graded against `printings_examined`, NOT `printing_span`. The latter is the
+# printing SPAN under the candidate cards, computed by the caller before the match kernel runs, so it
+# reports what a full scan would have cost rather than what happened. The two coincide in printing and
+# artwork mode -- those loops really do traverse the span -- which is why grading against the span
+# looked fine everywhere except card mode, where every kernel short-circuits. Reading the span as the
+# work done is how `cost.rs` came to assert that the scan plans "walk the full printing span of their
+# candidates in CARD mode too, not one row each"; they do not.
 PAIRS = (
     ("matches", "matches_pushed"),
     ("eval_domain", "cards_visited"),
-    ("scan_units", "printings_scanned"),
+    ("scan_units", "printings_examined"),
 )
+# Kept alongside so one run shows both gradings. The gap between the two columns IS the miscount, and
+# reporting it as a column beats asserting it in prose.
+SPAN_COUNTER = "printing_span"
 
 
-def scan_feature(plan: str, paging: str) -> str:
-    """Which feature the ARM actually charges its printing scan on.
+def scan_feature(plan: str, paging: str, tier_ns100: int) -> str | None:
+    """Which feature the ARM actually charges its printing scan on, or None if it charges none.
 
     One shared vector costs every plan, but they do not all read the same field, and comparing a
     counter to a feature the arm never touches manufactures a defect. Compose walks the set bits of
     its composed bitmap (`compose_scan_printings`) when it pages by Gather, and stops at
     `page_offset + limit` when it pages by walking (`printings_walked`); only the materializing scan
     plans read `scan_units`.
+
+    `StreamedSelect` reads it only WITH a residual. Its arm is
+    `if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }` -- with `all_match` (tier
+    0) P3 walks no printings and the term is switched off entirely. Graded anyway, those rows read
+    p50 2.72 / p70 3.08 against `printings_examined`, because `scan_units` there is GatheredScan's
+    full-span quantity while StreamedSelect's counting kernel answers existence from the first
+    matching printing. That is not a feature error -- it is a number the model never multiplies by
+    anything -- and reporting it as one sent `fit_cost_model.py`'s `counter_check` into refusing to
+    fit this plan at all.
     """
-    if plan != "PrintingCompose":
-        return "scan_units"
-    return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+    if plan == "PrintingCompose":
+        return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+    if plan == "StreamedSelect" and tier_ns100 == 0:
+        return None
+    return "scan_units"
 
 
 percentile = costbench.percentile
@@ -86,7 +109,13 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
     """One row per (query, plan, feature) where the plan reported the matching counter."""
     rows: list[dict] = []
     budget = costbench.Budget(seconds=seconds, warmups=NUM_WARMUPS, trials=NUM_TRIALS)
-    for sample in costbench.iter_samples(engine, sampler, rng, budget):
+    # `prefer` is sampled, not pinned: it decides whether the card-mode kernels stop at the first
+    # qualifying printing or must score every one, which is the single largest per-card work
+    # difference any sampled parameter reaches -- and the cost model cannot see it, since
+    # `PlanFeatures` does not carry `prefer` (see `explain`'s doc in lib.rs). A run pinned to
+    # `default` measures only the short-circuiting path and reads the feature as though the
+    # long path did not exist.
+    for sample in costbench.iter_samples(engine, sampler, rng, budget, vary_prefer=True):
         acq = sample.acquire
         for plan in sample.plans:
             if not plan["trials_ns"]:
@@ -94,21 +123,32 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
             paging = acq["compose_paging"]
             for feat, counter in PAIRS:
                 if feat == "scan_units":
-                    feat = scan_feature(plan["plan"], paging)  # noqa: PLW2901 - the arm decides which field it reads
+                    feat = scan_feature(plan["plan"], paging, acq["residual_tier_ns100"])  # noqa: PLW2901 - the arm decides
+                    if feat is None:
+                        continue  # this arm charges no scan term for this query; there is nothing to grade
                 got = plan.get(counter)
                 if got is None or got < MIN_COUNTER:
                     continue
+                span = plan.get(SPAN_COUNTER)
                 rows.append(
                     {
                         "feature": feat,
                         "plan": plan["plan"],
                         "acquire": acq["count_source"],
                         "unique": sample.kw["unique"],
+                        "orderby": sample.kw["orderby"],
+                        # Sampled, so this slice is the one that separates the short-circuiting
+                        # card-mode kernels from the ones that must score every printing.
+                        "prefer": sample.kw.get("prefer", "default"),
                         # Compose's arm reads `scan_units` ONLY in its Gather branch; Perm/OrderbyWalk
                         # stop at page_offset+limit and never scan the candidates. A ratio measured on
                         # those is comparing the feature to work the arm never charges for.
                         "paging": paging,
                         "ratio": acq[feat] / got,
+                        # What the same row would have read graded against the printing SPAN -- the
+                        # old comparison. `nan` where the plan publishes no span, which `percentile`
+                        # tolerates and `MIN_ROWS` cells then drop.
+                        "span_ratio": (acq[feat] / span) if span else float("nan"),
                     }
                 )
     return rows
@@ -122,12 +162,13 @@ def verdict(sorted_vals: list[float]) -> str:
     return "  OVER-COUNTS" if med > AGREE_HI else "  UNDER-COUNTS"
 
 
-def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 30) -> None:
+def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 30, value: str = "ratio") -> None:
     """Feature/counter percentiles for one grouping, worst-calibrated cells first."""
     costbench.percentile_table(
         rows,
         key,
         label,
+        value=value,
         rank=costbench.BY_MISCALIBRATION,
         limit=limit,
         min_rows=MIN_ROWS,
@@ -158,9 +199,28 @@ def main() -> None:
     # StreamedSelect, GatheredScan and compose's Gather branch alike. If they disagree here, no single
     # value of the feature is right for all of them and the fix is per-arm, not per-mode.
     table(rows, lambda r: f"{r['feature']} <{r['plan']}> / {r['unique']}", "feature <plan> / distinct-on")
+    # `prefer` decides whether the card-mode kernels early-break, and `PlanFeatures` does not carry
+    # it, so one feature value has to serve both regimes. If these two rows differ, the feature is not
+    # merely miscalibrated -- it is blind to a variable that changes the work.
+    scan = [r for r in rows if r["feature"] == "scan_units"]
+    table(scan, lambda r: f"scan_units / {r['unique']} / prefer={r['prefer']}", "scan_units by distinct-on and PREFER")
+    # Orderby was always sampled and never sliced, so its effect has never been visible. It selects
+    # the plan set (StreamedSelect needs a sort permutation; PlanePopcountOrder needs its column) and
+    # therefore which arm reads the shared vector at all.
+    table(rows, lambda r: f"{r['feature']} / orderby={r['orderby']}", "feature by ORDERBY", limit=40)
     # Compose only pays `scan_units` when it pages by Gather, so judge the feature on those rows.
     compose = [r for r in rows if r["plan"] == "PrintingCompose"]
     table(compose, lambda r: f"{r['feature']} <compose {r['paging']}> / {r['unique']}", "compose only: feature by PAGING branch")
+    # The old grading, same rows: `scan_units` against the printing SPAN rather than the printings
+    # actually examined. Printed last as the control -- if these cells sit at 1.0 where the real
+    # column does not, the span is what the constants were fit against.
+    spanned = [r for r in scan if math.isfinite(r["span_ratio"])]
+    table(
+        spanned,
+        lambda r: f"scan_units / {r['unique']}",
+        "CONTROL: scan_units vs printing SPAN (the old grading)",
+        value="span_ratio",
+    )
     print(f"\n  Cells outside [{AGREE_LO}, {AGREE_HI}] are flagged. A feature error cannot be fixed by any")
     print("  rate: fit_cost_model.py will bury it in whichever coefficient correlates with it.")
 

--- a/scripts/bench_query_latency_ab.py
+++ b/scripts/bench_query_latency_ab.py
@@ -50,7 +50,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from client.query_sampler import MODES, QuerySampler  # noqa: E402
+from client.query_sampler import ANY_SHAPE, MODES, QuerySampler, Shape  # noqa: E402
 from scripts.costbench import load_engine  # noqa: E402
 
 # Well above the shared costbench (2, 7), which is calibrated for comparisons INSIDE one
@@ -82,8 +82,24 @@ class Budget:
     trials: int = NUM_TRIALS
 
 
-def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget) -> list[dict]:
-    """Min-of-trials wall time for `query()` on each sampled query."""
+def measure(  # noqa: PLR0913 - a measurement function's arguments ARE the conditions it measures under
+    engine: object,
+    sampler: QuerySampler,
+    rng: random.Random,
+    budget: Budget,
+    shape: Shape = ANY_SHAPE,
+    *,
+    vary_prefer: bool = False,
+) -> list[dict]:
+    """Min-of-trials wall time for `query()` on each sampled query.
+
+    `vary_prefer` draws the printing preference instead of pinning it to `default`. Off by default
+    because drawing it consumes the rng and shifts the whole query stream, which would orphan every
+    baseline on disk -- but a run pinned to `default` cannot see a change to the custom-prefer path at
+    all. `Prefer::Default` is the only value that lets the card- and artwork-mode match kernels stop
+    at the first qualifying printing; the other four must score every printing of the card. `query()`
+    has taken `prefer` on every build this harness can target, so varying it stays A/B-safe.
+    """
     rows: list[dict] = []
     for _ in range(budget.sample):
         limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
@@ -94,15 +110,16 @@ def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: B
             "limit": limit,
             "offset": offset,
         }
-        q = sampler.query(rng)
+        q = sampler.query(rng, shape)
+        prefer = sampler.prefer(rng) if vary_prefer else "default"
         try:
             filters = parse_scryfall_query(q)
             for _ in range(budget.warmups):
-                engine.query(filters=filters, prefer="default", **kw)
+                engine.query(filters=filters, prefer=prefer, **kw)
             best = math.inf
             for _ in range(budget.trials):
                 t0 = time.perf_counter_ns()
-                engine.query(filters=filters, prefer="default", **kw)
+                engine.query(filters=filters, prefer=prefer, **kw)
                 best = min(best, time.perf_counter_ns() - t0)
         except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
             continue
@@ -110,6 +127,7 @@ def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: B
             {
                 "q": q,
                 **{k: kw[k] for k in ("unique", "orderby", "direction")},
+                "prefer": prefer,
                 "limit": limit,
                 "offset": offset,
                 "us": best / 1000.0,
@@ -134,7 +152,9 @@ def compare(path_a: pathlib.Path, path_b: pathlib.Path) -> None:
         out = {}
         for line in path.open():
             r = json.loads(line)
-            out[(r["q"], r["unique"], r["orderby"], r["direction"], r["limit"], r["offset"])] = r["us"]
+            # `.get` for `prefer`: files written before it was recorded pin it to default anyway, so
+            # they still pair with each other rather than failing to key.
+            out[(r["q"], r["unique"], r["orderby"], r["direction"], r.get("prefer", "default"), r["limit"], r["offset"])] = r["us"]
         return out
 
     a, b = rows(path_a), rows(path_b)
@@ -176,7 +196,23 @@ def main() -> None:
         "--trials", type=int, default=NUM_TRIALS, help="a cross-process A/B needs a converged floor; see the module docstring"
     )
     parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument(
+        "--vary-prefer",
+        action="store_true",
+        help="sample the printing preference instead of pinning it to default; the custom-prefer path is the only one where the match kernels cannot early-break",
+    )
     parser.add_argument("--mode", choices=MODES, default="realistic", help="latency asks what users wait for, so traffic-weighted")
+    parser.add_argument(
+        "--predicates",
+        type=int,
+        default=None,
+        help=(
+            "pin the conjunction width instead of drawing it from PREDICATE_COUNT_WEIGHTS (1/2/3 at "
+            "45/40/15). 4+ is reachable only this way, and on purpose: the sampler caps the natural "
+            "draw at 3 because deeper conjunctions narrow to nothing and stop exercising plan choice, "
+            "which is the thing being measured. Pin it to compare like against like at one width."
+        ),
+    )
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--shm-path", type=pathlib.Path, default=None)
     parser.add_argument("--out", type=pathlib.Path, help="write per-query latencies as JSONL")
@@ -189,8 +225,17 @@ def main() -> None:
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".latency.store"))
     sampler = QuerySampler(args.corpus, args.mode)
-    rows = measure(engine, sampler, random.Random(args.seed), Budget(args.sample, args.warmups, args.trials))
-    print(f"measured {len(rows):,} queries, mode={args.mode}")
+    shape = Shape(predicates=args.predicates) if args.predicates else ANY_SHAPE
+    rows = measure(
+        engine,
+        sampler,
+        random.Random(args.seed),
+        Budget(args.sample, args.warmups, args.trials),
+        shape,
+        vary_prefer=args.vary_prefer,
+    )
+    width = f", predicates={args.predicates}" if args.predicates else ""
+    print(f"measured {len(rows):,} queries, mode={args.mode}{width}")
     if args.out:
         with args.out.open("w") as handle:
             for row in rows:

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -136,7 +136,8 @@ PLAN_KEYS = frozenset(
         "trials_ns",
         "declined_ns",
         "cards_visited",
-        "printings_scanned",
+        "printing_span",
+        "printings_examined",
         "matches_pushed",
         "ns_setup",
         "ns_loop",
@@ -210,9 +211,20 @@ class Sample:
         return (self.q, self.kw["unique"], self.kw["orderby"], self.kw["direction"], self.kw["limit"], self.kw["offset"])
 
 
-def sample_kwargs(sampler: QuerySampler, rng: random.Random) -> dict:
-    """One query shape: distinct-on, order, direction and page, weighted by the sampler's mode."""
-    return {
+def sample_kwargs(sampler: QuerySampler, rng: random.Random, *, vary_prefer: bool = False) -> dict:
+    """One query shape: distinct-on, order, direction and page, weighted by the sampler's mode.
+
+    `vary_prefer` draws `prefer` from the sampler instead of pinning it to `"default"`, and it is
+    OFF by default for a reason that is not timidity: drawing it consumes the rng, so turning it on
+    shifts every subsequent query in the stream. Baselines on disk were taken without it, and a
+    harness comparing against one must keep the stream byte-identical.
+
+    Turn it on where `prefer` is the variable under study. It is not cosmetic -- it decides whether
+    the card-mode match kernels may stop at the first qualifying printing (`Prefer::Default`,
+    printings are stored in prefer-desc order) or must score all of them to find the max. That is a
+    ~3x difference in per-card work that no other sampled parameter reaches.
+    """
+    kwargs = {
         "filters": None,
         "unique": sampler.unique(rng),
         "orderby": sampler.orderby(rng),
@@ -220,13 +232,21 @@ def sample_kwargs(sampler: QuerySampler, rng: random.Random) -> dict:
         "limit": rng.choice(LIMITS),
         "offset": rng.choice(OFFSETS),
     }
+    if vary_prefer:
+        kwargs["prefer"] = sampler.prefer(rng)
+    return kwargs
 
 
-def iter_samples(engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget) -> Iterator[Sample]:
+def iter_samples(
+    engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget, *, vary_prefer: bool = False
+) -> Iterator[Sample]:
     """Yield measured queries until the budget runs out, skipping any the parser rejects.
 
     The schema is checked against the first response that comes back, so a run against a build whose
     `explain_analyze` has moved on fails immediately instead of part way through.
+
+    `vary_prefer` is forwarded to `sample_kwargs`; see there for why it defaults off. The drawn
+    `prefer` lands in `Sample.kw`, so a caller that turns it on can slice by it.
     """
     # Imported here, not at module scope, so `costbench` stays importable (and unit-testable)
     # without the `api` package on the path. The cost is one import per process.
@@ -237,12 +257,17 @@ def iter_samples(engine: object, sampler: QuerySampler, rng: random.Random, budg
     taken = 0
     while time.monotonic() < deadline and (budget.sample is None or taken < budget.sample):
         taken += 1
-        kw = sample_kwargs(sampler, rng)
+        kw = sample_kwargs(sampler, rng, vary_prefer=vary_prefer)
         q = sampler.query(rng)
         try:
             kw["filters"] = parse_scryfall_query(q)
+            # Both calls get the same `prefer`. Note what that does and does not buy: `PlanFeatures`
+            # does not carry `prefer`, so the features and every `predicted_ns` come back identical
+            # whatever is passed, while execution honours it. That asymmetry is what makes a prefer
+            # slice readable -- only the COUNTERS move, so a ratio that shifts with `prefer` is the
+            # feature failing to model a real difference in work, not two numbers drifting at once.
             acquire = engine.explain(**kw)["acquire"]
-            res = engine.explain_analyze(prefer="default", num_warmups=budget.warmups, num_trials=budget.trials, **kw)
+            res = engine.explain_analyze(num_warmups=budget.warmups, num_trials=budget.trials, **{"prefer": "default", **kw})
         except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
             continue
         if not checked:

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -91,7 +91,10 @@ CURRENT: dict[str, list[float]] = {
     # eval_domain, scan_units, tier scale, matches, page_span, fixed
     "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
-    "StreamedSelect": [6.46, 5.53, 8.18, 0.13, 1.36, 1.64, 0.02, 217.5],
+    # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
+    # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
+    # term the arm multiplies by zero. Median agreement 0.63 -> 0.92, within-25% 19% -> 58%.
+    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.21, 1.02, 0.02, 217.0],
     # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
@@ -167,10 +170,19 @@ def nnls(rows: list[list[float]], targets: list[float]) -> list[float]:
     return coeffs
 
 
-# The residual floors the shipped arms use inside `max(tier_ns, floor)`. They are NOT fitted here --
-# see design_row for why the max cannot be a plain linear column -- and were derived independently by
-# regressing per-card match-loop time on printings-per-card, split by tier class.
-SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 8.18}
+# The residual floors the shipped arms use inside `max(tier_ns, floor)`.
+#
+# These MUST equal the `*_RESIDUAL_FLOOR_NS` constants in cost.rs, and equal the third entry of the
+# matching `CURRENT` vector. All three are the same number: `design_row` makes the floor the
+# coefficient of the `eval_domain * residual_on` column AND uses it to compute the `excess` offset for
+# rows where the tier beats it. Change one without the others and `mirror_matches_engine` drops below
+# its 99% bar -- which is exactly how the 2026-08-02 refit was caught pasting a fitted floor of 6.58
+# into cost.rs while the offset here still assumed 8.18 (7.4% of rows disagreed).
+#
+# A consequence worth stating: the fitted floor is not directly pasteable, because the offset it was
+# fitted against assumed the OLD floor. Applying it and re-fitting is a fixed-point iteration, and
+# each run is only self-consistent with whatever is shipped at the time.
+SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 6.58}
 
 
 def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[float], list[str], float] | None:
@@ -277,12 +289,15 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
 
 def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
     """Realized counter vs the feature that should predict it, per plan. Ratios should be 1.00."""
-    pairs = (("cards_visited", "eval_domain"), ("printings_scanned", "scan_units"), ("matches_pushed", "matches"))
+    # `scan_units` pairs with `printings_examined`, not the `printing_span` this used to read: the span
+    # is computed by the caller before the match kernel runs, so in card mode -- where every kernel
+    # stops at the first qualifying printing -- it reports work that never happened.
+    pairs = (("cards_visited", "eval_domain"), ("printings_examined", "scan_units"), ("matches_pushed", "matches"))
 
     def feature_for(plan: str, counter: str, row: dict) -> str:
         """Compose reads its own scan field, and which one depends on the paging branch that runs."""
-        if counter != "printings_scanned" or plan != "PrintingCompose":
-            return {"cards_visited": "eval_domain", "printings_scanned": "scan_units", "matches_pushed": "matches"}[counter]
+        if counter != "printings_examined" or plan != "PrintingCompose":
+            return {"cards_visited": "eval_domain", "printings_examined": "scan_units", "matches_pushed": "matches"}[counter]
         return "compose_scan_printings" if row["acq"].get("compose_paging") == "Gather" else "printings_walked"
 
     out: dict[str, list[tuple[str, float]]] = {}
@@ -295,8 +310,17 @@ def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
             continue  # only the two scan plans carry counters; absent is not the same as wrong
         checks = []
         for counter, _default in pairs:
-            got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in instrumented]
-            feature = feature_for(plan, counter, instrumented[0])
+            # Only grade rows whose arm actually multiplies the feature by a rate. StreamedSelect's
+            # scan term is `if tier_ns > 0.0 { scan_units * ... } else { 0.0 }`, so on an all_match
+            # query (tier 0) `scan_units` is a number the model never reads -- and grading it anyway
+            # read 0.65 here and vetoed the whole plan's fit over a term that contributes zero.
+            graded = instrumented
+            if counter == "printings_examined" and plan == "StreamedSelect":
+                graded = [r for r in instrumented if r["acq"]["residual_tier_ns100"] > 0]
+            if not graded:
+                continue
+            got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in graded]
+            feature = feature_for(plan, counter, graded[0])
             if got:
                 checks.append((f"{counter}/{feature}", statistics.median(got)))
         if checks:
@@ -351,7 +375,8 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
                     "ns_setup": p["ns_setup"],
                     "ns_loop": p["ns_loop"],
                     "ns_finish": p["ns_finish"],
-                    "printings_scanned": p["printings_scanned"],
+                    "printing_span": p["printing_span"],
+                    "printings_examined": p["printings_examined"],
                     "matches_pushed": p["matches_pushed"],
                 }
             )
@@ -488,7 +513,10 @@ def main() -> None:
     args = parser.parse_args()
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".fit.store"))
-    samples = collect(engine, random.Random(args.seed), args.seconds)
+    # Pass the sampler explicitly: `collect`'s fallback builds one off a hardcoded corpus path, so
+    # `--corpus` was loading the engine from one file and drawing queries from another (or, off the
+    # default checkout, raising FileNotFoundError). Values must come from the corpus the engine holds.
+    samples = collect(engine, random.Random(args.seed), args.seconds, QuerySampler(args.corpus, "uniform"))
     print(f"\n{len(samples):,} plan-rows collected in {args.seconds:.0f}s")
 
     agree, checked = mirror_matches_engine(samples)


### PR DESCRIPTION
`printings_scanned` was computed by the CALLER as `end - start` per surviving candidate card, before the match kernel ran, so it reported the printing SPAN whatever the kernel then did. In printing and artwork mode the loops really do traverse the span and it was right. In card mode every kernel short-circuits — `card_match_count` returns from `all_match` without reading a printing at all, and both kernels return at the first qualifying printing under the default prefer — so there it reported work that never happened.

That counter was cited in `cost.rs` to justify a feature: *"the `printings_scanned` counter shows the scan plans walk the full printing span of their candidates in CARD mode too, not one row each"*. It cannot show that. The sentence is deleted and the reasoning that survives it is written out, because the span estimate does hold up in card mode for a different reason: under an inexact narrowing most candidates do not match, and a non-matching card is ruled out only after its whole span is walked.

`bench_cost_error_attribution.py` already knew this — its docstring said the span "counts the printing SPAN of each visited card, not rows examined" and refused to substitute it. That knowledge lived in one harness while `cost.rs` drew the opposite conclusion from the same number.

The kernels now return the printings they looked at, published as `printings_examined`; `printings_scanned` becomes `printing_span` for what it is. `scan_units` is graded against the new counter, and all six counter checks in `fit_cost_model` read 1.00 for the first time.

## Two things followed

**StreamedSelect's fit had been vetoed on every previous run.** Its `all_match` rows disagree with the span ~3x, over a term its arm multiplies by zero (`if tier_ns > 0.0 { scan_units * ... } else { 0.0 }`). Excluding zero-weight rows let it fit:

| | median | within 25% |
| --- | --: | --: |
| before | 0.63 | 19% |
| after | **0.91** | **58%** |

It had been under-costed ~1.6x, which biases the router toward picking it. Regret on the `candidates` slice (72% of all lost time) falls 3.53 → 3.26 and 3.49 → 3.33 across two seeds. GatheredScan and PrintingCompose were re-fit in the same run and deliberately **not** changed — GatheredScan reproduces its current values within 8% with no agreement gain, and compose's fit makes its median *worse* (0.95 → 0.86).

**The plane acquire's `scan_units` is now exact.** A True residual means `all_match`, so under the default prefer the kernels break after one printing and the popcount was right; under any other prefer they must score every printing to find the max. Graded per prefer, the old value read 1.00 for `default` and 0.16–0.35 for the other four — one number cannot serve both. The exact span is one pass over the set bits (~4.3 µs measured), and the default prefer, ~85% of traffic, returns before reaching it. `scan_units [plane]` p10–p70 now read exactly 1.00, spread 6.3 → 2.8.

## Paired A/B against main

Interleaved A/B/A/B, uniform mode, 2000 queries at (6, 30), `PYTHONPATH` values padded to equal length because of the known env-var-size artifact.

| comparison | isolates | rep 1 | rep 2 |
| --- | --- | --- | --- |
| same build | canary | +0.3 [-0.1, +0.7] | — |
| whole branch, prefer varied | everything | -0.4 [-0.8, +0.1] | -0.9 [-1.4, -0.5] |
| **constants alone** | **the refit** | **+1.0 [+0.6, +1.4]** | **+0.3 [-0.3, +1.0]** |
| pinned 4-predicate | conjunction depth | -0.2 [-0.5, +0.1] | — |

No regression, and no end-to-end win from the constants — consistent with the regret they remove being ~0.2 µs/query, well under this harness's 0.7 µs resolution. The regret matrix is the measurement that can see it; latency cannot.

Worth recording from the width slice: conjunctions get monotonically *cheaper* with depth (width 1 averages 186 µs, width 4 averages 41 µs), which confirms the sampler's stated reason for capping the natural draw at 3 — broad single-predicate queries are where plan choice costs real time.

## Harnesses

- `explain` takes `prefer`. It changes no prediction — `PlanFeatures` does not carry prefer — but taking it is what lets a prefer-aware feature be graded at all.
- `QuerySampler.prefer()`, with opt-in sampling in `costbench` / `bench_feature_accuracy` / `bench_query_latency_ab`. Off by default: drawing it consumes the rng and would orphan every baseline on disk.
- `bench_feature_accuracy` slices by prefer and by orderby — orderby was always sampled and never sliced, so its effect had never been visible — and prints the old span grading as a control.
- `bench_query_latency_ab --predicates` pins conjunction width, since the natural draw stops at 3 on purpose.
- `bench_cost_error_attribution` can substitute `scan_units` now, so its feature share is no longer a lower bound.
- **Bug:** `fit_cost_model`'s `--corpus` was ignored by its sampler, which built one off a hardcoded path — the engine loaded one corpus while queries were drawn from another, or it crashed outright off a clean checkout. `SHIPPED_RESIDUAL_FLOOR` is documented as the third copy of a number that must move with `cost.rs` and `CURRENT` together; the mirror check caught exactly that during this refit.

## Reviewer notes

- The refitted StreamedSelect constants are the one judgement call here. Agreement and regret both say they are directionally right; latency says neutral. They can be dropped without affecting anything else in the PR.
- Absolute rates were fit on one machine with Docker down but no other quiescing; `FIXED` and the absolute terms are machine-sensitive.
- Not addressed: `PrintingRangeScan`'s always-unnarrowed assumption (`eval_domain` p90 41.7), `PrintingCompose` publishing no executor counters at all, and compose's ±1.5–2x features.
- `cargo test --lib` 147 passed in debug; clippy clean apart from one pre-existing unused constant; ruff clean.
