### PR TITLE
Engine: Make PrintingCompose Measurable, and Fix What That Exposes

### DIFF
--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -12,6 +12,13 @@ crate-type = ["cdylib"]
 # Counting global allocator + reload memory breakdown, exposed via QueryEngine.mem_stats().
 # Measurement-only; never enable for production builds.
 alloc-counter = []
+# Disjoint acquire/choose/dispatch timing inside run_query_routed, exposed through
+# explain_analyze's `routed_*_ns`. Measurement-only, same rule as alloc-counter, and for a
+# measured reason: the four clock reads cost +2.7us and +2.3us on a ~40us median query
+# (~1.6%, paired interleaved A/B, both CIs excluding zero). Worth that in a diagnostic build --
+# acquire turns out to be 45% of a candidate-acquired query and the cost model prices none of
+# it -- and not worth it on every production request.
+routed-phases = []
 
 [dependencies]
 # extension-module is enabled by maturin (see pyproject.toml [tool.maturin]) so that

--- a/card_engine/src/bench_compose_card_projection.rs
+++ b/card_engine/src/bench_compose_card_projection.rs
@@ -131,7 +131,7 @@ fn bench_compose_card_projection() {
         let twice_ns = best_ns(|| derive_twice(&pbits, offsets, n_cards).1.len());
         let once_ns = best_ns(|| derive_once(&pbits, offsets, n_cards).1.len());
         let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards);
-        let gather_ns = best_ns(|| gather_composed_page(&ctx, &card_params(0), &pbits, Some(&card_bits)).len());
+        let gather_ns = best_ns(|| gather_composed_page(&ctx, &card_params(0), &pbits, Some(&card_bits)).0.len());
 
         let saved = twice_ns.saturating_sub(once_ns);
         let share = 100.0 * saved as f64 / (twice_ns + gather_ns) as f64;

--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -100,18 +100,15 @@ fn bench_compose_paging() {
             }
             let run_a = || {
                 walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset)
-                    .map_or(0, |p| p.len())
+                    .map_or(0, |p| p.0.len())
             };
-            let run_b = || {
-                gather_composed_page(&ctx, &bench_params(offset), &pbits, None)
-                    .len()
-            };
+            let run_b = || gather_composed_page(&ctx, &bench_params(offset), &pbits, None).0.len();
             // Cross-check identical page (offset 0 only — A declines into the null-price tail at deep
             // offsets, where only B is defined; that decline is itself the finding for those rows).
             let a_page = walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset);
-            let b_page = gather_composed_page(&ctx, &bench_params(offset), &pbits, None);
-            if let Some(a_page) = &a_page {
-                let a_ids: Vec<u128> = a_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
+            let (b_page, _) = gather_composed_page(&ctx, &bench_params(offset), &pbits, None);
+            if let Some((a_rows, _)) = &a_page {
+                let a_ids: Vec<u128> = a_rows.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
                 let b_ids: Vec<u128> = b_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
                 assert_eq!(a_ids, b_ids, "A and B disagree on the page for {label} @ offset {offset}");
             }

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -517,10 +517,12 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let limit = f64::from(f.limit);
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
 
-    // Printings walked to fill the page in a forward-permutation walk (both printing-space plans):
-    // roughly `page_span` rows at density `match_rate`.
-    let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
-    let printings_walked = page_span / match_rate;
+    // Printings walked to fill the page in a forward-permutation walk (both printing-space plans).
+    // Calls the shared `printings_walked` rather than recomputing `page_span / match_rate`: this was
+    // a second copy of that formula, and adding WALK_LENGTH_BIAS to the function alone changed what
+    // harnesses were TOLD without changing what the router CHARGED. `fit_cost_model`'s mirror check
+    // caught it as a 3.7% disagreement; there is now one definition.
+    let printings_walked = self::printings_walked(f);
     match plan {
         // #695 bare range, unique=printing: total is the range index's `k` (no synth, no popcount pass),
         // page is a forward permutation walk. So just the walk + fixed setup.

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -547,7 +547,8 @@ const WALK_LENGTH_BIAS: f64 = 1.45;
 
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
-    let n_printings = f64::from(f.n_printings);
+    // `n_printings` is no longer bound here: it was only feeding the local copy of the walk-length
+    // formula, which now calls `printings_walked` so there is one definition of it.
     let matches = f64::from(f.matches);
     let eval_domain = f64::from(f.eval_domain);
     let scan_units = f64::from(f.scan_units);

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -146,6 +146,31 @@ pub(crate) struct PlanFeatures {
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
     pub popcount_words: u32,
+    /// Set printings `gather_composed_page`'s GROUPING arm processes, or `0` when that arm is not the
+    /// one that runs.
+    ///
+    /// The Gather arm charged three things: a per-candidate-card pass, a per-printing bit test at
+    /// 0.38ns ("a cheap bit test, not a real residual scan"), and a per-match push. That describes
+    /// the printing-mode arm, which really does just test a bit and push. It does not describe the
+    /// `Mode::Card | Mode::Artwork` arm, which for every SET printing also reads the artwork group id,
+    /// computes `prefer_score`, and compares against `group_best` — real work, none of it a bit test.
+    ///
+    /// The unit is the load-bearing part. `matches` in artwork mode is the DEDUPED artwork count, so
+    /// `COMPOSE_GATHER_PUSH_PER_MATCH_NS` charges once per surviving group, while the grouping work
+    /// scales with the PRE-dedup printing matches feeding it. A card with twelve printings across two
+    /// artworks pays twelve groupings and two pushes. That is the same class of error
+    /// `bench_feature_accuracy` was written for, mirrored: there a printing count drove a per-result
+    /// term, here a deduped count drives a term whose work is pre-dedup.
+    ///
+    /// Measured consequence before this term existed: over 129 queries where compose was picked and
+    /// lost to GatheredScan, compose's real/predicted was **3.07** — 89% of the lost time in artwork,
+    /// 94% on the Gather branch, and every one of the five worst a single bare `f:` legality leaf at
+    /// ~300us. `PrintingCompose -> GatheredScan` is 99% miss and 11% of ALL routing regret.
+    ///
+    /// `0` for printing mode (the push term already covers its per-set-printing work, since `matches`
+    /// there IS the printing count) and for card mode under `Prefer::Default`, which takes the
+    /// early-break arm instead and never groups.
+    pub gather_group_printings: u32,
     /// Printings the #744 orderby walk's BUCKET SCAN covers before the page can fill, or `0` when the
     /// walk is not the branch (or its buckets are cheap value runs).
     ///
@@ -475,11 +500,24 @@ const COMPOSE_WALK_STEP_NS: f64 = 0.58;
 /// Per row emitted by the Perm / OrderbyWalk page fill.
 const COMPOSE_WALK_EMIT_PER_ROW_NS: f64 = 2.19;
 /// Per candidate card visited by `gather_composed_page`.
-const COMPOSE_GATHER_CARD_PASS_NS: f64 = 9.81;
+///
+/// Raised from 9.81 on 2026-08-03. `fit_cost_model` has wanted this higher in every run it was asked
+/// (1.23x, 1.35x, 1.60x across seeds) and it is the dominant term for the queries that dominate
+/// compose's regret: a bare `f:` legality leaf under `unique=artwork` puts `eval_domain` at nearly the
+/// whole corpus, so 31,508 candidate cards times a 3.4ns error is ~108us on ONE query. Those queries
+/// measure ~300us and `PrintingCompose -> GatheredScan` is 99% miss.
+///
+/// Its own constant, not shared with `GatheredScan`'s `GATHER_CARD_PASS_NS` (6.88) — the two loops do
+/// different per-card work, and moving this does not disturb that plan.
+const COMPOSE_GATHER_CARD_PASS_NS: f64 = 13.22;
 /// Per printing bit-tested against `pbits` inside the gather.
 const COMPOSE_GATHER_BITTEST_PER_PRINTING_NS: f64 = 0.38;
 /// Per match pushed into the bounded GatherSelect accumulator.
 const COMPOSE_GATHER_PUSH_PER_MATCH_NS: f64 = 3.39;
+/// Per SET printing the grouping arm scores and compares — see `gather_group_printings` for why this
+/// is not the bit-test rate and not the push rate. Cheaper than a push (no `sort_key_bits`, no
+/// buffer growth) and dearer than a bit test (a struct read plus `prefer_score`); fitted below.
+const COMPOSE_GATHER_GROUP_PER_PRINTING_NS: f64 = 1.5;
 /// Per-query setup for the compose fastpath.
 const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 
@@ -561,6 +599,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 super::ComposePaging::Gather => {
                     eval_domain * COMPOSE_GATHER_CARD_PASS_NS
                         + f64::from(f.compose_scan_printings) * COMPOSE_GATHER_BITTEST_PER_PRINTING_NS
+                        + f64::from(f.gather_group_printings) * COMPOSE_GATHER_GROUP_PER_PRINTING_NS
                         + matches * COMPOSE_GATHER_PUSH_PER_MATCH_NS
                 }
                 // The fastpath will refuse this query, so there is no page term to charge. Infinity

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -146,6 +146,21 @@ pub(crate) struct PlanFeatures {
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
     pub popcount_words: u32,
+    /// Printings the #744 orderby walk's BUCKET SCAN covers before the page can fill, or `0` when the
+    /// walk is not the branch (or its buckets are cheap value runs).
+    ///
+    /// The Perm and OrderbyWalk branches shared `printings_walked` — `page_span / match_rate`, a
+    /// page-fill length in MATCH units. That describes the permutation walk and does not describe a
+    /// bucket walk at all: `walk_rarity_orderby_page`'s interior buckets are one-hot PLANES, so a
+    /// single bucket ANDs `words_per_plane` words of the whole corpus whether two matches survive or
+    /// twenty thousand. Measured against the raw units actually scanned, the shared formula reads a
+    /// median 0.25 with spread 400 — it under-charges the walk ~4x, and under-charging is what
+    /// over-picks a plan.
+    ///
+    /// `usd` needs none of this: its buckets are value runs off the range index, small and
+    /// proportional to matches, which is the shape `printings_walked` already has. So this is `0`
+    /// there and the shared term stands.
+    pub orderby_walk_scan: u32,
     /// Which of `PrintingCompose`'s three paging strategies will actually run (see `ComposePaging`),
     /// decided the same way `printing_compose_fastpath` decides. The three have different cost shapes
     /// — the permutation walk and the #744 orderby-index walk are both offset-dependent (fill the page
@@ -475,8 +490,22 @@ const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
-    page_span / match_rate
+    page_span / match_rate * WALK_LENGTH_BIAS
 }
+
+/// The closed form above assumes matches are spread UNIFORMLY along the walk order, so a page of
+/// `page_span` rows arrives after `page_span / match_rate` printings. They are not: the permutation
+/// orders cards by the sort column, and matches cluster within that order, so the walk runs longer
+/// than uniform spacing predicts before the page fills.
+///
+/// Measured against `printings_examined` once the walk branches began reporting it, the raw form
+/// reads a median 0.69 -- consistently under on all three acquires that reach a walk
+/// (`printing_range_scan` 0.66, `printing_compose` 0.67, `card_range_popcount` 0.74), which is what
+/// makes it a bias worth dividing out rather than three separate errors.
+///
+/// Bias only. The spread stays wide (p90/p10 ~10-18) because how matches clump along a sort order is
+/// not something a density ratio can see, and no constant will fix that.
+const WALK_LENGTH_BIAS: f64 = 1.45;
 
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
@@ -515,7 +544,9 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // which is exactly why the COMPOSE_GATHER breadth gate is bypassed for it — broad is its
                 // best case, not its worst.
                 super::ComposePaging::Perm | super::ComposePaging::OrderbyWalk => {
-                    printings_walked * COMPOSE_WALK_STEP_NS  // walk to fill the page
+                    // `orderby_walk_scan` is 0 for Perm and for the usd walk, so this is the shared
+                    // page-fill term unless a bucket scan dominates it — see the field's doc.
+                    printings_walked.max(f64::from(f.orderby_walk_scan)) * COMPOSE_WALK_STEP_NS  // walk to fill the page
                         + limit * COMPOSE_WALK_EMIT_PER_ROW_NS  // emit one page of rows
                 }
                 // gather_composed_page: visits every candidate (eval_domain, same rate GatheredScan's

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7541,6 +7541,7 @@ fn mk_plan_feats(
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
         compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
+        gather_group_printings: 0, // only the compose branch, and only when its grouping arm runs
         orderby_walk_scan: 0,      // only the compose branch, and only for a plane-bucket orderby walk
     }
 }
@@ -7801,6 +7802,16 @@ fn acquire_plan_features(
         // however selective the filter is. `usd` walks small value runs instead and keeps the shared
         // page-fill term. See `PlanFeatures::orderby_walk_scan`.
         feats.orderby_walk_scan = if matches!(sort_col, SortCol::Rarity) { n_printings } else { 0 };
+        // The gather's grouping arm runs for artwork always, and for card only under a non-default
+        // prefer -- card/default takes the early-break arm and never groups. Printing mode gets 0
+        // because its push term already rides the printing count. Driven by the PRE-dedup printing
+        // matches, which is the whole point: see `PlanFeatures::gather_group_printings`.
+        let groups = match mode {
+            Mode::Artwork => true,
+            Mode::Card => !matches!(prefer, Prefer::Default),
+            Mode::Printing => false,
+        };
+        feats.gather_group_printings = if groups { printing_matches as u32 } else { 0 };
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
         // itself decides, through the same helpers, including whether it will decline. Only this
         // branch knows the estimated result total, so only it can predict the small-total bail. The
@@ -9043,6 +9054,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
         ("compose_scan_printings", g.compose_scan_printings),
+        ("gather_group_printings", g.gather_group_printings),
         ("orderby_walk_scan", g.orderby_walk_scan),
         // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk
         // paging branches are priced entirely on it and nothing else can check them.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6462,7 +6462,19 @@ fn exec_plane_popcount_order<'a>(
     }
     PLANE_BITMAP_POPCOUNT.with(|cell| {
         let mut bitmap = cell.borrow_mut();
+        // Timed and published as `ns_prepare`, for the same reason `prepare_candidates` is: this is a
+        // SHARED artifact that the router builds once during acquire and hands to whichever plan wins
+        // (`Prep::Plane`), so a forced run that rebuilds it is paying something the routed path does
+        // not pay at dispatch. Netting it is what makes the two comparable — see
+        // `costbench.plan_self_ns`.
+        //
+        // Without this the plane rows read NEGATIVE regret: routed dispatch reuses `plane_bits` while
+        // the forced trial re-evaluates the plane, so the router appeared to beat the best plan by a
+        // mean of 4.21us and held -13% of share. That is the `prepare_candidates` asymmetry again, one
+        // artifact along.
+        let t = std::time::Instant::now();
         eval_planes(plane_expr, &ctx.indexes.planes, &mut bitmap);
+        note_pending_prepare_ns(t.elapsed().as_nanos() as u64);
         exec_plane_popcount_order_with_bitmap(ctx, params, plane_expr, &bitmap)
     })
 }
@@ -6484,7 +6496,15 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
     let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
-    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
+    let out = run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None);
+    // Consume whatever `exec_plane_popcount_order` left in flight and publish it, so a harness can
+    // net the plane build out of a forced trial. Zero on the ROUTED path, which reaches this function
+    // directly with the acquire's bitmap and builds nothing — which is exactly the asymmetry being
+    // reported. Counters stay zero: this plan popcounts a bitmap and visits no cards, so it has
+    // nothing to report there and `plan_stats_never_leak_between_participants` still pins that.
+    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
+    PHASE_STATS.with(|c| c.set(PhaseStats { ns_prepare: prep_ns, ..PhaseStats::default() }));
+    out
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -7162,6 +7182,18 @@ fn timed_prepare_candidates(
 /// `PhaseStats::paging_taken` for why the predicted branch is not enough.
 fn note_paging_taken(which: PagingTaken) {
     PAGING_TAKEN.with(|c| c.set(which));
+}
+
+/// Hand a shared-artifact build time to the executor that follows, the same way
+/// `timed_prepare_candidates` does. Used by the plane path, whose artifact the router builds in
+/// acquire and a forced run has to rebuild; see `exec_plane_popcount_order`.
+fn note_pending_prepare_ns(ns: u64) {
+    debug_assert_eq!(
+        PENDING_PREPARE_NS.with(std::cell::Cell::get),
+        0,
+        "a previous shared-artifact build was not consumed by an executor; its time would be reported as this run's",
+    );
+    PENDING_PREPARE_NS.with(|c| c.set(ns));
 }
 
 /// Publish what a compose paging branch did, so `PrintingCompose` reports the same three quantities

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6597,15 +6597,17 @@ fn gather_composed_page<'a>(
     // `compose_scan_printings` is set to the composed bitmap's POPCOUNT, on the stated grounds that
     // compose "walks the set bits". This loop does not: except in the card/default-prefer arm it
     // iterates `start..end` of every candidate card and bit-tests each printing, so the real count is
-    // the SPAN of the candidate cards. Counted per arm below so the difference is measured rather
-    // than argued.
-    let mut work = ComposePageWork::default();
+    // the SPAN of the candidate cards.
+    //
+    // Only the span is accumulated. `cards_visited` is `candidate_cards.len()`, known before the loop
+    // starts, and `matches_pushed` is the total `GatherSelect` already computes and this function
+    // currently discards -- neither needs a per-iteration add.
+    let mut work = ComposePageWork { cards_visited: candidate_cards.len() as u64, ..Default::default() };
     for cid in candidate_cards {
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
-        work.cards_visited += 1;
         match mode {
             // Printing: every set printing is its own row (no grouping).
             Mode::Printing => {
@@ -6664,10 +6666,13 @@ fn gather_composed_page<'a>(
                 }
             }
         }
-        work.matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
-    let (_total, page_ids) = sel.finish(page_offset, limit); // total already known exactly via popcount; only the page is wanted here
+    // `total` is every match this branch pushed, which is what `matches_pushed` wants and what
+    // `GatherSelect` has been computing and this function discarding. The popcount already gave the
+    // caller the result total, hence the old `_total`.
+    let (total, page_ids) = sel.finish(page_offset, limit);
+    work.matches_pushed = total as u64;
     (page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect(), work)
 }
 
