### PR TITLE
Engine: Record Which Formats Diverge, and Skip Per-Printing Legality (stack 3/13)

### DIFF
--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -258,7 +258,7 @@ fn plane_popcount(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32)
     let mut bits: Vec<u64> = Vec::new();
     eval_planes(&pe, &indexes.planes, &mut bits);
     let c: u32 = bits.iter().map(|w| w.count_ones()).sum();
-    Some((c, plane_expr_is_existential(&pe)))
+    Some((c, plane_expr_is_existential(&pe, u64::from(indexes.planes.divergent_formats))))
 }
 
 /// A plane-backed leaf. `force_loose` forces the superset treatment

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7743,6 +7743,10 @@ fn exec_from_candidates<'a>(
 /// fallback it replaces on the model's own terms. Both paths are correct for any query either is
 /// applicable to — `force_plan_differential_agreement` holds every plan to identical results — so
 /// this changes only which correct plan runs.
+// Eight: the declined plan, the three shared query artifacts, the two split-filter pieces a sibling
+// needs to re-derive its own applicability, and the router's `choose`. A wrapper struct would only be
+// unpacked again at the two call sites.
+#[allow(clippy::too_many_arguments, reason = "shared query artifacts plus the router's choose; a wrapper struct would only be unpacked again")]
 fn declined_sibling_fastpath<'a>(
     declined: PhysicalPlan,
     ctx: &QueryCtx<'a>,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6387,14 +6387,21 @@ impl PhysicalPlan {
     /// prep is available, `PrintingRangeScan` exactly when the range-estimate prep is,
     /// so filtering `ALL` by `applicable` inside each prep branch yields the right
     /// candidate set with no per-branch plan list.
-    fn applicable(self, ctx: &QueryCtx, params: &QueryParams, filter: &FilterExpr, plane: Option<&PlaneExpr>) -> bool {
+    fn applicable(
+        self,
+        ctx: &QueryCtx,
+        params: &QueryParams,
+        filter: &FilterExpr,
+        unsplit: Option<&FilterExpr>,
+        plane: Option<&PlaneExpr>,
+    ) -> bool {
         let QueryCtx { cards, indexes, .. } = *ctx;
         let QueryParams { mode, sort_col, descending, .. } = *params;
         match self {
             PhysicalPlan::PrintingRangeScan => {
                 printing_range_scan_applicable(mode, plane, cards) && bare_range_bounds(filter, indexes).is_some()
             }
-            PhysicalPlan::PrintingCompose => printing_compose_applicable(filter, cards, plane, indexes),
+            PhysicalPlan::PrintingCompose => printing_compose_applicable(filter, unsplit, cards, plane, indexes),
             PhysicalPlan::PlanePopcountOrder => {
                 plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes)
             }
@@ -6558,11 +6565,46 @@ fn printing_range_scan_applicable(mode: Mode, plane: Option<&PlaneExpr>, cards: 
 /// docs/issues/local-engine-compose-permutation-fallback.md) — either way the total (a popcount over
 /// the already-exact composed bits) and the page are both correct; only *which* paging strategy runs
 /// depends on the permutation's presence, decided inside the fastpath itself.
-fn printing_compose_applicable(filter: &FilterExpr, cards: &[AOracleCard], plane: Option<&PlaneExpr>, indexes: &Archived<CardIndexes>) -> bool {
+///
+/// **`plane.is_none()` is about REPRESENTATION, not about routing**, and `unsplit` is what lifts it.
+/// Compose builds its printing bitmap from the filter TREE; a plane sitting alongside holds predicate
+/// this function cannot see, so composing the residual alone would silently drop it — wrong rows, not
+/// slow rows. That is why the guard exists. But `split_planes` runs at bind time, before any plan is
+/// costed, so consuming a leaf into a plane ELIMINATED compose before the argmin could weigh it: measured
+/// 1.83 us for compose against StreamedSelect's 99.38 on `f:commander`/printing, a plan the router never
+/// got to consider. `unsplit` carries the filter as bound, so compose can be costed on the whole
+/// predicate whether or not a plane took part of it, and `cost::plan_cost` decides as #702 intends.
+fn printing_compose_applicable(
+    filter: &FilterExpr,
+    unsplit: Option<&FilterExpr>,
+    cards: &[AOracleCard],
+    plane: Option<&PlaneExpr>,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
     // Mode-agnostic: the cost model arbitrates overlap with the specialized range plans. All three
     // range/compose plans are non-materializing (estimate-in-acquire), so nothing is eagerly built —
     // a losing plan costs only a binary search, never a wasted scatter.
-    *PRINTING_COMPOSE != 0 && !cards.is_empty() && plane.is_none() && is_printing_composable(filter, indexes) && printing_compose_indexes_built(indexes)
+    //
+    // With a plane present, the whole predicate is `unsplit` and compose must compose that; without one,
+    // the residual IS the whole predicate. A caller that supplies no `unsplit` keeps the old behaviour.
+    let whole = match (plane, unsplit) {
+        (None, _) => Some(filter),
+        (Some(_), Some(u)) => Some(u),
+        (Some(_), None) => None,
+    };
+    *PRINTING_COMPOSE != 0
+        && !cards.is_empty()
+        && whole.is_some_and(|f| is_printing_composable(f, indexes))
+        && printing_compose_indexes_built(indexes)
+}
+
+/// The predicate `PrintingCompose` composes for this query: the whole thing, wherever it lives. See
+/// `printing_compose_applicable` for why the two representations both have to be available.
+fn compose_source<'f>(filter: &'f FilterExpr, unsplit: Option<&'f FilterExpr>, plane: Option<&PlaneExpr>) -> &'f FilterExpr {
+    match (plane, unsplit) {
+        (Some(_), Some(u)) => u,
+        _ => filter,
+    }
 }
 
 /// `CardRangePopcount` needs `Mode::Card`, a **bare** range leaf as the whole filter — usd/cn/date,
@@ -7623,7 +7665,9 @@ fn run_query<'a>(
     // #702: plan selection is one cost-based routing layer (`run_query_routed`,
     // `argmin cost::plan_cost` over the applicable plans), not a hand-tuned decision tree.
     let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, page_offset);
-    run_query_routed(ctx, &params, filter, plane)
+    // `None`: this wrapper receives an already-split filter and has no unsplit form to offer, so compose
+    // is costed exactly as it was before the split became non-destructive. See `bind_and_split_filter`.
+    run_query_routed(ctx, &params, filter, None, plane)
 }
 
 /// `cost::PlanFeatures::scan_units` for a query: the rows the per-row residual
@@ -7704,6 +7748,7 @@ fn declined_sibling_fastpath<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
     feats: &cost::PlanFeatures,
     choose: &impl Fn(&FilterExpr, &cost::PlanFeatures, bool) -> PhysicalPlan,
@@ -7713,7 +7758,7 @@ fn declined_sibling_fastpath<'a>(
         PhysicalPlan::PrintingCompose => PhysicalPlan::PrintingRangeScan,
         _ => return None, // a materializing plan won the estimate; it has no fast-path sibling
     };
-    if !sibling.applicable(ctx, params, filter, plane) {
+    if !sibling.applicable(ctx, params, filter, unsplit, plane) {
         return None;
     }
     if cost::plan_cost(sibling, feats) >= cost::plan_cost(choose(filter, feats, true), feats) {
@@ -7721,7 +7766,7 @@ fn declined_sibling_fastpath<'a>(
     }
     match sibling {
         PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
-        PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
+        PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, compose_source(filter, unsplit, plane)),
         _ => unreachable!("sibling is one of the two printing-space fast paths"),
     }
 }
