### PR TITLE
Engine: Restrict the Router's Argmin to Plans Its Dispatch Arm Can Run

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1252,7 +1252,25 @@ class APIResource:
                     timer=timer,
                     fields=resolved_fields,
                 )
-            except Exception as e:
+            except BaseException as e:
+                # BaseException, not Exception: a Rust panic anywhere under `self._engine.query`
+                # surfaces as pyo3's `PanicException`, which derives from BaseException and so went
+                # straight past this handler — the one whose entire job is to let an engine failure
+                # degrade to the SQL path instead of failing the request. Falcon's own error handling
+                # catches Exception too, so nothing of ours ran: the panic left the WSGI handler and
+                # bjoern turned it into a bare 500 on a query the SQL path answers fine.
+                #
+                # Measured, because the obvious guess is worse than the truth and was in this comment:
+                # bjoern prints the traceback and keeps serving. The worker does NOT die, so
+                # `_all_workers_alive` in entrypoint.py — which tears down every worker when one dies
+                # — is not in play. The cost is one wrong 500, not lost capacity.
+                #
+                # `pyo3_runtime.PanicException` is not imported and named directly: the module only
+                # exists once a pyo3 extension has registered it, so naming it would couple this
+                # fallback to the engine having loaded and to pyo3's own module layout. The two
+                # BaseExceptions that must still propagate are the ones that are not failures.
+                if isinstance(e, (KeyboardInterrupt, SystemExit)):
+                    raise
                 logger.warning("Engine query failed for %r, falling back to SQL: %s", query, e, exc_info=True)
             else:
                 if settings.enable_cache:

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -1373,3 +1373,67 @@ class TestExplain:
             if not row["trials_ns"]:
                 continue  # declined at runtime, so it produced no total
             assert row["result_total"] == expected_total, f"{row['plan']} disagrees with query()'s total"
+
+
+class TestRouterDispatchScope:
+    """The router may only pick a plan the dispatch arm for its acquire can execute.
+
+    `PhysicalPlan::applicable` answers "is this plan correct for this query"; it says nothing about
+    which artifact the acquire step materialized. A `Prep::Plane` acquire holds the plane bitmap and
+    can run that plan's order walk or either candidate-list executor over it — nothing else. The
+    router's argmin was unrestricted, so it could hand that arm a plan with no executor there, which
+    `exec_from_candidates` met with `unreachable!` — a panic, and one that escapes the SQL fallback
+    (`PanicException` derives from `BaseException`), turning a valid query into a bare 500.
+
+    See docs/issues/ for the plane-acquire/plan-mismatch write-up. These queries are the ones that
+    panicked on this fixture before `PlanScope` existed, so this class is the regression that fails
+    on an engine without it.
+    """
+
+    # A bare border or rarity leaf under `unique=card` folds into a plane, so these acquire as
+    # `Prep::Plane`; `f:` does too via the legality fold. The limit matters: it is what tipped the
+    # cost model onto PrintingCompose, which the plane arm cannot run.
+    PLANE_QUERIES = ("f:pauper", "border:borderless", "border:black", "r:mythic", "f:legacy")
+
+    @pytest.mark.parametrize("query", PLANE_QUERIES)
+    @pytest.mark.parametrize("limit", [10, 200, 1_000_000])
+    def test_plane_acquired_query_never_panics(self, engine: QueryEngine, query: str, limit: int) -> None:
+        """1_000_000 is not a synthetic limit — it is what `_search` sends when a request has none."""
+        total, cards = _run(engine, query, unique="card", limit=limit)
+        assert total >= 0
+        assert len(cards) <= min(limit, total)
+
+    @pytest.mark.parametrize("query", PLANE_QUERIES)
+    def test_page_size_does_not_change_what_a_query_matches(self, engine: QueryEngine, query: str) -> None:
+        """The panic was reachable only at a large limit, so the totals either side of it must agree.
+
+        A plan swap is a performance decision; if the total moves with `limit`, the router swapped in
+        a plan that answers a different question.
+        """
+        small_total, _ = _run(engine, query, unique="card", limit=10)
+        large_total, large_cards = _run(engine, query, unique="card", limit=1_000_000)
+        assert small_total == large_total
+        assert len(large_cards) == large_total, "a limit past the total must return every match"
+
+    def test_the_router_picks_a_plan_its_acquire_can_run(self, engine: QueryEngine) -> None:
+        """`explain` marks `picked` as the in-scope argmin, not the cheapest plan overall.
+
+        The full ranking still lists every applicable plan — out-of-scope rows are real calibration
+        data for `explain_analyze`, which forces plans and does not route — so `picked` is the only
+        field that reports what `run_query_routed` would actually do.
+        """
+        candidate_plans = {"StreamedSelect", "GatheredScan"}
+        scope_of = {"plane": candidate_plans | {"PlanePopcountOrder"}, "candidates": candidate_plans}
+        checked = 0
+        for query in self.PLANE_QUERIES:
+            filters = parse_scryfall_query(query)
+            for limit in (10, 200, 1_000_000):
+                result = engine.explain(filters=filters, unique="card", limit=limit)
+                scope = scope_of.get(result["acquire"]["count_source"])
+                if scope is None:
+                    continue  # a Prep::Range acquire, whose arm runs every plan
+                picked = [row["plan"] for row in result["plans"] if row["picked"]]
+                assert len(picked) == 1, f"{query}@{limit}: exactly one plan is picked, got {picked}"
+                assert picked[0] in scope, f"{query}@{limit}: picked {picked[0]}, which this acquire cannot run"
+                checked += 1
+        assert checked, "no query in PLANE_QUERIES acquired through a plane or candidate list"

--- a/api/tests/test_parsing_errors.py
+++ b/api/tests/test_parsing_errors.py
@@ -96,6 +96,40 @@ class TestSearchRouting:
         mock_sql.assert_called_once()
         assert result is sentinel
 