@@ -6989,6 +6994,23 @@ thread_local! {
     /// `take_phase_stats` reassembles the two into one `PhaseStats`, so consumers see no seam.
     static PAGING_TAKEN: std::cell::Cell<PagingTaken> = const { std::cell::Cell::new(PagingTaken::NotEntered) };
 
+    /// The compose fastpath's three counters, stored apart from `PHASE_STATS` for exactly the reason
+    /// `PAGING_TAKEN` is: this is the production compose path, and a whole-struct publish there is a
+    /// read-modify-write of ~80 bytes to report 24.
+    ///
+    /// Measured, because the first version did write the whole struct: a paired A/B against the same
+    /// build without it read `+1.4 µs` and `+3.1 µs` on a 129 µs mean (slower on 619 and 863 queries
+    /// of ~2,000), and neutralising every cost-model change left the regression in place — the
+    /// publish WAS the regression. The note on `PAGING_TAKEN` above had already said so.
+    ///
+    /// Safe to leave unwritten by the other executors for the same reason `PHASE_STATS` is safe:
+    /// `take_phase_stats` replaces this with the default, and `explain_analyze` takes before every
+    /// participant runs, so a plan that does not publish here reads zeros rather than the last
+    /// compose's numbers. Outside that window nothing reads it at all.
+    static COMPOSE_WORK: std::cell::Cell<ComposePageWork> = const { std::cell::Cell::new(ComposePageWork {
+        cards_visited: 0, printings_examined: 0, matches_pushed: 0,
+    }) };
+
     /// `prepare_candidates`' time for the run in progress, handed to the executor that follows it —
     /// the two are separate calls in `run_query_with_plan`, and only the executor publishes stats.
     ///
@@ -7029,32 +7051,16 @@ fn note_paging_taken(which: PagingTaken) {
     PAGING_TAKEN.with(|c| c.set(which));
 }
 
-/// Publish what a compose paging branch did into the shared counters, so `PrintingCompose` reports
-/// the same three quantities the two materializing plans do.
+/// Publish what a compose paging branch did, so `PrintingCompose` reports the same three quantities
+/// the two materializing plans do.
 ///
-/// A WHOLE-struct set, like the other two publishers: nothing here is inherited, so compose cannot
-/// report a field an earlier participant wrote. `paging_taken` survives because it lives in
-/// `PAGING_TAKEN`, which this does not touch -- the same split `PhaseStats` documents.
-///
-/// The phase timings stay zero. Compose's cost arm is not decomposed into setup/loop/finish the way
-/// the scan plans' is, so there is nothing yet to check them against, and publishing an
-/// unvalidatable number is how `printings_scanned` became load-bearing in the first place.
+/// A 24-byte store into `COMPOSE_WORK`, not a write of the whole `PhaseStats` — see that slot's doc
+/// for the measurement that forced the split. `take_phase_stats` merges the two, so consumers see no
+/// seam, and the phase timings stay zero: compose's arm is not decomposed into setup/loop/finish, so
+/// there is nothing to check them against, and publishing an unvalidatable number is how
+/// `printing_span` became load-bearing in the first place.
 fn publish_compose_work(work: ComposePageWork) {
-    PHASE_STATS.with(|c| {
-        c.set(PhaseStats {
-            cards_visited: work.cards_visited,
-            printing_span: 0, // compose never materializes a candidate list, so there is no span
-            printings_examined: work.printings_examined,
-            matches_pushed: work.matches_pushed,
-            ns_setup: 0,
-            ns_loop: 0,
-            ns_finish: 0,
-            ns_round_total: 0, // filled by explain_analyze, which owns the round timer
-            ns_prepare: 0,
-            result_total: 0, // likewise
-            paging_taken: PagingTaken::NotEntered, // owned by PAGING_TAKEN; take_phase_stats merges it in
-        });
-    });
+    COMPOSE_WORK.with(|c| c.set(work));
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a
@@ -7066,6 +7072,16 @@ fn publish_compose_work(work: ComposePageWork) {
 fn take_phase_stats() -> PhaseStats {
     let mut stats = PHASE_STATS.with(|c| c.replace(PhaseStats::default()));
     stats.paging_taken = PAGING_TAKEN.with(|c| c.replace(PagingTaken::NotEntered));
+    // Compose's counters live in their own slot; fold them in so a consumer cannot tell which
+    // executor wrote them. Only ONE of the two publishes per run -- a materializing executor writes
+    // `PHASE_STATS` and never `COMPOSE_WORK`, compose the reverse -- so this cannot double-count, and
+    // taking both together is what stops either leaking into the next participant.
+    let compose = COMPOSE_WORK.with(|c| c.replace(ComposePageWork::default()));
+    if compose.cards_visited | compose.printings_examined | compose.matches_pushed != 0 {
+        stats.cards_visited = compose.cards_visited;
+        stats.printings_examined = compose.printings_examined;
+        stats.matches_pushed = compose.matches_pushed;
+    }
     stats
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7775,7 +7775,17 @@ fn acquire_plan_features(
                 // count stays where it belongs -- `project` (the printing->artwork pass) and
                 // `scan_units` both walk printings, as `printing_span` confirms.
                 let n_artworks = u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize;
-                let rt = artwork_estimate(printing_matches, est_cards, n_cards as usize, n_artworks);
+                // The UNCALIBRATED card count feeds the artwork capacity on purpose.
+                // `COMPOSE_CARD_ESTIMATE_BIAS` was measured against `cards_visited` -- distinct CARDS
+                // -- and `artwork_estimate` does not consume a card count as an answer, it uses it to
+                // size a capacity (`est_cards * n_artworks/n_cards`) that a second balls-into-bins then
+                // draws into. Feeding the calibrated value shrank both stages and moved
+                // `matches <Gather> / artwork` from 0.97 to 0.84, i.e. it made an already-good cell
+                // worse. Under-charging compose's push term is what over-picks it, and compose is
+                // over-picked in artwork specifically: that slice carries 21% of ALL routing regret at
+                // p99 205us against 40us for printing and 36us for card.
+                let capacity_cards = exact_cards.map_or_else(|| balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
+                let rt = artwork_estimate(printing_matches, capacity_cards, n_cards as usize, n_artworks);
                 // The bitmap `printing_bits_to_artwork_bits` popcounts is n_artworks bits wide, not
                 // n_printings -- 46,112 against 97,206 here, so this was 2.1x over as well.
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4952,6 +4952,27 @@ fn printing_range_fastpath<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    // Timed as one span rather than split into setup/loop/finish. The three-phase split exists where
+    // an executor HAS three phases to attribute cost between; this one has a dozen structurally
+    // different exits (three of them producing a page) and no common shape across them. What the
+    // harnesses need is that the phase sum equals the executor's own time, and one span satisfies
+    // that exactly -- `ns_loop` is the honest bucket for "the work", with the other two zero.
+    //
+    // Only a run that PRODUCED a page publishes. A decline returns `None`, records no trial, and must
+    // leave the slot as `take_phase_stats` cleared it.
+    let t = std::time::Instant::now();
+    let out = printing_range_fastpath_inner(ctx, params, filter);
+    if out.is_some() {
+        PHASE_STATS.with(|c| c.set(PhaseStats { ns_loop: t.elapsed().as_nanos() as u64, ..PhaseStats::default() }));
+    }
+    out
+}
+
+fn printing_range_fastpath_inner<'a>(
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
+    filter: &FilterExpr,
+) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
     let QueryCtx { cards, printings, indexes, .. } = *ctx;
     let QueryParams { sort_col, descending, limit, page_offset, .. } = *params;
     let Some((idx, lo, hi)) = bare_range_bounds(filter, indexes) else {
@@ -5734,6 +5755,14 @@ struct ComposePageWork {
     /// Rows the branch pushed. For the gather this is every match (it visits every candidate); for
     /// the two walks it is bounded by the page, which is the whole point of their cost shape.
     matches_pushed: u64,
+    /// The whole fastpath's wall time, merged into `ns_loop` by `take_phase_stats`.
+    ///
+    /// One span, not three. Compose's arm is not decomposed into setup/loop/finish -- it is a build
+    /// plus one of three structurally different paging branches -- so there is nothing to attribute
+    /// between phases. What the harnesses need is that the phase sum equals the executor's own time,
+    /// and one span gives that. Carried here rather than written to `PHASE_STATS` separately so the
+    /// production compose path still pays ONE store; see this slot's doc for what that cost.
+    ns_total: u64,
 }
 
 fn collect_orderby_page<'a>(
@@ -5791,6 +5820,8 @@ fn collect_orderby_page<'a>(
         cards_visited: 0,
         printings_examined: scanned,
         matches_pushed: collected.len() as u64,
+        // Filled by `printing_compose_fastpath`, which owns the span; this helper only reports work.
+        ns_total: 0,
     };
     let matches: Vec<Match> = collected
         .iter()
@@ -5932,6 +5963,9 @@ fn printing_compose_fastpath<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    // Ends at whichever exit produces a page; see `ComposePageWork::ns_total`. Declines return before
+    // any publish and so leave the slot as `take_phase_stats` cleared it.
+    let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, sort_col, descending, limit, page_offset, .. } = *params;
     if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
@@ -5979,10 +6013,10 @@ fn printing_compose_fastpath<'a>(
     };
     if total == 0 || page_offset >= total {
         note_paging_taken(PagingTaken::EmptyPage);
-        publish_compose_work(ComposePageWork::default());
+        publish_compose_work(ComposePageWork { ns_total: t_start.elapsed().as_nanos() as u64, ..Default::default() });
         return Some((total, Vec::new()));
     }
-    let (page, work) = match perm {
+    let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
@@ -6032,6 +6066,7 @@ fn printing_compose_fastpath<'a>(
             }
         }
     };
+    work.ns_total = t_start.elapsed().as_nanos() as u64;
     publish_compose_work(work);
     Some((total, page))
 }
@@ -6496,15 +6531,10 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
     let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
-    let out = run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None);
-    // Consume whatever `exec_plane_popcount_order` left in flight and publish it, so a harness can
-    // net the plane build out of a forced trial. Zero on the ROUTED path, which reaches this function
-    // directly with the acquire's bitmap and builds nothing — which is exactly the asymmetry being
-    // reported. Counters stay zero: this plan popcounts a bitmap and visits no cards, so it has
-    // nothing to report there and `plan_stats_never_leak_between_participants` still pins that.
-    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
-    PHASE_STATS.with(|c| c.set(PhaseStats { ns_prepare: prep_ns, ..PhaseStats::default() }));
-    out
+    // `run_query_streamed_popcount` publishes the phases and consumes the pending plane build; see
+    // `publish_popcount_phases`. Counters stay zero: this plan popcounts a bitmap and visits no
+    // cards, so it has nothing to report there.
+    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -7130,7 +7160,7 @@ thread_local! {
     /// participant runs, so a plan that does not publish here reads zeros rather than the last
     /// compose's numbers. Outside that window nothing reads it at all.
     static COMPOSE_WORK: std::cell::Cell<ComposePageWork> = const { std::cell::Cell::new(ComposePageWork {
-        cards_visited: 0, printings_examined: 0, matches_pushed: 0,
+        cards_visited: 0, printings_examined: 0, matches_pushed: 0, ns_total: 0,
     }) };
 
     /// The routed path's disjoint phase split — see `RoutedPhases`. Its own slot for the same reason
@@ -7222,10 +7252,13 @@ fn take_phase_stats() -> PhaseStats {
     // `PHASE_STATS` and never `COMPOSE_WORK`, compose the reverse -- so this cannot double-count, and
     // taking both together is what stops either leaking into the next participant.
     let compose = COMPOSE_WORK.with(|c| c.replace(ComposePageWork::default()));
-    if compose.cards_visited | compose.printings_examined | compose.matches_pushed != 0 {
+    if compose.cards_visited | compose.printings_examined | compose.matches_pushed | compose.ns_total != 0 {
         stats.cards_visited = compose.cards_visited;
         stats.printings_examined = compose.printings_examined;
         stats.matches_pushed = compose.matches_pushed;
+        // Compose reports one undivided span; `ns_loop` is where it belongs so the phase sum equals
+        // the executor's time. See `ComposePageWork::ns_total`.
+        stats.ns_loop = compose.ns_total;
     }
     stats
 }
@@ -8059,8 +8092,13 @@ fn run_query_routed<'a>(
         //   - a materializing plan (StreamedSelect/GatheredScan) that beat them narrows + runs.
         (PhysicalPlan::CardRangePopcount, Prep::Range(_)) => {
             let (idx, lo, hi) = bare_range_bounds(filter, ctx.indexes).expect("applicable ⇒ bare range");
+            // Timed and handed to the executor as `ns_prepare`: this build happens in DISPATCH on
+            // both paths, so it belongs to the plan's cost, and `card_range_popcount` being a
+            // RANGE_ACQUIRE is what tells `plan_self_ns` to add it rather than exclude it.
+            let t_build = std::time::Instant::now();
             let (card_bits, range_pbits) =
                 build_card_range_bits(idx, lo, hi, ctx.indexes, ctx.cards.len(), ctx.printings.len());
+            note_pending_prepare_ns(t_build.elapsed().as_nanos() as u64);
             exec_card_range_popcount(ctx, params, &card_bits, &range_pbits)
         }
         (plan, Prep::Range(_)) => {
@@ -8130,7 +8168,11 @@ fn run_query_with_plan<'a>(
                 return None;
             }
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicability guarantees a bare range");
+            // Timed exactly as the routed path times it, so a forced trial and dispatch contain the
+            // same work; see the routed call site.
+            let t_build = std::time::Instant::now();
             let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), ctx.printings.len());
+            note_pending_prepare_ns(t_build.elapsed().as_nanos() as u64);
             Some(exec_card_range_popcount(ctx, params, &card_bits, &range_pbits))
         }
         PhysicalPlan::StreamedSelect => {
@@ -8614,12 +8656,20 @@ fn run_query_streamed_popcount<'a>(
     plane: Option<&PlaneExpr>,
     range_bits: Option<&[u64]>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    // First of the three phase boundaries, same convention as `run_query_streamed`: everything to the
+    // skip scan is `ns_setup` (here the total popcount plus the permuted scatter), the skip scan is
+    // `ns_loop`, the emit walk is `ns_finish`. Shared by BOTH popcount plans, so instrumenting here
+    // covers `PlanePopcountOrder` and `CardRangePopcount` at once.
+    let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { prefer, limit, page_offset, .. } = *params;
     let planes = &indexes.planes;
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
     if total == 0 || page_offset >= total {
+        // Still publishes: an empty page is real work (the popcount) and a plan that ran must report
+        // a cost, or a consumer reading the phases as the executor's time gets zero for a real run.
+        publish_popcount_phases(t_start.elapsed().as_nanos() as u64, 0, 0);
         return (total, Vec::new());
     }
 
@@ -8643,6 +8693,9 @@ fn run_query_streamed_popcount<'a>(
                 permuted[pos / 64] |= 1u64 << (pos % 64);
             }
         }
+
+        // Ends `ns_setup` (popcount + scatter) and starts `ns_loop`.
+        let t_loop = std::time::Instant::now();
 
         // Skip: accumulate word popcounts until the boundary word containing
         // page_offset — 64 cards per word read, deep pagination is a
@@ -8672,6 +8725,8 @@ fn run_query_streamed_popcount<'a>(
         // even then: bounded by `limit` emitted cards, not the candidate set,
         // and only pays the extra check at all for legality-touching planes.
         let existential = plane.is_some_and(plane_expr_is_existential);
+        // Ends `ns_loop` (the skip scan) and starts `ns_finish` (the emit walk).
+        let t_finish = std::time::Instant::now();
         let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
         'walk: while word_idx < permuted.len() {
             let mut w = permuted[word_idx];
@@ -8723,8 +8778,25 @@ fn run_query_streamed_popcount<'a>(
             }
             word_idx += 1;
         }
+        publish_popcount_phases(
+            (t_loop - t_start).as_nanos() as u64,
+            (t_finish - t_loop).as_nanos() as u64,
+            t_finish.elapsed().as_nanos() as u64,
+        );
         (total, page)
     })
