### PR TITLE
Engine: Fuse an And's Same-Index Range Children (stack 5/13)

### DIFF
--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -658,6 +658,44 @@ const COMPOSE_GATHER_GROUP_PER_PRINTING_NS: f64 = 1.5;
 /// Per-query setup for the compose fastpath.
 const COMPOSE_FIXED_COST_NS: f64 = 163.56;
 
+/// The full-width printing-bitmap build, which no other term charges.
+///
+/// `compose_printing_bits` allocates an `n_printings`-wide bitmap and ANDs each child into it,
+/// `printing_bits_to_card_bits` projects it, and `bitmap_card_ids` walks the card bitmap to extract
+/// set ids. All three are O(corpus width) whatever the query matches, and `popcount_words` charges
+/// only the **result-space** bitmap, so the printing-space build was free in the model.
+///
+/// Measured as `meas - oracle_pred` on the gather population — realized counters substituted for every
+/// feature, shipped rates untouched, so what is left is work no term charges for. Nine corpus sizes
+/// from 0.5x to 5x, built by replicating the corpus and sampling the fractional part by oracle CARD
+/// (sampling printings would thin each card's span and change the printings-per-card distribution,
+/// which is the quantity under test), 33 cells each:
+///
+///     residual = -107 ns + 0.0835 ns/printing     R^2 = 0.998
+///
+/// The intercept is zero within noise: this is a width term, not a fixed cost, and
+/// `COMPOSE_FIXED_COST_NS` above stays as it is. `ns/printing` varies 1.13x over that 10x range with
+/// no trend — the bitmap crosses 6 KB to 59 KB, L1 to L2, without the rate moving — so the linear
+/// shape holds and this constant is not specific to the production corpus.
+///
+/// **Scoped to the Gather arm deliberately, though the work is physically a BUILD cost** shared by all
+/// three paging branches. `Perm` and `OrderbyWalk` had their rates fitted with this cost already
+/// absorbed into them, so charging it there as well double-counts: measured per branch over six sizes,
+/// `predicted/measured` on Perm goes 1.193 -> 1.544 at the production corpus when this term is added.
+/// Gather is the only branch whose error is a clean level (flat 0.52-0.55 across the whole 10x range),
+/// which is what makes a single constant the right instrument for it — and it fixes it, to 0.88-0.99.
+/// Widening this to the build section requires fixing `Perm`/`OrderbyWalk` first, and those two drift
+/// in OPPOSITE directions with corpus size while sharing their rates, so it is not a refit.
+/// See docs/issues/local-engine-sparse-compose-gather.md.
+///
+/// This DOES move production routing, and an earlier draft of this comment claimed it did not. The
+/// sparse-permutation case is declined, but `compose_paging_with_total` still returns `Gather` whenever
+/// there is no card-space permutation and the query is not printing-mode on usd/rarity — card and
+/// artwork on a usd/rarity orderby, which is ordinary traffic (13 of 45 cells in a quick sweep). So it
+/// carries a regret gate like any other arm change, not the free pass "it is behind the decline" would
+/// have bought.
+const COMPOSE_BUILD_PER_PRINTING_NS: f64 = 0.0835;
+
 /// Printings a forward-permutation / orderby walk steps over to fill one page: `page_span` result
 /// rows at density `match_rate`. Derived rather than stored, and exposed so a harness can check it
 /// against the `printing_span` counter -- the Perm and OrderbyWalk paging branches are priced
@@ -739,6 +777,7 @@ pub(crate) fn plan_cost(plan: PhysicalPlan, f: &PlanFeatures) -> f64 {
                         + f64::from(f.compose_scan_printings) * COMPOSE_GATHER_BITTEST_PER_PRINTING_NS
                         + f64::from(f.gather_group_printings) * COMPOSE_GATHER_GROUP_PER_PRINTING_NS
                         + matches * COMPOSE_GATHER_PUSH_PER_MATCH_NS
+                        + f64::from(f.n_printings) * COMPOSE_BUILD_PER_PRINTING_NS
                 }
                 // The fastpath will refuse this query, so there is no page term to charge. Infinity
                 // keeps the plan out of the argmin entirely — routing to a plan that returns `None`

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3382,23 +3382,35 @@ enum AndSource<'f, 'i> {
     /// printings — already probed, so the And arm reads it as the ranking probe instead of repeating
     /// the two binary searches. Constituents may include a `Not` (`bare_range_bounds` reduces
     /// `-usd<c` to `usd>=c`'s bounds itself); nothing downstream needs to know, because the
-    /// broad-interval gate below means `k` is always sparse and `range_narrowed` therefore takes its
-    /// vec path without ever consulting `broad_ok` — the one thing the negated arm cares about.
+    /// broad-interval gate below means `k` is always sparse under `sparse_only` and `range_narrowed`
+    /// therefore takes its vec path without ever consulting `broad_ok` — the one thing the negated arm
+    /// cares about. The compose builders don't consult `broad_ok` at all.
     FusedRange { idx: &'i Archived<PrintingRangeIndex>, lo: u32, hi: u32, k: usize },
 }
 
 /// Group an `And`'s children by which printing-range index they select on, fusing each group of two
 /// or more into a single interval — `lo = max(lo_i)`, `hi = min(hi_i)`.
 ///
-/// Children the range dispatch doesn't recognize, single-member groups, and groups whose fused
-/// interval is *still* broad all pass through untouched: those children keep taking their own arms, so
+/// Children the range dispatch doesn't recognize and single-member groups pass through untouched, so
 /// this cannot alter any query it doesn't fuse. Emission follows the written position of each group's
-/// first member, so the And arm's stable `sort_by_key` sees the tie-breaking it saw before for
-/// everything unfused.
+/// first member, so a caller that ranks its sources sees the tie-breaking it saw before for everything
+/// unfused.
 ///
 /// The fused interval is the exact conjunction of its constituents, which is what lets one source
-/// stand in for all of them — including in `every_child_included`'s tightness accounting.
-fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Archived<CardIndexes>) -> Vec<AndSource<'f, 'i>> {
+/// stand in for all of them — including in `narrow_rec`'s `every_child_included` tightness accounting.
+///
+/// `sparse_only` is the one thing the two callers disagree about. `narrow_rec` sets it, because a broad
+/// fused source reaches `range_narrowed` under a single `broad_ok` where two broad children each got
+/// their own, which takes a decision away from the And's per-child skip logic for no measured gain (see
+/// the gate below). The compose builders clear it: `range_leaf_bits` is an O(k) scatter at every k, so
+/// one scatter of the intersection always beats two scatters and an AND, and
+/// `compose_printing_estimate` reads the intersection's exact `k` where the unfused fold could only take
+/// the min of the two sides (measured: 33,862 against a true 879).
+fn fuse_and_range_children<'f, 'i>(
+    children: &'f [FilterExpr],
+    indexes: &'i Archived<CardIndexes>,
+    sparse_only: bool,
+) -> Vec<AndSource<'f, 'i>> {
     // At most one group per printing-range index (price / collector-number / released-at), so a
     // linear scan of the accumulator beats hashing a pointer.
     struct Group<'i> {
@@ -3424,15 +3436,14 @@ fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Arch
             None => groups.push(Group { first: pos, idx, lo, hi, count: 1 }),
         }
     }
-    // Fusion exists to DISCOVER a sparse intersection hiding behind broad halves. Where the
-    // intersection is itself broad there is nothing to discover — and fusing anyway is not neutral,
-    // because one broad source reaches `range_narrowed` under a single `broad_ok` where two broad
-    // children each got their own, so the And's per-child skip logic stops deciding per child.
+    // Under `sparse_only`, fusion exists to DISCOVER a sparse intersection hiding behind broad halves.
+    // Where the intersection is itself broad there is nothing to discover — and fusing anyway is not
+    // neutral, for the `broad_ok` reason in this function's doc.
     //
-    // This gate is a scope decision, not a measured win: paired traffic puts fused-vs-gated at 0.88 vs
+    // That gate is a scope decision, not a measured win: paired traffic puts fused-vs-gated at 0.88 vs
     // 0.86 of baseline on the fusible slice, and the per-query noise floor on a slice fusion cannot
     // touch at all is ±170 µs, so the two are indistinguishable. What the gate does buy is a bound —