+    def test_falls_back_to_sql_when_engine_panics(self) -> None:
+        """A pyo3 panic derives from BaseException, not Exception.
+
+        The SQL fallback exists so an engine failure degrades instead of failing the request; a
+        handler catching only Exception let a panic past it and out of the WSGI handler, killing
+        the worker. Stood in for by a bare BaseException subclass so the test does not need a
+        loaded pyo3 extension (or a way to make it panic on demand) to pin the behaviour.
+        """
+
+        class _Panic(BaseException):
+            pass
+
+        self.api_resource._engine.size.return_value = 87
+        sentinel = {"cards": [], "total_cards": 0, "query": "name:opt"}
+        with (
+            patch.object(self.api_resource, "_search_engine", side_effect=_Panic("engine panicked")),
+            patch.object(self.api_resource, "_search_sql", return_value=sentinel) as mock_sql,
+        ):
+            result = self.api_resource._search(query="name:opt", limit=10)
+        mock_sql.assert_called_once()
+        assert result is sentinel
+
+    @pytest.mark.parametrize("exc", [KeyboardInterrupt, SystemExit])
+    def test_interpreter_shutdown_signals_still_propagate(self, exc: type[BaseException]) -> None:
+        """Widening the catch to BaseException must not swallow Ctrl-C or interpreter exit."""
+        self.api_resource._engine.size.return_value = 87
+        with (
+            patch.object(self.api_resource, "_search_engine", side_effect=exc()),
+            patch.object(self.api_resource, "_search_sql") as mock_sql,
+            pytest.raises(exc),
+        ):
+            self.api_resource._search(query="name:opt", limit=10)
+        mock_sql.assert_not_called()
+
     def test_negative_limit_raises_bad_request(self) -> None:
         with pytest.raises(falcon.HTTPBadRequest) as exc_info:
             self.api_resource._search(query="name:opt", limit=-1)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8009,17 +8009,60 @@ impl PhysicalPlan {
         }
     }
 
-    /// Whether the plan runs off the shared materialized prep (plane bitmap /
-    /// candidate list) — true for all but the printing-space fast paths
-    /// (`PrintingRangeScan`/`PrintingCompose`), whose whole benefit is answering from a cheap estimate
-    /// and composing/walking only if they win. The router costs non-materializing plans from a cheap
-    /// estimate first (phase 1) and only materializes (phase 2) when a materializing plan wins or the
-    /// non-materializing one declines.
-    fn materializing(self) -> bool {
-        !matches!(
-            self,
-            PhysicalPlan::PrintingRangeScan | PhysicalPlan::PrintingCompose | PhysicalPlan::CardRangePopcount
-        )
+}
+
+/// The two plans that run off a materialized candidate list (P3/P4) — `exec_from_candidates`'s
+/// whole repertoire, as a type.
+///
+/// Narrower than `PhysicalPlan` on purpose. The executor's `match` used to be over all six plans
+/// ending in `unreachable!`, which made "the router only ever hands me one of these two" an
+/// undocumented invariant of `run_query_routed`'s argmin rather than something either side
+/// enforced — and the argmin did not enforce it (see `PlanScope`). Over this type the executor's
+/// match is exhaustive, so adding a plan cannot silently re-open that hole: `of` is the one place
+/// that decides whether a candidate list can run it, and it is exhaustive over `PhysicalPlan`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CandidatePlan {
+    StreamedSelect,
+    GatheredScan,
+}
+
+impl CandidatePlan {
+    /// The candidate-list executor for `plan`, if it has one. Exhaustive over `PhysicalPlan` rather
+    /// than a `_` arm: a new plan variant must state here whether a candidate list can run it.
+    fn of(plan: PhysicalPlan) -> Option<Self> {
+        match plan {
+            PhysicalPlan::StreamedSelect => Some(CandidatePlan::StreamedSelect),
+            PhysicalPlan::GatheredScan => Some(CandidatePlan::GatheredScan),
+            PhysicalPlan::PrintingRangeScan
+            | PhysicalPlan::PrintingCompose
+            | PhysicalPlan::PlanePopcountOrder
+            | PhysicalPlan::CardRangePopcount => None,
+        }
+    }
+
+    /// `of`, with `GatheredScan` — which answers every query correctly — where `of` says the plan
+    /// has no candidate-list executor.
+    ///
+    /// `PlanScope` is what makes the fallback unreachable: every caller restricts its argmin to a
+    /// scope this conversion is total over. It exists anyway, in place of the `unreachable!` that was
+    /// here, because the right failure mode for a router/executor disagreement is "runs a correct
+    /// plan, possibly not the cheapest" and not "panics".
+    ///
+    /// Not because a panic would escape — the same change taught `_search` to catch `BaseException`,
+    /// so one here is caught and the request degrades to SQL. That is what made the `unreachable!`
+    /// user-visible before (a `PanicException` derives from `BaseException`, so the fallback missed it
+    /// and the request 500ed), and it is closed on the Python side independently of this.
+    ///
+    /// The reason not to panic is that the fallback is a last resort rather than a licence: reaching
+    /// it throws away a correct engine plan and pays a Postgres round trip because the router
+    /// disagreed with its own executor — a latency cliff, where running the plan that was sitting
+    /// right there costs nothing. The `debug_assert` keeps that from being a silent papering-over: a
+    /// debug build (which is what CI's rust-test job runs) still fails loudly.
+    fn of_or_gathered(plan: PhysicalPlan) -> Self {
+        CandidatePlan::of(plan).unwrap_or_else(|| {
+            debug_assert!(false, "no candidate-list executor for {plan:?} — the argmin's PlanScope did not restrict it");
+            CandidatePlan::GatheredScan
+        })
     }
 }
 