+}
+
+/// Publish the popcount executor's three phases, consuming whatever build its caller handed over.
+///
+/// The pending value differs per plan and the `RANGE_ACQUIRES` rule is what makes both correct:
+/// `PlanePopcountOrder`'s plane eval is built during ACQUIRE on the routed path (so a forced run's
+/// rebuild must not count toward dispatch, and `plane` is not a range acquire), while
+/// `CardRangePopcount`'s bitmap is built in DISPATCH on both paths (so it must count, and
+/// `card_range_popcount` IS a range acquire). Same handoff, opposite treatment, both from one rule.
+fn publish_popcount_phases(ns_setup: u64, ns_loop: u64, ns_finish: u64) {
+    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
+    PHASE_STATS.with(|c| c.set(PhaseStats { ns_setup, ns_loop, ns_finish, ns_prepare: prep_ns, ..PhaseStats::default() }));
 }
 
 /// Streamed selection: match phase records per-card match counts (total is

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5610,6 +5610,108 @@ fn orderby_walk_available(sort_col: SortCol) -> bool {
 /// every match lives in the buckets (`collected` reaches `total`, no null tail), a short last page is
 /// windowed normally.
 #[allow(clippy::too_many_arguments)]
+/// The routed path's time, split into DISJOINT phases that cover all of `run_query_routed`.
+///
+/// Everything else here measures one participant at a time and cannot be added up. `acquire_ns` is
+/// timed in its own `explain_analyze` round — a standalone `acquire_plan_features` call with its own
+/// cache state — while `routed_ns` times a SEPARATE execution that does its own acquire inside. They
+/// are two independent measurements of overlapping work, not a part and a whole, which is why
+/// `acquire_ns / routed_ns` measured a nonsensical 104% at the median on candidate-acquired queries.
+///
+/// These three are read from ONE execution with four contiguous clock reads, so
+/// `ns_acquire + ns_choose + ns_dispatch` accounts for the whole call bar the reads themselves. The
+/// same shape `PhaseStats` uses for setup/loop/finish, one level up — and those three subdivide
+/// `ns_dispatch`, together with `ns_prepare`, so the two nest rather than overlap.
+///
+/// Why it is worth four clock reads on the production path: `plan_cost` prices only what happens
+/// AFTER acquire, so acquire is unpriced for every plan, and cost.rs records the model's median error
+/// as 1.09x `acquire_ns`. Acquire is the largest unmodelled component in the engine and nothing has
+/// ever measured it as a fraction of the query it belongs to.
+/// Behind the `routed-phases` cargo feature, and the reason is measured rather than cautious: the
+/// four clock reads cost +2.7us and +2.3us on a ~40us median query in a paired interleaved A/B, both
+/// intervals excluding zero. That is ~1.6% of every request to answer a question a diagnostic build
+/// can answer instead — the same trade `alloc-counter` already makes.
+///
+/// With the feature off, `RoutedPhaseTimer` is a zero-sized struct whose methods are empty, so the
+/// reads and the publish compile away entirely.
+#[derive(Default, Clone, Copy)]
+struct RoutedPhases {
+    /// `acquire_plan_features`: count source, feature build, and whatever artifact it materializes.
+    ns_acquire: u64,
+    /// The `argmin cost::plan_cost` over applicable plans. Expected to be negligible; measured so
+    /// that "expected" is not doing the work — it comes out at 41ns, 0.0% of the query.
+    ns_choose: u64,
+    /// Running the winner, including a lazy re-materialize and re-choose when a fastpath declines.
+    ns_dispatch: u64,
+}
+
+/// Marks the three phase boundaries in `run_query_routed`, or nothing at all when the
+/// `routed-phases` feature is off. See `RoutedPhases`.
+#[cfg(feature = "routed-phases")]
+struct RoutedPhaseTimer {
+    entry: std::time::Instant,
+    acquired: Option<std::time::Instant>,
+    chosen: Option<std::time::Instant>,
+}
+
+#[cfg(feature = "routed-phases")]
+impl RoutedPhaseTimer {
+    fn start() -> Self {
+        Self { entry: std::time::Instant::now(), acquired: None, chosen: None }
+    }
+    fn acquired(&mut self) {
+        self.acquired = Some(std::time::Instant::now());
+    }
+    fn chosen(&mut self) {
+        self.chosen = Some(std::time::Instant::now());
+    }
+    /// Publishes the three disjoint spans. A boundary that was never marked collapses to the entry
+    /// instant, which cannot happen on the one path that exists but keeps this total.
+    fn finish(self) {
+        let done = std::time::Instant::now();
+        let acquired = self.acquired.unwrap_or(self.entry);
+        let chosen = self.chosen.unwrap_or(acquired);
+        ROUTED_PHASES.with(|c| {
+            c.set(RoutedPhases {
+                ns_acquire: (acquired - self.entry).as_nanos() as u64,
+                ns_choose: (chosen - acquired).as_nanos() as u64,
+                ns_dispatch: (done - chosen).as_nanos() as u64,
+            });
+        });
+    }
+}
+
+#[cfg(not(feature = "routed-phases"))]
+struct RoutedPhaseTimer;
+
+#[cfg(not(feature = "routed-phases"))]
+impl RoutedPhaseTimer {
+    #[inline(always)]
+    fn start() -> Self {
+        Self
+    }
+    #[inline(always)]
+    fn acquired(&mut self) {}
+    #[inline(always)]
+    fn chosen(&mut self) {}
+    #[inline(always)]
+    fn finish(self) {}
+}
+
+/// The last routed execution's phase split, cleared. All zeros without the `routed-phases` feature,
+/// which is what `explain_analyze` then reports — a consumer sees three empty-looking spans rather
+/// than a missing key, so the schema does not change with the feature.
+fn take_routed_phases() -> RoutedPhases {
+    #[cfg(feature = "routed-phases")]
+    {
+        ROUTED_PHASES.with(|c| c.replace(RoutedPhases::default()))
+    }
+    #[cfg(not(feature = "routed-phases"))]
+    {
+        RoutedPhases::default()
+    }
+}
+
 /// What a compose paging branch actually did, against the three quantities its cost arm charges.
 ///
 /// `PrintingCompose` published no executor counters at all until this existed, which made it the one
@@ -7011,6 +7113,17 @@ thread_local! {
         cards_visited: 0, printings_examined: 0, matches_pushed: 0,
     }) };
 
+    /// The routed path's disjoint phase split — see `RoutedPhases`. Its own slot for the same reason
+    /// the two above have theirs: `run_query_routed` is the production entry point, and one 24-byte
+    /// store there is affordable where a read-modify-write of `PhaseStats` measurably was not.
+    ///
+    /// Written by `run_query_routed` only, so it never collides with the executors' slot; the routed
+    /// path's dispatch phase CONTAINS an executor publish into `PHASE_STATS`, and the two nest.
+    #[cfg(feature = "routed-phases")]
+    static ROUTED_PHASES: std::cell::Cell<RoutedPhases> = const { std::cell::Cell::new(RoutedPhases {
+        ns_acquire: 0, ns_choose: 0, ns_dispatch: 0,
+    }) };
+
     /// `prepare_candidates`' time for the run in progress, handed to the executor that follows it —
     /// the two are separate calls in `run_query_with_plan`, and only the executor publishes stats.
     ///
@@ -7873,14 +7986,24 @@ fn run_query_routed<'a>(
             .expect("GatheredScan is always applicable and materializing")
     };
 
+    // Marks three disjoint phases covering the whole call — see `RoutedPhases` for why acquire needed
+    // measuring from inside one execution rather than as its own `explain_analyze` participant, and
+    // why it is behind a feature. Compiles to nothing without `routed-phases`.
+    let mut phases = RoutedPhaseTimer::start();
+
     // ── acquire: pick the count source, build features, materialize its artifact ──
     let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    phases.acquired();
 
     // ── choose: cheapest applicable plan ──
     let plan = choose(filter, &feats, false);
+    phases.chosen();
 
     // ── dispatch: run the winner, reusing the acquired artifact ──
-    match (plan, &prep) {
+    // Bound, not returned directly, so the closing clock read happens before the result is handed
+    // back and the phase covers dispatch alone. The match has no early returns, so this one exit is
+    // the only place the phases can be published from.
+    let out = match (plan, &prep) {
         (PhysicalPlan::PlanePopcountOrder, Prep::Plane) => {
             exec_plane_popcount_order_with_bitmap(ctx, params, plane.expect("Prep::Plane ⇒ plane"), &plane_bits)
         }
@@ -7924,7 +8047,9 @@ fn run_query_routed<'a>(
                 }
             }
         }
-    }
+    };
+    phases.finish();
+    out
 }
 
 /// In-process force/dispatch entry point (#702 step 2): run `plan` for this
@@ -8088,6 +8213,17 @@ pub(crate) struct AcquireFacts {
     /// into the picked plan's executor, so a fixed position ahead of the plans would pre-warm
     /// exactly the plan whose selection the comparison is meant to question.
     pub(crate) routed_ns: Vec<u64>,
+    /// `routed_ns` split into disjoint phases, one triple per round, from INSIDE the same execution —
+    /// see `RoutedPhases`. `routed_acquire_ns[i] + routed_choose_ns[i] + routed_dispatch_ns[i]`
+    /// accounts for `routed_ns[i]` bar the clock reads.
+    ///
+    /// Not the same quantity as `acquire_ns`, and the difference is the point. That one times a
+    /// standalone `acquire_plan_features` in its own participant round, so it can be compared across
+    /// queries but cannot be divided into `routed_ns` — measured, the ratio comes out at 104% of the
+    /// median candidate-acquired query, which is how the two got read as a part and a whole.
+    pub(crate) routed_acquire_ns: Vec<u64>,
+    pub(crate) routed_choose_ns: Vec<u64>,
+    pub(crate) routed_dispatch_ns: Vec<u64>,
 }
 
 impl Prep {
@@ -8131,6 +8267,9 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
         feats, // moved: `eval_domain`/`n_cards`/`matches` live here and nowhere else
         acquire_ns: vec![acquire_ns],
         routed_ns: Vec::new(), // explain runs nothing
+        routed_acquire_ns: Vec::new(),
+        routed_choose_ns: Vec::new(),
+        routed_dispatch_ns: Vec::new(),
     };
     let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
         .into_iter()
@@ -8359,7 +8498,16 @@ fn explain_analyze(
             }
             match participant {
                 Participant::Acquire => facts.acquire_ns.push(dt),
-                Participant::Routed => facts.routed_ns.push(dt),
+                Participant::Routed => {
+                    facts.routed_ns.push(dt);
+                    // Taken from the slot `run_query_routed` just wrote, in the same round, so the
+                    // three sum to `dt`. Replaced with the default so a later participant that does
+                    // not publish here cannot report this round as its own.
+                    let ph = take_routed_phases();
+                    facts.routed_acquire_ns.push(ph.ns_acquire);
+                    facts.routed_choose_ns.push(ph.ns_choose);
+                    facts.routed_dispatch_ns.push(ph.ns_dispatch);
+                }
                 // A structurally-applicable plan's fastpath can still decline at runtime
                 // (e.g. PrintingCompose on a sparse total) — deterministic for this
                 // query/data, so a decliner simply never accumulates trials.
@@ -9037,6 +9185,9 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
     d.set_item("narrowed_repr", f.narrowed_repr.label())?;
     d.set_item("acquire_ns", f.acquire_ns.clone())?;
     d.set_item("routed_ns", f.routed_ns.clone())?;
+    d.set_item("routed_acquire_ns", f.routed_acquire_ns.clone())?;
+    d.set_item("routed_choose_ns", f.routed_choose_ns.clone())?;
+    d.set_item("routed_dispatch_ns", f.routed_dispatch_ns.clone())?;
     // The model's own inputs, so a calibration fit regresses on the same vector `plan_cost` reads.
     let g = &f.feats;
     for (k, v) in [

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5635,7 +5635,7 @@ struct ComposePageWork {
 }
 
 fn collect_orderby_page<'a>(
-    mut next_bucket: impl FnMut() -> Option<Vec<u32>>,
+    mut next_bucket: impl FnMut() -> Option<(u64, Vec<u32>)>,
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
     printing_to_card: &AOffsets,
@@ -5650,8 +5650,15 @@ fn collect_orderby_page<'a>(
     let mut cum = 0usize; // matches seen (skipped + collected) so far
     let mut first_touched = 0usize; // matches before the first collected bucket (the offset skip)
     let mut started = false;
+    // The work this walk really does, which is NOT `cum`. A bucket is produced by scanning a raw
+    // structure and intersecting it with `pbits`: a rarity PLANE bucket ANDs `words_per_plane` words
+    // (~n_printings/64) however few matches come out, a postings bucket walks its list, a range
+    // bucket walks its value run. `cum` counts what SURVIVED that scan, so pricing the walk on it
+    // charges nothing for a bucket that scanned the whole corpus and matched twice.
+    let mut scanned = 0u64;
     while cum < want {
-        let Some(bucket) = next_bucket() else { break };
+        let Some((raw, bucket)) = next_bucket() else { break };
+        scanned += raw;
         let m = bucket.len();
         if m == 0 {
             continue;
@@ -5674,13 +5681,13 @@ fn collect_orderby_page<'a>(
     if cum < want && cum < total {
         return None;
     }
-    // `cum` is what this branch stepped over to fill the page: matches seen, skipped and collected
-    // alike. That is the quantity `cost::printings_walked` predicts as `page_span / match_rate`, and
-    // until now nothing checked it. `cards_visited` stays 0 -- this walk steps a value structure and
-    // never iterates cards.
+    // `printings_examined` is the RAW units scanned, not `cum`: see `scanned`. `cost::printings_walked`
+    // predicts `page_span / match_rate`, a page-fill length in match units, which does not describe a
+    // bucket scan at all -- one rarity plane bucket costs the same whether it yields two matches or
+    // twenty thousand. `cards_visited` stays 0: this walk steps a value structure, never cards.
     let work = ComposePageWork {
         cards_visited: 0,
-        printings_examined: cum as u64,
+        printings_examined: scanned,
         matches_pushed: collected.len() as u64,
     };
     let matches: Vec<Match> = collected
@@ -5723,7 +5730,7 @@ fn walk_range_orderby_page<'a>(
 ) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let (mut lo, mut hi) = (0usize, idx.len());
-    let next = move || -> Option<Vec<u32>> {
+    let next = move || -> Option<(u64, Vec<u32>)> {
         if lo >= hi {
             return None;
         }
@@ -5743,7 +5750,8 @@ fn walk_range_orderby_page<'a>(
             (lo, b)
         };
         if descending { hi = bs } else { lo = be }
-        Some((bs..be).map(|t| u32::from(idx[t].1)).filter(|&pid| is_set(pid as usize)).collect())
+        // The value run is scanned in full and bit-tested per entry; `be - bs` is that cost.
+        Some(((be - bs) as u64, (bs..be).map(|t| u32::from(idx[t].1)).filter(|&pid| is_set(pid as usize)).collect()))
     };
     collect_orderby_page(next, cards, printings, printing_to_card, sort_col, descending, total, limit, page_offset)
 }
@@ -5776,10 +5784,13 @@ fn walk_rarity_orderby_page<'a>(
     }
     let wpp = words_per_plane(n_printings);
     let mut vi = 0usize;
-    let next = move || -> Option<Vec<u32>> {
+    let next = move || -> Option<(u64, Vec<u32>)> {
         let int = *values.get(vi)?;
         vi += 1;
-        let pids: Vec<u32> = if let Some(k) = RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == int) {
+        // `raw` is what the bucket cost to produce, which the two kinds pay very differently: a plane
+        // bucket ANDs `wpp` words of the whole corpus however few matches survive, while a postings
+        // bucket walks only its own list. Counted in the same units the caller sums.
+        let (raw, pids): (u64, Vec<u32>) = if let Some(k) = RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == int) {
             let plane = &rp.words[k * wpp..(k + 1) * wpp];
             let mut out = Vec::new();
             for (wi, (pw, bw)) in plane.iter().zip(pbits.iter()).enumerate() {
@@ -5789,14 +5800,20 @@ fn walk_rarity_orderby_page<'a>(
                     w &= w - 1;
                 }
             }
-            out
+            // One word covers 64 printings, so report the printings covered rather than the word
+            // count -- that keeps this comparable to the entry-scanning buckets and to a feature
+            // measured in printings.
+            ((wpp * 64) as u64, out)
         } else {
             match rp.postings.iter().find(|e| e.0 == int) {
-                Some(e) => e.1.iter().map(|p| u32::from(*p)).filter(|&pid| pbits[pid as usize >> 6] & (1u64 << (pid & 63)) != 0).collect(),
-                None => Vec::new(),
+                Some(e) => (
+                    e.1.len() as u64,
+                    e.1.iter().map(|p| u32::from(*p)).filter(|&pid| pbits[pid as usize >> 6] & (1u64 << (pid & 63)) != 0).collect(),
+                ),
+                None => (0, Vec::new()),
             }
         };
-        Some(pids)
+        Some((raw, pids))
     };
     collect_orderby_page(next, cards, printings, printing_to_card, SortCol::Rarity, descending, total, limit, page_offset)
 }
@@ -7308,6 +7325,68 @@ fn declined_sibling_fastpath<'a>(
 /// `domain * (1 - e^(-k/domain))`. Unlike `k.min(domain)` this does not saturate -- `cn<100` (35,021
 /// printings) and `usd<50` (80,527) both cap to exactly 31,508 against true counts of 17,616 and
 /// 31,217, losing the entire signal between them.
