### PR TITLE
Engine: Measure P3 and P4's Loop and Finish Phases With Built Designs

### DIFF
--- a/card_engine/src/bench_compose_card_projection.rs
+++ b/card_engine/src/bench_compose_card_projection.rs
@@ -31,7 +31,7 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, bitmap_card_ids, compose_printing_bits, gather_composed_page, printing_bits_to_card_bits, AOffsets,
-    CardData, CmpOp, CollField, FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortCol, ARCHIVE_HEADER_LEN,
+    CardData, CmpOp, CollField, FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortBound, SortCol, ARCHIVE_HEADER_LEN,
 };
 
 const ITERS: usize = 200;
@@ -42,7 +42,15 @@ const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/ver
 /// card-space sort permutation, and the printing-space orderby walk requires
 /// `Mode::Printing` — so card mode lands in `gather_composed_page`, the affected branch.
 fn card_params(page_offset: usize) -> QueryParams {
-    QueryParams { mode: Mode::Card, prefer: Prefer::Default, sort_col: SortCol::PriceUsd, descending: false, limit: LIMIT, page_offset }
+    QueryParams {
+        mode: Mode::Card,
+        prefer: Prefer::Default,
+        sort_col: SortCol::PriceUsd,
+        descending: false,
+        limit: LIMIT,
+        page_offset,
+        sort_bound: SortBound::UNBOUNDED,
+    }
 }
 
 fn best_ns(mut kernel: impl FnMut() -> usize) -> u128 {

--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -26,13 +26,21 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, compose_printing_bits, gather_composed_page, walk_range_orderby_page, CardData, CmpOp, CollField,
-    FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortCol, ARCHIVE_HEADER_LEN,
+    FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortBound, SortCol, ARCHIVE_HEADER_LEN,
 };
 
 /// This bench's fixed query shape: `unique=printing`, `orderby=usd` ascending,
 /// one page of `LIMIT` — only the offset sweeps.
 fn bench_params(page_offset: usize) -> QueryParams {
-    QueryParams { mode: Mode::Printing, prefer: Prefer::Default, sort_col: SortCol::PriceUsd, descending: false, limit: LIMIT, page_offset }
+    QueryParams {
+        mode: Mode::Printing,
+        prefer: Prefer::Default,
+        sort_col: SortCol::PriceUsd,
+        descending: false,
+        limit: LIMIT,
+        page_offset,
+        sort_bound: SortBound::UNBOUNDED,
+    }
 }
 
 const ITERS: usize = 200;

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -161,6 +161,7 @@
 //! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` — rebuild it the
 //! same way (see that module's docs) after any AOracleCard/APrinting layout change.
 
+use super::bench_loop_design::{store_path, CARD_COUNTS, ITERS, LIMIT, WIDE_MIN_PRINTINGS};
 use std::hint::black_box;
 
 use rkyv::Archived;
@@ -170,30 +171,6 @@ use super::{
     NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
 };
 
-/// Timed repetitions per cell; the minimum is reported, as elsewhere in these harnesses.
-const ITERS: usize = 200;
-/// A "wide" card has at least this many printings. Sets the leverage between the card column and
-/// the printing column: a bigger gap separates them better, but the corpus has a steep tail — the
-/// group-size table this prints shows only 1,910 cards reach 8 printings, which is too few to fill
-/// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
-const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at. Four sizes, geometric, because two things are being measured on this
-/// axis and they need opposite ends of it:
-///
-/// - **Linearity in the card term**, which the large end shows: the single-printing card cell measured
-///   8.33 / 8.53 / 10.11 ns/card at 400 / 1,500 / 4,500, so the per-card rate RISES with card count and
-///   a one-size design would bake whichever size it used into the constant.
-/// - **The intercept**, i.e. the per-query fixed cost, which only exists as the y-intercept of cells
-///   that vary in size — and which the SMALL end pins, because `intercept = t(n) - slope * n` multiplies
-///   any slope error by `n`. At a 400-card floor a 1 ns/card slope error is 400 ns of intercept error,
-///   against a shipped `GATHER_FIXED_COST_NS` of 169.6: unmeasurable. 100 shortens that lever 4x.
-///
-/// Bounded above by the wide group, which is the scarce one (see `WIDE_MIN_PRINTINGS`).
-const CARD_COUNTS: [usize; 4] = [100, 400, 1_500, 4_500];
-/// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
-/// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
-/// keeps that contribution proportional to matches rather than to the page.
-const LIMIT: usize = 60;
 /// (offset, limit) pairs for the finish-phase sweep. `GATHER_SELECT_PER_PAGE_SLOT_NS` is charged against
 /// `page_span = min(offset + limit, matches)`, and every cell above holds the page FIXED, so that term
 /// has never been varied here -- the loop rates were measured while the one term keyed on the page was
@@ -201,15 +178,7 @@ const LIMIT: usize = 60;
 /// per-slot rate from a fixed cost the phase pays regardless.
 const PAGE_SPECS: [(usize, usize); 4] = [(0, 15), (0, 60), (0, 600), (900, 60)];
 
-/// Default store. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep runs: build
-/// upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn. The real corpus is
-/// only ~68 MB, small enough that a full chunk rotation can stay resident in the system-level cache, so
-/// the rates it yields are still partly warm however the walk is ordered.
-const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
 
-fn store_path() -> String {
-    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
-}
 
 /// One measured design point: the realized counters, and the loop time they were produced by.
 struct Cell {

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -65,38 +65,39 @@
 //! it is dearer where cards are narrow and cheaper where they are wide. `ns_setup` is not the
 //! explanation either — the `group_best` allocation measures 83-125 ns, negligible.
 //!
-//! Adding an artwork ARM (per-card and per-printing rates gated on `artwork_seen_cards`, which is
-//! `eval_domain` in artwork mode and 0 otherwise) was tried next and measured:
+//! Three shapes were then fitted and each taken through the regret gate. The final one, which is what
+//! this harness now reports, fits each mode in the two-parameter space it can support and recovers the
+//! three rates from the pair of pairs -- no pooling:
 //!
-//!     card + printing pooled    3.41 ns/card   2.36 ns/printing   0.80 ns/match
-//!     printing mode             3.41           2.36               0.76  (card/row shared)
-//!     artwork mode              6.68           1.20               0.80  (push shared)
+//!     card mode      A_card  = LOOP + PUSH = 4.22    B_card  = SCAN        = 2.36
+//!     printing mode  A_print = LOOP        = 2.98    B_print = SCAN + PUSH = 3.24
+//!     artwork arm                            6.57                           1.09   + 1.06 ns/group
 //!
-//! Artwork does MORE per card (walk `touched`, push per group, reset `group_best`) and LESS per
-//! printing (a group-id lookup and compare instead of a sort-key push), which is the mechanism behind
-//! the sign flip. That arm FIXED artwork at the gate -- artwork went 52% -> 50% of lost time, mean
-//! 3.40 -> 3.55 -- but total regret was still worse, 40.7 -> 44.3 ms, with the damage moving to
-//! printing mode (mean 1.69 -> 2.10). Printing's own push rate fits 0.76 against 0.80, a 5% gap that
-//! cannot account for it, so a third arm does not fix it either: lowering P4's cost simply wins it
-//! more printing-mode queries where P3 was genuinely better. Reverted again.
+//! so LOOP = A_print, SCAN = B_card, and PUSH twice over: `A_card - A_print` = 1.24 and
+//! `B_print - B_card` = 0.88, two independent estimates from different columns of different modes. They
+//! agree to 1.41x -- a real if mild failure of linearity in these three counters, and the honest error
+//! bar on the push. PUSH comes out SHARED across modes (it is the same `GatherSelect` push), leaving
+//! only LOOP and SCAN mode-dependent. Worst-cell agreement 25% off, against 46% for the mode-blind
+//! triple.
 //!
-//! The structural obstacle found on the way is the durable result. No single mode can identify all
-//! three rates, because in each one a column is a DUPLICATE: card mode pushes once per card, so
-//! `matches == cards`; printing mode pushes every printing it examines, so `matches == printings`.
-//! Only pooling card and printing separates the three, which is in direct tension with the rates
-//! differing by mode. So "fit each mode separately" is not available, and the way out is to
-//! REPARAMETERISE onto what each mode can identify:
+//! **Every one of the three regressed at the gate, and the pattern is the result:**
 //!
-//!     card mode      (LOOP + PUSH) per card, SCAN per printing
-//!     printing mode  LOOP per card, (SCAN + PUSH) per printing
-//!     artwork mode   LOOP_art per card, SCAN_art per printing, PUSH per group
+//!     attempt                      LOOP ns/card   artwork arm   total regret
+//!     mode-blind triple                    3.25   no                   +43%
+//!     pooled + artwork arm                 3.67   yes                 +8.8%
+//!     reparameterised (this one)           2.98   yes                  +40%
 //!
-//! Every parameter there is identifiable in the mode that uses it, and no mode carries a column that
-//! duplicates another. That is the next thing to try; it is a different model, not a refit.
+//! With the artwork arm held fixed, regret tracks HOW FAR P4's per-card cost was lowered rather than how
+//! accurate it is -- the most accurate description of the loop produced the second-worst routing. That
+//! is not a parameterisation problem. `plan_cost` is only ever used comparatively, and P4's inflated arm
+//! is absorbing an over-estimate on P3's side, so any accurate isolated fix to P4 must regress until P3
+//! is measured the same way. Three successively better descriptions of P4's loop giving three
+//! regressions is the evidence for that.
 //!
-//! Until then the shipped mode-blind constants are doing real work by being too high: they absorb
-//! artwork's cost, and every attempt to lower them toward the measured card/printing truth has lost
-//! more elsewhere than it gained. The constants are deliberately unchanged.
+//! So the constants are deliberately unchanged, and the next step is NOT another P4 fit: it is the same
+//! built-design treatment for `run_query_streamed`'s loop, then applying both arms together. Independent
+//! support for that ordering -- P3's dispatch median is 32 us against P4's 4 us, and its finish phase is
+//! 12% of all measured ns at mean |log| 2.06.
 //!
 //! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
 //! behave as the page grows.
@@ -197,18 +198,21 @@ fn fit(cells: &[Cell], modes: &[&str]) -> Option<[f64; 3]> {
     solve3(normal)
 }
 
-/// Artwork's card and printing rates with the MATCH rate held at the value fitted for the other
-/// modes. Fitting all three on artwork alone is ill-conditioned -- artwork groups grow with printings,
-/// so `matches` and `printings` are collinear inside artwork, and the unconstrained solve answers with
-/// a large printing rate against a NEGATIVE match rate (-60 ns) that interpolates the cells and means
-/// nothing. Holding the push shared is not a convenience: it is the same `GatherSelect` push in every
-/// mode, so the constraint is the physical claim, and it leaves 2 unknowns against 3 ratio levels.
-fn fit_artwork(cells: &[Cell], push_ns: f64) -> Option<[f64; 2]> {
+/// Per-card and per-printing rates for ONE mode, with any per-match charge subtracted off the target
+/// first. Two unknowns, which is what a single mode can support.
+///
+/// Fitting a mode alone in the three-rate space is impossible, not merely noisy: card mode pushes once
+/// per card so `matches == cards`, and printing mode pushes every printing it examines so
+/// `matches == printings`. In each mode one column duplicates another. Collapsing to two parameters is
+/// what makes each mode independently fittable, and the collapsed pair means something different in
+/// each mode -- see `recover_rates`.
+fn fit_mode(cells: &[Cell], mode: &str, push_ns: f64) -> Option<[f64; 2]> {
     let mut normal = [[0.0f64; 3]; 2];
-    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "artwork") {
+    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == mode) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w];
-        // The shared push comes off the target, exactly as `design_row` handles cost.rs's offsets.
+        // Any shared per-match charge comes off the target, the way `design_row` handles cost.rs's
+        // non-linear offsets rather than trying to make them columns.
         let y = (c.ns_loop - c.matches * push_ns) * w;
         for i in 0..2 {
             for j in 0..2 {
@@ -227,25 +231,20 @@ fn fit_artwork(cells: &[Cell], push_ns: f64) -> Option<[f64; 2]> {
     ])
 }
 
-/// Printing mode's push rate, with per-card and per-printing held at the card-mode values.
+/// The three original rates, recovered from the two collapsed pairs without ever pooling the modes.
 ///
-/// Only one unknown is available: printing mode pushes every printing it examines, so `matches ==
-/// printings` exactly and those two columns are IDENTICAL within the mode -- no design over real cards
-/// can separate them. The bit test is the same work in both modes, so the rate that is allowed to move
-/// is the push, which is what actually differs (consecutive printings of one card push into the
-/// selector back to back, where card mode pushes one per card).
-fn fit_printing_push(cells: &[Cell], per_card: f64, per_row: f64) -> Option<f64> {
-    let (mut num, mut den) = (0.0f64, 0.0f64);
-    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "printing") {
-        let w = 1.0 / c.ns_loop;
-        let x = c.matches * w;
-        num += x * (c.ns_loop - c.cards * per_card - c.printings * per_row) * w;
-        den += x * x;
-    }
-    if den <= 0.0 {
-        return None;
-    }
-    Some(num / den)
+///     card mode      A_card = LOOP + PUSH      B_card  = SCAN
+///     printing mode  A_print = LOOP            B_print = SCAN + PUSH
+///
+/// so `LOOP = A_print`, `SCAN = B_card`, and PUSH drops out TWICE -- `A_card - A_print` and
+/// `B_print - B_card`. Those two are independent estimates of the same quantity, computed from
+/// different columns of different modes, so their agreement is a test of whether the loop is linear in
+/// these three counters at all. Wide disagreement would mean the model shape is wrong, not that a
+/// constant needs nudging.
+///
+/// Returns `(loop_ns, scan_ns, push_from_card_term, push_from_row_term)`.
+fn recover_rates(card: [f64; 2], printing: [f64; 2]) -> (f64, f64, f64, f64) {
+    (printing[0], card[1], card[0] - printing[0], printing[1] - card[1])
 }
 
 fn predict(c: &Cell, k: [f64; 3]) -> f64 {
@@ -495,31 +494,48 @@ fn bench_gather_loop() {
         );
     }
 
-    // The two candidate shapes, side by side. If artwork's triple differs from the other modes' while
-    // card and printing sit together under one triple, the model wants a two-way branch on mode
-    // (artwork vs not) rather than one mode-blind triple, an additive artwork correction, or a
-    // three-way branch. An additive correction cannot be right if artwork's per-printing rate comes
-    // out LOWER, since the term would have to be negative; a three-way branch is only justified if
-    // card and printing actually separate.
-    if let Some(a2) = fit_artwork(&cells, k[2]) {
-        let art = [a2[0], a2[1], k[2]];
-        println!("\n{:<26}{:>14}{:>14}{:>14}", "fitted separately", "ns/card", "ns/printing", "ns/match");
-        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}", "card + printing pooled", k[0], k[1], k[2]);
-        match fit_printing_push(&cells, k[0], k[1]) {
-            Some(push) => println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (card/row shared)", "printing mode", k[0], k[1], push),
-            None => println!("{:<26}  no printing cells", "printing mode"),
-        }
-        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (push shared)", "artwork mode", art[0], art[1], art[2]);
-        println!("\n  per-cell agreement under the triple fitted for that cell's OWN group:");
-        for c in cells.iter().filter(|c| !c.ran_card_pass) {
-            let own = if c.mode == "artwork" { art } else { k };
-            println!(
-                "    {:<24}{:>7}  own-group p/a {:>6.2}   card/printing-triple p/a {:>6.2}",
-                c.label,
-                c.n_cards_req,
-                predict(c, own) / c.ns_loop,
-                predict(c, k) / c.ns_loop
-            );
+    // The reparameterised fit: each mode fitted in the two-parameter space it can actually support,
+    // then the three original rates recovered from the pair of pairs.
+    let card_pair = fit_mode(&cells, "card", 0.0);
+    let print_pair = fit_mode(&cells, "printing", 0.0);
+    if let (Some(cp), Some(pp)) = (card_pair, print_pair) {
+        let (loop_ns, scan_ns, push_a, push_b) = recover_rates(cp, pp);
+        println!("\n{:<30}{:>14}{:>16}", "collapsed pair per mode", "ns/card", "ns/printing");
+        println!("{:<30}{:>14.2}{:>16.2}   = (LOOP+PUSH), SCAN", "card mode", cp[0], cp[1]);
+        println!("{:<30}{:>14.2}{:>16.2}   = LOOP, (SCAN+PUSH)", "printing mode", pp[0], pp[1]);
+        println!("\nrecovered, without pooling the modes:");
+        println!("  LOOP  = A_print          {loop_ns:>7.2} ns/card");
+        println!("  SCAN  = B_card           {scan_ns:>7.2} ns/printing");
+        println!("  PUSH  = A_card - A_print {push_a:>7.2} ns/match   <-- two independent estimates;");
+        println!("  PUSH  = B_print - B_card {push_b:>7.2} ns/match       agreement tests the model shape");
+        let (lo, hi) = (push_a.min(push_b), push_a.max(push_b));
+        let spread = if lo > 0.0 { hi / lo } else { f64::INFINITY };
+        println!("  spread {spread:>.2}x  (a linear loop in these three counters requires these to agree)");
+
+        // Artwork keeps all three terms: its matches are artwork GROUPS, ~1.2-2.4 per card, so the
+        // column is genuinely distinct there rather than a duplicate. The push is held at the recovered
+        // value because artwork groups grow with printings -- an unconstrained artwork solve answers
+        // with a negative match rate that interpolates the cells and means nothing.
+        let push = 0.5 * (push_a + push_b);
+        if let Some(ap) = fit_mode(&cells, "artwork", push) {
+            println!("\n{:<30}{:>14}{:>16}{:>14}", "artwork arm", "ns/card", "ns/printing", "ns/group");
+            println!("{:<30}{:>14.2}{:>16.2}{:>14.2}", "artwork mode", ap[0], ap[1], push);
+
+            // Agreement per cell under the reparameterised model, which is the only thing that decides
+            // whether this is better than the mode-blind triple it replaces.
+            println!("\n  per-cell agreement, reparameterised (predicted/actual):");
+            let mut worst = 0.0f64;
+            for c in cells.iter().filter(|c| !c.ran_card_pass) {
+                let pred = match c.mode {
+                    "artwork" => c.cards * ap[0] + c.printings * ap[1] + c.matches * push,
+                    "printing" => c.cards * pp[0] + c.printings * pp[1],
+                    _ => c.cards * cp[0] + c.printings * cp[1],
+                };
+                let ratio = pred / c.ns_loop;
+                worst = worst.max((ratio.ln()).abs());
+                println!("    {:<24}{:>7}{:>10.2}", c.label, c.n_cards_req, ratio);
+            }
+            println!("  worst |log ratio| {:.3}  ({:.0}% off at the worst cell)", worst, (worst.exp() - 1.0) * 100.0);
         }
     }
 

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -177,13 +177,19 @@ const ITERS: usize = 200;
 /// group-size table this prints shows only 1,910 cards reach 8 printings, which is too few to fill
 /// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
 const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at. Two sizes so linearity in the card term is measured, not assumed;
-/// bounded above by the wide group, which is the scarce one. 400 is here to give the INTERCEPT leverage:
-/// a per-query fixed cost only shows up as the y-intercept of cells that vary in size, and the smallest
-/// cell is what pins it. The single-printing cell runs 6.31 →
-/// 7.67 ns/card between the two, so this is not a formality — the card term is mildly superlinear
-/// and a one-size design would bake whichever size it used into the constant.
-const CARD_COUNTS: [usize; 3] = [400, 1_500, 4_500];
+/// Card counts each cell runs at. Four sizes, geometric, because two things are being measured on this
+/// axis and they need opposite ends of it:
+///
+/// - **Linearity in the card term**, which the large end shows: the single-printing card cell measured
+///   8.33 / 8.53 / 10.11 ns/card at 400 / 1,500 / 4,500, so the per-card rate RISES with card count and
+///   a one-size design would bake whichever size it used into the constant.
+/// - **The intercept**, i.e. the per-query fixed cost, which only exists as the y-intercept of cells
+///   that vary in size — and which the SMALL end pins, because `intercept = t(n) - slope * n` multiplies
+///   any slope error by `n`. At a 400-card floor a 1 ns/card slope error is 400 ns of intercept error,
+///   against a shipped `GATHER_FIXED_COST_NS` of 169.6: unmeasurable. 100 shortens that lever 4x.
+///
+/// Bounded above by the wide group, which is the scarce one (see `WIDE_MIN_PRINTINGS`).
+const CARD_COUNTS: [usize; 4] = [100, 400, 1_500, 4_500];
 /// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
 /// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
 /// keeps that contribution proportional to matches rather than to the page.
@@ -691,28 +697,73 @@ fn bench_gather_loop() {
     // its intercept absorbs every mis-specification the other columns cannot express -- it read 84 and
     // then 85 while COLLECT_PER_PAGE_ROW moved 15.0 -> 9.79 beneath it, which is exactly that. Here the
     // intercept is identified by cells that differ ONLY in size, so nothing else can hide in it.
+    //
+    // Grouped by CELL LABEL, and least-squares over that label's three sizes. Both matter, and the
+    // first is a correction: this used to filter to a shape and two-point solve on the smallest and
+    // largest cells matching it, which crossed cell boundaries whenever two labels shared a shape --
+    // it paired `A` at 400 cards with `A'` (the same shape on a different chunk stagger) at 4,500 and
+    // reported -1,305 ns, where `A` against itself gives -780. The sign was right either way, but half
+    // the magnitude was stagger noise, and the magnitude is what a refit decision needs. One label
+    // across sizes holds the chunk stagger fixed, so only the size varies; printing per label rather
+    // than per mode then shows the spread instead of hiding it inside one number.
     {
-        println!("\nloop-phase intercept per mode (the y-intercept IS the per-query fixed cost):");
-        for mode in ["card", "printing", "artwork"] {
-            // Two-point solve on the smallest and largest cells of one shape, which is all an intercept
-            // needs and avoids weighting choices skewing it.
-            let mut same: Vec<&Cell> = cells
-                .iter()
-                .filter(|c| c.mode == mode && !c.ran_card_pass && (c.printings / c.cards) < 1.5)
-                .collect();
-            same.sort_by(|a, b| a.cards.total_cmp(&b.cards));
-            if let (Some(lo), Some(hi)) = (same.first(), same.last()) {
-                if hi.cards > lo.cards {
-                    let slope = (hi.ns_loop - lo.ns_loop) / (hi.cards - lo.cards);
-                    let intercept = lo.ns_loop - slope * lo.cards;
-                    println!(
-                        "  {:<10}{:>6.0} -> {:>6.0} cards   {:>7.2} ns/card   intercept {:>8.0} ns",
-                        mode, lo.cards, hi.cards, slope, intercept
-                    );
-                }
+        println!("\nloop-phase fixed cost and curvature per cell, single-printing shapes:");
+        println!(
+            "  {:<26}{:>10}{:>12}{:>10}{:>10}{:>9}{:>12}",
+            "cell", "ns/card", "intercept", "small", "large", "curve", "fixed"
+        );
+        // First occurrence of each label, in design order. `dedup()` would not do: cells are emitted
+        // size-major, so every label recurs once per size and only CONSECUTIVE repeats would collapse.
+        let mut labels: Vec<&str> = Vec::new();
+        for c in &cells {
+            if !labels.contains(&c.label) {
+                labels.push(c.label);
             }
         }
+        for label in labels {
+            // Single-printing shapes only. A fit on `cards` alone is interpretable only where printings
+            // track cards: a wide cell's cost is mostly per-PRINTING, so its slope reads 22-26 ns/card
+            // instead of ~11 and its intercept collects whatever that mis-attribution leaves over
+            // (`D wide print/default` read +6,498 ns). Same filter the per-mode version used, kept.
+            let same: Vec<&Cell> =
+                cells.iter().filter(|c| c.label == label && !c.ran_card_pass && (c.printings / c.cards) < 1.5).collect();
+            // Least squares on `ns_loop = intercept + slope * cards`, over every size this label ran.
+            let n = same.len() as f64;
+            if n < 2.0 {
+                continue;
+            }
+            let (sx, sy) = (same.iter().map(|c| c.cards).sum::<f64>(), same.iter().map(|c| c.ns_loop).sum::<f64>());
+            let sxx = same.iter().map(|c| c.cards * c.cards).sum::<f64>();
+            let sxy = same.iter().map(|c| c.cards * c.ns_loop).sum::<f64>();
+            let denom = n * sxx - sx * sx;
+            if denom.abs() < f64::EPSILON {
+                continue;
+            }
+            let slope = (n * sxy - sx * sy) / denom;
+            let intercept = (sy - slope * sx) / n;
+            // The whole-range line is reported for continuity with earlier runs, but it is NOT the
+            // number to read: the two smallest and two largest sizes are dominated by different effects,
+            // and a single line through them lands between the two with a negative intercept. Solve them
+            // apart. The small pair is where a per-query fixed cost is visible at all (at 4,500 cards a
+            // 170 ns constant is 0.04 ns/card, far under the cell-to-cell spread); the large pair is
+            // where the per-card rate has grown, which is the curvature.
+            let mut by_size: Vec<&&Cell> = same.iter().collect();
+            by_size.sort_by(|a, b| a.cards.total_cmp(&b.cards));
+            let secant = |lo: &Cell, hi: &Cell| (hi.ns_loop - lo.ns_loop) / (hi.cards - lo.cards);
+            let (small, large) = match (by_size.first(), by_size.get(1), by_size.iter().rev().nth(1), by_size.last()) {
+                (Some(a), Some(b), Some(c), Some(d)) => (secant(a, b), secant(c, d)),
+                _ => (f64::NAN, f64::NAN),
+            };
+            let small_intercept = by_size.first().map_or(f64::NAN, |c| c.ns_loop - small * c.cards);
+            println!(
+                "  {:<26}{:>10.2}{:>12.0}{:>10.2}{:>10.2}{:>9.2}{:>12.0}",
+                label, slope, intercept, small, large, large / small, small_intercept
+            );
+        }
         println!("  shipped GATHER_FIXED_COST_NS 169.6; a whole-arm traffic fit puts it at 85.");
+        println!("  Read the last two columns, not the first two. `large/small` is the CURVATURE the arm has");
+        println!("  no term for; `fixed` is what the small pair says a per-query cost is, and the whole-range");
+        println!("  intercept goes NEGATIVE only because one line cannot hold both ends at once.");
     }
 
     // The reparameterised fit: each mode fitted in the two-parameter space it can actually support,

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -178,10 +178,12 @@ const ITERS: usize = 200;
 /// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
 const WIDE_MIN_PRINTINGS: usize = 4;
 /// Card counts each cell runs at. Two sizes so linearity in the card term is measured, not assumed;
-/// bounded above by the wide group, which is the scarce one. The single-printing cell runs 6.31 →
+/// bounded above by the wide group, which is the scarce one. 400 is here to give the INTERCEPT leverage:
+/// a per-query fixed cost only shows up as the y-intercept of cells that vary in size, and the smallest
+/// cell is what pins it. The single-printing cell runs 6.31 →
 /// 7.67 ns/card between the two, so this is not a formality — the card term is mildly superlinear
 /// and a one-size design would bake whichever size it used into the constant.
-const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+const CARD_COUNTS: [usize; 3] = [400, 1_500, 4_500];
 /// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
 /// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
 /// keeps that contribution proportional to matches rather than to the page.
@@ -682,6 +684,35 @@ fn bench_gather_loop() {
             (c.ns_loop - base) / c.printings,
             (c.ns_loop - base) / c.cards
         );
+    }
+
+    // A per-query FIXED cost, measured as the intercept of the loop phase rather than taken from a
+    // whole-arm traffic fit. `fit_cost_model.py` fits one equation per query against total dispatch, so
+    // its intercept absorbs every mis-specification the other columns cannot express -- it read 84 and
+    // then 85 while COLLECT_PER_PAGE_ROW moved 15.0 -> 9.79 beneath it, which is exactly that. Here the
+    // intercept is identified by cells that differ ONLY in size, so nothing else can hide in it.
+    {
+        println!("\nloop-phase intercept per mode (the y-intercept IS the per-query fixed cost):");
+        for mode in ["card", "printing", "artwork"] {
+            // Two-point solve on the smallest and largest cells of one shape, which is all an intercept
+            // needs and avoids weighting choices skewing it.
+            let mut same: Vec<&Cell> = cells
+                .iter()
+                .filter(|c| c.mode == mode && !c.ran_card_pass && (c.printings / c.cards) < 1.5)
+                .collect();
+            same.sort_by(|a, b| a.cards.total_cmp(&b.cards));
+            if let (Some(lo), Some(hi)) = (same.first(), same.last()) {
+                if hi.cards > lo.cards {
+                    let slope = (hi.ns_loop - lo.ns_loop) / (hi.cards - lo.cards);
+                    let intercept = lo.ns_loop - slope * lo.cards;
+                    println!(
+                        "  {:<10}{:>6.0} -> {:>6.0} cards   {:>7.2} ns/card   intercept {:>8.0} ns",
+                        mode, lo.cards, hi.cards, slope, intercept
+                    );
+                }
+            }
+        }
+        println!("  shipped GATHER_FIXED_COST_NS 169.6; a whole-arm traffic fit puts it at 85.");
     }
 
     // The reparameterised fit: each mode fitted in the two-parameter space it can actually support,

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -1,5 +1,22 @@
 //! Micro-benchmark that decomposes `GatheredScan`'s match loop into its three rates.
 //!
+//! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
+//! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
+//! second pass every card, printing and string it touches is resident. Production walks a candidate set
+//! once. Measuring the first pass against the warm minimum on cells that run after the mmap has faulted
+//! in gives 1.6-2.2x (A' 1.91x/1.74x, I 1.83x/1.59x, H 2.17x/2.14x; the 100x+ figures on the first cells
+//! are first-touch page faults on the 68 MB store, not cache effects).
+//!
+//! That 1.6-2x is the whole discrepancy. Warm 2.98 ns/card against 6.34 fitted on traffic is 2.1x; P3's
+//! warm 2.41 against a shipped 5.05 is 2.1x; the warm push 1.06 against 2.00 fitted is 1.9x. The
+//! counter/feature ratios all read 1.00, so the features were never the gap -- the TIME was, and the
+//! shipped constants include the miss cost this harness removes.
+//!
+//! So the five refits below did not fail because routing is a delicate joint surface. They failed
+//! because they lowered rates toward a cache state production never reaches. Read every ns figure in
+//! this file as "warm", useful for the SHAPE of the loop -- which terms exist, which are degenerate, how
+//! artwork differs -- and not as a candidate constant. Those shape findings stand; the levels do not.
+//!
 //! `cost.rs` charges that loop three ways — `GATHER_CARD_PASS_NS` per card visited,
 //! `GATHER_SCAN_PER_ROW_NS` per printing examined, `GATHER_PUSH_PER_MATCH_NS` per match
 //! pushed — and notes the three "could NOT be fit ... a STRUCTURAL collinearity no corpus
@@ -389,13 +406,22 @@ fn bench_gather_loop() {
         }
     }
 
+    // Iteration 0, kept because min-of-ITERS is a WARM-CACHE number: the same card list is walked 200
+    // times, so every card, printing and string it touches is resident by the second pass. Production
+    // walks a candidate set once. If the first pass is materially slower than the minimum, these rates
+    // describe a cache state production never sees, and that -- not a wrong feature -- is why shipping
+    // them regresses. The counter/feature ratios all read 1.00, so the features are not the gap.
+    let mut first_loop: Vec<f64> = vec![0.0; configs.len()];
     let mut best_setup: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
-    for _ in 0..ITERS {
+    for iter in 0..ITERS {
         for (i, cfg) in configs.iter().enumerate() {
             black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &cfg.prep, None));
             let s = take_phase_stats();
+            if iter == 0 {
+                first_loop[i] = s.ns_loop as f64;
+            }
             if (s.ns_loop as f64) < best_ns[i] {
                 best_ns[i] = s.ns_loop as f64;
             }
@@ -480,6 +506,24 @@ fn bench_gather_loop() {
     // What artwork mode costs ON TOP of the three fitted rates. cost.rs has no artwork term for P4,
     // so today this sits inside the shared rates, which is why measuring them without artwork in the
     // design and then lowering them under-costs artwork queries.
+    // The warm/cold gap, per cell. `cost.rs`'s constants are fitted on production traffic, which pays
+    // this; every rate this harness reports is a min-of-200 and does not.
+    println!("\nfirst pass vs warm minimum (min-of-{ITERS} hides whatever the cold walk costs):");
+    let (mut sum_first, mut sum_best) = (0.0f64, 0.0f64);
+    for (i, c) in cells.iter().enumerate() {
+        println!(
+            "  {:<24}{:>7}  first {:>9.2} ns/card   warm min {:>8.2}   ratio {:>5.2}x",
+            c.label,
+            c.n_cards_req,
+            first_loop[i] / c.cards,
+            c.ns_loop / c.cards,
+            first_loop[i] / c.ns_loop
+        );
+        sum_first += first_loop[i];
+        sum_best += c.ns_loop;
+    }
+    println!("  overall first/warm {:.2}x", sum_first / sum_best);
+
     println!("\nartwork surcharge over the card/printing fit (P4 has no artwork term today):");
     for c in cells.iter().filter(|c| c.mode == "artwork") {
         let base = predict(c, k);

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -65,10 +65,38 @@
 //! it is dearer where cards are narrow and cheaper where they are wide. `ns_setup` is not the
 //! explanation either — the `group_best` allocation measures 83-125 ns, negligible.
 //!
-//! So P4's loop needs rates fitted PER MODE (or a term keyed on printings-per-card), not one triple
-//! plus a linear artwork correction. Until that exists, the shipped mode-blind constants are doing
-//! real work by being too high: they absorb artwork's cost, and lowering them to the card/printing
-//! truth under-costs artwork and loses more than it gains. The constants are deliberately unchanged.
+//! Adding an artwork ARM (per-card and per-printing rates gated on `artwork_seen_cards`, which is
+//! `eval_domain` in artwork mode and 0 otherwise) was tried next and measured:
+//!
+//!     card + printing pooled    3.41 ns/card   2.36 ns/printing   0.80 ns/match
+//!     printing mode             3.41           2.36               0.76  (card/row shared)
+//!     artwork mode              6.68           1.20               0.80  (push shared)
+//!
+//! Artwork does MORE per card (walk `touched`, push per group, reset `group_best`) and LESS per
+//! printing (a group-id lookup and compare instead of a sort-key push), which is the mechanism behind
+//! the sign flip. That arm FIXED artwork at the gate -- artwork went 52% -> 50% of lost time, mean
+//! 3.40 -> 3.55 -- but total regret was still worse, 40.7 -> 44.3 ms, with the damage moving to
+//! printing mode (mean 1.69 -> 2.10). Printing's own push rate fits 0.76 against 0.80, a 5% gap that
+//! cannot account for it, so a third arm does not fix it either: lowering P4's cost simply wins it
+//! more printing-mode queries where P3 was genuinely better. Reverted again.
+//!
+//! The structural obstacle found on the way is the durable result. No single mode can identify all
+//! three rates, because in each one a column is a DUPLICATE: card mode pushes once per card, so
+//! `matches == cards`; printing mode pushes every printing it examines, so `matches == printings`.
+//! Only pooling card and printing separates the three, which is in direct tension with the rates
+//! differing by mode. So "fit each mode separately" is not available, and the way out is to
+//! REPARAMETERISE onto what each mode can identify:
+//!
+//!     card mode      (LOOP + PUSH) per card, SCAN per printing
+//!     printing mode  LOOP per card, (SCAN + PUSH) per printing
+//!     artwork mode   LOOP_art per card, SCAN_art per printing, PUSH per group
+//!
+//! Every parameter there is identifiable in the mode that uses it, and no mode carries a column that
+//! duplicates another. That is the next thing to try; it is a different model, not a refit.
+//!
+//! Until then the shipped mode-blind constants are doing real work by being too high: they absorb
+//! artwork's cost, and every attempt to lower them toward the measured card/printing truth has lost
+//! more elsewhere than it gained. The constants are deliberately unchanged.
 //!
 //! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
 //! behave as the page grows.
@@ -118,10 +146,9 @@ struct Cell {
     /// fit; the rows that DO call `card_pass` are used to price that call instead, and mixing them
     /// would fold a predicate evaluation into the card term.
     ran_card_pass: bool,
-    /// Artwork mode maintains `group_best`/`touched` per printing on top of everything the other modes
-    /// do. Those rows are held out of the three-rate fit and priced against it, because pooling them
-    /// would smear a mode-specific cost across rates that cost.rs applies to all three modes.
-    artwork: bool,
+    /// The `unique` mode this cell ran in. All three loops differ, so rates are fitted per mode:
+    /// pooling them smears mode-specific cost across rates that then fit none of the modes.
+    mode: &'static str,
 }
 
 /// Solve a 3×3 system by Gaussian elimination with partial pivoting.
@@ -148,9 +175,16 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
 /// Relative least squares over every cell: each equation is divided by its own measured time, so a
 /// cell running 50 µs does not outweigh one running 5 µs. Absolute OLS here would fit the largest
 /// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
-fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
+/// Fitted over the modes named, and it has to be more than one of them.
+///
+/// No single mode can identify all three rates, because in each one a column is a DUPLICATE: card mode
+/// pushes once per card, so `matches == cards`; printing mode pushes every printing it examines, so
+/// `matches == printings`. Pooling card and printing is what makes the three separable, which sits in
+/// direct tension with the rates differing by mode -- the tension is resolved by reparameterising
+/// (see the module docs), not by fitting each mode alone.
+fn fit(cells: &[Cell], modes: &[&str]) -> Option<[f64; 3]> {
     let mut normal = [[0.0f64; 4]; 3];
-    for c in cells.iter().filter(|c| !c.ran_card_pass && !c.artwork) {
+    for c in cells.iter().filter(|c| !c.ran_card_pass && modes.contains(&c.mode)) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w, c.matches * w];
         for i in 0..3 {
@@ -161,6 +195,57 @@ fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
         }
     }
     solve3(normal)
+}
+
+/// Artwork's card and printing rates with the MATCH rate held at the value fitted for the other
+/// modes. Fitting all three on artwork alone is ill-conditioned -- artwork groups grow with printings,
+/// so `matches` and `printings` are collinear inside artwork, and the unconstrained solve answers with
+/// a large printing rate against a NEGATIVE match rate (-60 ns) that interpolates the cells and means
+/// nothing. Holding the push shared is not a convenience: it is the same `GatherSelect` push in every
+/// mode, so the constraint is the physical claim, and it leaves 2 unknowns against 3 ratio levels.
+fn fit_artwork(cells: &[Cell], push_ns: f64) -> Option<[f64; 2]> {
+    let mut normal = [[0.0f64; 3]; 2];
+    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "artwork") {
+        let w = 1.0 / c.ns_loop;
+        let x = [c.cards * w, c.printings * w];
+        // The shared push comes off the target, exactly as `design_row` handles cost.rs's offsets.
+        let y = (c.ns_loop - c.matches * push_ns) * w;
+        for i in 0..2 {
+            for j in 0..2 {
+                normal[i][j] += x[i] * x[j];
+            }
+            normal[i][2] += x[i] * y;
+        }
+    }
+    let det = normal[0][0] * normal[1][1] - normal[0][1] * normal[1][0];
+    if det.abs() < 1e-12 {
+        return None;
+    }
+    Some([
+        (normal[0][2] * normal[1][1] - normal[0][1] * normal[1][2]) / det,
+        (normal[0][0] * normal[1][2] - normal[1][0] * normal[0][2]) / det,
+    ])
+}
+
+/// Printing mode's push rate, with per-card and per-printing held at the card-mode values.
+///
+/// Only one unknown is available: printing mode pushes every printing it examines, so `matches ==
+/// printings` exactly and those two columns are IDENTICAL within the mode -- no design over real cards
+/// can separate them. The bit test is the same work in both modes, so the rate that is allowed to move
+/// is the push, which is what actually differs (consecutive printings of one card push into the
+/// selector back to back, where card mode pushes one per card).
+fn fit_printing_push(cells: &[Cell], per_card: f64, per_row: f64) -> Option<f64> {
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "printing") {
+        let w = 1.0 / c.ns_loop;
+        let x = c.matches * w;
+        num += x * (c.ns_loop - c.cards * per_card - c.printings * per_row) * w;
+        den += x * x;
+    }
+    if den <= 0.0 {
+        return None;
+    }
+    Some(num / den)
 }
 
 fn predict(c: &Cell, k: [f64; 3]) -> f64 {
@@ -186,19 +271,22 @@ fn bench_gather_loop() {
 
     // Group cards by printing count. This is the knob sampled traffic does not have: it sets
     // printings-per-card independently of how many cards the loop visits.
-    let (mut singleton, mut wide): (Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new());
+    let (mut singleton, mut medium, mut wide): (Vec<u32>, Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new(), Vec::new());
     for cid in 0..data.cards.len() {
         let span = u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize;
         if span == 1 {
             singleton.push(cid as u32);
         } else if span >= WIDE_MIN_PRINTINGS {
             wide.push(cid as u32);
+        } else {
+            medium.push(cid as u32);
         }
     }
     println!(
-        "\n{} oracle cards: {} with 1 printing, {} with >={WIDE_MIN_PRINTINGS}",
+        "\n{} oracle cards: {} with 1 printing, {} with 2..{WIDE_MIN_PRINTINGS}, {} with >={WIDE_MIN_PRINTINGS}",
         data.cards.len(),
         singleton.len(),
+        medium.len(),
         wide.len()
     );
     // How much headroom `WIDE_MIN_PRINTINGS` and `CARD_COUNTS` have. The tail is steep, and the
@@ -247,13 +335,16 @@ fn bench_gather_loop() {
     // them low, under-costing artwork. Shipping that moved total routing regret 36.2 -> 51.7 ms, with
     // candidates/artwork going 19% -> 35% of all lost time. Artwork has to be in the design for these
     // rates to mean anything.
-    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 9] = [
+    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 12] = [
         ("A 1p  card/default", &singleton, "card", "default", true),
         ("B 1p  print/default", &singleton, "printing", "default", true),
         ("C wide card/oldest", &wide, "card", "oldest", true),
         ("D wide print/default", &wide, "printing", "default", true),
         ("E 1p  artwork/default", &singleton, "artwork", "default", true),
         ("F wide artwork/default", &wide, "artwork", "default", true),
+        ("G med artwork/default", &medium, "artwork", "default", true),
+        ("H med card/oldest", &medium, "card", "oldest", true),
+        ("I med print/default", &medium, "printing", "default", true),
         ("A' 1p card/default ctl", &singleton, "card", "default", true),
         ("A+ 1p  card, card_pass", &singleton, "card", "default", false),
         ("C+ wide card, card_pass", &wide, "card", "oldest", false),
@@ -275,7 +366,7 @@ fn bench_gather_loop() {
         prep: PreparedCandidates,
         params: QueryParams,
         ran_card_pass: bool,
-        artwork: bool,
+        mode: &'static str,
     }
     let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
@@ -294,7 +385,7 @@ fn bench_gather_loop() {
                 },
                 params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
                 ran_card_pass: !all_match_known,
-                artwork: *unique == "artwork",
+                mode: unique,
             });
         }
     }
@@ -330,7 +421,7 @@ fn bench_gather_loop() {
             matches,
             ns_loop: best_ns[i],
             ran_card_pass: cfg.ran_card_pass,
-            artwork: cfg.artwork,
+            mode: cfg.mode,
         };
         println!(
             "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}{:>11.0}",
@@ -383,7 +474,7 @@ fn bench_gather_loop() {
         }
     }
 
-    let Some(k) = fit(&cells) else {
+    let Some(k) = fit(&cells, &["card", "printing"]) else {
         println!("\nsystem still singular — the design did not separate the columns");
         return;
     };
@@ -391,7 +482,7 @@ fn bench_gather_loop() {
     // so today this sits inside the shared rates, which is why measuring them without artwork in the
     // design and then lowering them under-costs artwork queries.
     println!("\nartwork surcharge over the card/printing fit (P4 has no artwork term today):");
-    for c in cells.iter().filter(|c| c.artwork) {
+    for c in cells.iter().filter(|c| c.mode == "artwork") {
         let base = predict(c, k);
         println!(
             "  {:<26}{:>7}  measured {:>8.0} ns vs fit {:>8.0} ns   +{:>6.2} ns/printing  +{:>6.2} ns/card",
@@ -402,6 +493,34 @@ fn bench_gather_loop() {
             (c.ns_loop - base) / c.printings,
             (c.ns_loop - base) / c.cards
         );
+    }
+
+    // The two candidate shapes, side by side. If artwork's triple differs from the other modes' while
+    // card and printing sit together under one triple, the model wants a two-way branch on mode
+    // (artwork vs not) rather than one mode-blind triple, an additive artwork correction, or a
+    // three-way branch. An additive correction cannot be right if artwork's per-printing rate comes
+    // out LOWER, since the term would have to be negative; a three-way branch is only justified if
+    // card and printing actually separate.
+    if let Some(a2) = fit_artwork(&cells, k[2]) {
+        let art = [a2[0], a2[1], k[2]];
+        println!("\n{:<26}{:>14}{:>14}{:>14}", "fitted separately", "ns/card", "ns/printing", "ns/match");
+        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}", "card + printing pooled", k[0], k[1], k[2]);
+        match fit_printing_push(&cells, k[0], k[1]) {
+            Some(push) => println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (card/row shared)", "printing mode", k[0], k[1], push),
+            None => println!("{:<26}  no printing cells", "printing mode"),
+        }
+        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (push shared)", "artwork mode", art[0], art[1], art[2]);
+        println!("\n  per-cell agreement under the triple fitted for that cell's OWN group:");
+        for c in cells.iter().filter(|c| !c.ran_card_pass) {
+            let own = if c.mode == "artwork" { art } else { k };
+            println!(
+                "    {:<24}{:>7}  own-group p/a {:>6.2}   card/printing-triple p/a {:>6.2}",
+                c.label,
+                c.n_cards_req,
+                predict(c, own) / c.ns_loop,
+                predict(c, k) / c.ns_loop
+            );
+        }
     }
 
     println!("\n{:<34}{:>10}{:>10}", "rate", "shipped", "fitted");

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -1,0 +1,302 @@
+//! Micro-benchmark that decomposes `GatheredScan`'s match loop into its three rates.
+//!
+//! `cost.rs` charges that loop three ways — `GATHER_CARD_PASS_NS` per card visited,
+//! `GATHER_SCAN_PER_ROW_NS` per printing examined, `GATHER_PUSH_PER_MATCH_NS` per match
+//! pushed — and notes the three "could NOT be fit ... a STRUCTURAL collinearity no corpus
+//! size fixes", so the values came from a physical prior instead. The loop is ~90% of the
+//! plan's dispatch, and P3-vs-P4 routing turns on the split rather than the total, so the
+//! three rates are worth pinning down.
+//!
+//! Fitting them on sampled traffic was re-tried and fails for a sharper reason than corpus
+//! size: measured on 5,986 all_match rows, the three counters correlate 0.94–1.00 **inside
+//! every `unique` × `prefer` cell**, not merely pooled. `unique` and `prefer` do change the
+//! ratio between the columns, but within any one cell all three still scale with query size,
+//! and query size dominates the variance. `matches_pushed` fitted to exactly 0.00 on two
+//! independent seeds — pinned to the non-negativity boundary, i.e. unidentified rather than
+//! noisy. Balancing the cells made coefficient stability worse (1.06× → 1.46× across seeds),
+//! because all it can do is discard rows. No arrangement of sampled traffic fixes this: traffic
+//! never varies the ratio at FIXED SCALE, which is the only thing that separates the columns.
+//!
+//! So the design is built rather than sampled. Cards are grouped by printing count, which lets
+//! printings-per-card be set independently of card count, and `unique`/`prefer` then set
+//! matches independently of printings:
+//!
+//!     cell  printings/card  unique     prefer   cards  printings  matches
+//!     A     1               card       default    N        N         N
+//!     B     1               printing   default    N        N         N     (consistency check vs A)
+//!     C     ~W              card       oldest     N       ~WN        N
+//!     D     ~W              printing   default    N       ~WN       ~WN
+//!
+//! A, C and D give `[1 1 1; 1 W 1; 1 W W]`, whose determinant is nonzero — all three rates are
+//! pinned. Cell C is why `prefer` is in the design: under the default prefer the card-mode
+//! kernel breaks at the first match, so printings collapses back onto cards and the row stops
+//! being independent (see `push_card_matches`). Each cell is also run at two card counts, so
+//! linearity in the card term is checked rather than assumed.
+//!
+//! This calls the real `exec_gathered_scan` and reads `ns_loop` and the counters back off
+//! `PhaseStats` — the same fenceposts and the same counters production publishes. Nothing is
+//! reimplemented, so there is no second copy of the loop to keep in sync, and the fit is
+//! against the instrumentation the cost model is actually checked with.
+//!
+//! What it measured (2026-08-03), stable to 1.07× / 1.02× / 1.04× across three runs where the
+//! traffic fit could not pin the push rate off the boundary at all:
+//!
+//!     GATHER_CARD_PASS_NS        shipped 6.88   fitted 3.08-3.30
+//!     GATHER_SCAN_PER_ROW_NS     shipped 2.06   fitted 2.44-2.48
+//!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.91-0.95
+//!
+//! The shipped set over-predicts every cell (1.07-1.92 predicted/actual) and over-predicts MOST
+//! on single-printing cards, least on wide card-mode ones — so `GatheredScan` is systematically
+//! over-costed on card-heavy candidate sets, which is the direction that loses it to
+//! `StreamedSelect` wrongly.
+//!
+//! Two limits on reading these as drop-in replacements. `all_match_known` is set, so the loop
+//! never calls `card_pass` and the fitted card term is loop overhead with NO predicate evaluation
+//! in it — correct for the #634 path that also skips it, but queries reaching `card_pass` pay more,
+//! which is what the residual-tier term exists to cover. And `LIMIT` is fixed, so nothing here
+//! constrains how the rates behave as the page grows. Traffic-level regret and latency matrices
+//! remain the gate before any of this ships.
+//!
+//!     cargo test --release bench_gather_loop -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` — rebuild it the
+//! same way (see that module's docs) after any AOracleCard/APrinting layout change.
+
+use std::hint::black_box;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, exec_gathered_scan, take_phase_stats, CardData, CmpOp, FilterExpr, Mmap, NarrowedRepr,
+    PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
+};
+
+/// Timed repetitions per cell; the minimum is reported, as elsewhere in these harnesses.
+const ITERS: usize = 200;
+/// A "wide" card has at least this many printings. Sets the leverage between the card column and
+/// the printing column: a bigger gap separates them better, but the corpus has a steep tail — the
+/// group-size table this prints shows only 1,910 cards reach 8 printings, which is too few to fill
+/// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
+const WIDE_MIN_PRINTINGS: usize = 4;
+/// Card counts each cell runs at. Two sizes so linearity in the card term is measured, not assumed;
+/// bounded above by the wide group, which is the scarce one. The single-printing cell runs 6.31 →
+/// 7.67 ns/card between the two, so this is not a formality — the card term is mildly superlinear
+/// and a one-size design would bake whichever size it used into the constant.
+const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+/// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
+/// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
+/// keeps that contribution proportional to matches rather than to the page.
+const LIMIT: usize = 60;
+
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// One measured design point: the realized counters, and the loop time they were produced by.
+struct Cell {
+    label: &'static str,
+    n_cards_req: usize,
+    cards: f64,
+    printings: f64,
+    matches: f64,
+    ns_loop: f64,
+}
+
+/// Solve a 3×3 system by Gaussian elimination with partial pivoting.
+fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
+    for col in 0..3 {
+        let piv = (col..3).max_by(|&i, &j| a[i][col].abs().total_cmp(&a[j][col].abs()))?;
+        a.swap(col, piv);
+        if a[col][col].abs() < 1e-12 {
+            return None;
+        }
+        for row in 0..3 {
+            if row == col {
+                continue;
+            }
+            let f = a[row][col] / a[col][col];
+            for k in col..4 {
+                a[row][k] -= f * a[col][k];
+            }
+        }
+    }
+    Some([a[0][3] / a[0][0], a[1][3] / a[1][1], a[2][3] / a[2][2]])
+}
+
+/// Relative least squares over every cell: each equation is divided by its own measured time, so a
+/// cell running 50 µs does not outweigh one running 5 µs. Absolute OLS here would fit the largest
+/// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
+fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
+    let mut normal = [[0.0f64; 4]; 3];
+    for c in cells {
+        let w = 1.0 / c.ns_loop;
+        let x = [c.cards * w, c.printings * w, c.matches * w];
+        for i in 0..3 {
+            for j in 0..3 {
+                normal[i][j] += x[i] * x[j];
+            }
+            normal[i][3] += x[i] * (c.ns_loop * w);
+        }
+    }
+    solve3(normal)
+}
+
+fn predict(c: &Cell, k: [f64; 3]) -> f64 {
+    c.cards * k[0] + c.printings * k[1] + c.matches * k[2]
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_gather_loop() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and
+    // replaced atomically, and the header is re-validated below before the payload is trusted.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(data);
+
+    // Group cards by printing count. This is the knob sampled traffic does not have: it sets
+    // printings-per-card independently of how many cards the loop visits.
+    let (mut singleton, mut wide): (Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new());
+    for cid in 0..data.cards.len() {
+        let span = u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize;
+        if span == 1 {
+            singleton.push(cid as u32);
+        } else if span >= WIDE_MIN_PRINTINGS {
+            wide.push(cid as u32);
+        }
+    }
+    println!(
+        "\n{} oracle cards: {} with 1 printing, {} with >={WIDE_MIN_PRINTINGS}",
+        data.cards.len(),
+        singleton.len(),
+        wide.len()
+    );
+    // How much headroom `WIDE_MIN_PRINTINGS` and `CARD_COUNTS` have. The tail is steep, and the
+    // largest cell cannot exceed the wide group, so this is the table those two constants are
+    // chosen from rather than guessed at.
+    print!("cards with >=n printings:");
+    for threshold in 2..=10usize {
+        let n = (0..data.cards.len())
+            .filter(|&cid| u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize >= threshold)
+            .count();
+        print!("  {threshold}:{n}");
+    }
+    println!();
+
+    // all_match_known short-circuits `card_pass`, so the residual tier is exactly zero and this
+    // filter is never evaluated — the loop is card visit + push + absorb and nothing else. That
+    // isolates the three rates from the residual term, which is fitted separately.
+    // `mask: 0` with `Ge` is unconditionally true, but nothing evaluates it either way.
+    let filter = FilterExpr::TypeCmp { mask: 0, op: CmpOp::Ge };
+    let mut cells: Vec<Cell> = Vec::new();
+
+    // (label, source group, unique, prefer)
+    //
+    // A' repeats A last as a control. A and B are the same cards with one printing each and report
+    // identical counters, so any time difference between them is either a real `unique` effect or an
+    // artifact of A running first and paying first-touch on the mmap. A' vs A separates those: equal
+    // means the difference is real, A' matching B means it was ordering.
+    let designs: [(&'static str, &Vec<u32>, &str, &str); 5] = [
+        ("A 1p  card/default", &singleton, "card", "default"),
+        ("B 1p  print/default", &singleton, "printing", "default"),
+        ("C wide card/oldest", &wide, "card", "oldest"),
+        ("D wide print/default", &wide, "printing", "default"),
+        ("A' 1p card/default ctl", &singleton, "card", "default"),
+    ];
+
+    println!(
+        "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}",
+        "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card"
+    );
+    for n_req in CARD_COUNTS {
+        for (label, group, unique, prefer) in &designs {
+            if group.len() < n_req {
+                println!("{label:<22}{n_req:>7}   SKIP (only {} cards in group)", group.len());
+                continue;
+            }
+            let prep = PreparedCandidates {
+                candidate_cards: Some(group[..n_req].to_vec()),
+                all_match_known: true,
+                narrowed_repr: NarrowedRepr::Cards,
+            };
+            let params = QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0);
+            let mut best = f64::INFINITY;
+            let mut stats = take_phase_stats();
+            for _ in 0..ITERS {
+                black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
+                let s = take_phase_stats();
+                if (s.ns_loop as f64) < best {
+                    best = s.ns_loop as f64;
+                    stats = s;
+                }
+            }
+            let cell = Cell {
+                label,
+                n_cards_req: n_req,
+                cards: stats.cards_visited as f64,
+                printings: stats.printings_examined as f64,
+                matches: stats.matches_pushed as f64,
+                ns_loop: best,
+            };
+            println!(
+                "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
+                cell.label,
+                cell.n_cards_req,
+                cell.cards,
+                cell.printings,
+                cell.matches,
+                cell.ns_loop,
+                cell.ns_loop / cell.cards
+            );
+            cells.push(cell);
+        }
+    }
+
+    assert!(cells.len() >= 3, "need at least 3 design points to identify 3 rates, got {}", cells.len());
+
+    // The design's leverage, stated rather than assumed: printings-per-card and matches-per-card
+    // must differ across cells or the system is the degenerate one sampled traffic gives.
+    println!("\nper-card ratios by cell (these differing IS the design):");
+    for c in &cells {
+        println!(
+            "  {:<22}{:>7} printings/card {:>6.2}   matches/card {:>6.2}",
+            c.label,
+            c.n_cards_req,
+            c.printings / c.cards,
+            c.matches / c.cards
+        );
+    }
+
+    let Some(k) = fit(&cells) else {
+        println!("\nsystem still singular — the design did not separate the columns");
+        return;
+    };
+    println!("\n{:<34}{:>10}{:>10}", "rate", "shipped", "fitted");
+    for (name, shipped, got) in [
+        ("GATHER_CARD_PASS_NS", 6.88, k[0]),
+        ("GATHER_SCAN_PER_ROW_NS", 2.06, k[1]),
+        ("GATHER_PUSH_PER_MATCH_NS", 2.24, k[2]),
+    ] {
+        println!("{name:<34}{shipped:>10.2}{got:>10.2}");
+    }
+
+    // Per-cell agreement under both constant sets. The fitted set should beat the shipped one on
+    // every cell; if it only wins on average, the split is still not doing real work.
+    println!("\n{:<22}{:>7}{:>14}{:>14}", "cell", "n", "shipped p/a", "fitted p/a");
+    let shipped = [6.88, 2.06, 2.24];
+    for c in &cells {
+        println!(
+            "{:<22}{:>7}{:>14.2}{:>14.2}",
+            c.label,
+            c.n_cards_req,
+            predict(c, shipped) / c.ns_loop,
+            predict(c, k) / c.ns_loop
+        );
+    }
+}

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -186,6 +186,12 @@ const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
 /// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
 /// keeps that contribution proportional to matches rather than to the page.
 const LIMIT: usize = 60;
+/// (offset, limit) pairs for the finish-phase sweep. `GATHER_SELECT_PER_PAGE_SLOT_NS` is charged against
+/// `page_span = min(offset + limit, matches)`, and every cell above holds the page FIXED, so that term
+/// has never been varied here -- the loop rates were measured while the one term keyed on the page was
+/// held constant. These four move `page_span` ~40x at constant counters, which is what separates a
+/// per-slot rate from a fixed cost the phase pays regardless.
+const PAGE_SPECS: [(usize, usize); 4] = [(0, 15), (0, 60), (0, 600), (900, 60)];
 
 /// Default store. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep runs: build
 /// upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn. The real corpus is
@@ -596,6 +602,56 @@ fn bench_gather_loop() {
     // What artwork mode costs ON TOP of the three fitted rates. cost.rs has no artwork term for P4,
     // so today this sits inside the shared rates, which is why measuring them without artwork in the
     // design and then lowering them under-costs artwork queries.
+    // Finish-phase sweep. Runs the SAME candidate set at four pages, so the loop's work is identical
+    // across rows and every difference in `ns_finish` is the select-and-collect. Chunk-rotated like
+    // everything else, and the median is reported.
+    //
+    // `page_span` is `min(offset + limit, matches)`, so the (900, 60) row is capped by matches rather
+    // than by the page: with 4,500 matches it asks for span 960, where (0, 600) asks for 600. That is
+    // the row that separates a genuine per-slot rate from `offset` merely being large.
+    if singleton.len() >= CARD_COUNTS[1] {
+        println!("\nfinish phase vs page_span (same cards, four pages -- the loop is identical across rows):");
+        println!("  {:>7}{:>8}{:>12}{:>12}{:>14}", "offset", "limit", "page_span", "ns_finish", "ns per slot");
+        let mut rows: Vec<(f64, f64)> = Vec::new();
+        for (offset, limit) in PAGE_SPECS {
+            let params = QueryParams::from_strs("card", "default", "name", "asc", limit, offset);
+            let mut samples: Vec<f64> = Vec::with_capacity(ITERS);
+            let mut span = 0.0f64;
+            let chunks = (singleton.len() / CARD_COUNTS[1]).max(1);
+            for iter in 0..ITERS {
+                let start = (iter % chunks) * CARD_COUNTS[1];
+                let end = (start + CARD_COUNTS[1]).min(singleton.len());
+                let prep = PreparedCandidates {
+                    candidate_cards: Some(singleton[start..end].to_vec()),
+                    all_match_known: true,
+                    narrowed_repr: NarrowedRepr::Cards,
+                };
+                black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
+                let st = take_phase_stats();
+                span = (offset + limit).min(st.matches_pushed as usize) as f64;
+                samples.push(st.ns_finish as f64);
+            }
+            samples.sort_by(f64::total_cmp);
+            let ns = samples[samples.len() / 2];
+            println!("  {offset:>7}{limit:>8}{span:>12.0}{ns:>12.0}{:>14.2}", ns / span.max(1.0));
+            rows.push((span, ns));
+        }
+        // Two-point solve across the widest span gap, which is the cheapest way to see whether the phase
+        // has a fixed component. Through the origin the slope has to absorb any constant, which inflates
+        // it on the small-page rows -- the same error that made `GATHER_SELECT_PER_PAGE_SLOT_NS` look 5x
+        // wrong earlier in this branch.
+        if let (Some(lo), Some(hi)) = (rows.first(), rows.iter().max_by(|a, b| a.0.total_cmp(&b.0))) {
+            if hi.0 > lo.0 {
+                let slope = (hi.1 - lo.1) / (hi.0 - lo.0);
+                println!(
+                    "  two-point: {:.2} ns/slot + {:.0} ns fixed   (shipped GATHER_SELECT_PER_PAGE_SLOT_NS 3.51, no fixed term)",
+                    slope,
+                    lo.1 - slope * lo.0
+                );
+            }
+        }
+    }
+
     // The warm/cold gap, per cell. `cost.rs`'s constants are fitted on production traffic, which pays
     // this; every rate this harness reports is a min-of-200 and does not.
     println!("\nfirst pass vs warm minimum (min-of-{ITERS} hides whatever the cold walk costs):");

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -46,17 +46,32 @@
 //!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.90        (1.000x)
 //!     the card_pass call itself                 2.94-3.00 ns/card on singletons, 1.6-1.8 on wide
 //!
-//! Those last two lines are the finding, and they say the shipped constant is not simply wrong:
-//! 3.24 of loop overhead plus ~3.0 for the `card_pass` call is ~6.2 against a shipped 6.88, so
-//! `GATHER_CARD_PASS_NS` BUNDLES the predicate call. It is therefore about right for queries that
-//! make that call, and about 2x too high for the #634 `all_match_known` path, which skips
-//! `card_pass` entirely and is charged for it anyway. That is a model-shape error rather than a
-//! mis-fitted constant, and it over-costs `GatheredScan` precisely on the queries that should be
-//! cheapest for it — the direction that loses them to `StreamedSelect`.
+//! Those last two lines say the shipped constant is not simply wrong: 3.24 of loop overhead plus
+//! ~3.0 for the `card_pass` call is ~6.2 against a shipped 6.88, so `GATHER_CARD_PASS_NS` BUNDLES
+//! the predicate call. It is therefore about right for queries that make that call, and about 2x too
+//! high for the #634 `all_match_known` path, which skips `card_pass` entirely and is charged for it
+//! anyway — a model-shape error rather than a mis-fitted constant, and it over-costs `GatheredScan`
+//! precisely on the queries that should be cheapest for it.
 //!
-//! One limit remains on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
-//! behave as the page grows. Traffic-level regret and latency matrices remain the gate before any
-//! of it ships.
+//! **Shipping those constants FAILED the acceptance test, and that is the more important result.**
+//! Splitting the card term as measured and applying all three rates moved total routing regret
+//! 36.2 → 51.7 ms, with `candidates / artwork` going 19% → 35% of all lost time. The design had no
+//! artwork cell in it, and `cost.rs` applies one set of `GATHER_*` rates to all three modes.
+//!
+//! Adding artwork cells (E, F) shows why no single rate triple can work. Against the card/printing
+//! fit, artwork measures +19% and +36% on single-printing cards but −29% and −19% on wide ones: the
+//! surcharge FLIPS SIGN with printings-per-card. Artwork pushes ~2.4 matches/card where printing mode
+//! pushes ~6.9, and its per-printing group bookkeeping is cheaper than the push path it replaces, so
+//! it is dearer where cards are narrow and cheaper where they are wide. `ns_setup` is not the
+//! explanation either — the `group_best` allocation measures 83-125 ns, negligible.
+//!
+//! So P4's loop needs rates fitted PER MODE (or a term keyed on printings-per-card), not one triple
+//! plus a linear artwork correction. Until that exists, the shipped mode-blind constants are doing
+//! real work by being too high: they absorb artwork's cost, and lowering them to the card/printing
+//! truth under-costs artwork and loses more than it gains. The constants are deliberately unchanged.
+//!
+//! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
+//! behave as the page grows.
 //!
 //!     cargo test --release bench_gather_loop -- --ignored --nocapture
 //!
@@ -103,6 +118,10 @@ struct Cell {
     /// fit; the rows that DO call `card_pass` are used to price that call instead, and mixing them
     /// would fold a predicate evaluation into the card term.
     ran_card_pass: bool,
+    /// Artwork mode maintains `group_best`/`touched` per printing on top of everything the other modes
+    /// do. Those rows are held out of the three-rate fit and priced against it, because pooling them
+    /// would smear a mode-specific cost across rates that cost.rs applies to all three modes.
+    artwork: bool,
 }
 
 /// Solve a 3×3 system by Gaussian elimination with partial pivoting.
@@ -131,7 +150,7 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
 /// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
 fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
     let mut normal = [[0.0f64; 4]; 3];
-    for c in cells.iter().filter(|c| !c.ran_card_pass) {
+    for c in cells.iter().filter(|c| !c.ran_card_pass && !c.artwork) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w, c.matches * w];
         for i in 0..3 {
@@ -220,19 +239,29 @@ fn bench_gather_loop() {
     // `card_pass` call itself. Their gap over the matching `true` row prices that call, which is what
     // `GATHER_RESIDUAL_FLOOR` is for; without it, lowering the card term would silently remove charge
     // that was covering a predicate evaluation on every non-all_match query.
-    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 7] = [
+    // The E/F rows are artwork mode, and they are here because leaving them out is what made the
+    // first attempt at these constants fail. cost.rs applies one set of GATHER_* rates to all three
+    // modes, but the artwork loop also maintains `group_best` and `touched` per printing, and P4 has
+    // no artwork term to carry that (P3 has STREAM_ARTWORK_SEEN_PER_CARD_NS). So the extra work was
+    // absorbed into the shipped rates, and a design covering only card and printing mode measured
+    // them low, under-costing artwork. Shipping that moved total routing regret 36.2 -> 51.7 ms, with
+    // candidates/artwork going 19% -> 35% of all lost time. Artwork has to be in the design for these
+    // rates to mean anything.
+    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 9] = [
         ("A 1p  card/default", &singleton, "card", "default", true),
         ("B 1p  print/default", &singleton, "printing", "default", true),
         ("C wide card/oldest", &wide, "card", "oldest", true),
         ("D wide print/default", &wide, "printing", "default", true),
+        ("E 1p  artwork/default", &singleton, "artwork", "default", true),
+        ("F wide artwork/default", &wide, "artwork", "default", true),
         ("A' 1p card/default ctl", &singleton, "card", "default", true),
         ("A+ 1p  card, card_pass", &singleton, "card", "default", false),
         ("C+ wide card, card_pass", &wide, "card", "oldest", false),
     ];
 
     println!(
-        "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}",
-        "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card"
+        "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}{:>11}",
+        "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card", "ns_setup"
     );
     // Every cell is built up front, then all of them are run inside ONE iteration loop, so each
     // cell's minimum is drawn from the same time window as every other cell's. Running a cell to
@@ -246,6 +275,7 @@ fn bench_gather_loop() {
         prep: PreparedCandidates,
         params: QueryParams,
         ran_card_pass: bool,
+        artwork: bool,
     }
     let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
@@ -264,10 +294,12 @@ fn bench_gather_loop() {
                 },
                 params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
                 ran_card_pass: !all_match_known,
+                artwork: *unique == "artwork",
             });
         }
     }
 
+    let mut best_setup: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
     for _ in 0..ITERS {
@@ -276,6 +308,12 @@ fn bench_gather_loop() {
             let s = take_phase_stats();
             if (s.ns_loop as f64) < best_ns[i] {
                 best_ns[i] = s.ns_loop as f64;
+            }
+            // Tracked because artwork mode allocates and zeroes a `max_artwork_groups`-long buffer
+            // here, which is O(corpus) work no loop rate can represent and which P4's cost arm carries
+            // only in a flat GATHER_FIXED_COST_NS.
+            if (s.ns_setup as f64) < best_setup[i] {
+                best_setup[i] = s.ns_setup as f64;
             }
             // Counters are deterministic per cell, so any iteration's are the cell's; recording them
             // every time rather than only on the fastest keeps them independent of which run won.
@@ -292,10 +330,18 @@ fn bench_gather_loop() {
             matches,
             ns_loop: best_ns[i],
             ran_card_pass: cfg.ran_card_pass,
+            artwork: cfg.artwork,
         };
         println!(
-            "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
-            cell.label, cell.n_cards_req, cell.cards, cell.printings, cell.matches, cell.ns_loop, cell.ns_loop / cell.cards
+            "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}{:>11.0}",
+            cell.label,
+            cell.n_cards_req,
+            cell.cards,
+            cell.printings,
+            cell.matches,
+            cell.ns_loop,
+            cell.ns_loop / cell.cards,
+            best_setup[i]
         );
         cells.push(cell);
     }
@@ -341,6 +387,23 @@ fn bench_gather_loop() {
         println!("\nsystem still singular — the design did not separate the columns");
         return;
     };
+    // What artwork mode costs ON TOP of the three fitted rates. cost.rs has no artwork term for P4,
+    // so today this sits inside the shared rates, which is why measuring them without artwork in the
+    // design and then lowering them under-costs artwork queries.
+    println!("\nartwork surcharge over the card/printing fit (P4 has no artwork term today):");
+    for c in cells.iter().filter(|c| c.artwork) {
+        let base = predict(c, k);
+        println!(
+            "  {:<26}{:>7}  measured {:>8.0} ns vs fit {:>8.0} ns   +{:>6.2} ns/printing  +{:>6.2} ns/card",
+            c.label,
+            c.n_cards_req,
+            c.ns_loop,
+            base,
+            (c.ns_loop - base) / c.printings,
+            (c.ns_loop - base) / c.cards
+        );
+    }
+
     println!("\n{:<34}{:>10}{:>10}", "rate", "shipped", "fitted");
     for (name, shipped, got) in [
         ("GATHER_CARD_PASS_NS", 6.88, k[0]),

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -1,5 +1,42 @@
 //! Micro-benchmark that decomposes `GatheredScan`'s match loop into its three rates.
 //!
+//! **Cache state fixed, and the rates are corpus-size dependent (2026-08-03).** Chunk ROTATION (each
+//! iteration walks a different slice) plus per-cell STAGGER (cells sharing a group walk different slices
+//! in the same iteration) means no walk inherits another's cache lines, and the reported rate is the
+//! MEDIAN over rotated chunks rather than the luckiest minimum. Both were needed: rotation alone still
+//! had cell A at 10.50 ns/card against cell B's 6.11 on identical cards, because every cell on a group
+//! walked the same chunk and the first paid all the misses. `scripts/upscale_corpus.py` supplies stores
+//! big enough to rotate (the real corpus gives the wide group ONE chunk at 4,500 cards), selected with
+//! `BENCH_LOOP_STORE`.
+//!
+//! Swept over 31,508 / 126,032 / 409,604 oracle cards:
+//!
+//!     P4  LOOP  ns/card         6.27   11.37   15.04     2.4x
+//!     P4  SCAN  ns/printing     2.27    3.03    2.24     flat
+//!     P4  PUSH  ns/match        1.51    4.94    6.98     4.6x
+//!     P3  all_match ns/card     2.58    2.54    2.55     FLAT
+//!     P3  residual  ns/card     5.08   11.33   18.15     3.6x
+//!     P3  SCAN  ns/printing     3.30    5.57   10.85     3.3x
+//!
+//! P3's all_match arm being flat across a 13x corpus is the check that the method works: that path reads
+//! only the card record and does offset arithmetic, so it has no misses to gain, while everything that
+//! walks printings grows 3x+. A rate is therefore not a property of the code alone -- it is a property of
+//! the code AND how much of the archive fits in cache, and `cost.rs` has no term for the second.
+//!
+//! At the production corpus size the shipped P4 constants are confirmed: LOOP 6.27 against 6.88 (9%
+//! low), SCAN 2.27 against 2.06 (10% high), PUSH 1.51 against 2.24. That is the retraction closed from
+//! the other side -- warm measurement said 2.98 and was wrong; cold measurement says 6.27 and agrees
+//! with what ships.
+//!
+//! P3 does NOT agree: 2.58 against a shipped 5.05 per card, 5.08 against 11.63 with a residual, 3.30
+//! against 5.97 per printing -- about 2x over-costed. Both plans were measured identically, so this is
+//! not a cache artifact, but it is measured on `ns_loop` ONLY, and P3's arm may be absorbing setup or
+//! finish cost that its loop never pays. That has to be ruled out before the gap is called an error.
+//!
+//! The routing consequence is the durable one: the plans' rates scale DIFFERENTLY with corpus size, so
+//! the P3/P4 balance drifts as the corpus grows even with every constant left alone. Any refit is
+//! calibrated to the corpus it was measured on.
+//!
 //! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
 //! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
 //! second pass every card, printing and string it touches is resident. Production walks a candidate set
@@ -150,7 +187,15 @@ const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
 /// keeps that contribution proportional to matches rather than to the page.
 const LIMIT: usize = 60;
 
-const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+/// Default store. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep runs: build
+/// upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn. The real corpus is
+/// only ~68 MB, small enough that a full chunk rotation can stay resident in the system-level cache, so
+/// the rates it yields are still partly warm however the walk is ordered.
+const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn store_path() -> String {
+    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
+}
 
 /// One measured design point: the realized counters, and the loop time they were produced by.
 struct Cell {
@@ -271,17 +316,19 @@ fn predict(c: &Cell, k: [f64; 3]) -> f64 {
 #[test]
 #[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
 fn bench_gather_loop() {
-    let Ok(file) = std::fs::File::open(STORE_PATH) else {
-        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+    let path = store_path();
+    let Ok(file) = std::fs::File::open(&path) else {
+        eprintln!("SKIP: {path} not found (see module docs)");
         return;
     };
     // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and
     // replaced atomically, and the header is re-validated below before the payload is trusted.
     let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
     if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
-        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        eprintln!("SKIP: {path} header mismatch (stale archive — rebuild it, see module docs)");
         return;
     }
+    println!("\nstore {path}  ({:.0} MB)", mmap.len() as f64 / (1024.0 * 1024.0));
     let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
     let ctx = QueryCtx::from(data);
 
@@ -379,10 +426,35 @@ fn bench_gather_loop() {
     struct Config {
         label: &'static str,
         n_cards_req: usize,
-        prep: PreparedCandidates,
+        /// The WHOLE group, not one slice of it. Each iteration walks a different chunk of `n_cards_req`
+        /// cards, so consecutive walks of a cell share no cards and cannot inherit each other's cache
+        /// lines. Holding one fixed slice and taking the minimum over 200 passes is what made every rate
+        /// here a warm-cache number, 1.6-2.2x under what the first pass costs.
+        group: Vec<u32>,
+        all_match_known: bool,
         params: QueryParams,
         ran_card_pass: bool,
         mode: &'static str,
+    }
+    impl Config {
+        /// Candidates for one iteration: a rotating window over the group, wrapping when it runs out. A
+        /// full rotation touches every card in the group before returning to the first chunk.
+        /// `stagger` is the cell's own index, so cells sharing a group walk DIFFERENT chunks within one
+        /// iteration. Without it every cell on a group walked the same chunk, the first paid all the
+        /// misses and the rest inherited warm lines -- which read as cell A costing 10.50 ns/card against
+        /// cell B's 6.11 on identical cards. `chunks` therefore has to exceed the number of cells sharing
+        /// a group, which the real corpus cannot supply at the larger card counts (the wide group holds
+        /// 8,036 cards, so one chunk at 4,500). That is what `scripts/upscale_corpus.py` is for.
+        fn prep_for(&self, iter: usize, stagger: usize) -> PreparedCandidates {
+            let chunks = (self.group.len() / self.n_cards_req).max(1);
+            let start = ((iter + stagger) % chunks) * self.n_cards_req;
+            let end = (start + self.n_cards_req).min(self.group.len());
+            PreparedCandidates {
+                candidate_cards: Some(self.group[start..end].to_vec()),
+                all_match_known: self.all_match_known,
+                narrowed_repr: NarrowedRepr::Cards,
+            }
+        }
     }
     let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
@@ -394,11 +466,8 @@ fn bench_gather_loop() {
             configs.push(Config {
                 label,
                 n_cards_req: n_req,
-                prep: PreparedCandidates {
-                    candidate_cards: Some(group[..n_req].to_vec()),
-                    all_match_known: *all_match_known,
-                    narrowed_repr: NarrowedRepr::Cards,
-                },
+                group: (*group).clone(),
+                all_match_known: *all_match_known,
                 params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
                 ran_card_pass: !all_match_known,
                 mode: unique,
@@ -411,13 +480,24 @@ fn bench_gather_loop() {
     // walks a candidate set once. If the first pass is materially slower than the minimum, these rates
     // describe a cache state production never sees, and that -- not a wrong feature -- is why shipping
     // them regresses. The counter/feature ratios all read 1.00, so the features are not the gap.
+    // Chunks per cell. Fewer than the number of cells sharing a group means some of them collide on a
+    // chunk within an iteration and the later one measures a warm walk, so this is printed rather than
+    // assumed -- it is the check that the store is big enough for the design.
+    println!("\nchunks available per cell (want more than the cells sharing each group):");
+    for cfg in &configs {
+        println!("  {:<24}{:>7}  {:>3} chunks of {} from {} cards", cfg.label, cfg.n_cards_req, (cfg.group.len() / cfg.n_cards_req).max(1), cfg.n_cards_req, cfg.group.len());
+    }
     let mut first_loop: Vec<f64> = vec![0.0; configs.len()];
     let mut best_setup: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
+    // One per-card sample per iteration. With chunk rotation every pass walks unfamiliar cards, so this
+    // distribution is the real one and its MEDIAN is the honest rate; the minimum is just its luckiest draw.
+    let mut per_card_samples: Vec<Vec<f64>> = vec![Vec::with_capacity(ITERS); configs.len()];
     for iter in 0..ITERS {
         for (i, cfg) in configs.iter().enumerate() {
-            black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &cfg.prep, None));
+            let prep = cfg.prep_for(iter, i);
+            black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &prep, None));
             let s = take_phase_stats();
             if iter == 0 {
                 first_loop[i] = s.ns_loop as f64;
@@ -425,6 +505,10 @@ fn bench_gather_loop() {
             if (s.ns_loop as f64) < best_ns[i] {
                 best_ns[i] = s.ns_loop as f64;
             }
+            // Per-card, since rotating chunks vary slightly in length at the group's tail. The MEDIAN of
+            // these is what the fit uses: with rotation every pass walks unfamiliar cards, so the
+            // distribution is the real one and the minimum is just its luckiest draw.
+            per_card_samples[i].push(s.ns_loop as f64 / (s.cards_visited.max(1)) as f64);
             // Tracked because artwork mode allocates and zeroes a `max_artwork_groups`-long buffer
             // here, which is O(corpus) work no loop rate can represent and which P4's cost arm carries
             // only in a flat GATHER_FIXED_COST_NS.
@@ -444,7 +528,13 @@ fn bench_gather_loop() {
             cards,
             printings,
             matches,
-            ns_loop: best_ns[i],
+            // Median per-card time x cards, so every downstream fit sees a typical rotated walk rather
+            // than the warmest one. `best_ns` is kept only to report the warm/typical gap.
+            ns_loop: {
+                let v = &mut per_card_samples[i];
+                v.sort_by(f64::total_cmp);
+                v[v.len() / 2] * cards
+            },
             ran_card_pass: cfg.ran_card_pass,
             mode: cfg.mode,
         };

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -38,24 +38,25 @@
 //! reimplemented, so there is no second copy of the loop to keep in sync, and the fit is
 //! against the instrumentation the cost model is actually checked with.
 //!
-//! What it measured (2026-08-03), stable to 1.07× / 1.02× / 1.04× across three runs where the
-//! traffic fit could not pin the push rate off the boundary at all:
+//! What it measured (2026-08-03), across three runs, where the traffic fit could not pin the push
+//! rate off the boundary at all:
 //!
-//!     GATHER_CARD_PASS_NS        shipped 6.88   fitted 3.08-3.30
-//!     GATHER_SCAN_PER_ROW_NS     shipped 2.06   fitted 2.44-2.48
-//!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.91-0.95
+//!     GATHER_CARD_PASS_NS        shipped 6.88   fitted 3.15-3.33   (1.06x spread)
+//!     GATHER_SCAN_PER_ROW_NS     shipped 2.06   fitted 2.25-2.26   (1.004x)
+//!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.90        (1.000x)
+//!     the card_pass call itself                 2.94-3.00 ns/card on singletons, 1.6-1.8 on wide
 //!
-//! The shipped set over-predicts every cell (1.07-1.92 predicted/actual) and over-predicts MOST
-//! on single-printing cards, least on wide card-mode ones — so `GatheredScan` is systematically
-//! over-costed on card-heavy candidate sets, which is the direction that loses it to
-//! `StreamedSelect` wrongly.
+//! Those last two lines are the finding, and they say the shipped constant is not simply wrong:
+//! 3.24 of loop overhead plus ~3.0 for the `card_pass` call is ~6.2 against a shipped 6.88, so
+//! `GATHER_CARD_PASS_NS` BUNDLES the predicate call. It is therefore about right for queries that
+//! make that call, and about 2x too high for the #634 `all_match_known` path, which skips
+//! `card_pass` entirely and is charged for it anyway. That is a model-shape error rather than a
+//! mis-fitted constant, and it over-costs `GatheredScan` precisely on the queries that should be
+//! cheapest for it — the direction that loses them to `StreamedSelect`.
 //!
-//! Two limits on reading these as drop-in replacements. `all_match_known` is set, so the loop
-//! never calls `card_pass` and the fitted card term is loop overhead with NO predicate evaluation
-//! in it — correct for the #634 path that also skips it, but queries reaching `card_pass` pay more,
-//! which is what the residual-tier term exists to cover. And `LIMIT` is fixed, so nothing here
-//! constrains how the rates behave as the page grows. Traffic-level regret and latency matrices
-//! remain the gate before any of this ships.
+//! One limit remains on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
+//! behave as the page grows. Traffic-level regret and latency matrices remain the gate before any
+//! of it ships.
 //!
 //!     cargo test --release bench_gather_loop -- --ignored --nocapture
 //!
@@ -68,7 +69,7 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, exec_gathered_scan, take_phase_stats, CardData, CmpOp, FilterExpr, Mmap, NarrowedRepr,
-    PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
+    NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
 };
 
 /// Timed repetitions per cell; the minimum is reported, as elsewhere in these harnesses.
@@ -98,6 +99,10 @@ struct Cell {
     printings: f64,
     matches: f64,
     ns_loop: f64,
+    /// False when `all_match_known` short-circuited `card_pass`. Only these rows feed the three-rate
+    /// fit; the rows that DO call `card_pass` are used to price that call instead, and mixing them
+    /// would fold a predicate evaluation into the card term.
+    ran_card_pass: bool,
 }
 
 /// Solve a 3×3 system by Gaussian elimination with partial pivoting.
@@ -126,7 +131,7 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
 /// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
 fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
     let mut normal = [[0.0f64; 4]; 3];
-    for c in cells {
+    for c in cells.iter().filter(|c| !c.ran_card_pass) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w, c.matches * w];
         for i in 0..3 {
@@ -189,73 +194,110 @@ fn bench_gather_loop() {
     }
     println!();
 
-    // all_match_known short-circuits `card_pass`, so the residual tier is exactly zero and this
-    // filter is never evaluated — the loop is card visit + push + absorb and nothing else. That
-    // isolates the three rates from the residual term, which is fitted separately.
-    // `mask: 0` with `Ge` is unconditionally true, but nothing evaluates it either way.
-    let filter = FilterExpr::TypeCmp { mask: 0, op: CmpOp::Ge };
+    // `cmc >= -1` holds for every card, and cmc is a CARD field, so `card_pass` resolves it to
+    // Tri::True with an empty residual — the tier stays 0 and `push_card_matches` still gets
+    // `all_match = true`. On the `all_match_known` cells nothing evaluates it at all, so the loop is
+    // card visit + push + absorb and the three rates come out clean of any predicate cost. On the
+    // cells that clear that flag it IS evaluated, which is what prices the call.
+    //
+    // A real evaluated predicate rather than `FilterExpr::True`, deliberately: `True` short-circuits
+    // to nearly free and would price the call at ~0, and `NumericCmp` is what `bench_verify_cost`
+    // already classes as tier 0, so this is the cheapest predicate production actually runs.
+    let filter =
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Ge, rhs: NumExpr::Const(-1.0) };
     let mut cells: Vec<Cell> = Vec::new();
 
-    // (label, source group, unique, prefer)
+    // (label, source group, unique, prefer, all_match_known)
     //
     // A' repeats A last as a control. A and B are the same cards with one printing each and report
     // identical counters, so any time difference between them is either a real `unique` effect or an
     // artifact of A running first and paying first-touch on the mmap. A' vs A separates those: equal
     // means the difference is real, A' matching B means it was ordering.
-    let designs: [(&'static str, &Vec<u32>, &str, &str); 5] = [
-        ("A 1p  card/default", &singleton, "card", "default"),
-        ("B 1p  print/default", &singleton, "printing", "default"),
-        ("C wide card/oldest", &wide, "card", "oldest"),
-        ("D wide print/default", &wide, "printing", "default"),
-        ("A' 1p card/default ctl", &singleton, "card", "default"),
+    //
+    // The `false` rows are the same cells with `all_match_known` cleared, so `card_pass` actually
+    // runs. The filter answers `Tri::True` and leaves the residual empty, so `push_card_matches`
+    // still gets `all_match = true` and every counter is identical — the ONLY difference is the
+    // `card_pass` call itself. Their gap over the matching `true` row prices that call, which is what
+    // `GATHER_RESIDUAL_FLOOR` is for; without it, lowering the card term would silently remove charge
+    // that was covering a predicate evaluation on every non-all_match query.
+    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 7] = [
+        ("A 1p  card/default", &singleton, "card", "default", true),
+        ("B 1p  print/default", &singleton, "printing", "default", true),
+        ("C wide card/oldest", &wide, "card", "oldest", true),
+        ("D wide print/default", &wide, "printing", "default", true),
+        ("A' 1p card/default ctl", &singleton, "card", "default", true),
+        ("A+ 1p  card, card_pass", &singleton, "card", "default", false),
+        ("C+ wide card, card_pass", &wide, "card", "oldest", false),
     ];
 
     println!(
         "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}",
         "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card"
     );
+    // Every cell is built up front, then all of them are run inside ONE iteration loop, so each
+    // cell's minimum is drawn from the same time window as every other cell's. Running a cell to
+    // completion before starting the next one lets machine drift between cells enter the fit as if it
+    // were a rate difference: doing exactly that moved the card term to 4.34 while three interleaved
+    // runs held it inside 3.08-3.30, and left two cells with identical counters differing 1.8×. Same
+    // reason the query-level harnesses interleave A/B/A/B instead of running all of A then all of B.
+    struct Config {
+        label: &'static str,
+        n_cards_req: usize,
+        prep: PreparedCandidates,
+        params: QueryParams,
+        ran_card_pass: bool,
+    }
+    let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
-        for (label, group, unique, prefer) in &designs {
+        for (label, group, unique, prefer, all_match_known) in &designs {
             if group.len() < n_req {
                 println!("{label:<22}{n_req:>7}   SKIP (only {} cards in group)", group.len());
                 continue;
             }
-            let prep = PreparedCandidates {
-                candidate_cards: Some(group[..n_req].to_vec()),
-                all_match_known: true,
-                narrowed_repr: NarrowedRepr::Cards,
-            };
-            let params = QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0);
-            let mut best = f64::INFINITY;
-            let mut stats = take_phase_stats();
-            for _ in 0..ITERS {
-                black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
-                let s = take_phase_stats();
-                if (s.ns_loop as f64) < best {
-                    best = s.ns_loop as f64;
-                    stats = s;
-                }
-            }
-            let cell = Cell {
+            configs.push(Config {
                 label,
                 n_cards_req: n_req,
-                cards: stats.cards_visited as f64,
-                printings: stats.printings_examined as f64,
-                matches: stats.matches_pushed as f64,
-                ns_loop: best,
-            };
-            println!(
-                "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
-                cell.label,
-                cell.n_cards_req,
-                cell.cards,
-                cell.printings,
-                cell.matches,
-                cell.ns_loop,
-                cell.ns_loop / cell.cards
-            );
-            cells.push(cell);
+                prep: PreparedCandidates {
+                    candidate_cards: Some(group[..n_req].to_vec()),
+                    all_match_known: *all_match_known,
+                    narrowed_repr: NarrowedRepr::Cards,
+                },
+                params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
+                ran_card_pass: !all_match_known,
+            });
         }
+    }
+
+    let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
+    let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
+    for _ in 0..ITERS {
+        for (i, cfg) in configs.iter().enumerate() {
+            black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &cfg.prep, None));
+            let s = take_phase_stats();
+            if (s.ns_loop as f64) < best_ns[i] {
+                best_ns[i] = s.ns_loop as f64;
+            }
+            // Counters are deterministic per cell, so any iteration's are the cell's; recording them
+            // every time rather than only on the fastest keeps them independent of which run won.
+            counters[i] = (s.cards_visited as f64, s.printings_examined as f64, s.matches_pushed as f64);
+        }
+    }
+    for (i, cfg) in configs.iter().enumerate() {
+        let (cards, printings, matches) = counters[i];
+        let cell = Cell {
+            label: cfg.label,
+            n_cards_req: cfg.n_cards_req,
+            cards,
+            printings,
+            matches,
+            ns_loop: best_ns[i],
+            ran_card_pass: cfg.ran_card_pass,
+        };
+        println!(
+            "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
+            cell.label, cell.n_cards_req, cell.cards, cell.printings, cell.matches, cell.ns_loop, cell.ns_loop / cell.cards
+        );
+        cells.push(cell);
     }
 
     assert!(cells.len() >= 3, "need at least 3 design points to identify 3 rates, got {}", cells.len());
@@ -271,6 +313,28 @@ fn bench_gather_loop() {
             c.printings / c.cards,
             c.matches / c.cards
         );
+    }
+
+    // What a `card_pass` call costs per card, from the cells that differ ONLY by whether it ran.
+    // This is the floor `GATHER_RESIDUAL_FLOOR` has to cover for a tier-0 predicate, and it has to be
+    // read alongside the card term rather than after it: the two are set together or the total drifts.
+    println!("\ncost of the card_pass call itself (paired cells, identical counters):");
+    for c in cells.iter().filter(|c| c.ran_card_pass) {
+        // The `+` label marks the card_pass variant of the cell whose label shares its first letter.
+        let base = cells
+            .iter()
+            .find(|b| !b.ran_card_pass && b.n_cards_req == c.n_cards_req && b.label.as_bytes()[0] == c.label.as_bytes()[0]);
+        match base {
+            Some(b) => println!(
+                "  {:<26}{:>7}  {:>9.0} ns vs {:>9.0} ns   {:>7.2} ns/card for card_pass",
+                c.label,
+                c.n_cards_req,
+                c.ns_loop,
+                b.ns_loop,
+                (c.ns_loop - b.ns_loop) / c.cards
+            ),
+            None => println!("  {:<26}{:>7}  no paired all_match cell", c.label, c.n_cards_req),
+        }
     }
 
     let Some(k) = fit(&cells) else {

--- a/card_engine/src/bench_loop_design.rs
+++ b/card_engine/src/bench_loop_design.rs
@@ -1,0 +1,63 @@
+//! The design parameters `bench_gather_loop` (P4) and `bench_streamed_loop` (P3) must share.
+//!
+//! The two harnesses exist as a pair for one reason: P4 could not be fixed alone. Three successively
+//! better descriptions of its loop each REGRESSED routing (+43%, +8.8%, +40%), because `plan_cost` is only
+//! ever used comparatively and P4's inflated arm was absorbing an over-estimate on P3's side. So both arms
+//! get the same built-design treatment and are meant to be read side by side.
+//!
+//! That reading is only valid if the cells match. They had drifted: `CARD_COUNTS` was `[100, 400, 1500,
+//! 4500]` on the gather side and `[600, 1500, 4500]` on the streamed side, sharing just two sizes, so any
+//! P3-vs-P4 rate difference at the small end was confounded with a design difference. Living here, one
+//! definition, they cannot drift again — which is the same argument `divergent_formats_of` and
+//! `perm_primary_key` are single functions.
+//!
+//! Neither harness compares the two plans itself; each decomposes one plan's own loop. The per-query
+//! comparison is `explain_analyze`'s (predicted and measured for every plan at once) — see
+//! `docs/workflows/diagnosing-a-plan-cost-error.md`.
+
+/// Timed repetitions; the minimum per cell is reported, and all cells run inside this loop so every
+/// cell's minimum is drawn from the same time window. Running cells to completion one at a time let
+/// machine drift enter the fit as a rate difference — 1.8× between cells with identical counters — so
+/// both harnesses interleave from the start.
+pub(crate) const ITERS: usize = 200;
+
+/// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
+/// printings-per-card is what identifies two rates per mode with a degree of freedom left over, and it
+/// sets the leverage between the card column and the printing column. 4 keeps that leverage worth having
+/// while leaving the wide group ~4× bigger than at 8, where only 1,910 cards qualify.
+pub(crate) const WIDE_MIN_PRINTINGS: usize = 4;
+
+/// Card counts every cell runs at, on both harnesses. The UNION of what each needed separately, because
+/// each size is load-bearing for a different question and dropping any of them loses coverage:
+///
+/// - **100, 400** — the INTERCEPT. A per-query fixed cost only exists as the y-intercept of cells that
+///   vary in size, and `intercept = t(n) - slope * n` multiplies any slope error by `n`: at a 400-card
+///   floor a 1 ns/card slope error is already 400 ns against a shipped `GATHER_FIXED_COST_NS` of 169.6.
+///   Adding 100 is also what revealed the per-card average is U-SHAPED rather than monotone, which
+///   retracted the "negative intercept ⇒ the loop is convex" finding.
+/// - **600** — BELOW `STREAM_MIN_MATCHES` (1,024) in card mode, where matches == cards. P3's finish phase
+///   branches there: at or under the threshold the small-total gather scans `0..n_cards`, above it the
+///   permutation walk steps until the page fills. Every earlier cell exceeded it, so that branch and
+///   `STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` with it had never been measured.
+/// - **1,500, 4,500** — the linearity range, bounded above by the scarce wide group.
+///
+/// Five sizes on both sides costs the gather harness 25% more cells and the streamed one 67%, against
+/// runtimes of under a second and a few seconds respectively.
+pub(crate) const CARD_COUNTS: [usize; 5] = [100, 400, 600, 1_500, 4_500];
+
+/// Page requested. Small and fixed on both harnesses so the finish phase stays out of the loop
+/// measurement — P4's `sel.absorb()` prunes toward `offset + limit` INSIDE its loop, so holding it
+/// constant keeps that contribution proportional to matches rather than to the page, and P3's `ns_finish`
+/// branches on `total` rather than on the page at all.
+pub(crate) const LIMIT: usize = 60;
+
+/// Default store for both harnesses. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep
+/// runs: build upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn.
+///
+/// The real corpus is only ~68 MB, small enough that a full chunk rotation can stay resident in the
+/// system-level cache, so the rates it yields are still partly warm however the walk is ordered.
+const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+pub(crate) fn store_path() -> String {
+    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
+}

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -128,6 +128,7 @@
 //! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` and `bench_gather_loop`;
 //! rebuild it the same way (see `bench_verify_cost`'s module docs).
 
+use super::bench_loop_design::{store_path, CARD_COUNTS, ITERS, LIMIT, WIDE_MIN_PRINTINGS};
 use std::hint::black_box;
 
 use rkyv::Archived;
@@ -137,36 +138,12 @@ use super::{
     NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
 };
 
-/// Timed repetitions; the minimum per cell is reported, and all cells run inside this loop so every
-/// cell's minimum is drawn from the same time window. Running cells to completion one at a time let
-/// machine drift enter `bench_gather_loop`'s fit as a rate difference — 1.8× between cells with
-/// identical counters — so this interleaves from the start.
-const ITERS: usize = 200;
-/// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
-/// printings-per-card is what identifies two rates per mode with a degree of freedom left over.
-const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at, bounded above by the scarce wide group. Three sizes measure linearity
-/// in the card term rather than assuming it, and 600 sits BELOW `STREAM_MIN_MATCHES` (1,024) in card
-/// mode where matches == cards. That matters because the finish phase takes a different branch on each
-/// side: at or under the threshold the small-total gather scans `0..n_cards`, above it the permutation
-/// walk steps until the page fills. Every earlier cell exceeded the threshold, so the gather branch --
-/// and `STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` with it -- was never measured at all.
-const CARD_COUNTS: [usize; 3] = [600, 1_500, 4_500];
-/// Page requested. P3's `ns_finish` branches on `total` against `STREAM_MIN_MATCHES`, not on the page,
-/// so this only has to be small and fixed to keep the finish phase out of the loop measurement.
-const LIMIT: usize = 60;
 /// A release date no printing in the corpus reaches, so the residual predicate is always true. Keeps
 /// every printing matching, so `printings_examined` and `matches` are exactly the span (printing mode)
 /// or 1 per card (card mode, which returns at the first match) instead of a corpus-dependent fraction.
 const DATE_AFTER_EVERYTHING: u32 = 99_999_999;
 
-/// Default store; `BENCH_LOOP_STORE` overrides it, same as `bench_gather_loop`, so both harnesses sweep
-/// the same upscaled stores from `scripts/upscale_corpus.py`.
-const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
 
-fn store_path() -> String {
-    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
-}
 
 /// One measured design point.
 struct Cell {

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -145,9 +145,13 @@ const ITERS: usize = 200;
 /// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
 /// printings-per-card is what identifies two rates per mode with a degree of freedom left over.
 const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at, bounded above by the scarce wide group. Two sizes measure linearity
-/// in the card term rather than assuming it.
-const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+/// Card counts each cell runs at, bounded above by the scarce wide group. Three sizes measure linearity
+/// in the card term rather than assuming it, and 600 sits BELOW `STREAM_MIN_MATCHES` (1,024) in card
+/// mode where matches == cards. That matters because the finish phase takes a different branch on each
+/// side: at or under the threshold the small-total gather scans `0..n_cards`, above it the permutation
+/// walk steps until the page fills. Every earlier cell exceeded the threshold, so the gather branch --
+/// and `STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` with it -- was never measured at all.
+const CARD_COUNTS: [usize; 3] = [600, 1_500, 4_500];
 /// Page requested. P3's `ns_finish` branches on `total` against `STREAM_MIN_MATCHES`, not on the page,
 /// so this only has to be small and fixed to keep the finish phase out of the loop measurement.
 const LIMIT: usize = 60;
@@ -444,6 +448,33 @@ fn bench_streamed_loop() {
         let (lo, hi) = (cr.min(predicted), cr.max(predicted));
         println!("  spread {:>.2}x  (linearity in these two counters requires these to agree)", hi / lo.max(1e-9));
     }
+
+    // The finish phase, per branch, against the quantity each branch is actually driven by. This is what
+    // fits STREAM_PERM_STEP_NS and STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS, and it needs cells on both
+    // sides of STREAM_MIN_MATCHES to do it -- hence the 600-card row.
+    println!("\nfinish phase by branch (n_cards = {}):", data.cards.len());
+    println!("  {:<24}{:>7}{:>10}{:>12}{:>13}{:>12}", "cell", "n", "matches", "ns_finish", "branch", "ns per unit");
+    for c in &cells {
+        // Mirrors run_query_streamed's guards: an empty result or a page past the end returns before
+        // either branch, so those cells drive nothing and are labelled rather than fitted.
+        let (branch, units) = if c.matches <= 0.0 {
+            ("none", 0.0)
+        } else if c.matches <= 1024.0 {
+            ("gather", data.cards.len() as f64)
+        } else {
+            ("perm walk", (LIMIT as f64 * data.cards.len() as f64 / c.matches).min(data.cards.len() as f64))
+        };
+        let per_unit = if units > 0.0 { c.ns_finish / units } else { 0.0 };
+        println!(
+            "  {:<24}{:>7}{:>10.0}{:>12.0}{:>13}{:>12.3}",
+            c.label, c.n_cards_req, c.matches, c.ns_finish, branch, per_unit
+        );
+    }
+    println!(
+        "\n  gather rows are ns per card scanned, against a shipped STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS\n  \
+         of 1.02; perm-walk rows are ns per permutation entry, against STREAM_PERM_STEP_NS. Grade the\n  \
+         step ESTIMATE against the realized `perm_steps` counter separately -- this table assumes it."
+    );
 
     println!(
         "\n  shipped: STREAM_CARD_PASS_NS 5.05 per card, STREAM_SCAN_PER_ROW_NS 5.97 per printing,\n  \

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -1,6 +1,23 @@
 //! Micro-benchmark that decomposes `StreamedSelect`'s match loop, the companion to
 //! `bench_gather_loop`.
 //!
+//! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
+//! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
+//! second pass every card, printing and string it touches is resident. Production walks a candidate set
+//! once. Measuring the first pass against the warm minimum on cells that run after the mmap has faulted
+//! in gives 1.6-2.2x (A' 1.91x/1.74x, I 1.83x/1.59x, H 2.17x/2.14x; the 100x+ figures on the first cells
+//! are first-touch page faults on the 68 MB store, not cache effects).
+//!
+//! That 1.6-2x is the whole discrepancy. Warm 2.98 ns/card against 6.34 fitted on traffic is 2.1x; P3's
+//! warm 2.41 against a shipped 5.05 is 2.1x; the warm push 1.06 against 2.00 fitted is 1.9x. The
+//! counter/feature ratios all read 1.00, so the features were never the gap -- the TIME was, and the
+//! shipped constants include the miss cost this harness removes.
+//!
+//! So the five refits below did not fail because routing is a delicate joint surface. They failed
+//! because they lowered rates toward a cache state production never reaches. Read every ns figure in
+//! this file as "warm", useful for the SHAPE of the loop -- which terms exist, which are degenerate, how
+//! artwork differs -- and not as a candidate constant. Those shape findings stand; the levels do not.
+//!
 //! That harness established that P4 cannot be fixed alone: three successively better descriptions of
 //! its loop each REGRESSED routing (+43%, +8.8%, +40%), because `plan_cost` is only ever used
 //! comparatively and P4's inflated arm is absorbing an over-estimate on P3's side. So P3's loop gets

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -1,6 +1,43 @@
 //! Micro-benchmark that decomposes `StreamedSelect`'s match loop, the companion to
 //! `bench_gather_loop`.
 //!
+//! **Cache state fixed, and the rates are corpus-size dependent (2026-08-03).** Chunk ROTATION (each
+//! iteration walks a different slice) plus per-cell STAGGER (cells sharing a group walk different slices
+//! in the same iteration) means no walk inherits another's cache lines, and the reported rate is the
+//! MEDIAN over rotated chunks rather than the luckiest minimum. Both were needed: rotation alone still
+//! had cell A at 10.50 ns/card against cell B's 6.11 on identical cards, because every cell on a group
+//! walked the same chunk and the first paid all the misses. `scripts/upscale_corpus.py` supplies stores
+//! big enough to rotate (the real corpus gives the wide group ONE chunk at 4,500 cards), selected with
+//! `BENCH_LOOP_STORE`.
+//!
+//! Swept over 31,508 / 126,032 / 409,604 oracle cards:
+//!
+//!     P4  LOOP  ns/card         6.27   11.37   15.04     2.4x
+//!     P4  SCAN  ns/printing     2.27    3.03    2.24     flat
+//!     P4  PUSH  ns/match        1.51    4.94    6.98     4.6x
+//!     P3  all_match ns/card     2.58    2.54    2.55     FLAT
+//!     P3  residual  ns/card     5.08   11.33   18.15     3.6x
+//!     P3  SCAN  ns/printing     3.30    5.57   10.85     3.3x
+//!
+//! P3's all_match arm being flat across a 13x corpus is the check that the method works: that path reads
+//! only the card record and does offset arithmetic, so it has no misses to gain, while everything that
+//! walks printings grows 3x+. A rate is therefore not a property of the code alone -- it is a property of
+//! the code AND how much of the archive fits in cache, and `cost.rs` has no term for the second.
+//!
+//! At the production corpus size the shipped P4 constants are confirmed: LOOP 6.27 against 6.88 (9%
+//! low), SCAN 2.27 against 2.06 (10% high), PUSH 1.51 against 2.24. That is the retraction closed from
+//! the other side -- warm measurement said 2.98 and was wrong; cold measurement says 6.27 and agrees
+//! with what ships.
+//!
+//! P3 does NOT agree: 2.58 against a shipped 5.05 per card, 5.08 against 11.63 with a residual, 3.30
+//! against 5.97 per printing -- about 2x over-costed. Both plans were measured identically, so this is
+//! not a cache artifact, but it is measured on `ns_loop` ONLY, and P3's arm may be absorbing setup or
+//! finish cost that its loop never pays. That has to be ruled out before the gap is called an error.
+//!
+//! The routing consequence is the durable one: the plans' rates scale DIFFERENTLY with corpus size, so
+//! the P3/P4 balance drifts as the corpus grows even with every constant left alone. Any refit is
+//! calibrated to the corpus it was measured on.
+//!
 //! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
 //! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
 //! second pass every card, printing and string it touches is resident. Production walks a candidate set
@@ -119,7 +156,13 @@ const LIMIT: usize = 60;
 /// or 1 per card (card mode, which returns at the first match) instead of a corpus-dependent fraction.
 const DATE_AFTER_EVERYTHING: u32 = 99_999_999;
 
-const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+/// Default store; `BENCH_LOOP_STORE` overrides it, same as `bench_gather_loop`, so both harnesses sweep
+/// the same upscaled stores from `scripts/upscale_corpus.py`.
+const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn store_path() -> String {
+    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
+}
 
 /// One measured design point.
 struct Cell {
@@ -192,15 +235,16 @@ fn fit_pair(cells: &[Cell], mode: &str, residual: bool) -> Option<[f64; 2]> {
 #[test]
 #[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
 fn bench_streamed_loop() {
-    let Ok(file) = std::fs::File::open(STORE_PATH) else {
-        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+    let path = store_path();
+    let Ok(file) = std::fs::File::open(&path) else {
+        eprintln!("SKIP: {path} not found (see module docs)");
         return;
     };
     // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and replaced
     // atomically, and the header is re-validated below before the payload is trusted.
     let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
     if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
-        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        eprintln!("SKIP: {path} header mismatch (stale archive — rebuild it, see module docs)");
         return;
     }
     let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
@@ -236,7 +280,10 @@ fn bench_streamed_loop() {
         n_cards_req: usize,
         mode: &'static str,
         residual: bool,
-        prep: PreparedCandidates,
+        /// The whole group; each iteration walks a different chunk and each CELL is staggered onto a
+        /// different chunk, so no walk inherits another's cache lines. Holding one slice and taking a
+        /// minimum is what made the earlier rates warm-cache numbers, ~2x under production.
+        group: Vec<u32>,
         params: QueryParams,
     }
     // (label, group, unique, residual). `all_match_known` is set only on the no-residual cells; with a
@@ -269,11 +316,7 @@ fn bench_streamed_loop() {
                 n_cards_req: n_req,
                 mode: unique,
                 residual: *residual,
-                prep: PreparedCandidates {
-                    candidate_cards: Some(group[..n_req].to_vec()),
-                    all_match_known: !residual,
-                    narrowed_repr: NarrowedRepr::Cards,
-                },
+                group: (*group).clone(),
                 params: QueryParams::from_strs(unique, "default", "name", "asc", LIMIT, 0),
             });
         }
@@ -283,12 +326,22 @@ fn bench_streamed_loop() {
     let mut best_setup = vec![f64::INFINITY; configs.len()];
     let mut best_finish = vec![f64::INFINITY; configs.len()];
     let mut counters = vec![(0.0, 0.0, 0.0); configs.len()];
-    for _ in 0..ITERS {
+    // Median across rotated chunks is the honest rate; with rotation every pass walks unfamiliar cards.
+    let mut per_card_samples: Vec<Vec<f64>> = vec![Vec::with_capacity(ITERS); configs.len()];
+    for iter in 0..ITERS {
         for (i, cfg) in configs.iter().enumerate() {
             let filter = if cfg.residual { &printing_residual } else { &no_residual };
-            black_box(exec_streamed_select(&ctx, &cfg.params, filter, &cfg.prep, None));
+            let chunks = (cfg.group.len() / cfg.n_cards_req).max(1);
+            let start = ((iter + i) % chunks) * cfg.n_cards_req;
+            let end = (start + cfg.n_cards_req).min(cfg.group.len());
+            let prep = PreparedCandidates {
+                candidate_cards: Some(cfg.group[start..end].to_vec()),
+                all_match_known: !cfg.residual,
+                narrowed_repr: NarrowedRepr::Cards,
+            };
+            black_box(exec_streamed_select(&ctx, &cfg.params, filter, &prep, None));
             let s = take_phase_stats();
-            best_loop[i] = best_loop[i].min(s.ns_loop as f64);
+            per_card_samples[i].push(s.ns_loop as f64 / (s.cards_visited.max(1)) as f64);
             best_setup[i] = best_setup[i].min(s.ns_setup as f64);
             best_finish[i] = best_finish[i].min(s.ns_finish as f64);
             counters[i] = (s.cards_visited as f64, s.printings_examined as f64, s.matches_pushed as f64);
@@ -311,7 +364,11 @@ fn bench_streamed_loop() {
             printings,
             matches,
             ns_setup: best_setup[i],
-            ns_loop: best_loop[i],
+            ns_loop: {
+                let v = &mut per_card_samples[i];
+                v.sort_by(f64::total_cmp);
+                v[v.len() / 2] * cards
+            },
             ns_finish: best_finish[i],
         };
         println!(

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -1,0 +1,349 @@
+//! Micro-benchmark that decomposes `StreamedSelect`'s match loop, the companion to
+//! `bench_gather_loop`.
+//!
+//! That harness established that P4 cannot be fixed alone: three successively better descriptions of
+//! its loop each REGRESSED routing (+43%, +8.8%, +40%), because `plan_cost` is only ever used
+//! comparatively and P4's inflated arm is absorbing an over-estimate on P3's side. So P3's loop gets
+//! the same built-design treatment, and the two arms move together.
+//!
+//! P3's loop is a different shape from P4's, and the difference decides the design:
+//!
+//!   - It has NO per-match cost. The loop writes `counts[cid] = c` and accumulates `total`; nothing is
+//!     pushed. `STREAM_EMIT_PER_MATCH_NS` belongs to `ns_finish`, not here.
+//!   - `scan_units` is GATED on a residual. Under `all_match` (and outside artwork mode)
+//!     `card_match_count` answers from offset arithmetic without touching a printing, so the loop is
+//!     O(cards) regardless of how many printings those cards have.
+//!
+//! Two rates instead of three is what makes this tractable where P4 was not. P4 needed three rates and
+//! no single mode could identify them, because card mode pushes once per card (`matches == cards`) and
+//! printing mode pushes every printing (`matches == printings`), so a column duplicated another in
+//! every mode. Two rates against three printings-per-card levels is identifiable INSIDE one mode, so
+//! P3 needs neither pooling nor the reparameterisation P4 required.
+//!
+//! The cells:
+//!
+//!     all_match, per mode      cards visited only; printings never touched. Isolates the per-card
+//!                              overhead with `card_pass` short-circuited and counting O(1).
+//!     residual, per mode       `card_pass` runs, returns PrintingDep, and `card_match_count` walks.
+//!                              Gives (CARD_PASS + tier floor) per card and SCAN per printing.
+//!
+//! The residual predicate is `DateCmp` against a date every printing satisfies. Release date is a
+//! PRINTING field, so `card_pass` cannot resolve it and must hand back a residual — which is the whole
+//! point, since an always-true CARD predicate would answer `Tri::True` and never walk. Every printing
+//! matching keeps the counters clean: `printings_examined` is the full span in printing mode, and in
+//! card mode it is 1 per card because `card_match_count` returns at the first qualifying printing.
+//! `DateCmp` is a `MASK_COMPARE_NS100` tier, the cheapest real residual, so the fitted per-card figure
+//! is a floor on `STREAM_RESIDUAL_FLOOR_NS` rather than a typical value.
+//!
+//! Calls the real `exec_streamed_select` and reads `ns_setup`/`ns_loop`/`ns_finish` and the counters
+//! off `PhaseStats` — same fenceposts and counters production publishes, nothing reimplemented.
+//!
+//!     cargo test --release bench_streamed_loop -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` and `bench_gather_loop`;
+//! rebuild it the same way (see `bench_verify_cost`'s module docs).
+
+use std::hint::black_box;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, exec_streamed_select, take_phase_stats, CardData, CmpOp, FilterExpr, Mmap, NarrowedRepr,
+    NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
+};
+
+/// Timed repetitions; the minimum per cell is reported, and all cells run inside this loop so every
+/// cell's minimum is drawn from the same time window. Running cells to completion one at a time let
+/// machine drift enter `bench_gather_loop`'s fit as a rate difference — 1.8× between cells with
+/// identical counters — so this interleaves from the start.
+const ITERS: usize = 200;
+/// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
+/// printings-per-card is what identifies two rates per mode with a degree of freedom left over.
+const WIDE_MIN_PRINTINGS: usize = 4;
+/// Card counts each cell runs at, bounded above by the scarce wide group. Two sizes measure linearity
+/// in the card term rather than assuming it.
+const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+/// Page requested. P3's `ns_finish` branches on `total` against `STREAM_MIN_MATCHES`, not on the page,
+/// so this only has to be small and fixed to keep the finish phase out of the loop measurement.
+const LIMIT: usize = 60;
+/// A release date no printing in the corpus reaches, so the residual predicate is always true. Keeps
+/// every printing matching, so `printings_examined` and `matches` are exactly the span (printing mode)
+/// or 1 per card (card mode, which returns at the first match) instead of a corpus-dependent fraction.
+const DATE_AFTER_EVERYTHING: u32 = 99_999_999;
+
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// One measured design point.
+struct Cell {
+    label: &'static str,
+    n_cards_req: usize,
+    mode: &'static str,
+    /// True for the cells whose `card_pass` runs and leaves a printing-dependent residual behind. The
+    /// two groups are fitted apart: with no residual the loop never walks a printing, so pooling them
+    /// would regress a real printing column against a phase that did not pay for it.
+    residual: bool,
+    cards: f64,
+    printings: f64,
+    matches: f64,
+    ns_setup: f64,
+    ns_loop: f64,
+    ns_finish: f64,
+}
+
+/// A single per-card rate for one group, for the groups where that is all the design can support.
+///
+/// Two of the four groups are degenerate, and measurement is what showed it rather than assumption.
+/// The `all_match` rows examine ZERO printings at every printings-per-card level, because
+/// `card_match_count` answers from offset arithmetic there -- so the printing column is identically
+/// zero and there is nothing to fit but the per-card rate. The `card` + residual rows examine exactly
+/// ONE printing per card at every level, because the kernel returns at the first qualifying printing --
+/// so the printing column DUPLICATES the card column and only their sum is identifiable. Reporting one
+/// number for those groups is the honest form; a two-parameter fit there would be picking arbitrarily
+/// from a ridge of equally good answers.
+fn fit_per_card(cells: &[Cell], mode: &str, residual: bool) -> Option<f64> {
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for c in cells.iter().filter(|c| c.mode == mode && c.residual == residual) {
+        let w = 1.0 / c.ns_loop;
+        let x = c.cards * w;
+        num += x * (c.ns_loop * w);
+        den += x * x;
+    }
+    if den <= 0.0 {
+        return None;
+    }
+    Some(num / den)
+}
+
+/// Per-card and per-printing rates for one (mode, residual) group. Two unknowns, three ratio levels.
+fn fit_pair(cells: &[Cell], mode: &str, residual: bool) -> Option<[f64; 2]> {
+    let mut normal = [[0.0f64; 3]; 2];
+    let mut rows = 0;
+    for c in cells.iter().filter(|c| c.mode == mode && c.residual == residual) {
+        // Relative least squares: each equation divided by its own measured time, so a cell running
+        // 100 µs does not outweigh one running 5 µs.
+        let w = 1.0 / c.ns_loop;
+        let x = [c.cards * w, c.printings * w];
+        for i in 0..2 {
+            for j in 0..2 {
+                normal[i][j] += x[i] * x[j];
+            }
+            normal[i][2] += x[i] * (c.ns_loop * w);
+        }
+        rows += 1;
+    }
+    let det = normal[0][0] * normal[1][1] - normal[0][1] * normal[1][0];
+    if rows < 2 || det.abs() < 1e-12 {
+        return None;
+    }
+    Some([
+        (normal[0][2] * normal[1][1] - normal[0][1] * normal[1][2]) / det,
+        (normal[0][0] * normal[1][2] - normal[1][0] * normal[0][2]) / det,
+    ])
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_streamed_loop() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and replaced
+    // atomically, and the header is re-validated below before the payload is trusted.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(data);
+
+    let (mut singleton, mut medium, mut wide): (Vec<u32>, Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new(), Vec::new());
+    for cid in 0..data.cards.len() {
+        let span = u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize;
+        if span == 1 {
+            singleton.push(cid as u32);
+        } else if span >= WIDE_MIN_PRINTINGS {
+            wide.push(cid as u32);
+        } else {
+            medium.push(cid as u32);
+        }
+    }
+    println!(
+        "\n{} oracle cards: {} with 1 printing, {} with 2..{WIDE_MIN_PRINTINGS}, {} with >={WIDE_MIN_PRINTINGS}",
+        data.cards.len(),
+        singleton.len(),
+        medium.len(),
+        wide.len()
+    );
+
+    // `cmc >= -1` is always true and lives on the CARD, so `card_pass` resolves it to Tri::True with an
+    // empty residual — the all_match-shaped cells. `DateCmp` is always true but lives on the PRINTING,
+    // so `card_pass` must return PrintingDep and the loop walks; that is the residual shape.
+    let no_residual = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Ge, rhs: NumExpr::Const(-1.0) };
+    let printing_residual = FilterExpr::DateCmp { op: CmpOp::Lt, value: DATE_AFTER_EVERYTHING };
+
+    struct Config {
+        label: &'static str,
+        n_cards_req: usize,
+        mode: &'static str,
+        residual: bool,
+        prep: PreparedCandidates,
+        params: QueryParams,
+    }
+    // (label, group, unique, residual). `all_match_known` is set only on the no-residual cells; with a
+    // printing-dependent residual it must be false or the walk would be short-circuited and the cell
+    // would measure the other group again.
+    let designs: [(&'static str, &Vec<u32>, &str, bool); 12] = [
+        ("1p   card   all_match", &singleton, "card", false),
+        ("med  card   all_match", &medium, "card", false),
+        ("wide card   all_match", &wide, "card", false),
+        ("1p   print  all_match", &singleton, "printing", false),
+        ("med  print  all_match", &medium, "printing", false),
+        ("wide print  all_match", &wide, "printing", false),
+        ("1p   card   residual", &singleton, "card", true),
+        ("med  card   residual", &medium, "card", true),
+        ("wide card   residual", &wide, "card", true),
+        ("1p   print  residual", &singleton, "printing", true),
+        ("med  print  residual", &medium, "printing", true),
+        ("wide print  residual", &wide, "printing", true),
+    ];
+
+    let mut configs: Vec<Config> = Vec::new();
+    for n_req in CARD_COUNTS {
+        for (label, group, unique, residual) in &designs {
+            if group.len() < n_req {
+                println!("{label:<24}{n_req:>7}   SKIP (only {} cards in group)", group.len());
+                continue;
+            }
+            configs.push(Config {
+                label,
+                n_cards_req: n_req,
+                mode: unique,
+                residual: *residual,
+                prep: PreparedCandidates {
+                    candidate_cards: Some(group[..n_req].to_vec()),
+                    all_match_known: !residual,
+                    narrowed_repr: NarrowedRepr::Cards,
+                },
+                params: QueryParams::from_strs(unique, "default", "name", "asc", LIMIT, 0),
+            });
+        }
+    }
+
+    let mut best_loop = vec![f64::INFINITY; configs.len()];
+    let mut best_setup = vec![f64::INFINITY; configs.len()];
+    let mut best_finish = vec![f64::INFINITY; configs.len()];
+    let mut counters = vec![(0.0, 0.0, 0.0); configs.len()];
+    for _ in 0..ITERS {
+        for (i, cfg) in configs.iter().enumerate() {
+            let filter = if cfg.residual { &printing_residual } else { &no_residual };
+            black_box(exec_streamed_select(&ctx, &cfg.params, filter, &cfg.prep, None));
+            let s = take_phase_stats();
+            best_loop[i] = best_loop[i].min(s.ns_loop as f64);
+            best_setup[i] = best_setup[i].min(s.ns_setup as f64);
+            best_finish[i] = best_finish[i].min(s.ns_finish as f64);
+            counters[i] = (s.cards_visited as f64, s.printings_examined as f64, s.matches_pushed as f64);
+        }
+    }
+
+    let mut cells: Vec<Cell> = Vec::new();
+    println!(
+        "\n{:<24}{:>7}{:>9}{:>11}{:>10}{:>10}{:>11}{:>10}{:>10}",
+        "cell", "n", "cards", "printings", "matches", "ns_setup", "ns_loop", "ns/card", "ns_finish"
+    );
+    for (i, cfg) in configs.iter().enumerate() {
+        let (cards, printings, matches) = counters[i];
+        let cell = Cell {
+            label: cfg.label,
+            n_cards_req: cfg.n_cards_req,
+            mode: cfg.mode,
+            residual: cfg.residual,
+            cards,
+            printings,
+            matches,
+            ns_setup: best_setup[i],
+            ns_loop: best_loop[i],
+            ns_finish: best_finish[i],
+        };
+        println!(
+            "{:<24}{:>7}{:>9.0}{:>11.0}{:>10.0}{:>10.0}{:>11.0}{:>10.2}{:>10.0}",
+            cell.label,
+            cell.n_cards_req,
+            cell.cards,
+            cell.printings,
+            cell.matches,
+            cell.ns_setup,
+            cell.ns_loop,
+            cell.ns_loop / cell.cards.max(1.0),
+            cell.ns_finish
+        );
+        cells.push(cell);
+    }
+
+    // The design's leverage, stated rather than assumed. The all_match rows are the check that P3's
+    // loop really is O(cards): printings-per-card varies ~7x across them while the printing column
+    // should stay near zero, because `card_match_count` answers from offset arithmetic there.
+    println!("\nprintings examined per card (all_match rows should stay ~0 -- the loop never walks):");
+    for c in &cells {
+        println!(
+            "  {:<24}{:>7}  printings/card {:>6.2}   matches/card {:>6.2}",
+            c.label,
+            c.n_cards_req,
+            c.printings / c.cards.max(1.0),
+            c.matches / c.cards.max(1.0)
+        );
+    }
+
+    println!("\n{:<34}{:>12}{:>16}{}", "fitted per (mode, residual)", "ns/card", "ns/printing", "   note");
+    let mut recovered: Vec<(&str, f64, f64)> = Vec::new();
+    for mode in ["card", "printing"] {
+        for residual in [false, true] {
+            let tag = format!("{mode} / {}", if residual { "residual" } else { "all_match" });
+            // Only printing-mode-with-residual has a non-degenerate printing column; everything else
+            // gets the one rate it can support, with why printed alongside so the table is readable
+            // without the source.
+            match (mode, residual) {
+                ("printing", true) => match fit_pair(&cells, mode, residual) {
+                    Some(pair) => {
+                        println!("{tag:<34}{:>12.2}{:>16.2}   both identifiable", pair[0], pair[1]);
+                        recovered.push(("printing/residual", pair[0], pair[1]));
+                    }
+                    None => println!("{tag:<34}   pair not identifiable"),
+                },
+                _ => {
+                    let why = if residual { "printings==cards, so this is their SUM" } else { "printings==0, no printing term exists" };
+                    match fit_per_card(&cells, mode, residual) {
+                        Some(per_card) => {
+                            println!("{tag:<34}{per_card:>12.2}{:>16}   {why}", "--");
+                            recovered.push((if residual { "card/residual" } else { "all_match" }, per_card, 0.0));
+                        }
+                        None => println!("{tag:<34}   no cells"),
+                    }
+                }
+            }
+        }
+    }
+
+    // Cross-check, the counterpart to bench_gather_loop's two independent recoveries of PUSH. Card mode
+    // with a residual examines exactly one printing per card, so its single fitted rate must equal
+    // printing mode's per-card PLUS per-printing. Those come from different cells and different
+    // columns, so agreement is a test of whether the loop is linear in these two counters at all.
+    let card_resid = recovered.iter().find(|r| r.0 == "card/residual").map(|r| r.1);
+    let print_resid = recovered.iter().find(|r| r.0 == "printing/residual").copied();
+    if let (Some(cr), Some((_, pc, pp))) = (card_resid, print_resid) {
+        let predicted = pc + pp;
+        println!("\ncross-check (independent cells, independent columns):");
+        println!("  card/residual fitted directly          {cr:>7.2} ns/card");
+        println!("  printing/residual per-card + per-row   {predicted:>7.2} ns/card  ({pc:.2} + {pp:.2})");
+        let (lo, hi) = (cr.min(predicted), cr.max(predicted));
+        println!("  spread {:>.2}x  (linearity in these two counters requires these to agree)", hi / lo.max(1e-9));
+    }
+
+    println!(
+        "\n  shipped: STREAM_CARD_PASS_NS 5.05 per card, STREAM_SCAN_PER_ROW_NS 5.97 per printing,\n  \
+         STREAM_RESIDUAL_FLOOR_NS 6.58 added per card when a residual exists. So the residual rows here\n  \
+         compare against 5.05 + 6.58 = 11.63 per card, and the all_match rows against 5.05 with no\n  \
+         printing term at all -- which the zero printing column above confirms is the right shape."
+    );
+}

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -35,6 +35,37 @@
 //! `DateCmp` is a `MASK_COMPARE_NS100` tier, the cheapest real residual, so the fitted per-card figure
 //! is a floor on `STREAM_RESIDUAL_FLOOR_NS` rather than a typical value.
 //!
+//! What both harnesses together establish, which is the point of having them (2026-08-03).
+//!
+//! P3's loop is over-costed like P4's, and by more: 5.05 shipped against 2.41 measured per card on the
+//! all_match path, 11.63 (5.05 + the 6.58 floor) against 4.32 with a residual, 5.97 against 2.92 per
+//! printing. So BOTH scan arms are inflated ~2-3x as rates.
+//!
+//! Five refits were then taken through the regret gate, interleaved A/B/A/B:
+//!
+//!     P4 mode-blind triple                      +43%
+//!     P4 pooled + artwork arm                  +8.8%
+//!     P4 reparameterised                        +40%
+//!     P3 and P4 both refit                      +30%
+//!     ... plus symmetric residual floors        +90%
+//!
+//! Every one regressed, and the best was the one that moved LEAST from the shipped values. Two of the
+//! attempts were diagnosed and corrected mid-flight -- artwork needed its own arm, and leaving P4's
+//! residual floor at 18.89 while P3's went to 1.91 was an asymmetry that sent
+//! `StreamedSelect -> GatheredScan` from 407 queries at 38% of lost time to 653 at 44%. Fixing that
+//! asymmetry then made things worse still, because 18.89 was load-bearing despite being unmeasured.
+//!
+//! The conclusion is not about any constant. Every rate here is now measured against realized counters
+//! on a built design, and the rates are demonstrably wrong while the PRODUCTS they form are roughly
+//! right -- which is the signature of compensating error in the FEATURES, not the rates. `plan_cost`
+//! multiplies a rate by an estimate; a rate 2x high against an estimate 2x low predicts correctly and
+//! routes correctly, and correcting only the rate breaks it. The shipped constants are a jointly-tuned
+//! routing surface, not a set of independently valid ns figures, and that is why they have survived.
+//!
+//! So the next work is on the estimators (`eval_domain`, `scan_units`, `matches`) graded against the
+//! realized counters these harnesses publish -- not another refit. Correcting a feature and its rate
+//! TOGETHER is the only move that can hold the products fixed while making both halves true.
+//!
 //! Calls the real `exec_streamed_select` and reads `ns_setup`/`ns_loop`/`ns_finish` and the counters
 //! off `PhaseStats` — same fenceposts and counters production publishes, nothing reimplemented.
 //!

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -658,6 +658,44 @@ const COMPOSE_GATHER_GROUP_PER_PRINTING_NS: f64 = 1.5;
 /// Per-query setup for the compose fastpath.
 const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 
+/// The full-width printing-bitmap build, which no other term charges.
+///
+/// `compose_printing_bits` allocates an `n_printings`-wide bitmap and ANDs each child into it,
+/// `printing_bits_to_card_bits` projects it, and `bitmap_card_ids` walks the card bitmap to extract
+/// set ids. All three are O(corpus width) whatever the query matches, and `popcount_words` charges
+/// only the **result-space** bitmap, so the printing-space build was free in the model.
+///
+/// Measured as `meas - oracle_pred` on the gather population — realized counters substituted for every
+/// feature, shipped rates untouched, so what is left is work no term charges for. Nine corpus sizes
+/// from 0.5x to 5x, built by replicating the corpus and sampling the fractional part by oracle CARD
+/// (sampling printings would thin each card's span and change the printings-per-card distribution,
+/// which is the quantity under test), 33 cells each:
+///
+///     residual = -107 ns + 0.0835 ns/printing     R^2 = 0.998
+///
+/// The intercept is zero within noise: this is a width term, not a fixed cost, and
+/// `COMPOSE_FIXED_COST_NS` above stays as it is. `ns/printing` varies 1.13x over that 10x range with
+/// no trend — the bitmap crosses 6 KB to 59 KB, L1 to L2, without the rate moving — so the linear
+/// shape holds and this constant is not specific to the production corpus.
+///
+/// **Scoped to the Gather arm deliberately, though the work is physically a BUILD cost** shared by all
+/// three paging branches. `Perm` and `OrderbyWalk` had their rates fitted with this cost already
+/// absorbed into them, so charging it there as well double-counts: measured per branch over six sizes,
+/// `predicted/measured` on Perm goes 1.193 -> 1.544 at the production corpus when this term is added.
+/// Gather is the only branch whose error is a clean level (flat 0.52-0.55 across the whole 10x range),
+/// which is what makes a single constant the right instrument for it — and it fixes it, to 0.88-0.99.
+/// Widening this to the build section requires fixing `Perm`/`OrderbyWalk` first, and those two drift
+/// in OPPOSITE directions with corpus size while sharing their rates, so it is not a refit.
+/// See docs/issues/local-engine-sparse-compose-gather.md.
+///
+/// This DOES move production routing, and an earlier draft of this comment claimed it did not. The
+/// sparse-permutation case is declined, but `compose_paging_with_total` still returns `Gather` whenever
+/// there is no card-space permutation and the query is not printing-mode on usd/rarity — card and
+/// artwork on a usd/rarity orderby, which is ordinary traffic (13 of 45 cells in a quick sweep). So it
+/// carries a regret gate like any other arm change, not the free pass "it is behind the decline" would
+/// have bought.
+const COMPOSE_BUILD_PER_PRINTING_NS: f64 = 0.0835;
+
 /// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
 /// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
 /// against the `printing_span` counter -- the Perm and OrderbyWalk paging branches are priced
@@ -739,6 +777,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                         + f64::from(f.compose_scan_printings) * COMPOSE_GATHER_BITTEST_PER_PRINTING_NS
                         + f64::from(f.gather_group_printings) * COMPOSE_GATHER_GROUP_PER_PRINTING_NS
                         + matches * COMPOSE_GATHER_PUSH_PER_MATCH_NS
+                        + f64::from(f.n_printings) * COMPOSE_BUILD_PER_PRINTING_NS
                 }
                 // The fastpath will refuse this query, so there is no page term to charge. Infinity
                 // keeps the plan out of the argmin entirely — routing to a plan that returns `None`

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -430,7 +430,7 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// ns per permutation entry stepped in the streaming walk, the branch taken when
 /// `total > STREAM_MIN_MATCHES`.
 ///
-/// The walk steps the permutation until the page fills, so it visits about
+/// The walk covers the realized match span until the page fills, so it visits about
 /// `page_span * n_cards / matches` entries -- inversely proportional to selectivity, and the one
 /// quantity in P3's finish phase that no other feature is proportional to. Nothing charged for it
 /// before: the arm had `matches * EMIT + FIXED`, which is flat in `n_cards`, so at a fixed 1,500
@@ -445,7 +445,11 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// change a routing decision.
 ///
 /// The estimate is graded against the realized `perm_steps` counter rather than trusted, the same way
-/// `scan_units` is graded against `printings_examined`.
+/// `scan_units` is graded against `printings_examined`. **The rate survived the walk being bounded to
+/// its match span**, which is the useful thing that grade has said so far: traffic fit 1.17 before and
+/// 1.15 after, on the same seed and sample length, while realized steps at p90 fell 6.43x the estimate
+/// to 4.26x. A change that deletes a third of the steps at the tail and moves the per-step rate by 2%
+/// is the signature of a rate that is a real per-unit cost rather than a sink for the count's error.
 const STREAM_PERM_STEP_NS: f64 = 1.0;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
@@ -713,6 +717,17 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // Entries visited to accumulate `page_span` matches, when matches are spread uniformly
                 // through the permutation: one match per `n_cards / matches` entries. Bounded by the
                 // corpus, since the walk cannot step past the end of the permutation.
+                //
+                // The executor now bounds the walk to the realized match span (first matching card's
+                // sort position to the last), which this cannot see -- no `PlanFeatures` field carries
+                // it. The uniform-spread assumption absorbs it: the expected gap before the first match
+                // is one `n_cards / matches` stride, negligible against `page_span` of them. What the
+                // regrade showed is that the assumption's remaining error is a DIFFERENT shape.
+                // Realized/estimated ran p10 0.13 / median 1.00 / p90 6.43 before the span bound and
+                // p10 0.08 / median 0.90 / p90 4.26 after, on the same seed and sample: bounding the
+                // ends removed a third of the tail, so a third of it was the leading prefix. The
+                // remaining 4.26x is the part no seek can reach -- non-matching entries INTERIOR to the
+                // span, which is the popcount-skip mechanism's territory, not a start position's.
                 (page_span * n_cards / f64::from(f.matches)).min(n_cards)
             } else {
                 0.0

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -332,7 +332,18 @@ pub(crate) fn materialize_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
 /// 9,867 distinct shapes. P3 had been under-costed ~1.6x, which biases the router toward picking it.
 /// P4 and compose were re-fit in the same run and NOT changed: P4's fitted values reproduce these
 /// within 8% with no agreement gain, and compose's fit makes its median worse (0.95 -> 0.86).
-const STREAM_CARD_PASS_NS: f64 = 5.05;
+/// **Split 2026-08-03**, and the level below is now the CALL only. `bench_streamed_loop` measures P3's
+/// loop at 2.58 ns/card on the `all_match` path and 5.08 with a residual, on the same cells at the same
+/// corpus size — so ~2.5 of the shipped 5.05 was the `card_pass` call, charged to every candidate whether
+/// the call happened or not. The sum is preserved (2.58 + 2.47 = 5.05), so a residual-bearing query is
+/// costed exactly as before and only the `all_match` path gets cheaper.
+const STREAM_CARD_PASS_NS: f64 = 2.47;
+/// P3's loop body per candidate card, paid whether or not a residual exists: the `counts` write, the
+/// offsets arithmetic, and the match-count call that answers from the span alone under `all_match`.
+/// 2.58 ns/card measured by `bench_streamed_loop`, and the one rate in either loop that is FLAT across a
+/// 13× corpus (2.58 / 2.54 / 2.55) — it reads the card record and nothing else, so it has no misses to
+/// gain. That flatness is why it is the half worth stating as a constant.
+const STREAM_LOOP_PER_CARD_NS: f64 = 2.58;
 
 /// P3's per-scanned-row cost, charged ONLY when a residual is present.
 ///
@@ -478,7 +489,20 @@ const STREAM_FIXED_COST_NS: f64 = 217.0;
 /// ridge-anchored to the previous values because several columns barely vary on this corpus and
 /// are collinear with the intercept. Fitted on ~10k distinct feature vectors, stable to <3% across
 /// independent seeds. Median measured/predicted moved 1.78 -> 1.00 (P4) and 1.69 -> 1.06 (P3).
-const GATHER_CARD_PASS_NS: f64 = 6.88;
+/// **Split 2026-08-03**, and the level below is now the CALL only. The module header's own reading of
+/// `bench_gather_loop` said this constant "BUNDLES the predicate call": ~3.2 ns/card of loop overhead
+/// plus 2.94-3.00 for the `card_pass` call itself on singletons, summing to ~6.2 against the shipped
+/// 6.88. It was therefore "about right for queries that make that call, and about 2x too high for the
+/// #634 `all_match_known` path, which skips `card_pass` entirely and is charged for it anyway — a
+/// model-shape error rather than a mis-fitted constant". This is that error, fixed where it lives.
+///
+/// The sum is preserved (3.88 + 3.00 = 6.88), so residual-bearing queries are costed as before.
+const GATHER_CARD_PASS_NS: f64 = 3.00;
+/// P4's loop body per candidate card, paid whether or not a residual exists. 3.88 = the shipped 6.88
+/// less the 3.00 call above, rather than the kernel's 3.15-3.33 directly: the kernel figure is a warm
+/// rate (see the retraction in `bench_gather_loop`'s header) and holding the SUM at the shipped value
+/// keeps this change a pure re-gating, with no level moving on the queries that were costed correctly.
+const GATHER_LOOP_PER_CARD_NS: f64 = 3.88;
 /// ns per printing scanned in the gathered loop (residual test per row). The verify `tier`
 /// does NOT ride this term; see GATHER_VERIFY_TIER_SCALE and STREAM_SCAN_PER_ROW_NS.
 const GATHER_SCAN_PER_ROW_NS: f64 = 2.06;
@@ -746,7 +770,15 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             // residual is re-checked per row inside `push_card_matches`. Charging `tier_ns` per
             // scanned ROW instead is invisible in card mode (scan_units ≈ eval_domain) and
             // overcharges printing/artwork by the whole printings-per-card ratio.
-            eval_domain * (STREAM_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
+            //
+            // The per-card term is TWO terms, gated apart on the same `tier_ns > 0` signal this arm
+            // already uses for its scan: the loop body runs for every candidate, but the `card_pass`
+            // CALL only happens when there is a residual to check. `all_match_known` skips it outright
+            // (#634 step 1), and `tier_ns == 0` is exactly that condition. Charging the call anyway made
+            // the arm's card-mode body read p50 1.90 over-costed.
+            eval_domain
+                * (STREAM_LOOP_PER_CARD_NS
+                    + if tier_ns > 0.0 { STREAM_CARD_PASS_NS + tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
                 + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
@@ -761,7 +793,13 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     // page past the end of the matches collects fewer rows than `limit` asked for.
     let page_rows = f64::from(f.matches.saturating_sub(f.offset).min(f.limit));
             // Per-CARD verify tier, for the reason spelled out in the StreamedSelect arm above.
-            eval_domain * (GATHER_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
+            // Split and gated exactly as in the StreamedSelect arm above, and deliberately in the same
+            // change: this lowers both plans' cost on `all_match` queries, and the one asymmetric
+            // adjustment tried before (P3's residual floor moved while P4's stayed) sent
+            // `StreamedSelect -> GatheredScan` from 407 lost-time queries to 653.
+            eval_domain
+                * (GATHER_LOOP_PER_CARD_NS
+                    + if tier_ns > 0.0 { GATHER_CARD_PASS_NS + tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 + scan_units * GATHER_SCAN_PER_ROW_NS
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -105,6 +105,24 @@ pub(crate) struct PlanFeatures {
     /// non-matching cards dominate either way) and decisive under an exact one, which is why the plane
     /// branch of `acquire_plan_features` sets this field itself rather than taking the span estimate.
     pub scan_units: u32,
+    /// `scan_units` for `StreamedSelect` specifically, where that plan examines a DIFFERENT number of
+    /// printings from `GatheredScan` on the same query. One per-query field cannot serve both: P4's
+    /// `push_card_matches` must walk a card's span to push every match, while P3's `card_match_count`
+    /// answers from span arithmetic for every card `card_pass` resolves outright.
+    ///
+    /// Measured on the compose acquire, `scan_units` against the realized `printings_examined`:
+    ///
+    ///     f:modern / artwork      GatheredScan 101,716 / 73,783 = 1.38    StreamedSelect 101,716 / 7,770 = 13.09
+    ///     f:gladiator / artwork    88,026 / 54,213 = 1.62                  88,026 /  5,876 = 14.98
+    ///
+    /// Right for P4 to within 1.4-1.6x, wrong for P3 by 13-15x, and `scan_units * STREAM_SCAN_PER_ROW_NS`
+    /// is then 525 us of P3's 704 us prediction against a 91 us measured loop. That is a FEATURE error, the
+    /// one class no rate can absorb — unlike the residual floor, whose kernel-vs-traffic gap turned out to
+    /// be a cache artifact.
+    ///
+    /// Set by the acquire branch that knows the difference; `mk_plan_feats` defaults it to `scan_units`, so
+    /// a branch that has not been taught reads exactly as before.
+    pub stream_scan_units: u32,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
     pub residual_tier_ns100: u32,
@@ -797,7 +815,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 * (STREAM_LOOP_PER_CARD_NS
                     + if tier_ns > 0.0 { STREAM_CARD_PASS_NS + tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
-                + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
+                + if tier_ns > 0.0 { f64::from(f.stream_scan_units) * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
                 + perm_steps * STREAM_PERM_STEP_NS
                 + f64::from(f.artwork_seen_cards) * STREAM_ARTWORK_SEEN_PER_CARD_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -430,7 +430,7 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// ns per permutation entry stepped in the streaming walk, the branch taken when
 /// `total > STREAM_MIN_MATCHES`.
 ///
-/// The walk covers the realized match span until the page fills, so it visits about
+/// The walk covers its sort-column segment until the page fills, so it visits about
 /// `page_span * n_cards / matches` entries -- inversely proportional to selectivity, and the one
 /// quantity in P3's finish phase that no other feature is proportional to. Nothing charged for it
 /// before: the arm had `matches * EMIT + FIXED`, which is flat in `n_cards`, so at a fixed 1,500
@@ -446,10 +446,11 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 ///
 /// The estimate is graded against the realized `perm_steps` counter rather than trusted, the same way
 /// `scan_units` is graded against `printings_examined`. **The rate survived the walk being bounded to
-/// its match span**, which is the useful thing that grade has said so far: traffic fit 1.17 before and
-/// 1.15 after, on the same seed and sample length, while realized steps at p90 fell 6.43x the estimate
-/// to 4.26x. A change that deletes a third of the steps at the tail and moves the per-step rate by 2%
-/// is the signature of a rate that is a real per-unit cost rather than a sink for the count's error.
+/// its sort-column segment**, which is the useful thing that grade has said so far: traffic fit 1.17
+/// before and 1.19 after, on the same seed and sample length, while realized steps at p90 fell from
+/// 6.43x the estimate to 5.31x (and to 4.26x under the unshipped realized-span variant). A change that
+/// deletes a fifth of the steps at the tail while moving the per-step rate by 2% is the signature of a
+/// rate that is a real per-unit cost rather than a sink for the count's error.
 const STREAM_PERM_STEP_NS: f64 = 1.0;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
@@ -718,16 +719,24 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // through the permutation: one match per `n_cards / matches` entries. Bounded by the
                 // corpus, since the walk cannot step past the end of the permutation.
                 //
-                // The executor now bounds the walk to the realized match span (first matching card's
-                // sort position to the last), which this cannot see -- no `PlanFeatures` field carries
-                // it. The uniform-spread assumption absorbs it: the expected gap before the first match
-                // is one `n_cards / matches` stride, negligible against `page_span` of them. What the
-                // regrade showed is that the assumption's remaining error is a DIFFERENT shape.
-                // Realized/estimated ran p10 0.13 / median 1.00 / p90 6.43 before the span bound and
-                // p10 0.08 / median 0.90 / p90 4.26 after, on the same seed and sample: bounding the
-                // ends removed a third of the tail, so a third of it was the leading prefix. The
-                // remaining 4.26x is the part no seek can reach -- non-matching entries INTERIOR to the
-                // span, which is the popcount-skip mechanism's territory, not a start position's.
+                // The executor now starts and ends the walk at the segment its filter's bound on the
+                // SORT COLUMN admits (`walk_bounds`), which this cannot see -- no `PlanFeatures` field
+                // carries the filter's shape. The uniform-spread assumption absorbs it: the expected gap
+                // before the first match is one `n_cards / matches` stride, negligible against
+                // `page_span` of them. What the regrade showed is that the assumption's remaining error
+                // is a DIFFERENT shape. Realized/estimated over ~12.5k walking rows, same seed and
+                // sample length:
+                //
+                //     unbounded walk                 p10 0.13   median 1.00   p90 6.43
+                //     sort-column bound              p10 0.11   median 0.96   p90 5.31
+                //     realized inv_perm min/max      p10 0.08   median 0.90   p90 4.26
+                //
+                // The third row is not shipped -- it cost 0.51 ns per matching card -- but it bounds how
+                // much of the tail a start position can reach at all, and the gap between rows two and
+                // three is real: a realized minimum catches clustering from ANY source, while a bound
+                // catches only what the predicate names. What is left in BOTH is non-matching entries
+                // INTERIOR to the walked segment, which no start position reaches by construction. That
+                // is the popcount-skip mechanism's territory.
                 (page_span * n_cards / f64::from(f.matches)).min(n_cards)
             } else {
                 0.0

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -421,7 +421,32 @@ const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.21;
 /// ~52µs = 31508 × 1.65. Only added when `matches <= STREAM_MIN_MATCHES`, the
 /// exact condition that routes P3 into that gather branch. The 1.65 above was fit on three hand
 /// picked narrow queries; across the sampled space the floor measures ~31µs, not 52µs.
+///
+/// CONFIRMED 2026-08-03 by `bench_streamed_loop`, which needed 600-card cells to reach this branch at
+/// all -- every earlier cell had more than `STREAM_MIN_MATCHES` matches and took the permutation walk
+/// instead, so this constant had never been measured against the branch it prices. It now reads
+/// 1.075-1.250 ns per card scanned against the 1.02 shipped, on a 33.9 us finish phase. Left alone.
 const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
+/// ns per permutation entry stepped in the streaming walk, the branch taken when
+/// `total > STREAM_MIN_MATCHES`.
+///
+/// The walk steps the permutation until the page fills, so it visits about
+/// `page_span * n_cards / matches` entries -- inversely proportional to selectivity, and the one
+/// quantity in P3's finish phase that no other feature is proportional to. Nothing charged for it
+/// before: the arm had `matches * EMIT + FIXED`, which is flat in `n_cards`, so at a fixed 1,500
+/// matches it predicted ~397 ns while `bench_streamed_loop` measured 1,333 / 3,791 / 10,458 ns at
+/// 31.5k / 126k / 410k cards. Under by 3.4x at the production corpus and 26x at 410k, which is why
+/// that phase graded mean |log| 2.06 while carrying 12% of all measured nanoseconds.
+///
+/// Measured 0.958-1.256 ns/entry on the cells where the walk is long (1,500 matches, ~1,260 estimated
+/// steps): 1.0 is the middle of that. Cells whose walk is SHORT read 2.0-4.2 ns/entry, but those are a
+/// ~167-step estimate against a few hundred ns, where a fixed cost dominates and a per-step rate
+/// overstates -- the long-walk regime is the one worth fitting, being where the term is large enough to
+/// change a routing decision.
+///
+/// The estimate is graded against the realized `perm_steps` counter rather than trusted, the same way
+/// `scan_units` is graded against `printings_examined`.
+const STREAM_PERM_STEP_NS: f64 = 1.0;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
 /// `cards.len()` every query — a 126 kB memset on this corpus — and the emission walk is over the
@@ -639,6 +664,18 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 && f.matches > 0
                 && u64::from(f.offset) < u64::from(f.matches);
             let floor = if runs_small_gather { n_cards * STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS } else { 0.0 };
+            // The other branch: when the small-total gather does NOT run and there is a page to emit,
+            // the walk steps the permutation until it fills. Same guards as the gather -- a query with
+            // no matches, or a page past the end, returns before the walk too.
+            let walks_permutation = !runs_small_gather && f.matches > 0 && u64::from(f.offset) < u64::from(f.matches);
+            let perm_steps = if walks_permutation {
+                // Entries visited to accumulate `page_span` matches, when matches are spread uniformly
+                // through the permutation: one match per `n_cards / matches` entries. Bounded by the
+                // corpus, since the walk cannot step past the end of the permutation.
+                (page_span * n_cards / f64::from(f.matches)).min(n_cards)
+            } else {
+                0.0
+            };
             // card_pass — and the verify tier that prices it — is per candidate CARD: the loop
             // calls `filter.card_pass` once per `cid`, and only the cheaper printing-dependent
             // residual is re-checked per row inside `push_card_matches`. Charging `tier_ns` per
@@ -648,6 +685,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
                 + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
+                + perm_steps * STREAM_PERM_STEP_NS
                 + f64::from(f.artwork_seen_cards) * STREAM_ARTWORK_SEEN_PER_CARD_NS
                 + floor
                 + n_cards * STREAM_CORPUS_PASS_PER_CARD_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -487,6 +487,30 @@ const GATHER_PUSH_PER_MATCH_NS: f64 = 2.24;
 /// bounded by matches: narrow deep pages (offset > matches) measured ≈ shallow
 /// (select_page returns early), so the term uses min(offset+limit, matches).
 const GATHER_SELECT_PER_PAGE_SLOT_NS: f64 = 3.51;
+/// ns per row actually collected into the page — `page_ids.into_iter().map(..)`, two random array
+/// derefs per row into `cards` and `printings`.
+///
+/// A SECOND driver for this phase, found by `bench_gather_loop`'s page sweep 2026-08-03. The phase was
+/// charged on `page_span` alone, which the sweep falsifies directly: at identical candidates,
+/// `page_span` 960 (offset 900, limit 60) costs 11,250 ns while `page_span` 600 (offset 0, limit 600)
+/// costs 16,375. A bigger span costing less is impossible under one column. The quickselect scales with
+/// `offset + limit`, but the collect scales with the PAGE, and the two rows separate them because one
+/// pairs a large span with a small page.
+///
+/// Traffic cannot separate them -- span and page are correlated across the sampled query mix, which is
+/// why an earlier non-negative fit put this at exactly 0.00. Four designed rows do it. Same lesson as
+/// the loop's three collinear counters: shape from a built design, level from traffic.
+///
+/// The count is what `select_page` returns, `clamp(matches - offset, 0, limit)`, not `limit`: a page
+/// past the end of the matches collects fewer rows than asked for, and charging `limit` there would
+/// bill a deep page on a narrow query for rows that do not exist.
+/// Level from traffic, not from the sweep. The page sweep put this near 15 ns/row, but a traffic fit
+/// with the column present reads 9.79, and traffic is what the routing surface is calibrated against --
+/// kernel LEVELS have not transferred in this branch (first warm cache, then an unexplained 1.6x on
+/// P3's per-card rate), while kernel SHAPE has been reliable. Adding the column did not disturb
+/// `GATHER_SELECT_PER_PAGE_SLOT_NS`, which refits 3.44 against a shipped 3.51 -- so the two are
+/// additive in the sampled mix rather than trading off, and only this one moves.
+const GATHER_COLLECT_PER_PAGE_ROW_NS: f64 = 9.79;
 /// Fixed P4 setup. Fit from the narrowest query (cmc>=15 card shallow 208ns at
 /// eval_domain=5: 208 − 5×(GATHER_VISIT_PER_CARD_NS+GATHER_PUSH_PER_MATCH_NS) −
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
@@ -692,11 +716,15 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 + STREAM_FIXED_COST_NS
         }
         PhysicalPlan::GatheredScan => {
+    // Rows the collect actually walks: `select_page` yields `clamp(matches - offset, 0, limit)`, so a
+    // page past the end of the matches collects fewer rows than `limit` asked for.
+    let page_rows = f64::from(f.matches.saturating_sub(f.offset).min(f.limit));
             // Per-CARD verify tier, for the reason spelled out in the StreamedSelect arm above.
             eval_domain * (GATHER_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 + scan_units * GATHER_SCAN_PER_ROW_NS
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS
+                + page_rows * GATHER_COLLECT_PER_PAGE_ROW_NS
                 + GATHER_FIXED_COST_NS
         }
     }

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -123,6 +123,13 @@ pub(crate) struct PlanFeatures {
     /// Set by the acquire branch that knows the difference; `mk_plan_feats` defaults it to `scan_units`, so
     /// a branch that has not been taught reads exactly as before.
     pub stream_scan_units: u32,
+    /// Diagnostic: the residual compares only CARD-level fields, so `card_pass` answers `True`/`False`
+    /// per card and never `PrintingDep`. A matching candidate then contributes its whole printing span and
+    /// a non-matching one none of it, which is a different estimator shape from one where printings under a
+    /// single card disagree — and the latter is what `RESIDUAL_PASS_RATE_PRINTING`/`_ARTWORK` was fitted on.
+    /// Exposed so `matches`'s error can be split by population before any rate is touched. **Nothing in
+    /// `plan_cost` reads this.**
+    pub residual_card_invariant: bool,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
     pub residual_tier_ns100: u32,

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -401,6 +401,23 @@ const STREAM_SCAN_PER_ROW_NS: f64 = 5.97;
 /// That same regression also shows the residual's cost is per CARD, not per printing scanned: the
 /// SLOPE against printings-per-card is ~3.5 for every tier including none (P4) and ~2 for P3, i.e.
 /// independent of what the residual is. So the tier belongs on `eval_domain`, as it now sits.
+/// **Measured with a built design 2026-08-04, and NOT changed — the useful part is why.** The floor only
+/// ever binds on `MASK_COMPARE` (tier 4.00); every other tier exceeds 6.58 and `max` takes the tier. So
+/// `bench_streamed_loop`'s always-true `DateCmp` cells are exactly the population it governs, and they say
+/// the residual's per-card cost is 2.45 ns (printing/residual 4.97 less printing/all_match 2.52) against a
+/// charged `CARD_PASS + floor` of 9.05 — i.e. the `card_pass` call IS the whole cost and the mask compare
+/// adds nothing measurable.
+///
+/// Traffic disagrees, and traffic wins on levels: the fitted `CARD_PASS+FLOOR` column reads **8.19 against
+/// the shipped 9.05 (0.90)** for this arm and **21.59 against 21.89 (0.99)** for `GatheredScan`. Both
+/// floors are already right to within 10% and 1%.
+///
+/// That is the third time this file has caught the same artifact. The design measures an always-true
+/// predicate over chunk-rotated slices; production runs real residuals over a warmer archive, and the two
+/// differ by 3.3x here exactly as they differed by 1.6-2.2x in the retraction at the top of
+/// `bench_streamed_loop`. Shape from a built design, levels from traffic — the design's contribution is
+/// the SHAPE finding that the tier adds ~0 over the call for the cheapest class, which is worth knowing
+/// and is not a licence to move the level.
 const STREAM_RESIDUAL_FLOOR_NS: f64 = 6.58;
 /// ns per match, for the permutation-walk emit. Small — P3 measured nearly flat
 /// in match count once eval_domain is fixed (see STREAM_MATCH_PHASE_PER_CARD_NS),

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -514,6 +514,23 @@ const GATHER_COLLECT_PER_PAGE_ROW_NS: f64 = 9.79;
 /// Fixed P4 setup. Fit from the narrowest query (cmc>=15 card shallow 208ns at
 /// eval_domain=5: 208 − 5×(GATHER_VISIT_PER_CARD_NS+GATHER_PUSH_PER_MATCH_NS) −
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
+///
+/// NOT refit 2026-08-03, deliberately. A whole-arm traffic fit puts this at 85, half the shipped value,
+/// on a model whose every other term sits at 0.85-1.22 -- and an intercept that far out on an otherwise
+/// agreeing model is a symptom, not a measurement. `fit_cost_model.py` fits ONE equation per query
+/// against total dispatch, so its intercept absorbs whatever the other columns cannot express; it read
+/// 84 and then 85 while `GATHER_COLLECT_PER_PAGE_ROW_NS` moved 15.0 -> 9.79 underneath it.
+///
+/// Measuring the intercept directly says the same thing more sharply. `bench_gather_loop` solves it from
+/// cells differing ONLY in card count, where nothing else can hide, and gets card -1,084 ns and printing
+/// -845 ns. A negative fixed cost is impossible, so the linear-in-cards shape is wrong: the loop is
+/// CONVEX in card count (12.40 ns/card across 400-4,500 against 6.31-7.67 over 1,500-4,500), which is the
+/// same working-set effect the corpus sweep measured as rates growing 2.4x over 13x cards. A straight
+/// line through a convex curve drives its intercept negative.
+///
+/// So 85 is compensation for curvature, not a fixed cost, and pasting it would fit today's query-size mix
+/// and drift as either query sizes or the corpus change. The fix is a term for the curvature -- see the
+/// corpus-size note in `bench_gather_loop` -- not a smaller constant.
 const GATHER_FIXED_COST_NS: f64 = 169.6;
 
 // --- PrintingCompose's own rates -------------------------------------------------------------

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -258,7 +258,7 @@ fn plane_popcount(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32)
     let mut bits: Vec<u64> = Vec::new();
     eval_planes(&pe, &indexes.planes, &mut bits);
     let c: u32 = bits.iter().map(|w| w.count_ones()).sum();
-    Some((c, plane_expr_is_existential(&pe)))
+    Some((c, plane_expr_is_existential(&pe, u64::from(indexes.planes.divergent_formats))))
 }
 
 /// A plane-backed leaf. `force_loose` forces the superset treatment

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -670,6 +670,37 @@ pub(crate) fn regex_tier(pattern: &str) -> u32 {
 /// settles an And, a card-level True settles an Or), so a composite is
 /// printing-dependent only when ALL its children are.
 fn printing_dependent(f: &FilterExpr) -> bool {
+    match f {
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(printing_dependent),
+        FilterExpr::Not(inner) => printing_dependent(inner),
+        leaf => leaf_compares_printing_field(leaf),
+    }
+}
+
+/// Whether `f` compares a printing-level field **anywhere** — the `any` composition of the same leaf
+/// table `printing_dependent` reads with `all`. The two questions are different and both are wanted:
+///
+/// - `printing_dependent` asks "can this node never settle at card level", for verify ORDERING. A
+///   composite settles when ANY child can, so it is printing-dependent only when ALL children are.
+/// - this asks "could any part of this need a per-printing answer", for the result-total ESTIMATE. A
+///   card-invariant residual returns `True`/`False` per card and never `PrintingDep`, so each candidate
+///   contributes either its whole printing span or none of it — a different estimator shape from one where
+///   printings under a single card disagree.
+///
+/// `name:s AND usd>10` separates them: not `printing_dependent` (the name settles it), but it does touch a
+/// printing field, so the span of a matching card is not all-or-nothing.
+pub(crate) fn touches_printing_field(f: &FilterExpr) -> bool {
+    match f {
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().any(touches_printing_field),
+        FilterExpr::Not(inner) => touches_printing_field(inner),
+        leaf => leaf_compares_printing_field(leaf),
+    }
+}
+
+/// The per-leaf half of both questions above: does this NON-composite node compare a printing-level
+/// field. Composition is the callers' business, which is the whole reason this is factored out — the two
+/// callers disagree on it and must not disagree on the table.
+fn leaf_compares_printing_field(f: &FilterExpr) -> bool {
     fn num_pdep(e: &NumExpr) -> bool {
         match e {
             NumExpr::Const(_) => false,
@@ -712,8 +743,11 @@ fn printing_dependent(f: &FilterExpr) -> bool {
         // Divergent-legality cards defer to the printing, but they are a rare
         // exception (non-tournament reprints); rank by the common card-level case.
         FilterExpr::Legality { .. } => false,
-        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(printing_dependent),
-        FilterExpr::Not(inner) => printing_dependent(inner),
+        // Composites are composed by the two callers, which differ on `all` vs `any`; reaching here with
+        // one is a bug in whichever caller forgot to handle it, not a case to answer silently.
+        FilterExpr::And(_) | FilterExpr::Or(_) | FilterExpr::Not(_) => {
+            unreachable!("composites are composed by printing_dependent / touches_printing_field")
+        }
         // Exhaustive, not `_ => false`: a new variant must get a considered
         // answer here rather than silently inheriting "can settle at card level".
         FilterExpr::True

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -45,7 +45,9 @@ fn tri_bool(b: bool) -> Tri {
 
 // ─── Numeric expressions ──────────────────────────────────────────────────────
 
-#[derive(Clone, Copy)]
+// PartialEq so a caller can ask "is this leaf about the field I care about" — `sort_col_bound` matches
+// the sort column against the field a NumericCmp constrains.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NumField {
     Cmc,
     Power,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8298,7 +8298,19 @@ fn acquire_plan_features(
         // `eval_domain` and scanned 0.14x the claimed `scan_units`. Over-costing both plans inflates
         // the predicted GAP between them (P4 carries the larger per-row rates), which is what routing
         // reads -- measured as a GatheredScan-vs-StreamedSelect gap ratio of 0.32 on this acquire.
-        let scan_all = |cards: usize| ((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize;
+        // Clamped at `n_printings`, which is an INVARIANT and not a calibration: this estimates the
+        // printings under the candidate CARDS, and those are a subset of the corpus, so a value above
+        // `n_printings` is not a wrong estimate but an impossible one. `COMPOSE_CANDIDATE_SPAN_BIAS`'s 2.1
+        // says candidates are more reprinted than an average card, which is true when a composable
+        // predicate SELECTS by having a matching printing and false when it selects nearly everything —
+        // the same saturation failure `COMPOSE_CARD_ESTIMATE_BIAS` had, one multiplier downstream.
+        //
+        // `border:black` / printing reached 159,325 against a corpus of 97,206 and a realized
+        // `printings_examined` of exactly 97,206. The clamp makes that cell exact. It matters for routing
+        // because this feature is 76% of P3's arm on the broad-residual class, where it drove P3 to
+        // pred/meas 1.53 while P4 sat at 0.88 — the pair inverted, with both plans over the same feature.
+        let scan_all =
+            |cards: usize| (((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize).min(n_printings as usize);
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
             Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
             Mode::Card => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3382,23 +3382,35 @@ enum AndSource<'f, 'i> {
     /// printings — already probed, so the And arm reads it as the ranking probe instead of repeating
     /// the two binary searches. Constituents may include a `Not` (`bare_range_bounds` reduces
     /// `-usd<c` to `usd>=c`'s bounds itself); nothing downstream needs to know, because the
-    /// broad-interval gate below means `k` is always sparse and `range_narrowed` therefore takes its
-    /// vec path without ever consulting `broad_ok` — the one thing the negated arm cares about.
+    /// broad-interval gate below means `k` is always sparse under `sparse_only` and `range_narrowed`
+    /// therefore takes its vec path without ever consulting `broad_ok` — the one thing the negated arm
+    /// cares about. The compose builders don't consult `broad_ok` at all.
     FusedRange { idx: &'i Archived<PrintingRangeIndex>, lo: u32, hi: u32, k: usize },
 }
 
 /// Group an `And`'s children by which printing-range index they select on, fusing each group of two
 /// or more into a single interval — `lo = max(lo_i)`, `hi = min(hi_i)`.
 ///
-/// Children the range dispatch doesn't recognize, single-member groups, and groups whose fused
-/// interval is *still* broad all pass through untouched: those children keep taking their own arms, so
+/// Children the range dispatch doesn't recognize and single-member groups pass through untouched, so
 /// this cannot alter any query it doesn't fuse. Emission follows the written position of each group's
-/// first member, so the And arm's stable `sort_by_key` sees the tie-breaking it saw before for
-/// everything unfused.
+/// first member, so a caller that ranks its sources sees the tie-breaking it saw before for everything
+/// unfused.
 ///
 /// The fused interval is the exact conjunction of its constituents, which is what lets one source
-/// stand in for all of them — including in `every_child_included`'s tightness accounting.
-fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Archived<CardIndexes>) -> Vec<AndSource<'f, 'i>> {
+/// stand in for all of them — including in `narrow_rec`'s `every_child_included` tightness accounting.
+///
+/// `sparse_only` is the one thing the two callers disagree about. `narrow_rec` sets it, because a broad
+/// fused source reaches `range_narrowed` under a single `broad_ok` where two broad children each got
+/// their own, which takes a decision away from the And's per-child skip logic for no measured gain (see
+/// the gate below). The compose builders clear it: `range_leaf_bits` is an O(k) scatter at every k, so
+/// one scatter of the intersection always beats two scatters and an AND, and
+/// `compose_printing_estimate` reads the intersection's exact `k` where the unfused fold could only take
+/// the min of the two sides (measured: 33,862 against a true 879).
+fn fuse_and_range_children<'f, 'i>(
+    children: &'f [FilterExpr],
+    indexes: &'i Archived<CardIndexes>,
+    sparse_only: bool,
+) -> Vec<AndSource<'f, 'i>> {
     // At most one group per printing-range index (price / collector-number / released-at), so a
     // linear scan of the accumulator beats hashing a pointer.
     struct Group<'i> {
@@ -3424,15 +3436,14 @@ fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Arch
             None => groups.push(Group { first: pos, idx, lo, hi, count: 1 }),
         }
     }
-    // Fusion exists to DISCOVER a sparse intersection hiding behind broad halves. Where the
-    // intersection is itself broad there is nothing to discover — and fusing anyway is not neutral,
-    // because one broad source reaches `range_narrowed` under a single `broad_ok` where two broad
-    // children each got their own, so the And's per-child skip logic stops deciding per child.
+    // Under `sparse_only`, fusion exists to DISCOVER a sparse intersection hiding behind broad halves.
+    // Where the intersection is itself broad there is nothing to discover — and fusing anyway is not
+    // neutral, for the `broad_ok` reason in this function's doc.
     //
-    // This gate is a scope decision, not a measured win: paired traffic puts fused-vs-gated at 0.88 vs
+    // That gate is a scope decision, not a measured win: paired traffic puts fused-vs-gated at 0.88 vs
     // 0.86 of baseline on the fusible slice, and the per-query noise floor on a slice fusion cannot
     // touch at all is ±170 µs, so the two are indistinguishable. What the gate does buy is a bound —
-    // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), the change is a
+    // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), narrowing is a
     // provable no-op. `k` survives for the survivors so the probe isn't recomputed downstream.
     let mut fused: Vec<(&Group<'i>, usize)> = Vec::new();
     for g in &groups {
@@ -3441,7 +3452,7 @@ fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Arch
         }
         let s = g.idx.partition_point(|p| u32::from(p.0) < g.lo);
         let e = g.idx.partition_point(|p| u32::from(p.0) < g.hi);
-        if !range_too_broad_to_narrow(e - s, g.idx.len()) {
+        if !sparse_only || !range_too_broad_to_narrow(e - s, g.idx.len()) {
             fused.push((g, e - s));
         }
     }
@@ -4027,7 +4038,7 @@ fn narrow_rec(
             // Same-index range children fuse into one interval first (`fuse_and_range_children`),
             // because two individually-broad halves can intersect to something sparse and this arm
             // only ever intersects narrowing *results*, never the bounds.
-            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes)
+            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes, true)
                 .into_iter()
                 .map(|src| match src {
                     AndSource::Child(c) => {
@@ -5814,10 +5825,18 @@ fn compose_printing_bits(
     match filter {
         FilterExpr::True => all_printing_bits(n_printings),
         FilterExpr::And(v) => {
-            // empty And is vacuously true; start all-ones (tail masked) and intersect each child.
+            // empty And is vacuously true; start all-ones (tail masked) and intersect each source.
+            // Same-index range children fuse into one interval first, so `usd>=0.42 usd<=0.43` scatters
+            // the 879-printing intersection once instead of scattering 33,862 and 48,559 and ANDing
+            // them. Unconditional (`sparse_only: false`): `range_leaf_bits` is an O(k) scatter at every
+            // k, so one scatter of a subset can never lose to two of its supersets.
             let mut acc = all_printing_bits(n_printings);
-            for child in v.iter() {
-                and_bits_into(&mut acc, &compose_printing_bits(child, indexes, offsets, printings, n_printings));
+            for src in fuse_and_range_children(v, indexes, false) {
+                let bits = match src {
+                    AndSource::Child(c) => compose_printing_bits(c, indexes, offsets, printings, n_printings),
+                    AndSource::FusedRange { idx, lo, hi, .. } => range_leaf_bits(idx, lo, hi, n_printings),
+                };
+                and_bits_into(&mut acc, &bits);
             }
             acc
         }
@@ -5903,9 +5922,17 @@ fn compose_printing_estimate(
     let popcount = |bits: &[u64]| bits.iter().map(|w| w.count_ones() as usize).sum::<usize>();
     match filter {
         FilterExpr::True => (n_printings, 0, 0),
-        FilterExpr::And(v) => v
-            .iter()
-            .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
+        // The min-of-children fold is an intersection UPPER BOUND, and on a two-sided range it is a bad
+        // one: `usd>=0.42 usd<=0.43` folded to min(33,862, 48,559) against a true 879, and the summed
+        // scatter to 82,421 for an 879-row answer. Fusing same-index children first replaces both with
+        // the interval's exact `k` — the same two `partition_point` calls the one-sided arm below
+        // already makes, which is why a one-sided range estimates at 1.0x and this did not.
+        FilterExpr::And(v) => fuse_and_range_children(v, indexes, false)
+            .into_iter()
+            .map(|src| match src {
+                AndSource::Child(c) => compose_printing_estimate(c, indexes, offsets, n_printings),
+                AndSource::FusedRange { k, .. } => (k, 0, k),
+            })
             .fold((n_printings, 0, 0), |(m, bc, sc), (cm, cbc, csc)| (m.min(cm), bc + cbc, sc + csc)),
         FilterExpr::Or(v) => {
             let (m, bc, sc) = v

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7895,18 +7895,51 @@ const COMPOSE_GATHER_SPAN_PER_MATCH: f64 = 1.47;
 /// cancelling, and dividing `est_cards` by 1.78 moved it to 0.47.
 const COMPOSE_CANDIDATE_SPAN_BIAS: f64 = 2.1;
 
-/// `balls_into_bins` with its measured bias divided out. See `COMPOSE_CARD_ESTIMATE_BIAS`.
+/// `balls_into_bins` with its measured clustering bias divided out of the BALL COUNT. See
+/// `COMPOSE_CARD_ESTIMATE_BIAS` for the 1.78 and why clustering causes it.
+///
+/// The bias used to divide the estimator's OUTPUT, which broke its ceiling. `balls_into_bins` saturates
+/// toward `domain` — that is the whole point of using it over `k.min(domain)` — so scaling what it returns
+/// caps the calibrated estimate at `domain / 1.78`, i.e. **17,701 of 31,508 cards no matter how many
+/// printings match**. `border:black` matches 85,046 of 97,206 printings and visits every card in the corpus;
+/// the estimate read 16,511.
+///
+/// Clustering does not mean "fewer cards than the estimator says". It means the `k` matching printings are
+/// not `k` independent draws — a legality leaf broadcast down sets a whole card's printings at once — so the
+/// EFFECTIVE ball count is lower. That is an input. Dividing `k` instead is the same correction in the
+/// selective regime the 1.78 was fitted on (`balls_into_bins(k, d) ≈ k` for `k ≪ d`, so scaling either side
+/// agrees) and keeps the saturation the output form destroyed. Graded against P4's realized `cards_visited`
+/// over 3,490 estimator rows, estimate/realized:
+///
+///     breadth (k / n_printings)      bias on output        bias on input
+///     selective  < 0.1               p50 1.02              p50 1.02      <- fitted here, unchanged
+///     mid        0.1-0.5             p50 0.91              p50 1.18
+///     broad      > 0.5               p50 0.52              p50 0.78
+///     all                            p50 0.87  spread 3.3  p50 0.90  spread 2.7
+///
+/// The mid band overshoots because 1.78 was fitted against the output form; it is not re-fitted here, so
+/// this is the shape change alone. Re-fitting it is a fixed-point iteration on a constant whose own value
+/// depends on where it is applied — the same caveat `fit_cost_model` records for the residual floor.
+///
+/// Why this matters for routing and not just accuracy: `eval_domain` feeds a per-card term in both scan
+/// arms, and P4's rate is 25.77 ns/card against P3's 11.63, so under-counting candidates discounts P4 by
+/// 2.2× as much. On the broad-residual class that inverted the pair — P3 measured 819.7 µs against P4's
+/// 1,308.4 with the model pricing them within 5 µs of each other.
 fn calibrated_balls_into_bins(k: usize, domain: usize) -> usize {
-    let raw = balls_into_bins(k, domain) as f64;
-    ((raw / COMPOSE_CARD_ESTIMATE_BIAS).round() as usize).max(usize::from(k > 0))
+    balls_into_bins_effective(k as f64 / COMPOSE_CARD_ESTIMATE_BIAS, domain).max(usize::from(k > 0))
 }
 
 fn balls_into_bins(k: usize, domain: usize) -> usize {
+    balls_into_bins_effective(k as f64, domain).max(usize::from(k > 0))
+}
+
+/// `domain * (1 - e^(-k/domain))` for a possibly fractional ball count, clamped to the domain.
+fn balls_into_bins_effective(k: f64, domain: usize) -> usize {
     if domain == 0 {
         return 0;
     }
-    let est = domain as f64 * (-(k as f64) / domain as f64).exp().mul_add(-1.0, 1.0);
-    (est.round() as usize).min(domain).max(usize::from(k > 0))
+    let est = domain as f64 * (-k / domain as f64).exp().mul_add(-1.0, 1.0);
+    (est.round() as usize).min(domain)
 }
 
 /// Distinct **artworks** an estimated printing set touches, projected in two stages.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8059,6 +8059,7 @@ fn mk_plan_feats(
         matches,
         eval_domain,
         scan_units,
+        residual_card_invariant: false, // diagnostic; only the candidates acquire sets it
         // Defaults to `scan_units`: only an acquire that knows P3 examines fewer printings overrides it.
         stream_scan_units: scan_units,
         residual_tier_ns100,
@@ -8122,7 +8123,15 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
             }
         }
     };
-    mk_plan_feats(ctx, params, matches, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
+    let mut feats =
+        mk_plan_feats(ctx, params, matches, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) });
+    // Diagnostic only (`explain`), so the residual-pass-rate population can be split by traffic before any
+    // rate moves. A card-invariant residual answers `True`/`False` per card and never `PrintingDep`, so a
+    // matching candidate contributes its WHOLE printing span and a non-matching one none of it — the
+    // all-or-nothing shape. With a printing-level field in play the printings under one card disagree, which
+    // is the shape the single `RESIDUAL_PASS_RATE_*` was fitted on. Nothing reads this in routing.
+    feats.residual_card_invariant = !prep.all_match_known && !touches_printing_field(filter);
+    feats
 }
 
 /// The acquire step of `run_query_routed`'s three-step algorithm (see its doc
@@ -9806,6 +9815,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         // P3's own scan estimate; equals `scan_units` unless the acquire knew the two plans differ.
         ("stream_scan_units", g.stream_scan_units),
         ("residual_tier_ns100", g.residual_tier_ns100),
+        ("residual_card_invariant", u32::from(g.residual_card_invariant)),
         ("limit", g.limit),
         ("offset", g.offset),
         ("broadcast_printings", g.broadcast_printings),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2161,6 +2161,27 @@ fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
     lo
 }
 
+/// Which legality formats have printings that disagree, as a mask over the same 2-bit fields
+/// `format_shifts` indexes. See `CardData::divergent_formats` for why the per-format answer is worth
+/// more than the per-card boolean beside it.
+///
+/// One definition, used by `reload` AND by the test fixtures, because a fixture computing this
+/// differently from production would either exercise a shortcut production never takes or miss one it
+/// does — and the thing being decided is whether per-printing legality verification can be skipped.
+fn divergent_formats_of(printings: &[Printing], offsets: &[u32]) -> u64 {
+    let mut mask = 0u64;
+    for w in offsets.windows(2) {
+        let (start, end) = (w[0] as usize, w[1] as usize);
+        // XOR every printing against the group's first: a field that ever differs shows up in some XOR,
+        // and a field that never does contributes nothing from any pair.
+        let first = printings[start].card_legalities;
+        for pr in &printings[start + 1..end] {
+            mask |= first ^ pr.card_legalities;
+        }
+    }
+    mask
+}
+
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
@@ -9806,8 +9827,6 @@ impl QueryEngine {
         let mut cards: Vec<OracleCard> = Vec::new();
         let mut printings: Vec<Printing> = Vec::with_capacity(rows.len());
         let mut offsets: Vec<u32> = Vec::new();
-        // See `CardData::divergent_formats`: which formats disagree, not just that some card's did.
-        let mut divergent_formats: u64 = 0;
         for mut row in rows {
             let is_new = cards.last().is_none_or(|c| c.oracle_id != row.oracle_id);
             if is_new {
@@ -9845,8 +9864,6 @@ impl QueryEngine {
                 });
             } else if row.card_legalities != cards.last().map(|c| c.card_legalities).unwrap_or(0) {
                 cards.last_mut().unwrap().legality_divergent = true;
-                // Which 2-bit fields differ, not merely that some did. See `CardData::divergent_formats`.
-                divergent_formats |= row.card_legalities ^ cards.last().map(|c| c.card_legalities).unwrap_or(0);
             }
             printings.push(Printing {
                 scryfall_id: row.scryfall_id,
@@ -9973,6 +9990,9 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
+        // Computed over the grouped arrays rather than inside the grouping loop, so the fixtures can call
+        // the same function on the same shape. One pass over the printings against a ~2 s load.
+        let divergent_formats = divergent_formats_of(&printings, &offsets);
         let card_data = CardData {
             cards,
             printings,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4659,6 +4659,22 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// streaming's win grows fast (~1.8× by 8k), so the trigger stays put.
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));
 
+/// The emission walk tracks its match span only when candidates are at most `n_cards` over this — a
+/// quarter of the corpus. See the derivation at `track_span` in `run_query_streamed`.
+///
+/// Calibrated by `scripts/bench_walk_span.py`, which A/Bs this toggle inside ONE binary (cross-build
+/// comparison cannot resolve it: `ns_loop` wandered ±9% run to run on a phase neither build changed).
+/// Tracking costs **0.51 ns per matching card** and a walk step costs **0.37 ns**, so insurance that
+/// cannot pay for itself starts at `matching_cards = n_cards * 0.37 / (0.37 + 0.51)` = 0.42 ×
+/// `n_cards`; a quarter sits inside that with room for the estimate to be wrong. Ungated, the broad
+/// cells measured 1.13-1.21x SLOWER (`cmc>=1 order=edhrec`: `ns_loop` 78.54 -> 94.46 us over 30,318
+/// cards) while saving nothing, because a match set that big leaves no prefix to skip.
+///
+/// Set to 1 to track unconditionally, or above the corpus size to disable tracking; `bench_walk_span.py`
+/// uses exactly those two settings, spelled `00001` / `99999` so both arms carry an equal-length value.
+static SPAN_TRACK_CANDIDATE_DIVISOR: LazyLock<usize> =
+    LazyLock::new(|| guard_env("CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR", 4).max(1));
+
 /// Whether run_query reorders And/Or children cheapest-verification-first
 /// before the evaluation walk (see FilterExpr::order_children_by_verify_cost).
 /// Unlike the guards above this is a binary A/B switch, not a threshold:
@@ -6244,7 +6260,12 @@ impl PreparedCandidates {
     /// every card. Boxed because the two arms are different iterator types and
     /// both P3 and P4 want the same either-or — previously spelled out
     /// identically at the head of each.
-    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn Iterator<Item = u32> + 's> {
+    ///
+    /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a
+    /// `Range`), and an executor that wants the candidate count before its loop -- P3, to decide
+    /// whether tracking the walk's match span can pay -- would otherwise have to be handed the count
+    /// alongside the iterator and trust the two to agree.
+    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn ExactSizeIterator<Item = u32> + 's> {
         match &self.candidate_cards {
             Some(v) => Box::new(v.iter().copied()),
             None => Box::new(0..ctx.n_cards()),
@@ -8845,7 +8866,7 @@ fn run_query_streamed<'a>(
     filter: &FilterExpr,
     all_match_known: bool,
     order: SortOrder<'_>,
-    card_ids: Box<dyn Iterator<Item = u32> + '_>,
+    card_ids: Box<dyn ExactSizeIterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // First of the three phase boundaries — everything down to the match loop is `ns_setup`, which
@@ -8887,15 +8908,37 @@ fn run_query_streamed<'a>(
     // through every card ordered before the first match discarding on `counts[cid] == 0` -- `year>=2020
     // order=released asc` pays the entire pre-2020 prefix -- and, on any page it cannot fill, every
     // card ordered after the last match as well, since the only thing that stops it early is the page
-    // filling. This loop already visits every candidate, so the span costs one `inv_perm` read, a `min`
-    // and a `max` per MATCHING card, and candidates arrive in ascending `cid` order, which makes those
-    // reads a forward stream through `inv_perm` rather than random access.
+    // filling. Measured on this corpus: `cmc>=6 order=cmc asc` walked 28,275 entries for a 60-row page
+    // and spent 10.6 us of a 20.25 us execution doing it; bounded, it walks 60 and spends 0.38 us.
     //
     // Deliberately the REALIZED span rather than bounds derived from the predicate and the sort
     // column: it holds for any predicate (including a residual only `card_match_count` can resolve),
     // and it cannot be wrong about how ties inside the sort key are broken. Descending needs nothing
     // extra -- there are two permutations per column, one per direction, so `inv_perm` is already the
     // inverse of the order actually walked.
+    //
+    // GATED, because the span is emphatically not free. It costs an `inv_perm` read plus a `min` and a
+    // `max` per MATCHING card, and this loop's `all_match` arm is only ~2.6 ns/card to begin with, so
+    // 0.51 ns/card of tracking is a 20% tax on it: ungated, `cmc>=1 order=edhrec` measured `ns_loop`
+    // 78.54 -> 94.46 us over 30,318 cards while its walk stayed at 111 steps either way. The tax is
+    // paid on every streamed query; the saving only exists when the walk had something to skip.
+    //
+    // The bound is therefore insurance, and the gate is the premium being kept below the payout. A
+    // query with `m` matching cards has at most `n_cards - m` entries outside its span, so the most the
+    // bound can save is `(n_cards - m) * 0.37 ns` against a cost of `m * 0.51 ns` -- break-even at
+    // `m = 0.42 * n_cards`, and `SPAN_TRACK_CANDIDATE_DIVISOR` sits at a quarter, inside it. The
+    // regime below the gate is also where the unbounded walk is dangerous: steps go as
+    // `page_span * n_cards / matches`, so sparse matches are exactly what make it long.
+    //
+    // Candidates bound matching cards from above, and unlike the match count it is known HERE, before
+    // the loop -- so this is one perfectly-predicted branch per card, rather than a decision that could
+    // only be made after the cost had already been paid.
+    //
+    // What the gate does not fix: a query whose cluster sits at the NEAR end of the walked order pays
+    // the premium for nothing, because the page fills before the last-match bound can matter
+    // (`cmc>=6 order=cmc desc offset=900` measured 1.17x). That is the shape of the bet, not a defect
+    // in it -- which end a cluster lands on is not knowable before the loop runs.
+    let track_span = card_ids.len() <= cards.len() / *SPAN_TRACK_CANDIDATE_DIVISOR;
     let (mut first_match_pos, mut last_match_pos) = (u32::MAX, 0u32);
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
@@ -8943,7 +8986,7 @@ fn run_query_streamed<'a>(
         counts[cid as usize] = c;
         // Guarded on `c != 0` because a zero-count card is exactly what the walk skips: widening the
         // span to one would put entries inside it that the walk then discards, giving back the saving.
-        if c != 0 {
+        if track_span && c != 0 {
             let pos = u32::from(inv_perm[cid as usize]);
             first_match_pos = first_match_pos.min(pos);
             last_match_pos = last_match_pos.max(pos);
@@ -9024,11 +9067,16 @@ fn run_query_streamed<'a>(
     // outside it every entry has `counts[cid] == 0` by construction (the span is the min and max over
     // all cards with a nonzero count), and the walk's only effect on a zero-count entry is to
     // `continue`. `total > 0` here — the guard above returned otherwise — so some card set both ends.
-    debug_assert!(
-        first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
-        "total > 0 guarantees a matching card, so the match span must be a real permutation range"
-    );
-    let match_span = &perm[first_match_pos as usize..=last_match_pos as usize];
+    // Ungated, the whole permutation, exactly as before.
+    let match_span: &[Archived<u32>] = if track_span {
+        debug_assert!(
+            first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
+            "total > 0 guarantees a matching card, so the match span must be a real permutation range"
+        );
+        &perm[first_match_pos as usize..=last_match_pos as usize]
+    } else {
+        &perm[..]
+    };
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8101,6 +8101,21 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // where a residual survives, because roughly half the printings under a candidate then fail it.
     // Discount by the measured pass rate there; undiscounted it swapped a 2.4x under-count for a 2.6x
     // over-count. Result after both: 1.00 tight, 0.91-1.00 with a residual.
+    // Two exact-count routes were measured here and BOTH are worse than this span estimate, for one
+    // shared reason: the quantity wanted is `|candidates AND residual|`, and neither route provides an
+    // intersection.
+    //
+    // - `estimator::estimate_cardinality` (the engine already ships it, index-backed leaves, independence
+    //   over `And`): worse in every mode -- card mean |log| 1.31 against 0.79, p90 33.38 against 9.91.
+    // - `RangeCardCounts::distinct_cards`, which is genuinely EXACT and O(log n): available on only 9% of
+    //   rows with a residual (7% of the misordered ones, 2.0 of 46.5 ms of pairwise gap), and 6x worse where
+    //   it is available -- card p50 6.32 against 1.12. It counts cards matching the residual leaf GLOBALLY,
+    //   not cards matching it among the candidates, so it is exact for the wrong set.
+    //
+    // The exact answer needs the residual evaluated over the candidates, which is the work being costed. A
+    // bitmap AND of the candidate set with an indexed leaf's set would give it for that same 9%; nothing
+    // cheap covers the rest. See the candidates-acquire section of
+    // docs/issues/local-engine-loop-phase-measurement.md.
     let matches = match params.mode {
         Mode::Card => count,
         Mode::Printing | Mode::Artwork => {
@@ -8131,6 +8146,7 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // all-or-nothing shape. With a printing-level field in play the printings under one card disagree, which
     // is the shape the single `RESIDUAL_PASS_RATE_*` was fitted on. Nothing reads this in routing.
     feats.residual_card_invariant = !prep.all_match_known && !touches_printing_field(filter);
+
     feats
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10048,3 +10048,5 @@ mod bench_compose_card_projection;
 mod bench_candidate_materialize;
 #[cfg(test)]
 mod bench_gather_loop;
+#[cfg(test)]
+mod bench_streamed_loop;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3367,6 +3367,102 @@ fn probe_range_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Option
     Some(e - s)
 }
 
+/// One entry in the And arm's work list: a child exactly as written, or a half-open interval fused
+/// from two or more same-index range children.
+///
+/// `usd>=0.42 usd<=0.43` is the shape that motivated this. Each half matches most of the corpus, so
+/// each trips `range_too_broad_to_narrow` on its own and declines; their *intersection* is 837
+/// printings. `narrow_rec` narrows children independently and intersects the results, so the
+/// interval is never discovered — measured at 1,146.8 µs, against 26.7 µs for the one-sided
+/// `usd>=200`, which returns *more* rows. Fusing before ranking puts the two-sided form on the same
+/// sparse-vec path the one-sided form already takes.
+enum AndSource<'f, 'i> {
+    Child(&'f FilterExpr),
+    /// `[lo, hi)` on `idx`, the intersection of two or more children's intervals, holding `k`
+    /// printings — already probed, so the And arm reads it as the ranking probe instead of repeating
+    /// the two binary searches. Constituents may include a `Not` (`bare_range_bounds` reduces
+    /// `-usd<c` to `usd>=c`'s bounds itself); nothing downstream needs to know, because the
+    /// broad-interval gate below means `k` is always sparse and `range_narrowed` therefore takes its
+    /// vec path without ever consulting `broad_ok` — the one thing the negated arm cares about.
+    FusedRange { idx: &'i Archived<PrintingRangeIndex>, lo: u32, hi: u32, k: usize },
+}
+
+/// Group an `And`'s children by which printing-range index they select on, fusing each group of two
+/// or more into a single interval — `lo = max(lo_i)`, `hi = min(hi_i)`.
+///
+/// Children the range dispatch doesn't recognize, single-member groups, and groups whose fused
+/// interval is *still* broad all pass through untouched: those children keep taking their own arms, so
+/// this cannot alter any query it doesn't fuse. Emission follows the written position of each group's
+/// first member, so the And arm's stable `sort_by_key` sees the tie-breaking it saw before for
+/// everything unfused.
+///
+/// The fused interval is the exact conjunction of its constituents, which is what lets one source
+/// stand in for all of them — including in `every_child_included`'s tightness accounting.
+fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Archived<CardIndexes>) -> Vec<AndSource<'f, 'i>> {
+    // At most one group per printing-range index (price / collector-number / released-at), so a
+    // linear scan of the accumulator beats hashing a pointer.
+    struct Group<'i> {
+        first: usize,
+        idx: &'i Archived<PrintingRangeIndex>,
+        lo: u32,
+        hi: u32,
+        count: usize,
+    }
+    let mut groups: Vec<Group<'i>> = Vec::new();
+    for (pos, child) in children.iter().enumerate() {
+        let Some((idx, lo, hi)) = bare_range_bounds(child, indexes) else { continue };
+        match groups.iter_mut().find(|g| std::ptr::eq(g.idx, idx)) {
+            Some(g) => {
+                g.lo = g.lo.max(lo);
+                // An unsatisfiable fusion (`usd>=1 usd<=0.5`) gives `hi < lo`, and every consumer
+                // computes `k` as `partition_point(hi) - partition_point(lo)` — that subtraction
+                // underflows and panics. Clamping to `[lo, lo)` yields `k = 0`, which is what an
+                // empty range means and what every consumer already handles.
+                g.hi = g.hi.min(hi).max(g.lo);
+                g.count += 1;
+            }
+            None => groups.push(Group { first: pos, idx, lo, hi, count: 1 }),
+        }
+    }
+    // Fusion exists to DISCOVER a sparse intersection hiding behind broad halves. Where the
+    // intersection is itself broad there is nothing to discover — and fusing anyway is not neutral,
+    // because one broad source reaches `range_narrowed` under a single `broad_ok` where two broad
+    // children each got their own, so the And's per-child skip logic stops deciding per child.
+    //
+    // This gate is a scope decision, not a measured win: paired traffic puts fused-vs-gated at 0.88 vs
+    // 0.86 of baseline on the fusible slice, and the per-query noise floor on a slice fusion cannot
+    // touch at all is ±170 µs, so the two are indistinguishable. What the gate does buy is a bound —
+    // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), the change is a
+    // provable no-op. `k` survives for the survivors so the probe isn't recomputed downstream.
+    let mut fused: Vec<(&Group<'i>, usize)> = Vec::new();
+    for g in &groups {
+        if g.count < 2 {
+            continue;
+        }
+        let s = g.idx.partition_point(|p| u32::from(p.0) < g.lo);
+        let e = g.idx.partition_point(|p| u32::from(p.0) < g.hi);
+        if !range_too_broad_to_narrow(e - s, g.idx.len()) {
+            fused.push((g, e - s));
+        }
+    }
+    if fused.is_empty() {
+        return children.iter().map(AndSource::Child).collect();
+    }
+    let mut out: Vec<AndSource<'f, 'i>> = Vec::with_capacity(children.len());
+    for (pos, child) in children.iter().enumerate() {
+        let group = bare_range_bounds(child, indexes).and_then(|(idx, ..)| fused.iter().find(|(g, _)| std::ptr::eq(g.idx, idx)));
+        match group {
+            Some((g, k)) => {
+                if pos == g.first {
+                    out.push(AndSource::FusedRange { idx: g.idx, lo: g.lo, hi: g.hi, k: *k });
+                }
+            }
+            None => out.push(AndSource::Child(child)),
+        }
+    }
+    out
+}
+
 /// `broad_ok` says whether a broad printing-range child may materialize its
 /// bitmap: true under Or (the union consumes it) and Not (the complement
 /// trick needs it), false where nothing would — a lone broad set at the root
@@ -3928,12 +4024,20 @@ fn narrow_rec(
             // both shrinks the driver as fast as possible and removes the old
             // sensitivity to the order same-rank children happened to be written
             // in. Non-range children (no probe) sort after the ranges in-rank.
-            let mut ranked: Vec<(u8, Option<usize>, &FilterExpr)> = children
-                .iter()
-                .map(|c| {
-                    let rank = and_child_rank(c, indexes);
-                    let probe = if rank == 1 { probe_range_k(c, indexes) } else { None };
-                    (rank, probe, c)
+            // Same-index range children fuse into one interval first (`fuse_and_range_children`),
+            // because two individually-broad halves can intersect to something sparse and this arm
+            // only ever intersects narrowing *results*, never the bounds.
+            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes)
+                .into_iter()
+                .map(|src| match src {
+                    AndSource::Child(c) => {
+                        let rank = and_child_rank(c, indexes);
+                        let probe = if rank == 1 { probe_range_k(c, indexes) } else { None };
+                        (rank, probe, AndSource::Child(c))
+                    }
+                    // A fused interval is a printing range like any other — rank 1, and its probe is
+                    // the `k` its own broad-check already computed.
+                    AndSource::FusedRange { k, .. } => (1, Some(k), src),
                 })
                 .collect();
             ranked.sort_by_key(|(r, probe, _)| (*r, probe.unwrap_or(usize::MAX)));
@@ -3948,7 +4052,7 @@ fn narrow_rec(
             // per child meant popcounting every accumulated bitmap again on every
             // iteration — O(children² × words) for a value that only ever shrinks.
             let mut best: Option<usize> = None;
-            for (rank, probe, c) in ranked {
+            for (rank, probe, src) in ranked {
                 // A driver this selective already bounds the candidate set the
                 // residual re-verifies, so a costlier (rank>0) child usually
                 // narrows nothing the driver's verification doesn't already do
@@ -3974,7 +4078,14 @@ fn narrow_rec(
                     1 => !printing_sets.is_empty(),
                     _ => broad_ok,
                 };
-                if let Some(n) = narrow_rec(c, indexes, offsets, cards, child_broad_ok) {
+                let narrowed = match src {
+                    AndSource::Child(c) => narrow_rec(c, indexes, offsets, cards, child_broad_ok),
+                    // `range_narrowed` is what every unfused range child reaches too, with the same
+                    // `exact: true` (the bounds come from the same `int_range_bounds`/
+                    // `date_range_bounds`/`year_range_bounds` derivations).
+                    AndSource::FusedRange { idx, lo, hi, .. } => range_narrowed(idx, lo, hi, n_printings, child_broad_ok, true),
+                };
+                if let Some(n) = narrowed {
                     // A child covering most of its domain barely narrows the
                     // intersection; skipping it is advisory-sound and avoids
                     // paying its projection/materialization for ~nothing.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8345,6 +8345,30 @@ fn acquire_plan_features(
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
             }
         };
+        // `eval_domain` and `scan_units` describe what the MATERIALIZING alternatives walk, and when the
+        // narrowing does not shrink the candidate set they walk the whole corpus — at which point these are
+        // not badly estimated, they are estimating the wrong QUANTITY. `est_cards` is a count of MATCHING
+        // cards; `cards_visited` counts CANDIDATES, a superset whenever the narrowing is inexact. Measured
+        // against P4's `cards_visited` over 2,904 compose rows, the distribution is bimodal — 34% of rows
+        // visit every card — and on those rows:
+        //
+        //     est_cards            p10 0.43   p50 0.65   p90 0.83   mean |log| 0.454
+        //     n_cards              p10 1.00   p50 1.00   p90 1.00   mean |log| 0.000
+        //
+        // Exact by construction, not calibrated. Overall mean |log| 0.370 -> 0.216. Both plans visited the
+        // SAME card count on 100% of rows, which is also why this feature does not want splitting per plan.
+        //
+        // Predicted with the predicate and the constant the sibling `PrintingRangeScan` branch already uses
+        // for the identical decision — no new constant. Scored against the realized flag, `printing_matches`
+        // over `MAX_NARROW_FRACTION` (0.25) of `n_printings` catches **98%** of full-scan rows at 87%
+        // accuracy, beating every threshold on the two alternative signals tried. Its 26% false positives
+        // over-cost both materializing plans by the same factor, which an argmin largely absorbs; the false
+        // negatives are what were losing `GatheredScan vs StreamedSelect`, so recall is the side to favour.
+        let (eval_domain, scan_units) = if range_too_broad_to_narrow(printing_matches, n_printings as usize) {
+            (n_cards as usize, n_printings as usize)
+        } else {
+            (eval_domain, scan_units)
+        };
         // The tier is what the MATERIALIZING alternatives pay per candidate, so it must be asked about
         // the predicate THEY see (`filter` + `plane`), not about `composed` — and gated exactly as
         // `prepare_candidates` gates it, or the router charges a `card_pass` the kernels will skip. On a

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8164,6 +8164,21 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     if feats.residual_card_invariant {
         feats.stream_scan_units = 0;
     }
+    // Same signal, second term — **measured, and NOT applied.** `run_query_streamed` answers an artwork count
+    // from a STORED per-card group count when `all_match && have_group_counts`, touching no printing, and only
+    // walks the span to dedup groups when a residual survives per printing. So `artwork_seen_cards` charging
+    // `eval_domain` unconditionally is the wrong SHAPE, and measurably the wrong sign in the fast-path regime.
+    // Artwork-minus-printing `ns_loop` delta on identical candidate sets, against a charged +1.21 ns/card:
+    //
+    //     printings_examined == 0    (stored count)   median -0.46 ns/card   n=9
+    //     printings_examined == span (dedup walk)     median +0.38 ns/card   n=8
+    //
+    // Artwork is *cheaper* than printing when the fast path fires. Gating the term on
+    // `all_match_known || residual_card_invariant` duly improved absolute agreement — P3 went from p/m
+    // 1.58-1.83 to 1.14-1.34 on those cells — and **regressed routing**: the artwork regret slice went mean
+    // 1.59 -> 1.71 us and max 185.5 -> 732.5. So the +1.21 is compensating for something else in the P3/P4
+    // artwork balance, and cannot be removed alone. That is item 6, and it needs both arms at once — the same
+    // lesson as `bench_gather_loop`'s "P4 cannot be fixed alone".
 
     feats
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2797,6 +2797,21 @@ struct CardData {
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
     // legality shifts identically to the worker that built the archive.
     format_shifts: HashMap<String, u8>,
+    // WHICH formats actually have printings that disagree, as a mask over the same 2-bit fields
+    // `format_shifts` indexes. `legality_divergent` on the card is one boolean meaning "some format
+    // disagreed for this card", which is all the #667 carveout has ever had to work with — so every
+    // legality leaf is treated as existential and re-verified per printing, for every format.
+    //
+    // The data does not justify that. Over the production corpus, all 556 divergent cards diverge in
+    // `oldschool` and nothing else; `modern`, `commander`, `pauper` and the rest are card-invariant, and
+    // the per-printing re-verification on them is provably redundant (measured: 7,770 printing
+    // examinations by StreamedSelect on `f:modern` that cannot change an answer).
+    //
+    // Accumulated as the OR of the XOR between successive printings of a card, so it names exactly the
+    // 2-bit fields that ever differ, and it is derived from the data rather than asserting anything
+    // about `oldschool`: if Scryfall ever makes another format divergent, this picks it up on the next
+    // reload and the conservative path returns on its own.
+    divergent_formats: u64,
 }
 
 // ─── Candidate narrowing ─────────────────────────────────────────────────────
@@ -9368,7 +9383,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // current calendar date (20260723) and 20260724 were both already consumed by
 // earlier same-window archive changes (#737 columnar artwork_group_id, #741
 // watermark postings), so this takes the next distinct value — see the doc above.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260802;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260803;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -9791,6 +9806,8 @@ impl QueryEngine {
         let mut cards: Vec<OracleCard> = Vec::new();
         let mut printings: Vec<Printing> = Vec::with_capacity(rows.len());
         let mut offsets: Vec<u32> = Vec::new();
+        // See `CardData::divergent_formats`: which formats disagree, not just that some card's did.
+        let mut divergent_formats: u64 = 0;
         for mut row in rows {
             let is_new = cards.last().is_none_or(|c| c.oracle_id != row.oracle_id);
             if is_new {
@@ -9828,6 +9845,8 @@ impl QueryEngine {
                 });
             } else if row.card_legalities != cards.last().map(|c| c.card_legalities).unwrap_or(0) {
                 cards.last_mut().unwrap().legality_divergent = true;
+                // Which 2-bit fields differ, not merely that some did. See `CardData::divergent_formats`.
+                divergent_formats |= row.card_legalities ^ cards.last().map(|c| c.card_legalities).unwrap_or(0);
             }
             printings.push(Printing {
                 scryfall_id: row.scryfall_id,
@@ -9954,7 +9973,19 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, printings, offsets, strings, coll_vocab, coll_vocab_sorted, artist_vocab, mana_vocab, indexes, format_shifts: format_shifts_snapshot };
+        let card_data = CardData {
+            cards,
+            printings,
+            offsets,
+            strings,
+            coll_vocab,
+            coll_vocab_sorted,
+            artist_vocab,
+            mana_vocab,
+            indexes,
+            format_shifts: format_shifts_snapshot,
+            divergent_formats,
+        };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -10181,6 +10212,25 @@ impl QueryEngine {
         out.set_item("acquire", acquire_facts_to_pydict(py, &facts)?)?;
         out.set_item("plans", PyList::new(py, rows)?)?;
         Ok(out)
+    }
+
+    /// The formats whose printings actually disagree, as `{format: shift}` — the data behind
+    /// `CardData::divergent_formats`, so a harness can check the claim that only `oldschool` diverges
+    /// against a real store rather than by re-reading the corpus JSONL. Empty when the archive is
+    /// missing or from another build; `{}` also legitimately means "no format diverges".
+    fn divergent_formats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new(py);
+        let Ok(mmap) = self.get_mmap() else { return Ok(d) };
+        // Safety: see query()'s access_unchecked justification.
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+        let mask = u64::from(data.divergent_formats);
+        for (format, shift) in data.format_shifts.iter() {
+            // Two bits per format, so a format is divergent if either of its bits ever differed.
+            if mask >> *shift & 0b11 != 0 {
+                d.set_item(format.as_str(), *shift)?;
+            }
+        }
+        Ok(d)
     }
 
     fn size(&self) -> PyResult<usize> {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8146,6 +8146,24 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // all-or-nothing shape. With a printing-level field in play the printings under one card disagree, which
     // is the shape the single `RESIDUAL_PASS_RATE_*` was fitted on. Nothing reads this in routing.
     feats.residual_card_invariant = !prep.all_match_known && !touches_printing_field(filter);
+    // A residual that is invariant WITHIN a card never goes printing-dependent: `card_pass` returns
+    // `True`/`False` and never `Tri::PrintingDep`, so `run_query_streamed` sets its per-card `all_match` for
+    // every matching card and `card_match_count` answers from span arithmetic. P3 therefore examines **no
+    // printings at all** and `printings_examined` reads exactly 0 — while the arm was charging
+    // `scan_units * STREAM_SCAN_PER_ROW_NS` for the whole candidate span.
+    //
+    // `name:s` / artwork is the measured case: `scan_units` 97,206 against a realized 0 for P3 and 60,705 for
+    // P4, so the shared feature is 1.60x for the plan that does the work and infinitely wrong for the plan
+    // that does not. That charged P3 580 us of a 1,507 us prediction against a 456 us measurement and handed
+    // the query to `GatheredScan` at 824 us — 368 us lost on one query, repeated across every orderby.
+    //
+    // This is the `all_match_known` gate one step weaker. That gate needs the whole residual to be `True`;
+    // this needs only that it cannot vary within a card, which `name:s`, `o:`, `t:` and `cmc` all satisfy
+    // while being ordinary residuals. P4's `scan_units` is deliberately untouched — it walks each candidate's
+    // span to push, so its 60,705 is real work, and this is exactly the asymmetry an argmin needs.
+    if feats.residual_card_invariant {
+        feats.stream_scan_units = 0;
+    }
 
     feats
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6384,14 +6384,21 @@ impl PhysicalPlan {
     /// prep is available, `PrintingRangeScan` exactly when the range-estimate prep is,
     /// so filtering `ALL` by `applicable` inside each prep branch yields the right
     /// candidate set with no per-branch plan list.
-    fn applicable(self, ctx: &QueryCtx, params: &QueryParams, filter: &FilterExpr, plane: Option<&PlaneExpr>) -> bool {
+    fn applicable(
+        self,
+        ctx: &QueryCtx,
+        params: &QueryParams,
+        filter: &FilterExpr,
+        unsplit: Option<&FilterExpr>,
+        plane: Option<&PlaneExpr>,
+    ) -> bool {
         let QueryCtx { cards, indexes, .. } = *ctx;
         let QueryParams { mode, sort_col, descending, .. } = *params;
         match self {
             PhysicalPlan::PrintingRangeScan => {
                 printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
             }
-            PhysicalPlan::PrintingCompose => printing_compose_applicable(filter, cards, plane, indexes),
+            PhysicalPlan::PrintingCompose => printing_compose_applicable(filter, unsplit, cards, plane, indexes),
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
@@ -6555,11 +6562,46 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
 /// docs/issues/local-engine-compose-permutation-fallback.md) — either way the total (a popcount over
 /// the already-exact composed bits) and the page are both correct; only *which* paging strategy runs
 /// depends on the permutation's presence, decided inside the fastpath itself.
-fn printing_compose_applicable(filter: &FilterExpr, cards: &[AOracleCard], plane: Option<&PlaneExpr>, indexes: &Archived<CardIndexes>) -> bool {
+///
+/// **`plane.is_none()` is about REPRESENTATION, not about routing**, and `unsplit` is what lifts it.
+/// Compose builds its printing bitmap from the filter TREE; a plane sitting alongside holds predicate
+/// this function cannot see, so composing the residual alone would silently drop it — wrong rows, not
+/// slow rows. That is why the guard exists. But `split_planes` runs at bind time, before any plan is
+/// costed, so consuming a leaf into a plane ELIMINATED compose before the argmin could weigh it: measured
+/// 1.83 us for compose against StreamedSelect's 99.38 on `f:commander`/printing, a plan the router never
+/// got to consider. `unsplit` carries the filter as bound, so compose can be costed on the whole
+/// predicate whether or not a plane took part of it, and `cost::plan_cost` decides as #702 intends.
+fn printing_compose_applicable(
+    filter: &FilterExpr,
+    unsplit: Option<&FilterExpr>,
+    cards: &[AOracleCard],
+    plane: Option<&PlaneExpr>,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
     // Mode-agnostic: the cost model arbitrates overlap with the specialized range plans. All three
     // range/compose plans are non-materializing (estimate-in-acquire), so nothing is eagerly built —
     // a losing plan costs only a binary search, never a wasted scatter.
-    *PRINTING_COMPOSE != 0 && !cards.is_empty() && plane.is_none() && is_printing_composable(filter, indexes) && printing_compose_indexes_built(indexes)
+    //
+    // With a plane present, the whole predicate is `unsplit` and compose must compose that; without one,
+    // the residual IS the whole predicate. A caller that supplies no `unsplit` keeps the old behaviour.
+    let whole = match (plane, unsplit) {
+        (None, _) => Some(filter),
+        (Some(_), Some(u)) => Some(u),
+        (Some(_), None) => None,
+    };
+    *PRINTING_COMPOSE != 0
+        && !cards.is_empty()
+        && whole.is_some_and(|f| is_printing_composable(f, indexes))
+        && printing_compose_indexes_built(indexes)
+}
+
+/// The predicate `PrintingCompose` composes for this query: the whole thing, wherever it lives. See
+/// `printing_compose_applicable` for why the two representations both have to be available.
+fn compose_source<'f>(filter: &'f FilterExpr, unsplit: Option<&'f FilterExpr>, plane: Option<&PlaneExpr>) -> &'f FilterExpr {
+    match (plane, unsplit) {
+        (Some(_), Some(u)) => u,
+        _ => filter,
+    }
 }
 
 /// `CardRangePopcount` needs `Mode::Card`, a **bare** range leaf as the whole filter — usd/cn/date,
@@ -7620,7 +7662,9 @@ fn run_query<'a>(
     // #702: plan selection is one cost-based routing layer (`run_query_routed`,
     // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision tree.
     let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, page_offset);
-    run_query_routed(ctx, &params, filter, plane)
+    // `None`: this wrapper receives an already-split filter and has no unsplit form to offer, so compose
+    // is costed exactly as it was before the split became non-destructive. See `bind_and_split_filter`.
+    run_query_routed(ctx, &params, filter, None, plane)
 }
 
 /// `cost::PlanFeatures::scan_units` for a query: the rows the per-row residual
@@ -7701,6 +7745,7 @@ fn declined_sibling_fastpath<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
     feats: &cost::PlanFeatures,
     choose: &impl Fn(&FilterExpr, &cost::PlanFeatures, bool) -> PhysicalPlan,
@@ -7710,7 +7755,7 @@ fn declined_sibling_fastpath<'a>(
         PhysicalPlan::PrintingCompose => PhysicalPlan::PrintingRangeScan,
         _ => return None, // a materializing plan won the estimate; it has no fast-path sibling
     };
-    if !sibling.applicable(ctx, params, filter, plane) {
+    if !sibling.applicable(ctx, params, filter, unsplit, plane) {
         return None;
     }
     if cost::plan_cost(sibling, feats) >= cost::plan_cost(choose(filter, feats, true), feats) {
@@ -7718,7 +7763,7 @@ fn declined_sibling_fastpath<'a>(
     }
     match sibling {
         PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
-        PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
+        PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, compose_source(filter, unsplit, plane)),
         _ => unreachable!("sibling is one of the two printing-space fast paths"),
     }
 }
@@ -8031,6 +8076,7 @@ fn acquire_plan_features(
     ctx: &QueryCtx,
     params: &QueryParams,
     filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> (cost::PlanFeatures, Prep, Vec<u64>) {
     let QueryCtx { cards, offsets, indexes, .. } = *ctx;
@@ -8047,7 +8093,7 @@ fn acquire_plan_features(
     // empty (no alloc).
     let mut plane_bits: Vec<u64> = Vec::new();
 
-    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, plane) {
+    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, unsplit, plane) {
         // The ONE plane eval; its popcount IS the exact count. True residual ⇒ tier 0.
         eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
@@ -8086,7 +8132,7 @@ fn acquire_plan_features(
             span.min(u64::from(n_printings)) as u32
         };
         (mk_plan_feats(ctx, params, count, count, scan_units, 0), Prep::Plane)
-    } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, plane) {
+    } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, unsplit, plane) {
         // Exact in-range printing count `k` from the index partition points (two binary searches, no
         // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
         // plan wins — so a competing winner never eats a wasted build (re-deriving the bounds there is
@@ -8125,7 +8171,7 @@ fn acquire_plan_features(
         feats.compose_scan_printings = k;
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::CardRangePopcount))
-    } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
+    } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, unsplit, plane) {
         // Bare range: exact k from the index (no scan).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
@@ -8151,7 +8197,7 @@ fn acquire_plan_features(
         // never run. Compose's page term only reads `eval_domain` in the Gather branch.
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::PrintingRangeScan))
-    } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, plane) {
+    } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, unsplit, plane) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
@@ -8284,6 +8330,7 @@ fn run_query_routed<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // Generic argmin: the cheapest applicable plan. `filter` is passed per call (not
@@ -8293,7 +8340,7 @@ fn run_query_routed<'a>(
     let choose = |filter: &FilterExpr, feats: &cost::PlanFeatures, materializing_only: bool| -> PhysicalPlan {
         PhysicalPlan::ALL
             .into_iter()
-            .filter(|p| p.applicable(ctx, params, filter, plane) && (!materializing_only || p.materializing()))
+            .filter(|p| p.applicable(ctx, params, filter, unsplit, plane) && (!materializing_only || p.materializing()))
             .min_by(|a, b| cost::plan_cost(*a, feats).partial_cmp(&cost::plan_cost(*b, feats)).expect("plan_cost is finite"))
             .expect("GatheredScan is always applicable and materializing")
     };
@@ -8304,7 +8351,7 @@ fn run_query_routed<'a>(
     let mut phases = RoutedPhaseTimer::start();
 
     // ── acquire: pick the count source, build features, materialize its artifact ──
-    let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, unsplit, plane);
     phases.acquired();
 
     // ── choose: cheapest applicable plan ──
@@ -8351,10 +8398,10 @@ fn run_query_routed<'a>(
         (plan, Prep::Range(_)) => {
             let fast_page = match plan {
                 PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
-                PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
+                PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, compose_source(filter, unsplit, plane)),
                 _ => None, // a materializing plan won the estimate — materialize + run it below
             };
-            match fast_page.or_else(|| declined_sibling_fastpath(plan, ctx, params, filter, plane, &feats, &choose)) {
+            match fast_page.or_else(|| declined_sibling_fastpath(plan, ctx, params, filter, unsplit, plane, &feats, &choose)) {
                 Some(page) => page,
                 None => {
                     let prep = prepare_candidates(ctx, params, filter, plane);
@@ -8382,6 +8429,7 @@ fn run_query_with_plan<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
     let QueryCtx { cards, indexes, .. } = *ctx;
@@ -8396,12 +8444,12 @@ fn run_query_with_plan<'a>(
             printing_range_fastpath(ctx, params, filter)
         }
         PhysicalPlan::PrintingCompose => {
-            if !printing_compose_applicable(filter, cards, plane, indexes) {
+            if !printing_compose_applicable(filter, unsplit, cards, plane, indexes) {
                 return None;
             }
             // The fastpath composes, projects per mode, and walks — or declines (None) on a sparse
             // total, exactly as under the router.
-            printing_compose_fastpath(ctx, params, filter)
+            printing_compose_fastpath(ctx, params, compose_source(filter, unsplit, plane))
         }
         PhysicalPlan::PlanePopcountOrder => {
             if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
@@ -8578,9 +8626,15 @@ impl Prep {
 /// dispatch would compute if that plan actually won and got lazily re-costed
 /// against a materialized candidate list (see `acquire_plan_features`'s
 /// `PrintingRangeScan`/`PrintingCompose` branches).
-fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane: Option<&PlaneExpr>) -> (AcquireFacts, Vec<PlanEstimate>) {
+fn explain(
+    ctx: &QueryCtx,
+    params: &QueryParams,
+    filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
+    plane: Option<&PlaneExpr>,
+) -> (AcquireFacts, Vec<PlanEstimate>) {
     let t0 = std::time::Instant::now();
-    let (feats, prep, _plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    let (feats, prep, _plane_bits) = acquire_plan_features(ctx, params, filter, unsplit, plane);
     let acquire_ns = t0.elapsed().as_nanos() as u64;
     let facts = AcquireFacts {
         count_source: prep.count_source(),
@@ -8594,7 +8648,7 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
     };
     let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
         .into_iter()
-        .filter(|p| p.applicable(ctx, params, filter, plane))
+        .filter(|p| p.applicable(ctx, params, filter, unsplit, plane))
         .map(|plan| PlanEstimate {
             plan,
             predicted_ns: cost::plan_cost(plan, &facts.feats),
@@ -8760,6 +8814,7 @@ fn explain_analyze(
     ctx: &QueryCtx,
     params: &QueryParams,
     filter: &FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
     num_warmups: usize,
     num_trials: usize,
@@ -8769,7 +8824,7 @@ fn explain_analyze(
 
     // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
     // the timing loop below starts from `filter`'s untouched, pristine state.
-    let (mut facts, estimates) = explain(ctx, params, &mut filter.clone(), plane);
+    let (mut facts, estimates) = explain(ctx, params, &mut filter.clone(), unsplit, plane);
     // explain()'s single sample was taken outside the loop below, so it sits in a
     // different cache/allocator state than the plan trials it would be compared
     // against. Discard it and re-sample in-loop, one per round, from the same fresh
@@ -8801,9 +8856,9 @@ fn explain_analyze(
             let (mut ran, mut acquired, mut routed) = (None, None, None);
             let t0 = std::time::Instant::now();
             match participant {
-                Participant::Plan(i) => ran = run_query_with_plan(estimates[i].plan, ctx, params, &mut round_filter, plane),
-                Participant::Acquire => acquired = Some(acquire_plan_features(ctx, params, &mut round_filter, plane)),
-                Participant::Routed => routed = Some(run_query_routed(ctx, params, &mut round_filter, plane)),
+                Participant::Plan(i) => ran = run_query_with_plan(estimates[i].plan, ctx, params, &mut round_filter, unsplit, plane),
+                Participant::Acquire => acquired = Some(acquire_plan_features(ctx, params, &mut round_filter, unsplit, plane)),
+                Participant::Routed => routed = Some(run_query_routed(ctx, params, &mut round_filter, unsplit, plane)),
             }
             let dt = t0.elapsed().as_nanos() as u64;
             drop((acquired, routed));
@@ -9493,7 +9548,7 @@ fn bind_and_split_filter(
     unique: &str,
     data: &Archived<CardData>,
     sort_col: SortCol,
-) -> PyResult<(Option<PlaneExpr>, FilterExpr, SortBound)> {
+) -> PyResult<(Option<PlaneExpr>, FilterExpr, SortBound, FilterExpr)> {
     let to_json = filters.call_method0("to_json")?;
     let json_bytes: Vec<u8> = py
         .import("orjson")?
@@ -9513,12 +9568,19 @@ fn bind_and_split_filter(
 
     // Read before the split consumes the tree.
     let sort_bound = sort_col_bound(&filter_expr, sort_col);
+    // Kept, and this is the point: `split_planes` is a DESTRUCTIVE rewrite run before any plan is costed,
+    // and it moves predicate out of the tree that `PrintingCompose` composes from into a `PlaneExpr` it
+    // cannot read. Compose then fails its `plane.is_none()` guard and never reaches the argmin -- measured
+    // at 1.83 us against StreamedSelect's 99.38 on `f:commander`/printing, a plan the router was never
+    // offered. Retaining the unsplit form lets each plan be costed on the representation it can consume,
+    // which is what #702 says the routing layer is for. One clone of a small tree, once per query.
+    let unsplit = filter_expr.clone();
     let (plane, residual) = if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
         split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
     } else {
         (None, filter_expr)
     };
-    Ok((plane, residual, sort_bound))
+    Ok((plane, residual, sort_bound, unsplit))
 }
 
 fn plan_estimate_to_pydict<'py>(py: Python<'py>, e: &PlanEstimate) -> PyResult<Bound<'py, PyDict>> {
@@ -10089,12 +10151,13 @@ impl QueryEngine {
         // dispatch. Shared verbatim with explain()/explain_analyze() — see
         // bind_and_split_filter.
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
+        let (plane_expr, mut filter_expr, sort_bound, unsplit) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         let ctx = QueryCtx::from(data);
         // `run_query`'s string→enum adaptation, done here so the filter's sort-column bound can ride on
         // the params: `from_strs` is still the single interpretation of the four strings.
-        let (total, page) = run_query_routed(&ctx, &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
+        let (total, page) =
+            run_query_routed(&ctx, &params.with_sort_bound(sort_bound), &mut filter_expr, Some(&unsplit), plane_expr.as_ref());
 
         let matches: Vec<Bound<PyDict>> = page
             .iter()
@@ -10132,7 +10195,7 @@ impl QueryEngine {
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
+        let (plane_expr, mut filter_expr, sort_bound, unsplit) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // `prefer` is accepted and passed through, but note what it does NOT yet change:
         // `cost::plan_cost`/`PlanFeatures` still don't read it, so the argmin and every
@@ -10147,7 +10210,7 @@ impl QueryEngine {
         // prefer-aware feature be graded here at all; until one exists, an `explain` for a
         // non-default `prefer` still predicts the default's numbers.
         let (facts, estimates) =
-            explain(&QueryCtx::from(data), &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
+            explain(&QueryCtx::from(data), &params.with_sort_bound(sort_bound), &mut filter_expr, Some(&unsplit), plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
         let out = PyDict::new(py);
@@ -10181,7 +10244,7 @@ impl QueryEngine {
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (plane_expr, filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
+        let (plane_expr, filter_expr, sort_bound, unsplit) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // Release the GIL for the timing loop: it's pure Rust (no Python calls) and
         // runs plans × (warmups + trials) executions, so a long explain_analyze
@@ -10189,7 +10252,7 @@ impl QueryEngine {
         // conversion below stay on the GIL.
         let ctx = QueryCtx::from(data);
         let params = params.with_sort_bound(sort_bound);
-        let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
+        let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, Some(&unsplit), plane_expr.as_ref(), num_warmups, num_trials));
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;
         let out = PyDict::new(py);

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -9358,17 +9358,44 @@ fn run_query_streamed<'a>(
     for cid in card_ids {
         n_cards_visited += 1;
         let card = &cards[cid as usize];
-        // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True
-        // when the narrowing already proved every candidate matches. Gated
-        // off for Mode::Artwork specifically: measured a ~45% regression for
-        // `t:creature` unique=artwork with this applied unconditionally here
-        // (0.13ms -> 0.19ms typical, isolated by bisecting call sites) despite
-        // being a no-op change in card_pass's own return value (True either
-        // way) — an unexplained codegen/scheduling effect in this loop for
-        // that mode specifically, not a logical cost. Card/Printing modes
-        // showed no such effect and do benefit (this loop visits every
-        // candidate, not just the ~limit emitted).
-        let all_match = (all_match_known && !matches!(mode, Mode::Artwork))
+        // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True when the narrowing has
+        // already proved every candidate matches.
+        //
+        // **This was gated OFF for `Mode::Artwork`, and the gate is now removed (2026-08-04).** Its comment
+        // cited a ~45% regression on `t:creature`/artwork (0.13ms -> 0.19ms) from applying the skip here,
+        // called it "an unexplained codegen/scheduling effect ... not a logical cost", and said it was
+        // "isolated by bisecting call sites" — i.e. across builds, the one instrument this engine has
+        // repeatedly shown cannot resolve an effect that size and will hand you the wrong sign (see trap 1
+        // in docs/workflows/diagnosing-a-plan-cost-error.md).
+        //
+        // Re-measured with a runtime toggle inside ONE binary, `unique=artwork`, limit 175:
+        //
+        //     query         gate on      gate off    speedup
+        //     o:this        1047.7 us      47.5 us     22.1x
+        //     o:target       556.6         30.1        18.5x
+        //     o:creature    1010.5         56.6        17.9x
+        //     t:creature      84.1         43.0         2.0x   <- the query the gate existed to protect
+        //     o:flying        24.1         13.5         1.8x
+        //     c:r             32.2         18.5         1.7x
+        //     t:land          15.5         12.1         1.3x
+        //
+        // Every cell is faster and the cited regression does not reproduce in either direction. The cost was
+        // worst for an expensive residual: `o:creature` ran a full oracle-text containment check over all
+        // 23,155 candidates the narrowing had already proved matched, which is why the same query in printing
+        // mode — identical candidate set, identical span, `card_pass` skipped — took 56.7 us against
+        // artwork's 1010.5. That query was the single largest routing regret in the engine at 508.9 us, and
+        // the cost model was right about it throughout: it charges `tier = 0` here, because `all_match_known`
+        // is supposed to mean no `card_pass` runs.
+        //
+        // Row identity is what an `all_match` mistake breaks silently in this mode — totals do not move, the
+        // printing that REPS each artwork group does. 1,134 cells over 21 predicates x 3 modes x 3 orderbys x
+        // 3 pages x 2 prefers, hashing the returned `scryfall_id` sequence: **identical**, 378 of them
+        // artwork, including the existential-plane shapes (`f:*`, `border:*`, `r>=rare`, `watermark:*`,
+        // `-f:modern`) where a card-level True does not imply every printing matches. Soundness rests on
+        // `all_match_known` itself, which already refuses an existential plane outside card mode via
+        // `plane_leaves_nothing_to_verify`, and only trusts `residual_exact` when the narrowing was not
+        // printing-space.
+        let all_match = all_match_known
             || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
                 Tri::False | Tri::Null => continue,
                 Tri::True => true,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6879,6 +6879,16 @@ pub(crate) struct PhaseStats {
     /// span arithmetic alone, and the stored artwork group count answers without a printing either.
     pub(crate) printings_examined: u64,
     pub(crate) matches_pushed: u64,
+    /// Permutation entries `run_query_streamed`'s walk stepped over. Zero for every other executor and
+    /// for P3's other two exits (the empty/past-the-end return and the small-total gather).
+    ///
+    /// The walk steps the permutation until the page fills, so its length is
+    /// `page x n_cards / matches` -- inversely proportional to selectivity, and the one quantity in P3's
+    /// finish phase that no existing feature is proportional to. Measured against a fixed 1,500 matches
+    /// it runs 1,333 / 3,791 / 10,458 ns at 31.5k / 126k / 410k cards while the arm charged
+    /// `matches x EMIT + FIXED` ~ 397 ns throughout: under by 3.4x at the production corpus and 26x at
+    /// 410k. Published so the estimate can be GRADED rather than assumed, like the other three counters.
+    pub(crate) perm_steps: u64,
     /// Per-query scratch setup, before the match loop starts. Split out because it is neither
     /// prepare nor match and it is NOT negligible: `run_query_streamed` zeroes an `n_cards`-long
     /// counts buffer here (~126 kB on the real corpus) no matter how few candidates it is about to
@@ -7129,8 +7139,8 @@ thread_local! {
     /// owned elsewhere: `paging_taken` by `PAGING_TAKEN` below, `ns_round_total`/`result_total` by
     /// `explain_analyze`, which fills them after the take.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
-        cards_visited: 0, printing_span: 0, printings_examined: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
-        ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
+        cards_visited: 0, printing_span: 0, printings_examined: 0, matches_pushed: 0, perm_steps: 0, ns_setup: 0, ns_loop: 0,
+        ns_finish: 0, ns_round_total: 0, ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
     }) };
 
     /// The compose fastpath's branch label, stored apart from `PHASE_STATS` because it is the one
@@ -7345,6 +7355,7 @@ fn exec_gathered_scan<'a>(
             printing_span: n_printing_span,
             printings_examined: n_printings_examined,
             matches_pushed: n_matches_pushed,
+            perm_steps: 0, // GatheredScan never walks the permutation
             ns_setup: (t_loop - t_start).as_nanos() as u64,
             ns_loop: (t_finish - t_loop).as_nanos() as u64,
             ns_finish: (t_end - t_finish).as_nanos() as u64,
@@ -8896,7 +8907,7 @@ fn run_query_streamed<'a>(
     // Publishing helper: the walk below has several early returns, and every one of them must leave
     // the stats behind or the accounting silently attributes this plan's work to nothing. Each takes
     // the closing instant itself, so the emit phase is bounded without a second start marker.
-    let publish = |end: std::time::Instant| {
+    let publish = |end: std::time::Instant, perm_steps: u64| {
         let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
         PHASE_STATS.with(|c| {
             c.set(PhaseStats {
@@ -8904,6 +8915,7 @@ fn run_query_streamed<'a>(
                 printing_span: n_printing_span,
                 printings_examined: n_printings_examined,
                 matches_pushed: n_matches_pushed,
+                perm_steps,
                 ns_setup: (t_loop - t_start).as_nanos() as u64,
                 ns_loop: (t_finish - t_loop).as_nanos() as u64,
                 ns_finish: (end - t_finish).as_nanos() as u64,
@@ -8915,7 +8927,7 @@ fn run_query_streamed<'a>(
         });
     };
     if total == 0 || page_offset >= total {
-        publish(std::time::Instant::now());
+        publish(std::time::Instant::now(), 0);
         return (total, Vec::new());
     }
 
@@ -8950,7 +8962,7 @@ fn run_query_streamed<'a>(
             .into_iter()
             .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
             .collect();
-        publish(std::time::Instant::now());
+        publish(std::time::Instant::now(), 0);
         return (total, page);
     }
 
@@ -8961,7 +8973,12 @@ fn run_query_streamed<'a>(
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
+    // Counted for every entry the walk touches, including the ones skipped on a zero count -- that
+    // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. A plain
+    // local, published once, like the other counters.
+    let mut n_perm_steps = 0u64;
     'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
+        n_perm_steps += 1;
         let c = counts[cid as usize] as usize;
         if c == 0 {
             continue;
@@ -8993,7 +9010,7 @@ fn run_query_streamed<'a>(
         }
         skip = 0;
     }
-    publish(std::time::Instant::now());
+    publish(std::time::Instant::now(), n_perm_steps);
     (total, page)
     }) // COUNTS.with
 }
@@ -9269,6 +9286,7 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     d.set_item("printing_span", t.phases.printing_span)?;
     d.set_item("printings_examined", t.phases.printings_examined)?;
     d.set_item("matches_pushed", t.phases.matches_pushed)?;
+    d.set_item("perm_steps", t.phases.perm_steps)?;
     d.set_item("ns_setup", t.phases.ns_setup)?;
     d.set_item("ns_loop", t.phases.ns_loop)?;
     d.set_item("ns_finish", t.phases.ns_finish)?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6651,6 +6651,36 @@ fn card_range_popcount_applicable(
 
 // ─── Shared P3/P4 candidate preparation ─────────────────────────────────────
 
+/// Whether a plane-consumed predicate leaves the match kernels **nothing to verify per card** — i.e.
+/// `card_pass` is redundant and both kernels take their `all_match` arm.
+///
+/// Legality planes (docs/issues/00667-engine-legality-divergent-carveout.md) are existence
+/// projections ("*some* printing matches"), unlike every other plane (card-invariant fields, true or
+/// false alike for every printing of a card). For `unique=card` that is exactly the semantics wanted.
+/// But `Mode::Printing`/`Artwork` enumerate individual printings, and "the card has some legal
+/// printing" does not mean "this printing is legal" — `card_pass` must still run per printing there
+/// whenever the plane touched a *divergent* format, which is what `plane_expr_is_existential` tests
+/// against the data-derived `divergent_formats` mask.
+///
+/// Extracted so the ROUTER can ask the same question the EXECUTOR does. `prepare_candidates` had the
+/// only copy, and the compose acquire branch — which never calls it — therefore charged
+/// `verify_cost_tier` on every legality-composed query alike. On a card-invariant format that put P3
+/// at meas/pred 0.16-0.44 while `PrintingCompose` read 1.02-1.17, and the argmin lost those cells to a
+/// plan measuring ~2.5x slower. A boolean, not an estimated share: the two attempts to price this as a
+/// divergent *fraction* of the corpus under-charged `f:oldschool`, whose candidates largely ARE the
+/// divergent cards, and traded 408 mispicks for 118 worse ones.
+fn plane_leaves_nothing_to_verify(
+    filter: &FilterExpr,
+    mode: Mode,
+    plane: Option<&PlaneExpr>,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    matches!(filter, FilterExpr::True)
+        && plane.is_none_or(|expr| {
+            matches!(mode, Mode::Card) || !plane_expr_is_existential(expr, u64::from(indexes.planes.divergent_formats))
+        })
+}
+
 /// The candidate materialization + filter rewriting shared by `StreamedSelect`
 /// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
 /// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
@@ -6680,22 +6710,7 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // calls below and in run_query_streamed become redundant re-verification
     // of what the narrowing already established.
     //
-    // A plane-driven True residual needs one more check first: legality's
-    // planes (docs/issues/00667-engine-legality-divergent-carveout.md) are
-    // existence projections ("*some* printing matches"), unlike every other
-    // plane (card-invariant fields, true or false alike for every printing
-    // of a card). For unique=card that's exactly the semantics wanted --
-    // Mode::Card only needs *a* matching printing to exist, same as Step 2
-    // above. But Mode::Printing/Artwork enumerate individual printings, and
-    // "the card has some legal printing" does not mean "this printing is
-    // legal" -- card_pass must still run per printing there whenever the
-    // plane touched legality, so this only trusts a True residual for those
-    // modes when the plane is existential-free (plane_expr_is_existential).
-    let plane_true_for_mode =
-        plane.is_none_or(|expr| {
-            matches!(mode, Mode::Card) || !plane_expr_is_existential(expr, u64::from(ctx.indexes.planes.divergent_formats))
-        });
-    let all_match_known = (matches!(filter, FilterExpr::True) && plane_true_for_mode) || residual_exact;
+    let all_match_known = plane_leaves_nothing_to_verify(filter, mode, plane, ctx.indexes) || residual_exact;
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
     // subexpression (split_planes), so it composes with the residual's
@@ -8285,7 +8300,35 @@ fn acquire_plan_features(
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
             }
         };
-        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(composed));
+        // The tier is what the MATERIALIZING alternatives pay per candidate, so it must be asked about
+        // the predicate THEY see (`filter` + `plane`), not about `composed` — and gated exactly as
+        // `prepare_candidates` gates it, or the router charges a `card_pass` the kernels will skip. On a
+        // card-invariant legality format `card_pass` resolves at card level for every card, so
+        // `printings_examined` reads 0 and both the per-card residual and the per-row scan are dead
+        // terms; charging them anyway was 92-94% of P3's predicted cost on `f:modern`, `f:gladiator`,
+        // `f:commander` and `f:predh`. `residual_exact` is unavailable here (this branch never narrows),
+        // so this is the conservative half of the executor's disjunction: it can over-charge, never under.
+        let nothing_to_verify = plane_leaves_nothing_to_verify(filter, mode, plane, indexes);
+        let tier = if nothing_to_verify { 0 } else { verify_cost_tier(composed) };
+        // `GatheredScan` walks every printing of every candidate card, so its scan feature is the candidate
+        // SPAN. `scan_all` estimates that span as `est_cards x` the corpus-average printings-per-card `x 2.1`,
+        // which is the right shape only when candidates are an average sample. With nothing to verify they
+        // are not: every printing of a matching card matches, so the span IS `printing_matches` — exact,
+        // and already computed above for compose's own estimate. Graded against P4's realized
+        // `printings_examined` over 597 card-invariant compose queries:
+        //
+        //     scan_units (shipped)   p10 1.13   p50 1.76   p90 5.08
+        //     printing_matches       p10 0.68   p50 0.93   p90 3.08
+        //
+        // A 1.76x over-charge on the dominant term of P4's arm, which is what makes P3 win where P4 is
+        // better: `StreamedSelect -> GatheredScan` is the largest regret slice on this acquire. Scoped to
+        // the same boolean as the tier because the grading inverts on the other population — with a real
+        // residual `scan_units` is right at p50 0.97 and `printing_matches` badly under at 0.39.
+        //
+        // Fixes the BIAS, not the spread: both rows read p90/p10 4.5, so what remains is the candidate
+        // count's own variance (`eval_domain` grades p90/p10 3.1 here) and is not a scan-feature problem.
+        let scan_units = if nothing_to_verify { printing_matches } else { scan_units };
+        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, tier);
         // What `StreamedSelect` actually examines here, which is NOT `scan_units`. P4 walks a card's whole
         // span to push every match; P3's `card_match_count` answers from span arithmetic for every card
         // `card_pass` resolves at card level, and on a legality-composed filter that is every non-divergent
@@ -8298,11 +8341,20 @@ fn acquire_plan_features(
         // engine holds the set: `legal_divergent`. For a filter with no legality leaf the share is 1.0 and
         // this reduces to `scan_units`, which the same sweep showed is right to 1.0-2.4x on `border:black`,
         // `r:mythic` and `watermark:*` -- so the correction is confined to the case that measured wrong.
-        feats.stream_scan_units = if verify_cost_tier(composed) > 0 && filter_touches_legality(composed) {
+        feats.stream_scan_units = if tier == 0 {
+            // Nothing to verify: `card_match_count` answers every card from span arithmetic and examines
+            // no printings whatsoever. Reported as 0 so `bench_feature_accuracy` grades this against the
+            // realized `printings_examined` (also 0) instead of against a scan that never happens. The
+            // arm multiplies the term by zero on the same signal, so this changes no cost — only whether
+            // the feature can be graded honestly.
+            0
+        } else if filter_touches_legality(composed) {
             let divergent = indexes.legal_divergent.len() as f64;
             let share = (divergent / f64::from(n_cards)).min(1.0);
-            // Floored at one printing per candidate: even a fully card-invariant legality filter examines
-            // the boundary printing of the cards it does match, which the share alone would put at zero.
+            // Floored at one printing per candidate: with a divergent format in play the kernel does
+            // examine the boundary printing of the cards it matches, which the share alone would put at
+            // zero. Only reachable now when there IS something to verify, which is the case the floor was
+            // argued for -- the `tier == 0` arm above is where it used to be wrong.
             ((scan_units as f64) * share).max(eval_domain as f64) as u32
         } else {
             scan_units as u32

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5306,8 +5306,10 @@ fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) 
         {
             true
         }
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
-        | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
+        // Any rarity comparison, not only `== c`: the domain is closed and every present value has exact
+        // bits, so an inequality is the `Or` of the qualifying ones. See `rarity_cmp_leaf_bits`.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), rhs: NumExpr::Const(_), .. }
+        | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), rhs: NumExpr::Field(NumField::RarityInt), .. } => true,
         // Legality via #667's card `_EXISTS` plane + a divergent repair (see `legality_leaf_bits`).
         // Only a plane-backed status (legal/banned/restricted) with a present format; an absent format
         // (`shift: None`) matches nothing and stays on the general path.
@@ -5379,6 +5381,48 @@ fn rarity_leaf_bits(c: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: us
         Some(e) => scatter_bits(e.1.iter().map(|p| u32::from(*p)), n_printings),
         None => vec![0u64; wpp],
     }
+}
+
+/// The exact printing-space bitmap for **any** rarity comparison, not just `== c`.
+///
+/// Rarity's domain is closed and small: the four interior ints have laid-out planes and the sparse tail
+/// (special/bonus) has postings, so every value present in the store can be enumerated and its exact bits
+/// read. An inequality is then the `Or` of the values that satisfy it — the same enumeration
+/// `walk_rarity_orderby_page` already walks for its bucket order.
+///
+/// Two consequences worth stating. **NULL rarity is excluded for free**: a printing with no rarity appears in
+/// no plane and no posting, so it matches nothing here, which is the trivalent answer for every op including
+/// `Ne` (`-r:rare` must not match a rarity-less printing). And this is **strictly more capable than
+/// `compile_plane`'s** `compile_rarity_cmp`, which shares one "above mythic" plane and so declines
+/// (`BucketVerdict::Ambiguous`) whenever special must be told from bonus — `r:special`, `r>=bonus` and friends.
+/// Compose reads the two apart from their own postings, so it has no ambiguous case at all.
+///
+/// Was `Eq`-only, and the cost of that was not subtle: `r>=rare`/artwork fell off the compose path entirely
+/// and took **487.7 µs** through a full candidate scan, against **59.2 µs** for `r:rare` on the same corpus —
+/// 8× for a predicate that is just `rare ∨ mythic ∨ special ∨ bonus`.
+fn rarity_cmp_leaf_bits(op: CmpOp, threshold: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: usize) -> Vec<u64> {
+    let wpp = words_per_plane(n_printings);
+    let mut out = vec![0u64; wpp];
+    for int in rarity_ints_present(rp) {
+        if !planes::matches_op(op, f64::from(int), threshold) {
+            continue;
+        }
+        for (dst, src) in out.iter_mut().zip(rarity_leaf_bits(f64::from(int), rp, n_printings)) {
+            *dst |= src;
+        }
+    }
+    out
+}
+
+/// Every rarity int the store actually holds: the four interior values (planes, always laid out) plus
+/// whatever the sparse tail carries. One definition, shared by the compose leaf above and
+/// `walk_rarity_orderby_page`'s bucket walk, so the two cannot disagree about the domain.
+fn rarity_ints_present(rp: &Archived<RarityPrintingPlanes>) -> Vec<u8> {
+    let mut values: Vec<u8> = RARITY_PRINTING_PLANE_INTS.to_vec();
+    values.extend(rp.postings.iter().map(|e| e.0));
+    values.sort_unstable();
+    values.dedup();
+    values
 }
 
 /// #746: the exact printing-space bitmap for a bare tag-postings leaf (`set:VALUE`/`watermark:VALUE`)
@@ -5710,9 +5754,12 @@ fn compose_printing_bits(
             let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
             collection_negated_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
         }
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
-        | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
-            rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)
+        // `flip_op` on the const-first form so `2<=rarity` and `rarity>=2` build the same bitmap.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
+            rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            rarity_cmp_leaf_bits(flip_op(*op), *c, &indexes.rarity_printing, n_printings)
         }
         FilterExpr::Legality { shift: Some(shift), expected } => {
             legality_leaf_bits(*shift, *expected, indexes, offsets, printings, n_printings)
@@ -5805,9 +5852,11 @@ fn compose_printing_estimate(
             let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
             (n_printings.saturating_sub(k), 0, k)
         }
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
-        | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
-            (popcount(&rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)), 0, 0)
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
+            (popcount(&rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)), 0, 0)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            (popcount(&rarity_cmp_leaf_bits(flip_op(*op), *c, &indexes.rarity_printing, n_printings)), 0, 0)
         }
         // Legality: matches ≈ the legal-∃ cards' printings (existence-scaled from the cheap card
         // ∃-plane popcount). The build cost rides the *sparser* side (#744): a majority-legal format

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1942,6 +1942,29 @@ impl ArchivedSortPermutations {
         };
         Some(&pair[descending as usize])
     }
+
+    /// Both directions of one streamable column, length-checked against the card count, or `None` if
+    /// the column has no permutation. The single answer to "can a plan stream this orderby": every
+    /// plan that walks a permutation also indexes its inverse, so all three applicability predicates
+    /// and all three executors want the pair or neither.
+    fn order(&self, col: SortCol, descending: bool, n_cards: usize) -> Option<SortOrder<'_>> {
+        let perm = self.get(col, descending)?;
+        let inv = self.get_inv(col, descending)?;
+        (perm.len() == n_cards && inv.len() == n_cards).then_some(SortOrder { perm, inv })
+    }
+}
+
+/// One streamable column's card ordering and its inverse, which every permutation-walking plan needs
+/// together: the walk reads `perm`, and finding where in that order a card sits reads `inv`.
+///
+/// Paired in one value, obtained from one length-checked lookup (`ArchivedSortPermutations::order`),
+/// because the two were previously fetched by five call sites with two `expect`s each and applicability
+/// predicates that checked the forward array's length but not the inverse's — a store whose two arrays
+/// disagreed would have reached an indexing panic inside an executor rather than a decline.
+#[derive(Copy, Clone)]
+struct SortOrder<'a> {
+    perm: &'a Archived<Vec<u32>>,
+    inv:  &'a Archived<Vec<u32>>,
 }
 
 /// Dense byte-order rank of card_name_lower onto each card (equal names share
@@ -6283,13 +6306,16 @@ fn gathered_scan_applicable() -> bool {
 /// descending)` whose length matches the card count, over a non-empty store.
 /// `maybe_broad` is deliberately excluded — that is a routing/perf choice, not a
 /// correctness constraint; StreamedSelect returns correct rows at any breadth.
+///
+/// The INVERSE is required on the same terms, because the emission walk bounds itself to the match
+/// span through it — hence `order`, which yields the pair or nothing.
 fn streamed_select_applicable(
     cards: &[AOracleCard],
     sort_col: SortCol,
     descending: bool,
     indexes: &Archived<CardIndexes>,
 ) -> bool {
-    !cards.is_empty() && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+    !cards.is_empty() && indexes.sort_perms.order(sort_col, descending, cards.len()).is_some()
 }
 
 /// `PlanePopcountOrder` needs the filter fully consumed to `True`, `Mode::Card`,
@@ -6308,8 +6334,7 @@ fn plane_popcount_order_applicable(
         && matches!(mode, Mode::Card)
         && !cards.is_empty()
         && plane.is_some()
-        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
-        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
+        && indexes.sort_perms.order(sort_col, descending, cards.len()).is_some()
 }
 
 /// `PrintingRangeScan` structural eligibility only — whether it actually runs is
@@ -6367,8 +6392,7 @@ fn card_range_popcount_applicable(
         && !cards.is_empty()
         && plane.is_none()
         && bare_range_bounds(filter, indexes).is_some()
-        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
-        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
+        && indexes.sort_perms.order(sort_col, descending, cards.len()).is_some()
 }
 
 // ─── Shared P3/P4 candidate preparation ─────────────────────────────────────
@@ -6528,13 +6552,14 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
     let QueryParams { sort_col, descending, .. } = *params;
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
-    let inv_perm =
-        indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
+    let order = indexes
+        .sort_perms
+        .order(sort_col, descending, ctx.cards.len())
+        .expect("PlanePopcountOrder applicability guarantees a sort order");
     // `run_query_streamed_popcount` publishes the phases and consumes the pending plane build; see
     // `publish_popcount_phases`. Counters stay zero: this plan popcounts a bitmap and visits no
     // cards, so it has nothing to report there.
-    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
+    run_query_streamed_popcount(ctx, params, order, bitmap, Some(plane_expr), None)
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -6550,10 +6575,11 @@ fn exec_card_range_popcount<'a>(
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
     let QueryParams { sort_col, descending, .. } = *params;
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("CardRangePopcount applicability guarantees a permutation");
-    let inv_perm =
-        indexes.sort_perms.get_inv(sort_col, descending).expect("CardRangePopcount applicability guarantees an inverse permutation");
-    run_query_streamed_popcount(ctx, params, perm, inv_perm, card_bits, None, Some(range_pbits))
+    let order = indexes
+        .sort_perms
+        .order(sort_col, descending, ctx.cards.len())
+        .expect("CardRangePopcount applicability guarantees a sort order");
+    run_query_streamed_popcount(ctx, params, order, card_bits, None, Some(range_pbits))
 }
 
 /// Prefix-sum the per-card distinct-artwork counts (`artwork_groups`) into artwork-space offsets: a
@@ -6838,12 +6864,12 @@ fn exec_streamed_select<'a>(
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
-    let perm = indexes
+    let order = indexes
         .sort_perms
-        .get(params.sort_col, params.descending)
-        .expect("StreamedSelect applicability guarantees a permutation");
+        .order(params.sort_col, params.descending, ctx.cards.len())
+        .expect("StreamedSelect applicability guarantees a sort order");
     let existential_plane = existential_plane_for(params.mode, plane, indexes);
-    run_query_streamed(ctx, params, filter, prep.all_match_known, perm, prep.card_ids(ctx), existential_plane)
+    run_query_streamed(ctx, params, filter, prep.all_match_known, order, prep.card_ids(ctx), existential_plane)
 }
 
 /// Per-query execution counters and coarse phase timings, for checking the cost model against what
@@ -8661,8 +8687,7 @@ fn explain_analyze(
 fn run_query_streamed_popcount<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
-    perm: &Archived<Vec<u32>>,
-    inv_perm: &Archived<Vec<u32>>,
+    order: SortOrder<'_>,
     bitmap: &[u64],
     plane: Option<&PlaneExpr>,
     range_bits: Option<&[u64]>,
@@ -8674,6 +8699,7 @@ fn run_query_streamed_popcount<'a>(
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { prefer, limit, page_offset, .. } = *params;
+    let SortOrder { perm, inv: inv_perm } = order;
     let planes = &indexes.planes;
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
@@ -8818,7 +8844,7 @@ fn run_query_streamed<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
     all_match_known: bool,
-    perm: &Archived<Vec<u32>>,
+    order: SortOrder<'_>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
@@ -8827,6 +8853,7 @@ fn run_query_streamed<'a>(
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let SortOrder { perm, inv: inv_perm } = order;
     let artwork_groups = &indexes.artwork_groups;
     let artwork_group_col = &indexes.artwork_group_col;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -8855,6 +8882,21 @@ fn run_query_streamed<'a>(
     // `card_match_count` answer without reading a printing at all, so this can legitimately be 0
     // where `n_printing_span` is the full corpus span.
     let mut n_printings_examined = 0u64;
+    // The sort-order span the emission walk below has to cover: the smallest and largest position of
+    // any card that matched. The walk is over the WHOLE corpus permutation, so without these it grinds
+    // through every card ordered before the first match discarding on `counts[cid] == 0` -- `year>=2020
+    // order=released asc` pays the entire pre-2020 prefix -- and, on any page it cannot fill, every
+    // card ordered after the last match as well, since the only thing that stops it early is the page
+    // filling. This loop already visits every candidate, so the span costs one `inv_perm` read, a `min`
+    // and a `max` per MATCHING card, and candidates arrive in ascending `cid` order, which makes those
+    // reads a forward stream through `inv_perm` rather than random access.
+    //
+    // Deliberately the REALIZED span rather than bounds derived from the predicate and the sort
+    // column: it holds for any predicate (including a residual only `card_match_count` can resolve),
+    // and it cannot be wrong about how ties inside the sort key are broken. Descending needs nothing
+    // extra -- there are two permutations per column, one per direction, so `inv_perm` is already the
+    // inverse of the order actually walked.
+    let (mut first_match_pos, mut last_match_pos) = (u32::MAX, 0u32);
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -8899,6 +8941,13 @@ fn run_query_streamed<'a>(
             c
         };
         counts[cid as usize] = c;
+        // Guarded on `c != 0` because a zero-count card is exactly what the walk skips: widening the
+        // span to one would put entries inside it that the walk then discards, giving back the saving.
+        if c != 0 {
+            let pos = u32::from(inv_perm[cid as usize]);
+            first_match_pos = first_match_pos.min(pos);
+            last_match_pos = last_match_pos.max(pos);
+        }
         total += c as usize;
         n_matches_pushed += c as u64;
     }
@@ -8966,18 +9015,29 @@ fn run_query_streamed<'a>(
         return (total, page);
     }
 
-    // Stream: walk the permutation, consume page_offset from the counts, emit
-    // page cards only. Within a card, items order by (sort key, pid) — the
-    // same comparator select_page uses; across cards the permutation supplies
-    // the order.
+    // Stream: walk the permutation across the match span, consume page_offset
+    // from the counts, emit page cards only. Within a card, items order by
+    // (sort key, pid) — the same comparator select_page uses; across cards the
+    // permutation supplies the order.
+    //
+    // Restricting the walk to `first_match_pos..=last_match_pos` is exact, not an approximation:
+    // outside it every entry has `counts[cid] == 0` by construction (the span is the min and max over
+    // all cards with a nonzero count), and the walk's only effect on a zero-count entry is to
+    // `continue`. `total > 0` here — the guard above returned otherwise — so some card set both ends.
+    debug_assert!(
+        first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
+        "total > 0 guarantees a matching card, so the match span must be a real permutation range"
+    );
+    let match_span = &perm[first_match_pos as usize..=last_match_pos as usize];
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
     // Counted for every entry the walk touches, including the ones skipped on a zero count -- that
-    // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. A plain
-    // local, published once, like the other counters.
+    // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. Entries
+    // outside the match span are NOT counted: they are never stepped, and the counter's job is to
+    // grade the cost model against work actually done. A plain local, published once, like the others.
     let mut n_perm_steps = 0u64;
-    'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
+    'walk: for cid in match_span.iter().map(|x| u32::from(*x)) {
         n_perm_steps += 1;
         let c = counts[cid as usize] as usize;
         if c == 0 {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10046,3 +10046,5 @@ mod bench_compose_paging;
 mod bench_compose_card_projection;
 #[cfg(test)]
 mod bench_candidate_materialize;
+#[cfg(test)]
+mod bench_gather_loop;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5257,6 +5257,19 @@ fn printing_range_fastpath_inner<'a>(
 /// where the residual applies the correct trivalent semantics. Anything else (a text search, a range,
 /// an arithmetic compare) is likewise non-composable. A composable expression's bits are **exact** (a
 /// set bit *is* a matching printing), so no per-printing re-check is needed.
+/// Whether `filter` constrains legality anywhere. Used to scope the `stream_scan_units` correction to the
+/// case the sweep measured wrong: legality is the one printing-varying attribute `card_pass` can resolve at
+/// CARD level for most cards (only the divergent ones defer), so it is the only one where P3 and P4 examine
+/// wildly different printing counts. Border, rarity and watermark all measured at parity.
+fn filter_touches_legality(filter: &FilterExpr) -> bool {
+    match filter {
+        FilterExpr::Legality { .. } => true,
+        FilterExpr::And(cs) | FilterExpr::Or(cs) => cs.iter().any(filter_touches_legality),
+        FilterExpr::Not(inner) => filter_touches_legality(inner),
+        _ => false,
+    }
+}
+
 fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> bool {
     match filter {
         FilterExpr::True => true,
@@ -7998,6 +8011,8 @@ fn mk_plan_feats(
         matches,
         eval_domain,
         scan_units,
+        // Defaults to `scan_units`: only an acquire that knows P3 examines fewer printings overrides it.
+        stream_scan_units: scan_units,
         residual_tier_ns100,
         limit: params.limit as u32,
         offset: params.page_offset as u32,
@@ -8202,7 +8217,14 @@ fn acquire_plan_features(
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
         // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
-        let (printing_matches, broadcast, scatter) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
+        //
+        // Estimated from the SAME predicate the executor will compose (`compose_source`), not from the
+        // residual. Reading the residual once a plane had consumed the filter estimated `True` — every
+        // printing in the corpus — so `matches` came back as `n_printings` for every legality query alike
+        // and compose was costed as if it returned everything for nothing. Applicability, estimate and
+        // execution have to agree on which representation this plan is being judged on.
+        let composed = compose_source(filter, unsplit, plane);
+        let (printing_matches, broadcast, scatter) = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
         // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
         // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
         // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
@@ -8217,7 +8239,7 @@ fn acquire_plan_features(
         // projection -- and those are the bulk of what reaches here, since `bare_range_bounds`
         // matches one comparison, not an And of two. One-sided ranges DO land here in quantity:
         // every artwork-mode one, plus card-mode ones whose orderby has no permutation.
-        let exact_cards = bare_range_bounds(filter, indexes)
+        let exact_cards = bare_range_bounds(composed, indexes)
             .and_then(|(idx, lo, hi)| range_card_counts_for(indexes, idx).and_then(|counts| counts.distinct_cards(lo, hi)));
         let est_cards =
             exact_cards.map_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
@@ -8263,7 +8285,28 @@ fn acquire_plan_features(
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
             }
         };
-        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
+        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(composed));
+        // What `StreamedSelect` actually examines here, which is NOT `scan_units`. P4 walks a card's whole
+        // span to push every match; P3's `card_match_count` answers from span arithmetic for every card
+        // `card_pass` resolves at card level, and on a legality-composed filter that is every non-divergent
+        // card -- 556 of 31,508 in production diverge, all in `oldschool`. So P3 examines printings only for
+        // the divergent remainder plus the boundary cards, measured at 0.10-0.26x of P4's count where
+        // `scan_units` claimed parity: 7,770 against 73,783 on `f:modern`, 5,876 against 54,213 on
+        // `f:gladiator`.
+        //
+        // Estimated as the divergent SHARE of the candidate span rather than a fitted fraction, because the
+        // engine holds the set: `legal_divergent`. For a filter with no legality leaf the share is 1.0 and
+        // this reduces to `scan_units`, which the same sweep showed is right to 1.0-2.4x on `border:black`,
+        // `r:mythic` and `watermark:*` -- so the correction is confined to the case that measured wrong.
+        feats.stream_scan_units = if verify_cost_tier(composed) > 0 && filter_touches_legality(composed) {
+            let divergent = indexes.legal_divergent.len() as f64;
+            let share = (divergent / f64::from(n_cards)).min(1.0);
+            // Floored at one printing per candidate: even a fully card-invariant legality filter examines
+            // the boundary printing of the cards it does match, which the share alone would put at zero.
+            ((scan_units as f64) * share).max(eval_domain as f64) as u32
+        } else {
+            scan_units as u32
+        };
         feats.broadcast_printings = broadcast as u32;
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
@@ -9639,6 +9682,8 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("matches", g.matches),
         ("n_printings", g.n_printings),
         ("scan_units", g.scan_units),
+        // P3's own scan estimate; equals `scan_units` unless the acquire knew the two plans differ.
+        ("stream_scan_units", g.stream_scan_units),
         ("residual_tier_ns100", g.residual_tier_ns100),
         ("limit", g.limit),
         ("offset", g.offset),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8164,6 +8164,9 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     if feats.residual_card_invariant {
         feats.stream_scan_units = 0;
     }
+    if prep.all_match_known || feats.residual_card_invariant {
+        feats.artwork_seen_cards = 0;
+    }
     // Same signal, second term — **measured, and NOT applied.** `run_query_streamed` answers an artwork count
     // from a STORED per-card group count when `all_match && have_group_counts`, touching no printing, and only
     // walks the span to dedup groups when a residual survives per printing. So `artwork_seen_cards` charging

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6435,11 +6435,30 @@ fn printing_compose_fastpath<'a>(
     let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
+                // Sparse: hand the query back to the general path rather than paging it here.
+                //
+                // NOT for the reason this comment used to give ("the general path gathers + globally
+                // sorts, ordering ties differently"). That died with #815, which made row order total
+                // and filter-independent on (key1, key2, cid, pid), replacing the key-3 `prefer_score`
+                // that genuinely differed between the permutation (first STORED printing's score) and
+                // the gathered paths (first MATCHING one). Measured 2026-08-04 by toggling this decline
+                // off: 576 real invocations of the walk over 1,512 tie-heavy cells, 0 row differences,
+                // plus 14 inside `force_plan_differential_agreement`, which asserts full row order
+                // against GatheredScan. Either executor is correct here now.
+                //
+                // What keeps the decline is cost, not correctness. `gather_composed_page` is genuinely
+                // 1.3-2.7x faster than the plan that otherwise wins on this population, but `plan_cost`
+                // reads 0.27-0.53 of its real time, and the resulting mispicks cancel the wins exactly:
+                // regret 1.30 -> 1.51 us, compose miss% 7% -> 18%, compose-acquire wall time 1.00 over
+                // 2,341 paired queries. Neutral in time and worse in routing is not a trade worth the
+                // complexity. docs/issues/local-engine-sparse-compose-gather.md carries the four
+                // acceptance criteria this has to clear.
+                //
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
                 // one fires pre-compose off the estimator's upper bound, this one post-compose off
                 // the real total. A harness reading one label for both cannot tell which fired.
                 note_paging_taken(PagingTaken::DeclineSparseExact);
-                return None; // sparse: the general path gathers + globally sorts, ordering ties differently
+                return None;
             }
             note_paging_taken(PagingTaken::Perm);
             walk_grouped_page(ctx, params, &pbits, perm)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1995,6 +1995,172 @@ fn invert_perm(perm: &[u32]) -> Vec<u32> {
     inv
 }
 
+/// An inclusive value interval on the sort column that every match must satisfy, or `UNBOUNDED` when
+/// the filter says nothing about it. Extracted from the filter BEFORE `split_planes` consumes it (see
+/// `sort_col_bound`) and carried on `QueryParams`, because that is the only point at which the tree is
+/// still readable: `cmc>=6` compiles to mask algebra over bitplanes, and the residual left behind is
+/// `FilterExpr::True`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct SortBound {
+    lo: Option<f64>,
+    hi: Option<f64>,
+}
+
+impl SortBound {
+    /// No constraint: the walk covers the whole permutation, exactly as it did before this existed.
+    /// Also the safe default — every path that does not extract a bound gets this one, so a caller that
+    /// forgets to loses performance and not correctness.
+    const UNBOUNDED: SortBound = SortBound { lo: None, hi: None };
+
+    fn is_unbounded(self) -> bool {
+        self.lo.is_none() && self.hi.is_none()
+    }
+
+    /// Tighten with another interval — `And`'s rule, and the only way bounds combine.
+    fn intersect(self, other: SortBound) -> SortBound {
+        let tighter = |a: Option<f64>, b: Option<f64>, pick: fn(f64, f64) -> f64| match (a, b) {
+            (Some(x), Some(y)) => Some(pick(x, y)),
+            (v, None) | (None, v) => v,
+        };
+        SortBound { lo: tighter(self.lo, other.lo, f64::max), hi: tighter(self.hi, other.hi, f64::min) }
+    }
+}
+
+/// The inclusive interval on `sort_col` that every match of `filter` must satisfy.
+///
+/// Deliberately conservative in every direction, because the cost of being too wide is a longer walk
+/// and the cost of being too narrow is a wrong page:
+///
+/// - **`And` only.** An `Or` child can match outside any bound its sibling implies, and `Not` inverts
+///   into a union of two intervals that this cannot express. Both yield `UNBOUNDED` for that subtree,
+///   which an enclosing `And` then simply ignores.
+/// - **Strict comparisons are widened to inclusive.** `cmc>6` reports `lo = 6`, so the walk may start
+///   at the head of the `cmc == 6` tie block and step over it. One block of wasted steps against having
+///   to reason about float adjacency.
+/// - **Card-level columns only**, and only the three with numeric predicates. Everything else has no
+///   `NumericCmp` that can constrain it (there is no `edhrec>` in the query language), and `Rarity` /
+///   `PriceUsd` have no permutation to search.
+fn sort_col_bound(filter: &FilterExpr, sort_col: SortCol) -> SortBound {
+    let field = match sort_col {
+        SortCol::Cmc => NumField::Cmc,
+        SortCol::Power => NumField::Power,
+        SortCol::Toughness => NumField::Toughness,
+        _ => return SortBound::UNBOUNDED,
+    };
+    match filter {
+        FilterExpr::And(children) => {
+            children.iter().fold(SortBound::UNBOUNDED, |acc, c| acc.intersect(sort_col_bound(c, sort_col)))
+        }
+        // `op` reads left-to-right, so a constant on the left flips it: `6 <= cmc` bounds cmc BELOW.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(f), op, rhs: NumExpr::Const(v) } if *f == field => {
+            bound_from_cmp(*op, *v)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(f) } if *f == field => {
+            bound_from_cmp(flip_op(*op), *v)
+        }
+        _ => SortBound::UNBOUNDED,
+    }
+}
+
+/// One comparison's inclusive interval. `Ne` constrains nothing (it excludes a point from the middle,
+/// which is not an interval), and the strict operators widen to their inclusive neighbours.
+fn bound_from_cmp(op: CmpOp, v: f64) -> SortBound {
+    match op {
+        CmpOp::Ge | CmpOp::Gt => SortBound { lo: Some(v), hi: None },
+        CmpOp::Le | CmpOp::Lt => SortBound { lo: None, hi: Some(v) },
+        CmpOp::Eq => SortBound { lo: Some(v), hi: Some(v) },
+        CmpOp::Ne => SortBound::UNBOUNDED,
+    }
+}
+
+/// The permutation's PRIMARY key: the sort column's value, direction folded in by negation, absent
+/// sorting last. One function because two places must agree on it exactly — `build_sort_permutations`
+/// orders by it, and `walk_bounds` binary-searches for it to find where a value interval starts and
+/// ends in that order. A divergence between those two would not be a slow walk, it would be a walk
+/// that starts past real matches and silently returns the wrong page.
+///
+/// `u32::MAX` for absent is what makes a numeric bound safe to search for: a card with no value in the
+/// column sorts past every finite key in BOTH directions, and `numeric_cmp_tri` answers `Tri::Null` for
+/// it, so it can never be a match of a comparison against that column either.
+fn perm_primary_key(value: Option<f32>, descending: bool) -> u32 {
+    value.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }))
+}
+
+/// The sort column's value for one archived card, in the same units `build_sort_permutations` sorted
+/// on. Card-level columns only: `Rarity`/`PriceUsd` have no permutation (they depend on the
+/// prefer-chosen printing), which is why `ArchivedSortPermutations::get` returns `None` for them.
+fn sort_col_card_value(card: &AOracleCard, sort_col: SortCol) -> Option<f32> {
+    match sort_col {
+        SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
+        SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
+        // Single bytes, so archived and native are the same type — no `u8::from` to unwrap.
+        SortCol::Cmc        => card.cmc.as_ref().map(|v| f32::from(*v)),
+        SortCol::Power      => card.creature_power.as_ref().map(|v| f32::from(*v)),
+        SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| f32::from(*v)),
+        SortCol::Name       => Some(u32::from(card.name_rank) as f32),
+        SortCol::Rarity | SortCol::PriceUsd => None,
+    }
+}
+
+/// The segment of `perm` that can contain a match, from the filter's interval on the sort column.
+///
+/// The permutation is a sorted array on `perm_primary_key`, so an interval on the sort column's VALUE
+/// is a contiguous range of POSITIONS, found by two binary searches — O(log n_cards) probes once per
+/// query, against the alternative of reading `inv_perm` once per matching card. Which end of the walked
+/// order each side of the interval lands on depends on the direction, because the key negates: under
+/// `asc` the low bound starts the segment, under `desc` the high bound does.
+///
+/// Returns the whole permutation when the filter constrains nothing, which is also what every caller
+/// gets that does not extract a bound.
+fn walk_bounds<'p>(
+    perm: &'p Archived<Vec<u32>>,
+    cards: &[AOracleCard],
+    sort_col: SortCol,
+    descending: bool,
+    bound: SortBound,
+) -> &'p [Archived<u32>] {
+    let all = &perm[..];
+    if bound.is_unbounded() || perm.len() != cards.len() || *WALK_SORT_BOUND == 0 {
+        return all;
+    }
+    // Values are read through the same encoder the permutation was built with, so this comparison and
+    // that ordering cannot disagree.
+    let key_at = |pos: usize| {
+        let cid = u32::from(all[pos]) as usize;
+        perm_primary_key(sort_col_card_value(&cards[cid], sort_col), descending)
+    };
+    // Under `desc` the key is negated, so the interval's ends swap roles: the largest VALUE has the
+    // smallest key and therefore comes first.
+    let (first_v, last_v) = if descending { (bound.hi, bound.lo) } else { (bound.lo, bound.hi) };
+    let key_of = |v: f64| perm_primary_key(Some(v as f32), descending);
+    // `partition_point` over positions: the first position whose key reaches the interval, and the
+    // first position past it. Both sides are inclusive in value, so `start` excludes keys strictly
+    // before the interval and `end` includes the whole tie block at its far edge.
+    let start = first_v.map_or(0, |v| {
+        let k = key_of(v);
+        partition_point(all.len(), |pos| key_at(pos) < k)
+    });
+    let end = last_v.map_or(all.len(), |v| {
+        let k = key_of(v);
+        partition_point(all.len(), |pos| key_at(pos) <= k)
+    });
+    // An empty or inverted range means the interval falls between two stored values (`cmc>=6 cmc<=5`),
+    // so nothing can match; the walk then steps nothing rather than being handed a reversed slice.
+    if start >= end { &all[..0] } else { &all[start..end] }
+}
+
+/// `partition_point` over an index range: the first `i` in `0..len` where `pred(i)` is false, with
+/// `pred` monotone. `slice::partition_point` cannot be used directly because the predicate needs the
+/// POSITION (to read the card behind it), not the element.
+fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
+    let (mut lo, mut hi) = (0usize, len);
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if pred(mid) { lo = mid + 1 } else { hi = mid }
+    }
+    lo
+}
+
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
@@ -2002,7 +2168,7 @@ fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
         let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
         ids.sort_unstable_by_key(|&i| {
             let c = &cards[i as usize];
-            let pk = get(c).map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
+            let pk = perm_primary_key(get(c), descending);
             let e = c.edhrec_rank.unwrap_or(u32::MAX);
             // Canonical secondary: the first (store-preferred) printing's
             // default prefer score, matching sort_key_bits' third component
@@ -4233,6 +4399,14 @@ struct QueryParams {
     descending: bool,
     limit: usize,
     page_offset: usize,
+    /// What the filter says about the SORT COLUMN, which `StreamedSelect` turns into the segment of the
+    /// permutation its walk has to cover. Not a user parameter — it is derived from the filter — but it
+    /// travels here because it is only meaningful next to `sort_col`/`descending`, and because the point
+    /// where it can be extracted (before `split_planes`) is nowhere near the executor that uses it.
+    ///
+    /// Defaults to `UNBOUNDED` in `from_strs`, and every constructor that does not opt in gets that: a
+    /// missing bound costs a longer walk, never a wrong page. `with_sort_bound` is the opt-in.
+    sort_bound: SortBound,
 }
 
 impl QueryParams {
@@ -4251,7 +4425,15 @@ impl QueryParams {
             descending: direction == "desc",
             limit,
             page_offset,
+            sort_bound: SortBound::UNBOUNDED,
         }
+    }
+
+    /// Attach the filter's interval on the sort column. Called at the PyO3 boundary, next to
+    /// `bind_and_split_filter`, since that is the last place the unsplit filter exists.
+    fn with_sort_bound(mut self, sort_bound: SortBound) -> Self {
+        self.sort_bound = sort_bound;
+        self
     }
 }
 
@@ -4659,21 +4841,16 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// streaming's win grows fast (~1.8× by 8k), so the trigger stays put.
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));
 
-/// The emission walk tracks its match span only when candidates are at most `n_cards` over this — a
-/// quarter of the corpus. See the derivation at `track_span` in `run_query_streamed`.
+/// Kill-switch for narrowing the streamed walk to the filter's bound on the sort column
+/// (`walk_bounds`). Default on; 0 walks the whole permutation as the executor did before the bound
+/// existed. A binary switch, not a calibrated threshold — the bound costs O(log n_cards) probes once
+/// per query and nothing per card, so there is no crossover to find, and its predecessor (a per-card
+/// `inv_perm` min/max, gated on candidate count) was replaced precisely because it did have one.
 ///
-/// Calibrated by `scripts/bench_walk_span.py`, which A/Bs this toggle inside ONE binary (cross-build
-/// comparison cannot resolve it: `ns_loop` wandered ±9% run to run on a phase neither build changed).
-/// Tracking costs **0.51 ns per matching card** and a walk step costs **0.37 ns**, so insurance that
-/// cannot pay for itself starts at `matching_cards = n_cards * 0.37 / (0.37 + 0.51)` = 0.42 ×
-/// `n_cards`; a quarter sits inside that with room for the estimate to be wrong. Ungated, the broad
-/// cells measured 1.13-1.21x SLOWER (`cmc>=1 order=edhrec`: `ns_loop` 78.54 -> 94.46 us over 30,318
-/// cards) while saving nothing, because a match set that big leaves no prefix to skip.
-///
-/// Set to 1 to track unconditionally, or above the corpus size to disable tracking; `bench_walk_span.py`
-/// uses exactly those two settings, spelled `00001` / `99999` so both arms carry an equal-length value.
-static SPAN_TRACK_CANDIDATE_DIVISOR: LazyLock<usize> =
-    LazyLock::new(|| guard_env("CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR", 4).max(1));
+/// Exists because `scripts/bench_walk_span.py` needs both behaviours in ONE binary: the effect is
+/// smaller than the run-to-run spread of `ns_loop` across builds, so a cross-build A/B of it reports
+/// the wrong sign.
+static WALK_SORT_BOUND: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_WALK_SORT_BOUND", 1));
 
 /// Whether run_query reorders And/Or children cheapest-verification-first
 /// before the evaluation walk (see FilterExpr::order_children_by_verify_cost).
@@ -6664,7 +6841,7 @@ fn walk_grouped_page<'a>(
     perm: &Archived<Vec<u32>>,
 ) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -6769,7 +6946,7 @@ fn gather_composed_page<'a>(
     card_bits: Option<&[u64]>,
 ) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     // `card_bits` is `pbits` already projected into card space. `Mode::Card` computes that
@@ -6885,12 +7062,16 @@ fn exec_streamed_select<'a>(
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
-    let order = indexes
+    let perm = indexes
         .sort_perms
-        .order(params.sort_col, params.descending, ctx.cards.len())
-        .expect("StreamedSelect applicability guarantees a sort order");
+        .get(params.sort_col, params.descending)
+        .expect("StreamedSelect applicability guarantees a permutation");
+    // The walk's segment, decided here rather than inside the executor because it is a property of the
+    // QUERY (its filter's interval on the sort column) and not of the emission loop. Two binary searches
+    // when the filter constrains the sort column, the whole permutation otherwise.
+    let walk = walk_bounds(perm, ctx.cards, params.sort_col, params.descending, params.sort_bound);
     let existential_plane = existential_plane_for(params.mode, plane, indexes);
-    run_query_streamed(ctx, params, filter, prep.all_match_known, order, prep.card_ids(ctx), existential_plane)
+    run_query_streamed(ctx, params, filter, prep.all_match_known, walk, prep.card_ids(ctx), existential_plane)
 }
 
 /// Per-query execution counters and coarse phase timings, for checking the cost model against what
@@ -7333,7 +7514,7 @@ fn exec_gathered_scan<'a>(
     // First of the three phase boundaries — everything down to the match loop is `ns_setup`.
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let all_match_known = prep.all_match_known;
     let existential_plane = existential_plane_for(mode, plane, indexes);
     let card_ids = prep.card_ids(ctx);
@@ -7415,7 +7596,13 @@ fn exec_gathered_scan<'a>(
     (total, page)
 }
 
-#[allow(clippy::too_many_arguments)] // the PyO3 string surface, adapted in one place; the core takes two structs
+/// The six-string convenience form of `run_query_routed`, for tests that state a query the way the
+/// HTTP surface does. `QueryParams::from_strs` is still the single string→enum interpretation — the
+/// PyO3 methods call it directly, because they also have a `SortBound` to attach and this wrapper has
+/// no filter tree left to extract one from (see `bind_and_split_filter`). A query routed through here
+/// therefore walks the whole permutation, which is the correct-but-slower default.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)] // the string surface, adapted in one place; the core takes two structs
 fn run_query<'a>(
     ctx: &QueryCtx<'a>,
     filter: &mut FilterExpr,
@@ -7428,8 +7615,7 @@ fn run_query<'a>(
     page_offset: usize,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // #702: plan selection is one cost-based routing layer (`run_query_routed`,
-    // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision
-    // tree. `run_query` is the thin string→enum adapter; the core takes enums.
+    // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision tree.
     let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, page_offset);
     run_query_routed(ctx, &params, filter, plane)
 }
@@ -8865,7 +9051,7 @@ fn run_query_streamed<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
     all_match_known: bool,
-    order: SortOrder<'_>,
+    walk: &[Archived<u32>],
     card_ids: Box<dyn ExactSizeIterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
@@ -8873,8 +9059,7 @@ fn run_query_streamed<'a>(
     // for this executor is dominated by the `counts` zeroing below. See `PhaseStats::ns_setup`.
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
-    let SortOrder { perm, inv: inv_perm } = order;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let artwork_groups = &indexes.artwork_groups;
     let artwork_group_col = &indexes.artwork_group_col;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -8903,43 +9088,6 @@ fn run_query_streamed<'a>(
     // `card_match_count` answer without reading a printing at all, so this can legitimately be 0
     // where `n_printing_span` is the full corpus span.
     let mut n_printings_examined = 0u64;
-    // The sort-order span the emission walk below has to cover: the smallest and largest position of
-    // any card that matched. The walk is over the WHOLE corpus permutation, so without these it grinds
-    // through every card ordered before the first match discarding on `counts[cid] == 0` -- `year>=2020
-    // order=released asc` pays the entire pre-2020 prefix -- and, on any page it cannot fill, every
-    // card ordered after the last match as well, since the only thing that stops it early is the page
-    // filling. Measured on this corpus: `cmc>=6 order=cmc asc` walked 28,275 entries for a 60-row page
-    // and spent 10.6 us of a 20.25 us execution doing it; bounded, it walks 60 and spends 0.38 us.
-    //
-    // Deliberately the REALIZED span rather than bounds derived from the predicate and the sort
-    // column: it holds for any predicate (including a residual only `card_match_count` can resolve),
-    // and it cannot be wrong about how ties inside the sort key are broken. Descending needs nothing
-    // extra -- there are two permutations per column, one per direction, so `inv_perm` is already the
-    // inverse of the order actually walked.
-    //
-    // GATED, because the span is emphatically not free. It costs an `inv_perm` read plus a `min` and a
-    // `max` per MATCHING card, and this loop's `all_match` arm is only ~2.6 ns/card to begin with, so
-    // 0.51 ns/card of tracking is a 20% tax on it: ungated, `cmc>=1 order=edhrec` measured `ns_loop`
-    // 78.54 -> 94.46 us over 30,318 cards while its walk stayed at 111 steps either way. The tax is
-    // paid on every streamed query; the saving only exists when the walk had something to skip.
-    //
-    // The bound is therefore insurance, and the gate is the premium being kept below the payout. A
-    // query with `m` matching cards has at most `n_cards - m` entries outside its span, so the most the
-    // bound can save is `(n_cards - m) * 0.37 ns` against a cost of `m * 0.51 ns` -- break-even at
-    // `m = 0.42 * n_cards`, and `SPAN_TRACK_CANDIDATE_DIVISOR` sits at a quarter, inside it. The
-    // regime below the gate is also where the unbounded walk is dangerous: steps go as
-    // `page_span * n_cards / matches`, so sparse matches are exactly what make it long.
-    //
-    // Candidates bound matching cards from above, and unlike the match count it is known HERE, before
-    // the loop -- so this is one perfectly-predicted branch per card, rather than a decision that could
-    // only be made after the cost had already been paid.
-    //
-    // What the gate does not fix: a query whose cluster sits at the NEAR end of the walked order pays
-    // the premium for nothing, because the page fills before the last-match bound can matter
-    // (`cmc>=6 order=cmc desc offset=900` measured 1.17x). That is the shape of the bet, not a defect
-    // in it -- which end a cluster lands on is not knowable before the loop runs.
-    let track_span = card_ids.len() <= cards.len() / *SPAN_TRACK_CANDIDATE_DIVISOR;
-    let (mut first_match_pos, mut last_match_pos) = (u32::MAX, 0u32);
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -8984,13 +9132,6 @@ fn run_query_streamed<'a>(
             c
         };
         counts[cid as usize] = c;
-        // Guarded on `c != 0` because a zero-count card is exactly what the walk skips: widening the
-        // span to one would put entries inside it that the walk then discards, giving back the saving.
-        if track_span && c != 0 {
-            let pos = u32::from(inv_perm[cid as usize]);
-            first_match_pos = first_match_pos.min(pos);
-            last_match_pos = last_match_pos.max(pos);
-        }
         total += c as usize;
         n_matches_pushed += c as u64;
     }
@@ -9058,34 +9199,25 @@ fn run_query_streamed<'a>(
         return (total, page);
     }
 
-    // Stream: walk the permutation across the match span, consume page_offset
+    // Stream: walk the segment `walk_bounds` handed over, consume page_offset
     // from the counts, emit page cards only. Within a card, items order by
     // (sort key, pid) — the same comparator select_page uses; across cards the
     // permutation supplies the order.
     //
-    // Restricting the walk to `first_match_pos..=last_match_pos` is exact, not an approximation:
-    // outside it every entry has `counts[cid] == 0` by construction (the span is the min and max over
-    // all cards with a nonzero count), and the walk's only effect on a zero-count entry is to
-    // `continue`. `total > 0` here — the guard above returned otherwise — so some card set both ends.
-    // Ungated, the whole permutation, exactly as before.
-    let match_span: &[Archived<u32>] = if track_span {
-        debug_assert!(
-            first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
-            "total > 0 guarantees a matching card, so the match span must be a real permutation range"
-        );
-        &perm[first_match_pos as usize..=last_match_pos as usize]
-    } else {
-        &perm[..]
-    };
+    // The segment is the whole permutation unless the filter bounded the sort column, in which case
+    // every position outside it belongs to a card whose value cannot satisfy that bound and therefore
+    // has `counts[cid] == 0`. The walk's only effect on a zero-count entry is to `continue`, so
+    // narrowing the segment cannot change which rows come back — only how many entries are stepped to
+    // find them.
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
     // Counted for every entry the walk touches, including the ones skipped on a zero count -- that
     // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. Entries
-    // outside the match span are NOT counted: they are never stepped, and the counter's job is to
-    // grade the cost model against work actually done. A plain local, published once, like the others.
+    // outside the segment are NOT counted: they are never stepped, and the counter's job is to grade
+    // the cost model against work actually done. A plain local, published once, like the others.
     let mut n_perm_steps = 0u64;
-    'walk: for cid in match_span.iter().map(|x| u32::from(*x)) {
+    'walk: for cid in walk.iter().map(|x| u32::from(*x)) {
         n_perm_steps += 1;
         let c = counts[cid as usize] as usize;
         if c == 0 {
@@ -9345,7 +9477,20 @@ pub(crate) fn count_common_keywords(data: &Archived<CardData>) -> HashMap<String
 /// No `#[inline]`: this shares a crate with its only hot-path caller (`query`), so
 /// the compiler already inlines at its discretion, and the body is dominated by
 /// Python FFI (`to_json`, `orjson.dumps`) — a call boundary here is unmeasurable.
-fn bind_and_split_filter(py: Python<'_>, filters: &Bound<PyAny>, unique: &str, data: &Archived<CardData>) -> PyResult<(Option<PlaneExpr>, FilterExpr)> {
+/// Binds the Python filter, extracts what it says about `sort_col`, and splits it into plane + residual.
+///
+/// The `SortBound` comes out of here rather than out of the executor because this is the last moment the
+/// whole filter exists: `split_planes` compiles `cmc>=6` into mask algebra over bitplanes and leaves
+/// `FilterExpr::True` behind, so by the time a plan runs there is nothing left to read the bound from.
+/// Every caller that does not want it can ignore it and get `UNBOUNDED` behaviour — a longer walk, never
+/// a different page.
+fn bind_and_split_filter(
+    py: Python<'_>,
+    filters: &Bound<PyAny>,
+    unique: &str,
+    data: &Archived<CardData>,
+    sort_col: SortCol,
+) -> PyResult<(Option<PlaneExpr>, FilterExpr, SortBound)> {
     let to_json = filters.call_method0("to_json")?;
     let json_bytes: Vec<u8> = py
         .import("orjson")?
@@ -9363,11 +9508,14 @@ fn bind_and_split_filter(py: Python<'_>, filters: &Bound<PyAny>, unique: &str, d
         .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
     filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
 
-    Ok(if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
+    // Read before the split consumes the tree.
+    let sort_bound = sort_col_bound(&filter_expr, sort_col);
+    let (plane, residual) = if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
         split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
     } else {
         (None, filter_expr)
-    })
+    };
+    Ok((plane, residual, sort_bound))
 }
 
 fn plan_estimate_to_pydict<'py>(py: Python<'py>, e: &PlanEstimate) -> PyResult<Bound<'py, PyDict>> {
@@ -9926,10 +10074,13 @@ impl QueryEngine {
         // run_query evaluates in a few hundred word ops instead of per-card
         // dispatch. Shared verbatim with explain()/explain_analyze() — see
         // bind_and_split_filter.
-        let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         let ctx = QueryCtx::from(data);
-        let (total, page) = run_query(&ctx, &mut filter_expr, plane_expr.as_ref(), unique, prefer, orderby, direction, limit, offset);
+        // `run_query`'s string→enum adaptation, done here so the filter's sort-column bound can ride on
+        // the params: `from_strs` is still the single interpretation of the four strings.
+        let (total, page) = run_query_routed(&ctx, &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
 
         let matches: Vec<Bound<PyDict>> = page
             .iter()
@@ -9966,7 +10117,8 @@ impl QueryEngine {
         let mmap = self.get_mmap()?;
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
-        let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // `prefer` is accepted and passed through, but note what it does NOT yet change:
         // `cost::plan_cost`/`PlanFeatures` still don't read it, so the argmin and every
@@ -9980,8 +10132,8 @@ impl QueryEngine {
         // feature value cannot be right for both. Taking the parameter is what lets a
         // prefer-aware feature be graded here at all; until one exists, an `explain` for a
         // non-default `prefer` still predicts the default's numbers.
-        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (facts, estimates) = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
+        let (facts, estimates) =
+            explain(&QueryCtx::from(data), &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
         let out = PyDict::new(py);
@@ -10014,14 +10166,15 @@ impl QueryEngine {
         let mmap = self.get_mmap()?;
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
-        let (plane_expr, filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let (plane_expr, filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // Release the GIL for the timing loop: it's pure Rust (no Python calls) and
         // runs plans × (warmups + trials) executions, so a long explain_analyze
         // shouldn't block other Python threads. The bind above and the PyDict
         // conversion below stay on the GIL.
         let ctx = QueryCtx::from(data);
-        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let params = params.with_sort_bound(sort_bound);
         let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2161,27 +2161,6 @@ fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
     lo
 }
 
-/// Which legality formats have printings that disagree, as a mask over the same 2-bit fields
-/// `format_shifts` indexes. See `CardData::divergent_formats` for why the per-format answer is worth
-/// more than the per-card boolean beside it.
-///
-/// One definition, used by `reload` AND by the test fixtures, because a fixture computing this
-/// differently from production would either exercise a shortcut production never takes or miss one it
-/// does — and the thing being decided is whether per-printing legality verification can be skipped.
-fn divergent_formats_of(printings: &[Printing], offsets: &[u32]) -> u64 {
-    let mut mask = 0u64;
-    for w in offsets.windows(2) {
-        let (start, end) = (w[0] as usize, w[1] as usize);
-        // XOR every printing against the group's first: a field that ever differs shows up in some XOR,
-        // and a field that never does contributes nothing from any pair.
-        let first = printings[start].card_legalities;
-        for pr in &printings[start + 1..end] {
-            mask |= first ^ pr.card_legalities;
-        }
-    }
-    mask
-}
-
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
@@ -2818,21 +2797,6 @@ struct CardData {
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
     // legality shifts identically to the worker that built the archive.
     format_shifts: HashMap<String, u8>,
-    // WHICH formats actually have printings that disagree, as a mask over the same 2-bit fields
-    // `format_shifts` indexes. `legality_divergent` on the card is one boolean meaning "some format
-    // disagreed for this card", which is all the #667 carveout has ever had to work with — so every
-    // legality leaf is treated as existential and re-verified per printing, for every format.
-    //
-    // The data does not justify that. Over the production corpus, all 556 divergent cards diverge in
-    // `oldschool` and nothing else; `modern`, `commander`, `pauper` and the rest are card-invariant, and
-    // the per-printing re-verification on them is provably redundant (measured: 7,770 printing
-    // examinations by StreamedSelect on `f:modern` that cannot change an answer).
-    //
-    // Accumulated as the OR of the XOR between successive printings of a card, so it names exactly the
-    // 2-bit fields that ever differ, and it is derived from the data rather than asserting anything
-    // about `oldschool`: if Scryfall ever makes another format divergent, this picks it up on the next
-    // reload and the conservative path returns on its own.
-    divergent_formats: u64,
 }
 
 // ─── Candidate narrowing ─────────────────────────────────────────────────────
@@ -3493,7 +3457,7 @@ fn narrow_rec(
         // `Narrowed`'s doc and the dedicated `Legality` arms below), so a
         // compiled expression touching them can only narrow loosely here,
         // same as if it had fallen through to those arms directly.
-        return if plane_expr_is_existential(&pe) {
+        return if plane_expr_is_existential(&pe, u64::from(indexes.planes.divergent_formats)) {
             Narrowed::loose(Candidates::CardBits(bits))
         } else {
             Narrowed::tight(Candidates::CardBits(bits))
@@ -6520,7 +6484,9 @@ fn existential_plane_for<'a>(
     indexes: &'a Archived<CardIndexes>,
 ) -> Option<(&'a PlaneExpr, &'a Archived<BitPlanes>)> {
     match (mode, plane) {
-        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe) => Some((pe, &indexes.planes)),
+        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe, u64::from(indexes.planes.divergent_formats)) => {
+            Some((pe, &indexes.planes))
+        }
         _ => None,
     }
 }
@@ -6671,7 +6637,9 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // plane touched legality, so this only trusts a True residual for those
     // modes when the plane is existential-free (plane_expr_is_existential).
     let plane_true_for_mode =
-        plane.is_none_or(|expr| matches!(mode, Mode::Card) || !plane_expr_is_existential(expr));
+        plane.is_none_or(|expr| {
+            matches!(mode, Mode::Card) || !plane_expr_is_existential(expr, u64::from(ctx.indexes.planes.divergent_formats))
+        });
     let all_match_known = (matches!(filter, FilterExpr::True) && plane_true_for_mode) || residual_exact;
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
@@ -9003,7 +8971,7 @@ fn run_query_streamed_popcount<'a>(
         // blindly -- verify against `eval_plane_expr_for_printing` too. Cheap
         // even then: bounded by `limit` emitted cards, not the candidate set,
         // and only pays the extra check at all for legality-touching planes.
-        let existential = plane.is_some_and(plane_expr_is_existential);
+        let existential = plane.is_some_and(|e| plane_expr_is_existential(e, u64::from(planes.divergent_formats)));
         // Ends `ns_loop` (the skip scan) and starts `ns_finish` (the emit walk).
         let t_finish = std::time::Instant::now();
         let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -9990,9 +9958,6 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        // Computed over the grouped arrays rather than inside the grouping loop, so the fixtures can call
-        // the same function on the same shape. One pass over the printings against a ~2 s load.
-        let divergent_formats = divergent_formats_of(&printings, &offsets);
         let card_data = CardData {
             cards,
             printings,
@@ -10004,7 +9969,6 @@ impl QueryEngine {
             mana_vocab,
             indexes,
             format_shifts: format_shifts_snapshot,
-            divergent_formats,
         };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
@@ -10243,7 +10207,7 @@ impl QueryEngine {
         let Ok(mmap) = self.get_mmap() else { return Ok(d) };
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
-        let mask = u64::from(data.divergent_formats);
+        let mask = u64::from(data.indexes.planes.divergent_formats);
         for (format, shift) in data.format_shifts.iter() {
             // Two bits per format, so a format is divergent if either of its bits ever differed.
             if mask >> *shift & 0b11 != 0 {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10552,6 +10552,8 @@ mod bench_compose_card_projection;
 #[cfg(test)]
 mod bench_candidate_materialize;
 #[cfg(test)]
+mod bench_loop_design;
+#[cfg(test)]
 mod bench_gather_loop;
 #[cfg(test)]
 mod bench_streamed_loop;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6438,10 +6438,9 @@ impl PreparedCandidates {
     /// both P3 and P4 want the same either-or — previously spelled out
     /// identically at the head of each.
     ///
-    /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a
-    /// `Range`), and an executor that wants the candidate count before its loop -- P3, to decide
-    /// whether tracking the walk's match span can pay -- would otherwise have to be handed the count
-    /// alongside the iterator and trust the two to agree.
+    /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a `Range`),
+    /// so an executor that wants the candidate count before its loop can ask for it instead of being
+    /// handed the count alongside the iterator and trusting the two to agree.
     fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn ExactSizeIterator<Item = u32> + 's> {
         match &self.candidate_cards {
             Some(v) => Box::new(v.iter().copied()),

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -797,7 +797,7 @@ fn numeric_layout(field: NumField, bounds: &rkyv::Archived<BitPlanes>) -> Option
 /// `numeric_candidates` (lib.rs) uses, so the plane-compiled answer and the
 /// index-scan fallback can never disagree on a fractional-threshold edge
 /// case (e.g. `cmc>6.5`).
-fn matches_op(op: CmpOp, v: f64, threshold: f64) -> bool {
+pub(crate) fn matches_op(op: CmpOp, v: f64, threshold: f64) -> bool {
     match op {
         CmpOp::Eq => v == threshold,
         CmpOp::Ne => v != threshold,

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -221,6 +221,13 @@ pub(crate) struct BitPlanes {
     pub(crate) power_hi: BucketBounds,
     pub(crate) toughness_lo: BucketBounds,
     pub(crate) toughness_hi: BucketBounds,
+    /// Which legality formats have printings that disagree — see `divergent_formats_of`. Lives here
+    /// because it is a statement about what plane truth MEANS: a legality plane for a format outside this
+    /// mask is card-invariant, so a card-level bit implies every printing of that card, and the #667
+    /// existential carveout does not apply to it. Every site that asks "is this plane existential"
+    /// already holds `&Archived<BitPlanes>`, so keeping it here needs no new plumbing and leaves one
+    /// home for the fact.
+    pub(crate) divergent_formats: u64,
 }
 
 pub(crate) fn words_per_plane(n_cards: usize) -> usize {
@@ -280,6 +287,27 @@ fn set_numeric_plane(
         bounds.observe(v as i16);
         set(plane);
     }
+}
+
+/// Which legality formats have printings that disagree, as a mask over the same 2-bit fields
+/// `format_shifts` indexes. See `BitPlanes::divergent_formats` for why the per-format answer is worth
+/// more than `OracleCard::legality_divergent`, the per-card boolean beside it.
+///
+/// One definition, used by `reload` AND by the test fixtures, because a fixture computing this
+/// differently from production would either exercise a shortcut production never takes or miss one it
+/// does — and the thing being decided is whether per-printing legality verification can be skipped.
+pub(crate) fn divergent_formats_of(printings: &[Printing], offsets: &[u32]) -> u64 {
+    let mut mask = 0u64;
+    for w in offsets.windows(2) {
+        let (start, end) = (w[0] as usize, w[1] as usize);
+        // XOR every printing against the group's first: a field that ever differs shows up in some XOR,
+        // and a field that never does contributes nothing from any pair.
+        let first = printings[start].card_legalities;
+        for pr in &printings[start + 1..end] {
+            mask |= first ^ pr.card_legalities;
+        }
+    }
+    mask
 }
 
 pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32], strings: &[String]) -> BitPlanes {
@@ -420,7 +448,18 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
             (PLANE_TOUGHNESS_HI, &mut toughness_hi),
         );
     }
-    BitPlanes { n_cards: cards.len() as u32, words, cmc_hi, power_lo, power_hi, toughness_lo, toughness_hi }
+    BitPlanes {
+        n_cards: cards.len() as u32,
+        words,
+        cmc_hi,
+        power_lo,
+        power_hi,
+        toughness_lo,
+        toughness_hi,
+        // Computed here, from the same printings the planes were built from, so every fixture that builds
+        // planes gets it without a second call site to keep in step.
+        divergent_formats: divergent_formats_of(printings, offsets),
+    }
 }
 
 /// #724: printing-space border planes — bit per printing, **exact** (unlike #664's card-space
@@ -1071,6 +1110,26 @@ const PLANE_BLOCKS: [PlaneBlock; 10] = [
     PlaneBlock { base: PLANE_BORDER_OTHER, len: 1, kind: BlockKind::BorderOther },
 ];
 
+/// Whether plane `p` needs PER-PRINTING verification: an existential leaf whose fact can actually differ
+/// between the printings of one card.
+///
+/// For rarity and border that is every leaf — those are printing-varying by nature. For legality it is a
+/// per-FORMAT question, and the answer is usually no: `divergent_formats` names the formats whose
+/// printings ever disagree (one, `oldschool`, in the production corpus), and a legality plane outside that
+/// mask is card-invariant. A card-level bit for it implies every printing of the card, exactly like
+/// colors or types, so the #667 carveout does not apply and the per-printing re-verification it forces is
+/// work that cannot change an answer.
+///
+/// `u64::MAX` — every format divergent — is the conservative value and reproduces the behaviour that
+/// predates the mask, which is what a store built before it (or a fixture that does not care) supplies.
+fn needs_printing_verification(p: usize, divergent_formats: u64) -> bool {
+    match existential_leaf(p) {
+        Some(ExistentialLeaf::Legality { shift, .. }) => divergent_formats >> shift & 0b11 != 0,
+        Some(_) => true,
+        None => false,
+    }
+}
+
 /// Plane index `p`'s existential family and fact, or `None` for a
 /// card-invariant plane. Walks `PLANE_BLOCKS` once; which block `p` falls in
 /// (if any) says both which field it belongs to and, via the in-block
@@ -1106,20 +1165,20 @@ fn existential_leaf(p: usize) -> Option<ExistentialLeaf> {
 /// one. A literal duplicate leaf (`format:A AND format:A`) reads the same
 /// plane index and collapses to one entry, fine to compose -- the same
 /// underlying fact checked twice, not two facts needing a shared witness.
-fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
+fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>, divergent_formats: u64) {
     match expr {
         PlaneExpr::Plane(p) => {
-            if existential_leaf(*p as usize).is_some() && !out.contains(p) {
+            if needs_printing_verification(*p as usize, divergent_formats) && !out.contains(p) {
                 out.push(*p);
             }
         }
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => {}
         PlaneExpr::And(cs) | PlaneExpr::Or(cs) => {
             for c in cs {
-                collect_existential_indices(c, out);
+                collect_existential_indices(c, out, divergent_formats);
             }
         }
-        PlaneExpr::Not(inner) => collect_existential_indices(inner, out),
+        PlaneExpr::Not(inner) => collect_existential_indices(inner, out, divergent_formats),
     }
 }
 
@@ -1130,12 +1189,17 @@ fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
 /// (docs/issues/00667-engine-legality-divergent-carveout.md,
 /// docs/issues/00680-engine-existential-plane-generalization.md; Step 2's popcount
 /// path is already `Mode::Card`-only for unrelated reasons, see `run_query`).
-pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
+///
+/// Takes the divergence mask because "existential" is not a property of the plane index alone for
+/// legality: see `needs_printing_verification`. A caller with a `&Archived<BitPlanes>` passes
+/// `planes.divergent_formats`; one with no store in reach passes `u64::MAX` and gets the old,
+/// conservative answer.
+pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr, divergent_formats: u64) -> bool {
     match expr {
-        PlaneExpr::Plane(p) => existential_leaf(*p as usize).is_some(),
+        PlaneExpr::Plane(p) => needs_printing_verification(*p as usize, divergent_formats),
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => false,
-        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(plane_expr_is_existential),
-        PlaneExpr::Not(inner) => plane_expr_is_existential(inner),
+        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(|c| plane_expr_is_existential(c, divergent_formats)),
+        PlaneExpr::Not(inner) => plane_expr_is_existential(inner, divergent_formats),
     }
 }
 
@@ -1157,10 +1221,10 @@ pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
 /// shape nobody realistically writes --
 /// docs/issues/reference-engine-printing-varying-plane-repair-pattern.md has the joint
 /// per-printing evaluation this would need if it ever mattered enough to build.
-fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneExpr> {
+fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>, divergent_formats: u64) -> Option<PlaneExpr> {
     let mut formats = Vec::new();
     for c in &children {
-        collect_existential_indices(c, &mut formats);
+        collect_existential_indices(c, &mut formats, divergent_formats);
     }
     if formats.len() > 1 {
         return None;
@@ -1171,7 +1235,9 @@ fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneEx
 pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::True => Some(PlaneExpr::Const(true)),
-        FilterExpr::And(children) => and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words)?),
+        FilterExpr::And(children) => {
+            and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words)?, u64::MAX)
+        }
         FilterExpr::Or(children) => compile_plane_children(children, bounds, words).map(or_of),
         // De Morgan pushdown so a Not that reaches a Legality leaf lands on
         // `illegal_exists` instead of bit-complementing `legal_exists` (wrong
@@ -1283,7 +1349,7 @@ fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, wo
         FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words).map(or_of),
         // Not(Or(cs)) = And(Not(c) for c in cs) -- THIS does have the
         // shared-witness exposure (see and_of_checked_for_shared_witness).
-        FilterExpr::Or(children) => and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words)?),
+        FilterExpr::Or(children) => and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words)?, u64::MAX),
         FilterExpr::Not(inner) => compile_plane(inner, bounds, words), // double negation
         FilterExpr::True => Some(PlaneExpr::Const(false)),
         // Everything else: only Legality has a divergent-card correctness
@@ -1341,7 +1407,13 @@ pub(crate) fn split_planes(
         return (None, filter);
     }
     if let Some(pe) = compile_plane(&filter, bounds, words)
-        && (unique_is_card || !plane_expr_is_existential(&pe))
+        // `u64::MAX`, deliberately: using the divergence mask here would let a card-invariant legality
+        // leaf be consumed into a whole-filter plane, which makes the residual `True` -- and a `True`
+        // residual takes `PrintingCompose` out of the running entirely. Compose is the best plan for
+        // several of these queries by a wide margin (`f:commander`/printing measured 1.83 us against
+        // StreamedSelect's 99.38), so trading it away to skip per-printing verification is a large net
+        // loss. The mask is used below the applicability decisions, not inside them.
+        && (unique_is_card || !plane_expr_is_existential(&pe, u64::MAX))
     {
         return (Some(pe), FilterExpr::True);
     }
@@ -1364,7 +1436,7 @@ pub(crate) fn split_planes(
                 match compile_plane(&c, bounds, words) {
                     Some(pe) => {
                         let mut fmts = Vec::new();
-                        collect_existential_indices(&pe, &mut fmts);
+                        collect_existential_indices(&pe, &mut fmts, u64::MAX);
                         if fmts.is_empty() {
                             planes.push(pe);
                         } else {
@@ -1376,7 +1448,7 @@ pub(crate) fn split_planes(
             }
             let mut all_formats = Vec::new();
             for (_, pe) in &legality_children {
-                collect_existential_indices(pe, &mut all_formats);
+                collect_existential_indices(pe, &mut all_formats, u64::MAX);
             }
             if unique_is_card && all_formats.len() <= 1 {
                 for (_, pe) in legality_children {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1407,13 +1407,13 @@ pub(crate) fn split_planes(
         return (None, filter);
     }
     if let Some(pe) = compile_plane(&filter, bounds, words)
-        // `u64::MAX`, deliberately: using the divergence mask here would let a card-invariant legality
-        // leaf be consumed into a whole-filter plane, which makes the residual `True` -- and a `True`
-        // residual takes `PrintingCompose` out of the running entirely. Compose is the best plan for
-        // several of these queries by a wide margin (`f:commander`/printing measured 1.83 us against
-        // StreamedSelect's 99.38), so trading it away to skip per-printing verification is a large net
-        // loss. The mask is used below the applicability decisions, not inside them.
-        && (unique_is_card || !plane_expr_is_existential(&pe, u64::MAX))
+        // The store's real mask, which it could not be while consumption eliminated `PrintingCompose`:
+        // a card-invariant legality leaf consumes the whole filter, the residual becomes `True`, and
+        // compose used to fail its `plane.is_none()` guard and vanish from the argmin -- measured 1.83 us
+        // for compose against StreamedSelect's 99.38 on `f:commander`/printing. `bind_and_split_filter`
+        // now retains the unsplit filter, so compose is still costed on the whole predicate and simply
+        // wins where it is better.
+        && (unique_is_card || !plane_expr_is_existential(&pe, u64::from(bounds.divergent_formats)))
     {
         return (Some(pe), FilterExpr::True);
     }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -301,8 +301,6 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
-    // Before the literal moves `printings`/`offsets` into it.
-    let divergent_formats = divergent_formats_of(&printings, &offsets);
     CardData {
         cards,
         printings,
@@ -314,11 +312,6 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        // Computed by the same function `reload` uses, so a fixture cannot accidentally exercise a
-        // shortcut production would not take (or miss one it would). `stub_printing` gives every printing
-        // the same legality word, so a plain fixture store reads 0 here -- no format diverges -- and the
-        // fixtures that DO want divergence build their words explicitly (see `fuzz_store_n`).
-        divergent_formats,
     }
 }
 
@@ -1365,11 +1358,33 @@ fn plane_expr_is_existential_identifies_legality_only() {
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
+    // This fixture's card2 has two printings disagreeing at shifts 0 and 4, and nothing disagrees at
+    // shift 2 -- so it carries both regimes, and the mask says which is which. Asserted rather than
+    // assumed, because every expectation below depends on it.
+    let divergent = u64::from(bounds.divergent_formats);
+    assert_eq!(divergent >> 0 & 0b11, 0b01, "shift 0 diverges: card2 is legal in one printing, not the other");
+    assert_eq!(divergent >> 2 & 0b11, 0b00, "shift 2 is card-invariant across this fixture");
+    assert_ne!(divergent >> 4 & 0b11, 0b00, "shift 4 diverges: banned in one printing, legal in the other");
+
     let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words).unwrap();
-    assert!(super::plane_expr_is_existential(&legality_pe));
+    assert!(super::plane_expr_is_existential(&legality_pe, divergent), "a DIVERGENT format needs per-printing truth");
+
+    // The new half: a legality plane for a format whose printings never disagree is card-invariant, so it
+    // is not existential and the #667 carveout does not apply to it. This is what makes `f:modern` behave
+    // like `t:creature` -- in the production corpus every format but `oldschool` is in this case.
+    let invariant_pe = compile_plane(&FilterExpr::Legality { shift: Some(2), expected: 0b01 }, bounds, words).unwrap();
+    assert!(
+        !super::plane_expr_is_existential(&invariant_pe, divergent),
+        "a format no card diverges in is card-invariant, so its plane needs no per-printing verification",
+    );
+    // ...and the conservative mask still says yes, which is what a pre-mask store supplies.
+    assert!(
+        super::plane_expr_is_existential(&invariant_pe, u64::MAX),
+        "u64::MAX must reproduce the pre-mask behaviour for every format",
+    );
 
     let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words).unwrap();
-    assert!(!super::plane_expr_is_existential(&creature_pe));
+    assert!(!super::plane_expr_is_existential(&creature_pe, divergent));
 
     let mixed = compile_plane(
         &FilterExpr::And(vec![
@@ -1380,7 +1395,7 @@ fn plane_expr_is_existential_identifies_legality_only() {
         words,
     )
     .unwrap();
-    assert!(super::plane_expr_is_existential(&mixed), "one existential leaf must taint the whole And");
+    assert!(super::plane_expr_is_existential(&mixed, divergent), "one existential leaf must taint the whole And");
 }
 
 /// Regression for the mode-aware all_match bug found while building this
@@ -5577,6 +5592,12 @@ fn legality_and_of_two_formats_declines_but_or_compiles() {
     let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
     let b = || FilterExpr::Legality { shift: Some(2), expected: 0b01 };
 
+    // Still unconditional: `compile_plane` deliberately asks this question with `u64::MAX` rather than the
+    // store's divergence mask, because the answer decides whether the filter consumes to a plane -- and a
+    // consumed filter takes `PrintingCompose` out of the running, which measured a 54x loss on
+    // `f:commander`/printing. The mask is used below the applicability decisions, never inside them.
+    // Once compose is applicable to plane-consumed filters, `a AND invariant` becomes composable and this
+    // assertion is the one to revisit.
     assert!(
         compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words).is_none(),
         "two distinct formats ANDed must decline (shared-witness)"
@@ -5862,7 +5883,6 @@ fn bench_checked_vs_unchecked_access() {
         legal_divergent: build_divergent_ids(&cards),
         arith_tuple:    build_arith_tuple_index(&cards),
     };
-    let divergent_formats = divergent_formats_of(&printings, &offsets);
     let data = CardData {
         cards,
         printings,
@@ -5874,7 +5894,6 @@ fn bench_checked_vs_unchecked_access() {
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        divergent_formats,
     };
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -312,6 +312,9 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
+        // Every format divergent: the conservative value, so a fixture exercises the existential
+        // carveout rather than the card-invariant shortcut unless it opts in.
+        divergent_formats: u64::MAX,
     }
 }
 
@@ -5822,6 +5825,8 @@ fn bench_checked_vs_unchecked_access() {
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
+        // Conservative, as in `store_of`: every format treated as divergent.
+        divergent_formats: u64::MAX,
     };
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6388,9 +6388,9 @@ fn streamed_selection_matches_gathered() {
 
 /// The emission walk must cover the MATCH SPAN only, not the whole permutation — the
 /// `year>=2020 order=released asc` shape, built here as a corpus whose sort order and match set are
-/// deliberately anti-correlated: 4,500 non-matching cards sort ahead of the 1,500 that match.
+/// deliberately anti-correlated: 8,500 non-matching cards sort ahead of the 1,500 that match.
 ///
-/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 4,500-entry
+/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 8,500-entry
 /// prefix before its first emit; descending at a deep offset it used to run to the END of the
 /// permutation, because the only thing that stopped it was the page filling and a partial last page
 /// never fills.
@@ -6404,13 +6404,18 @@ fn streamed_selection_matches_gathered() {
 ///   no-op; the anti-correlation here is what makes it load-bearing.
 /// - **`perm_steps`**, which is how far the walk actually stepped. The row assertions pass just as well
 ///   on a walk that steps everything: unbounded, the ascending cells cost `offset + limit + PREFIX`
-///   steps and the deep descending ones the full 6,000.
+///   steps and the deep descending ones the full 10,000.
 #[test]
 fn streamed_walk_seeks_past_the_unmatched_prefix() {
     // > STREAM_MIN_MATCHES (1,024) in every mode, so the walk branch runs rather than the
-    // small-total gather -- the seek only exists on the walk.
+    // small-total gather -- the span bound only exists on the walk.
     const MATCHING: usize = 1_500;
-    const PREFIX: usize = 4_500; // cards sorting ahead of every match under `cmc asc`
+    // Cards sorting ahead of every match under `cmc asc`. Sized so matching cards are 15% of the
+    // corpus, comfortably under `SPAN_TRACK_CANDIDATE_DIVISOR`'s quarter -- at exactly a quarter this
+    // test would pass or fail on whether the narrowing returned 1,500 candidates or 6,000.
+    // `streamed_selection_matches_gathered` covers the other side of that gate: 1,125 matches among
+    // 1,500 cards is three quarters of the corpus, so its walk is the unbounded one.
+    const PREFIX: usize = 8_500;
     const N: usize = PREFIX + MATCHING;
     const MATCH_CMC: u8 = 5;
     const LIMIT: usize = 10;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4601,6 +4601,7 @@ fn plan_cost_model_matches_gold() {
                     // No compose acquire in this fixture, so P3's estimate is the shared one.
                     stream_scan_units: su,
                     residual_tier_ns100,
+                    residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32,
                     offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -4844,6 +4845,7 @@ fn plan_cost_refit() {
                     scan_units: su,
                     stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
+                    residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
@@ -5049,6 +5051,7 @@ fn printing_range_route_probe() {
                 scan_units: su,
                 stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                 residual_tier_ns100,
+                residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
@@ -5412,6 +5415,7 @@ fn plan_regret_report() {
                 scan_units: est.min(n_cards), // card-mode regret report ⇒ scan_units == eval_domain
                 stream_scan_units: est.min(n_cards),
                 residual_tier_ns100: tier,
+                residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32,
                 offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -5543,6 +5547,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 stream_scan_units: evd,
                 residual_tier_ns100: tier,
+                residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6386,6 +6386,105 @@ fn streamed_selection_matches_gathered() {
     }
 }
 
+/// The emission walk must cover the MATCH SPAN only, not the whole permutation — the
+/// `year>=2020 order=released asc` shape, built here as a corpus whose sort order and match set are
+/// deliberately anti-correlated: 4,500 non-matching cards sort ahead of the 1,500 that match.
+///
+/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 4,500-entry
+/// prefix before its first emit; descending at a deep offset it used to run to the END of the
+/// permutation, because the only thing that stopped it was the page filling and a partial last page
+/// never fills.
+///
+/// Two assertions, and neither substitutes for the other:
+///
+/// - **Row identity against `GatheredScan`** at several page offsets. The span moves where the paging
+///   walk starts and stops, so an end one entry off drops a row silently — a wrong page, not a crash,
+///   and only a reference comparison catches it. `streamed_selection_matches_gathered` pages the same
+///   way but on an evenly-spread match set, where the span is the whole corpus and bounding it is a
+///   no-op; the anti-correlation here is what makes it load-bearing.
+/// - **`perm_steps`**, which is how far the walk actually stepped. The row assertions pass just as well
+///   on a walk that steps everything: unbounded, the ascending cells cost `offset + limit + PREFIX`
+///   steps and the deep descending ones the full 6,000.
+#[test]
+fn streamed_walk_seeks_past_the_unmatched_prefix() {
+    // > STREAM_MIN_MATCHES (1,024) in every mode, so the walk branch runs rather than the
+    // small-total gather -- the seek only exists on the walk.
+    const MATCHING: usize = 1_500;
+    const PREFIX: usize = 4_500; // cards sorting ahead of every match under `cmc asc`
+    const N: usize = PREFIX + MATCHING;
+    const MATCH_CMC: u8 = 5;
+    const LIMIT: usize = 10;
+    // Two printings per card, so printing and artwork mode have more than one row per matching card
+    // to page through rather than degenerating to card mode.
+    const PRINTINGS_PER_CARD: usize = 2;
+
+    let mut vocab = VocabInterner::new();
+    let mut cards = Vec::with_capacity(N);
+    for i in 0..N {
+        let mut c = stub_card((i + 1) as u128, TYPE_CREATURE, &[], &mut vocab);
+        // The anti-correlation: cmc 0 for the prefix, MATCH_CMC for the tail, so the ascending cmc
+        // permutation puts every match last and the descending one puts every match first. One
+        // fixture then covers both "the seek skips almost everything" and "the seek is a no-op".
+        c.cmc = Some(if i < PREFIX { 0 } else { MATCH_CMC });
+        c.edhrec_rank = Some(((i * 37) % N) as u32 + 1); // distinct, shuffled: no full-key tie blocks
+        cards.push(c);
+    }
+    let data = store_of(cards, &vec![PRINTINGS_PER_CARD; N], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ctx = QueryCtx::from(archived);
+
+    let filt = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Cmc),
+        op: CmpOp::Ge,
+        rhs: NumExpr::Const(f64::from(MATCH_CMC)),
+    };
+    let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<(u128, u128)> {
+        page.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
+    };
+
+    let mut checked = 0usize;
+    for &(mode_label, mode) in &[("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)] {
+        for descending in [false, true] {
+            // Offsets across the page-depth range this plan sees, including one deep enough that the
+            // walk runs off the end of the matches (1,499 in card mode leaves a single row).
+            for offset in [0usize, 7, 750, 1_499] {
+                let params = kernel_params(mode, SortCol::Cmc, descending, LIMIT, offset);
+                let (pe, filter) = split_planes(
+                    filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+                );
+                // A pristine clone per plan: `prepare_candidates` rewrites the filter it is handed.
+                let mut streamed_filter = filter.clone();
+                take_phase_stats();
+                let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+                    .expect("store_of builds the cmc permutation, so StreamedSelect is applicable");
+                let stats = take_phase_stats();
+                let mut gathered_filter = filter.clone();
+                let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+                    .expect("GatheredScan is always applicable");
+
+                let case = format!("{mode_label}/{}/offset={offset}", if descending { "desc" } else { "asc" });
+                assert!(streamed.0 > *STREAM_MIN_MATCHES, "cell must reach the walk branch, not the gather: {case}");
+                assert_eq!(streamed.0, gathered.0, "total disagrees with GatheredScan: {case}");
+                assert_eq!(ids(&streamed.1), ids(&gathered.1), "page disagrees with GatheredScan: {case}");
+
+                // The walk consumes `offset` matches and emits at most `limit` more, and every entry
+                // inside the span is a match here (the matching group is contiguous in this fixture),
+                // so one step per match plus the entry the break lands on bounds it. Unbounded, the
+                // ascending cells were PREFIX higher than this and the deep descending ones ran to N.
+                let bound = (offset + LIMIT + 1) as u64;
+                assert!(
+                    stats.perm_steps <= bound,
+                    "walk stepped {} entries, over the {bound}-step bound — the match span did not bound it: {case}",
+                    stats.perm_steps,
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert_eq!(checked, 24, "every mode × direction × offset cell must have run");
+}
+
 // Group counts collapse duplicate illustrations within a card.
 #[test]
 fn artwork_group_counts_dedup_illustrations() {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4592,11 +4592,14 @@ fn plan_cost_model_matches_gold() {
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
                 // Tier reflects the residual AFTER memoize (what the walk pays).
                 let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
                 let feats = PlanFeatures {
                     n_cards, n_printings,
                     matches: total as u32,
                     eval_domain,
-                    scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
+                    scan_units: su,
+                    // No compose acquire in this fixture, so P3's estimate is the shared one.
+                    stream_scan_units: su,
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
@@ -4835,9 +4838,11 @@ fn plan_cost_refit() {
                 );
                 let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(mode_enum), &mut res, pe.as_ref());
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
                 let feats = PlanFeatures {
                     n_cards, n_printings, matches: total as u32, eval_domain,
-                    scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
+                    scan_units: su,
+                    stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -5038,9 +5043,11 @@ fn printing_range_route_probe() {
             let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Printing), &mut res, pe.as_ref());
             let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
             let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+            let su = scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain);
             let feats = PlanFeatures {
                 n_cards, n_printings, matches: total as u32, eval_domain,
-                scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
+                scan_units: su,
+                stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -5403,6 +5410,7 @@ fn plan_regret_report() {
                 matches: est,
                 eval_domain: est.min(n_cards),
                 scan_units: est.min(n_cards), // card-mode regret report ⇒ scan_units == eval_domain
+                stream_scan_units: est.min(n_cards),
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
@@ -5533,6 +5541,7 @@ fn plan_regret_fuzz() {
         for &(limit, offset) in &pages {
             let mk = |matches: u32, evd: u32| PlanFeatures {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
+                stream_scan_units: evd,
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11,7 +11,7 @@ use super::{
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
-    prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, Mode, QueryCtx, QueryParams, Prefer, SortBound,
+    prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, divergent_formats_of, Mode, QueryCtx, QueryParams, Prefer, SortBound,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -301,6 +301,8 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
+    // Before the literal moves `printings`/`offsets` into it.
+    let divergent_formats = divergent_formats_of(&printings, &offsets);
     CardData {
         cards,
         printings,
@@ -312,9 +314,11 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        // Every format divergent: the conservative value, so a fixture exercises the existential
-        // carveout rather than the card-invariant shortcut unless it opts in.
-        divergent_formats: u64::MAX,
+        // Computed by the same function `reload` uses, so a fixture cannot accidentally exercise a
+        // shortcut production would not take (or miss one it would). `stub_printing` gives every printing
+        // the same legality word, so a plain fixture store reads 0 here -- no format diverges -- and the
+        // fixtures that DO want divergence build their words explicitly (see `fuzz_store_n`).
+        divergent_formats,
     }
 }
 
@@ -1623,6 +1627,13 @@ const FUZZ_OPS: [CmpOp; 6] = [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp:
 // banned(0b11); NOT_LEGAL(0b00) is never a query leaf (the parser negates instead).
 const FUZZ_SHIFTS: [u8; 3] = [0, 2, 4];
 const FUZZ_STATUSES: [u64; 3] = [0b01, 0b10, 0b11];
+// Shifts a divergent card is allowed to disagree at. Deliberately NOT all of `FUZZ_SHIFTS`: production
+// has exactly one divergent format (`oldschool`, all 556 of the corpus's divergent cards) and the rest
+// are card-invariant, so a corpus where every format can diverge would only ever exercise the
+// conservative existential path. Queries still draw leaves from all three shifts, so both regimes get
+// hit -- and `FUZZ_SHIFT_INVARIANT` is the one whose per-printing verification is provably redundant.
+const FUZZ_SHIFTS_DIVERGENT: [u8; 2] = [0, 2];
+const FUZZ_SHIFT_INVARIANT: u8 = 4;
 
 fn fuzz_op(rng: &mut rand::rngs::SmallRng) -> CmpOp {
     FUZZ_OPS[rng.random_range(0..FUZZ_OPS.len())]
@@ -2269,26 +2280,29 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
         };
         counts.push(npr);
 
-        let mut words: Vec<u64> = (0..npr).map(|_| rand_word(rng)).collect();
+        // One base word shared by every printing, then divergence introduced at ONE format. Drawing a
+        // fresh `rand_word` per printing (as this did) made every format differ between the printings of
+        // a divergent card, so the whole corpus was divergent in all three and `FUZZ_SHIFT_INVARIANT`
+        // could not exist -- caught by `fuzz_corpus_has_both_divergent_and_invariant_formats`, which read
+        // a mask of 0x3f. Production diverges in exactly one format, so this is also the more faithful
+        // shape.
+        let base = rand_word(rng);
+        let mut words: Vec<u64> = vec![base; npr];
         if divergent {
-            // Force a real disagreement at one format between printings 0 and 1,
-            // so the "divergent flag but printings happen to agree" degenerate
-            // case is not all this branch produces.
-            let ds = FUZZ_SHIFTS[rng.random_range(0..FUZZ_SHIFTS.len())];
+            // Force a real disagreement at one DIVERGENT-ELIGIBLE format between printings 0 and 1, so
+            // the "divergent flag but printings happen to agree" degenerate case is not all this branch
+            // produces, and so the invariant shift stays invariant.
+            let ds = FUZZ_SHIFTS_DIVERGENT[rng.random_range(0..FUZZ_SHIFTS_DIVERGENT.len())];
             let s0 = rng.random_range(0..4u64);
             let s1 = { let c = rng.random_range(0..4u64); if c == s0 { (s0 + 1) & 0b11 } else { c } };
-            words[0] = (words[0] & !(0b11 << ds)) | (s0 << ds);
-            words[1] = (words[1] & !(0b11 << ds)) | (s1 << ds);
+            words[0] = (base & !(0b11 << ds)) | (s0 << ds);
+            words[1] = (base & !(0b11 << ds)) | (s1 << ds);
             // Card-level word is unused for divergent cards (eval reads per-printing).
             card.card_legalities = words[0];
         } else {
             // Non-divergent: every printing shares the card-level word (the
             // real-data invariant the exact card-level plane relies on).
-            let w = words[0];
-            for x in words.iter_mut() {
-                *x = w;
-            }
-            card.card_legalities = w;
+            card.card_legalities = base;
         }
 
         for &word in &words {
@@ -2811,6 +2825,40 @@ fn gather_select_matches_reference() {
             }
         }
     }
+}
+
+/// The fuzz corpus must contain BOTH regimes of legality, or every differential test that touches it
+/// verifies only the conservative one.
+///
+/// Production has exactly one divergent format (`oldschool`: all 556 of the corpus's divergent cards) and
+/// the rest are card-invariant, which is what makes skipping per-printing legality verification safe for
+/// them. A fuzz store where every format could diverge would exercise the carveout and never the
+/// shortcut; one where none could would do the opposite. This pins both, on the mask `reload` itself
+/// computes, so the two cannot drift apart silently.
+#[test]
+fn fuzz_corpus_has_both_divergent_and_invariant_formats() {
+    use rand::SeedableRng;
+    // Enough cards that the ~10% divergent branch fires on every shift it is allowed to use.
+    const CORPUS_CARDS: usize = 4_000;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(828_003);
+    let data = fuzz_store_n(&mut rng, CORPUS_CARDS);
+    let mask = divergent_formats_of(&data.printings, &data.offsets);
+
+    for shift in FUZZ_SHIFTS_DIVERGENT {
+        assert_ne!(
+            mask >> shift & 0b11,
+            0,
+            "shift {shift} is in FUZZ_SHIFTS_DIVERGENT but no card diverged there, so the existential \
+             legality path is unexercised for it (mask {mask:#x})",
+        );
+    }
+    assert_eq!(
+        mask >> FUZZ_SHIFT_INVARIANT & 0b11,
+        0,
+        "shift {FUZZ_SHIFT_INVARIANT} must be card-invariant across every card -- it is the format whose \
+         per-printing verification is provably redundant, and the only reason a test can assert a \
+         shortcut is safe (mask {mask:#x})",
+    );
 }
 
 /// #702 step 2 (force-plan seam): every physical plan that is *applicable* to a
@@ -5814,6 +5862,7 @@ fn bench_checked_vs_unchecked_access() {
         legal_divergent: build_divergent_ids(&cards),
         arith_tuple:    build_arith_tuple_index(&cards),
     };
+    let divergent_formats = divergent_formats_of(&printings, &offsets);
     let data = CardData {
         cards,
         printings,
@@ -5825,8 +5874,7 @@ fn bench_checked_vs_unchecked_access() {
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        // Conservative, as in `store_of`: every format treated as divergent.
-        divergent_formats: u64::MAX,
+        divergent_formats,
     };
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3113,7 +3113,7 @@ fn force_plan_differential_agreement() {
                 let (ref_total, ref_page) = run_query_with_plan(
                     PhysicalPlan::GatheredScan, &QueryCtx::from(archived),
                     &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
-                    &mut ref_res, ref_pe.as_ref(),
+                    &mut ref_res, None, ref_pe.as_ref(),
                 )
                 .expect("GatheredScan is always applicable");
                 ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
@@ -3137,7 +3137,7 @@ fn force_plan_differential_agreement() {
                     let out = run_query_with_plan(
                         plan, &QueryCtx::from(archived),
                         &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
-                        &mut res, pe.as_ref(),
+                        &mut res, None, pe.as_ref(),
                     );
                     let Some((total, page)) = out else { continue };
                     ran[plan_idx(plan)] += 1;
@@ -3283,7 +3283,7 @@ fn explain_reports_ranked_applicable_plans() {
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
             );
             let (facts, estimates): (AcquireFacts, Vec<PlanEstimate>) = explain(
-                &QueryCtx::from(archived), &explain_params(mode, 60), &mut filter, pe.as_ref(),
+                &QueryCtx::from(archived), &explain_params(mode, 60), &mut filter, None, pe.as_ref(),
             );
 
             // The acquire facts every plan in this call shares. `eval_domain` is what a
@@ -3388,13 +3388,13 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
         bound.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
     );
     let (ref_facts, reference): (AcquireFacts, Vec<PlanEstimate>) = explain(
-        &QueryCtx::from(archived), &explain_params(Mode::Card, 60), &mut ref_filter, ref_pe.as_ref(),
+        &QueryCtx::from(archived), &explain_params(Mode::Card, 60), &mut ref_filter, None, ref_pe.as_ref(),
     );
 
     let (pe, filter) = split_planes(bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
     let (facts, trials): (AcquireFacts, Vec<PlanTrial>) = explain_analyze(
         &QueryCtx::from(archived), &QueryParams::from_strs("card", "default", "edhrec", "asc", 60, 0),
-        &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS,
+        &filter, None, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS,
     );
 
     // The acquire facts describe the query, not the round, so they must agree with
@@ -3535,7 +3535,7 @@ fn compose_paging_prediction_matches_the_branch_taken() {
 
                             // The prediction, on its own clone -- acquire mutates the filter it reads.
                             let mut acq_filter = filter.clone();
-                            let (feats, prep, _bits) = acquire_plan_features(&ctx, &params, &mut acq_filter, pe.as_ref());
+                            let (feats, prep, _bits) = acquire_plan_features(&ctx, &params, &mut acq_filter, None, pe.as_ref());
                             if prep.count_source() != CountSource::PrintingCompose {
                                 continue; // not a compose acquire; compose_paging has no referent
                             }
@@ -3545,7 +3545,7 @@ fn compose_paging_prediction_matches_the_branch_taken() {
                             // iteration's label survives in the cell otherwise (see PHASE_STATS).
                             let mut run_filter = filter.clone();
                             take_phase_stats();
-                            let ran = run_query_with_plan(PhysicalPlan::PrintingCompose, &ctx, &params, &mut run_filter, pe.as_ref());
+                            let ran = run_query_with_plan(PhysicalPlan::PrintingCompose, &ctx, &params, &mut run_filter, None, pe.as_ref());
                             let taken = take_phase_stats().paging_taken;
 
                             let case = format!(
@@ -3720,7 +3720,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                 let mut streamed_filter = filter.clone();
                 take_phase_stats();
                 let streamed_ran =
-                    run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref());
+                    run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, None, pe.as_ref());
                 let streamed = take_phase_stats();
                 if streamed_ran.is_none() {
                     continue; // no sort permutation for this orderby; nothing to compare against
@@ -3729,7 +3729,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                 let mut gathered_filter = filter.clone();
                 take_phase_stats();
                 let gathered_ran =
-                    run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref());
+                    run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, None, pe.as_ref());
                 let gathered = take_phase_stats();
                 assert!(gathered_ran.is_some(), "GatheredScan is always applicable");
 
@@ -3905,7 +3905,7 @@ fn plan_stats_never_leak_between_participants() {
                 let (pe, filter) = split_planes(
                     bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
                 );
-                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
+                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, None, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
 
                 for t in &trials {
                     if t.trials_ns.is_empty() {
@@ -4140,7 +4140,7 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
                 let (pe, filter) = split_planes(
                     bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
                 );
-                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
+                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, None, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
 
                 for t in &trials {
                     if t.declined_ns.is_empty() {
@@ -4443,7 +4443,7 @@ fn plan_cost_calibration() {
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
                             *plan, &QueryCtx::from(archived),
-                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out {
@@ -4566,7 +4566,7 @@ fn plan_cost_model_matches_gold() {
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
                             *plan, &QueryCtx::from(archived),
-                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out {
@@ -4821,7 +4821,7 @@ fn plan_cost_refit() {
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
                             *plan, &QueryCtx::from(archived),
-                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { best = best.min(dt); } } None => break }
@@ -5015,7 +5015,7 @@ fn printing_range_route_probe() {
                     let t0 = Instant::now();
                     let out = black_box(run_query_with_plan(
                         *plan, &QueryCtx::from(archived),
-                        &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, pe.as_ref(),
+                        &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, None, pe.as_ref(),
                     ));
                     let dt = t0.elapsed().as_nanos() as u64;
                     match out {
@@ -5241,7 +5241,7 @@ fn idea1_vs_idea2_probe() {
                 let t0 = Instant::now();
                 let out = black_box(run_query_with_plan(
                     PhysicalPlan::PrintingRangeScan, &QueryCtx::from(archived),
-                    &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, pe.as_ref(),
+                    &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, None, pe.as_ref(),
                 ));
                 let dt = t0.elapsed().as_nanos() as u64;
                 match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { i1 = i1.min(dt); } } None => break }
@@ -5373,7 +5373,7 @@ fn plan_regret_report() {
                     let t0 = Instant::now();
                     let out = black_box(run_query_with_plan(
                         *plan, &QueryCtx::from(archived),
-                        &QueryParams::from_strs("card", "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                        &QueryParams::from_strs("card", "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                     ));
                     let dt = t0.elapsed().as_nanos() as u64;
                     match out {
@@ -6596,11 +6596,11 @@ fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
                 // A pristine clone per plan: `prepare_candidates` rewrites the filter it is handed.
                 let mut streamed_filter = filter.clone();
                 take_phase_stats();
-                let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+                let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, None, pe.as_ref())
                     .expect("store_of builds the cmc permutation, so StreamedSelect is applicable");
                 let stats = take_phase_stats();
                 let mut gathered_filter = filter.clone();
-                let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+                let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, None, pe.as_ref())
                     .expect("GatheredScan is always applicable");
 
                 let case = format!("{mode_label}/{}/offset={offset}", if descending { "desc" } else { "asc" });
@@ -6633,11 +6633,11 @@ fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
             split_planes(filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
         let mut streamed_filter = filter.clone();
         take_phase_stats();
-        let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+        let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, None, pe.as_ref())
             .expect("store_of builds the edhrec permutation too");
         let stats = take_phase_stats();
         let mut gathered_filter = filter.clone();
-        let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+        let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, None, pe.as_ref())
             .expect("GatheredScan is always applicable");
         assert_eq!(streamed.0, gathered.0, "unbounded total disagrees with GatheredScan: offset={offset}");
         assert_eq!(ids(&streamed.1), ids(&gathered.1), "unbounded page disagrees with GatheredScan: offset={offset}");

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11,7 +11,7 @@ use super::{
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
-    prepare_candidates, verify_cost_tier, scan_units, Mode, QueryCtx, QueryParams, Prefer,
+    prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, Mode, QueryCtx, QueryParams, Prefer, SortBound,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -32,7 +32,15 @@ use rand::RngExt;
 /// (`cost::PlanFeatures` has no such field), and `SortCol::EdhrecRank`/ascending
 /// is the default orderby these tests were written against.
 fn explain_params(mode: Mode, limit: usize) -> QueryParams {
-    QueryParams { mode, prefer: Prefer::Default, sort_col: SortCol::EdhrecRank, descending: false, limit, page_offset: 0 }
+    QueryParams {
+        mode,
+        prefer: Prefer::Default,
+        sort_col: SortCol::EdhrecRank,
+        descending: false,
+        limit,
+        page_offset: 0,
+        sort_bound: SortBound::UNBOUNDED,
+    }
 }
 
 /// `QueryParams` from the enum-space inputs a kernel-level test drives directly
@@ -40,7 +48,7 @@ fn explain_params(mode: Mode, limit: usize) -> QueryParams {
 /// `prefer` is `Default` — the value every one of these call sites passed
 /// explicitly before the bundle.
 fn kernel_params(mode: Mode, sort_col: SortCol, descending: bool, limit: usize, page_offset: usize) -> QueryParams {
-    QueryParams { mode, prefer: Prefer::Default, sort_col, descending, limit, page_offset }
+    QueryParams { mode, prefer: Prefer::Default, sort_col, descending, limit, page_offset, sort_bound: SortBound::UNBOUNDED }
 }
 
 /// `QueryParams` for a test calling a function that reads only `mode` —
@@ -2861,6 +2869,27 @@ fn force_plan_differential_agreement() {
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "edhrec", "asc"),
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 2.0 }), "edhrec", "desc"),
         (FuzzSpec::And(vec![FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), fuzz_leaf_color(&mut rng)]), "edhrec", "asc"),
+        // A numeric bound on the SORT column itself, which is what `walk_bounds` narrows a streamed
+        // walk with. Hand-built in BOTH directions, and in compound as well as bare form: the random
+        // generator draws its predicate and its orderby independently, so it produced descending
+        // bounded cases and no ascending ones (caught by the per-direction coverage assertion at the
+        // end). The compound case checks that an `And` sibling neither widens nor blocks the bound, and
+        // the `Or` case that a disjunction correctly yields no bound at all — a bound taken from one
+        // arm of an `Or` would cut off rows the other arm matches, and only a row-order comparison
+        // against the reference catches that.
+        (FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Ge, val: 4.0 }), "cmc", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Le, val: 3.0 }), "cmc", "desc"),
+        (FuzzSpec::And(vec![FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Ge, val: 3.0 }), fuzz_leaf_type(&mut rng)]), "cmc", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Power { op: CmpOp::Ge, val: 3.0 }), "power", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Toughness { op: CmpOp::Eq, val: 2.0 }), "toughness", "asc"),
+        (
+            FuzzSpec::Or(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Ge, val: 6.0 }),
+                fuzz_leaf_color(&mut rng),
+            ]),
+            "cmc",
+            "asc",
+        ),
         // PR 3: cn/date bare ranges also route through CardRangePopcount in card mode (the Date cases
         // above already exercise it; add collector_number + year over card-level perms too).
         (FuzzSpec::Leaf(FuzzLeaf::CollectorNumber { op: CmpOp::Lt, val: 100.0 }), "edhrec", "asc"),
@@ -2959,6 +2988,11 @@ fn force_plan_differential_agreement() {
         PhysicalPlan::GatheredScan => 5,
     };
     let mut ran = [0u32; 6];
+    // Coverage for the sort-column bound below: a corpus that never produced one would verify nothing
+    // about `walk_bounds`, and the assertion at the end of this test would pass vacuously. Counted per
+    // DIRECTION because `walk_bounds` negates the key under `desc`, so the two directions map an
+    // interval onto opposite ends of the permutation and a sign error would only show in one of them.
+    let mut bounded_cases = [0usize; 2];
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
@@ -2989,6 +3023,14 @@ fn force_plan_differential_agreement() {
     for (spec, orderby, direction) in &cases {
         let sort_col = orderby_to_col(orderby);
         let descending = *direction == "desc";
+        // Extracted from the unsplit filter, as `bind_and_split_filter` does in production, and passed
+        // to every plan. This is what holds `walk_bounds` to the reference across the whole fuzz corpus:
+        // numeric leaves on cmc/power/toughness appear under And, Or and Not here, so an extractor that
+        // read a bound out of a disjunction or inverted one out of a negation would return a short page
+        // for some case and fail the row-order assertion below. Applied to ALL plans, not just P3, since
+        // a bound that changed any plan's answer is equally wrong.
+        let sort_bound = sort_col_bound(&fuzz_bound_filter(spec, archived), sort_col);
+        bounded_cases[usize::from(descending)] += usize::from(!sort_bound.is_unbounded());
         // (key1, key2) = the top 64 bits of sort_key_bits; drop the low 32 (key 3).
         let key2_seq = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
             page.iter().map(|&(c, p)| sort_key_bits(c, p, sort_col, descending) >> 32).collect()
@@ -3004,7 +3046,8 @@ fn force_plan_differential_agreement() {
                 );
                 let (ref_total, ref_page) = run_query_with_plan(
                     PhysicalPlan::GatheredScan, &QueryCtx::from(archived),
-                    &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0), &mut ref_res, ref_pe.as_ref(),
+                    &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
+                    &mut ref_res, ref_pe.as_ref(),
                 )
                 .expect("GatheredScan is always applicable");
                 ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
@@ -3027,7 +3070,8 @@ fn force_plan_differential_agreement() {
                     );
                     let out = run_query_with_plan(
                         plan, &QueryCtx::from(archived),
-                        &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0), &mut res, pe.as_ref(),
+                        &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
+                        &mut res, pe.as_ref(),
                     );
                     let Some((total, page)) = out else { continue };
                     ran[plan_idx(plan)] += 1;
@@ -3069,6 +3113,14 @@ fn force_plan_differential_agreement() {
         assert!(
             ran[plan_idx(plan)] > 0,
             "plan {plan:?} was never exercised by the differential corpus — add coverage",
+        );
+    }
+    for (dir, count) in [("asc", bounded_cases[0]), ("desc", bounded_cases[1])] {
+        assert!(
+            count > 0,
+            "no {dir} case constrained its own sort column, so `walk_bounds` never narrowed a walk in that \
+             direction — the row assertions above did not verify it. Add a numeric leaf on \
+             cmc/power/toughness under a matching orderby.",
         );
     }
 }
@@ -6386,35 +6438,34 @@ fn streamed_selection_matches_gathered() {
     }
 }
 
-/// The emission walk must cover the MATCH SPAN only, not the whole permutation — the
-/// `year>=2020 order=released asc` shape, built here as a corpus whose sort order and match set are
-/// deliberately anti-correlated: 8,500 non-matching cards sort ahead of the 1,500 that match.
+/// The emission walk must cover only the segment of the permutation its filter's bound on the sort
+/// column admits — the `cmc>=6 order=cmc asc` shape, built here as a corpus whose sort order and match
+/// set are deliberately anti-correlated: 8,500 non-matching cards sort ahead of the 1,500 that match.
 ///
-/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 8,500-entry
-/// prefix before its first emit; descending at a deep offset it used to run to the END of the
-/// permutation, because the only thing that stopped it was the page filling and a partial last page
-/// never fills.
+/// Both ends matter, and one direction exercises each. Ascending, the walk would step the 8,500-entry
+/// prefix before its first emit; descending at a deep offset it would run to the END of the permutation,
+/// because the only thing that stops it is the page filling and a partial last page never fills. The
+/// bound is one interval either way: `walk_bounds` swaps which side of it starts the segment, since the
+/// permutation's key negates under `desc`.
 ///
-/// Two assertions, and neither substitutes for the other:
+/// Three assertions, and none substitutes for another:
 ///
-/// - **Row identity against `GatheredScan`** at several page offsets. The span moves where the paging
-///   walk starts and stops, so an end one entry off drops a row silently — a wrong page, not a crash,
-///   and only a reference comparison catches it. `streamed_selection_matches_gathered` pages the same
-///   way but on an evenly-spread match set, where the span is the whole corpus and bounding it is a
-///   no-op; the anti-correlation here is what makes it load-bearing.
+/// - **Row identity against `GatheredScan`** at several page offsets. The segment decides where the
+///   paging walk starts and stops, so an end one entry off drops a row silently — a wrong page, not a
+///   crash, and only a reference comparison catches it.
 /// - **`perm_steps`**, which is how far the walk actually stepped. The row assertions pass just as well
 ///   on a walk that steps everything: unbounded, the ascending cells cost `offset + limit + PREFIX`
 ///   steps and the deep descending ones the full 10,000.
+/// - **The unbounded control.** The same query ordered by a column the filter says nothing about
+///   (`edhrec`) must return identical rows while stepping the whole permutation — that is the fallback
+///   every query without a bound on its sort column takes, and it has to stay correct.
 #[test]
-fn streamed_walk_seeks_past_the_unmatched_prefix() {
+fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
     // > STREAM_MIN_MATCHES (1,024) in every mode, so the walk branch runs rather than the
     // small-total gather -- the span bound only exists on the walk.
     const MATCHING: usize = 1_500;
-    // Cards sorting ahead of every match under `cmc asc`. Sized so matching cards are 15% of the
-    // corpus, comfortably under `SPAN_TRACK_CANDIDATE_DIVISOR`'s quarter -- at exactly a quarter this
-    // test would pass or fail on whether the narrowing returned 1,500 candidates or 6,000.
-    // `streamed_selection_matches_gathered` covers the other side of that gate: 1,125 matches among
-    // 1,500 cards is three quarters of the corpus, so its walk is the unbounded one.
+    // Cards sorting ahead of every match under `cmc asc`, so the prefix the bound skips is 85% of the
+    // corpus and a walk that ignored the bound would be caught by an order of magnitude.
     const PREFIX: usize = 8_500;
     const N: usize = PREFIX + MATCHING;
     const MATCH_CMC: u8 = 5;
@@ -6448,13 +6499,25 @@ fn streamed_walk_seeks_past_the_unmatched_prefix() {
         page.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
     };
 
+    // Extracted from the UNSPLIT filter, exactly as `bind_and_split_filter` does: `cmc>=MATCH_CMC`
+    // plane-consumes to `FilterExpr::True`, so a bound read after the split would find nothing.
+    let cmc_bound = sort_col_bound(&filt(), SortCol::Cmc);
+    assert_eq!(
+        cmc_bound,
+        SortBound { lo: Some(f64::from(MATCH_CMC)), hi: None },
+        "a bare `cmc >= k` must bound the cmc column below and leave it unbounded above",
+    );
+    // The control: the same filter says nothing about `edhrec`, so ordering by it must fall back to
+    // walking everything.
+    assert_eq!(sort_col_bound(&filt(), SortCol::EdhrecRank), SortBound::UNBOUNDED, "cmc says nothing about edhrec");
+
     let mut checked = 0usize;
     for &(mode_label, mode) in &[("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)] {
         for descending in [false, true] {
             // Offsets across the page-depth range this plan sees, including one deep enough that the
             // walk runs off the end of the matches (1,499 in card mode leaves a single row).
             for offset in [0usize, 7, 750, 1_499] {
-                let params = kernel_params(mode, SortCol::Cmc, descending, LIMIT, offset);
+                let params = kernel_params(mode, SortCol::Cmc, descending, LIMIT, offset).with_sort_bound(cmc_bound);
                 let (pe, filter) = split_planes(
                     filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
                 );
@@ -6488,6 +6551,32 @@ fn streamed_walk_seeks_past_the_unmatched_prefix() {
         }
     }
     assert_eq!(checked, 24, "every mode × direction × offset cell must have run");
+
+    // The unbounded control: same filter, ordered by a column it constrains not at all. Rows must still
+    // agree with the reference, and the walk must step far more than the bounded cells did -- otherwise
+    // this test would pass with `walk_bounds` returning an empty slice for everything.
+    for offset in [0usize, 750] {
+        let params = kernel_params(Mode::Card, SortCol::EdhrecRank, false, LIMIT, offset);
+        let (pe, filter) =
+            split_planes(filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+        let mut streamed_filter = filter.clone();
+        take_phase_stats();
+        let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+            .expect("store_of builds the edhrec permutation too");
+        let stats = take_phase_stats();
+        let mut gathered_filter = filter.clone();
+        let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+            .expect("GatheredScan is always applicable");
+        assert_eq!(streamed.0, gathered.0, "unbounded total disagrees with GatheredScan: offset={offset}");
+        assert_eq!(ids(&streamed.1), ids(&gathered.1), "unbounded page disagrees with GatheredScan: offset={offset}");
+        // Matches are 15% of the corpus and scattered through edhrec order, so filling a 10-row page
+        // takes ~`limit / 0.15` steps at minimum -- far above the bounded cells' `offset + LIMIT + 1`.
+        assert!(
+            stats.perm_steps > (offset + LIMIT + 1) as u64,
+            "an unbounded walk must step more than a bounded one ({} steps at offset={offset})",
+            stats.perm_steps,
+        );
+    }
 }
 
 // Group counts collapse duplicate illustrations within a card.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -286,11 +286,34 @@ alone is 525 µs of P3's 704 µs prediction against a 91 µs measured loop.
 | f:modern / artwork | GatheredScan | 101,716 | 73,783 | 1.38 |
 | f:modern / artwork | StreamedSelect | 101,716 | **7,770** | **13.09** |
 
-Both plans receive the same per-query `scan_units`, but P3 examines 9× fewer printings: `card_match_count`
-returns at the first qualifying printing under `Prefer::Default`, while `push_card_matches` must walk the
-whole span to push every match. This module's header already says `prefer` "is the one thing this cannot
-see", and that `acquire_plan_features` therefore sets `scan_units` itself on the **plane** branch instead
-of taking the span estimate. The **compose** branch was never given the same treatment.
+Both plans receive the same per-query `scan_units`, but P3 examines 9× fewer printings. The reason is NOT
+the first-match break that the plane branch corrects for — sweeping ten composable filters shows the
+defect is confined to **legality**:
+
+| composed filter | P3 examined / P4 examined |
+| --- | --: |
+| `f:modern`, `f:commander`, `f:vintage`, `legal:pauper`, `f:standard`, `t:goblin or f:legacy` | **0.10 – 0.26** |
+| `border:black` | 1.00 |
+| `r:mythic` | 1.00 |
+| `watermark:riveteers` | 1.00 |
+
+For every other printing-varying leaf the two plans examine *identically* and `scan_units` is right to
+within 1.1–2.4×. Legality differs because `card_pass` resolves it at CARD level for every non-divergent
+card: `Tri::True` or `Tri::False` comes back without a printing being read, so `card_match_count` answers
+from span arithmetic and P3's per-printing cost exists only for the divergent subset. P4 has no such
+escape — `push_card_matches` must walk the span to push every match.
+
+The implied estimate is exact rather than fitted, because the engine already holds the set:
+`indexes.legal_divergent` is the divergent card list, so P3's scan on a legality-composed filter is
+`eval_domain × (divergent / n_cards) × printings_per_card`. Back-solving the measurements gives a divergent
+share of 16–22% (`f:modern` 7,770 examined ⇒ 2,514 of 15,700 candidates; `f:commander` 21.7%;
+`legal:pauper` 19.9%; `f:standard` 22.4%), which is one corpus constant and not a per-query guess.
+
+So this is NOT the plane branch's correction extended — that one is `prefer`-aware, this one has to be
+divergence-aware, and they share only the conclusion that one per-query `scan_units` cannot serve two
+plans whose kernels short-circuit differently. Implementing it needs a per-plan field on `PlanFeatures`
+(the pattern `compose_scan_printings` already establishes), set on the compose branch and read by P3's arm
+alone, plus the matching mirror column in `fit_cost_model.py`.
 
 So the fix is a feature correction on the compose acquire, not a rate — the category the toolkit says is
 the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 below: the 6× over-cost exists

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -705,20 +705,60 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
 
 1b. **Review the compose acquire's feature estimation — the foundational work, ahead of any rate work.** The
    oracle run above bounds this at 58% → 83% ordered right and a 9× cut in lost time on the pair, with rates
-   untouched. Three targets, in order:
+   untouched. Two questions of that bound are now answered by measurement.
 
-   - **Decompose the oracle gain into "better shared estimate" vs "per-plan feature".** The oracle used each
-     plan's own counters; `scan_units` is one shared number today and the two plans examine different amounts.
-     `stream_scan_units` already splits it for P3, but only on legality filters. This decides the shape of
-     everything below, so it comes first.
-   - **`eval_domain` on the failing population.** p50 **0.85** in the wrong group against 0.98 in the right
-     one, and P4's per-card rate is 2.2× P3's, so the residue discounts P4 asymmetrically. The broad class is
-     mostly range predicates, and `range_card_counts_for` already answers *exactly* — but `bare_range_bounds`
-     matches one comparison, so `cn<=226 year>2004` (an `And` of two) falls back to the estimator. Widening
-     that exact path is likely worth more than any estimator refinement.
-   - **`scan_units` on selective compose queries.** mean |log| **1.22**, p10 0.08, p90 3.62 — a ~45× spread
-     that none of the three bias variants improves (see the span-bias note). Not previously on any list, and
-     the worst-calibrated feature in the acquire.
+   **Which feature carries it — leave-one-out from the full oracle, shipped rates throughout, 2,768 pairs:**
+
+   | variant | ordered right | lost time |
+   | --- | --: | --: |
+   | shipped | 59% | 116.7 ms |
+   | full oracle (per-plan) | **83%** | **12.4 ms** |
+   | oracle, `eval_domain` back to its estimate | 68% | **91.2 ms** |
+   | oracle, `scan` back | 79% | 22.4 ms |
+   | oracle, `matches` back | 83% | 13.2 ms |
+   | oracle, `scan` forced **SHARED** (both read P4's) | 83% | 12.4 ms |
+   | oracle, `eval_domain` forced **SHARED** | 83% | 12.4 ms |
+
+   **`eval_domain` is ~75% of the recoverable loss** (78 of the 104 ms), `scan` ~10%, `matches` nothing.
+
+   **And per-plan features are worth exactly zero.** Forcing either feature to be shared, while keeping it
+   exact, costs nothing at all. So the answer is **not** to split features per plan — it is to make the one
+   shared number accurate. That is visible in the mechanism: on the broad-residual class both plans examine
+   the same 97,206 printings, and on the card-invariant class the verify-tier gate already zeroes P3's scan
+   term. **A corollary worth checking: `stream_scan_units` may now be redundant with that gate**, since the
+   divergence it was built for is the population the gate already handles.
+
+   **Where `eval_domain`'s error lives** (ratio against P4's realized `cards_visited`):
+
+   | path | n | p50 | mean \|log\| |
+   | --- | --: | --: | --: |
+   | EXACT (`range_card_counts_for`) | 574 | 0.92 | **0.236** |
+   | estimated (`calibrated_balls_into_bins`) | 3,154 | 0.90 | 0.382 |
+
+   | query shape | n | % estimated | p50 | mean \|log\| |
+   | --- | --: | --: | --: | --: |
+   | 1 leaf, range | 1,064 | 46% | 0.91 | **0.226** |
+   | 1 leaf, other | 1,384 | 100% | 1.15 | 0.317 |
+   | **2+ leaves, ALL range** | **745** | **100%** | **0.62** | **0.507** |
+   | 2+ leaves, mixed | 322 | 100% | 1.19 | 0.553 |
+   | 3+ leaves, ALL range | 108 | 100% | 0.70 | 0.541 |
+
+   The exact path is much better calibrated, and multi-leaf all-range (853 rows, 23% of the population) is
+   100% estimated at p50 0.62. That is the `cn<=226 year>2004` shape and the obvious target — but two things
+   must be settled before "widen `bare_range_bounds`" is the plan:
+
+   - **The exact path is not exact against the counter** (p50 0.92, p10 0.50), so it is not a 1.00 ceiling.
+   - **The two quantities may not be the same thing.** `eval_domain` estimates *matching* cards, while
+     `cards_visited` counts *candidates visited* — 24,592 against 31,508 (the whole corpus) on
+     `border:black`. Candidates ⊇ matches whenever the narrowing is inexact, which would explain systematic
+     under-counting far better than miscalibration does, and would mean the fix is to estimate the
+     **narrowed candidate count** rather than to calibrate a match count. Test this first; it decides whether
+     any of the above is the right work.
+   - Combining two exact range counts is also not free: the boundary table answers each range independently,
+     and an `And`'s distinct-card count is not derivable from the two without composing.
+
+   **`scan_units` on selective compose queries** stays on the list at mean |log| **1.22**, p10 0.08, p90 3.62
+   — a ~45× spread no bias variant improves — but is now known to be second-order for this pair (~10%).
 
 1c. **Build the pair-level loop harness, once the features stop moving.** `bench_streamed_loop` and `bench_gather_loop` now
    share `bench_loop_design`, so their cells match and can be read side by side — but neither computes the

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1237,3 +1237,64 @@ note here claimed the counter was missing and that a grouping walk was uncounted
 Artwork's per-card surcharge was the last of it. The executor gate was removed (up to 24×), P3's surcharge is
 gated on the same signal, and P4 was measured and needs nothing. What remains in artwork mode is a level
 question inside 0.86–1.25 on both arms, which is not worth a refit against a warm-cache design.
+
+## Compose was `Eq`-only on rarity, and that cost 167×
+
+Chasing `r>=rare`/artwork (100.1 µs regret, six appearances in the top 100) found something bigger than the
+routing error. Its full dump:
+
+    r>=rare  artwork  limit=175      acquire=candidates
+      GatheredScan     pred 484.4   meas 485.9   p/m 1.00   loop 482.2   ← picked
+      StreamedSelect   pred 518.5   meas 381.6   p/m 1.36   loop 376.1
+      eval_domain 12,887 = cards_visited     scan_units 58,656 = printings_examined (BOTH plans)
+
+**The features are exact and both arms are individually respectable**, yet the order inverts: the model
+charges P3 2.9× more per printing (5.97 vs 2.06) and P4 2.9× more per card, on the *same* 58,656 printings,
+and the two errors nearly cancel into a 34 µs predicted gap the wrong way against a 100 µs real one. That is
+the `SCAN_PER_ROW` ratio a pooled fit endorses, in its cleanest form.
+
+**But routing was the small half.** Splitting the phases shows what the query actually spends:
+
+| limit | loop (count) | finish (emit) | perm_steps |
+| --: | --: | --: | --: |
+| 10 | **386.6 µs** | 0.7 µs | 3 |
+| 175 | **374.4 µs** | 4.8 µs | 97 |
+
+`query()` returns `(total, page)`, so an exact `total = 20,979` requires visiting every candidate before
+anything can be emitted. **99.8% of the query produces the count**, flat in page size, while producing the
+rows costs 0.7–4.8 µs. Choosing the better plan wins 100 µs; not scanning at all wins 375.
+
+**And a plan that does not scan already existed — for `Eq` only.** `is_printing_composable` matched rarity
+with `CmpOp::Eq` and nothing else, so `r:rare` composed and `r>=rare` fell to a full candidate scan:
+
+| query | before | after | speedup |
+| --- | --: | --: | --: |
+| `r>=rare` / printing | 349.6 µs | **2.1** | **167×** |
+| `r<=uncommon` / printing | 378.8 | **1.9** | **199×** |
+| `r>uncommon` / printing | 344.5 | **2.1** | **164×** |
+| `r>=rare` / artwork | 487.7 | **82.7** | **5.9×** |
+| `r<=uncommon` / artwork | 421.7 | **125.7** | 3.4× |
+| `r>uncommon` / artwork | 531.7 | **91.4** | 5.8× |
+
+Printing mode becomes a popcount with no scan at all; artwork still pays the printing→artwork projection,
+which is why it is 3–6× rather than 100×.
+
+`rarity_cmp_leaf_bits` enumerates the closed domain — four interior planes plus the sparse tail's postings,
+one definition shared with `walk_rarity_orderby_page` via `rarity_ints_present` — and `Or`s the values that
+satisfy the op. Two properties fall out. **NULL rarity is excluded for free**, since a rarity-less printing is
+in no plane and no posting, which is the trivalent answer for every op including `Ne`. And this is **strictly
+more capable than `compile_plane`'s** `compile_rarity_cmp`, which shares one "above mythic" plane and declines
+`BucketVerdict::Ambiguous` whenever special must be told from bonus — compose reads those two apart from their
+own postings, so it has no ambiguous case.
+
+Row identity: **1,566 cells identical** — every rarity op, negations, conjunctions, `r:special`/`r:bonus`,
+three modes × three orderbys × three pages × two prefers, hashing the returned `scryfall_id` sequence.
+Regret mean 1.45 → **1.40 µs**; the compose acquire grows 7,532 → 8,636 queries as intended, and its share
+goes 22% → 27% because more queries live there now, at a much lower absolute cost.
+
+**The generalisable point**, given compose is meant to become the universal exact evaluator (#731): an
+applicability gate that is narrower than the machinery behind it is invisible to every routing metric. The
+router never sees the plan, so no regret figure, no pairwise ordering and no feature grading can report it —
+`r>=rare` looked like a 100 µs cost-model bug and was a 375 µs missing-plan bug. Auditing
+`is_printing_composable` leaf by leaf against what `compose_printing_bits` can actually build is likely to
+find more; `printing_compose / card` is now the worst cell at mean 2.55 µs and is the place to look next.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -297,6 +297,30 @@ the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 belo
 in printing mode too (6.23, 5.25), where compose happens to be genuinely faster, so the wrong ratio does
 not flip the pick. Artwork is only where the margin is thin enough to expose it.
 
+### But that correction alone does not flip the pick
+
+The term is linear, so the corrected prediction is exact arithmetic rather than a guess:
+
+| query / mode | P3 predicted | with the fix | P3 measured | compose predicted | winner after | truth |
+| --- | --: | --: | --: | --: | --- | --- |
+| f:gladiator / artwork | 704.0 | **213.6** | 102.5 | 178.7 | compose | **P3** (102 µs) |
+| f:modern / artwork | 813.7 | **252.8** | 142.8 | 188.8 | compose | **P3** (143 µs) |
+
+It removes 490–561 µs — the largest single error — and takes P3 from 6.9× over to **2.08×** and 5.7× to
+**1.77×**. But compose is predicted at 179/189, so P3 at 214/253 still loses and the 33 µs stays lost.
+
+What remains is P3's per-card term: `eval_domain × (2.58 + 2.47 + max(tier, 6.58))` = 13,587 × 11.63 =
+158 µs against a measured loop of 90.9 µs over those same cards — 6.7 ns/card actual, 11.63 charged. The
+dominant piece is `STREAM_RESIDUAL_FLOOR_NS`, and at ~2 ns/card the arm lands near 151 µs and P3 wins. So
+the floor is the load-bearing half, and it is the term with the worst history here: P4's analogue (18.89)
+"was load-bearing despite being unmeasured" and moving it made routing worse. Unmeasured is the point —
+it has never had the built-design treatment that corrected the loop intercept above.
+
+Two reasons to ship the feature correction first regardless. It is a realized-counter defect of 13–15×,
+which no rate can absorb; and it is **pick-preserving where picks are already right** — the printing-mode
+rows still choose compose after the fix, and compose is correct there (94 vs 111 µs, 38 vs 152 µs). So it
+buys accuracy without moving sound decisions, which is the cheapest kind of change to gate.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -743,9 +743,39 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    | 2+ leaves, mixed | 322 | 100% | 1.19 | 0.553 |
    | 3+ leaves, ALL range | 108 | 100% | 0.70 | 0.541 |
 
-   The exact path is much better calibrated, and multi-leaf all-range (853 rows, 23% of the population) is
-   100% estimated at p50 0.62. That is the `cn<=226 year>2004` shape and the obvious target — but two things
-   must be settled before "widen `bare_range_bounds`" is the plan:
+   **It was the quantity, and that is now fixed.** The third caveat below turned out to be the answer, so the
+   range-path widening was never the right work. `eval_domain` was `est_cards` — a count of *matching* cards —
+   graded against `cards_visited`, which counts *candidates*, a superset whenever the narrowing is inexact.
+   The distribution is bimodal: **34% of compose rows visit every card in the corpus**, and on those the right
+   value is not a better estimate but `n_cards`:
+
+   | on the 986 full-scan rows | p10 | p50 | p90 | mean \|log\| |
+   | --- | --: | --: | --: | --: |
+   | `est_cards` (was) | 0.43 | 0.65 | 0.83 | 0.454 |
+   | `n_cards` (now) | 1.00 | 1.00 | 1.00 | **0.000** |
+
+   Predicted with the predicate and constant the sibling `PrintingRangeScan` branch already uses for the
+   identical decision — `range_too_broad_to_narrow(printing_matches, n_printings)`, `MAX_NARROW_FRACTION`
+   0.25 — so no new constant. Scored against the realized flag it catches **98%** of full-scan rows at 87%
+   accuracy, beating every threshold on two alternative signals. Its 26% false positives over-cost both
+   materializing plans by the same factor, which an argmin absorbs; the false negatives were the ones losing
+   the pair, so recall is the side to favour.
+
+   | | before | after |
+   | --- | --: | --: |
+   | `eval_domain [printing_compose]` p50 / p10 | 0.91 / 0.45 | **1.00 / 0.68** |
+   | pair ordered right | 75% | **87%** |
+   | pair mean regret | 23.00 µs | **4.29 µs** |
+   | pair gap meas/pred | 0.96 | **0.98** |
+
+   That brings the acquire within reach of the well-behaved `candidates` acquire (92%, 2.42 µs). **Total regret
+   is flat** (1.52 against 1.54 µs) and `StreamedSelect -> GatheredScan` is still 967 queries — because
+   `bench_pairwise_ordering` scores every pair including queries where compose wins anyway, so the P3/P4
+   ordering never reaches the routing outcome there. Pairwise accuracy is a leading indicator, not the result;
+   the value banked is that the features are now trustworthy for everything downstream.
+
+   The other two caveats stand as recorded, and the remaining `eval_domain` error (p10 0.68) is in the
+   *narrowed* regime, where these still apply:
 
    - **The exact path is not exact against the counter** (p50 0.92, p10 0.50), so it is not a 1.00 ceiling.
    - **The two quantities may not be the same thing.** `eval_domain` estimates *matching* cards, while

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -125,8 +125,8 @@ Three things fall out of that table.
   (1) before (2).
 - **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.19 after. Deleting a fifth of
   the tail without moving the per-step rate is what a real per-unit cost looks like, as against a
-  coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS` turned out to be.
-  Left at the shipped 1.0; no refit.
+  coefficient absorbing its feature's error, which is what `GATHER_FIXED_COST_NS` does. Left at the
+  shipped 1.0; no refit.
 - **The third row bounds what any start position can do.** A realized minimum reached 4.26 because it sees
   clustering the predicate never mentions (`o:flying` correlates with cmc; a name prefix correlates with
   name order). That gap is now a measured property of the two mechanisms, not a guess — and it is the
@@ -138,19 +138,51 @@ segment, which no start position can skip by construction.
 ## What was declined, and why that is the more useful result
 
 **`GATHER_FIXED_COST_NS` (169.6, traffic says 85).** Looked like the cheapest win available: a 2×
-disagreement with no shape question. Measuring the intercept from cells differing *only* in card count
-gives **card −1,084 ns, printing −845 ns**. A negative fixed cost is impossible, so the linear-in-cards
-shape is wrong — the loop is **convex** in card count (12.40 ns/card across 400–4,500 against 6.31–7.67
-over 1,500–4,500). A straight line through a convex curve drives its intercept negative, and a
-whole-arm fit puts that same curvature in its intercept.
+disagreement with no shape question. It is still declined, but the first reason given for declining it was
+wrong and is retracted below.
 
-So 85 is curvature compensation, not a fixed cost. Two consequences:
+The design now runs four card counts — 100 / 400 / 1,500 / 4,500 — and the average per-card cost is
+**U-shaped**, not monotone:
 
-- **Every plan's `FIXED` is its arm's error sink.** `fit_cost_model.py` fits one equation per query
-  against total dispatch, so no plan's fixed cost should be read off it without an independent intercept
-  measurement. `STREAM_FIXED_COST_NS` (217, fitted 192) is unexamined on this basis.
-- The convexity **is** the corpus-size effect below. P4's `FIXED` disagreement and corpus drift are one
-  problem.
+| single-printing card cell, ns/card | 100 | 400 | 1,500 | 4,500 |
+| --- | --: | --: | --: | --: |
+| A | 11.25 | 9.16 | 9.11 | 10.65 |
+| A′ (same shape, different chunk stagger) | 10.42 | 10.00 | 8.69 | 11.65 |
+
+Two effects, at opposite ends. A per-query **fixed cost** is only visible at the small end (at 4,500 cards
+a 170 ns constant is 0.04 ns/card, far under the cell-to-cell spread), and **cache pressure** raises the
+marginal rate at the large end. Solving each end separately, over four single-printing cells and
+reproducible to ±0.01 across runs:
+
+| | marginal ns/card, 100→400 | marginal ns/card, 1,500→4,500 | curvature | fixed cost |
+| --- | --: | --: | --: | --: |
+| card | 7.92 | 10.93 | **1.38×** | 250 |
+| printing | 8.19 | 11.22 | **1.37×** | 98 |
+| artwork | 11.11 | 10.50 | 0.94× | 222 |
+| card (stagger control) | 9.30 | 12.88 | **1.38×** | 29 |
+
+So the fixed cost measures **29–250 ns**, which brackets both the shipped 169.6 and the fitted 85 — and
+that spread, wider than the disagreement being adjudicated, is why the refit stays declined. The
+curvature is the finding: 1.37–1.38× on card and printing, reproducible, and the arm has no term for it.
+Artwork shows none, which is consistent with it being a different loop.
+
+**Retracted: "the measured intercept is negative, so the fixed cost is impossible and 85 is curvature
+compensation."** The negative intercept (−864, −1,078, −1,616 in the table the bench still prints) is an
+artifact of fitting ONE line across a range where a fixed cost dominates one end and cache pressure the
+other; least squares weights the 4,500-card cell by `n²`, so the line tilts to the large end and its
+intercept dives below zero. Adding a 100-card cell and solving the ends apart removes it. The earlier
+run's "card −1,084 / printing −845" also crossed cell boundaries — it paired cell `A` at 400 cards with
+`A′` at 4,500 — so up to half its magnitude was chunk-stagger noise.
+
+What survives, on its own evidence rather than on that one:
+
+- **Every plan's `FIXED` is still its arm's error sink.** `fit_cost_model.py` fits one equation per query
+  against total dispatch, and `FIXED` is the only term with no feature attached. It read 84 and then 85
+  while `COLLECT_PER_PAGE_ROW` moved 15.0 → 9.79 underneath it: a term that does not budge when a
+  neighbour changes by 35% is absorbing error, not measuring a cost. `STREAM_FIXED_COST_NS` (217, fitted
+  192) is unexamined on this basis.
+- **The curvature is real and unmodelled**, at 1.38× within one store — and the corpus-size effect below
+  is the same phenomenon at a larger scale. Those two are one problem; the fixed cost is not part of it.
 
 ## Retractions
 

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -215,6 +215,37 @@ Recorded because both were believed and acted on:
   `all_match` per-card is flat (2.58 / 2.54 / 2.55) while its residual per-card grows 3.6× and P4's loop
   grows 2.4×. So the P3/P4 balance drifts as the corpus grows with every constant left alone.
 
+### The drift SATURATES, which three corpus sizes could not show
+
+Five log₂-spaced stores (31.5k / 63k / 126k / 252k / 504k cards, built by `upscale_corpus.py` at
+1/2/4/8/16 copies) against the previous 1×/4×/13×. The per-card loop rate, measured directly per cell —
+no differencing across modes, which is where `PUSH` goes unidentified:
+
+| store, oracle cards | 31.5k | 63k | 126k | 252k | 504k |
+| --- | --: | --: | --: | --: | --: |
+| A card, ns/card | 10.15 | 13.23 | 20.66 | 24.54 | **24.72** |
+| B printing | 10.64 | 14.47 | 22.94 | 25.75 | **25.95** |
+| E artwork | 10.96 | 15.99 | 29.90 | 33.01 | **33.19** |
+| A′ card (stagger control) | 11.70 | 11.90 | 19.06 | 24.96 | **25.40** |
+
+It is not a drift that keeps going: the rate roughly doubles to 126k, adds ~19% to 252k, and then stops
+— all four cells move under 2% between 252k and 504k. That is a cache-residency curve reaching its
+asymptote, and it changes both the shape to fit and the urgency:
+
+- **The term is bounded, not logarithmic.** Two levels — a resident rate ~10–11 ns/card and a
+  non-resident rate ~25 ns/card — with a knee between 126k and 252k cards on this machine. A `log(n)`
+  term fitted to three points would have extrapolated past the plateau and over-costed a large corpus.
+- **Production sits at the bottom of the curve** (31.5k cards, ~10 ns/card). So the constants are
+  calibrated in the resident regime and the drift is insurance against a ~4× corpus, not a routing defect
+  today. That demotes this from "the biggest single item" to "the best-understood one".
+- **The two axes are one mechanism.** The within-store curvature (100 → 4,500 cards visited) shrinks as
+  the store grows — 1.33–1.36× at 31.5k, 1.07–1.15× at 504k — which is what a single residency curve
+  predicts: once every access misses, visiting more cards cannot make it worse. So a curvature term keyed
+  on working-set residency should subsume both, rather than needing one term per axis.
+- **The "fixed cost" is still not identified.** It reads 14–305 ns at 31.5k and 305–499 ns at 504k. A
+  per-query constant cannot depend on corpus size, so something size-dependent is still leaking into that
+  end of the fit, and the `169.6`-vs-`85` question stays open.
+
 ## Tooling added
 
 - `card_engine/src/bench_gather_loop.rs`, `bench_streamed_loop.rs` — call the real executors and read

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1080,3 +1080,42 @@ unnarrowed query.
 The one route not yet closed is a bitmap AND of the candidate set against an indexed residual leaf — exact,
 conditional, and available on the ~9% where the residual is a single indexed leaf. Everything else on this
 acquire looks irreducibly estimated.
+
+## The largest single regret in the engine is item 6, and a mode sweep isolates it exactly
+
+`o:creature` / artwork / order=power / limit=175 loses **508.9 µs** — the worst routing miss measured. Held
+everything constant and varied only `unique`:
+
+| mode | P3 pred | P3 meas | p/m | P3 loop | eval_domain | printing_span | printings_examined |
+| --- | --: | --: | --: | --: | --: | --: | --: |
+| printing | 68.1 | **56.8** | **1.20** | 55.5 | 23,155 | 61,941 | 0 |
+| artwork | 92.5 | **978.1** | **0.09** | 974.0 | 23,155 | 61,941 | 0 |
+
+**Artwork costs P3 921 µs more than printing for identical work, and the model charges 24 µs more.** That is
+the whole regret, in one term: `STREAM_ARTWORK_SEEN_PER_CARD_NS` is 1.21 against a realized **39.8 ns/card**
+of surcharge — or 14.9 ns/printing over the span, which is very likely the right shape.
+
+Two things the dump makes plain.
+
+**The work is real and uncharged.** `residual_tier_ns100` is 0 here (the oracle word index resolves
+`o:creature` exactly), so P3's scan term is gated off — correctly, there being no residual to examine. But
+artwork's group-and-score pass walks the candidate span *regardless of the residual*, and no term covers it.
+
+**`printings_examined` does not count it.** It reads **0** while 61,941 printings are walked for grouping,
+because the counter covers residual examinations only. That is why every feature grading in this file looked
+clean on artwork: the instrument cannot see this work, so the error could only ever show up as a rate.
+
+**This is item 6, already measured and not shipped.** `bench_streamed_loop` found the shape — artwork needs
+its own per-card *and* per-printing rates, and its surcharge flips sign with printings-per-card so no additive
+correction expresses it. What is new here is that it is the **largest** routing error in the engine, not a
+tidy-up, and that a two-cell mode sweep sizes it without any built design.
+
+**And the pattern-A fix in this branch made it more visible**, which is worth stating rather than discovering
+later: the `scan_units × 5.97` charge that fix removes had been partly compensating for this missing artwork
+term on artwork queries *with* a residual. Same structure as the verify-tier gate — a correct removal
+exposing an unmodelled cost underneath. `o:creature` never had that compensation, since its tier is 0, which
+is why it shows the error at full size.
+
+Sequencing consequence: **item 6 moves ahead of everything else on this list.** It is one term, its shape is
+already measured, the population is identifiable (`unique=artwork`, which carries 33% of all lost time), and
+it needs a counter for the grouping walk before its feature can be graded at all.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1342,65 +1342,18 @@ predicts `Perm` and prices a cheap permutation walk while the executor runs a ga
 being handed the wrong branch. That is the same number as the original doc's p10 0.64 → 0.14.
 
 **Which makes the real prerequisite a two-sided range.** `bare_range_bounds` matches one comparison, so
-`usd>=0.42 usd<=0.43` composes as `And` of two one-sided slices — `scatter_printings` reads **82,421** for an
-answer of 837, and the estimate multiplies the two sides instead of intersecting one interval. Fusing an `And`
-of two comparisons on the same field into a single index interval fixes the estimate *and* the build cost at
-once, and only then does sparse-gather become predictable. That supersedes "widen `bare_range_bounds` for
-multi-leaf ranges" as an `eval_domain` idea — it was the wrong motivation for the right change.
+`usd>=0.42 usd<=0.43` composes as `And` of two one-sided slices — the estimate multiplies the two sides
+instead of intersecting one interval. Fusing them fixes the estimate *and* the build cost at once, and only
+then does sparse-gather become predictable. That supersedes "widen `bare_range_bounds` for multi-leaf ranges"
+as an `eval_domain` idea — it was the wrong motivation for the right change.
 
-Order to attempt it in: fuse the two-sided range, confirm `matches` on that population, then re-enable the
-gather behind the now-correct sparsity prediction, then re-check regret. Not before.
-
-## Fusing a two-sided range: the evidence, and where the code has to change
-
-The section above named this as sparse-gather's prerequisite. Measured, it is worth more than that, and for a
-reason that has nothing to do with compose: **the narrowing already handles a selective range and the `And`
-never reaches it.** All artwork, `orderby=toughness`, limit 10:
-
-| query | results | `eval_domain` | P3 `printings_examined` | best measured |
-| --- | --: | --: | --: | --: |
-| `usd>=200` | 160 | **148** | 6,089 | **26.7 µs** |
-| `usd<=0.02` | 103 | **100** | 339 | **3.2 µs** |
-| `cn>=20000` | 285 | **281** | 2,980 | **17.0 µs** |
-| **`usd>=0.42 usd<=0.43`** | 837 | **31,508** | **97,206** | **1,146.8 µs** |
-| **`cn>=100 cn<=101`** | 460 | **31,508** | **97,206** | **1,136.1 µs** |
-| `usd>=200 t:creature` | 36 | **36** (`narrowed_repr=printings`) | 532 | **2.5 µs** |
-| `usd>=0.42 usd<=0.43 t:creature` | 361 | 17,317 | 45,976 | 570.2 µs |
-
-A one-sided range with **160** results narrows to **148** candidates and finishes in 26.7 µs. A two-sided
-range with **837** results narrows to nothing and takes **43× longer for 5× more rows**.
-
-**The mechanism.** `narrow_rec` narrows each child independently and intersects. `usd>=0.42` matches most of
-the corpus and so does `usd<=0.43`, so each child trips `range_too_broad_to_narrow`
-(`MAX_NARROW_FRACTION` 0.25) and declines. Both halves give up, and that their *intersection* is 837 is never
-discovered. So the shape a reader intuitively wants — walk the index slice, test the residual, accumulate the
-page — **is** what the engine does for `usd>=200`; the two-sided form simply never gets there.
-
-Fusing `And` of same-index comparisons into one interval inside `bare_range_bounds` should therefore fix three
-things at once: the narrowing (the ~1,100 µs), compose's `matches` estimate (20,411 against a true 837), and
-`scatter_printings` (82,421 for an 837-row answer).
-
-### Four things to get right, found by reading the callers
-
-- **Clamp the empty interval.** Callers compute `k` as `partition_point(hi) - partition_point(lo)`. An
-  unsatisfiable fusion gives `hi < lo` and that subtraction **underflows and panics**. Clamping to
-  `hi.max(lo)` makes it `[lo, lo)` and `k = 0`, which every caller already handles — `run_query_streamed`
-  returns at `total == 0` before either branch.
-- **One arm covers usd/cn/date/year, so do not subset.** `bare_range_bounds` funnels all of them through a
-  single `leaf` helper. But `resolve_numeric_range_leaf` covers only `price_usd` and `collector_number`, so
-  **`eur` and `tix` are not in the dispatch at all** and stay unfused — worth knowing, since several top-100
-  rows are `eur:`/`tix:` ranges.
-- **Check the arm order per caller before claiming a win.** `is_printing_composable` and
-  `compose_printing_bits` both decompose `And` *before* any range guard, so a fused `bare_range_bounds`
-  improves the narrowing path without necessarily making compose stop scattering both sides. Verify which
-  paths actually change.
-- **Unsatisfiable short-circuit falls out here, but only for indexed fields.** `usd>=1 usd<=0.5` fuses to an
-  empty interval for free. `power=3 power=5` does **not** reach this code: `resolve_numeric_range_leaf`
-  returns `None` for `Power`, and `printing_dependent` classifies `Power`/`Cmc`/`Toughness`/`Loyalty` as
-  card-level, evaluated through `numeric_candidates`. Detecting that contradiction is separate work, most
-  naturally at bind time, and needs its own decision on `Ne` and null semantics.
-
-`usd>=200` is the working control: the fused two-sided path should look like it.
+Measured, the fusion turned out to be worth more than a prerequisite, for a reason with nothing to do with
+compose: the narrowing already handles a selective range and the `And` never reaches it, so
+`usd>=0.42 usd<=0.43` cost **1,146.8 µs** against **26.7 µs** for a one-sided range returning *more* rows.
+The narrowing half shipped in `4991759` (15–33× on that population, regret 1.42 → 1.35 µs); the compose half,
+which is what sparse-gather actually needs, has not moved. Both, with the evidence, the noise analysis behind
+the sparsity gate, and the order to attempt the rest in:
+[local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md).
 
 ## A note on the test counts quoted throughout
 

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1164,3 +1164,42 @@ mean no `card_pass` runs, and now it does not. What remains is a level, not a sh
 measurement, explicitly labelled unexplained, sat in the hot loop of the mode carrying 36% of all routing loss
 and cost up to 24x. This file has now retracted four cross-build findings; that instrument's output should be
 treated as unproven until re-measured in one binary, especially where it has been encoded as a permanent gate.
+
+### And yes, the constants need refitting — but the first correction is a gate, and it regresses routing
+
+Removing the artwork `card_pass` gate changed what the arm should charge, so the artwork constants — fitted
+against traffic that *included* the redundant `card_pass` — are now stale. P3 reads p/m **1.58–1.83** on the
+tier-0 artwork cells where printing mode reads 1.02–1.23 on the same queries, so the surcharge is the suspect.
+
+Measured as the artwork-minus-printing `ns_loop` delta on identical candidate sets, against a charged
+**+1.21 ns/card**:
+
+| regime | n | median ns/card | median ns/printing |
+| --- | --: | --: | --: |
+| `printings_examined == 0` (stored group count) | 9 | **−0.46** | −0.17 |
+| `printings_examined == span` (dedup walk) | 8 | **+0.38** | +0.12 |
+
+So it is a **shape** problem before it is a level one. `run_query_streamed` answers an artwork count from a
+stored per-card group count when `all_match && have_group_counts` — touching no printing — and only walks the
+span to dedup groups when a residual survives per printing. In the first regime artwork is *cheaper* than
+printing (one array read against printing's span arithmetic), so +1.21 has the wrong **sign**, not merely the
+wrong magnitude. Every `exam == 0` row is `all_match_known` or `residual_card_invariant`, including `name:s`
+(exam 0, artwork cheaper by 0.52 ns/card, p/m 2.20) — the same discriminator as the two fixes above.
+
+**Gated on that signal and measured: absolute agreement improves, routing gets worse.**
+
+| | before gate | after gate |
+| --- | --: | --: |
+| P3 p/m, tier-0 artwork cells | 1.58–1.83 | **1.14–1.34** |
+| artwork regret slice, mean | 1.59 µs | **1.71** |
+| artwork regret slice, max | 185.5 µs | **732.5** |
+| total regret, mean | 1.44 | 1.48 |
+
+**Not shipped.** The +1.21 is compensating for something else in the P3/P4 artwork balance and cannot be
+removed alone — which is `bench_gather_loop`'s "P4 cannot be fixed alone" for a third time, and is exactly
+what item 6 has to mean now: **both artwork arms together, or neither.** The measurement is recorded at the
+call site so the next attempt starts from the shape rather than rediscovering it.
+
+Fourth instance this session of a correct fix that removes a compensating error — after the verify-tier gate,
+the P4 span feature, and the estimator's ball count. Three of those paid once the exposed error was fixed too;
+this one has no partner fix yet, so it waits.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -537,14 +537,22 @@ dominant term of P4's arm is what makes P3 win where P4 is better, which is the 
 | baseline (HEAD) | 81.7 ms | 2.07 µs | 408 q, 27% of loss | 1,045 q, 37% |
 | tier gate alone | 129.7 ms | 3.50 µs | 33 q, 0% | 1,830 q, 79% |
 | gate + P4 scan | 61.2 ms | 1.55 µs | 48 q, 1% | 1,050 q, 50% |
-| **+ clustering bias on the ball count** | **56.4 ms** | **1.49 µs** | 49 q, 1% | 999 q, 51% |
+| + clustering bias on the ball count | 56.4 ms | **1.49 µs** | 49 q, 1% | 999 q, 51% |
+| **+ `scan_units` clamped at `n_printings`** | 57.0 ms | **1.54 µs** | 43 q, 1% | 999 q, 52% |
 
-Compare the **means**: the total is a sum over however many queries the budget reached (39,458 against 37,749
-here), so the totals are not directly comparable and the mean is. **−28% on the baseline.**
+Compare the **means**: the total is a sum over however many queries the budget reached (39,458 down to 37,111
+across these rows), so the totals are not comparable and the mean is. **−26% on the baseline.**
 
-**−25% regret against HEAD**, and the mispick class this started from is gone (408 → 48 queries, mean 54.27
-→ 13.58 µs). `cargo test` 149 debug / 148 release; row identity needs no new run because these are
-cost-only changes and `force_plan_differential_agreement` already proves every plan returns the same rows.
+The last two rows are within run noise of each other (1.49 against 1.54 µs on transition tables that are
+otherwise identical — 999 queries against 999 on the top slice), so the clamp is **aggregate-neutral**. It is
+kept for what the aggregate cannot see: it is the only one of the four that moved the pair
+`GatheredScan vs StreamedSelect [printing_compose]`, 69% → **75%** with mean pair regret 40.24 → 23.00 µs.
+Which is the same lesson as the table itself — a 3% move in a pooled mean is not evidence either way, and the
+per-pair diagnostic is what ranks routing work.
+
+The mispick class this started from is gone (408 → 43 queries, mean 54.27 → 13.93 µs). `cargo test` 149 debug
+/ 148 release throughout; row identity needs no new run because these are cost-only changes and
+`force_plan_differential_agreement` already proves every plan returns the same rows.
 
 The honest caveat: the P4 scan fix **did not fix the pair**. `GatheredScan vs StreamedSelect
 [printing_compose]` is still 69% ordered right (gap 0.89 → 0.91), and `StreamedSelect -> GatheredScan`
@@ -576,14 +584,28 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
 
 ## What is left
 
-1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,403 pairs at **69% ordered right**,
-   mean regret 36.40 µs — the engine's largest single routing error and the top item. Two corrections landed
-   against it and **neither moved its ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%,
-   gap 0.89 → 0.91). Both were worth doing — together −25% total regret — but they bought that by removing
-   biases that *amplified* this pair, not by ranking it. The pair itself is untouched.
+1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** Now **75% ordered right** over 4,825
+   non-tie pairs, mean regret 23.00 µs, gap 0.96 — still the engine's largest single routing error and still
+   the top item. Four feature corrections landed against it, and the pattern of which ones moved it is the
+   useful part:
 
-   **Not variance — a sub-population, and it is named.** The gap ratio of 0.91 invites reading this as noise
-   around a correct average; splitting the pairs by whether the sign is right says otherwise. Over 5,085
+   | correction | pair ordered right | pair mean regret | gap |
+   | --- | --: | --: | --: |
+   | baseline | 69% | 35.96 µs | 0.89 |
+   | verify-tier gate | 69% | 36.82 | 0.90 |
+   | P4's span feature | 69% | 40.24 | 0.91 |
+   | estimator bias onto the ball count | 69% | 40.24 | 0.93 |
+   | **`scan_units` clamped at `n_printings`** | **75%** | **23.00** | **0.96** |
+
+   Three of the four moved nothing, and the reason is instructive: `eval_domain` and `scan_units` feed **both**
+   arms, so a correction to either moves both predictions the same direction and the difference barely
+   changes. The clamp moved it because it lands **asymmetrically** — `scan_units` is 76% of P3's arm on this
+   class and 28% of P4's. **For an argmin, a feature fix only pays when the two plans weight the feature
+   differently.** That is the same principle as the module header's "a term wrong for every plan cancels",
+   applied to features rather than rates.
+
+   **Not variance — a sub-population, and it is named.** The gap ratio invites reading this as noise around a
+   correct average; splitting the pairs by whether the sign is right says otherwise. At 69%, over 5,085
    non-tie pairs:
 
    | group | n | P3 wins (measured) | P3 wins (predicted) | median \|gap\| |
@@ -614,24 +636,66 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    much as P3 because P4's per-card rate is 25.77 ns against 11.63. Fixed by moving the clustering bias onto
    the ball count (see the commit); the broad band went 0.52 → 0.78 against `cards_visited`.
 
-   **What survives three feature corrections is a rate problem, and that is now the evidence.** The tier
-   gate, P4's span feature and the estimator's shape each improved something else and each left this pair at
-   **exactly 69%**, with an unchanged internal structure — still 100% of wrong pairs in `tier > 0`, still P3
-   winning 98% of them while the model says 2%. The decisive number is `meas/pred` = **−0.97**: the predicted
-   gap is almost exactly the *negative* of the measured gap, consistently. Magnitude right, direction
-   inverted, immovable by any feature. That is what a mis-split between the per-card and per-printing rates
-   looks like when both features are maximal.
+   **Retracted a second time: "what survives three feature corrections is a rate problem."** A fourth
+   feature correction moved it 69% → 75%, so that inference was wrong — it rested on three fixes that could
+   not have moved the pair for the structural reason above, and read their failure as evidence about rates.
+   The estimator fix also made things temporarily worse in a way worth recording: it improved `eval_domain`
+   (16,511 → 24,592) and *degraded* `scan_units` (106,970 → **159,325** against a realized 97,206), because
+   `scan_all` derives from `est_cards`. P3 went 1.03 → 1.53 of its real time while P4 sat at 0.88 — both
+   plans over the same feature. A feature above `n_printings` is impossible rather than merely wrong, which
+   is what made the clamp an invariant instead of a calibration.
 
-   So the remaining work is a **built design over the broad-residual population**, not another feature hunt:
-   `bench_streamed_loop` and `bench_gather_loop` restricted to cells where both plans scan the whole corpus,
-   solving for each arm's per-card and per-printing rates separately. Two traps attached. A pooled traffic fit
-   **endorses both current rates** (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23),
-   so `fit_cost_model` cannot find this. And the built design will read warm-cache, so it gives the **shape**
-   — which of the two rates is misattributed — and not the level. Wrong-rate concentrates by mode: artwork
-   37%, printing 31%, card 19%.
+   **Features are still not exhausted at 75%.** The wrong group retains a feature asymmetry against the
+   right group, so the next step is not automatically a rate measurement:
+
+   | feature / realized counter | right group p50 | wrong group p50 |
+   | --- | --: | --: |
+   | `eval_domain` | 0.98 | **0.85** |
+   | `scan_units` | 0.95 | 1.00 (was 1.37 before the clamp) |
+   | `matches` | 1.00 | 1.11 |
+
+   `eval_domain` still under-counts by ~1.18× exactly where the ordering fails, and P4's per-card rate is
+   2.2× P3's, so that residue still discounts P4 asymmetrically. `meas/pred` reads **−1.17** in the wrong
+   group: magnitude right, sign inverted, as before.
+
+   **The open question is which of the two it now is, and no tool can currently answer it.** Distinguishing
+   "remaining feature error" from "rate misattribution" needs each arm's per-card and per-printing rates
+   measured on *identical* cells — and `bench_loop_design`'s header states that neither harness compares the
+   two plans, deferring that to `explain_analyze`, which compares predicted against measured per plan on
+   sampled traffic and cannot isolate a rate. So the next piece of work is a **pair-level harness**: see the
+   note below. What the existing harnesses already report is suggestive — P3 3.30 ns/printing against P4's
+   2.27, a ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both were
+   measured warm, but they were measured warm *together*, and a ratio between two equally-warm arms survives
+   the cache caveat that voids their levels.
+
+   Two traps attached to any rate work here. A pooled traffic fit **endorses both current rates**
+   (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23), so `fit_cost_model` cannot find
+   this and a pooled refit will confirm the status quo. And a built design reads warm-cache, so it yields the
+   **shape** — which of the two rates is misattributed — and not the level. Wrong-rate now concentrates by
+   mode at artwork 29%, printing 24%, card 18%.
 
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.
+
+1b. **Build the pair-level loop harness item 1 needs.** `bench_streamed_loop` and `bench_gather_loop` now
+   share `bench_loop_design`, so their cells match and can be read side by side — but neither computes the
+   cross-plan quantity, deliberately: the header defers plan comparison to `explain_analyze`. That deferral
+   is incomplete, because `explain_analyze` compares predicted against measured *per plan* on sampled
+   traffic and cannot isolate a per-unit rate. The result is that the one number routing depends on — P3's
+   per-printing rate against P4's, on identical cells — is produced by nothing.
+
+   **Extend, do not fork.** `bench_loop_design` exists precisely because a P3-vs-P4 rate comparison is only
+   valid when the cells match, and they had already drifted once (`CARD_COUNTS` sharing two of five sizes). A
+   third harness that built its own cells would reintroduce that. The increment is to move **cell
+   construction** into `bench_loop_design` alongside the parameters, then add one reporting test that runs
+   both arms over those cells and prints each rate, the measured ratio, and the shipped ratio beside it.
+
+   Two prerequisites, both already flagged in `bench_streamed_loop`'s own header. The rates there are
+   `ns_loop` only, and *"P3's arm may be absorbing setup or finish cost that its loop never pays — that has
+   to be ruled out before the gap is called an error."* `Cell` already carries `ns_setup` and `ns_finish`, so
+   the data exists and is unused. And the broad-residual population is already the `residual: true` group
+   (an always-true `DateCmp` via `DATE_AFTER_EVERYTHING`), so no new cell class is needed — only the
+   comparison.
 2. ~~**Decide the 13% regret debt.**~~ **Closed** — and neither of the two options on offer was the answer.
    The debt was never bounded by compose's arm; the mispriced arm was P3's. Gating the verify tier on the
    compose acquire plus fixing P4's candidate span took regret to **61.2 ms against the 81.7 ms measured

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1298,3 +1298,55 @@ router never sees the plan, so no regret figure, no pairwise ordering and no fea
 `r>=rare` looked like a 100 µs cost-model bug and was a 375 µs missing-plan bug. Auditing
 `is_printing_composable` leaf by leaf against what `compose_printing_bits` can actually build is likely to
 find more; `printing_compose / card` is now the worst cell at mean 2.55 µs and is the place to look next.
+
+## Sparse compose gather: attempted, and the blocker is now named exactly
+
+`usd>=0.42 usd<=0.43`/artwork appeared in the top 100 at 112 µs of regret. The dump says the regret figure
+is nearly irrelevant:
+
+    acquire=printing_compose
+      PrintingCompose   pred  105.9   meas    —      PICKED, then DeclineSparseExact
+      StreamedSelect    pred  988.2   meas 1249.8    exam 97,206
+      GatheredScan      pred 1058.2   meas 1161.5    exam 97,206
+      matches (estimated) 20,411      result_total (actual) 837
+
+The router picked compose, compose built the bitmap, **discarded it**, and dispatch re-derived everything with
+a full-corpus scan — 97,206 printings examined to return 837 matches, ~1,250 µs. The 112 µs the matrix reports
+is only the P3-vs-P4 difference among the fallbacks, because **regret compares only plans that ran** and a
+declining plan accumulates no trials. Second time today that blind spot hid the larger finding, after
+`r>=rare`.
+
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) had already designed the
+fix — `gather_composed_page` in place of the `return None` — and verified it byte-identical over 127,640
+queries. Its stated blocker was that `plan_cost` could not price the path, and this stack added the
+`ComposePaging::Gather` arm, so it looked unblocked.
+
+**Tried it. Two edits, not one:** the fastpath gathers, *and* `compose_paging_for` must predict `Gather`
+rather than `Decline`, since a `Decline` prediction costs infinity and keeps compose out of the argmin so the
+gather would never run. Rows verified again on this build: **2,304 cells identical** over the sparse
+two-sided ranges the change enables plus broad controls, four orderbys including the tie-heavy `usd` and
+`rarity`, deep offsets, both prefers.
+
+**And routing got worse, so it is reverted:**
+
+| | decline | gather |
+| --- | --: | --: |
+| regret mean | 1.43 µs | **1.55 (+8%)** |
+| `printing_compose` miss% | 7% | **18%** |
+| `printing_compose` mean | 1.69 | **2.43** |
+| `printing_compose` p90 | **0.00** | **7.92** |
+
+**The blocker is not the cost arm — it is that the prediction cannot tell the query is sparse.**
+`compose_paging_for` branches on `result_total`, which is the *estimate*: 20,411 against a true 837. So it
+predicts `Perm` and prices a cheap permutation walk while the executor runs a gather. The arm is fine; it is
+being handed the wrong branch. That is the same number as the original doc's p10 0.64 → 0.14.
+
+**Which makes the real prerequisite a two-sided range.** `bare_range_bounds` matches one comparison, so
+`usd>=0.42 usd<=0.43` composes as `And` of two one-sided slices — `scatter_printings` reads **82,421** for an
+answer of 837, and the estimate multiplies the two sides instead of intersecting one interval. Fusing an `And`
+of two comparisons on the same field into a single index interval fixes the estimate *and* the build cost at
+once, and only then does sparse-gather become predictable. That supersedes "widen `bare_range_bounds` for
+multi-leaf ranges" as an `eval_domain` idea — it was the wrong motivation for the right change.
+
+Order to attempt it in: fuse the two-sided range, confirm `matches` on that population, then re-enable the
+gather behind the now-correct sparsity prediction, then re-check regret. Not before.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1350,9 +1350,10 @@ as an `eval_domain` idea — it was the wrong motivation for the right change.
 Measured, the fusion turned out to be worth more than a prerequisite, for a reason with nothing to do with
 compose: the narrowing already handles a selective range and the `And` never reaches it, so
 `usd>=0.42 usd<=0.43` cost **1,146.8 µs** against **26.7 µs** for a one-sided range returning *more* rows.
-The narrowing half shipped in `4991759` (15–33× on that population, regret 1.42 → 1.35 µs); the compose half,
-which is what sparse-gather actually needs, has not moved. Both, with the evidence, the noise analysis behind
-the sparsity gate, and the order to attempt the rest in:
+Both halves have now shipped — `4991759` for the narrowing (15–33× on that population) and `7374e19` for
+compose's builders, where the estimate was 38.5× off a count that was two binary searches away. Together:
+regret 1.42 → 1.30 µs, and the fusible traffic slice to 0.81× of baseline. The evidence, the noise analysis
+behind the sparsity gate, and what is left (the sparse gather, now that its prediction is correct):
 [local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md).
 
 ## A note on the test counts quoted throughout

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1350,3 +1350,61 @@ multi-leaf ranges" as an `eval_domain` idea — it was the wrong motivation for 
 
 Order to attempt it in: fuse the two-sided range, confirm `matches` on that population, then re-enable the
 gather behind the now-correct sparsity prediction, then re-check regret. Not before.
+
+## Fusing a two-sided range: the evidence, and where the code has to change
+
+The section above named this as sparse-gather's prerequisite. Measured, it is worth more than that, and for a
+reason that has nothing to do with compose: **the narrowing already handles a selective range and the `And`
+never reaches it.** All artwork, `orderby=toughness`, limit 10:
+
+| query | results | `eval_domain` | P3 `printings_examined` | best measured |
+| --- | --: | --: | --: | --: |
+| `usd>=200` | 160 | **148** | 6,089 | **26.7 µs** |
+| `usd<=0.02` | 103 | **100** | 339 | **3.2 µs** |
+| `cn>=20000` | 285 | **281** | 2,980 | **17.0 µs** |
+| **`usd>=0.42 usd<=0.43`** | 837 | **31,508** | **97,206** | **1,146.8 µs** |
+| **`cn>=100 cn<=101`** | 460 | **31,508** | **97,206** | **1,136.1 µs** |
+| `usd>=200 t:creature` | 36 | **36** (`narrowed_repr=printings`) | 532 | **2.5 µs** |
+| `usd>=0.42 usd<=0.43 t:creature` | 361 | 17,317 | 45,976 | 570.2 µs |
+
+A one-sided range with **160** results narrows to **148** candidates and finishes in 26.7 µs. A two-sided
+range with **837** results narrows to nothing and takes **43× longer for 5× more rows**.
+
+**The mechanism.** `narrow_rec` narrows each child independently and intersects. `usd>=0.42` matches most of
+the corpus and so does `usd<=0.43`, so each child trips `range_too_broad_to_narrow`
+(`MAX_NARROW_FRACTION` 0.25) and declines. Both halves give up, and that their *intersection* is 837 is never
+discovered. So the shape a reader intuitively wants — walk the index slice, test the residual, accumulate the
+page — **is** what the engine does for `usd>=200`; the two-sided form simply never gets there.
+
+Fusing `And` of same-index comparisons into one interval inside `bare_range_bounds` should therefore fix three
+things at once: the narrowing (the ~1,100 µs), compose's `matches` estimate (20,411 against a true 837), and
+`scatter_printings` (82,421 for an 837-row answer).
+
+### Four things to get right, found by reading the callers
+
+- **Clamp the empty interval.** Callers compute `k` as `partition_point(hi) - partition_point(lo)`. An
+  unsatisfiable fusion gives `hi < lo` and that subtraction **underflows and panics**. Clamping to
+  `hi.max(lo)` makes it `[lo, lo)` and `k = 0`, which every caller already handles — `run_query_streamed`
+  returns at `total == 0` before either branch.
+- **One arm covers usd/cn/date/year, so do not subset.** `bare_range_bounds` funnels all of them through a
+  single `leaf` helper. But `resolve_numeric_range_leaf` covers only `price_usd` and `collector_number`, so
+  **`eur` and `tix` are not in the dispatch at all** and stay unfused — worth knowing, since several top-100
+  rows are `eur:`/`tix:` ranges.
+- **Check the arm order per caller before claiming a win.** `is_printing_composable` and
+  `compose_printing_bits` both decompose `And` *before* any range guard, so a fused `bare_range_bounds`
+  improves the narrowing path without necessarily making compose stop scattering both sides. Verify which
+  paths actually change.
+- **Unsatisfiable short-circuit falls out here, but only for indexed fields.** `usd>=1 usd<=0.5` fuses to an
+  empty interval for free. `power=3 power=5` does **not** reach this code: `resolve_numeric_range_leaf`
+  returns `None` for `Power`, and `printing_dependent` classifies `Power`/`Cmc`/`Toughness`/`Loyalty` as
+  card-level, evaluated through `numeric_candidates`. Detecting that contradiction is separate work, most
+  naturally at bind time, and needs its own decision on `Ne` and null semantics.
+
+`usd>=200` is the working control: the fused two-sided path should look like it.
+
+## A note on the test counts quoted throughout
+
+`149 debug / 148 release` is not a flake. The difference is exactly one test,
+`tests::arith_tuple_key_budget_catches_a_blown_domain`, which asserts a `debug_assert` tripwire and so is
+compiled out of a release build. That is why both profiles are run and quoted separately: CI's `rust-test`
+job is a debug build, and a release-only local run silently skips the engine's `debug_assert` guards.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -536,7 +536,11 @@ dominant term of P4's arm is what makes P3 win where P4 is better, which is the 
 | --- | --: | --: | --: | --: |
 | baseline (HEAD) | 81.7 ms | 2.07 µs | 408 q, 27% of loss | 1,045 q, 37% |
 | tier gate alone | 129.7 ms | 3.50 µs | 33 q, 0% | 1,830 q, 79% |
-| **gate + P4 scan** | **61.2 ms** | **1.55 µs** | 48 q, 1% | 1,050 q, 50% |
+| gate + P4 scan | 61.2 ms | 1.55 µs | 48 q, 1% | 1,050 q, 50% |
+| **+ clustering bias on the ball count** | **56.4 ms** | **1.49 µs** | 49 q, 1% | 999 q, 51% |
+
+Compare the **means**: the total is a sum over however many queries the budget reached (39,458 against 37,749
+here), so the totals are not directly comparable and the mean is. **−28% on the baseline.**
 
 **−25% regret against HEAD**, and the mispick class this started from is gone (408 → 48 queries, mean 54.27
 → 13.58 µs). `cargo test` 149 debug / 148 release; row identity needs no new run because these are
@@ -601,15 +605,30 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    | `cn<=226 year>2004` / printing | 1,025.3 | 1,454.7 | 789.6 | **756.4** |
    | `year<=2026` / artwork | 601.6 | 1,026.9 | 1,629.2 | **1,326.1** |
 
-   P3 is genuinely ~1.7× faster and the model has the pair tied to within 5 µs. What brings it to parity is
-   the two arms' per-printing scan rates: `STREAM_SCAN_PER_ROW_NS` 5.97 against `GATHER_SCAN_PER_ROW_NS`
-   2.06, a **2.9× ratio for what is nominally the same walk-a-printing-and-test work**. P3's higher rate
-   cancels its lower per-card rate exactly where both features are maximal.
+   P3 is genuinely ~1.7× faster and the model has the pair tied to within 5 µs.
 
-   The trap for whoever takes this: a pooled traffic fit **endorses both rates** (StreamedSelect
-   `SCAN_PER_ROW` fits 6.04, ratio 1.01; GatheredScan 2.53, ratio 1.23), so `fit_cost_model` will not find
-   this and a pooled refit cannot fix it. It needs the population split — the same lesson this file has now
-   learned three times. Wrong-rate concentrates by mode: artwork 38–46%, printing 25–46%, card 16–24%.
+   **Retracted guess: "the two scan rates cancel."** Decomposing both arms says the false tie is one-sided.
+   On `border:black`/printing, P3 predicts **1.03** of its real time and P4 predicts **0.64** — P3 is priced
+   correctly and P4 is under-charged 1.56×. Two errors are not cancelling; one plan is wrong. The mechanism
+   was `eval_domain` reading 16,511 where both plans visited all 31,508 cards, which discounts P4 by 2.2× as
+   much as P3 because P4's per-card rate is 25.77 ns against 11.63. Fixed by moving the clustering bias onto
+   the ball count (see the commit); the broad band went 0.52 → 0.78 against `cards_visited`.
+
+   **What survives three feature corrections is a rate problem, and that is now the evidence.** The tier
+   gate, P4's span feature and the estimator's shape each improved something else and each left this pair at
+   **exactly 69%**, with an unchanged internal structure — still 100% of wrong pairs in `tier > 0`, still P3
+   winning 98% of them while the model says 2%. The decisive number is `meas/pred` = **−0.97**: the predicted
+   gap is almost exactly the *negative* of the measured gap, consistently. Magnitude right, direction
+   inverted, immovable by any feature. That is what a mis-split between the per-card and per-printing rates
+   looks like when both features are maximal.
+
+   So the remaining work is a **built design over the broad-residual population**, not another feature hunt:
+   `bench_streamed_loop` and `bench_gather_loop` restricted to cells where both plans scan the whole corpus,
+   solving for each arm's per-card and per-printing rates separately. Two traps attached. A pooled traffic fit
+   **endorses both current rates** (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23),
+   so `fit_cost_model` cannot find this. And the built design will read warm-cache, so it gives the **shape**
+   — which of the two rates is misattributed — and not the level. Wrong-rate concentrates by mode: artwork
+   37%, printing 31%, card 19%.
 
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -344,6 +344,42 @@ which no rate can absorb; and it is **pick-preserving where picks are already ri
 rows still choose compose after the fix, and compose is correct there (94 vs 111 µs, 38 vs 152 µs). So it
 buys accuracy without moving sound decisions, which is the cheapest kind of change to gate.
 
+## The bigger lever underneath it: divergence is per-CARD but the data is per-FORMAT
+
+Chasing the estimate above turned up something that makes it partly moot. A full pass over the corpus,
+comparing each card's printings format by format:
+
+    97,206 printings, 31,508 oracle cards
+    cards with ANY divergent format: 556 (1.76%)
+    divergent cards per format:
+      oldschool       556
+
+**Every divergent card in the corpus diverges in `oldschool` and nothing else.** No other format has a
+single card whose printings disagree.
+
+The engine cannot use that, because it detects divergence as a whole-bitmask comparison and stores one
+boolean per card (`reload`: `row.card_legalities != cards.last()...card_legalities` sets
+`legality_divergent`). So `plane_expr_is_existential` is true for every legality leaf, the #667 carveout
+applies to every format, and `card_match_count` / `push_card_matches` / the popcount plans' `satisfies`
+closure all re-verify per printing — on `f:modern`, 7,770 printing examinations that are provably
+redundant, because modern legality is card-invariant in this data.
+
+The upgrade is one line at the detection site and is **self-maintaining**: OR the XOR of the two bitmasks
+into a corpus-level `divergent_formats: u64` instead of setting a boolean. Then a legality leaf whose
+format bit is outside that mask is card-invariant, `all_match` holds, and the per-printing work does not
+happen. Nothing hardcodes "oldschool" — if Scryfall ever makes another format divergent, the mask picks it
+up from the data and the conservative path returns on its own.
+
+Note what that does to the `scan_units` defect above: with legality non-existential, `split_planes`
+consumes the leaf and the residual becomes `True`, so `tier_ns` is 0 and P3's arm charges **no scan term
+at all** (`if tier_ns > 0.0`). The 525 µs over-cost stops existing for the queries where it mattered,
+rather than being estimated more accurately. Same for the mispick: P3 measured 102 µs against compose's
+182, and it is the over-cost that hides that.
+
+So the ordering is: this, then re-measure, and only then decide whether a per-plan `scan_units` field is
+still needed for the non-legality compose cases (`border:black`, `r:mythic`, `watermark:*`), where the
+current estimate is already right to 1.1-2.4x.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -930,3 +930,53 @@ for a per-predicate estimate rather than a better global rate:
 - The residual usually is not the whole predicate, so a global pass fraction still assumes independence
   from the candidate set — the assumption that just cost us on `eval_domain`. Preferring a direct count
   where the residual *is* the leaf avoids it; conjunctions still need care.
+
+### Tier 2: both exact-count routes measured and declined
+
+The plan was to replace the global pass rate with a per-predicate count, since the spread (0.06–0.87) is
+what a constant cannot fix. Two routes existed without new machinery. Both are worse than the span estimate,
+and they fail for the same reason.
+
+**`estimator::estimate_cardinality`** — already in the tree, index-backed leaves, `Cardinality {lo, est, hi}`
+with independence for `And` and `min` for the `hi` bound. In production it is called **once**, as a
+`hi <= STREAM_MIN_MATCHES` threshold check. Graded against `matches_pushed`:
+
+| mode | shipped `matches` | `estimate_cardinality` |
+| --- | --: | --: |
+| card | p50 1.40, p90 9.91, mean \|log\| **0.789** | p50 1.45, p90 **33.38**, **1.312** |
+| printing | p50 1.09, p90 11.03, **0.953** | p50 0.70, p90 17.12, 1.346 |
+| artwork | p50 1.19, p90 10.19, **0.807** | p50 1.17, p90 25.01, 1.281 |
+
+Uniformly worse, and worst in the tail — which is where this acquire's loss lives. It dates from the
+estimate-based era of the planner; its `lo` arm already documents that Bonferroni is *unsound* over two or
+more printing-varying children, because a card can enter each child's card-space projection via **different
+printings** while no single printing satisfies all.
+
+**`RangeCardCounts::distinct_cards`** — genuinely exact, not an estimate: `below`/`at_or_above`/`at` per
+distinct value, two `partition_point` probes, exact for every op but a true interior range. It is the right
+instinct and it still does not work here:
+
+- **Coverage 9%** of rows with a residual — 7% of the misordered ones, 2.0 ms of a 46.5 ms pairwise gap.
+- **6× worse where it applies** — card p50 **6.32** against the shipped 1.12.
+
+Because `bare_range_bounds` matches the **residual**, so the count is exact for `cn<100` *globally* while the
+feature needs cards matching `cn<100` **and the rest of the query**. Exact for the wrong set. The span
+estimate is worse in principle and better in practice because it at least reflects the candidate set.
+
+**The shared lesson, third instance today.** `eval_domain` confused candidates with matches; the compose
+`scan_units` clamp was an impossible value; and now both exact-count routes answer a marginal question where
+a conditional one was asked. The quantity is `|candidates ∩ residual|`, and its exact evaluation is the work
+being costed. A bitmap AND of the candidate set against an indexed leaf's set would deliver it for the same
+9%; nothing cheap covers the remaining 91%.
+
+**What is left for `matches`, in order of expected value:**
+
+1. **Condition the pass rate on the residual TIER, not just the mode.** The tier already exists as a feature
+   and it separates the populations: implied rates ~0.24–0.32 for `MASK`, ~0.35 for `SET_LOOKUP`, ~0.95 for
+   `TEXT_SCAN`/printing against a shipped 0.40. A level change fitted from traffic, so it is on the right
+   side of the branch's rule, and it needs no new machinery. It fixes medians, not the 14× spread.
+2. **Bitmap-AND the candidate set with an indexed residual leaf** for an exact conditional count on the 9%.
+   Related to `local-engine-candidate-materialize.md`'s finding that a bitmap beats a sorted vec from ~64
+   candidates up, though that doc measures the acquire, which regret excludes by construction.
+3. **Accept the spread.** The evidence so far is that `matches` is irreducibly estimated on this acquire
+   without doing the residual's own work, and that its error is what the P3/P4 pair mostly reflects.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -658,15 +658,41 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    2.2× P3's, so that residue still discounts P4 asymmetrically. `meas/pred` reads **−1.17** in the wrong
    group: magnitude right, sign inverted, as before.
 
-   **The open question is which of the two it now is, and no tool can currently answer it.** Distinguishing
-   "remaining feature error" from "rate misattribution" needs each arm's per-card and per-printing rates
-   measured on *identical* cells — and `bench_loop_design`'s header states that neither harness compares the
-   two plans, deferring that to `explain_analyze`, which compares predicted against measured per plan on
-   sampled traffic and cannot isolate a rate. So the next piece of work is a **pair-level harness**: see the
-   note below. What the existing harnesses already report is suggestive — P3 3.30 ns/printing against P4's
-   2.27, a ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both were
-   measured warm, but they were measured warm *together*, and a ratio between two equally-warm arms survives
-   the cache caveat that voids their levels.
+   **Answered, without a built design: it is the features, and by a wide margin.** An ORACLE run settles the
+   sequencing question directly — recompute both arms substituting each plan's *realized counters* for the
+   estimated features (`cards_visited`, `printings_examined`, `matches_pushed`), keeping every shipped rate
+   untouched, then re-run the argmin. Over 2,778 non-tie pairs with at least 100 realized cards on both plans:
+
+   | features | ordered right | lost time (sum) |
+   | --- | --: | --: |
+   | shipped estimates | 58% | 116.2 ms |
+   | **oracle (realized counters)** | **83%** | **12.8 ms** |
+
+   | mode | shipped | oracle |
+   | --- | --: | --: |
+   | card | 58% | **96%** |
+   | printing | 62% | 80% |
+   | artwork | 56% | 81% |
+
+   Perfect features against **today's rates** reach 83% and cut lost time **9×**. That is the ceiling any
+   estimator work can buy, and it is most of the gap — so the rates are adequate to 83% and the remaining 17%
+   is what is genuinely attributable to them. **Features are the foundation and come first**; the rate
+   question is real but second-order and should not be opened until the estimates stop moving.
+
+   (58% here is not the 75% above: this run requires ≥100 realized cards on *both* plans, which selects the
+   larger queries where estimator error dominates. The valid comparison is the internal one, 58 → 83 on
+   identical rows with identical rates.)
+
+   One structural caveat on that ceiling, and it is the first thing to settle. The oracle gave each plan **its
+   own** counter, where `scan_units` today is one shared number that both arms read while examining different
+   amounts — `stream_scan_units` splits it for P3 on legality filters only. So the 58 → 83 gain mixes two
+   distinct fixes: *more accurate* shared features, and *per-plan* features. Decomposing that is step one,
+   because it decides whether the work is a better estimator or a split feature.
+
+   For when the rate question does open: the existing harnesses already report P3 at 3.30 ns/printing against
+   P4's 2.27, a ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both
+   were measured warm, but *together*, and a ratio between two equally-warm arms survives the cache caveat
+   that voids their levels.
 
    Two traps attached to any rate work here. A pooled traffic fit **endorses both current rates**
    (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23), so `fit_cost_model` cannot find
@@ -677,7 +703,24 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.
 
-1b. **Build the pair-level loop harness item 1 needs.** `bench_streamed_loop` and `bench_gather_loop` now
+1b. **Review the compose acquire's feature estimation — the foundational work, ahead of any rate work.** The
+   oracle run above bounds this at 58% → 83% ordered right and a 9× cut in lost time on the pair, with rates
+   untouched. Three targets, in order:
+
+   - **Decompose the oracle gain into "better shared estimate" vs "per-plan feature".** The oracle used each
+     plan's own counters; `scan_units` is one shared number today and the two plans examine different amounts.
+     `stream_scan_units` already splits it for P3, but only on legality filters. This decides the shape of
+     everything below, so it comes first.
+   - **`eval_domain` on the failing population.** p50 **0.85** in the wrong group against 0.98 in the right
+     one, and P4's per-card rate is 2.2× P3's, so the residue discounts P4 asymmetrically. The broad class is
+     mostly range predicates, and `range_card_counts_for` already answers *exactly* — but `bare_range_bounds`
+     matches one comparison, so `cn<=226 year>2004` (an `And` of two) falls back to the estimator. Widening
+     that exact path is likely worth more than any estimator refinement.
+   - **`scan_units` on selective compose queries.** mean |log| **1.22**, p10 0.08, p90 3.62 — a ~45× spread
+     that none of the three bias variants improves (see the span-bias note). Not previously on any list, and
+     the worst-calibrated feature in the acquire.
+
+1c. **Build the pair-level loop harness, once the features stop moving.** `bench_streamed_loop` and `bench_gather_loop` now
    share `bench_loop_design`, so their cells match and can be read side by side — but neither computes the
    cross-plan quantity, deliberately: the header defers plan comparison to `explain_analyze`. That deferral
    is incomplete, because `explain_analyze` compares predicted against measured *per plan* on sampled

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -380,6 +380,47 @@ So the ordering is: this, then re-measure, and only then decide whether a per-pl
 still needed for the non-legality compose cases (`border:black`, `r:mythic`, `watermark:*`), where the
 current estimate is already right to 1.1-2.4x.
 
+## Making the split non-destructive, and what it cost
+
+`split_planes` is a destructive rewrite run at bind time, before any plan is costed: it moves predicate
+out of the filter tree `PrintingCompose` composes from into a `PlaneExpr` compose cannot read, so compose
+fails its `plane.is_none()` guard and never reaches the argmin. That guard is right — composing the
+residual alone would drop the plane's predicate — but the elimination happens blind, under a layer whose
+premise is "plan selection is one cost-based routing layer, not a hand-tuned decision tree". Measured
+consequence: compose ran `f:commander`/printing in 1.83 µs against StreamedSelect's 99.38, a plan the
+router was never offered.
+
+`bind_and_split_filter` now retains the filter as bound; `printing_compose_applicable` asks about the
+whole predicate, and `compose_source` is the one place that picks a representation. Every other plan keeps
+plane+residual. Row identity across the whole series: 60 (query, mode, offset) cells over ten legality
+shapes, identical on total, page length and a hash of returned `scryfall_id`s.
+
+| query / mode | before | after | ratio |
+| --- | --: | --: | --: |
+| `f:modern t:creature` / printing | 90.00 | **42.83** | **0.476** |
+| `f:modern t:creature` / artwork | 82.38 | 67.50 | 0.819 |
+| bare formats, both modes | — | — | 0.97–1.14, compose still picked |
+
+**And it raised regret 15%, which is the honest headline.** Total regret 48.7 → 56.1 ms, with the compose
+slice going 39% → 46% of lost time (mean 3.98 → 4.86 µs, miss 10% → 12%). Isolated by reverting just the
+consume guard: 56.8 ms with it off against 56.1 with it on — so the guard is **not** the cause and is now
+free, where before the split was retained it cost 54× on `f:commander`/printing. The rise is the split
+itself: handing the argmin a candidate whose arm is the worst-modelled in the engine (p90 41×, spread 136×
+on rarity/usd) imports mispicks.
+
+That is a real trade, and the two ways to read it are both defensible. Against: a measured 15% regret
+regression is exactly what this branch has declined six times before. For: the regret is now *visible and
+attributable* rather than hidden behind an elimination, and it is bounded by one arm's accuracy — the same
+arm whose two defects are already measured (`scan_units` overstating P3 by 13–15×,
+`STREAM_RESIDUAL_FLOOR_NS` charging 11.63 ns/card against a measured 6.7). Fixing those converts the
+exposure into the win.
+
+**The bare-format artwork mispick survives, and is now purely a cost error.** StreamedSelect with the
+consumed form measured 79.83 µs against compose's 177.83 on `f:gladiator`/artwork, and the router still
+picks compose — but now because it prices compose 4–6× too cheaply against P3, not because P3 was removed
+from the ballot. The architecture stopped hiding the problem, which is what makes the remaining work worth
+doing.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1,0 +1,125 @@
+# Measuring P3 and P4's loop and finish phases with built designs
+
+Branch `engine-compose-feature-accuracy`. Companion to
+[reference-cost-model-measurement.md](./reference-cost-model-measurement.md), which covers which tool
+answers which question; this covers what the tools said about `StreamedSelect` (P3) and
+`GatheredScan` (P4), and what is left.
+
+The earlier campaign in [local-engine-cost-model-agreement.md](./local-engine-cost-model-agreement.md)
+fitted rates from sampled traffic. This one built designed experiments instead, because several rates
+are **unidentifiable from traffic at any corpus size** — and that turned out to be the least
+interesting thing it found.
+
+## The one rule that came out of it
+
+**Shape from a built design; levels from traffic.** Not a preference — six refits of kernel-measured
+levels each made routing worse, and the two changes that shipped were both cases where a design found
+a *missing term* and traffic then set its rate.
+
+Built designs win on shape because the experimenter controls the ratios. Traffic wins on levels
+because it has production's cache state, query mix and interleaving, and every attempt to substitute
+a measured level for a fitted one has failed.
+
+## What shipped
+
+Two terms, both found by a design, both levelled by traffic, both mirror-verified at 100% and gated
+interleaved A/B/A/B.
+
+**`STREAM_PERM_STEP_NS`** — P3's permutation walk was not charged at all. The walk steps until the page
+fills, so it visits ~`page_span × n_cards / matches` entries: inversely proportional to selectivity, and
+proportional to nothing else in `PlanFeatures`. Against a fixed 1,500 matches the arm predicted ~397 ns
+while the walk cost 1,333 / 3,791 / 10,458 ns at 31.5k / 126k / 410k cards — under by 3.4× at the
+production corpus and 26× at 410k. Explains P3's finish phase grading mean |log| 2.06 while carrying 12%
+of all measured nanoseconds. Rate 1.0 from the kernel, 1.15 from traffic. **Regret neutral.**
+
+**`GATHER_COLLECT_PER_PAGE_ROW_NS`** — P4's finish phase was charged on `page_span` alone, which a
+four-row page sweep falsifies outright:
+
+| offset | limit | page_span | ns_finish |
+| --: | --: | --: | --: |
+| 0 | 15 | 15 | 125 |
+| 0 | 60 | 60 | 584 |
+| 0 | 600 | 600 | 16,375 |
+| 900 | 60 | 960 | 11,250 |
+
+`page_span` 960 costing less than 600 is impossible under one column: the quickselect scales with
+`offset + limit`, the collect with the page returned. Level 9.79 from traffic (the sweep said ~15).
+**Neutral to marginally negative** — taken for correctness, since a one-column model four rows disprove
+should not survive on a neutral gate.
+
+## What was declined, and why that is the more useful result
+
+**`GATHER_FIXED_COST_NS` (169.6, traffic says 85).** Looked like the cheapest win available: a 2×
+disagreement with no shape question. Measuring the intercept from cells differing *only* in card count
+gives **card −1,084 ns, printing −845 ns**. A negative fixed cost is impossible, so the linear-in-cards
+shape is wrong — the loop is **convex** in card count (12.40 ns/card across 400–4,500 against 6.31–7.67
+over 1,500–4,500). A straight line through a convex curve drives its intercept negative, and a
+whole-arm fit puts that same curvature in its intercept.
+
+So 85 is curvature compensation, not a fixed cost. Two consequences:
+
+- **Every plan's `FIXED` is its arm's error sink.** `fit_cost_model.py` fits one equation per query
+  against total dispatch, so no plan's fixed cost should be read off it without an independent intercept
+  measurement. `STREAM_FIXED_COST_NS` (217, fitted 192) is unexamined on this basis.
+- The convexity **is** the corpus-size effect below. P4's `FIXED` disagreement and corpus drift are one
+  problem.
+
+## Retractions
+
+Recorded because both were believed and acted on:
+
+- **"The shipped constants are ~2× too high."** They are not. `ITERS` walked one card list repeatedly
+  and kept the minimum, so every rate was warm-cache; the first pass costs 1.6–2.2× more. Cold and
+  rotated at production corpus size, P4 reads LOOP 6.27 against a shipped 6.88 and SCAN 2.27 against
+  2.06. Fixed by chunk **rotation** plus per-cell **stagger** — both needed, since rotation alone left
+  cells sharing a chunk, one paying all the misses (10.50 vs 6.11 ns/card on identical cards).
+- **"The error is in the features."** No. Every counter/feature ratio reads 1.00 for both plans. The
+  1.00s had already ruled it out.
+- **"`STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` is 24–40× too high."** No — those readings came from cells
+  in the *perm-walk* branch. 600-card cells reach the gather branch and measure 1.075–1.250 against the
+  shipped 1.02. Confirmed, not changed.
+
+## Structural findings that outlive the constants
+
+- **Degenerate columns.** No single `unique` mode identifies P4's three loop rates: card mode pushes once
+  per card (`matches == cards`), printing mode pushes every printing (`matches == printings`). Pooling
+  separates them but averages over the mode differences being measured. Resolved by fitting each mode in
+  the two-parameter space it supports and recovering the three from the pair of pairs — which yields
+  `PUSH` twice over (1.24 and 0.88, agreeing to 1.41×) as a linearity check.
+- **P3's loop is linear** in its two counters to 1.01×, cross-checked from different cells and columns.
+- **P3's gating is right**: zero printings examined under `all_match` at every printings-per-card level.
+- **Artwork is a different loop**, needing its own per-card and per-printing rates in P4 (6.57 / 1.09
+  against 2.98 / 2.36) while sharing the push. Its surcharge *flips sign* with printings-per-card, so no
+  additive correction can express it. Measured, shape-confirmed, **never gated on its own.**
+- **Rates are corpus-size dependent, and differently per plan** — over 31.5k → 410k cards, P3's
+  `all_match` per-card is flat (2.58 / 2.54 / 2.55) while its residual per-card grows 3.6× and P4's loop
+  grows 2.4×. So the P3/P4 balance drifts as the corpus grows with every constant left alone.
+
+## Tooling added
+
+- `card_engine/src/bench_gather_loop.rs`, `bench_streamed_loop.rs` — call the real executors and read
+  `PhaseStats`, so nothing is reimplemented. Chunk-rotated, per-cell staggered, median over rotations.
+  `BENCH_LOOP_STORE` selects the store.
+- `scripts/upscale_corpus.py` — replicates the real corpus, rewriting `oracle_id` / `scryfall_id` /
+  `illustration_id` and suffixing names, leaving everything cost-relevant alone. Needed because the real
+  corpus gives the wide group one chunk at 4,500 cards. **The 126k and 410k stores are ~1.4 GB in
+  `benchmarks/loop-scale/` — delete when done.**
+- `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
+
+## What is left
+
+1. **Seek the streamed walk to its first match.** The walk starts at permutation index 0 unconditionally,
+   so `year>=2020 order=released asc` grinds through the whole pre-2020 prefix discarding on
+   `counts[cid] == 0`. The match loop already visits every candidate, so one `inv[cid]` read plus a `min`
+   over matching cards gives the first match's position for free, and the walk can start there. Stronger
+   than deriving a bound from the predicate: it is the realized minimum, so it works for any predicate and
+   cannot be wrong about tie-breaking. Attacks the expensive tail directly — `perm_steps`
+   realized/estimated grades median 0.99 with **p10 0.12 / p90 7.01**, and p90 is exactly the late-cluster
+   case a seek deletes. Verify row identity against the reference, as this touches paging. Descending needs
+   nothing: there are two permutations per column, one per direction.
+2. **Re-grade the perm estimate after (1)**, then fit whatever spread remains. Doing it before would be
+   modelling wasted work we can cheaply stop doing.
+3. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
+4. **Gate P4's artwork arm on its own.**
+5. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
+   bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -47,6 +47,69 @@ four-row page sweep falsifies outright:
 **Neutral to marginally negative** — taken for correctness, since a one-column model four rows disprove
 should not survive on a neutral gate.
 
+**The emission walk's match span.** The walk started at permutation index 0 and stopped only when the
+page filled, so it stepped every entry ordered before the first match (`cmc>=6 order=cmc asc`: 28,275
+entries for a 60-row page, 10.6 us of a 20.25 us execution) and, on any page it could not fill, every
+entry after the last match. Bounded to `min..=max` of `inv_perm` over matching cards — realized, so it
+holds for any predicate and cannot be wrong about tie-breaking — the same query walks 60 entries in
+0.38 us. Row identity verified against `GatheredScan` on an anti-correlated corpus at four offsets in
+every mode and direction, because a bound one entry off drops a row rather than crashing.
+
+**Gated**, at candidates ≤ ¼ of the corpus, because the span costs 0.51 ns per matching card against a
+match loop that is ~2.6 ns/card: ungated it took `cmc>=1 order=edhrec`'s `ns_loop` from 78.54 to 94.46
+us while its walk stayed at 111 steps. The bound can save at most `(n_cards − m) × 0.37 ns` against
+`m × 0.51 ns`, so worst-case break-even is 0.42 × `n_cards` and the gate sits inside it.
+
+| exec, span on/off (geometric mean) | cells |
+| --- | --- |
+| clustered (predicate correlates with orderby) | **0.660** over 8 |
+| broad (gate off — identical path) | 1.000 over 4 |
+
+Pooled over 419 sampled `StreamedSelect` queries: no detectable difference, −0.10 us, CI [−0.62, +0.41].
+
+## Measuring this needed one binary, not two
+
+`scripts/bench_walk_span.py` A/Bs `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` in interleaved
+subprocesses of a single build, with equal-length env values. That is not fastidiousness — a
+cross-build attempt got the sign wrong:
+
+- `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on a phase neither build changed, ±9%
+  in both directions. A 0.5 ns/card effect is invisible under that.
+- `bench_plan_execution_ab.py` across builds called the change 2% **slower** — while its own acquire
+  control, which the change cannot touch, moved 1.9% the same way. Within one binary the control is
+  flat (+0.01 us, median ratio 1.000) and the verdict is no detectable difference.
+
+Both are the failure the toolkit already documents (`min` is a floor estimator; its error is
+common-mode within a run, so pairing does not cancel it). The toggle removes it by construction:
+identical code, identical layout, one process each.
+
+## Regrading the perm estimate
+
+`perm_steps` realized/estimated, same seed and sample length, ~12.3k walking rows:
+
+| walk | p10 | median | p90 |
+| --- | --: | --: | --: |
+| unbounded | 0.13 | 1.00 | 6.43 |
+| bounded, gated | 0.09 | 0.94 | 5.07 |
+| bounded, ungated | 0.08 | 0.90 | 4.26 |
+
+Three things fall out of that table.
+
+- **A third of the p90 tail was the leading prefix**, and it is gone. p90 is the late-cluster case, so
+  this is the estimate's largest error being deleted rather than modelled — which was the point of
+  doing (1) before (2).
+- **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.15–1.17 after. Deleting a
+  third of the steps at the tail without moving the per-step rate is what a real per-unit cost looks
+  like, as against a coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS`
+  turned out to be. Left at the shipped 1.0; no refit.
+- **The cost model prefers ungated and the runtime prefers gated.** Recorded, not resolved: the
+  mechanism that ends the tension is a predicate-derived start position (below), which costs nothing per
+  card and so needs no gate.
+
+What remains at p90 5.07 is **interior** to the span — non-matching entries between matches, which no
+start position can skip. Different mechanism, and one the engine already owns elsewhere: the
+popcount-skip walk.
+
 ## What was declined, and why that is the more useful result
 
 **`GATHER_FIXED_COST_NS` (169.6, traffic says 85).** Looked like the cheapest win available: a 2×
@@ -104,21 +167,30 @@ Recorded because both were believed and acted on:
   `illustration_id` and suffixing names, leaving everything cost-relevant alone. Needed because the real
   corpus gives the wide group one chunk at 4,500 cards. **The 126k and 410k stores are ~1.4 GB in
   `benchmarks/loop-scale/` — delete when done.**
+- `scripts/bench_walk_span.py` — A/Bs the walk's span bound through
+  `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` inside one binary, clustered cells against broad controls.
+  The pattern to copy for any change whose effect is smaller than the cross-build floor error: one build,
+  a runtime toggle, interleaved subprocesses, equal-length env values.
 - `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
 
 ## What is left
 
-1. **Seek the streamed walk to its first match.** The walk starts at permutation index 0 unconditionally,
-   so `year>=2020 order=released asc` grinds through the whole pre-2020 prefix discarding on
-   `counts[cid] == 0`. The match loop already visits every candidate, so one `inv[cid]` read plus a `min`
-   over matching cards gives the first match's position for free, and the walk can start there. Stronger
-   than deriving a bound from the predicate: it is the realized minimum, so it works for any predicate and
-   cannot be wrong about tie-breaking. Attacks the expensive tail directly — `perm_steps`
-   realized/estimated grades median 0.99 with **p10 0.12 / p90 7.01**, and p90 is exactly the late-cluster
-   case a seek deletes. Verify row identity against the reference, as this touches paging. Descending needs
-   nothing: there are two permutations per column, one per direction.
-2. **Re-grade the perm estimate after (1)**, then fit whatever spread remains. Doing it before would be
-   modelling wasted work we can cheaply stop doing.
+1. **A predicate-derived start position, which would cost nothing per card.** The permutation IS a sorted
+   array on `(sort key, edhrec, cid)`, so when the filter bounds the *sort column* — `cmc>=6` under
+   `order=cmc`, exactly the correlation that makes a cluster — a binary search for the first position whose
+   value satisfies the bound gives a start in O(log `n_cards`) once per query, against 0.51 ns × matching
+   cards for the realized span. Seek to the START of the boundary tie block and it can only start too
+   early, never too late, which answers the tie-breaking objection that made the realized span the first
+   choice. It composes with the span rather than replacing it (free ⇒ no gate ⇒ available to broad queries
+   too), and it is what would let the cost model have the ungated column of the regrade table above.
+   Conjunction analysis to extract the bound, plus row-identity verification, since it touches paging again.
+2. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 is
+   non-matching entries *interior* to the match span, and a start position cannot reach those by
+   construction. Scattering the match set through `inv_perm` and walking words at 64 cards a load is the
+   mechanism that can — `run_query_streamed_popcount` already does it for `unique=card` queries whose
+   filter fully consumed to `True`. Generalizing it needs per-card match counts for the skip (a popcount
+   counts cards, not matches, so printing/artwork mode cannot skip by popcount alone) and pays the same
+   per-card scatter the span bound pays, so it wants the same gate or the free start position above.
 3. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
 4. **Gate P4's artwork arm on its own.**
 5. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -980,3 +980,67 @@ being costed. A bitmap AND of the candidate set against an indexed leaf's set wo
    candidates up, though that doc measures the acquire, which regret excludes by construction.
 3. **Accept the spread.** The evidence so far is that `matches` is irreducibly estimated on this acquire
    without doing the residual's own work, and that its error is what the P3/P4 pair mostly reflects.
+
+### Miss size predicts the cause, which reverses how to read the 26%
+
+Splitting the candidates acquire's mis-picks (>2 µs gap) by whether realized counters would fix the order:
+
+| cause | n | % of n | sum lost | % of ms | mean | p90 |
+| --- | --: | --: | --: | --: | --: | --: |
+| feature (oracle fixes the order) | 625 | 26% | 27.9 ms | **37%** | **44.6 µs** | 81.3 |
+| rate/shape (survives the oracle) | 1,796 | 74% | 47.4 ms | 63% | 26.4 µs | 43.5 |
+
+| band | n | feature-caused, % of count |
+| --- | --: | --: |
+| 2–10 µs | 492 | 15% |
+| 10–30 µs | 929 | 16% |
+| 30–100 µs | 935 | **40%** |
+| >100 µs | 65 | **54%** |
+
+**Feature errors are the expensive tail; rate errors are the cheap bulk.** Since regret here is entirely a
+tail phenomenon (`p90 = 0.00` on every acquire), the 26% headcount understates feature work — it is 37% of
+avoidable time and 54% of the misses over 100 µs. An earlier note in this file called 25% the ceiling on
+feature work; that read the wrong column.
+
+### Pattern A shipped: P3's scan gated on within-card invariance
+
+Two feature defects produce all 625. The first is fixed.
+
+A residual invariant *within* a card never goes printing-dependent — `card_pass` returns `True`/`False` and
+never `Tri::PrintingDep`, so the streamed kernel sets its per-card `all_match` and `card_match_count` answers
+from span arithmetic. **P3 examines no printings at all.** The arm was charging `scan_units ×
+STREAM_SCAN_PER_ROW_NS` for the whole candidate span anyway:
+
+    name:s / artwork, order=cmc desc, limit=100        LOST 368.0 us
+      StreamedSelect   pred 1507.0 us   meas  456.0 us   <- best
+      GatheredScan     pred 1213.8 us   meas  824.0 us   <- picked
+      feature          used      P3 realized   P4 realized
+      eval_domain      31,508    31,508        31,508      1.00x
+      scan_units       97,206    0             60,705      1.60x
+      matches          31,508    29,169        29,169       1.08x
+
+580 µs of P3's 1,507 µs prediction, for work it does not do. `!touches_printing_field` is the test, so
+`stream_scan_units` goes to 0 there; P4's `scan_units` is untouched, since it walks each span to push and its
+60,705 is real. **That asymmetry is why it moves an argmin at all.**
+
+This is the `all_match_known` gate one step weaker: that needs the whole residual to be `True`, this needs
+only that it cannot vary within a card — which `name:s`, `o:`, `t:` and `cmc` satisfy as ordinary residuals.
+Third place this same class of defect has been found (compose's verify tier, compose's `eval_domain`, here).
+
+| | before | after |
+| --- | --: | --: |
+| regret mean, all queries | 1.52 µs | **1.43 µs** |
+| `candidates / printing` mean | 1.68 | **1.45** |
+| mis-picks >2 µs | 2,421 | 2,294 |
+| feature-caused lost time | 27.9 ms | **24.0 ms** |
+| feature-caused **max** single miss | **421.7 µs** | **272.4 µs** |
+| >100 µs band, feature-caused | 54% | **36%** |
+
+`GatheredScan vs StreamedSelect [candidates]` stays at 92% and 2.42 µs, because the class is a few hundred
+rows of 11,559 pairs — the win is the tail, not the rate. Earlier runs of the aggregate spanned 1.49–1.54 µs,
+so the 1.43 is only modestly outside run noise; the max-miss and band shifts are the load-bearing evidence.
+
+**Pattern B is not fixed**: `matches` over-estimated up to **219×** on selective conjunctions
+(`eur<=0.09 usd>=0.38 usd<=4.92` used 31,508 against a realized 144; `eur:0.39` 31,508 against 439). Both are
+tier-4 MASK price ranges where the span base is meaningless, and both routes to an exact count were measured
+and declined above.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -545,7 +545,10 @@ cost-only changes and `force_plan_differential_agreement` already proves every p
 The honest caveat: the P4 scan fix **did not fix the pair**. `GatheredScan vs StreamedSelect
 [printing_compose]` is still 69% ordered right (gap 0.89 → 0.91), and `StreamedSelect -> GatheredScan`
 returned to its baseline level rather than improving on it. What the fix removed was the bias that was
-*amplifying* the gate's exposure to that pair. The pair remains item 1.
+*amplifying* the gate's exposure to that pair. The pair remains item 1 — and it is now diagnosed there as a
+named sub-population (broad residuals, both plans scanning the corpus, the two arms' scan rates 2.9× apart)
+rather than the variance this section first guessed at. The card-invariant half of the acquire, which is what
+these two changes touched, orders **409/409** correctly.
 
 Also worth watching: `GatheredScan vs PrintingCompose [printing_compose]` gap sizing drifted 1.14 → 1.40
 while staying 92% ordered right, so it costs nothing yet and is a sign compose's arm is absorbing something.
@@ -569,29 +572,52 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
 
 ## What is left
 
-1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,391 pairs at **69% ordered right**,
-   mean regret 36.82 µs — the worst-ranked pair in the engine and now the top item, because it is the
-   prerequisite for the P3 tier gate above rather than a peer of it. The gate is written and measured
-   (targeted pair 80% → 96%, mean regret 11.04 → 1.57 µs) and cannot ship while this pair is 69%: correcting
-   P3 lets it into the argmin more often. Two corrections landed against it and **neither moved its
-   ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%, gap 0.89 → 0.91). Those bought
-   −25% total regret by removing biases that amplified this pair; the pair itself is untouched and is now the
-   engine's largest single routing error at 3,403 pairs and 36.40 µs mean regret.
+1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,403 pairs at **69% ordered right**,
+   mean regret 36.40 µs — the engine's largest single routing error and the top item. Two corrections landed
+   against it and **neither moved its ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%,
+   gap 0.89 → 0.91). Both were worth doing — together −25% total regret — but they bought that by removing
+   biases that *amplified* this pair, not by ranking it. The pair itself is untouched.
 
-   The gap ratio being 0.91 is the whole diagnosis: the model sizes this difference **correctly on average**
-   and gets the **sign** wrong 31% of the time. So no constant fixes it — it is variance, and the feature
-   grading says where the variance lives. `eval_domain` on this acquire reads p90/p10 **3.1** and `scan_units`
-   **4.5** even after the bias fix, because both descend from `calibrated_balls_into_bins` — an *estimate*,
-   where the `candidates` acquire (92% ordered right) has exact narrowed counts. The likely answer is not a
-   better estimator but making the two plans' costs depend on the estimate the *same* way, so its error
-   cancels in their difference the way the verify tier already does.
+   **Not variance — a sub-population, and it is named.** The gap ratio of 0.91 invites reading this as noise
+   around a correct average; splitting the pairs by whether the sign is right says otherwise. Over 5,085
+   non-tie pairs:
+
+   | group | n | P3 wins (measured) | P3 wins (predicted) | median \|gap\| |
+   | --- | --: | --: | --: | --: |
+   | right, tier 0 (card-invariant) | 409 | 100% | 100% | — |
+   | right, tier > 0 (real residual) | 3,100 | 5% | 5% | 31.8 µs |
+   | **wrong, tier > 0** | **1,576** | **98%** | **2%** | **98.4 µs** |
+
+   Every wrong pair is in the `tier > 0` regime — the card-invariant population the two fixes above touched
+   is ordered **409/409** correctly. And the wrong group is not mixed: P3 really wins 98% of it while the
+   model says P4 wins 98% of it. The model **over-picks P4** on a specific class.
+
+   That class is **broad residuals where both plans examine the whole corpus** — `border:black`,
+   `year<=2026`, `cn<336`, bare date ranges. Worst cells, `printings_examined` = 97,206 for *both* plans:
+
+   | query / mode | P3 meas | P4 meas | P3 pred | P4 pred |
+   | --- | --: | --: | --: | --: |
+   | `border:black` / printing | 861.3 | 1,489.8 | 841.8 | **838.2** |
+   | `cn<=226 year>2004` / printing | 1,025.3 | 1,454.7 | 789.6 | **756.4** |
+   | `year<=2026` / artwork | 601.6 | 1,026.9 | 1,629.2 | **1,326.1** |
+
+   P3 is genuinely ~1.7× faster and the model has the pair tied to within 5 µs. What brings it to parity is
+   the two arms' per-printing scan rates: `STREAM_SCAN_PER_ROW_NS` 5.97 against `GATHER_SCAN_PER_ROW_NS`
+   2.06, a **2.9× ratio for what is nominally the same walk-a-printing-and-test work**. P3's higher rate
+   cancels its lower per-card rate exactly where both features are maximal.
+
+   The trap for whoever takes this: a pooled traffic fit **endorses both rates** (StreamedSelect
+   `SCAN_PER_ROW` fits 6.04, ratio 1.01; GatheredScan 2.53, ratio 1.23), so `fit_cost_model` will not find
+   this and a pooled refit cannot fix it. It needs the population split — the same lesson this file has now
+   learned three times. Wrong-rate concentrates by mode: artwork 38–46%, printing 25–46%, card 16–24%.
 
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.
-2. **Decide the 13% regret debt.** Regret sits at 55.0 ms against a 48.7 ms baseline, all of it from making
-   the split non-destructive — which is correct, but hands the argmin a candidate whose arm is badly modelled.
-   Either (1) above pays it back, or revert the split and give back `f:modern t:creature`'s 0.476× until the
-   arm is fixed. Isolated: the consume guard is not the cause (56.8 ms with it off against 55.0 with it on).
+2. ~~**Decide the 13% regret debt.**~~ **Closed** — and neither of the two options on offer was the answer.
+   The debt was never bounded by compose's arm; the mispriced arm was P3's. Gating the verify tier on the
+   compose acquire plus fixing P4's candidate span took regret to **61.2 ms against the 81.7 ms measured
+   baseline, −25%**, without reverting the split, so `f:modern t:creature`'s 0.476× is kept. See the
+   retraction section above for why the original framing pointed at the wrong plan.
 3. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has two
    sources, neither reachable from a start position: entries *interior* to the walked segment, and clustering
    the predicate does not name (the 5.31-vs-4.26 gap in the regrade table). Scattering the match set through

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -479,16 +479,30 @@ candidate explanations for it have now been eliminated by measurement. Two hones
 
 ## What is left
 
-1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has
-   two sources, and neither is reachable from a start position: non-matching entries *interior* to the
-   walked segment, and clustering the predicate does not name (the 5.31-vs-4.26 gap in the regrade table).
-   Scattering the match set through `inv_perm` and walking words at 64 cards a load reaches both —
-   `run_query_streamed_popcount` already does exactly that for `unique=card` queries whose filter fully
-   consumed to `True`, and printing mode, where P3 is actually routed, is the case it does not cover.
-   Generalizing it needs per-card match counts for the skip (a popcount counts cards, not matches) and
-   pays a per-card scatter, so it inherits the cost question the realized span had — with the difference
-   that its payoff does not depend on matches being contiguous.
-2. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
-3. **Gate P4's artwork arm on its own.**
-4. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
+1. **Compose's remaining shape error, on compose-acquire artwork.** The largest open finding and the one that
+   pays the regret debt. After correcting `stream_scan_units` the model still prices compose ~1.5× under P3
+   where P3 measures ~1.7× faster — `f:gladiator`/artwork, P3 at 79.83 µs against compose's 177.83 — so ~2.5×
+   survives, and it is provably none of the three things already measured: not the residual floor (traffic
+   fits it at 0.90), not the scan feature (now correct against the realized counter), not the per-card level.
+   Sixteen mispicks remain. Compose is also the worst-modelled arm overall (p90 41×, spread 136× on
+   rarity/usd ordering), so this is where its arm should be attacked.
+2. **Decide the 13% regret debt.** Regret sits at 55.0 ms against a 48.7 ms baseline, all of it from making
+   the split non-destructive — which is correct, but hands the argmin a candidate whose arm is badly modelled.
+   Either (1) above pays it back, or revert the split and give back `f:modern t:creature`'s 0.476× until the
+   arm is fixed. Isolated: the consume guard is not the cause (56.8 ms with it off against 55.0 with it on).
+3. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has two
+   sources, neither reachable from a start position: entries *interior* to the walked segment, and clustering
+   the predicate does not name (the 5.31-vs-4.26 gap in the regrade table). Scattering the match set through
+   `inv_perm` and walking words at 64 cards a load reaches both, and `run_query_streamed_popcount` already
+   does that for `unique=card` + `True` — printing mode, where P3 is actually routed, is the case it does not
+   cover. Needs per-card counts for the skip, since a popcount counts cards and not matches.
+4. **Compose `format:A AND format:B` now that both are usually card-invariant.** The shared-witness objection
+   dissolves when neither format diverges: `∃p: A(p) ∧ B` is `(∃p: A(p)) ∧ B`. `compile_plane` still declines
+   it with `u64::MAX`, and `legality_and_of_two_formats_declines_but_or_compiles` names the assertion to
+   revisit.
+5. **A curvature term for the loop rates** — cause of both the `FIXED` disagreement and corpus drift, though
+   the five-size sweep demoted it: the drift saturates and production sits at the bottom of the curve.
+6. **Gate P4's artwork arm on its own.** Every surviving mispick is in artwork mode, which makes this more
+   interesting than when it was queued.
+7. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
    bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1195,11 +1195,45 @@ wrong magnitude. Every `exam == 0` row is `all_match_known` or `residual_card_in
 | artwork regret slice, max | 185.5 µs | **732.5** |
 | total regret, mean | 1.44 | 1.48 |
 
-**Not shipped.** The +1.21 is compensating for something else in the P3/P4 artwork balance and cannot be
-removed alone — which is `bench_gather_loop`'s "P4 cannot be fixed alone" for a third time, and is exactly
-what item 6 has to mean now: **both artwork arms together, or neither.** The measurement is recorded at the
-call site so the next attempt starts from the shape rather than rediscovering it.
+**Shipped, after the decline was retracted.** Two things overturned it.
 
-Fourth instance this session of a correct fix that removes a compensating error — after the verify-tier gate,
-the P4 span feature, and the estimator's ball count. Three of those paid once the exposed error was fixed too;
-this one has no partner fix yet, so it waits.
+**P4 needs no partner fix.** Measuring *both* arms' artwork-minus-printing delta — which the first attempt
+never did — shows P4 is already accurate in artwork mode and P3 is the only mispriced arm:
+
+| regime | | P3 | P4 |
+| --- | --- | --: | --: |
+| grouping walk does **not** run (n=9) | median surcharge | −0.52 ns/card | **−3.17** |
+| | **p/m** | **1.74** | **0.98** |
+| grouping walk **runs** (n=10) | median surcharge | +1.47 | −6.89 |
+| | **p/m** | 1.11 | 0.87 |
+
+P4's arm carries no mode-dependent term at all, yet lands at 0.87–0.98 — because its `matches` in artwork
+mode is the *deduped* artwork count, so its `PUSH` term already shrinks by roughly the real saving. So
+"+1.21 compensates for P4 being over-costed" was **false**, and there is only one arm to move.
+
+**And the alarming max was noise.** Re-measured over a longer sample:
+
+| run | total mean | artwork mean | artwork max |
+| --- | --: | --: | --: |
+| ungated, 180 s | 1.44 µs | 1.59 | 185.5 |
+| gated, 180 s | 1.48 | 1.71 | **732.5** |
+| gated, 240 s | 1.45 | 1.69 | **189.9** |
+
+The 4× max does not reproduce. What survives is a consistent ~6% cost on the artwork regret slice with total
+regret flat, against P3 going **p/m 1.74 → 1.25** where the walk does not run and 1.11 → 1.20 where it does.
+Both arms now sit inside 0.86–1.25 in artwork mode.
+
+Taken on the principle this file's own header states: ordering-correct-by-cancellation is a local optimum you
+cannot build on, because the next change has no ground truth to check itself against. Same trade as the
+non-destructive split, which was kept at a 15% regret cost for the same reason.
+
+**The counter this needed already existed**, which is the other correction. Both kernels publish the artwork
+grouping span in `printings_examined` — P4 accumulates `push_card_matches`'s return, P3 accumulates
+`card_match_count`'s second value — and P3's fast path correctly reports 0 because no walk happens. An earlier
+note here claimed the counter was missing and that a grouping walk was uncounted; both were wrong.
+
+### Item 6 is now closed
+
+Artwork's per-card surcharge was the last of it. The executor gate was removed (up to 24×), P3's surcharge is
+gated on the same signal, and P4 was measured and needs nothing. What remains in artwork mode is a level
+question inside 0.86–1.25 on both arms, which is not worth a refit against a warm-cache design.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -863,3 +863,70 @@ Three cautions in reading it, all of which change what the next item should be:
    interesting than when it was queued.
 7. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
    bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.
+
+## The candidates acquire: `matches`, and a declined tier-1 fix
+
+The re-baseline put `candidates` at 78% of lost time. Investigated, and it is a **different defect from the
+compose acquire's** — the compose-acquire lessons do not transfer.
+
+**It is not the features, mostly.** The oracle substitution that bought 89% on compose buys only **29%**
+here (60.0 → 42.3 ms). `eval_domain` is **exact at p10/p50/p90**, because on this acquire it is the
+materialized narrowed candidate count rather than an estimate. Every losing query is the P3/P4 pair, and it
+fails in **both directions** — `StreamedSelect -> GatheredScan` 1,159 queries / 38.8 ms and
+`GatheredScan -> StreamedSelect` 861 / 21.1 ms.
+
+**The one bad feature is `matches`, and the sign of its error picks the direction of the mispick:**
+
+| transition | n | `matches` / realized, p50 | sum lost |
+| --- | --: | --: | --: |
+| `StreamedSelect -> GatheredScan` | 782 | **29.85** | 27.5 ms |
+| `GatheredScan -> StreamedSelect` | 767 | **0.88** | 21.4 ms |
+| correct | 13,601 | **1.00** | 0.0 ms |
+
+The mechanism is an asymmetry: `matches` drives P4's `PUSH` at 2.24 ns against P3's `EMIT` at 0.12 — 18.7× —
+**and** enters P3's `perm_steps` inversely. Over-counting therefore charges P4 more and P3 less, both
+favouring P3. `matches_pushed` agreed between the two plans on 100% of rows, so one shared feature is
+structurally fine here; it is simply wrong.
+
+`matches` is the candidates' printing/artwork **span** discounted by one constant per mode
+(`RESIDUAL_PASS_RATE_PRINTING` 0.40, `_ARTWORK` 0.53). A p50 of 29.85 is far past what any rate explains: the
+span is ~75× the truth there, because under a loose narrowing most candidates do not match at all. **Same
+class of defect as `eval_domain`'s** — a span is the wrong base for a match estimate — one field over.
+
+### Tier 1, measured and declined as a fix
+
+`filter::touches_printing_field` is new: the `any` composition of the leaf table `printing_dependent` reads
+with `all`, factored so the two callers cannot disagree on the table. A card-invariant residual answers
+`True`/`False` per card, so a candidate contributes its whole span or none. Published as
+`residual_card_invariant`; **nothing in `plan_cost` reads it.**
+
+Implied true pass rate, `shipped / (matches / realized)`:
+
+| mode | residual class | n | p10 | p50 | p90 |
+| --- | --- | --: | --: | --: | --: |
+| printing | card-invariant | 257 | 0.00 | **0.78** | 1.00 |
+| printing | printing-varying | 2,544 | 0.06 | **0.35** | 0.87 |
+| artwork | card-invariant | 221 | 0.00 | **0.60** | 0.90 |
+| artwork | printing-varying | 2,386 | 0.09 | **0.43** | 0.74 |
+
+The classifier separates the populations — 2.2× in printing mode — and the shipped 0.40 sits on the
+printing-varying value, confirming it was fitted there. **But the hypothesis it was built to test is wrong.**
+"Card-invariant ⇒ pass rate 1.0" fails: p50 is 0.78 and **p10 is 0.00**. The all-or-nothing reasoning holds,
+but the rate is then "what fraction of *candidates* match", which the residual's class does not pin — the
+spread inside the class is the full 0.00–1.00. And the class is only **9% of rows**, so a perfect rate there
+moves almost nothing.
+
+**Split constants are therefore not worth shipping**, and the diagnostic is kept only to scope the next step.
+
+### Why tier 2 is the work
+
+Printing-varying is 91% of rows and its median is already within 14% of shipped (0.35 against 0.40). The
+defect there is **spread — 0.06 to 0.87, a 14× range** — which no constant can address. That is the argument
+for a per-predicate estimate rather than a better global rate:
+
+- **Indexed range residuals** (`usd`, `cn`, `date`) have an exact printing count from two
+  `partition_point` calls, which `bare_range_bounds` already uses for its `k`.
+- **Plane residuals** (border, rarity, legality) have stored popcounts.
+- The residual usually is not the whole predicate, so a global pass fraction still assumes independence
+  from the candidate set — the assumption that just cost us on `eval_domain`. Preferring a direct count
+  where the residual *is* the leaf avoids it; conjunctions still need care.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -582,6 +582,39 @@ candidate explanations for it have now been eliminated by measurement. Two hones
 **61.2 ms against the 81.7 ms measured baseline, −25%**, without reverting the split, so `f:modern
 t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: the P3/P4 pair at 69%, item 1.
 
+## Re-baselined after this series, because the ranking moved
+
+`bench_regret_matrix.py --seconds 180`, current build. The acquire this whole investigation was picked from
+has dropped from roughly half of all lost time to a fifth:
+
+| acquire | n | mean | SHARE |
+| --- | --: | --: | --: |
+| **candidates** | 26,251 | 1.69 µs | **78%** |
+| printing_compose | 7,536 | 1.60 µs | **21%** (was ~49%) |
+| printing_range_scan / plane / card_range_popcount | 3,370 | ≤0.22 | 0% |
+
+| cell | mean | SHARE |
+| --- | --: | --: |
+| candidates / artwork | 1.91 µs | 32% |
+| candidates / printing | 1.68 | 28% |
+| candidates / card | 1.43 | 19% |
+| printing_compose / printing | 1.63 | 8% |
+| printing_compose / card | **2.09** | 7% |
+| printing_compose / artwork | 1.25 | **6%** (was 32%) |
+
+Three cautions in reading it, all of which change what the next item should be:
+
+- **The compose acquire is no longer unusually broken.** Its mean is *lower* than `candidates`. The 78/21
+  split is volume — 3.5× the queries — not severity. "Candidates is now the problem" describes where the
+  aggregate lives, not a newly found defect.
+- **The loss is entirely tail.** `p90 = 0.00` on every acquire; only p99 (36–64 µs) carries anything. The
+  median query has zero regret, so a mean is the wrong thing to optimise and "improve the average estimate"
+  is the wrong instinct.
+- **The largest transition is unchanged**: `StreamedSelect -> GatheredScan`, 967 queries, mean 29.38 µs, 50%
+  of all loss. But on `candidates` that pair is already **92%** ordered right at 2.42 µs mean pair regret. So
+  what remains is the 8% tail of a well-ordered pair spread over high volume — a materially harder and
+  lower-yield target than anything fixed in this series, and it should be sized before it is started.
+
 ## What is left
 
 1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** Now **75% ordered right** over 4,825

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -466,26 +466,125 @@ where P3 measures ~1.7× faster, so ~2.5× survives a corrected feature — and 
 (traffic fits it at 0.90), not the floor, and not the scan feature. Something cell-specific to compose-acquire
 artwork is mis-shaped and none of the three things measured here is it.
 
+## It was not compose. It was P3, and fixing it uncovers a third pair
+
+**Retracted: "compose is priced ~1.5× under P3".** Attributing both arms term-by-term against measurement
+says the opposite — on the four card-invariant formats compose is the *well*-modelled plan and P3 is the
+broken one:
+
+| cell | P3 pred | P3 meas | P3 ratio | compose pred | compose meas | compose ratio |
+| --- | --: | --: | --: | --: | --: | --: |
+| `f:gladiator` / artwork | 259.58 | 72.58 | **0.28** | 178.73 | 186.54 | 1.04 |
+| `f:predh` / printing | 215.80 | 34.08 | **0.16** | 70.62 | 80.21 | 1.14 |
+| `f:commander` / artwork | 323.24 | 143.62 | **0.44** | 188.80 | 220.12 | 1.17 |
+| `f:oldschool` / artwork *(the divergent format)* | 31.88 | 35.62 | 1.12 | 14.82 | 37.00 | **2.50** |
+
+Compose is under-priced only on `oldschool` — the *opposite* format from where the mispicks are. The
+attribution reproduces `predicted_ns` exactly, so this is arithmetic on the shipped arm, not a re-fit.
+
+**The mechanism.** `acquire_plan_features`'s compose branch passed `verify_cost_tier(composed)` with no
+gate, where the general candidate path gates on `all_match_known`. On a card-invariant legality format
+`card_pass` returns `Tri::True` at card level for every card, so the kernel takes its `all_match` arm and
+`printings_examined` reads **0** — while the model charged `CARD_PASS + max(tier, FLOOR)` = 9.05 ns on every
+candidate *and* `stream_scan_units × 5.97`. Those two dead terms are **92–94% of P3's predicted cost** on
+these cells.
+
+**One retraction inside the fix.** A first attempt priced this as the divergent *share* of the corpus
+(`legal_divergent / n_cards`, ~1.76%). That is wrong in principle — for `f:oldschool` the candidates largely
+*are* the divergent cards, so a global share under-charges exactly the cells whose residual is real. It
+traded 408 mispicks for 118 that were four times worse (mean 54.27 → 206.24 µs) for a net 3.4%. The right
+signal is the boolean the engine already derives from data, `plane_expr_is_existential` against
+`divergent_formats`, extracted as `plane_leaves_nothing_to_verify` so the router asks what the executor asks.
+
+**The gate works on the pair it targets, and costs regret elsewhere.** Pairwise ordering, 120 s uniform:
+
+| pair, `[printing_compose]` acquire | baseline | with the gate |
+| --- | --: | --: |
+| `PrintingCompose vs StreamedSelect` | 80% ordered right, mean regret 11.04 µs | **96%, 1.57 µs** |
+| `GatheredScan vs StreamedSelect` | 69%, 35.96 µs, gap 0.89 | 69%, 36.82 µs, gap 0.90 |
+
+Total regret went **81.7 → 129.7 ms** (mean 2.07 → 3.50 µs), with `StreamedSelect -> GatheredScan` going
+1,045 → 1,830 queries and 37% → 79% of all lost time. The two facts are not in conflict: the P3/P4 pair is
+**69% accurate before and after**, unmoved by this change, and correcting P3's cost simply lets P3 reach the
+argmin far more often, which multiplies exposure to it. P3's inflated cost was *masking* a pair that was
+already wrong — a compensating error, and every measurement of that pair ever taken through it was confounded
+by P3 being priced 3–6× over.
+
+### What the gate exposed: P4's scan feature over-counts 1.76× on the same population
+
+`GatheredScan` walks every printing of every candidate, so its scan feature is the candidate SPAN, estimated
+by `scan_all` as `est_cards ×` corpus-average printings-per-card `× 2.1`. That shape is right only when
+candidates are an average sample of the corpus. With nothing to verify they are not — every printing of a
+matching card matches, so the span **is** `printing_matches`, a quantity the branch already computes.
+Graded against P4's realized `printings_examined`, 597 card-invariant compose queries:
+
+| feature | p10 | p50 | p90 | p90/p10 |
+| --- | --: | --: | --: | --: |
+| `scan_units` (was shipped) | 1.13 | **1.76** | 5.08 | 4.5 |
+| `printing_matches` (now) | 0.68 | **0.93** | 3.08 | 4.5 |
+
+Scoped to the same boolean, because the grading **inverts** on the other population: with a real residual
+`scan_units` is right at p50 0.97 and `printing_matches` badly under at 0.39. A 1.76× over-charge on the
+dominant term of P4's arm is what makes P3 win where P4 is better, which is the slice the gate inflated.
+
+### Both together, measured at identical settings
+
+| build | total regret | mean | `PrintingCompose -> StreamedSelect` | `StreamedSelect -> GatheredScan` |
+| --- | --: | --: | --: | --: |
+| baseline (HEAD) | 81.7 ms | 2.07 µs | 408 q, 27% of loss | 1,045 q, 37% |
+| tier gate alone | 129.7 ms | 3.50 µs | 33 q, 0% | 1,830 q, 79% |
+| **gate + P4 scan** | **61.2 ms** | **1.55 µs** | 48 q, 1% | 1,050 q, 50% |
+
+**−25% regret against HEAD**, and the mispick class this started from is gone (408 → 48 queries, mean 54.27
+→ 13.58 µs). `cargo test` 149 debug / 148 release; row identity needs no new run because these are
+cost-only changes and `force_plan_differential_agreement` already proves every plan returns the same rows.
+
+The honest caveat: the P4 scan fix **did not fix the pair**. `GatheredScan vs StreamedSelect
+[printing_compose]` is still 69% ordered right (gap 0.89 → 0.91), and `StreamedSelect -> GatheredScan`
+returned to its baseline level rather than improving on it. What the fix removed was the bias that was
+*amplifying* the gate's exposure to that pair. The pair remains item 1.
+
+Also worth watching: `GatheredScan vs PrintingCompose [printing_compose]` gap sizing drifted 1.14 → 1.40
+while staying 92% ordered right, so it costs nothing yet and is a sign compose's arm is absorbing something.
+
 ## The open decision: 13% of regret is unpaid
 
 Regret stands at **55.0 ms against a 48.7 ms baseline**. The rise came from making the split
 non-destructive — handing the argmin a candidate whose arm is the worst-modelled in the engine — and both
 candidate explanations for it have now been eliminated by measurement. Two honest options:
 
-- **Find compose's remaining shape error.** It is the largest single error in the model (p90 41×, spread 136×
-  on rarity/usd) and it is now applicable on more queries, so the debt is bounded by that one arm.
-- **Revert the non-destructive split** and give back `f:modern t:creature`'s 0.476× until compose's arm is
-  fixed. The plumbing is inert on its own; only compose's widened applicability carries the cost.
+- **Find compose's remaining shape error.** ~~It is the largest single error in the model~~ — retracted; the
+  error on the mispicked cells is P3's, and the real prerequisite is the P3/P4 pair at 69%. See the section
+  above. Compose's rarity/usd spread is still real but is not what the artwork mispicks were made of.
+- **Revert the non-destructive split** and give back `f:modern t:creature`'s 0.476× until the compose acquire
+  can rank its plans. The plumbing is inert on its own; only compose's widened applicability carries the cost.
+
+**This decision is now closed, and neither option was the answer.** The debt was not bounded by compose's arm
+— the arm mis-pricing the mispicked cells was P3's. Correcting it plus P4's scan feature took regret to
+**61.2 ms against the 81.7 ms measured baseline, −25%**, without reverting the split, so `f:modern
+t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: the P3/P4 pair at 69%, item 1.
 
 ## What is left
 
-1. **Compose's remaining shape error, on compose-acquire artwork.** The largest open finding and the one that
-   pays the regret debt. After correcting `stream_scan_units` the model still prices compose ~1.5× under P3
-   where P3 measures ~1.7× faster — `f:gladiator`/artwork, P3 at 79.83 µs against compose's 177.83 — so ~2.5×
-   survives, and it is provably none of the three things already measured: not the residual floor (traffic
-   fits it at 0.90), not the scan feature (now correct against the realized counter), not the per-card level.
-   Sixteen mispicks remain. Compose is also the worst-modelled arm overall (p90 41×, spread 136× on
-   rarity/usd ordering), so this is where its arm should be attacked.
+1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,391 pairs at **69% ordered right**,
+   mean regret 36.82 µs — the worst-ranked pair in the engine and now the top item, because it is the
+   prerequisite for the P3 tier gate above rather than a peer of it. The gate is written and measured
+   (targeted pair 80% → 96%, mean regret 11.04 → 1.57 µs) and cannot ship while this pair is 69%: correcting
+   P3 lets it into the argmin more often. Two corrections landed against it and **neither moved its
+   ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%, gap 0.89 → 0.91). Those bought
+   −25% total regret by removing biases that amplified this pair; the pair itself is untouched and is now the
+   engine's largest single routing error at 3,403 pairs and 36.40 µs mean regret.
+
+   The gap ratio being 0.91 is the whole diagnosis: the model sizes this difference **correctly on average**
+   and gets the **sign** wrong 31% of the time. So no constant fixes it — it is variance, and the feature
+   grading says where the variance lives. `eval_domain` on this acquire reads p90/p10 **3.1** and `scan_units`
+   **4.5** even after the bias fix, because both descend from `calibrated_balls_into_bins` — an *estimate*,
+   where the `candidates` acquire (92% ordered right) has exact narrowed counts. The likely answer is not a
+   better estimator but making the two plans' costs depend on the estimate the *same* way, so its error
+   cancels in their difference the way the verify tier already does.
+
+   Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
+   on the mispicked cells and only `oldschool` is under-priced.
 2. **Decide the 13% regret debt.** Regret sits at 55.0 ms against a 48.7 ms baseline, all of it from making
    the split non-destructive — which is correct, but hands the argmin a candidate whose arm is badly modelled.
    Either (1) above pays it back, or revert the split and give back `f:modern t:creature`'s 0.476× until the

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1116,6 +1116,51 @@ term on artwork queries *with* a residual. Same structure as the verify-tier gat
 exposing an unmodelled cost underneath. `o:creature` never had that compensation, since its tier is 0, which
 is why it shows the error at full size.
 
-Sequencing consequence: **item 6 moves ahead of everything else on this list.** It is one term, its shape is
-already measured, the population is identifiable (`unique=artwork`, which carries 33% of all lost time), and
-it needs a counter for the grouping walk before its feature can be graded at all.
+### Corrected, and it was not a cost-model defect at all
+
+The diagnosis above was wrong about the mechanism, and the correction is worth more than the original finding.
+`printings_examined` reading 0 is **right**: `run_query_streamed` has a fast path that answers an artwork
+count from a stored per-card group count without touching a printing. The 921 us was not a grouping walk.
+
+It was `card_pass`. The `all_match_known` skip was **gated off for `Mode::Artwork`**, so `o:creature`/artwork
+ran a full oracle-text containment check over all 23,155 candidates that the narrowing had already proved
+matched. Printing mode skips it and took 56.7 us for identical work. The gate's own comment cited a ~45%
+regression on `t:creature`/artwork, called it "an unexplained codegen/scheduling effect ... not a logical
+cost", and attributed it to bisecting **across builds** — trap 1 in the method doc.
+
+Re-measured with a runtime toggle in one binary, the cited regression does not reproduce in either direction,
+and **every artwork cell is faster with the gate removed**:
+
+| query, artwork, limit 175 | gate on | gate off | speedup |
+| --- | --: | --: | --: |
+| `o:this` | 1047.7 us | **43.8** | **24x** |
+| `o:target` | 556.6 | **28.7** | **19x** |
+| `o:creature` | 1010.5 | **50.6** | **20x** |
+| `t:creature` | 84.1 | **38.5** | **2.2x** (the query the gate protected) |
+| `o:flying` | 24.1 | 12.1 | 2.0x |
+| `c:r` | 32.2 | 16.6 | 1.9x |
+| `t:land` | 15.5 | 11.6 | 1.3x |
+
+Row identity is what an `all_match` error breaks silently here — totals do not move, the printing that REPS
+each artwork group does. **1,134 cells identical** (21 predicates x 3 modes x 3 orderbys x 3 pages x 2
+prefers, hashing the returned `scryfall_id` sequence), 378 of them artwork, including the existential shapes
+`f:*`, `border:*`, `r>=rare`, `watermark:*`, `-f:modern`.
+
+| | before | after |
+| --- | --: | --: |
+| `artwork` regret slice, mean | 1.87 us | **1.59** |
+| `artwork` regret slice, max | **504.5 us** | **185.5** |
+| total regret, mean | 1.43 us | 1.44 (flat) |
+
+Total regret is flat because this does not change any *pick* — it makes the picked plan faster. The user-facing
+win is latency, and it is the largest in this branch.
+
+**Item 6 inverts.** The artwork arm now **over**-costs: P3 reads p/m 1.58-1.83 on these cells against 0.09-0.11
+before, so `STREAM_ARTWORK_SEEN_PER_CARD_NS` at 1.21 is now too HIGH rather than 33x too low. The cost model
+was right about what should happen throughout — it charges `tier = 0` because `all_match_known` is supposed to
+mean no `card_pass` runs, and now it does not. What remains is a level, not a shape, and it is small.
+
+**The general lesson is about the comment, not the code.** A perf carve-out justified by a cross-build
+measurement, explicitly labelled unexplained, sat in the hot loop of the mode carrying 36% of all routing loss
+and cost up to 24x. This file has now retracted four cross-build findings; that instrument's output should be
+treated as unproven until re-measured in one binary, especially where it has been encoded as a permanent gate.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -261,6 +261,42 @@ asymptote, and it changes both the shape to fit and the urgency:
   a runtime toggle, interleaved subprocesses, equal-length env values.
 - `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
 
+## Where the routing loss actually is (2026-08-03, after the regret netting fix)
+
+With both sides of regret priced the same way, the largest single cell is `printing_compose / artwork` at
+**32% of all lost time** (n=1,435, mean 8.24 µs, max 904). Chased to the bottom, it is one feature defect:
+
+**Every bare format predicate mis-picks, in artwork mode only.** `f:predh` −55 µs, `f:gladiator` −75,
+`f:modern` −33, `f:standard` −31, `legal:pauper` −30, and so on for nine of twelve shapes probed. Card
+mode picks `PlanePopcountOrder` and is right; printing mode picks `PrintingCompose` and is right; artwork
+mode picks `PrintingCompose` when `StreamedSelect` is 1.8× faster. Compounds (`f:modern t:creature`) route
+to a candidates acquire and are fine.
+
+**Compose is not the problem — it is priced accurately.** On `f:gladiator` artwork, predicted/measured
+reads 0.98 for compose and **6.87 for StreamedSelect**; on `f:modern`, 1.10 and 5.70. The router is not
+over-confident about compose, it is over-charging P3 by ~6×, and `scan_units × STREAM_SCAN_PER_ROW_NS`
+alone is 525 µs of P3's 704 µs prediction against a 91 µs measured loop.
+
+**The feature overstates P3's work by 13–15×.** Graded against realized `printings_examined`:
+
+| query / mode | plan | `scan_units` | examined | ratio |
+| --- | --- | --: | --: | --: |
+| f:gladiator / artwork | GatheredScan | 88,026 | 54,213 | 1.62 |
+| f:gladiator / artwork | StreamedSelect | 88,026 | **5,876** | **14.98** |
+| f:modern / artwork | GatheredScan | 101,716 | 73,783 | 1.38 |
+| f:modern / artwork | StreamedSelect | 101,716 | **7,770** | **13.09** |
+
+Both plans receive the same per-query `scan_units`, but P3 examines 9× fewer printings: `card_match_count`
+returns at the first qualifying printing under `Prefer::Default`, while `push_card_matches` must walk the
+whole span to push every match. This module's header already says `prefer` "is the one thing this cannot
+see", and that `acquire_plan_features` therefore sets `scan_units` itself on the **plane** branch instead
+of taking the span estimate. The **compose** branch was never given the same treatment.
+
+So the fix is a feature correction on the compose acquire, not a rate — the category the toolkit says is
+the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 below: the 6× over-cost exists
+in printing mode too (6.23, 5.25), where compose happens to be genuinely faster, so the wrong ratio does
+not flip the pick. Artwork is only where the margin is thin enough to expose it.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -320,7 +320,7 @@ the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 belo
 in printing mode too (6.23, 5.25), where compose happens to be genuinely faster, so the wrong ratio does
 not flip the pick. Artwork is only where the margin is thin enough to expose it.
 
-### But that correction alone does not flip the pick
+### But that correction alone does not flip the pick (confirmed: it did not)
 
 The term is linear, so the corrected prediction is exact arithmetic rather than a guess:
 
@@ -420,6 +420,62 @@ consumed form measured 79.83 µs against compose's 177.83 on `f:gladiator`/artwo
 picks compose — but now because it prices compose 4–6× too cheaply against P3, not because P3 was removed
 from the ballot. The architecture stopped hiding the problem, which is what makes the remaining work worth
 doing.
+
+## The two cost-arm defects, both now measured
+
+### `STREAM_RESIDUAL_FLOOR_NS`: measured with a built design, and declined
+
+The floor only ever binds on `MASK_COMPARE` (tier 4.00); every other tier exceeds 6.58 and `max` takes the
+tier. So `bench_streamed_loop`'s always-true `DateCmp` cells are exactly its population, and at 31,508 cards
+they read `card/all_match` 2.49, `card/residual` 7.80, `printing/residual` 4.97 + 3.26 ns/printing.
+Subtracting the loop body puts the residual's per-card cost at **2.45 ns against a charged 9.05** — the
+`card_pass` call is the whole cost and the mask compare adds nothing measurable.
+
+Traffic disagrees and traffic wins on levels: the fitted `CARD_PASS+FLOOR` column reads **8.19 against the
+shipped 9.05 (0.90)** for P3 and **21.59 against 21.89 (0.99)** for P4. Nothing to correct.
+
+That is the **third** time this file has caught the same artifact — an always-true predicate over
+chunk-rotated slices measuring a cache state production never reaches, differing by 3.3× here as it differed
+1.6–2.2× in the retraction at the top of `bench_streamed_loop`. It is now recorded in the constant's own doc,
+so the next person measuring it finds the answer instead of the trap.
+
+### `stream_scan_units`: shipped, and it was necessary but not sufficient exactly as predicted
+
+P3 now has its own scan estimate on a legality-composed acquire, from the divergent share of the candidate
+span (`legal_divergent`, 556 of 31,508), floored at one printing per candidate and scoped to filters that
+touch legality — `border:black`, `r:mythic` and `watermark:*` measured at parity between the two plans.
+
+It also surfaced a defect this branch had introduced: `acquire_plan_features` was still calling
+`compose_printing_estimate` on the RESIDUAL. Once the divergence mask began consuming legality leaves that
+residual was `True`, so compose estimated all 97,206 printings for every legality query alike and was costed
+as if it returned the corpus for free — `matches` reading 97,206 identically across `f:modern`, `f:predh` and
+the rest, at a predicted pick/best ratio of 0.00. Applicability, estimate and execution now share one
+`compose_source`. **The numbers reported for the consume-guard commit were measured against that broken arm**
+and should not be read as they stand.
+
+| | before | after |
+| --- | --: | --: |
+| predicted pick/best on the artwork mispicks | 0.22 | **0.63–0.69** |
+| `StreamedSelect [printing_compose] / artwork` p90 | 6.69 | **4.73** |
+| its p90/p10 spread | 12.3 | **9.2** |
+| total regret | 56.1 ms | 55.0 ms |
+| row identity, 60 cells | — | identical |
+
+**The mispicks survive, and that is the result.** Sixteen remain. The model prices compose ~1.5× under P3
+where P3 measures ~1.7× faster, so ~2.5× survives a corrected feature — and it is not the per-card level
+(traffic fits it at 0.90), not the floor, and not the scan feature. Something cell-specific to compose-acquire
+artwork is mis-shaped and none of the three things measured here is it.
+
+## The open decision: 13% of regret is unpaid
+
+Regret stands at **55.0 ms against a 48.7 ms baseline**. The rise came from making the split
+non-destructive — handing the argmin a candidate whose arm is the worst-modelled in the engine — and both
+candidate explanations for it have now been eliminated by measurement. Two honest options:
+
+- **Find compose's remaining shape error.** It is the largest single error in the model (p90 41×, spread 136×
+  on rarity/usd) and it is now applicable on more queries, so the debt is bounded by that one arm.
+- **Revert the non-destructive split** and give back `f:modern t:creature`'s 0.476× until compose's arm is
+  fixed. The plumbing is inert on its own; only compose's widened applicability carries the cost.
 
 ## What is left
 

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -5,6 +5,9 @@ Branch `engine-compose-feature-accuracy`. Companion to
 answers which question; this covers what the tools said about `StreamedSelect` (P3) and
 `GatheredScan` (P4), and what is left.
 
+The method this campaign arrived at, extracted so it can be reused without reading the whole file:
+[diagnosing-a-plan-cost-error.md](../workflows/diagnosing-a-plan-cost-error.md).
+
 The earlier campaign in [local-engine-cost-model-agreement.md](./local-engine-cost-model-agreement.md)
 fitted rates from sampled traffic. This one built designed experiments instead, because several rates
 are **unidentifiable from traffic at any corpus size** — and that turned out to be the least

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1044,3 +1044,39 @@ so the 1.43 is only modestly outside run noise; the max-miss and band shifts are
 (`eur<=0.09 usd>=0.38 usd<=4.92` used 31,508 against a realized 144; `eur:0.39` 31,508 against 439). Both are
 tier-4 MASK price ranges where the span base is meaningless, and both routes to an exact count were measured
 and declined above.
+
+### Pattern B traced upstream: an unnarrowed query has no base for a match estimate
+
+`eur<=0.09 usd>=0.38 usd<=4.92` / artwork used `matches` 31,508 against a realized 144. The chain:
+
+1. every leaf individually exceeds `MAX_NARROW_FRACTION` (0.25), so narrowing declines;
+2. `eval_domain` becomes the whole corpus, 31,508;
+3. `in_space * RESIDUAL_PASS_RATE_ARTWORK` gives ~24,439, and then
+   **`.max(count.min(in_space))` forces 31,508** — the floor, not the rate.
+
+The floor asserts at least one match per candidate. That holds under a tight narrowing and is catastrophic
+under a loose one, which is the candidates-versus-matches confusion for the fourth time in this file.
+
+**Removing the floor is nonetheless not a fix.** Split by whether it binds (`matches == eval_domain`):
+
+| population | mode | n | p50 | p90 | mean \|log\| |
+| --- | --- | --: | --: | --: | --: |
+| floor binds | artwork | 2,883 | 1.06 | 23.25 | **0.936** |
+| rate applies | artwork | 1,179 | 1.34 | 8.29 | **0.799** |
+| floor binds | printing | 299 | 0.60 | 1.14 | **0.567** |
+| rate applies | printing | 4,010 | 1.22 | 17.92 | **1.094** |
+
+Worse in artwork, **better** in printing. Dropping it helps one mode and hurts the other. Two reading notes:
+card mode is excluded because its `matches` *is* `count`, so a "floor binds" detector flags all of it by
+construction; and the extreme tails sit in both populations (max 1,575× floored against 1,690× rated), so the
+tail is not the floor's doing either.
+
+**So the root cause is upstream of both terms.** When no leaf is selective enough for narrowing to fire, the
+candidate set is the corpus and *neither* a rate nor a floor has a base related to the answer. That is 57% of
+rows on this acquire. It is the same conclusion as compose's `eval_domain`, as tier 2's two dead ends, and as
+the floor here: the wanted quantity is `|candidates ∩ residual|`, and nothing cheap computes it for an
+unnarrowed query.
+
+The one route not yet closed is a bitmap AND of the candidate set against an indexed residual leaf — exact,
+conditional, and available on the ~9% where the residual is a single indexed leaf. Everything else on this
+acquire looks irreducibly estimated.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -22,8 +22,8 @@ a measured level for a fitted one has failed.
 
 ## What shipped
 
-Two terms, both found by a design, both levelled by traffic, both mirror-verified at 100% and gated
-interleaved A/B/A/B.
+Two cost terms — both found by a design, both levelled by traffic — and one executor change, all
+mirror-verified at 100% and gated interleaved A/B/A/B.
 
 **`STREAM_PERM_STEP_NS`** — P3's permutation walk was not charged at all. The walk steps until the page
 fills, so it visits ~`page_span × n_cards / matches` entries: inversely proportional to selectivity, and
@@ -47,68 +47,93 @@ four-row page sweep falsifies outright:
 **Neutral to marginally negative** — taken for correctness, since a one-column model four rows disprove
 should not survive on a neutral gate.
 
-**The emission walk's match span.** The walk started at permutation index 0 and stopped only when the
-page filled, so it stepped every entry ordered before the first match (`cmc>=6 order=cmc asc`: 28,275
-entries for a 60-row page, 10.6 us of a 20.25 us execution) and, on any page it could not fill, every
-entry after the last match. Bounded to `min..=max` of `inv_perm` over matching cards — realized, so it
-holds for any predicate and cannot be wrong about tie-breaking — the same query walks 60 entries in
-0.38 us. Row identity verified against `GatheredScan` on an anti-correlated corpus at four offsets in
-every mode and direction, because a bound one entry off drops a row rather than crashing.
+**The emission walk starts and ends at the filter's bound on the sort column.** The walk began at
+permutation index 0 and stopped only when the page filled, so `cmc>=6 order=cmc asc` stepped 28,275
+entries to fill a 60-row page — 10.6 us of a 20.25 us execution — and any page it could not fill also ran
+past the last match to the end of the corpus. The permutation is a sorted array on `perm_primary_key`, so
+an interval on the sort column's *value* is a contiguous range of *positions*: two binary searches, O(log
+n_cards) probes once per query, nothing per card. The same query in printing mode goes 18.29 → 8.71 us,
+stepping 4 entries.
 
-**Gated**, at candidates ≤ ¼ of the corpus, because the span costs 0.51 ns per matching card against a
-match loop that is ~2.6 ns/card: ungated it took `cmc>=1 order=edhrec`'s `ns_loop` from 78.54 to 94.46
-us while its walk stayed at 111 steps. The bound can save at most `(n_cards − m) × 0.37 ns` against
-`m × 0.51 ns`, so worst-case break-even is 0.42 × `n_cards` and the gate sits inside it.
-
-| exec, span on/off (geometric mean) | cells |
+| exec, bound on/off (geometric mean) | cells |
 | --- | --- |
-| clustered (predicate correlates with orderby) | **0.660** over 8 |
-| broad (gate off — identical path) | 1.000 over 4 |
+| clustered, `StreamedSelect` routed | **0.603** over 16 |
+| broad control, routed | 1.006 over 6 |
 
-Pooled over 419 sampled `StreamedSelect` queries: no detectable difference, −0.10 us, CI [−0.62, +0.41].
+Conservative in three directions, since a wide bound costs steps and a narrow one returns the wrong page:
+`And` only (an `Or` arm can match outside its sibling's bound, and `Not` inverts into a union of two
+intervals), strict comparisons widened to inclusive, and only the three columns that have numeric
+predicates at all. Extracted in `bind_and_split_filter` because `split_planes` compiles `cmc>=6` into mask
+algebra and leaves `FilterExpr::True` behind, then carried on `QueryParams` with `UNBOUNDED` as the
+default — a path that does not extract a bound walks everything, which is slower and never wrong.
+
+### The realized span it replaced, and why the replacement is not free of interest
+
+The first version tracked `min`/`max` of `inv_perm` over matching cards: realized, so it caught clustering
+from *any* source rather than only what the predicate names. It measured 0.51 ns per matching card against
+a match loop whose `all_match` arm is ~2.6 ns/card — a 20% tax on `ns_loop`, which forced a gate at ¼ of
+the corpus, which still let unlucky cells (`c:r`, and any cluster sitting at the *near* end of the walked
+order) pay a premium for nothing. The bound dominates it on every axis:
+
+| | tracked span + gate | sort-column bound |
+| --- | --: | --: |
+| clustered, routed | 0.689 | **0.603** |
+| broad control, routed | 1.034 | **1.006** |
+| worst near-end cell | 1.244 | **1.018** |
+
+What the realized span still has is reach: see the regrade below.
+
+### Card mode's win is latent, and only the mode sweep says so
+
+In `unique=card` a plane-consumable predicate leaves `FilterExpr::True`, which makes `PlanePopcountOrder`
+applicable — and the router picks it for exactly these clustered queries (`cmc>=6 order=cmc`: 2.46 us
+against P3's 12.38). So the card-mode cells improve a plan nobody runs. Printing and artwork mode have no
+popcount plan, because a popcount counts cards and not printings, so P3 is picked there and the
+improvement is what a user waits for. `bench_walk_span.py` prints the routed plan per cell for this
+reason; the first version of that harness measured card mode only and would have overclaimed.
 
 ## Measuring this needed one binary, not two
 
-`scripts/bench_walk_span.py` A/Bs `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` in interleaved
-subprocesses of a single build, with equal-length env values. That is not fastidiousness — a
-cross-build attempt got the sign wrong:
+`scripts/bench_walk_span.py` A/Bs `CARD_ENGINE_WALK_SORT_BOUND` in interleaved subprocesses of a single
+build, with equal-length env values. That is not fastidiousness — a cross-build attempt got the sign
+wrong:
 
-- `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on a phase neither build changed, ±9%
-  in both directions. A 0.5 ns/card effect is invisible under that.
+- `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on a phase neither build changed, ±9% in
+  both directions. A 0.5 ns/card effect is invisible under that.
 - `bench_plan_execution_ab.py` across builds called the change 2% **slower** — while its own acquire
-  control, which the change cannot touch, moved 1.9% the same way. Within one binary the control is
-  flat (+0.01 us, median ratio 1.000) and the verdict is no detectable difference.
+  control, which the change cannot touch, moved 1.9% the same way. Within one binary the control is flat
+  (median ratio 1.000) and the verdict is no detectable difference on 419 paired queries.
 
-Both are the failure the toolkit already documents (`min` is a floor estimator; its error is
-common-mode within a run, so pairing does not cancel it). The toggle removes it by construction:
-identical code, identical layout, one process each.
+Both are the failure the toolkit already documents (`min` is a floor estimator; its error is common-mode
+within a run, so pairing does not cancel it). The toggle removes it by construction: identical code,
+identical layout, one process each.
 
 ## Regrading the perm estimate
 
-`perm_steps` realized/estimated, same seed and sample length, ~12.3k walking rows:
+`perm_steps` realized/estimated, same seed and sample length, ~12.5k walking rows:
 
 | walk | p10 | median | p90 |
 | --- | --: | --: | --: |
 | unbounded | 0.13 | 1.00 | 6.43 |
-| bounded, gated | 0.09 | 0.94 | 5.07 |
-| bounded, ungated | 0.08 | 0.90 | 4.26 |
+| sort-column bound (shipped) | 0.11 | 0.96 | 5.31 |
+| realized `inv_perm` span (not shipped) | 0.08 | 0.90 | 4.26 |
 
 Three things fall out of that table.
 
-- **A third of the p90 tail was the leading prefix**, and it is gone. p90 is the late-cluster case, so
-  this is the estimate's largest error being deleted rather than modelled — which was the point of
-  doing (1) before (2).
-- **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.15–1.17 after. Deleting a
-  third of the steps at the tail without moving the per-step rate is what a real per-unit cost looks
-  like, as against a coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS`
-  turned out to be. Left at the shipped 1.0; no refit.
-- **The cost model prefers ungated and the runtime prefers gated.** Recorded, not resolved: the
-  mechanism that ends the tension is a predicate-derived start position (below), which costs nothing per
-  card and so needs no gate.
+- **A fifth of the p90 tail was the prefix a bound can name**, and it is gone. p90 is the late-cluster
+  case, so this is the estimate's largest error being deleted rather than modelled — the point of doing
+  (1) before (2).
+- **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.19 after. Deleting a fifth of
+  the tail without moving the per-step rate is what a real per-unit cost looks like, as against a
+  coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS` turned out to be.
+  Left at the shipped 1.0; no refit.
+- **The third row bounds what any start position can do.** A realized minimum reached 4.26 because it sees
+  clustering the predicate never mentions (`o:flying` correlates with cmc; a name prefix correlates with
+  name order). That gap is now a measured property of the two mechanisms, not a guess — and it is the
+  argument for the popcount-skip walk, which needs no bound at all.
 
-What remains at p90 5.07 is **interior** to the span — non-matching entries between matches, which no
-start position can skip. Different mechanism, and one the engine already owns elsewhere: the
-popcount-skip walk.
+What remains at p90 5.31 is partly that, and partly non-matching entries **interior** to the walked
+segment, which no start position can skip by construction.
 
 ## What was declined, and why that is the more useful result
 
@@ -167,31 +192,24 @@ Recorded because both were believed and acted on:
   `illustration_id` and suffixing names, leaving everything cost-relevant alone. Needed because the real
   corpus gives the wide group one chunk at 4,500 cards. **The 126k and 410k stores are ~1.4 GB in
   `benchmarks/loop-scale/` — delete when done.**
-- `scripts/bench_walk_span.py` — A/Bs the walk's span bound through
-  `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` inside one binary, clustered cells against broad controls.
+- `scripts/bench_walk_span.py` — A/Bs the walk's sort-column bound through `CARD_ENGINE_WALK_SORT_BOUND`
+  inside one binary, clustered cells against broad controls, sweeping `unique` so a latent win reads as one.
   The pattern to copy for any change whose effect is smaller than the cross-build floor error: one build,
   a runtime toggle, interleaved subprocesses, equal-length env values.
 - `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
 
 ## What is left
 
-1. **A predicate-derived start position, which would cost nothing per card.** The permutation IS a sorted
-   array on `(sort key, edhrec, cid)`, so when the filter bounds the *sort column* — `cmc>=6` under
-   `order=cmc`, exactly the correlation that makes a cluster — a binary search for the first position whose
-   value satisfies the bound gives a start in O(log `n_cards`) once per query, against 0.51 ns × matching
-   cards for the realized span. Seek to the START of the boundary tie block and it can only start too
-   early, never too late, which answers the tie-breaking objection that made the realized span the first
-   choice. It composes with the span rather than replacing it (free ⇒ no gate ⇒ available to broad queries
-   too), and it is what would let the cost model have the ungated column of the regrade table above.
-   Conjunction analysis to extract the bound, plus row-identity verification, since it touches paging again.
-2. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 is
-   non-matching entries *interior* to the match span, and a start position cannot reach those by
-   construction. Scattering the match set through `inv_perm` and walking words at 64 cards a load is the
-   mechanism that can — `run_query_streamed_popcount` already does it for `unique=card` queries whose
-   filter fully consumed to `True`. Generalizing it needs per-card match counts for the skip (a popcount
-   counts cards, not matches, so printing/artwork mode cannot skip by popcount alone) and pays the same
-   per-card scatter the span bound pays, so it wants the same gate or the free start position above.
-3. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
-4. **Gate P4's artwork arm on its own.**
-5. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
+1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has
+   two sources, and neither is reachable from a start position: non-matching entries *interior* to the
+   walked segment, and clustering the predicate does not name (the 5.31-vs-4.26 gap in the regrade table).
+   Scattering the match set through `inv_perm` and walking words at 64 cards a load reaches both —
+   `run_query_streamed_popcount` already does exactly that for `unique=card` queries whose filter fully
+   consumed to `True`, and printing mode, where P3 is actually routed, is the case it does not cover.
+   Generalizing it needs per-card match counts for the skip (a popcount counts cards, not matches) and
+   pays a per-card scatter, so it inherits the cost question the realized span had — with the difference
+   that its payoff does not depend on matches being contiguous.
+2. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
+3. **Gate P4's artwork arm on its own.**
+4. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
    bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -140,14 +140,58 @@ summary is *neutral in time, worse in routing*, which is not a trade worth takin
 slightly worse than the gather, as expected — the walk pays per permutation entry and a sparse total
 means stepping a long way to fill a page, where the gather is O(total).)
 
-## Prerequisite
+## Prerequisite: what the 0.40× actually is
 
-Price the compose `Gather` path. The 2026-08-04 measurement above narrows what that means: on the
-sparse population the arm reads a consistent **0.27–0.53 of real** across every case measured, which is
-a level error rather than a missing dependence on some feature — the ordering within the population is
-right, the magnitude is halved. The older "under by ~4-7x at p10 and over by 178x at p99" spanned a
-wider population that included broad queries; both readings should be reconciled before picking a term
-to move. Progress on the compose arm generally is tracked in
+Price the compose `Gather` path. Diagnosed 2026-08-04, features before rates, over 33–38 cells with the
+decline toggled off (15 trials each).
+
+**Features first, and they are a minority of it.** Each priced feature against its own realized counter:
+
+| feature | realized counter | median used/realized |
+| --- | --- | --: |
+| `eval_domain` | `cards_visited` | 0.70× |
+| **`compose_scan_printings`** | `printings_examined` | **0.15×** |
+| `matches` | `matches_pushed` | 0.88× |
+
+`compose_scan_printings` is off by 6.7×, and `gather_composed_page`'s own comment already predicted
+exactly this: the feature is the composed bitmap's **popcount**, on the grounds that compose "walks the
+set bits", but the loop iterates `start..end` of every candidate card and bit-tests each printing, so
+the realized quantity is the candidate cards' **span**. It is the same printings→distinct-rows
+projection error behind `eval_domain`'s 0.70×.
+
+An ORACLE re-pricing — realized counters substituted, every shipped rate untouched — settles the
+sequencing:
+
+| features | median pred/meas |
+| --- | --: |
+| shipped | **0.40×** |
+| `compose_scan_printings` corrected alone | 0.47× |
+| all three realized | **0.57×** |
+
+So perfect features close about 40% of the gap and leave 1.75×. That is the **opposite** of the P3/P4
+result in [the loop-phase doc](./local-engine-loop-phase-measurement.md), where the oracle reached 83%
+and features were the whole story — worth noting before reusing that conclusion on a different arm.
+
+**What is left is a missing term, not a level error.** The oracle column spans 0.32–0.79, so no single
+multiplier fits it. Taking `meas − oracle_pred` gives a residual of **7,639 ns median** (stdev 1,720)
+against a `COMPOSE_FIXED_COST_NS` of 163.56 ns. Re-running the whole measurement on a one-third corpus
+(32,402 printings) gives 4,210 ns — a factor of 1.81 where the corpus factor is 3.0, so it is neither
+fixed nor proportional. A two-point fit:
+
+    residual ≈ 2,496 ns  +  0.0529 ns/printing   (3.39 ns per 64-bit word)
+
+Both halves are plausible as *unmodelled work* rather than mis-levelled rates. `compose_printing_bits`
+allocates a full-width printing bitmap and ANDs each child into it — O(`n_printings`/64) per leaf,
+charged nowhere, since `popcount_words` counts the **result-space** bitmap, not the printing-space
+build. And `bitmap_card_ids` walks the whole card bitmap to extract set ids whatever the popcount.
+
+Two caveats before anyone moves a constant on this. It is a **two-point fit**, and the loop-phase doc's
+own saturation finding is the standing warning against trusting those — a third size is the next
+measurement, not the constant. And the older reading here ("under by ~4-7× at p10 and over by 178× at
+p99") spanned a wider population including broad queries; the two need reconciling, because a term
+added to fix the sparse end will move the broad end too.
+
+Progress on the compose arm generally is tracked in
 [the cost-model doc](local-engine-cost-model-agreement.md).
 
 ## Acceptance

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -30,6 +30,23 @@ below needs no small-total decline of its own, and its comment says so —
 > the gather fallback pages via the bounded GatherSelect, whose tie-break matches the general path
 > exactly (same GatherSelect, same comparator) — so no separate small-total decline is needed.
 
+**The stated reason no longer applies to the WALK either — the comment is stale (2026-08-04).** #815
+(`fe1afeb`, 2026-08-02) made row order total and filter-independent on `(key1, key2, cid, pid)`,
+replacing the key-3 `prefer_score` that used to differ between the permutation (first *stored*
+printing's score) and the gathered paths (first *matching* one). With `cid` and `pid` in the key there
+is no tie left for the two emission shapes to break differently. Measured by toggling the decline off
+and running the walk on tie-heavy orderbys (`power`/`toughness`/`cmc`, three modes, both directions,
+deep offsets): **576 real invocations, 1,512 cells, 0 row differences**, plus 14 invocations inside
+`force_plan_differential_agreement`, which asserts *full row order* against `GatheredScan` and passed.
+
+That matters less for shipping than it looks — the doc's proposal was always the gather, which was
+never blocked on tie order — but it retires the reason the code gives for the decline, and it means
+either executor is now correct.
+
+**Watch the vacuous A/B here.** The first attempt at this measurement showed 0 differences because the
+cost model still predicted `Decline`, so compose never ran and neither arm of the A/B executed the
+branch. Both halves must be toggled, and the fire count must be *counted*, not assumed.
+
 **Why it is cheap precisely here.** `gather_composed_page` walks `bitmap_card_ids` of the composed
 set — only cards holding a matching printing — so it is O(total), and `total <= STREAM_MIN_MATCHES`
 is the condition. Add one O(n_printings/64) projection. Declining instead discards the finished
@@ -81,12 +98,57 @@ mispricing was not the blocker, or not the only one.
 - **Removing the infinities exposes a pre-existing p99 of 178x OVER-cost** in the compose arm, which
   was always there and hidden behind `inf`. The arm is wrong in both directions on this population.
 
+## Re-measured 2026-08-04, after the two-sided range fusion
+
+[local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md) made
+`compose_printing_estimate` exact on ranges, which removed the second stated blocker: the prediction
+can now tell a sparse query from a broad one (879 against a true 879, where it read 20,411). Both
+executors were then re-tried behind a runtime toggle on one binary.
+
+**The gather really is faster on its population.** Warm, 15 trials, `PrintingCompose` against the best
+plan that would otherwise win:
+
+| query | mode | compose measured | compose predicted | best other |
+| --- | --- | --: | --: | --: |
+| `usd>=0.42 usd<=0.43` | artwork | **27.5 µs** | 13.5 | 75.0 |
+| `cn>=146 cn<=147` | artwork | **20.5** | 8.4 | 46.1 |
+| `set:lea` | artwork | **18.8** | 5.1 | 44.6 |
+| `usd>=200` | artwork | **15.6** | 4.6 | 27.5 |
+| `cn>=20000 r>=rare` | card | **13.9** | 4.3 | 17.6 |
+
+1.3–2.7× faster than the alternative, and **under-priced 2–4× in every row** (0.27–0.53 of real). That
+under-charge is the whole remaining problem, and it is narrow enough to be calibratable rather than
+structural.
+
+**And it is still not shippable, for a third reason that is neither of the first two.** The
+under-pricing over-picks compose on queries where it does *not* win, and those mispicks cancel the wins:
+
+| | decline | gather |
+| --- | --: | --: |
+| regret mean | 1.30 µs | **1.51 (+16%)** |
+| `printing_compose` miss% | 7% | **18%** |
+| `printing_compose` p90 | 0.00 | **8.12** |
+| compose-acquire wall time, 2,341 paired queries | 113.6 ms | **113.2 ms (1.00)** |
+
+**Read those two rows together, because separately each one lies.** Regret is a routing-error metric:
+a correct pick scores zero, so enabling a plan that is faster on its own population shows up as pure
+loss — the gains are invisible and only the new mispicks count. Wall time says the opposite is not true
+either: the win is real but confined, and the mispicks eat exactly as much as it earns. The honest
+summary is *neutral in time, worse in routing*, which is not a trade worth taking for added complexity.
+
+(The permutation walk was also measured, since it is what the stale comment is about: regret 1.52 µs,
+slightly worse than the gather, as expected — the walk pays per permutation entry and a sparse total
+means stepping a long way to fill a page, where the gather is O(total).)
+
 ## Prerequisite
 
-Price the compose `Gather` path. This is not a one-term tweak: the arm is under by ~4-7x at p10 and
-over by 178x at p99 on the population the change exposes. Progress on the compose arm generally is
-tracked in [the cost-model doc](local-engine-cost-model-agreement.md); this change should be retried
-whenever that cell reads sanely.
+Price the compose `Gather` path. The 2026-08-04 measurement above narrows what that means: on the
+sparse population the arm reads a consistent **0.27–0.53 of real** across every case measured, which is
+a level error rather than a missing dependence on some feature — the ordering within the population is
+right, the magnitude is halved. The older "under by ~4-7x at p10 and over by 178x at p99" spanned a
+wider population that included broad queries; both readings should be reconciled before picking a term
+to move. Progress on the compose arm generally is tracked in
+[the cost-model doc](local-engine-cost-model-agreement.md).
 
 ## Acceptance
 
@@ -98,3 +160,9 @@ whenever that cell reads sanely.
 
 The rows check is cheap and should be repeated rather than trusted from this document, since the
 comparator or the paging strategy may have moved since.
+
+Add a fourth, because criteria 1–2 alone would have passed a change that buys nothing:
+
+4. **Wall time better, not merely routing not-worse.** Paired routed dispatch on one binary with the
+   decline toggled, sliced to the compose acquire. The 2026-08-04 run reads 1.00 — the plan has to earn
+   more than it loses to its own mispicks, and regret cannot see the earning half.

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -191,6 +191,74 @@ measurement, not the constant. And the older reading here ("under by ~4-7× at p
 p99") spanned a wider population including broad queries; the two need reconciling, because a term
 added to fix the sparse end will move the broad end too.
 
+### Attempted and held: deriving the span feature from the candidate count
+
+`compose_scan_printings = scan_units` (the candidate span `GatheredScan` already estimates) in place
+of `printing_matches * COMPOSE_GATHER_SPAN_PER_MATCH`. It does what it claims — the feature grades
+0.15x -> **0.46x** of realized, and the shape becomes per-candidate instead of per-match, which is what
+the quantity actually is.
+
+**It is held, because routing got worse: regret 1.33 -> 1.41 us** (same-session baseline, so the 0.08
+is outside the ~0.03 run-to-run spread). And the cost barely moved, 0.40 -> **0.41x**, because bit
+tests are only 11% of the modelled page cost — the earlier "worth 0.40 -> 0.47" came from substituting
+a *perfect* counter, which `scan_units` at 0.46x does not deliver.
+
+The lesson is the sharper version of this branch's recurring one. Compose is under-priced by 2.5x
+overall; making one of its features honest while the level stays wrong does not move the level, it
+moves compose's *relative* position — and it was winning those argmins correctly while under-priced,
+so raising one term only loses them. **Partial accuracy on an argmin can be worse than consistent
+inaccuracy.** The span fix should land together with the missing ~7.7 us term, not before it. Patch
+kept at `scratchpad/span_fix.patch`.
+
+### The two constants are approximating something exactly computable
+
+`COMPOSE_CARD_ESTIMATE_BIAS` (1.78) and `COMPOSE_CANDIDATE_SPAN_BIAS` (2.1) both correct
+`balls_into_bins`, which is *uniform* occupancy — `domain * (1 - e^(-k/domain))`, every card an equally
+likely bin. Cards are not equally likely: a card is a candidate iff one of its `S` printings matches,
+so selection is size-biased. On this corpus the mean card holds 3.09 printings but the size-biased mean
+`E[S^2]/E[S]` is **42.30**, and the realized printings-per-candidate runs ~13 — between the two,
+because `k` is not infinitesimal. No single constant spans that.
+
+The size-aware form needs no fitted constant, only the printing-count histogram (one small table, built
+once at load):
+
+    E[candidate cards] = sum_c [1 - (1 - k/N)^S_c]
+    E[candidate span]  = sum_c S_c * [1 - (1 - k/N)^S_c]
+
+Both reduce to `balls_into_bins` when every `S_c` is equal, and both saturate correctly at `k = N`.
+Graded against exact truth (k from the printing-mode total, candidates from the card-mode result, span
+from the corpus) over 19 queries:
+
+| | size-aware | shipped |
+| --- | --: | --: |
+| candidate cards, median est/true | **1.10** | 0.72 |
+| candidate span, median est/true | **~1.1** | ~0.36 |
+
+Better centred on both, and with no constant to refit when the corpus changes. **But not uniformly
+better**: the span reads 9.85x on `usd<=0.02` and 4.73x on a narrow date range, because those
+predicates are *anti*-correlated with card size — the cheapest printings sit on small cards, so
+size-biased selection over-predicts. The uniform model is wrong in one direction, the size-biased one
+in the other, and neither knows which predicate it has.
+
+### Which makes the exact route the interesting one
+
+`RangeCardCounts` already answers distinct cards **exactly** for a range — and its `distinct_cards`
+returns `None` for an *interior* range, because "distinct counts do not subtract". That hole is exactly
+the two-sided population the range fusion just created, so those queries fall back to the estimator
+above precisely where an exact answer exists for their one-sided siblings.
+
+No 1-D prefix array closes it: whether a card has a printing in `[lo, hi)` is a 2-D question. But there
+is an exact structure. A card with values `v1 < ... < vk` has NO printing in `[lo, hi)` iff the interval
+fits inside one of its `k+1` gaps, so
+
+    cards missing the range = # gaps containing [lo, hi)     (at most one per card)
+
+over ~`n_printings + n_cards` gap intervals — a containment/dominance count, answerable exactly in
+O(log^2) with a merge tree, not a prefix sum. Weighting each gap by its card's printing count makes the
+**same** structure return the exact span as well. One structure, both features exact, both constants
+deleted, and the interior-range hole closed. That is a bigger change than a calibration and belongs in
+its own doc if it is taken up.
+
 Progress on the compose arm generally is tracked in
 [the cost-model doc](local-engine-cost-model-agreement.md).
 

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -255,9 +255,42 @@ fits inside one of its `k+1` gaps, so
 
 over ~`n_printings + n_cards` gap intervals — a containment/dominance count, answerable exactly in
 O(log^2) with a merge tree, not a prefix sum. Weighting each gap by its card's printing count makes the
-**same** structure return the exact span as well. One structure, both features exact, both constants
-deleted, and the interior-range hole closed. That is a bigger change than a calibration and belongs in
-its own doc if it is taken up.
+**same** structure return the exact span as well.
+
+**Measured against a cheaper approximation, and the merge tree loses.** A binned start x end triangle
+`T[i][j]` = distinct cards in bins i..j stores the union answer directly, so it subtracts where a
+prefix array cannot. 100 equal-printing bins is 5,050 u32 = **20 KB per index**, against ~274 KB for a
+wavelet tree over the gaps and ~8.8 MB for an explicit merge tree, and the query is a bisect plus two
+reads rather than O(log^2).
+
+Broad intervals bracket tightly -- `T[i+1][j-1]` is contained, `T[i][j]` contains, and the width is the
+two boundary bins: **0.3% / 1.0% / 2.3% / 2.6%** on the four broad cases measured.
+
+Narrow intervals collapse the bracket (fewer than three bins spanned means no interior, so the lower
+bound is 0) and more bins cannot fix that. But the upper bound is the estimator, and it pairs with a
+second free bound: `k`, the printings in the range, is the two partition points the range path already
+computes, and a card needs at least one printing in range. Over 14 narrow intervals spanning both ends
+of both value axes:
+
+| estimator | median | max | direction |
+| --- | --: | --: | --- |
+| `T[i][j]` | 2.16x | 8.52x | never under |
+| **`min(k, T[i][j])`** | **1.21x** | **1.41x** | never under |
+| shipped | 0.72x | — | unbounded either way |
+
+The two bounds are complementary for a structural reason worth keeping: equal-printing bins are narrow
+in VALUE space exactly where printings are dense, so at the cheap end a bin is two distinct prices wide
+and `T[i][i]` is exact (3 of 14 cells). Where values are sparse the bin spans 1,381 values against a
+query's 173 and `T` is useless -- but that is the regime where printings-per-value is low, so cards ~ k
+and the clamp takes over.
+
+So the whole feature is 20 KB, O(1), bounded at 1.41x over on narrow and 2.6% on broad. **The arm is
+under by 2.5x overall**, so buying exactness here is misallocated: the merge tree, and the O(k)
+count-it-directly variant, both cost more to fix an error smaller than the one that remains.
+
+Same shipping caveat as the span patch: `min(k, T)` is systematically OVER, which makes compose look
+more expensive -- the direction that lost argmins compose deserved. It lands with the level fix, not
+before it. And the 14 intervals are hand-picked; grade it over the regret matrix's traffic first.
 
 Progress on the compose arm generally is tracked in
 [the cost-model doc](local-engine-cost-model-agreement.md).

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -174,22 +174,80 @@ and features were the whole story — worth noting before reusing that conclusio
 
 **What is left is a missing term, not a level error.** The oracle column spans 0.32–0.79, so no single
 multiplier fits it. Taking `meas − oracle_pred` gives a residual of **7,639 ns median** (stdev 1,720)
-against a `COMPOSE_FIXED_COST_NS` of 163.56 ns. Re-running the whole measurement on a one-third corpus
-(32,402 printings) gives 4,210 ns — a factor of 1.81 where the corpus factor is 3.0, so it is neither
-fixed nor proportional. A two-point fit:
+against a `COMPOSE_FIXED_COST_NS` of 163.56 ns.
 
-    residual ≈ 2,496 ns  +  0.0529 ns/printing   (3.39 ns per 64-bit word)
+### Measured over a controlled 10x corpus axis: it is per-printing, and there is no fixed part
 
-Both halves are plausible as *unmodelled work* rather than mis-levelled rates. `compose_printing_bits`
-allocates a full-width printing bitmap and ANDs each child into it — O(`n_printings`/64) per leaf,
-charged nowhere, since `popcount_words` counts the **result-space** bitmap, not the printing-space
-build. And `bitmap_card_ids` walks the whole card bitmap to extract set ids whatever the popcount.
+`upscale_corpus.py --copies N` replicates the corpus with rewritten identities, so the value
+distribution is preserved exactly and both `n_printings` and `n_cards` scale by N. Fractional steps need
+a partial copy sampled by **oracle card**, not by printing — thinning each card's span would change the
+printings-per-card distribution, which is the quantity under test. `CARD_ENGINE_STREAM_MIN_MATCHES`
+scaled with the corpus keeps the sparse population from evaporating as results scale (without that, the
+cell count fell 33 -> 26 -> 13 and the 4x stdev was 5x its median).
 
-Two caveats before anyone moves a constant on this. It is a **two-point fit**, and the loop-phase doc's
-own saturation finding is the standing warning against trusting those — a third size is the next
-measurement, not the constant. And the older reading here ("under by ~4-7× at p10 and over by 178× at
-p99") spanned a wider population including broad queries; the two need reconciling, because a term
-added to fix the sparse end will move the broad end too.
+Nine sizes, 0.5x to 5x, 33 cells each:
+
+| n_printings | bitmap | residual | fitted | meas/fit | ns/printing |
+| --: | --: | --: | --: | --: | --: |
+| 48,161 | 6 KB | 4,045 | 3,914 | 1.033 | 0.0840 |
+| 97,206 | 12 KB | 7,597 | 8,009 | 0.949 | 0.0782 |
+| 194,412 | 24 KB | 15,276 | 16,126 | 0.947 | 0.0786 |
+| 339,779 | 41 KB | 28,724 | 28,264 | 1.016 | 0.0845 |
+| 486,030 | 59 KB | 40,459 | 40,475 | 1.000 | 0.0832 |
+
+    residual = -107 ns  +  0.0835 ns/printing   =  5.34 ns per 64-bit word     R^2 = 0.99832
+
+**The intercept is zero within noise.** There is no missing *fixed* cost — the whole 7.6 us is a
+per-corpus-width build term. And `ns/printing` varies only **1.13x across a 10x range with no trend**,
+which rules out the cache story worth worrying about here: the printing bitmap goes 6 KB (L1) to 59 KB
+(L2) over this sweep without the rate moving, so linear is the right shape and 5.34 is not
+corpus-specific.
+
+**Retracted: the earlier two-point fit** (2,496 ns fixed + 0.0529 ns/printing). Its small point was
+`head -32402` of the corpus — the first third of the file, not a uniform sample — and the spurious fixed
+term came entirely from that. Sampling by card is what fixed it.
+
+The mechanism matches: `compose_printing_bits` allocates a full-width printing bitmap and ANDs each
+child into it, `printing_bits_to_card_bits` projects it, and `bitmap_card_ids` walks the card bitmap to
+extract set ids — all O(corpus width), all charged nowhere, since `popcount_words` counts only the
+**result-space** bitmap.
+
+### But it cannot be added to the shared build section alone
+
+`compose_printing_bits` runs for every compose execution, so the physical argument says the term belongs
+in the build and applies to `Perm`/`OrderbyWalk` too. Measured over ten sizes, that is wrong — and
+wrong in a way only the many-point sweep shows. `PrintingCompose` `predicted/measured` on the Perm
+population, with and without the term applied:
+
+| corpus | pred/meas | + build term |
+| --- | --: | --: |
+| 0.5x | 1.244 | 1.482 |
+| **1.0x** | **1.185** | **1.449** |
+| 2.0x | 0.965 | 1.198 |
+| 3.0x | 0.916 | 1.152 |
+| 3.5x | 0.838 | 1.035 |
+| 4.5x | 0.834 | 1.046 |
+| 5.0x | 0.855 | 1.061 |
+
+**Both curves SATURATE past ~3.5x** — the same phenomenon [the loop-phase
+doc](./local-engine-loop-phase-measurement.md) already records, and the reason a linear term shifts this
+curve instead of flattening it. With the term the asymptote is ~1.045 (right) against ~0.845 (18% under)
+without, so the term is real here as well. But at the **production** size it makes Perm worse, 1.185 ->
+1.449, which is what happens when an arm's rates were fitted with the cost already absorbed into them.
+
+So the change is one of:
+
+1. **Gather-scoped term.** Lowest risk, and it changes no production routing at all, because the Gather
+   branch is declined in production — it is purely a prerequisite for the sparse-gather work.
+2. **Build-wide term plus a refit** of `COMPOSE_WALK_STEP_NS` (0.58) and `COMPOSE_WALK_EMIT_PER_ROW_NS`
+   (2.19) in the same commit. Correct, but it moves every compose query and needs its own regret gate.
+
+Option 1 first. Option 2 is a real improvement — Perm is 18% under at scale and would stay so — but it
+is a separate change with a separate gate, and this branch has now twice demonstrated that a partial
+accuracy fix on this arm loses regret.
+
+One older reading still needs reconciling: "under by ~4-7x at p10 and over by 178x at p99" spanned a
+wider population including broad queries, so a term fixed on the sparse end will move the broad end too.
 
 ### Attempted and held: deriving the span feature from the candidate count
 

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -235,16 +235,51 @@ curve instead of flattening it. With the term the asymptote is ~1.045 (right) ag
 without, so the term is real here as well. But at the **production** size it makes Perm worse, 1.185 ->
 1.449, which is what happens when an arm's rates were fitted with the cost already absorbed into them.
 
-So the change is one of:
+### It is not only Perm, and the three branches disagree about what is wrong
 
-1. **Gather-scoped term.** Lowest risk, and it changes no production routing at all, because the Gather
-   branch is declined in production — it is purely a prerequisite for the sparse-gather work.
-2. **Build-wide term plus a refit** of `COMPOSE_WALK_STEP_NS` (0.58) and `COMPOSE_WALK_EMIT_PER_ROW_NS`
-   (2.19) in the same commit. Correct, but it moves every compose query and needs its own regret gate.
+The sweep above conflated `Perm` with `OrderbyWalk`, and priced `Gather` by a different route (a residual
+on oracle features rather than `predicted/measured` on shipped ones), so the three were never comparable.
+Re-measured with one methodology — shipped features, `predicted_ns / plan_self_ns`, split by branch:
 
-Option 1 first. Option 2 is a real improvement — Perm is 18% under at scale and would stay so — but it
-is a separate change with a separate gate, and this branch has now twice demonstrated that a partial
-accuracy fix on this arm loses regret.
+| corpus | Perm (bare / +term) | OrderbyWalk | Gather |
+| --- | --: | --: | --: |
+| 0.5x | 1.259 / 1.630 | **0.571** / 1.243 | 0.544 / 0.992 |
+| 1.0x | 1.193 / 1.544 | 0.848 / 1.317 | 0.553 / 0.952 |
+| 2.0x | 0.926 / 1.223 | 0.953 / 1.358 | 0.540 / 0.944 |
+| 3.0x | 0.851 / 1.064 | 0.959 / 1.444 | 0.543 / 0.887 |
+| 5.0x | **0.721** / 0.924 | **0.997** / 1.314 | 0.518 / 0.876 |
+
+- **`Gather` is a clean LEVEL error** — flat at 0.52-0.55 across the whole 10x range, no scale dependence
+  whatsoever — and the build term fixes it (0.88-0.99). It is the branch the term was measured on and the
+  only one where it behaves as designed.
+- **`Perm` drifts DOWN 1.75x** (1.259 -> 0.721), and the term shifts the curve while leaving the same
+  1.76x drift. Perm's defect is not the build cost.
+- **`OrderbyWalk` drifts UP 1.75x** (0.571 -> 0.997) — the OPPOSITE sign. Nearly 2x under at half-corpus,
+  correct at 5x.
+
+**That rules out a shared refit.** Perm and OrderbyWalk both multiply `COMPOSE_WALK_STEP_NS` (0.58) and
+`COMPOSE_WALK_EMIT_PER_ROW_NS` (2.19), and no single refit of shared constants flattens two curves running
+in opposite directions. The shipped values are a compromise sitting where the two cross — near 1-2x, which
+is exactly why they look acceptable at the production corpus and diverge either side of it.
+
+And the cause is a FEATURE, not a rate, which is the rule this branch keeps re-confirming. The two
+branches multiply the same rate by different quantities: Perm uses `printings_walked` (`page_span /
+match_rate`, which does not scale with the corpus), while OrderbyWalk uses
+`max(printings_walked, orderby_walk_scan)` and `orderby_walk_scan` **is** `n_printings` for a rarity
+orderby. Same rate, differently-scaling features.
+
+### So the sequencing
+
+1. **Gather-scoped term.** Ready. Changes no production routing at all, because the Gather branch is
+   declined in production — purely a prerequisite for the sparse-gather work.
+2. **Perm and OrderbyWalk are separate investigations, features before rates.** The prerequisite for Perm
+   is a realized counter for `printings_walked`: it is an estimate with nothing to grade it against,
+   which is why an oracle pricing of that branch returns a stdev 15x its median. Same shape of blocker
+   `compose_scan_printings` was for Gather.
+
+A build-wide term plus a shared refit — the shape this was going to take — would have made the production
+corpus worse on Perm (1.193 -> 1.544) while fixing its asymptote, and over-corrected OrderbyWalk at every
+size. Ten points showed that; three would not have.
 
 One older reading still needs reconciling: "under by ~4-7x at p10 and over by 178x at p99" spanned a
 wider population including broad queries, so a term fixed on the sparse end will move the broad end too.

--- a/docs/issues/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/local-engine-two-sided-range-fusion.md
@@ -138,9 +138,13 @@ indexes fused inside one compose, unsatisfiable pairs, an `Or` of two fused `And
 
 ## What is left
 
-**Re-attempt the sparse gather**, now that the sparsity prediction is correct — the order the earlier
-attempt got wrong. Confirm `matches` holds on that population first, then flip `Decline` → `Gather`,
-then re-check regret.
+**The sparse gather was re-attempted and is still declined** — see
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md). The accurate estimate
+did remove its stated blocker (the prediction can now tell sparse from broad), and a second stale
+blocker fell with it (the tie-ordering reason the code gives for the decline died with #815). What
+remains is narrower and better quantified: the arm under-prices the gather to 0.27–0.53 of real, the
+resulting mispicks cancel a real 1.3–2.7x win, and the change measures neutral in wall time and 16%
+worse in regret.
 
 **Watch `printing_compose`'s own slice.** Its share of routed queries went 27% → 31% and its mean
 regret 1.65 → 1.80 µs across this commit, even as the total fell. More queries route there now and the

--- a/docs/issues/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/local-engine-two-sided-range-fusion.md
@@ -1,0 +1,114 @@
+# Fusing a two-sided range into one index interval
+
+Split out of [local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md),
+which found this while auditing plan-cost features and where the routing context lives. Shipped in
+`4991759`; the remaining work is the compose half, below.
+
+`narrow_rec`'s `And` arm narrows children independently and intersects the *results*, never the
+bounds. `usd>=0.42 usd<=0.43` therefore has both halves match most of the corpus, each trip
+`range_too_broad_to_narrow` (`MAX_NARROW_FRACTION` 0.25) on its own and decline — and that their
+intersection is 837 printings is never discovered.
+
+## The evidence that made it worth doing
+
+All artwork, `orderby=toughness`, limit 10, before the change:
+
+| query | results | `eval_domain` | P3 `printings_examined` | best measured |
+| --- | --: | --: | --: | --: |
+| `usd>=200` | 160 | **148** | 6,089 | **26.7 µs** |
+| `usd<=0.02` | 103 | **100** | 339 | **3.2 µs** |
+| `cn>=20000` | 285 | **281** | 2,980 | **17.0 µs** |
+| **`usd>=0.42 usd<=0.43`** | 837 | **31,508** | **97,206** | **1,146.8 µs** |
+| **`cn>=100 cn<=101`** | 460 | **31,508** | **97,206** | **1,136.1 µs** |
+| `usd>=200 t:creature` | 36 | **36** (`narrowed_repr=printings`) | 532 | **2.5 µs** |
+| `usd>=0.42 usd<=0.43 t:creature` | 361 | 17,317 | 45,976 | 570.2 µs |
+
+A one-sided range with **160** results narrows to **148** candidates and finishes in 26.7 µs. A
+two-sided range with **837** results narrows to nothing and takes **43× longer for 5× more rows**. So
+the shape a reader intuitively wants — walk the index slice, test the residual, accumulate the page —
+**is** what the engine does for `usd>=200`; the two-sided form simply never gets there.
+
+## What shipped
+
+`fuse_and_range_children` groups an `And`'s children by which printing-range index they select on and
+fuses each group of two or more into one half-open interval (`lo = max(lo_i)`, `hi = min(hi_i)`) before
+the arm ranks anything. The interval is the exact conjunction of its constituents, which is what lets
+one source stand in for all of them — including in `every_child_included`'s tightness accounting.
+
+| query | before | after |
+| --- | --: | --: |
+| `usd>=0.42 usd<=0.43` | 1,146.8 µs, exam 97,206 | **76.2 µs**, exam 9,273 |
+| `cn>=100 cn<=101` | 1,136.1 µs, exam 97,206 | **49.9 µs**, exam 5,604 |
+| `usd>=0.42 usd<=0.43 t:creature` | 570.2 µs, evd 17,317 | **17.0 µs**, evd 356 |
+
+**Regret cannot see this, which is why it was measured differently.** Fusion makes the plans that ran
+faster without changing which one wins, and regret is a difference between plans — the same blind spot
+that hid `r>=rare`'s missing plan and the sparse-gather decline. The measurement is paired routed
+dispatch over 11,915 traffic queries, same seed and stream on both builds, sliced by whether the query
+has two or more comparisons on one fusible field:
+
+| slice | n | base | fused | ratio |
+| --- | --: | --: | --: | --: |
+| fusible | 577 | 111.6 ms | **95.9 ms** | **0.86** |
+| the rest (fusion cannot touch it) | 11,338 | 915.6 ms | 897.6 ms | 0.98 |
+
+Regret mean went 1.42 → 1.35 µs, with 5% more queries fitting the same 180 s budget.
+
+**The untouchable slice is the noise gauge, and it is worth reading before believing any single row.**
+Fusion cannot alter those 11,338 queries at all, yet they move 2% in aggregate and up to **±170 µs**
+per query. Every apparent per-query regression in this data sits inside that envelope — including the
++166 µs on broad two-sided `cn`/`year` ranges that first looked like the gate below earning its keep.
+
+### The gate is a scope decision, not a measured win
+
+Fusion applies only where the fused interval is itself sparse. Fused-vs-gated is 0.88 against 0.86 of
+baseline on the fusible slice, which the noise floor above makes indistinguishable — so the honest
+claim is not that the gate is faster. What it buys is a bound: outside the sparse population where the
+win *is* demonstrated, the change is a provable no-op, because the constituents pass through to their
+own arms untouched.
+
+It also removes a live question. Fusing a still-broad interval is not neutral: one broad source reaches
+`range_narrowed` under a single `broad_ok` where two broad children each got their own, so the `And`'s
+per-child skip logic stops deciding per child. The gate means that never happens, and as a side effect
+`range_narrowed`'s `broad_ok` is unreachable from a fused source at all (a sparse `k` returns on the
+vec path first) — which is why the fused source carries no negation flag despite `bare_range_bounds`
+happily reducing `-usd<c` for it.
+
+### Row identity
+
+4,560 cells identical, hashing the returned `scryfall_id` sequence over three modes × five orderbys ×
+four pages × two prefers: two-sided `usd`/`cn`/`date`/`year`, negated halves, three constituents on one
+index, two indexes fused independently, unsatisfiable pairs, fused ranges under `Or` and `Not`, plus
+one-sided and broad controls. Harness: `scratchpad/fuserows.py`.
+
+The unsatisfiable case is load-bearing, not decoration. `usd>=1 usd<=0.5` fuses to `hi < lo`, and every
+consumer computes `k` as `partition_point(hi) - partition_point(lo)` — that subtraction **underflows
+and panics**. Clamping to `[lo, lo)` yields `k = 0`, which is what an empty range means and what every
+consumer already handles.
+
+## What is left
+
+**The compose half has not moved.** `eval_domain` still reads 31,508 on the bare two-sided form, and
+`printing_compose` is still the picked plan for it, because `is_printing_composable` and
+`compose_printing_bits` decompose `And` *before* any range guard — the fusion improves the narrowing
+path only. `compose_printing_estimate` therefore still multiplies the two sides instead of intersecting
+one interval (20,411 against a true 837), and `scatter_printings` still reads 82,421 for an 837-row
+answer. Doing the same fusion in those three functions is the next step, and it is the prerequisite
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) is actually blocked
+on: that design's `Decline` → `Gather` flip regressed routing purely because `compose_paging_for`
+branches on `result_total`, the *estimate*, and so cannot tell a sparse query from a broad one.
+
+Order: fuse compose's three range paths, confirm `matches` on that population, then re-enable the
+gather behind the now-correct sparsity prediction, then re-check regret. Not before.
+
+**`eur` and `tix` cannot fuse at all**, because `resolve_numeric_range_leaf` covers only `price_usd` and
+`collector_number` (plus `DateCmp`/`YearCmp` reaching `released_at` directly). That is the same root
+cause as [local-engine-eur-tix-range-index.md](./local-engine-eur-tix-range-index.md), and fusion adds
+one more reason to fix it: several top-100 regret rows are two-sided `eur:`/`tix:` ranges, which are
+exactly the shape that gains most and currently gains nothing.
+
+**Card-level numeric contradictions are separate work.** `usd>=1 usd<=0.5` short-circuits for free
+here, but `power=3 power=5` does not reach this code: `resolve_numeric_range_leaf` returns `None` for
+`Power`, and `printing_dependent` classifies `Power`/`Cmc`/`Toughness`/`Loyalty` as card-level,
+evaluated through `numeric_candidates`. Detecting that contradiction is most naturally a bind-time
+pass, and needs its own decision on `Ne` and null semantics.

--- a/docs/issues/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/local-engine-two-sided-range-fusion.md
@@ -1,8 +1,8 @@
 # Fusing a two-sided range into one index interval
 
 Split out of [local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md),
-which found this while auditing plan-cost features and where the routing context lives. Shipped in
-`4991759`; the remaining work is the compose half, below.
+which found this while auditing plan-cost features and where the routing context lives. Shipped in two
+commits — `4991759` for the narrowing, `7374e19` for the compose builders.
 
 `narrow_rec`'s `And` arm narrows children independently and intersects the *results*, never the
 bounds. `usd>=0.42 usd<=0.43` therefore has both halves match most of the corpus, each trip
@@ -86,20 +86,66 @@ consumer computes `k` as `partition_point(hi) - partition_point(lo)` — that su
 and panics**. Clamping to `[lo, lo)` yields `k = 0`, which is what an empty range means and what every
 consumer already handles.
 
+## The compose half, and why it was not an estimator problem
+
+The narrowing fusion left `compose_printing_bits` and `compose_printing_estimate` reading the unfused
+shape, because both decompose `And` before any range guard. Their fold takes the **min** of the
+children's match counts — an intersection upper bound, and a bad one here. (An earlier draft of this
+doc said it *multiplied* the two sides. It does not: 33,862 is exactly `min(33,862, 48,559)`. The
+summing is in `scatter_printings`, 82,421 = 33,862 + 48,559.)
+
+| query | mode | estimated `matches` | true total | est/true |
+| --- | --- | --: | --: | --: |
+| `usd>=0.42 usd<=0.43` | printing | 33,862 | **879** | 38.5× |
+| | artwork | 20,411 | **837** | 24.4× |
+| | card | 14,281 | **763** | 18.7× |
+| `cn>=100 cn<=101` | printing | 35,589 | **568** | 62.7× |
+| **`usd>=200`** (control) | printing | 258 | 258 | **1.0×** |
+
+**The control is the whole finding.** A *one-sided* range already estimates at 1.0×, because the leaf
+arm reads `k` off two `partition_point` calls. So nothing here needed a better estimator — the exact
+count was two binary searches away the entire time, and the fold simply never saw the interval. The
+card-side projection is equally cheap: `range_card_counts_for` pairs each range index with an exact
+`RangeCardCounts` table over the same interval, which is why `usd>=0.42`/card reads 12,408 against a
+true 12,408.
+
+Shipped by reusing `fuse_and_range_children` with `sparse_only: false`. The compose builders want the
+fusion at every width, unlike narrowing: `range_leaf_bits` is an O(k) scatter, so one scatter of a
+subset cannot lose to two scatters of its supersets plus an AND, and the estimate is exact rather than
+an upper bound at any width. After: printing mode reads **1.0×**, card and artwork 0.6–0.9× — the same
+ratios their one-sided forms already carry, since those project printings to distinct rows.
+
+**The paging prediction follows for free, which is the part sparse-gather needed.** 879 is under
+`STREAM_MIN_MATCHES`, so `compose_paging_with_total` now predicts `Decline` where it predicted `Perm` —
+matching what the fastpath actually does — and the pick moves off `PrintingCompose` onto the plan that
+was already answering. That removes the blocker named in
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md): its `Decline` →
+`Gather` flip regressed routing purely because `compose_paging_for` branches on `result_total`, the
+estimate, and so could not tell a sparse query from a broad one. It can now.
+
+Cumulative over both fusion commits, paired routed dispatch on the same seed and stream:
+
+| | base | + narrowing | + compose |
+| --- | --: | --: | --: |
+| fusible slice (577 queries) | 111.6 ms | 95.9 ms | **90.5 ms (0.81×)** |
+| the untouchable slice | 915.6 ms | 897.6 ms | 925.8 ms (1.01, noise) |
+| regret mean | 1.42 µs | 1.35 µs | **1.30 µs** |
+
+Row identity for this half: 3,120 further cells, aimed at what only the compose builders fuse — broad
+intervals, each composable leaf kind (`border`/`r`/`f`/`set`/`watermark`/`type` and negations), two
+indexes fused inside one compose, unsatisfiable pairs, an `Or` of two fused `And`s. Harness:
+`scratchpad/composerows.py`.
+
 ## What is left
 
-**The compose half has not moved.** `eval_domain` still reads 31,508 on the bare two-sided form, and
-`printing_compose` is still the picked plan for it, because `is_printing_composable` and
-`compose_printing_bits` decompose `And` *before* any range guard — the fusion improves the narrowing
-path only. `compose_printing_estimate` therefore still multiplies the two sides instead of intersecting
-one interval (20,411 against a true 837), and `scatter_printings` still reads 82,421 for an 837-row
-answer. Doing the same fusion in those three functions is the next step, and it is the prerequisite
-[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) is actually blocked
-on: that design's `Decline` → `Gather` flip regressed routing purely because `compose_paging_for`
-branches on `result_total`, the *estimate*, and so cannot tell a sparse query from a broad one.
+**Re-attempt the sparse gather**, now that the sparsity prediction is correct — the order the earlier
+attempt got wrong. Confirm `matches` holds on that population first, then flip `Decline` → `Gather`,
+then re-check regret.
 
-Order: fuse compose's three range paths, confirm `matches` on that population, then re-enable the
-gather behind the now-correct sparsity prediction, then re-check regret. Not before.
+**Watch `printing_compose`'s own slice.** Its share of routed queries went 27% → 31% and its mean
+regret 1.65 → 1.80 µs across this commit, even as the total fell. More queries route there now and the
+model prices them worse; that is the next thing to look at in the acquire, and it is the same cell the
+rarity widening flagged.
 
 **`eur` and `tix` cannot fuse at all**, because `resolve_numeric_range_leaf` covers only `price_usd` and
 `collector_number` (plus `DateCmp`/`YearCmp` reaching `released_at` directly). That is the same root

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -60,6 +60,12 @@ values (`bench_card_range_estimate`, `bench_cost_model_agreement`) and should mo
 purpose: `bench_plan_misselection --source wild-operators` and `census_candidate_materialize`, where
 the question is what users actually lose.
 
+For built designs — kernel harnesses that control the ratios instead of sampling them — and the rule
+that came out of them (**shape from a built design, levels from traffic**), see
+[local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md). It also records
+why a min-of-N benchmark over one candidate list measures a cache state production never reaches, and
+why a whole-arm fit's intercept cannot be read as a fixed cost.
+
 ## Acquire and dispatch are two bins, and plan timing means dispatch
 
 The routed path has exactly two phases that matter for measurement, and conflating them produced the

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -82,7 +82,21 @@ pick/best ratio from 0.22 to 0.63–0.69 and flipped nothing: 16 mispicks surviv
 and "the router now picks correctly" are separate measurements, and so is "the arm now predicts its own
 time" — see the table at the top.
 
-## Two traps that cost the most time
+**9. If the fix does not move the ordering, split the population before touching a rate.** A pair can be
+right on average and bimodal underneath, and the summary statistic that hides this is the one that looks most
+reassuring. `GatheredScan vs StreamedSelect [printing_compose]` reads a **gap ratio of 0.91** — the model
+sizes the difference almost exactly right — at **69% ordered right**. That invites "it is variance, no
+constant will fix it". Splitting the 5,085 non-tie pairs on the regime flag says otherwise:
+
+    right, tier 0 (card-invariant)   409    P3 wins 100% measured, 100% predicted
+    right, tier > 0 (real residual) 3,100   P3 wins   5% measured,   5% predicted
+    wrong, tier > 0                 1,576   P3 wins  98% measured,   2% predicted
+
+Every wrong pair is in one regime, and the wrong group is **homogeneous** — the model is not scattered around
+the truth, it is confidently inverted on one identifiable class (broad residuals where both plans scan the
+whole corpus). A mean gap ratio of 0.91 is what two opposed sub-populations look like after averaging.
+
+## Three traps that cost the most time
 
 **Cross-build timing cannot resolve a small effect, and will hand you the wrong sign.** On identical cells
 `ns_loop` wandered 43.00 / 45.38 / 47.17 µs across runs of builds that never touched that phase — ±9%, both
@@ -96,3 +110,12 @@ ns/card on a built design while traffic fit the same column at 8.19 against a sh
 third time this has been caught. **Shape from a built design, levels from traffic.** A design tells you which
 terms exist, which are degenerate and how two plans differ; it does not tell you what a constant should
 equal.
+
+**A pooled fit endorses the rates that are wrong on a sub-population, so it cannot be your check.** On the
+class in step 9, `STREAM_SCAN_PER_ROW_NS` 5.97 and `GATHER_SCAN_PER_ROW_NS` 2.06 are 2.9× apart for what is
+nominally the same walk-a-printing-and-test work, and P3's higher rate cancels its lower per-card rate exactly
+where both features are maximal. `fit_cost_model.py` fits **both** and pronounces them fine — 6.04 at ratio
+1.01 and 2.53 at 1.23. So a refit will not surface this and cannot fix it; it will confirm the status quo. Fit
+the split populations separately, or the fitter launders the error into an endorsement. Corollary for
+`--counters`: it grades a feature against a counter *pooled the same way*, so a feature that is right at the
+median and inverted on a quarter of rows passes.

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -1,0 +1,98 @@
+# Diagnosing a Plan Cost Error
+
+How to find out *why* one physical plan's cost arm is wrong, as opposed to *that* it is wrong.
+[reference-cost-model-measurement.md](../issues/reference-cost-model-measurement.md) says which tool answers
+which question; [performance-pr-workflow.md](./performance-pr-workflow.md) is the process for shipping the
+fix. This is the diagnosis in between.
+
+Every step below exists because skipping it produced a wrong answer at least once. The worked example
+throughout is `StreamedSelect` (P3) against `GatheredScan` (P4) and `PrintingCompose` on legality queries,
+from `local-engine-loop-phase-measurement.md`.
+
+## Where you are trying to end up
+
+**Both scan arms predicting their own real time, and the ordering correct.** Those are two goals, they move
+independently, and only one of them is currently met.
+
+Ordering-correct-by-cancellation is a real trap and the engine has been in it: `cost.rs`'s own header
+records that P3/P4 rates "are demonstrably wrong while the PRODUCTS they form are roughly right — which is
+the signature of compensating error", and that a rate 2× high against an estimate 2× low routes correctly
+and breaks the moment you fix either alone. That is a local optimum you cannot build on, because the next
+change has no ground truth to check itself against.
+
+So track absolute agreement per arm *and* regret, always. Absolute agreement today
+(`bench_cost_error_percentiles.py`, estimate/real, uniform mode):
+
+| plan | p10 | p50 | p90 | spread |
+| --- | --: | --: | --: | --: |
+| CardRangePopcount | 0.84 | 1.04 | 1.29 | **1.5** |
+| StreamedSelect | 0.74 | 1.09 | 1.90 | 2.6 |
+| GatheredScan | 0.68 | **1.28** | 2.67 | 3.9 |
+| PrintingCompose | 0.62 | 1.06 | 2.99 | 4.8 |
+
+P4 is still ~1.3× over at the median and compose's spread is the worst in the engine. Neither is finished.
+
+## The recipe
+
+**1. Pick the cell from regret, not from accuracy.** They disagree, sharply. P3's absolute error reaches p99
+47× and it barely appears as a regret source; the `plane` acquire has p50 errors of 1.2–1.3 and a **1% miss
+rate**. An argmin sees only *differences*, so a term wrong for every plan cancels. `bench_regret_matrix.py`
+sliced by acquire × unique is what ranks the work — `printing_compose / artwork` at 32% of all lost time.
+
+**2. On one query in that cell, get predicted AND measured for every plan.** `explain_analyze` runs each plan
+for real, so it is one call, and it says which side of the comparison is broken:
+
+    f:gladiator / artwork    predicted   measured   pred/meas
+    PrintingCompose             178.7      182.2      0.98    <- accurate
+    StreamedSelect              704.0      102.5      6.87    <- the problem
+
+We had assumed compose was over-picked because compose was under-costed. It was not; P3 was over-costed 7×.
+
+**3. Decompose the bad prediction into its terms by hand.** `scan_units × STREAM_SCAN_PER_ROW_NS` is
+88,026 × 5.97 = **525 µs of a 704 µs prediction**, against a 91 µs measured loop. Now one term is suspect
+rather than a whole arm.
+
+**4. Grade the suspect feature against its realized counter — for BOTH plans, on the same query.** This is
+the step that does the work:
+
+    scan_units charged (shared)   88,026        88,026
+    printings_examined realized   54,213 (P4)    5,876 (P3)
+    ratio                           1.62          14.98
+
+One per-query number cannot be right for both. This is what separates a **feature** error from a **rate**
+error, a distinction no refit can make — and the reason six refits of this surface failed before anyone
+looked. It only works because the executors publish realized counters into `PhaseStats`; if the counter you
+need does not exist, adding it is the first task, not an aside.
+
+**5. Sweep for scope before fixing anything.** Ten predicates × three modes. Legality read 0.10–0.26;
+`border:black`, `r:mythic` and `watermark:*` read exactly 1.00. A blanket "compose's `scan_units` is wrong"
+fix would have corrected four queries and broken the rest.
+
+**6. Name the mechanism, or do not believe the finding.** P3's `card_match_count` answers from span
+arithmetic whenever `card_pass` resolves a card outright; P4's `push_card_matches` must walk the span to push
+every match. Legality is the one printing-varying attribute that resolves at card level, for non-divergent
+cards. Without a mechanism you have found a coincidence.
+
+**7. Check whether the win is routed or latent.** Sweep `unique`. In card mode those same queries route to
+`PlanePopcountOrder` (2.46 µs against P3's 12.38), so a card-mode-only measurement optimises a plan nobody
+runs. Print the routed plan per cell so a latent win reads as one.
+
+**8. Verify the fix moved the DECISION, not just the number.** Correcting the feature took the predicted
+pick/best ratio from 0.22 to 0.63–0.69 and flipped nothing: 16 mispicks survived. "The estimate got better"
+and "the router now picks correctly" are separate measurements, and so is "the arm now predicts its own
+time" — see the table at the top.
+
+## Two traps that cost the most time
+
+**Cross-build timing cannot resolve a small effect, and will hand you the wrong sign.** On identical cells
+`ns_loop` wandered 43.00 / 45.38 / 47.17 µs across runs of builds that never touched that phase — ±9%, both
+directions. `bench_plan_execution_ab.py` called one change 2% *slower* while its own acquire control, which
+the change cannot touch, moved 1.9% the same way. Use **one binary with a runtime toggle**, interleaved
+subprocesses, and **equal-length env values** — an env var present in one arm only shifts process memory
+layout enough to move sub-100 µs queries a consistent ~15%. `scripts/bench_walk_span.py` is the pattern.
+
+**Kernel measurements are warm-cache; levels must come from traffic.** The residual floor measured 2.45
+ns/card on a built design while traffic fit the same column at 8.19 against a shipped 9.05 — and that is the
+third time this has been caught. **Shape from a built design, levels from traffic.** A design tells you which
+terms exist, which are degenerate and how two plans differ; it does not tell you what a constant should
+equal.

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -49,7 +49,15 @@ point step 11 next.
 **1. Pick the cell from regret, not from accuracy.** They disagree, sharply. P3's absolute error reaches p99
 47× and it barely appears as a regret source; the `plane` acquire has p50 errors of 1.2–1.3 and a **1% miss
 rate**. An argmin sees only *differences*, so a term wrong for every plan cancels. `bench_regret_matrix.py`
-sliced by acquire × unique is what ranks the work — `printing_compose / artwork` at 32% of all lost time.
+sliced by acquire × unique is what ranks the work — and **re-run it after every landed fix**, because the
+ranking moves under you. `printing_compose / artwork` was 32% of all lost time when the worked example below
+started and is **6%** now; `candidates / artwork` is 32%.
+
+Read the SHARE column knowing it is frequency × severity. `candidates` currently holds 78% of lost time at a
+mean of 1.69 µs against `printing_compose`'s 21% at 1.60 — i.e. the leading acquire is not the worse one per
+query, it is the one with 3.5× the queries. And **the loss is all tail**: p90 is 0.00 for every acquire, so
+the median query has no regret at all and only p99 (36–64 µs) is worth attacking. A mean is the wrong summary
+to optimise against here.
 
 **2. On one query in that cell, get predicted AND measured for every plan.** `explain_analyze` runs each plan
 for real, so it is one call, and it says which side of the comparison is broken:

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -20,17 +20,29 @@ the signature of compensating error", and that a rate 2× high against an estima
 and breaks the moment you fix either alone. That is a local optimum you cannot build on, because the next
 change has no ground truth to check itself against.
 
-So track absolute agreement per arm *and* regret, always. Absolute agreement today
-(`bench_cost_error_percentiles.py`, estimate/real, uniform mode):
+So track absolute agreement per arm *and* regret, always. Absolute agreement
+(`bench_cost_error_percentiles.py`, estimate/real, uniform mode, 79,718 plan-rows):
 
 | plan | p10 | p50 | p90 | spread |
 | --- | --: | --: | --: | --: |
-| CardRangePopcount | 0.84 | 1.04 | 1.29 | **1.5** |
-| StreamedSelect | 0.74 | 1.09 | 1.90 | 2.6 |
-| GatheredScan | 0.68 | **1.28** | 2.67 | 3.9 |
-| PrintingCompose | 0.62 | 1.06 | 2.99 | 4.8 |
+| CardRangePopcount | 0.84 | 1.05 | 1.30 | **1.6** |
+| StreamedSelect | 0.73 | 1.09 | 1.74 | 2.4 |
+| GatheredScan | 0.68 | **1.28** | 2.75 | 4.0 |
+| PrintingCompose | 0.66 | 1.07 | 3.08 | 4.7 |
 
 P4 is still ~1.3× over at the median and compose's spread is the worst in the engine. Neither is finished.
+
+**And that these two goals move independently is not a theoretical caveat.** The two fixes described
+throughout this doc took total regret down **25%** and moved this table by almost nothing — P3's spread
+2.6 → 2.4, P4's unchanged. Both fixes are confined to the `printing_compose` acquire, which is 4–10% of
+plan-rows, so a pooled per-arm view cannot see them at all. If you are optimising routing, this table is
+not your scoreboard; if you are trying to make an arm predict its own time, regret is not yours.
+
+One reading to attribute rather than trust: sliced to the cell that was worked,
+`StreamedSelect [printing_compose] / printing` now shows p50 1.04 with a **26.4 spread** (p90 13.90), and
+`/ card` 24.6. A long over-costing tail on the acquire whose median is fine. No before/after was captured for
+that cell, so whether the tier gate created it or merely revealed it is open — and it is the obvious place to
+point step 11 next.
 
 ## The recipe
 
@@ -52,6 +64,12 @@ We had assumed compose was over-picked because compose was under-costed. It was 
 88,026 × 5.97 = **525 µs of a 704 µs prediction**, against a 91 µs measured loop. Now one term is suspect
 rather than a whole arm.
 
+`explain` flattens the whole feature vector into its `acquire` dict, so a throwaway Python replica of the one
+arm is a few lines. **Assert the replica reproduces `predicted_ns` exactly before you attribute anything
+to it** — a term breakdown from a replica that has silently drifted is worse than no breakdown, and this is
+the same failure `fit_cost_model`'s mirror check exists to catch (it went two revisions reporting
+coefficients from a drifted mirror).
+
 **4. Grade the suspect feature against its realized counter — for BOTH plans, on the same query.** This is
 the step that does the work:
 
@@ -64,25 +82,64 @@ error, a distinction no refit can make — and the reason six refits of this sur
 looked. It only works because the executors publish realized counters into `PhaseStats`; if the counter you
 need does not exist, adding it is the first task, not an aside.
 
-**5. Sweep for scope before fixing anything.** Ten predicates × three modes. Legality read 0.10–0.26;
+**5. Ask whether the router and the executor are asking the same question.** A feature this wrong is rarely
+bad arithmetic; it is usually a condition the executor evaluates and the router does not. `prepare_candidates`
+held the only copy of `all_match_known`, so the compose acquire — which never calls it — charged
+`verify_cost_tier` on every legality query alike, and the two dead terms that bought were **92–94% of P3's
+predicted cost**. The fix was to extract the predicate (`plane_leaves_nothing_to_verify`) and call it from
+both layers, not to adjust a number.
+
+Two checks worth making routinely, because both failure modes are silent:
+
+- **Every acquire branch that builds `PlanFeatures` sets every gated field.** `mk_plan_feats` supplies
+  defaults, so a branch nobody taught is quietly wrong rather than a compile error.
+- **A condition both layers need is one function, not two copies.**
+  `compose_paging_prediction_matches_the_branch_taken` is the existing pattern for pinning that agreement, and
+  its doc says why: the same drift already happened once between `cost.rs` and its Python mirror.
+
+**6. Sweep for scope before fixing anything.** Ten predicates × three modes. Legality read 0.10–0.26;
 `border:black`, `r:mythic` and `watermark:*` read exactly 1.00. A blanket "compose's `scan_units` is wrong"
 fix would have corrected four queries and broken the rest.
 
-**6. Name the mechanism, or do not believe the finding.** P3's `card_match_count` answers from span
+**7. Name the mechanism, or do not believe the finding.** P3's `card_match_count` answers from span
 arithmetic whenever `card_pass` resolves a card outright; P4's `push_card_matches` must walk the span to push
 every match. Legality is the one printing-varying attribute that resolves at card level, for non-divergent
 cards. Without a mechanism you have found a coincidence.
 
-**7. Check whether the win is routed or latent.** Sweep `unique`. In card mode those same queries route to
+**8. Check whether the win is routed or latent.** Sweep `unique`. In card mode those same queries route to
 `PlanePopcountOrder` (2.46 µs against P3's 12.38), so a card-mode-only measurement optimises a plan nobody
 runs. Print the routed plan per cell so a latent win reads as one.
 
-**8. Verify the fix moved the DECISION, not just the number.** Correcting the feature took the predicted
+**9. Verify the fix moved the DECISION, not just the number.** Correcting the feature took the predicted
 pick/best ratio from 0.22 to 0.63–0.69 and flipped nothing: 16 mispicks survived. "The estimate got better"
 and "the router now picks correctly" are separate measurements, and so is "the arm now predicts its own
 time" — see the table at the top.
 
-**9. If the fix does not move the ordering, split the population before touching a rate.** A pair can be
+**10. If total regret ROSE, find out whether you removed a compensating error before reverting.** A correct
+fix can make routing worse, and the intermediate number will tell you to throw it away. Run
+`bench_pairwise_ordering.py` on the pair you targeted *and* on the others:
+
+| pair, `[printing_compose]` | before | after the tier gate |
+| --- | --: | --: |
+| `PrintingCompose vs StreamedSelect` (targeted) | 80% ordered right | **96%** |
+| `GatheredScan vs StreamedSelect` (untouched) | 69%, gap 0.89 | 69%, gap 0.90 |
+
+The targeted pair improved and no other pair moved, yet total regret went **81.7 → 129.7 ms**. That pattern
+means one thing: the fix let a correctly-cheap plan into the argmin far more often, and a *different* pair
+cannot rank it. Nothing regressed — an existing error stopped being masked. Fixing what it exposed (P4's span
+feature, 1.76× over) then took regret to **61.2 ms, −25% on baseline**. Reverting on the 129.7 ms would have
+discarded a correct change and left the real defect hidden, which is the trap this step exists for.
+
+Two things make the reading trustworthy. **Regret TOTAL is a sum over however many queries the budget
+reached**, so it is not comparable across runs — compare the mean, and measure your own baseline in the same
+session rather than against a number in a doc. The 48.7 ms and 55.0 ms figures still quoted in the earlier
+sections of `local-engine-loop-phase-measurement.md` were taken at unrecorded settings and are **not** on the
+same scale as the 81.7 → 61.2 ms above; that is why a fresh paired baseline was measured rather than compared
+against them. And a cost-only change
+needs **no new row-identity run**: `force_plan_differential_agreement` already proves every plan returns the
+same rows, which is exactly what makes re-routing safe.
+
+**11. If the fix does not move the ordering, split the population before touching a rate.** A pair can be
 right on average and bimodal underneath, and the summary statistic that hides this is the one that looks most
 reassuring. `GatheredScan vs StreamedSelect [printing_compose]` reads a **gap ratio of 0.91** — the model
 sizes the difference almost exactly right — at **69% ordered right**. That invites "it is variance, no
@@ -96,7 +153,17 @@ Every wrong pair is in one regime, and the wrong group is **homogeneous** — th
 the truth, it is confidently inverted on one identifiable class (broad residuals where both plans scan the
 whole corpus). A mean gap ratio of 0.91 is what two opposed sub-populations look like after averaging.
 
-## Three traps that cost the most time
+## Four traps that cost the most time
+
+**A corpus-wide share applied to a selected population is wrong exactly where it matters.** The first attempt
+at the fix above priced "how much of the residual is really printing-dependent" as the divergent fraction of
+the corpus — `legal_divergent / n_cards`, ~1.76%. It is the natural move and it is invalid whenever the filter
+*correlates with the thing being averaged*: for `f:oldschool` the candidates largely **are** the divergent
+cards, so a global share under-charges precisely the queries whose residual is real. Measured, it traded 408
+mispicks for 118 that were four times worse (mean 54.27 → 206.24 µs) for a net 3.4%. The replacement was a
+**boolean the engine already derives from data** (`plane_expr_is_existential` against `divergent_formats`), not
+a better fraction. Prefer an exact predicate the engine can answer over any estimated share, and if you must
+estimate one, condition it on the candidate set rather than the corpus.
 
 **Cross-build timing cannot resolve a small effect, and will hand you the wrong sign.** On identical cells
 `ns_loop` wandered 43.00 / 45.38 / 47.17 µs across runs of builds that never touched that phase — ±9%, both
@@ -112,7 +179,7 @@ terms exist, which are degenerate and how two plans differ; it does not tell you
 equal.
 
 **A pooled fit endorses the rates that are wrong on a sub-population, so it cannot be your check.** On the
-class in step 9, `STREAM_SCAN_PER_ROW_NS` 5.97 and `GATHER_SCAN_PER_ROW_NS` 2.06 are 2.9× apart for what is
+class in step 11, `STREAM_SCAN_PER_ROW_NS` 5.97 and `GATHER_SCAN_PER_ROW_NS` 2.06 are 2.9× apart for what is
 nominally the same walk-a-printing-and-test work, and P3's higher rate cancels its lower per-card rate exactly
 where both features are maximal. `fit_cost_model.py` fits **both** and pronounces them fine — 6.04 at ratio
 1.01 and 2.53 at 1.23. So a refit will not surface this and cannot fix it; it will confirm the status quo. Fit

--- a/docs/workflows/performance-pr-workflow.md
+++ b/docs/workflows/performance-pr-workflow.md
@@ -46,7 +46,9 @@ anything new rather than starting a twelfth private copy.
 For diagnosing *which* of features / model shape / coefficients is at fault once layer 1 or 2 shows
 an error, and for the regret and pairwise-ordering views, see
 [reference-cost-model-measurement.md](../../docs/issues/reference-cost-model-measurement.md). That is
-the tool-picking reference; this doc is the process.
+the tool-picking reference; this doc is the process. For the step-by-step diagnosis of one plan's arm —
+which cell to pick, how to tell a feature error from a rate error, and the two measurement traps that
+hand you the wrong sign — see [diagnosing-a-plan-cost-error.md](./diagnosing-a-plan-cost-error.md).
 
 ### Layers 1 and 2: read the shape, not the median
 

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -23,8 +23,10 @@ Those rows were **63% of all reported regret**, and `StreamedSelect -> StreamedS
 best, so not misrouting by definition — was the single largest slice at a 14.15 us mean. On this basis
 it is 1.16. The genuine misroutes are unmoved (`PrintingCompose -> GatheredScan` 65.94 -> 65.22).
 
-Needs a `routed-phases` build. Without the feature the phase keys publish as zeros and those queries
-are skipped with a warning rather than measured against a zero baseline.
+Only the DECLINE rows need a `routed-phases` build: when the picked plan declines at runtime nothing
+forced describes what ran, so those fall back to the routed dispatch phase and are skipped without the
+feature. Every other row prices both sides from forced trials, so the harness now measures the whole
+sample on a plain build instead of skipping ~58% of it.
 
 Regret is mostly zeros, so a median is useless here: read the SHARE column, which is what fraction of
 all lost time a slice accounts for. That ranks the work. p90/p99/max show whether a slice loses a
@@ -120,23 +122,47 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
             skipped_unpriced += 1
             continue
         best = min(ran, key=lambda p: selves[id(p)])
+        # The baseline is the PICKED plan measured exactly as `best` was -- same estimator, same netting,
+        # same round selection -- so a query whose picked plan is its best has regret identically 0 and
+        # contributes nothing. That is what the routed-dispatch baseline could not do: on 16,770 queries
+        # where picked IS best it read median +0.04 us but p10 -7.21 and mean -4.52, because it compared
+        # `min` over the routed path's dispatch trials against a phase sum from a forced run's fastest
+        # round. Two floor estimators of the same quantity agree at the median and disagree in the tail,
+        # and that tail was the whole negative total: -51.7 ms over the run, with SHARE columns of 127%.
+        #
+        # `routed_dispatch_ns` is still the only measurement that exists for the case it was introduced
+        # for: when the picked plan DECLINES at runtime, dispatch re-chooses among materializing plans
+        # only, so no forced trial describes what actually ran. Those rows keep it, and only those rows
+        # need a `routed-phases` build.
         dispatch = sample.res["acquire"].get("routed_dispatch_ns")
-        if not dispatch or not any(dispatch):
-            skipped_unphased += 1
-            continue
+        if declined or picked is None:
+            if not dispatch or not any(dispatch):
+                skipped_unphased += 1
+                continue
+            baseline_ns = float(min(dispatch))
+        else:
+            baseline_ns = float(selves[id(picked)])
         rows.append(
             {
+                "picked_is_best": picked is not None and not declined and id(picked) == id(best),
                 # SIGNED. A negative row is the routed path beating the best forced plan, which
                 # happens (the lazy re-choose, or a forced run paying a cold cache the routed one
                 # does not) and is information, not zero. Clamping it to 0 let a transition whose
                 # MEAN is negative still accumulate share as if it were loss.
-                "lost": min(dispatch) / 1000.0 - selves[id(best)] / 1000.0,
+                "lost": (baseline_ns - selves[id(best)]) / 1000.0,
                 "acquire": sample.acquire["count_source"],
                 "unique": sample.kw["unique"],
                 "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
                 "best": best["plan"],
             }
         )
+    # An invariant now, not a bias estimate: same estimator on both sides means these rows are exactly
+    # zero. Anything else is a bug in the pricing, so it is worth one line of output to keep honest.
+    zero_pop = [r for r in rows if r["picked_is_best"]]
+    if zero_pop:
+        worst = max(abs(r["lost"]) for r in zero_pop)
+        verdict = "exactly 0, as it must be" if worst == 0.0 else f"NONZERO -- max |{worst:.3f}| us, which is a pricing bug"
+        print(f"invariant: {len(zero_pop):,} queries where picked IS best price at {verdict}")
     if skipped_unpriced:
         print(f"skipped {skipped_unpriced:,} queries where a plan that ran published no phase timing and so cannot be priced")
     if skipped_unphased:

--- a/scripts/bench_walk_span.py
+++ b/scripts/bench_walk_span.py
@@ -1,0 +1,173 @@
+"""A/B the streamed walk's match-span bound (`CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR`).
+
+The bound trades work in two phases at once, so a single number cannot judge it:
+
+* `ns_finish` — the walk itself. Bounded to the match span it steps from the first matching card to
+  the last instead of from permutation index 0 to wherever the page happens to fill.
+* `ns_loop` — the match loop, which pays one `inv_perm` read plus a `min` and a `max` per MATCHING
+  card to learn that span.
+
+So the cells come in two groups. CLUSTERED pairs a predicate with an orderby it correlates with, which
+is where a walk from index 0 grinds through a long non-matching prefix. BROAD has matches spread
+through the permutation, so the walk fills its page in ~`limit` steps and the bound can only cost.
+Both groups matter: the change is only worth taking if the first group's win is real AND the second
+group's cost is not.
+
+**Why a toggle rather than two builds.** Cross-build comparison cannot resolve this. Measured on
+these cells, `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on the same two builds —
+±9%, in both directions, on a phase neither build changed. That is the common-mode floor error
+`bench_plan_execution_ab.py` documents, plus whatever the linker did to code layout, and the per-card
+cost being hunted here is smaller than it. One binary with a runtime toggle removes both: identical
+code, identical layout, and the only difference is a branch that was already there.
+
+Both variants set the env var, to EQUAL-LENGTH values (`00001` / `99999`, both parsed as usize), because
+an env var present in one branch only shifts process memory layout enough to move sub-100us queries a
+consistent ~15% either way -- the same bias `bench_verify_order.py` documents and equalizes.
+
+    .venv/bin/python scripts/bench_walk_span.py --reps 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import statistics
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+CORPUS = REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl"
+TOGGLE = "CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR"
+# Equal-length values, both valid usize: 1 tracks the span for every query (candidates <= n_cards),
+# 99999 for none (n_cards / 99999 == 0 on any real corpus).
+ON_ENV = {TOGGLE: "00001"}
+OFF_ENV = {TOGGLE: "99999"}
+# The cross-process regime's depth, for the reason `bench_plan_execution_ab.py` gives: `min` over
+# trials is a floor estimator whose error is common-mode within a run, so pairing does not cancel it.
+WARMUPS = 6
+TRIALS = 30
+LIMIT = 60
+
+# (query, orderby, direction, offset). The clustered cells put the match band at the far end of the
+# walked order (`asc` over a `>=` predicate on the sort column); the `desc` twin puts the same band at
+# the near end, where there is no prefix to skip and only the last-match bound can help. The broad
+# cells are the control: nothing to skip at either end.
+CLUSTERED = [
+    ("cmc>=6", "cmc", "asc", 0),
+    ("cmc>=6", "cmc", "asc", 900),
+    ("cmc>=6", "cmc", "desc", 900),
+    ("cmc>=5", "cmc", "asc", 0),
+    ("power>=6", "power", "asc", 0),
+    ("toughness>=6", "toughness", "asc", 0),
+    ("t:creature cmc>=5", "cmc", "asc", 0),
+    ("o:flying cmc>=4", "cmc", "asc", 0),
+]
+BROAD = [
+    ("t:creature", "edhrec", "asc", 0),
+    ("cmc>=1", "edhrec", "asc", 0),
+    ("o:the", "edhrec", "asc", 0),
+    ("c:r", "edhrec", "asc", 0),
+]
+GROUPS = {"CLUSTERED": CLUSTERED, "BROAD": BROAD}
+
+
+def measure_one_process() -> None:
+    """Child entry point: measure every cell on this process's toggle setting and print JSON."""
+    from api.parsing import parse_scryfall_query  # noqa: PLC0415
+    from scripts import costbench  # noqa: PLC0415
+
+    engine = costbench.load_engine(CORPUS, CORPUS.with_suffix(".walkspan.store"))
+    out = {}
+    for group, cells in GROUPS.items():
+        for q, orderby, direction, offset in cells:
+            res = engine.explain_analyze(
+                filters=parse_scryfall_query(q),
+                unique="card",
+                prefer="default",
+                orderby=orderby,
+                direction=direction,
+                limit=LIMIT,
+                offset=offset,
+                num_warmups=WARMUPS,
+                num_trials=TRIALS,
+            )
+            plan = next((p for p in res["plans"] if p["plan"] == "StreamedSelect"), None)
+            if plan is None:
+                continue
+            out[f"{group}|{q}|{orderby}|{direction}|{offset}"] = {
+                "exec_us": costbench.plan_self_ns(plan, res["acquire"]) / 1000.0,
+                "loop_us": plan["ns_loop"] / 1000.0,
+                "finish_us": plan["ns_finish"] / 1000.0,
+                "perm_steps": plan["perm_steps"],
+                "cards": plan["cards_visited"],
+                "total": plan["result_total"],
+            }
+    print("BENCHJSON " + json.dumps(out))
+
+
+def run_child(env_overlay: dict[str, str]) -> dict:
+    """One fresh subprocess: the toggle is a once-per-process LazyLock, so it cannot be re-read."""
+    proc = subprocess.run(
+        [sys.executable, str(pathlib.Path(__file__).resolve()), "--child"],
+        env={**os.environ, **env_overlay},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("BENCHJSON "))
+    return json.loads(line[len("BENCHJSON ") :])
+
+
+def main() -> None:
+    """Interleave ON/OFF subprocesses, then report per-cell medians and the paired ratio."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--reps", type=int, default=5, help="ON/OFF subprocess pairs, interleaved")
+    args = parser.parse_args()
+    if args.child:
+        measure_one_process()
+        return
+
+    runs: dict[str, list[dict]] = {"on": [], "off": []}
+    for rep in range(args.reps):
+        # A/B/B/A within each pair, so a monotonic drift over the run cannot land on one arm.
+        order = [("off", OFF_ENV), ("on", ON_ENV)] if rep % 2 else [("on", ON_ENV), ("off", OFF_ENV)]
+        for label, overlay in order:
+            runs[label].append(run_child(overlay))
+            print(f"  rep {rep + 1}/{args.reps} {label} done", flush=True)
+
+    cells = sorted(set(runs["on"][0]) & set(runs["off"][0]))
+    print(
+        f"\n{'cell':<44}{'steps off':>10}{'steps on':>9}"
+        f"{'loop off':>10}{'loop on':>9}{'exec off':>10}{'exec on':>9}{'on/off':>8}"
+    )
+    ratios: dict[str, list[float]] = {"CLUSTERED": [], "BROAD": []}
+    def med(label: str, cell: str, field: str) -> float:
+        """Median of one field for one cell across that arm's subprocesses."""
+        return statistics.median(r[cell][field] for r in runs[label])
+
+    for cell in cells:
+        group = cell.split("|", 1)[0]
+        totals = {r[cell]["total"] for r in runs["on"] + runs["off"]}
+        parity = "" if len(totals) == 1 else "  TOTALS DIFFER"
+        ratio = med("on", cell, "exec_us") / med("off", cell, "exec_us")
+        ratios[group].append(ratio)
+        label = cell.split("|", 1)[1].replace("|", " ")
+        print(
+            f"{label:<44}{med('off', cell, 'perm_steps'):>10,.0f}{med('on', cell, 'perm_steps'):>9,.0f}"
+            f"{med('off', cell, 'loop_us'):>10.2f}{med('on', cell, 'loop_us'):>9.2f}"
+            f"{med('off', cell, 'exec_us'):>10.2f}{med('on', cell, 'exec_us'):>9.2f}{ratio:>8.3f}{parity}"
+        )
+    print()
+    for group, rs in ratios.items():
+        if rs:
+            print(f"{group}: geometric mean exec on/off = {statistics.geometric_mean(rs):.3f} over {len(rs)} cells")
+    print("\nCLUSTERED below 1.0 is the win; BROAD above 1.0 is what the bound costs where it cannot help.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_walk_span.py
+++ b/scripts/bench_walk_span.py
@@ -1,28 +1,26 @@
-"""A/B the streamed walk's match-span bound (`CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR`).
+"""A/B the streamed walk's sort-column bound (`CARD_ENGINE_WALK_SORT_BOUND`).
 
-The bound trades work in two phases at once, so a single number cannot judge it:
+`StreamedSelect`'s emission walk steps the sort permutation until the page fills. When the filter bounds
+the SORT COLUMN -- `cmc>=6` under `order=cmc`, the correlation that puts every match at one end of the
+walked order -- two binary searches turn that into a walk over only the segment the bound admits. This
+prices that, per cell, against the same binary walking everything.
 
-* `ns_finish` — the walk itself. Bounded to the match span it steps from the first matching card to
-  the last instead of from permutation index 0 to wherever the page happens to fill.
-* `ns_loop` — the match loop, which pays one `inv_perm` read plus a `min` and a `max` per MATCHING
-  card to learn that span.
+Cells come in two groups. CLUSTERED pairs a predicate with an orderby it correlates with, which is where
+a walk from index 0 grinds through a long non-matching prefix. BROAD is the control: matches spread
+through the permutation, so the walk already fills its page in ~`limit` steps and the bound has nothing
+to skip. Both matter -- the change is only worth taking if the first group's win is real and the second
+group is untouched.
 
-So the cells come in two groups. CLUSTERED pairs a predicate with an orderby it correlates with, which
-is where a walk from index 0 grinds through a long non-matching prefix. BROAD has matches spread
-through the permutation, so the walk fills its page in ~`limit` steps and the bound can only cost.
-Both groups matter: the change is only worth taking if the first group's win is real AND the second
-group's cost is not.
+**Why a toggle rather than two builds.** Cross-build comparison cannot resolve this. Measured on these
+cells, `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs of two builds -- +-9%, in both
+directions, on a phase neither build changed -- and a cross-build `bench_plan_execution_ab.py` run
+reported the wrong SIGN for this change while its own acquire control moved 1.9% the same way. That is
+the common-mode floor error the toolkit documents, plus whatever the linker did to code layout. One
+binary with a runtime toggle removes both: identical code, identical layout.
 
-**Why a toggle rather than two builds.** Cross-build comparison cannot resolve this. Measured on
-these cells, `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on the same two builds —
-±9%, in both directions, on a phase neither build changed. That is the common-mode floor error
-`bench_plan_execution_ab.py` documents, plus whatever the linker did to code layout, and the per-card
-cost being hunted here is smaller than it. One binary with a runtime toggle removes both: identical
-code, identical layout, and the only difference is a branch that was already there.
-
-Both variants set the env var, to EQUAL-LENGTH values (`00001` / `99999`, both parsed as usize), because
-an env var present in one branch only shifts process memory layout enough to move sub-100us queries a
-consistent ~15% either way -- the same bias `bench_verify_order.py` documents and equalizes.
+Both arms set the env var, to EQUAL-LENGTH values, because an env var present in one arm only shifts
+process memory layout enough to move sub-100us queries a consistent ~15% either way -- the same bias
+`bench_verify_order.py` documents and equalizes.
 
     .venv/bin/python scripts/bench_walk_span.py --reps 5
 """
@@ -41,16 +39,25 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 CORPUS = REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl"
-TOGGLE = "CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR"
-# Equal-length values, both valid usize: 1 tracks the span for every query (candidates <= n_cards),
-# 99999 for none (n_cards / 99999 == 0 on any real corpus).
-ON_ENV = {TOGGLE: "00001"}
-OFF_ENV = {TOGGLE: "99999"}
+TOGGLE = "CARD_ENGINE_WALK_SORT_BOUND"
+# Two arms, equal-length values so neither carries a differently-sized environment: `0` walks the whole
+# permutation as the executor did before the bound existed, `1` narrows it to what the filter's interval
+# on the sort column admits.
+ARMS = {"off": "0", "on": "1"}
+BASELINE_ARM = "off"
 # The cross-process regime's depth, for the reason `bench_plan_execution_ab.py` gives: `min` over
 # trials is a floor estimator whose error is common-mode within a run, so pairing does not cancel it.
 WARMUPS = 6
 TRIALS = 30
 LIMIT = 60
+
+# Swept, because WHICH mode is measured decides whether the result is a routed win or a latent one.
+# In `unique=card` a plane-consumable predicate leaves `FilterExpr::True`, which makes
+# `PlanePopcountOrder` applicable, and the router picks it over `StreamedSelect` on exactly the
+# clustered cells here (`cmc>=6 order=cmc`: 2.46 us against P3's 12.38). Printing and artwork mode have
+# no popcount plan -- a popcount counts cards, not printings -- so P3 is picked and the same improvement
+# is what a user waits for. The `routed` column says which happened, per cell.
+UNIQUES = ("card", "printing", "artwork")
 
 # (query, orderby, direction, offset). The clustered cells put the match band at the far end of the
 # walked order (`asc` over a `>=` predicate on the sort column); the `desc` twin puts the same band at
@@ -83,29 +90,32 @@ def measure_one_process() -> None:
     engine = costbench.load_engine(CORPUS, CORPUS.with_suffix(".walkspan.store"))
     out = {}
     for group, cells in GROUPS.items():
-        for q, orderby, direction, offset in cells:
-            res = engine.explain_analyze(
-                filters=parse_scryfall_query(q),
-                unique="card",
-                prefer="default",
-                orderby=orderby,
-                direction=direction,
-                limit=LIMIT,
-                offset=offset,
-                num_warmups=WARMUPS,
-                num_trials=TRIALS,
-            )
-            plan = next((p for p in res["plans"] if p["plan"] == "StreamedSelect"), None)
-            if plan is None:
-                continue
-            out[f"{group}|{q}|{orderby}|{direction}|{offset}"] = {
-                "exec_us": costbench.plan_self_ns(plan, res["acquire"]) / 1000.0,
-                "loop_us": plan["ns_loop"] / 1000.0,
-                "finish_us": plan["ns_finish"] / 1000.0,
-                "perm_steps": plan["perm_steps"],
-                "cards": plan["cards_visited"],
-                "total": plan["result_total"],
-            }
+        for unique in UNIQUES:
+            for q, orderby, direction, offset in cells:
+                res = engine.explain_analyze(
+                    filters=parse_scryfall_query(q),
+                    unique=unique,
+                    prefer="default",
+                    orderby=orderby,
+                    direction=direction,
+                    limit=LIMIT,
+                    offset=offset,
+                    num_warmups=WARMUPS,
+                    num_trials=TRIALS,
+                )
+                plan = next((p for p in res["plans"] if p["plan"] == "StreamedSelect"), None)
+                if plan is None:
+                    continue
+                picked = next((p["plan"] for p in res["plans"] if p["picked"]), "?")
+                out[f"{group}|{unique}|{q}|{orderby}|{direction}|{offset}"] = {
+                    "exec_us": costbench.plan_self_ns(plan, res["acquire"]) / 1000.0,
+                    "loop_us": plan["ns_loop"] / 1000.0,
+                    "finish_us": plan["ns_finish"] / 1000.0,
+                    "perm_steps": plan["perm_steps"],
+                    "cards": plan["cards_visited"],
+                    "total": plan["result_total"],
+                    "picked": picked,
+                }
     print("BENCHJSON " + json.dumps(out))
 
 
@@ -132,41 +142,47 @@ def main() -> None:
         measure_one_process()
         return
 
-    runs: dict[str, list[dict]] = {"on": [], "off": []}
+    runs: dict[str, list[dict]] = {arm: [] for arm in ARMS}
     for rep in range(args.reps):
-        # A/B/B/A within each pair, so a monotonic drift over the run cannot land on one arm.
-        order = [("off", OFF_ENV), ("on", ON_ENV)] if rep % 2 else [("on", ON_ENV), ("off", OFF_ENV)]
-        for label, overlay in order:
-            runs[label].append(run_child(overlay))
+        # Arm order reversed on alternate reps, so a monotonic drift over the run cannot land on one arm.
+        arms = list(ARMS.items())
+        for label, value in arms if rep % 2 == 0 else reversed(arms):
+            runs[label].append(run_child({TOGGLE: value}))
             print(f"  rep {rep + 1}/{args.reps} {label} done", flush=True)
 
-    cells = sorted(set(runs["on"][0]) & set(runs["off"][0]))
-    print(
-        f"\n{'cell':<44}{'steps off':>10}{'steps on':>9}"
-        f"{'loop off':>10}{'loop on':>9}{'exec off':>10}{'exec on':>9}{'on/off':>8}"
-    )
-    ratios: dict[str, list[float]] = {"CLUSTERED": [], "BROAD": []}
+    cells = sorted(set.intersection(*(set(runs[arm][0]) for arm in ARMS)))
+    print(f"\n{'cell':<50}{'steps off':>10}{'steps on':>11}{'exec off':>10}{'exec on':>10}{'on/off':>9}{'routed':>20}")
+    # Keyed by group AND by whether P3 is the routed plan, because a ratio on a plan the router does not
+    # pick is a latent win and must not be averaged in with the realized ones.
+    ratios: dict[str, list[float]] = {}
+
     def med(label: str, cell: str, field: str) -> float:
         """Median of one field for one cell across that arm's subprocesses."""
         return statistics.median(r[cell][field] for r in runs[label])
 
     for cell in cells:
         group = cell.split("|", 1)[0]
-        totals = {r[cell]["total"] for r in runs["on"] + runs["off"]}
+        picked = runs["on"][0][cell]["picked"]
+        routed = picked == "StreamedSelect"
+        totals = {r[cell]["total"] for arm in ARMS for r in runs[arm]}
         parity = "" if len(totals) == 1 else "  TOTALS DIFFER"
-        ratio = med("on", cell, "exec_us") / med("off", cell, "exec_us")
-        ratios[group].append(ratio)
+        base = med(BASELINE_ARM, cell, "exec_us")
+        ship_ratio = med("on", cell, "exec_us") / base
+        ratios.setdefault(f"{group} {'routed' if routed else 'LATENT'}", []).append(ship_ratio)
         label = cell.split("|", 1)[1].replace("|", " ")
         print(
-            f"{label:<44}{med('off', cell, 'perm_steps'):>10,.0f}{med('on', cell, 'perm_steps'):>9,.0f}"
-            f"{med('off', cell, 'loop_us'):>10.2f}{med('on', cell, 'loop_us'):>9.2f}"
-            f"{med('off', cell, 'exec_us'):>10.2f}{med('on', cell, 'exec_us'):>9.2f}{ratio:>8.3f}{parity}"
+            f"{label:<50}{med('off', cell, 'perm_steps'):>10,.0f}{med('on', cell, 'perm_steps'):>11,.0f}"
+            f"{base:>10.2f}{med('on', cell, 'exec_us'):>10.2f}{ship_ratio:>9.3f}"
+            f"{picked:>20}{parity}"
         )
     print()
-    for group, rs in ratios.items():
-        if rs:
-            print(f"{group}: geometric mean exec on/off = {statistics.geometric_mean(rs):.3f} over {len(rs)} cells")
-    print("\nCLUSTERED below 1.0 is the win; BROAD above 1.0 is what the bound costs where it cannot help.")
+    for group, rs in sorted(ratios.items()):
+        print(f"{group:<20} geometric mean exec on/off = {statistics.geometric_mean(rs):.3f} over {len(rs)} cells")
+    print(
+        "\nCLUSTERED below 1.0 is the win; BROAD at 1.0 is the control staying put -- the bound costs\n"
+        "nothing per card, so a query it cannot help should be unchanged rather than taxed.\n"
+        "LATENT rows are cells where the router picks another plan, so their ratio is not what a user sees."
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -137,6 +137,10 @@ PLAN_KEYS = frozenset(
         "printing_span",
         "printings_examined",
         "matches_pushed",
+    # Permutation entries StreamedSelect's walk stepped. Realized ground truth for the estimate
+    # `page_span * n_cards / matches`, which assumes matches are spread uniformly through the
+    # permutation -- an assumption worth grading rather than trusting.
+    "perm_steps",
         "ns_setup",
         "ns_loop",
         "ns_finish",

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -215,6 +215,10 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     """
     eval_domain = float(acq["eval_domain"])
     scan_units = float(acq["scan_units"])
+    # P3's own scan estimate, which differs from `scan_units` on a legality-composed acquire -- see
+    # `PlanFeatures::stream_scan_units`. Absent from an older recorded run, in which case it equals
+    # `scan_units` and this mirrors the pre-split arm exactly.
+    stream_scan_units = float(acq.get("stream_scan_units", acq["scan_units"]))
     matches = float(acq["matches"])
     n_cards = float(acq["n_cards"])
     tier_ns = acq["residual_tier_ns100"] / 100.0
@@ -256,7 +260,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
         return (
             [
                 eval_domain,
-                scan_units * residual_on,
+                stream_scan_units * residual_on,
                 eval_domain * residual_on,
                 matches,
                 perm_steps,

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -113,7 +113,10 @@ CURRENT: dict[str, list[float]] = {
     # GATHER_GROUP_PER_PRINTING sits between the bit-test and push columns, matching design_row.
     # Added when the artwork tail was traced to the grouping arm's work being charged at the bit-test
     # rate; its 1.5 start is a physical guess (a struct read plus prefer_score), meant to be fitted.
-    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 13.22, 0.38, 1.5, 3.39, 163.56],
+    # BUILD_PER_PRINTING (second to last) is the full-width bitmap build, Gather-arm only: it was
+    # measured directly over a 10x corpus axis rather than fitted here, so a pooled fit disagreeing
+    # with 0.0835 is a signal to re-examine, not to paste.
+    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 13.22, 0.38, 1.5, 3.39, 0.0835, 163.56],
 }
 
 
@@ -309,6 +312,10 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 float(acq["compose_scan_printings"]) if gather else 0.0,
                 float(acq.get("gather_group_printings", 0)) if gather else 0.0,
                 matches if gather else 0.0,
+                # The full-width printing-bitmap build, charged on the Gather arm only -- Perm and
+                # OrderbyWalk had their rates fitted with it already absorbed. See
+                # `COMPOSE_BUILD_PER_PRINTING_NS` in cost.rs for why it is scoped rather than shared.
+                float(acq["n_printings"]) if gather else 0.0,
                 1.0,
             ],
             [
@@ -322,6 +329,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "GATHER_BITTEST_PER_PRINTING",
                 "GATHER_GROUP_PER_PRINTING",
                 "GATHER_PUSH_PER_MATCH",
+                "BUILD_PER_PRINTING",
                 "FIXED",
             ],
             0.0,  # no residual-floor term in this arm, so nothing comes off the target

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -302,6 +302,39 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     return None
 
 
+def perm_step_check(samples: list[dict]) -> tuple[int, float, float, float] | None:
+    """Realized `perm_steps` against the estimate cost.rs derives. The ratio should be 1.00.
+
+    Separate from `counter_check` because this feature is not published by acquire -- the arm computes
+    it from `page_span`, `n_cards` and `matches`. The rate was fitted and cross-validated (kernel
+    0.958-1.256 ns/entry, traffic 1.15), but a rate can look right while the quantity it multiplies is
+    wrong, so the ESTIMATE needs its own grade.
+
+    What is being tested is the uniform-spread assumption: the walk is modelled as finding one match
+    every `n_cards / matches` entries, which holds if matches are scattered evenly through the sort
+    permutation and fails if they cluster. Clustering is not far-fetched -- the permutation is ordered
+    by a sort column, and predicates correlate with sort columns (`year>=2020` under `order=released`
+    is the extreme case), so a real skew here would be a genuine model defect and not noise.
+
+    Returns (rows, p10, median, p90) of realized/estimated, or None if no row walked.
+    """
+    ratios = []
+    for s in samples:
+        if s["plan"] != "StreamedSelect" or not s.get("perm_steps"):
+            continue
+        acq, matches = s["acq"], float(s["acq"]["matches"])
+        if matches <= 0:
+            continue
+        page_span = float(min(s["offset"] + s["limit"], matches))
+        estimate = min(page_span * float(acq["n_cards"]) / matches, float(acq["n_cards"]))
+        if estimate > 0:
+            ratios.append(float(s["perm_steps"]) / estimate)
+    if not ratios:
+        return None
+    ratios.sort()
+    return (len(ratios), ratios[len(ratios) // 10], ratios[len(ratios) // 2], ratios[(9 * len(ratios)) // 10])
+
+
 def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
     """Realized counter vs the feature that should predict it, per plan. Ratios should be 1.00."""
     # `scan_units` pairs with `printings_examined`, not the `printing_span` this used to read: the span
@@ -403,6 +436,7 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
                     "paging_taken": p.get("paging_taken"),
                     "printings_examined": p["printings_examined"],
                     "matches_pushed": p["matches_pushed"],
+                    "perm_steps": p.get("perm_steps", 0),
                 }
             )
     return samples
@@ -563,6 +597,13 @@ def main() -> None:
                 suspect.add(plan)
             print(f"{plan:<20}{label:<40}{ratio:>9.2f}{flag}")
     print("  a ratio far from 1.00 is a miscounted feature; no rate can absorb it.")
+    perm = perm_step_check(samples)
+    if perm is not None:
+        rows, p10, med, p90 = perm
+        print(f"\nStreamedSelect perm_steps realized/estimated over {rows:,} walking rows:")
+        print(f"  p10 {p10:.2f}   median {med:.2f}   p90 {p90:.2f}")
+        print("  tests the uniform-spread assumption behind `page_span * n_cards / matches`; skew would")
+        print("  show as a median away from 1.00, and clustering as a wide p10-p90 spread.")
 
     by_plan: dict[str, list[dict]] = collections.defaultdict(list)
     for s in samples:

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -88,7 +88,10 @@ RIDGE_STRENGTH = 0.01
 # and the baseline each fitted rate is reported against.
 CURRENT: dict[str, list[float]] = {
     # eval_domain, scan_units, tier scale, matches, page_span, fixed
-    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 169.6],
+    # ..., page_span, page_rows, fixed -- page_rows new 2026-08-03. The phase has two drivers: the
+    # quickselect scales with offset+limit, the collect with the page actually returned. A designed page
+    # sweep separates them where traffic cannot, since the two are correlated in the sampled query mix.
+    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 9.79, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
@@ -207,14 +210,17 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     n_cards = float(acq["n_cards"])
     tier_ns = acq["residual_tier_ns100"] / 100.0
     page_span = float(min(offset + limit, acq["matches"]))
+    # Mirrors cost.rs: `select_page` returns clamp(matches - offset, 0, limit), so a page past the end of
+    # the matches collects fewer rows than requested.
+    page_rows = float(min(max(acq["matches"] - offset, 0), limit))
     residual_on = 1.0 if tier_ns > 0.0 else 0.0
     floor = SHIPPED_RESIDUAL_FLOOR.get(plan, 0.0)
     excess = eval_domain * max(tier_ns - floor, 0.0) if tier_ns > 0.0 else 0.0
 
     if plan == "GatheredScan":
         return (
-            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, 1.0],
-            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "FIXED"],
+            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, 1.0],
+            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "COLLECT_PER_PAGE_ROW", "FIXED"],
             excess,
         )
     if plan == "StreamedSelect":

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -322,6 +322,12 @@ def perm_step_check(samples: list[dict]) -> tuple[int, float, float, float] | No
     by a sort column, and predicates correlate with sort columns (`year>=2020` under `order=released`
     is the extreme case), so a real skew here would be a genuine model defect and not noise.
 
+    Read the SPREAD, not just the median. The executor bounds its walk to the realized match span, so
+    the ends of a cluster no longer cost anything and this ratio can only be inflated by non-matching
+    entries INTERIOR to the span. Bounding those ends took p90 from 6.43 to 4.26 (p10 0.13 -> 0.08,
+    median 1.00 -> 0.90) on one seed and sample length: a third of the tail was the leading prefix, and
+    what is left is a different mechanism's to fix.
+
     Returns (rows, p10, median, p90) of realized/estimated, or None if no row walked.
     """
     ratios = []

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -91,7 +91,11 @@ CURRENT: dict[str, list[float]] = {
     # ..., page_span, page_rows, fixed -- page_rows new 2026-08-03. The phase has two drivers: the
     # quickselect scales with offset+limit, the collect with the page actually returned. A designed page
     # sweep separates them where traffic cannot, since the two are correlated in the sampled query mix.
-    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 9.79, 169.6],
+    # 2026-08-03: the first column is now the UNCONDITIONAL loop rate and the third carries the
+    # `card_pass` call (3.00) on top of the floor (18.89), because the arm gates the call on
+    # `tier_ns > 0` -- `all_match_known` skips it. The design matrix already had these as two
+    # columns; only the arm and these labels changed.
+    "GatheredScan": [3.88, 2.06, 21.89, 2.24, 3.51, 9.79, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
@@ -99,7 +103,9 @@ CURRENT: dict[str, list[float]] = {
     # ..., perm_steps, ... -- the permutation walk's length, new 2026-08-03. It is the one quantity in
     # P3's finish phase no other feature is proportional to: the walk steps until the page fills, so it
     # visits ~page_span * n_cards / matches entries, inversely proportional to selectivity.
-    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.0, 1.21, 1.02, 0.02, 217.0],
+    # Same split as GatheredScan above: 2.58 unconditional, and the call (2.47) folded into the
+    # residual-gated column alongside the 6.58 floor.
+    "StreamedSelect": [2.58, 5.97, 9.05, 0.12, 1.0, 1.21, 1.02, 0.02, 217.0],
     # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
@@ -190,6 +196,9 @@ def nnls(rows: list[list[float]], targets: list[float]) -> list[float]:
 # A consequence worth stating: the fitted floor is not directly pasteable, because the offset it was
 # fitted against assumed the OLD floor. Applying it and re-fitting is a fixed-point iteration, and
 # each run is only self-consistent with whatever is shipped at the time.
+# The residual-gated column now prices the `card_pass` call as well as the floor, but the OFFSET
+# below is still about the floor alone: it captures `eval_domain * max(tier_ns - FLOOR, 0)`, the
+# excess where an expensive residual beats the floor, and the call is not part of that maximum.
 SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 6.58}
 
 
@@ -220,7 +229,15 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     if plan == "GatheredScan":
         return (
             [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, 1.0],
-            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "COLLECT_PER_PAGE_ROW", "FIXED"],
+            [
+                "LOOP_PER_CARD",
+                "SCAN_PER_ROW",
+                "CARD_PASS+FLOOR",
+                "PUSH_PER_MATCH",
+                "SELECT_PER_PAGE_SLOT",
+                "COLLECT_PER_PAGE_ROW",
+                "FIXED",
+            ],
             excess,
         )
     if plan == "StreamedSelect":
@@ -249,9 +266,9 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 1.0,
             ],
             [
-                "CARD_PASS",
+                "LOOP_PER_CARD",
                 "SCAN_PER_ROW",
-                "RESIDUAL_FLOOR",
+                "CARD_PASS+FLOOR",
                 "EMIT_PER_MATCH",
                 "PERM_STEP",
                 "ARTWORK_SEEN_PER_CARD",

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -93,7 +93,10 @@ CURRENT: dict[str, list[float]] = {
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
     # term the arm multiplies by zero. Median agreement 0.63 -> 0.92, within-25% 19% -> 58%.
-    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.21, 1.02, 0.02, 217.0],
+    # ..., perm_steps, ... -- the permutation walk's length, new 2026-08-03. It is the one quantity in
+    # P3's finish phase no other feature is proportional to: the walk steps until the page fills, so it
+    # visits ~page_span * n_cards / matches entries, inversely proportional to selectivity.
+    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.0, 1.21, 1.02, 0.02, 217.0],
     # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
@@ -215,6 +218,10 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
             excess,
         )
     if plan == "StreamedSelect":
+        # Mirrors the arm's guards: an empty result or a page past the end returns before BOTH branches,
+        # so neither the gather floor nor the walk is charged there.
+        walks_perm = matches > STREAM_MIN_MATCHES and matches > 0 and offset < matches
+        perm_steps = min(page_span * n_cards / matches, n_cards) if walks_perm else 0.0
         # Mirrors run_query_streamed's early return: zero matches, or a page past the total, never
         # reaches the small-total gather. See STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS in cost.rs.
         runs_small_gather = 0 < matches <= STREAM_MIN_MATCHES and offset < matches
@@ -229,6 +236,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 scan_units * residual_on,
                 eval_domain * residual_on,
                 matches,
+                perm_steps,
                 float(acq["artwork_seen_cards"]),
                 small_total,
                 n_cards,
@@ -239,6 +247,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "SCAN_PER_ROW",
                 "RESIDUAL_FLOOR",
                 "EMIT_PER_MATCH",
+                "PERM_STEP",
                 "ARTWORK_SEEN_PER_CARD",
                 "SMALL_TOTAL_FLOOR_PER_CARD",
                 "CORPUS_PASS_PER_CARD",

--- a/scripts/upscale_corpus.py
+++ b/scripts/upscale_corpus.py
@@ -1,0 +1,124 @@
+"""Build an upscaled store from the real corpus, so loop benchmarks can miss cache the way production does.
+
+`bench_gather_loop` and `bench_streamed_loop` walk one candidate list `ITERS` times and keep the minimum,
+which makes every rate they report a WARM-CACHE rate: from the second pass every card, printing and
+string is resident. Production walks a candidate set once. Measured against the warm minimum, the first
+pass costs 1.6-2.2x more, and that gap is the entire reason five refits of the shipped constants each
+made routing worse -- each lowered rates toward a cache state that never occurs.
+
+Two things fix that, and they compose:
+
+  chunk rotation   walk a DIFFERENT slice of candidates each iteration, so consecutive walks share no
+                   cards. Implemented in the harnesses themselves.
+  a bigger store   with 31,508 oracle cards the whole archive is ~68 MB, so a full rotation still fits
+                   in the system-level cache on this machine and chunk 0 may survive until it is walked
+                   again. At 4-13x that, a rotation cannot stay resident.
+
+The real corpus cannot supply 400k cards, so this replicates it. Each copy rewrites the three identity
+fields that decide how the engine groups rows -- `oracle_id` (which printings form one oracle card),
+`scryfall_id` (the printing key) and `illustration_id` (artwork groups) -- keeping UUID shape so nothing
+downstream has to special-case them. Everything that drives cost stays untouched: printings per card,
+the printings-per-card DISTRIBUTION, text lengths, legality masks, colours. So an upscaled store is the
+real corpus's shape at N times the size, which is what a cache measurement needs; it is NOT a
+realistic future corpus, and nothing about selectivity or query mix should be read off it.
+
+Names get a per-copy suffix, because `card_name` feeds the name index and the sort permutations and
+duplicate names across copies would collapse orderings that production keeps distinct.
+
+    .venv/bin/python scripts/upscale_corpus.py --copies 4 --out benchmarks/loop-scale/cards-4x.store
+
+Reports the realized card and printing counts, since those are what the harness needs to report
+alongside its rates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import costbench  # noqa: E402
+
+# Rows per `add_batch`, matching costbench.BATCH_SIZE's reasoning: large enough that per-call overhead
+# vanishes, small enough that the batch list stays cheap to hold.
+BATCH_SIZE = 2000
+# The identity fields a copy must rewrite. `oracle_id` decides which printings form one oracle card, so
+# leaving it would fold every copy's printings into the SAME cards -- the store would grow in printings
+# per card rather than in cards, which is the opposite of what this is for. `illustration_id` decides
+# artwork groups, and `scryfall_id` is the printing primary key.
+UUID_FIELDS = ("oracle_id", "scryfall_id", "illustration_id")
+
+
+def rewrite_uuid(value: str, copy: int) -> str:
+    """Replace a UUID's first block with the copy index, preserving shape and uniqueness.
+
+    The originals are unique within one copy, so stamping the copy index over the leading block keeps
+    them unique across copies without needing a counter or a hash. Values that are not UUID-shaped
+    (absent, null, or some other spelling) are returned unchanged rather than corrupted.
+    """
+    if not isinstance(value, str) or len(value) < 8 or "-" not in value:
+        return value
+    return f"{copy:08x}{value[8:]}"
+
+
+def replicate(record: dict, copy: int) -> dict:
+    """One copy of a record, with identities rewritten and everything cost-relevant left alone."""
+    out = dict(record)
+    for field in UUID_FIELDS:
+        if field in out:
+            out[field] = rewrite_uuid(out[field], copy)
+    # Names feed the name index and both sort permutations; duplicates across copies would collapse
+    # orderings production keeps distinct, and the permutation walk is exactly what P3 benchmarks.
+    if isinstance(out.get("card_name"), str):
+        out["card_name"] = f"{out['card_name']} c{copy}"
+    if isinstance(out.get("card_name_folded"), str):
+        out["card_name_folded"] = f"{out['card_name_folded']} c{copy}"
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copies", type=int, required=True, help="replication factor; 1 reproduces the real corpus")
+    ap.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks" / "bitplanes" / "corpus.jsonl")
+    ap.add_argument("--out", type=pathlib.Path, required=True, help="store path to write")
+    args = ap.parse_args()
+
+    if args.copies < 1:
+        msg = "--copies must be at least 1"
+        raise SystemExit(msg)
+
+    import card_engine  # noqa: PLC0415 - keeps this importable without the built extension
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = card_engine.QueryEngine(str(args.out))
+    if not engine.reload_begin():
+        msg = "reload_begin returned False (stale archive published concurrently?)"
+        raise SystemExit(msg)
+
+    # Streamed per copy rather than building the whole list: at 13 copies this is ~1.26M records, and
+    # holding them all would cost more than the store itself.
+    records = [json.loads(line) for line in args.corpus.open()]
+    print(f"read {len(records):,} printings from {args.corpus}", flush=True)
+    batch: list[dict] = []
+    for copy in range(args.copies):
+        for record in records:
+            batch.append(replicate(record, copy))
+            if len(batch) == BATCH_SIZE:
+                engine.add_batch(batch)
+                batch.clear()
+        print(f"  copy {copy + 1}/{args.copies} staged", flush=True)
+    if batch:
+        engine.add_batch(batch)
+    engine.reload_commit()
+
+    size_mb = args.out.stat().st_size / (1024 * 1024)
+    print(f"\nwrote {args.out}  ({size_mb:,.0f} MB, {engine.size():,} printings)")
+    print("card count comes from the harness, which reports it alongside its rates.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upscale_corpus.py
+++ b/scripts/upscale_corpus.py
@@ -41,8 +41,6 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts import costbench  # noqa: E402
-
 # Rows per `add_batch`, matching costbench.BATCH_SIZE's reasoning: large enough that per-call overhead
 # vanishes, small enough that the batch list stays cheap to hold.
 BATCH_SIZE = 2000
@@ -51,6 +49,8 @@ BATCH_SIZE = 2000
 # per card rather than in cards, which is the opposite of what this is for. `illustration_id` decides
 # artwork groups, and `scryfall_id` is the printing primary key.
 UUID_FIELDS = ("oracle_id", "scryfall_id", "illustration_id")
+# Hex characters in a UUID's leading block, which is the part `rewrite_uuid` stamps the copy index over.
+UUID_FIRST_BLOCK = 8
 
 
 def rewrite_uuid(value: str, copy: int) -> str:
@@ -60,9 +60,9 @@ def rewrite_uuid(value: str, copy: int) -> str:
     them unique across copies without needing a counter or a hash. Values that are not UUID-shaped
     (absent, null, or some other spelling) are returned unchanged rather than corrupted.
     """
-    if not isinstance(value, str) or len(value) < 8 or "-" not in value:
+    if not isinstance(value, str) or len(value) < UUID_FIRST_BLOCK or "-" not in value:
         return value
-    return f"{copy:08x}{value[8:]}"
+    return f"{copy:08x}{value[UUID_FIRST_BLOCK:]}"
 
 
 def replicate(record: dict, copy: int) -> dict:
@@ -81,6 +81,7 @@ def replicate(record: dict, copy: int) -> dict:
 
 
 def main() -> None:
+    """Build an upscaled store by replicating the corpus, then report what it came out as."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--copies", type=int, required=True, help="replication factor; 1 reproduces the real corpus")
     ap.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks" / "bitplanes" / "corpus.jsonl")


### PR DESCRIPTION
Stacked on #827 — base is `engine-compose-feature-accuracy`, so this diff is only the 60 commits after it.

Full write-up: `docs/issues/local-engine-loop-phase-measurement.md`. The method it produced is extracted to
`docs/workflows/diagnosing-a-plan-cost-error.md`.

## What this turned into

It started as built designs for P3's and P4's loop and finish phases. It ended up somewhere more useful, and
the through-line is one sentence: **the model repeatedly charged for work a kernel resolves at card level, and
one executor gate charged for work the narrowing had already proved unnecessary.** Six of those were found; the
largest was in the executor and is worth up to **24×**.

Two rules earned the hard way, both now in the method doc:

- **Shape from a built design, levels from traffic.** Six refits of kernel-measured levels each made routing
  worse. Every routing gain here is a shape or feature fix; not one is a level change.
- **A feature fix only pays for an argmin when the two plans weight the feature differently.** Three fixes
  moved the P3/P4 pair by *nothing* because both arms read the feature; the ones that moved it land
  asymmetrically.

## 1. The largest win is an executor gate that should not have existed

`run_query_streamed`'s count loop gated the #634 `all_match_known` skip **off for `Mode::Artwork`**, so an
artwork query ran `card_pass` for every candidate even where the narrowing had already proved every one
matches. On `o:creature` that is a full oracle-text containment check over 23,155 candidates.

The gate's comment cited a ~45% regression on `t:creature`/artwork, called it *"an unexplained
codegen/scheduling effect … not a logical cost"*, and said it was *"isolated by bisecting call sites"* — across
builds, the one instrument this engine has now had **four** findings retracted from. Re-measured with a runtime
toggle in **one binary**, it does not reproduce in either direction:

| query, artwork, limit 175 | gate on | gate off | speedup |
| --- | --: | --: | --: |
| `o:this` | 1047.7 µs | **43.8** | **24×** |
| `o:target` | 556.6 | **28.7** | **19×** |
| `o:creature` | 1010.5 | **50.6** | **20×** |
| `t:creature` | 84.1 | **38.5** | **2.2×** ← the query the gate protected |
| `o:flying` / `c:r` / `t:land` | 24.1 / 32.2 / 15.5 | 12.1 / 16.6 / 11.6 | 1.3–2.0× |

The same query in printing mode — identical candidate set, span and residual, `card_pass` skipped — always took
~57 µs. **The cost model was right about this throughout**: it charges `tier = 0` because `all_match_known` is
supposed to mean no `card_pass` runs.

Row identity is what an `all_match` error breaks silently here — totals do not move, the printing that *reps*
each artwork group does. **1,134 cells identical** (21 predicates × 3 modes × 3 orderbys × 3 pages × 2
prefers, hashing the returned `scryfall_id` sequence), 378 artwork, including the existential shapes `f:*`,
`border:*`, `r>=rare`, `watermark:*`, `-f:modern`.

## 2. Three execution changes from the original scope

**The emission walk starts and ends at the filter's bound on the sort column.** It began at index 0 and
stopped only when the page filled, so `cmc>=6 order=cmc asc` stepped 28,275 entries for a 60-row page. The
permutation is sorted on `perm_primary_key`, so a value interval is a contiguous *position* range: two binary
searches, **nothing per card**. That query goes **18.29 → 8.71 µs** in printing mode, stepping 4 entries.
Geometric mean **0.603** over 16 clustered cells, 1.006 over 6 broad controls. A realized `inv_perm` span was
built first and replaced — it caught clustering from any source but cost 0.51 ns per matching card against a
~2.6 ns/card match loop.

**Legality is card-invariant in every format but one, and the engine could not tell.** 556 of 31,508 cards
(1.76%) have any divergent format, and **every one is `oldschool`**. Divergence was a whole-bitmask comparison
stored as one boolean, so #667's carveout applied to every format — 7,770 printing examinations on `f:modern`
alone that cannot change an answer. `BitPlanes::divergent_formats` now names which formats disagree, derived
from data on reload. `f:modern t:creature`/printing **90.00 → 42.83 µs (0.476×)**.

**A plane could eliminate a plan before the argmin saw it.** `split_planes` moved predicate into a `PlaneExpr`
compose cannot read, so compose failed its `plane.is_none()` guard — it ran `f:commander`/printing in **1.83 µs
against StreamedSelect's 99.38**, never offered. `bind_and_split_filter` retains the filter; `compose_source` is
the single place that picks a representation.

## 3. Built designs for both scan loops

`bench_gather_loop.rs` and `bench_streamed_loop.rs` call the real executors and read `PhaseStats`. They exist as
a pair because **P4 cannot be fixed alone** — three better descriptions of its loop each regressed routing
(+43%, +8.8%, +40%), since `plan_cost` is only used comparatively. `bench_loop_design.rs` now owns what they
must share; their `CARD_COUNTS` had drifted to two sizes in common, confounding every P3-vs-P4 rate difference
with a design difference. `scripts/upscale_corpus.py` builds larger stores for the corpus sweep.

**Their central retraction: every rate they report is warm-cache.** `ITERS` walked one card list repeatedly and
kept the minimum. Cold and rotated at production size, P4 reads LOOP 6.27 against a shipped 6.88 — the shipped
constants are *confirmed*, not 2× high. Fixed with chunk rotation **plus** per-cell stagger; rotation alone left
cells sharing a chunk with one paying all the misses (10.50 vs 6.11 ns/card on identical cards).

Findings that outlive any constant: no single `unique` mode identifies P4's three loop rates (resolved by
fitting each mode in the space it supports and recovering three rates from the pair of pairs, yielding `PUSH`
twice as a linearity check); P3's loop is linear in its two counters to **1.01×**; rates are corpus-size
dependent *differently per plan*, so the P3/P4 balance drifts as the corpus grows with every constant left
alone.

## 4. Cost terms the designs found missing — three added, three declined

**Added.** `STREAM_PERM_STEP_NS` — P3's permutation walk was not charged at all; the arm predicted ~397 ns
against 1,333–10,458 ns measured across corpus sizes. `GATHER_COLLECT_PER_PAGE_ROW_NS` — P4's finish was on
`page_span` alone, which a four-row page sweep falsifies (`page_span` 960 costing less than 600 is impossible
under one column). And the `card_pass` call is now charged only where the loop makes it.

**Declined, each with the measurement.** `STREAM_RESIDUAL_FLOOR_NS`: the built design says 2.45 ns/card against
a charged 9.05, traffic fits the column at 0.90 — third instance of the warm-cache artifact, now in the
constant's own doc. `GATHER_FIXED_COST_NS`: traffic fits 85 against 169.6, but measuring the intercept directly
gives **−1,084 ns**, which is impossible — the loop is *convex*, so 85 is curvature compensation and **every
plan's `FIXED` is its arm's error sink**. And artwork's per-card surcharge — see §6.

## 5. Five feature defects on the two acquires, and where they paid

Routing, at 180 s uniform. Compare **means**; the total is a sum over a variable query count:

| | baseline | now |
| --- | --: | --: |
| regret mean, all queries | 2.07 µs | **1.44 µs (−30%)** |
| queries with any regret | 7.6% | **6.7%** |
| mean loss over *affected* queries | 27.4 µs | **22.6 µs** |
| `GatheredScan vs StreamedSelect [printing_compose]` | 69% ordered right, 35.96 µs | **87%, 4.29 µs** |
| `PrintingCompose vs StreamedSelect [printing_compose]` | 80%, 11.04 µs | **95%, 1.18 µs** |
| `printing_compose` share of lost time | ~49% | **22%** |
| `printing_compose / artwork` | 32% | **6%** |

~93% of queries are routed optimally and priced at exactly 0, so the all-query mean is not "the typical query
wastes 2 µs" — it is the product of a **rate** (7.6% → 6.7%) and a **severity** (27.4 → 22.6 µs).

**On the compose acquire.** The verify tier was passed ungated where the general path gates on
`all_match_known`, so a card-invariant legality format charged `CARD_PASS + max(tier, FLOOR)` per candidate and
a full `scan_units` — **92–94% of P3's predicted cost** for work whose realized counter is 0. This **retracts
the previous item 1**: compose reads meas/pred **1.02–1.17** on those cells while P3 reads **0.16–0.44**;
compose is under-priced only on `oldschool`. Then P4's span (`printing_matches` is exact when nothing needs
verifying, 1.76× before), the clustering bias moved from the estimator's *output* to its *ball count* (dividing
the output capped it at `domain/1.78` = 17,701 of 31,508 cards however many printings matched), a `scan_units`
clamp at `n_printings` (159,325 against a 97,206 corpus is impossible, not merely wrong), and `eval_domain`
switched from a *match* count to a *candidate* count — 34% of compose rows visit every card, where `n_cards` is
exact and `est_cards` read p50 0.65.

**On the candidates acquire**, P3's scan is now zero when the residual cannot vary within a card: `card_pass`
returns `True`/`False`, never `PrintingDep`, so the kernel takes `all_match` per card and examines no printings.
`name:s`/artwork charged 97,206 printings against a realized **0** for P3 and 60,705 for P4 — 580 µs of a
1,507 µs prediction, losing 368 µs per query across every orderby.

An **oracle run** sized the ceiling and set the order of work: substituting realized counters with rates
untouched takes the compose pair 58% → **83%** and 116.7 → **12.4 ms**. Leave-one-out attributes ~75% to
`eval_domain`, ~10% to `scan`, none to `matches` — and forcing either feature back to *shared* while keeping it
exact costs **nothing**, so per-plan features are worth zero and the work is a better shared estimate.

## 6. What is left, re-baselined because the ranking moved

`printing_compose` is down to 22% of lost time and **`candidates` is now 78%** — but at a *lower* mean per
query, so that split is volume (3.5× the queries), not a new defect. And the loss is entirely tail: **`p90 =
0.00` on every acquire**, only p99 (36–64 µs) carries anything.

1. **Item 6, and it now means both artwork arms at once.** Removing the executor gate made the artwork
   constants stale. The surcharge is measurably the wrong *shape*: artwork-minus-printing `ns_loop` delta is
   **−0.46 ns/card** when the stored group count fires and **+0.38** when the dedup walk runs, against a charged
   **+1.21**. Gating it improved absolute agreement (P3 p/m 1.58–1.83 → 1.14–1.34) and **regressed routing**
   (artwork regret mean 1.59 → 1.71, max 185.5 → 732.5), so it is not shipped: the +1.21 is compensating for
   something in the P3/P4 artwork balance. Fourth instance here of a correct fix removing a compensating error
   — the other three paid once the exposed error was also fixed; this one has no partner yet.
2. **`matches` on the candidates acquire is irreducibly estimated**, and three routes are measured and closed:
   `estimate_cardinality` is worse in every mode (index bounds under independence); `RangeCardCounts` is exact
   but answers the *marginal* count on 9% of rows and is 6× worse where it applies; and the
   `.max(count.min(in_space))` floor is worse in artwork and better in printing. All four failures are the same
   shape — the wanted quantity is `|candidates ∩ residual|` and nothing cheap computes it unnarrowed. One route
   is open: a bitmap AND against an indexed residual leaf, exact on that 9%.
3. Size the `candidates` tail on **p99 and miss-rate**, not the mean, before spending on it — that pair is
   already 92% ordered right.
4. Carried: extend the popcount-skip walk past `FilterExpr::True`; compose `format:A AND format:B` now that both
   are usually card-invariant; the pair-level loop harness (gated on the features settling).

## Retractions, recorded because each was believed and acted on

- **"The shipped constants are ~2× too high."** Warm-cache artifact of min-of-N over one card list.
- **"The error is in the features, not the rates."** Every counter/feature ratio read 1.00 for both plans.
- **"`STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` is 24–40× too high."** Those cells were in the perm-walk branch.
- **"The span bound taxes broad queries 3.5%."** A cross-build artifact; as shipped it costs nothing per card.
- **"The clustered win is 0.66×."** Measured in card mode, where the router picks `PlanePopcountOrder`.
- **"Compose is priced ~1.5× under P3."** P3 was over-priced 3–6×; compose reads 1.02–1.17.
- **"The two scan rates cancel."** One-sided: P3 at 1.03 of real time, P4 at 0.64.
- **"What survives three feature corrections is a rate problem."** A fourth feature correction moved it.
- **"Widen `bare_range_bounds` for multi-leaf ranges."** The defect was the quantity, not the calibration.
- **"An uncounted artwork grouping walk."** `printings_examined` reading 0 is correct — a fast path answers
  artwork counts from a stored per-card group count. It was `card_pass`.
- **"25% is the ceiling on feature work."** That read the count column: feature errors are 26% of mis-picks but
  **37% of avoidable time** and **54% of misses over 100 µs**. They are the expensive tail.

`cargo test` 149 debug / 148 release throughout; `fit_cost_model`'s arm mirror 100% exact at every step.
`ARCHIVE_FORMAT_VERSION` moves to 20260803, so existing stores are rejected by the header check and rebuilt.