@@ -8080,6 +8123,68 @@ enum Prep {
     Plane,
     /// The general residual path: a materialized candidate list.
     Candidates(PreparedCandidates),
+}
+
+/// Which plans `run_query_routed`'s argmin may return — the set the caller's dispatch arm actually
+/// has an executor for.
+///
+/// The router is "argmin over `ALL.filter(applicable)`, then dispatch on `(plan, &prep)`", and
+/// `applicable` is a *correctness* predicate about the query, not a statement about which artifact
+/// the acquire step materialized. Those are different questions, and only `Prep::Range` answers
+/// both the same way (its arm can run every plan: the fast paths walk, a materializing winner
+/// materializes lazily). The other two acquires hold exactly one artifact and can run exactly the
+/// plans that read it — so without this the argmin can hand them a plan their arm has no executor
+/// for, which `exec_from_candidates` met with `unreachable!`.
+///
+/// What kept that from firing was a coincidence in somebody else's predicate, not anything the
+/// router did: all three printing-space fast paths require `plane.is_none()` and
+/// `PlanePopcountOrder` requires `plane.is_some()`, so a plane acquire's applicable set happens to
+/// land inside its scope. Those guards are about how a predicate is REPRESENTED — a bare border
+/// under `unique=card` folds into a plane, so compose declines it — and not about what a dispatch
+/// arm can execute. Work in flight to let compose cost the unsplit filter alongside a plane removes
+/// the coincidence while leaving the router's reasoning exactly as it was, which is the case for
+/// stating the constraint where it belongs instead of relying on the overlap.
+///
+/// Restricting the argmin rather than teaching the arms to run more plans is also the right
+/// performance answer: the acquire already paid for its artifact, and a plan outside the scope
+/// would throw that work away and redo it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlanScope {
+    /// Every applicable plan — `Prep::Range`, whose dispatch arm covers all six.
+    All,
+    /// The candidate-list executors only (`CandidatePlan`): `Prep::Candidates`, and `Prep::Range`'s
+    /// lazy-materialize fallback once it has a candidate list in hand.
+    ///
+    /// Not `PlanePopcountOrder`, even though that plan reads a materialized artifact too — the
+    /// artifact it reads (the plane bitmap) is exactly what these two paths did *not* build. This
+    /// is the distinction the old `materializing()` flag, which grouped it with P3/P4, did not draw.
+    Candidates,
+    /// `Candidates` plus `PlanePopcountOrder`: `Prep::Plane`, which holds the plane bitmap that
+    /// plan walks, and which P3/P4 can equally read as their candidate list.
+    Plane,
+}
+
+impl PlanScope {
+    /// Whether the argmin may return `plan` in this scope.
+    fn admits(self, plan: PhysicalPlan) -> bool {
+        match self {
+            PlanScope::All => true,
+            PlanScope::Candidates => CandidatePlan::of(plan).is_some(),
+            PlanScope::Plane => CandidatePlan::of(plan).is_some() || matches!(plan, PhysicalPlan::PlanePopcountOrder),
+        }
+    }
+}
+
+impl Prep {
+    /// The plans this acquire's dispatch arm can execute. Paired with the `match (plan, &prep)` in
+    /// `run_query_routed`: every arm there is reachable only for plans this admits.
+    fn scope(&self) -> PlanScope {
+        match self {
+            Prep::Range(_) => PlanScope::All,
+            Prep::Plane => PlanScope::Plane,
+            Prep::Candidates(_) => PlanScope::Candidates,
+        }
+    }
 }
 
 /// Row selection (docs/issues/00667-engine-legality-divergent-carveout.md "Row
@@ -9365,8 +9470,12 @@ fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n
 /// phase-2 prep branches funnel their P3/P4 winner through here, so the executor
 /// call site exists once. `PlanePopcountOrder` is handled by its own bitmap
 /// executor and `PrintingRangeScan` never reaches here (non-materializing).
+///
+/// Takes `CandidatePlan`, not `PhysicalPlan`: the match below is then exhaustive, and the
+/// "only P3/P4 reach here" precondition is the caller's to satisfy in the type rather than a
+/// comment backed by an `unreachable!`.
 fn exec_from_candidates<'a>(
-    plan: PhysicalPlan,
+    plan: CandidatePlan,
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &FilterExpr,
@@ -9374,17 +9483,16 @@ fn exec_from_candidates<'a>(
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     match plan {
-        PhysicalPlan::StreamedSelect => exec_streamed_select(ctx, params, filter, prep, plane),
-        PhysicalPlan::GatheredScan => exec_gathered_scan(ctx, params, filter, prep, plane),
-        other => unreachable!("exec_from_candidates only runs P3/P4, got {other:?}"),
+        CandidatePlan::StreamedSelect => exec_streamed_select(ctx, params, filter, prep, plane),
+        CandidatePlan::GatheredScan => exec_gathered_scan(ctx, params, filter, prep, plane),
     }
 }
 
 /// When a `Prep::Range` fast path declines at runtime, try its non-materializing sibling before
 /// paying `prepare_candidates`.
 ///
-/// `run_query_routed`'s fallback re-chooses with `materializing_only = true`, and
-/// `PhysicalPlan::materializing()` excludes every fast path — so the sibling was unreachable even
+/// `run_query_routed`'s fallback re-chooses in `PlanScope::Candidates`, which excludes every fast
+/// path — so the sibling was unreachable even
 /// when it was applicable, would not decline, and was an order of magnitude cheaper. Measured on
 /// `usd>20` at `unique=printing`: `PrintingRangeScan` declines, the materializing fallback runs in
 /// ~105 µs, and `PrintingCompose` answers the same query in 2.3 µs.
@@ -9407,7 +9515,7 @@ fn declined_sibling_fastpath<'a>(
     unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
     feats: &cost::PlanFeatures,