+/// How much `balls_into_bins` over-states compose's distinct-card count, measured against
+/// `cards_visited` once `PrintingCompose` began reporting it.
+///
+/// The model assumes each matching printing lands in an independently chosen card. Compose's
+/// predicates are CLUSTERED instead -- a legality leaf broadcast down sets every printing of a
+/// matching card at once -- so the same `k` printings touch far fewer cards than independence
+/// predicts. Over 1,036 measured gather rows the raw estimator reads a median **1.73x** the truth.
+///
+/// A calibration constant and not a better model, deliberately: a size-biased estimator over the
+/// corpus's span histogram (`P(hit) = 1-(1-p)^s` per span-`s` card, which is the principled fix for
+/// treating every card as one equally likely bin) was tried and scored NO better -- log error 0.512
+/// against 0.513 -- because the failing assumption is independence, not uniform bins, and a
+/// size-biased model is still an independence model. Per-slice constants keyed on
+/// broadcast/range were also tried and added nothing once the exact rows below were separated out
+/// (test log error 0.439 against 0.438).
+///
+/// Fit on 1,036 rows, scored on a held-out 1,047: test log error 0.678 -> 0.438, median 1.73 -> 0.98,
+/// spread unchanged at 3.6. Spread is what a constant cannot fix, and it is what remains.
+///
+/// NOT applied where `range_card_counts_for` answers exactly -- those rows measure 1.000 with log
+/// error 0.056 and dividing them by anything would break them. That mixture is why the bias looked
+/// like 1.35 before the two populations were separated.
+const COMPOSE_CARD_ESTIMATE_BIAS: f64 = 1.78;
+
+/// Printings the gather BIT-TESTS per matching printing.
+///
+/// `compose_scan_printings` was the composed bitmap's popcount, on the stated grounds that compose
+/// "walks the set bits". `gather_composed_page` does not: except in its card/default-prefer arm it
+/// iterates `start..end` of every candidate card and tests each printing, so the real count is the
+/// SPAN of the candidate cards. Measured against `printings_examined`, the popcount reads a median
+/// 0.68 of the truth -- the gather tests 1.47 printings for every one that is set.
+///
+/// A single constant, unlike the card estimate's: per-slice constants keyed on broadcast/range were
+/// tried and made the held-out SPREAD worse (14.8 against 9.2) for a log-error gain of 0.005, which
+/// is overfitting four numbers to a mixture. Test log error 0.845 -> 0.700, median 0.66 -> 0.97.
+///
+/// The alternative is to make the feature true by changing the executor -- walking set bits, as the
+/// old comment claimed. Measured ceiling for that: bit tests on non-set printings are 11% of the
+/// gather's modelled page cost (`card_pass` is 60%, `push` 26%), so it is a constant-factor
+/// optimisation of one branch, not a model change. Left as a separate question.
+const COMPOSE_GATHER_SPAN_PER_MATCH: f64 = 1.47;
+
+/// How much bigger the candidate cards on a compose acquire are than an average card.
+///
+/// `scan_all` projects a card count into printings with the corpus mean (`printings_per_card`,
+/// 3.09). That is right when the candidates are a fair sample of the corpus and wrong here: a
+/// composable predicate selects cards by having a matching PRINTING, so heavily-reprinted cards are
+/// over-represented — the same size bias that makes compose's own gather test 13.2 printings per
+/// candidate card against a corpus mean of 3.09.
+///
+/// This multiplier is on `scan_units`, which costs the MATERIALIZING alternatives should compose
+/// lose, so it is a routing input even though compose never reads it. Calibrating the card estimate
+/// exposed it: `scan_units [printing_compose]` had been reading 0.75 with the two errors partly
+/// cancelling, and dividing `est_cards` by 1.78 moved it to 0.47.
+const COMPOSE_CANDIDATE_SPAN_BIAS: f64 = 2.1;
+
+/// `balls_into_bins` with its measured bias divided out. See `COMPOSE_CARD_ESTIMATE_BIAS`.
+fn calibrated_balls_into_bins(k: usize, domain: usize) -> usize {
+    let raw = balls_into_bins(k, domain) as f64;
+    ((raw / COMPOSE_CARD_ESTIMATE_BIAS).round() as usize).max(usize::from(k > 0))
+}
+
 fn balls_into_bins(k: usize, domain: usize) -> usize {
     if domain == 0 {
         return 0;
@@ -7446,6 +7525,7 @@ fn mk_plan_feats(
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
         compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
+        orderby_walk_scan: 0,      // only the compose branch, and only for a plane-bucket orderby walk
     }
 }
 
@@ -7604,11 +7684,23 @@ fn acquire_plan_features(
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::CardRangePopcount))
     } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
-        // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
-        // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
+        // Bare range: exact k from the index (no scan).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
+        // What the MATERIALIZING alternatives see, by the same test the sibling `CardRangePopcount`
+        // branch already applies: `range_narrowed` hands back an enumerable printing list only while
+        // the slice stays under `MAX_NARROW_FRACTION`, and degrades to a printing-space bitmap past
+        // it, which cannot yield card ids so the scan walks the whole corpus.
+        //
+        // This branch used to assume the degraded case ALWAYS, on the grounds that a narrow range
+        // makes P1 lose and dispatch materializes anyway. The sibling's comment went further and
+        // claimed the two "agree to within 1%". They agree at the MEDIAN and nowhere else: measured
+        // against `cards_visited`, `eval_domain` here reads 1.00 at p50 but 4.23 at p70 and 41.7 at
+        // p90, because a third of these queries do narrow. (The p100 of 315 is the harness's
+        // MIN_COUNTER floor, not the real maximum -- 31,508/100.)
+        let (eval_domain, scan_units) =
+            if range_too_broad_to_narrow(k as usize, idx.len()) { (n_cards, n_printings) } else { (k.min(n_cards), k) };
+        let mut feats = mk_plan_feats(ctx, params, k, eval_domain, scan_units, verify_cost_tier(filter));
         feats.compose_scan_printings = k;
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
         // Also for costing that competing compose: `eval_domain`/`scan_units` above are the