-    // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), the change is a
+    // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), narrowing is a
     // provable no-op. `k` survives for the survivors so the probe isn't recomputed downstream.
     let mut fused: Vec<(&Group<'i>, usize)> = Vec::new();
     for g in &groups {
@@ -3441,7 +3452,7 @@ fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Arch
         }
         let s = g.idx.partition_point(|p| u32::from(p.0) < g.lo);
         let e = g.idx.partition_point(|p| u32::from(p.0) < g.hi);
-        if !range_too_broad_to_narrow(e - s, g.idx.len()) {
+        if !sparse_only || !range_too_broad_to_narrow(e - s, g.idx.len()) {
             fused.push((g, e - s));
         }
     }
@@ -4027,7 +4038,7 @@ fn narrow_rec(
             // Same-index range children fuse into one interval first (`fuse_and_range_children`),
             // because two individually-broad halves can intersect to something sparse and this arm
             // only ever intersects narrowing *results*, never the bounds.
-            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes)
+            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes, true)
                 .into_iter()
                 .map(|src| match src {
                     AndSource::Child(c) => {
@@ -5814,10 +5825,18 @@ fn compose_printing_bits(
     match filter {
         FilterExpr::True => all_printing_bits(n_printings),
         FilterExpr::And(v) => {
-            // empty And is vacuously true; start all-ones (tail masked) and intersect each child.
+            // empty And is vacuously true; start all-ones (tail masked) and intersect each source.
+            // Same-index range children fuse into one interval first, so `usd>=0.42 usd<=0.43` scatters
+            // the 879-printing intersection once instead of scattering 33,862 and 48,559 and ANDing
+            // them. Unconditional (`sparse_only: false`): `range_leaf_bits` is an O(k) scatter at every
+            // k, so one scatter of a subset can never lose to two of its supersets.
             let mut acc = all_printing_bits(n_printings);
-            for child in v.iter() {
-                and_bits_into(&mut acc, &compose_printing_bits(child, indexes, offsets, printings, n_printings));
+            for src in fuse_and_range_children(v, indexes, false) {
+                let bits = match src {
+                    AndSource::Child(c) => compose_printing_bits(c, indexes, offsets, printings, n_printings),
+                    AndSource::FusedRange { idx, lo, hi, .. } => range_leaf_bits(idx, lo, hi, n_printings),
+                };
+                and_bits_into(&mut acc, &bits);
             }
             acc
         }
@@ -5903,9 +5922,17 @@ fn compose_printing_estimate(
     let popcount = |bits: &[u64]| bits.iter().map(|w| w.count_ones() as usize).sum::<usize>();
     match filter {
         FilterExpr::True => (n_printings, 0, 0),
-        FilterExpr::And(v) => v
-            .iter()
-            .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
+        // The min-of-children fold is an intersection UPPER BOUND, and on a two-sided range it is a bad
+        // one: `usd>=0.42 usd<=0.43` folded to min(33,862, 48,559) against a true 879, and the summed
+        // scatter to 82,421 for an 879-row answer. Fusing same-index children first replaces both with
+        // the interval's exact `k` — the same two `partition_point` calls the one-sided arm below
+        // already makes, which is why a one-sided range estimates at 1.0x and this did not.
+        FilterExpr::And(v) => fuse_and_range_children(v, indexes, false)
+            .into_iter()
+            .map(|src| match src {
+                AndSource::Child(c) => compose_printing_estimate(c, indexes, offsets, n_printings),
+                AndSource::FusedRange { k, .. } => (k, 0, k),
+            })
             .fold((n_printings, 0, 0), |(m, bc, sc), (cm, cbc, csc)| (m.min(cm), bc + cbc, sc + csc)),
         FilterExpr::Or(v) => {
             let (m, bc, sc) = v

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6438,11 +6438,30 @@ fn printing_compose_fastpath<'a>(
     let (page, mut work) = match perm {
         Some(perm) => {
             if total <= *STREAM_MIN_MATCHES {
+                // Sparse: hand the query back to the general path rather than paging it here.
+                //
+                // NOT for the reason this comment used to give ("the general path gathers + globally
+                // sorts, ordering ties differently"). That died with #815, which made row order total
+                // and filter-independent on (key1, key2, cid, pid), replacing the key-3 `prefer_score`
+                // that genuinely differed between the permutation (first STORED printing's score) and
+                // the gathered paths (first MATCHING one). Measured 2026-08-04 by toggling this decline
+                // off: 576 real invocations of the walk over 1,512 tie-heavy cells, 0 row differences,
+                // plus 14 inside `force_plan_differential_agreement`, which asserts full row order
+                // against GatheredScan. Either executor is correct here now.
+                //
+                // What keeps the decline is cost, not correctness. `gather_composed_page` is genuinely
+                // 1.3-2.7x faster than the plan that otherwise wins on this population, but `plan_cost`
+                // reads 0.27-0.53 of its real time, and the resulting mispicks cancel the wins exactly:
+                // regret 1.30 -> 1.51 us, compose miss% 7% -> 18%, compose-acquire wall time 1.00 over
+                // 2,341 paired queries. Neutral in time and worse in routing is not a trade worth the
+                // complexity. docs/issues/local-engine-sparse-compose-gather.md carries the four
+                // acceptance criteria this has to clear.
+                //
                 // `Exact` to distinguish it from `DeclineSparseEstimate` above: same intent, but that
                 // one fires pre-compose off the estimator's upper bound, this one post-compose off
                 // the real total. A harness reading one label for both cannot tell which fired.
                 note_paging_taken(PagingTaken::DeclineSparseExact);
-                return None; // sparse: the general path gathers + globally sorts, ordering ties differently
+                return None;
             }
             note_paging_taken(PagingTaken::Perm);
             walk_grouped_page(ctx, params, &pbits, perm)

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3367,6 +3367,102 @@ fn probe_range_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Option
     Some(e - s)
 }
 
+/// One entry in the And arm's work list: a child exactly as written, or a half-open interval fused
+/// from two or more same-index range children.
+///
+/// `usd>=0.42 usd<=0.43` is the shape that motivated this. Each half matches most of the corpus, so
+/// each trips `range_too_broad_to_narrow` on its own and declines; their *intersection* is 837
+/// printings. `narrow_rec` narrows children independently and intersects the results, so the
+/// interval is never discovered — measured at 1,146.8 µs, against 26.7 µs for the one-sided
+/// `usd>=200`, which returns *more* rows. Fusing before ranking puts the two-sided form on the same
+/// sparse-vec path the one-sided form already takes.
+enum AndSource<'f, 'i> {
+    Child(&'f FilterExpr),
+    /// `[lo, hi)` on `idx`, the intersection of two or more children's intervals, holding `k`
+    /// printings — already probed, so the And arm reads it as the ranking probe instead of repeating
+    /// the two binary searches. Constituents may include a `Not` (`bare_range_bounds` reduces
+    /// `-usd<c` to `usd>=c`'s bounds itself); nothing downstream needs to know, because the
+    /// broad-interval gate below means `k` is always sparse and `range_narrowed` therefore takes its
+    /// vec path without ever consulting `broad_ok` — the one thing the negated arm cares about.
+    FusedRange { idx: &'i Archived<PrintingRangeIndex>, lo: u32, hi: u32, k: usize },
+}
+
+/// Group an `And`'s children by which printing-range index they select on, fusing each group of two
+/// or more into a single interval — `lo = max(lo_i)`, `hi = min(hi_i)`.
+///
+/// Children the range dispatch doesn't recognize, single-member groups, and groups whose fused
+/// interval is *still* broad all pass through untouched: those children keep taking their own arms, so
+/// this cannot alter any query it doesn't fuse. Emission follows the written position of each group's
+/// first member, so the And arm's stable `sort_by_key` sees the tie-breaking it saw before for
+/// everything unfused.
+///
+/// The fused interval is the exact conjunction of its constituents, which is what lets one source
+/// stand in for all of them — including in `every_child_included`'s tightness accounting.
+fn fuse_and_range_children<'f, 'i>(children: &'f [FilterExpr], indexes: &'i Archived<CardIndexes>) -> Vec<AndSource<'f, 'i>> {
+    // At most one group per printing-range index (price / collector-number / released-at), so a
+    // linear scan of the accumulator beats hashing a pointer.
+    struct Group<'i> {
+        first: usize,
+        idx: &'i Archived<PrintingRangeIndex>,
+        lo: u32,
+        hi: u32,
+        count: usize,
+    }
+    let mut groups: Vec<Group<'i>> = Vec::new();
+    for (pos, child) in children.iter().enumerate() {
+        let Some((idx, lo, hi)) = bare_range_bounds(child, indexes) else { continue };
+        match groups.iter_mut().find(|g| std::ptr::eq(g.idx, idx)) {
+            Some(g) => {
+                g.lo = g.lo.max(lo);
+                // An unsatisfiable fusion (`usd>=1 usd<=0.5`) gives `hi < lo`, and every consumer
+                // computes `k` as `partition_point(hi) - partition_point(lo)` — that subtraction
+                // underflows and panics. Clamping to `[lo, lo)` yields `k = 0`, which is what an
+                // empty range means and what every consumer already handles.
+                g.hi = g.hi.min(hi).max(g.lo);
+                g.count += 1;
+            }
+            None => groups.push(Group { first: pos, idx, lo, hi, count: 1 }),
+        }
+    }
+    // Fusion exists to DISCOVER a sparse intersection hiding behind broad halves. Where the
+    // intersection is itself broad there is nothing to discover — and fusing anyway is not neutral,
+    // because one broad source reaches `range_narrowed` under a single `broad_ok` where two broad
+    // children each got their own, so the And's per-child skip logic stops deciding per child.
+    //
+    // This gate is a scope decision, not a measured win: paired traffic puts fused-vs-gated at 0.88 vs
+    // 0.86 of baseline on the fusible slice, and the per-query noise floor on a slice fusion cannot
+    // touch at all is ±170 µs, so the two are indistinguishable. What the gate does buy is a bound —
+    // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), the change is a
+    // provable no-op. `k` survives for the survivors so the probe isn't recomputed downstream.
+    let mut fused: Vec<(&Group<'i>, usize)> = Vec::new();
+    for g in &groups {
+        if g.count < 2 {
+            continue;
+        }
+        let s = g.idx.partition_point(|p| u32::from(p.0) < g.lo);
+        let e = g.idx.partition_point(|p| u32::from(p.0) < g.hi);
+        if !range_too_broad_to_narrow(e - s, g.idx.len()) {
+            fused.push((g, e - s));
+        }
+    }
+    if fused.is_empty() {
+        return children.iter().map(AndSource::Child).collect();
+    }
+    let mut out: Vec<AndSource<'f, 'i>> = Vec::with_capacity(children.len());
+    for (pos, child) in children.iter().enumerate() {
+        let group = bare_range_bounds(child, indexes).and_then(|(idx, ..)| fused.iter().find(|(g, _)| std::ptr::eq(g.idx, idx)));
+        match group {
+            Some((g, k)) => {
+                if pos == g.first {
+                    out.push(AndSource::FusedRange { idx: g.idx, lo: g.lo, hi: g.hi, k: *k });
+                }
+            }
+            None => out.push(AndSource::Child(child)),
+        }
+    }
+    out
+}
+
 /// `broad_ok` says whether a broad printing-range child may materialize its
 /// bitmap: true under Or (the union consumes it) and Not (the complement
 /// trick needs it), false where nothing would — a lone broad set at the root
@@ -3928,12 +4024,20 @@ fn narrow_rec(
             // both shrinks the driver as fast as possible and removes the old
             // sensitivity to the order same-rank children happened to be written
             // in. Non-range children (no probe) sort after the ranges in-rank.
-            let mut ranked: Vec<(u8, Option<usize>, &FilterExpr)> = children
-                .iter()
-                .map(|c| {
-                    let rank = and_child_rank(c, indexes);
-                    let probe = if rank == 1 { probe_range_k(c, indexes) } else { None };
-                    (rank, probe, c)
+            // Same-index range children fuse into one interval first (`fuse_and_range_children`),
+            // because two individually-broad halves can intersect to something sparse and this arm
+            // only ever intersects narrowing *results*, never the bounds.
+            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes)
+                .into_iter()
+                .map(|src| match src {
+                    AndSource::Child(c) => {
+                        let rank = and_child_rank(c, indexes);
+                        let probe = if rank == 1 { probe_range_k(c, indexes) } else { None };
+                        (rank, probe, AndSource::Child(c))
+                    }
+                    // A fused interval is a printing range like any other — rank 1, and its probe is
+                    // the `k` its own broad-check already computed.
+                    AndSource::FusedRange { k, .. } => (1, Some(k), src),
                 })
                 .collect();
             ranked.sort_by_key(|(r, probe, _)| (*r, probe.unwrap_or(usize::MAX)));
@@ -3948,7 +4052,7 @@ fn narrow_rec(
             // per child meant popcounting every accumulated bitmap again on every
             // iteration — O(children² × words) for a value that only ever shrinks.
             let mut best: Option<usize> = None;
-            for (rank, probe, c) in ranked {
+            for (rank, probe, src) in ranked {
                 // A driver this selective already bounds the candidate set the
                 // residual re-verifies, so a costlier (rank>0) child usually
                 // narrows nothing the driver's verification doesn't already do
@@ -3974,7 +4078,14 @@ fn narrow_rec(
                     1 => !printing_sets.is_empty(),
                     _ => broad_ok,
                 };
-                if let Some(n) = narrow_rec(c, indexes, offsets, cards, child_broad_ok) {
+                let narrowed = match src {
+                    AndSource::Child(c) => narrow_rec(c, indexes, offsets, cards, child_broad_ok),
+                    // `range_narrowed` is what every unfused range child reaches too, with the same
+                    // `exact: true` (the bounds come from the same `int_range_bounds`/
+                    // `date_range_bounds`/`year_range_bounds` derivations).
+                    AndSource::FusedRange { idx, lo, hi, .. } => range_narrowed(idx, lo, hi, n_printings, child_broad_ok, true),
+                };
+                if let Some(n) = narrowed {
                     // A child covering most of its domain barely narrows the
                     // intersection; skipping it is advisory-sound and avoids
                     // paying its projection/materialization for ~nothing.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5306,8 +5306,10 @@ fn is_printing_composable(filter: &FilterExpr, indexes: &Archived<CardIndexes>) 
         {
             true
         }
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(_) }
-        | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => true,
+        // Any rarity comparison, not only `== c`: the domain is closed and every present value has exact
+        // bits, so an inequality is the `Or` of the qualifying ones. See `rarity_cmp_leaf_bits`.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), rhs: NumExpr::Const(_), .. }
+        | FilterExpr::NumericCmp { lhs: NumExpr::Const(_), rhs: NumExpr::Field(NumField::RarityInt), .. } => true,
         // Legality via #667's card `_EXISTS` plane + a divergent repair (see `legality_leaf_bits`).
         // Only a plane-backed status (legal/banned/restricted) with a present format; an absent format
         // (`shift: None`) matches nothing and stays on the general path.
@@ -5379,6 +5381,48 @@ fn rarity_leaf_bits(c: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: us
         Some(e) => scatter_bits(e.1.iter().map(|p| u32::from(*p)), n_printings),
         None => vec![0u64; wpp],
     }
+}
+
+/// The exact printing-space bitmap for **any** rarity comparison, not just `== c`.
+///
+/// Rarity's domain is closed and small: the four interior ints have laid-out planes and the sparse tail
+/// (special/bonus) has postings, so every value present in the store can be enumerated and its exact bits
+/// read. An inequality is then the `Or` of the values that satisfy it — the same enumeration
+/// `walk_rarity_orderby_page` already walks for its bucket order.
+///
+/// Two consequences worth stating. **NULL rarity is excluded for free**: a printing with no rarity appears in
+/// no plane and no posting, so it matches nothing here, which is the trivalent answer for every op including
+/// `Ne` (`-r:rare` must not match a rarity-less printing). And this is **strictly more capable than
+/// `compile_plane`'s** `compile_rarity_cmp`, which shares one "above mythic" plane and so declines
+/// (`BucketVerdict::Ambiguous`) whenever special must be told from bonus — `r:special`, `r>=bonus` and friends.
+/// Compose reads the two apart from their own postings, so it has no ambiguous case at all.
+///
+/// Was `Eq`-only, and the cost of that was not subtle: `r>=rare`/artwork fell off the compose path entirely
+/// and took **487.7 µs** through a full candidate scan, against **59.2 µs** for `r:rare` on the same corpus —
+/// 8× for a predicate that is just `rare ∨ mythic ∨ special ∨ bonus`.
+fn rarity_cmp_leaf_bits(op: CmpOp, threshold: f64, rp: &Archived<RarityPrintingPlanes>, n_printings: usize) -> Vec<u64> {
+    let wpp = words_per_plane(n_printings);
+    let mut out = vec![0u64; wpp];
+    for int in rarity_ints_present(rp) {
+        if !planes::matches_op(op, f64::from(int), threshold) {
+            continue;
+        }
+        for (dst, src) in out.iter_mut().zip(rarity_leaf_bits(f64::from(int), rp, n_printings)) {
+            *dst |= src;
+        }
+    }
+    out
+}
+
+/// Every rarity int the store actually holds: the four interior values (planes, always laid out) plus
+/// whatever the sparse tail carries. One definition, shared by the compose leaf above and
+/// `walk_rarity_orderby_page`'s bucket walk, so the two cannot disagree about the domain.
+fn rarity_ints_present(rp: &Archived<RarityPrintingPlanes>) -> Vec<u8> {
+    let mut values: Vec<u8> = RARITY_PRINTING_PLANE_INTS.to_vec();
+    values.extend(rp.postings.iter().map(|e| e.0));
+    values.sort_unstable();
+    values.dedup();
+    values
 }
 
 /// #746: the exact printing-space bitmap for a bare tag-postings leaf (`set:VALUE`/`watermark:VALUE`)
@@ -5710,9 +5754,12 @@ fn compose_printing_bits(
             let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
             collection_negated_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
         }
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
-        | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
-            rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)
+        // `flip_op` on the const-first form so `2<=rarity` and `rarity>=2` build the same bitmap.
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
+            rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            rarity_cmp_leaf_bits(flip_op(*op), *c, &indexes.rarity_printing, n_printings)
         }
         FilterExpr::Legality { shift: Some(shift), expected } => {
             legality_leaf_bits(*shift, *expected, indexes, offsets, printings, n_printings)
@@ -5805,9 +5852,11 @@ fn compose_printing_estimate(
             let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
             (n_printings.saturating_sub(k), 0, k)
         }
-        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(c) }
-        | FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
-            (popcount(&rarity_leaf_bits(*c, &indexes.rarity_printing, n_printings)), 0, 0)
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
+            (popcount(&rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)), 0, 0)
+        }
+        FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            (popcount(&rarity_cmp_leaf_bits(flip_op(*op), *c, &indexes.rarity_printing, n_printings)), 0, 0)
         }
         // Legality: matches ≈ the legal-∃ cards' printings (existence-scaled from the cheap card
         // ∃-plane popcount). The build cost rides the *sparser* side (#744): a majority-legal format

--- a/card_engine/src/planes.rs
+++ b/card_engine/src/planes.rs
@@ -797,7 +797,7 @@ fn numeric_layout(field: NumField, bounds: &rkyv::Archived<BitPlanes>) -> Option
 /// `numeric_candidates` (lib.rs) uses, so the plane-compiled answer and the
 /// index-scan fallback can never disagree on a fractional-threshold edge
 /// case (e.g. `cmc>6.5`).
-fn matches_op(op: CmpOp, v: f64, threshold: f64) -> bool {
+pub(crate) fn matches_op(op: CmpOp, v: f64, threshold: f64) -> bool {
     match op {
         CmpOp::Eq => v == threshold,
         CmpOp::Ne => v != threshold,

--- a/docs/issues/local-engine-compose-paging-cost-based.md
+++ b/docs/issues/local-engine-compose-paging-cost-based.md
@@ -1,0 +1,84 @@
+# Let compose choose OrderbyWalk vs Gather on cost, not on shape
+
+`compose_paging_with_total` decides which paging branch `printing_compose_fastpath` will take, and for
+one case it decides by **shape** where the two candidates have wildly different costs:
+
+```rust
+if perm exists                              { ... Perm }
+else if printing && orderby_walk_available   { OrderbyWalk }   // <- unconditional
+else if gather_declines                      { Decline }
+else                                         { Gather }
+```
+
+Printing mode on a `usd`/`rarity` orderby always takes the walk. `Gather` is reachable only when the
+walk *declines* at runtime (the null-value tail, or a page past the value structure). So compose has no
+internal argmin, even though `plan_cost` already has a fully-formed arm for both branches.
+
+## Why that costs something
+
+The walk is fast when the filter's matches are dense near the start of the sort order and catastrophic
+when they are not. Measured on `r:mythic` ordered by `usd`, printing mode:
+
+| | |
+| --- | --: |
+| entries the walk scanned | **31,698** |
+| matches it needed | 60 (a page) |
+| matches it found in those entries | 75 |
+| the composed set's total size | 8,924 |
+
+Mythics are expensive and an ascending price walk starts at pennies, so almost every one of those 31,698
+bit-tests is a miss. `gather_composed_page` would page the same query in **O(8,924)** — it materialises
+the composed set and pages it with the bounded `GatherSelect` — so the branch the shape test forces is
+~3.5x more work than the one it forbids.
+
+Pricing, using the rate measured for plane-bucket steps in
+[local-engine-rarity-walk-cost.md](./local-engine-rarity-walk-cost.md) (1.07 ns/entry, not the shipped
+0.58):
+
+- walk, realized: 31,698 entries ≈ **34 µs**
+- walk, as charged: `printings_walked` = 948 × 0.58 ≈ **0.55 µs** — 60x under
+- gather, roughly: the Gather arm over ~8,924 printings / ~2,568 cards ≈ **34 µs**
+
+So correctly priced the two are close to a tie on this query, and either is acceptable. The damage is
+entirely from the walk being charged 60x under while being the only branch the shape test allows.
+
+## Why this is the cheap fix, and cheaper than the alternatives
+
+The clumping problem — that `printings_walked` divides by the GLOBAL match rate and cannot see where in
+the sort order the matches sit — is real and is documented as unfixable by a density ratio
+(`WALK_LENGTH_BIAS`'s own doc). Earlier notes on this branch treated that as the ceiling on the compose
+arm.
+
+It is not, and this is the reframing: **a router does not need to know how bad the walk is, only that it
+is bad.** That is a far weaker requirement than an accurate clumping model. `printings_walked` already
+grows as `matches` shrinks (948 for mythic against ~100 for `border:black`), so the signal that a walk
+will be long is present even when the magnitude is wrong — and `Gather` is O(matches), so it is exactly
+the branch that gets *safer* as the walk gets worse. The two arms fail in opposite directions, which is
+what makes an argmin between them worth having.
+
+It is also cheaper than either structural alternative:
+
+- A price-ordered index per rarity value would fix this query, but needs one index per (predicate value ×
+  sort column) — small individually, unbounded in combination.
+- [The value-major range index](./local-engine-range-index-value-major.md) fixes the *overshoot* and is
+  worth doing on its own merits, but clumping is *across* buckets and survives it untouched.
+
+## What to do
+
+1. Replace the unconditional `OrderbyWalk` with a comparison: price both branches through `plan_cost`
+   and take the cheaper. The arms exist; this is a branch selection, not a new model.
+2. The walk's charge must be fixed in the same change or the comparison is decided by the 60x error
+   rather than by cost. That means the rate split from the rarity-walk doc, and the usd feature from
+   [the walk-features doc](./local-engine-compose-walk-features.md).
+3. `compose_paging` is asserted against the branch actually taken by
+   `compose_paging_prediction_matches_the_branch_taken` — a cost-based choice must stay predictable, so
+   the prediction has to run the same comparison the executor will.
+
+Gate on the compose-paging slice `bench_regret_matrix` reports rather than the total: `OrderbyWalk` is 4%
+of rows, so a real improvement there is invisible in the aggregate.
+
+## Status
+
+Not measured. The costs above are the measured 31,698 entries and 8,924 total, times rates measured
+elsewhere — the arithmetic is sound but the conclusion that the branches are near-tied has not been
+verified by running both. Doing that is step zero: force each branch on the same query and time them.

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -204,7 +204,30 @@ Nothing shipped on this branch yet. Order to take it in:
    the cause is worth finding before the fix lands, because nothing in the change should reach a
    non-`OrderbyWalk` row.
 
-2. **Clumping is the real ceiling for both walks**, and it is one problem rather than two: `Perm`'s
+2. **OW/rarity: one rate serving two operations, plus a 124x feature over-charge.** Tested and
+   confirmed. `walk_rarity_orderby_page` produces two physically different buckets and reports both in
+   the same unit — a PLANE bucket (common/uncommon/rare/mythic) ANDs `words_per_plane` words of the whole
+   corpus and reports `wpp * 64` printings covered; a POSTINGS bucket (special/bonus) walks its own id
+   list and reports its length. Both are charged `COMPOSE_WALK_STEP_NS`. Split by which kind a query
+   consumes:
+
+   | group | n | charged/examined | realized ns per reported printing |
+   | --- | --: | --: | --: |
+   | plane-only | 56 | 0.50 | **1.069** |
+   | postings-only | 8 | **124.43** | **3.792** |
+   | mixed | 32 | 0.33 | 1.413 |
+
+   The two operations differ **3.5x** in realized rate and the shipped 0.58 is under both. That is the
+   rate half, and a constant is the right instrument because the error is flat across the corpus axis.
+
+   The bigger half is the feature: `orderby_walk_scan = n_printings` charges a whole corpus pass even
+   for `r:special`/`r:bonus`, whose walk only touches a short postings list — **124x over**. Fixable
+   without a popcount, because it is a filter-SHAPE question: a rarity equality on a postings int
+   (`special`=4/`bonus`=5) can never consume a plane bucket, and the acquire can see that from the
+   filter. That the aggregate read a dead-flat 0.67 was these two errors, in opposite directions,
+   mixing — which is why splitting the population was the necessary step and a median was not.
+
+3. **Clumping is the real ceiling for both walks**, and it is one problem rather than two: `Perm`'s
    `printings_walked` divides by the same global match rate and carries the same 10x spread. Neither
    branch gets low-error without it. This is the item to open next if the goal is a well-behaved arm
    rather than a well-behaved constant.

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -177,11 +177,29 @@ explain that cell too.
 
 Nothing shipped on this branch yet. Order to take it in:
 
-1. **Ship the run-boundary model for OW/usd.** Fully diagnosed and validated above; it makes the
-   feature scale with the corpus, which it currently cannot. Expect it to fix the broad cells and NOT
-   the `r:mythic` class — gate it on the compose-paging slice `bench_regret_matrix` now reports, since
-   OrderbyWalk is the worst-routed compose branch (miss% 12% against Perm's 3%) and is where any
-   movement will show.
+1. **The run-boundary model is implemented and held on an unresolved total.** Patch at
+   `scratchpad/run_boundary.patch` (`range_walk_run_boundary` plus a `SortCol::PriceUsd` arm in
+   `orderby_walk_scan`). What it does:
+
+   | | before | after |
+   | --- | --: | --: |
+   | OW/usd feature, 1x / 2x / 5x | 0.88 / 0.44 / 0.18 | **0.92 / 0.53 / 0.59** |
+   | drift across the range | 4.9x | **1.56x** |
+   | OrderbyWalk miss% | 12% | **11%** |
+   | OrderbyWalk mean | 2.55 µs | **2.40** |
+   | OrderbyWalk p90 | 2.75 | **2.25** |
+   | **total regret** | **1.32 µs** | **1.39** |
+
+   The targeted branch improves on every metric and the 1/N collapse is gone. The total moved +0.07 µs,
+   which OrderbyWalk cannot explain — it is 4% of rows and its own delta is -0.11 ms against a +3.4 ms
+   total. So either the total is noise or there is a second-order path I did not find, and a repeat on a
+   different seed settled nothing because the seed changes the query mix (1.51 with the change on seed 7,
+   with no seed-7 baseline to compare against).
+
+   **Resolving that is the next step, and it is cheap:** run both arms on three paired seeds. If the
+   total is noise, ship — the mechanism is validated and the targeted branch is better. If it is real,
+   the cause is worth finding before the fix lands, because nothing in the change should reach a
+   non-`OrderbyWalk` row.
 
 2. **Clumping is the real ceiling for both walks**, and it is one problem rather than two: `Perm`'s
    `printings_walked` divides by the same global match rate and carries the same 10x spread. Neither

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -89,20 +89,45 @@ So the flat charge of 1 is a defensible estimator (exact on 83/168, mean error 0
 cost a popcount per plane — the walk's own price — so the honest options are to leave it, or to make
 the executor report a realized bucket count and revisit with a direction-aware model.
 
-### OW/usd: a genuine feature drift, and the only one that gets worse with scale
+### OW/usd: diagnosed — the feature is corpus-invariant and the work is not
 
-0.88 at 1x, degrading monotonically to 0.18 by 5x — the feature progressively under-counts as the
-corpus grows, by 5x over the range. Unlike Perm's, this is the feature itself drifting, so it is
-fixable rather than a rate story. Not yet diagnosed; the usd walk steps value runs in the price index,
-and `printings_walked`'s uniform-density assumption is the obvious suspect.
+0.88 at 1x degrading monotonically to 0.18 at 5x, and it is exactly a `1/N` law:
+
+| corpus | measured | `0.88 / N` | ratio |
+| --- | --: | --: | --: |
+| 1x | 0.88 | 0.88 | 1.00 |
+| 2x | 0.44 | 0.44 | 1.00 |
+| 3x | 0.30 | 0.29 | 1.02 |
+| 4x | 0.23 | 0.22 | 1.05 |
+| 5x | 0.18 | 0.18 | 1.02 |
+
+**The feature cannot move with the corpus and the work must.** `printings_walked` is
+`page_span / match_rate * WALK_LENGTH_BIAS`; under replication `matches` and `n_printings` scale
+together so `match_rate` is unchanged, and `page_span` is a page, so the feature is *constant* across
+the whole axis. Meanwhile `collect_orderby_page` collects **whole value buckets** that the page window
+overlaps — and replication puts N times as many printings on each distinct price — so the realized
+count scales linearly. Constant over linear is `1/N`, which is what the table shows.
+
+**The fix follows from that: the walk's cost has a floor of one bucket.** Charge
+`max(printings_walked, printings per distinct value)`, exactly the shape `orderby_walk_scan` already
+gives the rarity walk, with the average bucket size available from the price index and its
+`RangeCardCounts.values` length (4,133 distinct usd values at 1x, so ~23.5 printings per value; ~118 at
+5x).
+
+That `max` form also **predicts the 0.5x outlier**, which is the reason to believe it. 0.5x measures
+0.42 where the `1/N` law extrapolates 1.76 — the law breaks below 1x. Under `max(page, bucket)` it
+should: at half corpus the average bucket falls below a page, so the page term dominates and the
+bucket floor stops binding. A model that explains the one point that does not fit the trend is worth
+more than one fitted to the trend.
 
 ## Where this stands
 
 Nothing shipped on this branch yet. Order to take it in:
 
-1. **OW/usd's drift.** Now the only one of the three that is both a real feature defect and worsens
-   with corpus growth (0.88 at 1x, 0.18 at 5x). Undiagnosed; `printings_walked`'s uniform-density
-   assumption over the price index is the obvious suspect.
+1. **OW/usd's bucket floor.** Diagnosed above, fix identified, not implemented. Charge
+   `max(printings_walked, n_printings / n_distinct_values)`. Needs the usual gate, and note the
+   direction: it RAISES compose's cost on this branch, and every raise on this arm so far has lost
+   argmins compose deserved — so it wants the Perm/OW cells watched, not just the total.
 2. **OW/rarity.** Attempted and declined — see above. Revisit only with a direction-aware model, and
    only if the tail (27% of cells undercharged 3-4x) shows up in regret. It has not yet.
 3. **Perm.** Leave it. 1.19 at production scale, and the drift is cache, not model.

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -227,7 +227,18 @@ Nothing shipped on this branch yet. Order to take it in:
    filter. That the aggregate read a dead-flat 0.67 was these two errors, in opposite directions,
    mixing — which is why splitting the population was the necessary step and a median was not.
 
-3. **Clumping is the real ceiling for both walks**, and it is one problem rather than two: `Perm`'s
+3. **Clumping is NOT the ceiling — see
+   [local-engine-compose-paging-cost-based.md](./local-engine-compose-paging-cost-based.md).** An earlier
+   revision of this doc said it was. The reframing: `compose_paging_with_total` picks `OrderbyWalk` by
+   SHAPE for printing mode on usd/rarity, so compose has no argmin between it and `Gather` even though
+   `plan_cost` has both arms. A router does not need to know how bad a clumped walk is, only that it is
+   bad — and `Gather` is O(matches), so it gets safer exactly as the walk gets worse. That is a far
+   weaker requirement than the density-along-the-sort-order feature the paragraph below asks for.
+
+   The full rarity-walk analysis, including why postings for mythic would be ~6x slower rather than
+   faster, is in [local-engine-rarity-walk-cost.md](./local-engine-rarity-walk-cost.md).
+
+4. **Clumping remains the ceiling on PRICING the walk**, and it is one problem rather than two: `Perm`'s
    `printings_walked` divides by the same global match rate and carries the same 10x spread. Neither
    branch gets low-error without it. This is the item to open next if the goal is a well-behaved arm
    rather than a well-behaved constant.

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -123,11 +123,50 @@ feature grade did not move at all (0.88 / 0.44 / 0.18, unchanged), because the f
 sizes** — the bucket COUNT is corpus-invariant and the bucket SIZE scales, which is the 1/N law, but it
 means the count is not `printings_walked / bucket_size` and the `max` shape cannot express it.
 
-So the mechanism (whole-bucket collection, bucket size scaling with the corpus) is confirmed and the
-*model* for how many buckets is still unknown. That is the open question, and the next step is reading
-`collect_orderby_page` for what actually terminates the bucket loop — it is documented as skipping whole
-buckets by match count up to `page_offset` and then collecting the buckets the window overlaps, which
-should need ~1 bucket at 5x and demonstrably does not.
+### Resolved: two buckets, and the run length where the WALK STARTS
+
+`walk_range_orderby_page` forms one bucket per distinct price and reports `raw = be - bs`, the value run
+length. `collect_orderby_page` then loops `while cum < want` with `cum` in matches, so it can overshoot
+by one whole bucket — and `matches_pushed` says it does, massively: **109 pushed for a 60-row page at 1x,
+545 at 5x.**
+
+Reconstructing from that, the walk consumes **two** buckets at both sizes. The first (~8 printings at 1x,
+40 at 5x) yields fewer than the 60 needed; the second overshoots hugely (~97 at 1x, ~485 at 5x). The
+bucket COUNT stays 2 while the bucket SIZES scale, which is exactly why `scanned` scales and
+`printings_walked` cannot.
+
+**And it is why both floors failed.** The corpus-wide average run is 19.7 entries, but the walk starts at
+the cheap end where runs are far denser than average — the statistic has to be the run length *where the
+walk starts*, not a corpus-wide mean.
+
+The model that follows needs no constant: walk `printings_walked` entries from the start of the value
+order, then extend to the end of the run you land in. One `partition_point`. Scored against realized
+`scanned`:
+
+| query | 1x | 5x |
+| --- | --: | --: |
+| `border:black` | **1.00** | **1.00** |
+| `usd>0.01` | **1.00** | **1.00** |
+| `f:modern` | 4.21 | **1.00** |
+| `r:common` | 4.21 | **1.00** |
+| `r:mythic` | 0.04 | 0.02 |
+
+**It fixes the SCALING exactly and inherits the CLUMPING error.** The broad filters all consume the same
+two cheap buckets because their local match density near the cheap end is ~100%, while `printings_walked`
+divides by the GLOBAL rate — so `f:modern` and `r:common` over-predict at 1x. `r:mythic` is the inverse
+and far worse: mythics are expensive, absent from the cheap end, so the walk grinds through 32% of the
+index (31,698 entries) to find 75 matches.
+
+That is not a new defect and not one this model introduces. `WALK_LENGTH_BIAS`'s own doc already declares
+it: "the spread stays wide because how matches clump along a sort order is not something a density ratio
+can see, and no constant will fix that." The run-boundary model is a strict improvement in SHAPE — the
+current feature cannot scale with the corpus at all, and this one does — but **OW/usd will not become
+low-error until clumping is addressed**, and that is a bigger problem than this branch.
+
+What clumping would need: the match density in the *first* part of the sort order, not the whole. For a
+price orderby that is answerable — the composed bitmap intersected with the first N index entries — but
+it costs a scan of those entries, which is the walk's own price. The cheaper route is a per-filter
+correlation hint, and nothing in `PlanFeatures` carries one today.
 
 One case worth carrying into that: `r:mythic` at `orderby=usd` charges 947 against a realized 31,698 at
 1x and 129,075 at 5x — a 33x undercharge, far worse than the broad queries, and a sparse-match regime
@@ -138,15 +177,16 @@ explain that cell too.
 
 Nothing shipped on this branch yet. Order to take it in:
 
-1. **OW/usd's bucket COUNT.** The mechanism is confirmed (whole-bucket collection, bucket size scaling
-   with the corpus, count invariant) and the one-bucket floor was implemented and reverted for not
-   binding. What is missing is why the count is ~5.7 and corpus-invariant: read
-   `collect_orderby_page`'s termination, and make it explain the `r:mythic` cell (947 charged against
-   31,698 realized) as well as the broad ones.
+1. **Ship the run-boundary model for OW/usd.** Fully diagnosed and validated above; it makes the
+   feature scale with the corpus, which it currently cannot. Expect it to fix the broad cells and NOT
+   the `r:mythic` class — gate it on the compose-paging slice `bench_regret_matrix` now reports, since
+   OrderbyWalk is the worst-routed compose branch (miss% 12% against Perm's 3%) and is where any
+   movement will show.
 
-   `bench_regret_matrix` now slices by compose paging branch, which is the instrument this needs — it
-   already shows OrderbyWalk as the worst-routed compose branch (miss% 12% against Perm's 3%), so the
-   defect is visible in routing and not only in the feature.
+2. **Clumping is the real ceiling for both walks**, and it is one problem rather than two: `Perm`'s
+   `printings_walked` divides by the same global match rate and carries the same 10x spread. Neither
+   branch gets low-error without it. This is the item to open next if the goal is a well-behaved arm
+   rather than a well-behaved constant.
 2. **OW/rarity.** Attempted and declined — see above. Revisit only with a direction-aware model, and
    only if the tail (27% of cells undercharged 3-4x) shows up in regret. It has not yet.
 3. **Perm.** Leave it. 1.19 at production scale, and the drift is cache, not model.

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -1,0 +1,112 @@
+# Compose's two walk branches, graded separately
+
+Branched off `engine-loop-phase-measurement` at `c11ad25`, which shipped the Gather arm's missing build
+term. That work left `Perm` and `OrderbyWalk` unaddressed and named them one problem. Measured, they
+are three, and only one of them is what it looked like.
+
+Context and the corpus-axis method:
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md).
+
+## The walk feature was never graded, and a counter for it already existed
+
+`printings_walked` (`page_span / match_rate * WALK_LENGTH_BIAS`) is what both branches multiply by
+`COMPOSE_WALK_STEP_NS`. `ComposePageWork` documents `cards_visited` as "permutation entries consumed for
+the forward walk" and `printings_examined` as the printings bit-tested, so the counter was there the
+whole time. Graded over 190 Perm cells:
+
+| feature / counter | p10 | p50 | p90 |
+| --- | --: | --: | --: |
+| `printings_walked` / `cards_visited` | 2.65 | 4.53 | 39.49 |
+| **`printings_walked` / `printings_examined`** | 0.17 | **1.17** | 1.75 |
+
+It tracks `printings_examined`, which the name already said. So the feature is not badly biased — the
+walk steps cards and examines each card's whole span, and ~4.5 printings per card is the corpus mean.
+
+## Split by branch and by sort column, across a 10x corpus axis
+
+`charged / printings_examined`, median, where `charged` is what the arm multiplies
+(`max(printings_walked, orderby_walk_scan)`):
+
+| corpus | Perm | OW/usd | OW/rarity |
+| --- | --: | --: | --: |
+| 0.5x | 1.25 | 0.42 | **0.67** |
+| 1.0x | 1.12 | 0.88 | **0.67** |
+| 2.0x | 1.22 | 0.44 | **0.67** |
+| 3.0x | 1.26 | 0.30 | **0.67** |
+| 4.0x | 1.36 | 0.23 | **0.67** |
+| 5.0x | 1.37 | 0.18 | **0.67** |
+
+Three different diagnoses, and the branch name hides two of them: `OrderbyWalk` charges
+`orderby_walk_scan` (= `n_printings`) for a rarity orderby and `printings_walked` for usd, so it is two
+features under one label and has to be graded as two.
+
+### Perm: the feature is fine; the arm's drift is a cache effect that saturates
+
+The feature is nearly flat (1.12-1.37 over a 10x range) while the ARM drifts 1.75x
+(pred/meas 1.259 -> 0.721). So the feature is not the cause. Decomposing: predicted grows exactly 10x
+across the axis while measured grows **14.6x** (21 us -> 306 us). The extra is superlinear cost in the
+executor, not a missing term — the working set outgrows a cache level — and it is why adding the build
+term shifted the curve without flattening it (drift 1.75x -> 1.76x).
+
+**So Perm does not need fixing for this corpus.** It reads 1.185 at production scale, and the drift is
+only visible at 3-5x. Recording it because the next person to see 0.72 at 5x will otherwise go looking
+for a missing feature that is not there. If the corpus ever grows that far, the answer is a
+cache-aware rate, not a new term.
+
+### OW/rarity: the charge has the wrong SHAPE, and the right one is discrete
+
+Exactly 0.67 at every corpus size is not a coincidence and not a constant to fit. `walk_rarity_orderby_page`
+walks rarity buckets in sort order, and the interior rarities are **planes** — each plane bucket ANDs
+`wpp` words of the whole corpus however few matches survive, so the walk costs
+`(buckets consumed) x n_printings`. `orderby_walk_scan` charges exactly one.
+
+Swept over pages and both directions (160 cells) the quantity is **discrete**:
+
+    corpus widths consumed:  0 -> 31 cells,  1 -> 83,  2 -> 10,  3 -> 22,  4 -> 14
+
+p50 is 1.00, so today's charge is right at the median and wrong in the tail — 27% of cells consume 3-4
+widths and are undercharged 3-4x, and 19% consume none and are overcharged. (An earlier read of "1.5x,
+fit a constant" came from sampling only `limit=60, offset=0`; sweeping the page is what exposed the
+distribution. A median is not a shape.)
+
+**A model was the obvious fix. It was tried and it does not work.** The walk consumes buckets in sort
+order until it has `page_offset + limit` rows, so the fraction of buckets touched should track the
+fraction of the result set skipped: `ceil(n_planes * page_span / total)`, needing no popcount and only
+quantities the acquire already holds. Scored against realized widths over 168 cells:
+
+| | mean abs err | p50 | p90 | exact |
+| --- | --: | --: | --: | --: |
+| **shipped (flat 1)** | **0.80 widths** | 1.00 | **2.00** | 83/168 |
+| `ceil(4 * span/total)` | 0.86 | **0.00** | 3.00 | 88/168 |
+
+Better at the median, worse in the tail, worse on the mean. The even-spread assumption is what fails:
+rarity is heavily skewed, so a page at offset 0 **ascending** lands entirely inside the common bucket
+and needs one width, while **descending** starts at mythic — tiny — and needs several before the page
+fills. Direction, not page depth, is doing most of the work, and `page_span / total` cannot see it.
+
+So the flat charge of 1 is a defensible estimator (exact on 83/168, mean error 0.80 widths) and this is
+**not the easy win it looked like**. Predicting it properly needs the per-rarity match counts, which
+cost a popcount per plane — the walk's own price — so the honest options are to leave it, or to make
+the executor report a realized bucket count and revisit with a direction-aware model.
+
+### OW/usd: a genuine feature drift, and the only one that gets worse with scale
+
+0.88 at 1x, degrading monotonically to 0.18 by 5x — the feature progressively under-counts as the
+corpus grows, by 5x over the range. Unlike Perm's, this is the feature itself drifting, so it is
+fixable rather than a rate story. Not yet diagnosed; the usd walk steps value runs in the price index,
+and `printings_walked`'s uniform-density assumption is the obvious suspect.
+
+## Where this stands
+
+Nothing shipped on this branch yet. Order to take it in:
+
+1. **OW/usd's drift.** Now the only one of the three that is both a real feature defect and worsens
+   with corpus growth (0.88 at 1x, 0.18 at 5x). Undiagnosed; `printings_walked`'s uniform-density
+   assumption over the price index is the obvious suspect.
+2. **OW/rarity.** Attempted and declined — see above. Revisit only with a direction-aware model, and
+   only if the tail (27% of cells undercharged 3-4x) shows up in regret. It has not yet.
+3. **Perm.** Leave it. 1.19 at production scale, and the drift is cache, not model.
+
+Each needs its own regret gate. This branch has twice shown that a partial accuracy fix on the compose
+arm loses regret — the `compose_scan_printings` span patch (1.33 -> 1.41 us) and the build term applied
+build-wide (Perm 1.193 -> 1.544 at production scale).

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -108,26 +108,45 @@ the whole axis. Meanwhile `collect_orderby_page` collects **whole value buckets*
 overlaps — and replication puts N times as many printings on each distinct price — so the realized
 count scales linearly. Constant over linear is `1/N`, which is what the table shows.
 
-**The fix follows from that: the walk's cost has a floor of one bucket.** Charge
-`max(printings_walked, printings per distinct value)`, exactly the shape `orderby_walk_scan` already
-gives the rarity walk, with the average bucket size available from the price index and its
-`RangeCardCounts.values` length (4,133 distinct usd values at 1x, so ~23.5 printings per value; ~118 at
-5x).
+**A one-bucket floor was the obvious fix. Implemented, measured, and it does not bind — reverted.**
+`max(printings_walked, printings per distinct value)`, the same shape `orderby_walk_scan` already gives
+the rarity walk, with the bucket size from the price index and its `RangeCardCounts.values` length. The
+feature grade did not move at all (0.88 / 0.44 / 0.18, unchanged), because the floor is far too small:
 
-That `max` form also **predicts the 0.5x outlier**, which is the reason to believe it. 0.5x measures
-0.42 where the `1/N` law extrapolates 1.76 — the law breaks below 1x. Under `max(page, bucket)` it
-should: at half corpus the average bucket falls below a page, so the page term dominates and the
-bucket floor stops binding. A model that explains the one point that does not fit the trend is worth
-more than one fitted to the trend.
+| corpus | `printings_walked` | floor | charged | realized `examined` |
+| --- | --: | --: | --: | --: |
+| 1x | 99 | 19 | 99 | **112** |
+| 5x | 99 | 98 | 99 | **560** |
+
+`examined` scales exactly 5x while `charged` cannot move, and at 5x one bucket is 98.6 printings, so
+`ceil(99 / 98.6) = 1` bucket predicts ~99 and not 560. **The walk consumes the same ~5.7 buckets at both
+sizes** — the bucket COUNT is corpus-invariant and the bucket SIZE scales, which is the 1/N law, but it
+means the count is not `printings_walked / bucket_size` and the `max` shape cannot express it.
+
+So the mechanism (whole-bucket collection, bucket size scaling with the corpus) is confirmed and the
+*model* for how many buckets is still unknown. That is the open question, and the next step is reading
+`collect_orderby_page` for what actually terminates the bucket loop — it is documented as skipping whole
+buckets by match count up to `page_offset` and then collecting the buckets the window overlaps, which
+should need ~1 bucket at 5x and demonstrably does not.
+
+One case worth carrying into that: `r:mythic` at `orderby=usd` charges 947 against a realized 31,698 at
+1x and 129,075 at 5x — a 33x undercharge, far worse than the broad queries, and a sparse-match regime
+(8,924 matches) where many buckets are needed to fill a page. Whatever explains the bucket count has to
+explain that cell too.
 
 ## Where this stands
 
 Nothing shipped on this branch yet. Order to take it in:
 
-1. **OW/usd's bucket floor.** Diagnosed above, fix identified, not implemented. Charge
-   `max(printings_walked, n_printings / n_distinct_values)`. Needs the usual gate, and note the
-   direction: it RAISES compose's cost on this branch, and every raise on this arm so far has lost
-   argmins compose deserved — so it wants the Perm/OW cells watched, not just the total.
+1. **OW/usd's bucket COUNT.** The mechanism is confirmed (whole-bucket collection, bucket size scaling
+   with the corpus, count invariant) and the one-bucket floor was implemented and reverted for not
+   binding. What is missing is why the count is ~5.7 and corpus-invariant: read
+   `collect_orderby_page`'s termination, and make it explain the `r:mythic` cell (947 charged against
+   31,698 realized) as well as the broad ones.
+
+   `bench_regret_matrix` now slices by compose paging branch, which is the instrument this needs — it
+   already shows OrderbyWalk as the worst-routed compose branch (miss% 12% against Perm's 3%), so the
+   defect is visible in routing and not only in the feature.
 2. **OW/rarity.** Attempted and declined — see above. Revisit only with a direction-aware model, and
    only if the tail (27% of cells undercharged 3-4x) shows up in regret. It has not yet.
 3. **Perm.** Leave it. 1.19 at production scale, and the drift is cache, not model.

--- a/docs/issues/local-engine-compose-walk-features.md
+++ b/docs/issues/local-engine-compose-walk-features.md
@@ -177,9 +177,12 @@ explain that cell too.
 
 Nothing shipped on this branch yet. Order to take it in:
 
-1. **The run-boundary model is implemented and held on an unresolved total.** Patch at
-   `scratchpad/run_boundary.patch` (`range_walk_run_boundary` plus a `SortCol::PriceUsd` arm in
-   `orderby_walk_scan`). What it does:
+1. **The run-boundary model is implemented and held on an unresolved total.** Tracked at
+   [patches/local-engine-compose-walk-usd-run-boundary.patch](./patches/local-engine-compose-walk-usd-run-boundary.patch)
+   — `range_walk_run_boundary` plus a `SortCol::PriceUsd` arm in `orderby_walk_scan`. Applies to
+   `card_engine/src/lib.rs` at `cf44da2` with `git apply`, and passes 149 debug / 148 release. Held
+   rather than applied: it is one measurement short, and leaving it in the tree would mean shipping a
+   5% total regression on "probably noise". What it does:
 
    | | before | after |
    | --- | --: | --: |

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1237,3 +1237,64 @@ note here claimed the counter was missing and that a grouping walk was uncounted
 Artwork's per-card surcharge was the last of it. The executor gate was removed (up to 24×), P3's surcharge is
 gated on the same signal, and P4 was measured and needs nothing. What remains in artwork mode is a level
 question inside 0.86–1.25 on both arms, which is not worth a refit against a warm-cache design.
+
+## Compose was `Eq`-only on rarity, and that cost 167×
+
+Chasing `r>=rare`/artwork (100.1 µs regret, six appearances in the top 100) found something bigger than the
+routing error. Its full dump:
+
+    r>=rare  artwork  limit=175      acquire=candidates
+      GatheredScan     pred 484.4   meas 485.9   p/m 1.00   loop 482.2   ← picked
+      StreamedSelect   pred 518.5   meas 381.6   p/m 1.36   loop 376.1
+      eval_domain 12,887 = cards_visited     scan_units 58,656 = printings_examined (BOTH plans)
+
+**The features are exact and both arms are individually respectable**, yet the order inverts: the model
+charges P3 2.9× more per printing (5.97 vs 2.06) and P4 2.9× more per card, on the *same* 58,656 printings,
+and the two errors nearly cancel into a 34 µs predicted gap the wrong way against a 100 µs real one. That is
+the `SCAN_PER_ROW` ratio a pooled fit endorses, in its cleanest form.
+
+**But routing was the small half.** Splitting the phases shows what the query actually spends:
+
+| limit | loop (count) | finish (emit) | perm_steps |
+| --: | --: | --: | --: |
+| 10 | **386.6 µs** | 0.7 µs | 3 |
+| 175 | **374.4 µs** | 4.8 µs | 97 |
+
+`query()` returns `(total, page)`, so an exact `total = 20,979` requires visiting every candidate before
+anything can be emitted. **99.8% of the query produces the count**, flat in page size, while producing the
+rows costs 0.7–4.8 µs. Choosing the better plan wins 100 µs; not scanning at all wins 375.
+
+**And a plan that does not scan already existed — for `Eq` only.** `is_printing_composable` matched rarity
+with `CmpOp::Eq` and nothing else, so `r:rare` composed and `r>=rare` fell to a full candidate scan:
+
+| query | before | after | speedup |
+| --- | --: | --: | --: |
+| `r>=rare` / printing | 349.6 µs | **2.1** | **167×** |
+| `r<=uncommon` / printing | 378.8 | **1.9** | **199×** |
+| `r>uncommon` / printing | 344.5 | **2.1** | **164×** |
+| `r>=rare` / artwork | 487.7 | **82.7** | **5.9×** |
+| `r<=uncommon` / artwork | 421.7 | **125.7** | 3.4× |
+| `r>uncommon` / artwork | 531.7 | **91.4** | 5.8× |
+
+Printing mode becomes a popcount with no scan at all; artwork still pays the printing→artwork projection,
+which is why it is 3–6× rather than 100×.
+
+`rarity_cmp_leaf_bits` enumerates the closed domain — four interior planes plus the sparse tail's postings,
+one definition shared with `walk_rarity_orderby_page` via `rarity_ints_present` — and `Or`s the values that
+satisfy the op. Two properties fall out. **NULL rarity is excluded for free**, since a rarity-less printing is
+in no plane and no posting, which is the trivalent answer for every op including `Ne`. And this is **strictly
+more capable than `compile_plane`'s** `compile_rarity_cmp`, which shares one "above mythic" plane and declines
+`BucketVerdict::Ambiguous` whenever special must be told from bonus — compose reads those two apart from their
+own postings, so it has no ambiguous case.
+
+Row identity: **1,566 cells identical** — every rarity op, negations, conjunctions, `r:special`/`r:bonus`,
+three modes × three orderbys × three pages × two prefers, hashing the returned `scryfall_id` sequence.
+Regret mean 1.45 → **1.40 µs**; the compose acquire grows 7,532 → 8,636 queries as intended, and its share
+goes 22% → 27% because more queries live there now, at a much lower absolute cost.
+
+**The generalisable point**, given compose is meant to become the universal exact evaluator (#731): an
+applicability gate that is narrower than the machinery behind it is invisible to every routing metric. The
+router never sees the plan, so no regret figure, no pairwise ordering and no feature grading can report it —
+`r>=rare` looked like a 100 µs cost-model bug and was a 375 µs missing-plan bug. Auditing
+`is_printing_composable` leaf by leaf against what `compose_printing_bits` can actually build is likely to
+find more; `printing_compose / card` is now the worst cell at mean 2.55 µs and is the place to look next.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1342,65 +1342,18 @@ predicts `Perm` and prices a cheap permutation walk while the executor runs a ga
 being handed the wrong branch. That is the same number as the original doc's p10 0.64 → 0.14.
 
 **Which makes the real prerequisite a two-sided range.** `bare_range_bounds` matches one comparison, so
-`usd>=0.42 usd<=0.43` composes as `And` of two one-sided slices — `scatter_printings` reads **82,421** for an
-answer of 837, and the estimate multiplies the two sides instead of intersecting one interval. Fusing an `And`
-of two comparisons on the same field into a single index interval fixes the estimate *and* the build cost at
-once, and only then does sparse-gather become predictable. That supersedes "widen `bare_range_bounds` for
-multi-leaf ranges" as an `eval_domain` idea — it was the wrong motivation for the right change.
+`usd>=0.42 usd<=0.43` composes as `And` of two one-sided slices — the estimate multiplies the two sides
+instead of intersecting one interval. Fusing them fixes the estimate *and* the build cost at once, and only
+then does sparse-gather become predictable. That supersedes "widen `bare_range_bounds` for multi-leaf ranges"
+as an `eval_domain` idea — it was the wrong motivation for the right change.
 
-Order to attempt it in: fuse the two-sided range, confirm `matches` on that population, then re-enable the
-gather behind the now-correct sparsity prediction, then re-check regret. Not before.
-
-## Fusing a two-sided range: the evidence, and where the code has to change
-
-The section above named this as sparse-gather's prerequisite. Measured, it is worth more than that, and for a
-reason that has nothing to do with compose: **the narrowing already handles a selective range and the `And`
-never reaches it.** All artwork, `orderby=toughness`, limit 10:
-
-| query | results | `eval_domain` | P3 `printings_examined` | best measured |
-| --- | --: | --: | --: | --: |
-| `usd>=200` | 160 | **148** | 6,089 | **26.7 µs** |
-| `usd<=0.02` | 103 | **100** | 339 | **3.2 µs** |
-| `cn>=20000` | 285 | **281** | 2,980 | **17.0 µs** |
-| **`usd>=0.42 usd<=0.43`** | 837 | **31,508** | **97,206** | **1,146.8 µs** |
-| **`cn>=100 cn<=101`** | 460 | **31,508** | **97,206** | **1,136.1 µs** |
-| `usd>=200 t:creature` | 36 | **36** (`narrowed_repr=printings`) | 532 | **2.5 µs** |
-| `usd>=0.42 usd<=0.43 t:creature` | 361 | 17,317 | 45,976 | 570.2 µs |
-
-A one-sided range with **160** results narrows to **148** candidates and finishes in 26.7 µs. A two-sided
-range with **837** results narrows to nothing and takes **43× longer for 5× more rows**.
-
-**The mechanism.** `narrow_rec` narrows each child independently and intersects. `usd>=0.42` matches most of
-the corpus and so does `usd<=0.43`, so each child trips `range_too_broad_to_narrow`
-(`MAX_NARROW_FRACTION` 0.25) and declines. Both halves give up, and that their *intersection* is 837 is never
-discovered. So the shape a reader intuitively wants — walk the index slice, test the residual, accumulate the
-page — **is** what the engine does for `usd>=200`; the two-sided form simply never gets there.
-
-Fusing `And` of same-index comparisons into one interval inside `bare_range_bounds` should therefore fix three
-things at once: the narrowing (the ~1,100 µs), compose's `matches` estimate (20,411 against a true 837), and
-`scatter_printings` (82,421 for an 837-row answer).
-
-### Four things to get right, found by reading the callers
-
-- **Clamp the empty interval.** Callers compute `k` as `partition_point(hi) - partition_point(lo)`. An
-  unsatisfiable fusion gives `hi < lo` and that subtraction **underflows and panics**. Clamping to
-  `hi.max(lo)` makes it `[lo, lo)` and `k = 0`, which every caller already handles — `run_query_streamed`
-  returns at `total == 0` before either branch.
-- **One arm covers usd/cn/date/year, so do not subset.** `bare_range_bounds` funnels all of them through a
-  single `leaf` helper. But `resolve_numeric_range_leaf` covers only `price_usd` and `collector_number`, so
-  **`eur` and `tix` are not in the dispatch at all** and stay unfused — worth knowing, since several top-100
-  rows are `eur:`/`tix:` ranges.
-- **Check the arm order per caller before claiming a win.** `is_printing_composable` and
-  `compose_printing_bits` both decompose `And` *before* any range guard, so a fused `bare_range_bounds`
-  improves the narrowing path without necessarily making compose stop scattering both sides. Verify which
-  paths actually change.
-- **Unsatisfiable short-circuit falls out here, but only for indexed fields.** `usd>=1 usd<=0.5` fuses to an
-  empty interval for free. `power=3 power=5` does **not** reach this code: `resolve_numeric_range_leaf`
-  returns `None` for `Power`, and `printing_dependent` classifies `Power`/`Cmc`/`Toughness`/`Loyalty` as
-  card-level, evaluated through `numeric_candidates`. Detecting that contradiction is separate work, most
-  naturally at bind time, and needs its own decision on `Ne` and null semantics.
-
-`usd>=200` is the working control: the fused two-sided path should look like it.
+Measured, the fusion turned out to be worth more than a prerequisite, for a reason with nothing to do with
+compose: the narrowing already handles a selective range and the `And` never reaches it, so
+`usd>=0.42 usd<=0.43` cost **1,146.8 µs** against **26.7 µs** for a one-sided range returning *more* rows.
+The narrowing half shipped in `4991759` (15–33× on that population, regret 1.42 → 1.35 µs); the compose half,
+which is what sparse-gather actually needs, has not moved. Both, with the evidence, the noise analysis behind
+the sparsity gate, and the order to attempt the rest in:
+[local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md).
 
 ## A note on the test counts quoted throughout
 

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1298,3 +1298,55 @@ router never sees the plan, so no regret figure, no pairwise ordering and no fea
 `r>=rare` looked like a 100 µs cost-model bug and was a 375 µs missing-plan bug. Auditing
 `is_printing_composable` leaf by leaf against what `compose_printing_bits` can actually build is likely to
 find more; `printing_compose / card` is now the worst cell at mean 2.55 µs and is the place to look next.
+
+## Sparse compose gather: attempted, and the blocker is now named exactly
+
+`usd>=0.42 usd<=0.43`/artwork appeared in the top 100 at 112 µs of regret. The dump says the regret figure
+is nearly irrelevant:
+
+    acquire=printing_compose
+      PrintingCompose   pred  105.9   meas    —      PICKED, then DeclineSparseExact
+      StreamedSelect    pred  988.2   meas 1249.8    exam 97,206
+      GatheredScan      pred 1058.2   meas 1161.5    exam 97,206
+      matches (estimated) 20,411      result_total (actual) 837
+
+The router picked compose, compose built the bitmap, **discarded it**, and dispatch re-derived everything with
+a full-corpus scan — 97,206 printings examined to return 837 matches, ~1,250 µs. The 112 µs the matrix reports
+is only the P3-vs-P4 difference among the fallbacks, because **regret compares only plans that ran** and a
+declining plan accumulates no trials. Second time today that blind spot hid the larger finding, after
+`r>=rare`.
+
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) had already designed the
+fix — `gather_composed_page` in place of the `return None` — and verified it byte-identical over 127,640
+queries. Its stated blocker was that `plan_cost` could not price the path, and this stack added the
+`ComposePaging::Gather` arm, so it looked unblocked.
+
+**Tried it. Two edits, not one:** the fastpath gathers, *and* `compose_paging_for` must predict `Gather`
+rather than `Decline`, since a `Decline` prediction costs infinity and keeps compose out of the argmin so the
+gather would never run. Rows verified again on this build: **2,304 cells identical** over the sparse
+two-sided ranges the change enables plus broad controls, four orderbys including the tie-heavy `usd` and
+`rarity`, deep offsets, both prefers.
+
+**And routing got worse, so it is reverted:**
+
+| | decline | gather |
+| --- | --: | --: |
+| regret mean | 1.43 µs | **1.55 (+8%)** |
+| `printing_compose` miss% | 7% | **18%** |
+| `printing_compose` mean | 1.69 | **2.43** |
+| `printing_compose` p90 | **0.00** | **7.92** |
+
+**The blocker is not the cost arm — it is that the prediction cannot tell the query is sparse.**
+`compose_paging_for` branches on `result_total`, which is the *estimate*: 20,411 against a true 837. So it
+predicts `Perm` and prices a cheap permutation walk while the executor runs a gather. The arm is fine; it is
+being handed the wrong branch. That is the same number as the original doc's p10 0.64 → 0.14.
+
+**Which makes the real prerequisite a two-sided range.** `bare_range_bounds` matches one comparison, so
+`usd>=0.42 usd<=0.43` composes as `And` of two one-sided slices — `scatter_printings` reads **82,421** for an
+answer of 837, and the estimate multiplies the two sides instead of intersecting one interval. Fusing an `And`
+of two comparisons on the same field into a single index interval fixes the estimate *and* the build cost at
+once, and only then does sparse-gather become predictable. That supersedes "widen `bare_range_bounds` for
+multi-leaf ranges" as an `eval_domain` idea — it was the wrong motivation for the right change.
+
+Order to attempt it in: fuse the two-sided range, confirm `matches` on that population, then re-enable the
+gather behind the now-correct sparsity prediction, then re-check regret. Not before.

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1350,9 +1350,10 @@ as an `eval_domain` idea — it was the wrong motivation for the right change.
 Measured, the fusion turned out to be worth more than a prerequisite, for a reason with nothing to do with
 compose: the narrowing already handles a selective range and the `And` never reaches it, so
 `usd>=0.42 usd<=0.43` cost **1,146.8 µs** against **26.7 µs** for a one-sided range returning *more* rows.
-The narrowing half shipped in `4991759` (15–33× on that population, regret 1.42 → 1.35 µs); the compose half,
-which is what sparse-gather actually needs, has not moved. Both, with the evidence, the noise analysis behind
-the sparsity gate, and the order to attempt the rest in:
+Both halves have now shipped — `4991759` for the narrowing (15–33× on that population) and `7374e19` for
+compose's builders, where the estimate was 38.5× off a count that was two binary searches away. Together:
+regret 1.42 → 1.30 µs, and the fusible traffic slice to 0.81× of baseline. The evidence, the noise analysis
+behind the sparsity gate, and what is left (the sparse gather, now that its prediction is correct):
 [local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md).
 
 ## A note on the test counts quoted throughout

--- a/docs/issues/local-engine-loop-phase-measurement.md
+++ b/docs/issues/local-engine-loop-phase-measurement.md
@@ -1350,3 +1350,61 @@ multi-leaf ranges" as an `eval_domain` idea — it was the wrong motivation for 
 
 Order to attempt it in: fuse the two-sided range, confirm `matches` on that population, then re-enable the
 gather behind the now-correct sparsity prediction, then re-check regret. Not before.
+
+## Fusing a two-sided range: the evidence, and where the code has to change
+
+The section above named this as sparse-gather's prerequisite. Measured, it is worth more than that, and for a
+reason that has nothing to do with compose: **the narrowing already handles a selective range and the `And`
+never reaches it.** All artwork, `orderby=toughness`, limit 10:
+
+| query | results | `eval_domain` | P3 `printings_examined` | best measured |
+| --- | --: | --: | --: | --: |
+| `usd>=200` | 160 | **148** | 6,089 | **26.7 µs** |
+| `usd<=0.02` | 103 | **100** | 339 | **3.2 µs** |
+| `cn>=20000` | 285 | **281** | 2,980 | **17.0 µs** |
+| **`usd>=0.42 usd<=0.43`** | 837 | **31,508** | **97,206** | **1,146.8 µs** |
+| **`cn>=100 cn<=101`** | 460 | **31,508** | **97,206** | **1,136.1 µs** |
+| `usd>=200 t:creature` | 36 | **36** (`narrowed_repr=printings`) | 532 | **2.5 µs** |
+| `usd>=0.42 usd<=0.43 t:creature` | 361 | 17,317 | 45,976 | 570.2 µs |
+
+A one-sided range with **160** results narrows to **148** candidates and finishes in 26.7 µs. A two-sided
+range with **837** results narrows to nothing and takes **43× longer for 5× more rows**.
+
+**The mechanism.** `narrow_rec` narrows each child independently and intersects. `usd>=0.42` matches most of
+the corpus and so does `usd<=0.43`, so each child trips `range_too_broad_to_narrow`
+(`MAX_NARROW_FRACTION` 0.25) and declines. Both halves give up, and that their *intersection* is 837 is never
+discovered. So the shape a reader intuitively wants — walk the index slice, test the residual, accumulate the
+page — **is** what the engine does for `usd>=200`; the two-sided form simply never gets there.
+
+Fusing `And` of same-index comparisons into one interval inside `bare_range_bounds` should therefore fix three
+things at once: the narrowing (the ~1,100 µs), compose's `matches` estimate (20,411 against a true 837), and
+`scatter_printings` (82,421 for an 837-row answer).
+
+### Four things to get right, found by reading the callers
+
+- **Clamp the empty interval.** Callers compute `k` as `partition_point(hi) - partition_point(lo)`. An
+  unsatisfiable fusion gives `hi < lo` and that subtraction **underflows and panics**. Clamping to
+  `hi.max(lo)` makes it `[lo, lo)` and `k = 0`, which every caller already handles — `run_query_streamed`
+  returns at `total == 0` before either branch.
+- **One arm covers usd/cn/date/year, so do not subset.** `bare_range_bounds` funnels all of them through a
+  single `leaf` helper. But `resolve_numeric_range_leaf` covers only `price_usd` and `collector_number`, so
+  **`eur` and `tix` are not in the dispatch at all** and stay unfused — worth knowing, since several top-100
+  rows are `eur:`/`tix:` ranges.
+- **Check the arm order per caller before claiming a win.** `is_printing_composable` and
+  `compose_printing_bits` both decompose `And` *before* any range guard, so a fused `bare_range_bounds`
+  improves the narrowing path without necessarily making compose stop scattering both sides. Verify which
+  paths actually change.
+- **Unsatisfiable short-circuit falls out here, but only for indexed fields.** `usd>=1 usd<=0.5` fuses to an
+  empty interval for free. `power=3 power=5` does **not** reach this code: `resolve_numeric_range_leaf`
+  returns `None` for `Power`, and `printing_dependent` classifies `Power`/`Cmc`/`Toughness`/`Loyalty` as
+  card-level, evaluated through `numeric_candidates`. Detecting that contradiction is separate work, most
+  naturally at bind time, and needs its own decision on `Ne` and null semantics.
+
+`usd>=200` is the working control: the fused two-sided path should look like it.
+
+## A note on the test counts quoted throughout
+
+`149 debug / 148 release` is not a flake. The difference is exactly one test,
+`tests::arith_tuple_key_budget_catches_a_blown_domain`, which asserts a `debug_assert` tripwire and so is
+compiled out of a release build. That is why both profiles are run and quoted separately: CI's `rust-test`
+job is a debug build, and a release-only local run silently skips the engine's `debug_assert` guards.

--- a/docs/issues/local-engine-range-index-value-major.md
+++ b/docs/issues/local-engine-range-index-value-major.md
@@ -1,0 +1,84 @@
+# Store range indexes value-major, with each value's printings pre-sorted by tiebreak
+
+`PrintingRangeIndex` is `Vec<(u32 value, u32 pid)>` sorted by value ([lib.rs:2271](../../card_engine/src/lib.rs#L2271)).
+Within one value the pids are in **pid** order, not sort-key order. That single fact is what forces the
+`usd` orderby walk to consume whole value runs, and it is the root of the largest remaining feature
+error on the compose arm.
+
+Proposed: a value array plus a pid array, each value's slice pre-sorted by the full tiebreak.
+
+    values:  Vec<(u32 value, u32 offset)>     // ascending, one entry per DISTINCT value
+    pids:    Vec<u32>                          // value-major; within a value, tiebreak order
+
+Diagnosis this comes out of:
+[local-engine-compose-walk-features.md](./local-engine-compose-walk-features.md).
+
+## What it buys
+
+**1. The overshoot disappears, and with it a whole feature.** `collect_orderby_page` loops
+`while cum < want` with `cum` in matches, and `walk_range_orderby_page` hands it whole runs, so the walk
+always finishes a bucket it has begun. Measured on a 60-row page it pushes **109** matches at the
+production corpus and **545** at 5x. Pre-sorted, it stops the instant the page fills.
+
+That removes the reason `orderby_walk_scan` exists for `usd` at all. The run-boundary model
+([patch](./patches/local-engine-compose-walk-usd-run-boundary.patch)) is an accurate description of an
+overshoot that should not happen — this deletes the overshoot and the model with it, which is the better
+outcome. `printings_walked` alone becomes the whole story for this branch.
+
+**2. One structure reads in both directions.** `sort_key_bits` negates only the PRIMARY under `desc`;
+keys 2+ (`edhrec_rank`, `prefer_score`) are not negated. So within a value the tiebreak order is the
+same in both directions — read the value array backwards and each value's pid slice forwards. No mirror
+index, no reversal at query time.
+
+**3. It is smaller.** Today: 8 bytes per printing, because the value is repeated per pid — ~652 KB for
+`price_usd` (81,542 priced printings). Proposed: 8 bytes per distinct value + 4 per printing =
+33 KB + 326 KB = **~359 KB**, a 45% reduction, and the same argument applies to `collector_number` and
+`released_at`.
+
+## What it does NOT buy, and this is the part to be clear about
+
+**Clumping survives untouched.** The overshoot is *within* a bucket; clumping is *across* buckets.
+`r:mythic` ordered by `usd` scans 31,698 entries to find 75 matches because mythics are expensive and an
+ascending walk starts at pennies — every one of those entries is a genuine bit-test miss against `pbits`,
+and no within-bucket ordering removes them. Expect this change to fix `border:black`, `f:modern`,
+`r:common` and `usd>0.01` cleanly and leave `r:mythic` exactly where it is.
+
+**It does nothing for the rarity walk**, which has no range index — its buckets are planes and postings.
+That branch's two defects are separate and recorded in the walk-features doc.
+
+## Blast radius
+
+`PrintingRangeIndex` appears 22 times in `lib.rs`, with ~26 sites doing direct `.0`/`.1` tuple access.
+The ones that need real thought rather than mechanical rewriting:
+
+- **`range_narrowed` / `range_candidates`** — collect `idx[s..e].map(p.1)` then `sort_unstable()`. With a
+  value-major layout the slice is `pids[off_s..off_e]`, still contiguous, and the sort is still needed
+  (tiebreak order is not pid order). Cheaper if anything: no stride over a tuple.
+- **`partition_point` on values** — every bounds lookup becomes a search over `values` (4,133 entries for
+  usd) instead of over 81,542 pairs. Strictly faster, and `bare_range_bounds`' contract is unchanged.
+- **`aligned_page`** — uses the index directly as the value-sorted permutation for a `usd` sort. This is
+  the one that gets *better* rather than just different: today it relies on the run being in pid order
+  and re-sorts; pre-sorted slices give it the page directly.
+- **`walk_range_orderby_page`** — the point of the change. Bucket formation stops scanning for run
+  boundaries (`while b > lo && idx[b-1].0 == v`) and becomes an offset subtraction.
+- **`range_leaf_bits` / `CardRangePopcount`'s build** — scatter `pids[off_s..off_e]`, unchanged in shape.
+- **Build + serialization** — one extra sort per index, by the tiebreak rather than by pid.
+
+**`ARCHIVE_FORMAT_VERSION` must be bumped to the actual current date**, not incremented: this is a
+layout change and a stale archive must fail the header check rather than be read as garbage.
+
+## Order to do it in
+
+1. Change the type and the build, bump `ARCHIVE_FORMAT_VERSION`, and get the suite green with every
+   consumer mechanically ported. No behaviour change intended at this step — `force_plan_differential_agreement`
+   asserts full row order across every plan and is the gate.
+2. Then change `walk_range_orderby_page` / `collect_orderby_page` to stop mid-bucket, which is where the
+   win is. Row identity again, because this alters which rows a page contains at a tie boundary if the
+   tiebreak sort is wrong.
+3. Then delete `range_walk_run_boundary` and the `SortCol::PriceUsd` arm of `orderby_walk_scan` if the
+   patch has landed by then, and re-grade `OW/usd` against `printings_examined` — it should read ~1.0 at
+   every corpus size for the non-clumped queries.
+4. Re-run the corpus-size sweep. The whole point is that the feature now scales; three sizes confirm it.
+
+Gate each step on the compose-paging slice `bench_regret_matrix` reports, not the total — `OrderbyWalk`
+is 4% of rows, so a real improvement there is invisible in an aggregate.

--- a/docs/issues/local-engine-rarity-walk-cost.md
+++ b/docs/issues/local-engine-rarity-walk-cost.md
@@ -1,0 +1,83 @@
+# The rarity orderby walk: postings for mythic would not help, and what does
+
+`walk_rarity_orderby_page` walks rarity buckets in sort order. The four interior rarities
+(`common`=0, `uncommon`=1, `rare`=2, `mythic`=3) are one-hot **planes**; the sparse tail
+(`special`=4, `bonus`=5) is **postings** ([planes.rs:184](../../card_engine/src/planes.rs#L184)).
+
+The idea this doc closes off: give mythic — and the other low-density rarities — postings too, so a
+selective query does not pay a whole-corpus plane AND.
+
+## It would be slower, and the current crossover is in the right place
+
+A plane bucket ANDs `words_per_plane` words of the corpus: **1,519** word operations at 97,206 printings,
+fixed, whatever the filter matches. A postings bucket walks its own id list: one bit-test per entry.
+
+| rarity | printings | plane cost | postings cost | cheaper |
+| --- | --: | --: | --: | --- |
+| common | ~27,500 | 1,519 words | ~27,500 entries | **plane** |
+| rare | — | 1,519 words | — | **plane** |
+| **mythic** | **8,924** | **1,519 words** | **~8,924 entries** | **plane, ~6x** |
+| special / bonus | sparse | 1,519 words | short list | **postings** |
+
+Mythic is 9% of printings, which sounds sparse but is still ~6x more entries than the plane has words.
+The crossover is where a rarity's printing count passes ~1,519, and every interior rarity is far above it
+while special/bonus are far below. So the representation is already right, and moving mythic to postings
+would cost ~6x on every rarity-ordered page that touches it.
+
+Nor does it help the case that motivated the question. `r:mythic` ordered by **usd** scans 31,698 entries
+of the *price* index — that walk never consults a rarity structure at all, it bit-tests `pbits`. Fixing it
+needs a price-ordered index per rarity value, which is one index per (predicate value × sort column) and
+unbounded in combination; the cheap fix is
+[making the paging branch cost-based](./local-engine-compose-paging-cost-based.md) so the walk is not
+taken.
+
+## The real defect: one rate for two operations
+
+Both bucket kinds report their cost in the same unit — a plane bucket reports `wpp * 64`, the printings
+*covered*, deliberately, "so it stays comparable to the entry-scanning buckets" — and both are then
+charged `COMPOSE_WALK_STEP_NS`. But a word-AND covering 64 printings and 64 individual bit-tests are not
+the same operation. Split by which kind a query consumes (printing mode, `orderby=rarity`, pages and both
+directions):
+
+| group | n | charged / examined | realized ns per reported printing |
+| --- | --: | --: | --: |
+| plane-only | 56 | 0.50 | **1.069** |
+| postings-only | 8 | **124.43** | **3.792** |
+| mixed | 32 | 0.33 | 1.413 |
+
+`COMPOSE_WALK_STEP_NS` ships at **0.58**, so it is under both, and the two differ **3.5x** from each
+other. This is the shape a constant *can* fix: the error is flat across a 10x corpus axis (the
+`charged/examined` ratio measured exactly 0.67 at 0.5x, 1x, 2x, 3x, 4x and 5x), which is what a
+mis-levelled rate looks like and what a missing feature does not.
+
+**Fix:** a separate rate for plane-bucket steps and entry steps. That needs the two counted separately —
+`ComposePageWork.printings_examined` currently sums both — so a second counter is the prerequisite,
+exactly as a realized counter was the prerequisite for grading `printings_walked`.
+
+## The larger error, and it points the other way
+
+`orderby_walk_scan = n_printings` charges a full corpus pass for *every* rarity-ordered compose query. For
+`r:special` / `r:bonus` the walk touches only a short postings list and never ANDs a plane at all, so the
+charge is **124x** over.
+
+That one needs no popcount and no new counter, because it is a filter-**shape** question: a rarity
+equality on a postings int (`special`=4, `bonus`=5) cannot consume a plane bucket, and the acquire can see
+that from the filter it already holds. The floor for those queries is the postings length, not the corpus.
+
+The two errors run in opposite directions, which is why the aggregate read a flat 0.67 and hid both — the
+plane population is 2x under, the postings population 124x over. Splitting the population was the
+necessary step; a median could not have shown it.
+
+## Order
+
+1. **The postings shape check** (124x, no prerequisite, small).
+2. **A plane-step counter**, then the rate split (3.5x, flat, needs the counter first).
+
+Both gate on the compose-paging slice, not the total.
+
+## Status
+
+The table is measured (96 cells, production corpus). The crossover arithmetic is arithmetic — 1,519 words
+against a printing count — not a timing, so if someone wants to move mythic to postings anyway, the thing
+to measure is a forced plane-bucket AND against a forced postings walk at equal selectivity. I would not
+expect it to change the conclusion at 6x.

--- a/docs/issues/local-engine-rarity-walk-cost.md
+++ b/docs/issues/local-engine-rarity-walk-cost.md
@@ -1,35 +1,58 @@
-# The rarity orderby walk: postings for mythic would not help, and what does
+# The rarity orderby walk collects whole buckets, and ordering the buckets fixes it
 
 `walk_rarity_orderby_page` walks rarity buckets in sort order. The four interior rarities
 (`common`=0, `uncommon`=1, `rare`=2, `mythic`=3) are one-hot **planes**; the sparse tail
 (`special`=4, `bonus`=5) is **postings** ([planes.rs:184](../../card_engine/src/planes.rs#L184)).
 
-The idea this doc closes off: give mythic — and the other low-density rarities — postings too, so a
-selective query does not pay a whole-corpus plane AND.
+A plane bucket yields its pids in **pid** order, so `collect_orderby_page` must take the bucket whole and
+sort it. Measured, printing mode, `limit=60 offset=0`:
 
-## It would be slower, and the current crossover is in the right place
+| query | dir | total | **pushed** | examined | widths | measured |
+| --- | --- | --: | --: | --: | --: | --: |
+| `border:black` | **asc** | 85,046 | **24,653** | 97,216 | 1.0 | **115.5 µs** |
+| `border:black` | desc | 85,046 | 337 | 391 | 0.0 | **2.5 µs** |
+| `f:modern` | **asc** | 73,783 | **22,853** | 97,216 | 1.0 | **142.3 µs** |
+| `f:modern` | desc | 73,783 | 315 | 391 | 0.0 | 40.6 µs |
+| `usd>0.01` | **asc** | 81,534 | **25,418** | 97,216 | 1.0 | **153.6 µs** |
+| `usd>0.01` | desc | 81,534 | 249 | 391 | 0.0 | 32.8 µs |
+| `r:mythic` | asc | 8,924 | 8,924 | 388,864 | **4.0** | 44.8 µs |
+| `r:mythic` | desc | 8,924 | 8,924 | 97,607 | 1.0 | 43.7 µs |
 
-A plane bucket ANDs `words_per_plane` words of the corpus: **1,519** word operations at 97,206 printings,
-fixed, whatever the filter matches. A postings bucket walks its own id list: one bit-test per entry.
+**Ascending collects the entire `common` bucket — 24,653 matches to serve 60 rows, a 411x overshoot — and
+runs 46x slower than the same query descending**, which fills from the sparse bonus/special postings and
+examines 391 entries. `r:mythic` ascending is the other shape: it ANDs common, uncommon and rare finding
+nothing, then takes all of mythic, for four corpus widths.
 
-| rarity | printings | plane cost | postings cost | cheaper |
-| --- | --: | --: | --: | --- |
-| common | ~27,500 | 1,519 words | ~27,500 entries | **plane** |
-| rare | — | 1,519 words | — | **plane** |
-| **mythic** | **8,924** | **1,519 words** | **~8,924 entries** | **plane, ~6x** |
-| special / bonus | sparse | 1,519 words | short list | **postings** |
+## The fix: tiebreak-ordered storage for the bucket a walk STARTS in
 
-Mythic is 9% of printings, which sounds sparse but is still ~6x more entries than the plane has words.
-The crossover is where a rarity's printing count passes ~1,519, and every interior rarity is far above it
-while special/bonus are far below. So the representation is already right, and moving mythic to postings
-would cost ~6x on every rarity-ordered page that touches it.
+Give the relevant rarity a postings list sorted by the full tiebreak, alongside its plane
+([the same layout proposed for range indexes](./local-engine-range-index-value-major.md)). The walk then
+bit-tests entries in page order and **stops when the page fills** — ~60-70 entries for a broad filter,
+against 24,653 collected today.
 
-Nor does it help the case that motivated the question. `r:mythic` ordered by **usd** scans 31,698 entries
-of the *price* index — that walk never consults a rarity structure at all, it bit-tests `pbits`. Fixing it
-needs a price-ordered index per rarity value, which is one index per (predicate value × sort column) and
-unbounded in combination; the cheap fix is
-[making the paging branch cost-based](./local-engine-compose-paging-cost-based.md) so the walk is not
-taken.
+Which buckets need it follows from the table, and it is not the one I first guessed:
+
+- **`common` is the priority.** Ascending always starts there, and that is the 115-154 µs case.
+- **`mythic` second**, for descending — though descending already examines only 391 entries when
+  bonus/special fill the page, so this matters mainly for filters those two cannot satisfy (`r:mythic`
+  itself, at 43.7 µs).
+- `uncommon`/`rare` are only reached when an earlier bucket fails to fill, so they can wait.
+
+Dual storage, kept deliberately: the plane is still what `rarity_cmp_leaf_bits` reads on the FILTER path,
+where a whole-bucket bitmap is exactly what compose wants. The postings list serves the WALK path, where
+early stop is what matters. ~110 KB for common, ~36 KB for mythic. And as you note, special/bonus need no
+plane at all — their bits can be twiddled in from postings when a filter wants them.
+
+**Retracted: "postings for mythic would be ~6x slower."** An earlier revision of this doc closed the idea
+off on that arithmetic — 1,519 plane words against 8,924 postings entries. That compares
+enumerate-the-whole-bucket both ways, which is the wrong comparison: the entire point of tiebreak ordering
+is that the walk does not enumerate the whole bucket. With early stop the crossover moves to roughly "does
+the filter match more than ~4% of this rarity", which nearly every query clears. The plane only wins when
+the filter is so sparse within the rarity that the walk drains the whole postings list anyway.
+
+**This is separate from the `r:mythic`-ordered-by-**usd** case**, which walks the price index and never
+consults a rarity structure —
+[that one is a paging-branch choice](./local-engine-compose-paging-cost-based.md).
 
 ## The real defect: one rate for two operations
 

--- a/docs/issues/local-engine-rarity-walk-cost.md
+++ b/docs/issues/local-engine-rarity-walk-cost.md
@@ -93,14 +93,26 @@ necessary step; a median could not have shown it.
 
 ## Order
 
-1. **The postings shape check** (124x, no prerequisite, small).
-2. **A plane-step counter**, then the rate split (3.5x, flat, needs the counter first).
+1. **Tiebreak-ordered postings for `common`** — the biggest win by far, and it is an executor change
+   rather than a cost-model one: 115-154 µs becomes ~2-3 µs on the commonest shape (ascending, broad
+   filter). ~110 KB. Then `mythic` for the descending/`r:mythic` case, ~36 KB.
+2. **The postings shape check** for `r:special`/`r:bonus` (124x over, no prerequisite, small).
+3. **A plane-step counter**, then the rate split (3.5x, flat, needs the counter first).
 
-Both gate on the compose-paging slice, not the total.
+Note that (1) changes what (3) is measuring — a walk that stops early no longer pays a whole plane AND
+per bucket, so the plane-step rate matters less once (1) lands. Do (1) first and re-grade before
+touching the rate.
+
+Row identity is the gate for (1), not regret: it changes which rows a page contains if the tiebreak
+order is wrong, and `force_plan_differential_agreement` asserts full row order against `GatheredScan`
+across every plan. (2) and (3) are cost-only and gate on the compose-paging slice.
 
 ## Status
 
-The table is measured (96 cells, production corpus). The crossover arithmetic is arithmetic — 1,519 words
-against a printing count — not a timing, so if someone wants to move mythic to postings anyway, the thing
-to measure is a forced plane-bucket AND against a forced postings walk at equal selectivity. I would not
-expect it to change the conclusion at 6x.
+The two tables are measured on the production corpus — the per-direction overshoot (8 cells, 15 trials)
+and the rate split (96 cells). Nothing is implemented.
+
+The one number that is arithmetic rather than a timing is the ~4% crossover for where a tiebreak-ordered
+postings walk stops beating a plane AND. If that matters to a decision, measure a forced plane-bucket AND
+against a forced postings walk at equal selectivity; it will not affect (1), where the filters are broad
+and the win is 40x.

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -140,14 +140,58 @@ summary is *neutral in time, worse in routing*, which is not a trade worth takin
 slightly worse than the gather, as expected — the walk pays per permutation entry and a sparse total
 means stepping a long way to fill a page, where the gather is O(total).)
 
-## Prerequisite
+## Prerequisite: what the 0.40× actually is
 
-Price the compose `Gather` path. The 2026-08-04 measurement above narrows what that means: on the
-sparse population the arm reads a consistent **0.27–0.53 of real** across every case measured, which is
-a level error rather than a missing dependence on some feature — the ordering within the population is
-right, the magnitude is halved. The older "under by ~4-7x at p10 and over by 178x at p99" spanned a
-wider population that included broad queries; both readings should be reconciled before picking a term
-to move. Progress on the compose arm generally is tracked in
+Price the compose `Gather` path. Diagnosed 2026-08-04, features before rates, over 33–38 cells with the
+decline toggled off (15 trials each).
+
+**Features first, and they are a minority of it.** Each priced feature against its own realized counter:
+
+| feature | realized counter | median used/realized |
+| --- | --- | --: |
+| `eval_domain` | `cards_visited` | 0.70× |
+| **`compose_scan_printings`** | `printings_examined` | **0.15×** |
+| `matches` | `matches_pushed` | 0.88× |
+
+`compose_scan_printings` is off by 6.7×, and `gather_composed_page`'s own comment already predicted
+exactly this: the feature is the composed bitmap's **popcount**, on the grounds that compose "walks the
+set bits", but the loop iterates `start..end` of every candidate card and bit-tests each printing, so
+the realized quantity is the candidate cards' **span**. It is the same printings→distinct-rows
+projection error behind `eval_domain`'s 0.70×.
+
+An ORACLE re-pricing — realized counters substituted, every shipped rate untouched — settles the
+sequencing:
+
+| features | median pred/meas |
+| --- | --: |
+| shipped | **0.40×** |
+| `compose_scan_printings` corrected alone | 0.47× |
+| all three realized | **0.57×** |
+
+So perfect features close about 40% of the gap and leave 1.75×. That is the **opposite** of the P3/P4
+result in [the loop-phase doc](./local-engine-loop-phase-measurement.md), where the oracle reached 83%
+and features were the whole story — worth noting before reusing that conclusion on a different arm.
+
+**What is left is a missing term, not a level error.** The oracle column spans 0.32–0.79, so no single
+multiplier fits it. Taking `meas − oracle_pred` gives a residual of **7,639 ns median** (stdev 1,720)
+against a `COMPOSE_FIXED_COST_NS` of 163.56 ns. Re-running the whole measurement on a one-third corpus
+(32,402 printings) gives 4,210 ns — a factor of 1.81 where the corpus factor is 3.0, so it is neither
+fixed nor proportional. A two-point fit:
+
+    residual ≈ 2,496 ns  +  0.0529 ns/printing   (3.39 ns per 64-bit word)
+
+Both halves are plausible as *unmodelled work* rather than mis-levelled rates. `compose_printing_bits`
+allocates a full-width printing bitmap and ANDs each child into it — O(`n_printings`/64) per leaf,
+charged nowhere, since `popcount_words` counts the **result-space** bitmap, not the printing-space
+build. And `bitmap_card_ids` walks the whole card bitmap to extract set ids whatever the popcount.
+
+Two caveats before anyone moves a constant on this. It is a **two-point fit**, and the loop-phase doc's
+own saturation finding is the standing warning against trusting those — a third size is the next
+measurement, not the constant. And the older reading here ("under by ~4-7× at p10 and over by 178× at
+p99") spanned a wider population including broad queries; the two need reconciling, because a term
+added to fix the sparse end will move the broad end too.
+
+Progress on the compose arm generally is tracked in
 [the cost-model doc](local-engine-cost-model-agreement.md).
 
 ## Acceptance

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -30,6 +30,23 @@ below needs no small-total decline of its own, and its comment says so —
 > the gather fallback pages via the bounded GatherSelect, whose tie-break matches the general path
 > exactly (same GatherSelect, same comparator) — so no separate small-total decline is needed.
 
+**The stated reason no longer applies to the WALK either — the comment is stale (2026-08-04).** #815
+(`fe1afeb`, 2026-08-02) made row order total and filter-independent on `(key1, key2, cid, pid)`,
+replacing the key-3 `prefer_score` that used to differ between the permutation (first *stored*
+printing's score) and the gathered paths (first *matching* one). With `cid` and `pid` in the key there
+is no tie left for the two emission shapes to break differently. Measured by toggling the decline off
+and running the walk on tie-heavy orderbys (`power`/`toughness`/`cmc`, three modes, both directions,
+deep offsets): **576 real invocations, 1,512 cells, 0 row differences**, plus 14 invocations inside
+`force_plan_differential_agreement`, which asserts *full row order* against `GatheredScan` and passed.
+
+That matters less for shipping than it looks — the doc's proposal was always the gather, which was
+never blocked on tie order — but it retires the reason the code gives for the decline, and it means
+either executor is now correct.
+
+**Watch the vacuous A/B here.** The first attempt at this measurement showed 0 differences because the
+cost model still predicted `Decline`, so compose never ran and neither arm of the A/B executed the
+branch. Both halves must be toggled, and the fire count must be *counted*, not assumed.
+
 **Why it is cheap precisely here.** `gather_composed_page` walks `bitmap_card_ids` of the composed
 set — only cards holding a matching printing — so it is O(total), and `total <= STREAM_MIN_MATCHES`
 is the condition. Add one O(n_printings/64) projection. Declining instead discards the finished
@@ -81,12 +98,57 @@ mispricing was not the blocker, or not the only one.
 - **Removing the infinities exposes a pre-existing p99 of 178x OVER-cost** in the compose arm, which
   was always there and hidden behind `inf`. The arm is wrong in both directions on this population.
 
+## Re-measured 2026-08-04, after the two-sided range fusion
+
+[local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md) made
+`compose_printing_estimate` exact on ranges, which removed the second stated blocker: the prediction
+can now tell a sparse query from a broad one (879 against a true 879, where it read 20,411). Both
+executors were then re-tried behind a runtime toggle on one binary.
+
+**The gather really is faster on its population.** Warm, 15 trials, `PrintingCompose` against the best
+plan that would otherwise win:
+
+| query | mode | compose measured | compose predicted | best other |
+| --- | --- | --: | --: | --: |
+| `usd>=0.42 usd<=0.43` | artwork | **27.5 µs** | 13.5 | 75.0 |
+| `cn>=146 cn<=147` | artwork | **20.5** | 8.4 | 46.1 |
+| `set:lea` | artwork | **18.8** | 5.1 | 44.6 |
+| `usd>=200` | artwork | **15.6** | 4.6 | 27.5 |
+| `cn>=20000 r>=rare` | card | **13.9** | 4.3 | 17.6 |
+
+1.3–2.7× faster than the alternative, and **under-priced 2–4× in every row** (0.27–0.53 of real). That
+under-charge is the whole remaining problem, and it is narrow enough to be calibratable rather than
+structural.
+
+**And it is still not shippable, for a third reason that is neither of the first two.** The
+under-pricing over-picks compose on queries where it does *not* win, and those mispicks cancel the wins:
+
+| | decline | gather |
+| --- | --: | --: |
+| regret mean | 1.30 µs | **1.51 (+16%)** |
+| `printing_compose` miss% | 7% | **18%** |
+| `printing_compose` p90 | 0.00 | **8.12** |
+| compose-acquire wall time, 2,341 paired queries | 113.6 ms | **113.2 ms (1.00)** |
+
+**Read those two rows together, because separately each one lies.** Regret is a routing-error metric:
+a correct pick scores zero, so enabling a plan that is faster on its own population shows up as pure
+loss — the gains are invisible and only the new mispicks count. Wall time says the opposite is not true
+either: the win is real but confined, and the mispicks eat exactly as much as it earns. The honest
+summary is *neutral in time, worse in routing*, which is not a trade worth taking for added complexity.
+
+(The permutation walk was also measured, since it is what the stale comment is about: regret 1.52 µs,
+slightly worse than the gather, as expected — the walk pays per permutation entry and a sparse total
+means stepping a long way to fill a page, where the gather is O(total).)
+
 ## Prerequisite
 
-Price the compose `Gather` path. This is not a one-term tweak: the arm is under by ~4-7x at p10 and
-over by 178x at p99 on the population the change exposes. Progress on the compose arm generally is
-tracked in [the cost-model doc](local-engine-cost-model-agreement.md); this change should be retried
-whenever that cell reads sanely.
+Price the compose `Gather` path. The 2026-08-04 measurement above narrows what that means: on the
+sparse population the arm reads a consistent **0.27–0.53 of real** across every case measured, which is
+a level error rather than a missing dependence on some feature — the ordering within the population is
+right, the magnitude is halved. The older "under by ~4-7x at p10 and over by 178x at p99" spanned a
+wider population that included broad queries; both readings should be reconciled before picking a term
+to move. Progress on the compose arm generally is tracked in
+[the cost-model doc](local-engine-cost-model-agreement.md).
 
 ## Acceptance
 
@@ -98,3 +160,9 @@ whenever that cell reads sanely.
 
 The rows check is cheap and should be repeated rather than trusted from this document, since the
 comparator or the paging strategy may have moved since.
+
+Add a fourth, because criteria 1–2 alone would have passed a change that buys nothing:
+
+4. **Wall time better, not merely routing not-worse.** Paired routed dispatch on one binary with the
+   decline toggled, sliced to the compose acquire. The 2026-08-04 run reads 1.00 — the plan has to earn
+   more than it loses to its own mispicks, and regret cannot see the earning half.

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -191,6 +191,74 @@ measurement, not the constant. And the older reading here ("under by ~4-7× at p
 p99") spanned a wider population including broad queries; the two need reconciling, because a term
 added to fix the sparse end will move the broad end too.
 
+### Attempted and held: deriving the span feature from the candidate count
+
+`compose_scan_printings = scan_units` (the candidate span `GatheredScan` already estimates) in place
+of `printing_matches * COMPOSE_GATHER_SPAN_PER_MATCH`. It does what it claims — the feature grades
+0.15x -> **0.46x** of realized, and the shape becomes per-candidate instead of per-match, which is what
+the quantity actually is.
+
+**It is held, because routing got worse: regret 1.33 -> 1.41 us** (same-session baseline, so the 0.08
+is outside the ~0.03 run-to-run spread). And the cost barely moved, 0.40 -> **0.41x**, because bit
+tests are only 11% of the modelled page cost — the earlier "worth 0.40 -> 0.47" came from substituting
+a *perfect* counter, which `scan_units` at 0.46x does not deliver.
+
+The lesson is the sharper version of this branch's recurring one. Compose is under-priced by 2.5x
+overall; making one of its features honest while the level stays wrong does not move the level, it
+moves compose's *relative* position — and it was winning those argmins correctly while under-priced,
+so raising one term only loses them. **Partial accuracy on an argmin can be worse than consistent
+inaccuracy.** The span fix should land together with the missing ~7.7 us term, not before it. Patch
+kept at `scratchpad/span_fix.patch`.
+
+### The two constants are approximating something exactly computable
+
+`COMPOSE_CARD_ESTIMATE_BIAS` (1.78) and `COMPOSE_CANDIDATE_SPAN_BIAS` (2.1) both correct
+`balls_into_bins`, which is *uniform* occupancy — `domain * (1 - e^(-k/domain))`, every card an equally
+likely bin. Cards are not equally likely: a card is a candidate iff one of its `S` printings matches,
+so selection is size-biased. On this corpus the mean card holds 3.09 printings but the size-biased mean
+`E[S^2]/E[S]` is **42.30**, and the realized printings-per-candidate runs ~13 — between the two,
+because `k` is not infinitesimal. No single constant spans that.
+
+The size-aware form needs no fitted constant, only the printing-count histogram (one small table, built
+once at load):
+
+    E[candidate cards] = sum_c [1 - (1 - k/N)^S_c]
+    E[candidate span]  = sum_c S_c * [1 - (1 - k/N)^S_c]
+
+Both reduce to `balls_into_bins` when every `S_c` is equal, and both saturate correctly at `k = N`.
+Graded against exact truth (k from the printing-mode total, candidates from the card-mode result, span
+from the corpus) over 19 queries:
+
+| | size-aware | shipped |
+| --- | --: | --: |
+| candidate cards, median est/true | **1.10** | 0.72 |
+| candidate span, median est/true | **~1.1** | ~0.36 |
+
+Better centred on both, and with no constant to refit when the corpus changes. **But not uniformly
+better**: the span reads 9.85x on `usd<=0.02` and 4.73x on a narrow date range, because those
+predicates are *anti*-correlated with card size — the cheapest printings sit on small cards, so
+size-biased selection over-predicts. The uniform model is wrong in one direction, the size-biased one
+in the other, and neither knows which predicate it has.
+
+### Which makes the exact route the interesting one
+
+`RangeCardCounts` already answers distinct cards **exactly** for a range — and its `distinct_cards`
+returns `None` for an *interior* range, because "distinct counts do not subtract". That hole is exactly
+the two-sided population the range fusion just created, so those queries fall back to the estimator
+above precisely where an exact answer exists for their one-sided siblings.
+
+No 1-D prefix array closes it: whether a card has a printing in `[lo, hi)` is a 2-D question. But there
+is an exact structure. A card with values `v1 < ... < vk` has NO printing in `[lo, hi)` iff the interval
+fits inside one of its `k+1` gaps, so
+
+    cards missing the range = # gaps containing [lo, hi)     (at most one per card)
+
+over ~`n_printings + n_cards` gap intervals — a containment/dominance count, answerable exactly in
+O(log^2) with a merge tree, not a prefix sum. Weighting each gap by its card's printing count makes the
+**same** structure return the exact span as well. One structure, both features exact, both constants
+deleted, and the interior-range hole closed. That is a bigger change than a calibration and belongs in
+its own doc if it is taken up.
+
 Progress on the compose arm generally is tracked in
 [the cost-model doc](local-engine-cost-model-agreement.md).
 

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -255,9 +255,42 @@ fits inside one of its `k+1` gaps, so
 
 over ~`n_printings + n_cards` gap intervals — a containment/dominance count, answerable exactly in
 O(log^2) with a merge tree, not a prefix sum. Weighting each gap by its card's printing count makes the
-**same** structure return the exact span as well. One structure, both features exact, both constants
-deleted, and the interior-range hole closed. That is a bigger change than a calibration and belongs in
-its own doc if it is taken up.
+**same** structure return the exact span as well.
+
+**Measured against a cheaper approximation, and the merge tree loses.** A binned start x end triangle
+`T[i][j]` = distinct cards in bins i..j stores the union answer directly, so it subtracts where a
+prefix array cannot. 100 equal-printing bins is 5,050 u32 = **20 KB per index**, against ~274 KB for a
+wavelet tree over the gaps and ~8.8 MB for an explicit merge tree, and the query is a bisect plus two
+reads rather than O(log^2).
+
+Broad intervals bracket tightly -- `T[i+1][j-1]` is contained, `T[i][j]` contains, and the width is the
+two boundary bins: **0.3% / 1.0% / 2.3% / 2.6%** on the four broad cases measured.
+
+Narrow intervals collapse the bracket (fewer than three bins spanned means no interior, so the lower
+bound is 0) and more bins cannot fix that. But the upper bound is the estimator, and it pairs with a
+second free bound: `k`, the printings in the range, is the two partition points the range path already
+computes, and a card needs at least one printing in range. Over 14 narrow intervals spanning both ends
+of both value axes:
+
+| estimator | median | max | direction |
+| --- | --: | --: | --- |
+| `T[i][j]` | 2.16x | 8.52x | never under |
+| **`min(k, T[i][j])`** | **1.21x** | **1.41x** | never under |
+| shipped | 0.72x | — | unbounded either way |
+
+The two bounds are complementary for a structural reason worth keeping: equal-printing bins are narrow
+in VALUE space exactly where printings are dense, so at the cheap end a bin is two distinct prices wide
+and `T[i][i]` is exact (3 of 14 cells). Where values are sparse the bin spans 1,381 values against a
+query's 173 and `T` is useless -- but that is the regime where printings-per-value is low, so cards ~ k
+and the clamp takes over.
+
+So the whole feature is 20 KB, O(1), bounded at 1.41x over on narrow and 2.6% on broad. **The arm is
+under by 2.5x overall**, so buying exactness here is misallocated: the merge tree, and the O(k)
+count-it-directly variant, both cost more to fix an error smaller than the one that remains.
+
+Same shipping caveat as the span patch: `min(k, T)` is systematically OVER, which makes compose look
+more expensive -- the direction that lost argmins compose deserved. It lands with the level fix, not
+before it. And the 14 intervals are hand-picked; grade it over the regret matrix's traffic first.
 
 Progress on the compose arm generally is tracked in
 [the cost-model doc](local-engine-cost-model-agreement.md).

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -174,22 +174,80 @@ and features were the whole story — worth noting before reusing that conclusio
 
 **What is left is a missing term, not a level error.** The oracle column spans 0.32–0.79, so no single
 multiplier fits it. Taking `meas − oracle_pred` gives a residual of **7,639 ns median** (stdev 1,720)
-against a `COMPOSE_FIXED_COST_NS` of 163.56 ns. Re-running the whole measurement on a one-third corpus
-(32,402 printings) gives 4,210 ns — a factor of 1.81 where the corpus factor is 3.0, so it is neither
-fixed nor proportional. A two-point fit:
+against a `COMPOSE_FIXED_COST_NS` of 163.56 ns.
 
-    residual ≈ 2,496 ns  +  0.0529 ns/printing   (3.39 ns per 64-bit word)
+### Measured over a controlled 10x corpus axis: it is per-printing, and there is no fixed part
 
-Both halves are plausible as *unmodelled work* rather than mis-levelled rates. `compose_printing_bits`
-allocates a full-width printing bitmap and ANDs each child into it — O(`n_printings`/64) per leaf,
-charged nowhere, since `popcount_words` counts the **result-space** bitmap, not the printing-space
-build. And `bitmap_card_ids` walks the whole card bitmap to extract set ids whatever the popcount.
+`upscale_corpus.py --copies N` replicates the corpus with rewritten identities, so the value
+distribution is preserved exactly and both `n_printings` and `n_cards` scale by N. Fractional steps need
+a partial copy sampled by **oracle card**, not by printing — thinning each card's span would change the
+printings-per-card distribution, which is the quantity under test. `CARD_ENGINE_STREAM_MIN_MATCHES`
+scaled with the corpus keeps the sparse population from evaporating as results scale (without that, the
+cell count fell 33 -> 26 -> 13 and the 4x stdev was 5x its median).
 
-Two caveats before anyone moves a constant on this. It is a **two-point fit**, and the loop-phase doc's
-own saturation finding is the standing warning against trusting those — a third size is the next
-measurement, not the constant. And the older reading here ("under by ~4-7× at p10 and over by 178× at
-p99") spanned a wider population including broad queries; the two need reconciling, because a term
-added to fix the sparse end will move the broad end too.
+Nine sizes, 0.5x to 5x, 33 cells each:
+
+| n_printings | bitmap | residual | fitted | meas/fit | ns/printing |
+| --: | --: | --: | --: | --: | --: |
+| 48,161 | 6 KB | 4,045 | 3,914 | 1.033 | 0.0840 |
+| 97,206 | 12 KB | 7,597 | 8,009 | 0.949 | 0.0782 |
+| 194,412 | 24 KB | 15,276 | 16,126 | 0.947 | 0.0786 |
+| 339,779 | 41 KB | 28,724 | 28,264 | 1.016 | 0.0845 |
+| 486,030 | 59 KB | 40,459 | 40,475 | 1.000 | 0.0832 |
+
+    residual = -107 ns  +  0.0835 ns/printing   =  5.34 ns per 64-bit word     R^2 = 0.99832
+
+**The intercept is zero within noise.** There is no missing *fixed* cost — the whole 7.6 us is a
+per-corpus-width build term. And `ns/printing` varies only **1.13x across a 10x range with no trend**,
+which rules out the cache story worth worrying about here: the printing bitmap goes 6 KB (L1) to 59 KB
+(L2) over this sweep without the rate moving, so linear is the right shape and 5.34 is not
+corpus-specific.
+
+**Retracted: the earlier two-point fit** (2,496 ns fixed + 0.0529 ns/printing). Its small point was
+`head -32402` of the corpus — the first third of the file, not a uniform sample — and the spurious fixed
+term came entirely from that. Sampling by card is what fixed it.
+
+The mechanism matches: `compose_printing_bits` allocates a full-width printing bitmap and ANDs each
+child into it, `printing_bits_to_card_bits` projects it, and `bitmap_card_ids` walks the card bitmap to
+extract set ids — all O(corpus width), all charged nowhere, since `popcount_words` counts only the
+**result-space** bitmap.
+
+### But it cannot be added to the shared build section alone
+
+`compose_printing_bits` runs for every compose execution, so the physical argument says the term belongs
+in the build and applies to `Perm`/`OrderbyWalk` too. Measured over ten sizes, that is wrong — and
+wrong in a way only the many-point sweep shows. `PrintingCompose` `predicted/measured` on the Perm
+population, with and without the term applied:
+
+| corpus | pred/meas | + build term |
+| --- | --: | --: |
+| 0.5x | 1.244 | 1.482 |
+| **1.0x** | **1.185** | **1.449** |
+| 2.0x | 0.965 | 1.198 |
+| 3.0x | 0.916 | 1.152 |
+| 3.5x | 0.838 | 1.035 |
+| 4.5x | 0.834 | 1.046 |
+| 5.0x | 0.855 | 1.061 |
+
+**Both curves SATURATE past ~3.5x** — the same phenomenon [the loop-phase
+doc](./local-engine-loop-phase-measurement.md) already records, and the reason a linear term shifts this
+curve instead of flattening it. With the term the asymptote is ~1.045 (right) against ~0.845 (18% under)
+without, so the term is real here as well. But at the **production** size it makes Perm worse, 1.185 ->
+1.449, which is what happens when an arm's rates were fitted with the cost already absorbed into them.
+
+So the change is one of:
+
+1. **Gather-scoped term.** Lowest risk, and it changes no production routing at all, because the Gather
+   branch is declined in production — it is purely a prerequisite for the sparse-gather work.
+2. **Build-wide term plus a refit** of `COMPOSE_WALK_STEP_NS` (0.58) and `COMPOSE_WALK_EMIT_PER_ROW_NS`
+   (2.19) in the same commit. Correct, but it moves every compose query and needs its own regret gate.
+
+Option 1 first. Option 2 is a real improvement — Perm is 18% under at scale and would stay so — but it
+is a separate change with a separate gate, and this branch has now twice demonstrated that a partial
+accuracy fix on this arm loses regret.
+
+One older reading still needs reconciling: "under by ~4-7x at p10 and over by 178x at p99" spanned a
+wider population including broad queries, so a term fixed on the sparse end will move the broad end too.
 
 ### Attempted and held: deriving the span feature from the candidate count
 

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -235,16 +235,51 @@ curve instead of flattening it. With the term the asymptote is ~1.045 (right) ag
 without, so the term is real here as well. But at the **production** size it makes Perm worse, 1.185 ->
 1.449, which is what happens when an arm's rates were fitted with the cost already absorbed into them.
 
-So the change is one of:
+### It is not only Perm, and the three branches disagree about what is wrong
 
-1. **Gather-scoped term.** Lowest risk, and it changes no production routing at all, because the Gather
-   branch is declined in production — it is purely a prerequisite for the sparse-gather work.
-2. **Build-wide term plus a refit** of `COMPOSE_WALK_STEP_NS` (0.58) and `COMPOSE_WALK_EMIT_PER_ROW_NS`
-   (2.19) in the same commit. Correct, but it moves every compose query and needs its own regret gate.
+The sweep above conflated `Perm` with `OrderbyWalk`, and priced `Gather` by a different route (a residual
+on oracle features rather than `predicted/measured` on shipped ones), so the three were never comparable.
+Re-measured with one methodology — shipped features, `predicted_ns / plan_self_ns`, split by branch:
 
-Option 1 first. Option 2 is a real improvement — Perm is 18% under at scale and would stay so — but it
-is a separate change with a separate gate, and this branch has now twice demonstrated that a partial
-accuracy fix on this arm loses regret.
+| corpus | Perm (bare / +term) | OrderbyWalk | Gather |
+| --- | --: | --: | --: |
+| 0.5x | 1.259 / 1.630 | **0.571** / 1.243 | 0.544 / 0.992 |
+| 1.0x | 1.193 / 1.544 | 0.848 / 1.317 | 0.553 / 0.952 |
+| 2.0x | 0.926 / 1.223 | 0.953 / 1.358 | 0.540 / 0.944 |
+| 3.0x | 0.851 / 1.064 | 0.959 / 1.444 | 0.543 / 0.887 |
+| 5.0x | **0.721** / 0.924 | **0.997** / 1.314 | 0.518 / 0.876 |
+
+- **`Gather` is a clean LEVEL error** — flat at 0.52-0.55 across the whole 10x range, no scale dependence
+  whatsoever — and the build term fixes it (0.88-0.99). It is the branch the term was measured on and the
+  only one where it behaves as designed.
+- **`Perm` drifts DOWN 1.75x** (1.259 -> 0.721), and the term shifts the curve while leaving the same
+  1.76x drift. Perm's defect is not the build cost.
+- **`OrderbyWalk` drifts UP 1.75x** (0.571 -> 0.997) — the OPPOSITE sign. Nearly 2x under at half-corpus,
+  correct at 5x.
+
+**That rules out a shared refit.** Perm and OrderbyWalk both multiply `COMPOSE_WALK_STEP_NS` (0.58) and
+`COMPOSE_WALK_EMIT_PER_ROW_NS` (2.19), and no single refit of shared constants flattens two curves running
+in opposite directions. The shipped values are a compromise sitting where the two cross — near 1-2x, which
+is exactly why they look acceptable at the production corpus and diverge either side of it.
+
+And the cause is a FEATURE, not a rate, which is the rule this branch keeps re-confirming. The two
+branches multiply the same rate by different quantities: Perm uses `printings_walked` (`page_span /
+match_rate`, which does not scale with the corpus), while OrderbyWalk uses
+`max(printings_walked, orderby_walk_scan)` and `orderby_walk_scan` **is** `n_printings` for a rarity
+orderby. Same rate, differently-scaling features.
+
+### So the sequencing
+
+1. **Gather-scoped term.** Ready. Changes no production routing at all, because the Gather branch is
+   declined in production — purely a prerequisite for the sparse-gather work.
+2. **Perm and OrderbyWalk are separate investigations, features before rates.** The prerequisite for Perm
+   is a realized counter for `printings_walked`: it is an estimate with nothing to grade it against,
+   which is why an oracle pricing of that branch returns a stdev 15x its median. Same shape of blocker
+   `compose_scan_printings` was for Gather.
+
+A build-wide term plus a shared refit — the shape this was going to take — would have made the production
+corpus worse on Perm (1.193 -> 1.544) while fixing its asymptote, and over-corrected OrderbyWalk at every
+size. Ten points showed that; three would not have.
 
 One older reading still needs reconciling: "under by ~4-7x at p10 and over by 178x at p99" spanned a
 wider population including broad queries, so a term fixed on the sparse end will move the broad end too.

--- a/docs/issues/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/local-engine-two-sided-range-fusion.md
@@ -138,9 +138,13 @@ indexes fused inside one compose, unsatisfiable pairs, an `Or` of two fused `And
 
 ## What is left
 
-**Re-attempt the sparse gather**, now that the sparsity prediction is correct — the order the earlier
-attempt got wrong. Confirm `matches` holds on that population first, then flip `Decline` → `Gather`,
-then re-check regret.
+**The sparse gather was re-attempted and is still declined** — see
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md). The accurate estimate
+did remove its stated blocker (the prediction can now tell sparse from broad), and a second stale
+blocker fell with it (the tie-ordering reason the code gives for the decline died with #815). What
+remains is narrower and better quantified: the arm under-prices the gather to 0.27–0.53 of real, the
+resulting mispicks cancel a real 1.3–2.7x win, and the change measures neutral in wall time and 16%
+worse in regret.
 
 **Watch `printing_compose`'s own slice.** Its share of routed queries went 27% → 31% and its mean
 regret 1.65 → 1.80 µs across this commit, even as the total fell. More queries route there now and the

--- a/docs/issues/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/local-engine-two-sided-range-fusion.md
@@ -1,0 +1,114 @@
+# Fusing a two-sided range into one index interval
+
+Split out of [local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md),
+which found this while auditing plan-cost features and where the routing context lives. Shipped in
+`4991759`; the remaining work is the compose half, below.
+
+`narrow_rec`'s `And` arm narrows children independently and intersects the *results*, never the
+bounds. `usd>=0.42 usd<=0.43` therefore has both halves match most of the corpus, each trip
+`range_too_broad_to_narrow` (`MAX_NARROW_FRACTION` 0.25) on its own and decline — and that their
+intersection is 837 printings is never discovered.
+
+## The evidence that made it worth doing
+
+All artwork, `orderby=toughness`, limit 10, before the change:
+
+| query | results | `eval_domain` | P3 `printings_examined` | best measured |
+| --- | --: | --: | --: | --: |
+| `usd>=200` | 160 | **148** | 6,089 | **26.7 µs** |
+| `usd<=0.02` | 103 | **100** | 339 | **3.2 µs** |
+| `cn>=20000` | 285 | **281** | 2,980 | **17.0 µs** |
+| **`usd>=0.42 usd<=0.43`** | 837 | **31,508** | **97,206** | **1,146.8 µs** |
+| **`cn>=100 cn<=101`** | 460 | **31,508** | **97,206** | **1,136.1 µs** |
+| `usd>=200 t:creature` | 36 | **36** (`narrowed_repr=printings`) | 532 | **2.5 µs** |
+| `usd>=0.42 usd<=0.43 t:creature` | 361 | 17,317 | 45,976 | 570.2 µs |
+
+A one-sided range with **160** results narrows to **148** candidates and finishes in 26.7 µs. A
+two-sided range with **837** results narrows to nothing and takes **43× longer for 5× more rows**. So
+the shape a reader intuitively wants — walk the index slice, test the residual, accumulate the page —
+**is** what the engine does for `usd>=200`; the two-sided form simply never gets there.
+
+## What shipped
+
+`fuse_and_range_children` groups an `And`'s children by which printing-range index they select on and
+fuses each group of two or more into one half-open interval (`lo = max(lo_i)`, `hi = min(hi_i)`) before
+the arm ranks anything. The interval is the exact conjunction of its constituents, which is what lets
+one source stand in for all of them — including in `every_child_included`'s tightness accounting.
+
+| query | before | after |
+| --- | --: | --: |
+| `usd>=0.42 usd<=0.43` | 1,146.8 µs, exam 97,206 | **76.2 µs**, exam 9,273 |
+| `cn>=100 cn<=101` | 1,136.1 µs, exam 97,206 | **49.9 µs**, exam 5,604 |
+| `usd>=0.42 usd<=0.43 t:creature` | 570.2 µs, evd 17,317 | **17.0 µs**, evd 356 |
+
+**Regret cannot see this, which is why it was measured differently.** Fusion makes the plans that ran
+faster without changing which one wins, and regret is a difference between plans — the same blind spot
+that hid `r>=rare`'s missing plan and the sparse-gather decline. The measurement is paired routed
+dispatch over 11,915 traffic queries, same seed and stream on both builds, sliced by whether the query
+has two or more comparisons on one fusible field:
+
+| slice | n | base | fused | ratio |
+| --- | --: | --: | --: | --: |
+| fusible | 577 | 111.6 ms | **95.9 ms** | **0.86** |
+| the rest (fusion cannot touch it) | 11,338 | 915.6 ms | 897.6 ms | 0.98 |
+
+Regret mean went 1.42 → 1.35 µs, with 5% more queries fitting the same 180 s budget.
+
+**The untouchable slice is the noise gauge, and it is worth reading before believing any single row.**
+Fusion cannot alter those 11,338 queries at all, yet they move 2% in aggregate and up to **±170 µs**
+per query. Every apparent per-query regression in this data sits inside that envelope — including the
++166 µs on broad two-sided `cn`/`year` ranges that first looked like the gate below earning its keep.
+
+### The gate is a scope decision, not a measured win
+
+Fusion applies only where the fused interval is itself sparse. Fused-vs-gated is 0.88 against 0.86 of
+baseline on the fusible slice, which the noise floor above makes indistinguishable — so the honest
+claim is not that the gate is faster. What it buys is a bound: outside the sparse population where the
+win *is* demonstrated, the change is a provable no-op, because the constituents pass through to their
+own arms untouched.
+
+It also removes a live question. Fusing a still-broad interval is not neutral: one broad source reaches
+`range_narrowed` under a single `broad_ok` where two broad children each got their own, so the `And`'s
+per-child skip logic stops deciding per child. The gate means that never happens, and as a side effect
+`range_narrowed`'s `broad_ok` is unreachable from a fused source at all (a sparse `k` returns on the
+vec path first) — which is why the fused source carries no negation flag despite `bare_range_bounds`
+happily reducing `-usd<c` for it.
+
+### Row identity
+
+4,560 cells identical, hashing the returned `scryfall_id` sequence over three modes × five orderbys ×
+four pages × two prefers: two-sided `usd`/`cn`/`date`/`year`, negated halves, three constituents on one
+index, two indexes fused independently, unsatisfiable pairs, fused ranges under `Or` and `Not`, plus
+one-sided and broad controls. Harness: `scratchpad/fuserows.py`.
+
+The unsatisfiable case is load-bearing, not decoration. `usd>=1 usd<=0.5` fuses to `hi < lo`, and every
+consumer computes `k` as `partition_point(hi) - partition_point(lo)` — that subtraction **underflows
+and panics**. Clamping to `[lo, lo)` yields `k = 0`, which is what an empty range means and what every
+consumer already handles.
+
+## What is left
+
+**The compose half has not moved.** `eval_domain` still reads 31,508 on the bare two-sided form, and
+`printing_compose` is still the picked plan for it, because `is_printing_composable` and
+`compose_printing_bits` decompose `And` *before* any range guard — the fusion improves the narrowing
+path only. `compose_printing_estimate` therefore still multiplies the two sides instead of intersecting
+one interval (20,411 against a true 837), and `scatter_printings` still reads 82,421 for an 837-row
+answer. Doing the same fusion in those three functions is the next step, and it is the prerequisite
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) is actually blocked
+on: that design's `Decline` → `Gather` flip regressed routing purely because `compose_paging_for`
+branches on `result_total`, the *estimate*, and so cannot tell a sparse query from a broad one.
+
+Order: fuse compose's three range paths, confirm `matches` on that population, then re-enable the
+gather behind the now-correct sparsity prediction, then re-check regret. Not before.
+
+**`eur` and `tix` cannot fuse at all**, because `resolve_numeric_range_leaf` covers only `price_usd` and
+`collector_number` (plus `DateCmp`/`YearCmp` reaching `released_at` directly). That is the same root
+cause as [local-engine-eur-tix-range-index.md](./local-engine-eur-tix-range-index.md), and fusion adds
+one more reason to fix it: several top-100 regret rows are two-sided `eur:`/`tix:` ranges, which are
+exactly the shape that gains most and currently gains nothing.
+
+**Card-level numeric contradictions are separate work.** `usd>=1 usd<=0.5` short-circuits for free
+here, but `power=3 power=5` does not reach this code: `resolve_numeric_range_leaf` returns `None` for
+`Power`, and `printing_dependent` classifies `Power`/`Cmc`/`Toughness`/`Loyalty` as card-level,
+evaluated through `numeric_candidates`. Detecting that contradiction is most naturally a bind-time
+pass, and needs its own decision on `Ne` and null semantics.

--- a/docs/issues/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/local-engine-two-sided-range-fusion.md
@@ -1,8 +1,8 @@
 # Fusing a two-sided range into one index interval
 
 Split out of [local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md),
-which found this while auditing plan-cost features and where the routing context lives. Shipped in
-`4991759`; the remaining work is the compose half, below.
+which found this while auditing plan-cost features and where the routing context lives. Shipped in two
+commits — `4991759` for the narrowing, `7374e19` for the compose builders.
 
 `narrow_rec`'s `And` arm narrows children independently and intersects the *results*, never the
 bounds. `usd>=0.42 usd<=0.43` therefore has both halves match most of the corpus, each trip
@@ -86,20 +86,66 @@ consumer computes `k` as `partition_point(hi) - partition_point(lo)` — that su
 and panics**. Clamping to `[lo, lo)` yields `k = 0`, which is what an empty range means and what every
 consumer already handles.
 
+## The compose half, and why it was not an estimator problem
+
+The narrowing fusion left `compose_printing_bits` and `compose_printing_estimate` reading the unfused
+shape, because both decompose `And` before any range guard. Their fold takes the **min** of the
+children's match counts — an intersection upper bound, and a bad one here. (An earlier draft of this
+doc said it *multiplied* the two sides. It does not: 33,862 is exactly `min(33,862, 48,559)`. The
+summing is in `scatter_printings`, 82,421 = 33,862 + 48,559.)
+
+| query | mode | estimated `matches` | true total | est/true |
+| --- | --- | --: | --: | --: |
+| `usd>=0.42 usd<=0.43` | printing | 33,862 | **879** | 38.5× |
+| | artwork | 20,411 | **837** | 24.4× |
+| | card | 14,281 | **763** | 18.7× |
+| `cn>=100 cn<=101` | printing | 35,589 | **568** | 62.7× |
+| **`usd>=200`** (control) | printing | 258 | 258 | **1.0×** |
+
+**The control is the whole finding.** A *one-sided* range already estimates at 1.0×, because the leaf
+arm reads `k` off two `partition_point` calls. So nothing here needed a better estimator — the exact
+count was two binary searches away the entire time, and the fold simply never saw the interval. The
+card-side projection is equally cheap: `range_card_counts_for` pairs each range index with an exact
+`RangeCardCounts` table over the same interval, which is why `usd>=0.42`/card reads 12,408 against a
+true 12,408.
+
+Shipped by reusing `fuse_and_range_children` with `sparse_only: false`. The compose builders want the
+fusion at every width, unlike narrowing: `range_leaf_bits` is an O(k) scatter, so one scatter of a
+subset cannot lose to two scatters of its supersets plus an AND, and the estimate is exact rather than
+an upper bound at any width. After: printing mode reads **1.0×**, card and artwork 0.6–0.9× — the same
+ratios their one-sided forms already carry, since those project printings to distinct rows.
+
+**The paging prediction follows for free, which is the part sparse-gather needed.** 879 is under
+`STREAM_MIN_MATCHES`, so `compose_paging_with_total` now predicts `Decline` where it predicted `Perm` —
+matching what the fastpath actually does — and the pick moves off `PrintingCompose` onto the plan that
+was already answering. That removes the blocker named in
+[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md): its `Decline` →
+`Gather` flip regressed routing purely because `compose_paging_for` branches on `result_total`, the
+estimate, and so could not tell a sparse query from a broad one. It can now.
+
+Cumulative over both fusion commits, paired routed dispatch on the same seed and stream:
+
+| | base | + narrowing | + compose |
+| --- | --: | --: | --: |
+| fusible slice (577 queries) | 111.6 ms | 95.9 ms | **90.5 ms (0.81×)** |
+| the untouchable slice | 915.6 ms | 897.6 ms | 925.8 ms (1.01, noise) |
+| regret mean | 1.42 µs | 1.35 µs | **1.30 µs** |
+
+Row identity for this half: 3,120 further cells, aimed at what only the compose builders fuse — broad
+intervals, each composable leaf kind (`border`/`r`/`f`/`set`/`watermark`/`type` and negations), two
+indexes fused inside one compose, unsatisfiable pairs, an `Or` of two fused `And`s. Harness:
+`scratchpad/composerows.py`.
+
 ## What is left
 
-**The compose half has not moved.** `eval_domain` still reads 31,508 on the bare two-sided form, and
-`printing_compose` is still the picked plan for it, because `is_printing_composable` and
-`compose_printing_bits` decompose `And` *before* any range guard — the fusion improves the narrowing
-path only. `compose_printing_estimate` therefore still multiplies the two sides instead of intersecting
-one interval (20,411 against a true 837), and `scatter_printings` still reads 82,421 for an 837-row
-answer. Doing the same fusion in those three functions is the next step, and it is the prerequisite
-[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) is actually blocked
-on: that design's `Decline` → `Gather` flip regressed routing purely because `compose_paging_for`
-branches on `result_total`, the *estimate*, and so cannot tell a sparse query from a broad one.
+**Re-attempt the sparse gather**, now that the sparsity prediction is correct — the order the earlier
+attempt got wrong. Confirm `matches` holds on that population first, then flip `Decline` → `Gather`,
+then re-check regret.
 
-Order: fuse compose's three range paths, confirm `matches` on that population, then re-enable the
-gather behind the now-correct sparsity prediction, then re-check regret. Not before.
+**Watch `printing_compose`'s own slice.** Its share of routed queries went 27% → 31% and its mean
+regret 1.65 → 1.80 µs across this commit, even as the total fell. More queries route there now and the
+model prices them worse; that is the next thing to look at in the acquire, and it is the same cell the
+rarity widening flagged.
 
 **`eur` and `tix` cannot fuse at all**, because `resolve_numeric_range_leaf` covers only `price_usd` and
 `collector_number` (plus `DateCmp`/`YearCmp` reaching `released_at` directly). That is the same root

--- a/docs/issues/patches/local-engine-compose-walk-usd-run-boundary.patch
+++ b/docs/issues/patches/local-engine-compose-walk-usd-run-boundary.patch
@@ -1,0 +1,80 @@
+diff --git a/card_engine/src/lib.rs b/card_engine/src/lib.rs
+index 866aee4..a276df3 100644
+--- a/card_engine/src/lib.rs
++++ b/card_engine/src/lib.rs
+@@ -5044,6 +5044,51 @@ fn range_card_counts_for<'i>(
+     }
+ }
+ 
++/// Entries a `usd` orderby walk scans to fill a page, given how many it would need if it could stop
++/// mid-bucket: the position where the value run containing entry `needed` ends, measured from the walk's
++/// starting end (index start ascending, end descending).
++///
++/// `walk_range_orderby_page` forms one bucket per distinct price and charges the whole value RUN, and
++/// `collect_orderby_page` loops on MATCHES accumulated, so it always finishes a bucket it has begun. The
++/// overshoot is not a rounding detail: measured on a 60-row page it pushed **109** matches at the
++/// production corpus and **545** at 5x, because the run it lands in holds far more than a page.
++///
++/// That overshoot is why `printings_walked` alone cannot price this walk *at all* — not merely
++/// imprecisely. `page_span / match_rate` is corpus-INVARIANT (both terms scale together under
++/// replication) while the run lengths scale, so the feature graded exactly `1/N` against realized work:
++/// 0.88 at 1x, 0.44 at 2x, 0.30 at 3x, 0.23 at 4x, 0.18 at 5x. Rounding to the run boundary is what
++/// restores the scaling, and it reads 1.00 at both 1x and 5x on `border:black` and `usd>0.01`.
++///
++/// Two earlier attempts used a corpus-wide AVERAGE run (19.7 entries here) and both failed — one did not
++/// even bind. The average is the wrong statistic because the walk starts at an END of the value order,
++/// and this corpus's cheap end is far denser than its mean. Landing in the actual run is the fix.
++///
++/// **Fixes scaling, not clumping.** `needed` still divides by the GLOBAL match rate, so a filter whose
++/// matches are denser than average near the walk's start is over-charged (`f:modern`, `r:common`: 4.2x at
++/// 1x) and one whose matches sit at the far end is under-charged badly (`r:mythic`: 0.04 — mythics are
++/// expensive, so the walk grinds 32% of the index for 75 matches). That is the spread
++/// `WALK_LENGTH_BIAS`'s doc already declares no density ratio can see, it is shared with `Perm` through
++/// the same feature, and it is the ceiling on this branch.
++/// docs/issues/local-engine-compose-walk-features.md.
++fn range_walk_run_boundary(idx: &Archived<PrintingRangeIndex>, needed: f64, descending: bool) -> u32 {
++    let n = idx.len();
++    if n == 0 {
++        return 0;
++    }
++    // Clamped before the cast: `needed` is a ratio of estimates and can exceed the index or arrive as a
++    // non-finite value, and a saturating cast would silently pin to `n` rather than say so here.
++    let want = (needed.max(1.0) as usize).min(n);
++    if descending {
++        // The walk starts at the high end, so entry `want` from that end is at `n - want`, and the run
++        // extends DOWN to the first entry sharing its value.
++        let at = u32::from(idx[n - want].0);
++        (n - idx.partition_point(|p| u32::from(p.0) < at)) as u32
++    } else {
++        let at = u32::from(idx[want - 1].0);
++        idx.partition_point(|p| u32::from(p.0) <= at) as u32
++    }
++}
++
+ /// Bare bounds for a printing-range-indexed comparison — `usd`/`cn`/`date`/`year` — and, since
+ /// `NOT(x op c) == x negate_op(op) c` is exact under this engine's null semantics (`negate_op`'s own
+ /// doc: verified against `tri()`'s actual `NumVal::Null` short-circuit, the same guarantee
+@@ -8700,10 +8745,19 @@ fn acquire_plan_features(
+         feats.project_printings = project as u32;
+         feats.popcount_words = popcount_words as u32;
+         feats.compose_scan_printings = (printing_matches as f64 * COMPOSE_GATHER_SPAN_PER_MATCH) as u32;
+-        // A rarity orderby walk pays a whole one-hot plane per bucket, so its floor is the corpus
+-        // however selective the filter is. `usd` walks small value runs instead and keeps the shared
+-        // page-fill term. See `PlanFeatures::orderby_walk_scan`.
+-        feats.orderby_walk_scan = if matches!(sort_col, SortCol::Rarity) { n_printings } else { 0 };
++        // Both orderby walks collect WHOLE value buckets, so both have a granularity floor the shared
++        // page-fill term cannot express. `orderby_walk_scan` is that floor and the arm takes
++        // `max(printings_walked, orderby_walk_scan)`.
++        //
++        // Rarity's bucket is a one-hot plane, so its floor is the whole corpus however selective the
++        // filter is. `usd`'s bucket is one distinct price and `walk_range_orderby_page` reports the value
++        // RUN LENGTH as its cost, so its floor is where the run containing the last needed entry ends —
++        // see `range_walk_run_boundary`, which is exact and one binary search.
++        feats.orderby_walk_scan = match sort_col {
++            SortCol::Rarity => n_printings,
++            SortCol::PriceUsd => range_walk_run_boundary(&indexes.price_usd, cost::printings_walked(&feats), descending),
++            _ => 0,
++        };
+         // The gather's grouping arm runs for artwork always, and for card only under a non-default
+         // prefer -- card/default takes the early-break arm and never groups. Printing mode gets 0
+         // because its push term already rides the printing count. Driven by the PRE-dedup printing

--- a/scripts/bench_regret_matrix.py
+++ b/scripts/bench_regret_matrix.py
@@ -152,6 +152,14 @@ def collect(engine: object, sampler: QuerySampler, rng: random.Random, seconds: 
                 "lost": (baseline_ns - selves[id(best)]) / 1000.0,
                 "acquire": sample.acquire["count_source"],
                 "unique": sample.kw["unique"],
+                # Which paging branch a compose-acquired query would take. The compose arm's terms are
+                # SHARED across its three branches while their errors are not -- Gather is a flat level
+                # error, Perm drifts one way with corpus size and OrderbyWalk the other -- so a compose
+                # change gated on the `acquire` total alone can improve one branch and regress another
+                # invisibly. That is not hypothetical: the build term measured fine on the total and
+                # would have taken Perm from 1.19 to 1.54 had it been charged there.
+                # `-` for every other acquire, which keeps the slice readable rather than dropping rows.
+                "paging": sample.acquire.get("compose_paging") or "-",
                 "picked": f"{picked['plan']}{'(declined)' if declined else ''}" if picked else "?",
                 "best": best["plan"],
             }
@@ -209,6 +217,15 @@ def main() -> None:
     table(rows, lambda r: r["acquire"], "acquire")
     table(rows, lambda r: r["unique"], "unique")
     table(rows, lambda r: f"{r['acquire']} / {r['unique']}", "acquire / unique")
+    table(
+        [r for r in rows if r["paging"] != "-"],
+        lambda r: r["paging"],
+        # Not only compose-ACQUIRED rows: the range acquires call `compose_paging_for` too, because
+        # compose is a competitor whose cost they have to price. That is the right population -- it is
+        # every row where the branch decided a compose cost -- but it is wider than the `acquire` table's
+        # `printing_compose` line, so the two n's do not match and should not be expected to.
+        "compose paging branch (every row where a compose cost was priced)",
+    )
     table(rows, lambda r: f"{r['picked']} -> {r['best']}", "picked -> best (only when they differ)")
     print("\n  SHARE is the fraction of ALL lost time, which is what ranks the work: frequency times")
     print("  severity. miss% counts queries losing more than 1µs. Regret is mostly zeros, so no median.")

--- a/scripts/fit_cost_model.py
+++ b/scripts/fit_cost_model.py
@@ -113,7 +113,10 @@ CURRENT: dict[str, list[float]] = {
     # GATHER_GROUP_PER_PRINTING sits between the bit-test and push columns, matching design_row.
     # Added when the artwork tail was traced to the grouping arm's work being charged at the bit-test
     # rate; its 1.5 start is a physical guess (a struct read plus prefer_score), meant to be fitted.
-    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 13.22, 0.38, 1.5, 3.39, 163.56],
+    # BUILD_PER_PRINTING (second to last) is the full-width bitmap build, Gather-arm only: it was
+    # measured directly over a 10x corpus axis rather than fitted here, so a pooled fit disagreeing
+    # with 0.0835 is a signal to re-examine, not to paste.
+    "PrintingCompose": [1.93, 0.48, 1.93, 1.07, 0.58, 2.19, 13.22, 0.38, 1.5, 3.39, 0.0835, 163.56],
 }
 
 
@@ -309,6 +312,10 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 float(acq["compose_scan_printings"]) if gather else 0.0,
                 float(acq.get("gather_group_printings", 0)) if gather else 0.0,
                 matches if gather else 0.0,
+                # The full-width printing-bitmap build, charged on the Gather arm only -- Perm and
+                # OrderbyWalk had their rates fitted with it already absorbed. See
+                # `COMPOSE_BUILD_PER_PRINTING_NS` in cost.rs for why it is scoped rather than shared.
+                float(acq["n_printings"]) if gather else 0.0,
                 1.0,
             ],
             [
@@ -322,6 +329,7 @@ def design_row(plan: str, acq: dict, limit: int, offset: int) -> tuple[list[floa
                 "GATHER_BITTEST_PER_PRINTING",
                 "GATHER_GROUP_PER_PRINTING",
                 "GATHER_PUSH_PER_MATCH",
+                "BUILD_PER_PRINTING",
                 "FIXED",
             ],
             0.0,  # no residual-floor term in this arm, so nothing comes off the target


### PR DESCRIPTION
**Layer 5 of 13.** Base: #836. Reference: #830. Clippy-clean as replayed.

`narrow_rec` narrows an `And`'s children independently and intersects the *results*, never the bounds —
so a two-sided range was invisible to it. `usd>=0.42 usd<=0.43` folded to `min(33,862, 48,559)` against a
true 879, and the summed scatter to 82,421 printings for an 879-row answer. Measured at 1,146.8 µs against
26.7 µs for the one-sided `usd>=200`, which returns *more* rows.

Fusing same-index children into one interval first puts the two-sided form on the same sparse path the
one-sided form already took — in narrowing, and separately in compose's builders, which had the same
blind spot.

Also: compose accepts any rarity comparison, not only equality.

Under `sparse_only` the fusion is gated to intervals that are actually sparse, which is a scope decision
rather than a measured win — the paired traffic puts fused-vs-gated at 0.88 against 0.86 and the noise
floor on that slice is ±170 µs. What the gate buys is a bound: outside the population where the win is
demonstrated (up to 1.3 ms/query) it is a provable no-op. That gate is revisited in layer 13.

## Verification

`cargo test` and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
No archived type changes.
