### PR TITLE
Engine: Instrumentation and Phase Timing (stack 1/13)

### DIFF
--- a/card_engine/Cargo.toml
+++ b/card_engine/Cargo.toml
@@ -12,6 +12,13 @@ crate-type = ["cdylib"]
 # Counting global allocator + reload memory breakdown, exposed via QueryEngine.mem_stats().
 # Measurement-only; never enable for production builds.
 alloc-counter = []
+# Disjoint acquire/choose/dispatch timing inside run_query_routed, exposed through
+# explain_analyze's `routed_*_ns`. Measurement-only, same rule as alloc-counter, and for a
+# measured reason: the four clock reads cost +2.7us and +2.3us on a ~40us median query
+# (~1.6%, paired interleaved A/B, both CIs excluding zero). Worth that in a diagnostic build --
+# acquire turns out to be 45% of a candidate-acquired query and the cost model prices none of
+# it -- and not worth it on every production request.
+routed-phases = []
 
 [dependencies]
 # extension-module is enabled by maturin (see pyproject.toml [tool.maturin]) so that

--- a/card_engine/src/bench_compose_card_projection.rs
+++ b/card_engine/src/bench_compose_card_projection.rs
@@ -131,7 +131,7 @@ fn bench_compose_card_projection() {
         let twice_ns = best_ns(|| derive_twice(&pbits, offsets, n_cards).1.len());
         let once_ns = best_ns(|| derive_once(&pbits, offsets, n_cards).1.len());
         let card_bits = printing_bits_to_card_bits(&pbits, offsets, n_cards);
-        let gather_ns = best_ns(|| gather_composed_page(&ctx, &card_params(0), &pbits, Some(&card_bits)).len());
+        let gather_ns = best_ns(|| gather_composed_page(&ctx, &card_params(0), &pbits, Some(&card_bits)).0.len());
 
         let saved = twice_ns.saturating_sub(once_ns);
         let share = 100.0 * saved as f64 / (twice_ns + gather_ns) as f64;

--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -100,18 +100,15 @@ fn bench_compose_paging() {
             }
             let run_a = || {
                 walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset)
-                    .map_or(0, |p| p.len())
+                    .map_or(0, |p| p.0.len())
             };
-            let run_b = || {
-                gather_composed_page(&ctx, &bench_params(offset), &pbits, None)
-                    .len()
-            };
+            let run_b = || gather_composed_page(&ctx, &bench_params(offset), &pbits, None).0.len();
             // Cross-check identical page (offset 0 only — A declines into the null-price tail at deep
             // offsets, where only B is defined; that decline is itself the finding for those rows).
             let a_page = walk_range_orderby_page(&data.indexes.price_usd, &pbits, cards, printings, p2c, SortCol::PriceUsd, false, total, LIMIT, offset);
-            let b_page = gather_composed_page(&ctx, &bench_params(offset), &pbits, None);
-            if let Some(a_page) = &a_page {
-                let a_ids: Vec<u128> = a_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
+            let (b_page, _) = gather_composed_page(&ctx, &bench_params(offset), &pbits, None);
+            if let Some((a_rows, _)) = &a_page {
+                let a_ids: Vec<u128> = a_rows.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
                 let b_ids: Vec<u128> = b_page.iter().map(|(_, p)| u128::from(p.scryfall_id)).collect();
                 assert_eq!(a_ids, b_ids, "A and B disagree on the page for {label} @ offset {offset}");
             }

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -65,38 +65,39 @@
 //! it is dearer where cards are narrow and cheaper where they are wide. `ns_setup` is not the
 //! explanation either — the `group_best` allocation measures 83-125 ns, negligible.
 //!
-//! Adding an artwork ARM (per-card and per-printing rates gated on `artwork_seen_cards`, which is
-//! `eval_domain` in artwork mode and 0 otherwise) was tried next and measured:
+//! Three shapes were then fitted and each taken through the regret gate. The final one, which is what
+//! this harness now reports, fits each mode in the two-parameter space it can support and recovers the
+//! three rates from the pair of pairs -- no pooling:
 //!
-//!     card + printing pooled    3.41 ns/card   2.36 ns/printing   0.80 ns/match
-//!     printing mode             3.41           2.36               0.76  (card/row shared)
-//!     artwork mode              6.68           1.20               0.80  (push shared)
+//!     card mode      A_card  = LOOP + PUSH = 4.22    B_card  = SCAN        = 2.36
+//!     printing mode  A_print = LOOP        = 2.98    B_print = SCAN + PUSH = 3.24
+//!     artwork arm                            6.57                           1.09   + 1.06 ns/group
 //!
-//! Artwork does MORE per card (walk `touched`, push per group, reset `group_best`) and LESS per
-//! printing (a group-id lookup and compare instead of a sort-key push), which is the mechanism behind
-//! the sign flip. That arm FIXED artwork at the gate -- artwork went 52% -> 50% of lost time, mean
-//! 3.40 -> 3.55 -- but total regret was still worse, 40.7 -> 44.3 ms, with the damage moving to
-//! printing mode (mean 1.69 -> 2.10). Printing's own push rate fits 0.76 against 0.80, a 5% gap that
-//! cannot account for it, so a third arm does not fix it either: lowering P4's cost simply wins it
-//! more printing-mode queries where P3 was genuinely better. Reverted again.
+//! so LOOP = A_print, SCAN = B_card, and PUSH twice over: `A_card - A_print` = 1.24 and
+//! `B_print - B_card` = 0.88, two independent estimates from different columns of different modes. They
+//! agree to 1.41x -- a real if mild failure of linearity in these three counters, and the honest error
+//! bar on the push. PUSH comes out SHARED across modes (it is the same `GatherSelect` push), leaving
+//! only LOOP and SCAN mode-dependent. Worst-cell agreement 25% off, against 46% for the mode-blind
+//! triple.
 //!
-//! The structural obstacle found on the way is the durable result. No single mode can identify all
-//! three rates, because in each one a column is a DUPLICATE: card mode pushes once per card, so
-//! `matches == cards`; printing mode pushes every printing it examines, so `matches == printings`.
-//! Only pooling card and printing separates the three, which is in direct tension with the rates
-//! differing by mode. So "fit each mode separately" is not available, and the way out is to
-//! REPARAMETERISE onto what each mode can identify:
+//! **Every one of the three regressed at the gate, and the pattern is the result:**
 //!
-//!     card mode      (LOOP + PUSH) per card, SCAN per printing
-//!     printing mode  LOOP per card, (SCAN + PUSH) per printing
-//!     artwork mode   LOOP_art per card, SCAN_art per printing, PUSH per group
+//!     attempt                      LOOP ns/card   artwork arm   total regret
+//!     mode-blind triple                    3.25   no                   +43%
+//!     pooled + artwork arm                 3.67   yes                 +8.8%
+//!     reparameterised (this one)           2.98   yes                  +40%
 //!
-//! Every parameter there is identifiable in the mode that uses it, and no mode carries a column that
-//! duplicates another. That is the next thing to try; it is a different model, not a refit.
+//! With the artwork arm held fixed, regret tracks HOW FAR P4's per-card cost was lowered rather than how
+//! accurate it is -- the most accurate description of the loop produced the second-worst routing. That
+//! is not a parameterisation problem. `plan_cost` is only ever used comparatively, and P4's inflated arm
+//! is absorbing an over-estimate on P3's side, so any accurate isolated fix to P4 must regress until P3
+//! is measured the same way. Three successively better descriptions of P4's loop giving three
+//! regressions is the evidence for that.
 //!
-//! Until then the shipped mode-blind constants are doing real work by being too high: they absorb
-//! artwork's cost, and every attempt to lower them toward the measured card/printing truth has lost
-//! more elsewhere than it gained. The constants are deliberately unchanged.
+//! So the constants are deliberately unchanged, and the next step is NOT another P4 fit: it is the same
+//! built-design treatment for `run_query_streamed`'s loop, then applying both arms together. Independent
+//! support for that ordering -- P3's dispatch median is 32 us against P4's 4 us, and its finish phase is
+//! 12% of all measured ns at mean |log| 2.06.
 //!
 //! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
 //! behave as the page grows.
@@ -197,18 +198,21 @@ fn fit(cells: &[Cell], modes: &[&str]) -> Option<[f64; 3]> {
     solve3(normal)
 }
 
-/// Artwork's card and printing rates with the MATCH rate held at the value fitted for the other
-/// modes. Fitting all three on artwork alone is ill-conditioned -- artwork groups grow with printings,
-/// so `matches` and `printings` are collinear inside artwork, and the unconstrained solve answers with
-/// a large printing rate against a NEGATIVE match rate (-60 ns) that interpolates the cells and means
-/// nothing. Holding the push shared is not a convenience: it is the same `GatherSelect` push in every
-/// mode, so the constraint is the physical claim, and it leaves 2 unknowns against 3 ratio levels.
-fn fit_artwork(cells: &[Cell], push_ns: f64) -> Option<[f64; 2]> {
+/// Per-card and per-printing rates for ONE mode, with any per-match charge subtracted off the target
+/// first. Two unknowns, which is what a single mode can support.
+///
+/// Fitting a mode alone in the three-rate space is impossible, not merely noisy: card mode pushes once
+/// per card so `matches == cards`, and printing mode pushes every printing it examines so
+/// `matches == printings`. In each mode one column duplicates another. Collapsing to two parameters is
+/// what makes each mode independently fittable, and the collapsed pair means something different in
+/// each mode -- see `recover_rates`.
+fn fit_mode(cells: &[Cell], mode: &str, push_ns: f64) -> Option<[f64; 2]> {
     let mut normal = [[0.0f64; 3]; 2];
-    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "artwork") {
+    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == mode) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w];
-        // The shared push comes off the target, exactly as `design_row` handles cost.rs's offsets.
+        // Any shared per-match charge comes off the target, the way `design_row` handles cost.rs's
+        // non-linear offsets rather than trying to make them columns.
         let y = (c.ns_loop - c.matches * push_ns) * w;
         for i in 0..2 {
             for j in 0..2 {
@@ -227,25 +231,20 @@ fn fit_artwork(cells: &[Cell], push_ns: f64) -> Option<[f64; 2]> {
     ])
 }
 
-/// Printing mode's push rate, with per-card and per-printing held at the card-mode values.
+/// The three original rates, recovered from the two collapsed pairs without ever pooling the modes.
 ///
-/// Only one unknown is available: printing mode pushes every printing it examines, so `matches ==
-/// printings` exactly and those two columns are IDENTICAL within the mode -- no design over real cards
-/// can separate them. The bit test is the same work in both modes, so the rate that is allowed to move
-/// is the push, which is what actually differs (consecutive printings of one card push into the
-/// selector back to back, where card mode pushes one per card).
-fn fit_printing_push(cells: &[Cell], per_card: f64, per_row: f64) -> Option<f64> {
-    let (mut num, mut den) = (0.0f64, 0.0f64);
-    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "printing") {
-        let w = 1.0 / c.ns_loop;
-        let x = c.matches * w;
-        num += x * (c.ns_loop - c.cards * per_card - c.printings * per_row) * w;
-        den += x * x;
-    }
-    if den <= 0.0 {
-        return None;
-    }
-    Some(num / den)
+///     card mode      A_card = LOOP + PUSH      B_card  = SCAN
+///     printing mode  A_print = LOOP            B_print = SCAN + PUSH
+///
+/// so `LOOP = A_print`, `SCAN = B_card`, and PUSH drops out TWICE -- `A_card - A_print` and
+/// `B_print - B_card`. Those two are independent estimates of the same quantity, computed from
+/// different columns of different modes, so their agreement is a test of whether the loop is linear in
+/// these three counters at all. Wide disagreement would mean the model shape is wrong, not that a
+/// constant needs nudging.
+///
+/// Returns `(loop_ns, scan_ns, push_from_card_term, push_from_row_term)`.
+fn recover_rates(card: [f64; 2], printing: [f64; 2]) -> (f64, f64, f64, f64) {
+    (printing[0], card[1], card[0] - printing[0], printing[1] - card[1])
 }
 
 fn predict(c: &Cell, k: [f64; 3]) -> f64 {
@@ -495,31 +494,48 @@ fn bench_gather_loop() {
         );
     }
 
-    // The two candidate shapes, side by side. If artwork's triple differs from the other modes' while
-    // card and printing sit together under one triple, the model wants a two-way branch on mode
-    // (artwork vs not) rather than one mode-blind triple, an additive artwork correction, or a
-    // three-way branch. An additive correction cannot be right if artwork's per-printing rate comes
-    // out LOWER, since the term would have to be negative; a three-way branch is only justified if
-    // card and printing actually separate.
-    if let Some(a2) = fit_artwork(&cells, k[2]) {
-        let art = [a2[0], a2[1], k[2]];
-        println!("\n{:<26}{:>14}{:>14}{:>14}", "fitted separately", "ns/card", "ns/printing", "ns/match");
-        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}", "card + printing pooled", k[0], k[1], k[2]);
-        match fit_printing_push(&cells, k[0], k[1]) {
-            Some(push) => println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (card/row shared)", "printing mode", k[0], k[1], push),
-            None => println!("{:<26}  no printing cells", "printing mode"),
-        }
-        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (push shared)", "artwork mode", art[0], art[1], art[2]);
-        println!("\n  per-cell agreement under the triple fitted for that cell's OWN group:");
-        for c in cells.iter().filter(|c| !c.ran_card_pass) {
-            let own = if c.mode == "artwork" { art } else { k };
-            println!(
-                "    {:<24}{:>7}  own-group p/a {:>6.2}   card/printing-triple p/a {:>6.2}",
-                c.label,
-                c.n_cards_req,
-                predict(c, own) / c.ns_loop,
-                predict(c, k) / c.ns_loop
-            );
+    // The reparameterised fit: each mode fitted in the two-parameter space it can actually support,
+    // then the three original rates recovered from the pair of pairs.
+    let card_pair = fit_mode(&cells, "card", 0.0);
+    let print_pair = fit_mode(&cells, "printing", 0.0);
+    if let (Some(cp), Some(pp)) = (card_pair, print_pair) {
+        let (loop_ns, scan_ns, push_a, push_b) = recover_rates(cp, pp);
+        println!("\n{:<30}{:>14}{:>16}", "collapsed pair per mode", "ns/card", "ns/printing");
+        println!("{:<30}{:>14.2}{:>16.2}   = (LOOP+PUSH), SCAN", "card mode", cp[0], cp[1]);
+        println!("{:<30}{:>14.2}{:>16.2}   = LOOP, (SCAN+PUSH)", "printing mode", pp[0], pp[1]);
+        println!("\nrecovered, without pooling the modes:");
+        println!("  LOOP  = A_print          {loop_ns:>7.2} ns/card");
+        println!("  SCAN  = B_card           {scan_ns:>7.2} ns/printing");
+        println!("  PUSH  = A_card - A_print {push_a:>7.2} ns/match   <-- two independent estimates;");
+        println!("  PUSH  = B_print - B_card {push_b:>7.2} ns/match       agreement tests the model shape");
+        let (lo, hi) = (push_a.min(push_b), push_a.max(push_b));
+        let spread = if lo > 0.0 { hi / lo } else { f64::INFINITY };
+        println!("  spread {spread:>.2}x  (a linear loop in these three counters requires these to agree)");
+
+        // Artwork keeps all three terms: its matches are artwork GROUPS, ~1.2-2.4 per card, so the
+        // column is genuinely distinct there rather than a duplicate. The push is held at the recovered
+        // value because artwork groups grow with printings -- an unconstrained artwork solve answers
+        // with a negative match rate that interpolates the cells and means nothing.
+        let push = 0.5 * (push_a + push_b);
+        if let Some(ap) = fit_mode(&cells, "artwork", push) {
+            println!("\n{:<30}{:>14}{:>16}{:>14}", "artwork arm", "ns/card", "ns/printing", "ns/group");
+            println!("{:<30}{:>14.2}{:>16.2}{:>14.2}", "artwork mode", ap[0], ap[1], push);
+
+            // Agreement per cell under the reparameterised model, which is the only thing that decides
+            // whether this is better than the mode-blind triple it replaces.
+            println!("\n  per-cell agreement, reparameterised (predicted/actual):");
+            let mut worst = 0.0f64;
+            for c in cells.iter().filter(|c| !c.ran_card_pass) {
+                let pred = match c.mode {
+                    "artwork" => c.cards * ap[0] + c.printings * ap[1] + c.matches * push,
+                    "printing" => c.cards * pp[0] + c.printings * pp[1],
+                    _ => c.cards * cp[0] + c.printings * cp[1],
+                };
+                let ratio = pred / c.ns_loop;
+                worst = worst.max((ratio.ln()).abs());
+                println!("    {:<24}{:>7}{:>10.2}", c.label, c.n_cards_req, ratio);
+            }
+            println!("  worst |log ratio| {:.3}  ({:.0}% off at the worst cell)", worst, (worst.exp() - 1.0) * 100.0);
         }
     }
 

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -227,8 +227,9 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
                 continue;
             }
             let f = a[row][col] / a[col][col];
-            for k in col..4 {
-                a[row][k] -= f * a[col][k];
+            let pivot = a[col];
+            for (k, cell) in a[row].iter_mut().enumerate().skip(col) {
+                *cell -= f * pivot[k];
             }
         }
     }

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -1,5 +1,22 @@
 //! Micro-benchmark that decomposes `GatheredScan`'s match loop into its three rates.
 //!
+//! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
+//! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
+//! second pass every card, printing and string it touches is resident. Production walks a candidate set
+//! once. Measuring the first pass against the warm minimum on cells that run after the mmap has faulted
+//! in gives 1.6-2.2x (A' 1.91x/1.74x, I 1.83x/1.59x, H 2.17x/2.14x; the 100x+ figures on the first cells
+//! are first-touch page faults on the 68 MB store, not cache effects).
+//!
+//! That 1.6-2x is the whole discrepancy. Warm 2.98 ns/card against 6.34 fitted on traffic is 2.1x; P3's
+//! warm 2.41 against a shipped 5.05 is 2.1x; the warm push 1.06 against 2.00 fitted is 1.9x. The
+//! counter/feature ratios all read 1.00, so the features were never the gap -- the TIME was, and the
+//! shipped constants include the miss cost this harness removes.
+//!
+//! So the five refits below did not fail because routing is a delicate joint surface. They failed
+//! because they lowered rates toward a cache state production never reaches. Read every ns figure in
+//! this file as "warm", useful for the SHAPE of the loop -- which terms exist, which are degenerate, how
+//! artwork differs -- and not as a candidate constant. Those shape findings stand; the levels do not.
+//!
 //! `cost.rs` charges that loop three ways — `GATHER_CARD_PASS_NS` per card visited,
 //! `GATHER_SCAN_PER_ROW_NS` per printing examined, `GATHER_PUSH_PER_MATCH_NS` per match
 //! pushed — and notes the three "could NOT be fit ... a STRUCTURAL collinearity no corpus
@@ -389,13 +406,22 @@ fn bench_gather_loop() {
         }
     }
 
+    // Iteration 0, kept because min-of-ITERS is a WARM-CACHE number: the same card list is walked 200
+    // times, so every card, printing and string it touches is resident by the second pass. Production
+    // walks a candidate set once. If the first pass is materially slower than the minimum, these rates
+    // describe a cache state production never sees, and that -- not a wrong feature -- is why shipping
+    // them regresses. The counter/feature ratios all read 1.00, so the features are not the gap.
+    let mut first_loop: Vec<f64> = vec![0.0; configs.len()];
     let mut best_setup: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
-    for _ in 0..ITERS {
+    for iter in 0..ITERS {
         for (i, cfg) in configs.iter().enumerate() {
             black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &cfg.prep, None));
             let s = take_phase_stats();
+            if iter == 0 {
+                first_loop[i] = s.ns_loop as f64;
+            }
             if (s.ns_loop as f64) < best_ns[i] {
                 best_ns[i] = s.ns_loop as f64;
             }
@@ -480,6 +506,24 @@ fn bench_gather_loop() {
     // What artwork mode costs ON TOP of the three fitted rates. cost.rs has no artwork term for P4,
     // so today this sits inside the shared rates, which is why measuring them without artwork in the
     // design and then lowering them under-costs artwork queries.
+    // The warm/cold gap, per cell. `cost.rs`'s constants are fitted on production traffic, which pays
+    // this; every rate this harness reports is a min-of-200 and does not.
+    println!("\nfirst pass vs warm minimum (min-of-{ITERS} hides whatever the cold walk costs):");
+    let (mut sum_first, mut sum_best) = (0.0f64, 0.0f64);
+    for (i, c) in cells.iter().enumerate() {
+        println!(
+            "  {:<24}{:>7}  first {:>9.2} ns/card   warm min {:>8.2}   ratio {:>5.2}x",
+            c.label,
+            c.n_cards_req,
+            first_loop[i] / c.cards,
+            c.ns_loop / c.cards,
+            first_loop[i] / c.ns_loop
+        );
+        sum_first += first_loop[i];
+        sum_best += c.ns_loop;
+    }
+    println!("  overall first/warm {:.2}x", sum_first / sum_best);
+
     println!("\nartwork surcharge over the card/printing fit (P4 has no artwork term today):");
     for c in cells.iter().filter(|c| c.mode == "artwork") {
         let base = predict(c, k);

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -65,10 +65,38 @@
 //! it is dearer where cards are narrow and cheaper where they are wide. `ns_setup` is not the
 //! explanation either — the `group_best` allocation measures 83-125 ns, negligible.
 //!
-//! So P4's loop needs rates fitted PER MODE (or a term keyed on printings-per-card), not one triple
-//! plus a linear artwork correction. Until that exists, the shipped mode-blind constants are doing
-//! real work by being too high: they absorb artwork's cost, and lowering them to the card/printing
-//! truth under-costs artwork and loses more than it gains. The constants are deliberately unchanged.
+//! Adding an artwork ARM (per-card and per-printing rates gated on `artwork_seen_cards`, which is
+//! `eval_domain` in artwork mode and 0 otherwise) was tried next and measured:
+//!
+//!     card + printing pooled    3.41 ns/card   2.36 ns/printing   0.80 ns/match
+//!     printing mode             3.41           2.36               0.76  (card/row shared)
+//!     artwork mode              6.68           1.20               0.80  (push shared)
+//!
+//! Artwork does MORE per card (walk `touched`, push per group, reset `group_best`) and LESS per
+//! printing (a group-id lookup and compare instead of a sort-key push), which is the mechanism behind
+//! the sign flip. That arm FIXED artwork at the gate -- artwork went 52% -> 50% of lost time, mean
+//! 3.40 -> 3.55 -- but total regret was still worse, 40.7 -> 44.3 ms, with the damage moving to
+//! printing mode (mean 1.69 -> 2.10). Printing's own push rate fits 0.76 against 0.80, a 5% gap that
+//! cannot account for it, so a third arm does not fix it either: lowering P4's cost simply wins it
+//! more printing-mode queries where P3 was genuinely better. Reverted again.
+//!
+//! The structural obstacle found on the way is the durable result. No single mode can identify all
+//! three rates, because in each one a column is a DUPLICATE: card mode pushes once per card, so
+//! `matches == cards`; printing mode pushes every printing it examines, so `matches == printings`.
+//! Only pooling card and printing separates the three, which is in direct tension with the rates
+//! differing by mode. So "fit each mode separately" is not available, and the way out is to
+//! REPARAMETERISE onto what each mode can identify:
+//!
+//!     card mode      (LOOP + PUSH) per card, SCAN per printing
+//!     printing mode  LOOP per card, (SCAN + PUSH) per printing
+//!     artwork mode   LOOP_art per card, SCAN_art per printing, PUSH per group
+//!
+//! Every parameter there is identifiable in the mode that uses it, and no mode carries a column that
+//! duplicates another. That is the next thing to try; it is a different model, not a refit.
+//!
+//! Until then the shipped mode-blind constants are doing real work by being too high: they absorb
+//! artwork's cost, and every attempt to lower them toward the measured card/printing truth has lost
+//! more elsewhere than it gained. The constants are deliberately unchanged.
 //!
 //! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
 //! behave as the page grows.
@@ -118,10 +146,9 @@ struct Cell {
     /// fit; the rows that DO call `card_pass` are used to price that call instead, and mixing them
     /// would fold a predicate evaluation into the card term.
     ran_card_pass: bool,
-    /// Artwork mode maintains `group_best`/`touched` per printing on top of everything the other modes
-    /// do. Those rows are held out of the three-rate fit and priced against it, because pooling them
-    /// would smear a mode-specific cost across rates that cost.rs applies to all three modes.
-    artwork: bool,
+    /// The `unique` mode this cell ran in. All three loops differ, so rates are fitted per mode:
+    /// pooling them smears mode-specific cost across rates that then fit none of the modes.
+    mode: &'static str,
 }
 
 /// Solve a 3×3 system by Gaussian elimination with partial pivoting.
@@ -148,9 +175,16 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
 /// Relative least squares over every cell: each equation is divided by its own measured time, so a
 /// cell running 50 µs does not outweigh one running 5 µs. Absolute OLS here would fit the largest
 /// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
-fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
+/// Fitted over the modes named, and it has to be more than one of them.
+///
+/// No single mode can identify all three rates, because in each one a column is a DUPLICATE: card mode
+/// pushes once per card, so `matches == cards`; printing mode pushes every printing it examines, so
+/// `matches == printings`. Pooling card and printing is what makes the three separable, which sits in
+/// direct tension with the rates differing by mode -- the tension is resolved by reparameterising
+/// (see the module docs), not by fitting each mode alone.
+fn fit(cells: &[Cell], modes: &[&str]) -> Option<[f64; 3]> {
     let mut normal = [[0.0f64; 4]; 3];
-    for c in cells.iter().filter(|c| !c.ran_card_pass && !c.artwork) {
+    for c in cells.iter().filter(|c| !c.ran_card_pass && modes.contains(&c.mode)) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w, c.matches * w];
         for i in 0..3 {
@@ -161,6 +195,57 @@ fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
         }
     }
     solve3(normal)
+}
+
+/// Artwork's card and printing rates with the MATCH rate held at the value fitted for the other
+/// modes. Fitting all three on artwork alone is ill-conditioned -- artwork groups grow with printings,
+/// so `matches` and `printings` are collinear inside artwork, and the unconstrained solve answers with
+/// a large printing rate against a NEGATIVE match rate (-60 ns) that interpolates the cells and means
+/// nothing. Holding the push shared is not a convenience: it is the same `GatherSelect` push in every
+/// mode, so the constraint is the physical claim, and it leaves 2 unknowns against 3 ratio levels.
+fn fit_artwork(cells: &[Cell], push_ns: f64) -> Option<[f64; 2]> {
+    let mut normal = [[0.0f64; 3]; 2];
+    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "artwork") {
+        let w = 1.0 / c.ns_loop;
+        let x = [c.cards * w, c.printings * w];
+        // The shared push comes off the target, exactly as `design_row` handles cost.rs's offsets.
+        let y = (c.ns_loop - c.matches * push_ns) * w;
+        for i in 0..2 {
+            for j in 0..2 {
+                normal[i][j] += x[i] * x[j];
+            }
+            normal[i][2] += x[i] * y;
+        }
+    }
+    let det = normal[0][0] * normal[1][1] - normal[0][1] * normal[1][0];
+    if det.abs() < 1e-12 {
+        return None;
+    }
+    Some([
+        (normal[0][2] * normal[1][1] - normal[0][1] * normal[1][2]) / det,
+        (normal[0][0] * normal[1][2] - normal[1][0] * normal[0][2]) / det,
+    ])
+}
+
+/// Printing mode's push rate, with per-card and per-printing held at the card-mode values.
+///
+/// Only one unknown is available: printing mode pushes every printing it examines, so `matches ==
+/// printings` exactly and those two columns are IDENTICAL within the mode -- no design over real cards
+/// can separate them. The bit test is the same work in both modes, so the rate that is allowed to move
+/// is the push, which is what actually differs (consecutive printings of one card push into the
+/// selector back to back, where card mode pushes one per card).
+fn fit_printing_push(cells: &[Cell], per_card: f64, per_row: f64) -> Option<f64> {
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for c in cells.iter().filter(|c| !c.ran_card_pass && c.mode == "printing") {
+        let w = 1.0 / c.ns_loop;
+        let x = c.matches * w;
+        num += x * (c.ns_loop - c.cards * per_card - c.printings * per_row) * w;
+        den += x * x;
+    }
+    if den <= 0.0 {
+        return None;
+    }
+    Some(num / den)
 }
 
 fn predict(c: &Cell, k: [f64; 3]) -> f64 {
@@ -186,19 +271,22 @@ fn bench_gather_loop() {
 
     // Group cards by printing count. This is the knob sampled traffic does not have: it sets
     // printings-per-card independently of how many cards the loop visits.
-    let (mut singleton, mut wide): (Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new());
+    let (mut singleton, mut medium, mut wide): (Vec<u32>, Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new(), Vec::new());
     for cid in 0..data.cards.len() {
         let span = u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize;
         if span == 1 {
             singleton.push(cid as u32);
         } else if span >= WIDE_MIN_PRINTINGS {
             wide.push(cid as u32);
+        } else {
+            medium.push(cid as u32);
         }
     }
     println!(
-        "\n{} oracle cards: {} with 1 printing, {} with >={WIDE_MIN_PRINTINGS}",
+        "\n{} oracle cards: {} with 1 printing, {} with 2..{WIDE_MIN_PRINTINGS}, {} with >={WIDE_MIN_PRINTINGS}",
         data.cards.len(),
         singleton.len(),
+        medium.len(),
         wide.len()
     );
     // How much headroom `WIDE_MIN_PRINTINGS` and `CARD_COUNTS` have. The tail is steep, and the
@@ -247,13 +335,16 @@ fn bench_gather_loop() {
     // them low, under-costing artwork. Shipping that moved total routing regret 36.2 -> 51.7 ms, with
     // candidates/artwork going 19% -> 35% of all lost time. Artwork has to be in the design for these
     // rates to mean anything.
-    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 9] = [
+    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 12] = [
         ("A 1p  card/default", &singleton, "card", "default", true),
         ("B 1p  print/default", &singleton, "printing", "default", true),
         ("C wide card/oldest", &wide, "card", "oldest", true),
         ("D wide print/default", &wide, "printing", "default", true),
         ("E 1p  artwork/default", &singleton, "artwork", "default", true),
         ("F wide artwork/default", &wide, "artwork", "default", true),
+        ("G med artwork/default", &medium, "artwork", "default", true),
+        ("H med card/oldest", &medium, "card", "oldest", true),
+        ("I med print/default", &medium, "printing", "default", true),
         ("A' 1p card/default ctl", &singleton, "card", "default", true),
         ("A+ 1p  card, card_pass", &singleton, "card", "default", false),
         ("C+ wide card, card_pass", &wide, "card", "oldest", false),
@@ -275,7 +366,7 @@ fn bench_gather_loop() {
         prep: PreparedCandidates,
         params: QueryParams,
         ran_card_pass: bool,
-        artwork: bool,
+        mode: &'static str,
     }
     let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
@@ -294,7 +385,7 @@ fn bench_gather_loop() {
                 },
                 params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
                 ran_card_pass: !all_match_known,
-                artwork: *unique == "artwork",
+                mode: unique,
             });
         }
     }
@@ -330,7 +421,7 @@ fn bench_gather_loop() {
             matches,
             ns_loop: best_ns[i],
             ran_card_pass: cfg.ran_card_pass,
-            artwork: cfg.artwork,
+            mode: cfg.mode,
         };
         println!(
             "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}{:>11.0}",
@@ -383,7 +474,7 @@ fn bench_gather_loop() {
         }
     }
 
-    let Some(k) = fit(&cells) else {
+    let Some(k) = fit(&cells, &["card", "printing"]) else {
         println!("\nsystem still singular — the design did not separate the columns");
         return;
     };
@@ -391,7 +482,7 @@ fn bench_gather_loop() {
     // so today this sits inside the shared rates, which is why measuring them without artwork in the
     // design and then lowering them under-costs artwork queries.
     println!("\nartwork surcharge over the card/printing fit (P4 has no artwork term today):");
-    for c in cells.iter().filter(|c| c.artwork) {
+    for c in cells.iter().filter(|c| c.mode == "artwork") {
         let base = predict(c, k);
         println!(
             "  {:<26}{:>7}  measured {:>8.0} ns vs fit {:>8.0} ns   +{:>6.2} ns/printing  +{:>6.2} ns/card",
@@ -402,6 +493,34 @@ fn bench_gather_loop() {
             (c.ns_loop - base) / c.printings,
             (c.ns_loop - base) / c.cards
         );
+    }
+
+    // The two candidate shapes, side by side. If artwork's triple differs from the other modes' while
+    // card and printing sit together under one triple, the model wants a two-way branch on mode
+    // (artwork vs not) rather than one mode-blind triple, an additive artwork correction, or a
+    // three-way branch. An additive correction cannot be right if artwork's per-printing rate comes
+    // out LOWER, since the term would have to be negative; a three-way branch is only justified if
+    // card and printing actually separate.
+    if let Some(a2) = fit_artwork(&cells, k[2]) {
+        let art = [a2[0], a2[1], k[2]];
+        println!("\n{:<26}{:>14}{:>14}{:>14}", "fitted separately", "ns/card", "ns/printing", "ns/match");
+        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}", "card + printing pooled", k[0], k[1], k[2]);
+        match fit_printing_push(&cells, k[0], k[1]) {
+            Some(push) => println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (card/row shared)", "printing mode", k[0], k[1], push),
+            None => println!("{:<26}  no printing cells", "printing mode"),
+        }
+        println!("{:<26}{:>14.2}{:>14.2}{:>14.2}  (push shared)", "artwork mode", art[0], art[1], art[2]);
+        println!("\n  per-cell agreement under the triple fitted for that cell's OWN group:");
+        for c in cells.iter().filter(|c| !c.ran_card_pass) {
+            let own = if c.mode == "artwork" { art } else { k };
+            println!(
+                "    {:<24}{:>7}  own-group p/a {:>6.2}   card/printing-triple p/a {:>6.2}",
+                c.label,
+                c.n_cards_req,
+                predict(c, own) / c.ns_loop,
+                predict(c, k) / c.ns_loop
+            );
+        }
     }
 
     println!("\n{:<34}{:>10}{:>10}", "rate", "shipped", "fitted");

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -1,0 +1,302 @@
+//! Micro-benchmark that decomposes `GatheredScan`'s match loop into its three rates.
+//!
+//! `cost.rs` charges that loop three ways — `GATHER_CARD_PASS_NS` per card visited,
+//! `GATHER_SCAN_PER_ROW_NS` per printing examined, `GATHER_PUSH_PER_MATCH_NS` per match
+//! pushed — and notes the three "could NOT be fit ... a STRUCTURAL collinearity no corpus
+//! size fixes", so the values came from a physical prior instead. The loop is ~90% of the
+//! plan's dispatch, and P3-vs-P4 routing turns on the split rather than the total, so the
+//! three rates are worth pinning down.
+//!
+//! Fitting them on sampled traffic was re-tried and fails for a sharper reason than corpus
+//! size: measured on 5,986 all_match rows, the three counters correlate 0.94–1.00 **inside
+//! every `unique` × `prefer` cell**, not merely pooled. `unique` and `prefer` do change the
+//! ratio between the columns, but within any one cell all three still scale with query size,
+//! and query size dominates the variance. `matches_pushed` fitted to exactly 0.00 on two
+//! independent seeds — pinned to the non-negativity boundary, i.e. unidentified rather than
+//! noisy. Balancing the cells made coefficient stability worse (1.06× → 1.46× across seeds),
+//! because all it can do is discard rows. No arrangement of sampled traffic fixes this: traffic
+//! never varies the ratio at FIXED SCALE, which is the only thing that separates the columns.
+//!
+//! So the design is built rather than sampled. Cards are grouped by printing count, which lets
+//! printings-per-card be set independently of card count, and `unique`/`prefer` then set
+//! matches independently of printings:
+//!
+//!     cell  printings/card  unique     prefer   cards  printings  matches
+//!     A     1               card       default    N        N         N
+//!     B     1               printing   default    N        N         N     (consistency check vs A)
+//!     C     ~W              card       oldest     N       ~WN        N
+//!     D     ~W              printing   default    N       ~WN       ~WN
+//!
+//! A, C and D give `[1 1 1; 1 W 1; 1 W W]`, whose determinant is nonzero — all three rates are
+//! pinned. Cell C is why `prefer` is in the design: under the default prefer the card-mode
+//! kernel breaks at the first match, so printings collapses back onto cards and the row stops
+//! being independent (see `push_card_matches`). Each cell is also run at two card counts, so
+//! linearity in the card term is checked rather than assumed.
+//!
+//! This calls the real `exec_gathered_scan` and reads `ns_loop` and the counters back off
+//! `PhaseStats` — the same fenceposts and the same counters production publishes. Nothing is
+//! reimplemented, so there is no second copy of the loop to keep in sync, and the fit is
+//! against the instrumentation the cost model is actually checked with.
+//!
+//! What it measured (2026-08-03), stable to 1.07× / 1.02× / 1.04× across three runs where the
+//! traffic fit could not pin the push rate off the boundary at all:
+//!
+//!     GATHER_CARD_PASS_NS        shipped 6.88   fitted 3.08-3.30
+//!     GATHER_SCAN_PER_ROW_NS     shipped 2.06   fitted 2.44-2.48
+//!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.91-0.95
+//!
+//! The shipped set over-predicts every cell (1.07-1.92 predicted/actual) and over-predicts MOST
+//! on single-printing cards, least on wide card-mode ones — so `GatheredScan` is systematically
+//! over-costed on card-heavy candidate sets, which is the direction that loses it to
+//! `StreamedSelect` wrongly.
+//!
+//! Two limits on reading these as drop-in replacements. `all_match_known` is set, so the loop
+//! never calls `card_pass` and the fitted card term is loop overhead with NO predicate evaluation
+//! in it — correct for the #634 path that also skips it, but queries reaching `card_pass` pay more,
+//! which is what the residual-tier term exists to cover. And `LIMIT` is fixed, so nothing here
+//! constrains how the rates behave as the page grows. Traffic-level regret and latency matrices
+//! remain the gate before any of this ships.
+//!
+//!     cargo test --release bench_gather_loop -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` — rebuild it the
+//! same way (see that module's docs) after any AOracleCard/APrinting layout change.
+
+use std::hint::black_box;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, exec_gathered_scan, take_phase_stats, CardData, CmpOp, FilterExpr, Mmap, NarrowedRepr,
+    PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
+};
+
+/// Timed repetitions per cell; the minimum is reported, as elsewhere in these harnesses.
+const ITERS: usize = 200;
+/// A "wide" card has at least this many printings. Sets the leverage between the card column and
+/// the printing column: a bigger gap separates them better, but the corpus has a steep tail — the
+/// group-size table this prints shows only 1,910 cards reach 8 printings, which is too few to fill
+/// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
+const WIDE_MIN_PRINTINGS: usize = 4;
+/// Card counts each cell runs at. Two sizes so linearity in the card term is measured, not assumed;
+/// bounded above by the wide group, which is the scarce one. The single-printing cell runs 6.31 →
+/// 7.67 ns/card between the two, so this is not a formality — the card term is mildly superlinear
+/// and a one-size design would bake whichever size it used into the constant.
+const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+/// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
+/// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
+/// keeps that contribution proportional to matches rather than to the page.
+const LIMIT: usize = 60;
+
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// One measured design point: the realized counters, and the loop time they were produced by.
+struct Cell {
+    label: &'static str,
+    n_cards_req: usize,
+    cards: f64,
+    printings: f64,
+    matches: f64,
+    ns_loop: f64,
+}
+
+/// Solve a 3×3 system by Gaussian elimination with partial pivoting.
+fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
+    for col in 0..3 {
+        let piv = (col..3).max_by(|&i, &j| a[i][col].abs().total_cmp(&a[j][col].abs()))?;
+        a.swap(col, piv);
+        if a[col][col].abs() < 1e-12 {
+            return None;
+        }
+        for row in 0..3 {
+            if row == col {
+                continue;
+            }
+            let f = a[row][col] / a[col][col];
+            for k in col..4 {
+                a[row][k] -= f * a[col][k];
+            }
+        }
+    }
+    Some([a[0][3] / a[0][0], a[1][3] / a[1][1], a[2][3] / a[2][2]])
+}
+
+/// Relative least squares over every cell: each equation is divided by its own measured time, so a
+/// cell running 50 µs does not outweigh one running 5 µs. Absolute OLS here would fit the largest
+/// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
+fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
+    let mut normal = [[0.0f64; 4]; 3];
+    for c in cells {
+        let w = 1.0 / c.ns_loop;
+        let x = [c.cards * w, c.printings * w, c.matches * w];
+        for i in 0..3 {
+            for j in 0..3 {
+                normal[i][j] += x[i] * x[j];
+            }
+            normal[i][3] += x[i] * (c.ns_loop * w);
+        }
+    }
+    solve3(normal)
+}
+
+fn predict(c: &Cell, k: [f64; 3]) -> f64 {
+    c.cards * k[0] + c.printings * k[1] + c.matches * k[2]
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_gather_loop() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and
+    // replaced atomically, and the header is re-validated below before the payload is trusted.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(data);
+
+    // Group cards by printing count. This is the knob sampled traffic does not have: it sets
+    // printings-per-card independently of how many cards the loop visits.
+    let (mut singleton, mut wide): (Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new());
+    for cid in 0..data.cards.len() {
+        let span = u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize;
+        if span == 1 {
+            singleton.push(cid as u32);
+        } else if span >= WIDE_MIN_PRINTINGS {
+            wide.push(cid as u32);
+        }
+    }
+    println!(
+        "\n{} oracle cards: {} with 1 printing, {} with >={WIDE_MIN_PRINTINGS}",
+        data.cards.len(),
+        singleton.len(),
+        wide.len()
+    );
+    // How much headroom `WIDE_MIN_PRINTINGS` and `CARD_COUNTS` have. The tail is steep, and the
+    // largest cell cannot exceed the wide group, so this is the table those two constants are
+    // chosen from rather than guessed at.
+    print!("cards with >=n printings:");
+    for threshold in 2..=10usize {
+        let n = (0..data.cards.len())
+            .filter(|&cid| u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize >= threshold)
+            .count();
+        print!("  {threshold}:{n}");
+    }
+    println!();
+
+    // all_match_known short-circuits `card_pass`, so the residual tier is exactly zero and this
+    // filter is never evaluated — the loop is card visit + push + absorb and nothing else. That
+    // isolates the three rates from the residual term, which is fitted separately.
+    // `mask: 0` with `Ge` is unconditionally true, but nothing evaluates it either way.
+    let filter = FilterExpr::TypeCmp { mask: 0, op: CmpOp::Ge };
+    let mut cells: Vec<Cell> = Vec::new();
+
+    // (label, source group, unique, prefer)
+    //
+    // A' repeats A last as a control. A and B are the same cards with one printing each and report
+    // identical counters, so any time difference between them is either a real `unique` effect or an
+    // artifact of A running first and paying first-touch on the mmap. A' vs A separates those: equal
+    // means the difference is real, A' matching B means it was ordering.
+    let designs: [(&'static str, &Vec<u32>, &str, &str); 5] = [
+        ("A 1p  card/default", &singleton, "card", "default"),
+        ("B 1p  print/default", &singleton, "printing", "default"),
+        ("C wide card/oldest", &wide, "card", "oldest"),
+        ("D wide print/default", &wide, "printing", "default"),
+        ("A' 1p card/default ctl", &singleton, "card", "default"),
+    ];
+
+    println!(
+        "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}",
+        "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card"
+    );
+    for n_req in CARD_COUNTS {
+        for (label, group, unique, prefer) in &designs {
+            if group.len() < n_req {
+                println!("{label:<22}{n_req:>7}   SKIP (only {} cards in group)", group.len());
+                continue;
+            }
+            let prep = PreparedCandidates {
+                candidate_cards: Some(group[..n_req].to_vec()),
+                all_match_known: true,
+                narrowed_repr: NarrowedRepr::Cards,
+            };
+            let params = QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0);
+            let mut best = f64::INFINITY;
+            let mut stats = take_phase_stats();
+            for _ in 0..ITERS {
+                black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
+                let s = take_phase_stats();
+                if (s.ns_loop as f64) < best {
+                    best = s.ns_loop as f64;
+                    stats = s;
+                }
+            }
+            let cell = Cell {
+                label,
+                n_cards_req: n_req,
+                cards: stats.cards_visited as f64,
+                printings: stats.printings_examined as f64,
+                matches: stats.matches_pushed as f64,
+                ns_loop: best,
+            };
+            println!(
+                "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
+                cell.label,
+                cell.n_cards_req,
+                cell.cards,
+                cell.printings,
+                cell.matches,
+                cell.ns_loop,
+                cell.ns_loop / cell.cards
+            );
+            cells.push(cell);
+        }
+    }
+
+    assert!(cells.len() >= 3, "need at least 3 design points to identify 3 rates, got {}", cells.len());
+
+    // The design's leverage, stated rather than assumed: printings-per-card and matches-per-card
+    // must differ across cells or the system is the degenerate one sampled traffic gives.
+    println!("\nper-card ratios by cell (these differing IS the design):");
+    for c in &cells {
+        println!(
+            "  {:<22}{:>7} printings/card {:>6.2}   matches/card {:>6.2}",
+            c.label,
+            c.n_cards_req,
+            c.printings / c.cards,
+            c.matches / c.cards
+        );
+    }
+
+    let Some(k) = fit(&cells) else {
+        println!("\nsystem still singular — the design did not separate the columns");
+        return;
+    };
+    println!("\n{:<34}{:>10}{:>10}", "rate", "shipped", "fitted");
+    for (name, shipped, got) in [
+        ("GATHER_CARD_PASS_NS", 6.88, k[0]),
+        ("GATHER_SCAN_PER_ROW_NS", 2.06, k[1]),
+        ("GATHER_PUSH_PER_MATCH_NS", 2.24, k[2]),
+    ] {
+        println!("{name:<34}{shipped:>10.2}{got:>10.2}");
+    }
+
+    // Per-cell agreement under both constant sets. The fitted set should beat the shipped one on
+    // every cell; if it only wins on average, the split is still not doing real work.
+    println!("\n{:<22}{:>7}{:>14}{:>14}", "cell", "n", "shipped p/a", "fitted p/a");
+    let shipped = [6.88, 2.06, 2.24];
+    for c in &cells {
+        println!(
+            "{:<22}{:>7}{:>14.2}{:>14.2}",
+            c.label,
+            c.n_cards_req,
+            predict(c, shipped) / c.ns_loop,
+            predict(c, k) / c.ns_loop
+        );
+    }
+}

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -46,17 +46,32 @@
 //!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.90        (1.000x)
 //!     the card_pass call itself                 2.94-3.00 ns/card on singletons, 1.6-1.8 on wide
 //!
-//! Those last two lines are the finding, and they say the shipped constant is not simply wrong:
-//! 3.24 of loop overhead plus ~3.0 for the `card_pass` call is ~6.2 against a shipped 6.88, so
-//! `GATHER_CARD_PASS_NS` BUNDLES the predicate call. It is therefore about right for queries that
-//! make that call, and about 2x too high for the #634 `all_match_known` path, which skips
-//! `card_pass` entirely and is charged for it anyway. That is a model-shape error rather than a
-//! mis-fitted constant, and it over-costs `GatheredScan` precisely on the queries that should be
-//! cheapest for it — the direction that loses them to `StreamedSelect`.
+//! Those last two lines say the shipped constant is not simply wrong: 3.24 of loop overhead plus
+//! ~3.0 for the `card_pass` call is ~6.2 against a shipped 6.88, so `GATHER_CARD_PASS_NS` BUNDLES
+//! the predicate call. It is therefore about right for queries that make that call, and about 2x too
+//! high for the #634 `all_match_known` path, which skips `card_pass` entirely and is charged for it
+//! anyway — a model-shape error rather than a mis-fitted constant, and it over-costs `GatheredScan`
+//! precisely on the queries that should be cheapest for it.
 //!
-//! One limit remains on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
-//! behave as the page grows. Traffic-level regret and latency matrices remain the gate before any
-//! of it ships.
+//! **Shipping those constants FAILED the acceptance test, and that is the more important result.**
+//! Splitting the card term as measured and applying all three rates moved total routing regret
+//! 36.2 → 51.7 ms, with `candidates / artwork` going 19% → 35% of all lost time. The design had no
+//! artwork cell in it, and `cost.rs` applies one set of `GATHER_*` rates to all three modes.
+//!
+//! Adding artwork cells (E, F) shows why no single rate triple can work. Against the card/printing
+//! fit, artwork measures +19% and +36% on single-printing cards but −29% and −19% on wide ones: the
+//! surcharge FLIPS SIGN with printings-per-card. Artwork pushes ~2.4 matches/card where printing mode
+//! pushes ~6.9, and its per-printing group bookkeeping is cheaper than the push path it replaces, so
+//! it is dearer where cards are narrow and cheaper where they are wide. `ns_setup` is not the
+//! explanation either — the `group_best` allocation measures 83-125 ns, negligible.
+//!
+//! So P4's loop needs rates fitted PER MODE (or a term keyed on printings-per-card), not one triple
+//! plus a linear artwork correction. Until that exists, the shipped mode-blind constants are doing
+//! real work by being too high: they absorb artwork's cost, and lowering them to the card/printing
+//! truth under-costs artwork and loses more than it gains. The constants are deliberately unchanged.
+//!
+//! One further limit on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
+//! behave as the page grows.
 //!
 //!     cargo test --release bench_gather_loop -- --ignored --nocapture
 //!
@@ -103,6 +118,10 @@ struct Cell {
     /// fit; the rows that DO call `card_pass` are used to price that call instead, and mixing them
     /// would fold a predicate evaluation into the card term.
     ran_card_pass: bool,
+    /// Artwork mode maintains `group_best`/`touched` per printing on top of everything the other modes
+    /// do. Those rows are held out of the three-rate fit and priced against it, because pooling them
+    /// would smear a mode-specific cost across rates that cost.rs applies to all three modes.
+    artwork: bool,
 }
 
 /// Solve a 3×3 system by Gaussian elimination with partial pivoting.
@@ -131,7 +150,7 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
 /// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
 fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
     let mut normal = [[0.0f64; 4]; 3];
-    for c in cells.iter().filter(|c| !c.ran_card_pass) {
+    for c in cells.iter().filter(|c| !c.ran_card_pass && !c.artwork) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w, c.matches * w];
         for i in 0..3 {
@@ -220,19 +239,29 @@ fn bench_gather_loop() {
     // `card_pass` call itself. Their gap over the matching `true` row prices that call, which is what
     // `GATHER_RESIDUAL_FLOOR` is for; without it, lowering the card term would silently remove charge
     // that was covering a predicate evaluation on every non-all_match query.
-    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 7] = [
+    // The E/F rows are artwork mode, and they are here because leaving them out is what made the
+    // first attempt at these constants fail. cost.rs applies one set of GATHER_* rates to all three
+    // modes, but the artwork loop also maintains `group_best` and `touched` per printing, and P4 has
+    // no artwork term to carry that (P3 has STREAM_ARTWORK_SEEN_PER_CARD_NS). So the extra work was
+    // absorbed into the shipped rates, and a design covering only card and printing mode measured
+    // them low, under-costing artwork. Shipping that moved total routing regret 36.2 -> 51.7 ms, with
+    // candidates/artwork going 19% -> 35% of all lost time. Artwork has to be in the design for these
+    // rates to mean anything.
+    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 9] = [
         ("A 1p  card/default", &singleton, "card", "default", true),
         ("B 1p  print/default", &singleton, "printing", "default", true),
         ("C wide card/oldest", &wide, "card", "oldest", true),
         ("D wide print/default", &wide, "printing", "default", true),
+        ("E 1p  artwork/default", &singleton, "artwork", "default", true),
+        ("F wide artwork/default", &wide, "artwork", "default", true),
         ("A' 1p card/default ctl", &singleton, "card", "default", true),
         ("A+ 1p  card, card_pass", &singleton, "card", "default", false),
         ("C+ wide card, card_pass", &wide, "card", "oldest", false),
     ];
 
     println!(
-        "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}",
-        "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card"
+        "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}{:>11}",
+        "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card", "ns_setup"
     );
     // Every cell is built up front, then all of them are run inside ONE iteration loop, so each
     // cell's minimum is drawn from the same time window as every other cell's. Running a cell to
@@ -246,6 +275,7 @@ fn bench_gather_loop() {
         prep: PreparedCandidates,
         params: QueryParams,
         ran_card_pass: bool,
+        artwork: bool,
     }
     let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
@@ -264,10 +294,12 @@ fn bench_gather_loop() {
                 },
                 params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
                 ran_card_pass: !all_match_known,
+                artwork: *unique == "artwork",
             });
         }
     }
 
+    let mut best_setup: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
     for _ in 0..ITERS {
@@ -276,6 +308,12 @@ fn bench_gather_loop() {
             let s = take_phase_stats();
             if (s.ns_loop as f64) < best_ns[i] {
                 best_ns[i] = s.ns_loop as f64;
+            }
+            // Tracked because artwork mode allocates and zeroes a `max_artwork_groups`-long buffer
+            // here, which is O(corpus) work no loop rate can represent and which P4's cost arm carries
+            // only in a flat GATHER_FIXED_COST_NS.
+            if (s.ns_setup as f64) < best_setup[i] {
+                best_setup[i] = s.ns_setup as f64;
             }
             // Counters are deterministic per cell, so any iteration's are the cell's; recording them
             // every time rather than only on the fastest keeps them independent of which run won.
@@ -292,10 +330,18 @@ fn bench_gather_loop() {
             matches,
             ns_loop: best_ns[i],
             ran_card_pass: cfg.ran_card_pass,
+            artwork: cfg.artwork,
         };
         println!(
-            "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
-            cell.label, cell.n_cards_req, cell.cards, cell.printings, cell.matches, cell.ns_loop, cell.ns_loop / cell.cards
+            "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}{:>11.0}",
+            cell.label,
+            cell.n_cards_req,
+            cell.cards,
+            cell.printings,
+            cell.matches,
+            cell.ns_loop,
+            cell.ns_loop / cell.cards,
+            best_setup[i]
         );
         cells.push(cell);
     }
@@ -341,6 +387,23 @@ fn bench_gather_loop() {
         println!("\nsystem still singular — the design did not separate the columns");
         return;
     };
+    // What artwork mode costs ON TOP of the three fitted rates. cost.rs has no artwork term for P4,
+    // so today this sits inside the shared rates, which is why measuring them without artwork in the
+    // design and then lowering them under-costs artwork queries.
+    println!("\nartwork surcharge over the card/printing fit (P4 has no artwork term today):");
+    for c in cells.iter().filter(|c| c.artwork) {
+        let base = predict(c, k);
+        println!(
+            "  {:<26}{:>7}  measured {:>8.0} ns vs fit {:>8.0} ns   +{:>6.2} ns/printing  +{:>6.2} ns/card",
+            c.label,
+            c.n_cards_req,
+            c.ns_loop,
+            base,
+            (c.ns_loop - base) / c.printings,
+            (c.ns_loop - base) / c.cards
+        );
+    }
+
     println!("\n{:<34}{:>10}{:>10}", "rate", "shipped", "fitted");
     for (name, shipped, got) in [
         ("GATHER_CARD_PASS_NS", 6.88, k[0]),

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -1,5 +1,42 @@
 //! Micro-benchmark that decomposes `GatheredScan`'s match loop into its three rates.
 //!
+//! **Cache state fixed, and the rates are corpus-size dependent (2026-08-03).** Chunk ROTATION (each
+//! iteration walks a different slice) plus per-cell STAGGER (cells sharing a group walk different slices
+//! in the same iteration) means no walk inherits another's cache lines, and the reported rate is the
+//! MEDIAN over rotated chunks rather than the luckiest minimum. Both were needed: rotation alone still
+//! had cell A at 10.50 ns/card against cell B's 6.11 on identical cards, because every cell on a group
+//! walked the same chunk and the first paid all the misses. `scripts/upscale_corpus.py` supplies stores
+//! big enough to rotate (the real corpus gives the wide group ONE chunk at 4,500 cards), selected with
+//! `BENCH_LOOP_STORE`.
+//!
+//! Swept over 31,508 / 126,032 / 409,604 oracle cards:
+//!
+//!     P4  LOOP  ns/card         6.27   11.37   15.04     2.4x
+//!     P4  SCAN  ns/printing     2.27    3.03    2.24     flat
+//!     P4  PUSH  ns/match        1.51    4.94    6.98     4.6x
+//!     P3  all_match ns/card     2.58    2.54    2.55     FLAT
+//!     P3  residual  ns/card     5.08   11.33   18.15     3.6x
+//!     P3  SCAN  ns/printing     3.30    5.57   10.85     3.3x
+//!
+//! P3's all_match arm being flat across a 13x corpus is the check that the method works: that path reads
+//! only the card record and does offset arithmetic, so it has no misses to gain, while everything that
+//! walks printings grows 3x+. A rate is therefore not a property of the code alone -- it is a property of
+//! the code AND how much of the archive fits in cache, and `cost.rs` has no term for the second.
+//!
+//! At the production corpus size the shipped P4 constants are confirmed: LOOP 6.27 against 6.88 (9%
+//! low), SCAN 2.27 against 2.06 (10% high), PUSH 1.51 against 2.24. That is the retraction closed from
+//! the other side -- warm measurement said 2.98 and was wrong; cold measurement says 6.27 and agrees
+//! with what ships.
+//!
+//! P3 does NOT agree: 2.58 against a shipped 5.05 per card, 5.08 against 11.63 with a residual, 3.30
+//! against 5.97 per printing -- about 2x over-costed. Both plans were measured identically, so this is
+//! not a cache artifact, but it is measured on `ns_loop` ONLY, and P3's arm may be absorbing setup or
+//! finish cost that its loop never pays. That has to be ruled out before the gap is called an error.
+//!
+//! The routing consequence is the durable one: the plans' rates scale DIFFERENTLY with corpus size, so
+//! the P3/P4 balance drifts as the corpus grows even with every constant left alone. Any refit is
+//! calibrated to the corpus it was measured on.
+//!
 //! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
 //! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
 //! second pass every card, printing and string it touches is resident. Production walks a candidate set
@@ -150,7 +187,15 @@ const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
 /// keeps that contribution proportional to matches rather than to the page.
 const LIMIT: usize = 60;
 
-const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+/// Default store. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep runs: build
+/// upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn. The real corpus is
+/// only ~68 MB, small enough that a full chunk rotation can stay resident in the system-level cache, so
+/// the rates it yields are still partly warm however the walk is ordered.
+const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn store_path() -> String {
+    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
+}
 
 /// One measured design point: the realized counters, and the loop time they were produced by.
 struct Cell {
@@ -271,17 +316,19 @@ fn predict(c: &Cell, k: [f64; 3]) -> f64 {
 #[test]
 #[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
 fn bench_gather_loop() {
-    let Ok(file) = std::fs::File::open(STORE_PATH) else {
-        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+    let path = store_path();
+    let Ok(file) = std::fs::File::open(&path) else {
+        eprintln!("SKIP: {path} not found (see module docs)");
         return;
     };
     // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and
     // replaced atomically, and the header is re-validated below before the payload is trusted.
     let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
     if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
-        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        eprintln!("SKIP: {path} header mismatch (stale archive — rebuild it, see module docs)");
         return;
     }
+    println!("\nstore {path}  ({:.0} MB)", mmap.len() as f64 / (1024.0 * 1024.0));
     let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
     let ctx = QueryCtx::from(data);
 
@@ -379,10 +426,35 @@ fn bench_gather_loop() {
     struct Config {
         label: &'static str,
         n_cards_req: usize,
-        prep: PreparedCandidates,
+        /// The WHOLE group, not one slice of it. Each iteration walks a different chunk of `n_cards_req`
+        /// cards, so consecutive walks of a cell share no cards and cannot inherit each other's cache
+        /// lines. Holding one fixed slice and taking the minimum over 200 passes is what made every rate
+        /// here a warm-cache number, 1.6-2.2x under what the first pass costs.
+        group: Vec<u32>,
+        all_match_known: bool,
         params: QueryParams,
         ran_card_pass: bool,
         mode: &'static str,
+    }
+    impl Config {
+        /// Candidates for one iteration: a rotating window over the group, wrapping when it runs out. A
+        /// full rotation touches every card in the group before returning to the first chunk.
+        /// `stagger` is the cell's own index, so cells sharing a group walk DIFFERENT chunks within one
+        /// iteration. Without it every cell on a group walked the same chunk, the first paid all the
+        /// misses and the rest inherited warm lines -- which read as cell A costing 10.50 ns/card against
+        /// cell B's 6.11 on identical cards. `chunks` therefore has to exceed the number of cells sharing
+        /// a group, which the real corpus cannot supply at the larger card counts (the wide group holds
+        /// 8,036 cards, so one chunk at 4,500). That is what `scripts/upscale_corpus.py` is for.
+        fn prep_for(&self, iter: usize, stagger: usize) -> PreparedCandidates {
+            let chunks = (self.group.len() / self.n_cards_req).max(1);
+            let start = ((iter + stagger) % chunks) * self.n_cards_req;
+            let end = (start + self.n_cards_req).min(self.group.len());
+            PreparedCandidates {
+                candidate_cards: Some(self.group[start..end].to_vec()),
+                all_match_known: self.all_match_known,
+                narrowed_repr: NarrowedRepr::Cards,
+            }
+        }
     }
     let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
@@ -394,11 +466,8 @@ fn bench_gather_loop() {
             configs.push(Config {
                 label,
                 n_cards_req: n_req,
-                prep: PreparedCandidates {
-                    candidate_cards: Some(group[..n_req].to_vec()),
-                    all_match_known: *all_match_known,
-                    narrowed_repr: NarrowedRepr::Cards,
-                },
+                group: (*group).clone(),
+                all_match_known: *all_match_known,
                 params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
                 ran_card_pass: !all_match_known,
                 mode: unique,
@@ -411,13 +480,24 @@ fn bench_gather_loop() {
     // walks a candidate set once. If the first pass is materially slower than the minimum, these rates
     // describe a cache state production never sees, and that -- not a wrong feature -- is why shipping
     // them regresses. The counter/feature ratios all read 1.00, so the features are not the gap.
+    // Chunks per cell. Fewer than the number of cells sharing a group means some of them collide on a
+    // chunk within an iteration and the later one measures a warm walk, so this is printed rather than
+    // assumed -- it is the check that the store is big enough for the design.
+    println!("\nchunks available per cell (want more than the cells sharing each group):");
+    for cfg in &configs {
+        println!("  {:<24}{:>7}  {:>3} chunks of {} from {} cards", cfg.label, cfg.n_cards_req, (cfg.group.len() / cfg.n_cards_req).max(1), cfg.n_cards_req, cfg.group.len());
+    }
     let mut first_loop: Vec<f64> = vec![0.0; configs.len()];
     let mut best_setup: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
     let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
+    // One per-card sample per iteration. With chunk rotation every pass walks unfamiliar cards, so this
+    // distribution is the real one and its MEDIAN is the honest rate; the minimum is just its luckiest draw.
+    let mut per_card_samples: Vec<Vec<f64>> = vec![Vec::with_capacity(ITERS); configs.len()];
     for iter in 0..ITERS {
         for (i, cfg) in configs.iter().enumerate() {
-            black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &cfg.prep, None));
+            let prep = cfg.prep_for(iter, i);
+            black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &prep, None));
             let s = take_phase_stats();
             if iter == 0 {
                 first_loop[i] = s.ns_loop as f64;
@@ -425,6 +505,10 @@ fn bench_gather_loop() {
             if (s.ns_loop as f64) < best_ns[i] {
                 best_ns[i] = s.ns_loop as f64;
             }
+            // Per-card, since rotating chunks vary slightly in length at the group's tail. The MEDIAN of
+            // these is what the fit uses: with rotation every pass walks unfamiliar cards, so the
+            // distribution is the real one and the minimum is just its luckiest draw.
+            per_card_samples[i].push(s.ns_loop as f64 / (s.cards_visited.max(1)) as f64);
             // Tracked because artwork mode allocates and zeroes a `max_artwork_groups`-long buffer
             // here, which is O(corpus) work no loop rate can represent and which P4's cost arm carries
             // only in a flat GATHER_FIXED_COST_NS.
@@ -444,7 +528,13 @@ fn bench_gather_loop() {
             cards,
             printings,
             matches,
-            ns_loop: best_ns[i],
+            // Median per-card time x cards, so every downstream fit sees a typical rotated walk rather
+            // than the warmest one. `best_ns` is kept only to report the warm/typical gap.
+            ns_loop: {
+                let v = &mut per_card_samples[i];
+                v.sort_by(f64::total_cmp);
+                v[v.len() / 2] * cards
+            },
             ran_card_pass: cfg.ran_card_pass,
             mode: cfg.mode,
         };

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -38,24 +38,25 @@
 //! reimplemented, so there is no second copy of the loop to keep in sync, and the fit is
 //! against the instrumentation the cost model is actually checked with.
 //!
-//! What it measured (2026-08-03), stable to 1.07× / 1.02× / 1.04× across three runs where the
-//! traffic fit could not pin the push rate off the boundary at all:
+//! What it measured (2026-08-03), across three runs, where the traffic fit could not pin the push
+//! rate off the boundary at all:
 //!
-//!     GATHER_CARD_PASS_NS        shipped 6.88   fitted 3.08-3.30
-//!     GATHER_SCAN_PER_ROW_NS     shipped 2.06   fitted 2.44-2.48
-//!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.91-0.95
+//!     GATHER_CARD_PASS_NS        shipped 6.88   fitted 3.15-3.33   (1.06x spread)
+//!     GATHER_SCAN_PER_ROW_NS     shipped 2.06   fitted 2.25-2.26   (1.004x)
+//!     GATHER_PUSH_PER_MATCH_NS   shipped 2.24   fitted 0.90        (1.000x)
+//!     the card_pass call itself                 2.94-3.00 ns/card on singletons, 1.6-1.8 on wide
 //!
-//! The shipped set over-predicts every cell (1.07-1.92 predicted/actual) and over-predicts MOST
-//! on single-printing cards, least on wide card-mode ones — so `GatheredScan` is systematically
-//! over-costed on card-heavy candidate sets, which is the direction that loses it to
-//! `StreamedSelect` wrongly.
+//! Those last two lines are the finding, and they say the shipped constant is not simply wrong:
+//! 3.24 of loop overhead plus ~3.0 for the `card_pass` call is ~6.2 against a shipped 6.88, so
+//! `GATHER_CARD_PASS_NS` BUNDLES the predicate call. It is therefore about right for queries that
+//! make that call, and about 2x too high for the #634 `all_match_known` path, which skips
+//! `card_pass` entirely and is charged for it anyway. That is a model-shape error rather than a
+//! mis-fitted constant, and it over-costs `GatheredScan` precisely on the queries that should be
+//! cheapest for it — the direction that loses them to `StreamedSelect`.
 //!
-//! Two limits on reading these as drop-in replacements. `all_match_known` is set, so the loop
-//! never calls `card_pass` and the fitted card term is loop overhead with NO predicate evaluation
-//! in it — correct for the #634 path that also skips it, but queries reaching `card_pass` pay more,
-//! which is what the residual-tier term exists to cover. And `LIMIT` is fixed, so nothing here
-//! constrains how the rates behave as the page grows. Traffic-level regret and latency matrices
-//! remain the gate before any of this ships.
+//! One limit remains on all of these: `LIMIT` is fixed, so nothing here constrains how the rates
+//! behave as the page grows. Traffic-level regret and latency matrices remain the gate before any
+//! of it ships.
 //!
 //!     cargo test --release bench_gather_loop -- --ignored --nocapture
 //!
@@ -68,7 +69,7 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, exec_gathered_scan, take_phase_stats, CardData, CmpOp, FilterExpr, Mmap, NarrowedRepr,
-    PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
+    NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
 };
 
 /// Timed repetitions per cell; the minimum is reported, as elsewhere in these harnesses.
@@ -98,6 +99,10 @@ struct Cell {
     printings: f64,
     matches: f64,
     ns_loop: f64,
+    /// False when `all_match_known` short-circuited `card_pass`. Only these rows feed the three-rate
+    /// fit; the rows that DO call `card_pass` are used to price that call instead, and mixing them
+    /// would fold a predicate evaluation into the card term.
+    ran_card_pass: bool,
 }
 
 /// Solve a 3×3 system by Gaussian elimination with partial pivoting.
@@ -126,7 +131,7 @@ fn solve3(mut a: [[f64; 4]; 3]) -> Option<[f64; 3]> {
 /// cell and ignore the rest, which is the same mistake that inflated the finish-phase rate.
 fn fit(cells: &[Cell]) -> Option<[f64; 3]> {
     let mut normal = [[0.0f64; 4]; 3];
-    for c in cells {
+    for c in cells.iter().filter(|c| !c.ran_card_pass) {
         let w = 1.0 / c.ns_loop;
         let x = [c.cards * w, c.printings * w, c.matches * w];
         for i in 0..3 {
@@ -189,73 +194,110 @@ fn bench_gather_loop() {
     }
     println!();
 
-    // all_match_known short-circuits `card_pass`, so the residual tier is exactly zero and this
-    // filter is never evaluated — the loop is card visit + push + absorb and nothing else. That
-    // isolates the three rates from the residual term, which is fitted separately.
-    // `mask: 0` with `Ge` is unconditionally true, but nothing evaluates it either way.
-    let filter = FilterExpr::TypeCmp { mask: 0, op: CmpOp::Ge };
+    // `cmc >= -1` holds for every card, and cmc is a CARD field, so `card_pass` resolves it to
+    // Tri::True with an empty residual — the tier stays 0 and `push_card_matches` still gets
+    // `all_match = true`. On the `all_match_known` cells nothing evaluates it at all, so the loop is
+    // card visit + push + absorb and the three rates come out clean of any predicate cost. On the
+    // cells that clear that flag it IS evaluated, which is what prices the call.
+    //
+    // A real evaluated predicate rather than `FilterExpr::True`, deliberately: `True` short-circuits
+    // to nearly free and would price the call at ~0, and `NumericCmp` is what `bench_verify_cost`
+    // already classes as tier 0, so this is the cheapest predicate production actually runs.
+    let filter =
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Ge, rhs: NumExpr::Const(-1.0) };
     let mut cells: Vec<Cell> = Vec::new();
 
-    // (label, source group, unique, prefer)
+    // (label, source group, unique, prefer, all_match_known)
     //
     // A' repeats A last as a control. A and B are the same cards with one printing each and report
     // identical counters, so any time difference between them is either a real `unique` effect or an
     // artifact of A running first and paying first-touch on the mmap. A' vs A separates those: equal
     // means the difference is real, A' matching B means it was ordering.
-    let designs: [(&'static str, &Vec<u32>, &str, &str); 5] = [
-        ("A 1p  card/default", &singleton, "card", "default"),
-        ("B 1p  print/default", &singleton, "printing", "default"),
-        ("C wide card/oldest", &wide, "card", "oldest"),
-        ("D wide print/default", &wide, "printing", "default"),
-        ("A' 1p card/default ctl", &singleton, "card", "default"),
+    //
+    // The `false` rows are the same cells with `all_match_known` cleared, so `card_pass` actually
+    // runs. The filter answers `Tri::True` and leaves the residual empty, so `push_card_matches`
+    // still gets `all_match = true` and every counter is identical — the ONLY difference is the
+    // `card_pass` call itself. Their gap over the matching `true` row prices that call, which is what
+    // `GATHER_RESIDUAL_FLOOR` is for; without it, lowering the card term would silently remove charge
+    // that was covering a predicate evaluation on every non-all_match query.
+    let designs: [(&'static str, &Vec<u32>, &str, &str, bool); 7] = [
+        ("A 1p  card/default", &singleton, "card", "default", true),
+        ("B 1p  print/default", &singleton, "printing", "default", true),
+        ("C wide card/oldest", &wide, "card", "oldest", true),
+        ("D wide print/default", &wide, "printing", "default", true),
+        ("A' 1p card/default ctl", &singleton, "card", "default", true),
+        ("A+ 1p  card, card_pass", &singleton, "card", "default", false),
+        ("C+ wide card, card_pass", &wide, "card", "oldest", false),
     ];
 
     println!(
         "\n{:<22}{:>7}{:>10}{:>11}{:>10}{:>12}{:>11}",
         "cell", "n", "cards", "printings", "matches", "ns_loop", "ns/card"
     );
+    // Every cell is built up front, then all of them are run inside ONE iteration loop, so each
+    // cell's minimum is drawn from the same time window as every other cell's. Running a cell to
+    // completion before starting the next one lets machine drift between cells enter the fit as if it
+    // were a rate difference: doing exactly that moved the card term to 4.34 while three interleaved
+    // runs held it inside 3.08-3.30, and left two cells with identical counters differing 1.8×. Same
+    // reason the query-level harnesses interleave A/B/A/B instead of running all of A then all of B.
+    struct Config {
+        label: &'static str,
+        n_cards_req: usize,
+        prep: PreparedCandidates,
+        params: QueryParams,
+        ran_card_pass: bool,
+    }
+    let mut configs: Vec<Config> = Vec::new();
     for n_req in CARD_COUNTS {
-        for (label, group, unique, prefer) in &designs {
+        for (label, group, unique, prefer, all_match_known) in &designs {
             if group.len() < n_req {
                 println!("{label:<22}{n_req:>7}   SKIP (only {} cards in group)", group.len());
                 continue;
             }
-            let prep = PreparedCandidates {
-                candidate_cards: Some(group[..n_req].to_vec()),
-                all_match_known: true,
-                narrowed_repr: NarrowedRepr::Cards,
-            };
-            let params = QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0);
-            let mut best = f64::INFINITY;
-            let mut stats = take_phase_stats();
-            for _ in 0..ITERS {
-                black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
-                let s = take_phase_stats();
-                if (s.ns_loop as f64) < best {
-                    best = s.ns_loop as f64;
-                    stats = s;
-                }
-            }
-            let cell = Cell {
+            configs.push(Config {
                 label,
                 n_cards_req: n_req,
-                cards: stats.cards_visited as f64,
-                printings: stats.printings_examined as f64,
-                matches: stats.matches_pushed as f64,
-                ns_loop: best,
-            };
-            println!(
-                "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
-                cell.label,
-                cell.n_cards_req,
-                cell.cards,
-                cell.printings,
-                cell.matches,
-                cell.ns_loop,
-                cell.ns_loop / cell.cards
-            );
-            cells.push(cell);
+                prep: PreparedCandidates {
+                    candidate_cards: Some(group[..n_req].to_vec()),
+                    all_match_known: *all_match_known,
+                    narrowed_repr: NarrowedRepr::Cards,
+                },
+                params: QueryParams::from_strs(unique, prefer, "name", "asc", LIMIT, 0),
+                ran_card_pass: !all_match_known,
+            });
         }
+    }
+
+    let mut best_ns: Vec<f64> = vec![f64::INFINITY; configs.len()];
+    let mut counters: Vec<(f64, f64, f64)> = vec![(0.0, 0.0, 0.0); configs.len()];
+    for _ in 0..ITERS {
+        for (i, cfg) in configs.iter().enumerate() {
+            black_box(exec_gathered_scan(&ctx, &cfg.params, &filter, &cfg.prep, None));
+            let s = take_phase_stats();
+            if (s.ns_loop as f64) < best_ns[i] {
+                best_ns[i] = s.ns_loop as f64;
+            }
+            // Counters are deterministic per cell, so any iteration's are the cell's; recording them
+            // every time rather than only on the fastest keeps them independent of which run won.
+            counters[i] = (s.cards_visited as f64, s.printings_examined as f64, s.matches_pushed as f64);
+        }
+    }
+    for (i, cfg) in configs.iter().enumerate() {
+        let (cards, printings, matches) = counters[i];
+        let cell = Cell {
+            label: cfg.label,
+            n_cards_req: cfg.n_cards_req,
+            cards,
+            printings,
+            matches,
+            ns_loop: best_ns[i],
+            ran_card_pass: cfg.ran_card_pass,
+        };
+        println!(
+            "{:<22}{:>7}{:>10.0}{:>11.0}{:>10.0}{:>12.0}{:>11.2}",
+            cell.label, cell.n_cards_req, cell.cards, cell.printings, cell.matches, cell.ns_loop, cell.ns_loop / cell.cards
+        );
+        cells.push(cell);
     }
 
     assert!(cells.len() >= 3, "need at least 3 design points to identify 3 rates, got {}", cells.len());
@@ -271,6 +313,28 @@ fn bench_gather_loop() {
             c.printings / c.cards,
             c.matches / c.cards
         );
+    }
+
+    // What a `card_pass` call costs per card, from the cells that differ ONLY by whether it ran.
+    // This is the floor `GATHER_RESIDUAL_FLOOR` has to cover for a tier-0 predicate, and it has to be
+    // read alongside the card term rather than after it: the two are set together or the total drifts.
+    println!("\ncost of the card_pass call itself (paired cells, identical counters):");
+    for c in cells.iter().filter(|c| c.ran_card_pass) {
+        // The `+` label marks the card_pass variant of the cell whose label shares its first letter.
+        let base = cells
+            .iter()
+            .find(|b| !b.ran_card_pass && b.n_cards_req == c.n_cards_req && b.label.as_bytes()[0] == c.label.as_bytes()[0]);
+        match base {
+            Some(b) => println!(
+                "  {:<26}{:>7}  {:>9.0} ns vs {:>9.0} ns   {:>7.2} ns/card for card_pass",
+                c.label,
+                c.n_cards_req,
+                c.ns_loop,
+                b.ns_loop,
+                (c.ns_loop - b.ns_loop) / c.cards
+            ),
+            None => println!("  {:<26}{:>7}  no paired all_match cell", c.label, c.n_cards_req),
+        }
     }
 
     let Some(k) = fit(&cells) else {

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -1,6 +1,23 @@
 //! Micro-benchmark that decomposes `StreamedSelect`'s match loop, the companion to
 //! `bench_gather_loop`.
 //!
+//! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
+//! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
+//! second pass every card, printing and string it touches is resident. Production walks a candidate set
+//! once. Measuring the first pass against the warm minimum on cells that run after the mmap has faulted
+//! in gives 1.6-2.2x (A' 1.91x/1.74x, I 1.83x/1.59x, H 2.17x/2.14x; the 100x+ figures on the first cells
+//! are first-touch page faults on the 68 MB store, not cache effects).
+//!
+//! That 1.6-2x is the whole discrepancy. Warm 2.98 ns/card against 6.34 fitted on traffic is 2.1x; P3's
+//! warm 2.41 against a shipped 5.05 is 2.1x; the warm push 1.06 against 2.00 fitted is 1.9x. The
+//! counter/feature ratios all read 1.00, so the features were never the gap -- the TIME was, and the
+//! shipped constants include the miss cost this harness removes.
+//!
+//! So the five refits below did not fail because routing is a delicate joint surface. They failed
+//! because they lowered rates toward a cache state production never reaches. Read every ns figure in
+//! this file as "warm", useful for the SHAPE of the loop -- which terms exist, which are degenerate, how
+//! artwork differs -- and not as a candidate constant. Those shape findings stand; the levels do not.
+//!
 //! That harness established that P4 cannot be fixed alone: three successively better descriptions of
 //! its loop each REGRESSED routing (+43%, +8.8%, +40%), because `plan_cost` is only ever used
 //! comparatively and P4's inflated arm is absorbing an over-estimate on P3's side. So P3's loop gets

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -1,6 +1,43 @@
 //! Micro-benchmark that decomposes `StreamedSelect`'s match loop, the companion to
 //! `bench_gather_loop`.
 //!
+//! **Cache state fixed, and the rates are corpus-size dependent (2026-08-03).** Chunk ROTATION (each
+//! iteration walks a different slice) plus per-cell STAGGER (cells sharing a group walk different slices
+//! in the same iteration) means no walk inherits another's cache lines, and the reported rate is the
+//! MEDIAN over rotated chunks rather than the luckiest minimum. Both were needed: rotation alone still
+//! had cell A at 10.50 ns/card against cell B's 6.11 on identical cards, because every cell on a group
+//! walked the same chunk and the first paid all the misses. `scripts/upscale_corpus.py` supplies stores
+//! big enough to rotate (the real corpus gives the wide group ONE chunk at 4,500 cards), selected with
+//! `BENCH_LOOP_STORE`.
+//!
+//! Swept over 31,508 / 126,032 / 409,604 oracle cards:
+//!
+//!     P4  LOOP  ns/card         6.27   11.37   15.04     2.4x
+//!     P4  SCAN  ns/printing     2.27    3.03    2.24     flat
+//!     P4  PUSH  ns/match        1.51    4.94    6.98     4.6x
+//!     P3  all_match ns/card     2.58    2.54    2.55     FLAT
+//!     P3  residual  ns/card     5.08   11.33   18.15     3.6x
+//!     P3  SCAN  ns/printing     3.30    5.57   10.85     3.3x
+//!
+//! P3's all_match arm being flat across a 13x corpus is the check that the method works: that path reads
+//! only the card record and does offset arithmetic, so it has no misses to gain, while everything that
+//! walks printings grows 3x+. A rate is therefore not a property of the code alone -- it is a property of
+//! the code AND how much of the archive fits in cache, and `cost.rs` has no term for the second.
+//!
+//! At the production corpus size the shipped P4 constants are confirmed: LOOP 6.27 against 6.88 (9%
+//! low), SCAN 2.27 against 2.06 (10% high), PUSH 1.51 against 2.24. That is the retraction closed from
+//! the other side -- warm measurement said 2.98 and was wrong; cold measurement says 6.27 and agrees
+//! with what ships.
+//!
+//! P3 does NOT agree: 2.58 against a shipped 5.05 per card, 5.08 against 11.63 with a residual, 3.30
+//! against 5.97 per printing -- about 2x over-costed. Both plans were measured identically, so this is
+//! not a cache artifact, but it is measured on `ns_loop` ONLY, and P3's arm may be absorbing setup or
+//! finish cost that its loop never pays. That has to be ruled out before the gap is called an error.
+//!
+//! The routing consequence is the durable one: the plans' rates scale DIFFERENTLY with corpus size, so
+//! the P3/P4 balance drifts as the corpus grows even with every constant left alone. Any refit is
+//! calibrated to the corpus it was measured on.
+//!
 //! **RETRACTION (2026-08-03): every rate this harness reports is a WARM-CACHE rate, and the shipped
 //! constants are not too high.** `ITERS` walks one card list repeatedly and keeps the minimum, so by the
 //! second pass every card, printing and string it touches is resident. Production walks a candidate set
@@ -119,7 +156,13 @@ const LIMIT: usize = 60;
 /// or 1 per card (card mode, which returns at the first match) instead of a corpus-dependent fraction.
 const DATE_AFTER_EVERYTHING: u32 = 99_999_999;
 
-const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+/// Default store; `BENCH_LOOP_STORE` overrides it, same as `bench_gather_loop`, so both harnesses sweep
+/// the same upscaled stores from `scripts/upscale_corpus.py`.
+const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+fn store_path() -> String {
+    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
+}
 
 /// One measured design point.
 struct Cell {
@@ -192,15 +235,16 @@ fn fit_pair(cells: &[Cell], mode: &str, residual: bool) -> Option<[f64; 2]> {
 #[test]
 #[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
 fn bench_streamed_loop() {
-    let Ok(file) = std::fs::File::open(STORE_PATH) else {
-        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+    let path = store_path();
+    let Ok(file) = std::fs::File::open(&path) else {
+        eprintln!("SKIP: {path} not found (see module docs)");
         return;
     };
     // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and replaced
     // atomically, and the header is re-validated below before the payload is trusted.
     let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
     if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
-        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        eprintln!("SKIP: {path} header mismatch (stale archive — rebuild it, see module docs)");
         return;
     }
     let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
@@ -236,7 +280,10 @@ fn bench_streamed_loop() {
         n_cards_req: usize,
         mode: &'static str,
         residual: bool,
-        prep: PreparedCandidates,
+        /// The whole group; each iteration walks a different chunk and each CELL is staggered onto a
+        /// different chunk, so no walk inherits another's cache lines. Holding one slice and taking a
+        /// minimum is what made the earlier rates warm-cache numbers, ~2x under production.
+        group: Vec<u32>,
         params: QueryParams,
     }
     // (label, group, unique, residual). `all_match_known` is set only on the no-residual cells; with a
@@ -269,11 +316,7 @@ fn bench_streamed_loop() {
                 n_cards_req: n_req,
                 mode: unique,
                 residual: *residual,
-                prep: PreparedCandidates {
-                    candidate_cards: Some(group[..n_req].to_vec()),
-                    all_match_known: !residual,
-                    narrowed_repr: NarrowedRepr::Cards,
-                },
+                group: (*group).clone(),
                 params: QueryParams::from_strs(unique, "default", "name", "asc", LIMIT, 0),
             });
         }
@@ -283,12 +326,22 @@ fn bench_streamed_loop() {
     let mut best_setup = vec![f64::INFINITY; configs.len()];
     let mut best_finish = vec![f64::INFINITY; configs.len()];
     let mut counters = vec![(0.0, 0.0, 0.0); configs.len()];
-    for _ in 0..ITERS {
+    // Median across rotated chunks is the honest rate; with rotation every pass walks unfamiliar cards.
+    let mut per_card_samples: Vec<Vec<f64>> = vec![Vec::with_capacity(ITERS); configs.len()];
+    for iter in 0..ITERS {
         for (i, cfg) in configs.iter().enumerate() {
             let filter = if cfg.residual { &printing_residual } else { &no_residual };
-            black_box(exec_streamed_select(&ctx, &cfg.params, filter, &cfg.prep, None));
+            let chunks = (cfg.group.len() / cfg.n_cards_req).max(1);
+            let start = ((iter + i) % chunks) * cfg.n_cards_req;
+            let end = (start + cfg.n_cards_req).min(cfg.group.len());
+            let prep = PreparedCandidates {
+                candidate_cards: Some(cfg.group[start..end].to_vec()),
+                all_match_known: !cfg.residual,
+                narrowed_repr: NarrowedRepr::Cards,
+            };
+            black_box(exec_streamed_select(&ctx, &cfg.params, filter, &prep, None));
             let s = take_phase_stats();
-            best_loop[i] = best_loop[i].min(s.ns_loop as f64);
+            per_card_samples[i].push(s.ns_loop as f64 / (s.cards_visited.max(1)) as f64);
             best_setup[i] = best_setup[i].min(s.ns_setup as f64);
             best_finish[i] = best_finish[i].min(s.ns_finish as f64);
             counters[i] = (s.cards_visited as f64, s.printings_examined as f64, s.matches_pushed as f64);
@@ -311,7 +364,11 @@ fn bench_streamed_loop() {
             printings,
             matches,
             ns_setup: best_setup[i],
-            ns_loop: best_loop[i],
+            ns_loop: {
+                let v = &mut per_card_samples[i];
+                v.sort_by(f64::total_cmp);
+                v[v.len() / 2] * cards
+            },
             ns_finish: best_finish[i],
         };
         println!(

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -322,7 +322,6 @@ fn bench_streamed_loop() {
         }
     }
 
-    let mut best_loop = vec![f64::INFINITY; configs.len()];
     let mut best_setup = vec![f64::INFINITY; configs.len()];
     let mut best_finish = vec![f64::INFINITY; configs.len()];
     let mut counters = vec![(0.0, 0.0, 0.0); configs.len()];
@@ -400,7 +399,7 @@ fn bench_streamed_loop() {
         );
     }
 
-    println!("\n{:<34}{:>12}{:>16}{}", "fitted per (mode, residual)", "ns/card", "ns/printing", "   note");
+    println!("\n{:<34}{:>12}{:>16}   note", "fitted per (mode, residual)", "ns/card", "ns/printing");
     let mut recovered: Vec<(&str, f64, f64)> = Vec::new();
     for mode in ["card", "printing"] {
         for residual in [false, true] {

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -1,0 +1,349 @@
+//! Micro-benchmark that decomposes `StreamedSelect`'s match loop, the companion to
+//! `bench_gather_loop`.
+//!
+//! That harness established that P4 cannot be fixed alone: three successively better descriptions of
+//! its loop each REGRESSED routing (+43%, +8.8%, +40%), because `plan_cost` is only ever used
+//! comparatively and P4's inflated arm is absorbing an over-estimate on P3's side. So P3's loop gets
+//! the same built-design treatment, and the two arms move together.
+//!
+//! P3's loop is a different shape from P4's, and the difference decides the design:
+//!
+//!   - It has NO per-match cost. The loop writes `counts[cid] = c` and accumulates `total`; nothing is
+//!     pushed. `STREAM_EMIT_PER_MATCH_NS` belongs to `ns_finish`, not here.
+//!   - `scan_units` is GATED on a residual. Under `all_match` (and outside artwork mode)
+//!     `card_match_count` answers from offset arithmetic without touching a printing, so the loop is
+//!     O(cards) regardless of how many printings those cards have.
+//!
+//! Two rates instead of three is what makes this tractable where P4 was not. P4 needed three rates and
+//! no single mode could identify them, because card mode pushes once per card (`matches == cards`) and
+//! printing mode pushes every printing (`matches == printings`), so a column duplicated another in
+//! every mode. Two rates against three printings-per-card levels is identifiable INSIDE one mode, so
+//! P3 needs neither pooling nor the reparameterisation P4 required.
+//!
+//! The cells:
+//!
+//!     all_match, per mode      cards visited only; printings never touched. Isolates the per-card
+//!                              overhead with `card_pass` short-circuited and counting O(1).
+//!     residual, per mode       `card_pass` runs, returns PrintingDep, and `card_match_count` walks.
+//!                              Gives (CARD_PASS + tier floor) per card and SCAN per printing.
+//!
+//! The residual predicate is `DateCmp` against a date every printing satisfies. Release date is a
+//! PRINTING field, so `card_pass` cannot resolve it and must hand back a residual — which is the whole
+//! point, since an always-true CARD predicate would answer `Tri::True` and never walk. Every printing
+//! matching keeps the counters clean: `printings_examined` is the full span in printing mode, and in
+//! card mode it is 1 per card because `card_match_count` returns at the first qualifying printing.
+//! `DateCmp` is a `MASK_COMPARE_NS100` tier, the cheapest real residual, so the fitted per-card figure
+//! is a floor on `STREAM_RESIDUAL_FLOOR_NS` rather than a typical value.
+//!
+//! Calls the real `exec_streamed_select` and reads `ns_setup`/`ns_loop`/`ns_finish` and the counters
+//! off `PhaseStats` — same fenceposts and counters production publishes, nothing reimplemented.
+//!
+//!     cargo test --release bench_streamed_loop -- --ignored --nocapture
+//!
+//! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` and `bench_gather_loop`;
+//! rebuild it the same way (see `bench_verify_cost`'s module docs).
+
+use std::hint::black_box;
+
+use rkyv::Archived;
+
+use super::{
+    archive_header, archive_payload, exec_streamed_select, take_phase_stats, CardData, CmpOp, FilterExpr, Mmap, NarrowedRepr,
+    NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
+};
+
+/// Timed repetitions; the minimum per cell is reported, and all cells run inside this loop so every
+/// cell's minimum is drawn from the same time window. Running cells to completion one at a time let
+/// machine drift enter `bench_gather_loop`'s fit as a rate difference — 1.8× between cells with
+/// identical counters — so this interleaves from the start.
+const ITERS: usize = 200;
+/// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
+/// printings-per-card is what identifies two rates per mode with a degree of freedom left over.
+const WIDE_MIN_PRINTINGS: usize = 4;
+/// Card counts each cell runs at, bounded above by the scarce wide group. Two sizes measure linearity
+/// in the card term rather than assuming it.
+const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+/// Page requested. P3's `ns_finish` branches on `total` against `STREAM_MIN_MATCHES`, not on the page,
+/// so this only has to be small and fixed to keep the finish phase out of the loop measurement.
+const LIMIT: usize = 60;
+/// A release date no printing in the corpus reaches, so the residual predicate is always true. Keeps
+/// every printing matching, so `printings_examined` and `matches` are exactly the span (printing mode)
+/// or 1 per card (card mode, which returns at the first match) instead of a corpus-dependent fraction.
+const DATE_AFTER_EVERYTHING: u32 = 99_999_999;
+
+const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+/// One measured design point.
+struct Cell {
+    label: &'static str,
+    n_cards_req: usize,
+    mode: &'static str,
+    /// True for the cells whose `card_pass` runs and leaves a printing-dependent residual behind. The
+    /// two groups are fitted apart: with no residual the loop never walks a printing, so pooling them
+    /// would regress a real printing column against a phase that did not pay for it.
+    residual: bool,
+    cards: f64,
+    printings: f64,
+    matches: f64,
+    ns_setup: f64,
+    ns_loop: f64,
+    ns_finish: f64,
+}
+
+/// A single per-card rate for one group, for the groups where that is all the design can support.
+///
+/// Two of the four groups are degenerate, and measurement is what showed it rather than assumption.
+/// The `all_match` rows examine ZERO printings at every printings-per-card level, because
+/// `card_match_count` answers from offset arithmetic there -- so the printing column is identically
+/// zero and there is nothing to fit but the per-card rate. The `card` + residual rows examine exactly
+/// ONE printing per card at every level, because the kernel returns at the first qualifying printing --
+/// so the printing column DUPLICATES the card column and only their sum is identifiable. Reporting one
+/// number for those groups is the honest form; a two-parameter fit there would be picking arbitrarily
+/// from a ridge of equally good answers.
+fn fit_per_card(cells: &[Cell], mode: &str, residual: bool) -> Option<f64> {
+    let (mut num, mut den) = (0.0f64, 0.0f64);
+    for c in cells.iter().filter(|c| c.mode == mode && c.residual == residual) {
+        let w = 1.0 / c.ns_loop;
+        let x = c.cards * w;
+        num += x * (c.ns_loop * w);
+        den += x * x;
+    }
+    if den <= 0.0 {
+        return None;
+    }
+    Some(num / den)
+}
+
+/// Per-card and per-printing rates for one (mode, residual) group. Two unknowns, three ratio levels.
+fn fit_pair(cells: &[Cell], mode: &str, residual: bool) -> Option<[f64; 2]> {
+    let mut normal = [[0.0f64; 3]; 2];
+    let mut rows = 0;
+    for c in cells.iter().filter(|c| c.mode == mode && c.residual == residual) {
+        // Relative least squares: each equation divided by its own measured time, so a cell running
+        // 100 µs does not outweigh one running 5 µs.
+        let w = 1.0 / c.ns_loop;
+        let x = [c.cards * w, c.printings * w];
+        for i in 0..2 {
+            for j in 0..2 {
+                normal[i][j] += x[i] * x[j];
+            }
+            normal[i][2] += x[i] * (c.ns_loop * w);
+        }
+        rows += 1;
+    }
+    let det = normal[0][0] * normal[1][1] - normal[0][1] * normal[1][0];
+    if rows < 2 || det.abs() < 1e-12 {
+        return None;
+    }
+    Some([
+        (normal[0][2] * normal[1][1] - normal[0][1] * normal[1][2]) / det,
+        (normal[0][0] * normal[1][2] - normal[1][0] * normal[0][2]) / det,
+    ])
+}
+
+#[test]
+#[ignore = "micro-benchmark; needs benchmarks/verify-order/real.store (see module docs)"]
+fn bench_streamed_loop() {
+    let Ok(file) = std::fs::File::open(STORE_PATH) else {
+        eprintln!("SKIP: {STORE_PATH} not found (see module docs)");
+        return;
+    };
+    // Safety: same contract as bench_verify_cost / get_mmap() — written by rkyv::to_bytes and replaced
+    // atomically, and the header is re-validated below before the payload is trusted.
+    let mmap = unsafe { Mmap::map(&file) }.expect("mmap real.store");
+    if mmap.len() < ARCHIVE_HEADER_LEN || mmap[..ARCHIVE_HEADER_LEN] != archive_header() {
+        eprintln!("SKIP: {STORE_PATH} header mismatch (stale archive — rebuild it, see module docs)");
+        return;
+    }
+    let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+    let ctx = QueryCtx::from(data);
+
+    let (mut singleton, mut medium, mut wide): (Vec<u32>, Vec<u32>, Vec<u32>) = (Vec::new(), Vec::new(), Vec::new());
+    for cid in 0..data.cards.len() {
+        let span = u32::from(data.offsets[cid + 1]) as usize - u32::from(data.offsets[cid]) as usize;
+        if span == 1 {
+            singleton.push(cid as u32);
+        } else if span >= WIDE_MIN_PRINTINGS {
+            wide.push(cid as u32);
+        } else {
+            medium.push(cid as u32);
+        }
+    }
+    println!(
+        "\n{} oracle cards: {} with 1 printing, {} with 2..{WIDE_MIN_PRINTINGS}, {} with >={WIDE_MIN_PRINTINGS}",
+        data.cards.len(),
+        singleton.len(),
+        medium.len(),
+        wide.len()
+    );
+
+    // `cmc >= -1` is always true and lives on the CARD, so `card_pass` resolves it to Tri::True with an
+    // empty residual — the all_match-shaped cells. `DateCmp` is always true but lives on the PRINTING,
+    // so `card_pass` must return PrintingDep and the loop walks; that is the residual shape.
+    let no_residual = FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::Cmc), op: CmpOp::Ge, rhs: NumExpr::Const(-1.0) };
+    let printing_residual = FilterExpr::DateCmp { op: CmpOp::Lt, value: DATE_AFTER_EVERYTHING };
+
+    struct Config {
+        label: &'static str,
+        n_cards_req: usize,
+        mode: &'static str,
+        residual: bool,
+        prep: PreparedCandidates,
+        params: QueryParams,
+    }
+    // (label, group, unique, residual). `all_match_known` is set only on the no-residual cells; with a
+    // printing-dependent residual it must be false or the walk would be short-circuited and the cell
+    // would measure the other group again.
+    let designs: [(&'static str, &Vec<u32>, &str, bool); 12] = [
+        ("1p   card   all_match", &singleton, "card", false),
+        ("med  card   all_match", &medium, "card", false),
+        ("wide card   all_match", &wide, "card", false),
+        ("1p   print  all_match", &singleton, "printing", false),
+        ("med  print  all_match", &medium, "printing", false),
+        ("wide print  all_match", &wide, "printing", false),
+        ("1p   card   residual", &singleton, "card", true),
+        ("med  card   residual", &medium, "card", true),
+        ("wide card   residual", &wide, "card", true),
+        ("1p   print  residual", &singleton, "printing", true),
+        ("med  print  residual", &medium, "printing", true),
+        ("wide print  residual", &wide, "printing", true),
+    ];
+
+    let mut configs: Vec<Config> = Vec::new();
+    for n_req in CARD_COUNTS {
+        for (label, group, unique, residual) in &designs {
+            if group.len() < n_req {
+                println!("{label:<24}{n_req:>7}   SKIP (only {} cards in group)", group.len());
+                continue;
+            }
+            configs.push(Config {
+                label,
+                n_cards_req: n_req,
+                mode: unique,
+                residual: *residual,
+                prep: PreparedCandidates {
+                    candidate_cards: Some(group[..n_req].to_vec()),
+                    all_match_known: !residual,
+                    narrowed_repr: NarrowedRepr::Cards,
+                },
+                params: QueryParams::from_strs(unique, "default", "name", "asc", LIMIT, 0),
+            });
+        }
+    }
+
+    let mut best_loop = vec![f64::INFINITY; configs.len()];
+    let mut best_setup = vec![f64::INFINITY; configs.len()];
+    let mut best_finish = vec![f64::INFINITY; configs.len()];
+    let mut counters = vec![(0.0, 0.0, 0.0); configs.len()];
+    for _ in 0..ITERS {
+        for (i, cfg) in configs.iter().enumerate() {
+            let filter = if cfg.residual { &printing_residual } else { &no_residual };
+            black_box(exec_streamed_select(&ctx, &cfg.params, filter, &cfg.prep, None));
+            let s = take_phase_stats();
+            best_loop[i] = best_loop[i].min(s.ns_loop as f64);
+            best_setup[i] = best_setup[i].min(s.ns_setup as f64);
+            best_finish[i] = best_finish[i].min(s.ns_finish as f64);
+            counters[i] = (s.cards_visited as f64, s.printings_examined as f64, s.matches_pushed as f64);
+        }
+    }
+
+    let mut cells: Vec<Cell> = Vec::new();
+    println!(
+        "\n{:<24}{:>7}{:>9}{:>11}{:>10}{:>10}{:>11}{:>10}{:>10}",
+        "cell", "n", "cards", "printings", "matches", "ns_setup", "ns_loop", "ns/card", "ns_finish"
+    );
+    for (i, cfg) in configs.iter().enumerate() {
+        let (cards, printings, matches) = counters[i];
+        let cell = Cell {
+            label: cfg.label,
+            n_cards_req: cfg.n_cards_req,
+            mode: cfg.mode,
+            residual: cfg.residual,
+            cards,
+            printings,
+            matches,
+            ns_setup: best_setup[i],
+            ns_loop: best_loop[i],
+            ns_finish: best_finish[i],
+        };
+        println!(
+            "{:<24}{:>7}{:>9.0}{:>11.0}{:>10.0}{:>10.0}{:>11.0}{:>10.2}{:>10.0}",
+            cell.label,
+            cell.n_cards_req,
+            cell.cards,
+            cell.printings,
+            cell.matches,
+            cell.ns_setup,
+            cell.ns_loop,
+            cell.ns_loop / cell.cards.max(1.0),
+            cell.ns_finish
+        );
+        cells.push(cell);
+    }
+
+    // The design's leverage, stated rather than assumed. The all_match rows are the check that P3's
+    // loop really is O(cards): printings-per-card varies ~7x across them while the printing column
+    // should stay near zero, because `card_match_count` answers from offset arithmetic there.
+    println!("\nprintings examined per card (all_match rows should stay ~0 -- the loop never walks):");
+    for c in &cells {
+        println!(
+            "  {:<24}{:>7}  printings/card {:>6.2}   matches/card {:>6.2}",
+            c.label,
+            c.n_cards_req,
+            c.printings / c.cards.max(1.0),
+            c.matches / c.cards.max(1.0)
+        );
+    }
+
+    println!("\n{:<34}{:>12}{:>16}{}", "fitted per (mode, residual)", "ns/card", "ns/printing", "   note");
+    let mut recovered: Vec<(&str, f64, f64)> = Vec::new();
+    for mode in ["card", "printing"] {
+        for residual in [false, true] {
+            let tag = format!("{mode} / {}", if residual { "residual" } else { "all_match" });
+            // Only printing-mode-with-residual has a non-degenerate printing column; everything else
+            // gets the one rate it can support, with why printed alongside so the table is readable
+            // without the source.
+            match (mode, residual) {
+                ("printing", true) => match fit_pair(&cells, mode, residual) {
+                    Some(pair) => {
+                        println!("{tag:<34}{:>12.2}{:>16.2}   both identifiable", pair[0], pair[1]);
+                        recovered.push(("printing/residual", pair[0], pair[1]));
+                    }
+                    None => println!("{tag:<34}   pair not identifiable"),
+                },
+                _ => {
+                    let why = if residual { "printings==cards, so this is their SUM" } else { "printings==0, no printing term exists" };
+                    match fit_per_card(&cells, mode, residual) {
+                        Some(per_card) => {
+                            println!("{tag:<34}{per_card:>12.2}{:>16}   {why}", "--");
+                            recovered.push((if residual { "card/residual" } else { "all_match" }, per_card, 0.0));
+                        }
+                        None => println!("{tag:<34}   no cells"),
+                    }
+                }
+            }
+        }
+    }
+
+    // Cross-check, the counterpart to bench_gather_loop's two independent recoveries of PUSH. Card mode
+    // with a residual examines exactly one printing per card, so its single fitted rate must equal
+    // printing mode's per-card PLUS per-printing. Those come from different cells and different
+    // columns, so agreement is a test of whether the loop is linear in these two counters at all.
+    let card_resid = recovered.iter().find(|r| r.0 == "card/residual").map(|r| r.1);
+    let print_resid = recovered.iter().find(|r| r.0 == "printing/residual").copied();
+    if let (Some(cr), Some((_, pc, pp))) = (card_resid, print_resid) {
+        let predicted = pc + pp;
+        println!("\ncross-check (independent cells, independent columns):");
+        println!("  card/residual fitted directly          {cr:>7.2} ns/card");
+        println!("  printing/residual per-card + per-row   {predicted:>7.2} ns/card  ({pc:.2} + {pp:.2})");
+        let (lo, hi) = (cr.min(predicted), cr.max(predicted));
+        println!("  spread {:>.2}x  (linearity in these two counters requires these to agree)", hi / lo.max(1e-9));
+    }
+
+    println!(
+        "\n  shipped: STREAM_CARD_PASS_NS 5.05 per card, STREAM_SCAN_PER_ROW_NS 5.97 per printing,\n  \
+         STREAM_RESIDUAL_FLOOR_NS 6.58 added per card when a residual exists. So the residual rows here\n  \
+         compare against 5.05 + 6.58 = 11.63 per card, and the all_match rows against 5.05 with no\n  \
+         printing term at all -- which the zero printing column above confirms is the right shape."
+    );
+}

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -35,6 +35,37 @@
 //! `DateCmp` is a `MASK_COMPARE_NS100` tier, the cheapest real residual, so the fitted per-card figure
 //! is a floor on `STREAM_RESIDUAL_FLOOR_NS` rather than a typical value.
 //!
+//! What both harnesses together establish, which is the point of having them (2026-08-03).
+//!
+//! P3's loop is over-costed like P4's, and by more: 5.05 shipped against 2.41 measured per card on the
+//! all_match path, 11.63 (5.05 + the 6.58 floor) against 4.32 with a residual, 5.97 against 2.92 per
+//! printing. So BOTH scan arms are inflated ~2-3x as rates.
+//!
+//! Five refits were then taken through the regret gate, interleaved A/B/A/B:
+//!
+//!     P4 mode-blind triple                      +43%
+//!     P4 pooled + artwork arm                  +8.8%
+//!     P4 reparameterised                        +40%
+//!     P3 and P4 both refit                      +30%
+//!     ... plus symmetric residual floors        +90%
+//!
+//! Every one regressed, and the best was the one that moved LEAST from the shipped values. Two of the
+//! attempts were diagnosed and corrected mid-flight -- artwork needed its own arm, and leaving P4's
+//! residual floor at 18.89 while P3's went to 1.91 was an asymmetry that sent
+//! `StreamedSelect -> GatheredScan` from 407 queries at 38% of lost time to 653 at 44%. Fixing that
+//! asymmetry then made things worse still, because 18.89 was load-bearing despite being unmeasured.
+//!
+//! The conclusion is not about any constant. Every rate here is now measured against realized counters
+//! on a built design, and the rates are demonstrably wrong while the PRODUCTS they form are roughly
+//! right -- which is the signature of compensating error in the FEATURES, not the rates. `plan_cost`
+//! multiplies a rate by an estimate; a rate 2x high against an estimate 2x low predicts correctly and
+//! routes correctly, and correcting only the rate breaks it. The shipped constants are a jointly-tuned
+//! routing surface, not a set of independently valid ns figures, and that is why they have survived.
+//!
+//! So the next work is on the estimators (`eval_domain`, `scan_units`, `matches`) graded against the
+//! realized counters these harnesses publish -- not another refit. Correcting a feature and its rate
+//! TOGETHER is the only move that can hold the products fixed while making both halves true.
+//!
 //! Calls the real `exec_streamed_select` and reads `ns_setup`/`ns_loop`/`ns_finish` and the counters
 //! off `PhaseStats` — same fenceposts and counters production publishes, nothing reimplemented.
 //!

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -517,10 +517,12 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let limit = f64::from(f.limit);
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
 
-    // Printings walked to fill the page in a forward-permutation walk (both printing-space plans):
-    // roughly `page_span` rows at density `match_rate`.
-    let match_rate = (matches / n_printings).max(MATCH_RATE_FLOOR);
-    let printings_walked = page_span / match_rate;
+    // Printings walked to fill the page in a forward-permutation walk (both printing-space plans).
+    // Calls the shared `printings_walked` rather than recomputing `page_span / match_rate`: this was
+    // a second copy of that formula, and adding WALK_LENGTH_BIAS to the function alone changed what
+    // harnesses were TOLD without changing what the router CHARGED. `fit_cost_model`'s mirror check
+    // caught it as a 3.7% disagreement; there is now one definition.
+    let printings_walked = self::printings_walked(f);
     match plan {
         // #695 bare range, unique=printing: total is the range index's `k` (no synth, no popcount pass),
         // page is a forward permutation walk. So just the walk + fixed setup.

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -547,7 +547,8 @@ const WALK_LENGTH_BIAS: f64 = 1.45;
 
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
-    let n_printings = f64::from(f.n_printings);
+    // `n_printings` is no longer bound here: it was only feeding the local copy of the walk-length
+    // formula, which now calls `printings_walked` so there is one definition of it.
     let matches = f64::from(f.matches);
     let eval_domain = f64::from(f.eval_domain);
     let scan_units = f64::from(f.scan_units);

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -146,6 +146,31 @@ pub(crate) struct PlanFeatures {
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
     pub popcount_words: u32,
+    /// Set printings `gather_composed_page`'s GROUPING arm processes, or `0` when that arm is not the
+    /// one that runs.
+    ///
+    /// The Gather arm charged three things: a per-candidate-card pass, a per-printing bit test at
+    /// 0.38ns ("a cheap bit test, not a real residual scan"), and a per-match push. That describes
+    /// the printing-mode arm, which really does just test a bit and push. It does not describe the
+    /// `Mode::Card | Mode::Artwork` arm, which for every SET printing also reads the artwork group id,
+    /// computes `prefer_score`, and compares against `group_best` — real work, none of it a bit test.
+    ///
+    /// The unit is the load-bearing part. `matches` in artwork mode is the DEDUPED artwork count, so
+    /// `COMPOSE_GATHER_PUSH_PER_MATCH_NS` charges once per surviving group, while the grouping work
+    /// scales with the PRE-dedup printing matches feeding it. A card with twelve printings across two
+    /// artworks pays twelve groupings and two pushes. That is the same class of error
+    /// `bench_feature_accuracy` was written for, mirrored: there a printing count drove a per-result
+    /// term, here a deduped count drives a term whose work is pre-dedup.
+    ///
+    /// Measured consequence before this term existed: over 129 queries where compose was picked and
+    /// lost to GatheredScan, compose's real/predicted was **3.07** — 89% of the lost time in artwork,
+    /// 94% on the Gather branch, and every one of the five worst a single bare `f:` legality leaf at
+    /// ~300us. `PrintingCompose -> GatheredScan` is 99% miss and 11% of ALL routing regret.
+    ///
+    /// `0` for printing mode (the push term already covers its per-set-printing work, since `matches`
+    /// there IS the printing count) and for card mode under `Prefer::Default`, which takes the
+    /// early-break arm instead and never groups.
+    pub gather_group_printings: u32,
     /// Printings the #744 orderby walk's BUCKET SCAN covers before the page can fill, or `0` when the
     /// walk is not the branch (or its buckets are cheap value runs).
     ///
@@ -475,11 +500,24 @@ const COMPOSE_WALK_STEP_NS: f64 = 0.58;
 /// Per row emitted by the Perm / OrderbyWalk page fill.
 const COMPOSE_WALK_EMIT_PER_ROW_NS: f64 = 2.19;
 /// Per candidate card visited by `gather_composed_page`.
-const COMPOSE_GATHER_CARD_PASS_NS: f64 = 9.81;
+///
+/// Raised from 9.81 on 2026-08-03. `fit_cost_model` has wanted this higher in every run it was asked
+/// (1.23x, 1.35x, 1.60x across seeds) and it is the dominant term for the queries that dominate
+/// compose's regret: a bare `f:` legality leaf under `unique=artwork` puts `eval_domain` at nearly the
+/// whole corpus, so 31,508 candidate cards times a 3.4ns error is ~108us on ONE query. Those queries
+/// measure ~300us and `PrintingCompose -> GatheredScan` is 99% miss.
+///
+/// Its own constant, not shared with `GatheredScan`'s `GATHER_CARD_PASS_NS` (6.88) — the two loops do
+/// different per-card work, and moving this does not disturb that plan.
+const COMPOSE_GATHER_CARD_PASS_NS: f64 = 13.22;
 /// Per printing bit-tested against `pbits` inside the gather.
 const COMPOSE_GATHER_BITTEST_PER_PRINTING_NS: f64 = 0.38;
 /// Per match pushed into the bounded GatherSelect accumulator.
 const COMPOSE_GATHER_PUSH_PER_MATCH_NS: f64 = 3.39;
+/// Per SET printing the grouping arm scores and compares — see `gather_group_printings` for why this
+/// is not the bit-test rate and not the push rate. Cheaper than a push (no `sort_key_bits`, no
+/// buffer growth) and dearer than a bit test (a struct read plus `prefer_score`); fitted below.
+const COMPOSE_GATHER_GROUP_PER_PRINTING_NS: f64 = 1.5;
 /// Per-query setup for the compose fastpath.
 const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 
@@ -561,6 +599,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 super::ComposePaging::Gather => {
                     eval_domain * COMPOSE_GATHER_CARD_PASS_NS
                         + f64::from(f.compose_scan_printings) * COMPOSE_GATHER_BITTEST_PER_PRINTING_NS
+                        + f64::from(f.gather_group_printings) * COMPOSE_GATHER_GROUP_PER_PRINTING_NS
                         + matches * COMPOSE_GATHER_PUSH_PER_MATCH_NS
                 }
                 // The fastpath will refuse this query, so there is no page term to charge. Infinity

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -146,6 +146,21 @@ pub(crate) struct PlanFeatures {
     /// that keeps the popcount term honest across distinct-ons: `n_printings/64` (printing),
     /// `n_cards/64` (card), `n_artworks/64` (artwork). Set by `PrintingCompose`; `0` elsewhere.
     pub popcount_words: u32,
+    /// Printings the #744 orderby walk's BUCKET SCAN covers before the page can fill, or `0` when the
+    /// walk is not the branch (or its buckets are cheap value runs).
+    ///
+    /// The Perm and OrderbyWalk branches shared `printings_walked` — `page_span / match_rate`, a
+    /// page-fill length in MATCH units. That describes the permutation walk and does not describe a
+    /// bucket walk at all: `walk_rarity_orderby_page`'s interior buckets are one-hot PLANES, so a
+    /// single bucket ANDs `words_per_plane` words of the whole corpus whether two matches survive or
+    /// twenty thousand. Measured against the raw units actually scanned, the shared formula reads a
+    /// median 0.25 with spread 400 — it under-charges the walk ~4x, and under-charging is what
+    /// over-picks a plan.
+    ///
+    /// `usd` needs none of this: its buckets are value runs off the range index, small and
+    /// proportional to matches, which is the shape `printings_walked` already has. So this is `0`
+    /// there and the shared term stands.
+    pub orderby_walk_scan: u32,
     /// Which of `PrintingCompose`'s three paging strategies will actually run (see `ComposePaging`),
     /// decided the same way `printing_compose_fastpath` decides. The three have different cost shapes
     /// — the permutation walk and the #744 orderby-index walk are both offset-dependent (fill the page
@@ -475,8 +490,22 @@ const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));
     let match_rate = (f64::from(f.matches) / f64::from(f.n_printings.max(1))).max(MATCH_RATE_FLOOR);
-    page_span / match_rate
+    page_span / match_rate * WALK_LENGTH_BIAS
 }
+
+/// The closed form above assumes matches are spread UNIFORMLY along the walk order, so a page of
+/// `page_span` rows arrives after `page_span / match_rate` printings. They are not: the permutation
+/// orders cards by the sort column, and matches cluster within that order, so the walk runs longer
+/// than uniform spacing predicts before the page fills.
+///
+/// Measured against `printings_examined` once the walk branches began reporting it, the raw form
+/// reads a median 0.69 -- consistently under on all three acquires that reach a walk
+/// (`printing_range_scan` 0.66, `printing_compose` 0.67, `card_range_popcount` 0.74), which is what
+/// makes it a bias worth dividing out rather than three separate errors.
+///
+/// Bias only. The spread stays wide (p90/p10 ~10-18) because how matches clump along a sort order is
+/// not something a density ratio can see, and no constant will fix that.
+const WALK_LENGTH_BIAS: f64 = 1.45;
 
 pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     let n_cards = f64::from(f.n_cards);
@@ -515,7 +544,9 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // which is exactly why the COMPOSE_GATHER breadth gate is bypassed for it — broad is its
                 // best case, not its worst.
                 super::ComposePaging::Perm | super::ComposePaging::OrderbyWalk => {
-                    printings_walked * COMPOSE_WALK_STEP_NS  // walk to fill the page
+                    // `orderby_walk_scan` is 0 for Perm and for the usd walk, so this is the shared
+                    // page-fill term unless a bucket scan dominates it — see the field's doc.
+                    printings_walked.max(f64::from(f.orderby_walk_scan)) * COMPOSE_WALK_STEP_NS  // walk to fill the page
                         + limit * COMPOSE_WALK_EMIT_PER_ROW_NS  // emit one page of rows
                 }
                 // gather_composed_page: visits every candidate (eval_domain, same rate GatheredScan's

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -40,8 +40,7 @@
 //! the per-card `card_pass` term is driven by `eval_domain` (candidate cards) and
 //! the per-row residual scan + its verify `tier` by `scan_units` (printings under the
 //! candidate cards). One mode-agnostic formula, and `scan_units()` no longer branches
-//! on mode at all: the `printings_scanned` counter shows the scan plans walk the full
-//! printing span of their candidates in CARD mode too, not one row each. The `_CARD_PASS`/`_SCAN` split of the old lumped
+//! on mode at all. The `_CARD_PASS`/`_SCAN` split of the old lumped
 //! `VISIT` constants was fit to hold card unchanged while correcting printing (see
 //! each constant's doc). Artwork rides the printing path (same all-printings scan);
 //! its confirming validation is still pending a bench run.
@@ -54,6 +53,27 @@
 //! rare). The `_CARD_PASS`/`_SCAN`/`PUSH` split is a physical prior resolving what
 //! data alone cannot. Model sits at ~1.4× absolute (slow bucket), ordering-correct
 //! (argmin==gold 87/88) — the identifiable ceiling for this workload.
+//!
+//! ## What the span counter could and could not show (2026-08-02)
+//!
+//! The paragraph above used to justify the mode-agnostic `scan_units` by asserting that "the
+//! `printings_scanned` counter shows the scan plans walk the full printing span of their candidates in
+//! CARD mode too, not one row each". That inference does not hold, and the sentence is now deleted
+//! rather than merely qualified: the counter (since renamed `printing_span`) was computed by the
+//! CALLER as `end - start` per surviving card, before the match kernel ran, so it reported the span
+//! whatever the kernel then did. It could not distinguish the two cases it was being cited for.
+//!
+//! The kernels do stop early in card mode. `card_match_count` returns from `all_match` without reading
+//! a printing at all, and both it and `push_card_matches` return at the FIRST qualifying printing
+//! under `Prefer::Default`. `printings_examined`, reported by the kernels themselves, is the quantity
+//! `scan_units` predicts, and grading against it is what `bench_feature_accuracy.py` now does.
+//!
+//! The mode-agnostic span estimate nonetheless survives that correction, for a reason the original
+//! note did not give: under an INEXACT narrowing most candidate cards do not match, and a
+//! non-matching card is ruled out only after its whole span is walked. So the span is a good proxy in
+//! card mode generally (`scan_units [candidates] / card` grades p50 1.00 against `printings_examined`)
+//! and wrong specifically where the narrowing is EXACT — the plane acquire, where `all_match` holds
+//! and `prefer` then decides everything. That case is handled in `acquire_plan_features`.
 
 use super::*;
 
@@ -73,10 +93,17 @@ pub(crate) struct PlanFeatures {
     /// candidate count when `prepare_candidates` produced a list, else `n_cards`.
     pub eval_domain: u32,
     /// Printings under the candidate cards — the dominant P3/P4 driver, and the same
-    /// quantity in all three distinct-ons. Card mode was long assumed to break at the
-    /// first matching printing (`scan_units ≈ eval_domain`); measured against
-    /// `printings_scanned`, that read 0.25-0.33 for both GatheredScan and StreamedSelect
-    /// while `eval_domain · n_printings/n_cards` reads 0.90-1.02 in every mode.
+    /// quantity in all three distinct-ons.
+    ///
+    /// Card mode DOES break at the first matching printing, so the `0.25-0.33` this note used to cite
+    /// against `printings_scanned` was the counter's artifact, not the feature's error — see the module
+    /// header. Graded against `printings_examined` the span estimate reads p50 1.00 in card mode
+    /// anyway, because an inexact narrowing makes non-matching candidates walk their whole span.
+    ///
+    /// `prefer` is the one thing this cannot see: it decides whether the kernels may break early at
+    /// all, and `PlanFeatures` does not carry it. That is invisible under an inexact narrowing (the
+    /// non-matching cards dominate either way) and decisive under an exact one, which is why the plane
+    /// branch of `acquire_plan_features` sets this field itself rather than taking the span estimate.
     pub scan_units: u32,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
@@ -88,22 +115,13 @@ pub(crate) struct PlanFeatures {
     ///
     /// `scan_units` is every printing under a candidate card — right for GatheredScan and
     /// StreamedSelect, which must test each one. Compose walks the set bits of the composed bitmap
-    /// instead, so it touches `printing_matches`. Measured against `printings_scanned`, compose reads
+    /// instead, so it touches `printing_matches`. Measured against `printing_span`, compose reads
     /// 1.00 on `matches` in printing mode and 1.00-1.01 on `project_printings` in artwork (the same
     /// value), while `scan_units` reads 2.0-2.8 for it.
     ///
     /// Sharing one feature between the two forced a compromise that was ~2x wrong for whichever arm
     /// lost: with the value GatheredScan needs, compose over-counts 2x; with compose's, the scan plans
     /// under-count 3.3x.
-    /// Printings compose's **Gather** paging branch bit-tests, which is NOT `scan_units`.
-    ///
-    /// `scan_units` is every printing under a candidate card -- right for GatheredScan and
-    /// StreamedSelect, which must test each one. Compose walks the set bits of the bitmap it just
-    /// built, so it touches `printing_matches`. Measured against `printings_scanned`, compose reads
-    /// 1.00 on `matches` in printing mode and 1.00-1.01 on `project_printings` in artwork (the same
-    /// value), while `scan_units` reads 2.0-2.8 for it.
-    ///
-    /// Sharing one feature between the two forced a compromise ~2x wrong for whichever arm lost.
     pub compose_scan_printings: u32,
     /// Page size (`limit`).
     pub limit: u32,
@@ -264,7 +282,17 @@ pub(crate) fn materialize_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
 /// ridge-anchored to the previous values because several columns barely vary on this corpus and
 /// are collinear with the intercept. Fitted on ~10k distinct feature vectors, stable to <3% across
 /// independent seeds. Median measured/predicted moved 1.78 -> 1.00 (P4) and 1.69 -> 1.06 (P3).
-const STREAM_CARD_PASS_NS: f64 = 6.46;
+///
+/// Refit again 2026-08-02, and this is the first fit of P3 that was allowed to happen: every earlier
+/// run of `fit_cost_model.py` REFUSED to fit this plan, because its `counter_check` graded
+/// `scan_units` against the printing SPAN, and P3's `all_match` rows disagree with the span by ~3x
+/// over a term this arm multiplies by zero (`if tier_ns > 0.0`). With `printings_examined` reported
+/// by the match kernels and the zero-weight rows excluded, all six counter checks read 1.00 and the
+/// fit ran: median predicted/measured 0.63 -> 0.92 and within-25% 19% -> 58% over 29,084 rows /
+/// 9,867 distinct shapes. P3 had been under-costed ~1.6x, which biases the router toward picking it.
+/// P4 and compose were re-fit in the same run and NOT changed: P4's fitted values reproduce these
+/// within 8% with no agreement gain, and compose's fit makes its median worse (0.95 -> 0.86).
+const STREAM_CARD_PASS_NS: f64 = 5.05;
 
 /// P3's per-scanned-row cost, charged ONLY when a residual is present.
 ///
@@ -286,7 +314,7 @@ const STREAM_CARD_PASS_NS: f64 = 6.46;
 ///
 /// This one is NOT common-mode with P4 — P4 pays `GATHER_SCAN_PER_ROW_NS` unconditionally — so
 /// unlike the verify tier it can move the argmin between the two.
-const STREAM_SCAN_PER_ROW_NS: f64 = 5.53;
+const STREAM_SCAN_PER_ROW_NS: f64 = 5.97;
 
 
 /// Per-card cost of RUNNING `card_pass` at all, on top of whatever the residual's own nodes cost.
@@ -322,11 +350,11 @@ const STREAM_SCAN_PER_ROW_NS: f64 = 5.53;
 /// That same regression also shows the residual's cost is per CARD, not per printing scanned: the
 /// SLOPE against printings-per-card is ~3.5 for every tier including none (P4) and ~2 for P3, i.e.
 /// independent of what the residual is. So the tier belongs on `eval_domain`, as it now sits.
-const STREAM_RESIDUAL_FLOOR_NS: f64 = 8.18;
+const STREAM_RESIDUAL_FLOOR_NS: f64 = 6.58;
 /// ns per match, for the permutation-walk emit. Small — P3 measured nearly flat
 /// in match count once eval_domain is fixed (see STREAM_MATCH_PHASE_PER_CARD_NS),
 /// so this is a minor term.
-const STREAM_EMIT_PER_MATCH_NS: f64 = 0.13;
+const STREAM_EMIT_PER_MATCH_NS: f64 = 0.12;
 /// ns per candidate card that ARTWORK mode pays and the other two do not.
 ///
 /// `card_match_count`'s artwork arm keeps a per-card `seen_words` bitmask to dedupe artwork groups,
@@ -346,14 +374,14 @@ const STREAM_EMIT_PER_MATCH_NS: f64 = 0.13;
 /// Two independently fitted per-card terms, both elevated in artwork by ~2.4 ns and never flipping
 /// sign. One mechanism showing up twice, so it belongs in its own term rather than as a mode-specific
 /// copy of each rate. ~16 word-ops per card is the right order for 2.4 ns.
-const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.36;
+const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.21;
 /// ns per card scanned in the small-total gather (`for cid in 0..n_cards`,
 /// counts[cid]==0 check). Cheaper than a match-phase visit (no filter work). Fit
 /// from the narrow-query floor: cmc>=15 / o:annihilator / cmc==7 card SHALLOW all
 /// ~52µs = 31508 × 1.65. Only added when `matches <= STREAM_MIN_MATCHES`, the
 /// exact condition that routes P3 into that gather branch. The 1.65 above was fit on three hand
 /// picked narrow queries; across the sampled space the floor measures ~31µs, not 52µs.
-const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.64;
+const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
 /// `cards.len()` every query — a 126 kB memset on this corpus — and the emission walk is over the
@@ -362,7 +390,7 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.64;
 /// as a per-card RATE rather than the previous flat constant so it tracks corpus size at all.
 const STREAM_CORPUS_PASS_PER_CARD_NS: f64 = 0.02;
 /// Fixed P3 setup, net of the O(n_cards) work above.
-const STREAM_FIXED_COST_NS: f64 = 217.5;
+const STREAM_FIXED_COST_NS: f64 = 217.0;
 
 // ─── P4: GatheredScan ───────────────────────────────────────────────────────
 // The universal fallback: per-card loop pushes every match's sort key into a
@@ -442,7 +470,7 @@ const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 
 /// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
 /// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
-/// against the `printings_scanned` counter -- the Perm and OrderbyWalk paging branches are priced
+/// against the `printing_span` counter -- the Perm and OrderbyWalk paging branches are priced
 /// entirely on this quantity and nothing else validates them.
 pub(crate) fn printings_walked(f: &PlanFeatures) -> f64 {
     let page_span = f64::from((f.offset.saturating_add(f.limit)).min(f.matches));

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4272,12 +4272,22 @@ enum Mode { Card, Artwork, Printing }
 /// silently under-count in production instead of failing loudly on reload.
 const ARTWORK_GROUP_WORDS: usize = 8;
 
-/// Matches this card contributes: 0/1 for Card mode (existence, short-circuit),
+/// Matches this card contributes, and how many printings it had to look at to know:
+/// `(matches, examined)`. 0/1 matches for Card mode (existence, short-circuit),
 /// passing printings for Printing mode, distinct illustrations with a passing
 /// printing for Artwork mode. `seen_words` is a reused scratch buffer: a
 /// fixed-size bitmask indexed by each printing's dense `artwork_group_id`
 /// (#629), one bit per group, `word = gid / 64` -- zeroed in full every card
 /// (cheap: ARTWORK_GROUP_WORDS is tiny), never resized.
+///
+/// `examined` is the number of times the per-printing loop body ran, which is the quantity
+/// `PlanFeatures::scan_units` claims to predict. It is NOT `end - start`: every Card-mode path here
+/// short-circuits, and the two `all_match` arms return without touching a printing at all. The
+/// `printing_span` counter used to be incremented as the full span by the CALLER, before this
+/// function ran, so it reported what a full scan would have cost rather than what happened -- and
+/// `cost.rs`'s "the `printing_span` counter shows the scan plans walk the full printing span of
+/// their candidates in CARD mode too, not one row each" was inferred from exactly that. Returning the
+/// truth from the only place that knows it is what makes the claim checkable.
 // #676 review: a legality leaf promoted into `plane` alongside a genuinely
 // printing-dependent residual (DateCmp, ArtistMatch, ...) needs *both*
 // checked against the *same* printing -- `all_match`/`residual_matches` alone
@@ -4308,7 +4318,7 @@ fn card_match_count(
     strings: &AStrings,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
     seen_words: &mut [u64; ARTWORK_GROUP_WORDS],
-) -> u32 {
+) -> (u32, u32) {
     // No existential plane: identical code shape to before #676's
     // existential_plane parameter existed at all -- no closure, no extra
     // branch inside the hot loop. This is the overwhelmingly common case
@@ -4325,18 +4335,20 @@ fn card_match_count(
         return match mode {
             Mode::Card => {
                 if all_match {
-                    return u32::from(start < end);
+                    // Existence is settled by the span being non-empty; no printing is read.
+                    return (u32::from(start < end), 0);
                 }
-                for p in &printings[start..end] {
+                for (i, p) in printings[start..end].iter().enumerate() {
                     if FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) {
-                        return 1;
+                        return (1, i as u32 + 1); // stopped here: i+1 printings looked at
                     }
                 }
-                0
+                (0, (end - start) as u32) // no match: the whole span was ruled out
             }
             Mode::Printing => {
                 if all_match {
-                    return (end - start) as u32;
+                    // The count is the span itself, arithmetic only -- no printing is read.
+                    return ((end - start) as u32, 0);
                 }
                 let mut n = 0u32;
                 for p in &printings[start..end] {
@@ -4344,7 +4356,7 @@ fn card_match_count(
                         n += 1;
                     }
                 }
-                n
+                (n, (end - start) as u32)
             }
             Mode::Artwork => {
                 // #737's skip-repped shortcut, which landed in the gather loop but not here. Read the
@@ -4368,7 +4380,8 @@ fn card_match_count(
                     }
                     seen_words[word] |= bit;
                 }
-                seen_words.iter().map(|w| w.count_ones()).sum()
+                // Artwork never short-circuits: a later printing can always rep an unseen group.
+                (seen_words.iter().map(|w| w.count_ones()).sum(), (end - start) as u32)
             }
         };
     };
@@ -4383,10 +4396,10 @@ fn card_match_count(
         Mode::Card => {
             for pid in start..end {
                 if satisfies(pid) {
-                    return 1;
+                    return (1, (pid - start) as u32 + 1);
                 }
             }
-            0
+            (0, (end - start) as u32)
         }
         Mode::Printing => {
             let mut n = 0u32;
@@ -4395,7 +4408,7 @@ fn card_match_count(
                     n += 1;
                 }
             }
-            n
+            (n, (end - start) as u32)
         }
         Mode::Artwork => {
             // Same skip-repped shortcut as the no-plane arm above, and it matters more here:
@@ -4409,13 +4422,20 @@ fn card_match_count(
                 }
                 seen_words[word] |= bit;
             }
-            seen_words.iter().map(|w| w.count_ones()).sum()
+            (seen_words.iter().map(|w| w.count_ones()).sum(), (end - start) as u32)
         }
     }
 }
 
 /// Emit this card's matches as (sort key, cid, pid) tuples — the per-card body
 /// of the gathered path, shared by the streamed path for page cards.
+///
+/// Returns how many printings the loop body ran on, the same `examined` quantity
+/// `card_match_count` reports and for the same reason: `scan_units` claims to predict it, and the
+/// span the caller used to add in its place is not it. Card mode with the default prefer stops at the
+/// first qualifying printing (one, not the span); a custom prefer must score every printing, so there
+/// the span IS the truth. That difference is invisible to a caller-side `end - start`, and it is
+/// exactly the difference the cost model needs to see.
 ///
 /// `existential_plane`: `Some((plane, planes))` iff `mode` is `Card` and the
 /// plane driving `all_match` touched a legality leaf
@@ -4454,7 +4474,7 @@ fn push_card_matches(
     out: &mut Vec<Match>,
     group_best: &mut [Option<(u32, f64)>],
     touched: &mut Vec<u16>,
-) {
+) -> u32 {
     match mode {
         Mode::Card => {
             // Printings are stored in descending default-prefer order, so
@@ -4471,13 +4491,19 @@ fn push_card_matches(
             // Kept as two separate closures (not one closure branching on
             // `existential_plane` every call) for the same reason
             // `card_match_count` is split this way — see its doc.
-            let chosen: Option<u32> = if let Some((pe, planes)) = existential_plane {
+            // `examined` rides alongside `chosen` rather than being counted in a separate local: on
+            // the two default-prefer paths the chosen printing IS the one the loop stopped at, so its
+            // offset from `start` is the count and no per-iteration bookkeeping is needed. The custom-
+            // prefer paths score every printing and so examine the whole span, unconditionally.
+            let span = (end - start) as u32;
+            let (chosen, examined): (Option<u32>, u32) = if let Some((pe, planes)) = existential_plane {
                 let satisfies = |pid: usize| {
                     eval_plane_expr_for_printing(pe, planes, cid, &printings[pid], strings)
                         && (all_match || FilterExpr::residual_matches(card, &printings[pid], strings, residual, residual_is_or))
                 };
                 if matches!(prefer, Prefer::Default) {
-                    (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32)
+                    let found = (start..end).find(|&pid| satisfies(pid)).map(|pid| pid as u32);
+                    (found, found.map_or(span, |pid| pid - start as u32 + 1))
                 } else {
                     let mut chosen: Option<(u32, f64)> = None;
                     for pid in start..end {
@@ -4489,7 +4515,7 @@ fn push_card_matches(
                             chosen = Some((pid as u32, score));
                         }
                     }
-                    chosen.map(|(pid, _)| pid)
+                    (chosen.map(|(pid, _)| pid), span)
                 }
             } else if matches!(prefer, Prefer::Default) {
                 let mut found: Option<u32> = None;
@@ -4499,7 +4525,7 @@ fn push_card_matches(
                         break;
                     }
                 }
-                found
+                (found, found.map_or(span, |pid| pid - start as u32 + 1))
             } else {
                 let mut chosen: Option<(u32, f64)> = None;
                 for pid in start..end {
@@ -4512,11 +4538,12 @@ fn push_card_matches(
                         chosen = Some((pid as u32, score));
                     }
                 }
-                chosen.map(|(pid, _)| pid)
+                (chosen.map(|(pid, _)| pid), span)
             };
             if let Some(pid) = chosen {
                 out.push((sort_key_bits(card, &printings[pid as usize], sort_col, descending), cid, pid));
             }
+            examined
         }
         Mode::Printing => {
             for pid in start..end {
@@ -4524,6 +4551,8 @@ fn push_card_matches(
                 if !all_match && !FilterExpr::residual_matches(card, p, strings, residual, residual_is_or) { continue; }
                 out.push((sort_key_bits(card, p, sort_col, descending), cid, pid as u32));
             }
+            // Every printing is a candidate row: no ordering lets this stop early.
+            (end - start) as u32
         }
         Mode::Artwork => {
             // Within-range order is prefer-score-desc (not illustration), so
@@ -4581,6 +4610,8 @@ fn push_card_matches(
                 let (bp, _) = group_best[gid as usize].take().unwrap();
                 out.push((sort_key_bits(card, &printings[bp as usize], sort_col, descending), cid, bp));
             }
+            // Both grouping loops run to `end`: a later printing can always rep a group not yet seen.
+            (end - start) as u32
         }
     }
 }
@@ -6586,7 +6617,7 @@ fn exec_streamed_select<'a>(
 /// the executors actually do rather than against a fitted curve.
 ///
 /// Two distinct questions, and the model can fail either:
-/// - are the FEATURE COUNTS right? `cards_visited` / `printings_scanned` / `matches_pushed` are the
+/// - are the FEATURE COUNTS right? `cards_visited` / `printing_span` / `matches_pushed` are the
 ///   real counts behind `eval_domain` / `scan_units` / `matches`. If a feature disagrees with its
 ///   counter, no rate constant can rescue the term.
 /// - is the WORK WHERE THE MODEL SAYS? `ns_setup` + `ns_loop` + `ns_finish` should account for the
@@ -6599,7 +6630,21 @@ fn exec_streamed_select<'a>(
 #[derive(Default, Clone, Copy)]
 pub(crate) struct PhaseStats {
     pub(crate) cards_visited: u64,
-    pub(crate) printings_scanned: u64,
+    /// The printings under the candidate cards — what a full scan of them WOULD cost. A span,
+    /// computed as `end - start` per surviving card, kept because it is the right comparison for
+    /// `scan_units` in printing and artwork mode, where the loops really do traverse the span.
+    ///
+    /// It is the WRONG comparison in card mode, and reading it as though it were the work done is how
+    /// `cost.rs` came to assert that "the scan plans walk the full printing span of their candidates
+    /// in CARD mode too, not one row each". They do not: see `card_match_count` and
+    /// `push_card_matches`, both of which stop at the first qualifying printing under the default
+    /// prefer. Compare against `printings_examined` for what actually ran.
+    pub(crate) printing_span: u64,
+    /// The printings the per-card body actually ran on — the quantity `scan_units` claims to predict.
+    /// Reported by the two match kernels, which are the only code that knows where they stopped.
+    /// Legitimately 0 for a whole query: both `all_match` arms of `card_match_count` answer from the
+    /// span arithmetic alone, and the stored artwork group count answers without a printing either.
+    pub(crate) printings_examined: u64,
     pub(crate) matches_pushed: u64,
     /// Per-query scratch setup, before the match loop starts. Split out because it is neither
     /// prepare nor match and it is NOT negligible: `run_query_streamed` zeroes an `n_cards`-long
@@ -6851,7 +6896,7 @@ thread_local! {
     /// owned elsewhere: `paging_taken` by `PAGING_TAKEN` below, `ns_round_total`/`result_total` by
     /// `explain_analyze`, which fills them after the take.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
-        cards_visited: 0, printings_scanned: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
+        cards_visited: 0, printing_span: 0, printings_examined: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
         ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
     }) };
 
@@ -6954,7 +6999,11 @@ fn exec_gathered_scan<'a>(
     let mut residual_is_or = false;
     // Counters for the three features this plan's cost arm keys on, so they can be checked against
     // what the loop really does. Plain locals — no atomics, no branch — published once at the end.
-    let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    let (mut n_cards_visited, mut n_printing_span, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    // The printings the per-card body actually ran on, which is NOT `n_printing_span` (the span).
+    // See `push_card_matches`; the two are published side by side so the gap is readable rather than
+    // inferred.
+    let mut n_printings_examined = 0u64;
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -6972,11 +7021,11 @@ fn exec_gathered_scan<'a>(
         let start = u32::from(offsets[cid as usize]) as usize;
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
-        n_printings_scanned += (end - start) as u64;
-        push_card_matches(
+        n_printing_span += (end - start) as u64;
+        n_printings_examined += u64::from(push_card_matches(
             card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, prefer,
             sort_col, descending, strings, existential_plane, sel.buf(), &mut group_best, &mut touched,
-        );
+        ));
         n_matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
@@ -6995,7 +7044,8 @@ fn exec_gathered_scan<'a>(
         // regardless — it lives in `PAGING_TAKEN`, which this does not touch.
         c.set(PhaseStats {
             cards_visited: n_cards_visited,
-            printings_scanned: n_printings_scanned,
+            printing_span: n_printing_span,
+            printings_examined: n_printings_examined,
             matches_pushed: n_matches_pushed,
             ns_setup: (t_loop - t_start).as_nanos() as u64,
             ns_loop: (t_finish - t_loop).as_nanos() as u64,
@@ -7037,7 +7087,7 @@ fn run_query<'a>(
 /// only paid when a candidate list exists. Called from `candidate_feats`.
 fn scan_units(mode: Mode, candidate_cards: Option<&[u32]>, offsets: &AOffsets, n_printings: u32, n_cards: u32) -> u32 {
     // Card mode used to short-circuit to `eval_domain`, on the theory that the loop breaks at the
-    // first matching printing of each card. The `printings_scanned` counter says otherwise: across
+    // first matching printing of each card. The `printing_span` counter says otherwise: across
     // every acquire branch, GatheredScan and StreamedSelect scan the FULL printing span of their
     // candidates in card mode too, and the old feature read 0.25-0.33 against it. So the QUANTITY is
     // the same in all three modes -- printings under the candidates -- and there is no mode branch in
@@ -7375,9 +7425,13 @@ fn acquire_plan_features(
     plane: Option<&PlaneExpr>,
 ) -> (cost::PlanFeatures, Prep, Vec<u64>) {
     let QueryCtx { cards, offsets, indexes, .. } = *ctx;
-    let QueryParams { mode, sort_col, descending, .. } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, .. } = *params;
     let n_cards = ctx.n_cards();
     let n_printings = ctx.n_printings();
+    // Mean printings per card, the factor between "one printing of each candidate" and "all of them".
+    // Both the plane branch and the compose branch's `scan_all` need it; `.max(1.0)` guards a corpus
+    // with more cards than printings, which cannot happen but costs nothing to exclude.
+    let printings_per_card = (f64::from(n_printings) / f64::from(n_cards)).max(1.0);
 
     // Scratch for the plane bitmap (`Prep::Plane` only). A fresh `Vec` allocates
     // just once, on the plane branch's `eval_planes`; non-plane queries leave it
@@ -7385,11 +7439,44 @@ fn acquire_plan_features(
     let mut plane_bits: Vec<u64> = Vec::new();
 
     let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, plane) {
-        // The ONE plane eval; its popcount IS the exact count. scan_units == count
-        // (Mode::Card breaks at first match); True residual ⇒ tier 0.
+        // The ONE plane eval; its popcount IS the exact count. True residual ⇒ tier 0.
         eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
-        (mk_plan_feats(ctx, params, count, count, count, 0), Prep::Plane)
+        // `scan_units` costs the MATERIALIZING alternatives to this plan (PlanePopcountOrder itself
+        // popcounts a bitmap and scans nothing), and here alone it depends on `prefer`.
+        //
+        // A True residual means `all_match`, so `push_card_matches` takes its first-match branch: under
+        // `Prefer::Default` printings are stored prefer-desc, the first printing IS the pick, and the
+        // loop breaks after one — `scan_units == count`. Under any other prefer the same loop must
+        // score every printing of the card to find the max, so it examines the full span.
+        //
+        // Measured against `printings_examined` over 4,136 plane-acquire rows: the old unconditional
+        // `count` graded 1.00 at p90-p100 (the default-prefer population) and 0.16-0.35 at p10-p50 (the
+        // other four prefers) — one value cannot be right for both, and the 3.09x between them is
+        // exactly `printings_per_card`. This is the only feature in the vector that reads `prefer`;
+        // everywhere else the span-shaped estimate already covers both regimes, because an inexact
+        // narrowing makes non-matching candidates burn their whole span regardless of prefer.
+        //
+        // The custom-prefer side takes the EXACT span rather than `count * printings_per_card`. The
+        // corpus mean puts the cell's median at 1.00 but leaves a 3.09x over-count tail (measured p90
+        // 3.05, p99 3.09) on plane sets whose cards are single-printing, and a mean cannot fix a
+        // spread. One pass over the set bits is exact and is paid only here — `Prefer::Default`, ~85%
+        // of traffic by `REALISTIC_PREFER_WEIGHTS`, returns before reaching it.
+        let scan_units = if matches!(prefer, Prefer::Default) {
+            count
+        } else {
+            let mut span = 0u64;
+            for (w, word) in plane_bits.iter().enumerate() {
+                let mut bits = *word;
+                while bits != 0 {
+                    let cid = w * 64 + bits.trailing_zeros() as usize;
+                    span += u64::from(u32::from(offsets[cid + 1]) - u32::from(offsets[cid]));
+                    bits &= bits - 1;
+                }
+            }
+            span.min(u64::from(n_printings)) as u32
+        };
+        (mk_plan_feats(ctx, params, count, count, scan_units, 0), Prep::Plane)
     } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, plane) {
         // Exact in-range printing count `k` from the index partition points (two binary searches, no
         // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
@@ -7473,7 +7560,6 @@ fn acquire_plan_features(
         // `eval_domain` and scanned 0.14x the claimed `scan_units`. Over-costing both plans inflates
         // the predicted GAP between them (P4 carries the larger per-row rates), which is what routing
         // reads -- measured as a GatheredScan-vs-StreamedSelect gap ratio of 0.32 on this acquire.
-        let printings_per_card = (f64::from(n_printings) / f64::from(n_cards)).max(1.0);
         let scan_all = |cards: usize| ((cards as f64) * printings_per_card) as usize;
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
             Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
@@ -7491,7 +7577,7 @@ fn acquire_plan_features(
                 // pushes 34,285, not the 68,687 printings it scans. Handing over the printing count
                 // over-charged every materializing alternative by ~2x on this acquire. The printing
                 // count stays where it belongs -- `project` (the printing->artwork pass) and
-                // `scan_units` both walk printings, as `printings_scanned` confirms.
+                // `scan_units` both walk printings, as `printing_span` confirms.
                 let n_artworks = u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize;
                 let rt = artwork_estimate(printing_matches, est_cards, n_cards as usize, n_artworks);
                 // The bitmap `printing_bits_to_artwork_bits` popcounts is n_artworks bits wide, not
@@ -8279,7 +8365,12 @@ fn run_query_streamed<'a>(
     let mut total: usize = 0;
     // Same counters GatheredScan publishes, so the two plans' arms can be checked the same way.
     // Locals in the loop; published once at the end. See PhaseStats.
-    let (mut n_cards_visited, mut n_printings_scanned, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    let (mut n_cards_visited, mut n_printing_span, mut n_matches_pushed) = (0u64, 0u64, 0u64);
+    // See the same local in the gathered loop. This plan only COUNTS here (the page is emitted
+    // below), and counting short-circuits harder than emitting does: both `all_match` arms of
+    // `card_match_count` answer without reading a printing at all, so this can legitimately be 0
+    // where `n_printing_span` is the full corpus span.
+    let mut n_printings_examined = 0u64;
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -8305,20 +8396,23 @@ fn run_query_streamed<'a>(
         let end   = u32::from(offsets[cid as usize + 1]) as usize;
         // Counted HERE, below the `card_pass` continue above, because a card rejected there never has
         // its printings touched. Counting at the top of the loop instead included them, so this plan
-        // and GatheredScan reported different `printings_scanned` for identical work whenever the
+        // and GatheredScan reported different `printing_span` for identical work whenever the
         // narrowing was inexact -- and `scan_units` has one definition, so at most one could be the
         // valid comparison.
-        n_printings_scanned += (end - start) as u64;
+        n_printing_span += (end - start) as u64;
         // Every printing matches: card/printing counts are O(1) inside the
         // helper, and the artwork group count is a build-time constant.
         let c = if all_match && matches!(mode, Mode::Artwork) && have_group_counts {
+            // A stored per-card group count: answered without looking at one printing.
             u32::from(u16::from(artwork_groups[cid as usize]))
         } else {
-            card_match_count(
+            let (c, examined) = card_match_count(
                 card, cid, printings, &indexes.artwork_group_col, start, end, all_match, &residual, residual_is_or, mode, strings,
                 existential_plane,
                 &mut seen_words,
-            )
+            );
+            n_printings_examined += u64::from(examined);
+            c
         };
         counts[cid as usize] = c;
         total += c as usize;
@@ -8334,7 +8428,8 @@ fn run_query_streamed<'a>(
         PHASE_STATS.with(|c| {
             c.set(PhaseStats {
                 cards_visited: n_cards_visited,
-                printings_scanned: n_printings_scanned,
+                printing_span: n_printing_span,
+                printings_examined: n_printings_examined,
                 matches_pushed: n_matches_pushed,
                 ns_setup: (t_loop - t_start).as_nanos() as u64,
                 ns_loop: (t_finish - t_loop).as_nanos() as u64,
@@ -8698,7 +8793,8 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     // `DeclineSparseExact` in particular pays a full compose first.
     d.set_item("declined_ns", t.declined_ns.clone())?;
     d.set_item("cards_visited", t.phases.cards_visited)?;
-    d.set_item("printings_scanned", t.phases.printings_scanned)?;
+    d.set_item("printing_span", t.phases.printing_span)?;
+    d.set_item("printings_examined", t.phases.printings_examined)?;
     d.set_item("matches_pushed", t.phases.matches_pushed)?;
     d.set_item("ns_setup", t.phases.ns_setup)?;
     d.set_item("ns_loop", t.phases.ns_loop)?;
@@ -9250,12 +9346,14 @@ impl QueryEngine {
     /// lazily re-materialize and re-choose on exact features at dispatch — so the
     /// executed plan can differ from `result[0]`. See the free `explain` fn's doc.
         #[allow(clippy::too_many_arguments)] // the PyO3 keyword surface; the free `explain` fn it calls takes 4
-    #[pyo3(signature = (*, filters, unique="card", orderby="edhrec", direction="asc", limit=100, offset=0))]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, filters, unique="card", prefer="default", orderby="edhrec", direction="asc", limit=100, offset=0))]
     fn explain<'py>(
         &self,
         py: Python<'py>,
         filters: &Bound<PyAny>,
         unique: &str,
+        prefer: &str,
         orderby: &str,
         direction: &str,
         limit: usize,
@@ -9266,19 +9364,19 @@ impl QueryEngine {
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
 
-        // This method's signature has never taken `prefer` (it predates #757), and
-        // substituting the default here is behavior-preserving *for what explain
-        // reports*: `cost::plan_cost`/`PlanFeatures` don't read `prefer` at all, so
-        // both the argmin and every `predicted_ns` are prefer-blind regardless of what
-        // is passed. That is a gap in the cost model, not a property of execution —
-        // `prefer` genuinely changes the work done (it picks each card's representative
-        // printing, and `Prefer::Default` specifically lets `gather_composed_page`
-        // early-break on the first set printing instead of scoring every printing of
-        // the card, and `run_query_streamed_popcount` likewise). So an `explain` for a
-        // non-default `prefer` predicts the same numbers while the real query would do
-        // more per-card work. `explain_analyze` does take `prefer` and really runs the
-        // plans, so its `trials_ns` reflect it even though its `predicted_ns` doesn't.
-        let params = QueryParams::from_strs(unique, "default", orderby, direction, limit, offset);
+        // `prefer` is accepted and passed through, but note what it does NOT yet change:
+        // `cost::plan_cost`/`PlanFeatures` still don't read it, so the argmin and every
+        // `predicted_ns` remain prefer-blind. That is a real gap, now measurable rather
+        // than merely asserted — `prefer` genuinely changes the work done, since it picks
+        // each card's representative printing and `Prefer::Default` alone lets the match
+        // kernels early-break on the first qualifying printing instead of scoring every
+        // printing of the card. Measured over the plane acquire (exact narrowing, so the
+        // early break is the whole per-card cost), `scan_units` grades 1.00 against
+        // `printings_examined` under `default` and 0.32 under each of the other four — one
+        // feature value cannot be right for both. Taking the parameter is what lets a
+        // prefer-aware feature be graded here at all; until one exists, an `explain` for a
+        // non-default `prefer` still predicts the default's numbers.
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
         let (facts, estimates) = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7541,6 +7541,7 @@ fn mk_plan_feats(
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
         compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
+        gather_group_printings: 0, // only the compose branch, and only when its grouping arm runs
         orderby_walk_scan: 0,      // only the compose branch, and only for a plane-bucket orderby walk
     }
 }
@@ -7801,6 +7802,16 @@ fn acquire_plan_features(
         // however selective the filter is. `usd` walks small value runs instead and keeps the shared
         // page-fill term. See `PlanFeatures::orderby_walk_scan`.
         feats.orderby_walk_scan = if matches!(sort_col, SortCol::Rarity) { n_printings } else { 0 };
+        // The gather's grouping arm runs for artwork always, and for card only under a non-default
+        // prefer -- card/default takes the early-break arm and never groups. Printing mode gets 0
+        // because its push term already rides the printing count. Driven by the PRE-dedup printing
+        // matches, which is the whole point: see `PlanFeatures::gather_group_printings`.
+        let groups = match mode {
+            Mode::Artwork => true,
+            Mode::Card => !matches!(prefer, Prefer::Default),
+            Mode::Printing => false,
+        };
+        feats.gather_group_printings = if groups { printing_matches as u32 } else { 0 };
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
         // itself decides, through the same helpers, including whether it will decline. Only this
         // branch knows the estimated result total, so only it can predict the small-total bail. The
@@ -9043,6 +9054,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
         ("compose_scan_printings", g.compose_scan_printings),
+        ("gather_group_printings", g.gather_group_printings),
         ("orderby_walk_scan", g.orderby_walk_scan),
         // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk
         // paging branches are priced entirely on it and nothing else can check them.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6462,7 +6462,19 @@ fn exec_plane_popcount_order<'a>(
     }
     PLANE_BITMAP_POPCOUNT.with(|cell| {
         let mut bitmap = cell.borrow_mut();
+        // Timed and published as `ns_prepare`, for the same reason `prepare_candidates` is: this is a
+        // SHARED artifact that the router builds once during acquire and hands to whichever plan wins
+        // (`Prep::Plane`), so a forced run that rebuilds it is paying something the routed path does
+        // not pay at dispatch. Netting it is what makes the two comparable — see
+        // `costbench.plan_self_ns`.
+        //
+        // Without this the plane rows read NEGATIVE regret: routed dispatch reuses `plane_bits` while
+        // the forced trial re-evaluates the plane, so the router appeared to beat the best plan by a
+        // mean of 4.21us and held -13% of share. That is the `prepare_candidates` asymmetry again, one
+        // artifact along.
+        let t = std::time::Instant::now();
         eval_planes(plane_expr, &ctx.indexes.planes, &mut bitmap);
+        note_pending_prepare_ns(t.elapsed().as_nanos() as u64);
         exec_plane_popcount_order_with_bitmap(ctx, params, plane_expr, &bitmap)
     })
 }
@@ -6484,7 +6496,15 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
     let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
-    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
+    let out = run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None);
+    // Consume whatever `exec_plane_popcount_order` left in flight and publish it, so a harness can
+    // net the plane build out of a forced trial. Zero on the ROUTED path, which reaches this function
+    // directly with the acquire's bitmap and builds nothing — which is exactly the asymmetry being
+    // reported. Counters stay zero: this plan popcounts a bitmap and visits no cards, so it has
+    // nothing to report there and `plan_stats_never_leak_between_participants` still pins that.
+    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
+    PHASE_STATS.with(|c| c.set(PhaseStats { ns_prepare: prep_ns, ..PhaseStats::default() }));
+    out
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -7162,6 +7182,18 @@ fn timed_prepare_candidates(
 /// `PhaseStats::paging_taken` for why the predicted branch is not enough.
 fn note_paging_taken(which: PagingTaken) {
     PAGING_TAKEN.with(|c| c.set(which));
+}
+
+/// Hand a shared-artifact build time to the executor that follows, the same way
+/// `timed_prepare_candidates` does. Used by the plane path, whose artifact the router builds in
+/// acquire and a forced run has to rebuild; see `exec_plane_popcount_order`.
+fn note_pending_prepare_ns(ns: u64) {
+    debug_assert_eq!(
+        PENDING_PREPARE_NS.with(std::cell::Cell::get),
+        0,
+        "a previous shared-artifact build was not consumed by an executor; its time would be reported as this run's",
+    );
+    PENDING_PREPARE_NS.with(|c| c.set(ns));
 }
 
 /// Publish what a compose paging branch did, so `PrintingCompose` reports the same three quantities

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10048,3 +10048,5 @@ mod bench_compose_card_projection;
 mod bench_candidate_materialize;
 #[cfg(test)]
 mod bench_gather_loop;
+#[cfg(test)]
+mod bench_streamed_loop;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6597,15 +6597,17 @@ fn gather_composed_page<'a>(
     // `compose_scan_printings` is set to the composed bitmap's POPCOUNT, on the stated grounds that
     // compose "walks the set bits". This loop does not: except in the card/default-prefer arm it
     // iterates `start..end` of every candidate card and bit-tests each printing, so the real count is
-    // the SPAN of the candidate cards. Counted per arm below so the difference is measured rather
-    // than argued.
-    let mut work = ComposePageWork::default();
+    // the SPAN of the candidate cards.
+    //
+    // Only the span is accumulated. `cards_visited` is `candidate_cards.len()`, known before the loop
+    // starts, and `matches_pushed` is the total `GatherSelect` already computes and this function
+    // currently discards -- neither needs a per-iteration add.
+    let mut work = ComposePageWork { cards_visited: candidate_cards.len() as u64, ..Default::default() };
     for cid in candidate_cards {
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
-        work.cards_visited += 1;
         match mode {
             // Printing: every set printing is its own row (no grouping).
             Mode::Printing => {
@@ -6664,10 +6666,13 @@ fn gather_composed_page<'a>(
                 }
             }
         }
-        work.matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
-    let (_total, page_ids) = sel.finish(page_offset, limit); // total already known exactly via popcount; only the page is wanted here
+    // `total` is every match this branch pushed, which is what `matches_pushed` wants and what
+    // `GatherSelect` has been computing and this function discarding. The popcount already gave the
+    // caller the result total, hence the old `_total`.
+    let (total, page_ids) = sel.finish(page_offset, limit);
+    work.matches_pushed = total as u64;
     (page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect(), work)
 }
 
@@ -6989,6 +6994,23 @@ thread_local! {
     /// `take_phase_stats` reassembles the two into one `PhaseStats`, so consumers see no seam.
     static PAGING_TAKEN: std::cell::Cell<PagingTaken> = const { std::cell::Cell::new(PagingTaken::NotEntered) };
 
+    /// The compose fastpath's three counters, stored apart from `PHASE_STATS` for exactly the reason
+    /// `PAGING_TAKEN` is: this is the production compose path, and a whole-struct publish there is a
+    /// read-modify-write of ~80 bytes to report 24.
+    ///
+    /// Measured, because the first version did write the whole struct: a paired A/B against the same
+    /// build without it read `+1.4 µs` and `+3.1 µs` on a 129 µs mean (slower on 619 and 863 queries
+    /// of ~2,000), and neutralising every cost-model change left the regression in place — the
+    /// publish WAS the regression. The note on `PAGING_TAKEN` above had already said so.
+    ///
+    /// Safe to leave unwritten by the other executors for the same reason `PHASE_STATS` is safe:
+    /// `take_phase_stats` replaces this with the default, and `explain_analyze` takes before every
+    /// participant runs, so a plan that does not publish here reads zeros rather than the last
+    /// compose's numbers. Outside that window nothing reads it at all.
+    static COMPOSE_WORK: std::cell::Cell<ComposePageWork> = const { std::cell::Cell::new(ComposePageWork {
+        cards_visited: 0, printings_examined: 0, matches_pushed: 0,
+    }) };
+
     /// `prepare_candidates`' time for the run in progress, handed to the executor that follows it —
     /// the two are separate calls in `run_query_with_plan`, and only the executor publishes stats.
     ///
@@ -7029,32 +7051,16 @@ fn note_paging_taken(which: PagingTaken) {
     PAGING_TAKEN.with(|c| c.set(which));
 }
 
-/// Publish what a compose paging branch did into the shared counters, so `PrintingCompose` reports
-/// the same three quantities the two materializing plans do.
+/// Publish what a compose paging branch did, so `PrintingCompose` reports the same three quantities
+/// the two materializing plans do.
 ///
-/// A WHOLE-struct set, like the other two publishers: nothing here is inherited, so compose cannot
-/// report a field an earlier participant wrote. `paging_taken` survives because it lives in
-/// `PAGING_TAKEN`, which this does not touch -- the same split `PhaseStats` documents.
-///
-/// The phase timings stay zero. Compose's cost arm is not decomposed into setup/loop/finish the way
-/// the scan plans' is, so there is nothing yet to check them against, and publishing an
-/// unvalidatable number is how `printings_scanned` became load-bearing in the first place.
+/// A 24-byte store into `COMPOSE_WORK`, not a write of the whole `PhaseStats` — see that slot's doc
+/// for the measurement that forced the split. `take_phase_stats` merges the two, so consumers see no
+/// seam, and the phase timings stay zero: compose's arm is not decomposed into setup/loop/finish, so
+/// there is nothing to check them against, and publishing an unvalidatable number is how
+/// `printing_span` became load-bearing in the first place.
 fn publish_compose_work(work: ComposePageWork) {
-    PHASE_STATS.with(|c| {
-        c.set(PhaseStats {
-            cards_visited: work.cards_visited,
-            printing_span: 0, // compose never materializes a candidate list, so there is no span
-            printings_examined: work.printings_examined,
-            matches_pushed: work.matches_pushed,
-            ns_setup: 0,
-            ns_loop: 0,
-            ns_finish: 0,
-            ns_round_total: 0, // filled by explain_analyze, which owns the round timer
-            ns_prepare: 0,
-            result_total: 0, // likewise
-            paging_taken: PagingTaken::NotEntered, // owned by PAGING_TAKEN; take_phase_stats merges it in
-        });
-    });
+    COMPOSE_WORK.with(|c| c.set(work));
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a
@@ -7066,6 +7072,16 @@ fn publish_compose_work(work: ComposePageWork) {
 fn take_phase_stats() -> PhaseStats {
     let mut stats = PHASE_STATS.with(|c| c.replace(PhaseStats::default()));
     stats.paging_taken = PAGING_TAKEN.with(|c| c.replace(PagingTaken::NotEntered));
+    // Compose's counters live in their own slot; fold them in so a consumer cannot tell which
+    // executor wrote them. Only ONE of the two publishes per run -- a materializing executor writes
+    // `PHASE_STATS` and never `COMPOSE_WORK`, compose the reverse -- so this cannot double-count, and
+    // taking both together is what stops either leaking into the next participant.
+    let compose = COMPOSE_WORK.with(|c| c.replace(ComposePageWork::default()));
+    if compose.cards_visited | compose.printings_examined | compose.matches_pushed != 0 {
+        stats.cards_visited = compose.cards_visited;
+        stats.printings_examined = compose.printings_examined;
+        stats.matches_pushed = compose.matches_pushed;
+    }
     stats
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7775,7 +7775,17 @@ fn acquire_plan_features(
                 // count stays where it belongs -- `project` (the printing->artwork pass) and
                 // `scan_units` both walk printings, as `printing_span` confirms.
                 let n_artworks = u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize;
-                let rt = artwork_estimate(printing_matches, est_cards, n_cards as usize, n_artworks);
+                // The UNCALIBRATED card count feeds the artwork capacity on purpose.
+                // `COMPOSE_CARD_ESTIMATE_BIAS` was measured against `cards_visited` -- distinct CARDS
+                // -- and `artwork_estimate` does not consume a card count as an answer, it uses it to
+                // size a capacity (`est_cards * n_artworks/n_cards`) that a second balls-into-bins then
+                // draws into. Feeding the calibrated value shrank both stages and moved
+                // `matches <Gather> / artwork` from 0.97 to 0.84, i.e. it made an already-good cell
+                // worse. Under-charging compose's push term is what over-picks it, and compose is
+                // over-picked in artwork specifically: that slice carries 21% of ALL routing regret at
+                // p99 205us against 40us for printing and 36us for card.
+                let capacity_cards = exact_cards.map_or_else(|| balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
+                let rt = artwork_estimate(printing_matches, capacity_cards, n_cards as usize, n_artworks);
                 // The bitmap `printing_bits_to_artwork_bits` popcounts is n_artworks bits wide, not
                 // n_printings -- 46,112 against 97,206 here, so this was 2.1x over as well.
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4952,6 +4952,27 @@ fn printing_range_fastpath<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    // Timed as one span rather than split into setup/loop/finish. The three-phase split exists where
+    // an executor HAS three phases to attribute cost between; this one has a dozen structurally
+    // different exits (three of them producing a page) and no common shape across them. What the
+    // harnesses need is that the phase sum equals the executor's own time, and one span satisfies
+    // that exactly -- `ns_loop` is the honest bucket for "the work", with the other two zero.
+    //
+    // Only a run that PRODUCED a page publishes. A decline returns `None`, records no trial, and must
+    // leave the slot as `take_phase_stats` cleared it.
+    let t = std::time::Instant::now();
+    let out = printing_range_fastpath_inner(ctx, params, filter);
+    if out.is_some() {
+        PHASE_STATS.with(|c| c.set(PhaseStats { ns_loop: t.elapsed().as_nanos() as u64, ..PhaseStats::default() }));
+    }
+    out
+}
+
+fn printing_range_fastpath_inner<'a>(
+    ctx: &QueryCtx<'a>,
+    params: &QueryParams,
+    filter: &FilterExpr,
+) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
     let QueryCtx { cards, printings, indexes, .. } = *ctx;
     let QueryParams { sort_col, descending, limit, page_offset, .. } = *params;
     let Some((idx, lo, hi)) = bare_range_bounds(filter, indexes) else {
@@ -5734,6 +5755,14 @@ struct ComposePageWork {
     /// Rows the branch pushed. For the gather this is every match (it visits every candidate); for
     /// the two walks it is bounded by the page, which is the whole point of their cost shape.
     matches_pushed: u64,
+    /// The whole fastpath's wall time, merged into `ns_loop` by `take_phase_stats`.
+    ///
+    /// One span, not three. Compose's arm is not decomposed into setup/loop/finish -- it is a build
+    /// plus one of three structurally different paging branches -- so there is nothing to attribute
+    /// between phases. What the harnesses need is that the phase sum equals the executor's own time,
+    /// and one span gives that. Carried here rather than written to `PHASE_STATS` separately so the
+    /// production compose path still pays ONE store; see this slot's doc for what that cost.
+    ns_total: u64,
 }
 
 fn collect_orderby_page<'a>(
@@ -5791,6 +5820,8 @@ fn collect_orderby_page<'a>(
         cards_visited: 0,
         printings_examined: scanned,
         matches_pushed: collected.len() as u64,
+        // Filled by `printing_compose_fastpath`, which owns the span; this helper only reports work.
+        ns_total: 0,
     };
     let matches: Vec<Match> = collected
         .iter()
@@ -5932,6 +5963,9 @@ fn printing_compose_fastpath<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
+    // Ends at whichever exit produces a page; see `ComposePageWork::ns_total`. Declines return before
+    // any publish and so leave the slot as `take_phase_stats` cleared it.
+    let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, sort_col, descending, limit, page_offset, .. } = *params;
     if !is_printing_composable(filter, indexes) || !printing_compose_indexes_built(indexes) {
@@ -5979,10 +6013,10 @@ fn printing_compose_fastpath<'a>(
     };
     if total == 0 || page_offset >= total {
         note_paging_taken(PagingTaken::EmptyPage);
-        publish_compose_work(ComposePageWork::default());
+        publish_compose_work(ComposePageWork { ns_total: t_start.elapsed().as_nanos() as u64, ..Default::default() });
         return Some((total, Vec::new()));
     }
-    let (page, work) = match perm {
+    let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
@@ -6032,6 +6066,7 @@ fn printing_compose_fastpath<'a>(
             }
         }
     };
+    work.ns_total = t_start.elapsed().as_nanos() as u64;
     publish_compose_work(work);
     Some((total, page))
 }
@@ -6496,15 +6531,10 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
     let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
     let inv_perm =
         indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
-    let out = run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None);
-    // Consume whatever `exec_plane_popcount_order` left in flight and publish it, so a harness can
-    // net the plane build out of a forced trial. Zero on the ROUTED path, which reaches this function
-    // directly with the acquire's bitmap and builds nothing — which is exactly the asymmetry being
-    // reported. Counters stay zero: this plan popcounts a bitmap and visits no cards, so it has
-    // nothing to report there and `plan_stats_never_leak_between_participants` still pins that.
-    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
-    PHASE_STATS.with(|c| c.set(PhaseStats { ns_prepare: prep_ns, ..PhaseStats::default() }));
-    out
+    // `run_query_streamed_popcount` publishes the phases and consumes the pending plane build; see
+    // `publish_popcount_phases`. Counters stay zero: this plan popcounts a bitmap and visits no
+    // cards, so it has nothing to report there.
+    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -7130,7 +7160,7 @@ thread_local! {
     /// participant runs, so a plan that does not publish here reads zeros rather than the last
     /// compose's numbers. Outside that window nothing reads it at all.
     static COMPOSE_WORK: std::cell::Cell<ComposePageWork> = const { std::cell::Cell::new(ComposePageWork {
-        cards_visited: 0, printings_examined: 0, matches_pushed: 0,
+        cards_visited: 0, printings_examined: 0, matches_pushed: 0, ns_total: 0,
     }) };
 
     /// The routed path's disjoint phase split — see `RoutedPhases`. Its own slot for the same reason
@@ -7222,10 +7252,13 @@ fn take_phase_stats() -> PhaseStats {
     // `PHASE_STATS` and never `COMPOSE_WORK`, compose the reverse -- so this cannot double-count, and
     // taking both together is what stops either leaking into the next participant.
     let compose = COMPOSE_WORK.with(|c| c.replace(ComposePageWork::default()));
-    if compose.cards_visited | compose.printings_examined | compose.matches_pushed != 0 {
+    if compose.cards_visited | compose.printings_examined | compose.matches_pushed | compose.ns_total != 0 {
         stats.cards_visited = compose.cards_visited;
         stats.printings_examined = compose.printings_examined;
         stats.matches_pushed = compose.matches_pushed;
+        // Compose reports one undivided span; `ns_loop` is where it belongs so the phase sum equals
+        // the executor's time. See `ComposePageWork::ns_total`.
+        stats.ns_loop = compose.ns_total;
     }
     stats
 }
@@ -8059,8 +8092,13 @@ fn run_query_routed<'a>(
         //   - a materializing plan (StreamedSelect/GatheredScan) that beat them narrows + runs.
         (PhysicalPlan::CardRangePopcount, Prep::Range(_)) => {
             let (idx, lo, hi) = bare_range_bounds(filter, ctx.indexes).expect("applicable ⇒ bare range");
+            // Timed and handed to the executor as `ns_prepare`: this build happens in DISPATCH on
+            // both paths, so it belongs to the plan's cost, and `card_range_popcount` being a
+            // RANGE_ACQUIRE is what tells `plan_self_ns` to add it rather than exclude it.
+            let t_build = std::time::Instant::now();
             let (card_bits, range_pbits) =
                 build_card_range_bits(idx, lo, hi, ctx.indexes, ctx.cards.len(), ctx.printings.len());
+            note_pending_prepare_ns(t_build.elapsed().as_nanos() as u64);
             exec_card_range_popcount(ctx, params, &card_bits, &range_pbits)
         }
         (plan, Prep::Range(_)) => {
@@ -8130,7 +8168,11 @@ fn run_query_with_plan<'a>(
                 return None;
             }
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicability guarantees a bare range");
+            // Timed exactly as the routed path times it, so a forced trial and dispatch contain the
+            // same work; see the routed call site.
+            let t_build = std::time::Instant::now();
             let (card_bits, range_pbits) = build_card_range_bits(idx, lo, hi, indexes, cards.len(), ctx.printings.len());
+            note_pending_prepare_ns(t_build.elapsed().as_nanos() as u64);
             Some(exec_card_range_popcount(ctx, params, &card_bits, &range_pbits))
         }
         PhysicalPlan::StreamedSelect => {
@@ -8614,12 +8656,20 @@ fn run_query_streamed_popcount<'a>(
     plane: Option<&PlaneExpr>,
     range_bits: Option<&[u64]>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
+    // First of the three phase boundaries, same convention as `run_query_streamed`: everything to the
+    // skip scan is `ns_setup` (here the total popcount plus the permuted scatter), the skip scan is
+    // `ns_loop`, the emit walk is `ns_finish`. Shared by BOTH popcount plans, so instrumenting here
+    // covers `PlanePopcountOrder` and `CardRangePopcount` at once.
+    let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { prefer, limit, page_offset, .. } = *params;
     let planes = &indexes.planes;
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
     if total == 0 || page_offset >= total {
+        // Still publishes: an empty page is real work (the popcount) and a plan that ran must report
+        // a cost, or a consumer reading the phases as the executor's time gets zero for a real run.
+        publish_popcount_phases(t_start.elapsed().as_nanos() as u64, 0, 0);
         return (total, Vec::new());
     }
 
@@ -8643,6 +8693,9 @@ fn run_query_streamed_popcount<'a>(
                 permuted[pos / 64] |= 1u64 << (pos % 64);
             }
         }
+
+        // Ends `ns_setup` (popcount + scatter) and starts `ns_loop`.
+        let t_loop = std::time::Instant::now();
 
         // Skip: accumulate word popcounts until the boundary word containing
         // page_offset — 64 cards per word read, deep pagination is a
@@ -8672,6 +8725,8 @@ fn run_query_streamed_popcount<'a>(
         // even then: bounded by `limit` emitted cards, not the candidate set,
         // and only pays the extra check at all for legality-touching planes.
         let existential = plane.is_some_and(plane_expr_is_existential);
+        // Ends `ns_loop` (the skip scan) and starts `ns_finish` (the emit walk).
+        let t_finish = std::time::Instant::now();
         let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
         'walk: while word_idx < permuted.len() {
             let mut w = permuted[word_idx];
@@ -8723,8 +8778,25 @@ fn run_query_streamed_popcount<'a>(
             }
             word_idx += 1;
         }
+        publish_popcount_phases(
+            (t_loop - t_start).as_nanos() as u64,
+            (t_finish - t_loop).as_nanos() as u64,
+            t_finish.elapsed().as_nanos() as u64,
+        );
         (total, page)
     })
+}
+
+/// Publish the popcount executor's three phases, consuming whatever build its caller handed over.
+///
+/// The pending value differs per plan and the `RANGE_ACQUIRES` rule is what makes both correct:
+/// `PlanePopcountOrder`'s plane eval is built during ACQUIRE on the routed path (so a forced run's
+/// rebuild must not count toward dispatch, and `plane` is not a range acquire), while
+/// `CardRangePopcount`'s bitmap is built in DISPATCH on both paths (so it must count, and
+/// `card_range_popcount` IS a range acquire). Same handoff, opposite treatment, both from one rule.
+fn publish_popcount_phases(ns_setup: u64, ns_loop: u64, ns_finish: u64) {
+    let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
+    PHASE_STATS.with(|c| c.set(PhaseStats { ns_setup, ns_loop, ns_finish, ns_prepare: prep_ns, ..PhaseStats::default() }));
 }
 
 /// Streamed selection: match phase records per-card match counts (total is

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5610,6 +5610,108 @@ fn orderby_walk_available(sort_col: SortCol) -> bool {
 /// every match lives in the buckets (`collected` reaches `total`, no null tail), a short last page is
 /// windowed normally.
 #[allow(clippy::too_many_arguments)]
+/// The routed path's time, split into DISJOINT phases that cover all of `run_query_routed`.
+///
+/// Everything else here measures one participant at a time and cannot be added up. `acquire_ns` is
+/// timed in its own `explain_analyze` round — a standalone `acquire_plan_features` call with its own
+/// cache state — while `routed_ns` times a SEPARATE execution that does its own acquire inside. They
+/// are two independent measurements of overlapping work, not a part and a whole, which is why
+/// `acquire_ns / routed_ns` measured a nonsensical 104% at the median on candidate-acquired queries.
+///
+/// These three are read from ONE execution with four contiguous clock reads, so
+/// `ns_acquire + ns_choose + ns_dispatch` accounts for the whole call bar the reads themselves. The
+/// same shape `PhaseStats` uses for setup/loop/finish, one level up — and those three subdivide
+/// `ns_dispatch`, together with `ns_prepare`, so the two nest rather than overlap.
+///
+/// Why it is worth four clock reads on the production path: `plan_cost` prices only what happens
+/// AFTER acquire, so acquire is unpriced for every plan, and cost.rs records the model's median error
+/// as 1.09x `acquire_ns`. Acquire is the largest unmodelled component in the engine and nothing has
+/// ever measured it as a fraction of the query it belongs to.
+/// Behind the `routed-phases` cargo feature, and the reason is measured rather than cautious: the
+/// four clock reads cost +2.7us and +2.3us on a ~40us median query in a paired interleaved A/B, both
+/// intervals excluding zero. That is ~1.6% of every request to answer a question a diagnostic build
+/// can answer instead — the same trade `alloc-counter` already makes.
+///
+/// With the feature off, `RoutedPhaseTimer` is a zero-sized struct whose methods are empty, so the
+/// reads and the publish compile away entirely.
+#[derive(Default, Clone, Copy)]
+struct RoutedPhases {
+    /// `acquire_plan_features`: count source, feature build, and whatever artifact it materializes.
+    ns_acquire: u64,
+    /// The `argmin cost::plan_cost` over applicable plans. Expected to be negligible; measured so
+    /// that "expected" is not doing the work — it comes out at 41ns, 0.0% of the query.
+    ns_choose: u64,
+    /// Running the winner, including a lazy re-materialize and re-choose when a fastpath declines.
+    ns_dispatch: u64,
+}
+
+/// Marks the three phase boundaries in `run_query_routed`, or nothing at all when the
+/// `routed-phases` feature is off. See `RoutedPhases`.
+#[cfg(feature = "routed-phases")]
+struct RoutedPhaseTimer {
+    entry: std::time::Instant,
+    acquired: Option<std::time::Instant>,
+    chosen: Option<std::time::Instant>,
+}
+
+#[cfg(feature = "routed-phases")]
+impl RoutedPhaseTimer {
+    fn start() -> Self {
+        Self { entry: std::time::Instant::now(), acquired: None, chosen: None }
+    }
+    fn acquired(&mut self) {
+        self.acquired = Some(std::time::Instant::now());
+    }
+    fn chosen(&mut self) {
+        self.chosen = Some(std::time::Instant::now());
+    }
+    /// Publishes the three disjoint spans. A boundary that was never marked collapses to the entry
+    /// instant, which cannot happen on the one path that exists but keeps this total.
+    fn finish(self) {
+        let done = std::time::Instant::now();
+        let acquired = self.acquired.unwrap_or(self.entry);
+        let chosen = self.chosen.unwrap_or(acquired);
+        ROUTED_PHASES.with(|c| {
+            c.set(RoutedPhases {
+                ns_acquire: (acquired - self.entry).as_nanos() as u64,
+                ns_choose: (chosen - acquired).as_nanos() as u64,
+                ns_dispatch: (done - chosen).as_nanos() as u64,
+            });
+        });
+    }
+}
+
+#[cfg(not(feature = "routed-phases"))]
+struct RoutedPhaseTimer;
+
+#[cfg(not(feature = "routed-phases"))]
+impl RoutedPhaseTimer {
+    #[inline(always)]
+    fn start() -> Self {
+        Self
+    }
+    #[inline(always)]
+    fn acquired(&mut self) {}
+    #[inline(always)]
+    fn chosen(&mut self) {}
+    #[inline(always)]
+    fn finish(self) {}
+}
+
+/// The last routed execution's phase split, cleared. All zeros without the `routed-phases` feature,
+/// which is what `explain_analyze` then reports — a consumer sees three empty-looking spans rather
+/// than a missing key, so the schema does not change with the feature.
+fn take_routed_phases() -> RoutedPhases {
+    #[cfg(feature = "routed-phases")]
+    {
+        ROUTED_PHASES.with(|c| c.replace(RoutedPhases::default()))
+    }
+    #[cfg(not(feature = "routed-phases"))]
+    {
+        RoutedPhases::default()
+    }
+}
+
 /// What a compose paging branch actually did, against the three quantities its cost arm charges.
 ///
 /// `PrintingCompose` published no executor counters at all until this existed, which made it the one
@@ -7011,6 +7113,17 @@ thread_local! {
         cards_visited: 0, printings_examined: 0, matches_pushed: 0,
     }) };
 
+    /// The routed path's disjoint phase split — see `RoutedPhases`. Its own slot for the same reason
+    /// the two above have theirs: `run_query_routed` is the production entry point, and one 24-byte
+    /// store there is affordable where a read-modify-write of `PhaseStats` measurably was not.
+    ///
+    /// Written by `run_query_routed` only, so it never collides with the executors' slot; the routed
+    /// path's dispatch phase CONTAINS an executor publish into `PHASE_STATS`, and the two nest.
+    #[cfg(feature = "routed-phases")]
+    static ROUTED_PHASES: std::cell::Cell<RoutedPhases> = const { std::cell::Cell::new(RoutedPhases {
+        ns_acquire: 0, ns_choose: 0, ns_dispatch: 0,
+    }) };
+
     /// `prepare_candidates`' time for the run in progress, handed to the executor that follows it —
     /// the two are separate calls in `run_query_with_plan`, and only the executor publishes stats.
     ///
@@ -7873,14 +7986,24 @@ fn run_query_routed<'a>(
             .expect("GatheredScan is always applicable and materializing")
     };
 
+    // Marks three disjoint phases covering the whole call — see `RoutedPhases` for why acquire needed
+    // measuring from inside one execution rather than as its own `explain_analyze` participant, and
+    // why it is behind a feature. Compiles to nothing without `routed-phases`.
+    let mut phases = RoutedPhaseTimer::start();
+
     // ── acquire: pick the count source, build features, materialize its artifact ──
     let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    phases.acquired();
 
     // ── choose: cheapest applicable plan ──
     let plan = choose(filter, &feats, false);
+    phases.chosen();
 
     // ── dispatch: run the winner, reusing the acquired artifact ──
-    match (plan, &prep) {
+    // Bound, not returned directly, so the closing clock read happens before the result is handed
+    // back and the phase covers dispatch alone. The match has no early returns, so this one exit is
+    // the only place the phases can be published from.
+    let out = match (plan, &prep) {
         (PhysicalPlan::PlanePopcountOrder, Prep::Plane) => {
             exec_plane_popcount_order_with_bitmap(ctx, params, plane.expect("Prep::Plane ⇒ plane"), &plane_bits)
         }
@@ -7924,7 +8047,9 @@ fn run_query_routed<'a>(
                 }
             }
         }
-    }
+    };
+    phases.finish();
+    out
 }
 
 /// In-process force/dispatch entry point (#702 step 2): run `plan` for this
@@ -8088,6 +8213,17 @@ pub(crate) struct AcquireFacts {
     /// into the picked plan's executor, so a fixed position ahead of the plans would pre-warm
     /// exactly the plan whose selection the comparison is meant to question.
     pub(crate) routed_ns: Vec<u64>,
+    /// `routed_ns` split into disjoint phases, one triple per round, from INSIDE the same execution —
+    /// see `RoutedPhases`. `routed_acquire_ns[i] + routed_choose_ns[i] + routed_dispatch_ns[i]`
+    /// accounts for `routed_ns[i]` bar the clock reads.
+    ///
+    /// Not the same quantity as `acquire_ns`, and the difference is the point. That one times a
+    /// standalone `acquire_plan_features` in its own participant round, so it can be compared across
+    /// queries but cannot be divided into `routed_ns` — measured, the ratio comes out at 104% of the
+    /// median candidate-acquired query, which is how the two got read as a part and a whole.
+    pub(crate) routed_acquire_ns: Vec<u64>,
+    pub(crate) routed_choose_ns: Vec<u64>,
+    pub(crate) routed_dispatch_ns: Vec<u64>,
 }
 
 impl Prep {
@@ -8131,6 +8267,9 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
         feats, // moved: `eval_domain`/`n_cards`/`matches` live here and nowhere else
         acquire_ns: vec![acquire_ns],
         routed_ns: Vec::new(), // explain runs nothing
+        routed_acquire_ns: Vec::new(),
+        routed_choose_ns: Vec::new(),
+        routed_dispatch_ns: Vec::new(),
     };
     let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
         .into_iter()
@@ -8359,7 +8498,16 @@ fn explain_analyze(
             }
             match participant {
                 Participant::Acquire => facts.acquire_ns.push(dt),
-                Participant::Routed => facts.routed_ns.push(dt),
+                Participant::Routed => {
+                    facts.routed_ns.push(dt);
+                    // Taken from the slot `run_query_routed` just wrote, in the same round, so the
+                    // three sum to `dt`. Replaced with the default so a later participant that does
+                    // not publish here cannot report this round as its own.
+                    let ph = take_routed_phases();
+                    facts.routed_acquire_ns.push(ph.ns_acquire);
+                    facts.routed_choose_ns.push(ph.ns_choose);
+                    facts.routed_dispatch_ns.push(ph.ns_dispatch);
+                }
                 // A structurally-applicable plan's fastpath can still decline at runtime
                 // (e.g. PrintingCompose on a sparse total) — deterministic for this
                 // query/data, so a decliner simply never accumulates trials.
@@ -9037,6 +9185,9 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
     d.set_item("narrowed_repr", f.narrowed_repr.label())?;
     d.set_item("acquire_ns", f.acquire_ns.clone())?;
     d.set_item("routed_ns", f.routed_ns.clone())?;
+    d.set_item("routed_acquire_ns", f.routed_acquire_ns.clone())?;
+    d.set_item("routed_choose_ns", f.routed_choose_ns.clone())?;
+    d.set_item("routed_dispatch_ns", f.routed_dispatch_ns.clone())?;
     // The model's own inputs, so a calibration fit regresses on the same vector `plan_cost` reads.
     let g = &f.feats;
     for (k, v) in [

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5635,7 +5635,7 @@ struct ComposePageWork {
 }
 
 fn collect_orderby_page<'a>(
-    mut next_bucket: impl FnMut() -> Option<Vec<u32>>,
+    mut next_bucket: impl FnMut() -> Option<(u64, Vec<u32>)>,
     cards: &'a [AOracleCard],
     printings: &'a [APrinting],
     printing_to_card: &AOffsets,
@@ -5650,8 +5650,15 @@ fn collect_orderby_page<'a>(
     let mut cum = 0usize; // matches seen (skipped + collected) so far
     let mut first_touched = 0usize; // matches before the first collected bucket (the offset skip)
     let mut started = false;
+    // The work this walk really does, which is NOT `cum`. A bucket is produced by scanning a raw
+    // structure and intersecting it with `pbits`: a rarity PLANE bucket ANDs `words_per_plane` words
+    // (~n_printings/64) however few matches come out, a postings bucket walks its list, a range
+    // bucket walks its value run. `cum` counts what SURVIVED that scan, so pricing the walk on it
+    // charges nothing for a bucket that scanned the whole corpus and matched twice.
+    let mut scanned = 0u64;
     while cum < want {
-        let Some(bucket) = next_bucket() else { break };
+        let Some((raw, bucket)) = next_bucket() else { break };
+        scanned += raw;
         let m = bucket.len();
         if m == 0 {
             continue;
@@ -5674,13 +5681,13 @@ fn collect_orderby_page<'a>(
     if cum < want && cum < total {
         return None;
     }
-    // `cum` is what this branch stepped over to fill the page: matches seen, skipped and collected
-    // alike. That is the quantity `cost::printings_walked` predicts as `page_span / match_rate`, and
-    // until now nothing checked it. `cards_visited` stays 0 -- this walk steps a value structure and
-    // never iterates cards.
+    // `printings_examined` is the RAW units scanned, not `cum`: see `scanned`. `cost::printings_walked`
+    // predicts `page_span / match_rate`, a page-fill length in match units, which does not describe a
+    // bucket scan at all -- one rarity plane bucket costs the same whether it yields two matches or
+    // twenty thousand. `cards_visited` stays 0: this walk steps a value structure, never cards.
     let work = ComposePageWork {
         cards_visited: 0,
-        printings_examined: cum as u64,
+        printings_examined: scanned,
         matches_pushed: collected.len() as u64,
     };
     let matches: Vec<Match> = collected
@@ -5723,7 +5730,7 @@ fn walk_range_orderby_page<'a>(
 ) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let (mut lo, mut hi) = (0usize, idx.len());
-    let next = move || -> Option<Vec<u32>> {
+    let next = move || -> Option<(u64, Vec<u32>)> {
         if lo >= hi {
             return None;
         }
@@ -5743,7 +5750,8 @@ fn walk_range_orderby_page<'a>(
             (lo, b)
         };
         if descending { hi = bs } else { lo = be }
-        Some((bs..be).map(|t| u32::from(idx[t].1)).filter(|&pid| is_set(pid as usize)).collect())
+        // The value run is scanned in full and bit-tested per entry; `be - bs` is that cost.
+        Some(((be - bs) as u64, (bs..be).map(|t| u32::from(idx[t].1)).filter(|&pid| is_set(pid as usize)).collect()))
     };
     collect_orderby_page(next, cards, printings, printing_to_card, sort_col, descending, total, limit, page_offset)
 }
@@ -5776,10 +5784,13 @@ fn walk_rarity_orderby_page<'a>(
     }
     let wpp = words_per_plane(n_printings);
     let mut vi = 0usize;
-    let next = move || -> Option<Vec<u32>> {
+    let next = move || -> Option<(u64, Vec<u32>)> {
         let int = *values.get(vi)?;
         vi += 1;
-        let pids: Vec<u32> = if let Some(k) = RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == int) {
+        // `raw` is what the bucket cost to produce, which the two kinds pay very differently: a plane
+        // bucket ANDs `wpp` words of the whole corpus however few matches survive, while a postings
+        // bucket walks only its own list. Counted in the same units the caller sums.
+        let (raw, pids): (u64, Vec<u32>) = if let Some(k) = RARITY_PRINTING_PLANE_INTS.iter().position(|&v| v == int) {
             let plane = &rp.words[k * wpp..(k + 1) * wpp];
             let mut out = Vec::new();
             for (wi, (pw, bw)) in plane.iter().zip(pbits.iter()).enumerate() {
@@ -5789,14 +5800,20 @@ fn walk_rarity_orderby_page<'a>(
                     w &= w - 1;
                 }
             }
-            out
+            // One word covers 64 printings, so report the printings covered rather than the word
+            // count -- that keeps this comparable to the entry-scanning buckets and to a feature
+            // measured in printings.
+            ((wpp * 64) as u64, out)
         } else {
             match rp.postings.iter().find(|e| e.0 == int) {
-                Some(e) => e.1.iter().map(|p| u32::from(*p)).filter(|&pid| pbits[pid as usize >> 6] & (1u64 << (pid & 63)) != 0).collect(),
-                None => Vec::new(),
+                Some(e) => (
+                    e.1.len() as u64,
+                    e.1.iter().map(|p| u32::from(*p)).filter(|&pid| pbits[pid as usize >> 6] & (1u64 << (pid & 63)) != 0).collect(),
+                ),
+                None => (0, Vec::new()),
             }
         };
-        Some(pids)
+        Some((raw, pids))
     };
     collect_orderby_page(next, cards, printings, printing_to_card, SortCol::Rarity, descending, total, limit, page_offset)
 }
@@ -7308,6 +7325,68 @@ fn declined_sibling_fastpath<'a>(
 /// `domain * (1 - e^(-k/domain))`. Unlike `k.min(domain)` this does not saturate -- `cn<100` (35,021
 /// printings) and `usd<50` (80,527) both cap to exactly 31,508 against true counts of 17,616 and
 /// 31,217, losing the entire signal between them.
+/// How much `balls_into_bins` over-states compose's distinct-card count, measured against
+/// `cards_visited` once `PrintingCompose` began reporting it.
+///
+/// The model assumes each matching printing lands in an independently chosen card. Compose's
+/// predicates are CLUSTERED instead -- a legality leaf broadcast down sets every printing of a
+/// matching card at once -- so the same `k` printings touch far fewer cards than independence
+/// predicts. Over 1,036 measured gather rows the raw estimator reads a median **1.73x** the truth.
+///
+/// A calibration constant and not a better model, deliberately: a size-biased estimator over the
+/// corpus's span histogram (`P(hit) = 1-(1-p)^s` per span-`s` card, which is the principled fix for
+/// treating every card as one equally likely bin) was tried and scored NO better -- log error 0.512
+/// against 0.513 -- because the failing assumption is independence, not uniform bins, and a
+/// size-biased model is still an independence model. Per-slice constants keyed on
+/// broadcast/range were also tried and added nothing once the exact rows below were separated out
+/// (test log error 0.439 against 0.438).
+///
+/// Fit on 1,036 rows, scored on a held-out 1,047: test log error 0.678 -> 0.438, median 1.73 -> 0.98,
+/// spread unchanged at 3.6. Spread is what a constant cannot fix, and it is what remains.
+///
+/// NOT applied where `range_card_counts_for` answers exactly -- those rows measure 1.000 with log
+/// error 0.056 and dividing them by anything would break them. That mixture is why the bias looked
+/// like 1.35 before the two populations were separated.
+const COMPOSE_CARD_ESTIMATE_BIAS: f64 = 1.78;
+
+/// Printings the gather BIT-TESTS per matching printing.
+///
+/// `compose_scan_printings` was the composed bitmap's popcount, on the stated grounds that compose
+/// "walks the set bits". `gather_composed_page` does not: except in its card/default-prefer arm it
+/// iterates `start..end` of every candidate card and tests each printing, so the real count is the
+/// SPAN of the candidate cards. Measured against `printings_examined`, the popcount reads a median
+/// 0.68 of the truth -- the gather tests 1.47 printings for every one that is set.
+///
+/// A single constant, unlike the card estimate's: per-slice constants keyed on broadcast/range were
+/// tried and made the held-out SPREAD worse (14.8 against 9.2) for a log-error gain of 0.005, which
+/// is overfitting four numbers to a mixture. Test log error 0.845 -> 0.700, median 0.66 -> 0.97.
+///
+/// The alternative is to make the feature true by changing the executor -- walking set bits, as the
+/// old comment claimed. Measured ceiling for that: bit tests on non-set printings are 11% of the
+/// gather's modelled page cost (`card_pass` is 60%, `push` 26%), so it is a constant-factor
+/// optimisation of one branch, not a model change. Left as a separate question.
+const COMPOSE_GATHER_SPAN_PER_MATCH: f64 = 1.47;
+
+/// How much bigger the candidate cards on a compose acquire are than an average card.
+///
+/// `scan_all` projects a card count into printings with the corpus mean (`printings_per_card`,
+/// 3.09). That is right when the candidates are a fair sample of the corpus and wrong here: a
+/// composable predicate selects cards by having a matching PRINTING, so heavily-reprinted cards are
+/// over-represented — the same size bias that makes compose's own gather test 13.2 printings per
+/// candidate card against a corpus mean of 3.09.
+///
+/// This multiplier is on `scan_units`, which costs the MATERIALIZING alternatives should compose
+/// lose, so it is a routing input even though compose never reads it. Calibrating the card estimate
+/// exposed it: `scan_units [printing_compose]` had been reading 0.75 with the two errors partly
+/// cancelling, and dividing `est_cards` by 1.78 moved it to 0.47.
+const COMPOSE_CANDIDATE_SPAN_BIAS: f64 = 2.1;
+
+/// `balls_into_bins` with its measured bias divided out. See `COMPOSE_CARD_ESTIMATE_BIAS`.
+fn calibrated_balls_into_bins(k: usize, domain: usize) -> usize {
+    let raw = balls_into_bins(k, domain) as f64;
+    ((raw / COMPOSE_CARD_ESTIMATE_BIAS).round() as usize).max(usize::from(k > 0))
+}
+
 fn balls_into_bins(k: usize, domain: usize) -> usize {
     if domain == 0 {
         return 0;
@@ -7446,6 +7525,7 @@ fn mk_plan_feats(
         // STREAM_ARTWORK_SEEN_PER_CARD_NS for the mechanism and the measurement.
         artwork_seen_cards: if matches!(params.mode, Mode::Artwork) { eval_domain } else { 0 },
         compose_scan_printings: 0, // set by every branch that costs a PrintingCompose (its own, or as a competitor)
+        orderby_walk_scan: 0,      // only the compose branch, and only for a plane-bucket orderby walk
     }
 }
 
@@ -7604,11 +7684,23 @@ fn acquire_plan_features(
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::CardRangePopcount))
     } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
-        // Bare range: exact k from the index (no scan). P3/P4 estimated unnarrowed
-        // (their broad regime — a narrow range makes P1 lose, and dispatch materializes).
+        // Bare range: exact k from the index (no scan).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
-        let mut feats = mk_plan_feats(ctx, params, k, n_cards, n_printings, verify_cost_tier(filter));
+        // What the MATERIALIZING alternatives see, by the same test the sibling `CardRangePopcount`
+        // branch already applies: `range_narrowed` hands back an enumerable printing list only while
+        // the slice stays under `MAX_NARROW_FRACTION`, and degrades to a printing-space bitmap past
+        // it, which cannot yield card ids so the scan walks the whole corpus.
+        //
+        // This branch used to assume the degraded case ALWAYS, on the grounds that a narrow range
+        // makes P1 lose and dispatch materializes anyway. The sibling's comment went further and
+        // claimed the two "agree to within 1%". They agree at the MEDIAN and nowhere else: measured
+        // against `cards_visited`, `eval_domain` here reads 1.00 at p50 but 4.23 at p70 and 41.7 at
+        // p90, because a third of these queries do narrow. (The p100 of 315 is the harness's
+        // MIN_COUNTER floor, not the real maximum -- 31,508/100.)
+        let (eval_domain, scan_units) =
+            if range_too_broad_to_narrow(k as usize, idx.len()) { (n_cards, n_printings) } else { (k.min(n_cards), k) };
+        let mut feats = mk_plan_feats(ctx, params, k, eval_domain, scan_units, verify_cost_tier(filter));
         feats.compose_scan_printings = k;
         feats.scatter_printings = k; // for costing a competing PrintingCompose (which would scatter k); P1 itself walks, so its own cost ignores this
         // Also for costing that competing compose: `eval_domain`/`scan_units` above are the
@@ -7639,7 +7731,8 @@ fn acquire_plan_features(
         // every artwork-mode one, plus card-mode ones whose orderby has no permutation.
         let exact_cards = bare_range_bounds(filter, indexes)
             .and_then(|(idx, lo, hi)| range_card_counts_for(indexes, idx).and_then(|counts| counts.distinct_cards(lo, hi)));
-        let est_cards = exact_cards.map_or_else(|| balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
+        let est_cards =
+            exact_cards.map_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
         // What the MATERIALIZING alternatives scan if compose loses. Every mode narrows -- a
         // composable filter has an index for every leaf -- so all three are the NARROWED counts.
         // Printing mode took the unnarrowed universe while card/artwork took a narrowed count; only
@@ -7647,7 +7740,7 @@ fn acquire_plan_features(
         // `eval_domain` and scanned 0.14x the claimed `scan_units`. Over-costing both plans inflates
         // the predicted GAP between them (P4 carries the larger per-row rates), which is what routing
         // reads -- measured as a GatheredScan-vs-StreamedSelect gap ratio of 0.32 on this acquire.
-        let scan_all = |cards: usize| ((cards as f64) * printings_per_card) as usize;
+        let scan_all = |cards: usize| ((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize;
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
             Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
             Mode::Card => {
@@ -7677,7 +7770,11 @@ fn acquire_plan_features(
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
         feats.popcount_words = popcount_words as u32;
-        feats.compose_scan_printings = printing_matches as u32;
+        feats.compose_scan_printings = (printing_matches as f64 * COMPOSE_GATHER_SPAN_PER_MATCH) as u32;
+        // A rarity orderby walk pays a whole one-hot plane per bucket, so its floor is the corpus
+        // however selective the filter is. `usd` walks small value runs instead and keeps the shared
+        // page-fill term. See `PlanFeatures::orderby_walk_scan`.
+        feats.orderby_walk_scan = if matches!(sort_col, SortCol::Rarity) { n_printings } else { 0 };
         // Which paging strategy the fastpath will actually use — decided the same way the fastpath
         // itself decides, through the same helpers, including whether it will decline. Only this
         // branch knows the estimated result total, so only it can predict the small-total bail. The
@@ -8920,6 +9017,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("popcount_words", g.popcount_words),
         ("artwork_seen_cards", g.artwork_seen_cards),
         ("compose_scan_printings", g.compose_scan_printings),
+        ("orderby_walk_scan", g.orderby_walk_scan),
         // Derived inside plan_cost rather than stored, and exposed because the Perm/OrderbyWalk
         // paging branches are priced entirely on it and nothing else can check them.
         ("printings_walked", cost::printings_walked(g) as u32),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5610,6 +5610,30 @@ fn orderby_walk_available(sort_col: SortCol) -> bool {
 /// every match lives in the buckets (`collected` reaches `total`, no null tail), a short last page is
 /// windowed normally.
 #[allow(clippy::too_many_arguments)]
+/// What a compose paging branch actually did, against the three quantities its cost arm charges.
+///
+/// `PrintingCompose` published no executor counters at all until this existed, which made it the one
+/// plan `bench_feature_accuracy.py` could say nothing about -- every cell labelled with a compose
+/// ACQUIRE was really measuring how well compose's shared feature vector described GatheredScan and
+/// StreamedSelect, the plans that do report. Its own arm terms (`compose_scan_printings`,
+/// `printings_walked`) were graded against nothing, and its paging table was structurally empty at
+/// any sample size. That matters more than the gap in coverage suggests: compose carries ~75% of all
+/// routing regret (docs/issues/reference-cost-model-measurement.md).
+///
+/// The three branches do different work and each fills these differently -- see the doc on each.
+#[derive(Default, Clone, Copy)]
+struct ComposePageWork {
+    /// Cards the branch iterated: candidate cards for the gather, permutation entries consumed for
+    /// the forward walk, `0` for the orderby walk (it steps a value structure, not cards).
+    cards_visited: u64,
+    /// Printings the branch touched: `pbits` membership tests for the gather and the forward walk,
+    /// matches stepped over for the orderby walk.
+    printings_examined: u64,
+    /// Rows the branch pushed. For the gather this is every match (it visits every candidate); for
+    /// the two walks it is bounded by the page, which is the whole point of their cost shape.
+    matches_pushed: u64,
+}
+
 fn collect_orderby_page<'a>(
     mut next_bucket: impl FnMut() -> Option<Vec<u32>>,
     cards: &'a [AOracleCard],
@@ -5620,7 +5644,7 @@ fn collect_orderby_page<'a>(
     total: usize,
     limit: usize,
     page_offset: usize,
-) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let want = page_offset + limit;
     let mut collected: Vec<u32> = Vec::new();
     let mut cum = 0usize; // matches seen (skipped + collected) so far
@@ -5650,6 +5674,15 @@ fn collect_orderby_page<'a>(
     if cum < want && cum < total {
         return None;
     }
+    // `cum` is what this branch stepped over to fill the page: matches seen, skipped and collected
+    // alike. That is the quantity `cost::printings_walked` predicts as `page_span / match_rate`, and
+    // until now nothing checked it. `cards_visited` stays 0 -- this walk steps a value structure and
+    // never iterates cards.
+    let work = ComposePageWork {
+        cards_visited: 0,
+        printings_examined: cum as u64,
+        matches_pushed: collected.len() as u64,
+    };
     let matches: Vec<Match> = collected
         .iter()
         .map(|&pid| {
@@ -5661,12 +5694,13 @@ fn collect_orderby_page<'a>(
     // of matches, so the `O(n log n)` sort's log factor is the dominant cost there — `select_page`
     // (same `page_cmp` comparator) is `O(collected + limit·log limit)`. `page_offset - first_touched`
     // rebases the offset onto the collected touched buckets.
-    Some(
+    Some((
         select_page(matches, page_offset - first_touched, limit)
             .into_iter()
             .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
             .collect(),
-    )
+        work,
+    ))
 }
 
 /// #744 orderby walk for a range-indexed sort column (`usd` — the only such `SortCol`; cn/date are
@@ -5686,7 +5720,7 @@ fn walk_range_orderby_page<'a>(
     total: usize,
     limit: usize,
     page_offset: usize,
-) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let (mut lo, mut hi) = (0usize, idx.len());
     let next = move || -> Option<Vec<u32>> {
@@ -5732,7 +5766,7 @@ fn walk_rarity_orderby_page<'a>(
     limit: usize,
     page_offset: usize,
     n_printings: usize,
-) -> Option<Vec<(&'a AOracleCard, &'a APrinting)>> {
+) -> Option<(Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork)> {
     // Every rarity int present: interior [0..3] (planes, always laid out) + the postings' ints.
     let mut values: Vec<u8> = RARITY_PRINTING_PLANE_INTS.to_vec();
     values.extend(rp.postings.iter().map(|e| e.0));
@@ -5826,9 +5860,10 @@ fn printing_compose_fastpath<'a>(
     };
     if total == 0 || page_offset >= total {
         note_paging_taken(PagingTaken::EmptyPage);
+        publish_compose_work(ComposePageWork::default());
         return Some((total, Vec::new()));
     }
-    let page = match perm {
+    let (page, work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
@@ -5861,9 +5896,9 @@ fn printing_compose_fastpath<'a>(
                 None
             };
             match walked {
-                Some(rows) => {
+                Some(rows_and_work) => {
                     note_paging_taken(PagingTaken::OrderbyWalk);
-                    rows
+                    rows_and_work
                 }
                 None => {
                     // Two different situations reach this gather, and `compose_paging` predicts
@@ -5878,6 +5913,7 @@ fn printing_compose_fastpath<'a>(
             }
         }
     };
+    publish_compose_work(work);
     Some((total, page))
 }
 
@@ -6410,7 +6446,7 @@ fn walk_grouped_page<'a>(
     params: &QueryParams,
     pbits: &[u64],
     perm: &Archived<Vec<u32>>,
-) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -6429,10 +6465,16 @@ fn walk_grouped_page<'a>(
     let mut touched: Vec<u16> = Vec::new();
     let mut scratch: Vec<Match> = Vec::new();
     let mut skip = page_offset;
+    // This walk pays per PERMUTATION ENTRY, not per match: it steps cards in sort order and bit-tests
+    // each one's whole printing span, stopping only when the page fills. `cost::printings_walked`
+    // models that as `page_span / match_rate`, which nothing checked before these counters.
+    let mut work = ComposePageWork::default();
     for cid in perm.iter().map(|x| u32::from(*x)) {
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
+        work.cards_visited += 1;
+        work.printings_examined += (end - start) as u64;
         scratch.clear();
         match mode {
             // Printing: every set printing is its own row (no grouping).
@@ -6472,6 +6514,7 @@ fn walk_grouped_page<'a>(
                 }
             }
         }
+        work.matches_pushed += scratch.len() as u64;
         if scratch.is_empty() {
             continue;
         }
@@ -6483,12 +6526,12 @@ fn walk_grouped_page<'a>(
         for m in scratch.iter().skip(skip) {
             page.push((&cards[m.1 as usize], &printings[m.2 as usize]));
             if page.len() == limit {
-                return page;
+                return (page, work);
             }
         }
         skip = 0;
     }
-    page
+    (page, work)
 }
 
 /// Permutation-free counterpart to `walk_grouped_page`, for when `orderby` has no card-space
@@ -6508,7 +6551,7 @@ fn gather_composed_page<'a>(
     params: &QueryParams,
     pbits: &[u64],
     card_bits: Option<&[u64]>,
-) -> Vec<(&'a AOracleCard, &'a APrinting)> {
+) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -6534,14 +6577,22 @@ fn gather_composed_page<'a>(
     let mut group_best: Vec<Option<(u32, f64)>> = vec![None; n];
     let mut touched: Vec<u16> = Vec::new();
     let mut sel = GatherSelect::new(page_offset, limit);
+    // `compose_scan_printings` is set to the composed bitmap's POPCOUNT, on the stated grounds that
+    // compose "walks the set bits". This loop does not: except in the card/default-prefer arm it
+    // iterates `start..end` of every candidate card and bit-tests each printing, so the real count is
+    // the SPAN of the candidate cards. Counted per arm below so the difference is measured rather
+    // than argued.
+    let mut work = ComposePageWork::default();
     for cid in candidate_cards {
         let card = &cards[cid as usize];
         let start = u32::from(offsets[cid as usize]) as usize;
         let end = u32::from(offsets[cid as usize + 1]) as usize;
         let before = sel.buf().len();
+        work.cards_visited += 1;
         match mode {
             // Printing: every set printing is its own row (no grouping).
             Mode::Printing => {
+                work.printings_examined += (end - start) as u64;
                 for pid in start..end {
                     if is_set(pid) {
                         sel.buf().push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
@@ -6557,12 +6608,19 @@ fn gather_composed_page<'a>(
             // cost that scales with total matches rather than `limit` is the dominant term for a broad
             // composed set.
             Mode::Card if matches!(prefer, Prefer::Default) => {
+                // The one arm that does stop early: `find` breaks at the first set printing, and a
+                // candidate card has at least one by construction, so this tests `first_set - start + 1`
+                // rather than the span.
                 if let Some(pid) = (start..end).find(|&pid| is_set(pid)) {
+                    work.printings_examined += (pid - start + 1) as u64;
                     sel.buf().push((sort_key_bits(card, &printings[pid], sort_col, descending), cid, pid as u32));
+                } else {
+                    work.printings_examined += (end - start) as u64;
                 }
             }
             // Card (non-default prefer) / Artwork: one best-prefer representative per group.
             Mode::Card | Mode::Artwork => {
+                work.printings_examined += (end - start) as u64;
                 touched.clear();
                 for pid in start..end {
                     if !is_set(pid) {
@@ -6589,10 +6647,11 @@ fn gather_composed_page<'a>(
                 }
             }
         }
+        work.matches_pushed += (sel.buf().len() - before) as u64;
         sel.absorb(before);
     }
     let (_total, page_ids) = sel.finish(page_offset, limit); // total already known exactly via popcount; only the page is wanted here
-    page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect()
+    (page_ids.into_iter().map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize])).collect(), work)
 }
 
 /// P3 executor: streamed selection over the sort permutation. Caller guarantees
@@ -6951,6 +7010,34 @@ fn timed_prepare_candidates(
 /// `PhaseStats::paging_taken` for why the predicted branch is not enough.
 fn note_paging_taken(which: PagingTaken) {
     PAGING_TAKEN.with(|c| c.set(which));
+}
+
+/// Publish what a compose paging branch did into the shared counters, so `PrintingCompose` reports
+/// the same three quantities the two materializing plans do.
+///
+/// A WHOLE-struct set, like the other two publishers: nothing here is inherited, so compose cannot
+/// report a field an earlier participant wrote. `paging_taken` survives because it lives in
+/// `PAGING_TAKEN`, which this does not touch -- the same split `PhaseStats` documents.
+///
+/// The phase timings stay zero. Compose's cost arm is not decomposed into setup/loop/finish the way
+/// the scan plans' is, so there is nothing yet to check them against, and publishing an
+/// unvalidatable number is how `printings_scanned` became load-bearing in the first place.
+fn publish_compose_work(work: ComposePageWork) {
+    PHASE_STATS.with(|c| {
+        c.set(PhaseStats {
+            cards_visited: work.cards_visited,
+            printing_span: 0, // compose never materializes a candidate list, so there is no span
+            printings_examined: work.printings_examined,
+            matches_pushed: work.matches_pushed,
+            ns_setup: 0,
+            ns_loop: 0,
+            ns_finish: 0,
+            ns_round_total: 0, // filled by explain_analyze, which owns the round timer
+            ns_prepare: 0,
+            result_total: 0, // likewise
+            paging_taken: PagingTaken::NotEntered, // owned by PAGING_TAKEN; take_phase_stats merges it in
+        });
+    });
 }
 
 /// Last executor run's phase stats, and clear them. `explain_analyze` reads this immediately after a

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10046,3 +10046,5 @@ mod bench_compose_paging;
 mod bench_compose_card_projection;
 #[cfg(test)]
 mod bench_candidate_materialize;
+#[cfg(test)]
+mod bench_gather_loop;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5765,6 +5765,9 @@ struct ComposePageWork {
     ns_total: u64,
 }
 
+// Nine: the bucket source, the three stores it reads through, the sort key's two halves, and the three
+// paging bounds. They are the page-fill's whole input and the one caller passes them straight through.
+#[allow(clippy::too_many_arguments, reason = "the page fill's whole input; the single caller passes them straight through")]
 fn collect_orderby_page<'a>(
     mut next_bucket: impl FnMut() -> Option<(u64, Vec<u32>)>,
     cards: &'a [AOracleCard],

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7281,7 +7281,7 @@ fn orderby_walk_matches_gather_composed() {
             for &descending in &[false, true] {
                 for &offset in &[0usize, 50, 200] {
                     let limit = 100usize;
-                    let gather = super::gather_composed_page(
+                    let (gather, _) = super::gather_composed_page(
                         &QueryCtx::from(archived), &kernel_params(Mode::Printing, sort_col, descending, limit, offset), &pbits, None,
                     );
                     let walk = match sort_col {
@@ -7295,7 +7295,7 @@ fn orderby_walk_matches_gather_composed() {
                         ),
                         _ => None,
                     };
-                    if let Some(walk) = walk {
+                    if let Some((walk, _)) = walk {
                         walked_any = true;
                         assert_eq!(
                             ids(&walk), ids(&gather),
@@ -9974,7 +9974,7 @@ fn range_compose_kernel_costs() {
             let page = super::walk_grouped_page(
                 &QueryCtx::from(archived), &kernel_params(Mode::Card, SortCol::EdhrecRank, false, LIMIT, 0), &pbits, perm,
             );
-            page.len() as u64
+            page.0.len() as u64
         });
         let per_prtg = scatter_ns as f64 / set_prtg.max(1) as f64;
         println!(

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3738,7 +3738,10 @@ fn plan_stats_never_leak_between_participants() {
     const CORPUS_SIZE: usize = 3_000;
     const NUM_WARMUPS: usize = 1;
     const NUM_TRIALS: usize = 3;
-    /// Publish no counters whatsoever — see the doc's leak 1.
+    /// Publish no per-card COUNTERS — they popcount bitmaps or walk an index and visit no cards, so
+    /// `cards_visited`/`printings_examined`/`matches_pushed` have nothing to report. They DO publish
+    /// phase timings: every plan does now, which is what lets `plan_self_ns` read the executor's own
+    /// time directly instead of recovering it by subtracting `ns_prepare` from a trial.
     const SILENT_PLANS: [PhysicalPlan; 3] =
         [PhysicalPlan::PrintingRangeScan, PhysicalPlan::PlanePopcountOrder, PhysicalPlan::CardRangePopcount];
     /// The subset of `SILENT_PLANS` that writes NO field at all, `paging_taken` included, so
@@ -3799,19 +3802,14 @@ fn plan_stats_never_leak_between_participants() {
                             (p.cards_visited, p.printing_span, p.printings_examined, p.matches_pushed), (0, 0, 0, 0),
                             "uninstrumented plan reported counters it never wrote: {case}",
                         );
-                        assert_eq!(
-                            (p.ns_setup, p.ns_loop, p.ns_finish), (0, 0, 0),
-                            "uninstrumented plan reported loop timings it never wrote: {case}",
+                        // The INVERSE of the old assertion, and a stronger statement: these plans must
+                        // publish a phase span, because `plan_self_ns` now reads the executor's own
+                        // time from the phases rather than recovering it by subtraction. A plan that
+                        // ran and reports no phase would be priced at zero.
+                        assert!(
+                            p.ns_setup + p.ns_loop + p.ns_finish > 0,
+                            "plan produced a page but published no phase timing, so it prices as zero: {case}",
                         );
-                        // `ns_prepare` is the one exception, and only for `PlanePopcountOrder`: the
-                        // router builds its plane bitmap during acquire and hands it over, so a FORCED
-                        // run has to rebuild it and reports that build here. Netting it is what makes
-                        // a plane row dispatch-comparable — without it the regret matrix read a mean
-                        // -4.21us on plane/card, the routed path apparently beating the best plan.
-                        // Every other silent plan still reports nothing.
-                        if t.plan != PhysicalPlan::PlanePopcountOrder {
-                            assert_eq!(p.ns_prepare, 0, "uninstrumented plan reported a prepare time it never wrote: {case}");
-                        }
                         // The label half splits: only the two plans that write nothing can be
                         // checked as "still NotEntered". `PrintingRangeScan` labels its own exits,
                         // so for it the equivalent — and stronger — statement is that the label is

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4478,6 +4478,7 @@ fn plan_cost_model_matches_gold() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
                 };
 
@@ -4717,6 +4718,7 @@ fn plan_cost_refit() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
@@ -4919,6 +4921,7 @@ fn printing_range_route_probe() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
             };
 
@@ -5281,6 +5284,7 @@ fn plan_regret_report() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
             };
 
@@ -5409,6 +5413,7 @@ fn plan_regret_fuzz() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                gather_group_printings: 0,
                 orderby_walk_scan: 0,
             };
             let feats_true = mk(true_total, eval_domain);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3800,9 +3800,18 @@ fn plan_stats_never_leak_between_participants() {
                             "uninstrumented plan reported counters it never wrote: {case}",
                         );
                         assert_eq!(
-                            (p.ns_setup, p.ns_loop, p.ns_finish, p.ns_prepare), (0, 0, 0, 0),
-                            "uninstrumented plan reported phase timings it never wrote: {case}",
+                            (p.ns_setup, p.ns_loop, p.ns_finish), (0, 0, 0),
+                            "uninstrumented plan reported loop timings it never wrote: {case}",
                         );
+                        // `ns_prepare` is the one exception, and only for `PlanePopcountOrder`: the
+                        // router builds its plane bitmap during acquire and hands it over, so a FORCED
+                        // run has to rebuild it and reports that build here. Netting it is what makes
+                        // a plane row dispatch-comparable — without it the regret matrix read a mean
+                        // -4.21us on plane/card, the routed path apparently beating the best plan.
+                        // Every other silent plan still reports nothing.
+                        if t.plan != PhysicalPlan::PlanePopcountOrder {
+                            assert_eq!(p.ns_prepare, 0, "uninstrumented plan reported a prepare time it never wrote: {case}");
+                        }
                         // The label half splits: only the two plans that write nothing can be
                         // checked as "still NotEntered". `PrintingRangeScan` labels its own exits,
                         // so for it the equivalent — and stronger — statement is that the label is

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3224,6 +3224,21 @@ fn explain_reports_ranked_applicable_plans() {
                 );
             }
             for e in &estimates {
+                // `PrintingCompose` alone may report `+inf`, and it means one specific thing: the
+                // fastpath is predicted to REFUSE this query, so `cost::plan_cost` returns
+                // `f64::INFINITY` to keep it out of the argmin rather than route to a plan that
+                // returns `None` and pays a detour. It still appears in `estimates` (sorted last),
+                // and `costbench.predicted_ns` screens it for exactly this reason.
+                //
+                // This assertion used to demand finiteness from every plan and passed only because
+                // the fixture never tripped the small-total decline. Calibrating the compose card
+                // estimate (it read a median 1.73x the truth) shrank `result_total` enough to
+                // predict declines here -- the prediction mirrors the fastpath's real
+                // `total <= STREAM_MIN_MATCHES` bail, so predicting more of them on a better
+                // estimate is the improvement, not a regression.
+                if e.plan == PhysicalPlan::PrintingCompose && e.predicted_ns == f64::INFINITY {
+                    continue;
+                }
                 assert!(e.predicted_ns.is_finite() && e.predicted_ns >= 0.0, "non-finite/negative predicted_ns for {:?}", e.plan);
             }
         }
@@ -4463,6 +4478,7 @@ fn plan_cost_model_matches_gold() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
                 };
 
                 // ── Model argmin over the applicable plans ──
@@ -4701,6 +4717,7 @@ fn plan_cost_refit() {
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
                 };
                 for (pi, plan) in all_plans.iter().enumerate() {
                     if let Some(meas) = ns[pi] {
@@ -4902,6 +4919,7 @@ fn printing_range_route_probe() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
             };
 
             // ── Three pickers ──
@@ -5263,6 +5281,7 @@ fn plan_regret_report() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
             };
 
             let gold = (0..4).filter_map(|i| ns[i].map(|v| (v, i))).min_by_key(|(v, _)| *v);
@@ -5390,6 +5409,7 @@ fn plan_regret_fuzz() {
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
                 compose_scan_printings: 0,
+                orderby_walk_scan: 0,
             };
             let feats_true = mk(true_total, eval_domain);
             let feats_est = mk(est, est.min(n_cards));

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3491,16 +3491,16 @@ fn compose_paging_prediction_matches_the_branch_taken() {
     assert!(declined > 0, "no compose query declined; the decline-label assertion is unexercised");
 }
 
-/// The two materializing plans must report identical `cards_visited` and `printings_scanned`.
+/// The two materializing plans must report identical `cards_visited` and `printing_span`.
 ///
 /// These are ONE counter under one name: `PhaseStats` has a single set of fields and both
 /// `exec_gathered_scan` and `run_query_streamed` publish into them, so a consumer reading
-/// `printings_scanned` off a `PlanTrial` cannot tell which executor produced it. `scan_units` has
+/// `printing_span` off a `PlanTrial` cannot tell which executor produced it. `scan_units` has
 /// one definition too, and both plans' cost arms key on it — so if the executors count differently,
 /// at most one of them is the valid comparison, and the damage surfaces as a rate constant that
 /// will not calibrate rather than as anything that looks like a bug.
 ///
-/// `printings_scanned` is the load-bearing half, and the reason is a one-line placement: both
+/// `printing_span` is the load-bearing half, and the reason is a one-line placement: both
 /// executors count it BELOW the `card_pass` continue, because a card rejected there never has its
 /// printings touched. Counting at the top of the loop instead is the exact defect this pins, and it
 /// is the shape a plausible "just count once at the top" cleanup would reintroduce silently.
@@ -3515,6 +3515,12 @@ fn compose_paging_prediction_matches_the_branch_taken() {
 /// while streamed calls it and could hit the `continue`. The counts stay equal only if
 /// `all_match_known` is honest, so the artwork/all-match cell checks the narrowing's own claim as
 /// well as the counters — which is why it is guarded for coverage separately below.
+///
+/// `printings_examined` is deliberately NOT in this set, and must not be added: the two executors do
+/// genuinely different work there, which is the whole reason it exists as a second counter. Streamed
+/// only COUNTS, so both `all_match` arms of `card_match_count` answer from span arithmetic and examine
+/// zero printings; gathered must EMIT, so it reads the one printing it picks. Asserting equality would
+/// pin the very conflation `printing_span` already suffered from — see `PhaseStats`.
 ///
 /// `matches_pushed` is asserted two ways: plan-vs-plan like the others, and against the total each
 /// run actually returned. The second is what carries it. Plan-vs-plan alone cannot catch both
@@ -3536,7 +3542,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
     // never fires and the two loops trivially agree. Only an inexact narrowing (an oracle-text
     // trigram superset, an arithmetic comparison across a card and a printing field) hands the
     // executors candidates that `card_pass` then rejects, which is the only condition under which
-    // `printings_scanned` can diverge at all. Verified: without the second group `saw_continue` is
+    // `printing_span` can diverge at all. Verified: without the second group `saw_continue` is
     // 0 across the whole sweep and both assertions pass without exercising anything.
     let specs = [
         fuzz_leaf_type(&mut rng),
@@ -3601,9 +3607,9 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                     streamed.cards_visited, gathered.cards_visited,
                 );
                 assert_eq!(
-                    streamed.printings_scanned, gathered.printings_scanned,
-                    "printings_scanned disagrees (streamed {} vs gathered {}): {case}",
-                    streamed.printings_scanned, gathered.printings_scanned,
+                    streamed.printing_span, gathered.printing_span,
+                    "printing_span disagrees (streamed {} vs gathered {}): {case}",
+                    streamed.printing_span, gathered.printing_span,
                 );
                 assert_eq!(
                     streamed.matches_pushed, gathered.matches_pushed,
@@ -3639,7 +3645,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                 }
                 // Did the `card_pass` continue actually fire? Only then do the two loops take
                 // different numbers of trips past the counter, which is the only way
-                // `printings_scanned` can come apart at all. Measured as "fewer printings scanned
+                // `printing_span` can come apart at all. Measured as "fewer printings scanned
                 // than the candidate set holds", not guessed from the counters alone.
                 let scannable: u64 = prep
                     .card_ids(&ctx)
@@ -3648,7 +3654,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                         u64::from(u32::from(e) - u32::from(s))
                     })
                     .sum();
-                if gathered.printings_scanned < scannable {
+                if gathered.printing_span < scannable {
                     saw_continue += 1;
                 }
             }
@@ -3666,12 +3672,12 @@ fn materializing_plans_agree_on_the_counters_they_share() {
         artwork_all_match > 0,
         "no artwork query had all_match_known; the one cell where the two all_match gates diverge is unchecked",
     );
-    // And the continue must actually fire somewhere, or `printings_scanned` equality is trivial:
+    // And the continue must actually fire somewhere, or `printing_span` equality is trivial:
     // with every candidate passing, both loops scan every printing and cannot disagree. This is
     // what the inexact-narrowing specs are in the list for -- drop them and this drops to 0.
     assert!(
         saw_continue > 0,
-        "card_pass never rejected a candidate; printings_scanned agreed only because nothing was skipped",
+        "card_pass never rejected a candidate; printing_span agreed only because nothing was skipped",
     );
 }
 
@@ -3775,7 +3781,7 @@ fn plan_stats_never_leak_between_participants() {
                         // Leak 1. `ns_round_total` and `result_total` are excluded: `explain_analyze`
                         // fills both itself after the take, so they are non-zero by design here.
                         assert_eq!(
-                            (p.cards_visited, p.printings_scanned, p.matches_pushed), (0, 0, 0),
+                            (p.cards_visited, p.printing_span, p.printings_examined, p.matches_pushed), (0, 0, 0, 0),
                             "uninstrumented plan reported counters it never wrote: {case}",
                         );
                         assert_eq!(
@@ -4016,7 +4022,7 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
                     // No executor ran, so anything non-zero here came from somewhere else.
                     let p = &t.phases;
                     assert_eq!(
-                        (p.cards_visited, p.printings_scanned, p.matches_pushed), (0, 0, 0),
+                        (p.cards_visited, p.printing_span, p.printings_examined, p.matches_pushed), (0, 0, 0, 0),
                         "a declining plan reported counters no executor wrote: {case}",
                     );
                     assert_eq!(

--- a/client/query_sampler.py
+++ b/client/query_sampler.py
@@ -768,6 +768,17 @@ class QuerySampler:
         """An orderby, weighted by mode. Which one gates StreamedSelect/PlanePopcountOrder."""
         return self._choose(self._restrict(self.orderbys, shape.orderby), rng)
 
+    def prefer(self, rng: random.Random) -> str:
+        """A printing-preference, weighted by mode.
+
+        Exposed alongside `unique`/`orderby` because it is not merely a result-shaping knob: the
+        card- and artwork-mode match kernels may stop at the first qualifying printing under
+        `default` (printings are stored in prefer-desc order, so the first match IS the pick) and
+        must score every printing under any other value. A harness that pins this to `default`
+        measures only the short-circuiting path.
+        """
+        return self._choose(self.prefers, rng)
+
     def params(self, rng: random.Random, shape: Shape = ANY_SHAPE) -> dict[str, str | int]:
         """Every result-shaping parameter at once: unique, orderby, prefer, direction, offset."""
         return {

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -23,6 +23,11 @@ Pick by question:
 | Where does routing actually lose time? | [`bench_regret_matrix.py`](../../scripts/bench_regret_matrix.py) |
 | Did this PLAN's executor get faster, picked or not? | [`bench_plan_execution_ab.py`](../../scripts/bench_plan_execution_ab.py) `--compare` |
 | Did a change help end to end? | [`bench_query_latency_ab.py`](../../scripts/bench_query_latency_ab.py) vs `main` |
+| Where does the routed path spend its time? | any harness, on a `--features routed-phases` build |
+
+Several of these need a `routed-phases` build to be read correctly — `bench_regret_matrix.py` refuses
+to run without it. See the two-bin section below for what the feature buys and why it is not on by
+default (~1.6% of every request).
 
 All of them are built on [`scripts/costbench.py`](../../scripts/costbench.py), which owns the
 sampling loop, the nearest-rank percentiles, the paired-bootstrap comparison, and — the one that
@@ -42,8 +47,10 @@ bands, because a mean over this distribution understates the tail and a p99 over
 Most of them draw queries from one universe, [`query_sampler.py`](../../client/query_sampler.py), in
 one of two weightings. Diagnostics default to `uniform` because their job is to FIND errors and
 uniform reaches the rare tails; latency defaults to `realistic` because there the question is what
-users wait for. Both matter: artwork is 5% of realistic traffic and carries **50% of all routing
-regret**.
+users wait for. Both matter: artwork is 5% of realistic traffic and carries a wildly disproportionate
+share of routing regret — on the dispatch basis, `printing_compose / artwork` alone is **33% of all
+lost time** against 5% for printing and 2% for card. (An older reading put artwork at 50% overall; that
+predates the dispatch re-base and should not be quoted.)
 
 Constrain the draw with `Shape` rather than writing a generator — `Shape(families={"range"},
 predicates=1, unique={"printing"})` gives a bare printing-space range while keeping corpus-derived
@@ -52,6 +59,65 @@ values (`bench_card_range_estimate`, `bench_cost_model_agreement`) and should mo
 [local-benchmark-toolkit-audit.md](local-benchmark-toolkit-audit.md). Two draw from real traffic on
 purpose: `bench_plan_misselection --source wild-operators` and `census_candidate_materialize`, where
 the question is what users actually lose.
+
+## Acquire and dispatch are two bins, and plan timing means dispatch
+
+The routed path has exactly two phases that matter for measurement, and conflating them produced the
+single largest error this toolkit has reported.
+
+**Acquire** runs once, before any plan is chosen, and is identical whichever plan wins. It picks the
+count source, builds the cost features, and materialises the artifact those imply — the plane bitmap,
+a range `k`, or `prepare_candidates`. **Dispatch** runs the winner.
+
+`cost::plan_cost` prices only the second: "only what happens AFTER the acquire step". So any
+plan-versus-plan comparison must be dispatch-only on both sides. A baseline that includes acquire
+charges the router for work no plan choice could have avoided.
+
+Measured with the `routed-phases` fenceposts (below), acquire is not a rounding error:
+
+| acquire flavor | routed µs | acquire | choose | dispatch |
+| --- | --: | --: | --: | --: |
+| `candidates` | 10.42 | **45%** | 0.0% | 53% |
+| `plane` | 10.08 | **55%** | 0.1% | 45% |
+| `printing_compose` | 5.46 | 3% | 0.0% | 96% |
+| `printing_range_scan` | 4.65 | 1% | 0.3% | 97% |
+| `card_range_popcount` | 44.42 | 1% | 0.1% | 99% |
+
+Two things to take from it. `choose` — the `argmin` itself — is **41 ns**, so the routing decision is
+free and only what it selects matters. And acquire is ~45% of the dominant flavor while being entirely
+unpriced, which is the quantified form of the note in `cost.rs` that the model's median error is
+`1.09x acquire_ns`. Acquire is a **latency** target, not a routing one: being common-mode within a
+query, it cannot change an `argmin`.
+
+### Getting the two sides comparable
+
+A forced run (`run_query_with_plan`, which is what `trials_ns` measures) rebuilds shared artifacts the
+router would have supplied, so its trial is not dispatch. `costbench.plan_self_ns` nets that back out,
+and the netting is not a correction for a mistake — it is the conversion:
+
+- **candidates acquire** — the routed path runs `prepare_candidates` inside acquire and dispatch reuses
+  the result, so netting `ns_prepare` yields the executor-only quantity dispatch measures.
+- **range / compose acquire** — nothing is prepared during acquire; dispatch pays it if a materializing
+  plan wins, and both sides already include it. Hence `RANGE_ACQUIRES` is excluded.
+- **plane acquire** — the plane eval is published as `ns_prepare` for the same reason, so a forced
+  `PlanePopcountOrder` can be netted down to its walk.
+
+**A plan you cannot price has no computable regret.** `plan_self_ns` returns `None` when netting
+overshoots, and taking the best of what remains substitutes a slower plan for the true best — which
+reads as the router beating it. `bench_regret_matrix` skips and counts those queries; on the bitplanes
+corpus that is ~39%, which is the price of recovering the executor's time by subtraction rather than
+reading `ns_setup + ns_loop + ns_finish` directly.
+
+### What ignoring this cost
+
+Regret was `routed_ns - best_dispatch`, mixing the whole path against a dispatch-only baseline. On the
+21,463 queries whose picked plan *was* the best — zero misrouting by construction — that read a mean
+**6.13 µs** instead of **-0.01 µs**, and those rows were **63% of all reported regret**. The top slice
+of the matrix was `StreamedSelect -> StreamedSelect`, which is not a misroute by definition. Re-based,
+it is 3%, and P3/P4 confusion turns out to be **66%** of lost time rather than the 40% it looked like.
+
+SHARE therefore sums *signed* regret. Clamping each row at zero let a slice whose mean is negative
+accumulate share as though it were losing time.
 
 ## The two matrices, and why both
 
@@ -78,19 +144,33 @@ while those two drove OPPOSITE routing errors.
 
 ### The regret matrix — where being wrong costs time
 
-Regret is `routed_ns - best_measured_ns`, so a correct pick contributes 0. Measured against
-`routed_ns`, not the picked plan's own trial, because those differ exactly when the picked plan
-DECLINES and dispatch re-chooses among materializing plans only.
+Regret is `routed_dispatch_ns - best_dispatch_ns`, so a correct pick contributes 0. Measured against
+the routed path, not the picked plan's own trial, because those differ exactly when the picked plan
+DECLINES and dispatch re-chooses among materializing plans only — and dispatch-to-dispatch, for the
+reason in the two-bin section above.
 
 Regret is mostly zeros, so **read SHARE** — the fraction of all lost time a slice accounts for, which
-is frequency times severity and is what ranks work. It found compose carrying **75%** of all lost
-time, and one transition (`StreamedSelect -> PrintingCompose`) losing a mean of 190 µs over 150
-queries.
+is frequency times severity and is what ranks work.
 
-**Split compose-like regret by DIRECTION before acting.** "75% of lost time" is compatible with two
-opposite fixes, and here it was both at once: over-picked 38:1 in artwork, under-picked 10:1 in
-printing. A change that made compose uniformly cheaper was therefore right for one mode and wrong for
-the other, and lost overall.
+**Every share figure predating the dispatch re-base is wrong, including the ones this file used to
+quote.** The old baseline mixed the whole routed path against a dispatch-only best, so 63% of reported
+regret was acquire on correctly-routed queries. What it looked like, and what it is:
+
+| slice | on `routed_ns` | on dispatch |
+| --- | --: | --: |
+| `StreamedSelect -> StreamedSelect` (picked == best, so not a misroute) | 31% | **3%** |
+| `StreamedSelect -> GatheredScan` | 23% | **41%** |
+| `GatheredScan -> StreamedSelect` | 17% | **25%** |
+| `PrintingCompose -> GatheredScan` | 11% | **21%** |
+
+So P3/P4 confusion is **66%** of lost time, not the ~40% it appeared to be, and compose over-picking
+is 34%. The older "compose carries 75%" reading came from the same conflation and does not survive it.
+
+**Split compose-like regret by DIRECTION before acting.** A single share figure is compatible with two
+opposite fixes, and for compose it was both at once: over-picked in artwork, under-picked in printing.
+A change that made compose uniformly cheaper was therefore right for one mode and wrong for the other,
+and lost overall. Compose's regret is still artwork-concentrated — `printing_compose / artwork` is 33%
+of all lost time against 5% for printing and 2% for card.
 
 ## Traps, each one paid for
 

--- a/scripts/bench_cost_error_attribution.py
+++ b/scripts/bench_cost_error_attribution.py
@@ -22,11 +22,14 @@ whatever error survives both is (2), the floor imposed by the arm's shape.
 
 Scoped to GatheredScan and StreamedSelect: they are the two plans with full executor counters, and
 they take the large majority of queries. `cards_visited` and `matches_pushed` are exact
-(verified 1.00 against their features on the candidates branch). `printings_scanned` is deliberately
-NOT substituted -- it counts the printing SPAN of each visited card, not rows examined, so in card
-mode where the loop breaks at the first match it overstates real work. Substituting it would
-manufacture a feature error that is really a counter definition. That makes the feature share here a
-LOWER bound, which is the safe direction.
+(verified 1.00 against their features on the candidates branch).
+
+`scan_units` is now substituted too, from `printings_examined`. It used to be left alone because the
+only counter available was `printing_span` (then named `printings_scanned`), which counts the printing
+SPAN of each visited card rather than rows examined -- so in card mode, where the kernels break at the
+first qualifying printing, it overstates real work and substituting it would have manufactured a
+feature error that was really a counter definition. `printings_examined` is reported by the match
+kernels themselves, so the feature share here is no longer a LOWER bound.
 
     .venv/bin/python scripts/bench_cost_error_attribution.py --seconds 600 --mode realistic
 """
@@ -124,16 +127,18 @@ def rows_for(samples: list[dict], plan: str, *, realized: bool) -> tuple[list[li
             continue
         a = s["acq"]
         tier = a["residual_tier_ns100"] / 100.0
-        # Realized: substitute the two EXACT counters. scan_units is left alone on purpose -- see the
-        # module docstring on why printings_scanned is not a drop-in for it.
+        # Realized: substitute all three counters. `printings_examined` is the match kernels' own
+        # report of rows touched, so unlike the `printing_span` it replaces it IS a drop-in for
+        # `scan_units` -- see the module docstring.
         eval_domain = float(s["cards_visited"] if realized else a["eval_domain"])
         matches = float(s["matches_pushed"] if realized else a["matches"])
+        scan_units = float(s["printings_examined"] if realized else a["scan_units"])
         design.append(
             terms(
                 plan,
                 Feats(
                     eval_domain=eval_domain,
-                    scan_units=float(a["scan_units"]),
+                    scan_units=scan_units,
                     matches=matches,
                     n_cards=float(a["n_cards"]),
                     tier_ns=tier,

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -29,6 +29,7 @@ while the pooled median looks fine.
 from __future__ import annotations
 
 import argparse
+import math
 import pathlib
 import random
 import sys
@@ -58,25 +59,47 @@ AGREE_LO, AGREE_HI = 0.8, 1.25
 MIN_COUNTER = 100
 
 # feature name on the shared acquire vector -> the executor counter that realizes it.
+#
+# `scan_units` is graded against `printings_examined`, NOT `printing_span`. The latter is the
+# printing SPAN under the candidate cards, computed by the caller before the match kernel runs, so it
+# reports what a full scan would have cost rather than what happened. The two coincide in printing and
+# artwork mode -- those loops really do traverse the span -- which is why grading against the span
+# looked fine everywhere except card mode, where every kernel short-circuits. Reading the span as the
+# work done is how `cost.rs` came to assert that the scan plans "walk the full printing span of their
+# candidates in CARD mode too, not one row each"; they do not.
 PAIRS = (
     ("matches", "matches_pushed"),
     ("eval_domain", "cards_visited"),
-    ("scan_units", "printings_scanned"),
+    ("scan_units", "printings_examined"),
 )
+# Kept alongside so one run shows both gradings. The gap between the two columns IS the miscount, and
+# reporting it as a column beats asserting it in prose.
+SPAN_COUNTER = "printing_span"
 
 
-def scan_feature(plan: str, paging: str) -> str:
-    """Which feature the ARM actually charges its printing scan on.
+def scan_feature(plan: str, paging: str, tier_ns100: int) -> str | None:
+    """Which feature the ARM actually charges its printing scan on, or None if it charges none.
 
     One shared vector costs every plan, but they do not all read the same field, and comparing a
     counter to a feature the arm never touches manufactures a defect. Compose walks the set bits of
     its composed bitmap (`compose_scan_printings`) when it pages by Gather, and stops at
     `page_offset + limit` when it pages by walking (`printings_walked`); only the materializing scan
     plans read `scan_units`.
+
+    `StreamedSelect` reads it only WITH a residual. Its arm is
+    `if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }` -- with `all_match` (tier
+    0) P3 walks no printings and the term is switched off entirely. Graded anyway, those rows read
+    p50 2.72 / p70 3.08 against `printings_examined`, because `scan_units` there is GatheredScan's
+    full-span quantity while StreamedSelect's counting kernel answers existence from the first
+    matching printing. That is not a feature error -- it is a number the model never multiplies by
+    anything -- and reporting it as one sent `fit_cost_model.py`'s `counter_check` into refusing to
+    fit this plan at all.
     """
-    if plan != "PrintingCompose":
-        return "scan_units"
-    return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+    if plan == "PrintingCompose":
+        return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+    if plan == "StreamedSelect" and tier_ns100 == 0:
+        return None
+    return "scan_units"
 
 
 percentile = costbench.percentile
@@ -86,7 +109,13 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
     """One row per (query, plan, feature) where the plan reported the matching counter."""
     rows: list[dict] = []
     budget = costbench.Budget(seconds=seconds, warmups=NUM_WARMUPS, trials=NUM_TRIALS)
-    for sample in costbench.iter_samples(engine, sampler, rng, budget):
+    # `prefer` is sampled, not pinned: it decides whether the card-mode kernels stop at the first
+    # qualifying printing or must score every one, which is the single largest per-card work
+    # difference any sampled parameter reaches -- and the cost model cannot see it, since
+    # `PlanFeatures` does not carry `prefer` (see `explain`'s doc in lib.rs). A run pinned to
+    # `default` measures only the short-circuiting path and reads the feature as though the
+    # long path did not exist.
+    for sample in costbench.iter_samples(engine, sampler, rng, budget, vary_prefer=True):
         acq = sample.acquire
         for plan in sample.plans:
             if not plan["trials_ns"]:
@@ -94,21 +123,32 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
             paging = acq["compose_paging"]
             for feat, counter in PAIRS:
                 if feat == "scan_units":
-                    feat = scan_feature(plan["plan"], paging)  # noqa: PLW2901 - the arm decides which field it reads
+                    feat = scan_feature(plan["plan"], paging, acq["residual_tier_ns100"])  # noqa: PLW2901 - the arm decides
+                    if feat is None:
+                        continue  # this arm charges no scan term for this query; there is nothing to grade
                 got = plan.get(counter)
                 if got is None or got < MIN_COUNTER:
                     continue
+                span = plan.get(SPAN_COUNTER)
                 rows.append(
                     {
                         "feature": feat,
                         "plan": plan["plan"],
                         "acquire": acq["count_source"],
                         "unique": sample.kw["unique"],
+                        "orderby": sample.kw["orderby"],
+                        # Sampled, so this slice is the one that separates the short-circuiting
+                        # card-mode kernels from the ones that must score every printing.
+                        "prefer": sample.kw.get("prefer", "default"),
                         # Compose's arm reads `scan_units` ONLY in its Gather branch; Perm/OrderbyWalk
                         # stop at page_offset+limit and never scan the candidates. A ratio measured on
                         # those is comparing the feature to work the arm never charges for.
                         "paging": paging,
                         "ratio": acq[feat] / got,
+                        # What the same row would have read graded against the printing SPAN -- the
+                        # old comparison. `nan` where the plan publishes no span, which `percentile`
+                        # tolerates and `MIN_ROWS` cells then drop.
+                        "span_ratio": (acq[feat] / span) if span else float("nan"),
                     }
                 )
     return rows
@@ -122,12 +162,13 @@ def verdict(sorted_vals: list[float]) -> str:
     return "  OVER-COUNTS" if med > AGREE_HI else "  UNDER-COUNTS"
 
 
-def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 30) -> None:
+def table(rows: list[dict], key: Callable[[dict], object], label: str, *, limit: int = 30, value: str = "ratio") -> None:
     """Feature/counter percentiles for one grouping, worst-calibrated cells first."""
     costbench.percentile_table(
         rows,
         key,
         label,
+        value=value,
         rank=costbench.BY_MISCALIBRATION,
         limit=limit,
         min_rows=MIN_ROWS,
@@ -158,9 +199,28 @@ def main() -> None:
     # StreamedSelect, GatheredScan and compose's Gather branch alike. If they disagree here, no single
     # value of the feature is right for all of them and the fix is per-arm, not per-mode.
     table(rows, lambda r: f"{r['feature']} <{r['plan']}> / {r['unique']}", "feature <plan> / distinct-on")
+    # `prefer` decides whether the card-mode kernels early-break, and `PlanFeatures` does not carry
+    # it, so one feature value has to serve both regimes. If these two rows differ, the feature is not
+    # merely miscalibrated -- it is blind to a variable that changes the work.
+    scan = [r for r in rows if r["feature"] == "scan_units"]
+    table(scan, lambda r: f"scan_units / {r['unique']} / prefer={r['prefer']}", "scan_units by distinct-on and PREFER")
+    # Orderby was always sampled and never sliced, so its effect has never been visible. It selects
+    # the plan set (StreamedSelect needs a sort permutation; PlanePopcountOrder needs its column) and
+    # therefore which arm reads the shared vector at all.
+    table(rows, lambda r: f"{r['feature']} / orderby={r['orderby']}", "feature by ORDERBY", limit=40)
     # Compose only pays `scan_units` when it pages by Gather, so judge the feature on those rows.
     compose = [r for r in rows if r["plan"] == "PrintingCompose"]
     table(compose, lambda r: f"{r['feature']} <compose {r['paging']}> / {r['unique']}", "compose only: feature by PAGING branch")
+    # The old grading, same rows: `scan_units` against the printing SPAN rather than the printings
+    # actually examined. Printed last as the control -- if these cells sit at 1.0 where the real
+    # column does not, the span is what the constants were fit against.
+    spanned = [r for r in scan if math.isfinite(r["span_ratio"])]
+    table(
+        spanned,
+        lambda r: f"scan_units / {r['unique']}",
+        "CONTROL: scan_units vs printing SPAN (the old grading)",
+        value="span_ratio",
+    )
     print(f"\n  Cells outside [{AGREE_LO}, {AGREE_HI}] are flagged. A feature error cannot be fixed by any")
     print("  rate: fit_cost_model.py will bury it in whichever coefficient correlates with it.")
 

--- a/scripts/bench_feature_accuracy.py
+++ b/scripts/bench_feature_accuracy.py
@@ -77,6 +77,33 @@ PAIRS = (
 SPAN_COUNTER = "printing_span"
 
 
+#: Which of the three PAIRS features each compose paging branch's cost arm actually multiplies by a
+#: rate. `Perm` and `OrderbyWalk` are priced `printings_walked * WALK_STEP + limit * WALK_EMIT_PER_ROW`
+#: -- they charge NEITHER `matches` nor `eval_domain`, and grading those against a walk that stops at
+#: `page_offset + limit` produced cells reading 100-200x off numbers the model never reads. Only
+#: `Gather` charges all three (`eval_domain`, `compose_scan_printings`, `matches`).
+COMPOSE_ARM_CHARGES: dict[str, frozenset[str]] = {
+    "Perm": frozenset({"printings_walked"}),
+    "OrderbyWalk": frozenset({"printings_walked"}),
+    "Gather": frozenset({"eval_domain", "compose_scan_printings", "matches"}),
+    # The walk was available, was attempted, declined, and fell into the gather -- so the gather is
+    # what ran and the gather's terms are what to grade.
+    "GatherWalkDeclined": frozenset({"eval_domain", "compose_scan_printings", "matches"}),
+}
+
+
+def compose_grades(paging_taken: str, feat: str) -> bool:
+    """Whether compose's arm charges `feat` on the branch it actually took.
+
+    Keyed on `paging_taken` -- what RAN -- not on the acquire's `compose_paging`, which is the
+    model's PREDICTION of the branch. Those disagree exactly where a walk was predicted and declined,
+    and grading a gather's counters against a walk's terms is how the two get conflated.
+    """
+    charged = COMPOSE_ARM_CHARGES.get(paging_taken)
+    # An exit with no cost arm of its own (EmptyPage, the declines): nothing ran that a term describes.
+    return feat in charged if charged is not None else False
+
+
 def scan_feature(plan: str, paging: str, tier_ns100: int) -> str | None:
     """Which feature the ARM actually charges its printing scan on, or None if it charges none.
 
@@ -96,7 +123,8 @@ def scan_feature(plan: str, paging: str, tier_ns100: int) -> str | None:
     fit this plan at all.
     """
     if plan == "PrintingCompose":
-        return "compose_scan_printings" if paging == "Gather" else "printings_walked"
+        # `GatherWalkDeclined` IS the gather -- a walk was attempted, declined, and fell into it.
+        return "compose_scan_printings" if paging in ("Gather", "GatherWalkDeclined") else "printings_walked"
     if plan == "StreamedSelect" and tier_ns100 == 0:
         return None
     return "scan_units"
@@ -120,12 +148,16 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
         for plan in sample.plans:
             if not plan["trials_ns"]:
                 continue  # declined: it ran nothing, so there is no counter to check against
-            paging = acq["compose_paging"]
+            # `compose_paging` is the model's PREDICTION; `paging_taken` is what ran. Label and grade
+            # compose on the latter -- they disagree exactly where a walk was predicted and declined.
+            paging = plan.get("paging_taken") if plan["plan"] == "PrintingCompose" else acq["compose_paging"]
             for feat, counter in PAIRS:
                 if feat == "scan_units":
                     feat = scan_feature(plan["plan"], paging, acq["residual_tier_ns100"])  # noqa: PLW2901 - the arm decides
                     if feat is None:
                         continue  # this arm charges no scan term for this query; there is nothing to grade
+                if plan["plan"] == "PrintingCompose" and not compose_grades(paging, feat):
+                    continue  # this branch's arm never multiplies this feature by a rate
                 got = plan.get(counter)
                 if got is None or got < MIN_COUNTER:
                     continue

--- a/scripts/bench_query_latency_ab.py
+++ b/scripts/bench_query_latency_ab.py
@@ -50,7 +50,7 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from api.parsing import parse_scryfall_query  # noqa: E402
-from client.query_sampler import MODES, QuerySampler  # noqa: E402
+from client.query_sampler import ANY_SHAPE, MODES, QuerySampler, Shape  # noqa: E402
 from scripts.costbench import load_engine  # noqa: E402
 
 # Well above the shared costbench (2, 7), which is calibrated for comparisons INSIDE one
@@ -82,8 +82,24 @@ class Budget:
     trials: int = NUM_TRIALS
 
 
-def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget) -> list[dict]:
-    """Min-of-trials wall time for `query()` on each sampled query."""
+def measure(  # noqa: PLR0913 - a measurement function's arguments ARE the conditions it measures under
+    engine: object,
+    sampler: QuerySampler,
+    rng: random.Random,
+    budget: Budget,
+    shape: Shape = ANY_SHAPE,
+    *,
+    vary_prefer: bool = False,
+) -> list[dict]:
+    """Min-of-trials wall time for `query()` on each sampled query.
+
+    `vary_prefer` draws the printing preference instead of pinning it to `default`. Off by default
+    because drawing it consumes the rng and shifts the whole query stream, which would orphan every
+    baseline on disk -- but a run pinned to `default` cannot see a change to the custom-prefer path at
+    all. `Prefer::Default` is the only value that lets the card- and artwork-mode match kernels stop
+    at the first qualifying printing; the other four must score every printing of the card. `query()`
+    has taken `prefer` on every build this harness can target, so varying it stays A/B-safe.
+    """
     rows: list[dict] = []
     for _ in range(budget.sample):
         limit, offset = rng.choice(LIMITS), rng.choice(OFFSETS)
@@ -94,15 +110,16 @@ def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: B
             "limit": limit,
             "offset": offset,
         }
-        q = sampler.query(rng)
+        q = sampler.query(rng, shape)
+        prefer = sampler.prefer(rng) if vary_prefer else "default"
         try:
             filters = parse_scryfall_query(q)
             for _ in range(budget.warmups):
-                engine.query(filters=filters, prefer="default", **kw)
+                engine.query(filters=filters, prefer=prefer, **kw)
             best = math.inf
             for _ in range(budget.trials):
                 t0 = time.perf_counter_ns()
-                engine.query(filters=filters, prefer="default", **kw)
+                engine.query(filters=filters, prefer=prefer, **kw)
                 best = min(best, time.perf_counter_ns() - t0)
         except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
             continue
@@ -110,6 +127,7 @@ def measure(engine: object, sampler: QuerySampler, rng: random.Random, budget: B
             {
                 "q": q,
                 **{k: kw[k] for k in ("unique", "orderby", "direction")},
+                "prefer": prefer,
                 "limit": limit,
                 "offset": offset,
                 "us": best / 1000.0,
@@ -134,7 +152,9 @@ def compare(path_a: pathlib.Path, path_b: pathlib.Path) -> None:
         out = {}
         for line in path.open():
             r = json.loads(line)
-            out[(r["q"], r["unique"], r["orderby"], r["direction"], r["limit"], r["offset"])] = r["us"]
+            # `.get` for `prefer`: files written before it was recorded pin it to default anyway, so
+            # they still pair with each other rather than failing to key.
+            out[(r["q"], r["unique"], r["orderby"], r["direction"], r.get("prefer", "default"), r["limit"], r["offset"])] = r["us"]
         return out
 
     a, b = rows(path_a), rows(path_b)
@@ -176,7 +196,23 @@ def main() -> None:
         "--trials", type=int, default=NUM_TRIALS, help="a cross-process A/B needs a converged floor; see the module docstring"
     )
     parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument(
+        "--vary-prefer",
+        action="store_true",
+        help="sample the printing preference instead of pinning it to default; the custom-prefer path is the only one where the match kernels cannot early-break",
+    )
     parser.add_argument("--mode", choices=MODES, default="realistic", help="latency asks what users wait for, so traffic-weighted")
+    parser.add_argument(
+        "--predicates",
+        type=int,
+        default=None,
+        help=(
+            "pin the conjunction width instead of drawing it from PREDICATE_COUNT_WEIGHTS (1/2/3 at "
+            "45/40/15). 4+ is reachable only this way, and on purpose: the sampler caps the natural "
+            "draw at 3 because deeper conjunctions narrow to nothing and stop exercising plan choice, "
+            "which is the thing being measured. Pin it to compare like against like at one width."
+        ),
+    )
     parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
     parser.add_argument("--shm-path", type=pathlib.Path, default=None)
     parser.add_argument("--out", type=pathlib.Path, help="write per-query latencies as JSONL")
@@ -189,8 +225,17 @@ def main() -> None:
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".latency.store"))
     sampler = QuerySampler(args.corpus, args.mode)
-    rows = measure(engine, sampler, random.Random(args.seed), Budget(args.sample, args.warmups, args.trials))
-    print(f"measured {len(rows):,} queries, mode={args.mode}")
+    shape = Shape(predicates=args.predicates) if args.predicates else ANY_SHAPE
+    rows = measure(
+        engine,
+        sampler,
+        random.Random(args.seed),
+        Budget(args.sample, args.warmups, args.trials),
+        shape,
+        vary_prefer=args.vary_prefer,
+    )
+    width = f", predicates={args.predicates}" if args.predicates else ""
+    print(f"measured {len(rows):,} queries, mode={args.mode}{width}")
     if args.out:
         with args.out.open("w") as handle:
             for row in rows:

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -110,7 +110,7 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
         declined = picked is not None and not picked["trials_ns"]
         # Best on the SAME dispatch-equivalent definition the baseline uses, and EVERY plan that ran
         # must be priceable on it. `plan_self_ns` returns None when netting overshoots
-        # the timer noise floor, and taking the best of what is left silently substitutes a slower
+        # no phase timing, and taking the best of what is left silently substitutes a slower
         # plan for the true best -- which reads as the router beating it. Measured on plane queries,
         # where the plane build is a large share of a forced trial: PlanePopcountOrder is dropped 37%
         # of the time (median ns_prepare/trial 0.38), and those rows drove the plane slice to a mean
@@ -138,7 +138,7 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
             }
         )
     if skipped_unpriced:
-        print(f"skipped {skipped_unpriced:,} queries where a plan that ran could not be priced (netting overshoot)")
+        print(f"skipped {skipped_unpriced:,} queries where a plan that ran published no phase timing and so cannot be priced")
     if skipped_unphased:
         print(f"skipped {skipped_unphased:,} queries with no routed phase split -- build with --features routed-phases")
     return rows

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -5,17 +5,38 @@ says where being wrong COSTS something. They disagree often enough to matter —
 by 100x on a plan that never wins anyway, and correct to 5% on one where the margin decides every
 query.
 
-Regret is `routed_ns - best_measured_ns`: what the router gave up against the best plan that ran, so a
-correct pick contributes exactly 0. It is measured against `routed_ns` rather than the picked plan's
-own trial because those differ in the case that matters most — when the picked plan DECLINES at
-runtime, dispatch re-chooses among materializing plans only, and a non-materializing fast path that
-would have won is never reconsidered.
+Regret is `routed_dispatch_ns - best_dispatch_ns`: what the router gave up against the best plan that
+ran, so a correct pick contributes exactly 0. It is measured against the routed path rather than the
+picked plan's own trial because those differ in the case that matters most — when the picked plan
+DECLINES at runtime, dispatch re-chooses among materializing plans only, and a non-materializing fast
+path that would have won is never reconsidered.
+
+**Both sides are DISPATCH, and that is load-bearing.** The engine's routed path has two bins: acquire
+runs once before any plan is chosen and is identical whichever wins, and dispatch runs the winner.
+`cost::plan_cost` prices only the second — "only what happens AFTER the acquire step" — so a plan
+comparison that includes acquire charges the router for work no plan choice could have avoided. This
+used to subtract from `routed_ns`, the whole path, and acquire is ~45% of a candidate-acquired query.
+
+The size of that mistake, measured on the population where regret is provably zero (21,463 queries
+whose picked plan WAS the best): mean `6.13 us` against `routed_ns`, `-0.01 us` against dispatch.
+Those rows were **63% of all reported regret**, and `StreamedSelect -> StreamedSelect` — picked equals
+best, so not misrouting by definition — was the single largest slice at a 14.15 us mean. On this basis
+it is 1.16. The genuine misroutes are unmoved (`PrintingCompose -> GatheredScan` 65.94 -> 65.22).
+
+Needs a `routed-phases` build. Without the feature the phase keys publish as zeros and those queries
+are skipped with a warning rather than measured against a zero baseline.
 
 Regret is mostly zeros, so a median is useless here: read the SHARE column, which is what fraction of
 all lost time a slice accounts for. That ranks the work. p90/p99/max show whether a slice loses a
 little constantly or a lot rarely.
 
-    .venv/bin/python scripts/bench_regret_matrix.py --seconds 180
+SHARE sums SIGNED regret. A transition can have a negative mean — the routed path beating the best
+forced plan, via the lazy re-choose or simply a forced run paying a cold cache the routed one does not
+— and clamping each row at zero let such a slice accumulate share as though it were losing time.
+`GatheredScan -> StreamedSelect` is the live example: mean `-18.91 us`, and it held 23% of share under
+the clamp.
+
+    .venv/bin/python scripts/bench_regret_matrix.py --seconds 180   # build --features routed-phases
 """
 
 from __future__ import annotations
@@ -52,33 +73,65 @@ percentile = costbench.percentile
 def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
     """One row per multi-plan query: what it lost, and everything to slice that by.
 
-    Deliberately does NOT use `costbench.plan_self_ns`. That nets `ns_prepare` back out to make a
-    plan comparable to the cost model's per-plan prediction; regret compares against `routed_ns`,
-    a whole real execution with the prep included. Netting one side of that subtraction and not the
-    other would invent time that was never saved.
+    Both sides of the subtraction are DISPATCH, which is what makes the difference attributable to
+    plan choice at all. Acquire is a separate bin: it runs once, before any plan is chosen, is
+    identical whichever plan wins, and `cost::plan_cost` prices none of it. Including it in the
+    baseline charged the router for work no plan choice could have avoided.
+
+    Measured, on the population where that is provably zero -- 21,463 queries whose picked plan WAS
+    the best one, so there is no misrouting by construction:
+
+        mean vs routed_ns          6.13 us
+        mean vs routed_dispatch   -0.01 us
+
+    Those rows were 63% of all reported regret. `StreamedSelect -> StreamedSelect` alone read a 14.15
+    us mean and the top share; on this basis it is 1.16. The genuine misroutes barely move
+    (`PrintingCompose -> GatheredScan` 65.94 -> 65.22), which is the signature of having removed
+    acquire rather than signal.
+
+    `plan_self_ns` IS used, and its netting is what makes the two sides comparable rather than a
+    correction for anything: on a candidates acquire the routed path runs `prepare_candidates` inside
+    `acquire_plan_features` and dispatch reuses the artifact, so netting turns a forced trial
+    (prepare + executor) into the executor-only quantity dispatch measures. On a range or compose
+    acquire nothing is prepared during acquire, dispatch pays it if a materializing plan wins, and
+    both sides already include it -- which is exactly what `RANGE_ACQUIRES` excludes.
+
+    Requires a `routed-phases` build; without the feature the phase keys are published as zeros and
+    there is nothing to re-base on, so those runs are skipped rather than silently measured wrong.
     """
     rows: list[dict] = []
+    skipped_unphased = 0
     for sample in costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds)):
         ran = [p for p in sample.plans if p["trials_ns"]]
         if len(ran) < 2:  # noqa: PLR2004 - one applicable plan means there is nothing to get wrong
             continue
         picked = next((p for p in sample.plans if p["picked"]), None)
         declined = picked is not None and not picked["trials_ns"]
-        best = min(ran, key=lambda p: min(p["trials_ns"]))
-        # routed_ns lives on explain_analyze's acquire; `explain` runs nothing and leaves it empty.
-        routed = sample.res["acquire"]["routed_ns"]
-        if not routed:
+        # Best on the SAME dispatch-equivalent definition the baseline uses.
+        selves = {id(p): costbench.plan_self_ns(p, sample.acquire) for p in ran}
+        comparable = [p for p in ran if selves[id(p)] is not None]
+        if len(comparable) < 2:  # noqa: PLR2004 - netting dropped too many to have a comparison
             continue
-        routed_us = min(routed) / 1000.0
+        best = min(comparable, key=lambda p: selves[id(p)])
+        dispatch = sample.res["acquire"].get("routed_dispatch_ns")
+        if not dispatch or not any(dispatch):
+            skipped_unphased += 1
+            continue
         rows.append(
             {
-                "lost": max(routed_us - min(best["trials_ns"]) / 1000.0, 0.0),
+                # SIGNED. A negative row is the routed path beating the best forced plan, which
+                # happens (the lazy re-choose, or a forced run paying a cold cache the routed one
+                # does not) and is information, not zero. Clamping it to 0 let a transition whose
+                # MEAN is negative still accumulate share as if it were loss.
+                "lost": min(dispatch) / 1000.0 - selves[id(best)] / 1000.0,
                 "acquire": sample.acquire["count_source"],
                 "unique": sample.kw["unique"],
                 "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
                 "best": best["plan"],
             }
         )
+    if skipped_unphased:
+        print(f"skipped {skipped_unphased:,} queries with no routed phase split -- build with --features routed-phases")
     return rows
 
 

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -110,7 +110,7 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
         declined = picked is not None and not picked["trials_ns"]
         # Best on the SAME dispatch-equivalent definition the baseline uses, and EVERY plan that ran
         # must be priceable on it. `plan_self_ns` returns None when netting overshoots
-        # `NETTING_RESIDUAL_FLOOR`, and taking the best of what is left silently substitutes a slower
+        # the timer noise floor, and taking the best of what is left silently substitutes a slower
         # plan for the true best -- which reads as the router beating it. Measured on plane queries,
         # where the plane build is a large share of a forced trial: PlanePopcountOrder is dropped 37%
         # of the time (median ns_prepare/trial 0.38), and those rows drove the plane slice to a mean

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -101,18 +101,25 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
     """
     rows: list[dict] = []
     skipped_unphased = 0
+    skipped_unpriced = 0
     for sample in costbench.iter_samples(engine, sampler, rng, costbench.Budget(seconds=seconds)):
         ran = [p for p in sample.plans if p["trials_ns"]]
         if len(ran) < 2:  # noqa: PLR2004 - one applicable plan means there is nothing to get wrong
             continue
         picked = next((p for p in sample.plans if p["picked"]), None)
         declined = picked is not None and not picked["trials_ns"]
-        # Best on the SAME dispatch-equivalent definition the baseline uses.
+        # Best on the SAME dispatch-equivalent definition the baseline uses, and EVERY plan that ran
+        # must be priceable on it. `plan_self_ns` returns None when netting overshoots
+        # `NETTING_RESIDUAL_FLOOR`, and taking the best of what is left silently substitutes a slower
+        # plan for the true best -- which reads as the router beating it. Measured on plane queries,
+        # where the plane build is a large share of a forced trial: PlanePopcountOrder is dropped 37%
+        # of the time (median ns_prepare/trial 0.38), and those rows drove the plane slice to a mean
+        # of -6.27us. A query with an unpriceable plan has no computable regret; skip it and say so.
         selves = {id(p): costbench.plan_self_ns(p, sample.acquire) for p in ran}
-        comparable = [p for p in ran if selves[id(p)] is not None]
-        if len(comparable) < 2:  # noqa: PLR2004 - netting dropped too many to have a comparison
+        if any(v is None for v in selves.values()):
+            skipped_unpriced += 1
             continue
-        best = min(comparable, key=lambda p: selves[id(p)])
+        best = min(ran, key=lambda p: selves[id(p)])
         dispatch = sample.res["acquire"].get("routed_dispatch_ns")
         if not dispatch or not any(dispatch):
             skipped_unphased += 1
@@ -130,6 +137,8 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
                 "best": best["plan"],
             }
         )
+    if skipped_unpriced:
+        print(f"skipped {skipped_unpriced:,} queries where a plan that ran could not be priced (netting overshoot)")
     if skipped_unphased:
         print(f"skipped {skipped_unphased:,} queries with no routed phase split -- build with --features routed-phases")
     return rows

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -111,21 +111,12 @@ MIN_ROWS = 30
 # Below this, a per-query difference is timer jitter rather than a real change.
 NOISE_FLOOR_US = 1.0
 
-# Acquire sources whose routed path re-pays `prepare_candidates`, so a plan's `trials_ns` is NOT
-# double-counting it and must not be netted. Everywhere else the prep is shared and the plan is
-# charged for a copy it would not pay under the router.
+# Acquire sources where acquire only ESTIMATED, so DISPATCH pays the artifact build itself -- either
+# `prepare_candidates` on a lazy materialize, or `build_card_range_bits` for CardRangePopcount. On
+# these `ns_prepare` is part of the plan's cost and `plan_self_ns` ADDS it. Everywhere else the router
+# built the artifact during acquire and dispatch merely reuses it, so a forced run rebuilding it is
+# reporting work dispatch never pays.
 RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
-# Below this many nanoseconds, a netted residual is timer noise rather than a smaller measurement, so
-# the row is dropped instead of reporting a number built out of two nearly-equal quantities.
-#
-# ABSOLUTE, where this used to be a fraction of the trial (0.5). The fraction cost real coverage for no
-# reason: `ns_prepare` comes from the same round as the trial it is subtracted from (`explain_analyze`
-# keeps the fastest round's phases), so the subtraction is exact rather than cross-round, and a residual
-# that is 40% of a 10us trial is 4us -- perfectly measurable. The fractional guard was dropping
-# `PlanePopcountOrder` on 37% of plane queries, which made `bench_regret_matrix` skip 39% of all
-# queries as unpriceable. What matters is whether the residual clears the timer, not what share of the
-# trial it is.
-NETTING_RESIDUAL_FLOOR_NS = NOISE_FLOOR_US * 1000.0
 
 BOOTSTRAP_RESAMPLES = 10_000
 BOOTSTRAP_CI = 0.95
@@ -315,46 +306,41 @@ def predicted_ns(plan: dict) -> float | None:
 def plan_self_ns(plan: dict, acquire: dict) -> float | None:
     """What this plan costs to RUN, in nanoseconds -- the single definition every harness uses.
 
-    The quantity wanted is the executor's own time: dispatch, excluding any shared artifact the router
-    would have built during acquire and handed over. Two ways to get it, and the direct one is
-    preferred.
+    The quantity wanted is DISPATCH: what the routed path spends after it has chosen. It is built by
+    ADDITION now, from two measured pieces, where it used to be recovered by subtracting `ns_prepare`
+    from a trial.
 
-    **Measured directly, where the executor publishes phases.** `ns_setup + ns_loop + ns_finish` are
-    contiguous by construction -- four instants bounding three spans -- so their sum IS the executor,
-    with no subtraction and nothing to overshoot. Verified against the netted figure on 45k paired
-    rows: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), with 0.08us of the round left
-    unaccounted by any phase. Only the two materializing plans publish them.
+    **The executor**, from `ns_setup + ns_loop + ns_finish`. Contiguous by construction, so the sum IS
+    the executor -- exact, with nothing to overshoot. Every plan publishes these; the two materializing
+    ones split them three ways, and the four others report one undivided span in `ns_loop` because they
+    have no three phases to attribute between. Verified against the old netted figure on 45k paired
+    rows before the switch: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), 0.08us of the
+    round unaccounted.
 
-    **Netted, otherwise.** The other four plans publish no phases, so their executor time is recovered
-    as `min(trials_ns) - ns_prepare`: a forced run rebuilds the shared artifact (candidate list, or the
-    plane bitmap) that the router acquires once, and `ns_prepare` is that build. Except under a
-    range-style acquire, where the routed path re-pays it too and it IS the plan's cost -- hence
-    `RANGE_ACQUIRES`.
+    **Plus any shared artifact DISPATCH pays for**, which depends on the acquire and not on the plan:
 
-    The guard on that subtraction is an ABSOLUTE floor, not a fraction. It used to drop any row where
-    netting removed more than half the trial, which cost real coverage for no reason: `ns_prepare` and
-    the trial come from the SAME round (`explain_analyze` keeps the fastest round's phases), so the
-    subtraction is exact rather than cross-round, and a residual that is 40% of a 10us trial is 4us --
-    measurable, not noise. That guard was dropping `PlanePopcountOrder` on 37% of plane queries, which
-    made `bench_regret_matrix` skip 39% of all queries as unpriceable. What matters is whether the
-    residual clears the timer, so the floor is `NOISE_FLOOR_US`.
+    - `candidates` / `plane` acquire -- the router built the artifact during acquire and dispatch just
+      reuses it, so dispatch is the executor alone. A forced run rebuilt it and reported the rebuild in
+      `ns_prepare`; that is exactly what must NOT be counted.
+    - `RANGE_ACQUIRES` -- acquire only estimated. Dispatch pays the build itself, whether that is
+      `prepare_candidates` on a lazy materialize or `build_card_range_bits` for `CardRangePopcount`, so
+      `ns_prepare` IS part of the plan's cost and is added.
+
+    Why this is better than the subtraction it replaces: an addition cannot overshoot, so the guard
+    that dropped rows is gone, and with it the reason `bench_regret_matrix` was skipping queries. That
+    guard cost 39% of all queries as a fraction and 1.8% as an absolute floor; it is now 0%.
 
     Returns:
-        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or if
-        the netted residual falls below the timer's noise floor.
+        The plan's dispatch nanoseconds, or None if it produced no page (declined, or never ran).
     """
     if not plan["trials_ns"]:
         return None
-    phases = float(plan["ns_setup"] + plan["ns_loop"] + plan["ns_finish"])
-    if phases > 0:
-        return phases
-    real = float(min(plan["trials_ns"]))
-    if plan["ns_round_total"] and acquire["count_source"] not in RANGE_ACQUIRES:
-        netted = real - plan["ns_prepare"]
-        if netted < NETTING_RESIDUAL_FLOOR_NS:
-            return None
-        real = netted
-    return real
+    dispatch = float(plan["ns_setup"] + plan["ns_loop"] + plan["ns_finish"])
+    if dispatch <= 0:
+        return None  # ran but published no phase: cannot be priced, and must not read as zero
+    if acquire["count_source"] in RANGE_ACQUIRES:
+        dispatch += float(plan["ns_prepare"])
+    return dispatch
 
 
 # ── statistics and tables ─────────────────────────────────────────────────────────────────────

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -136,7 +136,8 @@ PLAN_KEYS = frozenset(
         "trials_ns",
         "declined_ns",
         "cards_visited",
-        "printings_scanned",
+        "printing_span",
+        "printings_examined",
         "matches_pushed",
         "ns_setup",
         "ns_loop",
@@ -210,9 +211,20 @@ class Sample:
         return (self.q, self.kw["unique"], self.kw["orderby"], self.kw["direction"], self.kw["limit"], self.kw["offset"])
 
 
-def sample_kwargs(sampler: QuerySampler, rng: random.Random) -> dict:
-    """One query shape: distinct-on, order, direction and page, weighted by the sampler's mode."""
-    return {
+def sample_kwargs(sampler: QuerySampler, rng: random.Random, *, vary_prefer: bool = False) -> dict:
+    """One query shape: distinct-on, order, direction and page, weighted by the sampler's mode.
+
+    `vary_prefer` draws `prefer` from the sampler instead of pinning it to `"default"`, and it is
+    OFF by default for a reason that is not timidity: drawing it consumes the rng, so turning it on
+    shifts every subsequent query in the stream. Baselines on disk were taken without it, and a
+    harness comparing against one must keep the stream byte-identical.
+
+    Turn it on where `prefer` is the variable under study. It is not cosmetic -- it decides whether
+    the card-mode match kernels may stop at the first qualifying printing (`Prefer::Default`,
+    printings are stored in prefer-desc order) or must score all of them to find the max. That is a
+    ~3x difference in per-card work that no other sampled parameter reaches.
+    """
+    kwargs = {
         "filters": None,
         "unique": sampler.unique(rng),
         "orderby": sampler.orderby(rng),
@@ -220,13 +232,21 @@ def sample_kwargs(sampler: QuerySampler, rng: random.Random) -> dict:
         "limit": rng.choice(LIMITS),
         "offset": rng.choice(OFFSETS),
     }
+    if vary_prefer:
+        kwargs["prefer"] = sampler.prefer(rng)
+    return kwargs
 
 
-def iter_samples(engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget) -> Iterator[Sample]:
+def iter_samples(
+    engine: object, sampler: QuerySampler, rng: random.Random, budget: Budget, *, vary_prefer: bool = False
+) -> Iterator[Sample]:
     """Yield measured queries until the budget runs out, skipping any the parser rejects.
 
     The schema is checked against the first response that comes back, so a run against a build whose
     `explain_analyze` has moved on fails immediately instead of part way through.
+
+    `vary_prefer` is forwarded to `sample_kwargs`; see there for why it defaults off. The drawn
+    `prefer` lands in `Sample.kw`, so a caller that turns it on can slice by it.
     """
     # Imported here, not at module scope, so `costbench` stays importable (and unit-testable)
     # without the `api` package on the path. The cost is one import per process.
@@ -237,12 +257,17 @@ def iter_samples(engine: object, sampler: QuerySampler, rng: random.Random, budg
     taken = 0
     while time.monotonic() < deadline and (budget.sample is None or taken < budget.sample):
         taken += 1
-        kw = sample_kwargs(sampler, rng)
+        kw = sample_kwargs(sampler, rng, vary_prefer=vary_prefer)
         q = sampler.query(rng)
         try:
             kw["filters"] = parse_scryfall_query(q)
+            # Both calls get the same `prefer`. Note what that does and does not buy: `PlanFeatures`
+            # does not carry `prefer`, so the features and every `predicted_ns` come back identical
+            # whatever is passed, while execution honours it. That asymmetry is what makes a prefer
+            # slice readable -- only the COUNTERS move, so a ratio that shifts with `prefer` is the
+            # feature failing to model a real difference in work, not two numbers drifting at once.
             acquire = engine.explain(**kw)["acquire"]
-            res = engine.explain_analyze(prefer="default", num_warmups=budget.warmups, num_trials=budget.trials, **kw)
+            res = engine.explain_analyze(num_warmups=budget.warmups, num_trials=budget.trials, **{"prefer": "default", **kw})
         except Exception:  # noqa: BLE001, S112 - a rejected query is a skipped sample
             continue
         if not checked:

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -148,7 +148,20 @@ PLAN_KEYS = frozenset(
         "paging_taken",
     }
 )
-ACQUIRE_KEYS = frozenset({"count_source", "narrowed_repr", "acquire_ns", "routed_ns", "compose_paging"})
+# The routed phase split is asserted here too: it is a partition of `routed_ns`, so a build that
+# stops publishing it should fail loudly rather than have a consumer silently read an empty list.
+ACQUIRE_KEYS = frozenset(
+    {
+        "count_source",
+        "narrowed_repr",
+        "acquire_ns",
+        "routed_ns",
+        "routed_acquire_ns",
+        "routed_choose_ns",
+        "routed_dispatch_ns",
+        "compose_paging",
+    }
+)
 
 
 def require_schema(res: dict) -> None:

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -115,10 +115,17 @@ NOISE_FLOOR_US = 1.0
 # double-counting it and must not be netted. Everywhere else the prep is shared and the plan is
 # charged for a copy it would not pay under the router.
 RANGE_ACQUIRES = frozenset({"card_range_popcount", "printing_range_scan", "printing_compose"})
-# If netting `ns_prepare` removes more than this fraction of the measured round, the subtraction has
-# overshot and the residual is noise rather than a smaller measurement. Drop the row instead of
-# reporting a number built out of two nearly-equal quantities.
-NETTING_RESIDUAL_FLOOR = 0.5
+# Below this many nanoseconds, a netted residual is timer noise rather than a smaller measurement, so
+# the row is dropped instead of reporting a number built out of two nearly-equal quantities.
+#
+# ABSOLUTE, where this used to be a fraction of the trial (0.5). The fraction cost real coverage for no
+# reason: `ns_prepare` comes from the same round as the trial it is subtracted from (`explain_analyze`
+# keeps the fastest round's phases), so the subtraction is exact rather than cross-round, and a residual
+# that is 40% of a 10us trial is 4us -- perfectly measurable. The fractional guard was dropping
+# `PlanePopcountOrder` on 37% of plane queries, which made `bench_regret_matrix` skip 39% of all
+# queries as unpriceable. What matters is whether the residual clears the timer, not what share of the
+# trial it is.
+NETTING_RESIDUAL_FLOOR_NS = NOISE_FLOOR_US * 1000.0
 
 BOOTSTRAP_RESAMPLES = 10_000
 BOOTSTRAP_CI = 0.95
@@ -308,24 +315,43 @@ def predicted_ns(plan: dict) -> float | None:
 def plan_self_ns(plan: dict, acquire: dict) -> float | None:
     """What this plan costs to RUN, in nanoseconds -- the single definition every harness uses.
 
-    `min` over the trials, because the question is what the plan costs when nothing interferes, and
-    the distribution's upper tail is machine noise rather than the plan.
+    The quantity wanted is the executor's own time: dispatch, excluding any shared artifact the router
+    would have built during acquire and handed over. Two ways to get it, and the direct one is
+    preferred.
 
-    Materializing plans re-run `prepare_candidates` inside their own forced round, where the router
-    would have acquired the artifact once and shared it. That prep is published per plan as
-    `ns_prepare`, so it can be netted back out -- except under a range-style acquire, where the
-    routed path re-pays it too and it IS the plan's cost.
+    **Measured directly, where the executor publishes phases.** `ns_setup + ns_loop + ns_finish` are
+    contiguous by construction -- four instants bounding three spans -- so their sum IS the executor,
+    with no subtraction and nothing to overshoot. Verified against the netted figure on 45k paired
+    rows: median ratio 0.998 (GatheredScan) and 0.997 (StreamedSelect), with 0.08us of the round left
+    unaccounted by any phase. Only the two materializing plans publish them.
+
+    **Netted, otherwise.** The other four plans publish no phases, so their executor time is recovered
+    as `min(trials_ns) - ns_prepare`: a forced run rebuilds the shared artifact (candidate list, or the
+    plane bitmap) that the router acquires once, and `ns_prepare` is that build. Except under a
+    range-style acquire, where the routed path re-pays it too and it IS the plan's cost -- hence
+    `RANGE_ACQUIRES`.
+
+    The guard on that subtraction is an ABSOLUTE floor, not a fraction. It used to drop any row where
+    netting removed more than half the trial, which cost real coverage for no reason: `ns_prepare` and
+    the trial come from the SAME round (`explain_analyze` keeps the fastest round's phases), so the
+    subtraction is exact rather than cross-round, and a residual that is 40% of a 10us trial is 4us --
+    measurable, not noise. That guard was dropping `PlanePopcountOrder` on 37% of plane queries, which
+    made `bench_regret_matrix` skip 39% of all queries as unpriceable. What matters is whether the
+    residual clears the timer, so the floor is `NOISE_FLOOR_US`.
 
     Returns:
-        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or
-        if netting overshot far enough that the residual is noise.
+        The plan's own nanoseconds, or None if the plan produced no page (declined, or never ran) or if
+        the netted residual falls below the timer's noise floor.
     """
     if not plan["trials_ns"]:
         return None
+    phases = float(plan["ns_setup"] + plan["ns_loop"] + plan["ns_finish"])
+    if phases > 0:
+        return phases
     real = float(min(plan["trials_ns"]))
     if plan["ns_round_total"] and acquire["count_source"] not in RANGE_ACQUIRES:
         netted = real - plan["ns_prepare"]
-        if netted < real * NETTING_RESIDUAL_FLOOR:
+        if netted < NETTING_RESIDUAL_FLOOR_NS:
             return None
         real = netted
     return real

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -91,7 +91,10 @@ CURRENT: dict[str, list[float]] = {
     # eval_domain, scan_units, tier scale, matches, page_span, fixed
     "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
-    "StreamedSelect": [6.46, 5.53, 8.18, 0.13, 1.36, 1.64, 0.02, 217.5],
+    # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
+    # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
+    # term the arm multiplies by zero. Median agreement 0.63 -> 0.92, within-25% 19% -> 58%.
+    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.21, 1.02, 0.02, 217.0],
     # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
@@ -167,10 +170,19 @@ def nnls(rows: list[list[float]], targets: list[float]) -> list[float]:
     return coeffs
 
 
-# The residual floors the shipped arms use inside `max(tier_ns, floor)`. They are NOT fitted here --
-# see design_row for why the max cannot be a plain linear column -- and were derived independently by
-# regressing per-card match-loop time on printings-per-card, split by tier class.
-SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 8.18}
+# The residual floors the shipped arms use inside `max(tier_ns, floor)`.
+#
+# These MUST equal the `*_RESIDUAL_FLOOR_NS` constants in cost.rs, and equal the third entry of the
+# matching `CURRENT` vector. All three are the same number: `design_row` makes the floor the
+# coefficient of the `eval_domain * residual_on` column AND uses it to compute the `excess` offset for
+# rows where the tier beats it. Change one without the others and `mirror_matches_engine` drops below
+# its 99% bar -- which is exactly how the 2026-08-02 refit was caught pasting a fitted floor of 6.58
+# into cost.rs while the offset here still assumed 8.18 (7.4% of rows disagreed).
+#
+# A consequence worth stating: the fitted floor is not directly pasteable, because the offset it was
+# fitted against assumed the OLD floor. Applying it and re-fitting is a fixed-point iteration, and
+# each run is only self-consistent with whatever is shipped at the time.
+SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 6.58}
 
 
 def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[float], list[str], float] | None:
@@ -277,12 +289,15 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
 
 def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
     """Realized counter vs the feature that should predict it, per plan. Ratios should be 1.00."""
-    pairs = (("cards_visited", "eval_domain"), ("printings_scanned", "scan_units"), ("matches_pushed", "matches"))
+    # `scan_units` pairs with `printings_examined`, not the `printing_span` this used to read: the span
+    # is computed by the caller before the match kernel runs, so in card mode -- where every kernel
+    # stops at the first qualifying printing -- it reports work that never happened.
+    pairs = (("cards_visited", "eval_domain"), ("printings_examined", "scan_units"), ("matches_pushed", "matches"))
 
     def feature_for(plan: str, counter: str, row: dict) -> str:
         """Compose reads its own scan field, and which one depends on the paging branch that runs."""
-        if counter != "printings_scanned" or plan != "PrintingCompose":
-            return {"cards_visited": "eval_domain", "printings_scanned": "scan_units", "matches_pushed": "matches"}[counter]
+        if counter != "printings_examined" or plan != "PrintingCompose":
+            return {"cards_visited": "eval_domain", "printings_examined": "scan_units", "matches_pushed": "matches"}[counter]
         return "compose_scan_printings" if row["acq"].get("compose_paging") == "Gather" else "printings_walked"
 
     out: dict[str, list[tuple[str, float]]] = {}
@@ -295,8 +310,17 @@ def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
             continue  # only the two scan plans carry counters; absent is not the same as wrong
         checks = []
         for counter, _default in pairs:
-            got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in instrumented]
-            feature = feature_for(plan, counter, instrumented[0])
+            # Only grade rows whose arm actually multiplies the feature by a rate. StreamedSelect's
+            # scan term is `if tier_ns > 0.0 { scan_units * ... } else { 0.0 }`, so on an all_match
+            # query (tier 0) `scan_units` is a number the model never reads -- and grading it anyway
+            # read 0.65 here and vetoed the whole plan's fit over a term that contributes zero.
+            graded = instrumented
+            if counter == "printings_examined" and plan == "StreamedSelect":
+                graded = [r for r in instrumented if r["acq"]["residual_tier_ns100"] > 0]
+            if not graded:
+                continue
+            got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in graded]
+            feature = feature_for(plan, counter, graded[0])
             if got:
                 checks.append((f"{counter}/{feature}", statistics.median(got)))
         if checks:
@@ -351,7 +375,8 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
                     "ns_setup": p["ns_setup"],
                     "ns_loop": p["ns_loop"],
                     "ns_finish": p["ns_finish"],
-                    "printings_scanned": p["printings_scanned"],
+                    "printing_span": p["printing_span"],
+                    "printings_examined": p["printings_examined"],
                     "matches_pushed": p["matches_pushed"],
                 }
             )
@@ -488,7 +513,10 @@ def main() -> None:
     args = parser.parse_args()
 
     engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".fit.store"))
-    samples = collect(engine, random.Random(args.seed), args.seconds)
+    # Pass the sampler explicitly: `collect`'s fallback builds one off a hardcoded corpus path, so
+    # `--corpus` was loading the engine from one file and drawing queries from another (or, off the
+    # default checkout, raising FileNotFoundError). Values must come from the corpus the engine holds.
+    samples = collect(engine, random.Random(args.seed), args.seconds, QuerySampler(args.corpus, "uniform"))
     print(f"\n{len(samples):,} plan-rows collected in {args.seconds:.0f}s")
 
     agree, checked = mirror_matches_engine(samples)

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -102,7 +102,10 @@ CURRENT: dict[str, list[float]] = {
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
     # with the other arm's is information about the shared constant, not a number to paste blindly.
-    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 9.81, 0.38, 3.39, 163.56],
+    # GATHER_GROUP_PER_PRINTING sits between the bit-test and push columns, matching design_row.
+    # Added when the artwork tail was traced to the grouping arm's work being charged at the bit-test
+    # rate; its 1.5 start is a physical guess (a struct read plus prefer_score), meant to be fitted.
+    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 13.22, 0.38, 1.5, 3.39, 163.56],
 }
 
 
@@ -272,6 +275,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 limit if not gather else 0.0,
                 eval_domain if gather else 0.0,
                 float(acq["compose_scan_printings"]) if gather else 0.0,
+                float(acq.get("gather_group_printings", 0)) if gather else 0.0,
                 matches if gather else 0.0,
                 1.0,
             ],
@@ -284,6 +288,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "WALK_EMIT_PER_ROW",
                 "GATHER_CARD_PASS",
                 "GATHER_BITTEST_PER_PRINTING",
+                "GATHER_GROUP_PER_PRINTING",
                 "GATHER_PUSH_PER_MATCH",
                 "FIXED",
             ],

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -61,10 +61,6 @@ WALK_LENGTH_BIAS = 1.45
 # A realized counter this far from the feature meant to predict it is a FEATURE bug; refitting rates
 # on top of it just relocates the error.
 COUNTER_TOL = 0.15
-# Netting prepare_candidates out can overshoot (different round than the min trial). Keep a row only
-# if what remains is at least this fraction of the raw time; below that the residual is noise.
-# Now enforced inside `costbench.plan_self_ns`, which every harness shares.
-MIN_NETTED_FRACTION = costbench.NETTING_RESIDUAL_FLOOR
 # The mirror check's tolerance. This is a reimplementation of cost.rs in Python, so it can drift --
 # and did: the arms moved to `max(tier, floor)` and gained a residual-gated per-row term while
 # `design_row` still modelled the tier as a multiplier, which silently invalidated every coefficient

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -55,6 +55,9 @@ MIN_ROWS_FOR_FIT = 200
 STREAM_MIN_MATCHES = 1024
 # Mirrors cost.rs MATCH_RATE_FLOOR, the density floor under the page-fill walk length.
 MATCH_RATE_FLOOR = 1.0 / 1_000_000.0
+# Mirrors cost.rs WALK_LENGTH_BIAS: matches clump along the sort order, so a walk runs ~1.45x longer
+# than uniform spacing predicts. Measured 0.69 against `printings_examined` before this existed.
+WALK_LENGTH_BIAS = 1.45
 # A realized counter this far from the feature meant to predict it is a FEATURE bug; refitting rates
 # on top of it just relocates the error.
 COUNTER_TOL = 0.15
@@ -256,7 +259,9 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
         # Recomputed rather than read from the exposed u32, which is truncated for display. The
         # mirror has to match cost.rs bit for bit or its self-check fails on small walks.
         match_rate = max(matches / max(float(acq["n_printings"]), 1.0), MATCH_RATE_FLOOR)
-        walk = (page_span / match_rate) if not gather else 0.0
+        # Mirrors `cost::printings_walked`: the closed form times WALK_LENGTH_BIAS, then floored by
+        # `orderby_walk_scan` for the plane-bucket orderby walk (0 for Perm and for the usd walk).
+        walk = max(page_span / match_rate * WALK_LENGTH_BIAS, float(acq.get("orderby_walk_scan", 0))) if not gather else 0.0
         return (
             [
                 float(acq["broadcast_printings"]),
@@ -317,6 +322,15 @@ def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
             graded = instrumented
             if counter == "printings_examined" and plan == "StreamedSelect":
                 graded = [r for r in instrumented if r["acq"]["residual_tier_ns100"] > 0]
+            # Compose's three paging branches charge different features, so grading a row against a
+            # feature its branch never multiplies by a rate manufactures a defect. Its Gather branch
+            # charges eval_domain/compose_scan_printings/matches; Perm and OrderbyWalk charge only
+            # printings_walked and stop at page_offset+limit, so their `cards_visited` is 0 (the
+            # orderby walk steps a value structure, not cards) and their `matches_pushed` is a page,
+            # not a total. Ungated, those read 0.02 and 0.01 and vetoed the plan's whole fit.
+            if plan == "PrintingCompose":
+                gather_only = counter in ("cards_visited", "matches_pushed")
+                graded = [r for r in graded if (r.get("paging_taken") in ("Gather", "GatherWalkDeclined")) == gather_only]
             if not graded:
                 continue
             got = [r[counter] / max(r["acq"][feature_for(plan, counter, r)], 1) for r in graded]
@@ -376,6 +390,7 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
                     "ns_loop": p["ns_loop"],
                     "ns_finish": p["ns_finish"],
                     "printing_span": p["printing_span"],
+                    "paging_taken": p.get("paging_taken"),
                     "printings_examined": p["printings_examined"],
                     "matches_pushed": p["matches_pushed"],
                 }

--- a/scripts/fit_plan_gap.py
+++ b/scripts/fit_plan_gap.py
@@ -1,0 +1,330 @@
+"""Fit the P3/P4 pair as LEVEL + DELTA, so absolute accuracy and ordering stop competing.
+
+`argmin` consumes only differences, and `cost.rs` records why fitting each arm's absolute time cannot
+settle these two: "P3/P4 could NOT be fit -- SCAN goes negative because `scan_units` and `matches` both
+scale with printing count in the workload, a STRUCTURAL collinearity no corpus size fixes". A collinear
+direction is one the absolute objective cannot see. It is often one the DIFFERENCE can.
+
+And the difference is where the losses are. On the dispatch basis `StreamedSelect -> GatheredScan` and
+`GatheredScan -> StreamedSelect` are 36% and 21% of all routing regret, both directions large -- the
+signature of a model that cannot separate two plans near the margin rather than one biased about
+either. The confusion is almost entirely on queries WITH a residual (22% order-wrong against 1% for
+`all_match`) and ABOVE `STREAM_MIN_MATCHES` (25% against 3%), which is exactly where the arms diverge:
+P3 charges `scan_units * 5.97` gated on a residual, P4 charges `scan_units * 2.06` unconditionally.
+
+## Why fitting the gap alone is not enough
+
+Fitting only `log(real3/real4)` was tried and it works on its own terms -- held-out order agreement
+86.9% -> 94.4%, and 80.5% -> 92.1% on residual queries. But it wrecked what it was not looking at:
+StreamedSelect's absolute within-25% fell 58% -> 23%, and the regret it bought in one direction it
+gave back in the other (`GatheredScan -> StreamedSelect` share 22% -> 6%, `StreamedSelect ->
+GatheredScan` 34% -> 43%). A gap objective is blind to the overall level, so nothing stopped it
+wandering there.
+
+## The re-parameterisation
+
+Terms whose FEATURE appears in both arms are written as a level plus a delta:
+
+    P4 cost = sum   x_k        * f_k
+    P3 cost = sum ( x_k + d_k) * f_k
+
+`x` is what the absolute objective identifies; `d` is what the gap objective identifies. Written this
+way the two objectives inform different parameters instead of pulling on the same ones, so both can be
+optimised at once:
+
+    minimise  ABS_WEIGHT * sum over both plans (log pred - log real)^2
+            + GAP_WEIGHT * sum (log(pred3/pred4) - log(real3/real4))^2
+            + ridge
+
+with the ridge TIGHT on `x` and loose on `d` -- the level is already calibrated and the delta is the
+part known to be wrong. Terms unique to one arm (P3's artwork/small-total/corpus-pass/emit, P4's
+push/select) have no counterpart and are fitted directly.
+
+The gap term is weighted by |real gap|, because regret is milliseconds and not decisions: a wrong call
+on a 300us gap costs 300x one on a 1us gap. Unweighted, the fit took held-out order agreement
+86.2% -> 94.1% and left total regret FLAT (63.6 -> 62.1 ms, 66.5 -> 68.0 ms on two seeds) by trading
+404 cheap wrong-GatheredScan picks for 230 dear wrong-StreamedSelect ones.
+
+## DO NOT SHIP THIS FITTER'S OUTPUT. It is a diagnostic.
+
+Every version of this was validated against `bench_regret_matrix.py`, and the best of them made real
+routing WORSE:
+
+    variant                     held-out order   held-out lost   ACTUAL total regret
+    current                              86.5%         188 ms    60.4 / 69.7 ms
+    gap only                             94.4%              -    62.1 / 68.0 ms
+    level+delta, unweighted              94.1%              -    62.1 / 68.0 ms
+    level+delta, time-weighted           94.1%          22 ms    80.1 / 77.9 ms  <-- worse
+
+The reason is a flaw in the objective, not in the arithmetic: **routing is a multi-way argmin and this
+fits a pair.** `P3 = level + delta`, so moving the delta moves P3's ABSOLUTE cost -- and P3 then wins
+more often against `PrintingCompose` and the range plans too, which this objective cannot see. The
+time-weighted fit dropped P3's rates hard (CARD_PASS 5.05 -> 3.08, SCAN_PER_ROW 5.97 -> 2.45), fixed
+the direction it was looking at (`GatheredScan -> StreamedSelect` 544 -> 106 misroutes) and created
+far more of the other (`StreamedSelect -> GatheredScan` 703 -> 1184).
+
+What the pairwise view DID establish, and what is worth keeping:
+
+- The confusion is localised: residual queries above `STREAM_MIN_MATCHES`, 22% order-wrong against 1%
+  for `all_match`.
+- The discriminating term is the per-row scan rate, and its shipped 3x split (5.97 against 2.06) is
+  far too wide. Every weighting drove `D:SCAN_PER_ROW` down hard -- to 0.37 when time-weighted, i.e.
+  the two rates want to be nearly EQUAL. That is a real finding about the model's shape.
+- Absolute agreement and ordering do NOT have to trade, once re-parameterised: the time-weighted fit
+  improved both medians and `within` while improving order.
+
+A sound version needs the objective to be the actual routing outcome over ALL applicable plans -- the
+regret matrix as the loss, not a pairwise proxy for it.
+
+    .venv/bin/python scripts/fit_plan_gap.py --seconds 300   # build --features routed-phases
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import pathlib
+import random
+import statistics
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from client.query_sampler import MODES, QuerySampler  # noqa: E402
+from scripts import costbench  # noqa: E402
+from scripts import fit_cost_model as fitmod  # noqa: E402
+from scripts.costbench import load_engine  # noqa: E402
+
+P3, P4 = "StreamedSelect", "GatheredScan"
+#: Terms whose feature column is the same in both arms, so a level/delta split is meaningful. Keyed by
+#: the P3 term name; the value is P4's name for the same feature.
+SHARED: dict[str, str] = {
+    "CARD_PASS": "CARD_PASS",
+    "SCAN_PER_ROW": "SCAN_PER_ROW",
+    "RESIDUAL_FLOOR": "RESIDUAL_FLOOR",
+    "FIXED": "FIXED",
+}
+# Both objectives matter, and the gap one is what routing reads, so it carries more weight. Absolute
+# accuracy is not free to abandon though: several harnesses read `predicted_ns` as a time.
+ABS_WEIGHT = 1.0
+GAP_WEIGHT = 3.0
+# Ridge, relative to the shipped value. TIGHT on the level (already calibrated by the absolute fit) and
+# loose on the delta (the part the collinearity left unidentified).
+RIDGE_LEVEL = 0.5
+RIDGE_DELTA = 0.01
+NUM_SWEEPS = 10
+SEARCH_SPAN = 4.0
+GOLDEN_ITERS = 32
+BRACKET_EPS = 1e-9
+# A gap below this is a tie no model can be expected to call; grading ties makes order agreement look
+# worse than the routing it produces.
+TIE_FLOOR_US = 1.0
+# Below this a shipped value is effectively zero and a relative ridge would divide by nothing.
+ZERO_EPS = 1e-9
+# The agreement band every other harness grades against, so these numbers are comparable to theirs.
+AGREE_LO, AGREE_HI = 0.8, 1.25
+
+
+def term_names() -> dict[str, list[str]]:
+    """Each arm's term names, straight from `design_row` so they cannot drift from the design."""
+    dummy = {
+        "eval_domain": 1,
+        "scan_units": 1,
+        "matches": 1,
+        "n_cards": 1,
+        "n_printings": 1,
+        "residual_tier_ns100": 100,
+        "artwork_seen_cards": 0,
+        "compose_paging": "Gather",
+        "broadcast_printings": 0,
+        "scatter_printings": 0,
+        "project_printings": 0,
+        "popcount_words": 0,
+        "compose_scan_printings": 0,
+        "gather_group_printings": 0,
+        "orderby_walk_scan": 0,
+    }
+    return {plan: fitmod.design_row(plan, dummy, 100, 0)[1] for plan in (P3, P4)}
+
+
+def collect_pairs(engine: object, sampler: QuerySampler, rng: random.Random, seconds: float) -> list[dict]:
+    """One row per query where BOTH plans ran and are priceable, with each side's design row."""
+    rows: list[dict] = []
+    budget = costbench.Budget(seconds=seconds, warmups=fitmod.NUM_WARMUPS, trials=fitmod.NUM_TRIALS)
+    for sample in costbench.iter_samples(engine, sampler, rng, budget, vary_prefer=True):
+        plans = {p["plan"]: p for p in sample.plans}
+        if not all(n in plans and plans[n]["trials_ns"] for n in (P3, P4)):
+            continue
+        selves = {n: costbench.plan_self_ns(plans[n], sample.acquire) for n in (P3, P4)}
+        if any(v is None or v <= 0 for v in selves.values()):
+            continue
+        designs = {n: fitmod.design_row(n, sample.acquire, sample.kw["limit"], sample.kw["offset"]) for n in (P3, P4)}
+        if any(d is None for d in designs.values()):
+            continue
+        rows.append(
+            {
+                "real": {n: selves[n] for n in (P3, P4)},
+                "row": {n: designs[n][0] for n in (P3, P4)},
+                "off": {n: designs[n][2] for n in (P3, P4)},
+                "gap_us": (selves[P3] - selves[P4]) / 1000.0,
+                # TIME weight. Regret is milliseconds, not decisions: getting the order wrong on a
+                # 300us gap costs 300x what getting it wrong on a 1us gap does. An unweighted fit
+                # treats those equally and will happily trade many cheap wins for a few dear losses --
+                # measured, exactly that happened. The level+delta fit took held-out order agreement
+                # 86.2% -> 94.1% and left total regret flat (63.6 -> 62.1 ms, 66.5 -> 68.0 ms on two
+                # seeds), because it converted 404 cheap wrong-GatheredScan picks into 230 expensive
+                # wrong-StreamedSelect ones (28.66us against 12.46us mean).
+                "weight": abs(selves[P3] - selves[P4]) / 1000.0,
+                "tier": "residual" if sample.acquire["residual_tier_ns100"] > 0 else "all_match",
+            }
+        )
+    return rows
+
+
+def coeffs_from(params: dict[str, float], names: dict[str, list[str]]) -> dict[str, list[float]]:
+    """Expand the level/delta parameters back into one coefficient vector per arm."""
+    out: dict[str, list[float]] = {}
+    out[P4] = [params[f"{P4}:{nm}"] for nm in names[P4]]
+    p3: list[float] = []
+    for nm in names[P3]:
+        if nm in SHARED:
+            p3.append(max(params[f"{P4}:{SHARED[nm]}"] + params[f"D:{nm}"], 0.0))
+        else:
+            p3.append(params[f"{P3}:{nm}"])
+    out[P3] = p3
+    return out
+
+
+def predict(coeffs: dict[str, list[float]], r: dict, plan: str) -> float:
+    """One arm's predicted dispatch cost, mirroring `design_row`'s row-plus-offset contract."""
+    return max(sum(c * v for c, v in zip(coeffs[plan], r["row"][plan], strict=True)) + r["off"][plan], 1.0)
+
+
+def objective(params: dict[str, float], rows: list[dict], names: dict[str, list[str]], base: dict[str, float]) -> float:
+    """Weighted absolute + gap log error, plus the split ridge."""
+    coeffs = coeffs_from(params, names)
+    total = 0.0
+    for r in rows:
+        q3, q4 = predict(coeffs, r, P3), predict(coeffs, r, P4)
+        total += ABS_WEIGHT * (math.log(q3 / r["real"][P3]) ** 2 + math.log(q4 / r["real"][P4]) ** 2)
+        # The gap term carries the TIME weight -- see the `weight` field. The absolute term does not:
+        # absolute accuracy is wanted uniformly across queries, not concentrated on the expensive ones.
+        total += GAP_WEIGHT * r["weight"] * (math.log(q3 / q4) - math.log(r["real"][P3] / r["real"][P4])) ** 2
+    pull = 0.0
+    for k, v in params.items():
+        b = base[k]
+        strength = RIDGE_DELTA if k.startswith("D:") else RIDGE_LEVEL
+        denom = abs(b) if abs(b) > ZERO_EPS else 1.0
+        pull += strength * ((v - b) / denom) ** 2
+    # Scaled by the same total weight the data term carries, so the ridge's relative strength does not
+    # change when the gap weighting does.
+    scale = sum(1.0 + GAP_WEIGHT * r["weight"] for r in rows)
+    return total + scale * pull
+
+
+def fit(rows: list[dict], names: dict[str, list[str]], base: dict[str, float]) -> dict[str, float]:
+    """Coordinate descent with a golden-section line search per parameter."""
+    params = dict(base)
+    inv = (math.sqrt(5.0) - 1.0) / 2.0
+    for _ in range(NUM_SWEEPS):
+        for key in params:
+            b = base[key]
+            span = max(abs(b) * SEARCH_SPAN, 1.0)
+            lo, hi = (b - span, b + span) if key.startswith("D:") else (0.0, b + span)
+            a, c = lo + (1 - inv) * (hi - lo), lo + inv * (hi - lo)
+            params[key] = a
+            fa = objective(params, rows, names, base)
+            params[key] = c
+            fc = objective(params, rows, names, base)
+            for _ in range(GOLDEN_ITERS):
+                if hi - lo < BRACKET_EPS:
+                    break
+                if fa < fc:
+                    hi, c, fc = c, a, fa
+                    a = lo + (1 - inv) * (hi - lo)
+                    params[key] = a
+                    fa = objective(params, rows, names, base)
+                else:
+                    lo, a, fa = a, c, fc
+                    c = lo + inv * (hi - lo)
+                    params[key] = c
+                    fc = objective(params, rows, names, base)
+            params[key] = (lo + hi) / 2.0
+    return params
+
+
+def report(label: str, coeffs: dict[str, list[float]], rows: list[dict]) -> None:
+    """Order agreement AND the time those wrong calls cost, plus each arm's absolute ratio.
+
+    Both columns are needed and they can disagree. Order agreement counts queries; regret counts
+    milliseconds. A model that calls more queries right can still lose more time, by trading cheap
+    wins for dear losses -- measured, and it is why `lost ms` is here.
+    """
+    graded = [r for r in rows if abs(r["gap_us"]) >= TIE_FLOOR_US]
+    right, lost_us = 0, 0.0
+    for r in graded:
+        ok = (predict(coeffs, r, P3) > predict(coeffs, r, P4)) == (r["real"][P3] > r["real"][P4])
+        right += ok
+        if not ok:
+            lost_us += abs(r["gap_us"])
+    abs3 = statistics.median(predict(coeffs, r, P3) / r["real"][P3] for r in rows)
+    abs4 = statistics.median(predict(coeffs, r, P4) / r["real"][P4] for r in rows)
+    within = statistics.fmean(
+        1.0 if AGREE_LO <= predict(coeffs, r, p) / r["real"][p] <= AGREE_HI else 0.0 for r in rows for p in (P3, P4)
+    )
+    print(f"  {label:<18}{right / max(len(graded), 1):>14.1%}{lost_us / 1000:>11.1f}{abs3:>10.2f}{abs4:>10.2f}{within:>12.0%}")
+
+
+def main() -> None:
+    """Collect pairs, fit level+delta on half, and score ordering and absolutes on the held-out half."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--seconds", type=float, default=240.0)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--mode", choices=MODES, default="uniform")
+    parser.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl")
+    parser.add_argument("--shm-path", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    engine = load_engine(args.corpus, args.shm_path or args.corpus.with_suffix(".gapfit.store"))
+    sampler = QuerySampler(args.corpus, args.mode)
+    rows = collect_pairs(engine, sampler, random.Random(args.seed), args.seconds)
+    print(f"\n{len(rows):,} queries where both {P3} and {P4} ran and are priceable")
+    if len(rows) < fitmod.MIN_ROWS_FOR_FIT:
+        print("too few rows to fit")
+        return
+
+    names = term_names()
+    cur = {plan: list(fitmod.CURRENT[plan]) for plan in (P3, P4)}
+    base: dict[str, float] = {f"{P4}:{nm}": v for nm, v in zip(names[P4], cur[P4], strict=True)}
+    for nm, v in zip(names[P3], cur[P3], strict=True):
+        if nm in SHARED:
+            base[f"D:{nm}"] = v - cur[P4][names[P4].index(SHARED[nm])]
+        else:
+            base[f"{P3}:{nm}"] = v
+
+    train = [r for i, r in enumerate(rows) if i % 2 == 0]
+    test = [r for i, r in enumerate(rows) if i % 2 == 1]
+    fitted = fit(train, names, base)
+
+    print(f"\n{'parameter':<34}{'current':>10}{'fitted':>10}{'x':>8}")
+    for key in sorted(base):
+        b, f = base[key], fitted[key]
+        print(f"{key:<34}{b:>10.2f}{f:>10.2f}{(f / b if abs(b) > ZERO_EPS else float('nan')):>8.2f}")
+
+    print(f"\n  {'variant':<18}{'order correct':>14}{'lost ms':>11}{'P3 abs':>10}{'P4 abs':>10}{'within':>12}")
+    for label, rs in (("-- train", train), ("-- TEST", test)):
+        print(f" {label}")
+        report("current", cur, rs)
+        report("level+delta", coeffs_from(fitted, names), rs)
+    for tier in ("residual", "all_match"):
+        sub = [r for r in test if r["tier"] == tier]
+        if len(sub) < 200:  # noqa: PLR2004 - a thin tier says nothing
+            continue
+        print(f" -- TEST, {tier} ({len(sub):,})")
+        report("current", cur, sub)
+        report("level+delta", coeffs_from(fitted, names), sub)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upscale_corpus.py
+++ b/scripts/upscale_corpus.py
@@ -1,0 +1,124 @@
+"""Build an upscaled store from the real corpus, so loop benchmarks can miss cache the way production does.
+
+`bench_gather_loop` and `bench_streamed_loop` walk one candidate list `ITERS` times and keep the minimum,
+which makes every rate they report a WARM-CACHE rate: from the second pass every card, printing and
+string is resident. Production walks a candidate set once. Measured against the warm minimum, the first
+pass costs 1.6-2.2x more, and that gap is the entire reason five refits of the shipped constants each
+made routing worse -- each lowered rates toward a cache state that never occurs.
+
+Two things fix that, and they compose:
+
+  chunk rotation   walk a DIFFERENT slice of candidates each iteration, so consecutive walks share no
+                   cards. Implemented in the harnesses themselves.
+  a bigger store   with 31,508 oracle cards the whole archive is ~68 MB, so a full rotation still fits
+                   in the system-level cache on this machine and chunk 0 may survive until it is walked
+                   again. At 4-13x that, a rotation cannot stay resident.
+
+The real corpus cannot supply 400k cards, so this replicates it. Each copy rewrites the three identity
+fields that decide how the engine groups rows -- `oracle_id` (which printings form one oracle card),
+`scryfall_id` (the printing key) and `illustration_id` (artwork groups) -- keeping UUID shape so nothing
+downstream has to special-case them. Everything that drives cost stays untouched: printings per card,
+the printings-per-card DISTRIBUTION, text lengths, legality masks, colours. So an upscaled store is the
+real corpus's shape at N times the size, which is what a cache measurement needs; it is NOT a
+realistic future corpus, and nothing about selectivity or query mix should be read off it.
+
+Names get a per-copy suffix, because `card_name` feeds the name index and the sort permutations and
+duplicate names across copies would collapse orderings that production keeps distinct.
+
+    .venv/bin/python scripts/upscale_corpus.py --copies 4 --out benchmarks/loop-scale/cards-4x.store
+
+Reports the realized card and printing counts, since those are what the harness needs to report
+alongside its rates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import costbench  # noqa: E402
+
+# Rows per `add_batch`, matching costbench.BATCH_SIZE's reasoning: large enough that per-call overhead
+# vanishes, small enough that the batch list stays cheap to hold.
+BATCH_SIZE = 2000
+# The identity fields a copy must rewrite. `oracle_id` decides which printings form one oracle card, so
+# leaving it would fold every copy's printings into the SAME cards -- the store would grow in printings
+# per card rather than in cards, which is the opposite of what this is for. `illustration_id` decides
+# artwork groups, and `scryfall_id` is the printing primary key.
+UUID_FIELDS = ("oracle_id", "scryfall_id", "illustration_id")
+
+
+def rewrite_uuid(value: str, copy: int) -> str:
+    """Replace a UUID's first block with the copy index, preserving shape and uniqueness.
+
+    The originals are unique within one copy, so stamping the copy index over the leading block keeps
+    them unique across copies without needing a counter or a hash. Values that are not UUID-shaped
+    (absent, null, or some other spelling) are returned unchanged rather than corrupted.
+    """
+    if not isinstance(value, str) or len(value) < 8 or "-" not in value:
+        return value
+    return f"{copy:08x}{value[8:]}"
+
+
+def replicate(record: dict, copy: int) -> dict:
+    """One copy of a record, with identities rewritten and everything cost-relevant left alone."""
+    out = dict(record)
+    for field in UUID_FIELDS:
+        if field in out:
+            out[field] = rewrite_uuid(out[field], copy)
+    # Names feed the name index and both sort permutations; duplicates across copies would collapse
+    # orderings production keeps distinct, and the permutation walk is exactly what P3 benchmarks.
+    if isinstance(out.get("card_name"), str):
+        out["card_name"] = f"{out['card_name']} c{copy}"
+    if isinstance(out.get("card_name_folded"), str):
+        out["card_name_folded"] = f"{out['card_name_folded']} c{copy}"
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--copies", type=int, required=True, help="replication factor; 1 reproduces the real corpus")
+    ap.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks" / "bitplanes" / "corpus.jsonl")
+    ap.add_argument("--out", type=pathlib.Path, required=True, help="store path to write")
+    args = ap.parse_args()
+
+    if args.copies < 1:
+        msg = "--copies must be at least 1"
+        raise SystemExit(msg)
+
+    import card_engine  # noqa: PLC0415 - keeps this importable without the built extension
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    engine = card_engine.QueryEngine(str(args.out))
+    if not engine.reload_begin():
+        msg = "reload_begin returned False (stale archive published concurrently?)"
+        raise SystemExit(msg)
+
+    # Streamed per copy rather than building the whole list: at 13 copies this is ~1.26M records, and
+    # holding them all would cost more than the store itself.
+    records = [json.loads(line) for line in args.corpus.open()]
+    print(f"read {len(records):,} printings from {args.corpus}", flush=True)
+    batch: list[dict] = []
+    for copy in range(args.copies):
+        for record in records:
+            batch.append(replicate(record, copy))
+            if len(batch) == BATCH_SIZE:
+                engine.add_batch(batch)
+                batch.clear()
+        print(f"  copy {copy + 1}/{args.copies} staged", flush=True)
+    if batch:
+        engine.add_batch(batch)
+    engine.reload_commit()
+
+    size_mb = args.out.stat().st_size / (1024 * 1024)
+    print(f"\nwrote {args.out}  ({size_mb:,.0f} MB, {engine.size():,} printings)")
+    print("card count comes from the harness, which reports it alongside its rates.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upscale_corpus.py
+++ b/scripts/upscale_corpus.py
@@ -41,8 +41,6 @@ import sys
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from scripts import costbench  # noqa: E402
-
 # Rows per `add_batch`, matching costbench.BATCH_SIZE's reasoning: large enough that per-call overhead
 # vanishes, small enough that the batch list stays cheap to hold.
 BATCH_SIZE = 2000
@@ -51,6 +49,8 @@ BATCH_SIZE = 2000
 # per card rather than in cards, which is the opposite of what this is for. `illustration_id` decides
 # artwork groups, and `scryfall_id` is the printing primary key.
 UUID_FIELDS = ("oracle_id", "scryfall_id", "illustration_id")
+# Hex characters in a UUID's leading block, which is the part `rewrite_uuid` stamps the copy index over.
+UUID_FIRST_BLOCK = 8
 
 
 def rewrite_uuid(value: str, copy: int) -> str:
@@ -60,9 +60,9 @@ def rewrite_uuid(value: str, copy: int) -> str:
     them unique across copies without needing a counter or a hash. Values that are not UUID-shaped
     (absent, null, or some other spelling) are returned unchanged rather than corrupted.
     """
-    if not isinstance(value, str) or len(value) < 8 or "-" not in value:
+    if not isinstance(value, str) or len(value) < UUID_FIRST_BLOCK or "-" not in value:
         return value
-    return f"{copy:08x}{value[8:]}"
+    return f"{copy:08x}{value[UUID_FIRST_BLOCK:]}"
 
 
 def replicate(record: dict, copy: int) -> dict:
@@ -81,6 +81,7 @@ def replicate(record: dict, copy: int) -> dict:
 
 
 def main() -> None:
+    """Build an upscaled store by replicating the corpus, then report what it came out as."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--copies", type=int, required=True, help="replication factor; 1 reproduces the real corpus")
     ap.add_argument("--corpus", type=pathlib.Path, default=REPO_ROOT / "benchmarks" / "bitplanes" / "corpus.jsonl")


### PR DESCRIPTION
**Layer 1 of 13.** Reference: #830, which carries the whole change set and the end-to-end measurement.
This layer is the measurement substrate everything above it is priced with.

## What it does

Makes the engine report what each plan actually did, so the cost model can be graded against reality
instead of against itself.

- **Per-plan counters** — `printings_examined`, `cards_visited`, `matches_pushed`, `printing_span`,
  `perm_steps`. Published without the 80-byte write the first cut cost.
- **Phase timing** — `ns_setup` / `ns_prepare` / `ns_loop` / `ns_finish` per plan, and `plan_self_ns`
  computed by *adding* phases rather than subtracting a shared prepare. Subtraction was giving plane rows
  negative regret, because the routed path reuses an artifact a forced trial rebuilds.
- **Regret re-based on dispatch** rather than the whole routed path, and plane rows made
  dispatch-comparable so unpriceable ones are refused rather than counted as free.
- **Two loop benches** (`bench_gather_loop`, `bench_streamed_loop`) that decompose the match loops on an
  orthogonal design.

## Why it is worth reviewing on its own

Several findings in the layers above are *corrections* of conclusions that were wrong before these
counters existed — the cost model had arms nothing had ever measured. Two commits here retract earlier
rate findings after discovering a min-of-200 was measuring a warm cache, and one records that the fitted
rates must not ship. The benches print rates that are deliberately **not** adopted.

## Risk

Behaviour-neutral apart from the counters themselves and the regret re-basing, which changes reported
numbers rather than plan choices. No archived type changes, so no `ARCHIVE_FORMAT_VERSION` bump.

## Verification

`cargo test` and `cargo clippy --all-targets -- -D warnings` green on both manifests at this layer.

24 commits, 7 engine files, +2,018/−150 in `card_engine/src`.