@@ -7639,7 +7731,8 @@ fn acquire_plan_features(
         // every artwork-mode one, plus card-mode ones whose orderby has no permutation.
         let exact_cards = bare_range_bounds(filter, indexes)
             .and_then(|(idx, lo, hi)| range_card_counts_for(indexes, idx).and_then(|counts| counts.distinct_cards(lo, hi)));
-        let est_cards = exact_cards.map_or_else(|| balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
+        let est_cards =
+            exact_cards.map_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
         // What the MATERIALIZING alternatives scan if compose loses. Every mode narrows -- a
         // composable filter has an index for every leaf -- so all three are the NARROWED counts.
         // Printing mode took the unnarrowed universe while card/artwork took a narrowed count; only
@@ -7647,7 +7740,7 @@ fn acquire_plan_features(
         // `eval_domain` and scanned 0.14x the claimed `scan_units`. Over-costing both plans inflates
         // the predicted GAP between them (P4 carries the larger per-row rates), which is what routing
         // reads -- measured as a GatheredScan-vs-StreamedSelect gap ratio of 0.32 on this acquire.
-        let scan_all = |cards: usize| ((cards as f64) * printings_per_card) as usize;
+        let scan_all = |cards: usize| ((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize;
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
             Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
             Mode::Card => {
@@ -7677,7 +7770,11 @@ fn acquire_plan_features(
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
-        feats.compose_scan_printings = printing_matches as u32;
+        feats.compose_scan_printings = (printing_matches as f64 * COMPOSE_GATHER_SPAN_PER_MATCH) as u32;
+        // A rarity orderby walk pays a whole one-hot plane per bucket, so its floor is the corpus
+        // however selective the filter is. `usd` walks small value runs instead and keeps the shared
+        // page-fill term. See `PlanFeatures::orderby_walk_scan`.
+        feats.orderby_walk_scan = if matches!(sort_col, SortCol::Rarity) { n_printings } else { 0 };
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
         // itself decides, through the same helpers, including whether it will decline. Only this
         // branch knows the estimated result total, so only it can predict the small-total bail. The
@@ -8920,6 +9017,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
         ("compose_scan_printings", g.compose_scan_printings),
+        ("orderby_walk_scan", g.orderby_walk_scan),
         // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk
         // paging branches are priced entirely on it and nothing else can check them.
         ("printings_walked", cost::printings_walked(g) as u32),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5610,6 +5610,30 @@ fn orderby_walk_available(sort_col: SortCol) -> bool {
 /// every match lives in the buckets (`collected` reaches `total`, no null tail), a short last page is
 /// windowed normally.
 #[allow(clippy::too_many_arguments)]
+/// What a compose paging branch actually did, against the three quantities its cost arm charges.
+///
+/// `PrintingCompose` published no executor counters at all until this existed, which made it the one
+/// plan `bench_feature_accuracy.py` could say nothing about -- every cell labelled with a compose
+/// ACQUIRE was really measuring how well compose's shared feature vector described GatheredScan and
+/// StreamedSelect, the plans that do report. Its own arm terms (`compose_scan_printings`,
+/// `printings_walked`) were graded against nothing, and its paging table was structurally empty at
+/// any sample size. That matters more than the gap in coverage suggests: compose carries ~75% of all
+/// routing regret (docs/issues/reference-cost-model-measurement.md).
+///
+/// The three branches do different work and each fills these differently -- see the doc on each.
+#[derive(Default, Clone, Copy)]
+struct ComposePageWork {
+    /// Cards the branch iterated: candidate cards for the gather, permutation entries consumed for
+    /// the forward walk, `0` for the orderby walk (it steps a value structure, not cards).
+    cards_visited: u64,
+    /// Printings the branch touched: `pbits` membership tests for the gather and the forward walk,
+    /// matches stepped over for the orderby walk.
+    printings_examined: u64,
+    /// Rows the branch pushed. For the gather this is every match (it visits every candidate); for
+    /// the two walks it is bounded by the page, which is the whole point of their cost shape.
+    matches_pushed: u64,
+}
+
 fn collect_orderby_page<'a>(
     mut next_bucket: impl FnMut() -> Option<Vec<u32>>,
     cards: &'a [AOracleCard],
@@ -5620,7 +5644,7 @@ fn collect_orderby_page<'a>(
     total: usize,
     limit: usize,
     page_offset: usize,
-) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let want = page_offset + limit;
     let mut collected: Vec<u32> = Vec::new();
     let mut cum = 0usize; // matches seen (skipped + collected) so far
@@ -5650,6 +5674,15 @@ fn collect_orderby_page<'a>(
     if cum < want && cum < total {
         return None;
     }
+    // `cum` is what this branch stepped over to fill the page: matches seen, skipped and collected
+    // alike. That is the quantity `cost::printings_walked` predicts as `page_span / match_rate`, and
+    // until now nothing checked it. `cards_visited` stays 0 -- this walk steps a value structure and
+    // never iterates cards.
+    let work = ComposePageWork {
+        cards_visited: 0,
+        printings_examined: cum as u64,
+        matches_pushed: collected.len() as u64,
+    };
     let matches: Vec<Match> = collected
         .iter()
         .map(|&pid| {
@@ -5661,12 +5694,13 @@ fn collect_orderby_page<'a>(
     // of matches, so the `O(n log n)` sort's log factor is the dominant cost there — `select_page`
     // (same `page_cmp` comparator) is `O(collected + limit·log limit)`. `page_offset - first_touched`
     // rebases the offset onto the collected touched buckets.
-    Some(
+    Some((
         select_page(matches, page_offset - first_touched, limit)
             .into_iter()
             .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
             .collect(),
-    )
+        work,
+    ))
 }
 
 /// #744 orderby walk for a range-indexed sort column (`usd` — the only such `SortCol`; cn/date are
@@ -5686,7 +5720,7 @@ fn walk_range_orderby_page<'a>(
     total: usize,
     limit: usize,
     page_offset: usize,
-) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let (mut lo, mut hi) = (0usize, idx.len());
     let next = move || -> Option<Vec<u32>> {
@@ -5732,7 +5766,7 @@ fn walk_rarity_orderby_page<'a>(
     limit: usize,
     page_offset: usize,
     n_printings: usize,
-) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     // Every rarity int present: interior [0..3] (planes, always laid out) + the postings' ints.
     let mut values: Vec<u8> = RARITY_PRINTING_PLANE_INTS.to_vec();
     values.extend(rp.postings.iter().map(|e| e.0));
@@ -5826,9 +5860,10 @@ fn printing_compose_fastpath<'a>(
     };
     if total == 0 || page_offset >= total {
         note_paging_taken(PagingTaken::EmptyPage);
+        publish_compose_work(ComposePageWork::default());
         return Some((total, Vec::new()));
     }
-    let page = match perm {
+    let (page, work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
@@ -5861,9 +5896,9 @@ fn printing_compose_fastpath<'a>(
                 None
             };
             match walked {
-                Some(rows) => {
+                Some(rows_and_work) => {
                     note_paging_taken(PagingTaken::OrderbyWalk);
-                    rows
+                    rows_and_work
                 }
                 None => {
                     // Two different situations reach this gather, and `compose_paging` predicts
@@ -5878,6 +5913,7 @@ fn printing_compose_fastpath<'a>(
             }
         }
     };
+    publish_compose_work(work);
     Some((total, page))
 }
 
@@ -6410,7 +6446,7 @@ fn walk_grouped_page<'a>(
     params: &QueryParams,
     pbits: &[u64],
     perm: &Archived<Vec<u32>>,
-) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -6429,10 +6465,16 @@ fn walk_grouped_page<'a>(
     let mut touched: Vec<u16> = Vec::new();
     let mut scratch: Vec<Match> = Vec::new();
     let mut skip = page_offset;
+    // This walk pays per PERMUTATION ENTRY, not per match: it steps cards in sort order and bit-tests
+    // each one's whole printing span, stopping only when the page fills. `cost::printings_walked`
+    // models that as `page_span / match_rate`, which nothing checked before these counters.
+    let mut work = ComposePageWork::default();
     for cid in perm.iter().map(|x| u32::from(*x)) {
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
+        work.cards_visited += 1;
+        work.printings_examined += (end - start) as u64;
         scratch.clear();
         match mode {
             // Printing: every set printing is its own row (no grouping).
@@ -6472,6 +6514,7 @@ fn walk_grouped_page<'a>(
                 }
             }
         }
+        work.matches_pushed += scratch.len() as u64;
         if scratch.is_empty() {
             continue;
         }
@@ -6483,12 +6526,12 @@ fn walk_grouped_page<'a>(
         for m in scratch.iter().skip(skip) {
             page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
             if page.len() == limit {
-                return page;
+                return (page, work);
             }
         }
         skip = 0;
     }
-    page
+    (page, work)
 }
 
 /// Permutation-free counterpart to `walk_grouped_page`, for when `orderby` has no card-space
@@ -6508,7 +6551,7 @@ fn gather_composed_page<'a>(
     params: &QueryParams,
     pbits: &[u64],
     card_bits: Option<&[u64]>,
-) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -6534,14 +6577,22 @@ fn gather_composed_page<'a>(
     let mut group_best: Vec<Option<(u32, f64)>> = vec![None; n];
     let mut touched: Vec<u16> = Vec::new();
     let mut sel = GatherSelect::new(page_offset, limit);
+    // `compose_scan_printings` is set to the composed bitmap's POPCOUNT, on the stated grounds that
+    // compose "walks the set bits". This loop does not: except in the card/default-prefer arm it
+    // iterates `start..end` of every candidate card and bit-tests each printing, so the real count is
+    // the SPAN of the candidate cards. Counted per arm below so the difference is measured rather
+    // than argued.
+    let mut work = ComposePageWork::default();
     for cid in candidate_cards {
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
+        work.cards_visited += 1;
         match mode {
             // Printing: every set printing is its own row (no grouping).
             Mode::Printing => {
+                work.printings_examined += (end - start) as u64;
                 for pid in start..end {
                     if is_set(pid) {
                         sel.buf().push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
@@ -6557,12 +6608,19 @@ fn gather_composed_page<'a>(
             // cost that scales with total matches rather than `limit` is the dominant term for a broad
             // composed set.
             Mode::Card if matches!(prefer, Prefer::Default) => {
+                // The one arm that does stop early: `find` breaks at the first set printing, and a
+                // candidate card has at least one by construction, so this tests `first_set - start + 1`
+                // rather than the span.
                 if let Some(pid) = (start..end).find(|&pid| is_set(pid)) {
+                    work.printings_examined += (pid - start + 1) as u64;
                     sel.buf().push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
+                } else {
+                    work.printings_examined += (end - start) as u64;
                 }
             }
             // Card (non-default prefer) / Artwork: one best-prefer representative per group.
             Mode::Card | Mode::Artwork => {
+                work.printings_examined += (end - start) as u64;
                 touched.clear();
                 for pid in start..end {
                     if !is_set(pid) {
@@ -6589,10 +6647,11 @@ fn gather_composed_page<'a>(
                 }
             }
         }
+        work.matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
     let (_total, page_ids) = sel.finish(page_offset, limit); // total already known exactly via popcount; only the page is wanted here
-    page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect()
+    (page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect(), work)
 }
 
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
@@ -6951,6 +7010,34 @@ fn timed_prepare_candidates(
 /// `PhaseStats::paging_taken` for why the predicted branch is not enough.
 fn note_paging_taken(which: PagingTaken) {
     PAGING_TAKEN.with(|c| c.set(which));
+}
+
+/// Publish what a compose paging branch did into the shared counters, so `PrintingCompose` reports
+/// the same three quantities the two materializing plans do.
+///
+/// A WHOLE-struct set, like the other two publishers: nothing here is inherited, so compose cannot
+/// report a field an earlier participant wrote. `paging_taken` survives because it lives in
+/// `PAGING_TAKEN`, which this does not touch -- the same split `PhaseStats` documents.
+///
+/// The phase timings stay zero. Compose's cost arm is not decomposed into setup/loop/finish the way
+/// the scan plans' is, so there is nothing yet to check them against, and publishing an
+/// unvalidatable number is how `printings_scanned` became load-bearing in the first place.
+fn publish_compose_work(work: ComposePageWork) {
+    PHASE_STATS.with(|c| {
+        c.set(PhaseStats {
+            cards_visited: work.cards_visited,
+            printing_span: 0, // compose never materializes a candidate list, so there is no span
+            printings_examined: work.printings_examined,
+            matches_pushed: work.matches_pushed,
+            ns_setup: 0,
+            ns_loop: 0,
+            ns_finish: 0,
+            ns_round_total: 0, // filled by explain_analyze, which owns the round timer
+            ns_prepare: 0,
+            result_total: 0, // likewise
+            paging_taken: PagingTaken::NotEntered, // owned by PAGING_TAKEN; take_phase_stats merges it in
+        });
+    });
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7281,7 +7281,7 @@ fn orderby_walk_matches_gather_composed() {
             for &descending in &[false, true] {
                 for &offset in &[0usize, 50, 200] {
                     let limit = 100usize;
-                    let gather = super::gather_composed_page(
+                    let (gather, _) = super::gather_composed_page(
                         &QueryCtx::from(archived), &kernel_params(Mode::Printing, sort_col, descending, limit, offset), &pbits, None,
                     );
                     let walk = match sort_col {
@@ -7295,7 +7295,7 @@ fn orderby_walk_matches_gather_composed() {
                         ),
                         _ => None,
                     };
-                    if let Some(walk) = walk {
+                    if let Some((walk, _)) = walk {
                         walked_any = true;
                         assert_eq!(
                             ids(&walk), ids(&gather),
@@ -9974,7 +9974,7 @@ fn range_compose_kernel_costs() {
             let page = super::walk_grouped_page(
                 &QueryCtx::from(archived), &kernel_params(Mode::Card, SortCol::EdhrecRank, false, LIMIT, 0), &pbits, perm,
             );
-            page.len() as u64
+            page.0.len() as u64
         });
         let per_prtg = scatter_ns as f64 / set_prtg.max(1) as f64;
         println!(

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3738,7 +3738,10 @@ fn plan_stats_never_leak_between_participants() {
     const CORPUS_SIZE: usize = 3_000;
     const NUM_WARMUPS: usize = 1;
     const NUM_TRIALS: usize = 3;
-    /// Publish no counters whatsoever — see the doc's leak 1.
+    /// Publish no per-card COUNTERS — they popcount bitmaps or walk an index and visit no cards, so
+    /// `cards_visited`/`printings_examined`/`matches_pushed` have nothing to report. They DO publish
+    /// phase timings: every plan does now, which is what lets `plan_self_ns` read the executor's own
+    /// time directly instead of recovering it by subtracting `ns_prepare` from a trial.
     const SILENT_PLANS: [PhysicalPlan; 3] =
         [PhysicalPlan::PrintingRangeScan, PhysicalPlan::PlanePopcountOrder, PhysicalPlan::CardRangePopcount];
     /// The subset of `SILENT_PLANS` that writes NO field at all, `paging_taken` included, so
@@ -3799,19 +3802,14 @@ fn plan_stats_never_leak_between_participants() {
                             (p.cards_visited, p.printing_span, p.printings_examined, p.matches_pushed), (0, 0, 0, 0),
                             "uninstrumented plan reported counters it never wrote: {case}",
                         );
-                        assert_eq!(
-                            (p.ns_setup, p.ns_loop, p.ns_finish), (0, 0, 0),
-                            "uninstrumented plan reported loop timings it never wrote: {case}",
+                        // The INVERSE of the old assertion, and a stronger statement: these plans must
+                        // publish a phase span, because `plan_self_ns` now reads the executor's own
+                        // time from the phases rather than recovering it by subtraction. A plan that
+                        // ran and reports no phase would be priced at zero.
+                        assert!(
+                            p.ns_setup + p.ns_loop + p.ns_finish > 0,
+                            "plan produced a page but published no phase timing, so it prices as zero: {case}",
                         );
-                        // `ns_prepare` is the one exception, and only for `PlanePopcountOrder`: the
-                        // router builds its plane bitmap during acquire and hands it over, so a FORCED
-                        // run has to rebuild it and reports that build here. Netting it is what makes
-                        // a plane row dispatch-comparable — without it the regret matrix read a mean
-                        // -4.21us on plane/card, the routed path apparently beating the best plan.
-                        // Every other silent plan still reports nothing.
-                        if t.plan != PhysicalPlan::PlanePopcountOrder {
-                            assert_eq!(p.ns_prepare, 0, "uninstrumented plan reported a prepare time it never wrote: {case}");
-                        }
                         // The label half splits: only the two plans that write nothing can be
                         // checked as "still NotEntered". `PrintingRangeScan` labels its own exits,
                         // so for it the equivalent — and stronger — statement is that the label is

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4478,6 +4478,7 @@ fn plan_cost_model_matches_gold() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
                 };
 
@@ -4717,6 +4718,7 @@ fn plan_cost_refit() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
@@ -4919,6 +4921,7 @@ fn printing_range_route_probe() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
             };
 
@@ -5281,6 +5284,7 @@ fn plan_regret_report() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
             };
 
@@ -5409,6 +5413,7 @@ fn plan_regret_fuzz() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
             };
             let feats_true = mk(true_total, eval_domain);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3800,9 +3800,18 @@ fn plan_stats_never_leak_between_participants() {
                             "uninstrumented plan reported counters it never wrote: {case}",
                         );
                         assert_eq!(
-                            (p.ns_setup, p.ns_loop, p.ns_finish, p.ns_prepare), (0, 0, 0, 0),
-                            "uninstrumented plan reported phase timings it never wrote: {case}",
+                            (p.ns_setup, p.ns_loop, p.ns_finish), (0, 0, 0),
+                            "uninstrumented plan reported loop timings it never wrote: {case}",
                         );
+                        // `ns_prepare` is the one exception, and only for `PlanePopcountOrder`: the
+                        // router builds its plane bitmap during acquire and hands it over, so a FORCED
+                        // run has to rebuild it and reports that build here. Netting it is what makes
+                        // a plane row dispatch-comparable — without it the regret matrix read a mean
+                        // -4.21us on plane/card, the routed path apparently beating the best plan.
+                        // Every other silent plan still reports nothing.
+                        if t.plan != PhysicalPlan::PlanePopcountOrder {
+                            assert_eq!(p.ns_prepare, 0, "uninstrumented plan reported a prepare time it never wrote: {case}");
+                        }
                         // The label half splits: only the two plans that write nothing can be
                         // checked as "still NotEntered". `PrintingRangeScan` labels its own exits,
                         // so for it the equivalent — and stronger — statement is that the label is

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3224,6 +3224,21 @@ fn explain_reports_ranked_applicable_plans() {
                 );
             }
             for e in &estimates {
+                // `PrintingCompose` alone may report `+inf`, and it means one specific thing: the
+                // fastpath is predicted to REFUSE this query, so `cost::plan_cost` returns
+                // `f64::INFINITY` to keep it out of the argmin rather than route to a plan that
+                // returns `None` and pays a detour. It still appears in `estimates` (sorted last),
+                // and `costbench.predicted_ns` screens it for exactly this reason.
+                //
+                // This assertion used to demand finiteness from every plan and passed only because
+                // the fixture never tripped the small-total decline. Calibrating the compose card
+                // estimate (it read a median 1.73x the truth) shrank `result_total` enough to
+                // predict declines here -- the prediction mirrors the fastpath's real
+                // `total <= STREAM_MIN_MATCHES` bail, so predicting more of them on a better
+                // estimate is the improvement, not a regression.
+                if e.plan == PhysicalPlan::PrintingCompose && e.predicted_ns == f64::INFINITY {
+                    continue;
+                }
                 assert!(e.predicted_ns.is_finite() && e.predicted_ns >= 0.0, "non-finite/negative predicted_ns for {:?}", e.plan);
             }
         }
@@ -4463,6 +4478,7 @@ fn plan_cost_model_matches_gold() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -4701,6 +4717,7 @@ fn plan_cost_refit() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -4902,6 +4919,7 @@ fn printing_range_route_probe() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
             };
 
             // ── Three pickers ──
@@ -5263,6 +5281,7 @@ fn plan_regret_report() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -5390,6 +5409,7 @@ fn plan_regret_fuzz() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -23,6 +23,11 @@ Pick by question:
 | Where does routing actually lose time? | [`bench_regret_matrix.py`](../../scripts/bench_regret_matrix.py) |
 | Did this PLAN's executor get faster, picked or not? | [`bench_plan_execution_ab.py`](../../scripts/bench_plan_execution_ab.py) `--compare` |
 | Did a change help end to end? | [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py) vs `main` |
+| Where does the routed path spend its time? | any harness, on a `--features routed-phases` build |
+
+Several of these need a `routed-phases` build to be read correctly — `bench_regret_matrix.py` refuses
+to run without it. See the two-bin section below for what the feature buys and why it is not on by
+default (~1.6% of every request).
 
 All of them are built on [`scripts/costbench.py`](../../scripts/costbench.py), which owns the
 sampling loop, the nearest-rank percentiles, the paired-bootstrap comparison, and — the one that
@@ -42,8 +47,10 @@ bands, because a mean over this distribution understates the tail and a p99 over
 Most of them draw queries from one universe, [`query_sampler.py`](../../client/query_sampler.py), in
 one of two weightings. Diagnostics default to `uniform` because their job is to FIND errors and
 uniform reaches the rare tails; latency defaults to `realistic` because there the question is what
-users wait for. Both matter: artwork is 5% of realistic traffic and carries **50% of all routing
-regret**.
+users wait for. Both matter: artwork is 5% of realistic traffic and carries a wildly disproportionate
+share of routing regret — on the dispatch basis, `printing_compose / artwork` alone is **33% of all
+lost time** against 5% for printing and 2% for card. (An older reading put artwork at 50% overall; that
+predates the dispatch re-base and should not be quoted.)
 
 Constrain the draw with `Shape` rather than writing a generator — `Shape(families={"range"},
 predicates=1, unique={"printing"})` gives a bare printing-space range while keeping corpus-derived
@@ -52,6 +59,65 @@ values (`bench_card_range_estimate`, `bench_cost_model_agreement`) and should mo
 [local-benchmark-toolkit-audit.md](local-benchmark-toolkit-audit.md). Two draw from real traffic on
 purpose: `bench_plan_misselection --source wild-operators` and `census_candidate_materialize`, where
 the question is what users actually lose.
+
+## Acquire and dispatch are two bins, and plan timing means dispatch
+
+The routed path has exactly two phases that matter for measurement, and conflating them produced the
+single largest error this toolkit has reported.
+
+**Acquire** runs once, before any plan is chosen, and is identical whichever plan wins. It picks the
+count source, builds the cost features, and materialises the artifact those imply — the plane bitmap,
+a range `k`, or `prepare_candidates`. **Dispatch** runs the winner.
+
+`cost::plan_cost` prices only the second: "only what happens AFTER the acquire step". So any
+plan-versus-plan comparison must be dispatch-only on both sides. A baseline that includes acquire
+charges the router for work no plan choice could have avoided.
+
+Measured with the `routed-phases` fenceposts (below), acquire is not a rounding error:
+
+| acquire flavor | routed µs | acquire | choose | dispatch |
+| --- | --: | --: | --: | --: |
+| `candidates` | 10.42 | **45%** | 0.0% | 53% |
+| `plane` | 10.08 | **55%** | 0.1% | 45% |
+| `printing_compose` | 5.46 | 3% | 0.0% | 96% |
+| `printing_range_scan` | 4.65 | 1% | 0.3% | 97% |
+| `card_range_popcount` | 44.42 | 1% | 0.1% | 99% |
+
+Two things to take from it. `choose` — the `argmin` itself — is **41 ns**, so the routing decision is
+free and only what it selects matters. And acquire is ~45% of the dominant flavor while being entirely
+unpriced, which is the quantified form of the note in `cost.rs` that the model's median error is
+`1.09x acquire_ns`. Acquire is a **latency** target, not a routing one: being common-mode within a
+query, it cannot change an `argmin`.
+
+### Getting the two sides comparable
+
+A forced run (`run_query_with_plan`, which is what `trials_ns` measures) rebuilds shared artifacts the
+router would have supplied, so its trial is not dispatch. `costbench.plan_self_ns` nets that back out,
+and the netting is not a correction for a mistake — it is the conversion:
+
+- **candidates acquire** — the routed path runs `prepare_candidates` inside acquire and dispatch reuses
+  the result, so netting `ns_prepare` yields the executor-only quantity dispatch measures.
+- **range / compose acquire** — nothing is prepared during acquire; dispatch pays it if a materializing
+  plan wins, and both sides already include it. Hence `RANGE_ACQUIRES` is excluded.
+- **plane acquire** — the plane eval is published as `ns_prepare` for the same reason, so a forced
+  `PlanePopcountOrder` can be netted down to its walk.
+
+**A plan you cannot price has no computable regret.** `plan_self_ns` returns `None` when netting
+overshoots, and taking the best of what remains substitutes a slower plan for the true best — which
+reads as the router beating it. `bench_regret_matrix` skips and counts those queries; on the bitplanes
+corpus that is ~39%, which is the price of recovering the executor's time by subtraction rather than
+reading `ns_setup + ns_loop + ns_finish` directly.
+
+### What ignoring this cost
+
+Regret was `routed_ns - best_dispatch`, mixing the whole path against a dispatch-only baseline. On the
+21,463 queries whose picked plan *was* the best — zero misrouting by construction — that read a mean
+**6.13 µs** instead of **-0.01 µs**, and those rows were **63% of all reported regret**. The top slice
+of the matrix was `StreamedSelect -> StreamedSelect`, which is not a misroute by definition. Re-based,
+it is 3%, and P3/P4 confusion turns out to be **66%** of lost time rather than the 40% it looked like.
+
+SHARE therefore sums *signed* regret. Clamping each row at zero let a slice whose mean is negative
+accumulate share as though it were losing time.
 
 ## The two matrices, and why both
 
@@ -78,19 +144,33 @@ while those two drove OPPOSITE routing errors.
 
 ### The regret matrix — where being wrong costs time
 
-Regret is `routed_ns - best_measured_ns`, so a correct pick contributes 0. Measured against
-`routed_ns`, not the picked plan's own trial, because those differ exactly when the picked plan
-DECLINES and dispatch re-chooses among materializing plans only.
+Regret is `routed_dispatch_ns - best_dispatch_ns`, so a correct pick contributes 0. Measured against
+the routed path, not the picked plan's own trial, because those differ exactly when the picked plan
+DECLINES and dispatch re-chooses among materializing plans only — and dispatch-to-dispatch, for the
+reason in the two-bin section above.
 
 Regret is mostly zeros, so **read SHARE** — the fraction of all lost time a slice accounts for, which
-is frequency times severity and is what ranks work. It found compose carrying **75%** of all lost
-time, and one transition (`StreamedSelect -> PrintingCompose`) losing a mean of 190 µs over 150
-queries.
+is frequency times severity and is what ranks work.
 
-**Split compose-like regret by DIRECTION before acting.** "75% of lost time" is compatible with two
-opposite fixes, and here it was both at once: over-picked 38:1 in artwork, under-picked 10:1 in
-printing. A change that made compose uniformly cheaper was therefore right for one mode and wrong for
-the other, and lost overall.
+**Every share figure predating the dispatch re-base is wrong, including the ones this file used to
+quote.** The old baseline mixed the whole routed path against a dispatch-only best, so 63% of reported
+regret was acquire on correctly-routed queries. What it looked like, and what it is:
+
+| slice | on `routed_ns` | on dispatch |
+| --- | --: | --: |
+| `StreamedSelect -> StreamedSelect` (picked == best, so not a misroute) | 31% | **3%** |
+| `StreamedSelect -> GatheredScan` | 23% | **41%** |
+| `GatheredScan -> StreamedSelect` | 17% | **25%** |
+| `PrintingCompose -> GatheredScan` | 11% | **21%** |
+
+So P3/P4 confusion is **66%** of lost time, not the ~40% it appeared to be, and compose over-picking
+is 34%. The older "compose carries 75%" reading came from the same conflation and does not survive it.
+
+**Split compose-like regret by DIRECTION before acting.** A single share figure is compatible with two
+opposite fixes, and for compose it was both at once: over-picked in artwork, under-picked in printing.
+A change that made compose uniformly cheaper was therefore right for one mode and wrong for the other,
+and lost overall. Compose's regret is still artwork-concentrated — `printing_compose / artwork` is 33%
+of all lost time against 5% for printing and 2% for card.
 
 ## Traps, each one paid for
 

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -77,6 +77,33 @@ PAIRS = (
 SPAN_COUNTER = "printing_span"
 
 
+#: Which of the three PAIRS features each compose paging branch's cost arm actually multiplies by a
+#: rate. `Perm` and `OrderbyWalk` are priced `printings_walked * WALK_STEP + limit * WALK_EMIT_PER_ROW`
+#: -- they charge NEITHER `matches` nor `eval_domain`, and grading those against a walk that stops at
+#: `page_offset + limit` produced cells reading 100-200x off numbers the model never reads. Only
+#: `Gather` charges all three (`eval_domain`, `compose_scan_printings`, `matches`).
+COMPOSE_ARM_CHARGES: dict[str, frozenset[str]] = {
+    "Perm": frozenset({"printings_walked"}),
+    "OrderbyWalk": frozenset({"printings_walked"}),
+    "Gather": frozenset({"eval_domain", "compose_scan_printings", "matches"}),
+    # The walk was available, was attempted, declined, and fell into the gather -- so the gather is
+    # what ran and the gather's terms are what to grade.
+    "GatherWalkDeclined": frozenset({"eval_domain", "compose_scan_printings", "matches"}),
+}
+
+
+def compose_grades(paging_taken: str, feat: str) -> bool:
+    """Whether compose's arm charges `feat` on the branch it actually took.
+
+    Keyed on `paging_taken` -- what RAN -- not on the acquire's `compose_paging`, which is the
+    model's PREDICTION of the branch. Those disagree exactly where a walk was predicted and declined,
+    and grading a gather's counters against a walk's terms is how the two get conflated.
+    """
+    charged = COMPOSE_ARM_CHARGES.get(paging_taken)
+    # An exit with no cost arm of its own (EmptyPage, the declines): nothing ran that a term describes.
+    return feat in charged if charged is not None else False
+
+
 def scan_feature(plan: str, paging: str, tier_ns100: int) -> str | None:
     """Which feature the ARM actually charges its printing scan on, or None if it charges none.
 
@@ -96,7 +123,8 @@ def scan_feature(plan: str, paging: str, tier_ns100: int) -> str | None:
     fit this plan at all.
     """
     if plan == "PrintingCompose":
-        return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+        # `GatherWalkDeclined` IS the gather -- a walk was attempted, declined, and fell into it.
+        return "compose_scan_printings" if paging in ("Gather", "GatherWalkDeclined") else "printings_walked"
     if plan == "StreamedSelect" and tier_ns100 == 0:
         return None
     return "scan_units"
@@ -120,12 +148,16 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
         for plan in sample.plans:
             if not plan["trials_ns"]:
                 continue  # declined: it ran nothing, so there is no counter to check against
-            paging = acq["compose_paging"]
+            # `compose_paging` is the model's PREDICTION; `paging_taken` is what ran. Label and grade
+            # compose on the latter -- they disagree exactly where a walk was predicted and declined.
+            paging = plan.get("paging_taken") if plan["plan"] == "PrintingCompose" else acq["compose_paging"]
             for feat, counter in PAIRS:
                 if feat == "scan_units":
                     feat = scan_feature(plan["plan"], paging, acq["residual_tier_ns100"])  # noqa: PLW2901 - the arm decides
                     if feat is None:
                         continue  # this arm charges no scan term for this query; there is nothing to grade
+                if plan["plan"] == "PrintingCompose" and not compose_grades(paging, feat):
+                    continue  # this branch's arm never multiplies this feature by a rate
                 got = plan.get(counter)
                 if got is None or got < MIN_COUNTER:
                     continue

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -110,7 +110,7 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
         declined = picked is not None and not picked["trials_ns"]
         # Best on the SAME dispatch-equivalent definition the baseline uses, and EVERY plan that ran
         # must be priceable on it. `plan_self_ns` returns None when netting overshoots
-        # the timer noise floor, and taking the best of what is left silently substitutes a slower
+        # no phase timing, and taking the best of what is left silently substitutes a slower
         # plan for the true best -- which reads as the router beating it. Measured on plane queries,
         # where the plane build is a large share of a forced trial: PlanePopcountOrder is dropped 37%
         # of the time (median ns_prepare/trial 0.38), and those rows drove the plane slice to a mean
@@ -138,7 +138,7 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
             }
         )
     if skipped_unpriced:
-        print(f"skipped {skipped_unpriced:,} queries where a plan that ran could not be priced (netting overshoot)")
+        print(f"skipped {skipped_unpriced:,} queries where a plan that ran published no phase timing and so cannot be priced")
     if skipped_unphased:
         print(f"skipped {skipped_unphased:,} queries with no routed phase split -- build with --features routed-phases")
     return rows

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -5,17 +5,38 @@ says where being wrong COSTS something. They disagree often enough to matter —
 by 100x on a plan that never wins anyway, and correct to 5% on one where the margin decides every
 query.
 
-Regret is `routed_ns - best_measured_ns`: what the router gave up against the best plan that ran, so a
-correct pick contributes exactly 0. It is measured against `routed_ns` rather than the picked plan's
-own trial because those differ in the case that matters most — when the picked plan DECLINES at
-runtime, dispatch re-chooses among materializing plans only, and a non-materializing fast path that
-would have won is never reconsidered.
+Regret is `routed_dispatch_ns - best_dispatch_ns`: what the router gave up against the best plan that
+ran, so a correct pick contributes exactly 0. It is measured against the routed path rather than the
+picked plan's own trial because those differ in the case that matters most — when the picked plan
+DECLINES at runtime, dispatch re-chooses among materializing plans only, and a non-materializing fast
+path that would have won is never reconsidered.
+
+**Both sides are DISPATCH, and that is load-bearing.** The engine's routed path has two bins: acquire
+runs once before any plan is chosen and is identical whichever wins, and dispatch runs the winner.
+`cost::plan_cost` prices only the second — "only what happens AFTER the acquire step" — so a plan
+comparison that includes acquire charges the router for work no plan choice could have avoided. This
+used to subtract from `routed_ns`, the whole path, and acquire is ~45% of a candidate-acquired query.
+
+The size of that mistake, measured on the population where regret is provably zero (21,463 queries
+whose picked plan WAS the best): mean `6.13 us` against `routed_ns`, `-0.01 us` against dispatch.
+Those rows were **63% of all reported regret**, and `StreamedSelect -> StreamedSelect` — picked equals
+best, so not misrouting by definition — was the single largest slice at a 14.15 us mean. On this basis
+it is 1.16. The genuine misroutes are unmoved (`PrintingCompose -> GatheredScan` 65.94 -> 65.22).
+
+Needs a `routed-phases` build. Without the feature the phase keys publish as zeros and those queries
+are skipped with a warning rather than measured against a zero baseline.
 
 Regret is mostly zeros, so a median is useless here: read the SHARE column, which is what fraction of
 all lost time a slice accounts for. That ranks the work. p90/p99/max show whether a slice loses a
 little constantly or a lot rarely.
 
-    .venv/bin/python scripts/bench_regret_matrix.py --seconds 180
+SHARE sums SIGNED regret. A transition can have a negative mean — the routed path beating the best
+forced plan, via the lazy re-choose or simply a forced run paying a cold cache the routed one does not
+— and clamping each row at zero let such a slice accumulate share as though it were losing time.
+`GatheredScan -> StreamedSelect` is the live example: mean `-18.91 us`, and it held 23% of share under
+the clamp.
+
+    .venv/bin/python scripts/bench_regret_matrix.py --seconds 180   # build --features routed-phases
 """
 
 from __future__ import annotations
@@ -52,33 +73,65 @@ percentile = costbench.percentile
 def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
     """One row per multi-plan query: what it lost, and everything to slice that by.
 
-    Deliberately does NOT use `costbench.plan_self_ns`. That nets `ns_prepare` back out to make a
-    plan comparable to the cost model's per-plan prediction; regret compares against `routed_ns`,
-    a whole real execution with the prep included. Netting one side of that subtraction and not the
-    other would invent time that was never saved.
+    Both sides of the subtraction are DISPATCH, which is what makes the difference attributable to
+    plan choice at all. Acquire is a separate bin: it runs once, before any plan is chosen, is
+    identical whichever plan wins, and `cost::plan_cost` prices none of it. Including it in the
+    baseline charged the router for work no plan choice could have avoided.
+
+    Measured, on the population where that is provably zero -- 21,463 queries whose picked plan WAS
+    the best one, so there is no misrouting by construction:
+
+        mean vs routed_ns          6.13 us
+        mean vs routed_dispatch   -0.01 us
+
+    Those rows were 63% of all reported regret. `StreamedSelect -> StreamedSelect` alone read a 14.15
+    us mean and the top share; on this basis it is 1.16. The genuine misroutes barely move
+    (`PrintingCompose -> GatheredScan` 65.94 -> 65.22), which is the signature of having removed
+    acquire rather than signal.
+
+    `plan_self_ns` IS used, and its netting is what makes the two sides comparable rather than a
+    correction for anything: on a candidates acquire the routed path runs `prepare_candidates` inside
+    `acquire_plan_features` and dispatch reuses the artifact, so netting turns a forced trial
+    (prepare + executor) into the executor-only quantity dispatch measures. On a range or compose
+    acquire nothing is prepared during acquire, dispatch pays it if a materializing plan wins, and
+    both sides already include it -- which is exactly what `RANGE_ACQUIRES` excludes.
+
+    Requires a `routed-phases` build; without the feature the phase keys are published as zeros and
+    there is nothing to re-base on, so those runs are skipped rather than silently measured wrong.
     """
     rows: list[dict] = []
+    skipped_unphased = 0
     for sample in costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds)):
         ran = [p for p in sample.plans if p["trials_ns"]]
         if len(ran) < 2:  # noqa: PLR2004 - one applicable plan means there is nothing to get wrong
             continue
         picked = next((p for p in sample.plans if p["picked"]), None)
         declined = picked is not None and not picked["trials_ns"]
-        best = min(ran, key=lambda p: min(p["trials_ns"]))
-        # routed_ns lives on explain_analyze's acquire; `explain` runs nothing and leaves it empty.
-        routed = sample.res["acquire"]["routed_ns"]
-        if not routed:
+        # Best on the SAME dispatch-equivalent definition the baseline uses.
+        selves = {id(p): costbench.plan_self_ns(p, sample.acquire) for p in ran}
+        comparable = [p for p in ran if selves[id(p)] is not None]
+        if len(comparable) < 2:  # noqa: PLR2004 - netting dropped too many to have a comparison
             continue
-        routed_us = min(routed) / 1000.0
+        best = min(comparable, key=lambda p: selves[id(p)])
+        dispatch = sample.res["acquire"].get("routed_dispatch_ns")
+        if not dispatch or not any(dispatch):
+            skipped_unphased += 1
+            continue
         rows.append(
             {
-                "lost": max(routed_us - min(best["trials_ns"]) / 1000.0, 0.0),
+                # SIGNED. A negative row is the routed path beating the best forced plan, which
+                # happens (the lazy re-choose, or a forced run paying a cold cache the routed one
+                # does not) and is information, not zero. Clamping it to 0 let a transition whose
+                # MEAN is negative still accumulate share as if it were loss.
+                "lost": min(dispatch) / 1000.0 - selves[id(best)] / 1000.0,
                 "acquire": sample.acquire["count_source"],
                 "unique": sample.kw["unique"],
                 "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
                 "best": best["plan"],
             }
         )
+    if skipped_unphased:
+        print(f"skipped {skipped_unphased:,} queries with no routed phase split -- build with --features routed-phases")
     return rows
 
 

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -110,7 +110,7 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
         declined = picked is not None and not picked["trials_ns"]
         # Best on the SAME dispatch-equivalent definition the baseline uses, and EVERY plan that ran
         # must be priceable on it. `plan_self_ns` returns None when netting overshoots
-        # `NETTING_RESIDUAL_FLOOR`, and taking the best of what is left silently substitutes a slower
+        # the timer noise floor, and taking the best of what is left silently substitutes a slower
         # plan for the true best -- which reads as the router beating it. Measured on plane queries,
         # where the plane build is a large share of a forced trial: PlanePopcountOrder is dropped 37%
         # of the time (median ns_prepare/trial 0.38), and those rows drove the plane slice to a mean

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -101,18 +101,25 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
     """
     rows: list[dict] = []
     skipped_unphased = 0
+    skipped_unpriced = 0
     for sample in costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds)):
         ran = [p for p in sample.plans if p["trials_ns"]]
         if len(ran) < 2:  # noqa: PLR2004 - one applicable plan means there is nothing to get wrong
             continue
         picked = next((p for p in sample.plans if p["picked"]), None)
         declined = picked is not None and not picked["trials_ns"]
-        # Best on the SAME dispatch-equivalent definition the baseline uses.
+        # Best on the SAME dispatch-equivalent definition the baseline uses, and EVERY plan that ran
+        # must be priceable on it. `plan_self_ns` returns None when netting overshoots
+        # `NETTING_RESIDUAL_FLOOR`, and taking the best of what is left silently substitutes a slower
+        # plan for the true best -- which reads as the router beating it. Measured on plane queries,
+        # where the plane build is a large share of a forced trial: PlanePopcountOrder is dropped 37%
+        # of the time (median ns_prepare/trial 0.38), and those rows drove the plane slice to a mean
+        # of -6.27us. A query with an unpriceable plan has no computable regret; skip it and say so.
         selves = {id(p): costbench.plan_self_ns(p, sample.acquire) for p in ran}
-        comparable = [p for p in ran if selves[id(p)] is not None]
-        if len(comparable) < 2:  # noqa: PLR2004 - netting dropped too many to have a comparison
+        if any(v is None for v in selves.values()):
+            skipped_unpriced += 1
             continue
-        best = min(comparable, key=lambda p: selves[id(p)])
+        best = min(ran, key=lambda p: selves[id(p)])
         dispatch = sample.res["acquire"].get("routed_dispatch_ns")
         if not dispatch or not any(dispatch):
             skipped_unphased += 1
@@ -130,6 +137,8 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
                 "best": best["plan"],
             }
         )
+    if skipped_unpriced:
+        print(f"skipped {skipped_unpriced:,} queries where a plan that ran could not be priced (netting overshoot)")
     if skipped_unphased:
         print(f"skipped {skipped_unphased:,} queries with no routed phase split -- build with --features routed-phases")
     return rows

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -111,21 +111,12 @@ MIN_ROWS = 30
 # Below this, a per-query difference is timer jitter rather than a real change.
 NOISE_FLOOR_US = 1.0
 
-# Acquire sources whose routed path re-pays `prepare_candidates`, so a plan's `trials_ns` is NOT
-# double-counting it and must not be netted. Everywhere else the prep is shared and the plan is
-# charged for a copy it would not pay under the router.
+# Acquire sources where acquire only ESTIMATED, so DISPATCH pays the artifact build itself -- either
+# `prepare_candidates` on a lazy materialize, or `build_card_range_bits` for CardRangePopcount. On
+# these `ns_prepare` is part of the plan's cost and `plan_self_ns` ADDS it. Everywhere else the router
+# built the artifact during acquire and dispatch merely reuses it, so a forced run rebuilding it is
+# reporting work dispatch never pays.
 RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
-# Below this many nanoseconds, a netted residual is timer noise rather than a smaller measurement, so
-# the row is dropped instead of reporting a number built out of two nearly-equal quantities.
-#
-# ABSOLUTE, where this used to be a fraction of the trial (0.5). The fraction cost real coverage for no
-# reason: `ns_prepare` comes from the same round as the trial it is subtracted from (`explain_analyze`
-# keeps the fastest round's phases), so the subtraction is exact rather than cross-round, and a residual
-# that is 40% of a 10us trial is 4us -- perfectly measurable. The fractional guard was dropping
-# `PlanePopcountOrder` on 37% of plane queries, which made `bench_regret_matrix` skip 39% of all
-# queries as unpriceable. What matters is whether the residual clears the timer, not what share of the
-# trial it is.
-NETTING_RESIDUAL_FLOOR_NS = NOISE_FLOOR_US * 1000.0
 
 BOOTSTRAP_RESAMPLES = 10_000
 BOOTSTRAP_CI = 0.95
@@ -315,46 +306,41 @@ def predicted_ns(plan: dict) -> float | None:
 def plan_self_ns(plan: dict, acquire: dict) -> float | None:
     """What this plan costs to RUN, in nanoseconds -- the single definition every harness uses.
 
-    The quantity wanted is the executor's own time: dispatch, excluding any shared artifact the router
-    would have built during acquire and handed over. Two ways to get it, and the direct one is
-    preferred.
+    The quantity wanted is DISPATCH: what the routed path spends after it has chosen. It is built by
+    ADDITION now, from two measured pieces, where it used to be recovered by subtracting `ns_prepare`
+    from a trial.
 
-    **Measured directly, where the executor publishes phases.** `ns_setup + ns_loop + ns_finish` are
-    contiguous by construction -- four instants bounding three spans -- so their sum IS the executor,
-    with no subtraction and nothing to overshoot. Verified against the netted figure on 45k paired
-    rows: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), with 0.08us of the round left
-    unaccounted by any phase. Only the two materializing plans publish them.
+    **The executor**, from `ns_setup + ns_loop + ns_finish`. Contiguous by construction, so the sum IS
+    the executor -- exact, with nothing to overshoot. Every plan publishes these; the two materializing
+    ones split them three ways, and the four others report one undivided span in `ns_loop` because they
+    have no three phases to attribute between. Verified against the old netted figure on 45k paired
+    rows before the switch: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), 0.08us of the
+    round unaccounted.
 
-    **Netted, otherwise.** The other four plans publish no phases, so their executor time is recovered
-    as `min(trials_ns) - ns_prepare`: a forced run rebuilds the shared artifact (candidate list, or the
-    plane bitmap) that the router acquires once, and `ns_prepare` is that build. Except under a
-    range-style acquire, where the routed path re-pays it too and it IS the plan's cost -- hence
-    `RANGE_ACQUIRES`.
+    **Plus any shared artifact DISPATCH pays for**, which depends on the acquire and not on the plan:
 
-    The guard on that subtraction is an ABSOLUTE floor, not a fraction. It used to drop any row where
-    netting removed more than half the trial, which cost real coverage for no reason: `ns_prepare` and
-    the trial come from the SAME round (`explain_analyze` keeps the fastest round's phases), so the
-    subtraction is exact rather than cross-round, and a residual that is 40% of a 10us trial is 4us --
-    measurable, not noise. That guard was dropping `PlanePopcountOrder` on 37% of plane queries, which
-    made `bench_regret_matrix` skip 39% of all queries as unpriceable. What matters is whether the
-    residual clears the timer, so the floor is `NOISE_FLOOR_US`.
+    - `candidates` / `plane` acquire -- the router built the artifact during acquire and dispatch just
+      reuses it, so dispatch is the executor alone. A forced run rebuilt it and reported the rebuild in
+      `ns_prepare`; that is exactly what must NOT be counted.
+    - `RANGE_ACQUIRES` -- acquire only estimated. Dispatch pays the build itself, whether that is
+      `prepare_candidates` on a lazy materialize or `build_card_range_bits` for `CardRangePopcount`, so
+      `ns_prepare` IS part of the plan's cost and is added.
+
+    Why this is better than the subtraction it replaces: an addition cannot overshoot, so the guard
+    that dropped rows is gone, and with it the reason `bench_regret_matrix` was skipping queries. That
+    guard cost 39% of all queries as a fraction and 1.8% as an absolute floor; it is now 0%.
 
     Returns:
-        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or if
-        the netted residual falls below the timer's noise floor.
+        The plan's dispatch nanoseconds, or None if it produced no page (declined, or never ran).
     """
     if not plan["trials_ns"]:
         return None
-    phases = float(plan["ns_setup"] + plan["ns_loop"] + plan["ns_finish"])
-    if phases > 0:
-        return phases
-    real = float(min(plan["trials_ns"]))
-    if plan["ns_round_total"] and acquire["count_source"] not in RANGE_ACQUIRES:
-        netted = real - plan["ns_prepare"]
-        if netted < NETTING_RESIDUAL_FLOOR_NS:
-            return None
-        real = netted
-    return real
+    dispatch = float(plan["ns_setup"] + plan["ns_loop"] + plan["ns_finish"])
+    if dispatch <= 0:
+        return None  # ran but published no phase: cannot be priced, and must not read as zero
+    if acquire["count_source"] in RANGE_ACQUIRES:
+        dispatch += float(plan["ns_prepare"])
+    return dispatch
 
 
 # ── statistics and tables ─────────────────────────────────────────────────────────────────────

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -148,7 +148,20 @@ PLAN_KEYS = frozenset(
         "paging_taken",
     }
 )
-ACQUIRE_KEYS = frozenset({"count_source", "narrowed_repr", "acquire_ns", "routed_ns", "compose_paging"})
+# The routed phase split is asserted here too: it is a partition of `routed_ns`, so a build that
+# stops publishing it should fail loudly rather than have a consumer silently read an empty list.
+ACQUIRE_KEYS = frozenset(
+    {
+        "count_source",
+        "narrowed_repr",
+        "acquire_ns",
+        "routed_ns",
+        "routed_acquire_ns",
+        "routed_choose_ns",
+        "routed_dispatch_ns",
+        "compose_paging",
+    }
+)
 
 
 def require_schema(res: dict) -> None:

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -115,10 +115,17 @@ NOISE_FLOOR_US = 1.0
 # double-counting it and must not be netted. Everywhere else the prep is shared and the plan is
 # charged for a copy it would not pay under the router.
 RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
-# If netting `ns_prepare` removes more than this fraction of the measured round, the subtraction has
-# overshot and the residual is noise rather than a smaller measurement. Drop the row instead of
-# reporting a number built out of two nearly-equal quantities.
-NETTING_RESIDUAL_FLOOR = 0.5
+# Below this many nanoseconds, a netted residual is timer noise rather than a smaller measurement, so
+# the row is dropped instead of reporting a number built out of two nearly-equal quantities.
+#
+# ABSOLUTE, where this used to be a fraction of the trial (0.5). The fraction cost real coverage for no
+# reason: `ns_prepare` comes from the same round as the trial it is subtracted from (`explain_analyze`
+# keeps the fastest round's phases), so the subtraction is exact rather than cross-round, and a residual
+# that is 40% of a 10us trial is 4us -- perfectly measurable. The fractional guard was dropping
+# `PlanePopcountOrder` on 37% of plane queries, which made `bench_regret_matrix` skip 39% of all
+# queries as unpriceable. What matters is whether the residual clears the timer, not what share of the
+# trial it is.
+NETTING_RESIDUAL_FLOOR_NS = NOISE_FLOOR_US * 1000.0
 
 BOOTSTRAP_RESAMPLES = 10_000
 BOOTSTRAP_CI = 0.95
@@ -308,24 +315,43 @@ def predicted_ns(plan: dict) -> float | None:
 def plan_self_ns(plan: dict, acquire: dict) -> float | None:
     """What this plan costs to RUN, in nanoseconds -- the single definition every harness uses.
 
-    `min` over the trials, because the question is what the plan costs when nothing interferes, and
-    the distribution's upper tail is machine noise rather than the plan.
+    The quantity wanted is the executor's own time: dispatch, excluding any shared artifact the router
+    would have built during acquire and handed over. Two ways to get it, and the direct one is
+    preferred.
 
-    Materializing plans re-run `prepare_candidates` inside their own forced round, where the router
-    would have acquired the artifact once and shared it. That prep is published per plan as
-    `ns_prepare`, so it can be netted back out -- except under a range-style acquire, where the
-    routed path re-pays it too and it IS the plan's cost.
+    **Measured directly, where the executor publishes phases.** `ns_setup + ns_loop + ns_finish` are
+    contiguous by construction -- four instants bounding three spans -- so their sum IS the executor,
+    with no subtraction and nothing to overshoot. Verified against the netted figure on 45k paired
+    rows: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), with 0.08us of the round left
+    unaccounted by any phase. Only the two materializing plans publish them.
+
+    **Netted, otherwise.** The other four plans publish no phases, so their executor time is recovered
+    as `min(trials_ns) - ns_prepare`: a forced run rebuilds the shared artifact (candidate list, or the
+    plane bitmap) that the router acquires once, and `ns_prepare` is that build. Except under a
+    range-style acquire, where the routed path re-pays it too and it IS the plan's cost -- hence
+    `RANGE_ACQUIRES`.
+
+    The guard on that subtraction is an ABSOLUTE floor, not a fraction. It used to drop any row where
+    netting removed more than half the trial, which cost real coverage for no reason: `ns_prepare` and
+    the trial come from the SAME round (`explain_analyze` keeps the fastest round's phases), so the
+    subtraction is exact rather than cross-round, and a residual that is 40% of a 10us trial is 4us --
+    measurable, not noise. That guard was dropping `PlanePopcountOrder` on 37% of plane queries, which
+    made `bench_regret_matrix` skip 39% of all queries as unpriceable. What matters is whether the
+    residual clears the timer, so the floor is `NOISE_FLOOR_US`.
 
     Returns:
-        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or
-        if netting overshot far enough that the residual is noise.
+        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or if
+        the netted residual falls below the timer's noise floor.
     """
     if not plan["trials_ns"]:
         return None
+    phases = float(plan["ns_setup"] + plan["ns_loop"] + plan["ns_finish"])
+    if phases > 0:
+        return phases
     real = float(min(plan["trials_ns"]))
     if plan["ns_round_total"] and acquire["count_source"] not in RANGE_ACQUIRES:
         netted = real - plan["ns_prepare"]
-        if netted < real * NETTING_RESIDUAL_FLOOR:
+        if netted < NETTING_RESIDUAL_FLOOR_NS:
             return None
         real = netted
     return real

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -102,7 +102,10 @@ CURRENT: dict[str, list[float]] = {
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
     # with the other arm's is information about the shared constant, not a number to paste blindly.
-    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 9.81, 0.38, 3.39, 163.56],
+    # GATHER_GROUP_PER_PRINTING sits between the bit-test and push columns, matching design_row.
+    # Added when the artwork tail was traced to the grouping arm's work being charged at the bit-test
+    # rate; its 1.5 start is a physical guess (a struct read plus prefer_score), meant to be fitted.
+    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 13.22, 0.38, 1.5, 3.39, 163.56],
 }
 
 
@@ -272,6 +275,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 limit if not gather else 0.0,
                 eval_domain if gather else 0.0,
                 float(acq["compose_scan_printings"]) if gather else 0.0,
+                float(acq.get("gather_group_printings", 0)) if gather else 0.0,
                 matches if gather else 0.0,
                 1.0,
             ],
