### PR TITLE
Engine: Cost-Model Calibration (stack 2/13)

### DIFF
--- a/card_engine/src/bench_compose_card_projection.rs
+++ b/card_engine/src/bench_compose_card_projection.rs
@@ -31,7 +31,7 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, bitmap_card_ids, compose_printing_bits, gather_composed_page, printing_bits_to_card_bits, AOffsets,
-    CardData, CmpOp, CollField, FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortCol, ARCHIVE_HEADER_LEN,
+    CardData, CmpOp, CollField, FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortBound, SortCol, ARCHIVE_HEADER_LEN,
 };
 
 const ITERS: usize = 200;
@@ -42,7 +42,15 @@ const STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/ver
 /// card-space sort permutation, and the printing-space orderby walk requires
 /// `Mode::Printing` — so card mode lands in `gather_composed_page`, the affected branch.
 fn card_params(page_offset: usize) -> QueryParams {
-    QueryParams { mode: Mode::Card, prefer: Prefer::Default, sort_col: SortCol::PriceUsd, descending: false, limit: LIMIT, page_offset }
+    QueryParams {
+        mode: Mode::Card,
+        prefer: Prefer::Default,
+        sort_col: SortCol::PriceUsd,
+        descending: false,
+        limit: LIMIT,
+        page_offset,
+        sort_bound: SortBound::UNBOUNDED,
+    }
 }
 
 fn best_ns(mut kernel: impl FnMut() -> usize) -> u128 {

--- a/card_engine/src/bench_compose_paging.rs
+++ b/card_engine/src/bench_compose_paging.rs
@@ -26,13 +26,21 @@ use rkyv::Archived;
 
 use super::{
     archive_header, archive_payload, compose_printing_bits, gather_composed_page, walk_range_orderby_page, CardData, CmpOp, CollField,
-    FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortCol, ARCHIVE_HEADER_LEN,
+    FilterExpr, Mmap, Mode, Prefer, QueryCtx, QueryParams, SortBound, SortCol, ARCHIVE_HEADER_LEN,
 };
 
 /// This bench's fixed query shape: `unique=printing`, `orderby=usd` ascending,
 /// one page of `LIMIT` — only the offset sweeps.
 fn bench_params(page_offset: usize) -> QueryParams {
-    QueryParams { mode: Mode::Printing, prefer: Prefer::Default, sort_col: SortCol::PriceUsd, descending: false, limit: LIMIT, page_offset }
+    QueryParams {
+        mode: Mode::Printing,
+        prefer: Prefer::Default,
+        sort_col: SortCol::PriceUsd,
+        descending: false,
+        limit: LIMIT,
+        page_offset,
+        sort_bound: SortBound::UNBOUNDED,
+    }
 }
 
 const ITERS: usize = 200;

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -186,6 +186,12 @@ const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
 /// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
 /// keeps that contribution proportional to matches rather than to the page.
 const LIMIT: usize = 60;
+/// (offset, limit) pairs for the finish-phase sweep. `GATHER_SELECT_PER_PAGE_SLOT_NS` is charged against
+/// `page_span = min(offset + limit, matches)`, and every cell above holds the page FIXED, so that term
+/// has never been varied here -- the loop rates were measured while the one term keyed on the page was
+/// held constant. These four move `page_span` ~40x at constant counters, which is what separates a
+/// per-slot rate from a fixed cost the phase pays regardless.
+const PAGE_SPECS: [(usize, usize); 4] = [(0, 15), (0, 60), (0, 600), (900, 60)];
 
 /// Default store. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep runs: build
 /// upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn. The real corpus is
@@ -597,6 +603,56 @@ fn bench_gather_loop() {
     // What artwork mode costs ON TOP of the three fitted rates. cost.rs has no artwork term for P4,
     // so today this sits inside the shared rates, which is why measuring them without artwork in the
     // design and then lowering them under-costs artwork queries.
+    // Finish-phase sweep. Runs the SAME candidate set at four pages, so the loop's work is identical
+    // across rows and every difference in `ns_finish` is the select-and-collect. Chunk-rotated like
+    // everything else, and the median is reported.
+    //
+    // `page_span` is `min(offset + limit, matches)`, so the (900, 60) row is capped by matches rather
+    // than by the page: with 4,500 matches it asks for span 960, where (0, 600) asks for 600. That is
+    // the row that separates a genuine per-slot rate from `offset` merely being large.
+    if singleton.len() >= CARD_COUNTS[1] {
+        println!("\nfinish phase vs page_span (same cards, four pages -- the loop is identical across rows):");
+        println!("  {:>7}{:>8}{:>12}{:>12}{:>14}", "offset", "limit", "page_span", "ns_finish", "ns per slot");
+        let mut rows: Vec<(f64, f64)> = Vec::new();
+        for (offset, limit) in PAGE_SPECS {
+            let params = QueryParams::from_strs("card", "default", "name", "asc", limit, offset);
+            let mut samples: Vec<f64> = Vec::with_capacity(ITERS);
+            let mut span = 0.0f64;
+            let chunks = (singleton.len() / CARD_COUNTS[1]).max(1);
+            for iter in 0..ITERS {
+                let start = (iter % chunks) * CARD_COUNTS[1];
+                let end = (start + CARD_COUNTS[1]).min(singleton.len());
+                let prep = PreparedCandidates {
+                    candidate_cards: Some(singleton[start..end].to_vec()),
+                    all_match_known: true,
+                    narrowed_repr: NarrowedRepr::Cards,
+                };
+                black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
+                let st = take_phase_stats();
+                span = (offset + limit).min(st.matches_pushed as usize) as f64;
+                samples.push(st.ns_finish as f64);
+            }
+            samples.sort_by(f64::total_cmp);
+            let ns = samples[samples.len() / 2];
+            println!("  {offset:>7}{limit:>8}{span:>12.0}{ns:>12.0}{:>14.2}", ns / span.max(1.0));
+            rows.push((span, ns));
+        }
+        // Two-point solve across the widest span gap, which is the cheapest way to see whether the phase
+        // has a fixed component. Through the origin the slope has to absorb any constant, which inflates
+        // it on the small-page rows -- the same error that made `GATHER_SELECT_PER_PAGE_SLOT_NS` look 5x
+        // wrong earlier in this branch.
+        if let (Some(lo), Some(hi)) = (rows.first(), rows.iter().max_by(|a, b| a.0.total_cmp(&b.0))) {
+            if hi.0 > lo.0 {
+                let slope = (hi.1 - lo.1) / (hi.0 - lo.0);
+                println!(
+                    "  two-point: {:.2} ns/slot + {:.0} ns fixed   (shipped GATHER_SELECT_PER_PAGE_SLOT_NS 3.51, no fixed term)",
+                    slope,
+                    lo.1 - slope * lo.0
+                );
+            }
+        }
+    }
+
     // The warm/cold gap, per cell. `cost.rs`'s constants are fitted on production traffic, which pays
     // this; every rate this harness reports is a min-of-200 and does not.
     println!("\nfirst pass vs warm minimum (min-of-{ITERS} hides whatever the cold walk costs):");

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -178,10 +178,12 @@ const ITERS: usize = 200;
 /// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
 const WIDE_MIN_PRINTINGS: usize = 4;
 /// Card counts each cell runs at. Two sizes so linearity in the card term is measured, not assumed;
-/// bounded above by the wide group, which is the scarce one. The single-printing cell runs 6.31 →
+/// bounded above by the wide group, which is the scarce one. 400 is here to give the INTERCEPT leverage:
+/// a per-query fixed cost only shows up as the y-intercept of cells that vary in size, and the smallest
+/// cell is what pins it. The single-printing cell runs 6.31 →
 /// 7.67 ns/card between the two, so this is not a formality — the card term is mildly superlinear
 /// and a one-size design would bake whichever size it used into the constant.
-const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+const CARD_COUNTS: [usize; 3] = [400, 1_500, 4_500];
 /// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
 /// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
 /// keeps that contribution proportional to matches rather than to the page.
@@ -683,6 +685,35 @@ fn bench_gather_loop() {
             (c.ns_loop - base) / c.printings,
             (c.ns_loop - base) / c.cards
         );
+    }
+
+    // A per-query FIXED cost, measured as the intercept of the loop phase rather than taken from a
+    // whole-arm traffic fit. `fit_cost_model.py` fits one equation per query against total dispatch, so
+    // its intercept absorbs every mis-specification the other columns cannot express -- it read 84 and
+    // then 85 while COLLECT_PER_PAGE_ROW moved 15.0 -> 9.79 beneath it, which is exactly that. Here the
+    // intercept is identified by cells that differ ONLY in size, so nothing else can hide in it.
+    {
+        println!("\nloop-phase intercept per mode (the y-intercept IS the per-query fixed cost):");
+        for mode in ["card", "printing", "artwork"] {
+            // Two-point solve on the smallest and largest cells of one shape, which is all an intercept
+            // needs and avoids weighting choices skewing it.
+            let mut same: Vec<&Cell> = cells
+                .iter()
+                .filter(|c| c.mode == mode && !c.ran_card_pass && (c.printings / c.cards) < 1.5)
+                .collect();
+            same.sort_by(|a, b| a.cards.total_cmp(&b.cards));
+            if let (Some(lo), Some(hi)) = (same.first(), same.last()) {
+                if hi.cards > lo.cards {
+                    let slope = (hi.ns_loop - lo.ns_loop) / (hi.cards - lo.cards);
+                    let intercept = lo.ns_loop - slope * lo.cards;
+                    println!(
+                        "  {:<10}{:>6.0} -> {:>6.0} cards   {:>7.2} ns/card   intercept {:>8.0} ns",
+                        mode, lo.cards, hi.cards, slope, intercept
+                    );
+                }
+            }
+        }
+        println!("  shipped GATHER_FIXED_COST_NS 169.6; a whole-arm traffic fit puts it at 85.");
     }
 
     // The reparameterised fit: each mode fitted in the two-parameter space it can actually support,

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -649,8 +649,10 @@ fn bench_gather_loop() {
         // has a fixed component. Through the origin the slope has to absorb any constant, which inflates
         // it on the small-page rows -- the same error that made `GATHER_SELECT_PER_PAGE_SLOT_NS` look 5x
         // wrong earlier in this branch.
-        if let (Some(lo), Some(hi)) = (rows.first(), rows.iter().max_by(|a, b| a.0.total_cmp(&b.0))) {
-            if hi.0 > lo.0 {
+        if let (Some(lo), Some(hi)) = (rows.first(), rows.iter().max_by(|a, b| a.0.total_cmp(&b.0)))
+            && hi.0 > lo.0
+        {
+            {
                 let slope = (hi.1 - lo.1) / (hi.0 - lo.0);
                 println!(
                     "  two-point: {:.2} ns/slot + {:.0} ns fixed   (shipped GATHER_SELECT_PER_PAGE_SLOT_NS 3.51, no fixed term)",

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -177,13 +177,19 @@ const ITERS: usize = 200;
 /// group-size table this prints shows only 1,910 cards reach 8 printings, which is too few to fill
 /// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
 const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at. Two sizes so linearity in the card term is measured, not assumed;
-/// bounded above by the wide group, which is the scarce one. 400 is here to give the INTERCEPT leverage:
-/// a per-query fixed cost only shows up as the y-intercept of cells that vary in size, and the smallest
-/// cell is what pins it. The single-printing cell runs 6.31 →
-/// 7.67 ns/card between the two, so this is not a formality — the card term is mildly superlinear
-/// and a one-size design would bake whichever size it used into the constant.
-const CARD_COUNTS: [usize; 3] = [400, 1_500, 4_500];
+/// Card counts each cell runs at. Four sizes, geometric, because two things are being measured on this
+/// axis and they need opposite ends of it:
+///
+/// - **Linearity in the card term**, which the large end shows: the single-printing card cell measured
+///   8.33 / 8.53 / 10.11 ns/card at 400 / 1,500 / 4,500, so the per-card rate RISES with card count and
+///   a one-size design would bake whichever size it used into the constant.
+/// - **The intercept**, i.e. the per-query fixed cost, which only exists as the y-intercept of cells
+///   that vary in size — and which the SMALL end pins, because `intercept = t(n) - slope * n` multiplies
+///   any slope error by `n`. At a 400-card floor a 1 ns/card slope error is 400 ns of intercept error,
+///   against a shipped `GATHER_FIXED_COST_NS` of 169.6: unmeasurable. 100 shortens that lever 4x.
+///
+/// Bounded above by the wide group, which is the scarce one (see `WIDE_MIN_PRINTINGS`).
+const CARD_COUNTS: [usize; 4] = [100, 400, 1_500, 4_500];
 /// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
 /// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
 /// keeps that contribution proportional to matches rather than to the page.
@@ -692,28 +698,73 @@ fn bench_gather_loop() {
     // its intercept absorbs every mis-specification the other columns cannot express -- it read 84 and
     // then 85 while COLLECT_PER_PAGE_ROW moved 15.0 -> 9.79 beneath it, which is exactly that. Here the
     // intercept is identified by cells that differ ONLY in size, so nothing else can hide in it.
+    //
+    // Grouped by CELL LABEL, and least-squares over that label's three sizes. Both matter, and the
+    // first is a correction: this used to filter to a shape and two-point solve on the smallest and
+    // largest cells matching it, which crossed cell boundaries whenever two labels shared a shape --
+    // it paired `A` at 400 cards with `A'` (the same shape on a different chunk stagger) at 4,500 and
+    // reported -1,305 ns, where `A` against itself gives -780. The sign was right either way, but half
+    // the magnitude was stagger noise, and the magnitude is what a refit decision needs. One label
+    // across sizes holds the chunk stagger fixed, so only the size varies; printing per label rather
+    // than per mode then shows the spread instead of hiding it inside one number.
     {
-        println!("\nloop-phase intercept per mode (the y-intercept IS the per-query fixed cost):");
-        for mode in ["card", "printing", "artwork"] {
-            // Two-point solve on the smallest and largest cells of one shape, which is all an intercept
-            // needs and avoids weighting choices skewing it.
-            let mut same: Vec<&Cell> = cells
-                .iter()
-                .filter(|c| c.mode == mode && !c.ran_card_pass && (c.printings / c.cards) < 1.5)
-                .collect();
-            same.sort_by(|a, b| a.cards.total_cmp(&b.cards));
-            if let (Some(lo), Some(hi)) = (same.first(), same.last()) {
-                if hi.cards > lo.cards {
-                    let slope = (hi.ns_loop - lo.ns_loop) / (hi.cards - lo.cards);
-                    let intercept = lo.ns_loop - slope * lo.cards;
-                    println!(
-                        "  {:<10}{:>6.0} -> {:>6.0} cards   {:>7.2} ns/card   intercept {:>8.0} ns",
-                        mode, lo.cards, hi.cards, slope, intercept
-                    );
-                }
+        println!("\nloop-phase fixed cost and curvature per cell, single-printing shapes:");
+        println!(
+            "  {:<26}{:>10}{:>12}{:>10}{:>10}{:>9}{:>12}",
+            "cell", "ns/card", "intercept", "small", "large", "curve", "fixed"
+        );
+        // First occurrence of each label, in design order. `dedup()` would not do: cells are emitted
+        // size-major, so every label recurs once per size and only CONSECUTIVE repeats would collapse.
+        let mut labels: Vec<&str> = Vec::new();
+        for c in &cells {
+            if !labels.contains(&c.label) {
+                labels.push(c.label);
             }
         }
+        for label in labels {
+            // Single-printing shapes only. A fit on `cards` alone is interpretable only where printings
+            // track cards: a wide cell's cost is mostly per-PRINTING, so its slope reads 22-26 ns/card
+            // instead of ~11 and its intercept collects whatever that mis-attribution leaves over
+            // (`D wide print/default` read +6,498 ns). Same filter the per-mode version used, kept.
+            let same: Vec<&Cell> =
+                cells.iter().filter(|c| c.label == label && !c.ran_card_pass && (c.printings / c.cards) < 1.5).collect();
+            // Least squares on `ns_loop = intercept + slope * cards`, over every size this label ran.
+            let n = same.len() as f64;
+            if n < 2.0 {
+                continue;
+            }
+            let (sx, sy) = (same.iter().map(|c| c.cards).sum::<f64>(), same.iter().map(|c| c.ns_loop).sum::<f64>());
+            let sxx = same.iter().map(|c| c.cards * c.cards).sum::<f64>();
+            let sxy = same.iter().map(|c| c.cards * c.ns_loop).sum::<f64>();
+            let denom = n * sxx - sx * sx;
+            if denom.abs() < f64::EPSILON {
+                continue;
+            }
+            let slope = (n * sxy - sx * sy) / denom;
+            let intercept = (sy - slope * sx) / n;
+            // The whole-range line is reported for continuity with earlier runs, but it is NOT the
+            // number to read: the two smallest and two largest sizes are dominated by different effects,
+            // and a single line through them lands between the two with a negative intercept. Solve them
+            // apart. The small pair is where a per-query fixed cost is visible at all (at 4,500 cards a
+            // 170 ns constant is 0.04 ns/card, far under the cell-to-cell spread); the large pair is
+            // where the per-card rate has grown, which is the curvature.
+            let mut by_size: Vec<&&Cell> = same.iter().collect();
+            by_size.sort_by(|a, b| a.cards.total_cmp(&b.cards));
+            let secant = |lo: &Cell, hi: &Cell| (hi.ns_loop - lo.ns_loop) / (hi.cards - lo.cards);
+            let (small, large) = match (by_size.first(), by_size.get(1), by_size.iter().rev().nth(1), by_size.last()) {
+                (Some(a), Some(b), Some(c), Some(d)) => (secant(a, b), secant(c, d)),
+                _ => (f64::NAN, f64::NAN),
+            };
+            let small_intercept = by_size.first().map_or(f64::NAN, |c| c.ns_loop - small * c.cards);
+            println!(
+                "  {:<26}{:>10.2}{:>12.0}{:>10.2}{:>10.2}{:>9.2}{:>12.0}",
+                label, slope, intercept, small, large, large / small, small_intercept
+            );
+        }
         println!("  shipped GATHER_FIXED_COST_NS 169.6; a whole-arm traffic fit puts it at 85.");
+        println!("  Read the last two columns, not the first two. `large/small` is the CURVATURE the arm has");
+        println!("  no term for; `fixed` is what the small pair says a per-query cost is, and the whole-range");
+        println!("  intercept goes NEGATIVE only because one line cannot hold both ends at once.");
     }
 
     // The reparameterised fit: each mode fitted in the two-parameter space it can actually support,

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -145,9 +145,13 @@ const ITERS: usize = 200;
 /// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
 /// printings-per-card is what identifies two rates per mode with a degree of freedom left over.
 const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at, bounded above by the scarce wide group. Two sizes measure linearity
-/// in the card term rather than assuming it.
-const CARD_COUNTS: [usize; 2] = [1_500, 4_500];
+/// Card counts each cell runs at, bounded above by the scarce wide group. Three sizes measure linearity
+/// in the card term rather than assuming it, and 600 sits BELOW `STREAM_MIN_MATCHES` (1,024) in card
+/// mode where matches == cards. That matters because the finish phase takes a different branch on each
+/// side: at or under the threshold the small-total gather scans `0..n_cards`, above it the permutation
+/// walk steps until the page fills. Every earlier cell exceeded the threshold, so the gather branch --
+/// and `STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` with it -- was never measured at all.
+const CARD_COUNTS: [usize; 3] = [600, 1_500, 4_500];
 /// Page requested. P3's `ns_finish` branches on `total` against `STREAM_MIN_MATCHES`, not on the page,
 /// so this only has to be small and fixed to keep the finish phase out of the loop measurement.
 const LIMIT: usize = 60;
@@ -443,6 +447,33 @@ fn bench_streamed_loop() {
         let (lo, hi) = (cr.min(predicted), cr.max(predicted));
         println!("  spread {:>.2}x  (linearity in these two counters requires these to agree)", hi / lo.max(1e-9));
     }
+
+    // The finish phase, per branch, against the quantity each branch is actually driven by. This is what
+    // fits STREAM_PERM_STEP_NS and STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS, and it needs cells on both
+    // sides of STREAM_MIN_MATCHES to do it -- hence the 600-card row.
+    println!("\nfinish phase by branch (n_cards = {}):", data.cards.len());
+    println!("  {:<24}{:>7}{:>10}{:>12}{:>13}{:>12}", "cell", "n", "matches", "ns_finish", "branch", "ns per unit");
+    for c in &cells {
+        // Mirrors run_query_streamed's guards: an empty result or a page past the end returns before
+        // either branch, so those cells drive nothing and are labelled rather than fitted.
+        let (branch, units) = if c.matches <= 0.0 {
+            ("none", 0.0)
+        } else if c.matches <= 1024.0 {
+            ("gather", data.cards.len() as f64)
+        } else {
+            ("perm walk", (LIMIT as f64 * data.cards.len() as f64 / c.matches).min(data.cards.len() as f64))
+        };
+        let per_unit = if units > 0.0 { c.ns_finish / units } else { 0.0 };
+        println!(
+            "  {:<24}{:>7}{:>10.0}{:>12.0}{:>13}{:>12.3}",
+            c.label, c.n_cards_req, c.matches, c.ns_finish, branch, per_unit
+        );
+    }
+    println!(
+        "\n  gather rows are ns per card scanned, against a shipped STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS\n  \
+         of 1.02; perm-walk rows are ns per permutation entry, against STREAM_PERM_STEP_NS. Grade the\n  \
+         step ESTIMATE against the realized `perm_steps` counter separately -- this table assumes it."
+    );
 
     println!(
         "\n  shipped: STREAM_CARD_PASS_NS 5.05 per card, STREAM_SCAN_PER_ROW_NS 5.97 per printing,\n  \

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -430,7 +430,7 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// ns per permutation entry stepped in the streaming walk, the branch taken when
 /// `total > STREAM_MIN_MATCHES`.
 ///
-/// The walk steps the permutation until the page fills, so it visits about
+/// The walk covers the realized match span until the page fills, so it visits about
 /// `page_span * n_cards / matches` entries -- inversely proportional to selectivity, and the one
 /// quantity in P3's finish phase that no other feature is proportional to. Nothing charged for it
 /// before: the arm had `matches * EMIT + FIXED`, which is flat in `n_cards`, so at a fixed 1,500
@@ -445,7 +445,11 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// change a routing decision.
 ///
 /// The estimate is graded against the realized `perm_steps` counter rather than trusted, the same way
-/// `scan_units` is graded against `printings_examined`.
+/// `scan_units` is graded against `printings_examined`. **The rate survived the walk being bounded to
+/// its match span**, which is the useful thing that grade has said so far: traffic fit 1.17 before and
+/// 1.15 after, on the same seed and sample length, while realized steps at p90 fell 6.43x the estimate
+/// to 4.26x. A change that deletes a third of the steps at the tail and moves the per-step rate by 2%
+/// is the signature of a rate that is a real per-unit cost rather than a sink for the count's error.
 const STREAM_PERM_STEP_NS: f64 = 1.0;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
@@ -713,6 +717,17 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // Entries visited to accumulate `page_span` matches, when matches are spread uniformly
                 // through the permutation: one match per `n_cards / matches` entries. Bounded by the
                 // corpus, since the walk cannot step past the end of the permutation.
+                //
+                // The executor now bounds the walk to the realized match span (first matching card's
+                // sort position to the last), which this cannot see -- no `PlanFeatures` field carries
+                // it. The uniform-spread assumption absorbs it: the expected gap before the first match
+                // is one `n_cards / matches` stride, negligible against `page_span` of them. What the
+                // regrade showed is that the assumption's remaining error is a DIFFERENT shape.
+                // Realized/estimated ran p10 0.13 / median 1.00 / p90 6.43 before the span bound and
+                // p10 0.08 / median 0.90 / p90 4.26 after, on the same seed and sample: bounding the
+                // ends removed a third of the tail, so a third of it was the leading prefix. The
+                // remaining 4.26x is the part no seek can reach -- non-matching entries INTERIOR to the
+                // span, which is the popcount-skip mechanism's territory, not a start position's.
                 (page_span * n_cards / f64::from(f.matches)).min(n_cards)
             } else {
                 0.0

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -332,7 +332,18 @@ pub(crate) fn materialize_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
 /// 9,867 distinct shapes. P3 had been under-costed ~1.6x, which biases the router toward picking it.
 /// P4 and compose were re-fit in the same run and NOT changed: P4's fitted values reproduce these
 /// within 8% with no agreement gain, and compose's fit makes its median worse (0.95 -> 0.86).
-const STREAM_CARD_PASS_NS: f64 = 5.05;
+/// **Split 2026-08-03**, and the level below is now the CALL only. `bench_streamed_loop` measures P3's
+/// loop at 2.58 ns/card on the `all_match` path and 5.08 with a residual, on the same cells at the same
+/// corpus size — so ~2.5 of the shipped 5.05 was the `card_pass` call, charged to every candidate whether
+/// the call happened or not. The sum is preserved (2.58 + 2.47 = 5.05), so a residual-bearing query is
+/// costed exactly as before and only the `all_match` path gets cheaper.
+const STREAM_CARD_PASS_NS: f64 = 2.47;
+/// P3's loop body per candidate card, paid whether or not a residual exists: the `counts` write, the
+/// offsets arithmetic, and the match-count call that answers from the span alone under `all_match`.
+/// 2.58 ns/card measured by `bench_streamed_loop`, and the one rate in either loop that is FLAT across a
+/// 13× corpus (2.58 / 2.54 / 2.55) — it reads the card record and nothing else, so it has no misses to
+/// gain. That flatness is why it is the half worth stating as a constant.
+const STREAM_LOOP_PER_CARD_NS: f64 = 2.58;
 
 /// P3's per-scanned-row cost, charged ONLY when a residual is present.
 ///
@@ -478,7 +489,20 @@ const STREAM_FIXED_COST_NS: f64 = 217.0;
 /// ridge-anchored to the previous values because several columns barely vary on this corpus and
 /// are collinear with the intercept. Fitted on ~10k distinct feature vectors, stable to <3% across
 /// independent seeds. Median measured/predicted moved 1.78 -> 1.00 (P4) and 1.69 -> 1.06 (P3).
-const GATHER_CARD_PASS_NS: f64 = 6.88;
+/// **Split 2026-08-03**, and the level below is now the CALL only. The module header's own reading of
+/// `bench_gather_loop` said this constant "BUNDLES the predicate call": ~3.2 ns/card of loop overhead
+/// plus 2.94-3.00 for the `card_pass` call itself on singletons, summing to ~6.2 against the shipped
+/// 6.88. It was therefore "about right for queries that make that call, and about 2x too high for the
+/// #634 `all_match_known` path, which skips `card_pass` entirely and is charged for it anyway — a
+/// model-shape error rather than a mis-fitted constant". This is that error, fixed where it lives.
+///
+/// The sum is preserved (3.88 + 3.00 = 6.88), so residual-bearing queries are costed as before.
+const GATHER_CARD_PASS_NS: f64 = 3.00;
+/// P4's loop body per candidate card, paid whether or not a residual exists. 3.88 = the shipped 6.88
+/// less the 3.00 call above, rather than the kernel's 3.15-3.33 directly: the kernel figure is a warm
+/// rate (see the retraction in `bench_gather_loop`'s header) and holding the SUM at the shipped value
+/// keeps this change a pure re-gating, with no level moving on the queries that were costed correctly.
+const GATHER_LOOP_PER_CARD_NS: f64 = 3.88;
 /// ns per printing scanned in the gathered loop (residual test per row). The verify `tier`
 /// does NOT ride this term; see GATHER_VERIFY_TIER_SCALE and STREAM_SCAN_PER_ROW_NS.
 const GATHER_SCAN_PER_ROW_NS: f64 = 2.06;
@@ -746,7 +770,15 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
             // residual is re-checked per row inside `push_card_matches`. Charging `tier_ns` per
             // scanned ROW instead is invisible in card mode (scan_units ≈ eval_domain) and
             // overcharges printing/artwork by the whole printings-per-card ratio.
-            eval_domain * (STREAM_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
+            //
+            // The per-card term is TWO terms, gated apart on the same `tier_ns > 0` signal this arm
+            // already uses for its scan: the loop body runs for every candidate, but the `card_pass`
+            // CALL only happens when there is a residual to check. `all_match_known` skips it outright
+            // (#634 step 1), and `tier_ns == 0` is exactly that condition. Charging the call anyway made
+            // the arm's card-mode body read p50 1.90 over-costed.
+            eval_domain
+                * (STREAM_LOOP_PER_CARD_NS
+                    + if tier_ns > 0.0 { STREAM_CARD_PASS_NS + tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
                 + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
@@ -761,7 +793,13 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
     // page past the end of the matches collects fewer rows than `limit` asked for.
     let page_rows = f64::from(f.matches.saturating_sub(f.offset).min(f.limit));
             // Per-CARD verify tier, for the reason spelled out in the StreamedSelect arm above.
-            eval_domain * (GATHER_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
+            // Split and gated exactly as in the StreamedSelect arm above, and deliberately in the same
+            // change: this lowers both plans' cost on `all_match` queries, and the one asymmetric
+            // adjustment tried before (P3's residual floor moved while P4's stayed) sent
+            // `StreamedSelect -> GatheredScan` from 407 lost-time queries to 653.
+            eval_domain
+                * (GATHER_LOOP_PER_CARD_NS
+                    + if tier_ns > 0.0 { GATHER_CARD_PASS_NS + tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 + scan_units * GATHER_SCAN_PER_ROW_NS
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -430,7 +430,7 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 /// ns per permutation entry stepped in the streaming walk, the branch taken when
 /// `total > STREAM_MIN_MATCHES`.
 ///
-/// The walk covers the realized match span until the page fills, so it visits about
+/// The walk covers its sort-column segment until the page fills, so it visits about
 /// `page_span * n_cards / matches` entries -- inversely proportional to selectivity, and the one
 /// quantity in P3's finish phase that no other feature is proportional to. Nothing charged for it
 /// before: the arm had `matches * EMIT + FIXED`, which is flat in `n_cards`, so at a fixed 1,500
@@ -446,10 +446,11 @@ const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
 ///
 /// The estimate is graded against the realized `perm_steps` counter rather than trusted, the same way
 /// `scan_units` is graded against `printings_examined`. **The rate survived the walk being bounded to
-/// its match span**, which is the useful thing that grade has said so far: traffic fit 1.17 before and
-/// 1.15 after, on the same seed and sample length, while realized steps at p90 fell 6.43x the estimate
-/// to 4.26x. A change that deletes a third of the steps at the tail and moves the per-step rate by 2%
-/// is the signature of a rate that is a real per-unit cost rather than a sink for the count's error.
+/// its sort-column segment**, which is the useful thing that grade has said so far: traffic fit 1.17
+/// before and 1.19 after, on the same seed and sample length, while realized steps at p90 fell from
+/// 6.43x the estimate to 5.31x (and to 4.26x under the unshipped realized-span variant). A change that
+/// deletes a fifth of the steps at the tail while moving the per-step rate by 2% is the signature of a
+/// rate that is a real per-unit cost rather than a sink for the count's error.
 const STREAM_PERM_STEP_NS: f64 = 1.0;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
@@ -718,16 +719,24 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // through the permutation: one match per `n_cards / matches` entries. Bounded by the
                 // corpus, since the walk cannot step past the end of the permutation.
                 //
-                // The executor now bounds the walk to the realized match span (first matching card's
-                // sort position to the last), which this cannot see -- no `PlanFeatures` field carries
-                // it. The uniform-spread assumption absorbs it: the expected gap before the first match
-                // is one `n_cards / matches` stride, negligible against `page_span` of them. What the
-                // regrade showed is that the assumption's remaining error is a DIFFERENT shape.
-                // Realized/estimated ran p10 0.13 / median 1.00 / p90 6.43 before the span bound and
-                // p10 0.08 / median 0.90 / p90 4.26 after, on the same seed and sample: bounding the
-                // ends removed a third of the tail, so a third of it was the leading prefix. The
-                // remaining 4.26x is the part no seek can reach -- non-matching entries INTERIOR to the
-                // span, which is the popcount-skip mechanism's territory, not a start position's.
+                // The executor now starts and ends the walk at the segment its filter's bound on the
+                // SORT COLUMN admits (`walk_bounds`), which this cannot see -- no `PlanFeatures` field
+                // carries the filter's shape. The uniform-spread assumption absorbs it: the expected gap
+                // before the first match is one `n_cards / matches` stride, negligible against
+                // `page_span` of them. What the regrade showed is that the assumption's remaining error
+                // is a DIFFERENT shape. Realized/estimated over ~12.5k walking rows, same seed and
+                // sample length:
+                //
+                //     unbounded walk                 p10 0.13   median 1.00   p90 6.43
+                //     sort-column bound              p10 0.11   median 0.96   p90 5.31
+                //     realized inv_perm min/max      p10 0.08   median 0.90   p90 4.26
+                //
+                // The third row is not shipped -- it cost 0.51 ns per matching card -- but it bounds how
+                // much of the tail a start position can reach at all, and the gap between rows two and
+                // three is real: a realized minimum catches clustering from ANY source, while a bound
+                // catches only what the predicate names. What is left in BOTH is non-matching entries
+                // INTERIOR to the walked segment, which no start position reaches by construction. That
+                // is the popcount-skip mechanism's territory.
                 (page_span * n_cards / f64::from(f.matches)).min(n_cards)
             } else {
                 0.0

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -421,7 +421,32 @@ const STREAM_ARTWORK_SEEN_PER_CARD_NS: f64 = 1.21;
 /// ~52µs = 31508 × 1.65. Only added when `matches <= STREAM_MIN_MATCHES`, the
 /// exact condition that routes P3 into that gather branch. The 1.65 above was fit on three hand
 /// picked narrow queries; across the sampled space the floor measures ~31µs, not 52µs.
+///
+/// CONFIRMED 2026-08-03 by `bench_streamed_loop`, which needed 600-card cells to reach this branch at
+/// all -- every earlier cell had more than `STREAM_MIN_MATCHES` matches and took the permutation walk
+/// instead, so this constant had never been measured against the branch it prices. It now reads
+/// 1.075-1.250 ns per card scanned against the 1.02 shipped, on a 33.9 us finish phase. Left alone.
 const STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS: f64 = 1.02;
+/// ns per permutation entry stepped in the streaming walk, the branch taken when
+/// `total > STREAM_MIN_MATCHES`.
+///
+/// The walk steps the permutation until the page fills, so it visits about
+/// `page_span * n_cards / matches` entries -- inversely proportional to selectivity, and the one
+/// quantity in P3's finish phase that no other feature is proportional to. Nothing charged for it
+/// before: the arm had `matches * EMIT + FIXED`, which is flat in `n_cards`, so at a fixed 1,500
+/// matches it predicted ~397 ns while `bench_streamed_loop` measured 1,333 / 3,791 / 10,458 ns at
+/// 31.5k / 126k / 410k cards. Under by 3.4x at the production corpus and 26x at 410k, which is why
+/// that phase graded mean |log| 2.06 while carrying 12% of all measured nanoseconds.
+///
+/// Measured 0.958-1.256 ns/entry on the cells where the walk is long (1,500 matches, ~1,260 estimated
+/// steps): 1.0 is the middle of that. Cells whose walk is SHORT read 2.0-4.2 ns/entry, but those are a
+/// ~167-step estimate against a few hundred ns, where a fixed cost dominates and a per-step rate
+/// overstates -- the long-walk regime is the one worth fitting, being where the term is large enough to
+/// change a routing decision.
+///
+/// The estimate is graded against the realized `perm_steps` counter rather than trusted, the same way
+/// `scan_units` is graded against `printings_examined`.
+const STREAM_PERM_STEP_NS: f64 = 1.0;
 /// Per-card cost P3 pays over the WHOLE corpus regardless of how narrow the query is, charged on
 /// `n_cards` rather than `eval_domain`. The thread-local counts buffer is resized and cleared to
 /// `cards.len()` every query — a 126 kB memset on this corpus — and the emission walk is over the
@@ -639,6 +664,18 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 && f.matches > 0
                 && u64::from(f.offset) < u64::from(f.matches);
             let floor = if runs_small_gather { n_cards * STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS } else { 0.0 };
+            // The other branch: when the small-total gather does NOT run and there is a page to emit,
+            // the walk steps the permutation until it fills. Same guards as the gather -- a query with
+            // no matches, or a page past the end, returns before the walk too.
+            let walks_permutation = !runs_small_gather && f.matches > 0 && u64::from(f.offset) < u64::from(f.matches);
+            let perm_steps = if walks_permutation {
+                // Entries visited to accumulate `page_span` matches, when matches are spread uniformly
+                // through the permutation: one match per `n_cards / matches` entries. Bounded by the
+                // corpus, since the walk cannot step past the end of the permutation.
+                (page_span * n_cards / f64::from(f.matches)).min(n_cards)
+            } else {
+                0.0
+            };
             // card_pass — and the verify tier that prices it — is per candidate CARD: the loop
             // calls `filter.card_pass` once per `cid`, and only the cheaper printing-dependent
             // residual is re-checked per row inside `push_card_matches`. Charging `tier_ns` per
@@ -648,6 +685,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
                 + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
+                + perm_steps * STREAM_PERM_STEP_NS
                 + f64::from(f.artwork_seen_cards) * STREAM_ARTWORK_SEEN_PER_CARD_NS
                 + floor
                 + n_cards * STREAM_CORPUS_PASS_PER_CARD_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -487,6 +487,30 @@ const GATHER_PUSH_PER_MATCH_NS: f64 = 2.24;
 /// bounded by matches: narrow deep pages (offset > matches) measured ≈ shallow
 /// (select_page returns early), so the term uses min(offset+limit, matches).
 const GATHER_SELECT_PER_PAGE_SLOT_NS: f64 = 3.51;
+/// ns per row actually collected into the page — `page_ids.into_iter().map(..)`, two random array
+/// derefs per row into `cards` and `printings`.
+///
+/// A SECOND driver for this phase, found by `bench_gather_loop`'s page sweep 2026-08-03. The phase was
+/// charged on `page_span` alone, which the sweep falsifies directly: at identical candidates,
+/// `page_span` 960 (offset 900, limit 60) costs 11,250 ns while `page_span` 600 (offset 0, limit 600)
+/// costs 16,375. A bigger span costing less is impossible under one column. The quickselect scales with
+/// `offset + limit`, but the collect scales with the PAGE, and the two rows separate them because one
+/// pairs a large span with a small page.
+///
+/// Traffic cannot separate them -- span and page are correlated across the sampled query mix, which is
+/// why an earlier non-negative fit put this at exactly 0.00. Four designed rows do it. Same lesson as
+/// the loop's three collinear counters: shape from a built design, level from traffic.
+///
+/// The count is what `select_page` returns, `clamp(matches - offset, 0, limit)`, not `limit`: a page
+/// past the end of the matches collects fewer rows than asked for, and charging `limit` there would
+/// bill a deep page on a narrow query for rows that do not exist.
+/// Level from traffic, not from the sweep. The page sweep put this near 15 ns/row, but a traffic fit
+/// with the column present reads 9.79, and traffic is what the routing surface is calibrated against --
+/// kernel LEVELS have not transferred in this branch (first warm cache, then an unexplained 1.6x on
+/// P3's per-card rate), while kernel SHAPE has been reliable. Adding the column did not disturb
+/// `GATHER_SELECT_PER_PAGE_SLOT_NS`, which refits 3.44 against a shipped 3.51 -- so the two are
+/// additive in the sampled mix rather than trading off, and only this one moves.
+const GATHER_COLLECT_PER_PAGE_ROW_NS: f64 = 9.79;
 /// Fixed P4 setup. Fit from the narrowest query (cmc>=15 card shallow 208ns at
 /// eval_domain=5: 208 − 5×(GATHER_VISIT_PER_CARD_NS+GATHER_PUSH_PER_MATCH_NS) −
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
@@ -692,11 +716,15 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 + STREAM_FIXED_COST_NS
         }
         PhysicalPlan::GatheredScan => {
+    // Rows the collect actually walks: `select_page` yields `clamp(matches - offset, 0, limit)`, so a
+    // page past the end of the matches collects fewer rows than `limit` asked for.
+    let page_rows = f64::from(f.matches.saturating_sub(f.offset).min(f.limit));
             // Per-CARD verify tier, for the reason spelled out in the StreamedSelect arm above.
             eval_domain * (GATHER_CARD_PASS_NS + if tier_ns > 0.0 { tier_ns.max(GATHER_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 + scan_units * GATHER_SCAN_PER_ROW_NS
                 + matches * GATHER_PUSH_PER_MATCH_NS
                 + page_span * GATHER_SELECT_PER_PAGE_SLOT_NS
+                + page_rows * GATHER_COLLECT_PER_PAGE_ROW_NS
                 + GATHER_FIXED_COST_NS
         }
     }

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -514,6 +514,23 @@ const GATHER_COLLECT_PER_PAGE_ROW_NS: f64 = 9.79;
 /// Fixed P4 setup. Fit from the narrowest query (cmc>=15 card shallow 208ns at
 /// eval_domain=5: 208 − 5×(GATHER_VISIT_PER_CARD_NS+GATHER_PUSH_PER_MATCH_NS) −
 /// 5×GATHER_SELECT_PER_PAGE_SLOT_NS ≈ 170).
+///
+/// NOT refit 2026-08-03, deliberately. A whole-arm traffic fit puts this at 85, half the shipped value,
+/// on a model whose every other term sits at 0.85-1.22 -- and an intercept that far out on an otherwise
+/// agreeing model is a symptom, not a measurement. `fit_cost_model.py` fits ONE equation per query
+/// against total dispatch, so its intercept absorbs whatever the other columns cannot express; it read
+/// 84 and then 85 while `GATHER_COLLECT_PER_PAGE_ROW_NS` moved 15.0 -> 9.79 underneath it.
+///
+/// Measuring the intercept directly says the same thing more sharply. `bench_gather_loop` solves it from
+/// cells differing ONLY in card count, where nothing else can hide, and gets card -1,084 ns and printing
+/// -845 ns. A negative fixed cost is impossible, so the linear-in-cards shape is wrong: the loop is
+/// CONVEX in card count (12.40 ns/card across 400-4,500 against 6.31-7.67 over 1,500-4,500), which is the
+/// same working-set effect the corpus sweep measured as rates growing 2.4x over 13x cards. A straight
+/// line through a convex curve drives its intercept negative.
+///
+/// So 85 is compensation for curvature, not a fixed cost, and pasting it would fit today's query-size mix
+/// and drift as either query sizes or the corpus change. The fix is a term for the curvature -- see the
+/// corpus-size note in `bench_gather_loop` -- not a smaller constant.
 const GATHER_FIXED_COST_NS: f64 = 169.6;
 
 // --- PrintingCompose's own rates -------------------------------------------------------------

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -45,7 +45,9 @@ fn tri_bool(b: bool) -> Tri {
 
 // ─── Numeric expressions ──────────────────────────────────────────────────────
 
-#[derive(Clone, Copy)]
+// PartialEq so a caller can ask "is this leaf about the field I care about" — `sort_col_bound` matches
+// the sort column against the field a NumericCmp constrains.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NumField {
     Cmc,
     Power,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4659,6 +4659,22 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// streaming's win grows fast (~1.8× by 8k), so the trigger stays put.
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));
 
+/// The emission walk tracks its match span only when candidates are at most `n_cards` over this — a
+/// quarter of the corpus. See the derivation at `track_span` in `run_query_streamed`.
+///
+/// Calibrated by `scripts/bench_walk_span.py`, which A/Bs this toggle inside ONE binary (cross-build
+/// comparison cannot resolve it: `ns_loop` wandered ±9% run to run on a phase neither build changed).
+/// Tracking costs **0.51 ns per matching card** and a walk step costs **0.37 ns**, so insurance that
+/// cannot pay for itself starts at `matching_cards = n_cards * 0.37 / (0.37 + 0.51)` = 0.42 ×
+/// `n_cards`; a quarter sits inside that with room for the estimate to be wrong. Ungated, the broad
+/// cells measured 1.13-1.21x SLOWER (`cmc>=1 order=edhrec`: `ns_loop` 78.54 -> 94.46 us over 30,318
+/// cards) while saving nothing, because a match set that big leaves no prefix to skip.
+///
+/// Set to 1 to track unconditionally, or above the corpus size to disable tracking; `bench_walk_span.py`
+/// uses exactly those two settings, spelled `00001` / `99999` so both arms carry an equal-length value.
+static SPAN_TRACK_CANDIDATE_DIVISOR: LazyLock<usize> =
+    LazyLock::new(|| guard_env("CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR", 4).max(1));
+
 /// Whether run_query reorders And/Or children cheapest-verification-first
 /// before the evaluation walk (see FilterExpr::order_children_by_verify_cost).
 /// Unlike the guards above this is a binary A/B switch, not a threshold:
@@ -6247,7 +6263,12 @@ impl PreparedCandidates {
     /// every card. Boxed because the two arms are different iterator types and
     /// both P3 and P4 want the same either-or — previously spelled out
     /// identically at the head of each.
-    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn Iterator<Item = u32> + 's> {
+    ///
+    /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a
+    /// `Range`), and an executor that wants the candidate count before its loop -- P3, to decide
+    /// whether tracking the walk's match span can pay -- would otherwise have to be handed the count
+    /// alongside the iterator and trust the two to agree.
+    fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn ExactSizeIterator<Item = u32> + 's> {
         match &self.candidate_cards {
             Some(v) => Box::new(v.iter().copied()),
             None => Box::new(0..ctx.n_cards()),
@@ -8848,7 +8869,7 @@ fn run_query_streamed<'a>(
     filter: &FilterExpr,
     all_match_known: bool,
     order: SortOrder<'_>,
-    card_ids: Box<dyn Iterator<Item = u32> + '_>,
+    card_ids: Box<dyn ExactSizeIterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // First of the three phase boundaries — everything down to the match loop is `ns_setup`, which
@@ -8890,15 +8911,37 @@ fn run_query_streamed<'a>(
     // through every card ordered before the first match discarding on `counts[cid] == 0` -- `year>=2020
     // order=released asc` pays the entire pre-2020 prefix -- and, on any page it cannot fill, every
     // card ordered after the last match as well, since the only thing that stops it early is the page
-    // filling. This loop already visits every candidate, so the span costs one `inv_perm` read, a `min`
-    // and a `max` per MATCHING card, and candidates arrive in ascending `cid` order, which makes those
-    // reads a forward stream through `inv_perm` rather than random access.
+    // filling. Measured on this corpus: `cmc>=6 order=cmc asc` walked 28,275 entries for a 60-row page
+    // and spent 10.6 us of a 20.25 us execution doing it; bounded, it walks 60 and spends 0.38 us.
     //
     // Deliberately the REALIZED span rather than bounds derived from the predicate and the sort
     // column: it holds for any predicate (including a residual only `card_match_count` can resolve),
     // and it cannot be wrong about how ties inside the sort key are broken. Descending needs nothing
     // extra -- there are two permutations per column, one per direction, so `inv_perm` is already the
     // inverse of the order actually walked.
+    //
+    // GATED, because the span is emphatically not free. It costs an `inv_perm` read plus a `min` and a
+    // `max` per MATCHING card, and this loop's `all_match` arm is only ~2.6 ns/card to begin with, so
+    // 0.51 ns/card of tracking is a 20% tax on it: ungated, `cmc>=1 order=edhrec` measured `ns_loop`
+    // 78.54 -> 94.46 us over 30,318 cards while its walk stayed at 111 steps either way. The tax is
+    // paid on every streamed query; the saving only exists when the walk had something to skip.
+    //
+    // The bound is therefore insurance, and the gate is the premium being kept below the payout. A
+    // query with `m` matching cards has at most `n_cards - m` entries outside its span, so the most the
+    // bound can save is `(n_cards - m) * 0.37 ns` against a cost of `m * 0.51 ns` -- break-even at
+    // `m = 0.42 * n_cards`, and `SPAN_TRACK_CANDIDATE_DIVISOR` sits at a quarter, inside it. The
+    // regime below the gate is also where the unbounded walk is dangerous: steps go as
+    // `page_span * n_cards / matches`, so sparse matches are exactly what make it long.
+    //
+    // Candidates bound matching cards from above, and unlike the match count it is known HERE, before
+    // the loop -- so this is one perfectly-predicted branch per card, rather than a decision that could
+    // only be made after the cost had already been paid.
+    //
+    // What the gate does not fix: a query whose cluster sits at the NEAR end of the walked order pays
+    // the premium for nothing, because the page fills before the last-match bound can matter
+    // (`cmc>=6 order=cmc desc offset=900` measured 1.17x). That is the shape of the bet, not a defect
+    // in it -- which end a cluster lands on is not knowable before the loop runs.
+    let track_span = card_ids.len() <= cards.len() / *SPAN_TRACK_CANDIDATE_DIVISOR;
     let (mut first_match_pos, mut last_match_pos) = (u32::MAX, 0u32);
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
@@ -8946,7 +8989,7 @@ fn run_query_streamed<'a>(
         counts[cid as usize] = c;
         // Guarded on `c != 0` because a zero-count card is exactly what the walk skips: widening the
         // span to one would put entries inside it that the walk then discards, giving back the saving.
-        if c != 0 {
+        if track_span && c != 0 {
             let pos = u32::from(inv_perm[cid as usize]);
             first_match_pos = first_match_pos.min(pos);
             last_match_pos = last_match_pos.max(pos);
@@ -9027,11 +9070,16 @@ fn run_query_streamed<'a>(
     // outside it every entry has `counts[cid] == 0` by construction (the span is the min and max over
     // all cards with a nonzero count), and the walk's only effect on a zero-count entry is to
     // `continue`. `total > 0` here — the guard above returned otherwise — so some card set both ends.
-    debug_assert!(
-        first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
-        "total > 0 guarantees a matching card, so the match span must be a real permutation range"
-    );
-    let match_span = &perm[first_match_pos as usize..=last_match_pos as usize];
+    // Ungated, the whole permutation, exactly as before.
+    let match_span: &[Archived<u32>] = if track_span {
+        debug_assert!(
+            first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
+            "total > 0 guarantees a matching card, so the match span must be a real permutation range"
+        );
+        &perm[first_match_pos as usize..=last_match_pos as usize]
+    } else {
+        &perm[..]
+    };
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6882,6 +6882,16 @@ pub(crate) struct PhaseStats {
     /// span arithmetic alone, and the stored artwork group count answers without a printing either.
     pub(crate) printings_examined: u64,
     pub(crate) matches_pushed: u64,
+    /// Permutation entries `run_query_streamed`'s walk stepped over. Zero for every other executor and
+    /// for P3's other two exits (the empty/past-the-end return and the small-total gather).
+    ///
+    /// The walk steps the permutation until the page fills, so its length is
+    /// `page x n_cards / matches` -- inversely proportional to selectivity, and the one quantity in P3's
+    /// finish phase that no existing feature is proportional to. Measured against a fixed 1,500 matches
+    /// it runs 1,333 / 3,791 / 10,458 ns at 31.5k / 126k / 410k cards while the arm charged
+    /// `matches x EMIT + FIXED` ~ 397 ns throughout: under by 3.4x at the production corpus and 26x at
+    /// 410k. Published so the estimate can be GRADED rather than assumed, like the other three counters.
+    pub(crate) perm_steps: u64,
     /// Per-query scratch setup, before the match loop starts. Split out because it is neither
     /// prepare nor match and it is NOT negligible: `run_query_streamed` zeroes an `n_cards`-long
     /// counts buffer here (~126 kB on the real corpus) no matter how few candidates it is about to
@@ -7132,8 +7142,8 @@ thread_local! {
     /// owned elsewhere: `paging_taken` by `PAGING_TAKEN` below, `ns_round_total`/`result_total` by
     /// `explain_analyze`, which fills them after the take.
     static PHASE_STATS: std::cell::Cell<PhaseStats> = const { std::cell::Cell::new(PhaseStats {
-        cards_visited: 0, printing_span: 0, printings_examined: 0, matches_pushed: 0, ns_setup: 0, ns_loop: 0, ns_finish: 0, ns_round_total: 0,
-        ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
+        cards_visited: 0, printing_span: 0, printings_examined: 0, matches_pushed: 0, perm_steps: 0, ns_setup: 0, ns_loop: 0,
+        ns_finish: 0, ns_round_total: 0, ns_prepare: 0, result_total: 0, paging_taken: PagingTaken::NotEntered,
     }) };
 
     /// The compose fastpath's branch label, stored apart from `PHASE_STATS` because it is the one
@@ -7348,6 +7358,7 @@ fn exec_gathered_scan<'a>(
             printing_span: n_printing_span,
             printings_examined: n_printings_examined,
             matches_pushed: n_matches_pushed,
+            perm_steps: 0, // GatheredScan never walks the permutation
             ns_setup: (t_loop - t_start).as_nanos() as u64,
             ns_loop: (t_finish - t_loop).as_nanos() as u64,
             ns_finish: (t_end - t_finish).as_nanos() as u64,
@@ -8899,7 +8910,7 @@ fn run_query_streamed<'a>(
     // Publishing helper: the walk below has several early returns, and every one of them must leave
     // the stats behind or the accounting silently attributes this plan's work to nothing. Each takes
     // the closing instant itself, so the emit phase is bounded without a second start marker.
-    let publish = |end: std::time::Instant| {
+    let publish = |end: std::time::Instant, perm_steps: u64| {
         let prep_ns = PENDING_PREPARE_NS.with(|c| c.replace(0));
         PHASE_STATS.with(|c| {
             c.set(PhaseStats {
@@ -8907,6 +8918,7 @@ fn run_query_streamed<'a>(
                 printing_span: n_printing_span,
                 printings_examined: n_printings_examined,
                 matches_pushed: n_matches_pushed,
+                perm_steps,
                 ns_setup: (t_loop - t_start).as_nanos() as u64,
                 ns_loop: (t_finish - t_loop).as_nanos() as u64,
                 ns_finish: (end - t_finish).as_nanos() as u64,
@@ -8918,7 +8930,7 @@ fn run_query_streamed<'a>(
         });
     };
     if total == 0 || page_offset >= total {
-        publish(std::time::Instant::now());
+        publish(std::time::Instant::now(), 0);
         return (total, Vec::new());
     }
 
@@ -8953,7 +8965,7 @@ fn run_query_streamed<'a>(
             .into_iter()
             .map(|(cid, pid)| (&cards[cid as usize], &printings[pid as usize]))
             .collect();
-        publish(std::time::Instant::now());
+        publish(std::time::Instant::now(), 0);
         return (total, page);
     }
 
@@ -8964,7 +8976,12 @@ fn run_query_streamed<'a>(
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
+    // Counted for every entry the walk touches, including the ones skipped on a zero count -- that
+    // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. A plain
+    // local, published once, like the other counters.
+    let mut n_perm_steps = 0u64;
     'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
+        n_perm_steps += 1;
         let c = counts[cid as usize] as usize;
         if c == 0 {
             continue;
@@ -8996,7 +9013,7 @@ fn run_query_streamed<'a>(
         }
         skip = 0;
     }
-    publish(std::time::Instant::now());
+    publish(std::time::Instant::now(), n_perm_steps);
     (total, page)
     }) // COUNTS.with
 }
@@ -9272,6 +9289,7 @@ fn plan_trial_to_pydict<'py>(py: Python<'py>, t: &PlanTrial) -> PyResult<Bound<'
     d.set_item("printing_span", t.phases.printing_span)?;
     d.set_item("printings_examined", t.phases.printings_examined)?;
     d.set_item("matches_pushed", t.phases.matches_pushed)?;
+    d.set_item("perm_steps", t.phases.perm_steps)?;
     d.set_item("ns_setup", t.phases.ns_setup)?;
     d.set_item("ns_loop", t.phases.ns_loop)?;
     d.set_item("ns_finish", t.phases.ns_finish)?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6441,10 +6441,9 @@ impl PreparedCandidates {
     /// both P3 and P4 want the same either-or — previously spelled out
     /// identically at the head of each.
     ///
-    /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a
-    /// `Range`), and an executor that wants the candidate count before its loop -- P3, to decide
-    /// whether tracking the walk's match span can pay -- would otherwise have to be handed the count
-    /// alongside the iterator and trust the two to agree.
+    /// `ExactSizeIterator` rather than `Iterator`: both arms know their length (a `Vec` and a `Range`),
+    /// so an executor that wants the candidate count before its loop can ask for it instead of being
+    /// handed the count alongside the iterator and trusting the two to agree.
     fn card_ids<'s>(&'s self, ctx: &QueryCtx) -> Box<dyn ExactSizeIterator<Item = u32> + 's> {
         match &self.candidate_cards {
             Some(v) => Box::new(v.iter().copied()),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1995,6 +1995,172 @@ fn invert_perm(perm: &[u32]) -> Vec<u32> {
     inv
 }
 
+/// An inclusive value interval on the sort column that every match must satisfy, or `UNBOUNDED` when
+/// the filter says nothing about it. Extracted from the filter BEFORE `split_planes` consumes it (see
+/// `sort_col_bound`) and carried on `QueryParams`, because that is the only point at which the tree is
+/// still readable: `cmc>=6` compiles to mask algebra over bitplanes, and the residual left behind is
+/// `FilterExpr::True`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct SortBound {
+    lo: Option<f64>,
+    hi: Option<f64>,
+}
+
+impl SortBound {
+    /// No constraint: the walk covers the whole permutation, exactly as it did before this existed.
+    /// Also the safe default — every path that does not extract a bound gets this one, so a caller that
+    /// forgets to loses performance and not correctness.
+    const UNBOUNDED: SortBound = SortBound { lo: None, hi: None };
+
+    fn is_unbounded(self) -> bool {
+        self.lo.is_none() && self.hi.is_none()
+    }
+
+    /// Tighten with another interval — `And`'s rule, and the only way bounds combine.
+    fn intersect(self, other: SortBound) -> SortBound {
+        let tighter = |a: Option<f64>, b: Option<f64>, pick: fn(f64, f64) -> f64| match (a, b) {
+            (Some(x), Some(y)) => Some(pick(x, y)),
+            (v, None) | (None, v) => v,
+        };
+        SortBound { lo: tighter(self.lo, other.lo, f64::max), hi: tighter(self.hi, other.hi, f64::min) }
+    }
+}
+
+/// The inclusive interval on `sort_col` that every match of `filter` must satisfy.
+///
+/// Deliberately conservative in every direction, because the cost of being too wide is a longer walk
+/// and the cost of being too narrow is a wrong page:
+///
+/// - **`And` only.** An `Or` child can match outside any bound its sibling implies, and `Not` inverts
+///   into a union of two intervals that this cannot express. Both yield `UNBOUNDED` for that subtree,
+///   which an enclosing `And` then simply ignores.
+/// - **Strict comparisons are widened to inclusive.** `cmc>6` reports `lo = 6`, so the walk may start
+///   at the head of the `cmc == 6` tie block and step over it. One block of wasted steps against having
+///   to reason about float adjacency.
+/// - **Card-level columns only**, and only the three with numeric predicates. Everything else has no
+///   `NumericCmp` that can constrain it (there is no `edhrec>` in the query language), and `Rarity` /
+///   `PriceUsd` have no permutation to search.
+fn sort_col_bound(filter: &FilterExpr, sort_col: SortCol) -> SortBound {
+    let field = match sort_col {
+        SortCol::Cmc => NumField::Cmc,
+        SortCol::Power => NumField::Power,
+        SortCol::Toughness => NumField::Toughness,
+        _ => return SortBound::UNBOUNDED,
+    };
+    match filter {
+        FilterExpr::And(children) => {
+            children.iter().fold(SortBound::UNBOUNDED, |acc, c| acc.intersect(sort_col_bound(c, sort_col)))
+        }
+        // `op` reads left-to-right, so a constant on the left flips it: `6 <= cmc` bounds cmc BELOW.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(f), op, rhs: NumExpr::Const(v) } if *f == field => {
+            bound_from_cmp(*op, *v)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(f) } if *f == field => {
+            bound_from_cmp(flip_op(*op), *v)
+        }
+        _ => SortBound::UNBOUNDED,
+    }
+}
+
+/// One comparison's inclusive interval. `Ne` constrains nothing (it excludes a point from the middle,
+/// which is not an interval), and the strict operators widen to their inclusive neighbours.
+fn bound_from_cmp(op: CmpOp, v: f64) -> SortBound {
+    match op {
+        CmpOp::Ge | CmpOp::Gt => SortBound { lo: Some(v), hi: None },
+        CmpOp::Le | CmpOp::Lt => SortBound { lo: None, hi: Some(v) },
+        CmpOp::Eq => SortBound { lo: Some(v), hi: Some(v) },
+        CmpOp::Ne => SortBound::UNBOUNDED,
+    }
+}
+
+/// The permutation's PRIMARY key: the sort column's value, direction folded in by negation, absent
+/// sorting last. One function because two places must agree on it exactly — `build_sort_permutations`
+/// orders by it, and `walk_bounds` binary-searches for it to find where a value interval starts and
+/// ends in that order. A divergence between those two would not be a slow walk, it would be a walk
+/// that starts past real matches and silently returns the wrong page.
+///
+/// `u32::MAX` for absent is what makes a numeric bound safe to search for: a card with no value in the
+/// column sorts past every finite key in BOTH directions, and `numeric_cmp_tri` answers `Tri::Null` for
+/// it, so it can never be a match of a comparison against that column either.
+fn perm_primary_key(value: Option<f32>, descending: bool) -> u32 {
+    value.map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }))
+}
+
+/// The sort column's value for one archived card, in the same units `build_sort_permutations` sorted
+/// on. Card-level columns only: `Rarity`/`PriceUsd` have no permutation (they depend on the
+/// prefer-chosen printing), which is why `ArchivedSortPermutations::get` returns `None` for them.
+fn sort_col_card_value(card: &AOracleCard, sort_col: SortCol) -> Option<f32> {
+    match sort_col {
+        SortCol::EdhrecRank => card.edhrec_rank.as_ref().map(|v| u32::from(*v) as f32),
+        SortCol::Cubecobra  => card.cubecobra_score.as_ref().map(|v| f32::from(*v)),
+        // Single bytes, so archived and native are the same type — no `u8::from` to unwrap.
+        SortCol::Cmc        => card.cmc.as_ref().map(|v| f32::from(*v)),
+        SortCol::Power      => card.creature_power.as_ref().map(|v| f32::from(*v)),
+        SortCol::Toughness  => card.creature_toughness.as_ref().map(|v| f32::from(*v)),
+        SortCol::Name       => Some(u32::from(card.name_rank) as f32),
+        SortCol::Rarity | SortCol::PriceUsd => None,
+    }
+}
+
+/// The segment of `perm` that can contain a match, from the filter's interval on the sort column.
+///
+/// The permutation is a sorted array on `perm_primary_key`, so an interval on the sort column's VALUE
+/// is a contiguous range of POSITIONS, found by two binary searches — O(log n_cards) probes once per
+/// query, against the alternative of reading `inv_perm` once per matching card. Which end of the walked
+/// order each side of the interval lands on depends on the direction, because the key negates: under
+/// `asc` the low bound starts the segment, under `desc` the high bound does.
+///
+/// Returns the whole permutation when the filter constrains nothing, which is also what every caller
+/// gets that does not extract a bound.
+fn walk_bounds<'p>(
+    perm: &'p Archived<Vec<u32>>,
+    cards: &[AOracleCard],
+    sort_col: SortCol,
+    descending: bool,
+    bound: SortBound,
+) -> &'p [Archived<u32>] {
+    let all = &perm[..];
+    if bound.is_unbounded() || perm.len() != cards.len() || *WALK_SORT_BOUND == 0 {
+        return all;
+    }
+    // Values are read through the same encoder the permutation was built with, so this comparison and
+    // that ordering cannot disagree.
+    let key_at = |pos: usize| {
+        let cid = u32::from(all[pos]) as usize;
+        perm_primary_key(sort_col_card_value(&cards[cid], sort_col), descending)
+    };
+    // Under `desc` the key is negated, so the interval's ends swap roles: the largest VALUE has the
+    // smallest key and therefore comes first.
+    let (first_v, last_v) = if descending { (bound.hi, bound.lo) } else { (bound.lo, bound.hi) };
+    let key_of = |v: f64| perm_primary_key(Some(v as f32), descending);
+    // `partition_point` over positions: the first position whose key reaches the interval, and the
+    // first position past it. Both sides are inclusive in value, so `start` excludes keys strictly
+    // before the interval and `end` includes the whole tie block at its far edge.
+    let start = first_v.map_or(0, |v| {
+        let k = key_of(v);
+        partition_point(all.len(), |pos| key_at(pos) < k)
+    });
+    let end = last_v.map_or(all.len(), |v| {
+        let k = key_of(v);
+        partition_point(all.len(), |pos| key_at(pos) <= k)
+    });
+    // An empty or inverted range means the interval falls between two stored values (`cmc>=6 cmc<=5`),
+    // so nothing can match; the walk then steps nothing rather than being handed a reversed slice.
+    if start >= end { &all[..0] } else { &all[start..end] }
+}
+
+/// `partition_point` over an index range: the first `i` in `0..len` where `pred(i)` is false, with
+/// `pred` monotone. `slice::partition_point` cannot be used directly because the predicate needs the
+/// POSITION (to read the card behind it), not the element.
+fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
+    let (mut lo, mut hi) = (0usize, len);
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if pred(mid) { lo = mid + 1 } else { hi = mid }
+    }
+    lo
+}
+
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
@@ -2002,7 +2168,7 @@ fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
         let mut ids: Vec<u32> = (0..cards.len() as u32).collect();
         ids.sort_unstable_by_key(|&i| {
             let c = &cards[i as usize];
-            let pk = get(c).map_or(u32::MAX, |v| f32_sort_bits(if descending { -v } else { v }));
+            let pk = perm_primary_key(get(c), descending);
             let e = c.edhrec_rank.unwrap_or(u32::MAX);
             // Canonical secondary: the first (store-preferred) printing's
             // default prefer score, matching sort_key_bits' third component
@@ -4233,6 +4399,14 @@ struct QueryParams {
     descending: bool,
     limit: usize,
     page_offset: usize,
+    /// What the filter says about the SORT COLUMN, which `StreamedSelect` turns into the segment of the
+    /// permutation its walk has to cover. Not a user parameter — it is derived from the filter — but it
+    /// travels here because it is only meaningful next to `sort_col`/`descending`, and because the point
+    /// where it can be extracted (before `split_planes`) is nowhere near the executor that uses it.
+    ///
+    /// Defaults to `UNBOUNDED` in `from_strs`, and every constructor that does not opt in gets that: a
+    /// missing bound costs a longer walk, never a wrong page. `with_sort_bound` is the opt-in.
+    sort_bound: SortBound,
 }
 
 impl QueryParams {
@@ -4251,7 +4425,15 @@ impl QueryParams {
             descending: direction == "desc",
             limit,
             page_offset,
+            sort_bound: SortBound::UNBOUNDED,
         }
+    }
+
+    /// Attach the filter's interval on the sort column. Called at the PyO3 boundary, next to
+    /// `bind_and_split_filter`, since that is the last place the unsplit filter exists.
+    fn with_sort_bound(mut self, sort_bound: SortBound) -> Self {
+        self.sort_bound = sort_bound;
+        self
     }
 }
 
@@ -4659,21 +4841,16 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// streaming's win grows fast (~1.8× by 8k), so the trigger stays put.
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));
 
-/// The emission walk tracks its match span only when candidates are at most `n_cards` over this — a
-/// quarter of the corpus. See the derivation at `track_span` in `run_query_streamed`.
+/// Kill-switch for narrowing the streamed walk to the filter's bound on the sort column
+/// (`walk_bounds`). Default on; 0 walks the whole permutation as the executor did before the bound
+/// existed. A binary switch, not a calibrated threshold — the bound costs O(log n_cards) probes once
+/// per query and nothing per card, so there is no crossover to find, and its predecessor (a per-card
+/// `inv_perm` min/max, gated on candidate count) was replaced precisely because it did have one.
 ///
-/// Calibrated by `scripts/bench_walk_span.py`, which A/Bs this toggle inside ONE binary (cross-build
-/// comparison cannot resolve it: `ns_loop` wandered ±9% run to run on a phase neither build changed).
-/// Tracking costs **0.51 ns per matching card** and a walk step costs **0.37 ns**, so insurance that
-/// cannot pay for itself starts at `matching_cards = n_cards * 0.37 / (0.37 + 0.51)` = 0.42 ×
-/// `n_cards`; a quarter sits inside that with room for the estimate to be wrong. Ungated, the broad
-/// cells measured 1.13-1.21x SLOWER (`cmc>=1 order=edhrec`: `ns_loop` 78.54 -> 94.46 us over 30,318
-/// cards) while saving nothing, because a match set that big leaves no prefix to skip.
-///
-/// Set to 1 to track unconditionally, or above the corpus size to disable tracking; `bench_walk_span.py`
-/// uses exactly those two settings, spelled `00001` / `99999` so both arms carry an equal-length value.
-static SPAN_TRACK_CANDIDATE_DIVISOR: LazyLock<usize> =
-    LazyLock::new(|| guard_env("CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR", 4).max(1));
+/// Exists because `scripts/bench_walk_span.py` needs both behaviours in ONE binary: the effect is
+/// smaller than the run-to-run spread of `ns_loop` across builds, so a cross-build A/B of it reports
+/// the wrong sign.
+static WALK_SORT_BOUND: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_WALK_SORT_BOUND", 1));
 
 /// Whether run_query reorders And/Or children cheapest-verification-first
 /// before the evaluation walk (see FilterExpr::order_children_by_verify_cost).
@@ -6667,7 +6844,7 @@ fn walk_grouped_page<'a>(
     perm: &Archived<Vec<u32>>,
 ) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -6772,7 +6949,7 @@ fn gather_composed_page<'a>(
     card_bits: Option<&[u64]>,
 ) -> (Vec<(&'a AOracleCard, &'a APrinting)>, ComposePageWork) {
     let QueryCtx { cards, printings, offsets, indexes, .. } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
     let is_set = |pid: usize| pbits[pid >> 6] & (1u64 << (pid & 63)) != 0;
     // `card_bits` is `pbits` already projected into card space. `Mode::Card` computes that
@@ -6888,12 +7065,16 @@ fn exec_streamed_select<'a>(
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
-    let order = indexes
+    let perm = indexes
         .sort_perms
-        .order(params.sort_col, params.descending, ctx.cards.len())
-        .expect("StreamedSelect applicability guarantees a sort order");
+        .get(params.sort_col, params.descending)
+        .expect("StreamedSelect applicability guarantees a permutation");
+    // The walk's segment, decided here rather than inside the executor because it is a property of the
+    // QUERY (its filter's interval on the sort column) and not of the emission loop. Two binary searches
+    // when the filter constrains the sort column, the whole permutation otherwise.
+    let walk = walk_bounds(perm, ctx.cards, params.sort_col, params.descending, params.sort_bound);
     let existential_plane = existential_plane_for(params.mode, plane, indexes);
-    run_query_streamed(ctx, params, filter, prep.all_match_known, order, prep.card_ids(ctx), existential_plane)
+    run_query_streamed(ctx, params, filter, prep.all_match_known, walk, prep.card_ids(ctx), existential_plane)
 }
 
 /// Per-query execution counters and coarse phase timings, for checking the cost model against what
@@ -7336,7 +7517,7 @@ fn exec_gathered_scan<'a>(
     // First of the three phase boundaries — everything down to the match loop is `ns_setup`.
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let all_match_known = prep.all_match_known;
     let existential_plane = existential_plane_for(mode, plane, indexes);
     let card_ids = prep.card_ids(ctx);
@@ -7418,7 +7599,13 @@ fn exec_gathered_scan<'a>(
     (total, page)
 }
 
-#[allow(clippy::too_many_arguments)] // the PyO3 string surface, adapted in one place; the core takes two structs
+/// The six-string convenience form of `run_query_routed`, for tests that state a query the way the
+/// HTTP surface does. `QueryParams::from_strs` is still the single string→enum interpretation — the
+/// PyO3 methods call it directly, because they also have a `SortBound` to attach and this wrapper has
+/// no filter tree left to extract one from (see `bind_and_split_filter`). A query routed through here
+/// therefore walks the whole permutation, which is the correct-but-slower default.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)] // the string surface, adapted in one place; the core takes two structs
 fn run_query<'a>(
     ctx: &QueryCtx<'a>,
     filter: &mut FilterExpr,
@@ -7431,8 +7618,7 @@ fn run_query<'a>(
     page_offset: usize,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // #702: plan selection is one cost-based routing layer (`run_query_routed`,
-    // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision
-    // tree. `run_query` is the thin string→enum adapter; the core takes enums.
+    // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision tree.
     let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, page_offset);
     run_query_routed(ctx, &params, filter, plane)
 }
@@ -8868,7 +9054,7 @@ fn run_query_streamed<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
     all_match_known: bool,
-    order: SortOrder<'_>,
+    walk: &[Archived<u32>],
     card_ids: Box<dyn ExactSizeIterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
@@ -8876,8 +9062,7 @@ fn run_query_streamed<'a>(
     // for this executor is dominated by the `counts` zeroing below. See `PhaseStats::ns_setup`.
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
-    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
-    let SortOrder { perm, inv: inv_perm } = order;
+    let QueryParams { mode, prefer, sort_col, descending, limit, page_offset, .. } = *params;
     let artwork_groups = &indexes.artwork_groups;
     let artwork_group_col = &indexes.artwork_group_col;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -8906,43 +9091,6 @@ fn run_query_streamed<'a>(
     // `card_match_count` answer without reading a printing at all, so this can legitimately be 0
     // where `n_printing_span` is the full corpus span.
     let mut n_printings_examined = 0u64;
-    // The sort-order span the emission walk below has to cover: the smallest and largest position of
-    // any card that matched. The walk is over the WHOLE corpus permutation, so without these it grinds
-    // through every card ordered before the first match discarding on `counts[cid] == 0` -- `year>=2020
-    // order=released asc` pays the entire pre-2020 prefix -- and, on any page it cannot fill, every
-    // card ordered after the last match as well, since the only thing that stops it early is the page
-    // filling. Measured on this corpus: `cmc>=6 order=cmc asc` walked 28,275 entries for a 60-row page
-    // and spent 10.6 us of a 20.25 us execution doing it; bounded, it walks 60 and spends 0.38 us.
-    //
-    // Deliberately the REALIZED span rather than bounds derived from the predicate and the sort
-    // column: it holds for any predicate (including a residual only `card_match_count` can resolve),
-    // and it cannot be wrong about how ties inside the sort key are broken. Descending needs nothing
-    // extra -- there are two permutations per column, one per direction, so `inv_perm` is already the
-    // inverse of the order actually walked.
-    //
-    // GATED, because the span is emphatically not free. It costs an `inv_perm` read plus a `min` and a
-    // `max` per MATCHING card, and this loop's `all_match` arm is only ~2.6 ns/card to begin with, so
-    // 0.51 ns/card of tracking is a 20% tax on it: ungated, `cmc>=1 order=edhrec` measured `ns_loop`
-    // 78.54 -> 94.46 us over 30,318 cards while its walk stayed at 111 steps either way. The tax is
-    // paid on every streamed query; the saving only exists when the walk had something to skip.
-    //
-    // The bound is therefore insurance, and the gate is the premium being kept below the payout. A
-    // query with `m` matching cards has at most `n_cards - m` entries outside its span, so the most the
-    // bound can save is `(n_cards - m) * 0.37 ns` against a cost of `m * 0.51 ns` -- break-even at
-    // `m = 0.42 * n_cards`, and `SPAN_TRACK_CANDIDATE_DIVISOR` sits at a quarter, inside it. The
-    // regime below the gate is also where the unbounded walk is dangerous: steps go as
-    // `page_span * n_cards / matches`, so sparse matches are exactly what make it long.
-    //
-    // Candidates bound matching cards from above, and unlike the match count it is known HERE, before
-    // the loop -- so this is one perfectly-predicted branch per card, rather than a decision that could
-    // only be made after the cost had already been paid.
-    //
-    // What the gate does not fix: a query whose cluster sits at the NEAR end of the walked order pays
-    // the premium for nothing, because the page fills before the last-match bound can matter
-    // (`cmc>=6 order=cmc desc offset=900` measured 1.17x). That is the shape of the bet, not a defect
-    // in it -- which end a cluster lands on is not knowable before the loop runs.
-    let track_span = card_ids.len() <= cards.len() / *SPAN_TRACK_CANDIDATE_DIVISOR;
-    let (mut first_match_pos, mut last_match_pos) = (u32::MAX, 0u32);
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -8987,13 +9135,6 @@ fn run_query_streamed<'a>(
             c
         };
         counts[cid as usize] = c;
-        // Guarded on `c != 0` because a zero-count card is exactly what the walk skips: widening the
-        // span to one would put entries inside it that the walk then discards, giving back the saving.
-        if track_span && c != 0 {
-            let pos = u32::from(inv_perm[cid as usize]);
-            first_match_pos = first_match_pos.min(pos);
-            last_match_pos = last_match_pos.max(pos);
-        }
         total += c as usize;
         n_matches_pushed += c as u64;
     }
@@ -9061,34 +9202,25 @@ fn run_query_streamed<'a>(
         return (total, page);
     }
 
-    // Stream: walk the permutation across the match span, consume page_offset
+    // Stream: walk the segment `walk_bounds` handed over, consume page_offset
     // from the counts, emit page cards only. Within a card, items order by
     // (sort key, pid) — the same comparator select_page uses; across cards the
     // permutation supplies the order.
     //
-    // Restricting the walk to `first_match_pos..=last_match_pos` is exact, not an approximation:
-    // outside it every entry has `counts[cid] == 0` by construction (the span is the min and max over
-    // all cards with a nonzero count), and the walk's only effect on a zero-count entry is to
-    // `continue`. `total > 0` here — the guard above returned otherwise — so some card set both ends.
-    // Ungated, the whole permutation, exactly as before.
-    let match_span: &[Archived<u32>] = if track_span {
-        debug_assert!(
-            first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
-            "total > 0 guarantees a matching card, so the match span must be a real permutation range"
-        );
-        &perm[first_match_pos as usize..=last_match_pos as usize]
-    } else {
-        &perm[..]
-    };
+    // The segment is the whole permutation unless the filter bounded the sort column, in which case
+    // every position outside it belongs to a card whose value cannot satisfy that bound and therefore
+    // has `counts[cid] == 0`. The walk's only effect on a zero-count entry is to `continue`, so
+    // narrowing the segment cannot change which rows come back — only how many entries are stepped to
+    // find them.
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
     // Counted for every entry the walk touches, including the ones skipped on a zero count -- that
     // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. Entries
-    // outside the match span are NOT counted: they are never stepped, and the counter's job is to
-    // grade the cost model against work actually done. A plain local, published once, like the others.
+    // outside the segment are NOT counted: they are never stepped, and the counter's job is to grade
+    // the cost model against work actually done. A plain local, published once, like the others.
     let mut n_perm_steps = 0u64;
-    'walk: for cid in match_span.iter().map(|x| u32::from(*x)) {
+    'walk: for cid in walk.iter().map(|x| u32::from(*x)) {
         n_perm_steps += 1;
         let c = counts[cid as usize] as usize;
         if c == 0 {
@@ -9348,7 +9480,20 @@ pub(crate) fn count_common_keywords(data: &Archived<CardData>) -> HashMap<String
 /// No `#[inline]`: this shares a crate with its only hot-path caller (`query`), so
 /// the compiler already inlines at its discretion, and the body is dominated by
 /// Python FFI (`to_json`, `orjson.dumps`) — a call boundary here is unmeasurable.
-fn bind_and_split_filter(py: Python<'_>, filters: &Bound<PyAny>, unique: &str, data: &Archived<CardData>) -> PyResult<(Option<PlaneExpr>, FilterExpr)> {
+/// Binds the Python filter, extracts what it says about `sort_col`, and splits it into plane + residual.
+///
+/// The `SortBound` comes out of here rather than out of the executor because this is the last moment the
+/// whole filter exists: `split_planes` compiles `cmc>=6` into mask algebra over bitplanes and leaves
+/// `FilterExpr::True` behind, so by the time a plan runs there is nothing left to read the bound from.
+/// Every caller that does not want it can ignore it and get `UNBOUNDED` behaviour — a longer walk, never
+/// a different page.
+fn bind_and_split_filter(
+    py: Python<'_>,
+    filters: &Bound<PyAny>,
+    unique: &str,
+    data: &Archived<CardData>,
+    sort_col: SortCol,
+) -> PyResult<(Option<PlaneExpr>, FilterExpr, SortBound)> {
     let to_json = filters.call_method0("to_json")?;
     let json_bytes: Vec<u8> = py
         .import("orjson")?
@@ -9366,11 +9511,14 @@ fn bind_and_split_filter(py: Python<'_>, filters: &Bound<PyAny>, unique: &str, d
         .map_err(|e| QueryError::new_err(format!("build_filter: {e}")))?;
     filter_expr.bind(&data.coll_vocab, &data.coll_vocab_sorted, &data.artist_vocab, &data.mana_vocab, &data.indexes.flavor, &data.strings);
 
-    Ok(if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
+    // Read before the split consumes the tree.
+    let sort_bound = sort_col_bound(&filter_expr, sort_col);
+    let (plane, residual) = if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
         split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
     } else {
         (None, filter_expr)
-    })
+    };
+    Ok((plane, residual, sort_bound))
 }
 
 fn plan_estimate_to_pydict<'py>(py: Python<'py>, e: &PlanEstimate) -> PyResult<Bound<'py, PyDict>> {
@@ -9929,10 +10077,13 @@ impl QueryEngine {
         // run_query evaluates in a few hundred word ops instead of per-card
         // dispatch. Shared verbatim with explain()/explain_analyze() — see
         // bind_and_split_filter.
-        let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         let ctx = QueryCtx::from(data);
-        let (total, page) = run_query(&ctx, &mut filter_expr, plane_expr.as_ref(), unique, prefer, orderby, direction, limit, offset);
+        // `run_query`'s string→enum adaptation, done here so the filter's sort-column bound can ride on
+        // the params: `from_strs` is still the single interpretation of the four strings.
+        let (total, page) = run_query_routed(&ctx, &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
 
         let matches: Vec<Bound<PyDict>> = page
             .iter()
@@ -9969,7 +10120,8 @@ impl QueryEngine {
         let mmap = self.get_mmap()?;
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
-        let (plane_expr, mut filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // `prefer` is accepted and passed through, but note what it does NOT yet change:
         // `cost::plan_cost`/`PlanFeatures` still don't read it, so the argmin and every
@@ -9983,8 +10135,8 @@ impl QueryEngine {
         // feature value cannot be right for both. Taking the parameter is what lets a
         // prefer-aware feature be graded here at all; until one exists, an `explain` for a
         // non-default `prefer` still predicts the default's numbers.
-        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (facts, estimates) = explain(&QueryCtx::from(data), &params, &mut filter_expr, plane_expr.as_ref());
+        let (facts, estimates) =
+            explain(&QueryCtx::from(data), &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
         let out = PyDict::new(py);
@@ -10017,14 +10169,15 @@ impl QueryEngine {
         let mmap = self.get_mmap()?;
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
-        let (plane_expr, filter_expr) = bind_and_split_filter(py, filters, unique, data)?;
+        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let (plane_expr, filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // Release the GIL for the timing loop: it's pure Rust (no Python calls) and
         // runs plans × (warmups + trials) executions, so a long explain_analyze
         // shouldn't block other Python threads. The bind above and the PyDict
         // conversion below stay on the GIL.
         let ctx = QueryCtx::from(data);
-        let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
+        let params = params.with_sort_bound(sort_bound);
         let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1942,6 +1942,29 @@ impl ArchivedSortPermutations {
         };
         Some(&pair[descending as usize])
     }
+
+    /// Both directions of one streamable column, length-checked against the card count, or `None` if
+    /// the column has no permutation. The single answer to "can a plan stream this orderby": every
+    /// plan that walks a permutation also indexes its inverse, so all three applicability predicates
+    /// and all three executors want the pair or neither.
+    fn order(&self, col: SortCol, descending: bool, n_cards: usize) -> Option<SortOrder<'_>> {
+        let perm = self.get(col, descending)?;
+        let inv = self.get_inv(col, descending)?;
+        (perm.len() == n_cards && inv.len() == n_cards).then_some(SortOrder { perm, inv })
+    }
+}
+
+/// One streamable column's card ordering and its inverse, which every permutation-walking plan needs
+/// together: the walk reads `perm`, and finding where in that order a card sits reads `inv`.
+///
+/// Paired in one value, obtained from one length-checked lookup (`ArchivedSortPermutations::order`),
+/// because the two were previously fetched by five call sites with two `expect`s each and applicability
+/// predicates that checked the forward array's length but not the inverse's — a store whose two arrays
+/// disagreed would have reached an indexing panic inside an executor rather than a decline.
+#[derive(Copy, Clone)]
+struct SortOrder<'a> {
+    perm: &'a Archived<Vec<u32>>,
+    inv:  &'a Archived<Vec<u32>>,
 }
 
 /// Dense byte-order rank of card_name_lower onto each card (equal names share
@@ -6286,13 +6309,16 @@ fn gathered_scan_applicable() -> bool {
 /// descending)` whose length matches the card count, over a non-empty store.
 /// `maybe_broad` is deliberately excluded — that is a routing/perf choice, not a
 /// correctness constraint; StreamedSelect returns correct rows at any breadth.
+///
+/// The INVERSE is required on the same terms, because the emission walk bounds itself to the match
+/// span through it — hence `order`, which yields the pair or nothing.
 fn streamed_select_applicable(
     cards: &[AOracleCard],
     sort_col: SortCol,
     descending: bool,
     indexes: &Archived<CardIndexes>,
 ) -> bool {
-    !cards.is_empty() && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
+    !cards.is_empty() && indexes.sort_perms.order(sort_col, descending, cards.len()).is_some()
 }
 
 /// `PlanePopcountOrder` needs the filter fully consumed to `True`, `Mode::Card`,
@@ -6311,8 +6337,7 @@ fn plane_popcount_order_applicable(
         && matches!(mode, Mode::Card)
         && !cards.is_empty()
         && plane.is_some()
-        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
-        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
+        && indexes.sort_perms.order(sort_col, descending, cards.len()).is_some()
 }
 
 /// `PrintingRangeScan` structural eligibility only — whether it actually runs is
@@ -6370,8 +6395,7 @@ fn card_range_popcount_applicable(
         && !cards.is_empty()
         && plane.is_none()
         && bare_range_bounds(filter, indexes).is_some()
-        && indexes.sort_perms.get(sort_col, descending).is_some_and(|p| p.len() == cards.len())
-        && indexes.sort_perms.get_inv(sort_col, descending).is_some()
+        && indexes.sort_perms.order(sort_col, descending, cards.len()).is_some()
 }
 
 // ─── Shared P3/P4 candidate preparation ─────────────────────────────────────
@@ -6531,13 +6555,14 @@ fn exec_plane_popcount_order_with_bitmap<'a>(
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
     let QueryParams { sort_col, descending, .. } = *params;
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("PlanePopcountOrder applicability guarantees a permutation");
-    let inv_perm =
-        indexes.sort_perms.get_inv(sort_col, descending).expect("PlanePopcountOrder applicability guarantees an inverse permutation");
+    let order = indexes
+        .sort_perms
+        .order(sort_col, descending, ctx.cards.len())
+        .expect("PlanePopcountOrder applicability guarantees a sort order");
     // `run_query_streamed_popcount` publishes the phases and consumes the pending plane build; see
     // `publish_popcount_phases`. Counters stay zero: this plan popcounts a bitmap and visits no
     // cards, so it has nothing to report there.
-    run_query_streamed_popcount(ctx, params, perm, inv_perm, bitmap, Some(plane_expr), None)
+    run_query_streamed_popcount(ctx, params, order, bitmap, Some(plane_expr), None)
 }
 
 /// `CardRangePopcount` executor: the same popcount-skip order phase as P2, but its match bitmap is a
@@ -6553,10 +6578,11 @@ fn exec_card_range_popcount<'a>(
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
     let QueryParams { sort_col, descending, .. } = *params;
-    let perm = indexes.sort_perms.get(sort_col, descending).expect("CardRangePopcount applicability guarantees a permutation");
-    let inv_perm =
-        indexes.sort_perms.get_inv(sort_col, descending).expect("CardRangePopcount applicability guarantees an inverse permutation");
-    run_query_streamed_popcount(ctx, params, perm, inv_perm, card_bits, None, Some(range_pbits))
+    let order = indexes
+        .sort_perms
+        .order(sort_col, descending, ctx.cards.len())
+        .expect("CardRangePopcount applicability guarantees a sort order");
+    run_query_streamed_popcount(ctx, params, order, card_bits, None, Some(range_pbits))
 }
 
 /// Prefix-sum the per-card distinct-artwork counts (`artwork_groups`) into artwork-space offsets: a
@@ -6841,12 +6867,12 @@ fn exec_streamed_select<'a>(
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     let indexes = ctx.indexes;
-    let perm = indexes
+    let order = indexes
         .sort_perms
-        .get(params.sort_col, params.descending)
-        .expect("StreamedSelect applicability guarantees a permutation");
+        .order(params.sort_col, params.descending, ctx.cards.len())
+        .expect("StreamedSelect applicability guarantees a sort order");
     let existential_plane = existential_plane_for(params.mode, plane, indexes);
-    run_query_streamed(ctx, params, filter, prep.all_match_known, perm, prep.card_ids(ctx), existential_plane)
+    run_query_streamed(ctx, params, filter, prep.all_match_known, order, prep.card_ids(ctx), existential_plane)
 }
 
 /// Per-query execution counters and coarse phase timings, for checking the cost model against what
@@ -8664,8 +8690,7 @@ fn explain_analyze(
 fn run_query_streamed_popcount<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
-    perm: &Archived<Vec<u32>>,
-    inv_perm: &Archived<Vec<u32>>,
+    order: SortOrder<'_>,
     bitmap: &[u64],
     plane: Option<&PlaneExpr>,
     range_bits: Option<&[u64]>,
@@ -8677,6 +8702,7 @@ fn run_query_streamed_popcount<'a>(
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { prefer, limit, page_offset, .. } = *params;
+    let SortOrder { perm, inv: inv_perm } = order;
     let planes = &indexes.planes;
     let n_cards = cards.len();
     let total: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
@@ -8821,7 +8847,7 @@ fn run_query_streamed<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
     all_match_known: bool,
-    perm: &Archived<Vec<u32>>,
+    order: SortOrder<'_>,
     card_ids: Box<dyn Iterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
@@ -8830,6 +8856,7 @@ fn run_query_streamed<'a>(
     let t_start = std::time::Instant::now();
     let QueryCtx { cards, printings, offsets, strings, indexes } = *ctx;
     let QueryParams { mode, prefer, sort_col, descending, limit, page_offset } = *params;
+    let SortOrder { perm, inv: inv_perm } = order;
     let artwork_groups = &indexes.artwork_groups;
     let artwork_group_col = &indexes.artwork_group_col;
     let max_artwork_groups = u16::from(indexes.max_artwork_groups);
@@ -8858,6 +8885,21 @@ fn run_query_streamed<'a>(
     // `card_match_count` answer without reading a printing at all, so this can legitimately be 0
     // where `n_printing_span` is the full corpus span.
     let mut n_printings_examined = 0u64;
+    // The sort-order span the emission walk below has to cover: the smallest and largest position of
+    // any card that matched. The walk is over the WHOLE corpus permutation, so without these it grinds
+    // through every card ordered before the first match discarding on `counts[cid] == 0` -- `year>=2020
+    // order=released asc` pays the entire pre-2020 prefix -- and, on any page it cannot fill, every
+    // card ordered after the last match as well, since the only thing that stops it early is the page
+    // filling. This loop already visits every candidate, so the span costs one `inv_perm` read, a `min`
+    // and a `max` per MATCHING card, and candidates arrive in ascending `cid` order, which makes those
+    // reads a forward stream through `inv_perm` rather than random access.
+    //
+    // Deliberately the REALIZED span rather than bounds derived from the predicate and the sort
+    // column: it holds for any predicate (including a residual only `card_match_count` can resolve),
+    // and it cannot be wrong about how ties inside the sort key are broken. Descending needs nothing
+    // extra -- there are two permutations per column, one per direction, so `inv_perm` is already the
+    // inverse of the order actually walked.
+    let (mut first_match_pos, mut last_match_pos) = (u32::MAX, 0u32);
     // Ends `ns_setup` and starts `ns_loop` — one read, two phases.
     let t_loop = std::time::Instant::now();
     for cid in card_ids {
@@ -8902,6 +8944,13 @@ fn run_query_streamed<'a>(
             c
         };
         counts[cid as usize] = c;
+        // Guarded on `c != 0` because a zero-count card is exactly what the walk skips: widening the
+        // span to one would put entries inside it that the walk then discards, giving back the saving.
+        if c != 0 {
+            let pos = u32::from(inv_perm[cid as usize]);
+            first_match_pos = first_match_pos.min(pos);
+            last_match_pos = last_match_pos.max(pos);
+        }
         total += c as usize;
         n_matches_pushed += c as u64;
     }
@@ -8969,18 +9018,29 @@ fn run_query_streamed<'a>(
         return (total, page);
     }
 
-    // Stream: walk the permutation, consume page_offset from the counts, emit
-    // page cards only. Within a card, items order by (sort key, pid) — the
-    // same comparator select_page uses; across cards the permutation supplies
-    // the order.
+    // Stream: walk the permutation across the match span, consume page_offset
+    // from the counts, emit page cards only. Within a card, items order by
+    // (sort key, pid) — the same comparator select_page uses; across cards the
+    // permutation supplies the order.
+    //
+    // Restricting the walk to `first_match_pos..=last_match_pos` is exact, not an approximation:
+    // outside it every entry has `counts[cid] == 0` by construction (the span is the min and max over
+    // all cards with a nonzero count), and the walk's only effect on a zero-count entry is to
+    // `continue`. `total > 0` here — the guard above returned otherwise — so some card set both ends.
+    debug_assert!(
+        first_match_pos <= last_match_pos && (last_match_pos as usize) < perm.len(),
+        "total > 0 guarantees a matching card, so the match span must be a real permutation range"
+    );
+    let match_span = &perm[first_match_pos as usize..=last_match_pos as usize];
     let mut skip = page_offset;
     let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
     let mut scratch: Vec<Match> = Vec::new();
     // Counted for every entry the walk touches, including the ones skipped on a zero count -- that
-    // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. A plain
-    // local, published once, like the other counters.
+    // skip IS the walk's cost, and it is what grows as matches thin out in a larger corpus. Entries
+    // outside the match span are NOT counted: they are never stepped, and the counter's job is to
+    // grade the cost model against work actually done. A plain local, published once, like the others.
     let mut n_perm_steps = 0u64;
-    'walk: for cid in perm.iter().map(|x| u32::from(*x)) {
+    'walk: for cid in match_span.iter().map(|x| u32::from(*x)) {
         n_perm_steps += 1;
         let c = counts[cid as usize] as usize;
         if c == 0 {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6388,9 +6388,9 @@ fn streamed_selection_matches_gathered() {
 
 /// The emission walk must cover the MATCH SPAN only, not the whole permutation — the
 /// `year>=2020 order=released asc` shape, built here as a corpus whose sort order and match set are
-/// deliberately anti-correlated: 4,500 non-matching cards sort ahead of the 1,500 that match.
+/// deliberately anti-correlated: 8,500 non-matching cards sort ahead of the 1,500 that match.
 ///
-/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 4,500-entry
+/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 8,500-entry
 /// prefix before its first emit; descending at a deep offset it used to run to the END of the
 /// permutation, because the only thing that stopped it was the page filling and a partial last page
 /// never fills.
@@ -6404,13 +6404,18 @@ fn streamed_selection_matches_gathered() {
 ///   no-op; the anti-correlation here is what makes it load-bearing.
 /// - **`perm_steps`**, which is how far the walk actually stepped. The row assertions pass just as well
 ///   on a walk that steps everything: unbounded, the ascending cells cost `offset + limit + PREFIX`
-///   steps and the deep descending ones the full 6,000.
+///   steps and the deep descending ones the full 10,000.
 #[test]
 fn streamed_walk_seeks_past_the_unmatched_prefix() {
     // > STREAM_MIN_MATCHES (1,024) in every mode, so the walk branch runs rather than the
-    // small-total gather -- the seek only exists on the walk.
+    // small-total gather -- the span bound only exists on the walk.
     const MATCHING: usize = 1_500;
-    const PREFIX: usize = 4_500; // cards sorting ahead of every match under `cmc asc`
+    // Cards sorting ahead of every match under `cmc asc`. Sized so matching cards are 15% of the
+    // corpus, comfortably under `SPAN_TRACK_CANDIDATE_DIVISOR`'s quarter -- at exactly a quarter this
+    // test would pass or fail on whether the narrowing returned 1,500 candidates or 6,000.
+    // `streamed_selection_matches_gathered` covers the other side of that gate: 1,125 matches among
+    // 1,500 cards is three quarters of the corpus, so its walk is the unbounded one.
+    const PREFIX: usize = 8_500;
     const N: usize = PREFIX + MATCHING;
     const MATCH_CMC: u8 = 5;
     const LIMIT: usize = 10;

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -6386,6 +6386,105 @@ fn streamed_selection_matches_gathered() {
     }
 }
 
+/// The emission walk must cover the MATCH SPAN only, not the whole permutation — the
+/// `year>=2020 order=released asc` shape, built here as a corpus whose sort order and match set are
+/// deliberately anti-correlated: 4,500 non-matching cards sort ahead of the 1,500 that match.
+///
+/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 4,500-entry
+/// prefix before its first emit; descending at a deep offset it used to run to the END of the
+/// permutation, because the only thing that stopped it was the page filling and a partial last page
+/// never fills.
+///
+/// Two assertions, and neither substitutes for the other:
+///
+/// - **Row identity against `GatheredScan`** at several page offsets. The span moves where the paging
+///   walk starts and stops, so an end one entry off drops a row silently — a wrong page, not a crash,
+///   and only a reference comparison catches it. `streamed_selection_matches_gathered` pages the same
+///   way but on an evenly-spread match set, where the span is the whole corpus and bounding it is a
+///   no-op; the anti-correlation here is what makes it load-bearing.
+/// - **`perm_steps`**, which is how far the walk actually stepped. The row assertions pass just as well
+///   on a walk that steps everything: unbounded, the ascending cells cost `offset + limit + PREFIX`
+///   steps and the deep descending ones the full 6,000.
+#[test]
+fn streamed_walk_seeks_past_the_unmatched_prefix() {
+    // > STREAM_MIN_MATCHES (1,024) in every mode, so the walk branch runs rather than the
+    // small-total gather -- the seek only exists on the walk.
+    const MATCHING: usize = 1_500;
+    const PREFIX: usize = 4_500; // cards sorting ahead of every match under `cmc asc`
+    const N: usize = PREFIX + MATCHING;
+    const MATCH_CMC: u8 = 5;
+    const LIMIT: usize = 10;
+    // Two printings per card, so printing and artwork mode have more than one row per matching card
+    // to page through rather than degenerating to card mode.
+    const PRINTINGS_PER_CARD: usize = 2;
+
+    let mut vocab = VocabInterner::new();
+    let mut cards = Vec::with_capacity(N);
+    for i in 0..N {
+        let mut c = stub_card((i + 1) as u128, TYPE_CREATURE, &[], &mut vocab);
+        // The anti-correlation: cmc 0 for the prefix, MATCH_CMC for the tail, so the ascending cmc
+        // permutation puts every match last and the descending one puts every match first. One
+        // fixture then covers both "the seek skips almost everything" and "the seek is a no-op".
+        c.cmc = Some(if i < PREFIX { 0 } else { MATCH_CMC });
+        c.edhrec_rank = Some(((i * 37) % N) as u32 + 1); // distinct, shuffled: no full-key tie blocks
+        cards.push(c);
+    }
+    let data = store_of(cards, &vec![PRINTINGS_PER_CARD; N], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let ctx = QueryCtx::from(archived);
+
+    let filt = || FilterExpr::NumericCmp {
+        lhs: NumExpr::Field(NumField::Cmc),
+        op: CmpOp::Ge,
+        rhs: NumExpr::Const(f64::from(MATCH_CMC)),
+    };
+    let ids = |page: &[(&super::AOracleCard, &super::APrinting)]| -> Vec<(u128, u128)> {
+        page.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
+    };
+
+    let mut checked = 0usize;
+    for &(mode_label, mode) in &[("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)] {
+        for descending in [false, true] {
+            // Offsets across the page-depth range this plan sees, including one deep enough that the
+            // walk runs off the end of the matches (1,499 in card mode leaves a single row).
+            for offset in [0usize, 7, 750, 1_499] {
+                let params = kernel_params(mode, SortCol::Cmc, descending, LIMIT, offset);
+                let (pe, filter) = split_planes(
+                    filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
+                );
+                // A pristine clone per plan: `prepare_candidates` rewrites the filter it is handed.
+                let mut streamed_filter = filter.clone();
+                take_phase_stats();
+                let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+                    .expect("store_of builds the cmc permutation, so StreamedSelect is applicable");
+                let stats = take_phase_stats();
+                let mut gathered_filter = filter.clone();
+                let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+                    .expect("GatheredScan is always applicable");
+
+                let case = format!("{mode_label}/{}/offset={offset}", if descending { "desc" } else { "asc" });
+                assert!(streamed.0 > *STREAM_MIN_MATCHES, "cell must reach the walk branch, not the gather: {case}");
+                assert_eq!(streamed.0, gathered.0, "total disagrees with GatheredScan: {case}");
+                assert_eq!(ids(&streamed.1), ids(&gathered.1), "page disagrees with GatheredScan: {case}");
+
+                // The walk consumes `offset` matches and emits at most `limit` more, and every entry
+                // inside the span is a match here (the matching group is contiguous in this fixture),
+                // so one step per match plus the entry the break lands on bounds it. Unbounded, the
+                // ascending cells were PREFIX higher than this and the deep descending ones ran to N.
+                let bound = (offset + LIMIT + 1) as u64;
+                assert!(
+                    stats.perm_steps <= bound,
+                    "walk stepped {} entries, over the {bound}-step bound — the match span did not bound it: {case}",
+                    stats.perm_steps,
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert_eq!(checked, 24, "every mode × direction × offset cell must have run");
+}
+
 // Group counts collapse duplicate illustrations within a card.
 #[test]
 fn artwork_group_counts_dedup_illustrations() {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11,7 +11,7 @@ use super::{
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
-    prepare_candidates, verify_cost_tier, scan_units, Mode, QueryCtx, QueryParams, Prefer,
+    prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, Mode, QueryCtx, QueryParams, Prefer, SortBound,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -32,7 +32,15 @@ use rand::RngExt;
 /// (`cost::PlanFeatures` has no such field), and `SortCol::EdhrecRank`/ascending
 /// is the default orderby these tests were written against.
 fn explain_params(mode: Mode, limit: usize) -> QueryParams {
-    QueryParams { mode, prefer: Prefer::Default, sort_col: SortCol::EdhrecRank, descending: false, limit, page_offset: 0 }
+    QueryParams {
+        mode,
+        prefer: Prefer::Default,
+        sort_col: SortCol::EdhrecRank,
+        descending: false,
+        limit,
+        page_offset: 0,
+        sort_bound: SortBound::UNBOUNDED,
+    }
 }
 
 /// `QueryParams` from the enum-space inputs a kernel-level test drives directly
@@ -40,7 +48,7 @@ fn explain_params(mode: Mode, limit: usize) -> QueryParams {
 /// `prefer` is `Default` — the value every one of these call sites passed
 /// explicitly before the bundle.
 fn kernel_params(mode: Mode, sort_col: SortCol, descending: bool, limit: usize, page_offset: usize) -> QueryParams {
-    QueryParams { mode, prefer: Prefer::Default, sort_col, descending, limit, page_offset }
+    QueryParams { mode, prefer: Prefer::Default, sort_col, descending, limit, page_offset, sort_bound: SortBound::UNBOUNDED }
 }
 
 /// `QueryParams` for a test calling a function that reads only `mode` —
@@ -2861,6 +2869,27 @@ fn force_plan_differential_agreement() {
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), "edhrec", "asc"),
         (FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 2.0 }), "edhrec", "desc"),
         (FuzzSpec::And(vec![FuzzSpec::Leaf(FuzzLeaf::Price { op: CmpOp::Lt, val: 100_000.0 }), fuzz_leaf_color(&mut rng)]), "edhrec", "asc"),
+        // A numeric bound on the SORT column itself, which is what `walk_bounds` narrows a streamed
+        // walk with. Hand-built in BOTH directions, and in compound as well as bare form: the random
+        // generator draws its predicate and its orderby independently, so it produced descending
+        // bounded cases and no ascending ones (caught by the per-direction coverage assertion at the
+        // end). The compound case checks that an `And` sibling neither widens nor blocks the bound, and
+        // the `Or` case that a disjunction correctly yields no bound at all — a bound taken from one
+        // arm of an `Or` would cut off rows the other arm matches, and only a row-order comparison
+        // against the reference catches that.
+        (FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Ge, val: 4.0 }), "cmc", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Le, val: 3.0 }), "cmc", "desc"),
+        (FuzzSpec::And(vec![FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Ge, val: 3.0 }), fuzz_leaf_type(&mut rng)]), "cmc", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Power { op: CmpOp::Ge, val: 3.0 }), "power", "asc"),
+        (FuzzSpec::Leaf(FuzzLeaf::Toughness { op: CmpOp::Eq, val: 2.0 }), "toughness", "asc"),
+        (
+            FuzzSpec::Or(vec![
+                FuzzSpec::Leaf(FuzzLeaf::Cmc { op: CmpOp::Ge, val: 6.0 }),
+                fuzz_leaf_color(&mut rng),
+            ]),
+            "cmc",
+            "asc",
+        ),
         // PR 3: cn/date bare ranges also route through CardRangePopcount in card mode (the Date cases
         // above already exercise it; add collector_number + year over card-level perms too).
         (FuzzSpec::Leaf(FuzzLeaf::CollectorNumber { op: CmpOp::Lt, val: 100.0 }), "edhrec", "asc"),
@@ -2959,6 +2988,11 @@ fn force_plan_differential_agreement() {
         PhysicalPlan::GatheredScan => 5,
     };
     let mut ran = [0u32; 6];
+    // Coverage for the sort-column bound below: a corpus that never produced one would verify nothing
+    // about `walk_bounds`, and the assertion at the end of this test would pass vacuously. Counted per
+    // DIRECTION because `walk_bounds` negates the key under `desc`, so the two directions map an
+    // interval onto opposite ends of the permutation and a sign error would only show in one of them.
+    let mut bounded_cases = [0usize; 2];
 
     // >= any possible total, so the offset-0 page is the complete ordered result.
     let full_limit = archived.printings.len().max(1);
@@ -2989,6 +3023,14 @@ fn force_plan_differential_agreement() {
     for (spec, orderby, direction) in &cases {
         let sort_col = orderby_to_col(orderby);
         let descending = *direction == "desc";
+        // Extracted from the unsplit filter, as `bind_and_split_filter` does in production, and passed
+        // to every plan. This is what holds `walk_bounds` to the reference across the whole fuzz corpus:
+        // numeric leaves on cmc/power/toughness appear under And, Or and Not here, so an extractor that
+        // read a bound out of a disjunction or inverted one out of a negation would return a short page
+        // for some case and fail the row-order assertion below. Applied to ALL plans, not just P3, since
+        // a bound that changed any plan's answer is equally wrong.
+        let sort_bound = sort_col_bound(&fuzz_bound_filter(spec, archived), sort_col);
+        bounded_cases[usize::from(descending)] += usize::from(!sort_bound.is_unbounded());
         // (key1, key2) = the top 64 bits of sort_key_bits; drop the low 32 (key 3).
         let key2_seq = |page: &[(&Archived<OracleCard>, &Archived<Printing>)]| -> Vec<u128> {
             page.iter().map(|&(c, p)| sort_key_bits(c, p, sort_col, descending) >> 32).collect()
@@ -3004,7 +3046,8 @@ fn force_plan_differential_agreement() {
                 );
                 let (ref_total, ref_page) = run_query_with_plan(
                     PhysicalPlan::GatheredScan, &QueryCtx::from(archived),
-                    &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0), &mut ref_res, ref_pe.as_ref(),
+                    &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
+                    &mut ref_res, ref_pe.as_ref(),
                 )
                 .expect("GatheredScan is always applicable");
                 ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
@@ -3027,7 +3070,8 @@ fn force_plan_differential_agreement() {
                     );
                     let out = run_query_with_plan(
                         plan, &QueryCtx::from(archived),
-                        &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0), &mut res, pe.as_ref(),
+                        &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
+                        &mut res, pe.as_ref(),
                     );
                     let Some((total, page)) = out else { continue };
                     ran[plan_idx(plan)] += 1;
@@ -3069,6 +3113,14 @@ fn force_plan_differential_agreement() {
         assert!(
             ran[plan_idx(plan)] > 0,
             "plan {plan:?} was never exercised by the differential corpus — add coverage",
+        );
+    }
+    for (dir, count) in [("asc", bounded_cases[0]), ("desc", bounded_cases[1])] {
+        assert!(
+            count > 0,
+            "no {dir} case constrained its own sort column, so `walk_bounds` never narrowed a walk in that \
+             direction — the row assertions above did not verify it. Add a numeric leaf on \
+             cmc/power/toughness under a matching orderby.",
         );
     }
 }
@@ -6386,35 +6438,34 @@ fn streamed_selection_matches_gathered() {
     }
 }
 
-/// The emission walk must cover the MATCH SPAN only, not the whole permutation — the
-/// `year>=2020 order=released asc` shape, built here as a corpus whose sort order and match set are
-/// deliberately anti-correlated: 8,500 non-matching cards sort ahead of the 1,500 that match.
+/// The emission walk must cover only the segment of the permutation its filter's bound on the sort
+/// column admits — the `cmc>=6 order=cmc asc` shape, built here as a corpus whose sort order and match
+/// set are deliberately anti-correlated: 8,500 non-matching cards sort ahead of the 1,500 that match.
 ///
-/// Both ends matter, and one direction exercises each. Ascending, the walk used to step the 8,500-entry
-/// prefix before its first emit; descending at a deep offset it used to run to the END of the
-/// permutation, because the only thing that stopped it was the page filling and a partial last page
-/// never fills.
+/// Both ends matter, and one direction exercises each. Ascending, the walk would step the 8,500-entry
+/// prefix before its first emit; descending at a deep offset it would run to the END of the permutation,
+/// because the only thing that stops it is the page filling and a partial last page never fills. The
+/// bound is one interval either way: `walk_bounds` swaps which side of it starts the segment, since the
+/// permutation's key negates under `desc`.
 ///
-/// Two assertions, and neither substitutes for the other:
+/// Three assertions, and none substitutes for another:
 ///
-/// - **Row identity against `GatheredScan`** at several page offsets. The span moves where the paging
-///   walk starts and stops, so an end one entry off drops a row silently — a wrong page, not a crash,
-///   and only a reference comparison catches it. `streamed_selection_matches_gathered` pages the same
-///   way but on an evenly-spread match set, where the span is the whole corpus and bounding it is a
-///   no-op; the anti-correlation here is what makes it load-bearing.
+/// - **Row identity against `GatheredScan`** at several page offsets. The segment decides where the
+///   paging walk starts and stops, so an end one entry off drops a row silently — a wrong page, not a
+///   crash, and only a reference comparison catches it.
 /// - **`perm_steps`**, which is how far the walk actually stepped. The row assertions pass just as well
 ///   on a walk that steps everything: unbounded, the ascending cells cost `offset + limit + PREFIX`
 ///   steps and the deep descending ones the full 10,000.
+/// - **The unbounded control.** The same query ordered by a column the filter says nothing about
+///   (`edhrec`) must return identical rows while stepping the whole permutation — that is the fallback
+///   every query without a bound on its sort column takes, and it has to stay correct.
 #[test]
-fn streamed_walk_seeks_past_the_unmatched_prefix() {
+fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
     // > STREAM_MIN_MATCHES (1,024) in every mode, so the walk branch runs rather than the
     // small-total gather -- the span bound only exists on the walk.
     const MATCHING: usize = 1_500;
-    // Cards sorting ahead of every match under `cmc asc`. Sized so matching cards are 15% of the
-    // corpus, comfortably under `SPAN_TRACK_CANDIDATE_DIVISOR`'s quarter -- at exactly a quarter this
-    // test would pass or fail on whether the narrowing returned 1,500 candidates or 6,000.
-    // `streamed_selection_matches_gathered` covers the other side of that gate: 1,125 matches among
-    // 1,500 cards is three quarters of the corpus, so its walk is the unbounded one.
+    // Cards sorting ahead of every match under `cmc asc`, so the prefix the bound skips is 85% of the
+    // corpus and a walk that ignored the bound would be caught by an order of magnitude.
     const PREFIX: usize = 8_500;
     const N: usize = PREFIX + MATCHING;
     const MATCH_CMC: u8 = 5;
@@ -6448,13 +6499,25 @@ fn streamed_walk_seeks_past_the_unmatched_prefix() {
         page.iter().map(|(c, p)| (u128::from(c.oracle_id), u128::from(p.scryfall_id))).collect()
     };
 
+    // Extracted from the UNSPLIT filter, exactly as `bind_and_split_filter` does: `cmc>=MATCH_CMC`
+    // plane-consumes to `FilterExpr::True`, so a bound read after the split would find nothing.
+    let cmc_bound = sort_col_bound(&filt(), SortCol::Cmc);
+    assert_eq!(
+        cmc_bound,
+        SortBound { lo: Some(f64::from(MATCH_CMC)), hi: None },
+        "a bare `cmc >= k` must bound the cmc column below and leave it unbounded above",
+    );
+    // The control: the same filter says nothing about `edhrec`, so ordering by it must fall back to
+    // walking everything.
+    assert_eq!(sort_col_bound(&filt(), SortCol::EdhrecRank), SortBound::UNBOUNDED, "cmc says nothing about edhrec");
+
     let mut checked = 0usize;
     for &(mode_label, mode) in &[("card", Mode::Card), ("printing", Mode::Printing), ("artwork", Mode::Artwork)] {
         for descending in [false, true] {
             // Offsets across the page-depth range this plan sees, including one deep enough that the
             // walk runs off the end of the matches (1,499 in card mode leaves a single row).
             for offset in [0usize, 7, 750, 1_499] {
-                let params = kernel_params(mode, SortCol::Cmc, descending, LIMIT, offset);
+                let params = kernel_params(mode, SortCol::Cmc, descending, LIMIT, offset).with_sort_bound(cmc_bound);
                 let (pe, filter) = split_planes(
                     filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
                 );
@@ -6488,6 +6551,32 @@ fn streamed_walk_seeks_past_the_unmatched_prefix() {
         }
     }
     assert_eq!(checked, 24, "every mode × direction × offset cell must have run");
+
+    // The unbounded control: same filter, ordered by a column it constrains not at all. Rows must still
+    // agree with the reference, and the walk must step far more than the bounded cells did -- otherwise
+    // this test would pass with `walk_bounds` returning an empty slice for everything.
+    for offset in [0usize, 750] {
+        let params = kernel_params(Mode::Card, SortCol::EdhrecRank, false, LIMIT, offset);
+        let (pe, filter) =
+            split_planes(filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
+        let mut streamed_filter = filter.clone();
+        take_phase_stats();
+        let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+            .expect("store_of builds the edhrec permutation too");
+        let stats = take_phase_stats();
+        let mut gathered_filter = filter.clone();
+        let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+            .expect("GatheredScan is always applicable");
+        assert_eq!(streamed.0, gathered.0, "unbounded total disagrees with GatheredScan: offset={offset}");
+        assert_eq!(ids(&streamed.1), ids(&gathered.1), "unbounded page disagrees with GatheredScan: offset={offset}");
+        // Matches are 15% of the corpus and scattered through edhrec order, so filling a 10-row page
+        // takes ~`limit / 0.15` steps at minimum -- far above the bounded cells' `offset + LIMIT + 1`.
+        assert!(
+            stats.perm_steps > (offset + LIMIT + 1) as u64,
+            "an unbounded walk must step more than a bounded one ({} steps at offset={offset})",
+            stats.perm_steps,
+        );
+    }
 }
 
 // Group counts collapse duplicate illustrations within a card.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -286,11 +286,34 @@ alone is 525 µs of P3's 704 µs prediction against a 91 µs measured loop.
 | f:modern / artwork | GatheredScan | 101,716 | 73,783 | 1.38 |
 | f:modern / artwork | StreamedSelect | 101,716 | **7,770** | **13.09** |
 
-Both plans receive the same per-query `scan_units`, but P3 examines 9× fewer printings: `card_match_count`
-returns at the first qualifying printing under `Prefer::Default`, while `push_card_matches` must walk the
-whole span to push every match. This module's header already says `prefer` "is the one thing this cannot
-see", and that `acquire_plan_features` therefore sets `scan_units` itself on the **plane** branch instead
-of taking the span estimate. The **compose** branch was never given the same treatment.
+Both plans receive the same per-query `scan_units`, but P3 examines 9× fewer printings. The reason is NOT
+the first-match break that the plane branch corrects for — sweeping ten composable filters shows the
+defect is confined to **legality**:
+
+| composed filter | P3 examined / P4 examined |
+| --- | --: |
+| `f:modern`, `f:commander`, `f:vintage`, `legal:pauper`, `f:standard`, `t:goblin or f:legacy` | **0.10 – 0.26** |
+| `border:black` | 1.00 |
+| `r:mythic` | 1.00 |
+| `watermark:riveteers` | 1.00 |
+
+For every other printing-varying leaf the two plans examine *identically* and `scan_units` is right to
+within 1.1–2.4×. Legality differs because `card_pass` resolves it at CARD level for every non-divergent
+card: `Tri::True` or `Tri::False` comes back without a printing being read, so `card_match_count` answers
+from span arithmetic and P3's per-printing cost exists only for the divergent subset. P4 has no such
+escape — `push_card_matches` must walk the span to push every match.
+
+The implied estimate is exact rather than fitted, because the engine already holds the set:
+`indexes.legal_divergent` is the divergent card list, so P3's scan on a legality-composed filter is
+`eval_domain × (divergent / n_cards) × printings_per_card`. Back-solving the measurements gives a divergent
+share of 16–22% (`f:modern` 7,770 examined ⇒ 2,514 of 15,700 candidates; `f:commander` 21.7%;
+`legal:pauper` 19.9%; `f:standard` 22.4%), which is one corpus constant and not a per-query guess.
+
+So this is NOT the plane branch's correction extended — that one is `prefer`-aware, this one has to be
+divergence-aware, and they share only the conclusion that one per-query `scan_units` cannot serve two
+plans whose kernels short-circuit differently. Implementing it needs a per-plan field on `PlanFeatures`
+(the pattern `compose_scan_printings` already establishes), set on the compose branch and read by P3's arm
+alone, plus the matching mirror column in `fit_cost_model.py`.
 
 So the fix is a feature correction on the compose acquire, not a rate — the category the toolkit says is
 the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 below: the 6× over-cost exists

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -297,6 +297,30 @@ the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 belo
 in printing mode too (6.23, 5.25), where compose happens to be genuinely faster, so the wrong ratio does
 not flip the pick. Artwork is only where the margin is thin enough to expose it.
 
+### But that correction alone does not flip the pick
+
+The term is linear, so the corrected prediction is exact arithmetic rather than a guess:
+
+| query / mode | P3 predicted | with the fix | P3 measured | compose predicted | winner after | truth |
+| --- | --: | --: | --: | --: | --- | --- |
+| f:gladiator / artwork | 704.0 | **213.6** | 102.5 | 178.7 | compose | **P3** (102 µs) |
+| f:modern / artwork | 813.7 | **252.8** | 142.8 | 188.8 | compose | **P3** (143 µs) |
+
+It removes 490–561 µs — the largest single error — and takes P3 from 6.9× over to **2.08×** and 5.7× to
+**1.77×**. But compose is predicted at 179/189, so P3 at 214/253 still loses and the 33 µs stays lost.
+
+What remains is P3's per-card term: `eval_domain × (2.58 + 2.47 + max(tier, 6.58))` = 13,587 × 11.63 =
+158 µs against a measured loop of 90.9 µs over those same cards — 6.7 ns/card actual, 11.63 charged. The
+dominant piece is `STREAM_RESIDUAL_FLOOR_NS`, and at ~2 ns/card the arm lands near 151 µs and P3 wins. So
+the floor is the load-bearing half, and it is the term with the worst history here: P4's analogue (18.89)
+"was load-bearing despite being unmeasured" and moving it made routing worse. Unmeasured is the point —
+it has never had the built-design treatment that corrected the loop intercept above.
+
+Two reasons to ship the feature correction first regardless. It is a realized-counter defect of 13–15×,
+which no rate can absorb; and it is **pick-preserving where picks are already right** — the printing-mode
+rows still choose compose after the fix, and compose is correct there (94 vs 111 µs, 38 vs 152 µs). So it
+buys accuracy without moving sound decisions, which is the cheapest kind of change to gate.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -125,8 +125,8 @@ Three things fall out of that table.
   (1) before (2).
 - **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.19 after. Deleting a fifth of
   the tail without moving the per-step rate is what a real per-unit cost looks like, as against a
-  coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS` turned out to be.
-  Left at the shipped 1.0; no refit.
+  coefficient absorbing its feature's error, which is what `GATHER_FIXED_COST_NS` does. Left at the
+  shipped 1.0; no refit.
 - **The third row bounds what any start position can do.** A realized minimum reached 4.26 because it sees
   clustering the predicate never mentions (`o:flying` correlates with cmc; a name prefix correlates with
   name order). That gap is now a measured property of the two mechanisms, not a guess — and it is the
@@ -138,19 +138,51 @@ segment, which no start position can skip by construction.
 ## What was declined, and why that is the more useful result
 
 **`GATHER_FIXED_COST_NS` (169.6, traffic says 85).** Looked like the cheapest win available: a 2×
-disagreement with no shape question. Measuring the intercept from cells differing *only* in card count
-gives **card −1,084 ns, printing −845 ns**. A negative fixed cost is impossible, so the linear-in-cards
-shape is wrong — the loop is **convex** in card count (12.40 ns/card across 400–4,500 against 6.31–7.67
-over 1,500–4,500). A straight line through a convex curve drives its intercept negative, and a
-whole-arm fit puts that same curvature in its intercept.
+disagreement with no shape question. It is still declined, but the first reason given for declining it was
+wrong and is retracted below.
 
-So 85 is curvature compensation, not a fixed cost. Two consequences:
+The design now runs four card counts — 100 / 400 / 1,500 / 4,500 — and the average per-card cost is
+**U-shaped**, not monotone:
 
-- **Every plan's `FIXED` is its arm's error sink.** `fit_cost_model.py` fits one equation per query
-  against total dispatch, so no plan's fixed cost should be read off it without an independent intercept
-  measurement. `STREAM_FIXED_COST_NS` (217, fitted 192) is unexamined on this basis.
-- The convexity **is** the corpus-size effect below. P4's `FIXED` disagreement and corpus drift are one
-  problem.
+| single-printing card cell, ns/card | 100 | 400 | 1,500 | 4,500 |
+| --- | --: | --: | --: | --: |
+| A | 11.25 | 9.16 | 9.11 | 10.65 |
+| A′ (same shape, different chunk stagger) | 10.42 | 10.00 | 8.69 | 11.65 |
+
+Two effects, at opposite ends. A per-query **fixed cost** is only visible at the small end (at 4,500 cards
+a 170 ns constant is 0.04 ns/card, far under the cell-to-cell spread), and **cache pressure** raises the
+marginal rate at the large end. Solving each end separately, over four single-printing cells and
+reproducible to ±0.01 across runs:
+
+| | marginal ns/card, 100→400 | marginal ns/card, 1,500→4,500 | curvature | fixed cost |
+| --- | --: | --: | --: | --: |
+| card | 7.92 | 10.93 | **1.38×** | 250 |
+| printing | 8.19 | 11.22 | **1.37×** | 98 |
+| artwork | 11.11 | 10.50 | 0.94× | 222 |
+| card (stagger control) | 9.30 | 12.88 | **1.38×** | 29 |
+
+So the fixed cost measures **29–250 ns**, which brackets both the shipped 169.6 and the fitted 85 — and
+that spread, wider than the disagreement being adjudicated, is why the refit stays declined. The
+curvature is the finding: 1.37–1.38× on card and printing, reproducible, and the arm has no term for it.
+Artwork shows none, which is consistent with it being a different loop.
+
+**Retracted: "the measured intercept is negative, so the fixed cost is impossible and 85 is curvature
+compensation."** The negative intercept (−864, −1,078, −1,616 in the table the bench still prints) is an
+artifact of fitting ONE line across a range where a fixed cost dominates one end and cache pressure the
+other; least squares weights the 4,500-card cell by `n²`, so the line tilts to the large end and its
+intercept dives below zero. Adding a 100-card cell and solving the ends apart removes it. The earlier
+run's "card −1,084 / printing −845" also crossed cell boundaries — it paired cell `A` at 400 cards with
+`A′` at 4,500 — so up to half its magnitude was chunk-stagger noise.
+
+What survives, on its own evidence rather than on that one:
+
+- **Every plan's `FIXED` is still its arm's error sink.** `fit_cost_model.py` fits one equation per query
+  against total dispatch, and `FIXED` is the only term with no feature attached. It read 84 and then 85
+  while `COLLECT_PER_PAGE_ROW` moved 15.0 → 9.79 underneath it: a term that does not budge when a
+  neighbour changes by 35% is absorbing error, not measuring a cost. `STREAM_FIXED_COST_NS` (217, fitted
+  192) is unexamined on this basis.
+- **The curvature is real and unmodelled**, at 1.38× within one store — and the corpus-size effect below
+  is the same phenomenon at a larger scale. Those two are one problem; the fixed cost is not part of it.
 
 ## Retractions
 

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -215,6 +215,37 @@ Recorded because both were believed and acted on:
   `all_match` per-card is flat (2.58 / 2.54 / 2.55) while its residual per-card grows 3.6× and P4's loop
   grows 2.4×. So the P3/P4 balance drifts as the corpus grows with every constant left alone.
 
+### The drift SATURATES, which three corpus sizes could not show
+
+Five log₂-spaced stores (31.5k / 63k / 126k / 252k / 504k cards, built by `upscale_corpus.py` at
+1/2/4/8/16 copies) against the previous 1×/4×/13×. The per-card loop rate, measured directly per cell —
+no differencing across modes, which is where `PUSH` goes unidentified:
+
+| store, oracle cards | 31.5k | 63k | 126k | 252k | 504k |
+| --- | --: | --: | --: | --: | --: |
+| A card, ns/card | 10.15 | 13.23 | 20.66 | 24.54 | **24.72** |
+| B printing | 10.64 | 14.47 | 22.94 | 25.75 | **25.95** |
+| E artwork | 10.96 | 15.99 | 29.90 | 33.01 | **33.19** |
+| A′ card (stagger control) | 11.70 | 11.90 | 19.06 | 24.96 | **25.40** |
+
+It is not a drift that keeps going: the rate roughly doubles to 126k, adds ~19% to 252k, and then stops
+— all four cells move under 2% between 252k and 504k. That is a cache-residency curve reaching its
+asymptote, and it changes both the shape to fit and the urgency:
+
+- **The term is bounded, not logarithmic.** Two levels — a resident rate ~10–11 ns/card and a
+  non-resident rate ~25 ns/card — with a knee between 126k and 252k cards on this machine. A `log(n)`
+  term fitted to three points would have extrapolated past the plateau and over-costed a large corpus.
+- **Production sits at the bottom of the curve** (31.5k cards, ~10 ns/card). So the constants are
+  calibrated in the resident regime and the drift is insurance against a ~4× corpus, not a routing defect
+  today. That demotes this from "the biggest single item" to "the best-understood one".
+- **The two axes are one mechanism.** The within-store curvature (100 → 4,500 cards visited) shrinks as
+  the store grows — 1.33–1.36× at 31.5k, 1.07–1.15× at 504k — which is what a single residency curve
+  predicts: once every access misses, visiting more cards cannot make it worse. So a curvature term keyed
+  on working-set residency should subsume both, rather than needing one term per axis.
+- **The "fixed cost" is still not identified.** It reads 14–305 ns at 31.5k and 305–499 ns at 504k. A
+  per-query constant cannot depend on corpus size, so something size-dependent is still leaking into that
+  end of the fit, and the `169.6`-vs-`85` question stays open.
+
 ## Tooling added
 
 - `card_engine/src/bench_gather_loop.rs`, `bench_streamed_loop.rs` — call the real executors and read

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -344,6 +344,42 @@ which no rate can absorb; and it is **pick-preserving where picks are already ri
 rows still choose compose after the fix, and compose is correct there (94 vs 111 µs, 38 vs 152 µs). So it
 buys accuracy without moving sound decisions, which is the cheapest kind of change to gate.
 
+## The bigger lever underneath it: divergence is per-CARD but the data is per-FORMAT
+
+Chasing the estimate above turned up something that makes it partly moot. A full pass over the corpus,
+comparing each card's printings format by format:
+
+    97,206 printings, 31,508 oracle cards
+    cards with ANY divergent format: 556 (1.76%)
+    divergent cards per format:
+      oldschool       556
+
+**Every divergent card in the corpus diverges in `oldschool` and nothing else.** No other format has a
+single card whose printings disagree.
+
+The engine cannot use that, because it detects divergence as a whole-bitmask comparison and stores one
+boolean per card (`reload`: `row.card_legalities != cards.last()...card_legalities` sets
+`legality_divergent`). So `plane_expr_is_existential` is true for every legality leaf, the #667 carveout
+applies to every format, and `card_match_count` / `push_card_matches` / the popcount plans' `satisfies`
+closure all re-verify per printing — on `f:modern`, 7,770 printing examinations that are provably
+redundant, because modern legality is card-invariant in this data.
+
+The upgrade is one line at the detection site and is **self-maintaining**: OR the XOR of the two bitmasks
+into a corpus-level `divergent_formats: u64` instead of setting a boolean. Then a legality leaf whose
+format bit is outside that mask is card-invariant, `all_match` holds, and the per-printing work does not
+happen. Nothing hardcodes "oldschool" — if Scryfall ever makes another format divergent, the mask picks it
+up from the data and the conservative path returns on its own.
+
+Note what that does to the `scan_units` defect above: with legality non-existential, `split_planes`
+consumes the leaf and the residual becomes `True`, so `tier_ns` is 0 and P3's arm charges **no scan term
+at all** (`if tier_ns > 0.0`). The 525 µs over-cost stops existing for the queries where it mattered,
+rather than being estimated more accurately. Same for the mispick: P3 measured 102 µs against compose's
+182, and it is the over-cost that hides that.
+
+So the ordering is: this, then re-measure, and only then decide whether a per-plan `scan_units` field is
+still needed for the non-legality compose cases (`border:black`, `r:mythic`, `watermark:*`), where the
+current estimate is already right to 1.1-2.4x.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1,0 +1,125 @@
+# Measuring P3 and P4's loop and finish phases with built designs
+
+Branch `engine-compose-feature-accuracy`. Companion to
+[reference-cost-model-measurement.md](./reference-cost-model-measurement.md), which covers which tool
+answers which question; this covers what the tools said about `StreamedSelect` (P3) and
+`GatheredScan` (P4), and what is left.
+
+The earlier campaign in [local-engine-cost-model-agreement.md](./local-engine-cost-model-agreement.md)
+fitted rates from sampled traffic. This one built designed experiments instead, because several rates
+are **unidentifiable from traffic at any corpus size** — and that turned out to be the least
+interesting thing it found.
+
+## The one rule that came out of it
+
+**Shape from a built design; levels from traffic.** Not a preference — six refits of kernel-measured
+levels each made routing worse, and the two changes that shipped were both cases where a design found
+a *missing term* and traffic then set its rate.
+
+Built designs win on shape because the experimenter controls the ratios. Traffic wins on levels
+because it has production's cache state, query mix and interleaving, and every attempt to substitute
+a measured level for a fitted one has failed.
+
+## What shipped
+
+Two terms, both found by a design, both levelled by traffic, both mirror-verified at 100% and gated
+interleaved A/B/A/B.
+
+**`STREAM_PERM_STEP_NS`** — P3's permutation walk was not charged at all. The walk steps until the page
+fills, so it visits ~`page_span × n_cards / matches` entries: inversely proportional to selectivity, and
+proportional to nothing else in `PlanFeatures`. Against a fixed 1,500 matches the arm predicted ~397 ns
+while the walk cost 1,333 / 3,791 / 10,458 ns at 31.5k / 126k / 410k cards — under by 3.4× at the
+production corpus and 26× at 410k. Explains P3's finish phase grading mean |log| 2.06 while carrying 12%
+of all measured nanoseconds. Rate 1.0 from the kernel, 1.15 from traffic. **Regret neutral.**
+
+**`GATHER_COLLECT_PER_PAGE_ROW_NS`** — P4's finish phase was charged on `page_span` alone, which a
+four-row page sweep falsifies outright:
+
+| offset | limit | page_span | ns_finish |
+| --: | --: | --: | --: |
+| 0 | 15 | 15 | 125 |
+| 0 | 60 | 60 | 584 |
+| 0 | 600 | 600 | 16,375 |
+| 900 | 60 | 960 | 11,250 |
+
+`page_span` 960 costing less than 600 is impossible under one column: the quickselect scales with
+`offset + limit`, the collect with the page returned. Level 9.79 from traffic (the sweep said ~15).
+**Neutral to marginally negative** — taken for correctness, since a one-column model four rows disprove
+should not survive on a neutral gate.
+
+## What was declined, and why that is the more useful result
+
+**`GATHER_FIXED_COST_NS` (169.6, traffic says 85).** Looked like the cheapest win available: a 2×
+disagreement with no shape question. Measuring the intercept from cells differing *only* in card count
+gives **card −1,084 ns, printing −845 ns**. A negative fixed cost is impossible, so the linear-in-cards
+shape is wrong — the loop is **convex** in card count (12.40 ns/card across 400–4,500 against 6.31–7.67
+over 1,500–4,500). A straight line through a convex curve drives its intercept negative, and a
+whole-arm fit puts that same curvature in its intercept.
+
+So 85 is curvature compensation, not a fixed cost. Two consequences:
+
+- **Every plan's `FIXED` is its arm's error sink.** `fit_cost_model.py` fits one equation per query
+  against total dispatch, so no plan's fixed cost should be read off it without an independent intercept
+  measurement. `STREAM_FIXED_COST_NS` (217, fitted 192) is unexamined on this basis.
+- The convexity **is** the corpus-size effect below. P4's `FIXED` disagreement and corpus drift are one
+  problem.
+
+## Retractions
+
+Recorded because both were believed and acted on:
+
+- **"The shipped constants are ~2× too high."** They are not. `ITERS` walked one card list repeatedly
+  and kept the minimum, so every rate was warm-cache; the first pass costs 1.6–2.2× more. Cold and
+  rotated at production corpus size, P4 reads LOOP 6.27 against a shipped 6.88 and SCAN 2.27 against
+  2.06. Fixed by chunk **rotation** plus per-cell **stagger** — both needed, since rotation alone left
+  cells sharing a chunk, one paying all the misses (10.50 vs 6.11 ns/card on identical cards).
+- **"The error is in the features."** No. Every counter/feature ratio reads 1.00 for both plans. The
+  1.00s had already ruled it out.
+- **"`STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` is 24–40× too high."** No — those readings came from cells
+  in the *perm-walk* branch. 600-card cells reach the gather branch and measure 1.075–1.250 against the
+  shipped 1.02. Confirmed, not changed.
+
+## Structural findings that outlive the constants
+
+- **Degenerate columns.** No single `unique` mode identifies P4's three loop rates: card mode pushes once
+  per card (`matches == cards`), printing mode pushes every printing (`matches == printings`). Pooling
+  separates them but averages over the mode differences being measured. Resolved by fitting each mode in
+  the two-parameter space it supports and recovering the three from the pair of pairs — which yields
+  `PUSH` twice over (1.24 and 0.88, agreeing to 1.41×) as a linearity check.
+- **P3's loop is linear** in its two counters to 1.01×, cross-checked from different cells and columns.
+- **P3's gating is right**: zero printings examined under `all_match` at every printings-per-card level.
+- **Artwork is a different loop**, needing its own per-card and per-printing rates in P4 (6.57 / 1.09
+  against 2.98 / 2.36) while sharing the push. Its surcharge *flips sign* with printings-per-card, so no
+  additive correction can express it. Measured, shape-confirmed, **never gated on its own.**
+- **Rates are corpus-size dependent, and differently per plan** — over 31.5k → 410k cards, P3's
+  `all_match` per-card is flat (2.58 / 2.54 / 2.55) while its residual per-card grows 3.6× and P4's loop
+  grows 2.4×. So the P3/P4 balance drifts as the corpus grows with every constant left alone.
+
+## Tooling added
+
+- `card_engine/src/bench_gather_loop.rs`, `bench_streamed_loop.rs` — call the real executors and read
+  `PhaseStats`, so nothing is reimplemented. Chunk-rotated, per-cell staggered, median over rotations.
+  `BENCH_LOOP_STORE` selects the store.
+- `scripts/upscale_corpus.py` — replicates the real corpus, rewriting `oracle_id` / `scryfall_id` /
+  `illustration_id` and suffixing names, leaving everything cost-relevant alone. Needed because the real
+  corpus gives the wide group one chunk at 4,500 cards. **The 126k and 410k stores are ~1.4 GB in
+  `benchmarks/loop-scale/` — delete when done.**
+- `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
+
+## What is left
+
+1. **Seek the streamed walk to its first match.** The walk starts at permutation index 0 unconditionally,
+   so `year>=2020 order=released asc` grinds through the whole pre-2020 prefix discarding on
+   `counts[cid] == 0`. The match loop already visits every candidate, so one `inv[cid]` read plus a `min`
+   over matching cards gives the first match's position for free, and the walk can start there. Stronger
+   than deriving a bound from the predicate: it is the realized minimum, so it works for any predicate and
+   cannot be wrong about tie-breaking. Attacks the expensive tail directly — `perm_steps`
+   realized/estimated grades median 0.99 with **p10 0.12 / p90 7.01**, and p90 is exactly the late-cluster
+   case a seek deletes. Verify row identity against the reference, as this touches paging. Descending needs
+   nothing: there are two permutations per column, one per direction.
+2. **Re-grade the perm estimate after (1)**, then fit whatever spread remains. Doing it before would be
+   modelling wasted work we can cheaply stop doing.
+3. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
+4. **Gate P4's artwork arm on its own.**
+5. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
+   bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -47,6 +47,69 @@ four-row page sweep falsifies outright:
 **Neutral to marginally negative** — taken for correctness, since a one-column model four rows disprove
 should not survive on a neutral gate.
 
+**The emission walk's match span.** The walk started at permutation index 0 and stopped only when the
+page filled, so it stepped every entry ordered before the first match (`cmc>=6 order=cmc asc`: 28,275
+entries for a 60-row page, 10.6 us of a 20.25 us execution) and, on any page it could not fill, every
+entry after the last match. Bounded to `min..=max` of `inv_perm` over matching cards — realized, so it
+holds for any predicate and cannot be wrong about tie-breaking — the same query walks 60 entries in
+0.38 us. Row identity verified against `GatheredScan` on an anti-correlated corpus at four offsets in
+every mode and direction, because a bound one entry off drops a row rather than crashing.
+
+**Gated**, at candidates ≤ ¼ of the corpus, because the span costs 0.51 ns per matching card against a
+match loop that is ~2.6 ns/card: ungated it took `cmc>=1 order=edhrec`'s `ns_loop` from 78.54 to 94.46
+us while its walk stayed at 111 steps. The bound can save at most `(n_cards − m) × 0.37 ns` against
+`m × 0.51 ns`, so worst-case break-even is 0.42 × `n_cards` and the gate sits inside it.
+
+| exec, span on/off (geometric mean) | cells |
+| --- | --- |
+| clustered (predicate correlates with orderby) | **0.660** over 8 |
+| broad (gate off — identical path) | 1.000 over 4 |
+
+Pooled over 419 sampled `StreamedSelect` queries: no detectable difference, −0.10 us, CI [−0.62, +0.41].
+
+## Measuring this needed one binary, not two
+
+`scripts/bench_walk_span.py` A/Bs `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` in interleaved
+subprocesses of a single build, with equal-length env values. That is not fastidiousness — a
+cross-build attempt got the sign wrong:
+
+- `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on a phase neither build changed, ±9%
+  in both directions. A 0.5 ns/card effect is invisible under that.
+- `bench_plan_execution_ab.py` across builds called the change 2% **slower** — while its own acquire
+  control, which the change cannot touch, moved 1.9% the same way. Within one binary the control is
+  flat (+0.01 us, median ratio 1.000) and the verdict is no detectable difference.
+
+Both are the failure the toolkit already documents (`min` is a floor estimator; its error is
+common-mode within a run, so pairing does not cancel it). The toggle removes it by construction:
+identical code, identical layout, one process each.
+
+## Regrading the perm estimate
+
+`perm_steps` realized/estimated, same seed and sample length, ~12.3k walking rows:
+
+| walk | p10 | median | p90 |
+| --- | --: | --: | --: |
+| unbounded | 0.13 | 1.00 | 6.43 |
+| bounded, gated | 0.09 | 0.94 | 5.07 |
+| bounded, ungated | 0.08 | 0.90 | 4.26 |
+
+Three things fall out of that table.
+
+- **A third of the p90 tail was the leading prefix**, and it is gone. p90 is the late-cluster case, so
+  this is the estimate's largest error being deleted rather than modelled — which was the point of
+  doing (1) before (2).
+- **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.15–1.17 after. Deleting a
+  third of the steps at the tail without moving the per-step rate is what a real per-unit cost looks
+  like, as against a coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS`
+  turned out to be. Left at the shipped 1.0; no refit.
+- **The cost model prefers ungated and the runtime prefers gated.** Recorded, not resolved: the
+  mechanism that ends the tension is a predicate-derived start position (below), which costs nothing per
+  card and so needs no gate.
+
+What remains at p90 5.07 is **interior** to the span — non-matching entries between matches, which no
+start position can skip. Different mechanism, and one the engine already owns elsewhere: the
+popcount-skip walk.
+
 ## What was declined, and why that is the more useful result
 
 **`GATHER_FIXED_COST_NS` (169.6, traffic says 85).** Looked like the cheapest win available: a 2×
@@ -104,21 +167,30 @@ Recorded because both were believed and acted on:
   `illustration_id` and suffixing names, leaving everything cost-relevant alone. Needed because the real
   corpus gives the wide group one chunk at 4,500 cards. **The 126k and 410k stores are ~1.4 GB in
   `benchmarks/loop-scale/` — delete when done.**
+- `scripts/bench_walk_span.py` — A/Bs the walk's span bound through
+  `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` inside one binary, clustered cells against broad controls.
+  The pattern to copy for any change whose effect is smaller than the cross-build floor error: one build,
+  a runtime toggle, interleaved subprocesses, equal-length env values.
 - `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
 
 ## What is left
 
-1. **Seek the streamed walk to its first match.** The walk starts at permutation index 0 unconditionally,
-   so `year>=2020 order=released asc` grinds through the whole pre-2020 prefix discarding on
-   `counts[cid] == 0`. The match loop already visits every candidate, so one `inv[cid]` read plus a `min`
-   over matching cards gives the first match's position for free, and the walk can start there. Stronger
-   than deriving a bound from the predicate: it is the realized minimum, so it works for any predicate and
-   cannot be wrong about tie-breaking. Attacks the expensive tail directly — `perm_steps`
-   realized/estimated grades median 0.99 with **p10 0.12 / p90 7.01**, and p90 is exactly the late-cluster
-   case a seek deletes. Verify row identity against the reference, as this touches paging. Descending needs
-   nothing: there are two permutations per column, one per direction.
-2. **Re-grade the perm estimate after (1)**, then fit whatever spread remains. Doing it before would be
-   modelling wasted work we can cheaply stop doing.
+1. **A predicate-derived start position, which would cost nothing per card.** The permutation IS a sorted
+   array on `(sort key, edhrec, cid)`, so when the filter bounds the *sort column* — `cmc>=6` under
+   `order=cmc`, exactly the correlation that makes a cluster — a binary search for the first position whose
+   value satisfies the bound gives a start in O(log `n_cards`) once per query, against 0.51 ns × matching
+   cards for the realized span. Seek to the START of the boundary tie block and it can only start too
+   early, never too late, which answers the tie-breaking objection that made the realized span the first
+   choice. It composes with the span rather than replacing it (free ⇒ no gate ⇒ available to broad queries
+   too), and it is what would let the cost model have the ungated column of the regrade table above.
+   Conjunction analysis to extract the bound, plus row-identity verification, since it touches paging again.
+2. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 is
+   non-matching entries *interior* to the match span, and a start position cannot reach those by
+   construction. Scattering the match set through `inv_perm` and walking words at 64 cards a load is the
+   mechanism that can — `run_query_streamed_popcount` already does it for `unique=card` queries whose
+   filter fully consumed to `True`. Generalizing it needs per-card match counts for the skip (a popcount
+   counts cards, not matches, so printing/artwork mode cannot skip by popcount alone) and pays the same
+   per-card scatter the span bound pays, so it wants the same gate or the free start position above.
 3. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
 4. **Gate P4's artwork arm on its own.**
 5. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -261,6 +261,42 @@ asymptote, and it changes both the shape to fit and the urgency:
   a runtime toggle, interleaved subprocesses, equal-length env values.
 - `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
 
+## Where the routing loss actually is (2026-08-03, after the regret netting fix)
+
+With both sides of regret priced the same way, the largest single cell is `printing_compose / artwork` at
+**32% of all lost time** (n=1,435, mean 8.24 µs, max 904). Chased to the bottom, it is one feature defect:
+
+**Every bare format predicate mis-picks, in artwork mode only.** `f:predh` −55 µs, `f:gladiator` −75,
+`f:modern` −33, `f:standard` −31, `legal:pauper` −30, and so on for nine of twelve shapes probed. Card
+mode picks `PlanePopcountOrder` and is right; printing mode picks `PrintingCompose` and is right; artwork
+mode picks `PrintingCompose` when `StreamedSelect` is 1.8× faster. Compounds (`f:modern t:creature`) route
+to a candidates acquire and are fine.
+
+**Compose is not the problem — it is priced accurately.** On `f:gladiator` artwork, predicted/measured
+reads 0.98 for compose and **6.87 for StreamedSelect**; on `f:modern`, 1.10 and 5.70. The router is not
+over-confident about compose, it is over-charging P3 by ~6×, and `scan_units × STREAM_SCAN_PER_ROW_NS`
+alone is 525 µs of P3's 704 µs prediction against a 91 µs measured loop.
+
+**The feature overstates P3's work by 13–15×.** Graded against realized `printings_examined`:
+
+| query / mode | plan | `scan_units` | examined | ratio |
+| --- | --- | --: | --: | --: |
+| f:gladiator / artwork | GatheredScan | 88,026 | 54,213 | 1.62 |
+| f:gladiator / artwork | StreamedSelect | 88,026 | **5,876** | **14.98** |
+| f:modern / artwork | GatheredScan | 101,716 | 73,783 | 1.38 |
+| f:modern / artwork | StreamedSelect | 101,716 | **7,770** | **13.09** |
+
+Both plans receive the same per-query `scan_units`, but P3 examines 9× fewer printings: `card_match_count`
+returns at the first qualifying printing under `Prefer::Default`, while `push_card_matches` must walk the
+whole span to push every match. This module's header already says `prefer` "is the one thing this cannot
+see", and that `acquire_plan_features` therefore sets `scan_units` itself on the **plane** branch instead
+of taking the span estimate. The **compose** branch was never given the same treatment.
+
+So the fix is a feature correction on the compose acquire, not a rate — the category the toolkit says is
+the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 below: the 6× over-cost exists
+in printing mode too (6.23, 5.25), where compose happens to be genuinely faster, so the wrong ratio does
+not flip the pick. Artwork is only where the margin is thin enough to expose it.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -22,8 +22,8 @@ a measured level for a fitted one has failed.
 
 ## What shipped
 
-Two terms, both found by a design, both levelled by traffic, both mirror-verified at 100% and gated
-interleaved A/B/A/B.
+Two cost terms — both found by a design, both levelled by traffic — and one executor change, all
+mirror-verified at 100% and gated interleaved A/B/A/B.
 
 **`STREAM_PERM_STEP_NS`** — P3's permutation walk was not charged at all. The walk steps until the page
 fills, so it visits ~`page_span × n_cards / matches` entries: inversely proportional to selectivity, and
@@ -47,68 +47,93 @@ four-row page sweep falsifies outright:
 **Neutral to marginally negative** — taken for correctness, since a one-column model four rows disprove
 should not survive on a neutral gate.
 
-**The emission walk's match span.** The walk started at permutation index 0 and stopped only when the
-page filled, so it stepped every entry ordered before the first match (`cmc>=6 order=cmc asc`: 28,275
-entries for a 60-row page, 10.6 us of a 20.25 us execution) and, on any page it could not fill, every
-entry after the last match. Bounded to `min..=max` of `inv_perm` over matching cards — realized, so it
-holds for any predicate and cannot be wrong about tie-breaking — the same query walks 60 entries in
-0.38 us. Row identity verified against `GatheredScan` on an anti-correlated corpus at four offsets in
-every mode and direction, because a bound one entry off drops a row rather than crashing.
+**The emission walk starts and ends at the filter's bound on the sort column.** The walk began at
+permutation index 0 and stopped only when the page filled, so `cmc>=6 order=cmc asc` stepped 28,275
+entries to fill a 60-row page — 10.6 us of a 20.25 us execution — and any page it could not fill also ran
+past the last match to the end of the corpus. The permutation is a sorted array on `perm_primary_key`, so
+an interval on the sort column's *value* is a contiguous range of *positions*: two binary searches, O(log
+n_cards) probes once per query, nothing per card. The same query in printing mode goes 18.29 → 8.71 us,
+stepping 4 entries.
 
-**Gated**, at candidates ≤ ¼ of the corpus, because the span costs 0.51 ns per matching card against a
-match loop that is ~2.6 ns/card: ungated it took `cmc>=1 order=edhrec`'s `ns_loop` from 78.54 to 94.46
-us while its walk stayed at 111 steps. The bound can save at most `(n_cards − m) × 0.37 ns` against
-`m × 0.51 ns`, so worst-case break-even is 0.42 × `n_cards` and the gate sits inside it.
-
-| exec, span on/off (geometric mean) | cells |
+| exec, bound on/off (geometric mean) | cells |
 | --- | --- |
-| clustered (predicate correlates with orderby) | **0.660** over 8 |
-| broad (gate off — identical path) | 1.000 over 4 |
+| clustered, `StreamedSelect` routed | **0.603** over 16 |
+| broad control, routed | 1.006 over 6 |
 
-Pooled over 419 sampled `StreamedSelect` queries: no detectable difference, −0.10 us, CI [−0.62, +0.41].
+Conservative in three directions, since a wide bound costs steps and a narrow one returns the wrong page:
+`And` only (an `Or` arm can match outside its sibling's bound, and `Not` inverts into a union of two
+intervals), strict comparisons widened to inclusive, and only the three columns that have numeric
+predicates at all. Extracted in `bind_and_split_filter` because `split_planes` compiles `cmc>=6` into mask
+algebra and leaves `FilterExpr::True` behind, then carried on `QueryParams` with `UNBOUNDED` as the
+default — a path that does not extract a bound walks everything, which is slower and never wrong.
+
+### The realized span it replaced, and why the replacement is not free of interest
+
+The first version tracked `min`/`max` of `inv_perm` over matching cards: realized, so it caught clustering
+from *any* source rather than only what the predicate names. It measured 0.51 ns per matching card against
+a match loop whose `all_match` arm is ~2.6 ns/card — a 20% tax on `ns_loop`, which forced a gate at ¼ of
+the corpus, which still let unlucky cells (`c:r`, and any cluster sitting at the *near* end of the walked
+order) pay a premium for nothing. The bound dominates it on every axis:
+
+| | tracked span + gate | sort-column bound |
+| --- | --: | --: |
+| clustered, routed | 0.689 | **0.603** |
+| broad control, routed | 1.034 | **1.006** |
+| worst near-end cell | 1.244 | **1.018** |
+
+What the realized span still has is reach: see the regrade below.
+
+### Card mode's win is latent, and only the mode sweep says so
+
+In `unique=card` a plane-consumable predicate leaves `FilterExpr::True`, which makes `PlanePopcountOrder`
+applicable — and the router picks it for exactly these clustered queries (`cmc>=6 order=cmc`: 2.46 us
+against P3's 12.38). So the card-mode cells improve a plan nobody runs. Printing and artwork mode have no
+popcount plan, because a popcount counts cards and not printings, so P3 is picked there and the
+improvement is what a user waits for. `bench_walk_span.py` prints the routed plan per cell for this
+reason; the first version of that harness measured card mode only and would have overclaimed.
 
 ## Measuring this needed one binary, not two
 
-`scripts/bench_walk_span.py` A/Bs `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` in interleaved
-subprocesses of a single build, with equal-length env values. That is not fastidiousness — a
-cross-build attempt got the sign wrong:
+`scripts/bench_walk_span.py` A/Bs `CARD_ENGINE_WALK_SORT_BOUND` in interleaved subprocesses of a single
+build, with equal-length env values. That is not fastidiousness — a cross-build attempt got the sign
+wrong:
 
-- `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on a phase neither build changed, ±9%
-  in both directions. A 0.5 ns/card effect is invisible under that.
+- `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on a phase neither build changed, ±9% in
+  both directions. A 0.5 ns/card effect is invisible under that.
 - `bench_plan_execution_ab.py` across builds called the change 2% **slower** — while its own acquire
-  control, which the change cannot touch, moved 1.9% the same way. Within one binary the control is
-  flat (+0.01 us, median ratio 1.000) and the verdict is no detectable difference.
+  control, which the change cannot touch, moved 1.9% the same way. Within one binary the control is flat
+  (median ratio 1.000) and the verdict is no detectable difference on 419 paired queries.
 
-Both are the failure the toolkit already documents (`min` is a floor estimator; its error is
-common-mode within a run, so pairing does not cancel it). The toggle removes it by construction:
-identical code, identical layout, one process each.
+Both are the failure the toolkit already documents (`min` is a floor estimator; its error is common-mode
+within a run, so pairing does not cancel it). The toggle removes it by construction: identical code,
+identical layout, one process each.
 
 ## Regrading the perm estimate
 
-`perm_steps` realized/estimated, same seed and sample length, ~12.3k walking rows:
+`perm_steps` realized/estimated, same seed and sample length, ~12.5k walking rows:
 
 | walk | p10 | median | p90 |
 | --- | --: | --: | --: |
 | unbounded | 0.13 | 1.00 | 6.43 |
-| bounded, gated | 0.09 | 0.94 | 5.07 |
-| bounded, ungated | 0.08 | 0.90 | 4.26 |
+| sort-column bound (shipped) | 0.11 | 0.96 | 5.31 |
+| realized `inv_perm` span (not shipped) | 0.08 | 0.90 | 4.26 |
 
 Three things fall out of that table.
 
-- **A third of the p90 tail was the leading prefix**, and it is gone. p90 is the late-cluster case, so
-  this is the estimate's largest error being deleted rather than modelled — which was the point of
-  doing (1) before (2).
-- **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.15–1.17 after. Deleting a
-  third of the steps at the tail without moving the per-step rate is what a real per-unit cost looks
-  like, as against a coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS`
-  turned out to be. Left at the shipped 1.0; no refit.
-- **The cost model prefers ungated and the runtime prefers gated.** Recorded, not resolved: the
-  mechanism that ends the tension is a predicate-derived start position (below), which costs nothing per
-  card and so needs no gate.
+- **A fifth of the p90 tail was the prefix a bound can name**, and it is gone. p90 is the late-cluster
+  case, so this is the estimate's largest error being deleted rather than modelled — the point of doing
+  (1) before (2).
+- **The rate did not move.** Traffic fits `PERM_STEP` at 1.17 before and 1.19 after. Deleting a fifth of
+  the tail without moving the per-step rate is what a real per-unit cost looks like, as against a
+  coefficient absorbing its feature's error — the failure mode `GATHER_FIXED_COST_NS` turned out to be.
+  Left at the shipped 1.0; no refit.
+- **The third row bounds what any start position can do.** A realized minimum reached 4.26 because it sees
+  clustering the predicate never mentions (`o:flying` correlates with cmc; a name prefix correlates with
+  name order). That gap is now a measured property of the two mechanisms, not a guess — and it is the
+  argument for the popcount-skip walk, which needs no bound at all.
 
-What remains at p90 5.07 is **interior** to the span — non-matching entries between matches, which no
-start position can skip. Different mechanism, and one the engine already owns elsewhere: the
-popcount-skip walk.
+What remains at p90 5.31 is partly that, and partly non-matching entries **interior** to the walked
+segment, which no start position can skip by construction.
 
 ## What was declined, and why that is the more useful result
 
@@ -167,31 +192,24 @@ Recorded because both were believed and acted on:
   `illustration_id` and suffixing names, leaving everything cost-relevant alone. Needed because the real
   corpus gives the wide group one chunk at 4,500 cards. **The 126k and 410k stores are ~1.4 GB in
   `benchmarks/loop-scale/` — delete when done.**
-- `scripts/bench_walk_span.py` — A/Bs the walk's span bound through
-  `CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR` inside one binary, clustered cells against broad controls.
+- `scripts/bench_walk_span.py` — A/Bs the walk's sort-column bound through `CARD_ENGINE_WALK_SORT_BOUND`
+  inside one binary, clustered cells against broad controls, sweeping `unique` so a latent win reads as one.
   The pattern to copy for any change whose effect is smaller than the cross-build floor error: one build,
   a runtime toggle, interleaved subprocesses, equal-length env values.
 - `perm_steps` published on `PhaseStats` and graded in `fit_cost_model.py`.
 
 ## What is left
 
-1. **A predicate-derived start position, which would cost nothing per card.** The permutation IS a sorted
-   array on `(sort key, edhrec, cid)`, so when the filter bounds the *sort column* — `cmc>=6` under
-   `order=cmc`, exactly the correlation that makes a cluster — a binary search for the first position whose
-   value satisfies the bound gives a start in O(log `n_cards`) once per query, against 0.51 ns × matching
-   cards for the realized span. Seek to the START of the boundary tie block and it can only start too
-   early, never too late, which answers the tie-breaking objection that made the realized span the first
-   choice. It composes with the span rather than replacing it (free ⇒ no gate ⇒ available to broad queries
-   too), and it is what would let the cost model have the ungated column of the regrade table above.
-   Conjunction analysis to extract the bound, plus row-identity verification, since it touches paging again.
-2. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 is
-   non-matching entries *interior* to the match span, and a start position cannot reach those by
-   construction. Scattering the match set through `inv_perm` and walking words at 64 cards a load is the
-   mechanism that can — `run_query_streamed_popcount` already does it for `unique=card` queries whose
-   filter fully consumed to `True`. Generalizing it needs per-card match counts for the skip (a popcount
-   counts cards, not matches, so printing/artwork mode cannot skip by popcount alone) and pays the same
-   per-card scatter the span bound pays, so it wants the same gate or the free start position above.
-3. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
-4. **Gate P4's artwork arm on its own.**
-5. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
+1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has
+   two sources, and neither is reachable from a start position: non-matching entries *interior* to the
+   walked segment, and clustering the predicate does not name (the 5.31-vs-4.26 gap in the regrade table).
+   Scattering the match set through `inv_perm` and walking words at 64 cards a load reaches both —
+   `run_query_streamed_popcount` already does exactly that for `unique=card` queries whose filter fully
+   consumed to `True`, and printing mode, where P3 is actually routed, is the case it does not cover.
+   Generalizing it needs per-card match counts for the skip (a popcount counts cards, not matches) and
+   pays a per-card scatter, so it inherits the cost question the realized span had — with the difference
+   that its payoff does not depend on matches being contiguous.
+2. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
+3. **Gate P4's artwork arm on its own.**
+4. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
    bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -60,6 +60,12 @@ values (`bench_card_range_estimate`, `bench_cost_model_agreement`) and should mo
 purpose: `bench_plan_misselection --source wild-operators` and `census_candidate_materialize`, where
 the question is what users actually lose.
 
+For built designs — kernel harnesses that control the ratios instead of sampling them — and the rule
+that came out of them (**shape from a built design, levels from traffic**), see
+[local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md). It also records
+why a min-of-N benchmark over one candidate list measures a cache state production never reaches, and
+why a whole-arm fit's intercept cannot be read as a fixed cost.
+
 ## Acquire and dispatch are two bins, and plan timing means dispatch
 
 The routed path has exactly two phases that matter for measurement, and conflating them produced the

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -23,8 +23,10 @@ Those rows were **63% of all reported regret**, and `StreamedSelect -> StreamedS
 best, so not misrouting by definition — was the single largest slice at a 14.15 us mean. On this basis
 it is 1.16. The genuine misroutes are unmoved (`PrintingCompose -> GatheredScan` 65.94 -> 65.22).
 
-Needs a `routed-phases` build. Without the feature the phase keys publish as zeros and those queries
-are skipped with a warning rather than measured against a zero baseline.
+Only the DECLINE rows need a `routed-phases` build: when the picked plan declines at runtime nothing
+forced describes what ran, so those fall back to the routed dispatch phase and are skipped without the
+feature. Every other row prices both sides from forced trials, so the harness now measures the whole
+sample on a plain build instead of skipping ~58% of it.
 
 Regret is mostly zeros, so a median is useless here: read the SHARE column, which is what fraction of
 all lost time a slice accounts for. That ranks the work. p90/p99/max show whether a slice loses a
@@ -120,23 +122,47 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
             skipped_unpriced += 1
             continue
         best = min(ran, key=lambda p: selves[id(p)])
+        # The baseline is the PICKED plan measured exactly as `best` was -- same estimator, same netting,
+        # same round selection -- so a query whose picked plan is its best has regret identically 0 and
+        # contributes nothing. That is what the routed-dispatch baseline could not do: on 16,770 queries
+        # where picked IS best it read median +0.04 us but p10 -7.21 and mean -4.52, because it compared
+        # `min` over the routed path's dispatch trials against a phase sum from a forced run's fastest
+        # round. Two floor estimators of the same quantity agree at the median and disagree in the tail,
+        # and that tail was the whole negative total: -51.7 ms over the run, with SHARE columns of 127%.
+        #
+        # `routed_dispatch_ns` is still the only measurement that exists for the case it was introduced
+        # for: when the picked plan DECLINES at runtime, dispatch re-chooses among materializing plans
+        # only, so no forced trial describes what actually ran. Those rows keep it, and only those rows
+        # need a `routed-phases` build.
         dispatch = sample.res["acquire"].get("routed_dispatch_ns")
-        if not dispatch or not any(dispatch):
-            skipped_unphased += 1
-            continue
+        if declined or picked is None:
+            if not dispatch or not any(dispatch):
+                skipped_unphased += 1
+                continue
+            baseline_ns = float(min(dispatch))
+        else:
+            baseline_ns = float(selves[id(picked)])
         rows.append(
             {
+                "picked_is_best": picked is not None and not declined and id(picked) == id(best),
                 # SIGNED. A negative row is the routed path beating the best forced plan, which
                 # happens (the lazy re-choose, or a forced run paying a cold cache the routed one
                 # does not) and is information, not zero. Clamping it to 0 let a transition whose
                 # MEAN is negative still accumulate share as if it were loss.
-                "lost": min(dispatch) / 1000.0 - selves[id(best)] / 1000.0,
+                "lost": (baseline_ns - selves[id(best)]) / 1000.0,
                 "acquire": sample.acquire["count_source"],
                 "unique": sample.kw["unique"],
                 "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
                 "best": best["plan"],
             }
         )
+    # An invariant now, not a bias estimate: same estimator on both sides means these rows are exactly
+    # zero. Anything else is a bug in the pricing, so it is worth one line of output to keep honest.
+    zero_pop = [r for r in rows if r["picked_is_best"]]
+    if zero_pop:
+        worst = max(abs(r["lost"]) for r in zero_pop)
+        verdict = "exactly 0, as it must be" if worst == 0.0 else f"NONZERO -- max |{worst:.3f}| us, which is a pricing bug"
+        print(f"invariant: {len(zero_pop):,} queries where picked IS best price at {verdict}")
     if skipped_unpriced:
         print(f"skipped {skipped_unpriced:,} queries where a plan that ran published no phase timing and so cannot be priced")
     if skipped_unphased:

--- a/scripts/bench_walk_span.py
+++ b/scripts/bench_walk_span.py
@@ -1,0 +1,173 @@
+"""A/B the streamed walk's match-span bound (`CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR`).
+
+The bound trades work in two phases at once, so a single number cannot judge it:
+
+* `ns_finish` — the walk itself. Bounded to the match span it steps from the first matching card to
+  the last instead of from permutation index 0 to wherever the page happens to fill.
+* `ns_loop` — the match loop, which pays one `inv_perm` read plus a `min` and a `max` per MATCHING
+  card to learn that span.
+
+So the cells come in two groups. CLUSTERED pairs a predicate with an orderby it correlates with, which
+is where a walk from index 0 grinds through a long non-matching prefix. BROAD has matches spread
+through the permutation, so the walk fills its page in ~`limit` steps and the bound can only cost.
+Both groups matter: the change is only worth taking if the first group's win is real AND the second
+group's cost is not.
+
+**Why a toggle rather than two builds.** Cross-build comparison cannot resolve this. Measured on
+these cells, `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on the same two builds —
+±9%, in both directions, on a phase neither build changed. That is the common-mode floor error
+`bench_plan_execution_ab.py` documents, plus whatever the linker did to code layout, and the per-card
+cost being hunted here is smaller than it. One binary with a runtime toggle removes both: identical
+code, identical layout, and the only difference is a branch that was already there.
+
+Both variants set the env var, to EQUAL-LENGTH values (`00001` / `99999`, both parsed as usize), because
+an env var present in one branch only shifts process memory layout enough to move sub-100us queries a
+consistent ~15% either way -- the same bias `bench_verify_order.py` documents and equalizes.
+
+    .venv/bin/python scripts/bench_walk_span.py --reps 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import statistics
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+CORPUS = REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl"
+TOGGLE = "CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR"
+# Equal-length values, both valid usize: 1 tracks the span for every query (candidates <= n_cards),
+# 99999 for none (n_cards / 99999 == 0 on any real corpus).
+ON_ENV = {TOGGLE: "00001"}
+OFF_ENV = {TOGGLE: "99999"}
+# The cross-process regime's depth, for the reason `bench_plan_execution_ab.py` gives: `min` over
+# trials is a floor estimator whose error is common-mode within a run, so pairing does not cancel it.
+WARMUPS = 6
+TRIALS = 30
+LIMIT = 60
+
+# (query, orderby, direction, offset). The clustered cells put the match band at the far end of the
+# walked order (`asc` over a `>=` predicate on the sort column); the `desc` twin puts the same band at
+# the near end, where there is no prefix to skip and only the last-match bound can help. The broad
+# cells are the control: nothing to skip at either end.
+CLUSTERED = [
+    ("cmc>=6", "cmc", "asc", 0),
+    ("cmc>=6", "cmc", "asc", 900),
+    ("cmc>=6", "cmc", "desc", 900),
+    ("cmc>=5", "cmc", "asc", 0),
+    ("power>=6", "power", "asc", 0),
+    ("toughness>=6", "toughness", "asc", 0),
+    ("t:creature cmc>=5", "cmc", "asc", 0),
+    ("o:flying cmc>=4", "cmc", "asc", 0),
+]
+BROAD = [
+    ("t:creature", "edhrec", "asc", 0),
+    ("cmc>=1", "edhrec", "asc", 0),
+    ("o:the", "edhrec", "asc", 0),
+    ("c:r", "edhrec", "asc", 0),
+]
+GROUPS = {"CLUSTERED": CLUSTERED, "BROAD": BROAD}
+
+
+def measure_one_process() -> None:
+    """Child entry point: measure every cell on this process's toggle setting and print JSON."""
+    from api.parsing import parse_scryfall_query  # noqa: PLC0415
+    from scripts import costbench  # noqa: PLC0415
+
+    engine = costbench.load_engine(CORPUS, CORPUS.with_suffix(".walkspan.store"))
+    out = {}
+    for group, cells in GROUPS.items():
+        for q, orderby, direction, offset in cells:
+            res = engine.explain_analyze(
+                filters=parse_scryfall_query(q),
+                unique="card",
+                prefer="default",
+                orderby=orderby,
+                direction=direction,
+                limit=LIMIT,
+                offset=offset,
+                num_warmups=WARMUPS,
+                num_trials=TRIALS,
+            )
+            plan = next((p for p in res["plans"] if p["plan"] == "StreamedSelect"), None)
+            if plan is None:
+                continue
+            out[f"{group}|{q}|{orderby}|{direction}|{offset}"] = {
+                "exec_us": costbench.plan_self_ns(plan, res["acquire"]) / 1000.0,
+                "loop_us": plan["ns_loop"] / 1000.0,
+                "finish_us": plan["ns_finish"] / 1000.0,
+                "perm_steps": plan["perm_steps"],
+                "cards": plan["cards_visited"],
+                "total": plan["result_total"],
+            }
+    print("BENCHJSON " + json.dumps(out))
+
+
+def run_child(env_overlay: dict[str, str]) -> dict:
+    """One fresh subprocess: the toggle is a once-per-process LazyLock, so it cannot be re-read."""
+    proc = subprocess.run(
+        [sys.executable, str(pathlib.Path(__file__).resolve()), "--child"],
+        env={**os.environ, **env_overlay},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("BENCHJSON "))
+    return json.loads(line[len("BENCHJSON ") :])
+
+
+def main() -> None:
+    """Interleave ON/OFF subprocesses, then report per-cell medians and the paired ratio."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--reps", type=int, default=5, help="ON/OFF subprocess pairs, interleaved")
+    args = parser.parse_args()
+    if args.child:
+        measure_one_process()
+        return
+
+    runs: dict[str, list[dict]] = {"on": [], "off": []}
+    for rep in range(args.reps):
+        # A/B/B/A within each pair, so a monotonic drift over the run cannot land on one arm.
+        order = [("off", OFF_ENV), ("on", ON_ENV)] if rep % 2 else [("on", ON_ENV), ("off", OFF_ENV)]
+        for label, overlay in order:
+            runs[label].append(run_child(overlay))
+            print(f"  rep {rep + 1}/{args.reps} {label} done", flush=True)
+
+    cells = sorted(set(runs["on"][0]) & set(runs["off"][0]))
+    print(
+        f"\n{'cell':<44}{'steps off':>10}{'steps on':>9}"
+        f"{'loop off':>10}{'loop on':>9}{'exec off':>10}{'exec on':>9}{'on/off':>8}"
+    )
+    ratios: dict[str, list[float]] = {"CLUSTERED": [], "BROAD": []}
+    def med(label: str, cell: str, field: str) -> float:
+        """Median of one field for one cell across that arm's subprocesses."""
+        return statistics.median(r[cell][field] for r in runs[label])
+
+    for cell in cells:
+        group = cell.split("|", 1)[0]
+        totals = {r[cell]["total"] for r in runs["on"] + runs["off"]}
+        parity = "" if len(totals) == 1 else "  TOTALS DIFFER"
+        ratio = med("on", cell, "exec_us") / med("off", cell, "exec_us")
+        ratios[group].append(ratio)
+        label = cell.split("|", 1)[1].replace("|", " ")
+        print(
+            f"{label:<44}{med('off', cell, 'perm_steps'):>10,.0f}{med('on', cell, 'perm_steps'):>9,.0f}"
+            f"{med('off', cell, 'loop_us'):>10.2f}{med('on', cell, 'loop_us'):>9.2f}"
+            f"{med('off', cell, 'exec_us'):>10.2f}{med('on', cell, 'exec_us'):>9.2f}{ratio:>8.3f}{parity}"
+        )
+    print()
+    for group, rs in ratios.items():
+        if rs:
+            print(f"{group}: geometric mean exec on/off = {statistics.geometric_mean(rs):.3f} over {len(rs)} cells")
+    print("\nCLUSTERED below 1.0 is the win; BROAD above 1.0 is what the bound costs where it cannot help.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_walk_span.py
+++ b/scripts/bench_walk_span.py
@@ -1,28 +1,26 @@
-"""A/B the streamed walk's match-span bound (`CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR`).
+"""A/B the streamed walk's sort-column bound (`CARD_ENGINE_WALK_SORT_BOUND`).
 
-The bound trades work in two phases at once, so a single number cannot judge it:
+`StreamedSelect`'s emission walk steps the sort permutation until the page fills. When the filter bounds
+the SORT COLUMN -- `cmc>=6` under `order=cmc`, the correlation that puts every match at one end of the
+walked order -- two binary searches turn that into a walk over only the segment the bound admits. This
+prices that, per cell, against the same binary walking everything.
 
-* `ns_finish` — the walk itself. Bounded to the match span it steps from the first matching card to
-  the last instead of from permutation index 0 to wherever the page happens to fill.
-* `ns_loop` — the match loop, which pays one `inv_perm` read plus a `min` and a `max` per MATCHING
-  card to learn that span.
+Cells come in two groups. CLUSTERED pairs a predicate with an orderby it correlates with, which is where
+a walk from index 0 grinds through a long non-matching prefix. BROAD is the control: matches spread
+through the permutation, so the walk already fills its page in ~`limit` steps and the bound has nothing
+to skip. Both matter -- the change is only worth taking if the first group's win is real and the second
+group is untouched.
 
-So the cells come in two groups. CLUSTERED pairs a predicate with an orderby it correlates with, which
-is where a walk from index 0 grinds through a long non-matching prefix. BROAD has matches spread
-through the permutation, so the walk fills its page in ~`limit` steps and the bound can only cost.
-Both groups matter: the change is only worth taking if the first group's win is real AND the second
-group's cost is not.
+**Why a toggle rather than two builds.** Cross-build comparison cannot resolve this. Measured on these
+cells, `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs of two builds -- +-9%, in both
+directions, on a phase neither build changed -- and a cross-build `bench_plan_execution_ab.py` run
+reported the wrong SIGN for this change while its own acquire control moved 1.9% the same way. That is
+the common-mode floor error the toolkit documents, plus whatever the linker did to code layout. One
+binary with a runtime toggle removes both: identical code, identical layout.
 
-**Why a toggle rather than two builds.** Cross-build comparison cannot resolve this. Measured on
-these cells, `ns_loop` wandered 43.00 / 45.38 / 47.17 us across three runs on the same two builds —
-±9%, in both directions, on a phase neither build changed. That is the common-mode floor error
-`bench_plan_execution_ab.py` documents, plus whatever the linker did to code layout, and the per-card
-cost being hunted here is smaller than it. One binary with a runtime toggle removes both: identical
-code, identical layout, and the only difference is a branch that was already there.
-
-Both variants set the env var, to EQUAL-LENGTH values (`00001` / `99999`, both parsed as usize), because
-an env var present in one branch only shifts process memory layout enough to move sub-100us queries a
-consistent ~15% either way -- the same bias `bench_verify_order.py` documents and equalizes.
+Both arms set the env var, to EQUAL-LENGTH values, because an env var present in one arm only shifts
+process memory layout enough to move sub-100us queries a consistent ~15% either way -- the same bias
+`bench_verify_order.py` documents and equalizes.
 
     .venv/bin/python scripts/bench_walk_span.py --reps 5
 """
@@ -41,16 +39,25 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 CORPUS = REPO_ROOT / "benchmarks/bitplanes/corpus.jsonl"
-TOGGLE = "CARD_ENGINE_SPAN_TRACK_CANDIDATE_DIVISOR"
-# Equal-length values, both valid usize: 1 tracks the span for every query (candidates <= n_cards),
-# 99999 for none (n_cards / 99999 == 0 on any real corpus).
-ON_ENV = {TOGGLE: "00001"}
-OFF_ENV = {TOGGLE: "99999"}
+TOGGLE = "CARD_ENGINE_WALK_SORT_BOUND"
+# Two arms, equal-length values so neither carries a differently-sized environment: `0` walks the whole
+# permutation as the executor did before the bound existed, `1` narrows it to what the filter's interval
+# on the sort column admits.
+ARMS = {"off": "0", "on": "1"}
+BASELINE_ARM = "off"
 # The cross-process regime's depth, for the reason `bench_plan_execution_ab.py` gives: `min` over
 # trials is a floor estimator whose error is common-mode within a run, so pairing does not cancel it.
 WARMUPS = 6
 TRIALS = 30
 LIMIT = 60
+
+# Swept, because WHICH mode is measured decides whether the result is a routed win or a latent one.
+# In `unique=card` a plane-consumable predicate leaves `FilterExpr::True`, which makes
+# `PlanePopcountOrder` applicable, and the router picks it over `StreamedSelect` on exactly the
+# clustered cells here (`cmc>=6 order=cmc`: 2.46 us against P3's 12.38). Printing and artwork mode have
+# no popcount plan -- a popcount counts cards, not printings -- so P3 is picked and the same improvement
+# is what a user waits for. The `routed` column says which happened, per cell.
+UNIQUES = ("card", "printing", "artwork")
 
 # (query, orderby, direction, offset). The clustered cells put the match band at the far end of the
 # walked order (`asc` over a `>=` predicate on the sort column); the `desc` twin puts the same band at
@@ -83,29 +90,32 @@ def measure_one_process() -> None:
     engine = costbench.load_engine(CORPUS, CORPUS.with_suffix(".walkspan.store"))
     out = {}
     for group, cells in GROUPS.items():
-        for q, orderby, direction, offset in cells:
-            res = engine.explain_analyze(
-                filters=parse_scryfall_query(q),
-                unique="card",
-                prefer="default",
-                orderby=orderby,
-                direction=direction,
-                limit=LIMIT,
-                offset=offset,
-                num_warmups=WARMUPS,
-                num_trials=TRIALS,
-            )
-            plan = next((p for p in res["plans"] if p["plan"] == "StreamedSelect"), None)
-            if plan is None:
-                continue
-            out[f"{group}|{q}|{orderby}|{direction}|{offset}"] = {
-                "exec_us": costbench.plan_self_ns(plan, res["acquire"]) / 1000.0,
-                "loop_us": plan["ns_loop"] / 1000.0,
-                "finish_us": plan["ns_finish"] / 1000.0,
-                "perm_steps": plan["perm_steps"],
-                "cards": plan["cards_visited"],
-                "total": plan["result_total"],
-            }
+        for unique in UNIQUES:
+            for q, orderby, direction, offset in cells:
+                res = engine.explain_analyze(
+                    filters=parse_scryfall_query(q),
+                    unique=unique,
+                    prefer="default",
+                    orderby=orderby,
+                    direction=direction,
+                    limit=LIMIT,
+                    offset=offset,
+                    num_warmups=WARMUPS,
+                    num_trials=TRIALS,
+                )
+                plan = next((p for p in res["plans"] if p["plan"] == "StreamedSelect"), None)
+                if plan is None:
+                    continue
+                picked = next((p["plan"] for p in res["plans"] if p["picked"]), "?")
+                out[f"{group}|{unique}|{q}|{orderby}|{direction}|{offset}"] = {
+                    "exec_us": costbench.plan_self_ns(plan, res["acquire"]) / 1000.0,
+                    "loop_us": plan["ns_loop"] / 1000.0,
+                    "finish_us": plan["ns_finish"] / 1000.0,
+                    "perm_steps": plan["perm_steps"],
+                    "cards": plan["cards_visited"],
+                    "total": plan["result_total"],
+                    "picked": picked,
+                }
     print("BENCHJSON " + json.dumps(out))
 
 
@@ -132,41 +142,47 @@ def main() -> None:
         measure_one_process()
         return
 
-    runs: dict[str, list[dict]] = {"on": [], "off": []}
+    runs: dict[str, list[dict]] = {arm: [] for arm in ARMS}
     for rep in range(args.reps):
-        # A/B/B/A within each pair, so a monotonic drift over the run cannot land on one arm.
-        order = [("off", OFF_ENV), ("on", ON_ENV)] if rep % 2 else [("on", ON_ENV), ("off", OFF_ENV)]
-        for label, overlay in order:
-            runs[label].append(run_child(overlay))
+        # Arm order reversed on alternate reps, so a monotonic drift over the run cannot land on one arm.
+        arms = list(ARMS.items())
+        for label, value in arms if rep % 2 == 0 else reversed(arms):
+            runs[label].append(run_child({TOGGLE: value}))
             print(f"  rep {rep + 1}/{args.reps} {label} done", flush=True)
 
-    cells = sorted(set(runs["on"][0]) & set(runs["off"][0]))
-    print(
-        f"\n{'cell':<44}{'steps off':>10}{'steps on':>9}"
-        f"{'loop off':>10}{'loop on':>9}{'exec off':>10}{'exec on':>9}{'on/off':>8}"
-    )
-    ratios: dict[str, list[float]] = {"CLUSTERED": [], "BROAD": []}
+    cells = sorted(set.intersection(*(set(runs[arm][0]) for arm in ARMS)))
+    print(f"\n{'cell':<50}{'steps off':>10}{'steps on':>11}{'exec off':>10}{'exec on':>10}{'on/off':>9}{'routed':>20}")
+    # Keyed by group AND by whether P3 is the routed plan, because a ratio on a plan the router does not
+    # pick is a latent win and must not be averaged in with the realized ones.
+    ratios: dict[str, list[float]] = {}
+
     def med(label: str, cell: str, field: str) -> float:
         """Median of one field for one cell across that arm's subprocesses."""
         return statistics.median(r[cell][field] for r in runs[label])
 
     for cell in cells:
         group = cell.split("|", 1)[0]
-        totals = {r[cell]["total"] for r in runs["on"] + runs["off"]}
+        picked = runs["on"][0][cell]["picked"]
+        routed = picked == "StreamedSelect"
+        totals = {r[cell]["total"] for arm in ARMS for r in runs[arm]}
         parity = "" if len(totals) == 1 else "  TOTALS DIFFER"
-        ratio = med("on", cell, "exec_us") / med("off", cell, "exec_us")
-        ratios[group].append(ratio)
+        base = med(BASELINE_ARM, cell, "exec_us")
+        ship_ratio = med("on", cell, "exec_us") / base
+        ratios.setdefault(f"{group} {'routed' if routed else 'LATENT'}", []).append(ship_ratio)
         label = cell.split("|", 1)[1].replace("|", " ")
         print(
-            f"{label:<44}{med('off', cell, 'perm_steps'):>10,.0f}{med('on', cell, 'perm_steps'):>9,.0f}"
-            f"{med('off', cell, 'loop_us'):>10.2f}{med('on', cell, 'loop_us'):>9.2f}"
-            f"{med('off', cell, 'exec_us'):>10.2f}{med('on', cell, 'exec_us'):>9.2f}{ratio:>8.3f}{parity}"
+            f"{label:<50}{med('off', cell, 'perm_steps'):>10,.0f}{med('on', cell, 'perm_steps'):>11,.0f}"
+            f"{base:>10.2f}{med('on', cell, 'exec_us'):>10.2f}{ship_ratio:>9.3f}"
+            f"{picked:>20}{parity}"
         )
     print()
-    for group, rs in ratios.items():
-        if rs:
-            print(f"{group}: geometric mean exec on/off = {statistics.geometric_mean(rs):.3f} over {len(rs)} cells")
-    print("\nCLUSTERED below 1.0 is the win; BROAD above 1.0 is what the bound costs where it cannot help.")
+    for group, rs in sorted(ratios.items()):
+        print(f"{group:<20} geometric mean exec on/off = {statistics.geometric_mean(rs):.3f} over {len(rs)} cells")
+    print(
+        "\nCLUSTERED below 1.0 is the win; BROAD at 1.0 is the control staying put -- the bound costs\n"
+        "nothing per card, so a query it cannot help should be unchanged rather than taxed.\n"
+        "LATENT rows are cells where the router picks another plan, so their ratio is not what a user sees."
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/costbench.py
+++ b/scripts/costbench.py
@@ -137,6 +137,10 @@ PLAN_KEYS = frozenset(
         "printing_span",
         "printings_examined",
         "matches_pushed",
+    # Permutation entries StreamedSelect's walk stepped. Realized ground truth for the estimate
+    # `page_span * n_cards / matches`, which assumes matches are spread uniformly through the
+    # permutation -- an assumption worth grading rather than trusting.
+    "perm_steps",
         "ns_setup",
         "ns_loop",
         "ns_finish",

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -302,6 +302,39 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     return None
 
 
+def perm_step_check(samples: list[dict]) -> tuple[int, float, float, float] | None:
+    """Realized `perm_steps` against the estimate cost.rs derives. The ratio should be 1.00.
+
+    Separate from `counter_check` because this feature is not published by acquire -- the arm computes
+    it from `page_span`, `n_cards` and `matches`. The rate was fitted and cross-validated (kernel
+    0.958-1.256 ns/entry, traffic 1.15), but a rate can look right while the quantity it multiplies is
+    wrong, so the ESTIMATE needs its own grade.
+
+    What is being tested is the uniform-spread assumption: the walk is modelled as finding one match
+    every `n_cards / matches` entries, which holds if matches are scattered evenly through the sort
+    permutation and fails if they cluster. Clustering is not far-fetched -- the permutation is ordered
+    by a sort column, and predicates correlate with sort columns (`year>=2020` under `order=released`
+    is the extreme case), so a real skew here would be a genuine model defect and not noise.
+
+    Returns (rows, p10, median, p90) of realized/estimated, or None if no row walked.
+    """
+    ratios = []
+    for s in samples:
+        if s["plan"] != "StreamedSelect" or not s.get("perm_steps"):
+            continue
+        acq, matches = s["acq"], float(s["acq"]["matches"])
+        if matches <= 0:
+            continue
+        page_span = float(min(s["offset"] + s["limit"], matches))
+        estimate = min(page_span * float(acq["n_cards"]) / matches, float(acq["n_cards"]))
+        if estimate > 0:
+            ratios.append(float(s["perm_steps"]) / estimate)
+    if not ratios:
+        return None
+    ratios.sort()
+    return (len(ratios), ratios[len(ratios) // 10], ratios[len(ratios) // 2], ratios[(9 * len(ratios)) // 10])
+
+
 def counter_check(samples: list[dict]) -> dict[str, list[tuple[str, float]]]:
     """Realized counter vs the feature that should predict it, per plan. Ratios should be 1.00."""
     # `scan_units` pairs with `printings_examined`, not the `printing_span` this used to read: the span
@@ -403,6 +436,7 @@ def collect(engine: object, rng: random.Random, seconds: float, sampler: QuerySa
                     "paging_taken": p.get("paging_taken"),
                     "printings_examined": p["printings_examined"],
                     "matches_pushed": p["matches_pushed"],
+                    "perm_steps": p.get("perm_steps", 0),
                 }
             )
     return samples
@@ -563,6 +597,13 @@ def main() -> None:
                 suspect.add(plan)
             print(f"{plan:<20}{label:<40}{ratio:>9.2f}{flag}")
     print("  a ratio far from 1.00 is a miscounted feature; no rate can absorb it.")
+    perm = perm_step_check(samples)
+    if perm is not None:
+        rows, p10, med, p90 = perm
+        print(f"\nStreamedSelect perm_steps realized/estimated over {rows:,} walking rows:")
+        print(f"  p10 {p10:.2f}   median {med:.2f}   p90 {p90:.2f}")
+        print("  tests the uniform-spread assumption behind `page_span * n_cards / matches`; skew would")
+        print("  show as a median away from 1.00, and clustering as a wide p10-p90 spread.")
 
     by_plan: dict[str, list[dict]] = collections.defaultdict(list)
     for s in samples:

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -88,7 +88,10 @@ RIDGE_STRENGTH = 0.01
 # and the baseline each fitted rate is reported against.
 CURRENT: dict[str, list[float]] = {
     # eval_domain, scan_units, tier scale, matches, page_span, fixed
-    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 169.6],
+    # ..., page_span, page_rows, fixed -- page_rows new 2026-08-03. The phase has two drivers: the
+    # quickselect scales with offset+limit, the collect with the page actually returned. A designed page
+    # sweep separates them where traffic cannot, since the two are correlated in the sampled query mix.
+    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 9.79, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
@@ -207,14 +210,17 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     n_cards = float(acq["n_cards"])
     tier_ns = acq["residual_tier_ns100"] / 100.0
     page_span = float(min(offset + limit, acq["matches"]))
+    # Mirrors cost.rs: `select_page` returns clamp(matches - offset, 0, limit), so a page past the end of
+    # the matches collects fewer rows than requested.
+    page_rows = float(min(max(acq["matches"] - offset, 0), limit))
     residual_on = 1.0 if tier_ns > 0.0 else 0.0
     floor = SHIPPED_RESIDUAL_FLOOR.get(plan, 0.0)
     excess = eval_domain * max(tier_ns - floor, 0.0) if tier_ns > 0.0 else 0.0
 
     if plan == "GatheredScan":
         return (
-            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, 1.0],
-            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "FIXED"],
+            [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, 1.0],
+            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "COLLECT_PER_PAGE_ROW", "FIXED"],
             excess,
         )
     if plan == "StreamedSelect":

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -322,6 +322,12 @@ def perm_step_check(samples: list[dict]) -> tuple[int, float, float, float] | No
     by a sort column, and predicates correlate with sort columns (`year>=2020` under `order=released`
     is the extreme case), so a real skew here would be a genuine model defect and not noise.
 
+    Read the SPREAD, not just the median. The executor bounds its walk to the realized match span, so
+    the ends of a cluster no longer cost anything and this ratio can only be inflated by non-matching
+    entries INTERIOR to the span. Bounding those ends took p90 from 6.43 to 4.26 (p10 0.13 -> 0.08,
+    median 1.00 -> 0.90) on one seed and sample length: a third of the tail was the leading prefix, and
+    what is left is a different mechanism's to fix.
+
     Returns (rows, p10, median, p90) of realized/estimated, or None if no row walked.
     """
     ratios = []

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -91,7 +91,11 @@ CURRENT: dict[str, list[float]] = {
     # ..., page_span, page_rows, fixed -- page_rows new 2026-08-03. The phase has two drivers: the
     # quickselect scales with offset+limit, the collect with the page actually returned. A designed page
     # sweep separates them where traffic cannot, since the two are correlated in the sampled query mix.
-    "GatheredScan": [6.88, 2.06, 18.89, 2.24, 3.51, 9.79, 169.6],
+    # 2026-08-03: the first column is now the UNCONDITIONAL loop rate and the third carries the
+    # `card_pass` call (3.00) on top of the floor (18.89), because the arm gates the call on
+    # `tier_ns > 0` -- `all_match_known` skips it. The design matrix already had these as two
+    # columns; only the arm and these labels changed.
+    "GatheredScan": [3.88, 2.06, 21.89, 2.24, 3.51, 9.79, 169.6],
     # eval_domain, scan_units, residual floor, matches, artwork_seen_cards, n_cards floor, corpus pass, fixed
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
@@ -99,7 +103,9 @@ CURRENT: dict[str, list[float]] = {
     # ..., perm_steps, ... -- the permutation walk's length, new 2026-08-03. It is the one quantity in
     # P3's finish phase no other feature is proportional to: the walk steps until the page fills, so it
     # visits ~page_span * n_cards / matches entries, inversely proportional to selectivity.
-    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.0, 1.21, 1.02, 0.02, 217.0],
+    # Same split as GatheredScan above: 2.58 unconditional, and the call (2.47) folded into the
+    # residual-gated column alongside the 6.58 floor.
+    "StreamedSelect": [2.58, 5.97, 9.05, 0.12, 1.0, 1.21, 1.02, 0.02, 217.0],
     # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
@@ -190,6 +196,9 @@ def nnls(rows: list[list[float]], targets: list[float]) -> list[float]:
 # A consequence worth stating: the fitted floor is not directly pasteable, because the offset it was
 # fitted against assumed the OLD floor. Applying it and re-fitting is a fixed-point iteration, and
 # each run is only self-consistent with whatever is shipped at the time.
+# The residual-gated column now prices the `card_pass` call as well as the floor, but the OFFSET
+# below is still about the floor alone: it captures `eval_domain * max(tier_ns - FLOOR, 0)`, the
+# excess where an expensive residual beats the floor, and the call is not part of that maximum.
 SHIPPED_RESIDUAL_FLOOR = {"GatheredScan": 18.89, "StreamedSelect": 6.58}
 
 
@@ -220,7 +229,15 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     if plan == "GatheredScan":
         return (
             [eval_domain, scan_units, eval_domain * residual_on, matches, page_span, page_rows, 1.0],
-            ["CARD_PASS", "SCAN_PER_ROW", "RESIDUAL_FLOOR", "PUSH_PER_MATCH", "SELECT_PER_PAGE_SLOT", "COLLECT_PER_PAGE_ROW", "FIXED"],
+            [
+                "LOOP_PER_CARD",
+                "SCAN_PER_ROW",
+                "CARD_PASS+FLOOR",
+                "PUSH_PER_MATCH",
+                "SELECT_PER_PAGE_SLOT",
+                "COLLECT_PER_PAGE_ROW",
+                "FIXED",
+            ],
             excess,
         )
     if plan == "StreamedSelect":
@@ -249,9 +266,9 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 1.0,
             ],
             [
-                "CARD_PASS",
+                "LOOP_PER_CARD",
                 "SCAN_PER_ROW",
-                "RESIDUAL_FLOOR",
+                "CARD_PASS+FLOOR",
                 "EMIT_PER_MATCH",
                 "PERM_STEP",
                 "ARTWORK_SEEN_PER_CARD",

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -93,7 +93,10 @@ CURRENT: dict[str, list[float]] = {
     # Refit once `printings_examined` existed: this plan's fit was vetoed for as long as the only
     # available counter was the printing SPAN, which its all_match rows disagree with by ~3x over a
     # term the arm multiplies by zero. Median agreement 0.63 -> 0.92, within-25% 19% -> 58%.
-    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.21, 1.02, 0.02, 217.0],
+    # ..., perm_steps, ... -- the permutation walk's length, new 2026-08-03. It is the one quantity in
+    # P3's finish phase no other feature is proportional to: the walk steps until the page fills, so it
+    # visits ~page_span * n_cards / matches entries, inversely proportional to selectivity.
+    "StreamedSelect": [5.05, 5.97, 6.58, 0.12, 1.0, 1.21, 1.02, 0.02, 217.0],
     # broadcast, scatter, project, popcount, walk step, walk emit, gather card pass, gather bittest,
     # gather push, fixed. Several of these are SHARED with other arms in cost.rs (LINEAR_PASS,
     # RANGE_SCATTER, GATHER_CARD_PASS, GATHER_PUSH_PER_MATCH, ...), so a fitted value that disagrees
@@ -215,6 +218,10 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
             excess,
         )
     if plan == "StreamedSelect":
+        # Mirrors the arm's guards: an empty result or a page past the end returns before BOTH branches,
+        # so neither the gather floor nor the walk is charged there.
+        walks_perm = matches > STREAM_MIN_MATCHES and matches > 0 and offset < matches
+        perm_steps = min(page_span * n_cards / matches, n_cards) if walks_perm else 0.0
         # Mirrors run_query_streamed's early return: zero matches, or a page past the total, never
         # reaches the small-total gather. See STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS in cost.rs.
         runs_small_gather = 0 < matches <= STREAM_MIN_MATCHES and offset < matches
@@ -229,6 +236,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 scan_units * residual_on,
                 eval_domain * residual_on,
                 matches,
+                perm_steps,
                 float(acq["artwork_seen_cards"]),
                 small_total,
                 n_cards,
@@ -239,6 +247,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "SCAN_PER_ROW",
                 "RESIDUAL_FLOOR",
                 "EMIT_PER_MATCH",
+                "PERM_STEP",
                 "ARTWORK_SEEN_PER_CARD",
                 "SMALL_TOTAL_FLOOR_PER_CARD",
                 "CORPUS_PASS_PER_CARD",


### PR DESCRIPTION
**Layer 2 of 13.** Base: #833. Reference: #830.

Calibrates the cost model against the counters layer 1 added. Nineteen commits, and several of them
*decline* to move a constant — the measurement is the deliverable either way.

- **StreamedSelect's permutation walk** and **GatheredScan's page collect** get charged; neither had a
  term, and `page_span` alone cannot describe the collect.
- **The streamed walk is bounded to its realized match span**, then gated, then started from the filter's
  own bound on the sort column.
- **`card_pass` is charged only where the loop actually calls it** — per candidate card, not per scanned
  row, which was overcharging printing and artwork by the whole printings-per-card ratio.
- **`STREAM_RESIDUAL_FLOOR_NS` measured with a built design and left alone**, because the measurement did
  not support moving it.

## Risk

No archived type changes, so no `ARCHIVE_FORMAT_VERSION` bump. Changes plan *pricing*, so it can change
plan choice; the aggregate effect of the whole branch is in #830.

## Verification

`cargo test` and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
