### PR TITLE
Engine: Calibrate the Compose Acquire (stack 4/13)

### DIFF
--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -161,6 +161,7 @@
 //! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` — rebuild it the
 //! same way (see that module's docs) after any AOracleCard/APrinting layout change.
 
+use super::bench_loop_design::{store_path, CARD_COUNTS, ITERS, LIMIT, WIDE_MIN_PRINTINGS};
 use std::hint::black_box;
 
 use rkyv::Archived;
@@ -170,30 +171,6 @@ use super::{
     NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
 };
 
-/// Timed repetitions per cell; the minimum is reported, as elsewhere in these harnesses.
-const ITERS: usize = 200;
-/// A "wide" card has at least this many printings. Sets the leverage between the card column and
-/// the printing column: a bigger gap separates them better, but the corpus has a steep tail — the
-/// group-size table this prints shows only 1,910 cards reach 8 printings, which is too few to fill
-/// the larger cells. 4 keeps the leverage worth having and the wide group ~4× bigger.
-const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at. Four sizes, geometric, because two things are being measured on this
-/// axis and they need opposite ends of it:
-///
-/// - **Linearity in the card term**, which the large end shows: the single-printing card cell measured
-///   8.33 / 8.53 / 10.11 ns/card at 400 / 1,500 / 4,500, so the per-card rate RISES with card count and
-///   a one-size design would bake whichever size it used into the constant.
-/// - **The intercept**, i.e. the per-query fixed cost, which only exists as the y-intercept of cells
-///   that vary in size — and which the SMALL end pins, because `intercept = t(n) - slope * n` multiplies
-///   any slope error by `n`. At a 400-card floor a 1 ns/card slope error is 400 ns of intercept error,
-///   against a shipped `GATHER_FIXED_COST_NS` of 169.6: unmeasurable. 100 shortens that lever 4x.
-///
-/// Bounded above by the wide group, which is the scarce one (see `WIDE_MIN_PRINTINGS`).
-const CARD_COUNTS: [usize; 4] = [100, 400, 1_500, 4_500];
-/// Page requested. Small and fixed: `sel.absorb()` runs INSIDE the loop and prunes toward
-/// `offset + limit`, so this is part of what the per-match rate has to cover — keeping it constant
-/// keeps that contribution proportional to matches rather than to the page.
-const LIMIT: usize = 60;
 /// (offset, limit) pairs for the finish-phase sweep. `GATHER_SELECT_PER_PAGE_SLOT_NS` is charged against
 /// `page_span = min(offset + limit, matches)`, and every cell above holds the page FIXED, so that term
 /// has never been varied here -- the loop rates were measured while the one term keyed on the page was
@@ -201,15 +178,7 @@ const LIMIT: usize = 60;
 /// per-slot rate from a fixed cost the phase pays regardless.
 const PAGE_SPECS: [(usize, usize); 4] = [(0, 15), (0, 60), (0, 600), (900, 60)];
 
-/// Default store. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep runs: build
-/// upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn. The real corpus is
-/// only ~68 MB, small enough that a full chunk rotation can stay resident in the system-level cache, so
-/// the rates it yields are still partly warm however the walk is ordered.
-const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
 