@@ -284,6 +288,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "WALK_EMIT_PER_ROW",
                 "GATHER_CARD_PASS",
                 "GATHER_BITTEST_PER_PRINTING",
+                "GATHER_GROUP_PER_PRINTING",
                 "GATHER_PUSH_PER_MATCH",
                 "FIXED",
             ],

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -61,10 +61,6 @@ WALK_LENGTH_BIAS = 1.45
 # A realized counter this far from the feature meant to predict it is a FEATURE bug; refitting rates
 # on top of it just relocates the error.
 COUNTER_TOL = 0.15
-# Netting prepare_candidates out can overshoot (different round than the min trial). Keep a row only
-# if what remains is at least this fraction of the raw time; below that the residual is noise.
-# Now enforced inside `costbench.plan_self_ns`, which every harness shares.
-MIN_NETTED_FRACTION = costbench.NETTING_RESIDUAL_FLOOR
 # The mirror check's tolerance. This is a reimplementation of cost.rs in Python, so it can drift --
 # and did: the arms moved to `max(tier, floor)` and gained a residual-gated per-row term while
 # `design_row` still modelled the tier as a multiplier, which silently invalidated every coefficient

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -55,6 +55,9 @@ MIN_ROWS_FOR_FIT = 200
 STREAM_MIN_MATCHES = 1024
 # Mirrors cost.rs MATCH_RATE_FLOOR, the density floor under the page-fill walk length.
 MATCH_RATE_FLOOR = 1.0 / 1_000_000.0