@@ -8034,6 +8079,7 @@ fn acquire_plan_features(
     ctx: &QueryCtx,
     params: &QueryParams,
     filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> (cost::PlanFeatures, Prep, Vec<u64>) {
     let QueryCtx { cards, offsets, indexes, .. } = *ctx;
@@ -8050,7 +8096,7 @@ fn acquire_plan_features(
     // empty (no alloc).
     let mut plane_bits: Vec<u64> = Vec::new();
 
-    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, plane) {
+    let (feats, prep) = if PhysicalPlan::PlanePopcountOrder.applicable(ctx, params, filter, unsplit, plane) {
         // The ONE plane eval; its popcount IS the exact count. True residual ⇒ tier 0.
         eval_planes(plane.expect("PlanePopcountOrder ⇒ plane"), &indexes.planes, &mut plane_bits);
         let count: u32 = plane_bits.iter().map(|w| w.count_ones()).sum();
@@ -8089,7 +8135,7 @@ fn acquire_plan_features(
             span.min(u64::from(n_printings)) as u32
         };
         (mk_plan_feats(ctx, params, count, count, scan_units, 0), Prep::Plane)
-    } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, plane) {
+    } else if PhysicalPlan::CardRangePopcount.applicable(ctx, params, filter, unsplit, plane) {
         // Exact in-range printing count `k` from the index partition points (two binary searches, no
         // scan, no scatter). The O(k) card-bitmap build is deferred to dispatch and paid only if this
         // plan wins — so a competing winner never eats a wasted build (re-deriving the bounds there is
@@ -8128,7 +8174,7 @@ fn acquire_plan_features(
         feats.compose_scan_printings = k;
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::CardRangePopcount))
-    } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, plane) {
+    } else if PhysicalPlan::PrintingRangeScan.applicable(ctx, params, filter, unsplit, plane) {
         // Bare range: exact k from the index (no scan).
         let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("applicable ⇒ bare range");
         let k = (idx.partition_point(|p| u32::from(p.0) < hi) - idx.partition_point(|p| u32::from(p.0) < lo)) as u32;
@@ -8154,7 +8200,7 @@ fn acquire_plan_features(
         // never run. Compose's page term only reads `eval_domain` in the Gather branch.
         feats.compose_paging = compose_paging_for(indexes, cards.len(), mode, sort_col, descending);
         (feats, Prep::Range(CountSource::PrintingRangeScan))
-    } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, plane) {
+    } else if PhysicalPlan::PrintingCompose.applicable(ctx, params, filter, unsplit, plane) {
         // Composable printing-space expr, any distinct-on. Estimate the counts cheaply — the fast path
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
@@ -8287,6 +8333,7 @@ fn run_query_routed<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> (usize, Vec<(&'a AOracleCard, &'a APrinting)>) {
     // Generic argmin: the cheapest applicable plan. `filter` is passed per call (not
@@ -8296,7 +8343,7 @@ fn run_query_routed<'a>(
     let choose = |filter: &FilterExpr, feats: &cost::PlanFeatures, materializing_only: bool| -> PhysicalPlan {
         PhysicalPlan::ALL
             .into_iter()
-            .filter(|p| p.applicable(ctx, params, filter, plane) && (!materializing_only || p.materializing()))
+            .filter(|p| p.applicable(ctx, params, filter, unsplit, plane) && (!materializing_only || p.materializing()))
             .min_by(|a, b| cost::plan_cost(*a, feats).partial_cmp(&cost::plan_cost(*b, feats)).expect("plan_cost is finite"))
             .expect("GatheredScan is always applicable and materializing")
     };
@@ -8307,7 +8354,7 @@ fn run_query_routed<'a>(
     let mut phases = RoutedPhaseTimer::start();
 
     // ── acquire: pick the count source, build features, materialize its artifact ──
-    let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    let (feats, prep, plane_bits) = acquire_plan_features(ctx, params, filter, unsplit, plane);
     phases.acquired();
 
     // ── choose: cheapest applicable plan ──
@@ -8354,10 +8401,10 @@ fn run_query_routed<'a>(
         (plan, Prep::Range(_)) => {
             let fast_page = match plan {
                 PhysicalPlan::PrintingRangeScan => printing_range_fastpath(ctx, params, filter),
-                PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, filter),
+                PhysicalPlan::PrintingCompose => printing_compose_fastpath(ctx, params, compose_source(filter, unsplit, plane)),
                 _ => None, // a materializing plan won the estimate — materialize + run it below
             };
-            match fast_page.or_else(|| declined_sibling_fastpath(plan, ctx, params, filter, plane, &feats, &choose)) {
+            match fast_page.or_else(|| declined_sibling_fastpath(plan, ctx, params, filter, unsplit, plane, &feats, &choose)) {
                 Some(page) => page,
                 None => {
                     let prep = prepare_candidates(ctx, params, filter, plane);
@@ -8385,6 +8432,7 @@ fn run_query_with_plan<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,
     filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
 ) -> Option<(usize, Vec<(&'a AOracleCard, &'a APrinting)>)> {
     let QueryCtx { cards, indexes, .. } = *ctx;
@@ -8399,12 +8447,12 @@ fn run_query_with_plan<'a>(
             printing_range_fastpath(ctx, params, filter)
         }
         PhysicalPlan::PrintingCompose => {
-            if !printing_compose_applicable(filter, cards, plane, indexes) {
+            if !printing_compose_applicable(filter, unsplit, cards, plane, indexes) {
                 return None;
             }
             // The fastpath composes, projects per mode, and walks — or declines (None) on a sparse
             // total, exactly as under the router.
-            printing_compose_fastpath(ctx, params, filter)
+            printing_compose_fastpath(ctx, params, compose_source(filter, unsplit, plane))
         }
         PhysicalPlan::PlanePopcountOrder => {
             if !plane_popcount_order_applicable(filter, mode, cards, plane, sort_col, descending, indexes) {
@@ -8581,9 +8629,15 @@ impl Prep {
 /// dispatch would compute if that plan actually won and got lazily re-costed
 /// against a materialized candidate list (see `acquire_plan_features`'s
 /// `PrintingRangeScan`/`PrintingCompose` branches).
-fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane: Option<&PlaneExpr>) -> (AcquireFacts, Vec<PlanEstimate>) {
+fn explain(
+    ctx: &QueryCtx,
+    params: &QueryParams,
+    filter: &mut FilterExpr,
+    unsplit: Option<&FilterExpr>,
+    plane: Option<&PlaneExpr>,
+) -> (AcquireFacts, Vec<PlanEstimate>) {
     let t0 = std::time::Instant::now();
-    let (feats, prep, _plane_bits) = acquire_plan_features(ctx, params, filter, plane);
+    let (feats, prep, _plane_bits) = acquire_plan_features(ctx, params, filter, unsplit, plane);
     let acquire_ns = t0.elapsed().as_nanos() as u64;
     let facts = AcquireFacts {
         count_source: prep.count_source(),
@@ -8597,7 +8651,7 @@ fn explain(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterExpr, plane:
     };
     let mut estimates: Vec<PlanEstimate> = PhysicalPlan::ALL
         .into_iter()
-        .filter(|p| p.applicable(ctx, params, filter, plane))
+        .filter(|p| p.applicable(ctx, params, filter, unsplit, plane))
         .map(|plan| PlanEstimate {
             plan,
             predicted_ns: cost::plan_cost(plan, &facts.feats),
@@ -8763,6 +8817,7 @@ fn explain_analyze(
     ctx: &QueryCtx,
     params: &QueryParams,
     filter: &FilterExpr,
+    unsplit: Option<&FilterExpr>,
     plane: Option<&PlaneExpr>,
     num_warmups: usize,
     num_trials: usize,
@@ -8772,7 +8827,7 @@ fn explain_analyze(
 
     // explain() needs `&mut` for its own (one-time) acquire-step mutation; clone so
     // the timing loop below starts from `filter`'s untouched, pristine state.
-    let (mut facts, estimates) = explain(ctx, params, &mut filter.clone(), plane);
+    let (mut facts, estimates) = explain(ctx, params, &mut filter.clone(), unsplit, plane);
     // explain()'s single sample was taken outside the loop below, so it sits in a
     // different cache/allocator state than the plan trials it would be compared
     // against. Discard it and re-sample in-loop, one per round, from the same fresh
@@ -8804,9 +8859,9 @@ fn explain_analyze(
             let (mut ran, mut acquired, mut routed) = (None, None, None);
             let t0 = std::time::Instant::now();
             match participant {
-                Participant::Plan(i) => ran = run_query_with_plan(estimates[i].plan, ctx, params, &mut round_filter, plane),
-                Participant::Acquire => acquired = Some(acquire_plan_features(ctx, params, &mut round_filter, plane)),
-                Participant::Routed => routed = Some(run_query_routed(ctx, params, &mut round_filter, plane)),
+                Participant::Plan(i) => ran = run_query_with_plan(estimates[i].plan, ctx, params, &mut round_filter, unsplit, plane),
+                Participant::Acquire => acquired = Some(acquire_plan_features(ctx, params, &mut round_filter, unsplit, plane)),
+                Participant::Routed => routed = Some(run_query_routed(ctx, params, &mut round_filter, unsplit, plane)),
             }
             let dt = t0.elapsed().as_nanos() as u64;
             drop((acquired, routed));
@@ -9496,7 +9551,7 @@ fn bind_and_split_filter(
     unique: &str,
     data: &Archived<CardData>,
     sort_col: SortCol,
-) -> PyResult<(Option<PlaneExpr>, FilterExpr, SortBound)> {
+) -> PyResult<(Option<PlaneExpr>, FilterExpr, SortBound, FilterExpr)> {
     let to_json = filters.call_method0("to_json")?;
     let json_bytes: Vec<u8> = py
         .import("orjson")?
@@ -9516,12 +9571,19 @@ fn bind_and_split_filter(
 
     // Read before the split consumes the tree.
     let sort_bound = sort_col_bound(&filter_expr, sort_col);
+    // Kept, and this is the point: `split_planes` is a DESTRUCTIVE rewrite run before any plan is costed,
+    // and it moves predicate out of the tree that `PrintingCompose` composes from into a `PlaneExpr` it
+    // cannot read. Compose then fails its `plane.is_none()` guard and never reaches the argmin -- measured
+    // at 1.83 us against StreamedSelect's 99.38 on `f:commander`/printing, a plan the router was never
+    // offered. Retaining the unsplit form lets each plan be costed on the representation it can consume,
+    // which is what #702 says the routing layer is for. One clone of a small tree, once per query.
+    let unsplit = filter_expr.clone();
     let (plane, residual) = if u32::from(data.indexes.planes.n_cards) as usize == data.cards.len() && !data.cards.is_empty() {
         split_planes(filter_expr, &data.indexes.planes, &data.indexes.oracle_trigram.words, !matches!(unique, "artwork" | "printing"))
     } else {
         (None, filter_expr)
     };
-    Ok((plane, residual, sort_bound))
+    Ok((plane, residual, sort_bound, unsplit))
 }
 
 fn plan_estimate_to_pydict<'py>(py: Python<'py>, e: &PlanEstimate) -> PyResult<Bound<'py, PyDict>> {
@@ -10092,12 +10154,13 @@ impl QueryEngine {
         // dispatch. Shared verbatim with explain()/explain_analyze() — see
         // bind_and_split_filter.
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
+        let (plane_expr, mut filter_expr, sort_bound, unsplit) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         let ctx = QueryCtx::from(data);
         // `run_query`'s string→enum adaptation, done here so the filter's sort-column bound can ride on
         // the params: `from_strs` is still the single interpretation of the four strings.
-        let (total, page) = run_query_routed(&ctx, &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
+        let (total, page) =
+            run_query_routed(&ctx, &params.with_sort_bound(sort_bound), &mut filter_expr, Some(&unsplit), plane_expr.as_ref());
 
         let matches: Vec<Bound<PyDict>> = page
             .iter()
@@ -10135,7 +10198,7 @@ impl QueryEngine {
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (plane_expr, mut filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
+        let (plane_expr, mut filter_expr, sort_bound, unsplit) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // `prefer` is accepted and passed through, but note what it does NOT yet change:
         // `cost::plan_cost`/`PlanFeatures` still don't read it, so the argmin and every
@@ -10150,7 +10213,7 @@ impl QueryEngine {
         // prefer-aware feature be graded here at all; until one exists, an `explain` for a
         // non-default `prefer` still predicts the default's numbers.
         let (facts, estimates) =
-            explain(&QueryCtx::from(data), &params.with_sort_bound(sort_bound), &mut filter_expr, plane_expr.as_ref());
+            explain(&QueryCtx::from(data), &params.with_sort_bound(sort_bound), &mut filter_expr, Some(&unsplit), plane_expr.as_ref());
 
         let rows: Vec<Bound<PyDict>> = estimates.iter().map(|e| plan_estimate_to_pydict(py, e)).collect::<PyResult<Vec<_>>>()?;
         let out = PyDict::new(py);
@@ -10184,7 +10247,7 @@ impl QueryEngine {
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
         let params = QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset);
-        let (plane_expr, filter_expr, sort_bound) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
+        let (plane_expr, filter_expr, sort_bound, unsplit) = bind_and_split_filter(py, filters, unique, data, params.sort_col)?;
 
         // Release the GIL for the timing loop: it's pure Rust (no Python calls) and
         // runs plans × (warmups + trials) executions, so a long explain_analyze
@@ -10192,7 +10255,7 @@ impl QueryEngine {
         // conversion below stay on the GIL.
         let ctx = QueryCtx::from(data);
         let params = params.with_sort_bound(sort_bound);
-        let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, plane_expr.as_ref(), num_warmups, num_trials));
+        let (facts, trials) = py.detach(|| explain_analyze(&ctx, &params, &filter_expr, Some(&unsplit), plane_expr.as_ref(), num_warmups, num_trials));
 
         let rows: Vec<Bound<PyDict>> = trials.iter().map(|t| plan_trial_to_pydict(py, t)).collect::<PyResult<Vec<_>>>()?;
         let out = PyDict::new(py);

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -9430,7 +9430,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // current calendar date (20260723) and 20260724 were both already consumed by
 // earlier same-window archive changes (#737 columnar artwork_group_id, #741
 // watermark postings), so this takes the next distinct value — see the doc above.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260803;
+const ARCHIVE_FORMAT_VERSION: u32 = 2026080503;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2161,27 +2161,6 @@ fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
     lo
 }
 
-/// Which legality formats have printings that disagree, as a mask over the same 2-bit fields
-/// `format_shifts` indexes. See `CardData::divergent_formats` for why the per-format answer is worth
-/// more than the per-card boolean beside it.
-///
-/// One definition, used by `reload` AND by the test fixtures, because a fixture computing this
-/// differently from production would either exercise a shortcut production never takes or miss one it
-/// does — and the thing being decided is whether per-printing legality verification can be skipped.
-fn divergent_formats_of(printings: &[Printing], offsets: &[u32]) -> u64 {
-    let mut mask = 0u64;
-    for w in offsets.windows(2) {
-        let (start, end) = (w[0] as usize, w[1] as usize);
-        // XOR every printing against the group's first: a field that ever differs shows up in some XOR,
-        // and a field that never does contributes nothing from any pair.
-        let first = printings[start].card_legalities;
-        for pr in &printings[start + 1..end] {
-            mask |= first ^ pr.card_legalities;
-        }
-    }
-    mask
-}
-
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
@@ -2818,21 +2797,6 @@ struct CardData {
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
     // legality shifts identically to the worker that built the archive.
     format_shifts: HashMap<String, u8>,
-    // WHICH formats actually have printings that disagree, as a mask over the same 2-bit fields
-    // `format_shifts` indexes. `legality_divergent` on the card is one boolean meaning "some format
-    // disagreed for this card", which is all the #667 carveout has ever had to work with — so every
-    // legality leaf is treated as existential and re-verified per printing, for every format.
-    //
-    // The data does not justify that. Over the production corpus, all 556 divergent cards diverge in
-    // `oldschool` and nothing else; `modern`, `commander`, `pauper` and the rest are card-invariant, and
-    // the per-printing re-verification on them is provably redundant (measured: 7,770 printing
-    // examinations by StreamedSelect on `f:modern` that cannot change an answer).
-    //
-    // Accumulated as the OR of the XOR between successive printings of a card, so it names exactly the
-    // 2-bit fields that ever differ, and it is derived from the data rather than asserting anything
-    // about `oldschool`: if Scryfall ever makes another format divergent, this picks it up on the next
-    // reload and the conservative path returns on its own.
-    divergent_formats: u64,
 }
 
 // ─── Candidate narrowing ─────────────────────────────────────────────────────
@@ -3493,7 +3457,7 @@ fn narrow_rec(
         // `Narrowed`'s doc and the dedicated `Legality` arms below), so a
         // compiled expression touching them can only narrow loosely here,
         // same as if it had fallen through to those arms directly.
-        return if plane_expr_is_existential(&pe) {
+        return if plane_expr_is_existential(&pe, u64::from(indexes.planes.divergent_formats)) {
             Narrowed::loose(Candidates::CardBits(bits))
         } else {
             Narrowed::tight(Candidates::CardBits(bits))
@@ -6523,7 +6487,9 @@ fn existential_plane_for<'a>(
     indexes: &'a Archived<CardIndexes>,
 ) -> Option<(&'a PlaneExpr, &'a Archived<BitPlanes>)> {
     match (mode, plane) {
-        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe) => Some((pe, &indexes.planes)),
+        (Mode::Card, Some(pe)) if plane_expr_is_existential(pe, u64::from(indexes.planes.divergent_formats)) => {
+            Some((pe, &indexes.planes))
+        }
         _ => None,
     }
 }
@@ -6674,7 +6640,9 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // plane touched legality, so this only trusts a True residual for those
     // modes when the plane is existential-free (plane_expr_is_existential).
     let plane_true_for_mode =
-        plane.is_none_or(|expr| matches!(mode, Mode::Card) || !plane_expr_is_existential(expr));
+        plane.is_none_or(|expr| {
+            matches!(mode, Mode::Card) || !plane_expr_is_existential(expr, u64::from(ctx.indexes.planes.divergent_formats))
+        });
     let all_match_known = (matches!(filter, FilterExpr::True) && plane_true_for_mode) || residual_exact;
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
@@ -9006,7 +8974,7 @@ fn run_query_streamed_popcount<'a>(
         // blindly -- verify against `eval_plane_expr_for_printing` too. Cheap
         // even then: bounded by `limit` emitted cards, not the candidate set,
         // and only pays the extra check at all for legality-touching planes.
-        let existential = plane.is_some_and(plane_expr_is_existential);
+        let existential = plane.is_some_and(|e| plane_expr_is_existential(e, u64::from(planes.divergent_formats)));
         // Ends `ns_loop` (the skip scan) and starts `ns_finish` (the emit walk).
         let t_finish = std::time::Instant::now();
         let mut page: Vec<(&AOracleCard, &APrinting)> = Vec::with_capacity(limit);
@@ -9993,9 +9961,6 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        // Computed over the grouped arrays rather than inside the grouping loop, so the fixtures can call
-        // the same function on the same shape. One pass over the printings against a ~2 s load.
-        let divergent_formats = divergent_formats_of(&printings, &offsets);
         let card_data = CardData {
             cards,
             printings,
@@ -10007,7 +9972,6 @@ impl QueryEngine {
             mana_vocab,
             indexes,
             format_shifts: format_shifts_snapshot,
-            divergent_formats,
         };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
@@ -10246,7 +10210,7 @@ impl QueryEngine {
         let Ok(mmap) = self.get_mmap() else { return Ok(d) };
         // Safety: see query()'s access_unchecked justification.
         let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
-        let mask = u64::from(data.divergent_formats);
+        let mask = u64::from(data.indexes.planes.divergent_formats);
         for (format, shift) in data.format_shifts.iter() {
             // Two bits per format, so a format is divergent if either of its bits ever differed.
             if mask >> *shift & 0b11 != 0 {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2161,6 +2161,27 @@ fn partition_point(len: usize, pred: impl Fn(usize) -> bool) -> usize {
     lo
 }
 
+/// Which legality formats have printings that disagree, as a mask over the same 2-bit fields
+/// `format_shifts` indexes. See `CardData::divergent_formats` for why the per-format answer is worth
+/// more than the per-card boolean beside it.
+///
+/// One definition, used by `reload` AND by the test fixtures, because a fixture computing this
+/// differently from production would either exercise a shortcut production never takes or miss one it
+/// does — and the thing being decided is whether per-printing legality verification can be skipped.
+fn divergent_formats_of(printings: &[Printing], offsets: &[u32]) -> u64 {
+    let mut mask = 0u64;
+    for w in offsets.windows(2) {
+        let (start, end) = (w[0] as usize, w[1] as usize);
+        // XOR every printing against the group's first: a field that ever differs shows up in some XOR,
+        // and a field that never does contributes nothing from any pair.
+        let first = printings[start].card_legalities;
+        for pr in &printings[start + 1..end] {
+            mask |= first ^ pr.card_legalities;
+        }
+    }
+    mask
+}
+
 fn build_sort_permutations(cards: &[OracleCard]) -> SortPermutations {
     // Purely card-space now: the printings/offsets arguments existed only to read the first stored
     // printing's prefer_score, which is no longer a sort key (see the closure below).
@@ -9809,8 +9830,6 @@ impl QueryEngine {
         let mut cards: Vec<OracleCard> = Vec::new();
         let mut printings: Vec<Printing> = Vec::with_capacity(rows.len());
         let mut offsets: Vec<u32> = Vec::new();
-        // See `CardData::divergent_formats`: which formats disagree, not just that some card's did.
-        let mut divergent_formats: u64 = 0;
         for mut row in rows {
             let is_new = cards.last().is_none_or(|c| c.oracle_id != row.oracle_id);
             if is_new {
@@ -9848,8 +9867,6 @@ impl QueryEngine {
                 });
             } else if row.card_legalities != cards.last().map(|c| c.card_legalities).unwrap_or(0) {
                 cards.last_mut().unwrap().legality_divergent = true;
-                // Which 2-bit fields differ, not merely that some did. See `CardData::divergent_formats`.
-                divergent_formats |= row.card_legalities ^ cards.last().map(|c| c.card_legalities).unwrap_or(0);
             }
             printings.push(Printing {
                 scryfall_id: row.scryfall_id,
@@ -9976,6 +9993,9 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
+        // Computed over the grouped arrays rather than inside the grouping loop, so the fixtures can call
+        // the same function on the same shape. One pass over the printings against a ~2 s load.
+        let divergent_formats = divergent_formats_of(&printings, &offsets);
         let card_data = CardData {
             cards,
             printings,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2797,6 +2797,21 @@ struct CardData {
     // which never run the load path that feeds FORMAT_SHIFTS — resolve
     // legality shifts identically to the worker that built the archive.
     format_shifts: HashMap<String, u8>,
+    // WHICH formats actually have printings that disagree, as a mask over the same 2-bit fields
+    // `format_shifts` indexes. `legality_divergent` on the card is one boolean meaning "some format
+    // disagreed for this card", which is all the #667 carveout has ever had to work with — so every
+    // legality leaf is treated as existential and re-verified per printing, for every format.
+    //
+    // The data does not justify that. Over the production corpus, all 556 divergent cards diverge in
+    // `oldschool` and nothing else; `modern`, `commander`, `pauper` and the rest are card-invariant, and
+    // the per-printing re-verification on them is provably redundant (measured: 7,770 printing
+    // examinations by StreamedSelect on `f:modern` that cannot change an answer).
+    //
+    // Accumulated as the OR of the XOR between successive printings of a card, so it names exactly the
+    // 2-bit fields that ever differ, and it is derived from the data rather than asserting anything
+    // about `oldschool`: if Scryfall ever makes another format divergent, this picks it up on the next
+    // reload and the conservative path returns on its own.
+    divergent_formats: u64,
 }
 
 // ─── Candidate narrowing ─────────────────────────────────────────────────────
@@ -9371,7 +9386,7 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 // current calendar date (20260723) and 20260724 were both already consumed by
 // earlier same-window archive changes (#737 columnar artwork_group_id, #741
 // watermark postings), so this takes the next distinct value — see the doc above.
-const ARCHIVE_FORMAT_VERSION: u32 = 20260802;
+const ARCHIVE_FORMAT_VERSION: u32 = 20260803;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -9794,6 +9809,8 @@ impl QueryEngine {
         let mut cards: Vec<OracleCard> = Vec::new();
         let mut printings: Vec<Printing> = Vec::with_capacity(rows.len());
         let mut offsets: Vec<u32> = Vec::new();
+        // See `CardData::divergent_formats`: which formats disagree, not just that some card's did.
+        let mut divergent_formats: u64 = 0;
         for mut row in rows {
             let is_new = cards.last().is_none_or(|c| c.oracle_id != row.oracle_id);
             if is_new {
@@ -9831,6 +9848,8 @@ impl QueryEngine {
                 });
             } else if row.card_legalities != cards.last().map(|c| c.card_legalities).unwrap_or(0) {
                 cards.last_mut().unwrap().legality_divergent = true;
+                // Which 2-bit fields differ, not merely that some did. See `CardData::divergent_formats`.
+                divergent_formats |= row.card_legalities ^ cards.last().map(|c| c.card_legalities).unwrap_or(0);
             }
             printings.push(Printing {
                 scryfall_id: row.scryfall_id,
@@ -9957,7 +9976,19 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
-        let card_data = CardData { cards, printings, offsets, strings, coll_vocab, coll_vocab_sorted, artist_vocab, mana_vocab, indexes, format_shifts: format_shifts_snapshot };
+        let card_data = CardData {
+            cards,
+            printings,
+            offsets,
+            strings,
+            coll_vocab,
+            coll_vocab_sorted,
+            artist_vocab,
+            mana_vocab,
+            indexes,
+            format_shifts: format_shifts_snapshot,
+            divergent_formats,
+        };
 
         // Write atomically: stream into a per-PID .tmp, then rename over shm_path.
         // Per-PID avoids the race where two workers write to the same .tmp and
@@ -10184,6 +10215,25 @@ impl QueryEngine {
         out.set_item("acquire", acquire_facts_to_pydict(py, &facts)?)?;
         out.set_item("plans", PyList::new(py, rows)?)?;
         Ok(out)
+    }
+
+    /// The formats whose printings actually disagree, as `{format: shift}` — the data behind
+    /// `CardData::divergent_formats`, so a harness can check the claim that only `oldschool` diverges
+    /// against a real store rather than by re-reading the corpus JSONL. Empty when the archive is
+    /// missing or from another build; `{}` also legitimately means "no format diverges".
+    fn divergent_formats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new(py);
+        let Ok(mmap) = self.get_mmap() else { return Ok(d) };
+        // Safety: see query()'s access_unchecked justification.
+        let data = unsafe { rkyv::access_unchecked::<Archived<CardData>>(archive_payload(&mmap)) };
+        let mask = u64::from(data.divergent_formats);
+        for (format, shift) in data.format_shifts.iter() {
+            // Two bits per format, so a format is divergent if either of its bits ever differed.
+            if mask >> *shift & 0b11 != 0 {
+                d.set_item(format.as_str(), *shift)?;
+            }
+        }
+        Ok(d)
     }
 
     fn size(&self) -> PyResult<usize> {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -221,6 +221,13 @@ pub(crate) struct BitPlanes {
     pub(crate) power_hi: BucketBounds,
     pub(crate) toughness_lo: BucketBounds,
     pub(crate) toughness_hi: BucketBounds,
+    /// Which legality formats have printings that disagree — see `divergent_formats_of`. Lives here
+    /// because it is a statement about what plane truth MEANS: a legality plane for a format outside this
+    /// mask is card-invariant, so a card-level bit implies every printing of that card, and the #667
+    /// existential carveout does not apply to it. Every site that asks "is this plane existential"
+    /// already holds `&Archived<BitPlanes>`, so keeping it here needs no new plumbing and leaves one
+    /// home for the fact.
+    pub(crate) divergent_formats: u64,
 }
 
 pub(crate) fn words_per_plane(n_cards: usize) -> usize {
@@ -280,6 +287,27 @@ fn set_numeric_plane(
         bounds.observe(v as i16);
         set(plane);
     }
+}
+
+/// Which legality formats have printings that disagree, as a mask over the same 2-bit fields
+/// `format_shifts` indexes. See `BitPlanes::divergent_formats` for why the per-format answer is worth
+/// more than `OracleCard::legality_divergent`, the per-card boolean beside it.
+///
+/// One definition, used by `reload` AND by the test fixtures, because a fixture computing this
+/// differently from production would either exercise a shortcut production never takes or miss one it
+/// does — and the thing being decided is whether per-printing legality verification can be skipped.
+pub(crate) fn divergent_formats_of(printings: &[Printing], offsets: &[u32]) -> u64 {
+    let mut mask = 0u64;
+    for w in offsets.windows(2) {
+        let (start, end) = (w[0] as usize, w[1] as usize);
+        // XOR every printing against the group's first: a field that ever differs shows up in some XOR,
+        // and a field that never does contributes nothing from any pair.
+        let first = printings[start].card_legalities;
+        for pr in &printings[start + 1..end] {
+            mask |= first ^ pr.card_legalities;
+        }
+    }
+    mask
 }
 
 pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], offsets: &[u32], strings: &[String]) -> BitPlanes {
@@ -420,7 +448,18 @@ pub(crate) fn build_bit_planes(cards: &[OracleCard], printings: &[Printing], off
             (PLANE_TOUGHNESS_HI, &mut toughness_hi),
         );
     }
-    BitPlanes { n_cards: cards.len() as u32, words, cmc_hi, power_lo, power_hi, toughness_lo, toughness_hi }
+    BitPlanes {
+        n_cards: cards.len() as u32,
+        words,
+        cmc_hi,
+        power_lo,
+        power_hi,
+        toughness_lo,
+        toughness_hi,
+        // Computed here, from the same printings the planes were built from, so every fixture that builds
+        // planes gets it without a second call site to keep in step.
+        divergent_formats: divergent_formats_of(printings, offsets),
+    }
 }
 
 /// #724: printing-space border planes — bit per printing, **exact** (unlike #664's card-space
@@ -1071,6 +1110,26 @@ const PLANE_BLOCKS: [PlaneBlock; 10] = [
     PlaneBlock { base: PLANE_BORDER_OTHER, len: 1, kind: BlockKind::BorderOther },
 ];
 
+/// Whether plane `p` needs PER-PRINTING verification: an existential leaf whose fact can actually differ
+/// between the printings of one card.
+///
+/// For rarity and border that is every leaf — those are printing-varying by nature. For legality it is a
+/// per-FORMAT question, and the answer is usually no: `divergent_formats` names the formats whose
+/// printings ever disagree (one, `oldschool`, in the production corpus), and a legality plane outside that
+/// mask is card-invariant. A card-level bit for it implies every printing of the card, exactly like
+/// colors or types, so the #667 carveout does not apply and the per-printing re-verification it forces is
+/// work that cannot change an answer.
+///
+/// `u64::MAX` — every format divergent — is the conservative value and reproduces the behaviour that
+/// predates the mask, which is what a store built before it (or a fixture that does not care) supplies.
+fn needs_printing_verification(p: usize, divergent_formats: u64) -> bool {
+    match existential_leaf(p) {
+        Some(ExistentialLeaf::Legality { shift, .. }) => divergent_formats >> shift & 0b11 != 0,
+        Some(_) => true,
+        None => false,
+    }
+}
+
 /// Plane index `p`'s existential family and fact, or `None` for a
 /// card-invariant plane. Walks `PLANE_BLOCKS` once; which block `p` falls in
 /// (if any) says both which field it belongs to and, via the in-block
@@ -1106,20 +1165,20 @@ fn existential_leaf(p: usize) -> Option<ExistentialLeaf> {
 /// one. A literal duplicate leaf (`format:A AND format:A`) reads the same
 /// plane index and collapses to one entry, fine to compose -- the same
 /// underlying fact checked twice, not two facts needing a shared witness.
-fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
+fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>, divergent_formats: u64) {
     match expr {
         PlaneExpr::Plane(p) => {
-            if existential_leaf(*p as usize).is_some() && !out.contains(p) {
+            if needs_printing_verification(*p as usize, divergent_formats) && !out.contains(p) {
                 out.push(*p);
             }
         }
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => {}
         PlaneExpr::And(cs) | PlaneExpr::Or(cs) => {
             for c in cs {
-                collect_existential_indices(c, out);
+                collect_existential_indices(c, out, divergent_formats);
             }
         }
-        PlaneExpr::Not(inner) => collect_existential_indices(inner, out),
+        PlaneExpr::Not(inner) => collect_existential_indices(inner, out, divergent_formats),
     }
 }
 
@@ -1130,12 +1189,17 @@ fn collect_existential_indices(expr: &PlaneExpr, out: &mut Vec<u16>) {
 /// (docs/issues/00667-engine-legality-divergent-carveout.md,
 /// docs/issues/00680-engine-existential-plane-generalization.md; Step 2's popcount
 /// path is already `Mode::Card`-only for unrelated reasons, see `run_query`).
-pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
+///
+/// Takes the divergence mask because "existential" is not a property of the plane index alone for
+/// legality: see `needs_printing_verification`. A caller with a `&Archived<BitPlanes>` passes
+/// `planes.divergent_formats`; one with no store in reach passes `u64::MAX` and gets the old,
+/// conservative answer.
+pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr, divergent_formats: u64) -> bool {
     match expr {
-        PlaneExpr::Plane(p) => existential_leaf(*p as usize).is_some(),
+        PlaneExpr::Plane(p) => needs_printing_verification(*p as usize, divergent_formats),
         PlaneExpr::Bits(_) | PlaneExpr::Const(_) => false,
-        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(plane_expr_is_existential),
-        PlaneExpr::Not(inner) => plane_expr_is_existential(inner),
+        PlaneExpr::And(cs) | PlaneExpr::Or(cs) => cs.iter().any(|c| plane_expr_is_existential(c, divergent_formats)),
+        PlaneExpr::Not(inner) => plane_expr_is_existential(inner, divergent_formats),
     }
 }
 
@@ -1157,10 +1221,10 @@ pub(crate) fn plane_expr_is_existential(expr: &PlaneExpr) -> bool {
 /// shape nobody realistically writes --
 /// docs/issues/reference-engine-printing-varying-plane-repair-pattern.md has the joint
 /// per-printing evaluation this would need if it ever mattered enough to build.
-fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneExpr> {
+fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>, divergent_formats: u64) -> Option<PlaneExpr> {
     let mut formats = Vec::new();
     for c in &children {
-        collect_existential_indices(c, &mut formats);
+        collect_existential_indices(c, &mut formats, divergent_formats);
     }
     if formats.len() > 1 {
         return None;
@@ -1171,7 +1235,9 @@ fn and_of_checked_for_shared_witness(children: Vec<PlaneExpr>) -> Option<PlaneEx
 pub(crate) fn compile_plane(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, words: &rkyv::Archived<OracleWordIndex>) -> Option<PlaneExpr> {
     match filter {
         FilterExpr::True => Some(PlaneExpr::Const(true)),
-        FilterExpr::And(children) => and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words)?),
+        FilterExpr::And(children) => {
+            and_of_checked_for_shared_witness(compile_plane_children(children, bounds, words)?, u64::MAX)
+        }
         FilterExpr::Or(children) => compile_plane_children(children, bounds, words).map(or_of),
         // De Morgan pushdown so a Not that reaches a Legality leaf lands on
         // `illegal_exists` instead of bit-complementing `legal_exists` (wrong
@@ -1283,7 +1349,7 @@ fn compile_plane_neg(filter: &FilterExpr, bounds: &rkyv::Archived<BitPlanes>, wo
         FilterExpr::And(children) => compile_plane_neg_children(children, bounds, words).map(or_of),
         // Not(Or(cs)) = And(Not(c) for c in cs) -- THIS does have the
         // shared-witness exposure (see and_of_checked_for_shared_witness).
-        FilterExpr::Or(children) => and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words)?),
+        FilterExpr::Or(children) => and_of_checked_for_shared_witness(compile_plane_neg_children(children, bounds, words)?, u64::MAX),
         FilterExpr::Not(inner) => compile_plane(inner, bounds, words), // double negation
         FilterExpr::True => Some(PlaneExpr::Const(false)),
         // Everything else: only Legality has a divergent-card correctness
@@ -1341,7 +1407,13 @@ pub(crate) fn split_planes(
         return (None, filter);
     }
     if let Some(pe) = compile_plane(&filter, bounds, words)
-        && (unique_is_card || !plane_expr_is_existential(&pe))
+        // `u64::MAX`, deliberately: using the divergence mask here would let a card-invariant legality
+        // leaf be consumed into a whole-filter plane, which makes the residual `True` -- and a `True`
+        // residual takes `PrintingCompose` out of the running entirely. Compose is the best plan for
+        // several of these queries by a wide margin (`f:commander`/printing measured 1.83 us against
+        // StreamedSelect's 99.38), so trading it away to skip per-printing verification is a large net
+        // loss. The mask is used below the applicability decisions, not inside them.
+        && (unique_is_card || !plane_expr_is_existential(&pe, u64::MAX))
     {
         return (Some(pe), FilterExpr::True);
     }
@@ -1364,7 +1436,7 @@ pub(crate) fn split_planes(
                 match compile_plane(&c, bounds, words) {
                     Some(pe) => {
                         let mut fmts = Vec::new();
-                        collect_existential_indices(&pe, &mut fmts);
+                        collect_existential_indices(&pe, &mut fmts, u64::MAX);
                         if fmts.is_empty() {
                             planes.push(pe);
                         } else {
@@ -1376,7 +1448,7 @@ pub(crate) fn split_planes(
             }
             let mut all_formats = Vec::new();
             for (_, pe) in &legality_children {
-                collect_existential_indices(pe, &mut all_formats);
+                collect_existential_indices(pe, &mut all_formats, u64::MAX);
             }
             if unique_is_card && all_formats.len() <= 1 {
                 for (_, pe) in legality_children {

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -1407,13 +1407,13 @@ pub(crate) fn split_planes(
         return (None, filter);
     }
     if let Some(pe) = compile_plane(&filter, bounds, words)
-        // `u64::MAX`, deliberately: using the divergence mask here would let a card-invariant legality
-        // leaf be consumed into a whole-filter plane, which makes the residual `True` -- and a `True`
-        // residual takes `PrintingCompose` out of the running entirely. Compose is the best plan for
-        // several of these queries by a wide margin (`f:commander`/printing measured 1.83 us against
-        // StreamedSelect's 99.38), so trading it away to skip per-printing verification is a large net
-        // loss. The mask is used below the applicability decisions, not inside them.
-        && (unique_is_card || !plane_expr_is_existential(&pe, u64::MAX))
+        // The store's real mask, which it could not be while consumption eliminated `PrintingCompose`:
+        // a card-invariant legality leaf consumes the whole filter, the residual becomes `True`, and
+        // compose used to fail its `plane.is_none()` guard and vanish from the argmin -- measured 1.83 us
+        // for compose against StreamedSelect's 99.38 on `f:commander`/printing. `bind_and_split_filter`
+        // now retains the unsplit filter, so compose is still costed on the whole predicate and simply
+        // wins where it is better.
+        && (unique_is_card || !plane_expr_is_existential(&pe, u64::from(bounds.divergent_formats)))
     {
         return (Some(pe), FilterExpr::True);
     }

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1362,7 +1362,7 @@ fn plane_expr_is_existential_identifies_legality_only() {
     // shift 2 -- so it carries both regimes, and the mask says which is which. Asserted rather than
     // assumed, because every expectation below depends on it.
     let divergent = u64::from(bounds.divergent_formats);
-    assert_eq!(divergent >> 0 & 0b11, 0b01, "shift 0 diverges: card2 is legal in one printing, not the other");
+    assert_eq!(divergent & 0b11, 0b01, "shift 0 diverges: card2 is legal in one printing, not the other");
     assert_eq!(divergent >> 2 & 0b11, 0b00, "shift 2 is card-invariant across this fixture");
     assert_ne!(divergent >> 4 & 0b11, 0b00, "shift 4 diverges: banned in one printing, legal in the other");
 

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -301,8 +301,6 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
-    // Before the literal moves `printings`/`offsets` into it.
-    let divergent_formats = divergent_formats_of(&printings, &offsets);
     CardData {
         cards,
         printings,
@@ -314,11 +312,6 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        // Computed by the same function `reload` uses, so a fixture cannot accidentally exercise a
-        // shortcut production would not take (or miss one it would). `stub_printing` gives every printing
-        // the same legality word, so a plain fixture store reads 0 here -- no format diverges -- and the
-        // fixtures that DO want divergence build their words explicitly (see `fuzz_store_n`).
-        divergent_formats,
     }
 }
 
@@ -1365,11 +1358,33 @@ fn plane_expr_is_existential_identifies_legality_only() {
     let bounds = &archived.indexes.planes;
     let words = &archived.indexes.oracle_trigram.words;
 
+    // This fixture's card2 has two printings disagreeing at shifts 0 and 4, and nothing disagrees at
+    // shift 2 -- so it carries both regimes, and the mask says which is which. Asserted rather than
+    // assumed, because every expectation below depends on it.
+    let divergent = u64::from(bounds.divergent_formats);
+    assert_eq!(divergent >> 0 & 0b11, 0b01, "shift 0 diverges: card2 is legal in one printing, not the other");
+    assert_eq!(divergent >> 2 & 0b11, 0b00, "shift 2 is card-invariant across this fixture");
+    assert_ne!(divergent >> 4 & 0b11, 0b00, "shift 4 diverges: banned in one printing, legal in the other");
+
     let legality_pe = compile_plane(&FilterExpr::Legality { shift: Some(0), expected: 0b01 }, bounds, words).unwrap();
-    assert!(super::plane_expr_is_existential(&legality_pe));
+    assert!(super::plane_expr_is_existential(&legality_pe, divergent), "a DIVERGENT format needs per-printing truth");
+
+    // The new half: a legality plane for a format whose printings never disagree is card-invariant, so it
+    // is not existential and the #667 carveout does not apply to it. This is what makes `f:modern` behave
+    // like `t:creature` -- in the production corpus every format but `oldschool` is in this case.
+    let invariant_pe = compile_plane(&FilterExpr::Legality { shift: Some(2), expected: 0b01 }, bounds, words).unwrap();
+    assert!(
+        !super::plane_expr_is_existential(&invariant_pe, divergent),
+        "a format no card diverges in is card-invariant, so its plane needs no per-printing verification",
+    );
+    // ...and the conservative mask still says yes, which is what a pre-mask store supplies.
+    assert!(
+        super::plane_expr_is_existential(&invariant_pe, u64::MAX),
+        "u64::MAX must reproduce the pre-mask behaviour for every format",
+    );
 
     let creature_pe = compile_plane(&FilterExpr::TypeCmp { mask: TYPE_CREATURE, op: CmpOp::Ge }, bounds, words).unwrap();
-    assert!(!super::plane_expr_is_existential(&creature_pe));
+    assert!(!super::plane_expr_is_existential(&creature_pe, divergent));
 
     let mixed = compile_plane(
         &FilterExpr::And(vec![
@@ -1380,7 +1395,7 @@ fn plane_expr_is_existential_identifies_legality_only() {
         words,
     )
     .unwrap();
-    assert!(super::plane_expr_is_existential(&mixed), "one existential leaf must taint the whole And");
+    assert!(super::plane_expr_is_existential(&mixed, divergent), "one existential leaf must taint the whole And");
 }
 
 /// Regression for the mode-aware all_match bug found while building this
@@ -5577,6 +5592,12 @@ fn legality_and_of_two_formats_declines_but_or_compiles() {
     let a = || FilterExpr::Legality { shift: Some(0), expected: 0b01 };
     let b = || FilterExpr::Legality { shift: Some(2), expected: 0b01 };
 
+    // Still unconditional: `compile_plane` deliberately asks this question with `u64::MAX` rather than the
+    // store's divergence mask, because the answer decides whether the filter consumes to a plane -- and a
+    // consumed filter takes `PrintingCompose` out of the running, which measured a 54x loss on
+    // `f:commander`/printing. The mask is used below the applicability decisions, never inside them.
+    // Once compose is applicable to plane-consumed filters, `a AND invariant` becomes composable and this
+    // assertion is the one to revisit.
     assert!(
         compile_plane(&FilterExpr::And(vec![a(), b()]), bounds, words).is_none(),
         "two distinct formats ANDed must decline (shared-witness)"
@@ -5862,7 +5883,6 @@ fn bench_checked_vs_unchecked_access() {
         legal_divergent: build_divergent_ids(&cards),
         arith_tuple:    build_arith_tuple_index(&cards),
     };
-    let divergent_formats = divergent_formats_of(&printings, &offsets);
     let data = CardData {
         cards,
         printings,
@@ -5874,7 +5894,6 @@ fn bench_checked_vs_unchecked_access() {
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        divergent_formats,
     };
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -312,6 +312,9 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
+        // Every format divergent: the conservative value, so a fixture exercises the existential
+        // carveout rather than the card-invariant shortcut unless it opts in.
+        divergent_formats: u64::MAX,
     }
 }
 
@@ -5822,6 +5825,8 @@ fn bench_checked_vs_unchecked_access() {
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
+        // Conservative, as in `store_of`: every format treated as divergent.
+        divergent_formats: u64::MAX,
     };
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -11,7 +11,7 @@ use super::{
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingRangeIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
-    prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, Mode, QueryCtx, QueryParams, Prefer, SortBound,
+    prepare_candidates, verify_cost_tier, scan_units, sort_col_bound, divergent_formats_of, Mode, QueryCtx, QueryParams, Prefer, SortBound,
     GatherSelect, select_page, GATHER_PRUNE_CHUNK, Match,
     archive_header, archive_payload, ARCHIVE_HEADER_LEN, Mmap,
     bitmap_contains, bitmap_card_ids, compile_plane, eval_planes, split_planes,
@@ -301,6 +301,8 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         printing_to_card: build_printing_to_card(&offsets),
         ..Default::default()
     };
+    // Before the literal moves `printings`/`offsets` into it.
+    let divergent_formats = divergent_formats_of(&printings, &offsets);
     CardData {
         cards,
         printings,
@@ -312,9 +314,11 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        // Every format divergent: the conservative value, so a fixture exercises the existential
-        // carveout rather than the card-invariant shortcut unless it opts in.
-        divergent_formats: u64::MAX,
+        // Computed by the same function `reload` uses, so a fixture cannot accidentally exercise a
+        // shortcut production would not take (or miss one it would). `stub_printing` gives every printing
+        // the same legality word, so a plain fixture store reads 0 here -- no format diverges -- and the
+        // fixtures that DO want divergence build their words explicitly (see `fuzz_store_n`).
+        divergent_formats,
     }
 }
 
@@ -1623,6 +1627,13 @@ const FUZZ_OPS: [CmpOp; 6] = [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp:
 // banned(0b11); NOT_LEGAL(0b00) is never a query leaf (the parser negates instead).
 const FUZZ_SHIFTS: [u8; 3] = [0, 2, 4];
 const FUZZ_STATUSES: [u64; 3] = [0b01, 0b10, 0b11];
+// Shifts a divergent card is allowed to disagree at. Deliberately NOT all of `FUZZ_SHIFTS`: production
+// has exactly one divergent format (`oldschool`, all 556 of the corpus's divergent cards) and the rest
+// are card-invariant, so a corpus where every format can diverge would only ever exercise the
+// conservative existential path. Queries still draw leaves from all three shifts, so both regimes get
+// hit -- and `FUZZ_SHIFT_INVARIANT` is the one whose per-printing verification is provably redundant.
+const FUZZ_SHIFTS_DIVERGENT: [u8; 2] = [0, 2];
+const FUZZ_SHIFT_INVARIANT: u8 = 4;
 
 fn fuzz_op(rng: &mut rand::rngs::SmallRng) -> CmpOp {
     FUZZ_OPS[rng.random_range(0..FUZZ_OPS.len())]
@@ -2269,26 +2280,29 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
         };
         counts.push(npr);
 
-        let mut words: Vec<u64> = (0..npr).map(|_| rand_word(rng)).collect();
+        // One base word shared by every printing, then divergence introduced at ONE format. Drawing a
+        // fresh `rand_word` per printing (as this did) made every format differ between the printings of
+        // a divergent card, so the whole corpus was divergent in all three and `FUZZ_SHIFT_INVARIANT`
+        // could not exist -- caught by `fuzz_corpus_has_both_divergent_and_invariant_formats`, which read
+        // a mask of 0x3f. Production diverges in exactly one format, so this is also the more faithful
+        // shape.
+        let base = rand_word(rng);
+        let mut words: Vec<u64> = vec![base; npr];
         if divergent {
-            // Force a real disagreement at one format between printings 0 and 1,
-            // so the "divergent flag but printings happen to agree" degenerate
-            // case is not all this branch produces.
-            let ds = FUZZ_SHIFTS[rng.random_range(0..FUZZ_SHIFTS.len())];
+            // Force a real disagreement at one DIVERGENT-ELIGIBLE format between printings 0 and 1, so
+            // the "divergent flag but printings happen to agree" degenerate case is not all this branch
+            // produces, and so the invariant shift stays invariant.
+            let ds = FUZZ_SHIFTS_DIVERGENT[rng.random_range(0..FUZZ_SHIFTS_DIVERGENT.len())];
             let s0 = rng.random_range(0..4u64);
             let s1 = { let c = rng.random_range(0..4u64); if c == s0 { (s0 + 1) & 0b11 } else { c } };
-            words[0] = (words[0] & !(0b11 << ds)) | (s0 << ds);
-            words[1] = (words[1] & !(0b11 << ds)) | (s1 << ds);
+            words[0] = (base & !(0b11 << ds)) | (s0 << ds);
+            words[1] = (base & !(0b11 << ds)) | (s1 << ds);
             // Card-level word is unused for divergent cards (eval reads per-printing).
             card.card_legalities = words[0];
         } else {
             // Non-divergent: every printing shares the card-level word (the
             // real-data invariant the exact card-level plane relies on).
-            let w = words[0];
-            for x in words.iter_mut() {
-                *x = w;
-            }
-            card.card_legalities = w;
+            card.card_legalities = base;
         }
 
         for &word in &words {
@@ -2811,6 +2825,40 @@ fn gather_select_matches_reference() {
             }
         }
     }
+}
+
+/// The fuzz corpus must contain BOTH regimes of legality, or every differential test that touches it
+/// verifies only the conservative one.
+///
+/// Production has exactly one divergent format (`oldschool`: all 556 of the corpus's divergent cards) and
+/// the rest are card-invariant, which is what makes skipping per-printing legality verification safe for
+/// them. A fuzz store where every format could diverge would exercise the carveout and never the
+/// shortcut; one where none could would do the opposite. This pins both, on the mask `reload` itself
+/// computes, so the two cannot drift apart silently.
+#[test]
+fn fuzz_corpus_has_both_divergent_and_invariant_formats() {
+    use rand::SeedableRng;
+    // Enough cards that the ~10% divergent branch fires on every shift it is allowed to use.
+    const CORPUS_CARDS: usize = 4_000;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(828_003);
+    let data = fuzz_store_n(&mut rng, CORPUS_CARDS);
+    let mask = divergent_formats_of(&data.printings, &data.offsets);
+
+    for shift in FUZZ_SHIFTS_DIVERGENT {
+        assert_ne!(
+            mask >> shift & 0b11,
+            0,
+            "shift {shift} is in FUZZ_SHIFTS_DIVERGENT but no card diverged there, so the existential \
+             legality path is unexercised for it (mask {mask:#x})",
+        );
+    }
+    assert_eq!(
+        mask >> FUZZ_SHIFT_INVARIANT & 0b11,
+        0,
+        "shift {FUZZ_SHIFT_INVARIANT} must be card-invariant across every card -- it is the format whose \
+         per-printing verification is provably redundant, and the only reason a test can assert a \
+         shortcut is safe (mask {mask:#x})",
+    );
 }
 
 /// #702 step 2 (force-plan seam): every physical plan that is *applicable* to a
@@ -5814,6 +5862,7 @@ fn bench_checked_vs_unchecked_access() {
         legal_divergent: build_divergent_ids(&cards),
         arith_tuple:    build_arith_tuple_index(&cards),
     };
+    let divergent_formats = divergent_formats_of(&printings, &offsets);
     let data = CardData {
         cards,
         printings,
@@ -5825,8 +5874,7 @@ fn bench_checked_vs_unchecked_access() {
         mana_vocab: vec![],
         indexes,
         format_shifts: HashMap::new(),
-        // Conservative, as in `store_of`: every format treated as divergent.
-        divergent_formats: u64::MAX,
+        divergent_formats,
     };
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     println!("archive size: {:.1} MB", bytes.len() as f64 / 1e6);

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -3113,7 +3113,7 @@ fn force_plan_differential_agreement() {
                 let (ref_total, ref_page) = run_query_with_plan(
                     PhysicalPlan::GatheredScan, &QueryCtx::from(archived),
                     &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
-                    &mut ref_res, ref_pe.as_ref(),
+                    &mut ref_res, None, ref_pe.as_ref(),
                 )
                 .expect("GatheredScan is always applicable");
                 ran[plan_idx(PhysicalPlan::GatheredScan)] += 1;
@@ -3137,7 +3137,7 @@ fn force_plan_differential_agreement() {
                     let out = run_query_with_plan(
                         plan, &QueryCtx::from(archived),
                         &QueryParams::from_strs(mode, prefer, orderby, direction, full_limit, 0).with_sort_bound(sort_bound),
-                        &mut res, pe.as_ref(),
+                        &mut res, None, pe.as_ref(),
                     );
                     let Some((total, page)) = out else { continue };
                     ran[plan_idx(plan)] += 1;
@@ -3283,7 +3283,7 @@ fn explain_reports_ranked_applicable_plans() {
                 fuzz_bound_filter(spec, archived), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
             );
             let (facts, estimates): (AcquireFacts, Vec<PlanEstimate>) = explain(
-                &QueryCtx::from(archived), &explain_params(mode, 60), &mut filter, pe.as_ref(),
+                &QueryCtx::from(archived), &explain_params(mode, 60), &mut filter, None, pe.as_ref(),
             );
 
             // The acquire facts every plan in this call shares. `eval_domain` is what a
@@ -3388,13 +3388,13 @@ fn explain_analyze_matches_explain_and_times_every_plan() {
         bound.clone(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true,
     );
     let (ref_facts, reference): (AcquireFacts, Vec<PlanEstimate>) = explain(
-        &QueryCtx::from(archived), &explain_params(Mode::Card, 60), &mut ref_filter, ref_pe.as_ref(),
+        &QueryCtx::from(archived), &explain_params(Mode::Card, 60), &mut ref_filter, None, ref_pe.as_ref(),
     );
 
     let (pe, filter) = split_planes(bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
     let (facts, trials): (AcquireFacts, Vec<PlanTrial>) = explain_analyze(
         &QueryCtx::from(archived), &QueryParams::from_strs("card", "default", "edhrec", "asc", 60, 0),
-        &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS,
+        &filter, None, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS,
     );
 
     // The acquire facts describe the query, not the round, so they must agree with
@@ -3535,7 +3535,7 @@ fn compose_paging_prediction_matches_the_branch_taken() {
 
                             // The prediction, on its own clone -- acquire mutates the filter it reads.
                             let mut acq_filter = filter.clone();
-                            let (feats, prep, _bits) = acquire_plan_features(&ctx, &params, &mut acq_filter, pe.as_ref());
+                            let (feats, prep, _bits) = acquire_plan_features(&ctx, &params, &mut acq_filter, None, pe.as_ref());
                             if prep.count_source() != CountSource::PrintingCompose {
                                 continue; // not a compose acquire; compose_paging has no referent
                             }
@@ -3545,7 +3545,7 @@ fn compose_paging_prediction_matches_the_branch_taken() {
                             // iteration's label survives in the cell otherwise (see PHASE_STATS).
                             let mut run_filter = filter.clone();
                             take_phase_stats();
-                            let ran = run_query_with_plan(PhysicalPlan::PrintingCompose, &ctx, &params, &mut run_filter, pe.as_ref());
+                            let ran = run_query_with_plan(PhysicalPlan::PrintingCompose, &ctx, &params, &mut run_filter, None, pe.as_ref());
                             let taken = take_phase_stats().paging_taken;
 
                             let case = format!(
@@ -3720,7 +3720,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                 let mut streamed_filter = filter.clone();
                 take_phase_stats();
                 let streamed_ran =
-                    run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref());
+                    run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, None, pe.as_ref());
                 let streamed = take_phase_stats();
                 if streamed_ran.is_none() {
                     continue; // no sort permutation for this orderby; nothing to compare against
@@ -3729,7 +3729,7 @@ fn materializing_plans_agree_on_the_counters_they_share() {
                 let mut gathered_filter = filter.clone();
                 take_phase_stats();
                 let gathered_ran =
-                    run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref());
+                    run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, None, pe.as_ref());
                 let gathered = take_phase_stats();
                 assert!(gathered_ran.is_some(), "GatheredScan is always applicable");
 
@@ -3905,7 +3905,7 @@ fn plan_stats_never_leak_between_participants() {
                 let (pe, filter) = split_planes(
                     bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
                 );
-                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
+                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, None, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
 
                 for t in &trials {
                     if t.trials_ns.is_empty() {
@@ -4140,7 +4140,7 @@ fn declining_plans_report_their_gate_through_explain_analyze() {
                 let (pe, filter) = split_planes(
                     bound, &archived.indexes.planes, &archived.indexes.oracle_trigram.words, matches!(mode, Mode::Card),
                 );
-                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
+                let (_facts, trials) = explain_analyze(&ctx, &params, &filter, None, pe.as_ref(), NUM_WARMUPS, NUM_TRIALS);
 
                 for t in &trials {
                     if t.declined_ns.is_empty() {
@@ -4443,7 +4443,7 @@ fn plan_cost_calibration() {
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
                             *plan, &QueryCtx::from(archived),
-                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out {
@@ -4566,7 +4566,7 @@ fn plan_cost_model_matches_gold() {
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
                             *plan, &QueryCtx::from(archived),
-                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out {
@@ -4821,7 +4821,7 @@ fn plan_cost_refit() {
                         let t0 = Instant::now();
                         let out = black_box(run_query_with_plan(
                             *plan, &QueryCtx::from(archived),
-                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                            &QueryParams::from_strs(mode, "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                         ));
                         let dt = t0.elapsed().as_nanos() as u64;
                         match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { best = best.min(dt); } } None => break }
@@ -5015,7 +5015,7 @@ fn printing_range_route_probe() {
                     let t0 = Instant::now();
                     let out = black_box(run_query_with_plan(
                         *plan, &QueryCtx::from(archived),
-                        &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, pe.as_ref(),
+                        &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, None, pe.as_ref(),
                     ));
                     let dt = t0.elapsed().as_nanos() as u64;
                     match out {
@@ -5241,7 +5241,7 @@ fn idea1_vs_idea2_probe() {
                 let t0 = Instant::now();
                 let out = black_box(run_query_with_plan(
                     PhysicalPlan::PrintingRangeScan, &QueryCtx::from(archived),
-                    &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, pe.as_ref(),
+                    &QueryParams::from_strs("printing", "default", "edhrec", "asc", LIMIT, offset), &mut res, None, pe.as_ref(),
                 ));
                 let dt = t0.elapsed().as_nanos() as u64;
                 match out { Some((t, _)) => { total = t; applicable = true; if it >= WARMUP { i1 = i1.min(dt); } } None => break }
@@ -5373,7 +5373,7 @@ fn plan_regret_report() {
                     let t0 = Instant::now();
                     let out = black_box(run_query_with_plan(
                         *plan, &QueryCtx::from(archived),
-                        &QueryParams::from_strs("card", "default", "edhrec", "asc", limit, offset), &mut res, pe.as_ref(),
+                        &QueryParams::from_strs("card", "default", "edhrec", "asc", limit, offset), &mut res, None, pe.as_ref(),
                     ));
                     let dt = t0.elapsed().as_nanos() as u64;
                     match out {
@@ -6596,11 +6596,11 @@ fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
                 // A pristine clone per plan: `prepare_candidates` rewrites the filter it is handed.
                 let mut streamed_filter = filter.clone();
                 take_phase_stats();
-                let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+                let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, None, pe.as_ref())
                     .expect("store_of builds the cmc permutation, so StreamedSelect is applicable");
                 let stats = take_phase_stats();
                 let mut gathered_filter = filter.clone();
-                let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+                let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, None, pe.as_ref())
                     .expect("GatheredScan is always applicable");
 
                 let case = format!("{mode_label}/{}/offset={offset}", if descending { "desc" } else { "asc" });
@@ -6633,11 +6633,11 @@ fn streamed_walk_bounds_itself_by_the_sort_column_predicate() {
             split_planes(filt(), &archived.indexes.planes, &archived.indexes.oracle_trigram.words, true);
         let mut streamed_filter = filter.clone();
         take_phase_stats();
-        let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, pe.as_ref())
+        let streamed = run_query_with_plan(PhysicalPlan::StreamedSelect, &ctx, &params, &mut streamed_filter, None, pe.as_ref())
             .expect("store_of builds the edhrec permutation too");
         let stats = take_phase_stats();
         let mut gathered_filter = filter.clone();
-        let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, pe.as_ref())
+        let gathered = run_query_with_plan(PhysicalPlan::GatheredScan, &ctx, &params, &mut gathered_filter, None, pe.as_ref())
             .expect("GatheredScan is always applicable");
         assert_eq!(streamed.0, gathered.0, "unbounded total disagrees with GatheredScan: offset={offset}");
         assert_eq!(ids(&streamed.1), ids(&gathered.1), "unbounded page disagrees with GatheredScan: offset={offset}");


### PR DESCRIPTION
**Layer 3 of 13.** Base: #834. Reference: #830.

**Archive bump: `2026080503`.** This layer adds a divergence mask to the archived planes, so a store built
against layer 2 must fail the header check and be rebuilt rather than be read as garbage. The header
comparison is equality, not ordering — the only invariant is that a value is never reused for a different
layout, and `20260805NN` numbers the patch in this stack so it cannot collide with the date-based values
used before or after.

## What it does

Legality is card-level for almost every card: only non-tournament reprints (30A, Collectors' Edition,
gold border) carry per-printing legality. The engine knew *that some card* diverged; it now records
**which formats** do.

With that, a filter on a card-invariant format skips per-printing legality verification entirely — the
common case stops paying for the rare one. 556 of 31,508 cards diverge, all in `oldschool`.

Also keeps the unsplit filter alongside the plane-split one, so a plane consuming part of an expression
can no longer eliminate `PrintingCompose` from the argmin before it is priced.

## Verification

`cargo test` and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