-    choose: &impl Fn(&FilterExpr, &cost::PlanFeatures, bool) -> PhysicalPlan,
+    choose: &impl Fn(&FilterExpr, &cost::PlanFeatures, PlanScope) -> PhysicalPlan,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
     let sibling = match declined {
         PhysicalPlan::PrintingRangeScan => PhysicalPlan::PrintingCompose,
@@ -9417,7 +9525,7 @@ fn declined_sibling_fastpath<'a>(
     if !sibling.applicable(ctx, params, filter, unsplit, plane) {
         return None;
     }
-    if cost::plan_cost(sibling, feats) >= cost::plan_cost(choose(filter, feats, true), feats) {
+    if cost::plan_cost(sibling, feats) >= cost::plan_cost(choose(filter, feats, PlanScope::Candidates), feats) {
         return None;
     }
     match sibling {
@@ -10253,14 +10361,14 @@ fn acquire_plan_features(
 ///    a True-residual plane's popcount (`Prep::Plane`), a bare range's index-`k`
 ///    (`Prep::Range`, nothing materialized), or `prepare_candidates`
 ///    (`Prep::Candidates`). This 3-way is the engine's entire materialization story.
-/// 2. **choose** — `argmin cost::plan_cost` over `ALL.filter(applicable)`. No
-///    hand-written plan list; applicability encodes prep availability, so the right
-///    candidates fall out per acquire branch.
+/// 2. **choose** — `argmin cost::plan_cost` over `ALL.filter(applicable)`, narrowed to the plans
+///    step 3's arm for this prep can execute (`Prep::scope`). No hand-written plan list;
+///    applicability encodes prep availability, so the right candidates fall out per acquire branch.
 /// 3. **dispatch** — run the winner, reusing the acquired artifact.
 ///
 /// Plan choice is a pure performance decision — every plan returns identical rows
 /// (guaranteed by `force_plan_differential_agreement`). Adding a plan is declaring
-/// its `applicable`/`cost`/`materializing`/executor arms; only a genuinely new
+/// its `applicable`/`cost`/`PlanScope`/executor arms; only a genuinely new
 /// count source (a new `Prep`) touches acquire/dispatch. The one subtlety is
 /// `Prep::Range`: it costs `PrintingRangeScan` (non-materializing) from a cheap
 /// estimate, so if a *materializing* plan wins there — or `PrintingRangeScan` wins
@@ -10273,16 +10381,17 @@ fn run_query_routed<'a>(
     unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
-    // Generic argmin: the cheapest applicable plan. `filter` is passed per call (not
-    // captured) so it stays free for `prepare_candidates`'s `&mut`. `materializing`
-    // restricts to plans runnable off a materialized prep (the lazy-materialize path
-    // below). GatheredScan is always applicable and materializing → min never empty.
-    let choose = |filter: &FilterExpr, feats: &cost::PlanFeatures, materializing_only: bool| -> PhysicalPlan {
+    // Generic argmin: the cheapest applicable plan the caller's dispatch arm can run. `filter` is
+    // passed per call (not captured) so it stays free for `prepare_candidates`'s `&mut`. `scope`
+    // narrows `ALL` to the plans that arm has an executor for — see `PlanScope`, and note that
+    // `applicable` alone does NOT imply runnable-here. GatheredScan is applicable to every query
+    // and admitted by every scope → the min is never empty.
+    let choose = |filter: &FilterExpr, feats: &cost::PlanFeatures, scope: PlanScope| -> PhysicalPlan {
         PhysicalPlan::ALL
             .into_iter()
-            .filter(|p| p.applicable(ctx, params, filter, unsplit, plane) && (!materializing_only || p.materializing()))
+            .filter(|p| p.applicable(ctx, params, filter, unsplit, plane) && scope.admits(*p))
             .min_by(|a, b| cost::plan_cost(*a, feats).partial_cmp(&cost::plan_cost(*b, feats)).expect("plan_cost is finite"))
-            .expect("GatheredScan is always applicable and materializing")
+            .expect("GatheredScan is always applicable and in every scope")
     };
 
     // Marks three disjoint phases covering the whole call — see `RoutedPhases` for why acquire needed
@@ -10294,8 +10403,8 @@ fn run_query_routed<'a>(
     let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, unsplit, plane);
     phases.acquired();
 
-    // ── choose: cheapest applicable plan ──
-    let plan = choose(filter, &feats, false);
+    // ── choose: cheapest applicable plan this acquire's dispatch arm can run ──
+    let plan = choose(filter, &feats, prep.scope());
     phases.chosen();
 
     // ── dispatch: run the winner, reusing the acquired artifact ──
@@ -10309,7 +10418,7 @@ fn run_query_routed<'a>(
         // P3/P4 reuse the plane bitmap as their candidate list — identical to what
         // prepare_candidates yields for a True-residual plane query.
         (p, Prep::Plane) => exec_from_candidates(
-            p, ctx, params, filter,
+            CandidatePlan::of_or_gathered(p), ctx, params, filter,
             // `None`, matching what `Prep::narrowed_repr` reports for a plane acquire: the field
             // means "what the residual NARROWING produced", and no narrowing ran here — the list
             // came from the plane bitmap. Diagnostic-only and unread on this path, but `CardBits`
@@ -10317,7 +10426,7 @@ fn run_query_routed<'a>(
             &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, proven_conjuncts: 0, narrowed_repr: NarrowedRepr::None },
             plane,
         ),
-        (p, Prep::Candidates(prep)) => exec_from_candidates(p, ctx, params, filter, prep, plane),
+        (p, Prep::Candidates(prep)) => exec_from_candidates(CandidatePlan::of_or_gathered(p), ctx, params, filter, prep, plane),
         // `Prep::Range` = "cheap estimate acquired, nothing materialized" — shared by CardRangePopcount
         // (#725), PrintingRangeScan (#695), and PrintingCompose (#724). Each winner does its own O(k)
         // work here, so no plan eats a build for a competing winner:
@@ -10346,8 +10455,13 @@ fn run_query_routed<'a>(
                 None => {
                     let prep = prepare_candidates(ctx, params, filter, plane);
                     let feats = candidate_feats(ctx, params, &prep, filter);
-                    let plan = choose(filter, &feats, true);
-                    exec_from_candidates(plan, ctx, params, filter, &prep, plane)
+                    // `PlanScope::Candidates`, not the old "materializing plans", which admitted
+                    // `PlanePopcountOrder` too — and this path holds a candidate list, not the
+                    // plane bitmap that plan reads. Re-chosen on a filter `prepare_candidates` has
+                    // just rewritten in place, so the applicable set here is not the one acquire
+                    // saw and the scope is what states which of it this arm can run.
+                    let plan = choose(filter, &feats, PlanScope::Candidates);
+                    exec_from_candidates(CandidatePlan::of_or_gathered(plan), ctx, params, filter, &prep, plane)
                 }
             }
         }
@@ -10442,10 +10556,13 @@ pub(crate) struct PlanEstimate {
     /// (`eval_domain = n_cards`), so this figure has no referent there -- do not pool range-acquired
     /// rows with candidate-acquired ones when reading it.
     pub(crate) materialize_ns: f64,
-    /// Whether this is the plan `run_query_routed` would run: the cheapest `predicted_ns`, which
-    /// after the ascending sort is index 0. Reported explicitly so a caller never has to
-    /// reconstruct the argmin — doing that over only the plans that *ran* (dropping runtime
-    /// decliners) silently diverges from what the router picks.
+    /// Whether this is the plan `run_query_routed` would run: the cheapest `predicted_ns` among the
+    /// plans this acquire's dispatch arm can execute (`Prep::scope`). That is index 0 after the
+    /// ascending sort for a `Prep::Range` acquire, whose arm runs everything, but not necessarily
+    /// for the other two — the ranking below still lists every applicable plan, including ones the
+    /// router could not reach. Reported explicitly so a caller never has to reconstruct the argmin —
+    /// doing that over only the plans that *ran* (dropping runtime decliners), or over the full
+    /// ranking without the scope, silently diverges from what the router picks.
     ///
     /// One documented exception it cannot capture: for a `Prep::Range` acquire the router may
     /// re-materialize and re-choose at dispatch, so the executed plan can still differ. See the
@@ -10597,10 +10714,18 @@ fn explain(
         })
         .collect();
     estimates.sort_by(|a, b| a.predicted_ns.partial_cmp(&b.predicted_ns).expect("plan_cost is finite"));
-    // The router's argmin is index 0 after the sort. Marked here rather than left for the caller
-    // to re-derive, which is where a caller filtering out runtime decliners gets it wrong.
-    if let Some(first) = estimates.first_mut() {
-        first.picked = true;
+    // The router's argmin is the cheapest plan its dispatch arm for this acquire can RUN, which is
+    // index 0 only when the acquire's scope admits everything applicable (`Prep::Range`). Under a
+    // plane or candidate acquire the ranking can lead with a plan `run_query_routed` would never
+    // reach — reporting that one as picked is how the same conflation `PlanScope` fixes in the
+    // router used to show up here as a plausible-looking but wrong answer. Marked here rather than
+    // left for the caller to re-derive, which is where a caller filtering out runtime decliners
+    // gets it wrong. The full ranking still reports every applicable plan: a plan out of scope for
+    // this acquire is still real calibration data for `explain_analyze`, which forces plans through
+    // `run_query_with_plan` and does not route.
+    let scope = prep.scope();
+    if let Some(picked) = estimates.iter_mut().find(|e| scope.admits(e.plan)) {
+        picked.picked = true;
     }
     (facts, estimates)
 }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -5,10 +5,10 @@ use super::{
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
-    range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
+    range_too_broad_to_narrow, run_query, run_query_routed, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
     EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, PairTotals, build_all_value_totals, build_pair_totals, build_range_card_counts, exact_result_total,
-    PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
+    PhysicalPlan, PlanScope, CandidatePlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
     prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, divergent_formats_of, Mode, QueryCtx, QueryParams, Prefer, SortBound,
@@ -3536,6 +3536,153 @@ fn exact_result_total_is_exact_for_rarity() {
     // every assertion above. The one shape that must decline is a negated `Eq`, i.e. `Ne`, which covers
     // two disjoint windows and so is not a range at all: 7 values x 3 modes of the 210 cells.
     assert_eq!(answered, (7 * 5 * 2 - 7) * 3, "the rarity arm should answer every op except `Ne`, in every mode");
+}
+
+/// #702 router invariant, as a table: every plan a `PlanScope` admits is one the dispatch arm that
+/// uses that scope can actually execute.
+///
+/// `PhysicalPlan::applicable` is a correctness predicate about the QUERY. It says nothing about
+/// which artifact `acquire_plan_features` materialized, and the two answers are different questions:
+/// a plane acquire holds the plane bitmap, so it can run the bitmap's own order walk or either
+/// candidate-list executor over that bitmap, but it has no candidate list for anything else and no
+/// business re-deriving one. An argmin over `applicable` alone can return a plan the arm has no
+/// executor for, which is a panic and not a wrong answer — and a panic is the one engine failure the
+/// API's engine-failed-fall-back-to-SQL wrapper did not absorb, because `PanicException` derives from
+/// `BaseException`. So a query the SQL path answers fine returned a bare 500 instead.
+///
+/// This is not hypothetical and it is not a second lock on a bolted door, which is what an earlier
+/// version of this comment claimed. The bolt was somebody else's — all three printing-space fast
+/// paths required `plane.is_none()`, which is a statement about how a predicate is REPRESENTED (a
+/// bare border under `unique=card` folds into a plane, so compose declined it) and not about what a
+/// dispatch arm can run. #836 lifted that guard so compose costs the unsplit filter alongside a
+/// plane, and the door came open: on the committed API fixture, `f:pauper` at `unique=card` with
+/// `limit=200` panicked. This test pins the property that has to hold regardless of whichever
+/// applicability predicate happens to be covering for the router this month.
+#[test]
+fn plan_scope_admits_only_plans_its_dispatch_arm_can_run() {
+    for plan in PhysicalPlan::ALL {
+        // `PlanScope::Candidates` — `Prep::Candidates` and `Prep::Range`'s lazy-materialize
+        // fallback — dispatches through `exec_from_candidates` and nothing else.
+        assert_eq!(
+            PlanScope::Candidates.admits(plan),
+            CandidatePlan::of(plan).is_some(),
+            "{plan:?}: PlanScope::Candidates must admit exactly the plans exec_from_candidates runs",
+        );
+        // `PlanScope::Plane` adds the one plan that reads the plane bitmap directly, and nothing
+        // else: `Prep::Plane`'s arm is that executor plus the candidate-list pair.
+        assert_eq!(
+            PlanScope::Plane.admits(plan),
+            CandidatePlan::of(plan).is_some() || plan == PhysicalPlan::PlanePopcountOrder,
+            "{plan:?}: PlanScope::Plane must admit exactly its own bitmap walk plus the candidate pair",
+        );
+        // `Prep::Range` is the only acquire whose arm covers every plan — the fast paths walk, and a
+        // materializing winner materializes lazily and re-chooses. That is what makes it `All`.
+        assert!(PlanScope::All.admits(plan), "{plan:?}: PlanScope::All must admit every plan");
+    }
+
+    // The scope a plane acquire hands the argmin must not admit a plan whose executor needs the
+    // candidate list that acquire never built... and must admit the one whose bitmap it did.
+    assert!(!PlanScope::Candidates.admits(PhysicalPlan::PlanePopcountOrder));
+    assert!(PlanScope::Plane.admits(PhysicalPlan::PlanePopcountOrder));
+    // The distinction the retired `materializing()` flag could not draw: it grouped
+    // `PlanePopcountOrder` with the candidate pair, so "restrict to materializing plans" — which is
+    // what `Prep::Range`'s fallback and `declined_sibling_fastpath` asked for — could hand a
+    // candidate-list-only path the one plan that reads a bitmap instead.
+    for plan in [PhysicalPlan::StreamedSelect, PhysicalPlan::GatheredScan] {
+        assert!(PlanScope::Candidates.admits(plan), "{plan:?} is a candidate-list executor");
+    }
+}
+
+/// The routed path agrees with `GatheredScan` at every page size, including the one the API sends
+/// when a request carries no `limit` at all.
+///
+/// `force_plan_differential_agreement` holds the plans to identical results, but forces each one and
+/// so never exercises the argmin; and it runs a single page size. This drives `run_query_routed`
+/// itself across a `limit` sweep, which is the axis the cost model reads most directly: several arms
+/// carry a per-emitted-row term, `_search_engine` turns an absent limit into 1,000,000, and
+/// `_validate_limit` sets no ceiling above that. A page size no plan can fill is an ordinary request
+/// shape here, not a synthetic one, so both the routing and the rows it produces have to hold up at
+/// the top of that range.
+#[test]
+fn routed_agrees_with_gathered_scan_across_page_sizes() {
+    use rand::SeedableRng;
+    const CORPUS_CARDS: usize = 2_000;
+    const RANDOM_QUERIES: usize = 60;
+    const MAX_DEPTH: u8 = 3;
+    /// What `_search_engine` sends when the request carries no limit at all.
+    const NO_LIMIT_SENTINEL: usize = 1_000_000;
+
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(806_001);
+    let data = fuzz_store_n(&mut rng, CORPUS_CARDS);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ctx = QueryCtx::from(archived);
+
+    // Hand-built shapes that pin the acquires with a per-emitted-row cost term: a bare border or
+    // rarity leaf folds to a plane under `unique=card` (`Prep::Plane` → `PlanePopcountOrder`), a
+    // bare price range acquires as `Prep::Range`, and colour+type is the plane-only control.
+    let mut specs = vec![
+        FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
+        FuzzSpec::Leaf(FuzzLeaf::Rarity { op: CmpOp::Eq, val: 2.0 }),
+        FuzzSpec::Leaf(FuzzLeaf::Price { field: NumField::PriceUsd, op: CmpOp::Lt, val: 100_000.0 }),
+        FuzzSpec::And(vec![fuzz_leaf_color(&mut rng), fuzz_leaf_type(&mut rng)]),
+    ];
+    for _ in 0..RANDOM_QUERIES {
+        specs.push(fuzz_gen(&mut rng, MAX_DEPTH));
+    }
+
+    let modes = ["card", "printing", "artwork"];
+    // 1 and 60 are ordinary pages; 5,000 exceeds most totals in this corpus without reaching the
+    // sentinel, which is where the unclamped emit terms used to diverge fastest.
+    let limits = [1_usize, 60, 5_000, NO_LIMIT_SENTINEL];
+    let sorts = [("edhrec", "asc"), ("usd", "desc")];
+
+    let ids = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
+        let mut v: Vec<u128> = page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
+        v.sort_unstable();
+        v
+    };
+
+    for spec in &specs {
+        for &mode in &modes {
+            for &limit in &limits {
+                for &(orderby, direction) in &sorts {
+                    let unique_is_card = mode == "card";
+                    let params = QueryParams::from_strs(mode, "default", orderby, direction, limit, 0);
+                    // A fresh bound + split filter per call throughout: both paths rewrite it.
+                    //
+                    // `unsplit` is supplied, as `bind_and_split_filter` does in production, and it is
+                    // load-bearing for what this test is for: without it `printing_compose_applicable`
+                    // fails its `plane.is_none()` guard and compose never reaches the argmin at all, so
+                    // the plane acquire's applicable set would stay inside its scope by accident and the
+                    // sweep below would prove nothing.
+                    let unsplit = fuzz_bound_filter(spec, archived);
+                    let (pe, mut filter) = split_planes(
+                        unsplit.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
+                    );
+                    let (routed_total, routed_page) = run_query_routed(&ctx, &params, &mut filter, Some(&unsplit), pe.as_ref());
+
+                    let (ref_pe, mut ref_filter) = split_planes(
+                        unsplit.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, unique_is_card,
+                    );
+                    let (ref_total, ref_page) =
+                        run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut ref_filter, Some(&unsplit), ref_pe.as_ref())
+                            .expect("GatheredScan is always applicable");
+
+                    let where_ = format!("mode={mode}, limit={limit}, orderby={orderby} {direction}, filter={}", fuzz_describe(spec));
+                    assert_eq!(routed_total, ref_total, "routed total disagrees with GatheredScan ({where_})");
+                    assert_eq!(ids(&routed_page), ids(&ref_page), "routed rows disagree with GatheredScan ({where_})");
+                    // A limit past the total must not inflate the page: the router may only return
+                    // what the query matched, whatever the request asked for.
+                    assert!(
+                        routed_page.len() <= limit.min(routed_total),
+                        "routed page of {} rows exceeds min(limit, total) ({where_})",
+                        routed_page.len(),
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// The per-value count table must be EXACT, not close, in BOTH spaces it carries: every one-sided

--- a/docs/issues/done/00829-engine-plane-acquire-plan-mismatch.md
+++ b/docs/issues/done/00829-engine-plane-acquire-plan-mismatch.md
@@ -1,0 +1,138 @@
+# The router could pick a plan its dispatch arm cannot run
+
+**Fixed in [#829](https://github.com/jbylund/sylvan_librarian/pull/829).** Found 2026-08-04 while
+measuring the compose Gather arm; re-measured against `main` @ `b758901` on 2026-08-06.
+
+Written under the `security-` prefix and kept out of the tree while unfixed. It is here now for the
+reason [README.md](../README.md#unfixed-security-findings) gives — the write-up is a record rather
+than a map once the fix has shipped — and because the impact turned out not to be a security one at
+all. See "Severity, measured".
+
+## The defect
+
+`run_query_routed` is "argmin over `ALL.filter(applicable)`, then dispatch on `(plan, &prep)`".
+`applicable` is a correctness predicate about the **query**: it says nothing about which artifact the
+acquire step materialized. Those are different questions, and only `Prep::Range` answers both the
+same way — its arm can run every plan, because the fast paths walk and a materializing winner
+materializes lazily.
+
+The other two acquires hold exactly one artifact and can run exactly the plans that read it. A
+`Prep::Plane` acquire holds the plane bitmap: it can run that bitmap's own order walk
+(`PlanePopcountOrder`) or either candidate-list executor over it, and nothing else. Its dispatch arm
+forwarded everything that was not `PlanePopcountOrder` into `exec_from_candidates`, whose match ended
+in `unreachable!`. Nothing constrained the argmin to the plans that arm could execute.
+
+## Reachability
+
+What had been keeping this from firing was a coincidence in somebody else's predicate: all three
+printing-space fast paths required `plane.is_none()`, so a plane acquire's applicable set landed
+inside its scope by accident. That guard is about how a predicate is *represented* — a bare border
+under `unique=card` folds into a plane, so compose declined it — not about what a dispatch arm can
+execute.
+
+[#836](https://github.com/jbylund/sylvan_librarian/pull/836) lifted it, letting compose cost the
+`unsplit` filter alongside a plane. The door came open. On the committed API fixture
+(`api/tests/fixtures/engine_cards.json`, 16 cards / 90 printings), release build of `main`:
+
+```
+ok    q='f:pauper'          unique=card limit=10   total=4
+PANIC q='f:pauper'          unique=card limit=200  PanicException: internal error: entered
+                                                   unreachable code: exec_from_candidates
+                                                   only runs P3/P4, got PrintingCompose
+PANIC q='border:borderless' unique=card limit=200  … got PrintingCompose
+```
+
+**Corpus size is not the axis.** Slicing the 97,206-printing benchmark corpus, `border:borderless` at
+`unique=card`, `limit=10_000`:
+
+| printings | 90 | 500 | 2,000 | 5,000 | 10,000 | 20,000 | 40,000 | 97,206 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| out-of-scope winner | yes | yes | no | yes | yes | no | no | no |
+
+**The production corpus was clean, by 12%.** Two sweeps over all 97,206 printings, comparing each
+plane/candidates-acquired argmin against the set its arm can run:
+
+- 49,248 configs — 239 sampled queries (both `QuerySampler` modes) × 3 uniques × 8 orderbys × 2
+  directions × 3 limits × 2 offsets.
+- 625 configs — 303 exhaustively enumerated plane-forming predicates (every border, rarity, format
+  and frame value, plus 200 sets) × 3 uniques × 5 limits.
+
+Zero out-of-scope winners in either. Closest margin **1.12×**, on `border:white` at `unique=card`
+with a large limit: `StreamedSelect` picked, `PrintingCompose` 12% behind it. Then `f:oldschool` at
+1.17× and `r:mythic` at 1.30×.
+
+`limit` is the largest single lever and it is unbounded — `_validate_limit` rejects negatives and
+non-integers but sets no ceiling, and the SSR search path in the `/` handler calls `_search` with no
+limit at all, which becomes `1_000_000` at the engine call. So `GET /?q=border:white` was the shape
+sitting closest to the flip.
+
+Per [README.md](../README.md#findings-split-by-blast-radius) this is the kind that ships in the repo,
+so it affected anyone deploying it — and the reachable corpus sizes above are exactly what a partial
+import or a small self-hosted collection looks like.
+
+## Severity, measured
+
+The first draft of this doc, and #829's original description, both said the panic took the worker
+process with it. **It did not.** Measured by raising a `BaseException` subclass out of a WSGI app
+under `bjoern.run` in a child process:
+
+```
+before panic:       200 b'alive'
+panicking request:  HTTPError 500
+worker alive after: True exitcode: None
+after panic:        200 b'alive'
+```
+
+bjoern prints the traceback and keeps serving. That also settles the follow-on worry:
+`_all_workers_alive` in [api/entrypoint.py](../../../api/entrypoint.py) tears down *every* worker when
+one dies, which would have been the blast radius — and it never fires.
+
+`PanicException` derives from `BaseException`, so neither Falcon's error handling nor `_search`'s
+engine-failed-fall-back-to-SQL wrapper caught it. No handler of ours ran. But the cost was **one
+wrong 500 on a query the SQL path answers fine** — no capacity loss, so no DoS, and
+[#782](https://github.com/jbylund/sylvan_librarian/pull/782) had already made the 500 body opaque, so
+no disclosure. An availability bug for one request, not a security finding.
+
+## What shipped
+
+- **`PlanScope`** (`All` / `Candidates` / `Plane`), from `Prep::scope`, narrows the argmin to the
+  plans the dispatch arm for that acquire has an executor for. Restricting the argmin rather than
+  teaching the arms to run more plans is also the right performance answer: the acquire already paid
+  for its artifact, and a plan outside the scope would throw that work away and redo it.
+- **`CandidatePlan`** is the P3/P4 pair as a type, so `exec_from_candidates`'s match is exhaustive.
+  The one remaining conversion falls back to `GatheredScan` under a `debug_assert` — a
+  router/executor disagreement should run a correct plan, not panic.
+- Replaces `PhysicalPlan::materializing()`, which grouped `PlanePopcountOrder` with the candidate pair
+  and so could hand a candidate-list-only path the one plan that reads a bitmap.
+- `explain` marks `picked` as the cheapest **in-scope** plan rather than index 0.
+- `_search` catches `BaseException`, re-raising `KeyboardInterrupt`/`SystemExit`.
+
+**It excludes plans; it does not reorder them.** Over 1,545 configs on the 97,206-printing corpus,
+comparing isolated builds of the branch and of `main`: 0 differ. Same picked plan, same totals, same
+row counts. Note what that implies about the change being a no-op *today* — the value is in the
+constraint being stated where it belongs, not in a measurable win.
+
+## Deliberately not included
+
+#829 originally carried a cost-model correction too: `plan_cost`'s per-emitted-row terms read
+`f.limit` raw, where `page_span` was already clamped to `matches` for exactly that reason. On the
+fixture, `PlanePopcountOrder` at `limit=1_000_000` priced at 2,000,203 ns for a query with 4 results —
+1M × the 2.0 ns emit term.
+
+It is independently correct and it is **split out**, because it reorders: 226 of those same 1,545
+configs pick a different plan, all `StreamedSelect`/`GatheredScan` → `PlanePopcountOrder` at limits of
+100,000 and above. That wants wall-clock p50/p90/p99 behind it and a refit of `cost_terms`' EMIT
+regressor against a rebuilt `benchmarks/verify-order/real.store`, which is stale. Branch:
+`engine-cost-emit-clamp`.
+
+## Still open
+
+- **The 1.12× margin is undefended.** `plan_scope_admits_only_plans_its_dispatch_arm_can_run` pins the
+  structural invariant, not the distance between the cheapest in-scope plan and the cheapest
+  out-of-scope one. That margin moves with a corpus refresh as well as with code, and nothing watches
+  it. Promoting the sweep to a bench would.
+- **A `limit` cap is not a fix for this**, contrary to what an earlier draft suggested. The fixture
+  panics at `limit=200`, and at 90 printings at `limit=175` — a front-end page size. Worth having as
+  defence in depth on its own merits; it closes nothing here.
+- Whether any other `unreachable!` in the dispatch path is reachable by the same argument — an
+  invariant an executor assumes but no caller enforces.


### PR DESCRIPTION
`run_query_routed` chose over `ALL.filter(applicable)` and then dispatched on `(plan, &prep)`. `applicable` is a correctness predicate about the query and says nothing about which artifact the acquire step materialized, so the two disagree: a plane acquire holds the plane bitmap and can run that plan's order walk or either candidate-list executor, and nothing else. `exec_from_candidates` met the difference with `unreachable!`.

## This is reachable on main

The earlier version of this PR argued it was not, because all three printing-space fast paths required `plane.is_none()`. That argument expired: **#836 let compose cost the unsplit filter alongside a plane**, which is exactly the coincidence the router was relying on. Reproduced on `main` @ `b758901`, release build, against the repo's own committed fixture (`api/tests/fixtures/engine_cards.json`, 16 cards / 90 printings):

```
ok    q='f:pauper'          unique=card limit=10   total=4
PANIC q='f:pauper'          unique=card limit=200  PanicException: internal error: entered
                                                   unreachable code: exec_from_candidates
                                                   only runs P3/P4, got PrintingCompose
PANIC q='border:borderless' unique=card limit=200  … got PrintingCompose
```

Corpus size is not the axis. Slicing the 97,206-printing benchmark corpus, `border:borderless` at `unique=card`, `limit=10_000`:

| printings | 90 | 500 | 2,000 | 5,000 | 10,000 | 20,000 | 40,000 | 97,206 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| out-of-scope winner | yes | yes | no | yes | yes | no | no | no |

**The production corpus is currently clean, by 12%.** Two sweeps over all 97,206 printings, checking every plane/candidates-acquired argmin against the set its dispatch arm can run: 49,248 configs (239 sampled queries × 3 uniques × 8 orderbys × 2 directions × 3 limits × 2 offsets) and 625 configs (303 exhaustively enumerated border/rarity/format/frame/set predicates × 3 uniques × 5 limits) — zero out-of-scope winners. Closest margin **1.12×**, on `border:white` at `unique=card` with a large limit. That margin is a cost-model number: it moves with a corpus refresh as well as with code, and nothing in CI watches it.

## What the failure actually costs

Correcting this PR's own earlier claim, which said the panic takes the worker process with it. **It does not.** Measured by raising a `BaseException` subclass out of a WSGI app under `bjoern.run`:

```
before panic:       200 b'alive'
panicking request:  HTTPError 500
worker alive after: True exitcode: None
after panic:        200 b'alive'
```

bjoern prints the traceback and keeps serving. `_all_workers_alive` in `entrypoint.py` — which tears down every worker when one dies — is not in play. Neither Falcon nor the SQL fallback catches it, so the real cost is one wrong 500 on a query the SQL path answers fine. No capacity loss, and #782 already made the 500 body opaque.

## The guard

- **`PlanScope`** (`All` / `Candidates` / `Plane`), from `Prep::scope`, narrows the argmin to the plans the dispatch arm for that acquire has an executor for.
- **`CandidatePlan`** is the P3/P4 pair as a type, so `exec_from_candidates`'s match is exhaustive and the `unreachable!` is gone. The one remaining conversion falls back to `GatheredScan` under a `debug_assert` — a router/executor disagreement should run a correct plan, not panic.
- Replaces `PhysicalPlan::materializing()`, which grouped `PlanePopcountOrder` with the candidate pair and so could hand a candidate-list-only path (`Prep::Range`'s lazy-materialize fallback, `declined_sibling_fastpath`) the one plan that reads a bitmap.
- `explain` marks `picked` as the cheapest **in-scope** plan rather than index 0. The full ranking still reports every applicable plan — out-of-scope rows are real calibration data for `explain_analyze`, which forces plans and does not route.
- **The SQL fallback catches panics.** `_search`'s `except Exception` is the wrapper whose entire job is to let an engine failure degrade to the SQL path; a pyo3 panic derives from `BaseException` and went straight past it. Now catches `BaseException` and re-raises `KeyboardInterrupt`/`SystemExit`. `pyo3_runtime.PanicException` is deliberately not imported by name — that module only exists once a pyo3 extension has registered it.

## It excludes plans; it does not reorder them

Over 1,545 configs on the 97,206-printing corpus (every border, rarity, format and frame predicate × 3 uniques × 5 limits), comparing an isolated build of this branch against an isolated build of `main`: **0 configs differ**. Same picked plan, same totals, same row counts, no panics on either side.

That is the whole intent — narrow the argmin to what the arm can execute, and change nothing else.

The cost-model change that rode along with the previous version of this PR (clamping `plan_cost`'s per-emitted-row terms to `page_span - offset` instead of the raw `limit`) is **split out and not included here**. It is independently correct, but it *does* reorder: 226 of those same 1,545 configs pick a different plan, all `StreamedSelect`/`GatheredScan` → `PlanePopcountOrder` at limits of 100,000 and above. That belongs behind wall-clock p50/p90/p99 and a refit of `cost_terms`' EMIT regressor against a rebuilt `benchmarks/verify-order/real.store`, which is currently stale.

## Testing

- `TestRouterDispatchScope` (`api/tests/test_engine_unit.py`) — the regression that is **red on main**: the plane-acquired queries that panic on the committed fixture, across `limit` 10 / 200 / 1,000,000, plus a check that `explain`'s `picked` plan is always one its acquire can run.
- `plan_scope_admits_only_plans_its_dispatch_arm_can_run` — pins the scope/executor pairing as a table over `PhysicalPlan::ALL`.
- `routed_agrees_with_gathered_scan_across_page_sizes` — drives `run_query_routed` itself (not forced plans, as `force_plan_differential_agreement` does) across modes × limits `[1, 60, 5_000, 1_000_000]` × sorts. It supplies `unsplit`, which is load-bearing: without it compose fails its `plane.is_none()` guard and never reaches the argmin, so the sweep would prove nothing.
- `test_falls_back_to_sql_when_engine_panics` and `test_interpreter_shutdown_signals_still_propagate`.
- 157 Rust tests in a **debug** build (so the `debug_assert` tripwires are live) + clippy `--all-targets` clean; 180 Python engine tests.

**Not run:** `api/tests/test_parsing_errors.py`, which holds the two SQL-fallback tests above. The root `conftest.py` mounts a session-scoped `PostgresContainer` and Docker would not start in this environment. Both are pure-mock and need no database, but the fixture gates the module — worth a run in CI before merge.

## Doc

[docs/issues/done/00829-engine-plane-acquire-plan-mismatch.md](https://github.com/jbylund/sylvan_librarian/blob/engine-router-plan-guard/docs/issues/done/00829-engine-plane-acquire-plan-mismatch.md), added here. It was written under the `security-` prefix and kept out of the tree while unfixed; `docs/issues/README.md` says to rename off the prefix once the fix ships, and it goes straight to `done/` numbered after this PR since the finding never had a GitHub issue of its own. It carries the reachability measurements above, the bjoern result that corrected the severity, and the two follow-ups this PR does not do — the undefended 1.12× margin, and the cost clamp on `engine-cost-emit-clamp`.