+# Mirrors cost.rs WALK_LENGTH_BIAS: matches clump along the sort order, so a walk runs ~1.45x longer
+# than uniform spacing predicts. Measured 0.69 against `printings_examined` before this existed.
+WALK_LENGTH_BIAS = 1.45
 # A realized counter this far from the feature meant to predict it is a FEATURE bug; refitting rates
 # on top of it just relocates the error.
 COUNTER_TOL = 0.15
@@ -256,7 +259,9 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
         # Recomputed rather than read from the exposed u32, which is truncated for display. The
         # mirror has to match cost.rs bit for bit or its self-check fails on small walks.
         match_rate = max(matches / max(float(acq["n_printings"]), 1.0), MATCH_RATE_FLOOR)
-        walk = (page_span / match_rate) if not gather else 0.0
+        # Mirrors `cost::printings_walked`: the closed form times WALK_LENGTH_BIAS, then floored by
+        # `orderby_walk_scan` for the plane-bucket orderby walk (0 for Perm and for the usd walk).
+        walk = max(page_span / match_rate * WALK_LENGTH_BIAS, float(acq.get("orderby_walk_scan", 0))) if not gather else 0.0
         return (
             [
                 float(acq["broadcast_printings"]),
@@ -317,6 +322,15 @@ def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
             graded = instrumented
             if counter == "printings_examined" and plan == "StreamedSelect":
                 graded = [r for r in instrumented if r["acq"]["residual_tier_ns100"] > 0]
+            # Compose's three paging branches charge different features, so grading a row against a
+            # feature its branch never multiplies by a rate manufactures a defect. Its Gather branch
+            # charges eval_domain/compose_scan_printings/matches; Perm and OrderbyWalk charge only
+            # printings_walked and stop at page_offset+limit, so their `cards_visited` is 0 (the
+            # orderby walk steps a value structure, not cards) and their `matches_pushed` is a page,
+            # not a total. Ungated, those read 0.02 and 0.01 and vetoed the plan's whole fit.
+            if plan == "PrintingCompose":
+                gather_only = counter in ("cards_visited", "matches_pushed")
+                graded = [r for r in graded if (r.get("paging_taken") in ("Gather", "GatherWalkDeclined")) == gather_only]
             if not graded:
                 continue
             got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in graded]
@@ -376,6 +390,7 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
                     "ns_loop": p["ns_loop"],
                     "ns_finish": p["ns_finish"],
                     "printing_span": p["printing_span"],
+                    "paging_taken": p.get("paging_taken"),
                     "printings_examined": p["printings_examined"],
                     "matches_pushed": p["matches_pushed"],
                 }