-fn store_path() -> String {
-    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
-}
 
 /// One measured design point: the realized counters, and the loop time they were produced by.
 struct Cell {

--- a/card_engine/src/bench_loop_design.rs
+++ b/card_engine/src/bench_loop_design.rs
@@ -1,0 +1,63 @@
+//! The design parameters `bench_gather_loop` (P4) and `bench_streamed_loop` (P3) must share.
+//!
+//! The two harnesses exist as a pair for one reason: P4 could not be fixed alone. Three successively
+//! better descriptions of its loop each REGRESSED routing (+43%, +8.8%, +40%), because `plan_cost` is only
+//! ever used comparatively and P4's inflated arm was absorbing an over-estimate on P3's side. So both arms
+//! get the same built-design treatment and are meant to be read side by side.
+//!
+//! That reading is only valid if the cells match. They had drifted: `CARD_COUNTS` was `[100, 400, 1500,
+//! 4500]` on the gather side and `[600, 1500, 4500]` on the streamed side, sharing just two sizes, so any
+//! P3-vs-P4 rate difference at the small end was confounded with a design difference. Living here, one
+//! definition, they cannot drift again — which is the same argument `divergent_formats_of` and
+//! `perm_primary_key` are single functions.
+//!
+//! Neither harness compares the two plans itself; each decomposes one plan's own loop. The per-query
+//! comparison is `explain_analyze`'s (predicted and measured for every plan at once) — see
+//! `docs/workflows/diagnosing-a-plan-cost-error.md`.
+
+/// Timed repetitions; the minimum per cell is reported, and all cells run inside this loop so every
+/// cell's minimum is drawn from the same time window. Running cells to completion one at a time let
+/// machine drift enter the fit as a rate difference — 1.8× between cells with identical counters — so
+/// both harnesses interleave from the start.
+pub(crate) const ITERS: usize = 200;
+
+/// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
+/// printings-per-card is what identifies two rates per mode with a degree of freedom left over, and it
+/// sets the leverage between the card column and the printing column. 4 keeps that leverage worth having
+/// while leaving the wide group ~4× bigger than at 8, where only 1,910 cards qualify.
+pub(crate) const WIDE_MIN_PRINTINGS: usize = 4;
+
+/// Card counts every cell runs at, on both harnesses. The UNION of what each needed separately, because
+/// each size is load-bearing for a different question and dropping any of them loses coverage:
+///
+/// - **100, 400** — the INTERCEPT. A per-query fixed cost only exists as the y-intercept of cells that
+///   vary in size, and `intercept = t(n) - slope * n` multiplies any slope error by `n`: at a 400-card
+///   floor a 1 ns/card slope error is already 400 ns against a shipped `GATHER_FIXED_COST_NS` of 169.6.
+///   Adding 100 is also what revealed the per-card average is U-SHAPED rather than monotone, which
+///   retracted the "negative intercept ⇒ the loop is convex" finding.
+/// - **600** — BELOW `STREAM_MIN_MATCHES` (1,024) in card mode, where matches == cards. P3's finish phase
+///   branches there: at or under the threshold the small-total gather scans `0..n_cards`, above it the
+///   permutation walk steps until the page fills. Every earlier cell exceeded it, so that branch and
+///   `STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` with it had never been measured.
+/// - **1,500, 4,500** — the linearity range, bounded above by the scarce wide group.
+///
+/// Five sizes on both sides costs the gather harness 25% more cells and the streamed one 67%, against
+/// runtimes of under a second and a few seconds respectively.
+pub(crate) const CARD_COUNTS: [usize; 5] = [100, 400, 600, 1_500, 4_500];
+
+/// Page requested. Small and fixed on both harnesses so the finish phase stays out of the loop
+/// measurement — P4's `sel.absorb()` prunes toward `offset + limit` INSIDE its loop, so holding it
+/// constant keeps that contribution proportional to matches rather than to the page, and P3's `ns_finish`
+/// branches on `total` rather than on the page at all.
+pub(crate) const LIMIT: usize = 60;
+
+/// Default store for both harnesses. `BENCH_LOOP_STORE` overrides it, which is how the corpus-size sweep
+/// runs: build upscaled stores with `scripts/upscale_corpus.py` and point this at each in turn.
+///
+/// The real corpus is only ~68 MB, small enough that a full chunk rotation can stay resident in the
+/// system-level cache, so the rates it yields are still partly warm however the walk is ordered.
+const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
+
+pub(crate) fn store_path() -> String {
+    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
+}

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -128,6 +128,7 @@
 //! Needs benchmarks/verify-order/real.store, shared with `bench_verify_cost` and `bench_gather_loop`;
 //! rebuild it the same way (see `bench_verify_cost`'s module docs).
 
+use super::bench_loop_design::{store_path, CARD_COUNTS, ITERS, LIMIT, WIDE_MIN_PRINTINGS};
 use std::hint::black_box;
 
 use rkyv::Archived;
@@ -137,36 +138,12 @@ use super::{
     NumExpr, NumField, PreparedCandidates, QueryCtx, QueryParams, ARCHIVE_HEADER_LEN,
 };
 
-/// Timed repetitions; the minimum per cell is reported, and all cells run inside this loop so every
-/// cell's minimum is drawn from the same time window. Running cells to completion one at a time let
-/// machine drift enter `bench_gather_loop`'s fit as a rate difference — 1.8× between cells with
-/// identical counters — so this interleaves from the start.
-const ITERS: usize = 200;
-/// A "wide" card has at least this many printings; below it and above 1 is "medium". Three levels of
-/// printings-per-card is what identifies two rates per mode with a degree of freedom left over.
-const WIDE_MIN_PRINTINGS: usize = 4;
-/// Card counts each cell runs at, bounded above by the scarce wide group. Three sizes measure linearity
-/// in the card term rather than assuming it, and 600 sits BELOW `STREAM_MIN_MATCHES` (1,024) in card
-/// mode where matches == cards. That matters because the finish phase takes a different branch on each
-/// side: at or under the threshold the small-total gather scans `0..n_cards`, above it the permutation
-/// walk steps until the page fills. Every earlier cell exceeded the threshold, so the gather branch --
-/// and `STREAM_SMALL_TOTAL_FLOOR_PER_CARD_NS` with it -- was never measured at all.
-const CARD_COUNTS: [usize; 3] = [600, 1_500, 4_500];
-/// Page requested. P3's `ns_finish` branches on `total` against `STREAM_MIN_MATCHES`, not on the page,
-/// so this only has to be small and fixed to keep the finish phase out of the loop measurement.
-const LIMIT: usize = 60;
 /// A release date no printing in the corpus reaches, so the residual predicate is always true. Keeps
 /// every printing matching, so `printings_examined` and `matches` are exactly the span (printing mode)
 /// or 1 per card (card mode, which returns at the first match) instead of a corpus-dependent fraction.
 const DATE_AFTER_EVERYTHING: u32 = 99_999_999;
 
-/// Default store; `BENCH_LOOP_STORE` overrides it, same as `bench_gather_loop`, so both harnesses sweep
-/// the same upscaled stores from `scripts/upscale_corpus.py`.
-const DEFAULT_STORE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../benchmarks/verify-order/real.store");
 
-fn store_path() -> String {
-    std::env::var("BENCH_LOOP_STORE").unwrap_or_else(|_| DEFAULT_STORE_PATH.to_string())
-}
 
 /// One measured design point.
 struct Cell {

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -105,6 +105,24 @@ pub(crate) struct PlanFeatures {
     /// non-matching cards dominate either way) and decisive under an exact one, which is why the plane
     /// branch of `acquire_plan_features` sets this field itself rather than taking the span estimate.
     pub scan_units: u32,
+    /// `scan_units` for `StreamedSelect` specifically, where that plan examines a DIFFERENT number of
+    /// printings from `GatheredScan` on the same query. One per-query field cannot serve both: P4's
+    /// `push_card_matches` must walk a card's span to push every match, while P3's `card_match_count`
+    /// answers from span arithmetic for every card `card_pass` resolves outright.
+    ///
+    /// Measured on the compose acquire, `scan_units` against the realized `printings_examined`:
+    ///
+    ///     f:modern / artwork      GatheredScan 101,716 / 73,783 = 1.38    StreamedSelect 101,716 / 7,770 = 13.09
+    ///     f:gladiator / artwork    88,026 / 54,213 = 1.62                  88,026 /  5,876 = 14.98
+    ///
+    /// Right for P4 to within 1.4-1.6x, wrong for P3 by 13-15x, and `scan_units * STREAM_SCAN_PER_ROW_NS`
+    /// is then 525 us of P3's 704 us prediction against a 91 us measured loop. That is a FEATURE error, the
+    /// one class no rate can absorb — unlike the residual floor, whose kernel-vs-traffic gap turned out to
+    /// be a cache artifact.
+    ///
+    /// Set by the acquire branch that knows the difference; `mk_plan_feats` defaults it to `scan_units`, so
+    /// a branch that has not been taught reads exactly as before.
+    pub stream_scan_units: u32,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
     pub residual_tier_ns100: u32,
@@ -797,7 +815,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                 * (STREAM_LOOP_PER_CARD_NS
                     + if tier_ns > 0.0 { STREAM_CARD_PASS_NS + tier_ns.max(STREAM_RESIDUAL_FLOOR_NS) } else { 0.0 })
                 // Only with a residual does P3 walk printings; see STREAM_SCAN_PER_ROW_NS.
-                + if tier_ns > 0.0 { scan_units * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
+                + if tier_ns > 0.0 { f64::from(f.stream_scan_units) * STREAM_SCAN_PER_ROW_NS } else { 0.0 }
                 + matches * STREAM_EMIT_PER_MATCH_NS
                 + perm_steps * STREAM_PERM_STEP_NS
                 + f64::from(f.artwork_seen_cards) * STREAM_ARTWORK_SEEN_PER_CARD_NS

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -123,6 +123,13 @@ pub(crate) struct PlanFeatures {
     /// Set by the acquire branch that knows the difference; `mk_plan_feats` defaults it to `scan_units`, so
     /// a branch that has not been taught reads exactly as before.
     pub stream_scan_units: u32,
+    /// Diagnostic: the residual compares only CARD-level fields, so `card_pass` answers `True`/`False`
+    /// per card and never `PrintingDep`. A matching candidate then contributes its whole printing span and
+    /// a non-matching one none of it, which is a different estimator shape from one where printings under a
+    /// single card disagree — and the latter is what `RESIDUAL_PASS_RATE_PRINTING`/`_ARTWORK` was fitted on.
+    /// Exposed so `matches`'s error can be split by population before any rate is touched. **Nothing in
+    /// `plan_cost` reads this.**
+    pub residual_card_invariant: bool,
     /// Per-card verify cost of the residual, ns×100 (`verify_cost_tier`); `0`
     /// when `all_match_known` (the walk skips `card_pass` entirely).
     pub residual_tier_ns100: u32,

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -401,6 +401,23 @@ const STREAM_SCAN_PER_ROW_NS: f64 = 5.97;
 /// That same regression also shows the residual's cost is per CARD, not per printing scanned: the
 /// SLOPE against printings-per-card is ~3.5 for every tier including none (P4) and ~2 for P3, i.e.
 /// independent of what the residual is. So the tier belongs on `eval_domain`, as it now sits.
+/// **Measured with a built design 2026-08-04, and NOT changed — the useful part is why.** The floor only
+/// ever binds on `MASK_COMPARE` (tier 4.00); every other tier exceeds 6.58 and `max` takes the tier. So
+/// `bench_streamed_loop`'s always-true `DateCmp` cells are exactly the population it governs, and they say
+/// the residual's per-card cost is 2.45 ns (printing/residual 4.97 less printing/all_match 2.52) against a
+/// charged `CARD_PASS + floor` of 9.05 — i.e. the `card_pass` call IS the whole cost and the mask compare
+/// adds nothing measurable.
+///
+/// Traffic disagrees, and traffic wins on levels: the fitted `CARD_PASS+FLOOR` column reads **8.19 against
+/// the shipped 9.05 (0.90)** for this arm and **21.59 against 21.89 (0.99)** for `GatheredScan`. Both
+/// floors are already right to within 10% and 1%.
+///
+/// That is the third time this file has caught the same artifact. The design measures an always-true
+/// predicate over chunk-rotated slices; production runs real residuals over a warmer archive, and the two
+/// differ by 3.3x here exactly as they differed by 1.6-2.2x in the retraction at the top of
+/// `bench_streamed_loop`. Shape from a built design, levels from traffic — the design's contribution is
+/// the SHAPE finding that the tier adds ~0 over the call for the cheapest class, which is worth knowing
+/// and is not a licence to move the level.
 const STREAM_RESIDUAL_FLOOR_NS: f64 = 6.58;
 /// ns per match, for the permutation-walk emit. Small — P3 measured nearly flat
 /// in match count once eval_domain is fixed (see STREAM_MATCH_PHASE_PER_CARD_NS),

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -670,6 +670,37 @@ pub(crate) fn regex_tier(pattern: &str) -> u32 {
 /// settles an And, a card-level True settles an Or), so a composite is
 /// printing-dependent only when ALL its children are.
 fn printing_dependent(f: &FilterExpr) -> bool {
+    match f {
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(printing_dependent),
+        FilterExpr::Not(inner) => printing_dependent(inner),
+        leaf => leaf_compares_printing_field(leaf),
+    }
+}
+
+/// Whether `f` compares a printing-level field **anywhere** — the `any` composition of the same leaf
+/// table `printing_dependent` reads with `all`. The two questions are different and both are wanted:
+///
+/// - `printing_dependent` asks "can this node never settle at card level", for verify ORDERING. A
+///   composite settles when ANY child can, so it is printing-dependent only when ALL children are.
+/// - this asks "could any part of this need a per-printing answer", for the result-total ESTIMATE. A
+///   card-invariant residual returns `True`/`False` per card and never `PrintingDep`, so each candidate
+///   contributes either its whole printing span or none of it — a different estimator shape from one where
+///   printings under a single card disagree.
+///
+/// `name:s AND usd>10` separates them: not `printing_dependent` (the name settles it), but it does touch a
+/// printing field, so the span of a matching card is not all-or-nothing.
+pub(crate) fn touches_printing_field(f: &FilterExpr) -> bool {
+    match f {
+        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().any(touches_printing_field),
+        FilterExpr::Not(inner) => touches_printing_field(inner),
+        leaf => leaf_compares_printing_field(leaf),
+    }
+}
+
+/// The per-leaf half of both questions above: does this NON-composite node compare a printing-level
+/// field. Composition is the callers' business, which is the whole reason this is factored out — the two
+/// callers disagree on it and must not disagree on the table.
+fn leaf_compares_printing_field(f: &FilterExpr) -> bool {
     fn num_pdep(e: &NumExpr) -> bool {
         match e {
             NumExpr::Const(_) => false,
@@ -712,8 +743,11 @@ fn printing_dependent(f: &FilterExpr) -> bool {
         // Divergent-legality cards defer to the printing, but they are a rare
         // exception (non-tournament reprints); rank by the common card-level case.
         FilterExpr::Legality { .. } => false,
-        FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(printing_dependent),
-        FilterExpr::Not(inner) => printing_dependent(inner),
+        // Composites are composed by the two callers, which differ on `all` vs `any`; reaching here with
+        // one is a bug in whichever caller forgot to handle it, not a case to answer silently.
+        FilterExpr::And(_) | FilterExpr::Or(_) | FilterExpr::Not(_) => {
+            unreachable!("composites are composed by printing_dependent / touches_printing_field")
+        }
         // Exhaustive, not `_ => false`: a new variant must get a considered
         // answer here rather than silently inheriting "can settle at card level".
         FilterExpr::True

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8352,6 +8352,30 @@ fn acquire_plan_features(
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
             }
         };
+        // `eval_domain` and `scan_units` describe what the MATERIALIZING alternatives walk, and when the
+        // narrowing does not shrink the candidate set they walk the whole corpus — at which point these are
+        // not badly estimated, they are estimating the wrong QUANTITY. `est_cards` is a count of MATCHING
+        // cards; `cards_visited` counts CANDIDATES, a superset whenever the narrowing is inexact. Measured
+        // against P4's `cards_visited` over 2,904 compose rows, the distribution is bimodal — 34% of rows
+        // visit every card — and on those rows:
+        //
+        //     est_cards            p10 0.43   p50 0.65   p90 0.83   mean |log| 0.454
+        //     n_cards              p10 1.00   p50 1.00   p90 1.00   mean |log| 0.000
+        //
+        // Exact by construction, not calibrated. Overall mean |log| 0.370 -> 0.216. Both plans visited the
+        // SAME card count on 100% of rows, which is also why this feature does not want splitting per plan.
+        //
+        // Predicted with the predicate and the constant the sibling `PrintingRangeScan` branch already uses
+        // for the identical decision — no new constant. Scored against the realized flag, `printing_matches`
+        // over `MAX_NARROW_FRACTION` (0.25) of `n_printings` catches **98%** of full-scan rows at 87%
+        // accuracy, beating every threshold on the two alternative signals tried. Its 26% false positives
+        // over-cost both materializing plans by the same factor, which an argmin largely absorbs; the false
+        // negatives are what were losing `GatheredScan vs StreamedSelect`, so recall is the side to favour.
+        let (eval_domain, scan_units) = if range_too_broad_to_narrow(printing_matches, n_printings as usize) {
+            (n_cards as usize, n_printings as usize)
+        } else {
+            (eval_domain, scan_units)
+        };
         // The tier is what the MATERIALIZING alternatives pay per candidate, so it must be asked about
         // the predicate THEY see (`filter` + `plane`), not about `composed` — and gated exactly as
         // `prepare_candidates` gates it, or the router charges a `card_pass` the kernels will skip. On a

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -9365,17 +9365,44 @@ fn run_query_streamed<'a>(
     for cid in card_ids {
         n_cards_visited += 1;
         let card = &cards[cid as usize];
-        // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True
-        // when the narrowing already proved every candidate matches. Gated
-        // off for Mode::Artwork specifically: measured a ~45% regression for
-        // `t:creature` unique=artwork with this applied unconditionally here
-        // (0.13ms -> 0.19ms typical, isolated by bisecting call sites) despite
-        // being a no-op change in card_pass's own return value (True either
-        // way) — an unexplained codegen/scheduling effect in this loop for
-        // that mode specifically, not a logical cost. Card/Printing modes
-        // showed no such effect and do benefit (this loop visits every
-        // candidate, not just the ~limit emitted).
-        let all_match = (all_match_known && !matches!(mode, Mode::Artwork))
+        // #634 Step 1: skip the redundant card_pass re-derivation of Tri::True when the narrowing has
+        // already proved every candidate matches.
+        //
+        // **This was gated OFF for `Mode::Artwork`, and the gate is now removed (2026-08-04).** Its comment
+        // cited a ~45% regression on `t:creature`/artwork (0.13ms -> 0.19ms) from applying the skip here,
+        // called it "an unexplained codegen/scheduling effect ... not a logical cost", and said it was
+        // "isolated by bisecting call sites" — i.e. across builds, the one instrument this engine has
+        // repeatedly shown cannot resolve an effect that size and will hand you the wrong sign (see trap 1
+        // in docs/workflows/diagnosing-a-plan-cost-error.md).
+        //
+        // Re-measured with a runtime toggle inside ONE binary, `unique=artwork`, limit 175:
+        //
+        //     query         gate on      gate off    speedup
+        //     o:this        1047.7 us      47.5 us     22.1x
+        //     o:target       556.6         30.1        18.5x
+        //     o:creature    1010.5         56.6        17.9x
+        //     t:creature      84.1         43.0         2.0x   <- the query the gate existed to protect
+        //     o:flying        24.1         13.5         1.8x
+        //     c:r             32.2         18.5         1.7x
+        //     t:land          15.5         12.1         1.3x
+        //
+        // Every cell is faster and the cited regression does not reproduce in either direction. The cost was
+        // worst for an expensive residual: `o:creature` ran a full oracle-text containment check over all
+        // 23,155 candidates the narrowing had already proved matched, which is why the same query in printing
+        // mode — identical candidate set, identical span, `card_pass` skipped — took 56.7 us against
+        // artwork's 1010.5. That query was the single largest routing regret in the engine at 508.9 us, and
+        // the cost model was right about it throughout: it charges `tier = 0` here, because `all_match_known`
+        // is supposed to mean no `card_pass` runs.
+        //
+        // Row identity is what an `all_match` mistake breaks silently in this mode — totals do not move, the
+        // printing that REPS each artwork group does. 1,134 cells over 21 predicates x 3 modes x 3 orderbys x
+        // 3 pages x 2 prefers, hashing the returned `scryfall_id` sequence: **identical**, 378 of them
+        // artwork, including the existential-plane shapes (`f:*`, `border:*`, `r>=rare`, `watermark:*`,
+        // `-f:modern`) where a card-level True does not imply every printing matches. Soundness rests on
+        // `all_match_known` itself, which already refuses an existential plane outside card mode via
+        // `plane_leaves_nothing_to_verify`, and only trusts `residual_exact` when the narrowing was not
+        // printing-space.
+        let all_match = all_match_known
             || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
                 Tri::False | Tri::Null => continue,
                 Tri::True => true,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8171,6 +8171,9 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     if feats.residual_card_invariant {
         feats.stream_scan_units = 0;
     }
+    if prep.all_match_known || feats.residual_card_invariant {
+        feats.artwork_seen_cards = 0;
+    }
     // Same signal, second term — **measured, and NOT applied.** `run_query_streamed` answers an artwork count
     // from a STORED per-card group count when `all_match && have_group_counts`, touching no printing, and only
     // walks the span to dedup groups when a residual survives per printing. So `artwork_seen_cards` charging

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8171,6 +8171,21 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     if feats.residual_card_invariant {
         feats.stream_scan_units = 0;
     }
+    // Same signal, second term — **measured, and NOT applied.** `run_query_streamed` answers an artwork count
+    // from a STORED per-card group count when `all_match && have_group_counts`, touching no printing, and only
+    // walks the span to dedup groups when a residual survives per printing. So `artwork_seen_cards` charging
+    // `eval_domain` unconditionally is the wrong SHAPE, and measurably the wrong sign in the fast-path regime.
+    // Artwork-minus-printing `ns_loop` delta on identical candidate sets, against a charged +1.21 ns/card:
+    //
+    //     printings_examined == 0    (stored count)   median -0.46 ns/card   n=9
+    //     printings_examined == span (dedup walk)     median +0.38 ns/card   n=8
+    //
+    // Artwork is *cheaper* than printing when the fast path fires. Gating the term on
+    // `all_match_known || residual_card_invariant` duly improved absolute agreement — P3 went from p/m
+    // 1.58-1.83 to 1.14-1.34 on those cells — and **regressed routing**: the artwork regret slice went mean
+    // 1.59 -> 1.71 us and max 185.5 -> 732.5. So the +1.21 is compensating for something else in the P3/P4
+    // artwork balance, and cannot be removed alone. That is item 6, and it needs both arms at once — the same
+    // lesson as `bench_gather_loop`'s "P4 cannot be fixed alone".
 
     feats
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8305,7 +8305,19 @@ fn acquire_plan_features(
         // `eval_domain` and scanned 0.14x the claimed `scan_units`. Over-costing both plans inflates
         // the predicted GAP between them (P4 carries the larger per-row rates), which is what routing
         // reads -- measured as a GatheredScan-vs-StreamedSelect gap ratio of 0.32 on this acquire.
-        let scan_all = |cards: usize| ((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize;
+        // Clamped at `n_printings`, which is an INVARIANT and not a calibration: this estimates the
+        // printings under the candidate CARDS, and those are a subset of the corpus, so a value above
+        // `n_printings` is not a wrong estimate but an impossible one. `COMPOSE_CANDIDATE_SPAN_BIAS`'s 2.1
+        // says candidates are more reprinted than an average card, which is true when a composable
+        // predicate SELECTS by having a matching printing and false when it selects nearly everything —
+        // the same saturation failure `COMPOSE_CARD_ESTIMATE_BIAS` had, one multiplier downstream.
+        //
+        // `border:black` / printing reached 159,325 against a corpus of 97,206 and a realized
+        // `printings_examined` of exactly 97,206. The clamp makes that cell exact. It matters for routing
+        // because this feature is 76% of P3's arm on the broad-residual class, where it drove P3 to
+        // pred/meas 1.53 while P4 sat at 0.88 — the pair inverted, with both plans over the same feature.
+        let scan_all =
+            |cards: usize| (((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize).min(n_printings as usize);
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
             Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
             Mode::Card => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8066,6 +8066,7 @@ fn mk_plan_feats(
         matches,
         eval_domain,
         scan_units,
+        residual_card_invariant: false, // diagnostic; only the candidates acquire sets it
         // Defaults to `scan_units`: only an acquire that knows P3 examines fewer printings overrides it.
         stream_scan_units: scan_units,
         residual_tier_ns100,
@@ -8129,7 +8130,15 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
             }
         }
     };
-    mk_plan_feats(ctx, params, matches, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) })
+    let mut feats =
+        mk_plan_feats(ctx, params, matches, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) });
+    // Diagnostic only (`explain`), so the residual-pass-rate population can be split by traffic before any
+    // rate moves. A card-invariant residual answers `True`/`False` per card and never `PrintingDep`, so a
+    // matching candidate contributes its WHOLE printing span and a non-matching one none of it — the
+    // all-or-nothing shape. With a printing-level field in play the printings under one card disagree, which
+    // is the shape the single `RESIDUAL_PASS_RATE_*` was fitted on. Nothing reads this in routing.
+    feats.residual_card_invariant = !prep.all_match_known && !touches_printing_field(filter);
+    feats
 }
 
 /// The acquire step of `run_query_routed`'s three-step algorithm (see its doc
@@ -9813,6 +9822,7 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         // P3's own scan estimate; equals `scan_units` unless the acquire knew the two plans differ.
         ("stream_scan_units", g.stream_scan_units),
         ("residual_tier_ns100", g.residual_tier_ns100),
+        ("residual_card_invariant", u32::from(g.residual_card_invariant)),
         ("limit", g.limit),
         ("offset", g.offset),
         ("broadcast_printings", g.broadcast_printings),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8153,6 +8153,24 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // all-or-nothing shape. With a printing-level field in play the printings under one card disagree, which
     // is the shape the single `RESIDUAL_PASS_RATE_*` was fitted on. Nothing reads this in routing.
     feats.residual_card_invariant = !prep.all_match_known && !touches_printing_field(filter);
+    // A residual that is invariant WITHIN a card never goes printing-dependent: `card_pass` returns
+    // `True`/`False` and never `Tri::PrintingDep`, so `run_query_streamed` sets its per-card `all_match` for
+    // every matching card and `card_match_count` answers from span arithmetic. P3 therefore examines **no
+    // printings at all** and `printings_examined` reads exactly 0 — while the arm was charging
+    // `scan_units * STREAM_SCAN_PER_ROW_NS` for the whole candidate span.
+    //
+    // `name:s` / artwork is the measured case: `scan_units` 97,206 against a realized 0 for P3 and 60,705 for
+    // P4, so the shared feature is 1.60x for the plan that does the work and infinitely wrong for the plan
+    // that does not. That charged P3 580 us of a 1,507 us prediction against a 456 us measurement and handed
+    // the query to `GatheredScan` at 824 us — 368 us lost on one query, repeated across every orderby.
+    //
+    // This is the `all_match_known` gate one step weaker. That gate needs the whole residual to be `True`;
+    // this needs only that it cannot vary within a card, which `name:s`, `o:`, `t:` and `cmc` all satisfy
+    // while being ordinary residuals. P4's `scan_units` is deliberately untouched — it walks each candidate's
+    // span to push, so its 60,705 is real work, and this is exactly the asymmetry an argmin needs.
+    if feats.residual_card_invariant {
+        feats.stream_scan_units = 0;
+    }
 
     feats
 }

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -8108,6 +8108,21 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // where a residual survives, because roughly half the printings under a candidate then fail it.
     // Discount by the measured pass rate there; undiscounted it swapped a 2.4x under-count for a 2.6x
     // over-count. Result after both: 1.00 tight, 0.91-1.00 with a residual.
+    // Two exact-count routes were measured here and BOTH are worse than this span estimate, for one
+    // shared reason: the quantity wanted is `|candidates AND residual|`, and neither route provides an
+    // intersection.
+    //
+    // - `estimator::estimate_cardinality` (the engine already ships it, index-backed leaves, independence
+    //   over `And`): worse in every mode -- card mean |log| 1.31 against 0.79, p90 33.38 against 9.91.
+    // - `RangeCardCounts::distinct_cards`, which is genuinely EXACT and O(log n): available on only 9% of
+    //   rows with a residual (7% of the misordered ones, 2.0 of 46.5 ms of pairwise gap), and 6x worse where
+    //   it is available -- card p50 6.32 against 1.12. It counts cards matching the residual leaf GLOBALLY,
+    //   not cards matching it among the candidates, so it is exact for the wrong set.
+    //
+    // The exact answer needs the residual evaluated over the candidates, which is the work being costed. A
+    // bitmap AND of the candidate set with an indexed leaf's set would give it for that same 9%; nothing
+    // cheap covers the rest. See the candidates-acquire section of
+    // docs/issues/local-engine-loop-phase-measurement.md.
     let matches = match params.mode {
         Mode::Card => count,
         Mode::Printing | Mode::Artwork => {
@@ -8138,6 +8153,7 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // all-or-nothing shape. With a printing-level field in play the printings under one card disagree, which
     // is the shape the single `RESIDUAL_PASS_RATE_*` was fitted on. Nothing reads this in routing.
     feats.residual_card_invariant = !prep.all_match_known && !touches_printing_field(filter);
+
     feats
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -7902,18 +7902,51 @@ const COMPOSE_GATHER_SPAN_PER_MATCH: f64 = 1.47;
 /// cancelling, and dividing `est_cards` by 1.78 moved it to 0.47.
 const COMPOSE_CANDIDATE_SPAN_BIAS: f64 = 2.1;
 
-/// `balls_into_bins` with its measured bias divided out. See `COMPOSE_CARD_ESTIMATE_BIAS`.
+/// `balls_into_bins` with its measured clustering bias divided out of the BALL COUNT. See
+/// `COMPOSE_CARD_ESTIMATE_BIAS` for the 1.78 and why clustering causes it.
+///
+/// The bias used to divide the estimator's OUTPUT, which broke its ceiling. `balls_into_bins` saturates
+/// toward `domain` — that is the whole point of using it over `k.min(domain)` — so scaling what it returns
+/// caps the calibrated estimate at `domain / 1.78`, i.e. **17,701 of 31,508 cards no matter how many
+/// printings match**. `border:black` matches 85,046 of 97,206 printings and visits every card in the corpus;
+/// the estimate read 16,511.
+///
+/// Clustering does not mean "fewer cards than the estimator says". It means the `k` matching printings are
+/// not `k` independent draws — a legality leaf broadcast down sets a whole card's printings at once — so the
+/// EFFECTIVE ball count is lower. That is an input. Dividing `k` instead is the same correction in the
+/// selective regime the 1.78 was fitted on (`balls_into_bins(k, d) ≈ k` for `k ≪ d`, so scaling either side
+/// agrees) and keeps the saturation the output form destroyed. Graded against P4's realized `cards_visited`
+/// over 3,490 estimator rows, estimate/realized:
+///
+///     breadth (k / n_printings)      bias on output        bias on input
+///     selective  < 0.1               p50 1.02              p50 1.02      <- fitted here, unchanged
+///     mid        0.1-0.5             p50 0.91              p50 1.18
+///     broad      > 0.5               p50 0.52              p50 0.78
+///     all                            p50 0.87  spread 3.3  p50 0.90  spread 2.7
+///
+/// The mid band overshoots because 1.78 was fitted against the output form; it is not re-fitted here, so
+/// this is the shape change alone. Re-fitting it is a fixed-point iteration on a constant whose own value
+/// depends on where it is applied — the same caveat `fit_cost_model` records for the residual floor.
+///
+/// Why this matters for routing and not just accuracy: `eval_domain` feeds a per-card term in both scan
+/// arms, and P4's rate is 25.77 ns/card against P3's 11.63, so under-counting candidates discounts P4 by
+/// 2.2× as much. On the broad-residual class that inverted the pair — P3 measured 819.7 µs against P4's
+/// 1,308.4 with the model pricing them within 5 µs of each other.
 fn calibrated_balls_into_bins(k: usize, domain: usize) -> usize {
-    let raw = balls_into_bins(k, domain) as f64;
-    ((raw / COMPOSE_CARD_ESTIMATE_BIAS).round() as usize).max(usize::from(k > 0))
+    balls_into_bins_effective(k as f64 / COMPOSE_CARD_ESTIMATE_BIAS, domain).max(usize::from(k > 0))
 }
 
 fn balls_into_bins(k: usize, domain: usize) -> usize {
+    balls_into_bins_effective(k as f64, domain).max(usize::from(k > 0))
+}
+
+/// `domain * (1 - e^(-k/domain))` for a possibly fractional ball count, clamped to the domain.
+fn balls_into_bins_effective(k: f64, domain: usize) -> usize {
     if domain == 0 {
         return 0;
     }
-    let est = domain as f64 * (-(k as f64) / domain as f64).exp().mul_add(-1.0, 1.0);
-    (est.round() as usize).min(domain).max(usize::from(k > 0))
+    let est = domain as f64 * (-k / domain as f64).exp().mul_add(-1.0, 1.0);
+    (est.round() as usize).min(domain)
 }
 
 /// Distinct **artworks** an estimated printing set touches, projected in two stages.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6654,6 +6654,36 @@ fn card_range_popcount_applicable(
 
 // ─── Shared P3/P4 candidate preparation ─────────────────────────────────────
 
+/// Whether a plane-consumed predicate leaves the match kernels **nothing to verify per card** — i.e.
+/// `card_pass` is redundant and both kernels take their `all_match` arm.
+///
+/// Legality planes (docs/issues/00667-engine-legality-divergent-carveout.md) are existence
+/// projections ("*some* printing matches"), unlike every other plane (card-invariant fields, true or
+/// false alike for every printing of a card). For `unique=card` that is exactly the semantics wanted.
+/// But `Mode::Printing`/`Artwork` enumerate individual printings, and "the card has some legal
+/// printing" does not mean "this printing is legal" — `card_pass` must still run per printing there
+/// whenever the plane touched a *divergent* format, which is what `plane_expr_is_existential` tests
+/// against the data-derived `divergent_formats` mask.
+///
+/// Extracted so the ROUTER can ask the same question the EXECUTOR does. `prepare_candidates` had the
+/// only copy, and the compose acquire branch — which never calls it — therefore charged
+/// `verify_cost_tier` on every legality-composed query alike. On a card-invariant format that put P3
+/// at meas/pred 0.16-0.44 while `PrintingCompose` read 1.02-1.17, and the argmin lost those cells to a
+/// plan measuring ~2.5x slower. A boolean, not an estimated share: the two attempts to price this as a
+/// divergent *fraction* of the corpus under-charged `f:oldschool`, whose candidates largely ARE the
+/// divergent cards, and traded 408 mispicks for 118 worse ones.
+fn plane_leaves_nothing_to_verify(
+    filter: &FilterExpr,
+    mode: Mode,
+    plane: Option<&PlaneExpr>,
+    indexes: &Archived<CardIndexes>,
+) -> bool {
+    matches!(filter, FilterExpr::True)
+        && plane.is_none_or(|expr| {
+            matches!(mode, Mode::Card) || !plane_expr_is_existential(expr, u64::from(indexes.planes.divergent_formats))
+        })
+}
+
 /// The candidate materialization + filter rewriting shared by `StreamedSelect`
 /// and `GatheredScan`, extracted verbatim from `run_query`. Mutates `filter` via
 /// `memoize_text_predicates` + `order_children_by_verify_cost` under the same
@@ -6683,22 +6713,7 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // calls below and in run_query_streamed become redundant re-verification
     // of what the narrowing already established.
     //
-    // A plane-driven True residual needs one more check first: legality's
-    // planes (docs/issues/00667-engine-legality-divergent-carveout.md) are
-    // existence projections ("*some* printing matches"), unlike every other
-    // plane (card-invariant fields, true or false alike for every printing
-    // of a card). For unique=card that's exactly the semantics wanted --
-    // Mode::Card only needs *a* matching printing to exist, same as Step 2
-    // above. But Mode::Printing/Artwork enumerate individual printings, and
-    // "the card has some legal printing" does not mean "this printing is
-    // legal" -- card_pass must still run per printing there whenever the
-    // plane touched legality, so this only trusts a True residual for those
-    // modes when the plane is existential-free (plane_expr_is_existential).
-    let plane_true_for_mode =
-        plane.is_none_or(|expr| {
-            matches!(mode, Mode::Card) || !plane_expr_is_existential(expr, u64::from(ctx.indexes.planes.divergent_formats))
-        });
-    let all_match_known = (matches!(filter, FilterExpr::True) && plane_true_for_mode) || residual_exact;
+    let all_match_known = plane_leaves_nothing_to_verify(filter, mode, plane, ctx.indexes) || residual_exact;
 
     // The plane bitmap is the exact card-level truth of the plane-consumed
     // subexpression (split_planes), so it composes with the residual's
@@ -8292,7 +8307,35 @@ fn acquire_plan_features(
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
             }
         };
-        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(composed));
+        // The tier is what the MATERIALIZING alternatives pay per candidate, so it must be asked about
+        // the predicate THEY see (`filter` + `plane`), not about `composed` — and gated exactly as
+        // `prepare_candidates` gates it, or the router charges a `card_pass` the kernels will skip. On a
+        // card-invariant legality format `card_pass` resolves at card level for every card, so
+        // `printings_examined` reads 0 and both the per-card residual and the per-row scan are dead
+        // terms; charging them anyway was 92-94% of P3's predicted cost on `f:modern`, `f:gladiator`,
+        // `f:commander` and `f:predh`. `residual_exact` is unavailable here (this branch never narrows),
+        // so this is the conservative half of the executor's disjunction: it can over-charge, never under.
+        let nothing_to_verify = plane_leaves_nothing_to_verify(filter, mode, plane, indexes);
+        let tier = if nothing_to_verify { 0 } else { verify_cost_tier(composed) };
+        // `GatheredScan` walks every printing of every candidate card, so its scan feature is the candidate
+        // SPAN. `scan_all` estimates that span as `est_cards x` the corpus-average printings-per-card `x 2.1`,
+        // which is the right shape only when candidates are an average sample. With nothing to verify they
+        // are not: every printing of a matching card matches, so the span IS `printing_matches` — exact,
+        // and already computed above for compose's own estimate. Graded against P4's realized
+        // `printings_examined` over 597 card-invariant compose queries:
+        //
+        //     scan_units (shipped)   p10 1.13   p50 1.76   p90 5.08
+        //     printing_matches       p10 0.68   p50 0.93   p90 3.08
+        //
+        // A 1.76x over-charge on the dominant term of P4's arm, which is what makes P3 win where P4 is
+        // better: `StreamedSelect -> GatheredScan` is the largest regret slice on this acquire. Scoped to
+        // the same boolean as the tier because the grading inverts on the other population — with a real
+        // residual `scan_units` is right at p50 0.97 and `printing_matches` badly under at 0.39.
+        //
+        // Fixes the BIAS, not the spread: both rows read p90/p10 4.5, so what remains is the candidate
+        // count's own variance (`eval_domain` grades p90/p10 3.1 here) and is not a scan-feature problem.
+        let scan_units = if nothing_to_verify { printing_matches } else { scan_units };
+        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, tier);
         // What `StreamedSelect` actually examines here, which is NOT `scan_units`. P4 walks a card's whole
         // span to push every match; P3's `card_match_count` answers from span arithmetic for every card
         // `card_pass` resolves at card level, and on a legality-composed filter that is every non-divergent
@@ -8305,11 +8348,20 @@ fn acquire_plan_features(
         // engine holds the set: `legal_divergent`. For a filter with no legality leaf the share is 1.0 and
         // this reduces to `scan_units`, which the same sweep showed is right to 1.0-2.4x on `border:black`,
         // `r:mythic` and `watermark:*` -- so the correction is confined to the case that measured wrong.
-        feats.stream_scan_units = if verify_cost_tier(composed) > 0 && filter_touches_legality(composed) {
+        feats.stream_scan_units = if tier == 0 {
+            // Nothing to verify: `card_match_count` answers every card from span arithmetic and examines
+            // no printings whatsoever. Reported as 0 so `bench_feature_accuracy` grades this against the
+            // realized `printings_examined` (also 0) instead of against a scan that never happens. The
+            // arm multiplies the term by zero on the same signal, so this changes no cost — only whether
+            // the feature can be graded honestly.
+            0
+        } else if filter_touches_legality(composed) {
             let divergent = indexes.legal_divergent.len() as f64;
             let share = (divergent / f64::from(n_cards)).min(1.0);
-            // Floored at one printing per candidate: even a fully card-invariant legality filter examines
-            // the boundary printing of the cards it does match, which the share alone would put at zero.
+            // Floored at one printing per candidate: with a divergent format in play the kernel does
+            // examine the boundary printing of the cards it matches, which the share alone would put at
+            // zero. Only reachable now when there IS something to verify, which is the case the floor was
+            // argued for -- the `tier == 0` arm above is where it used to be wrong.
             ((scan_units as f64) * share).max(eval_domain as f64) as u32
         } else {
             scan_units as u32

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10559,6 +10559,8 @@ mod bench_compose_card_projection;
 #[cfg(test)]
 mod bench_candidate_materialize;
 #[cfg(test)]
+mod bench_loop_design;
+#[cfg(test)]
 mod bench_gather_loop;
 #[cfg(test)]
 mod bench_streamed_loop;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5257,6 +5257,19 @@ fn printing_range_fastpath_inner<'a>(
 /// where the residual applies the correct trivalent semantics. Anything else (a text search, a range,
 /// an arithmetic compare) is likewise non-composable. A composable expression's bits are **exact** (a
 /// set bit *is* a matching printing), so no per-printing re-check is needed.
+/// Whether `filter` constrains legality anywhere. Used to scope the `stream_scan_units` correction to the
+/// case the sweep measured wrong: legality is the one printing-varying attribute `card_pass` can resolve at
+/// CARD level for most cards (only the divergent ones defer), so it is the only one where P3 and P4 examine
+/// wildly different printing counts. Border, rarity and watermark all measured at parity.
+fn filter_touches_legality(filter: &FilterExpr) -> bool {
+    match filter {
+        FilterExpr::Legality { .. } => true,
+        FilterExpr::And(cs) | FilterExpr::Or(cs) => cs.iter().any(filter_touches_legality),
+        FilterExpr::Not(inner) => filter_touches_legality(inner),
+        _ => false,
+    }
+}
+
 fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> bool {
     match filter {
         FilterExpr::True => true,
@@ -8005,6 +8018,8 @@ fn mk_plan_feats(
         matches,
         eval_domain,
         scan_units,
+        // Defaults to `scan_units`: only an acquire that knows P3 examines fewer printings overrides it.
+        stream_scan_units: scan_units,
         residual_tier_ns100,
         limit: params.limit as u32,
         offset: params.page_offset as u32,
@@ -8209,7 +8224,14 @@ fn acquire_plan_features(
         // composes once, only if this plan wins (never in acquire; a legality broadcast paid here and
         // then discarded would be pure waste). `synth_printings` = broadcast down (legality) + projection
         // up (card/artwork; 0 for printing). `popcount_words` = the result-space bitmap the total scans.
-        let (printing_matches, broadcast, scatter) = compose_printing_estimate(filter, indexes, offsets, n_printings as usize);
+        //
+        // Estimated from the SAME predicate the executor will compose (`compose_source`), not from the
+        // residual. Reading the residual once a plane had consumed the filter estimated `True` — every
+        // printing in the corpus — so `matches` came back as `n_printings` for every legality query alike
+        // and compose was costed as if it returned everything for nothing. Applicability, estimate and
+        // execution have to agree on which representation this plan is being judged on.
+        let composed = compose_source(filter, unsplit, plane);
+        let (printing_matches, broadcast, scatter) = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
         // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
         // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
         // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
@@ -8224,7 +8246,7 @@ fn acquire_plan_features(
         // projection -- and those are the bulk of what reaches here, since `bare_range_bounds`
         // matches one comparison, not an And of two. One-sided ranges DO land here in quantity:
         // every artwork-mode one, plus card-mode ones whose orderby has no permutation.
-        let exact_cards = bare_range_bounds(filter, indexes)
+        let exact_cards = bare_range_bounds(composed, indexes)
             .and_then(|(idx, lo, hi)| range_card_counts_for(indexes, idx).and_then(|counts| counts.distinct_cards(lo, hi)));
         let est_cards =
             exact_cards.map_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize), |n| n as usize);
@@ -8270,7 +8292,28 @@ fn acquire_plan_features(
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
             }
         };
-        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(filter));
+        let mut feats = mk_plan_feats(ctx, params, result_total as u32, eval_domain as u32, scan_units as u32, verify_cost_tier(composed));
+        // What `StreamedSelect` actually examines here, which is NOT `scan_units`. P4 walks a card's whole
+        // span to push every match; P3's `card_match_count` answers from span arithmetic for every card
+        // `card_pass` resolves at card level, and on a legality-composed filter that is every non-divergent
+        // card -- 556 of 31,508 in production diverge, all in `oldschool`. So P3 examines printings only for
+        // the divergent remainder plus the boundary cards, measured at 0.10-0.26x of P4's count where
+        // `scan_units` claimed parity: 7,770 against 73,783 on `f:modern`, 5,876 against 54,213 on
+        // `f:gladiator`.
+        //
+        // Estimated as the divergent SHARE of the candidate span rather than a fitted fraction, because the
+        // engine holds the set: `legal_divergent`. For a filter with no legality leaf the share is 1.0 and
+        // this reduces to `scan_units`, which the same sweep showed is right to 1.0-2.4x on `border:black`,
+        // `r:mythic` and `watermark:*` -- so the correction is confined to the case that measured wrong.
+        feats.stream_scan_units = if verify_cost_tier(composed) > 0 && filter_touches_legality(composed) {
+            let divergent = indexes.legal_divergent.len() as f64;
+            let share = (divergent / f64::from(n_cards)).min(1.0);
+            // Floored at one printing per candidate: even a fully card-invariant legality filter examines
+            // the boundary printing of the cards it does match, which the share alone would put at zero.
+            ((scan_units as f64) * share).max(eval_domain as f64) as u32
+        } else {
+            scan_units as u32
+        };
         feats.broadcast_printings = broadcast as u32;
         feats.scatter_printings = scatter as u32;
         feats.project_printings = project as u32;
@@ -9646,6 +9689,8 @@ fn acquire_facts_to_pydict<'py>(py: Python<'py>, f: &AcquireFacts) -> PyResult<B
         ("matches", g.matches),
         ("n_printings", g.n_printings),
         ("scan_units", g.scan_units),
+        // P3's own scan estimate; equals `scan_units` unless the acquire knew the two plans differ.
+        ("stream_scan_units", g.stream_scan_units),
         ("residual_tier_ns100", g.residual_tier_ns100),
         ("limit", g.limit),
         ("offset", g.offset),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4601,6 +4601,7 @@ fn plan_cost_model_matches_gold() {
                     // No compose acquire in this fixture, so P3's estimate is the shared one.
                     stream_scan_units: su,
                     residual_tier_ns100,
+                    residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32,
                     offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -4844,6 +4845,7 @@ fn plan_cost_refit() {
                     scan_units: su,
                     stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
+                    residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
@@ -5049,6 +5051,7 @@ fn printing_range_route_probe() {
                 scan_units: su,
                 stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                 residual_tier_ns100,
+                residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture
@@ -5412,6 +5415,7 @@ fn plan_regret_report() {
                 scan_units: est.min(n_cards), // card-mode regret report ⇒ scan_units == eval_domain
                 stream_scan_units: est.min(n_cards),
                 residual_tier_ns100: tier,
+                residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32,
                 offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -5543,6 +5547,7 @@ fn plan_regret_fuzz() {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
                 stream_scan_units: evd,
                 residual_tier_ns100: tier,
+                residual_card_invariant: false, // diagnostic only; nothing in plan_cost reads it
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
                 artwork_seen_cards: 0, // no artwork per-card dedupe bitmask in this fixture

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -4592,11 +4592,14 @@ fn plan_cost_model_matches_gold() {
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
                 // Tier reflects the residual AFTER memoize (what the walk pays).
                 let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
                 let feats = PlanFeatures {
                     n_cards, n_printings,
                     matches: total as u32,
                     eval_domain,
-                    scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
+                    scan_units: su,
+                    // No compose acquire in this fixture, so P3's estimate is the shared one.
+                    stream_scan_units: su,
                     residual_tier_ns100,
                     limit: limit as u32,
                     offset: offset as u32,
@@ -4835,9 +4838,11 @@ fn plan_cost_refit() {
                 );
                 let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(mode_enum), &mut res, pe.as_ref());
                 let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
+                let su = scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain);
                 let feats = PlanFeatures {
                     n_cards, n_printings, matches: total as u32, eval_domain,
-                    scan_units: scan_units(mode_enum, prep.candidate_cards.as_deref(), &archived.offsets, n_printings, eval_domain),
+                    scan_units: su,
+                    stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                     residual_tier_ns100: if prep.all_match_known { 0 } else { verify_cost_tier(&res) },
                     limit: limit as u32, offset: offset as u32,
                     broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -5038,9 +5043,11 @@ fn printing_range_route_probe() {
             let prep = prepare_candidates(&QueryCtx::from(archived), &mode_only_params(Mode::Printing), &mut res, pe.as_ref());
             let eval_domain = prep.candidate_cards.as_ref().map_or(n_cards, |v| v.len() as u32);
             let residual_tier_ns100 = if prep.all_match_known { 0 } else { verify_cost_tier(&res) };
+            let su = scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain);
             let feats = PlanFeatures {
                 n_cards, n_printings, matches: total as u32, eval_domain,
-                scan_units: scan_units(Mode::Printing, prep.candidate_cards.as_deref(), &archived.offsets, n_printings as u32, eval_domain),
+                scan_units: su,
+                stream_scan_units: su, // no compose acquire here, so P3's estimate is the shared one
                 residual_tier_ns100,
                 limit: LIMIT as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,
@@ -5403,6 +5410,7 @@ fn plan_regret_report() {
                 matches: est,
                 eval_domain: est.min(n_cards),
                 scan_units: est.min(n_cards), // card-mode regret report ⇒ scan_units == eval_domain
+                stream_scan_units: est.min(n_cards),
                 residual_tier_ns100: tier,
                 limit: limit as u32,
                 offset: offset as u32,
@@ -5533,6 +5541,7 @@ fn plan_regret_fuzz() {
         for &(limit, offset) in &pages {
             let mk = |matches: u32, evd: u32| PlanFeatures {
                 n_cards, n_printings, matches, eval_domain: evd, scan_units: evd, // card mode ⇒ scan_units == eval_domain
+                stream_scan_units: evd,
                 residual_tier_ns100: tier,
                 limit: limit as u32, offset: offset as u32,
                 broadcast_printings: 0, scatter_printings: 0, project_printings: 0, popcount_words: 0, compose_paging: ComposePaging::Gather,

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -705,20 +705,60 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
 
 1b. **Review the compose acquire's feature estimation — the foundational work, ahead of any rate work.** The
    oracle run above bounds this at 58% → 83% ordered right and a 9× cut in lost time on the pair, with rates
-   untouched. Three targets, in order:
+   untouched. Two questions of that bound are now answered by measurement.
 
-   - **Decompose the oracle gain into "better shared estimate" vs "per-plan feature".** The oracle used each
-     plan's own counters; `scan_units` is one shared number today and the two plans examine different amounts.
-     `stream_scan_units` already splits it for P3, but only on legality filters. This decides the shape of
-     everything below, so it comes first.
-   - **`eval_domain` on the failing population.** p50 **0.85** in the wrong group against 0.98 in the right
-     one, and P4's per-card rate is 2.2× P3's, so the residue discounts P4 asymmetrically. The broad class is
-     mostly range predicates, and `range_card_counts_for` already answers *exactly* — but `bare_range_bounds`
-     matches one comparison, so `cn<=226 year>2004` (an `And` of two) falls back to the estimator. Widening
-     that exact path is likely worth more than any estimator refinement.
-   - **`scan_units` on selective compose queries.** mean |log| **1.22**, p10 0.08, p90 3.62 — a ~45× spread
-     that none of the three bias variants improves (see the span-bias note). Not previously on any list, and
-     the worst-calibrated feature in the acquire.
+   **Which feature carries it — leave-one-out from the full oracle, shipped rates throughout, 2,768 pairs:**
+
+   | variant | ordered right | lost time |
+   | --- | --: | --: |
+   | shipped | 59% | 116.7 ms |
+   | full oracle (per-plan) | **83%** | **12.4 ms** |
+   | oracle, `eval_domain` back to its estimate | 68% | **91.2 ms** |
+   | oracle, `scan` back | 79% | 22.4 ms |
+   | oracle, `matches` back | 83% | 13.2 ms |
+   | oracle, `scan` forced **SHARED** (both read P4's) | 83% | 12.4 ms |
+   | oracle, `eval_domain` forced **SHARED** | 83% | 12.4 ms |
+
+   **`eval_domain` is ~75% of the recoverable loss** (78 of the 104 ms), `scan` ~10%, `matches` nothing.
+
+   **And per-plan features are worth exactly zero.** Forcing either feature to be shared, while keeping it
+   exact, costs nothing at all. So the answer is **not** to split features per plan — it is to make the one
+   shared number accurate. That is visible in the mechanism: on the broad-residual class both plans examine
+   the same 97,206 printings, and on the card-invariant class the verify-tier gate already zeroes P3's scan
+   term. **A corollary worth checking: `stream_scan_units` may now be redundant with that gate**, since the
+   divergence it was built for is the population the gate already handles.
+
+   **Where `eval_domain`'s error lives** (ratio against P4's realized `cards_visited`):
+
+   | path | n | p50 | mean \|log\| |
+   | --- | --: | --: | --: |
+   | EXACT (`range_card_counts_for`) | 574 | 0.92 | **0.236** |
+   | estimated (`calibrated_balls_into_bins`) | 3,154 | 0.90 | 0.382 |
+
+   | query shape | n | % estimated | p50 | mean \|log\| |
+   | --- | --: | --: | --: | --: |
+   | 1 leaf, range | 1,064 | 46% | 0.91 | **0.226** |
+   | 1 leaf, other | 1,384 | 100% | 1.15 | 0.317 |
+   | **2+ leaves, ALL range** | **745** | **100%** | **0.62** | **0.507** |
+   | 2+ leaves, mixed | 322 | 100% | 1.19 | 0.553 |
+   | 3+ leaves, ALL range | 108 | 100% | 0.70 | 0.541 |
+
+   The exact path is much better calibrated, and multi-leaf all-range (853 rows, 23% of the population) is
+   100% estimated at p50 0.62. That is the `cn<=226 year>2004` shape and the obvious target — but two things
+   must be settled before "widen `bare_range_bounds`" is the plan:
+
+   - **The exact path is not exact against the counter** (p50 0.92, p10 0.50), so it is not a 1.00 ceiling.
+   - **The two quantities may not be the same thing.** `eval_domain` estimates *matching* cards, while
+     `cards_visited` counts *candidates visited* — 24,592 against 31,508 (the whole corpus) on
+     `border:black`. Candidates ⊇ matches whenever the narrowing is inexact, which would explain systematic
+     under-counting far better than miscalibration does, and would mean the fix is to estimate the
+     **narrowed candidate count** rather than to calibrate a match count. Test this first; it decides whether
+     any of the above is the right work.
+   - Combining two exact range counts is also not free: the boundary table answers each range independently,
+     and an `And`'s distinct-card count is not derivable from the two without composing.
+
+   **`scan_units` on selective compose queries** stays on the list at mean |log| **1.22**, p10 0.08, p90 3.62
+   — a ~45× spread no bias variant improves — but is now known to be second-order for this pair (~10%).
 
 1c. **Build the pair-level loop harness, once the features stop moving.** `bench_streamed_loop` and `bench_gather_loop` now
    share `bench_loop_design`, so their cells match and can be read side by side — but neither computes the

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -743,9 +743,39 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    | 2+ leaves, mixed | 322 | 100% | 1.19 | 0.553 |
    | 3+ leaves, ALL range | 108 | 100% | 0.70 | 0.541 |
 
-   The exact path is much better calibrated, and multi-leaf all-range (853 rows, 23% of the population) is
-   100% estimated at p50 0.62. That is the `cn<=226 year>2004` shape and the obvious target — but two things
-   must be settled before "widen `bare_range_bounds`" is the plan:
+   **It was the quantity, and that is now fixed.** The third caveat below turned out to be the answer, so the
+   range-path widening was never the right work. `eval_domain` was `est_cards` — a count of *matching* cards —
+   graded against `cards_visited`, which counts *candidates*, a superset whenever the narrowing is inexact.
+   The distribution is bimodal: **34% of compose rows visit every card in the corpus**, and on those the right
+   value is not a better estimate but `n_cards`:
+
+   | on the 986 full-scan rows | p10 | p50 | p90 | mean \|log\| |
+   | --- | --: | --: | --: | --: |
+   | `est_cards` (was) | 0.43 | 0.65 | 0.83 | 0.454 |
+   | `n_cards` (now) | 1.00 | 1.00 | 1.00 | **0.000** |
+
+   Predicted with the predicate and constant the sibling `PrintingRangeScan` branch already uses for the
+   identical decision — `range_too_broad_to_narrow(printing_matches, n_printings)`, `MAX_NARROW_FRACTION`
+   0.25 — so no new constant. Scored against the realized flag it catches **98%** of full-scan rows at 87%
+   accuracy, beating every threshold on two alternative signals. Its 26% false positives over-cost both
+   materializing plans by the same factor, which an argmin absorbs; the false negatives were the ones losing
+   the pair, so recall is the side to favour.
+
+   | | before | after |
+   | --- | --: | --: |
+   | `eval_domain [printing_compose]` p50 / p10 | 0.91 / 0.45 | **1.00 / 0.68** |
+   | pair ordered right | 75% | **87%** |
+   | pair mean regret | 23.00 µs | **4.29 µs** |
+   | pair gap meas/pred | 0.96 | **0.98** |
+
+   That brings the acquire within reach of the well-behaved `candidates` acquire (92%, 2.42 µs). **Total regret
+   is flat** (1.52 against 1.54 µs) and `StreamedSelect -> GatheredScan` is still 967 queries — because
+   `bench_pairwise_ordering` scores every pair including queries where compose wins anyway, so the P3/P4
+   ordering never reaches the routing outcome there. Pairwise accuracy is a leading indicator, not the result;
+   the value banked is that the features are now trustworthy for everything downstream.
+
+   The other two caveats stand as recorded, and the remaining `eval_domain` error (p10 0.68) is in the
+   *narrowed* regime, where these still apply:
 
    - **The exact path is not exact against the counter** (p50 0.92, p10 0.50), so it is not a 1.00 ceiling.
    - **The two quantities may not be the same thing.** `eval_domain` estimates *matching* cards, while

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1080,3 +1080,42 @@ unnarrowed query.
 The one route not yet closed is a bitmap AND of the candidate set against an indexed residual leaf — exact,
 conditional, and available on the ~9% where the residual is a single indexed leaf. Everything else on this
 acquire looks irreducibly estimated.
+
+## The largest single regret in the engine is item 6, and a mode sweep isolates it exactly
+
+`o:creature` / artwork / order=power / limit=175 loses **508.9 µs** — the worst routing miss measured. Held
+everything constant and varied only `unique`:
+
+| mode | P3 pred | P3 meas | p/m | P3 loop | eval_domain | printing_span | printings_examined |
+| --- | --: | --: | --: | --: | --: | --: | --: |
+| printing | 68.1 | **56.8** | **1.20** | 55.5 | 23,155 | 61,941 | 0 |
+| artwork | 92.5 | **978.1** | **0.09** | 974.0 | 23,155 | 61,941 | 0 |
+
+**Artwork costs P3 921 µs more than printing for identical work, and the model charges 24 µs more.** That is
+the whole regret, in one term: `STREAM_ARTWORK_SEEN_PER_CARD_NS` is 1.21 against a realized **39.8 ns/card**
+of surcharge — or 14.9 ns/printing over the span, which is very likely the right shape.
+
+Two things the dump makes plain.
+
+**The work is real and uncharged.** `residual_tier_ns100` is 0 here (the oracle word index resolves
+`o:creature` exactly), so P3's scan term is gated off — correctly, there being no residual to examine. But
+artwork's group-and-score pass walks the candidate span *regardless of the residual*, and no term covers it.
+
+**`printings_examined` does not count it.** It reads **0** while 61,941 printings are walked for grouping,
+because the counter covers residual examinations only. That is why every feature grading in this file looked
+clean on artwork: the instrument cannot see this work, so the error could only ever show up as a rate.
+
+**This is item 6, already measured and not shipped.** `bench_streamed_loop` found the shape — artwork needs
+its own per-card *and* per-printing rates, and its surcharge flips sign with printings-per-card so no additive
+correction expresses it. What is new here is that it is the **largest** routing error in the engine, not a
+tidy-up, and that a two-cell mode sweep sizes it without any built design.
+
+**And the pattern-A fix in this branch made it more visible**, which is worth stating rather than discovering
+later: the `scan_units × 5.97` charge that fix removes had been partly compensating for this missing artwork
+term on artwork queries *with* a residual. Same structure as the verify-tier gate — a correct removal
+exposing an unmodelled cost underneath. `o:creature` never had that compensation, since its tier is 0, which
+is why it shows the error at full size.
+
+Sequencing consequence: **item 6 moves ahead of everything else on this list.** It is one term, its shape is
+already measured, the population is identifiable (`unique=artwork`, which carries 33% of all lost time), and
+it needs a counter for the grouping walk before its feature can be graded at all.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1164,3 +1164,42 @@ mean no `card_pass` runs, and now it does not. What remains is a level, not a sh
 measurement, explicitly labelled unexplained, sat in the hot loop of the mode carrying 36% of all routing loss
 and cost up to 24x. This file has now retracted four cross-build findings; that instrument's output should be
 treated as unproven until re-measured in one binary, especially where it has been encoded as a permanent gate.
+
+### And yes, the constants need refitting — but the first correction is a gate, and it regresses routing
+
+Removing the artwork `card_pass` gate changed what the arm should charge, so the artwork constants — fitted
+against traffic that *included* the redundant `card_pass` — are now stale. P3 reads p/m **1.58–1.83** on the
+tier-0 artwork cells where printing mode reads 1.02–1.23 on the same queries, so the surcharge is the suspect.
+
+Measured as the artwork-minus-printing `ns_loop` delta on identical candidate sets, against a charged
+**+1.21 ns/card**:
+
+| regime | n | median ns/card | median ns/printing |
+| --- | --: | --: | --: |
+| `printings_examined == 0` (stored group count) | 9 | **−0.46** | −0.17 |
+| `printings_examined == span` (dedup walk) | 8 | **+0.38** | +0.12 |
+
+So it is a **shape** problem before it is a level one. `run_query_streamed` answers an artwork count from a
+stored per-card group count when `all_match && have_group_counts` — touching no printing — and only walks the
+span to dedup groups when a residual survives per printing. In the first regime artwork is *cheaper* than
+printing (one array read against printing's span arithmetic), so +1.21 has the wrong **sign**, not merely the
+wrong magnitude. Every `exam == 0` row is `all_match_known` or `residual_card_invariant`, including `name:s`
+(exam 0, artwork cheaper by 0.52 ns/card, p/m 2.20) — the same discriminator as the two fixes above.
+
+**Gated on that signal and measured: absolute agreement improves, routing gets worse.**
+
+| | before gate | after gate |
+| --- | --: | --: |
+| P3 p/m, tier-0 artwork cells | 1.58–1.83 | **1.14–1.34** |
+| artwork regret slice, mean | 1.59 µs | **1.71** |
+| artwork regret slice, max | 185.5 µs | **732.5** |
+| total regret, mean | 1.44 | 1.48 |
+
+**Not shipped.** The +1.21 is compensating for something else in the P3/P4 artwork balance and cannot be
+removed alone — which is `bench_gather_loop`'s "P4 cannot be fixed alone" for a third time, and is exactly
+what item 6 has to mean now: **both artwork arms together, or neither.** The measurement is recorded at the
+call site so the next attempt starts from the shape rather than rediscovering it.
+
+Fourth instance this session of a correct fix that removes a compensating error — after the verify-tier gate,
+the P4 span feature, and the estimator's ball count. Three of those paid once the exposed error was fixed too;
+this one has no partner fix yet, so it waits.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -537,14 +537,22 @@ dominant term of P4's arm is what makes P3 win where P4 is better, which is the 
 | baseline (HEAD) | 81.7 ms | 2.07 µs | 408 q, 27% of loss | 1,045 q, 37% |
 | tier gate alone | 129.7 ms | 3.50 µs | 33 q, 0% | 1,830 q, 79% |
 | gate + P4 scan | 61.2 ms | 1.55 µs | 48 q, 1% | 1,050 q, 50% |
-| **+ clustering bias on the ball count** | **56.4 ms** | **1.49 µs** | 49 q, 1% | 999 q, 51% |
+| + clustering bias on the ball count | 56.4 ms | **1.49 µs** | 49 q, 1% | 999 q, 51% |
+| **+ `scan_units` clamped at `n_printings`** | 57.0 ms | **1.54 µs** | 43 q, 1% | 999 q, 52% |
 
-Compare the **means**: the total is a sum over however many queries the budget reached (39,458 against 37,749
-here), so the totals are not directly comparable and the mean is. **−28% on the baseline.**
+Compare the **means**: the total is a sum over however many queries the budget reached (39,458 down to 37,111
+across these rows), so the totals are not comparable and the mean is. **−26% on the baseline.**
 
-**−25% regret against HEAD**, and the mispick class this started from is gone (408 → 48 queries, mean 54.27
-→ 13.58 µs). `cargo test` 149 debug / 148 release; row identity needs no new run because these are
-cost-only changes and `force_plan_differential_agreement` already proves every plan returns the same rows.
+The last two rows are within run noise of each other (1.49 against 1.54 µs on transition tables that are
+otherwise identical — 999 queries against 999 on the top slice), so the clamp is **aggregate-neutral**. It is
+kept for what the aggregate cannot see: it is the only one of the four that moved the pair
+`GatheredScan vs StreamedSelect [printing_compose]`, 69% → **75%** with mean pair regret 40.24 → 23.00 µs.
+Which is the same lesson as the table itself — a 3% move in a pooled mean is not evidence either way, and the
+per-pair diagnostic is what ranks routing work.
+
+The mispick class this started from is gone (408 → 43 queries, mean 54.27 → 13.93 µs). `cargo test` 149 debug
+/ 148 release throughout; row identity needs no new run because these are cost-only changes and
+`force_plan_differential_agreement` already proves every plan returns the same rows.
 
 The honest caveat: the P4 scan fix **did not fix the pair**. `GatheredScan vs StreamedSelect
 [printing_compose]` is still 69% ordered right (gap 0.89 → 0.91), and `StreamedSelect -> GatheredScan`
@@ -576,14 +584,28 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
 
 ## What is left
 
-1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,403 pairs at **69% ordered right**,
-   mean regret 36.40 µs — the engine's largest single routing error and the top item. Two corrections landed
-   against it and **neither moved its ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%,
-   gap 0.89 → 0.91). Both were worth doing — together −25% total regret — but they bought that by removing
-   biases that *amplified* this pair, not by ranking it. The pair itself is untouched.
+1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** Now **75% ordered right** over 4,825
+   non-tie pairs, mean regret 23.00 µs, gap 0.96 — still the engine's largest single routing error and still
+   the top item. Four feature corrections landed against it, and the pattern of which ones moved it is the
+   useful part:
 
-   **Not variance — a sub-population, and it is named.** The gap ratio of 0.91 invites reading this as noise
-   around a correct average; splitting the pairs by whether the sign is right says otherwise. Over 5,085
+   | correction | pair ordered right | pair mean regret | gap |
+   | --- | --: | --: | --: |
+   | baseline | 69% | 35.96 µs | 0.89 |
+   | verify-tier gate | 69% | 36.82 | 0.90 |
+   | P4's span feature | 69% | 40.24 | 0.91 |
+   | estimator bias onto the ball count | 69% | 40.24 | 0.93 |
+   | **`scan_units` clamped at `n_printings`** | **75%** | **23.00** | **0.96** |
+
+   Three of the four moved nothing, and the reason is instructive: `eval_domain` and `scan_units` feed **both**
+   arms, so a correction to either moves both predictions the same direction and the difference barely
+   changes. The clamp moved it because it lands **asymmetrically** — `scan_units` is 76% of P3's arm on this
+   class and 28% of P4's. **For an argmin, a feature fix only pays when the two plans weight the feature
+   differently.** That is the same principle as the module header's "a term wrong for every plan cancels",
+   applied to features rather than rates.
+
+   **Not variance — a sub-population, and it is named.** The gap ratio invites reading this as noise around a
+   correct average; splitting the pairs by whether the sign is right says otherwise. At 69%, over 5,085
    non-tie pairs:
 
    | group | n | P3 wins (measured) | P3 wins (predicted) | median \|gap\| |
@@ -614,24 +636,66 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    much as P3 because P4's per-card rate is 25.77 ns against 11.63. Fixed by moving the clustering bias onto
    the ball count (see the commit); the broad band went 0.52 → 0.78 against `cards_visited`.
 
-   **What survives three feature corrections is a rate problem, and that is now the evidence.** The tier
-   gate, P4's span feature and the estimator's shape each improved something else and each left this pair at
-   **exactly 69%**, with an unchanged internal structure — still 100% of wrong pairs in `tier > 0`, still P3
-   winning 98% of them while the model says 2%. The decisive number is `meas/pred` = **−0.97**: the predicted
-   gap is almost exactly the *negative* of the measured gap, consistently. Magnitude right, direction
-   inverted, immovable by any feature. That is what a mis-split between the per-card and per-printing rates
-   looks like when both features are maximal.
+   **Retracted a second time: "what survives three feature corrections is a rate problem."** A fourth
+   feature correction moved it 69% → 75%, so that inference was wrong — it rested on three fixes that could
+   not have moved the pair for the structural reason above, and read their failure as evidence about rates.
+   The estimator fix also made things temporarily worse in a way worth recording: it improved `eval_domain`
+   (16,511 → 24,592) and *degraded* `scan_units` (106,970 → **159,325** against a realized 97,206), because
+   `scan_all` derives from `est_cards`. P3 went 1.03 → 1.53 of its real time while P4 sat at 0.88 — both
+   plans over the same feature. A feature above `n_printings` is impossible rather than merely wrong, which
+   is what made the clamp an invariant instead of a calibration.
 
-   So the remaining work is a **built design over the broad-residual population**, not another feature hunt:
-   `bench_streamed_loop` and `bench_gather_loop` restricted to cells where both plans scan the whole corpus,
-   solving for each arm's per-card and per-printing rates separately. Two traps attached. A pooled traffic fit
-   **endorses both current rates** (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23),
-   so `fit_cost_model` cannot find this. And the built design will read warm-cache, so it gives the **shape**
-   — which of the two rates is misattributed — and not the level. Wrong-rate concentrates by mode: artwork
-   37%, printing 31%, card 19%.
+   **Features are still not exhausted at 75%.** The wrong group retains a feature asymmetry against the
+   right group, so the next step is not automatically a rate measurement:
+
+   | feature / realized counter | right group p50 | wrong group p50 |
+   | --- | --: | --: |
+   | `eval_domain` | 0.98 | **0.85** |
+   | `scan_units` | 0.95 | 1.00 (was 1.37 before the clamp) |
+   | `matches` | 1.00 | 1.11 |
+
+   `eval_domain` still under-counts by ~1.18× exactly where the ordering fails, and P4's per-card rate is
+   2.2× P3's, so that residue still discounts P4 asymmetrically. `meas/pred` reads **−1.17** in the wrong
+   group: magnitude right, sign inverted, as before.
+
+   **The open question is which of the two it now is, and no tool can currently answer it.** Distinguishing
+   "remaining feature error" from "rate misattribution" needs each arm's per-card and per-printing rates
+   measured on *identical* cells — and `bench_loop_design`'s header states that neither harness compares the
+   two plans, deferring that to `explain_analyze`, which compares predicted against measured per plan on
+   sampled traffic and cannot isolate a rate. So the next piece of work is a **pair-level harness**: see the
+   note below. What the existing harnesses already report is suggestive — P3 3.30 ns/printing against P4's
+   2.27, a ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both were
+   measured warm, but they were measured warm *together*, and a ratio between two equally-warm arms survives
+   the cache caveat that voids their levels.
+
+   Two traps attached to any rate work here. A pooled traffic fit **endorses both current rates**
+   (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23), so `fit_cost_model` cannot find
+   this and a pooled refit will confirm the status quo. And a built design reads warm-cache, so it yields the
+   **shape** — which of the two rates is misattributed — and not the level. Wrong-rate now concentrates by
+   mode at artwork 29%, printing 24%, card 18%.
 
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.
+
+1b. **Build the pair-level loop harness item 1 needs.** `bench_streamed_loop` and `bench_gather_loop` now
+   share `bench_loop_design`, so their cells match and can be read side by side — but neither computes the
+   cross-plan quantity, deliberately: the header defers plan comparison to `explain_analyze`. That deferral
+   is incomplete, because `explain_analyze` compares predicted against measured *per plan* on sampled
+   traffic and cannot isolate a per-unit rate. The result is that the one number routing depends on — P3's
+   per-printing rate against P4's, on identical cells — is produced by nothing.
+
+   **Extend, do not fork.** `bench_loop_design` exists precisely because a P3-vs-P4 rate comparison is only
+   valid when the cells match, and they had already drifted once (`CARD_COUNTS` sharing two of five sizes). A
+   third harness that built its own cells would reintroduce that. The increment is to move **cell
+   construction** into `bench_loop_design` alongside the parameters, then add one reporting test that runs
+   both arms over those cells and prints each rate, the measured ratio, and the shipped ratio beside it.
+
+   Two prerequisites, both already flagged in `bench_streamed_loop`'s own header. The rates there are
+   `ns_loop` only, and *"P3's arm may be absorbing setup or finish cost that its loop never pays — that has
+   to be ruled out before the gap is called an error."* `Cell` already carries `ns_setup` and `ns_finish`, so
+   the data exists and is unused. And the broad-residual population is already the `residual: true` group
+   (an always-true `DateCmp` via `DATE_AFTER_EVERYTHING`), so no new cell class is needed — only the
+   comparison.
 2. ~~**Decide the 13% regret debt.**~~ **Closed** — and neither of the two options on offer was the answer.
    The debt was never bounded by compose's arm; the mispriced arm was P3's. Gating the verify tier on the
    compose acquire plus fixing P4's candidate span took regret to **61.2 ms against the 81.7 ms measured

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -536,7 +536,11 @@ dominant term of P4's arm is what makes P3 win where P4 is better, which is the 
 | --- | --: | --: | --: | --: |
 | baseline (HEAD) | 81.7 ms | 2.07 µs | 408 q, 27% of loss | 1,045 q, 37% |
 | tier gate alone | 129.7 ms | 3.50 µs | 33 q, 0% | 1,830 q, 79% |
-| **gate + P4 scan** | **61.2 ms** | **1.55 µs** | 48 q, 1% | 1,050 q, 50% |
+| gate + P4 scan | 61.2 ms | 1.55 µs | 48 q, 1% | 1,050 q, 50% |
+| **+ clustering bias on the ball count** | **56.4 ms** | **1.49 µs** | 49 q, 1% | 999 q, 51% |
+
+Compare the **means**: the total is a sum over however many queries the budget reached (39,458 against 37,749
+here), so the totals are not directly comparable and the mean is. **−28% on the baseline.**
 
 **−25% regret against HEAD**, and the mispick class this started from is gone (408 → 48 queries, mean 54.27
 → 13.58 µs). `cargo test` 149 debug / 148 release; row identity needs no new run because these are
@@ -601,15 +605,30 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    | `cn<=226 year>2004` / printing | 1,025.3 | 1,454.7 | 789.6 | **756.4** |
    | `year<=2026` / artwork | 601.6 | 1,026.9 | 1,629.2 | **1,326.1** |
 
-   P3 is genuinely ~1.7× faster and the model has the pair tied to within 5 µs. What brings it to parity is
-   the two arms' per-printing scan rates: `STREAM_SCAN_PER_ROW_NS` 5.97 against `GATHER_SCAN_PER_ROW_NS`
-   2.06, a **2.9× ratio for what is nominally the same walk-a-printing-and-test work**. P3's higher rate
-   cancels its lower per-card rate exactly where both features are maximal.
+   P3 is genuinely ~1.7× faster and the model has the pair tied to within 5 µs.
 
-   The trap for whoever takes this: a pooled traffic fit **endorses both rates** (StreamedSelect
-   `SCAN_PER_ROW` fits 6.04, ratio 1.01; GatheredScan 2.53, ratio 1.23), so `fit_cost_model` will not find
-   this and a pooled refit cannot fix it. It needs the population split — the same lesson this file has now
-   learned three times. Wrong-rate concentrates by mode: artwork 38–46%, printing 25–46%, card 16–24%.
+   **Retracted guess: "the two scan rates cancel."** Decomposing both arms says the false tie is one-sided.
+   On `border:black`/printing, P3 predicts **1.03** of its real time and P4 predicts **0.64** — P3 is priced
+   correctly and P4 is under-charged 1.56×. Two errors are not cancelling; one plan is wrong. The mechanism
+   was `eval_domain` reading 16,511 where both plans visited all 31,508 cards, which discounts P4 by 2.2× as
+   much as P3 because P4's per-card rate is 25.77 ns against 11.63. Fixed by moving the clustering bias onto
+   the ball count (see the commit); the broad band went 0.52 → 0.78 against `cards_visited`.
+
+   **What survives three feature corrections is a rate problem, and that is now the evidence.** The tier
+   gate, P4's span feature and the estimator's shape each improved something else and each left this pair at
+   **exactly 69%**, with an unchanged internal structure — still 100% of wrong pairs in `tier > 0`, still P3
+   winning 98% of them while the model says 2%. The decisive number is `meas/pred` = **−0.97**: the predicted
+   gap is almost exactly the *negative* of the measured gap, consistently. Magnitude right, direction
+   inverted, immovable by any feature. That is what a mis-split between the per-card and per-printing rates
+   looks like when both features are maximal.
+
+   So the remaining work is a **built design over the broad-residual population**, not another feature hunt:
+   `bench_streamed_loop` and `bench_gather_loop` restricted to cells where both plans scan the whole corpus,
+   solving for each arm's per-card and per-printing rates separately. Two traps attached. A pooled traffic fit
+   **endorses both current rates** (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23),
+   so `fit_cost_model` cannot find this. And the built design will read warm-cache, so it gives the **shape**
+   — which of the two rates is misattributed — and not the level. Wrong-rate concentrates by mode: artwork
+   37%, printing 31%, card 19%.
 
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -930,3 +930,53 @@ for a per-predicate estimate rather than a better global rate:
 - The residual usually is not the whole predicate, so a global pass fraction still assumes independence
   from the candidate set — the assumption that just cost us on `eval_domain`. Preferring a direct count
   where the residual *is* the leaf avoids it; conjunctions still need care.
+
+### Tier 2: both exact-count routes measured and declined
+
+The plan was to replace the global pass rate with a per-predicate count, since the spread (0.06–0.87) is
+what a constant cannot fix. Two routes existed without new machinery. Both are worse than the span estimate,
+and they fail for the same reason.
+
+**`estimator::estimate_cardinality`** — already in the tree, index-backed leaves, `Cardinality {lo, est, hi}`
+with independence for `And` and `min` for the `hi` bound. In production it is called **once**, as a
+`hi <= STREAM_MIN_MATCHES` threshold check. Graded against `matches_pushed`:
+
+| mode | shipped `matches` | `estimate_cardinality` |
+| --- | --: | --: |
+| card | p50 1.40, p90 9.91, mean \|log\| **0.789** | p50 1.45, p90 **33.38**, **1.312** |
+| printing | p50 1.09, p90 11.03, **0.953** | p50 0.70, p90 17.12, 1.346 |
+| artwork | p50 1.19, p90 10.19, **0.807** | p50 1.17, p90 25.01, 1.281 |
+
+Uniformly worse, and worst in the tail — which is where this acquire's loss lives. It dates from the
+estimate-based era of the planner; its `lo` arm already documents that Bonferroni is *unsound* over two or
+more printing-varying children, because a card can enter each child's card-space projection via **different
+printings** while no single printing satisfies all.
+
+**`RangeCardCounts::distinct_cards`** — genuinely exact, not an estimate: `below`/`at_or_above`/`at` per
+distinct value, two `partition_point` probes, exact for every op but a true interior range. It is the right
+instinct and it still does not work here:
+
+- **Coverage 9%** of rows with a residual — 7% of the misordered ones, 2.0 ms of a 46.5 ms pairwise gap.
+- **6× worse where it applies** — card p50 **6.32** against the shipped 1.12.
+
+Because `bare_range_bounds` matches the **residual**, so the count is exact for `cn<100` *globally* while the
+feature needs cards matching `cn<100` **and the rest of the query**. Exact for the wrong set. The span
+estimate is worse in principle and better in practice because it at least reflects the candidate set.
+
+**The shared lesson, third instance today.** `eval_domain` confused candidates with matches; the compose
+`scan_units` clamp was an impossible value; and now both exact-count routes answer a marginal question where
+a conditional one was asked. The quantity is `|candidates ∩ residual|`, and its exact evaluation is the work
+being costed. A bitmap AND of the candidate set against an indexed leaf's set would deliver it for the same
+9%; nothing cheap covers the remaining 91%.
+
+**What is left for `matches`, in order of expected value:**
+
+1. **Condition the pass rate on the residual TIER, not just the mode.** The tier already exists as a feature
+   and it separates the populations: implied rates ~0.24–0.32 for `MASK`, ~0.35 for `SET_LOOKUP`, ~0.95 for
+   `TEXT_SCAN`/printing against a shipped 0.40. A level change fitted from traffic, so it is on the right
+   side of the branch's rule, and it needs no new machinery. It fixes medians, not the 14× spread.
+2. **Bitmap-AND the candidate set with an indexed residual leaf** for an exact conditional count on the 9%.
+   Related to `local-engine-candidate-materialize.md`'s finding that a bitmap beats a sorted vec from ~64
+   candidates up, though that doc measures the acquire, which regret excludes by construction.
+3. **Accept the spread.** The evidence so far is that `matches` is irreducibly estimated on this acquire
+   without doing the residual's own work, and that its error is what the P3/P4 pair mostly reflects.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -658,15 +658,41 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    2.2× P3's, so that residue still discounts P4 asymmetrically. `meas/pred` reads **−1.17** in the wrong
    group: magnitude right, sign inverted, as before.
 
-   **The open question is which of the two it now is, and no tool can currently answer it.** Distinguishing
-   "remaining feature error" from "rate misattribution" needs each arm's per-card and per-printing rates
-   measured on *identical* cells — and `bench_loop_design`'s header states that neither harness compares the
-   two plans, deferring that to `explain_analyze`, which compares predicted against measured per plan on
-   sampled traffic and cannot isolate a rate. So the next piece of work is a **pair-level harness**: see the
-   note below. What the existing harnesses already report is suggestive — P3 3.30 ns/printing against P4's
-   2.27, a ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both were
-   measured warm, but they were measured warm *together*, and a ratio between two equally-warm arms survives
-   the cache caveat that voids their levels.
+   **Answered, without a built design: it is the features, and by a wide margin.** An ORACLE run settles the
+   sequencing question directly — recompute both arms substituting each plan's *realized counters* for the
+   estimated features (`cards_visited`, `printings_examined`, `matches_pushed`), keeping every shipped rate
+   untouched, then re-run the argmin. Over 2,778 non-tie pairs with at least 100 realized cards on both plans:
+
+   | features | ordered right | lost time (sum) |
+   | --- | --: | --: |
+   | shipped estimates | 58% | 116.2 ms |
+   | **oracle (realized counters)** | **83%** | **12.8 ms** |
+
+   | mode | shipped | oracle |
+   | --- | --: | --: |
+   | card | 58% | **96%** |
+   | printing | 62% | 80% |
+   | artwork | 56% | 81% |
+
+   Perfect features against **today's rates** reach 83% and cut lost time **9×**. That is the ceiling any
+   estimator work can buy, and it is most of the gap — so the rates are adequate to 83% and the remaining 17%
+   is what is genuinely attributable to them. **Features are the foundation and come first**; the rate
+   question is real but second-order and should not be opened until the estimates stop moving.
+
+   (58% here is not the 75% above: this run requires ≥100 realized cards on *both* plans, which selects the
+   larger queries where estimator error dominates. The valid comparison is the internal one, 58 → 83 on
+   identical rows with identical rates.)
+
+   One structural caveat on that ceiling, and it is the first thing to settle. The oracle gave each plan **its
+   own** counter, where `scan_units` today is one shared number that both arms read while examining different
+   amounts — `stream_scan_units` splits it for P3 on legality filters only. So the 58 → 83 gain mixes two
+   distinct fixes: *more accurate* shared features, and *per-plan* features. Decomposing that is step one,
+   because it decides whether the work is a better estimator or a split feature.
+
+   For when the rate question does open: the existing harnesses already report P3 at 3.30 ns/printing against
+   P4's 2.27, a ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both
+   were measured warm, but *together*, and a ratio between two equally-warm arms survives the cache caveat
+   that voids their levels.
 
    Two traps attached to any rate work here. A pooled traffic fit **endorses both current rates**
    (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01; GatheredScan 2.53, 1.23), so `fit_cost_model` cannot find
@@ -677,7 +703,24 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.
 
-1b. **Build the pair-level loop harness item 1 needs.** `bench_streamed_loop` and `bench_gather_loop` now
+1b. **Review the compose acquire's feature estimation — the foundational work, ahead of any rate work.** The
+   oracle run above bounds this at 58% → 83% ordered right and a 9× cut in lost time on the pair, with rates
+   untouched. Three targets, in order:
+
+   - **Decompose the oracle gain into "better shared estimate" vs "per-plan feature".** The oracle used each
+     plan's own counters; `scan_units` is one shared number today and the two plans examine different amounts.
+     `stream_scan_units` already splits it for P3, but only on legality filters. This decides the shape of
+     everything below, so it comes first.
+   - **`eval_domain` on the failing population.** p50 **0.85** in the wrong group against 0.98 in the right
+     one, and P4's per-card rate is 2.2× P3's, so the residue discounts P4 asymmetrically. The broad class is
+     mostly range predicates, and `range_card_counts_for` already answers *exactly* — but `bare_range_bounds`
+     matches one comparison, so `cn<=226 year>2004` (an `And` of two) falls back to the estimator. Widening
+     that exact path is likely worth more than any estimator refinement.
+   - **`scan_units` on selective compose queries.** mean |log| **1.22**, p10 0.08, p90 3.62 — a ~45× spread
+     that none of the three bias variants improves (see the span-bias note). Not previously on any list, and
+     the worst-calibrated feature in the acquire.
+
+1c. **Build the pair-level loop harness, once the features stop moving.** `bench_streamed_loop` and `bench_gather_loop` now
    share `bench_loop_design`, so their cells match and can be read side by side — but neither computes the
    cross-plan quantity, deliberately: the header defers plan comparison to `explain_analyze`. That deferral
    is incomplete, because `explain_analyze` compares predicted against measured *per plan* on sampled

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -380,6 +380,47 @@ So the ordering is: this, then re-measure, and only then decide whether a per-pl
 still needed for the non-legality compose cases (`border:black`, `r:mythic`, `watermark:*`), where the
 current estimate is already right to 1.1-2.4x.
 
+## Making the split non-destructive, and what it cost
+
+`split_planes` is a destructive rewrite run at bind time, before any plan is costed: it moves predicate
+out of the filter tree `PrintingCompose` composes from into a `PlaneExpr` compose cannot read, so compose
+fails its `plane.is_none()` guard and never reaches the argmin. That guard is right — composing the
+residual alone would drop the plane's predicate — but the elimination happens blind, under a layer whose
+premise is "plan selection is one cost-based routing layer, not a hand-tuned decision tree". Measured
+consequence: compose ran `f:commander`/printing in 1.83 µs against StreamedSelect's 99.38, a plan the
+router was never offered.
+
+`bind_and_split_filter` now retains the filter as bound; `printing_compose_applicable` asks about the
+whole predicate, and `compose_source` is the one place that picks a representation. Every other plan keeps
+plane+residual. Row identity across the whole series: 60 (query, mode, offset) cells over ten legality
+shapes, identical on total, page length and a hash of returned `scryfall_id`s.
+
+| query / mode | before | after | ratio |
+| --- | --: | --: | --: |
+| `f:modern t:creature` / printing | 90.00 | **42.83** | **0.476** |
+| `f:modern t:creature` / artwork | 82.38 | 67.50 | 0.819 |
+| bare formats, both modes | — | — | 0.97–1.14, compose still picked |
+
+**And it raised regret 15%, which is the honest headline.** Total regret 48.7 → 56.1 ms, with the compose
+slice going 39% → 46% of lost time (mean 3.98 → 4.86 µs, miss 10% → 12%). Isolated by reverting just the
+consume guard: 56.8 ms with it off against 56.1 with it on — so the guard is **not** the cause and is now
+free, where before the split was retained it cost 54× on `f:commander`/printing. The rise is the split
+itself: handing the argmin a candidate whose arm is the worst-modelled in the engine (p90 41×, spread 136×
+on rarity/usd) imports mispicks.
+
+That is a real trade, and the two ways to read it are both defensible. Against: a measured 15% regret
+regression is exactly what this branch has declined six times before. For: the regret is now *visible and
+attributable* rather than hidden behind an elimination, and it is bounded by one arm's accuracy — the same
+arm whose two defects are already measured (`scan_units` overstating P3 by 13–15×,
+`STREAM_RESIDUAL_FLOOR_NS` charging 11.63 ns/card against a measured 6.7). Fixing those converts the
+exposure into the win.
+
+**The bare-format artwork mispick survives, and is now purely a cost error.** StreamedSelect with the
+consumed form measured 79.83 µs against compose's 177.83 on `f:gladiator`/artwork, and the router still
+picks compose — but now because it prices compose 4–6× too cheaply against P3, not because P3 was removed
+from the ballot. The architecture stopped hiding the problem, which is what makes the remaining work worth
+doing.
+
 ## What is left
 
 1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -980,3 +980,67 @@ being costed. A bitmap AND of the candidate set against an indexed leaf's set wo
    candidates up, though that doc measures the acquire, which regret excludes by construction.
 3. **Accept the spread.** The evidence so far is that `matches` is irreducibly estimated on this acquire
    without doing the residual's own work, and that its error is what the P3/P4 pair mostly reflects.
+
+### Miss size predicts the cause, which reverses how to read the 26%
+
+Splitting the candidates acquire's mis-picks (>2 µs gap) by whether realized counters would fix the order:
+
+| cause | n | % of n | sum lost | % of ms | mean | p90 |
+| --- | --: | --: | --: | --: | --: | --: |
+| feature (oracle fixes the order) | 625 | 26% | 27.9 ms | **37%** | **44.6 µs** | 81.3 |
+| rate/shape (survives the oracle) | 1,796 | 74% | 47.4 ms | 63% | 26.4 µs | 43.5 |
+
+| band | n | feature-caused, % of count |
+| --- | --: | --: |
+| 2–10 µs | 492 | 15% |
+| 10–30 µs | 929 | 16% |
+| 30–100 µs | 935 | **40%** |
+| >100 µs | 65 | **54%** |
+
+**Feature errors are the expensive tail; rate errors are the cheap bulk.** Since regret here is entirely a
+tail phenomenon (`p90 = 0.00` on every acquire), the 26% headcount understates feature work — it is 37% of
+avoidable time and 54% of the misses over 100 µs. An earlier note in this file called 25% the ceiling on
+feature work; that read the wrong column.
+
+### Pattern A shipped: P3's scan gated on within-card invariance
+
+Two feature defects produce all 625. The first is fixed.
+
+A residual invariant *within* a card never goes printing-dependent — `card_pass` returns `True`/`False` and
+never `Tri::PrintingDep`, so the streamed kernel sets its per-card `all_match` and `card_match_count` answers
+from span arithmetic. **P3 examines no printings at all.** The arm was charging `scan_units ×
+STREAM_SCAN_PER_ROW_NS` for the whole candidate span anyway:
+
+    name:s / artwork, order=cmc desc, limit=100        LOST 368.0 us
+      StreamedSelect   pred 1507.0 us   meas  456.0 us   <- best
+      GatheredScan     pred 1213.8 us   meas  824.0 us   <- picked
+      feature          used      P3 realized   P4 realized
+      eval_domain      31,508    31,508        31,508      1.00x
+      scan_units       97,206    0             60,705      1.60x
+      matches          31,508    29,169        29,169       1.08x
+
+580 µs of P3's 1,507 µs prediction, for work it does not do. `!touches_printing_field` is the test, so
+`stream_scan_units` goes to 0 there; P4's `scan_units` is untouched, since it walks each span to push and its
+60,705 is real. **That asymmetry is why it moves an argmin at all.**
+
+This is the `all_match_known` gate one step weaker: that needs the whole residual to be `True`, this needs
+only that it cannot vary within a card — which `name:s`, `o:`, `t:` and `cmc` satisfy as ordinary residuals.
+Third place this same class of defect has been found (compose's verify tier, compose's `eval_domain`, here).
+
+| | before | after |
+| --- | --: | --: |
+| regret mean, all queries | 1.52 µs | **1.43 µs** |
+| `candidates / printing` mean | 1.68 | **1.45** |
+| mis-picks >2 µs | 2,421 | 2,294 |
+| feature-caused lost time | 27.9 ms | **24.0 ms** |
+| feature-caused **max** single miss | **421.7 µs** | **272.4 µs** |
+| >100 µs band, feature-caused | 54% | **36%** |
+
+`GatheredScan vs StreamedSelect [candidates]` stays at 92% and 2.42 µs, because the class is a few hundred
+rows of 11,559 pairs — the win is the tail, not the rate. Earlier runs of the aggregate spanned 1.49–1.54 µs,
+so the 1.43 is only modestly outside run noise; the max-miss and band shifts are the load-bearing evidence.
+
+**Pattern B is not fixed**: `matches` over-estimated up to **219×** on selective conjunctions
+(`eur<=0.09 usd>=0.38 usd<=4.92` used 31,508 against a realized 144; `eur:0.39` 31,508 against 439). Both are
+tier-4 MASK price ranges where the span base is meaningless, and both routes to an exact count were measured
+and declined above.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -545,7 +545,10 @@ cost-only changes and `force_plan_differential_agreement` already proves every p
 The honest caveat: the P4 scan fix **did not fix the pair**. `GatheredScan vs StreamedSelect
 [printing_compose]` is still 69% ordered right (gap 0.89 → 0.91), and `StreamedSelect -> GatheredScan`
 returned to its baseline level rather than improving on it. What the fix removed was the bias that was
-*amplifying* the gate's exposure to that pair. The pair remains item 1.
+*amplifying* the gate's exposure to that pair. The pair remains item 1 — and it is now diagnosed there as a
+named sub-population (broad residuals, both plans scanning the corpus, the two arms' scan rates 2.9× apart)
+rather than the variance this section first guessed at. The card-invariant half of the acquire, which is what
+these two changes touched, orders **409/409** correctly.
 
 Also worth watching: `GatheredScan vs PrintingCompose [printing_compose]` gap sizing drifted 1.14 → 1.40
 while staying 92% ordered right, so it costs nothing yet and is a sign compose's arm is absorbing something.
@@ -569,29 +572,52 @@ t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: th
 
 ## What is left
 
-1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,391 pairs at **69% ordered right**,
-   mean regret 36.82 µs — the worst-ranked pair in the engine and now the top item, because it is the
-   prerequisite for the P3 tier gate above rather than a peer of it. The gate is written and measured
-   (targeted pair 80% → 96%, mean regret 11.04 → 1.57 µs) and cannot ship while this pair is 69%: correcting
-   P3 lets it into the argmin more often. Two corrections landed against it and **neither moved its
-   ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%, gap 0.89 → 0.91). Those bought
-   −25% total regret by removing biases that amplified this pair; the pair itself is untouched and is now the
-   engine's largest single routing error at 3,403 pairs and 36.40 µs mean regret.
+1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,403 pairs at **69% ordered right**,
+   mean regret 36.40 µs — the engine's largest single routing error and the top item. Two corrections landed
+   against it and **neither moved its ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%,
+   gap 0.89 → 0.91). Both were worth doing — together −25% total regret — but they bought that by removing
+   biases that *amplified* this pair, not by ranking it. The pair itself is untouched.
 
-   The gap ratio being 0.91 is the whole diagnosis: the model sizes this difference **correctly on average**
-   and gets the **sign** wrong 31% of the time. So no constant fixes it — it is variance, and the feature
-   grading says where the variance lives. `eval_domain` on this acquire reads p90/p10 **3.1** and `scan_units`
-   **4.5** even after the bias fix, because both descend from `calibrated_balls_into_bins` — an *estimate*,
-   where the `candidates` acquire (92% ordered right) has exact narrowed counts. The likely answer is not a
-   better estimator but making the two plans' costs depend on the estimate the *same* way, so its error
-   cancels in their difference the way the verify tier already does.
+   **Not variance — a sub-population, and it is named.** The gap ratio of 0.91 invites reading this as noise
+   around a correct average; splitting the pairs by whether the sign is right says otherwise. Over 5,085
+   non-tie pairs:
+
+   | group | n | P3 wins (measured) | P3 wins (predicted) | median \|gap\| |
+   | --- | --: | --: | --: | --: |
+   | right, tier 0 (card-invariant) | 409 | 100% | 100% | — |
+   | right, tier > 0 (real residual) | 3,100 | 5% | 5% | 31.8 µs |
+   | **wrong, tier > 0** | **1,576** | **98%** | **2%** | **98.4 µs** |
+
+   Every wrong pair is in the `tier > 0` regime — the card-invariant population the two fixes above touched
+   is ordered **409/409** correctly. And the wrong group is not mixed: P3 really wins 98% of it while the
+   model says P4 wins 98% of it. The model **over-picks P4** on a specific class.
+
+   That class is **broad residuals where both plans examine the whole corpus** — `border:black`,
+   `year<=2026`, `cn<336`, bare date ranges. Worst cells, `printings_examined` = 97,206 for *both* plans:
+
+   | query / mode | P3 meas | P4 meas | P3 pred | P4 pred |
+   | --- | --: | --: | --: | --: |
+   | `border:black` / printing | 861.3 | 1,489.8 | 841.8 | **838.2** |
+   | `cn<=226 year>2004` / printing | 1,025.3 | 1,454.7 | 789.6 | **756.4** |
+   | `year<=2026` / artwork | 601.6 | 1,026.9 | 1,629.2 | **1,326.1** |
+
+   P3 is genuinely ~1.7× faster and the model has the pair tied to within 5 µs. What brings it to parity is
+   the two arms' per-printing scan rates: `STREAM_SCAN_PER_ROW_NS` 5.97 against `GATHER_SCAN_PER_ROW_NS`
+   2.06, a **2.9× ratio for what is nominally the same walk-a-printing-and-test work**. P3's higher rate
+   cancels its lower per-card rate exactly where both features are maximal.
+
+   The trap for whoever takes this: a pooled traffic fit **endorses both rates** (StreamedSelect
+   `SCAN_PER_ROW` fits 6.04, ratio 1.01; GatheredScan 2.53, ratio 1.23), so `fit_cost_model` will not find
+   this and a pooled refit cannot fix it. It needs the population split — the same lesson this file has now
+   learned three times. Wrong-rate concentrates by mode: artwork 38–46%, printing 25–46%, card 16–24%.
 
    Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
    on the mispicked cells and only `oldschool` is under-priced.
-2. **Decide the 13% regret debt.** Regret sits at 55.0 ms against a 48.7 ms baseline, all of it from making
-   the split non-destructive — which is correct, but hands the argmin a candidate whose arm is badly modelled.
-   Either (1) above pays it back, or revert the split and give back `f:modern t:creature`'s 0.476× until the
-   arm is fixed. Isolated: the consume guard is not the cause (56.8 ms with it off against 55.0 with it on).
+2. ~~**Decide the 13% regret debt.**~~ **Closed** — and neither of the two options on offer was the answer.
+   The debt was never bounded by compose's arm; the mispriced arm was P3's. Gating the verify tier on the
+   compose acquire plus fixing P4's candidate span took regret to **61.2 ms against the 81.7 ms measured
+   baseline, −25%**, without reverting the split, so `f:modern t:creature`'s 0.476× is kept. See the
+   retraction section above for why the original framing pointed at the wrong plan.
 3. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has two
    sources, neither reachable from a start position: entries *interior* to the walked segment, and clustering
    the predicate does not name (the 5.31-vs-4.26 gap in the regrade table). Scattering the match set through

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -479,16 +479,30 @@ candidate explanations for it have now been eliminated by measurement. Two hones
 
 ## What is left
 
-1. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has
-   two sources, and neither is reachable from a start position: non-matching entries *interior* to the
-   walked segment, and clustering the predicate does not name (the 5.31-vs-4.26 gap in the regrade table).
-   Scattering the match set through `inv_perm` and walking words at 64 cards a load reaches both —
-   `run_query_streamed_popcount` already does exactly that for `unique=card` queries whose filter fully
-   consumed to `True`, and printing mode, where P3 is actually routed, is the case it does not cover.
-   Generalizing it needs per-card match counts for the skip (a popcount counts cards, not matches) and
-   pays a per-card scatter, so it inherits the cost question the realized span had — with the difference
-   that its payoff does not depend on matches being contiguous.
-2. **A curvature term for the loop rates** — the cause of both the `FIXED` disagreement and corpus drift.
-3. **Gate P4's artwork arm on its own.**
-4. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
+1. **Compose's remaining shape error, on compose-acquire artwork.** The largest open finding and the one that
+   pays the regret debt. After correcting `stream_scan_units` the model still prices compose ~1.5× under P3
+   where P3 measures ~1.7× faster — `f:gladiator`/artwork, P3 at 79.83 µs against compose's 177.83 — so ~2.5×
+   survives, and it is provably none of the three things already measured: not the residual floor (traffic
+   fits it at 0.90), not the scan feature (now correct against the realized counter), not the per-card level.
+   Sixteen mispicks remain. Compose is also the worst-modelled arm overall (p90 41×, spread 136× on
+   rarity/usd ordering), so this is where its arm should be attacked.
+2. **Decide the 13% regret debt.** Regret sits at 55.0 ms against a 48.7 ms baseline, all of it from making
+   the split non-destructive — which is correct, but hands the argmin a candidate whose arm is badly modelled.
+   Either (1) above pays it back, or revert the split and give back `f:modern t:creature`'s 0.476× until the
+   arm is fixed. Isolated: the consume guard is not the cause (56.8 ms with it off against 55.0 with it on).
+3. **Extend the popcount-skip walk past `FilterExpr::True`.** What is left of the perm estimate's p90 has two
+   sources, neither reachable from a start position: entries *interior* to the walked segment, and clustering
+   the predicate does not name (the 5.31-vs-4.26 gap in the regrade table). Scattering the match set through
+   `inv_perm` and walking words at 64 cards a load reaches both, and `run_query_streamed_popcount` already
+   does that for `unique=card` + `True` — printing mode, where P3 is actually routed, is the case it does not
+   cover. Needs per-card counts for the skip, since a popcount counts cards and not matches.
+4. **Compose `format:A AND format:B` now that both are usually card-invariant.** The shared-witness objection
+   dissolves when neither format diverges: `∃p: A(p) ∧ B` is `(∃p: A(p)) ∧ B`. `compile_plane` still declines
+   it with `u64::MAX`, and `legality_and_of_two_formats_declines_but_or_compiles` names the assertion to
+   revisit.
+5. **A curvature term for the loop rates** — cause of both the `FIXED` disagreement and corpus drift, though
+   the five-size sweep demoted it: the drift saturates and production sits at the bottom of the curve.
+6. **Gate P4's artwork arm on its own.** Every surviving mispick is in artwork mode, which makes this more
+   interesting than when it was queued.
+7. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
    bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1195,11 +1195,45 @@ wrong magnitude. Every `exam == 0` row is `all_match_known` or `residual_card_in
 | artwork regret slice, max | 185.5 µs | **732.5** |
 | total regret, mean | 1.44 | 1.48 |
 
-**Not shipped.** The +1.21 is compensating for something else in the P3/P4 artwork balance and cannot be
-removed alone — which is `bench_gather_loop`'s "P4 cannot be fixed alone" for a third time, and is exactly
-what item 6 has to mean now: **both artwork arms together, or neither.** The measurement is recorded at the
-call site so the next attempt starts from the shape rather than rediscovering it.
+**Shipped, after the decline was retracted.** Two things overturned it.
 
-Fourth instance this session of a correct fix that removes a compensating error — after the verify-tier gate,
-the P4 span feature, and the estimator's ball count. Three of those paid once the exposed error was fixed too;
-this one has no partner fix yet, so it waits.
+**P4 needs no partner fix.** Measuring *both* arms' artwork-minus-printing delta — which the first attempt
+never did — shows P4 is already accurate in artwork mode and P3 is the only mispriced arm:
+
+| regime | | P3 | P4 |
+| --- | --- | --: | --: |
+| grouping walk does **not** run (n=9) | median surcharge | −0.52 ns/card | **−3.17** |
+| | **p/m** | **1.74** | **0.98** |
+| grouping walk **runs** (n=10) | median surcharge | +1.47 | −6.89 |
+| | **p/m** | 1.11 | 0.87 |
+
+P4's arm carries no mode-dependent term at all, yet lands at 0.87–0.98 — because its `matches` in artwork
+mode is the *deduped* artwork count, so its `PUSH` term already shrinks by roughly the real saving. So
+"+1.21 compensates for P4 being over-costed" was **false**, and there is only one arm to move.
+
+**And the alarming max was noise.** Re-measured over a longer sample:
+
+| run | total mean | artwork mean | artwork max |
+| --- | --: | --: | --: |
+| ungated, 180 s | 1.44 µs | 1.59 | 185.5 |
+| gated, 180 s | 1.48 | 1.71 | **732.5** |
+| gated, 240 s | 1.45 | 1.69 | **189.9** |
+
+The 4× max does not reproduce. What survives is a consistent ~6% cost on the artwork regret slice with total
+regret flat, against P3 going **p/m 1.74 → 1.25** where the walk does not run and 1.11 → 1.20 where it does.
+Both arms now sit inside 0.86–1.25 in artwork mode.
+
+Taken on the principle this file's own header states: ordering-correct-by-cancellation is a local optimum you
+cannot build on, because the next change has no ground truth to check itself against. Same trade as the
+non-destructive split, which was kept at a 15% regret cost for the same reason.
+
+**The counter this needed already existed**, which is the other correction. Both kernels publish the artwork
+grouping span in `printings_examined` — P4 accumulates `push_card_matches`'s return, P3 accumulates
+`card_match_count`'s second value — and P3's fast path correctly reports 0 because no walk happens. An earlier
+note here claimed the counter was missing and that a grouping walk was uncounted; both were wrong.
+
+### Item 6 is now closed
+
+Artwork's per-card surcharge was the last of it. The executor gate was removed (up to 24×), P3's surcharge is
+gated on the same signal, and P4 was measured and needs nothing. What remains in artwork mode is a level
+question inside 0.86–1.25 on both arms, which is not worth a refit against a warm-cache design.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -863,3 +863,70 @@ Three cautions in reading it, all of which change what the next item should be:
    interesting than when it was queued.
 7. Carried over: make the fit loss the actual multi-way routing outcome rather than a pairwise proxy;
    bitmap+extract candidate materialization in the 64–4,095 band; the 4096+ prep band.
+
+## The candidates acquire: `matches`, and a declined tier-1 fix
+
+The re-baseline put `candidates` at 78% of lost time. Investigated, and it is a **different defect from the
+compose acquire's** — the compose-acquire lessons do not transfer.
+
+**It is not the features, mostly.** The oracle substitution that bought 89% on compose buys only **29%**
+here (60.0 → 42.3 ms). `eval_domain` is **exact at p10/p50/p90**, because on this acquire it is the
+materialized narrowed candidate count rather than an estimate. Every losing query is the P3/P4 pair, and it
+fails in **both directions** — `StreamedSelect -> GatheredScan` 1,159 queries / 38.8 ms and
+`GatheredScan -> StreamedSelect` 861 / 21.1 ms.
+
+**The one bad feature is `matches`, and the sign of its error picks the direction of the mispick:**
+
+| transition | n | `matches` / realized, p50 | sum lost |
+| --- | --: | --: | --: |
+| `StreamedSelect -> GatheredScan` | 782 | **29.85** | 27.5 ms |
+| `GatheredScan -> StreamedSelect` | 767 | **0.88** | 21.4 ms |
+| correct | 13,601 | **1.00** | 0.0 ms |
+
+The mechanism is an asymmetry: `matches` drives P4's `PUSH` at 2.24 ns against P3's `EMIT` at 0.12 — 18.7× —
+**and** enters P3's `perm_steps` inversely. Over-counting therefore charges P4 more and P3 less, both
+favouring P3. `matches_pushed` agreed between the two plans on 100% of rows, so one shared feature is
+structurally fine here; it is simply wrong.
+
+`matches` is the candidates' printing/artwork **span** discounted by one constant per mode
+(`RESIDUAL_PASS_RATE_PRINTING` 0.40, `_ARTWORK` 0.53). A p50 of 29.85 is far past what any rate explains: the
+span is ~75× the truth there, because under a loose narrowing most candidates do not match at all. **Same
+class of defect as `eval_domain`'s** — a span is the wrong base for a match estimate — one field over.
+
+### Tier 1, measured and declined as a fix
+
+`filter::touches_printing_field` is new: the `any` composition of the leaf table `printing_dependent` reads
+with `all`, factored so the two callers cannot disagree on the table. A card-invariant residual answers
+`True`/`False` per card, so a candidate contributes its whole span or none. Published as
+`residual_card_invariant`; **nothing in `plan_cost` reads it.**
+
+Implied true pass rate, `shipped / (matches / realized)`:
+
+| mode | residual class | n | p10 | p50 | p90 |
+| --- | --- | --: | --: | --: | --: |
+| printing | card-invariant | 257 | 0.00 | **0.78** | 1.00 |
+| printing | printing-varying | 2,544 | 0.06 | **0.35** | 0.87 |
+| artwork | card-invariant | 221 | 0.00 | **0.60** | 0.90 |
+| artwork | printing-varying | 2,386 | 0.09 | **0.43** | 0.74 |
+
+The classifier separates the populations — 2.2× in printing mode — and the shipped 0.40 sits on the
+printing-varying value, confirming it was fitted there. **But the hypothesis it was built to test is wrong.**
+"Card-invariant ⇒ pass rate 1.0" fails: p50 is 0.78 and **p10 is 0.00**. The all-or-nothing reasoning holds,
+but the rate is then "what fraction of *candidates* match", which the residual's class does not pin — the
+spread inside the class is the full 0.00–1.00. And the class is only **9% of rows**, so a perfect rate there
+moves almost nothing.
+
+**Split constants are therefore not worth shipping**, and the diagnostic is kept only to scope the next step.
+
+### Why tier 2 is the work
+
+Printing-varying is 91% of rows and its median is already within 14% of shipped (0.35 against 0.40). The
+defect there is **spread — 0.06 to 0.87, a 14× range** — which no constant can address. That is the argument
+for a per-predicate estimate rather than a better global rate:
+
+- **Indexed range residuals** (`usd`, `cn`, `date`) have an exact printing count from two
+  `partition_point` calls, which `bare_range_bounds` already uses for its `k`.
+- **Plane residuals** (border, rarity, legality) have stored popcounts.
+- The residual usually is not the whole predicate, so a global pass fraction still assumes independence
+  from the candidate set — the assumption that just cost us on `eval_domain`. Preferring a direct count
+  where the residual *is* the leaf avoids it; conjunctions still need care.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -582,6 +582,39 @@ candidate explanations for it have now been eliminated by measurement. Two hones
 **61.2 ms against the 81.7 ms measured baseline, −25%**, without reverting the split, so `f:modern
 t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: the P3/P4 pair at 69%, item 1.
 
+## Re-baselined after this series, because the ranking moved
+
+`bench_regret_matrix.py --seconds 180`, current build. The acquire this whole investigation was picked from
+has dropped from roughly half of all lost time to a fifth:
+
+| acquire | n | mean | SHARE |
+| --- | --: | --: | --: |
+| **candidates** | 26,251 | 1.69 µs | **78%** |
+| printing_compose | 7,536 | 1.60 µs | **21%** (was ~49%) |
+| printing_range_scan / plane / card_range_popcount | 3,370 | ≤0.22 | 0% |
+
+| cell | mean | SHARE |
+| --- | --: | --: |
+| candidates / artwork | 1.91 µs | 32% |
+| candidates / printing | 1.68 | 28% |
+| candidates / card | 1.43 | 19% |
+| printing_compose / printing | 1.63 | 8% |
+| printing_compose / card | **2.09** | 7% |
+| printing_compose / artwork | 1.25 | **6%** (was 32%) |
+
+Three cautions in reading it, all of which change what the next item should be:
+
+- **The compose acquire is no longer unusually broken.** Its mean is *lower* than `candidates`. The 78/21
+  split is volume — 3.5× the queries — not severity. "Candidates is now the problem" describes where the
+  aggregate lives, not a newly found defect.
+- **The loss is entirely tail.** `p90 = 0.00` on every acquire; only p99 (36–64 µs) carries anything. The
+  median query has zero regret, so a mean is the wrong thing to optimise and "improve the average estimate"
+  is the wrong instinct.
+- **The largest transition is unchanged**: `StreamedSelect -> GatheredScan`, 967 queries, mean 29.38 µs, 50%
+  of all loss. But on `candidates` that pair is already **92%** ordered right at 2.42 µs mean pair regret. So
+  what remains is the 8% tail of a well-ordered pair spread over high volume — a materially harder and
+  lower-yield target than anything fixed in this series, and it should be sized before it is started.
+
 ## What is left
 
 1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** Now **75% ordered right** over 4,825

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -466,26 +466,125 @@ where P3 measures ~1.7× faster, so ~2.5× survives a corrected feature — and 
 (traffic fits it at 0.90), not the floor, and not the scan feature. Something cell-specific to compose-acquire
 artwork is mis-shaped and none of the three things measured here is it.
 
+## It was not compose. It was P3, and fixing it uncovers a third pair
+
+**Retracted: "compose is priced ~1.5× under P3".** Attributing both arms term-by-term against measurement
+says the opposite — on the four card-invariant formats compose is the *well*-modelled plan and P3 is the
+broken one:
+
+| cell | P3 pred | P3 meas | P3 ratio | compose pred | compose meas | compose ratio |
+| --- | --: | --: | --: | --: | --: | --: |
+| `f:gladiator` / artwork | 259.58 | 72.58 | **0.28** | 178.73 | 186.54 | 1.04 |
+| `f:predh` / printing | 215.80 | 34.08 | **0.16** | 70.62 | 80.21 | 1.14 |
+| `f:commander` / artwork | 323.24 | 143.62 | **0.44** | 188.80 | 220.12 | 1.17 |
+| `f:oldschool` / artwork *(the divergent format)* | 31.88 | 35.62 | 1.12 | 14.82 | 37.00 | **2.50** |
+
+Compose is under-priced only on `oldschool` — the *opposite* format from where the mispicks are. The
+attribution reproduces `predicted_ns` exactly, so this is arithmetic on the shipped arm, not a re-fit.
+
+**The mechanism.** `acquire_plan_features`'s compose branch passed `verify_cost_tier(composed)` with no
+gate, where the general candidate path gates on `all_match_known`. On a card-invariant legality format
+`card_pass` returns `Tri::True` at card level for every card, so the kernel takes its `all_match` arm and
+`printings_examined` reads **0** — while the model charged `CARD_PASS + max(tier, FLOOR)` = 9.05 ns on every
+candidate *and* `stream_scan_units × 5.97`. Those two dead terms are **92–94% of P3's predicted cost** on
+these cells.
+
+**One retraction inside the fix.** A first attempt priced this as the divergent *share* of the corpus
+(`legal_divergent / n_cards`, ~1.76%). That is wrong in principle — for `f:oldschool` the candidates largely
+*are* the divergent cards, so a global share under-charges exactly the cells whose residual is real. It
+traded 408 mispicks for 118 that were four times worse (mean 54.27 → 206.24 µs) for a net 3.4%. The right
+signal is the boolean the engine already derives from data, `plane_expr_is_existential` against
+`divergent_formats`, extracted as `plane_leaves_nothing_to_verify` so the router asks what the executor asks.
+
+**The gate works on the pair it targets, and costs regret elsewhere.** Pairwise ordering, 120 s uniform:
+
+| pair, `[printing_compose]` acquire | baseline | with the gate |
+| --- | --: | --: |
+| `PrintingCompose vs StreamedSelect` | 80% ordered right, mean regret 11.04 µs | **96%, 1.57 µs** |
+| `GatheredScan vs StreamedSelect` | 69%, 35.96 µs, gap 0.89 | 69%, 36.82 µs, gap 0.90 |
+
+Total regret went **81.7 → 129.7 ms** (mean 2.07 → 3.50 µs), with `StreamedSelect -> GatheredScan` going
+1,045 → 1,830 queries and 37% → 79% of all lost time. The two facts are not in conflict: the P3/P4 pair is
+**69% accurate before and after**, unmoved by this change, and correcting P3's cost simply lets P3 reach the
+argmin far more often, which multiplies exposure to it. P3's inflated cost was *masking* a pair that was
+already wrong — a compensating error, and every measurement of that pair ever taken through it was confounded
+by P3 being priced 3–6× over.
+
+### What the gate exposed: P4's scan feature over-counts 1.76× on the same population
+
+`GatheredScan` walks every printing of every candidate, so its scan feature is the candidate SPAN, estimated
+by `scan_all` as `est_cards ×` corpus-average printings-per-card `× 2.1`. That shape is right only when
+candidates are an average sample of the corpus. With nothing to verify they are not — every printing of a
+matching card matches, so the span **is** `printing_matches`, a quantity the branch already computes.
+Graded against P4's realized `printings_examined`, 597 card-invariant compose queries:
+
+| feature | p10 | p50 | p90 | p90/p10 |
+| --- | --: | --: | --: | --: |
+| `scan_units` (was shipped) | 1.13 | **1.76** | 5.08 | 4.5 |
+| `printing_matches` (now) | 0.68 | **0.93** | 3.08 | 4.5 |
+
+Scoped to the same boolean, because the grading **inverts** on the other population: with a real residual
+`scan_units` is right at p50 0.97 and `printing_matches` badly under at 0.39. A 1.76× over-charge on the
+dominant term of P4's arm is what makes P3 win where P4 is better, which is the slice the gate inflated.
+
+### Both together, measured at identical settings
+
+| build | total regret | mean | `PrintingCompose -> StreamedSelect` | `StreamedSelect -> GatheredScan` |
+| --- | --: | --: | --: | --: |
+| baseline (HEAD) | 81.7 ms | 2.07 µs | 408 q, 27% of loss | 1,045 q, 37% |
+| tier gate alone | 129.7 ms | 3.50 µs | 33 q, 0% | 1,830 q, 79% |
+| **gate + P4 scan** | **61.2 ms** | **1.55 µs** | 48 q, 1% | 1,050 q, 50% |
+
+**−25% regret against HEAD**, and the mispick class this started from is gone (408 → 48 queries, mean 54.27
+→ 13.58 µs). `cargo test` 149 debug / 148 release; row identity needs no new run because these are
+cost-only changes and `force_plan_differential_agreement` already proves every plan returns the same rows.
+
+The honest caveat: the P4 scan fix **did not fix the pair**. `GatheredScan vs StreamedSelect
+[printing_compose]` is still 69% ordered right (gap 0.89 → 0.91), and `StreamedSelect -> GatheredScan`
+returned to its baseline level rather than improving on it. What the fix removed was the bias that was
+*amplifying* the gate's exposure to that pair. The pair remains item 1.
+
+Also worth watching: `GatheredScan vs PrintingCompose [printing_compose]` gap sizing drifted 1.14 → 1.40
+while staying 92% ordered right, so it costs nothing yet and is a sign compose's arm is absorbing something.
+
 ## The open decision: 13% of regret is unpaid
 
 Regret stands at **55.0 ms against a 48.7 ms baseline**. The rise came from making the split
 non-destructive — handing the argmin a candidate whose arm is the worst-modelled in the engine — and both
 candidate explanations for it have now been eliminated by measurement. Two honest options:
 
-- **Find compose's remaining shape error.** It is the largest single error in the model (p90 41×, spread 136×
-  on rarity/usd) and it is now applicable on more queries, so the debt is bounded by that one arm.
-- **Revert the non-destructive split** and give back `f:modern t:creature`'s 0.476× until compose's arm is
-  fixed. The plumbing is inert on its own; only compose's widened applicability carries the cost.
+- **Find compose's remaining shape error.** ~~It is the largest single error in the model~~ — retracted; the
+  error on the mispicked cells is P3's, and the real prerequisite is the P3/P4 pair at 69%. See the section
+  above. Compose's rarity/usd spread is still real but is not what the artwork mispicks were made of.
+- **Revert the non-destructive split** and give back `f:modern t:creature`'s 0.476× until the compose acquire
+  can rank its plans. The plumbing is inert on its own; only compose's widened applicability carries the cost.
+
+**This decision is now closed, and neither option was the answer.** The debt was not bounded by compose's arm
+— the arm mis-pricing the mispicked cells was P3's. Correcting it plus P4's scan feature took regret to
+**61.2 ms against the 81.7 ms measured baseline, −25%**, without reverting the split, so `f:modern
+t:creature`'s 0.476× is kept. What is left is not a debt but a named defect: the P3/P4 pair at 69%, item 1.
 
 ## What is left
 
-1. **Compose's remaining shape error, on compose-acquire artwork.** The largest open finding and the one that
-   pays the regret debt. After correcting `stream_scan_units` the model still prices compose ~1.5× under P3
-   where P3 measures ~1.7× faster — `f:gladiator`/artwork, P3 at 79.83 µs against compose's 177.83 — so ~2.5×
-   survives, and it is provably none of the three things already measured: not the residual floor (traffic
-   fits it at 0.90), not the scan feature (now correct against the realized counter), not the per-card level.
-   Sixteen mispicks remain. Compose is also the worst-modelled arm overall (p90 41×, spread 136× on
-   rarity/usd ordering), so this is where its arm should be attacked.
+1. **Rank `GatheredScan vs StreamedSelect` on the compose acquire.** 3,391 pairs at **69% ordered right**,
+   mean regret 36.82 µs — the worst-ranked pair in the engine and now the top item, because it is the
+   prerequisite for the P3 tier gate above rather than a peer of it. The gate is written and measured
+   (targeted pair 80% → 96%, mean regret 11.04 → 1.57 µs) and cannot ship while this pair is 69%: correcting
+   P3 lets it into the argmin more often. Two corrections landed against it and **neither moved its
+   ordering**: the tier gate (69% → 69%) and P4's scan feature (69% → 69%, gap 0.89 → 0.91). Those bought
+   −25% total regret by removing biases that amplified this pair; the pair itself is untouched and is now the
+   engine's largest single routing error at 3,403 pairs and 36.40 µs mean regret.
+
+   The gap ratio being 0.91 is the whole diagnosis: the model sizes this difference **correctly on average**
+   and gets the **sign** wrong 31% of the time. So no constant fixes it — it is variance, and the feature
+   grading says where the variance lives. `eval_domain` on this acquire reads p90/p10 **3.1** and `scan_units`
+   **4.5** even after the bias fix, because both descend from `calibrated_balls_into_bins` — an *estimate*,
+   where the `candidates` acquire (92% ordered right) has exact narrowed counts. The likely answer is not a
+   better estimator but making the two plans' costs depend on the estimate the *same* way, so its error
+   cancels in their difference the way the verify tier already does.
+
+   Superseded item 1 ("compose's remaining shape error") — see the retraction above; compose reads 1.02–1.17
+   on the mispicked cells and only `oldschool` is under-priced.
 2. **Decide the 13% regret debt.** Regret sits at 55.0 ms against a 48.7 ms baseline, all of it from making
    the split non-destructive — which is correct, but hands the argmin a candidate whose arm is badly modelled.
    Either (1) above pays it back, or revert the split and give back `f:modern t:creature`'s 0.476× until the

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1116,6 +1116,51 @@ term on artwork queries *with* a residual. Same structure as the verify-tier gat
 exposing an unmodelled cost underneath. `o:creature` never had that compensation, since its tier is 0, which
 is why it shows the error at full size.
 
-Sequencing consequence: **item 6 moves ahead of everything else on this list.** It is one term, its shape is
-already measured, the population is identifiable (`unique=artwork`, which carries 33% of all lost time), and
-it needs a counter for the grouping walk before its feature can be graded at all.
+### Corrected, and it was not a cost-model defect at all
+
+The diagnosis above was wrong about the mechanism, and the correction is worth more than the original finding.
+`printings_examined` reading 0 is **right**: `run_query_streamed` has a fast path that answers an artwork
+count from a stored per-card group count without touching a printing. The 921 us was not a grouping walk.
+
+It was `card_pass`. The `all_match_known` skip was **gated off for `Mode::Artwork`**, so `o:creature`/artwork
+ran a full oracle-text containment check over all 23,155 candidates that the narrowing had already proved
+matched. Printing mode skips it and took 56.7 us for identical work. The gate's own comment cited a ~45%
+regression on `t:creature`/artwork, called it "an unexplained codegen/scheduling effect ... not a logical
+cost", and attributed it to bisecting **across builds** — trap 1 in the method doc.
+
+Re-measured with a runtime toggle in one binary, the cited regression does not reproduce in either direction,
+and **every artwork cell is faster with the gate removed**:
+
+| query, artwork, limit 175 | gate on | gate off | speedup |
+| --- | --: | --: | --: |
+| `o:this` | 1047.7 us | **43.8** | **24x** |
+| `o:target` | 556.6 | **28.7** | **19x** |
+| `o:creature` | 1010.5 | **50.6** | **20x** |
+| `t:creature` | 84.1 | **38.5** | **2.2x** (the query the gate protected) |
+| `o:flying` | 24.1 | 12.1 | 2.0x |
+| `c:r` | 32.2 | 16.6 | 1.9x |
+| `t:land` | 15.5 | 11.6 | 1.3x |
+
+Row identity is what an `all_match` error breaks silently here — totals do not move, the printing that REPS
+each artwork group does. **1,134 cells identical** (21 predicates x 3 modes x 3 orderbys x 3 pages x 2
+prefers, hashing the returned `scryfall_id` sequence), 378 of them artwork, including the existential shapes
+`f:*`, `border:*`, `r>=rare`, `watermark:*`, `-f:modern`.
+
+| | before | after |
+| --- | --: | --: |
+| `artwork` regret slice, mean | 1.87 us | **1.59** |
+| `artwork` regret slice, max | **504.5 us** | **185.5** |
+| total regret, mean | 1.43 us | 1.44 (flat) |
+
+Total regret is flat because this does not change any *pick* — it makes the picked plan faster. The user-facing
+win is latency, and it is the largest in this branch.
+
+**Item 6 inverts.** The artwork arm now **over**-costs: P3 reads p/m 1.58-1.83 on these cells against 0.09-0.11
+before, so `STREAM_ARTWORK_SEEN_PER_CARD_NS` at 1.21 is now too HIGH rather than 33x too low. The cost model
+was right about what should happen throughout — it charges `tier = 0` because `all_match_known` is supposed to
+mean no `card_pass` runs, and now it does not. What remains is a level, not a shape, and it is small.
+
+**The general lesson is about the comment, not the code.** A perf carve-out justified by a cross-build
+measurement, explicitly labelled unexplained, sat in the hot loop of the mode carrying 36% of all routing loss
+and cost up to 24x. This file has now retracted four cross-build findings; that instrument's output should be
+treated as unproven until re-measured in one binary, especially where it has been encoded as a permanent gate.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -320,7 +320,7 @@ the only one a rate cannot rescue. It is also NOT the artwork arm of item 4 belo
 in printing mode too (6.23, 5.25), where compose happens to be genuinely faster, so the wrong ratio does
 not flip the pick. Artwork is only where the margin is thin enough to expose it.
 
-### But that correction alone does not flip the pick
+### But that correction alone does not flip the pick (confirmed: it did not)
 
 The term is linear, so the corrected prediction is exact arithmetic rather than a guess:
 
@@ -420,6 +420,62 @@ consumed form measured 79.83 µs against compose's 177.83 on `f:gladiator`/artwo
 picks compose — but now because it prices compose 4–6× too cheaply against P3, not because P3 was removed
 from the ballot. The architecture stopped hiding the problem, which is what makes the remaining work worth
 doing.
+
+## The two cost-arm defects, both now measured
+
+### `STREAM_RESIDUAL_FLOOR_NS`: measured with a built design, and declined
+
+The floor only ever binds on `MASK_COMPARE` (tier 4.00); every other tier exceeds 6.58 and `max` takes the
+tier. So `bench_streamed_loop`'s always-true `DateCmp` cells are exactly its population, and at 31,508 cards
+they read `card/all_match` 2.49, `card/residual` 7.80, `printing/residual` 4.97 + 3.26 ns/printing.
+Subtracting the loop body puts the residual's per-card cost at **2.45 ns against a charged 9.05** — the
+`card_pass` call is the whole cost and the mask compare adds nothing measurable.
+
+Traffic disagrees and traffic wins on levels: the fitted `CARD_PASS+FLOOR` column reads **8.19 against the
+shipped 9.05 (0.90)** for P3 and **21.59 against 21.89 (0.99)** for P4. Nothing to correct.
+
+That is the **third** time this file has caught the same artifact — an always-true predicate over
+chunk-rotated slices measuring a cache state production never reaches, differing by 3.3× here as it differed
+1.6–2.2× in the retraction at the top of `bench_streamed_loop`. It is now recorded in the constant's own doc,
+so the next person measuring it finds the answer instead of the trap.
+
+### `stream_scan_units`: shipped, and it was necessary but not sufficient exactly as predicted
+
+P3 now has its own scan estimate on a legality-composed acquire, from the divergent share of the candidate
+span (`legal_divergent`, 556 of 31,508), floored at one printing per candidate and scoped to filters that
+touch legality — `border:black`, `r:mythic` and `watermark:*` measured at parity between the two plans.
+
+It also surfaced a defect this branch had introduced: `acquire_plan_features` was still calling
+`compose_printing_estimate` on the RESIDUAL. Once the divergence mask began consuming legality leaves that
+residual was `True`, so compose estimated all 97,206 printings for every legality query alike and was costed
+as if it returned the corpus for free — `matches` reading 97,206 identically across `f:modern`, `f:predh` and
+the rest, at a predicted pick/best ratio of 0.00. Applicability, estimate and execution now share one
+`compose_source`. **The numbers reported for the consume-guard commit were measured against that broken arm**
+and should not be read as they stand.
+
+| | before | after |
+| --- | --: | --: |
+| predicted pick/best on the artwork mispicks | 0.22 | **0.63–0.69** |
+| `StreamedSelect [printing_compose] / artwork` p90 | 6.69 | **4.73** |
+| its p90/p10 spread | 12.3 | **9.2** |
+| total regret | 56.1 ms | 55.0 ms |
+| row identity, 60 cells | — | identical |
+
+**The mispicks survive, and that is the result.** Sixteen remain. The model prices compose ~1.5× under P3
+where P3 measures ~1.7× faster, so ~2.5× survives a corrected feature — and it is not the per-card level
+(traffic fits it at 0.90), not the floor, and not the scan feature. Something cell-specific to compose-acquire
+artwork is mis-shaped and none of the three things measured here is it.
+
+## The open decision: 13% of regret is unpaid
+
+Regret stands at **55.0 ms against a 48.7 ms baseline**. The rise came from making the split
+non-destructive — handing the argmin a candidate whose arm is the worst-modelled in the engine — and both
+candidate explanations for it have now been eliminated by measurement. Two honest options:
+
+- **Find compose's remaining shape error.** It is the largest single error in the model (p90 41×, spread 136×
+  on rarity/usd) and it is now applicable on more queries, so the debt is bounded by that one arm.
+- **Revert the non-destructive split** and give back `f:modern t:creature`'s 0.476× until compose's arm is
+  fixed. The plumbing is inert on its own; only compose's widened applicability carries the cost.
 
 ## What is left
 

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -5,6 +5,9 @@ Branch `engine-compose-feature-accuracy`. Companion to
 answers which question; this covers what the tools said about `StreamedSelect` (P3) and
 `GatheredScan` (P4), and what is left.
 
+The method this campaign arrived at, extracted so it can be reused without reading the whole file:
+[diagnosing-a-plan-cost-error.md](../workflows/diagnosing-a-plan-cost-error.md).
+
 The earlier campaign in [local-engine-cost-model-agreement.md](./local-engine-cost-model-agreement.md)
 fitted rates from sampled traffic. This one built designed experiments instead, because several rates
 are **unidentifiable from traffic at any corpus size** — and that turned out to be the least

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1044,3 +1044,39 @@ so the 1.43 is only modestly outside run noise; the max-miss and band shifts are
 (`eur<=0.09 usd>=0.38 usd<=4.92` used 31,508 against a realized 144; `eur:0.39` 31,508 against 439). Both are
 tier-4 MASK price ranges where the span base is meaningless, and both routes to an exact count were measured
 and declined above.
+
+### Pattern B traced upstream: an unnarrowed query has no base for a match estimate
+
+`eur<=0.09 usd>=0.38 usd<=4.92` / artwork used `matches` 31,508 against a realized 144. The chain:
+
+1. every leaf individually exceeds `MAX_NARROW_FRACTION` (0.25), so narrowing declines;
+2. `eval_domain` becomes the whole corpus, 31,508;
+3. `in_space * RESIDUAL_PASS_RATE_ARTWORK` gives ~24,439, and then
+   **`.max(count.min(in_space))` forces 31,508** — the floor, not the rate.
+
+The floor asserts at least one match per candidate. That holds under a tight narrowing and is catastrophic
+under a loose one, which is the candidates-versus-matches confusion for the fourth time in this file.
+
+**Removing the floor is nonetheless not a fix.** Split by whether it binds (`matches == eval_domain`):
+
+| population | mode | n | p50 | p90 | mean \|log\| |
+| --- | --- | --: | --: | --: | --: |
+| floor binds | artwork | 2,883 | 1.06 | 23.25 | **0.936** |
+| rate applies | artwork | 1,179 | 1.34 | 8.29 | **0.799** |
+| floor binds | printing | 299 | 0.60 | 1.14 | **0.567** |
+| rate applies | printing | 4,010 | 1.22 | 17.92 | **1.094** |
+
+Worse in artwork, **better** in printing. Dropping it helps one mode and hurts the other. Two reading notes:
+card mode is excluded because its `matches` *is* `count`, so a "floor binds" detector flags all of it by
+construction; and the extreme tails sit in both populations (max 1,575× floored against 1,690× rated), so the
+tail is not the floor's doing either.
+
+**So the root cause is upstream of both terms.** When no leaf is selective enough for narrowing to fire, the
+candidate set is the corpus and *neither* a rate nor a floor has a base related to the answer. That is 57% of
+rows on this acquire. It is the same conclusion as compose's `eval_domain`, as tier 2's two dead ends, and as
+the floor here: the wanted quantity is `|candidates ∩ residual|`, and nothing cheap computes it for an
+unnarrowed query.
+
+The one route not yet closed is a bitmap AND of the candidate set against an indexed residual leaf — exact,
+conditional, and available on the ~9% where the residual is a single indexed leaf. Everything else on this
+acquire looks irreducibly estimated.

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -82,7 +82,21 @@ pick/best ratio from 0.22 to 0.63–0.69 and flipped nothing: 16 mispicks surviv
 and "the router now picks correctly" are separate measurements, and so is "the arm now predicts its own
 time" — see the table at the top.
 
-## Two traps that cost the most time
+**9. If the fix does not move the ordering, split the population before touching a rate.** A pair can be
+right on average and bimodal underneath, and the summary statistic that hides this is the one that looks most
+reassuring. `GatheredScan vs StreamedSelect [printing_compose]` reads a **gap ratio of 0.91** — the model
+sizes the difference almost exactly right — at **69% ordered right**. That invites "it is variance, no
+constant will fix it". Splitting the 5,085 non-tie pairs on the regime flag says otherwise:
+
+    right, tier 0 (card-invariant)   409    P3 wins 100% measured, 100% predicted
+    right, tier > 0 (real residual) 3,100   P3 wins   5% measured,   5% predicted
+    wrong, tier > 0                 1,576   P3 wins  98% measured,   2% predicted
+
+Every wrong pair is in one regime, and the wrong group is **homogeneous** — the model is not scattered around
+the truth, it is confidently inverted on one identifiable class (broad residuals where both plans scan the
+whole corpus). A mean gap ratio of 0.91 is what two opposed sub-populations look like after averaging.
+
+## Three traps that cost the most time
 
 **Cross-build timing cannot resolve a small effect, and will hand you the wrong sign.** On identical cells
 `ns_loop` wandered 43.00 / 45.38 / 47.17 µs across runs of builds that never touched that phase — ±9%, both
@@ -96,3 +110,12 @@ ns/card on a built design while traffic fit the same column at 8.19 against a sh
 third time this has been caught. **Shape from a built design, levels from traffic.** A design tells you which
 terms exist, which are degenerate and how two plans differ; it does not tell you what a constant should
 equal.
+
+**A pooled fit endorses the rates that are wrong on a sub-population, so it cannot be your check.** On the
+class in step 9, `STREAM_SCAN_PER_ROW_NS` 5.97 and `GATHER_SCAN_PER_ROW_NS` 2.06 are 2.9× apart for what is
+nominally the same walk-a-printing-and-test work, and P3's higher rate cancels its lower per-card rate exactly
+where both features are maximal. `fit_cost_model.py` fits **both** and pronounces them fine — 6.04 at ratio
+1.01 and 2.53 at 1.23. So a refit will not surface this and cannot fix it; it will confirm the status quo. Fit
+the split populations separately, or the fitter launders the error into an endorsement. Corollary for
+`--counters`: it grades a feature against a counter *pooled the same way*, so a feature that is right at the
+median and inverted on a quarter of rows passes.

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -1,0 +1,98 @@
+# Diagnosing a Plan Cost Error
+
+How to find out *why* one physical plan's cost arm is wrong, as opposed to *that* it is wrong.
+[reference-cost-model-measurement.md](../issues/reference-cost-model-measurement.md) says which tool answers
+which question; [performance-pr-workflow.md](./performance-pr-workflow.md) is the process for shipping the
+fix. This is the diagnosis in between.
+
+Every step below exists because skipping it produced a wrong answer at least once. The worked example
+throughout is `StreamedSelect` (P3) against `GatheredScan` (P4) and `PrintingCompose` on legality queries,
+from `local-engine-loop-phase-measurement.md`.
+
+## Where you are trying to end up
+
+**Both scan arms predicting their own real time, and the ordering correct.** Those are two goals, they move
+independently, and only one of them is currently met.
+
+Ordering-correct-by-cancellation is a real trap and the engine has been in it: `cost.rs`'s own header
+records that P3/P4 rates "are demonstrably wrong while the PRODUCTS they form are roughly right — which is
+the signature of compensating error", and that a rate 2× high against an estimate 2× low routes correctly
+and breaks the moment you fix either alone. That is a local optimum you cannot build on, because the next
+change has no ground truth to check itself against.
+
+So track absolute agreement per arm *and* regret, always. Absolute agreement today
+(`bench_cost_error_percentiles.py`, estimate/real, uniform mode):
+
+| plan | p10 | p50 | p90 | spread |
+| --- | --: | --: | --: | --: |
+| CardRangePopcount | 0.84 | 1.04 | 1.29 | **1.5** |
+| StreamedSelect | 0.74 | 1.09 | 1.90 | 2.6 |
+| GatheredScan | 0.68 | **1.28** | 2.67 | 3.9 |
+| PrintingCompose | 0.62 | 1.06 | 2.99 | 4.8 |
+
+P4 is still ~1.3× over at the median and compose's spread is the worst in the engine. Neither is finished.
+
+## The recipe
+
+**1. Pick the cell from regret, not from accuracy.** They disagree, sharply. P3's absolute error reaches p99
+47× and it barely appears as a regret source; the `plane` acquire has p50 errors of 1.2–1.3 and a **1% miss
+rate**. An argmin sees only *differences*, so a term wrong for every plan cancels. `bench_regret_matrix.py`
+sliced by acquire × unique is what ranks the work — `printing_compose / artwork` at 32% of all lost time.
+
+**2. On one query in that cell, get predicted AND measured for every plan.** `explain_analyze` runs each plan
+for real, so it is one call, and it says which side of the comparison is broken:
+
+    f:gladiator / artwork    predicted   measured   pred/meas
+    PrintingCompose             178.7      182.2      0.98    <- accurate
+    StreamedSelect              704.0      102.5      6.87    <- the problem
+
+We had assumed compose was over-picked because compose was under-costed. It was not; P3 was over-costed 7×.
+
+**3. Decompose the bad prediction into its terms by hand.** `scan_units × STREAM_SCAN_PER_ROW_NS` is
+88,026 × 5.97 = **525 µs of a 704 µs prediction**, against a 91 µs measured loop. Now one term is suspect
+rather than a whole arm.
+
+**4. Grade the suspect feature against its realized counter — for BOTH plans, on the same query.** This is
+the step that does the work:
+
+    scan_units charged (shared)   88,026        88,026
+    printings_examined realized   54,213 (P4)    5,876 (P3)
+    ratio                           1.62          14.98
+
+One per-query number cannot be right for both. This is what separates a **feature** error from a **rate**
+error, a distinction no refit can make — and the reason six refits of this surface failed before anyone
+looked. It only works because the executors publish realized counters into `PhaseStats`; if the counter you
+need does not exist, adding it is the first task, not an aside.
+
+**5. Sweep for scope before fixing anything.** Ten predicates × three modes. Legality read 0.10–0.26;
+`border:black`, `r:mythic` and `watermark:*` read exactly 1.00. A blanket "compose's `scan_units` is wrong"
+fix would have corrected four queries and broken the rest.
+
+**6. Name the mechanism, or do not believe the finding.** P3's `card_match_count` answers from span
+arithmetic whenever `card_pass` resolves a card outright; P4's `push_card_matches` must walk the span to push
+every match. Legality is the one printing-varying attribute that resolves at card level, for non-divergent
+cards. Without a mechanism you have found a coincidence.
+
+**7. Check whether the win is routed or latent.** Sweep `unique`. In card mode those same queries route to
+`PlanePopcountOrder` (2.46 µs against P3's 12.38), so a card-mode-only measurement optimises a plan nobody
+runs. Print the routed plan per cell so a latent win reads as one.
+
+**8. Verify the fix moved the DECISION, not just the number.** Correcting the feature took the predicted
+pick/best ratio from 0.22 to 0.63–0.69 and flipped nothing: 16 mispicks survived. "The estimate got better"
+and "the router now picks correctly" are separate measurements, and so is "the arm now predicts its own
+time" — see the table at the top.
+
+## Two traps that cost the most time
+
+**Cross-build timing cannot resolve a small effect, and will hand you the wrong sign.** On identical cells
+`ns_loop` wandered 43.00 / 45.38 / 47.17 µs across runs of builds that never touched that phase — ±9%, both
+directions. `bench_plan_execution_ab.py` called one change 2% *slower* while its own acquire control, which
+the change cannot touch, moved 1.9% the same way. Use **one binary with a runtime toggle**, interleaved
+subprocesses, and **equal-length env values** — an env var present in one arm only shifts process memory
+layout enough to move sub-100 µs queries a consistent ~15%. `scripts/bench_walk_span.py` is the pattern.
+
+**Kernel measurements are warm-cache; levels must come from traffic.** The residual floor measured 2.45
+ns/card on a built design while traffic fit the same column at 8.19 against a shipped 9.05 — and that is the
+third time this has been caught. **Shape from a built design, levels from traffic.** A design tells you which
+terms exist, which are degenerate and how two plans differ; it does not tell you what a constant should
+equal.

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -49,7 +49,15 @@ point step 11 next.
 **1. Pick the cell from regret, not from accuracy.** They disagree, sharply. P3's absolute error reaches p99
 47× and it barely appears as a regret source; the `plane` acquire has p50 errors of 1.2–1.3 and a **1% miss
 rate**. An argmin sees only *differences*, so a term wrong for every plan cancels. `bench_regret_matrix.py`
-sliced by acquire × unique is what ranks the work — `printing_compose / artwork` at 32% of all lost time.
+sliced by acquire × unique is what ranks the work — and **re-run it after every landed fix**, because the
+ranking moves under you. `printing_compose / artwork` was 32% of all lost time when the worked example below
+started and is **6%** now; `candidates / artwork` is 32%.
+
+Read the SHARE column knowing it is frequency × severity. `candidates` currently holds 78% of lost time at a
+mean of 1.69 µs against `printing_compose`'s 21% at 1.60 — i.e. the leading acquire is not the worse one per
+query, it is the one with 3.5× the queries. And **the loss is all tail**: p90 is 0.00 for every acquire, so
+the median query has no regret at all and only p99 (36–64 µs) is worth attacking. A mean is the wrong summary
+to optimise against here.
 
 **2. On one query in that cell, get predicted AND measured for every plan.** `explain_analyze` runs each plan
 for real, so it is one call, and it says which side of the comparison is broken:

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -20,17 +20,29 @@ the signature of compensating error", and that a rate 2× high against an estima
 and breaks the moment you fix either alone. That is a local optimum you cannot build on, because the next
 change has no ground truth to check itself against.
 
-So track absolute agreement per arm *and* regret, always. Absolute agreement today
-(`bench_cost_error_percentiles.py`, estimate/real, uniform mode):
+So track absolute agreement per arm *and* regret, always. Absolute agreement
+(`bench_cost_error_percentiles.py`, estimate/real, uniform mode, 79,718 plan-rows):
 
 | plan | p10 | p50 | p90 | spread |
 | --- | --: | --: | --: | --: |
-| CardRangePopcount | 0.84 | 1.04 | 1.29 | **1.5** |
-| StreamedSelect | 0.74 | 1.09 | 1.90 | 2.6 |
-| GatheredScan | 0.68 | **1.28** | 2.67 | 3.9 |
-| PrintingCompose | 0.62 | 1.06 | 2.99 | 4.8 |
+| CardRangePopcount | 0.84 | 1.05 | 1.30 | **1.6** |
+| StreamedSelect | 0.73 | 1.09 | 1.74 | 2.4 |
+| GatheredScan | 0.68 | **1.28** | 2.75 | 4.0 |
+| PrintingCompose | 0.66 | 1.07 | 3.08 | 4.7 |
 
 P4 is still ~1.3× over at the median and compose's spread is the worst in the engine. Neither is finished.
+
+**And that these two goals move independently is not a theoretical caveat.** The two fixes described
+throughout this doc took total regret down **25%** and moved this table by almost nothing — P3's spread
+2.6 → 2.4, P4's unchanged. Both fixes are confined to the `printing_compose` acquire, which is 4–10% of
+plan-rows, so a pooled per-arm view cannot see them at all. If you are optimising routing, this table is
+not your scoreboard; if you are trying to make an arm predict its own time, regret is not yours.
+
+One reading to attribute rather than trust: sliced to the cell that was worked,
+`StreamedSelect [printing_compose] / printing` now shows p50 1.04 with a **26.4 spread** (p90 13.90), and
+`/ card` 24.6. A long over-costing tail on the acquire whose median is fine. No before/after was captured for
+that cell, so whether the tier gate created it or merely revealed it is open — and it is the obvious place to
+point step 11 next.
 
 ## The recipe
 
@@ -52,6 +64,12 @@ We had assumed compose was over-picked because compose was under-costed. It was 
 88,026 × 5.97 = **525 µs of a 704 µs prediction**, against a 91 µs measured loop. Now one term is suspect
 rather than a whole arm.
 
+`explain` flattens the whole feature vector into its `acquire` dict, so a throwaway Python replica of the one
+arm is a few lines. **Assert the replica reproduces `predicted_ns` exactly before you attribute anything
+to it** — a term breakdown from a replica that has silently drifted is worse than no breakdown, and this is
+the same failure `fit_cost_model`'s mirror check exists to catch (it went two revisions reporting
+coefficients from a drifted mirror).
+
 **4. Grade the suspect feature against its realized counter — for BOTH plans, on the same query.** This is
 the step that does the work:
 
@@ -64,25 +82,64 @@ error, a distinction no refit can make — and the reason six refits of this sur
 looked. It only works because the executors publish realized counters into `PhaseStats`; if the counter you
 need does not exist, adding it is the first task, not an aside.
 
-**5. Sweep for scope before fixing anything.** Ten predicates × three modes. Legality read 0.10–0.26;
+**5. Ask whether the router and the executor are asking the same question.** A feature this wrong is rarely
+bad arithmetic; it is usually a condition the executor evaluates and the router does not. `prepare_candidates`
+held the only copy of `all_match_known`, so the compose acquire — which never calls it — charged
+`verify_cost_tier` on every legality query alike, and the two dead terms that bought were **92–94% of P3's
+predicted cost**. The fix was to extract the predicate (`plane_leaves_nothing_to_verify`) and call it from
+both layers, not to adjust a number.
+
+Two checks worth making routinely, because both failure modes are silent:
+
+- **Every acquire branch that builds `PlanFeatures` sets every gated field.** `mk_plan_feats` supplies
+  defaults, so a branch nobody taught is quietly wrong rather than a compile error.
+- **A condition both layers need is one function, not two copies.**
+  `compose_paging_prediction_matches_the_branch_taken` is the existing pattern for pinning that agreement, and
+  its doc says why: the same drift already happened once between `cost.rs` and its Python mirror.
+
+**6. Sweep for scope before fixing anything.** Ten predicates × three modes. Legality read 0.10–0.26;
 `border:black`, `r:mythic` and `watermark:*` read exactly 1.00. A blanket "compose's `scan_units` is wrong"
 fix would have corrected four queries and broken the rest.
 
-**6. Name the mechanism, or do not believe the finding.** P3's `card_match_count` answers from span
+**7. Name the mechanism, or do not believe the finding.** P3's `card_match_count` answers from span
 arithmetic whenever `card_pass` resolves a card outright; P4's `push_card_matches` must walk the span to push
 every match. Legality is the one printing-varying attribute that resolves at card level, for non-divergent
 cards. Without a mechanism you have found a coincidence.
 
-**7. Check whether the win is routed or latent.** Sweep `unique`. In card mode those same queries route to
+**8. Check whether the win is routed or latent.** Sweep `unique`. In card mode those same queries route to
 `PlanePopcountOrder` (2.46 µs against P3's 12.38), so a card-mode-only measurement optimises a plan nobody
 runs. Print the routed plan per cell so a latent win reads as one.
 
-**8. Verify the fix moved the DECISION, not just the number.** Correcting the feature took the predicted
+**9. Verify the fix moved the DECISION, not just the number.** Correcting the feature took the predicted
 pick/best ratio from 0.22 to 0.63–0.69 and flipped nothing: 16 mispicks survived. "The estimate got better"
 and "the router now picks correctly" are separate measurements, and so is "the arm now predicts its own
 time" — see the table at the top.
 
-**9. If the fix does not move the ordering, split the population before touching a rate.** A pair can be
+**10. If total regret ROSE, find out whether you removed a compensating error before reverting.** A correct
+fix can make routing worse, and the intermediate number will tell you to throw it away. Run
+`bench_pairwise_ordering.py` on the pair you targeted *and* on the others:
+
+| pair, `[printing_compose]` | before | after the tier gate |
+| --- | --: | --: |
+| `PrintingCompose vs StreamedSelect` (targeted) | 80% ordered right | **96%** |
+| `GatheredScan vs StreamedSelect` (untouched) | 69%, gap 0.89 | 69%, gap 0.90 |
+
+The targeted pair improved and no other pair moved, yet total regret went **81.7 → 129.7 ms**. That pattern
+means one thing: the fix let a correctly-cheap plan into the argmin far more often, and a *different* pair
+cannot rank it. Nothing regressed — an existing error stopped being masked. Fixing what it exposed (P4's span
+feature, 1.76× over) then took regret to **61.2 ms, −25% on baseline**. Reverting on the 129.7 ms would have
+discarded a correct change and left the real defect hidden, which is the trap this step exists for.
+
+Two things make the reading trustworthy. **Regret TOTAL is a sum over however many queries the budget
+reached**, so it is not comparable across runs — compare the mean, and measure your own baseline in the same
+session rather than against a number in a doc. The 48.7 ms and 55.0 ms figures still quoted in the earlier
+sections of `local-engine-loop-phase-measurement.md` were taken at unrecorded settings and are **not** on the
+same scale as the 81.7 → 61.2 ms above; that is why a fresh paired baseline was measured rather than compared
+against them. And a cost-only change
+needs **no new row-identity run**: `force_plan_differential_agreement` already proves every plan returns the
+same rows, which is exactly what makes re-routing safe.
+
+**11. If the fix does not move the ordering, split the population before touching a rate.** A pair can be
 right on average and bimodal underneath, and the summary statistic that hides this is the one that looks most
 reassuring. `GatheredScan vs StreamedSelect [printing_compose]` reads a **gap ratio of 0.91** — the model
 sizes the difference almost exactly right — at **69% ordered right**. That invites "it is variance, no
@@ -96,7 +153,17 @@ Every wrong pair is in one regime, and the wrong group is **homogeneous** — th
 the truth, it is confidently inverted on one identifiable class (broad residuals where both plans scan the
 whole corpus). A mean gap ratio of 0.91 is what two opposed sub-populations look like after averaging.
 
-## Three traps that cost the most time
+## Four traps that cost the most time
+
+**A corpus-wide share applied to a selected population is wrong exactly where it matters.** The first attempt
+at the fix above priced "how much of the residual is really printing-dependent" as the divergent fraction of
+the corpus — `legal_divergent / n_cards`, ~1.76%. It is the natural move and it is invalid whenever the filter
+*correlates with the thing being averaged*: for `f:oldschool` the candidates largely **are** the divergent
+cards, so a global share under-charges precisely the queries whose residual is real. Measured, it traded 408
+mispicks for 118 that were four times worse (mean 54.27 → 206.24 µs) for a net 3.4%. The replacement was a
+**boolean the engine already derives from data** (`plane_expr_is_existential` against `divergent_formats`), not
+a better fraction. Prefer an exact predicate the engine can answer over any estimated share, and if you must
+estimate one, condition it on the candidate set rather than the corpus.
 
 **Cross-build timing cannot resolve a small effect, and will hand you the wrong sign.** On identical cells
 `ns_loop` wandered 43.00 / 45.38 / 47.17 µs across runs of builds that never touched that phase — ±9%, both
@@ -112,7 +179,7 @@ terms exist, which are degenerate and how two plans differ; it does not tell you
 equal.
 
 **A pooled fit endorses the rates that are wrong on a sub-population, so it cannot be your check.** On the
-class in step 9, `STREAM_SCAN_PER_ROW_NS` 5.97 and `GATHER_SCAN_PER_ROW_NS` 2.06 are 2.9× apart for what is
+class in step 11, `STREAM_SCAN_PER_ROW_NS` 5.97 and `GATHER_SCAN_PER_ROW_NS` 2.06 are 2.9× apart for what is
 nominally the same walk-a-printing-and-test work, and P3's higher rate cancels its lower per-card rate exactly
 where both features are maximal. `fit_cost_model.py` fits **both** and pronounces them fine — 6.04 at ratio
 1.01 and 2.53 at 1.23. So a refit will not surface this and cannot fix it; it will confirm the status quo. Fit

--- a/docs/workflows/performance-pr-workflow.md
+++ b/docs/workflows/performance-pr-workflow.md
@@ -46,7 +46,9 @@ anything new rather than starting a twelfth private copy.
 For diagnosing *which* of features / model shape / coefficients is at fault once layer 1 or 2 shows
 an error, and for the regret and pairwise-ordering views, see
 [reference-cost-model-measurement.md](../../docs/issues/reference-cost-model-measurement.md). That is
-the tool-picking reference; this doc is the process.
+the tool-picking reference; this doc is the process. For the step-by-step diagnosis of one plan's arm —
+which cell to pick, how to tell a feature error from a rate error, and the two measurement traps that
+hand you the wrong sign — see [diagnosing-a-plan-cost-error.md](./diagnosing-a-plan-cost-error.md).
 
 ### Layers 1 and 2: read the shape, not the median
 

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -215,6 +215,10 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
     """
     eval_domain = float(acq["eval_domain"])
     scan_units = float(acq["scan_units"])
+    # P3's own scan estimate, which differs from `scan_units` on a legality-composed acquire -- see
+    # `PlanFeatures::stream_scan_units`. Absent from an older recorded run, in which case it equals
+    # `scan_units` and this mirrors the pre-split arm exactly.
+    stream_scan_units = float(acq.get("stream_scan_units", acq["scan_units"]))
     matches = float(acq["matches"])
     n_cards = float(acq["n_cards"])
     tier_ns = acq["residual_tier_ns100"] / 100.0
@@ -256,7 +260,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
         return (
             [
                 eval_domain,
-                scan_units * residual_on,
+                stream_scan_units * residual_on,
                 eval_domain * residual_on,
                 matches,
                 perm_steps,


### PR DESCRIPTION
**Layer 4 of 13.** Base: #835. Reference: #830. Clippy-clean as replayed — no fixes needed at this layer.

Calibration resumes now that the divergence work is in. Twenty-seven commits, mostly on the compose
acquire, which was the one arm carrying ~75% of measured routing regret and the one arm no tool had
calibrated.

- **Compose estimated from the residual, not from what it will actually compose.** Reading the residual
  once a plane had consumed part of the filter estimated `True` — every printing in the corpus — so
  `matches` came back as `n_printings` for every legality query alike.
- **The candidate span is clamped at the corpus it is a subset of.** `border:black`/printing reached
  159,325 against a corpus of 97,206 and a realized 97,206 exactly.
- **The clustering bias moved onto the ball count** rather than the estimate.
- **`StreamedSelect` gets its own `scan_units`**, and is charged no scan at all when the residual cannot
  vary within a card — it then examines zero printings, which `printings_examined` confirms.
- **Artwork's per-card surcharge measured on both arms and gated**, after a first attempt that improved
  absolute agreement and regressed routing.

Several commits record a measurement and decline to act on it; that is deliberate.

## Risk

No archived type changes, so no bump. Changes pricing, so it can change plan choice.

## Verification

`cargo test` and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