--- a/scripts/fit_plan_gap.py
+++ b/scripts/fit_plan_gap.py
@@ -1,0 +1,330 @@
+"""Fit the P3/P4 pair as LEVEL + DELTA, so absolute accuracy and ordering stop competing.
+
+`argmin` consumes only differences, and `cost.rs` records why fitting each arm's absolute time cannot
+settle these two: "P3/P4 could NOT be fit -- SCAN goes negative because `scan_units` and `matches` both
+scale with printing count in the workload, a STRUCTURAL collinearity no corpus size fixes". A collinear
+direction is one the absolute objective cannot see. It is often one the DIFFERENCE can.
+
+And the difference is where the losses are. On the dispatch basis `StreamedSelect -> GatheredScan` and
+`GatheredScan -> StreamedSelect` are 36% and 21% of all routing regret, both directions large -- the
+signature of a model that cannot separate two plans near the margin rather than one biased about
+either. The confusion is almost entirely on queries WITH a residual (22% order-wrong against 1% for
+`all_match`) and ABOVE `STREAM_MIN_MATCHES` (25% against 3%), which is exactly where the arms diverge:
+P3 charges `scan_units * 5.97` gated on a residual, P4 charges `scan_units * 2.06` unconditionally.
+
+## Why fitting the gap alone is not enough
+
+Fitting only `log(real3/real4)` was tried and it works on its own terms -- held-out order agreement
+86.9% -> 94.4%, and 80.5% -> 92.1% on residual queries. But it wrecked what it was not looking at:
+StreamedSelect's absolute within-25% fell 58% -> 23%, and the regret it bought in one direction it
+gave back in the other (`GatheredScan -> StreamedSelect` share 22% -> 6%, `StreamedSelect ->
+GatheredScan` 34% -> 43%). A gap objective is blind to the overall level, so nothing stopped it
+wandering there.
+
+## The re-parameterisation
+
+Terms whose FEATURE appears in both arms are written as a level plus a delta:
+
+    P4 cost = sum   x_k        * f_k
+    P3 cost = sum ( x_k + d_k) * f_k
+
+`x` is what the absolute objective identifies; `d` is what the gap objective identifies. Written this
+way the two objectives inform different parameters instead of pulling on the same ones, so both can be
+optimised at once:
+
+    minimise  ABS_WEIGHT * sum over both plans (log pred - log real)^2
+            + GAP_WEIGHT * sum (log(pred3/pred4) - log(real3/real4))^2
+            + ridge
+
+with the ridge TIGHT on `x` and loose on `d` -- the level is already calibrated and the delta is the
+part known to be wrong. Terms unique to one arm (P3's artwork/small-total/corpus-pass/emit, P4's
+push/select) have no counterpart and are fitted directly.
+
+The gap term is weighted by |real gap|, because regret is milliseconds and not decisions: a wrong call
+on a 300us gap costs 300x one on a 1us gap. Unweighted, the fit took held-out order agreement
+86.2% -> 94.1% and left total regret FLAT (63.6 -> 62.1 ms, 66.5 -> 68.0 ms on two seeds) by trading
+404 cheap wrong-GatheredScan picks for 230 dear wrong-StreamedSelect ones.
+
+## DO NOT SHIP THIS FITTER'S OUTPUT. It is a diagnostic.
+
+Every version of this was validated against `bench_regret_matrix.py`, and the best of them made real
+routing WORSE:
+
+    variant                     held-out order   held-out lost   ACTUAL total regret
+    current                              86.5%         188 ms    60.4 / 69.7 ms
+    gap only                             94.4%              -    62.1 / 68.0 ms
+    level+delta, unweighted              94.1%              -    62.1 / 68.0 ms
+    level+delta, time-weighted           94.1%          22 ms    80.1 / 77.9 ms  <-- worse
+
+The reason is a flaw in the objective, not in the arithmetic: **routing is a multi-way argmin and this
+fits a pair.** `P3 = level + delta`, so moving the delta moves P3's ABSOLUTE cost -- and P3 then wins
+more often against `PrintingCompose` and the range plans too, which this objective cannot see. The
+time-weighted fit dropped P3's rates hard (CARD_PASS 5.05 -> 3.08, SCAN_PER_ROW 5.97 -> 2.45), fixed
+the direction it was looking at (`GatheredScan -> StreamedSelect` 544 -> 106 misroutes) and created
+far more of the other (`StreamedSelect -> GatheredScan` 703 -> 1184).
+
+What the pairwise view DID establish, and what is worth keeping:
+
+- The confusion is localised: residual queries above `STREAM_MIN_MATCHES`, 22% order-wrong against 1%
+  for `all_match`.
+- The discriminating term is the per-row scan rate, and its shipped 3x split (5.97 against 2.06) is
+  far too wide. Every weighting drove `D:SCAN_PER_ROW` down hard -- to 0.37 when time-weighted, i.e.
+  the two rates want to be nearly EQUAL. That is a real finding about the model's shape.
+- Absolute agreement and ordering do NOT have to trade, once re-parameterised: the time-weighted fit
+  improved both medians and `within` while improving order.
+
+A sound version needs the objective to be the actual routing outcome over ALL applicable plans -- the
+regret matrix as the loss, not a pairwise proxy for it.
+
+    .venv/bin/python scripts/fit_plan_gap.py --seconds 300   # build --features routed-phases
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import pathlib
+import random
+import statistics
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from client.query_sampler import MODES, QuerySampler  # noqa: E402
+from scripts import costbench  # noqa: E402
+from scripts import fit_cost_model as fitmod  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
+
+P3, P4 = "StreamedSelect", "GatheredScan"
+#: Terms whose feature column is the same in both arms, so a level/delta split is meaningful. Keyed by
+#: the P3 term name; the value is P4's name for the same feature.
+SHARED: dict[str, str] = {
+    "CARD_PASS": "CARD_PASS",
+    "SCAN_PER_ROW": "SCAN_PER_ROW",
+    "RESIDUAL_FLOOR": "RESIDUAL_FLOOR",
+    "FIXED": "FIXED",
+}
+# Both objectives matter, and the gap one is what routing reads, so it carries more weight. Absolute
+# accuracy is not free to abandon though: several harnesses read `predicted_ns` as a time.
+ABS_WEIGHT = 1.0
+GAP_WEIGHT = 3.0
+# Ridge, relative to the shipped value. TIGHT on the level (already calibrated by the absolute fit) and
+# loose on the delta (the part the collinearity left unidentified).
+RIDGE_LEVEL = 0.5
+RIDGE_DELTA = 0.01
+NUM_SWEEPS = 10
+SEARCH_SPAN = 4.0
+GOLDEN_ITERS = 32
+BRACKET_EPS = 1e-9
+# A gap below this is a tie no model can be expected to call; grading ties makes order agreement look
+# worse than the routing it produces.
+TIE_FLOOR_US = 1.0
+# Below this a shipped value is effectively zero and a relative ridge would divide by nothing.
+ZERO_EPS = 1e-9
+# The agreement band every other harness grades against, so these numbers are comparable to theirs.
+AGREE_LO, AGREE_HI = 0.8, 1.25
+
+
+def term_names() -> dict[str, list[str]]:
+    """Each arm's term names, straight from `design_row` so they cannot drift from the design."""
+    dummy = {
+        "eval_domain": 1,
+        "scan_units": 1,
+        "matches": 1,
+        "n_cards": 1,
+        "n_printings": 1,
+        "residual_tier_ns100": 100,
+        "artwork_seen_cards": 0,
+        "compose_paging": "Gather",
+        "broadcast_printings": 0,
+        "scatter_printings": 0,
+        "project_printings": 0,
+        "popcount_words": 0,
+        "compose_scan_printings": 0,
+        "gather_group_printings": 0,
+        "orderby_walk_scan": 0,
+    }
+    return {plan: fitmod.design_row(plan, dummy, 100, 0)[1] for plan in (P3, P4)}
+
+
+def collect_pairs(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
+    """One row per query where BOTH plans ran and are priceable, with each side's design row."""
+    rows: list[dict] = []
+    budget = costbench.Budget(seconds=seconds, warmups=fitmod.NUM_WARMUPS, trials=fitmod.NUM_TRIALS)
+    for sample in costbench.iter_samples(engine, sampler, rng, budget, vary_prefer=True):
+        plans = {p["plan"]: p for p in sample.plans}
+        if not all(n in plans and plans[n]["trials_ns"] for n in (P3, P4)):
+            continue
+        selves = {n: costbench.plan_self_ns(plans[n], sample.acquire) for n in (P3, P4)}
+        if any(v is None or v <= 0 for v in selves.values()):
+            continue
+        designs = {n: fitmod.design_row(n, sample.acquire, sample.kw["limit"], sample.kw["offset"]) for n in (P3, P4)}
+        if any(d is None for d in designs.values()):
+            continue
+        rows.append(
+            {
+                "real": {n: selves[n] for n in (P3, P4)},
+                "row": {n: designs[n][0] for n in (P3, P4)},
+                "off": {n: designs[n][2] for n in (P3, P4)},
+                "gap_us": (selves[P3] - selves[P4]) / 1000.0,
+                # TIME weight. Regret is milliseconds, not decisions: getting the order wrong on a
+                # 300us gap costs 300x what getting it wrong on a 1us gap does. An unweighted fit
+                # treats those equally and will happily trade many cheap wins for a few dear losses --
+                # measured, exactly that happened. The level+delta fit took held-out order agreement
+                # 86.2% -> 94.1% and left total regret flat (63.6 -> 62.1 ms, 66.5 -> 68.0 ms on two
+                # seeds), because it converted 404 cheap wrong-GatheredScan picks into 230 expensive
+                # wrong-StreamedSelect ones (28.66us against 12.46us mean).
+                "weight": abs(selves[P3] - selves[P4]) / 1000.0,
+                "tier": "residual" if sample.acquire["residual_tier_ns100"] > 0 else "all_match",
+            }
+        )
+    return rows
+
+
+def coeffs_from(params: dict[str, float], names: dict[str, list[str]]) -> dict[str, list[float]]:
+    """Expand the level/delta parameters back into one coefficient vector per arm."""
+    out: dict[str, list[float]] = {}
+    out[P4] = [params[f"{P4}:{nm}"] for nm in names[P4]]
+    p3: list[float] = []
+    for nm in names[P3]:
+        if nm in SHARED:
+            p3.append(max(params[f"{P4}:{SHARED[nm]}"] + params[f"D:{nm}"], 0.0))
+        else:
+            p3.append(params[f"{P3}:{nm}"])
+    out[P3] = p3
+    return out
+
+
+def predict(coeffs: dict[str, list[float]], r: dict, plan: str) -> float:
+    """One arm's predicted dispatch cost, mirroring `design_row`'s row-plus-offset contract."""
+    return max(sum(c * v for c, v in zip(coeffs[plan], r["row"][plan], strict=True)) + r["off"][plan], 1.0)
+
+
+def objective(params: dict[str, float], rows: list[dict], names: dict[str, list[str]], base: dict[str, float]) -> float:
+    """Weighted absolute + gap log error, plus the split ridge."""
+    coeffs = coeffs_from(params, names)
+    total = 0.0
+    for r in rows:
+        q3, q4 = predict(coeffs, r, P3), predict(coeffs, r, P4)
+        total += ABS_WEIGHT * (math.log(q3 / r["real"][P3]) ** 2 + math.log(q4 / r["real"][P4]) ** 2)
+        # The gap term carries the TIME weight -- see the `weight` field. The absolute term does not:
+        # absolute accuracy is wanted uniformly across queries, not concentrated on the expensive ones.
+        total += GAP_WEIGHT * r["weight"] * (math.log(q3 / q4) - math.log(r["real"][P3] / r["real"][P4])) ** 2
+    pull = 0.0
+    for k, v in params.items():
+        b = base[k]
+        strength = RIDGE_DELTA if k.startswith("D:") else RIDGE_LEVEL
+        denom = abs(b) if abs(b) > ZERO_EPS else 1.0
+        pull += strength * ((v - b) / denom) ** 2
+    # Scaled by the same total weight the data term carries, so the ridge's relative strength does not
+    # change when the gap weighting does.
+    scale = sum(1.0 + GAP_WEIGHT * r["weight"] for r in rows)
+    return total + scale * pull
+
+
+def fit(rows: list[dict], names: dict[str, list[str]], base: dict[str, float]) -> dict[str, float]:
+    """Coordinate descent with a golden-section line search per parameter."""
+    params = dict(base)
+    inv = (math.sqrt(5.0) - 1.0) / 2.0
+    for _ in range(NUM_SWEEPS):
+        for key in params:
+            b = base[key]
+            span = max(abs(b) * SEARCH_SPAN, 1.0)
+            lo, hi = (b - span, b + span) if key.startswith("D:") else (0.0, b + span)
+            a, c = lo + (1 - inv) * (hi - lo), lo + inv * (hi - lo)
+            params[key] = a
+            fa = objective(params, rows, names, base)
+            params[key] = c
+            fc = objective(params, rows, names, base)
+            for _ in range(GOLDEN_ITERS):
+                if hi - lo < BRACKET_EPS:
+                    break
+                if fa < fc:
+                    hi, c, fc = c, a, fa
+                    a = lo + (1 - inv) * (hi - lo)
+                    params[key] = a
+                    fa = objective(params, rows, names, base)
+                else:
+                    lo, a, fa = a, c, fc
+                    c = lo + inv * (hi - lo)
+                    params[key] = c
+                    fc = objective(params, rows, names, base)
+            params[key] = (lo + hi) / 2.0
+    return params
+
+
+def report(label: str, coeffs: dict[str, list[float]], rows: list[dict]) -> None:
+    """Order agreement AND the time those wrong calls cost, plus each arm's absolute ratio.
+
+    Both columns are needed and they can disagree. Order agreement counts queries; regret counts
+    milliseconds. A model that calls more queries right can still lose more time, by trading cheap
+    wins for dear losses -- measured, and it is why `lost ms` is here.
+    """
+    graded = [r for r in rows if abs(r["gap_us"]) >= TIE_FLOOR_US]
+    right, lost_us = 0, 0.0
+    for r in graded:
+        ok = (predict(coeffs, r, P3) > predict(coeffs, r, P4)) == (r["real"][P3] > r["real"][P4])
+        right += ok
+        if not ok:
+            lost_us += abs(r["gap_us"])
+    abs3 = statistics.median(predict(coeffs, r, P3) / r["real"][P3] for r in rows)
+    abs4 = statistics.median(predict(coeffs, r, P4) / r["real"][P4] for r in rows)
+    within = statistics.fmean(
+        1.0 if AGREE_LO <= predict(coeffs, r, p) / r["real"][p] <= AGREE_HI else 0.0 for r in rows for p in (P3, P4)
+    )
+    print(f"  {label:<18}{right / max(len(graded), 1):>14.1%}{lost_us / 1000:>11.1f}{abs3:>10.2f}{abs4:>10.2f}{within:>12.0%}")
+
+
+def main() -> None:
+    """Collect pairs, fit level+delta on half, and score ordering and absolutes on the held-out half."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=240.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--mode", choices=MODES, default="uniform")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".gapfit.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = collect_pairs(engine, sampler, random.Random(args.seed), args.seconds)
+    print(f"\n{len(rows):,} queries where both {P3} and {P4} ran and are priceable")
+    if len(rows) < fitmod.MIN_ROWS_FOR_FIT:
+        print("too few rows to fit")
+        return
+
+    names = term_names()
+    cur = {plan: list(fitmod.CURRENT[plan]) for plan in (P3, P4)}
+    base: dict[str, float] = {f"{P4}:{nm}": v for nm, v in zip(names[P4], cur[P4], strict=True)}
+    for nm, v in zip(names[P3], cur[P3], strict=True):
+        if nm in SHARED:
+            base[f"D:{nm}"] = v - cur[P4][names[P4].index(SHARED[nm])]
+        else:
+            base[f"{P3}:{nm}"] = v
+
+    train = [r for i, r in enumerate(rows) if i % 2 == 0]
+    test = [r for i, r in enumerate(rows) if i % 2 == 1]
+    fitted = fit(train, names, base)
+
+    print(f"\n{'parameter':<34}{'current':>10}{'fitted':>10}{'x':>8}")
+    for key in sorted(base):
+        b, f = base[key], fitted[key]
+        print(f"{key:<34}{b:>10.2f}{f:>10.2f}{(f / b if abs(b) > ZERO_EPS else float('nan')):>8.2f}")
+
+    print(f"\n  {'variant':<18}{'order correct':>14}{'lost ms':>11}{'P3 abs':>10}{'P4 abs':>10}{'within':>12}")
+    for label, rs in (("-- train", train), ("-- TEST", test)):
+        print(f" {label}")
+        report("current", cur, rs)
+        report("level+delta", coeffs_from(fitted, names), rs)
+    for tier in ("residual", "all_match"):
+        sub = [r for r in test if r["tier"] == tier]
+        if len(sub) < 200:  # noqa: PLR2004 - a thin tier says nothing
+            continue
+        print(f" -- TEST, {tier} ({len(sub):,})")
+        report("current", cur, sub)
+        report("level+delta", coeffs_from(fitted, names), sub)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stacked on #826. Makes `PrintingCompose` measurable, finds and fixes five feature errors, and reports two negative results that are worth more than the fixes.

## PrintingCompose reported nothing

It published no executor counters at all, so every cell `bench_feature_accuracy` labelled with a compose *acquire* was really measuring how well compose's shared feature vector described GatheredScan and StreamedSelect. Its own arm terms were graded against nothing and its paging table printed `no cell reached 30 samples` at any sample size. That is the arm the regret matrix puts ~75% of lost time on.

Fixing the harness mattered as much as adding the counters, and it was the same bug class twice:

- **Grade each branch on what its arm charges.** `Perm`/`OrderbyWalk` are priced `printings_walked * WALK_STEP + limit * WALK_EMIT` and charge neither `matches` nor `eval_domain`. Graded anyway, `matches <compose Perm>` read a median **196x** — the walk stops at `page_offset+limit` while `matches` is the full result total.
- **Grade on `paging_taken`, not `compose_paging`.** The latter is the model's *prediction*; they disagree exactly where a walk was predicted and declined into the gather.

`fit_cost_model`'s `counter_check` had the same blindness and read 0.02 / 0.01 for compose, vetoing the plan's entire fit.

## Five feature errors, each measured then fixed

| feature | before | after |
| --- | --: | --: |
| `matches` / `eval_domain <Gather>` (card) | 1.37 | **1.00** |
| `compose_scan_printings <Gather>` | 0.61 | **0.94** |
| `scan_units [printing_compose]` | 0.75 | **0.99** |
| `printings_walked` (pooled) | 0.25 | **0.99** |
| `eval_domain [printing_range_scan]` p90 | 41.7 | **1.94** |

`compose_scan_printings` was the composed bitmap's popcount, on the stated grounds that compose "walks the set bits". `gather_composed_page` does not — except in its card/default-prefer arm it iterates `start..end` per candidate card and bit-tests each, so the truth is the **span**. `eval_domain [printing_range_scan]`'s spread went 49.5 → 1.9 by porting the `range_too_broad_to_narrow` conditional its sibling `CardRangePopcount` branch already had; the sibling's claim that the two "agree to within 1%" held at the median and nowhere else.

`printings_walked` was measured in the wrong unit entirely — `collect_orderby_page` counted matches collected, while the work is the raw bucket scan, and a rarity bucket ANDs a whole one-hot plane however few matches survive. Counter fixed first, then the feature, plus an `orderby_walk_scan` floor because one plane bucket costs the corpus regardless of page depth.

Also: `plan_cost` recomputed the walk length locally instead of calling `printings_walked`, so patching the function changed what harnesses were *told* without changing what the router *charged*. The mirror check caught it as a 3.7% disagreement; there is one definition now and the mirror is exact on 72,949 rows.

## Negative results, recorded so they are not re-derived

**A principled estimator did not beat a constant.** A size-biased model over the corpus span histogram (`P(hit) = 1-(1-p)^s` per span-`s` card) is the textbook fix for `balls_into_bins` treating every card as one equally likely bin. It scored **no better** (log err 0.512 vs 0.513), because the failing assumption is *independence*, not uniform bins — compose's predicates are clustered, since a legality leaf broadcast down sets every printing of a card at once. Per-slice constants keyed on broadcast/range were also tried and rejected: they made held-out spread worse (14.8 vs 9.2) for 0.005 of log error.

**Exactness is unavailable here.** `CardRangePopcount` justified an exact card count by winning 138 of 142 range queries — if the winner builds the artifact anyway, moving the build into acquire is a reordering. Compose wins only **32.6%** of the time when applicable and declines at runtime 40.1%, so composing eagerly would waste the build on two-thirds of queries.

Calibration was fit on 1,036 rows and scored on a held-out 1,047 (test log error 0.678 → 0.438). It is **not** applied where `range_card_counts_for` answers exactly — those 480 rows measure 1.000 with log error 0.056, and mixing them with the estimated ones is what made the bias look like 1.35 instead of its real 1.73.

## The refit is reported and declined

All three plans became fittable in one run for the first time. On corrected features the fit makes agreement **worse**:

```
GatheredScan     0.89 -> 0.83   within-25%  52% -> 41%
PrintingCompose  0.95 -> 0.89   within-25%  45% -> 42%
StreamedSelect   0.91 -> 0.92   within-25%  58% -> 57%
```

All three medians already sit inside the `[0.8, 1.25]` band after the feature corrections. The fitter minimises log ratio, which is not the metric the band measures, and the shipped constants are closer to the band than its optimum.

## Routing did not improve, and the instrumentation nearly cost us

**Regret matrix**, PR baseline vs this branch, two seeds — flat on every slice (`candidates` 3.12 → 3.12 and 3.14 → 3.16; `printing_compose` 4.40 → 4.48). `argmin` is insensitive to errors that scale all plans alike, and compose's regret lives in a few large misses (p99 76–83 µs, max 300+) rather than in median bias.

**Latency A/B** first read `+1.9 µs CI [+1.6,+2.2]` and `+0.8 µs CI [+0.4,+1.2]` — slower. Neutralising every cost-model change in the branch left the regression exactly in place, which identified the cause as the instrumentation rather than the calibrations: `publish_compose_work` wrote the whole ~80-byte `PhaseStats` on the production compose path, which is the specific thing `PAGING_TAKEN`'s doc already says not to do there.

Now a 24-byte store into its own slot, with two of the three counters derived rather than accumulated (`cards_visited` is `candidate_cards.len()`; `matches_pushed` is the total `GatherSelect` already computed and the function discarded). Re-measured on the same protocol: `+0.7 CI [+0.3,+1.1]` and `-0.4 CI [-0.7,-0.0]` — direction flips between replicates, median per-query ratio 1.004, inside the ±0.7 µs the same-build canary establishes.

## Reviewer notes

- Net effect is **neutral latency, neutral regret, materially better measurement**. The value is that compose is now gradeable at all and five errors are quantified rather than argued.
- The calibration constants are neutral, not a win — do not read them as one.
- All A/Bs interleaved A/B/A/B, uniform mode, 2000 queries, (6 warmups, 30 trials), `PYTHONPATH` padded to equal length for the known env-var-size artifact, same-build canary run first.
- Two replicates disagreed more than usual on the final numbers; the machine was not fully quiesced. Direction is consistent across four independent comparisons but I would re-run on an idle box before trusting a magnitude.
- `cargo test --lib` 147 passed in debug; ruff clean.
