### PR TITLE
Engine: frame_data Becomes a Hybrid Index (stack 8/13)

### DIFF
--- a/benchmarks
+++ b/benchmarks
@@ -1,0 +1,1 @@
+/Users/joseph.bylund/scratch/sylvan_librarian/benchmarks

--- a/benchmarks
+++ b/benchmarks
@@ -1,1 +1,0 @@
-/Users/joseph.bylund/scratch/sylvan_librarian/benchmarks

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -418,13 +418,20 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
 
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } => {
             // Mirror narrow_rec's field dispatch (lib.rs:3040-3047).
+            // frame_data is the hybrid index: the count comes from `len_of` (a popcount for a bitmap)
+            // and absence proves emptiness. Mirrors narrow_rec's branch so the estimate describes the
+            // path that will actually run.
+            if matches!(field, CollField::FrameData) {
+                let cnt = indexes.frame_data.len_of(value.as_str()).unwrap_or(0) as u32;
+                return project(cnt, n_cards, n_printings);
+            }
             let (idx, card_space, complete) = match field {
                 CollField::Subtypes => (&indexes.subtypes, true, true),
                 CollField::Keywords => (&indexes.keywords, true, true),
                 CollField::OracleTags => (&indexes.oracle_tags, true, true),
                 CollField::ArtTags => (&indexes.art_tags, false, true),
                 CollField::IsTags => (&indexes.is_tags, false, true),
-                CollField::FrameData => (&indexes.frame_data, false, false),
+                CollField::FrameData => unreachable!("handled above"),
             };
             match idx.get(value.as_str()) {
                 Some(v) => {

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -417,23 +417,35 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
         },
 
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } => {
-            // Mirror narrow_rec's field dispatch. frame_data is the hybrid index (bitmap for dense
-            // values, postings for the tail), so its count comes from `len_of` -- a popcount when the
-            // value is a bitmap -- rather than a postings length. Every index is `complete` now: nothing
-            // is dropped at build, so absence proves the value matches nothing.
-            let count = match field {
-                CollField::FrameData => (indexes.frame_data.len_of(value.as_str()), false),
-                CollField::Subtypes => (indexes.subtypes.get(value.as_str()).map(|v| v.len()), true),
-                CollField::Keywords => (indexes.keywords.get(value.as_str()).map(|v| v.len()), true),
-                CollField::OracleTags => (indexes.oracle_tags.get(value.as_str()).map(|v| v.len()), true),
-                CollField::ArtTags => (indexes.art_tags.get(value.as_str()).map(|v| v.len()), false),
-                CollField::IsTags => (indexes.is_tags.get(value.as_str()).map(|v| v.len()), false),
+            // Mirror narrow_rec's field dispatch (lib.rs:3040-3047).
+            let (idx, card_space, complete) = match field {
+                CollField::Subtypes => (&indexes.subtypes, true, true),
+                CollField::Keywords => (&indexes.keywords, true, true),
+                CollField::OracleTags => (&indexes.oracle_tags, true, true),
+                CollField::ArtTags => (&indexes.art_tags, false, true),
+                CollField::IsTags => (&indexes.is_tags, false, true),
+                CollField::FrameData => (&indexes.frame_data, false, false),
             };
-            let (cnt, card_space) = (count.0.unwrap_or(0) as u32, count.1);
-            if card_space {
-                exact(cnt)
-            } else {
-                project(cnt, n_cards, n_printings)
+            match idx.get(value.as_str()) {
+                Some(v) => {
+                    let cnt = v.len() as u32;
+                    if card_space {
+                        exact(cnt)
+                    } else {
+                        project(cnt, n_cards, n_printings)
+                    }
+                }
+                None if complete => {
+                    // Absent from a complete index ⇒ matches nothing.
+                    if card_space {
+                        exact(0)
+                    } else {
+                        project(0, n_cards, n_printings)
+                    }
+                }
+                // frame_data drops dense values at build (#628), so absence
+                // proves nothing → unknown.
+                None => unknown(n),
             }
         }
         FilterExpr::CollectionCmp { .. } => unknown(n),

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -417,35 +417,23 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
         },
 
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } => {
-            // Mirror narrow_rec's field dispatch (lib.rs:3040-3047).
-            let (idx, card_space, complete) = match field {
-                CollField::Subtypes => (&indexes.subtypes, true, true),
-                CollField::Keywords => (&indexes.keywords, true, true),
-                CollField::OracleTags => (&indexes.oracle_tags, true, true),
-                CollField::ArtTags => (&indexes.art_tags, false, true),
-                CollField::IsTags => (&indexes.is_tags, false, true),
-                CollField::FrameData => (&indexes.frame_data, false, false),
+            // Mirror narrow_rec's field dispatch. frame_data is the hybrid index (bitmap for dense
+            // values, postings for the tail), so its count comes from `len_of` -- a popcount when the
+            // value is a bitmap -- rather than a postings length. Every index is `complete` now: nothing
+            // is dropped at build, so absence proves the value matches nothing.
+            let count = match field {
+                CollField::FrameData => (indexes.frame_data.len_of(value.as_str()), false),
+                CollField::Subtypes => (indexes.subtypes.get(value.as_str()).map(|v| v.len()), true),
+                CollField::Keywords => (indexes.keywords.get(value.as_str()).map(|v| v.len()), true),
+                CollField::OracleTags => (indexes.oracle_tags.get(value.as_str()).map(|v| v.len()), true),
+                CollField::ArtTags => (indexes.art_tags.get(value.as_str()).map(|v| v.len()), false),
+                CollField::IsTags => (indexes.is_tags.get(value.as_str()).map(|v| v.len()), false),
             };
-            match idx.get(value.as_str()) {
-                Some(v) => {
-                    let cnt = v.len() as u32;
-                    if card_space {
-                        exact(cnt)
-                    } else {
-                        project(cnt, n_cards, n_printings)
-                    }
-                }
-                None if complete => {
-                    // Absent from a complete index ⇒ matches nothing.
-                    if card_space {
-                        exact(0)
-                    } else {
-                        project(0, n_cards, n_printings)
-                    }
-                }
-                // frame_data drops dense values at build (#628), so absence
-                // proves nothing → unknown.
-                None => unknown(n),
+            let (cnt, card_space) = (count.0.unwrap_or(0) as u32, count.1);
+            if card_space {
+                exact(cnt)
+            } else {
+                project(cnt, n_cards, n_printings)
             }
         }
         FilterExpr::CollectionCmp { .. } => unknown(n),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3492,6 +3492,35 @@ fn probe_range_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Option
     Some(e - s)
 }
 
+/// The exact match count of a containment collection child, read from its index without materializing
+/// anything — the collection analogue of [`probe_range_k`], and it exists for the same reason: the And
+/// arm's skip decision is a COST comparison, and it can only be made for children whose size is known
+/// cheaply.
+///
+/// `None` when there is nothing to probe: a non-containment op, or a value absent from the index. Both
+/// keep the caller on its previous behaviour — an absent value in a complete index narrows to the empty
+/// set, which is the best driver there is and must never be skipped.
+///
+/// Card-space fields count CARDS and printing-space fields count PRINTINGS, which is the same space
+/// mismatch `probe_range_k` already lives with when its `k` is compared against `best`. It biases
+/// toward skipping a printing-space child (printings outnumber cards ~3:1), and skipping is the safe
+/// direction for a child that cannot become the driver anyway.
+fn probe_collection_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> Option<usize> {
+    let FilterExpr::CollectionCmp { field, op, value, .. } = filter else { return None };
+    if !matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) {
+        return None;
+    }
+    let idx = match field {
+        CollField::Subtypes => &indexes.subtypes,
+        CollField::Keywords => &indexes.keywords,
+        CollField::OracleTags => &indexes.oracle_tags,
+        CollField::ArtTags => &indexes.art_tags,
+        CollField::IsTags => &indexes.is_tags,
+        CollField::FrameData => &indexes.frame_data,
+    };
+    idx.get(value.as_str()).map(|v| v.len())
+}
+
 /// One entry in the And arm's work list: a child exactly as written, or a half-open interval fused
 /// from two or more same-index range children.
 ///
@@ -4169,20 +4198,29 @@ fn narrow_rec(
             // Same-index range children fuse into one interval first (`fuse_and_range_children`),
             // because two individually-broad halves can intersect to something sparse and this arm
             // only ever intersects narrowing *results*, never the bounds.
-            let mut ranked: Vec<(u8, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes, true)
+            // `sort_k` orders within a rank; `size_k` is the cost-comparison input for the skip below.
+            // They are separate because collection children only just gained a probe: feeding it into
+            // the sort as well would reorder rank-0 children in the same change that starts skipping
+            // them, and the two effects could not then be attributed.
+            let mut ranked: Vec<(u8, Option<usize>, Option<usize>, AndSource)> = fuse_and_range_children(children, indexes, true)
                 .into_iter()
                 .map(|src| match src {
                     AndSource::Child(c) => {
                         let rank = and_child_rank(c, indexes);
-                        let probe = if rank == 1 { probe_range_k(c, indexes) } else { None };
-                        (rank, probe, AndSource::Child(c))
+                        let sort_k = if rank == 1 { probe_range_k(c, indexes) } else { None };
+                        // A rank-0 child is assumed CHEAP to materialize, and for a plane or a short
+                        // posting list it is. A containment collection can be enormous (`is:spell` is
+                        // ~60k printing ids), and `frame_data`'s dense values more so, so probe it and
+                        // let the same cost rule apply.
+                        let size_k = sort_k.or_else(|| probe_collection_k(c, indexes));
+                        (rank, sort_k, size_k, AndSource::Child(c))
                     }
                     // A fused interval is a printing range like any other — rank 1, and its probe is
                     // the `k` its own broad-check already computed.
-                    AndSource::FusedRange { k, .. } => (1, Some(k), src),
+                    AndSource::FusedRange { k, .. } => (1, Some(k), Some(k), src),
                 })
                 .collect();
-            ranked.sort_by_key(|(r, probe, _)| (*r, probe.unwrap_or(usize::MAX)));
+            ranked.sort_by_key(|(r, sort_k, _, _)| (*r, sort_k.unwrap_or(usize::MAX)));
             let mut card_sets: Vec<Narrowed> = Vec::new();
             let mut printing_sets: Vec<Narrowed> = Vec::new();
             // Tightness of the And requires every child to be represented in
@@ -4194,7 +4232,7 @@ fn narrow_rec(
             // per child meant popcounting every accumulated bitmap again on every
             // iteration — O(children² × words) for a value that only ever shrinks.
             let mut best: Option<usize> = None;
-            for (rank, probe, src) in ranked {
+            for (rank, _sort_k, size_k, src) in ranked {
                 // A driver this selective already bounds the candidate set the
                 // residual re-verifies, so a costlier (rank>0) child usually
                 // narrows nothing the driver's verification doesn't already do
@@ -4206,8 +4244,18 @@ fn narrow_rec(
                 // is always sparse under a selective driver, so it only ever
                 // takes range_narrowed's cheap vec path. `continue`, not
                 // `break`: a later, smaller-k range child may still qualify.
-                if let Some(b) = best.filter(|&b| rank > 0 && b <= *AND_SKIP_THRESHOLD)
-                    && !probe.is_some_and(|k| k < b || k <= *AND_PROBE_FLOOR)
+                //
+                // The `rank > 0` this used to carry has become "we know what the child costs": a
+                // probed child is judged on its real `k` at ANY rank, because the decision is a cost
+                // comparison and rank is only a proxy for cost. A rank-0 child whose `k` exceeds the
+                // driver would be materialized and intersected — O(k) — purely to filter a set already
+                // smaller than itself, which is the shape `broad_ok` was introduced to prevent and
+                // which rank-0 children were never checked against. An UNPROBED rank-0 child keeps its
+                // benefit of the doubt, so planes and short postings behave exactly as before.
+                let unprobed_cheap = rank == 0 && size_k.is_none();
+                if let Some(b) = best.filter(|&b| b <= *AND_SKIP_THRESHOLD)
+                    && !unprobed_cheap
+                    && !size_k.is_some_and(|k| k < b || k <= *AND_PROBE_FLOOR)
                 {
                     every_child_included = false;
                     continue;
@@ -6471,14 +6519,6 @@ fn exact_card_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, n_ca
     None
 }
 
-/// The size of the query's RESULT space: every printing, card, or artwork in the store.
-fn compose_result_domain(mode: Mode, n_cards: usize, indexes: &Archived<CardIndexes>) -> usize {
-    match mode {
-        Mode::Printing => indexes.printing_to_card.len(),
-        Mode::Card => n_cards,
-        Mode::Artwork => u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize,
-    }
-}
 
 /// Whether composing `filter` needs a card-space plane BROADCAST down into printing space -- today,
 /// exactly a legality leaf (`repair_divergent_printings` / `broadcast_card_bits_to_printings`). Purely

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10267,13 +10267,12 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-// Stack layer 06: the three printing-range indexes changed shape from `Vec<(value, pid)>` to the
-// value-major `PrintingValueIndex`, a fourth of the same type was added for the rarity orderby walk,
-// and `price_eur`/`price_tix` gained indexes plus card-count tables. All archived-layout changes, so a
-// store built under the previous layer must fail the header check and be rebuilt rather than be read
-// as garbage. Numbered by stack patch rather than by date: the header check is EQUALITY, so the only
-// invariant is that a value is never reused for a different layout.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026080506;
+// Stack layer 08: `frame_data` becomes a `HybridTagIndex` -- a printing bitmap for the dense values,
+// postings for the sparse tail -- which is an archived-layout change, so a store built against the
+// previous layer must fail the header check and be rebuilt rather than be read as garbage.
+// Numbered by stack patch; the header check is EQUALITY, so the invariant is only that a value is
+// never reused for a different layout.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026080508;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1688,17 +1688,80 @@ struct ArtistIndex {
     printings: Vec<u32>,
 }
 
-/// build_tag_index with the printing-space selectivity threshold applied at
-/// build time: values whose posting would be declined by the range guard
-/// anyway (frame:2015 covers 66% of printings) are simply not stored — the
-/// absent-key convention already means "no narrowing", so dropped and unknown
-/// values both fall back to the scan. Third application of the threshold
-/// after the range guard (#609) and rarity's union ceiling (#618).
-fn build_thresholded_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> TagIndex {
-    let mut idx = build_tag_index(rows, vocab, get_ids);
+/// A printing-space collection index that stores each value in whichever representation is CHEAPER: a
+/// bitmap for dense values, postings for the sparse tail. The same plane/postings split
+/// `BorderPrintingPlanes` and `RarityPrintingPlanes` already use, which `frame_data` never got.
+///
+/// This replaces `build_thresholded_tag_index`, which DROPPED any value past
+/// `range_too_broad_to_narrow` because "the absent-key convention already means no narrowing, so
+/// dropped and unknown values both fall back to the scan". That reasoning expired twice over: #636
+/// taught the consumer to scatter a broad list into a bitmap rather than decline, and the drop cost
+/// three things where only the first was intended.
+///
+/// 1. `frame:2015` could not narrow at all — a full 31,508-card scan, ~600 µs.
+/// 2. The index was not `complete`, so an unknown frame value could not narrow to provably-empty.
+/// 3. `collection_compose_index` excluded `FrameData` outright *for that reason*, keeping every frame
+///    query off `PrintingCompose` — the path that pages `border:black` in 26 µs.
+///
+/// Storing every value makes the index complete, which is what unlocks (2) and (3). And the guard was
+/// inverted rather than merely stale: of the 29 `frame_data` values, it dropped the ONE where a bitmap
+/// wins by the largest margin (`2015`, 250.5 KB of postings against 11.9 KB of bitmap) while keeping as
+/// postings six more that would also be smaller as bitmaps. Per-value cheaper-of-the-two is 111 KB
+/// against the 240 KB stored before, so this is smaller AND faster, not a trade.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct HybridTagIndex {
+    /// Values above the density crossover: one printing-space bitmap each, ready to use with no scatter.
+    dense: HashMap<String, Vec<u64>>,
+    /// Everything below it: sorted printing ids, exactly as `TagIndex`.
+    ///
+    /// A sparse value can never be "broad" downstream: the crossover is 1/32 (3.1%) and
+    /// `range_too_broad_to_narrow` fires at 25%, so anything landing here is far under that guard.
+    sparse: TagIndex,
+}
+
+/// A stored bitmap is smaller than a posting list once `4 * k > n / 8` bytes, i.e. `k * 32 > n` —
+/// density above 1/32. Integer arithmetic so the boundary is exact.
+fn bitmap_beats_postings(k: usize, n_rows: usize) -> bool {
+    k.saturating_mul(32) > n_rows
+}
+
+fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> HybridTagIndex {
     let n = rows.len();
-    idx.retain(|_, postings| !range_too_broad_to_narrow(postings.len(), n));
-    idx
+    let mut out = HybridTagIndex::default();
+    for (value, postings) in build_tag_index(rows, vocab, get_ids) {
+        if bitmap_beats_postings(postings.len(), n) {
+            out.dense.insert(value, scatter_bits(postings, n));
+        } else {
+            out.sparse.insert(value, postings);
+        }
+    }
+    out
+}
+
+impl ArchivedHybridTagIndex {
+    /// Whether this value is stored as a bitmap, i.e. whether `bits` costs a copy rather than a scatter.
+    fn is_dense(&self, value: &str) -> bool {
+        self.dense.get(value).is_some()
+    }
+
+    /// The value's printing-space bitmap, materialized from postings if that is how it is stored.
+    /// `None` only when the value is absent from the store entirely — nothing is dropped, so that is a
+    /// proof rather than a gap.
+    fn bits(&self, value: &str, n_printings: usize) -> Option<Vec<u64>> {
+        if let Some(b) = self.dense.get(value) {
+            return Some(b.iter().map(|w| u64::from(*w)).collect());
+        }
+        self.sparse.get(value).map(|v| scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings))
+    }
+
+    /// Printings carrying this value, for the estimator and for the sparse narrowing path. Counts
+    /// without materializing when the value is a bitmap.
+    fn len_of(&self, value: &str) -> Option<usize> {
+        if let Some(b) = self.dense.get(value) {
+            return Some(b.iter().map(|w| u64::from(*w).count_ones() as usize).sum());
+        }
+        self.sparse.get(value).map(|v| v.len())
+    }
 }
 
 fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
@@ -2840,7 +2903,7 @@ struct CardIndexes {
     oracle_tags:    TagIndex,        // card space
     art_tags:       TagIndex,        // printing space
     is_tags:        TagIndex,        // printing space
-    frame_data:     TagIndex,        // printing space (selectivity-thresholded)
+    frame_data:     HybridTagIndex,  // printing space (bitmap for dense values, postings for the tail)
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
@@ -4023,23 +4086,43 @@ fn narrow_rec(
         // condition is needed. (#700; Le/Lt/Ne genuinely can't reuse this —
         // they're not expressible as `contains` plus a length check.)
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) => {
-            // `complete` marks indexes that post every occurrence of every
-            // value — all of them except frame_data, whose dense values are
-            // deliberately dropped at build (#628), so absence proves nothing
-            // there.
-            let (idx, card_space, complete) = match field {
-                CollField::Subtypes   => (&indexes.subtypes,    true,  true),
-                CollField::Keywords   => (&indexes.keywords,    true,  true),
-                CollField::OracleTags => (&indexes.oracle_tags, true,  true),
-                CollField::ArtTags    => (&indexes.art_tags,    false, true),
-                CollField::IsTags     => (&indexes.is_tags,     false, true),
-                CollField::FrameData  => (&indexes.frame_data,  false, false),
-            };
             // Ge's postings are exact for Ge itself; for Eq/Gt they're only a
             // loose superset (they prove `contains(value)` but not the length
             // condition), so the residual `matches()` check the driver always
             // runs is load-bearing for those two ops.
             let mk = |set| if matches!(op, CmpOp::Ge) { Narrowed::tight(set) } else { Narrowed::loose(set) };
+            // frame_data is the one HYBRID index: dense values are stored as printing bitmaps and the
+            // sparse tail as postings (see `HybridTagIndex`). Handled before the postings-only table
+            // below because a dense hit needs no scatter at all.
+            if matches!(field, CollField::FrameData) {
+                let idx = &indexes.frame_data;
+                if idx.is_dense(value.as_str()) {
+                    // `broad_ok` exists to refuse PAYING to materialize a broad set -- "the scatter
+                    // would be pure waste". A stored bitmap is already materialized, so that premise
+                    // does not hold and the gate does not apply: this costs an 11.9 KB copy against the
+                    // ~600 us full scan it replaces. Requiring `broad_ok` here is what kept a lone
+                    // `frame:2015` on the scan path even once the bitmap existed.
+                    let bits = idx.bits(value.as_str(), n_printings)?;
+                    return mk(Candidates::PrintingBits(bits));
+                }
+                // Sparse values cannot be broad -- the storage crossover is 1/32 and the broadness
+                // guard fires at 1/4 -- so the postings go straight through with no guard.
+                return match idx.sparse.get(value.as_str()) {
+                    None => Narrowed::tight(Candidates::Printings(Vec::new())),
+                    Some(v) => mk(Candidates::Printings(v.iter().map(|x| u32::from(*x)).collect())),
+                };
+            }
+            // Every remaining index posts every occurrence of every value, so absence is a proof. That
+            // is now true of `frame_data` too, handled above -- it was the sole exception only because
+            // its dense values were dropped at build.
+            let (idx, card_space) = match field {
+                CollField::Subtypes   => (&indexes.subtypes,    true),
+                CollField::Keywords   => (&indexes.keywords,    true),
+                CollField::OracleTags => (&indexes.oracle_tags, true),
+                CollField::ArtTags    => (&indexes.art_tags,    false),
+                CollField::IsTags     => (&indexes.is_tags,     false),
+                CollField::FrameData  => unreachable!("frame_data is the hybrid index, handled above"),
+            };
             match idx.get(value.as_str()) {
                 // A value with no postings in a complete index proves
                 // `contains(value)` false for every row, which makes Ge, Eq,
@@ -4047,10 +4130,9 @@ fn narrow_rec(
                 // them without first satisfying containment. Exact for all
                 // three ops, not just Ge: `is:permanent` spent 0.6 ms
                 // full-scanning to return zero results.
-                None if complete => {
+                None => {
                     Narrowed::tight(if card_space { Candidates::Cards(Vec::new()) } else { Candidates::Printings(Vec::new()) })
                 }
-                None => None,
                 Some(v) => {
                     // Broad printing-space postings pay the same gather cost
                     // the range indexes guard against (is:spell is ~60k ids);
@@ -5732,23 +5814,34 @@ fn broadcast_card_ids_to_printings(card_ids: impl Iterator<Item = u32>, offsets:
     pbits
 }
 
-/// Maps a `CollectionCmp` field to its compose backing: the postings index and whether it is
-/// **card-space** (postings are card ids → project each card's printing range up with
-/// `broadcast_card_ids_to_printings`) or **printing-space** (postings are printing ids → scatter
-/// directly, like `set:`/`watermark:`). Returns `None` for `FrameData` — the only non-`complete`
-/// collection index (its dense values are dropped at build, #628, so absence proves nothing there and
-/// it cannot be an exact compose leaf); it stays on the general path. This is the single source of
-/// truth `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their
-/// field tables can't drift apart.
-fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<(&Archived<TagIndex>, bool)> {
-    match field {
-        CollField::Subtypes   => Some((&indexes.subtypes,    true)),
-        CollField::Keywords   => Some((&indexes.keywords,    true)),
-        CollField::OracleTags => Some((&indexes.oracle_tags, true)),
-        CollField::ArtTags    => Some((&indexes.art_tags,    false)),
-        CollField::IsTags     => Some((&indexes.is_tags,     false)),
-        CollField::FrameData  => None,
-    }
+/// Which structure backs a `CollectionCmp` field on the compose path.
+enum CollComposeSource<'i> {
+    /// Postings. `true` = card-space ids (project each card's printing range up with
+    /// `broadcast_card_ids_to_printings`), `false` = printing ids (scatter directly, like
+    /// `set:`/`watermark:`).
+    Postings(&'i Archived<TagIndex>, bool),
+    /// The one hybrid printing-space index: a stored bitmap for dense values, postings for the tail.
+    Hybrid(&'i Archived<HybridTagIndex>),
+}
+
+/// Maps a `CollectionCmp` field to its compose backing. The single source of truth
+/// `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their field
+/// tables can't drift apart.
+///
+/// **Every field is composable now.** `FrameData` used to return `None` here, as the only non-`complete`
+/// collection index — its dense values were dropped at build, so absence proved nothing and it could not
+/// be an exact compose leaf. `HybridTagIndex` stores those values as bitmaps instead, which makes the
+/// index complete and puts frame queries on this path. The `Option` stays because the callers read it as
+/// "is this composable", and a future non-complete field would want it.
+fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<CollComposeSource<'_>> {
+    Some(match field {
+        CollField::Subtypes   => CollComposeSource::Postings(&indexes.subtypes,    true),
+        CollField::Keywords   => CollComposeSource::Postings(&indexes.keywords,    true),
+        CollField::OracleTags => CollComposeSource::Postings(&indexes.oracle_tags, true),
+        CollField::ArtTags    => CollComposeSource::Postings(&indexes.art_tags,    false),
+        CollField::IsTags     => CollComposeSource::Postings(&indexes.is_tags,     false),
+        CollField::FrameData  => CollComposeSource::Hybrid(&indexes.frame_data),
+    })
 }
 
 /// The exact printing-space bitmap for a bare containment collection leaf (`type:`/`kw:`/`otag:`/
@@ -5761,11 +5854,17 @@ fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -
 /// are tight for `Ge`, but only a loose superset for `Eq`/`Gt` (they prove `contains(value)`, not the
 /// collection-length condition, ~lib.rs:3441), and the compose path has no residual re-check, so
 /// `Eq`/`Gt` stay on the general path.
-fn collection_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    match idx.get(value) {
-        None => vec![0u64; words_per_plane(n_printings)],
-        Some(v) if card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
-        Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
+fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    match src {
+        // Dense values are already a printing bitmap, so this is a copy rather than a scatter.
+        CollComposeSource::Hybrid(idx) => {
+            idx.bits(value, n_printings).unwrap_or_else(|| vec![0u64; words_per_plane(n_printings)])
+        }
+        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
+            None => vec![0u64; words_per_plane(n_printings)],
+            Some(v) if *card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
+            Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
+        },
     }
 }
 
@@ -5774,17 +5873,21 @@ fn collection_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool,
 /// space: the postings length (one posting = one printing). Exact (a valid upper bound and then some),
 /// so the estimate for a bare collection leaf is exact, matching set/watermark. O(card postings) — the
 /// same order as the eventual scatter, cheap for the sparse subtype/keyword/oracle-tag posting lists.
-fn collection_leaf_printing_count(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets) -> usize {
-    match idx.get(value) {
-        None => 0,
-        Some(v) if card_space => v
-            .iter()
-            .map(|c| {
-                let c = u32::from(*c) as usize;
-                (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
-            })
-            .sum(),
-        Some(v) => v.len(),
+fn collection_leaf_printing_count(src: &CollComposeSource, value: &str, offsets: &AOffsets) -> usize {
+    match src {
+        // A popcount when the value is a bitmap; a postings length otherwise.
+        CollComposeSource::Hybrid(idx) => idx.len_of(value).unwrap_or(0),
+        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
+            None => 0,
+            Some(v) if *card_space => v
+                .iter()
+                .map(|c| {
+                    let c = u32::from(*c) as usize;
+                    (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
+                })
+                .sum(),
+            Some(v) => v.len(),
+        },
     }
 }
 
@@ -5795,8 +5898,8 @@ fn collection_leaf_printing_count(idx: &Archived<TagIndex>, value: &str, card_sp
 /// the (exact, `Ge`) positive set is precisely the negated match set, with no trivalent-NULL printing
 /// wrongly swept in. Ge only, same reason as the positive leaf (a loose positive set would give a
 /// loose complement).
-fn collection_negated_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    let mut bits = collection_leaf_bits(idx, value, card_space, offsets, n_printings);
+fn collection_negated_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    let mut bits = collection_leaf_bits(src, value, offsets, n_printings);
     complement_bits(&mut bits, n_printings);
     bits
 }
@@ -5970,8 +6073,8 @@ fn compose_printing_bits(
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
-            collection_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
+            let src = collection_compose_index(indexes, *field).expect("guarded by the if");
+            collection_leaf_bits(&src, value.as_str(), offsets, n_printings)
         }
         // Negated collection leaf — the exact complement of the positive leaf.
         FilterExpr::Not(inner)
@@ -5980,8 +6083,8 @@ fn compose_printing_bits(
             let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
                 unreachable!("guarded by the matches! above")
             };
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
-            collection_negated_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
+            let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            collection_negated_leaf_bits(&src, value.as_str(), offsets, n_printings)
         }
         // `flip_op` on the const-first form so `2<=rarity` and `rarity>=2` build the same bitmap.
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
@@ -6073,8 +6176,8 @@ fn compose_printing_estimate(
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
-            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
+            let src = collection_compose_index(indexes, *field).expect("guarded by the if");
+            let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
             (k, 0, k)
         }
         // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
@@ -6085,8 +6188,8 @@ fn compose_printing_estimate(
             let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
                 unreachable!("guarded by the matches! above")
             };
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
-            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
+            let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
             (n_printings.saturating_sub(k), 0, k)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
@@ -6471,17 +6574,6 @@ fn exact_card_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, n_ca
     None
 }
 
-/// The size of the query's RESULT space: every printing, card, or artwork in the store.
-// Not called yet at this layer -- the compose acquire starts reading it when the exact three-space
-// totals land, and it is deleted again once `ComposeEstimate` carries the domain explicitly.
-#[allow(dead_code)]
-fn compose_result_domain(mode: Mode, n_cards: usize, indexes: &Archived<CardIndexes>) -> usize {
-    match mode {
-        Mode::Printing => indexes.printing_to_card.len(),
-        Mode::Card => n_cards,
-        Mode::Artwork => u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize,
-    }
-}
 
 /// Whether composing `filter` needs a card-space plane BROADCAST down into printing space -- today,
 /// exactly a legality leaf (`repair_divergent_printings` / `broadcast_card_bits_to_printings`). Purely
@@ -10665,7 +10757,7 @@ impl QueryEngine {
             oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
             art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
-            frame_data:     build_thresholded_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
+            frame_data:     build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
             artists:        build_artist_index(&printings, artist_vocab.len()),
             flavor:         build_flavor_index(&printings, &strings),
             set_codes:      {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1688,17 +1688,85 @@ struct ArtistIndex {
     printings: Vec<u32>,
 }
 
-/// build_tag_index with the printing-space selectivity threshold applied at
-/// build time: values whose posting would be declined by the range guard
-/// anyway (frame:2015 covers 66% of printings) are simply not stored — the
-/// absent-key convention already means "no narrowing", so dropped and unknown
-/// values both fall back to the scan. Third application of the threshold
-/// after the range guard (#609) and rarity's union ceiling (#618).
-fn build_thresholded_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> TagIndex {
-    let mut idx = build_tag_index(rows, vocab, get_ids);
+
+/// A printing-space collection index that stores each value in whichever representation is CHEAPER: a
+/// bitmap for dense values, postings for the sparse tail. The same plane/postings split
+/// `BorderPrintingPlanes` and `RarityPrintingPlanes` already use, which `frame_data` never got.
+///
+/// Built ALONGSIDE `build_thresholded_tag_index` for now and selected by `FRAME_HYBRID`, so an
+/// interleaved A/B can switch representations per process with both arms reading an identical archive --
+/// which removes the layout shift that made the first attempt's measurement unreadable.
+///
+/// It is intended to replace `build_thresholded_tag_index`, which DROPS any value past
+/// `range_too_broad_to_narrow` because "the absent-key convention already means no narrowing, so
+/// dropped and unknown values both fall back to the scan". That reasoning expired twice over: #636
+/// taught the consumer to scatter a broad list into a bitmap rather than decline, and the drop cost
+/// three things where only the first was intended.
+///
+/// 1. `frame:2015` could not narrow at all — a full 31,508-card scan, ~600 µs.
+/// 2. The index was not `complete`, so an unknown frame value could not narrow to provably-empty.
+/// 3. `collection_compose_index` excluded `FrameData` outright *for that reason*, keeping every frame
+///    query off `PrintingCompose` — the path that pages `border:black` in 26 µs.
+///
+/// Storing every value makes the index complete, which is what unlocks (2) and (3). And the guard was
+/// inverted rather than merely stale: of the 29 `frame_data` values, it dropped the ONE where a bitmap
+/// wins by the largest margin (`2015`, 250.5 KB of postings against 11.9 KB of bitmap) while keeping as
+/// postings six more that would also be smaller as bitmaps. Per-value cheaper-of-the-two is 111 KB
+/// against the 240 KB stored before, so this is smaller AND faster, not a trade.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct HybridTagIndex {
+    /// Values above the density crossover: one printing-space bitmap each, ready to use with no scatter.
+    dense: HashMap<String, Vec<u64>>,
+    /// Everything below it: sorted printing ids, exactly as `TagIndex`.
+    ///
+    /// A sparse value can never be "broad" downstream: the crossover is 1/32 (3.1%) and
+    /// `range_too_broad_to_narrow` fires at 25%, so anything landing here is far under that guard.
+    sparse: TagIndex,
+}
+
+/// A stored bitmap is smaller than a posting list once `4 * k > n / 8` bytes, i.e. `k * 32 > n` —
+/// density above 1/32. Integer arithmetic so the boundary is exact.
+fn bitmap_beats_postings(k: usize, n_rows: usize) -> bool {
+    k.saturating_mul(32) > n_rows
+}
+
+fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> HybridTagIndex {
     let n = rows.len();
-    idx.retain(|_, postings| !range_too_broad_to_narrow(postings.len(), n));
-    idx
+    let mut out = HybridTagIndex::default();
+    for (value, postings) in build_tag_index(rows, vocab, get_ids) {
+        if bitmap_beats_postings(postings.len(), n) {
+            out.dense.insert(value, scatter_bits(postings, n));
+        } else {
+            out.sparse.insert(value, postings);
+        }
+    }
+    out
+}
+
+impl ArchivedHybridTagIndex {
+    /// Whether this value is stored as a bitmap, i.e. whether `bits` costs a copy rather than a scatter.
+    fn is_dense(&self, value: &str) -> bool {
+        self.dense.get(value).is_some()
+    }
+
+    /// The value's printing-space bitmap, materialized from postings if that is how it is stored.
+    /// `None` only when the value is absent from the store entirely — nothing is dropped, so that is a
+    /// proof rather than a gap.
+    fn bits(&self, value: &str, n_printings: usize) -> Option<Vec<u64>> {
+        if let Some(b) = self.dense.get(value) {
+            return Some(b.iter().map(|w| u64::from(*w)).collect());
+        }
+        self.sparse.get(value).map(|v| scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings))
+    }
+
+    /// Printings carrying this value, for the estimator and for the sparse narrowing path. Counts
+    /// without materializing when the value is a bitmap.
+    fn len_of(&self, value: &str) -> Option<usize> {
+        if let Some(b) = self.dense.get(value) {
+            return Some(b.iter().map(|w| u64::from(*w).count_ones() as usize).sum());
+        }
+        self.sparse.get(value).map(|v| v.len())
+    }
 }
 
 fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
@@ -2840,7 +2908,7 @@ struct CardIndexes {
     oracle_tags:    TagIndex,        // card space
     art_tags:       TagIndex,        // printing space
     is_tags:        TagIndex,        // printing space
-    frame_data:     TagIndex,        // printing space (selectivity-thresholded)
+    frame_data:     HybridTagIndex,  // printing space (bitmap for dense values, postings for the sparse tail)
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
@@ -3510,13 +3578,17 @@ fn probe_collection_k(filter: &FilterExpr, indexes: &Archived<CardIndexes>) -> O
     if !matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) {
         return None;
     }
+    // frame_data is the hybrid index, so its count is a popcount or a postings length, never a `get`.
+    if matches!(field, CollField::FrameData) {
+        return indexes.frame_data.len_of(value.as_str());
+    }
     let idx = match field {
         CollField::Subtypes => &indexes.subtypes,
         CollField::Keywords => &indexes.keywords,
         CollField::OracleTags => &indexes.oracle_tags,
         CollField::ArtTags => &indexes.art_tags,
         CollField::IsTags => &indexes.is_tags,
-        CollField::FrameData => &indexes.frame_data,
+        CollField::FrameData => unreachable!("handled above"),
     };
     idx.get(value.as_str()).map(|v| v.len())
 }
@@ -4052,23 +4124,44 @@ fn narrow_rec(
         // condition is needed. (#700; Le/Lt/Ne genuinely can't reuse this —
         // they're not expressible as `contains` plus a length check.)
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) => {
-            // `complete` marks indexes that post every occurrence of every
-            // value — all of them except frame_data, whose dense values are
-            // deliberately dropped at build (#628), so absence proves nothing
-            // there.
-            let (idx, card_space, complete) = match field {
-                CollField::Subtypes   => (&indexes.subtypes,    true,  true),
-                CollField::Keywords   => (&indexes.keywords,    true,  true),
-                CollField::OracleTags => (&indexes.oracle_tags, true,  true),
-                CollField::ArtTags    => (&indexes.art_tags,    false, true),
-                CollField::IsTags     => (&indexes.is_tags,     false, true),
-                CollField::FrameData  => (&indexes.frame_data,  false, false),
-            };
-            // Ge's postings are exact for Ge itself; for Eq/Gt they're only a
-            // loose superset (they prove `contains(value)` but not the length
-            // condition), so the residual `matches()` check the driver always
-            // runs is load-bearing for those two ops.
+            // Ge's postings are exact for Ge itself; for Eq/Gt they're only a loose superset, so the
+            // residual `matches()` check the driver always runs is load-bearing for those two ops.
             let mk = |set| if matches!(op, CmpOp::Ge) { Narrowed::tight(set) } else { Narrowed::loose(set) };
+            // frame_data is the one HYBRID index: every value is stored, so absence is a PROOF and a
+            // dense value hands back a ready-made bitmap with no scatter.
+            //
+            // `broad_ok` is honoured, unlike the first attempt at this, which bypassed it for dense
+            // values reasoning that a STORED bitmap has no scatter to pay. That misread the gate --
+            // it means "nothing downstream would consume this usefully", not "the scatter would be
+            // wasted" -- and cost 1.3-1.8x on sparse `And`s. `3cfd441` since gave the And arm a cost
+            // probe for collection children, so a broad frame child under a selective driver is now
+            // skipped on COST before this is even reached.
+            if matches!(field, CollField::FrameData) {
+                let idx = &indexes.frame_data;
+                if idx.is_dense(value.as_str()) {
+                    if !broad_ok {
+                        return None;
+                    }
+                    return mk(Candidates::PrintingBits(idx.bits(value.as_str(), n_printings)?));
+                }
+                // A sparse value cannot be broad: the storage crossover is 1/32 and the broadness guard
+                // fires at 1/4, so these postings go straight through.
+                return match idx.sparse.get(value.as_str()) {
+                    None => Narrowed::tight(Candidates::Printings(Vec::new())),
+                    Some(v) => mk(Candidates::Printings(v.iter().map(|x| u32::from(*x)).collect())),
+                };
+            }
+            // Every remaining index posts every occurrence of every value, so absence is a proof. That
+            // is now true of frame_data too, handled above — it was the sole exception only because its
+            // dense values were dropped at build (#628).
+            let (idx, card_space) = match field {
+                CollField::Subtypes   => (&indexes.subtypes,    true),
+                CollField::Keywords   => (&indexes.keywords,    true),
+                CollField::OracleTags => (&indexes.oracle_tags, true),
+                CollField::ArtTags    => (&indexes.art_tags,    false),
+                CollField::IsTags     => (&indexes.is_tags,     false),
+                CollField::FrameData  => unreachable!("frame_data is the hybrid index, handled above"),
+            };
             match idx.get(value.as_str()) {
                 // A value with no postings in a complete index proves
                 // `contains(value)` false for every row, which makes Ge, Eq,
@@ -4076,10 +4169,9 @@ fn narrow_rec(
                 // them without first satisfying containment. Exact for all
                 // three ops, not just Ge: `is:permanent` spent 0.6 ms
                 // full-scanning to return zero results.
-                None if complete => {
+                None => {
                     Narrowed::tight(if card_space { Candidates::Cards(Vec::new()) } else { Candidates::Printings(Vec::new()) })
                 }
-                None => None,
                 Some(v) => {
                     // Broad printing-space postings pay the same gather cost
                     // the range indexes guard against (is:spell is ~60k ids);
@@ -5788,15 +5880,29 @@ fn broadcast_card_ids_to_printings(card_ids: impl Iterator<Item = u32>, offsets:
 /// it cannot be an exact compose leaf); it stays on the general path. This is the single source of
 /// truth `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their
 /// field tables can't drift apart.
-fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<(&Archived<TagIndex>, bool)> {
-    match field {
-        CollField::Subtypes   => Some((&indexes.subtypes,    true)),
-        CollField::Keywords   => Some((&indexes.keywords,    true)),
-        CollField::OracleTags => Some((&indexes.oracle_tags, true)),
-        CollField::ArtTags    => Some((&indexes.art_tags,    false)),
-        CollField::IsTags     => Some((&indexes.is_tags,     false)),
-        CollField::FrameData  => None,
-    }
+/// Which structure backs a `CollectionCmp` field on the compose path.
+enum CollComposeSource<'i> {
+    /// Postings. `true` = card-space ids (project each card's printing range up with
+    /// `broadcast_card_ids_to_printings`), `false` = printing ids (scatter directly).
+    Postings(&'i Archived<TagIndex>, bool),
+    /// The hybrid printing-space index: a stored bitmap for dense values, postings for the tail.
+    Hybrid(&'i Archived<HybridTagIndex>),
+}
+
+fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<CollComposeSource<'_>> {
+    Some(match field {
+        CollField::Subtypes   => CollComposeSource::Postings(&indexes.subtypes,    true),
+        CollField::Keywords   => CollComposeSource::Postings(&indexes.keywords,    true),
+        CollField::OracleTags => CollComposeSource::Postings(&indexes.oracle_tags, true),
+        CollField::ArtTags    => CollComposeSource::Postings(&indexes.art_tags,    false),
+        CollField::IsTags     => CollComposeSource::Postings(&indexes.is_tags,     false),
+        // `frame_data` used to return `None` here, and that exclusion was never about frames as such:
+        // it was the one index that was not `complete`, because its dense values were dropped at build,
+        // so absence could not prove emptiness and it could not be an exact compose leaf. Storing every
+        // value makes it complete, which makes it composable — and that chain is most of this change's
+        // win: `frame:2015` under `unique=printing` went 1,375 -> 41 us.
+        CollField::FrameData => CollComposeSource::Hybrid(&indexes.frame_data),
+    })
 }
 
 /// The exact printing-space bitmap for a bare containment collection leaf (`type:`/`kw:`/`otag:`/
@@ -5809,11 +5915,17 @@ fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -
 /// are tight for `Ge`, but only a loose superset for `Eq`/`Gt` (they prove `contains(value)`, not the
 /// collection-length condition, ~lib.rs:3441), and the compose path has no residual re-check, so
 /// `Eq`/`Gt` stay on the general path.
-fn collection_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    match idx.get(value) {
-        None => vec![0u64; words_per_plane(n_printings)],
-        Some(v) if card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
-        Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
+fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    match src {
+        // A dense value is already a printing bitmap, so this is a copy rather than a scatter.
+        CollComposeSource::Hybrid(idx) => {
+            idx.bits(value, n_printings).unwrap_or_else(|| vec![0u64; words_per_plane(n_printings)])
+        }
+        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
+            None => vec![0u64; words_per_plane(n_printings)],
+            Some(v) if *card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
+            Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
+        },
     }
 }
 
@@ -5822,17 +5934,21 @@ fn collection_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool,
 /// space: the postings length (one posting = one printing). Exact (a valid upper bound and then some),
 /// so the estimate for a bare collection leaf is exact, matching set/watermark. O(card postings) — the
 /// same order as the eventual scatter, cheap for the sparse subtype/keyword/oracle-tag posting lists.
-fn collection_leaf_printing_count(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets) -> usize {
-    match idx.get(value) {
-        None => 0,
-        Some(v) if card_space => v
-            .iter()
-            .map(|c| {
-                let c = u32::from(*c) as usize;
-                (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
-            })
-            .sum(),
-        Some(v) => v.len(),
+fn collection_leaf_printing_count(src: &CollComposeSource, value: &str, offsets: &AOffsets) -> usize {
+    match src {
+        // A popcount when the value is a bitmap; a postings length otherwise.
+        CollComposeSource::Hybrid(idx) => idx.len_of(value).unwrap_or(0),
+        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
+            None => 0,
+            Some(v) if *card_space => v
+                .iter()
+                .map(|c| {
+                    let c = u32::from(*c) as usize;
+                    (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
+                })
+                .sum(),
+            Some(v) => v.len(),
+        },
     }
 }
 
@@ -5843,8 +5959,8 @@ fn collection_leaf_printing_count(idx: &Archived<TagIndex>, value: &str, card_sp
 /// the (exact, `Ge`) positive set is precisely the negated match set, with no trivalent-NULL printing
 /// wrongly swept in. Ge only, same reason as the positive leaf (a loose positive set would give a
 /// loose complement).
-fn collection_negated_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    let mut bits = collection_leaf_bits(idx, value, card_space, offsets, n_printings);
+fn collection_negated_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    let mut bits = collection_leaf_bits(src, value, offsets, n_printings);
     complement_bits(&mut bits, n_printings);
     bits
 }
@@ -6018,8 +6134,8 @@ fn compose_printing_bits(
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
-            collection_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
+            let src = collection_compose_index(indexes, *field).expect("guarded by the if");
+            collection_leaf_bits(&src, value.as_str(), offsets, n_printings)
         }
         // Negated collection leaf — the exact complement of the positive leaf.
         FilterExpr::Not(inner)
@@ -6028,8 +6144,8 @@ fn compose_printing_bits(
             let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
                 unreachable!("guarded by the matches! above")
             };
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
-            collection_negated_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
+            let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            collection_negated_leaf_bits(&src, value.as_str(), offsets, n_printings)
         }
         // `flip_op` on the const-first form so `2<=rarity` and `rarity>=2` build the same bitmap.
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
@@ -6121,8 +6237,8 @@ fn compose_printing_estimate(
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
-            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
+            let src = collection_compose_index(indexes, *field).expect("guarded by the if");
+            let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
             (k, 0, k)
         }
         // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
@@ -6133,8 +6249,8 @@ fn compose_printing_estimate(
             let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
                 unreachable!("guarded by the matches! above")
             };
-            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
-            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
+            let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
             (n_printings.saturating_sub(k), 0, k)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
@@ -10702,7 +10818,7 @@ impl QueryEngine {
             oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
             art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
-            frame_data:     build_thresholded_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
+            frame_data:     build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
             artists:        build_artist_index(&printings, artist_vocab.len()),
             flavor:         build_flavor_index(&printings, &strings),
             set_codes:      {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1688,80 +1688,17 @@ struct ArtistIndex {
     printings: Vec<u32>,
 }
 
-/// A printing-space collection index that stores each value in whichever representation is CHEAPER: a
-/// bitmap for dense values, postings for the sparse tail. The same plane/postings split
-/// `BorderPrintingPlanes` and `RarityPrintingPlanes` already use, which `frame_data` never got.
-///
-/// This replaces `build_thresholded_tag_index`, which DROPPED any value past
-/// `range_too_broad_to_narrow` because "the absent-key convention already means no narrowing, so
-/// dropped and unknown values both fall back to the scan". That reasoning expired twice over: #636
-/// taught the consumer to scatter a broad list into a bitmap rather than decline, and the drop cost
-/// three things where only the first was intended.
-///
-/// 1. `frame:2015` could not narrow at all — a full 31,508-card scan, ~600 µs.
-/// 2. The index was not `complete`, so an unknown frame value could not narrow to provably-empty.
-/// 3. `collection_compose_index` excluded `FrameData` outright *for that reason*, keeping every frame
-///    query off `PrintingCompose` — the path that pages `border:black` in 26 µs.
-///
-/// Storing every value makes the index complete, which is what unlocks (2) and (3). And the guard was
-/// inverted rather than merely stale: of the 29 `frame_data` values, it dropped the ONE where a bitmap
-/// wins by the largest margin (`2015`, 250.5 KB of postings against 11.9 KB of bitmap) while keeping as
-/// postings six more that would also be smaller as bitmaps. Per-value cheaper-of-the-two is 111 KB
-/// against the 240 KB stored before, so this is smaller AND faster, not a trade.
-#[derive(Archive, Serialize, Deserialize, Default)]
-struct HybridTagIndex {
-    /// Values above the density crossover: one printing-space bitmap each, ready to use with no scatter.
-    dense: HashMap<String, Vec<u64>>,
-    /// Everything below it: sorted printing ids, exactly as `TagIndex`.
-    ///
-    /// A sparse value can never be "broad" downstream: the crossover is 1/32 (3.1%) and
-    /// `range_too_broad_to_narrow` fires at 25%, so anything landing here is far under that guard.
-    sparse: TagIndex,
-}
-
-/// A stored bitmap is smaller than a posting list once `4 * k > n / 8` bytes, i.e. `k * 32 > n` —
-/// density above 1/32. Integer arithmetic so the boundary is exact.
-fn bitmap_beats_postings(k: usize, n_rows: usize) -> bool {
-    k.saturating_mul(32) > n_rows
-}
-
-fn build_hybrid_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> HybridTagIndex {
+/// build_tag_index with the printing-space selectivity threshold applied at
+/// build time: values whose posting would be declined by the range guard
+/// anyway (frame:2015 covers 66% of printings) are simply not stored — the
+/// absent-key convention already means "no narrowing", so dropped and unknown
+/// values both fall back to the scan. Third application of the threshold
+/// after the range guard (#609) and rarity's union ceiling (#618).
+fn build_thresholded_tag_index<T>(rows: &[T], vocab: &[String], get_ids: impl Fn(&T) -> &Vec<u16>) -> TagIndex {
+    let mut idx = build_tag_index(rows, vocab, get_ids);
     let n = rows.len();
-    let mut out = HybridTagIndex::default();
-    for (value, postings) in build_tag_index(rows, vocab, get_ids) {
-        if bitmap_beats_postings(postings.len(), n) {
-            out.dense.insert(value, scatter_bits(postings, n));
-        } else {
-            out.sparse.insert(value, postings);
-        }
-    }
-    out
-}
-
-impl ArchivedHybridTagIndex {
-    /// Whether this value is stored as a bitmap, i.e. whether `bits` costs a copy rather than a scatter.
-    fn is_dense(&self, value: &str) -> bool {
-        self.dense.get(value).is_some()
-    }
-
-    /// The value's printing-space bitmap, materialized from postings if that is how it is stored.
-    /// `None` only when the value is absent from the store entirely — nothing is dropped, so that is a
-    /// proof rather than a gap.
-    fn bits(&self, value: &str, n_printings: usize) -> Option<Vec<u64>> {
-        if let Some(b) = self.dense.get(value) {
-            return Some(b.iter().map(|w| u64::from(*w)).collect());
-        }
-        self.sparse.get(value).map(|v| scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings))
-    }
-
-    /// Printings carrying this value, for the estimator and for the sparse narrowing path. Counts
-    /// without materializing when the value is a bitmap.
-    fn len_of(&self, value: &str) -> Option<usize> {
-        if let Some(b) = self.dense.get(value) {
-            return Some(b.iter().map(|w| u64::from(*w).count_ones() as usize).sum());
-        }
-        self.sparse.get(value).map(|v| v.len())
-    }
+    idx.retain(|_, postings| !range_too_broad_to_narrow(postings.len(), n));
+    idx
 }
 
 fn build_artist_index(printings: &[Printing], n_artists: usize) -> ArtistIndex {
@@ -2903,7 +2840,7 @@ struct CardIndexes {
     oracle_tags:    TagIndex,        // card space
     art_tags:       TagIndex,        // printing space
     is_tags:        TagIndex,        // printing space
-    frame_data:     HybridTagIndex,  // printing space (bitmap for dense values, postings for the tail)
+    frame_data:     TagIndex,        // printing space (selectivity-thresholded)
     artists:        ArtistIndex,     // printing space (CSR by artist vocab id)
     flavor:         FlavorIndex,     // printing space (CSR by dense flavor text id)
     set_codes:      TagIndex,        // printing space
@@ -4086,43 +4023,23 @@ fn narrow_rec(
         // condition is needed. (#700; Le/Lt/Ne genuinely can't reuse this —
         // they're not expressible as `contains` plus a length check.)
         FilterExpr::CollectionCmp { field, op, value, .. } if matches!(op, CmpOp::Ge | CmpOp::Eq | CmpOp::Gt) => {
+            // `complete` marks indexes that post every occurrence of every
+            // value — all of them except frame_data, whose dense values are
+            // deliberately dropped at build (#628), so absence proves nothing
+            // there.
+            let (idx, card_space, complete) = match field {
+                CollField::Subtypes   => (&indexes.subtypes,    true,  true),
+                CollField::Keywords   => (&indexes.keywords,    true,  true),
+                CollField::OracleTags => (&indexes.oracle_tags, true,  true),
+                CollField::ArtTags    => (&indexes.art_tags,    false, true),
+                CollField::IsTags     => (&indexes.is_tags,     false, true),
+                CollField::FrameData  => (&indexes.frame_data,  false, false),
+            };
             // Ge's postings are exact for Ge itself; for Eq/Gt they're only a
             // loose superset (they prove `contains(value)` but not the length
             // condition), so the residual `matches()` check the driver always
             // runs is load-bearing for those two ops.
             let mk = |set| if matches!(op, CmpOp::Ge) { Narrowed::tight(set) } else { Narrowed::loose(set) };
-            // frame_data is the one HYBRID index: dense values are stored as printing bitmaps and the
-            // sparse tail as postings (see `HybridTagIndex`). Handled before the postings-only table
-            // below because a dense hit needs no scatter at all.
-            if matches!(field, CollField::FrameData) {
-                let idx = &indexes.frame_data;
-                if idx.is_dense(value.as_str()) {
-                    // `broad_ok` exists to refuse PAYING to materialize a broad set -- "the scatter
-                    // would be pure waste". A stored bitmap is already materialized, so that premise
-                    // does not hold and the gate does not apply: this costs an 11.9 KB copy against the
-                    // ~600 us full scan it replaces. Requiring `broad_ok` here is what kept a lone
-                    // `frame:2015` on the scan path even once the bitmap existed.
-                    let bits = idx.bits(value.as_str(), n_printings)?;
-                    return mk(Candidates::PrintingBits(bits));
-                }
-                // Sparse values cannot be broad -- the storage crossover is 1/32 and the broadness
-                // guard fires at 1/4 -- so the postings go straight through with no guard.
-                return match idx.sparse.get(value.as_str()) {
-                    None => Narrowed::tight(Candidates::Printings(Vec::new())),
-                    Some(v) => mk(Candidates::Printings(v.iter().map(|x| u32::from(*x)).collect())),
-                };
-            }
-            // Every remaining index posts every occurrence of every value, so absence is a proof. That
-            // is now true of `frame_data` too, handled above -- it was the sole exception only because
-            // its dense values were dropped at build.
-            let (idx, card_space) = match field {
-                CollField::Subtypes   => (&indexes.subtypes,    true),
-                CollField::Keywords   => (&indexes.keywords,    true),
-                CollField::OracleTags => (&indexes.oracle_tags, true),
-                CollField::ArtTags    => (&indexes.art_tags,    false),
-                CollField::IsTags     => (&indexes.is_tags,     false),
-                CollField::FrameData  => unreachable!("frame_data is the hybrid index, handled above"),
-            };
             match idx.get(value.as_str()) {
                 // A value with no postings in a complete index proves
                 // `contains(value)` false for every row, which makes Ge, Eq,
@@ -4130,9 +4047,10 @@ fn narrow_rec(
                 // them without first satisfying containment. Exact for all
                 // three ops, not just Ge: `is:permanent` spent 0.6 ms
                 // full-scanning to return zero results.
-                None => {
+                None if complete => {
                     Narrowed::tight(if card_space { Candidates::Cards(Vec::new()) } else { Candidates::Printings(Vec::new()) })
                 }
+                None => None,
                 Some(v) => {
                     // Broad printing-space postings pay the same gather cost
                     // the range indexes guard against (is:spell is ~60k ids);
@@ -5814,34 +5732,23 @@ fn broadcast_card_ids_to_printings(card_ids: impl Iterator<Item = u32>, offsets:
     pbits
 }
 
-/// Which structure backs a `CollectionCmp` field on the compose path.
-enum CollComposeSource<'i> {
-    /// Postings. `true` = card-space ids (project each card's printing range up with
-    /// `broadcast_card_ids_to_printings`), `false` = printing ids (scatter directly, like
-    /// `set:`/`watermark:`).
-    Postings(&'i Archived<TagIndex>, bool),
-    /// The one hybrid printing-space index: a stored bitmap for dense values, postings for the tail.
-    Hybrid(&'i Archived<HybridTagIndex>),
-}
-
-/// Maps a `CollectionCmp` field to its compose backing. The single source of truth
-/// `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their field
-/// tables can't drift apart.
-///
-/// **Every field is composable now.** `FrameData` used to return `None` here, as the only non-`complete`
-/// collection index — its dense values were dropped at build, so absence proved nothing and it could not
-/// be an exact compose leaf. `HybridTagIndex` stores those values as bitmaps instead, which makes the
-/// index complete and puts frame queries on this path. The `Option` stays because the callers read it as
-/// "is this composable", and a future non-complete field would want it.
-fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<CollComposeSource<'_>> {
-    Some(match field {
-        CollField::Subtypes   => CollComposeSource::Postings(&indexes.subtypes,    true),
-        CollField::Keywords   => CollComposeSource::Postings(&indexes.keywords,    true),
-        CollField::OracleTags => CollComposeSource::Postings(&indexes.oracle_tags, true),
-        CollField::ArtTags    => CollComposeSource::Postings(&indexes.art_tags,    false),
-        CollField::IsTags     => CollComposeSource::Postings(&indexes.is_tags,     false),
-        CollField::FrameData  => CollComposeSource::Hybrid(&indexes.frame_data),
-    })
+/// Maps a `CollectionCmp` field to its compose backing: the postings index and whether it is
+/// **card-space** (postings are card ids → project each card's printing range up with
+/// `broadcast_card_ids_to_printings`) or **printing-space** (postings are printing ids → scatter
+/// directly, like `set:`/`watermark:`). Returns `None` for `FrameData` — the only non-`complete`
+/// collection index (its dense values are dropped at build, #628, so absence proves nothing there and
+/// it cannot be an exact compose leaf); it stays on the general path. This is the single source of
+/// truth `is_printing_composable`/`compose_printing_bits`/`compose_printing_estimate` share so their
+/// field tables can't drift apart.
+fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -> Option<(&Archived<TagIndex>, bool)> {
+    match field {
+        CollField::Subtypes   => Some((&indexes.subtypes,    true)),
+        CollField::Keywords   => Some((&indexes.keywords,    true)),
+        CollField::OracleTags => Some((&indexes.oracle_tags, true)),
+        CollField::ArtTags    => Some((&indexes.art_tags,    false)),
+        CollField::IsTags     => Some((&indexes.is_tags,     false)),
+        CollField::FrameData  => None,
+    }
 }
 
 /// The exact printing-space bitmap for a bare containment collection leaf (`type:`/`kw:`/`otag:`/
@@ -5854,17 +5761,11 @@ fn collection_compose_index(indexes: &Archived<CardIndexes>, field: CollField) -
 /// are tight for `Ge`, but only a loose superset for `Eq`/`Gt` (they prove `contains(value)`, not the
 /// collection-length condition, ~lib.rs:3441), and the compose path has no residual re-check, so
 /// `Eq`/`Gt` stay on the general path.
-fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    match src {
-        // Dense values are already a printing bitmap, so this is a copy rather than a scatter.
-        CollComposeSource::Hybrid(idx) => {
-            idx.bits(value, n_printings).unwrap_or_else(|| vec![0u64; words_per_plane(n_printings)])
-        }
-        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
-            None => vec![0u64; words_per_plane(n_printings)],
-            Some(v) if *card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
-            Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
-        },
+fn collection_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    match idx.get(value) {
+        None => vec![0u64; words_per_plane(n_printings)],
+        Some(v) if card_space => broadcast_card_ids_to_printings(v.iter().map(|x| u32::from(*x)), offsets, n_printings),
+        Some(v) => scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings),
     }
 }
 
@@ -5873,21 +5774,17 @@ fn collection_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets
 /// space: the postings length (one posting = one printing). Exact (a valid upper bound and then some),
 /// so the estimate for a bare collection leaf is exact, matching set/watermark. O(card postings) — the
 /// same order as the eventual scatter, cheap for the sparse subtype/keyword/oracle-tag posting lists.
-fn collection_leaf_printing_count(src: &CollComposeSource, value: &str, offsets: &AOffsets) -> usize {
-    match src {
-        // A popcount when the value is a bitmap; a postings length otherwise.
-        CollComposeSource::Hybrid(idx) => idx.len_of(value).unwrap_or(0),
-        CollComposeSource::Postings(idx, card_space) => match idx.get(value) {
-            None => 0,
-            Some(v) if *card_space => v
-                .iter()
-                .map(|c| {
-                    let c = u32::from(*c) as usize;
-                    (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
-                })
-                .sum(),
-            Some(v) => v.len(),
-        },
+fn collection_leaf_printing_count(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets) -> usize {
+    match idx.get(value) {
+        None => 0,
+        Some(v) if card_space => v
+            .iter()
+            .map(|c| {
+                let c = u32::from(*c) as usize;
+                (u32::from(offsets[c + 1]) - u32::from(offsets[c])) as usize
+            })
+            .sum(),
+        Some(v) => v.len(),
     }
 }
 
@@ -5898,8 +5795,8 @@ fn collection_leaf_printing_count(src: &CollComposeSource, value: &str, offsets:
 /// the (exact, `Ge`) positive set is precisely the negated match set, with no trivalent-NULL printing
 /// wrongly swept in. Ge only, same reason as the positive leaf (a loose positive set would give a
 /// loose complement).
-fn collection_negated_leaf_bits(src: &CollComposeSource, value: &str, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
-    let mut bits = collection_leaf_bits(src, value, offsets, n_printings);
+fn collection_negated_leaf_bits(idx: &Archived<TagIndex>, value: &str, card_space: bool, offsets: &AOffsets, n_printings: usize) -> Vec<u64> {
+    let mut bits = collection_leaf_bits(idx, value, card_space, offsets, n_printings);
     complement_bits(&mut bits, n_printings);
     bits
 }
@@ -6073,8 +5970,8 @@ fn compose_printing_bits(
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
-            let src = collection_compose_index(indexes, *field).expect("guarded by the if");
-            collection_leaf_bits(&src, value.as_str(), offsets, n_printings)
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
+            collection_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
         }
         // Negated collection leaf — the exact complement of the positive leaf.
         FilterExpr::Not(inner)
@@ -6083,8 +5980,8 @@ fn compose_printing_bits(
             let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
                 unreachable!("guarded by the matches! above")
             };
-            let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
-            collection_negated_leaf_bits(&src, value.as_str(), offsets, n_printings)
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            collection_negated_leaf_bits(idx, value.as_str(), card_space, offsets, n_printings)
         }
         // `flip_op` on the const-first form so `2<=rarity` and `rarity>=2` build the same bitmap.
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
@@ -6176,8 +6073,8 @@ fn compose_printing_estimate(
         FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. }
             if collection_compose_index(indexes, *field).is_some() =>
         {
-            let src = collection_compose_index(indexes, *field).expect("guarded by the if");
-            let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the if");
+            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
             (k, 0, k)
         }
         // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
@@ -6188,8 +6085,8 @@ fn compose_printing_estimate(
             let FilterExpr::CollectionCmp { field, value, .. } = inner.as_ref() else {
                 unreachable!("guarded by the matches! above")
             };
-            let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
-            let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
+            let (idx, card_space) = collection_compose_index(indexes, *field).expect("guarded by the matches!");
+            let k = collection_leaf_printing_count(idx, value.as_str(), card_space, offsets);
             (n_printings.saturating_sub(k), 0, k)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
@@ -6574,6 +6471,14 @@ fn exact_card_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, n_ca
     None
 }
 
+/// The size of the query's RESULT space: every printing, card, or artwork in the store.
+fn compose_result_domain(mode: Mode, n_cards: usize, indexes: &Archived<CardIndexes>) -> usize {
+    match mode {
+        Mode::Printing => indexes.printing_to_card.len(),
+        Mode::Card => n_cards,
+        Mode::Artwork => u32::from(*indexes.artwork_base.last().expect("artwork_base has n_cards+1 entries")) as usize,
+    }
+}
 
 /// Whether composing `filter` needs a card-space plane BROADCAST down into printing space -- today,
 /// exactly a legality leaf (`repair_divergent_printings` / `broadcast_card_bits_to_printings`). Purely
@@ -10757,7 +10662,7 @@ impl QueryEngine {
             oracle_tags:    build_tag_index(&cards, &coll_vocab, |c| &c.card_oracle_tags),
             art_tags:       build_tag_index(&printings, &coll_vocab, |p| &p.card_art_tags),
             is_tags:        build_tag_index(&printings, &coll_vocab, |p| &p.card_is_tags),
-            frame_data:     build_hybrid_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
+            frame_data:     build_thresholded_tag_index(&printings, &coll_vocab, |p| &p.card_frame_data),
             artists:        build_artist_index(&printings, artist_vocab.len()),
             flavor:         build_flavor_index(&printings, &strings),
             set_codes:      {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -366,9 +366,12 @@ fn narrow_candidates_spaces() {
         Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent tag narrows to the exact empty set"),
         _ => panic!("absent tag must narrow to empty, not decline"),
     }
-    // frame_data is selectivity-thresholded (#628): dense values are absent by
-    // design, so absence proves nothing and it must keep declining.
-    assert!(narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]).is_none());
+    // frame_data stores every value now (`HybridTagIndex`), so absence proves emptiness here exactly as
+    // it does for every other collection index. It used to be the sole exception.
+    match narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty(), "frame_data is complete: absence is a proof"),
+        other => panic!("an absent frame value must narrow to empty, got {other:?}"),
+    }
 
     // And of mixed spaces projects the printing product up and intersects in
     // card space: art printings {0,2} → cards {0,1}, ∩ keyword cards {1} = {1}.
@@ -429,11 +432,14 @@ fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
             other => panic!("{op:?} over an absent value must narrow to empty, not decline, got {other:?}"),
         }
     }
-    // frame_data stays excluded for Eq/Gt too (#628: incomplete index, absence
-    // proves nothing), same as it already is for Ge.
+    // frame_data joins them for Eq/Gt as well, now that it is complete: an absent value cannot satisfy
+    // containment, so it cannot satisfy Eq or Gt either, and the empty set is exact for all three.
     let frame = |op| FilterExpr::CollectionCmp { field: CollField::FrameData, op, value: "zombie".to_string(), value_id: None };
     for op in [CmpOp::Eq, CmpOp::Gt, CmpOp::Ge] {
-        assert!(narrow_candidates(&frame(op), archived, offsets, &[]).is_none(), "{op:?} over frame_data must decline, not narrow");
+        match narrow_candidates(&frame(op), archived, offsets, &[]) {
+            Some(Candidates::Printings(v)) => assert!(v.is_empty(), "{op:?} over an absent value is empty"),
+            other => panic!("{op:?} over frame_data must narrow to empty, got {other:?}"),
+        }
     }
 }
 
@@ -2432,7 +2438,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.oracle_tags = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
     data.indexes.art_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
     data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
-    data.indexes.frame_data = build_thresholded_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
+    data.indexes.frame_data = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
     data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
     // Text narrowing indexes — same load-bearing property. name/oracle drive trigram + bigram
     // narrowing and the full-scan memoization; flavor is the printing-space CSR bind() resolves against.
@@ -5927,7 +5933,7 @@ fn bench_checked_vs_unchecked_access() {
         oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
         art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
-        frame_data:     HashMap::new(),
+        frame_data:     HybridTagIndex::default(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),
@@ -6476,48 +6482,52 @@ fn popcount_skip_matches_non_popcount_path() {
     assert_eq!(ids_pc, ids_old);
 }
 
-// Frame postings are selectivity-thresholded at build: values covering more
-// of printing space than the range guard would accept are not stored, and the
-// absent-key convention makes them (and unknown values) fall back to the scan.
+// The representation split: `build_hybrid_tag_index` decides per value by size, and the crossover is
+// arithmetic, so assert it directly. This replaces `frame_postings_thresholded_at_build`, which pinned
+// the opposite contract -- that dense values are DROPPED.
 #[test]
-fn frame_postings_thresholded_at_build() {
+fn hybrid_tag_index_splits_dense_from_sparse_at_the_size_crossover() {
+    // A bitmap costs 1 bit per row and a posting 4 bytes, so a bitmap is smaller once k * 32 > n.
+    assert!(!bitmap_beats_postings(62, 2000) && bitmap_beats_postings(63, 2000), "crossover is 1/32");
+    assert!(!bitmap_beats_postings(0, 2000), "an absent value is not dense");
+
     let mut vocab = VocabInterner::new();
     let modern = vocab_ids(&mut vocab, &["2015"]);
     let showcase = vocab_ids(&mut vocab, &["Showcase"]);
-    // 2,000 printings: all carry "2015" (dominant, must be dropped: >1,000 and
-    // >25%), the first 40 also carry "Showcase" (selective, must be kept).
+    // 1,200 of 2,000 carry "2015" (60%, dense); the first 40 also carry "Showcase" (2%, sparse).
     let mut printings: Vec<Printing> = (1..=2000u128).map(|i| stub_printing(i, i, None)).collect();
     for (i, p) in printings.iter_mut().enumerate() {
-        p.card_frame_data = modern.clone();
+        if i < 1200 {
+            p.card_frame_data = modern.clone();
+        }
         if i < 40 {
             p.card_frame_data = [modern.clone(), showcase.clone()].concat();
             p.card_frame_data.sort_unstable();
         }
     }
-    let idx = build_thresholded_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
-    assert!(!idx.contains_key("2015"), "dominant value must be dropped by the threshold");
-    assert_eq!(idx.get("Showcase").map(|v| v.len()), Some(40));
+    let idx = build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
+    assert!(idx.dense.contains_key("2015"), "a dense value belongs in `dense`, not dropped");
+    assert!(!idx.sparse.contains_key("2015"), "and not duplicated into `sparse`");
+    assert_eq!(idx.sparse.get("Showcase").map(|v| v.len()), Some(40), "a sparse value stays postings");
+    assert!(!idx.dense.contains_key("Showcase"));
+    // Nothing dropped: that is what makes the index complete, and completeness is what lets absence
+    // prove emptiness and puts frame leaves on the compose path.
+    assert_eq!(idx.dense.len() + idx.sparse.len(), 2, "every value is stored in exactly one form");
 
-    // Wired into narrowing: selective value narrows in printing space, the
-    // dropped value declines (None, not empty — the scan still answers it).
-    let indexes = CardIndexes { frame_data: idx, ..Default::default() };
-    let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
-    let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
-    let offsets_bytes = rkyv::to_bytes::<Error>(&vec![0u32, 2000]).expect("serialize offsets");
-    let offsets = rkyv::access::<Archived<Vec<u32>>, Error>(&offsets_bytes).expect("access offsets");
-    let coll = |value: &str| FilterExpr::CollectionCmp {
-        field: CollField::FrameData,
-        op: CmpOp::Ge,
-        value: value.to_string(),
-        value_id: None,
-    };
-    match narrow_candidates(&coll("Showcase"), archived, offsets, &[]) {
-        Some(Candidates::Printings(v)) => assert_eq!(v.len(), 40),
-        _ => panic!("selective frame value must narrow in printing space"),
+    // The archived accessors agree on the count whichever form backs the value.
+    let bytes = rkyv::to_bytes::<Error>(&idx).expect("serialize");
+    let archived = rkyv::access::<Archived<HybridTagIndex>, Error>(&bytes).expect("access");
+    assert!(archived.is_dense("2015") && !archived.is_dense("Showcase"));
+    assert_eq!(archived.len_of("2015"), Some(1200), "popcount of the bitmap");
+    assert_eq!(archived.len_of("Showcase"), Some(40), "length of the postings");
+    assert_eq!(archived.len_of("Zzz"), None, "absent is absent, not zero-length");
+    for value in ["2015", "Showcase"] {
+        let bits = archived.bits(value, 2000).expect("present");
+        let want = if value == "2015" { 1200 } else { 40 };
+        assert_eq!(bits.iter().map(|w| w.count_ones() as usize).sum::<usize>(), want, "{value} bits");
     }
-    assert!(narrow_candidates(&coll("2015"), archived, offsets, &[]).is_none());
-    assert!(narrow_candidates(&coll("Zzz"), archived, offsets, &[]).is_none());
 }
+
 
 // Streamed selection must agree with the gathered path. Two stores identical
 // except for the presence of sort permutations: the perm-less store takes the
@@ -7172,9 +7182,12 @@ fn collection_compose_leaves() {
         assert!(!super::is_printing_composable(&f, &archived.indexes), "type:goblin op={op:?} (loose) must stay off the compose path");
         assert!(!super::is_printing_composable(&not(f), &archived.indexes), "-(loose collection) must stay off the compose path");
     }
+    // Composability follows completeness: the index used to drop dense values, so absence proved nothing
+    // and it could not be an exact compose leaf. Storing everything makes it complete, hence composable,
+    // and that chain is most of this change's win.
     let frame = coll(CollField::FrameData, CmpOp::Ge, "showcase");
-    assert!(!super::is_printing_composable(&frame, &archived.indexes), "frame: (non-complete) must stay off the compose path");
-    assert!(!super::is_printing_composable(&not(frame), &archived.indexes), "-frame: must stay off the compose path");
+    assert!(super::is_printing_composable(&frame.clone(), &archived.indexes), "frame: is complete and composes");
+    assert!(super::is_printing_composable(&not(frame), &archived.indexes), "-frame: composes via the Not arm");
     // A loose Eq inside an And keeps the whole And off the compose path.
     let mixed = FilterExpr::And(vec![ge(CollField::Subtypes, "goblin"), coll(CollField::Keywords, CmpOp::Eq, "Flying")]);
     assert!(!super::is_printing_composable(&mixed, &archived.indexes), "a loose Eq collection inside an And keeps the whole And off the compose path");

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_hybrid_tag_index, HybridTagIndex, build_sort_permutations,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -366,9 +366,12 @@ fn narrow_candidates_spaces() {
         Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent tag narrows to the exact empty set"),
         _ => panic!("absent tag must narrow to empty, not decline"),
     }
-    // frame_data is selectivity-thresholded (#628): dense values are absent by
-    // design, so absence proves nothing and it must keep declining.
-    assert!(narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]).is_none());
+    // frame_data is complete now (`HybridTagIndex` stores dense values as bitmaps instead of dropping
+    // them), so absence proves emptiness here exactly as it does for the other collection indexes.
+    match narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent frame value narrows to empty"),
+        other => panic!("frame_data is complete now; an absent value must narrow to empty, got {other:?}"),
+    }
 
     // And of mixed spaces projects the printing product up and intersects in
     // card space: art printings {0,2} → cards {0,1}, ∩ keyword cards {1} = {1}.
@@ -429,11 +432,14 @@ fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
             other => panic!("{op:?} over an absent value must narrow to empty, not decline, got {other:?}"),
         }
     }
-    // frame_data stays excluded for Eq/Gt too (#628: incomplete index, absence
-    // proves nothing), same as it already is for Ge.
+    // frame_data joins them for Eq/Gt as well, now that it is complete: an absent value cannot satisfy
+    // containment, so it cannot satisfy Eq or Gt either, and the empty set is exact for all three.
     let frame = |op| FilterExpr::CollectionCmp { field: CollField::FrameData, op, value: "zombie".to_string(), value_id: None };
     for op in [CmpOp::Eq, CmpOp::Gt, CmpOp::Ge] {
-        assert!(narrow_candidates(&frame(op), archived, offsets, &[]).is_none(), "{op:?} over frame_data must decline, not narrow");
+        match narrow_candidates(&frame(op), archived, offsets, &[]) {
+            Some(Candidates::Printings(v)) => assert!(v.is_empty(), "{op:?} over an absent frame value is empty"),
+            other => panic!("{op:?} over frame_data must narrow to empty, got {other:?}"),
+        }
     }
 }
 
@@ -2432,7 +2438,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.oracle_tags = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
     data.indexes.art_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
     data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
-    data.indexes.frame_data = build_thresholded_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
+    data.indexes.frame_data = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
     data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
     // Text narrowing indexes — same load-bearing property. name/oracle drive trigram + bigram
     // narrowing and the full-scan memoization; flavor is the printing-space CSR bind() resolves against.
@@ -5927,7 +5933,7 @@ fn bench_checked_vs_unchecked_access() {
         oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
         art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
-        frame_data:     HashMap::new(),
+        frame_data:     HybridTagIndex::default(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),
@@ -6476,30 +6482,39 @@ fn popcount_skip_matches_non_popcount_path() {
     assert_eq!(ids_pc, ids_old);
 }
 
-// Frame postings are selectivity-thresholded at build: values covering more
-// of printing space than the range guard would accept are not stored, and the
-// absent-key convention makes them (and unknown values) fall back to the scan.
+// Frame values are stored in whichever representation is cheaper -- a printing bitmap for dense
+// values, postings for the sparse tail -- and NOTHING is dropped, which is what makes the index
+// complete. This test inverts the assertions it replaced (`frame_postings_thresholded_at_build`), which
+// pinned the old build-time drop: that guard is what kept `frame:2015` on a full scan, kept the index
+// non-complete so unknown values could not prove empty, and excluded FrameData from the compose path.
 #[test]
-fn frame_postings_thresholded_at_build() {
+fn frame_values_stored_dense_or_sparse_and_nothing_dropped() {
     let mut vocab = VocabInterner::new();
     let modern = vocab_ids(&mut vocab, &["2015"]);
     let showcase = vocab_ids(&mut vocab, &["Showcase"]);
-    // 2,000 printings: all carry "2015" (dominant, must be dropped: >1,000 and
-    // >25%), the first 40 also carry "Showcase" (selective, must be kept).
+    // 2,000 printings: the first 1,200 carry "2015" (60% density -- past the 1/32 storage crossover so
+    // it becomes a bitmap, and under `narrow_candidates_exact`'s own 75% root gate so the result is not
+    // then discarded as too broad to be worth narrowing). The real corpus value is 66%, in the same band.
+    // The first 40 also carry "Showcase" (2% -> postings, since 40 * 32 = 1,280 < 2,000).
     let mut printings: Vec<Printing> = (1..=2000u128).map(|i| stub_printing(i, i, None)).collect();
     for (i, p) in printings.iter_mut().enumerate() {
-        p.card_frame_data = modern.clone();
+        if i < 1200 {
+            p.card_frame_data = modern.clone();
+        }
         if i < 40 {
             p.card_frame_data = [modern.clone(), showcase.clone()].concat();
             p.card_frame_data.sort_unstable();
         }
     }
-    let idx = build_thresholded_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
-    assert!(!idx.contains_key("2015"), "dominant value must be dropped by the threshold");
-    assert_eq!(idx.get("Showcase").map(|v| v.len()), Some(40));
+    let idx = build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
+    assert!(idx.dense.contains_key("2015"), "a dominant value belongs in `dense`, not dropped");
+    assert!(!idx.sparse.contains_key("2015"), "and not duplicated into `sparse`");
+    assert_eq!(idx.sparse.get("Showcase").map(|v| v.len()), Some(40), "a sparse value stays postings");
+    assert!(!idx.dense.contains_key("Showcase"));
+    // The crossover is a size comparison, so check it directly rather than trusting the two cases above.
+    assert!(super::bitmap_beats_postings(1200, 2000) && !super::bitmap_beats_postings(40, 2000));
+    assert!(super::bitmap_beats_postings(63, 2000) && !super::bitmap_beats_postings(62, 2000), "crossover is 1/32");
 
-    // Wired into narrowing: selective value narrows in printing space, the
-    // dropped value declines (None, not empty — the scan still answers it).
     let indexes = CardIndexes { frame_data: idx, ..Default::default() };
     let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
     let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
@@ -6511,12 +6526,25 @@ fn frame_postings_thresholded_at_build() {
         value: value.to_string(),
         value_id: None,
     };
+    // Sparse: postings, in printing space, exactly as before.
     match narrow_candidates(&coll("Showcase"), archived, offsets, &[]) {
         Some(Candidates::Printings(v)) => assert_eq!(v.len(), 40),
-        _ => panic!("selective frame value must narrow in printing space"),
+        other => panic!("selective frame value must narrow in printing space, got {other:?}"),
     }
-    assert!(narrow_candidates(&coll("2015"), archived, offsets, &[]).is_none());
-    assert!(narrow_candidates(&coll("Zzz"), archived, offsets, &[]).is_none());
+    // Dense: a printing BITMAP, and it arrives despite `narrow_candidates` passing `broad_ok = false` --
+    // that gate refuses to PAY for a scatter, and a stored bitmap has none to pay. This is the case that
+    // used to be a full scan.
+    match narrow_candidates(&coll("2015"), archived, offsets, &[]) {
+        Some(Candidates::PrintingBits(b)) => {
+            assert_eq!(b.iter().map(|w| w.count_ones() as usize).sum::<usize>(), 1200);
+        }
+        other => panic!("a dense frame value must narrow to a printing bitmap, got {other:?}"),
+    }
+    // Absent: now a PROOF of emptiness rather than a shrug, because nothing is dropped.
+    match narrow_candidates(&coll("Zzz"), archived, offsets, &[]) {
+        Some(Candidates::Printings(v)) => assert!(v.is_empty(), "unknown value must narrow to empty"),
+        other => panic!("an unknown frame value must be provably empty, got {other:?}"),
+    }
 }
 
 // Streamed selection must agree with the gathered path. Two stores identical
@@ -7172,9 +7200,11 @@ fn collection_compose_leaves() {
         assert!(!super::is_printing_composable(&f, &archived.indexes), "type:goblin op={op:?} (loose) must stay off the compose path");
         assert!(!super::is_printing_composable(&not(f), &archived.indexes), "-(loose collection) must stay off the compose path");
     }
+    // frame_data is complete now, so it composes like every other containment leaf -- the whole point of
+    // storing its dense values rather than dropping them. It was the sole exclusion here.
     let frame = coll(CollField::FrameData, CmpOp::Ge, "showcase");
-    assert!(!super::is_printing_composable(&frame, &archived.indexes), "frame: (non-complete) must stay off the compose path");
-    assert!(!super::is_printing_composable(&not(frame), &archived.indexes), "-frame: must stay off the compose path");
+    assert!(super::is_printing_composable(&frame.clone(), &archived.indexes), "frame: is complete and must compose");
+    assert!(super::is_printing_composable(&not(frame), &archived.indexes), "-frame: composes via the Not arm");
     // A loose Eq inside an And keeps the whole And off the compose path.
     let mixed = FilterExpr::And(vec![ge(CollField::Subtypes, "goblin"), coll(CollField::Keywords, CmpOp::Eq, "Flying")]);
     assert!(!super::is_printing_composable(&mixed, &archived.indexes), "a loose Eq collection inside an And keeps the whole And off the compose path");

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
-    build_rarity_index, build_flavor_index, build_hybrid_tag_index, HybridTagIndex, build_sort_permutations,
+    build_rarity_index, build_flavor_index, build_thresholded_tag_index, build_sort_permutations,
     assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
@@ -366,12 +366,9 @@ fn narrow_candidates_spaces() {
         Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent tag narrows to the exact empty set"),
         _ => panic!("absent tag must narrow to empty, not decline"),
     }
-    // frame_data is complete now (`HybridTagIndex` stores dense values as bitmaps instead of dropping
-    // them), so absence proves emptiness here exactly as it does for the other collection indexes.
-    match narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]) {
-        Some(Candidates::Printings(v)) => assert!(v.is_empty(), "absent frame value narrows to empty"),
-        other => panic!("frame_data is complete now; an absent value must narrow to empty, got {other:?}"),
-    }
+    // frame_data is selectivity-thresholded (#628): dense values are absent by
+    // design, so absence proves nothing and it must keep declining.
+    assert!(narrow_candidates(&coll(CollField::FrameData, "zombie"), archived, offsets, &[]).is_none());
 
     // And of mixed spaces projects the printing product up and intersects in
     // card space: art printings {0,2} → cards {0,1}, ∩ keyword cards {1} = {1}.
@@ -432,14 +429,11 @@ fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
             other => panic!("{op:?} over an absent value must narrow to empty, not decline, got {other:?}"),
         }
     }
-    // frame_data joins them for Eq/Gt as well, now that it is complete: an absent value cannot satisfy
-    // containment, so it cannot satisfy Eq or Gt either, and the empty set is exact for all three.
+    // frame_data stays excluded for Eq/Gt too (#628: incomplete index, absence
+    // proves nothing), same as it already is for Ge.
     let frame = |op| FilterExpr::CollectionCmp { field: CollField::FrameData, op, value: "zombie".to_string(), value_id: None };
     for op in [CmpOp::Eq, CmpOp::Gt, CmpOp::Ge] {
-        match narrow_candidates(&frame(op), archived, offsets, &[]) {
-            Some(Candidates::Printings(v)) => assert!(v.is_empty(), "{op:?} over an absent frame value is empty"),
-            other => panic!("{op:?} over frame_data must narrow to empty, got {other:?}"),
-        }
+        assert!(narrow_candidates(&frame(op), archived, offsets, &[]).is_none(), "{op:?} over frame_data must decline, not narrow");
     }
 }
 
@@ -2438,7 +2432,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.oracle_tags = build_tag_index(&data.cards, &data.coll_vocab, |c| &c.card_oracle_tags);
     data.indexes.art_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_art_tags);
     data.indexes.is_tags = build_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_is_tags);
-    data.indexes.frame_data = build_hybrid_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
+    data.indexes.frame_data = build_thresholded_tag_index(&data.printings, &data.coll_vocab, |p| &p.card_frame_data);
     data.indexes.artists = build_artist_index(&data.printings, data.artist_vocab.len());
     // Text narrowing indexes — same load-bearing property. name/oracle drive trigram + bigram
     // narrowing and the full-scan memoization; flavor is the printing-space CSR bind() resolves against.
@@ -5933,7 +5927,7 @@ fn bench_checked_vs_unchecked_access() {
         oracle_tags:    build_tag_index(&cards, &vocab.strings, |c| &c.card_oracle_tags),
         art_tags:       build_tag_index(&printings, &vocab.strings, |p| &p.card_art_tags),
         is_tags:        build_tag_index(&printings, &vocab.strings, |p| &p.card_is_tags),
-        frame_data:     HybridTagIndex::default(),
+        frame_data:     HashMap::new(),
         artists:        ArtistIndex::default(),
         flavor:         build_flavor_index(&printings, &strings),
         set_codes:      HashMap::new(),
@@ -6482,39 +6476,30 @@ fn popcount_skip_matches_non_popcount_path() {
     assert_eq!(ids_pc, ids_old);
 }
 
-// Frame values are stored in whichever representation is cheaper -- a printing bitmap for dense
-// values, postings for the sparse tail -- and NOTHING is dropped, which is what makes the index
-// complete. This test inverts the assertions it replaced (`frame_postings_thresholded_at_build`), which
-// pinned the old build-time drop: that guard is what kept `frame:2015` on a full scan, kept the index
-// non-complete so unknown values could not prove empty, and excluded FrameData from the compose path.
+// Frame postings are selectivity-thresholded at build: values covering more
+// of printing space than the range guard would accept are not stored, and the
+// absent-key convention makes them (and unknown values) fall back to the scan.
 #[test]
-fn frame_values_stored_dense_or_sparse_and_nothing_dropped() {
+fn frame_postings_thresholded_at_build() {
     let mut vocab = VocabInterner::new();
     let modern = vocab_ids(&mut vocab, &["2015"]);
     let showcase = vocab_ids(&mut vocab, &["Showcase"]);
-    // 2,000 printings: the first 1,200 carry "2015" (60% density -- past the 1/32 storage crossover so
-    // it becomes a bitmap, and under `narrow_candidates_exact`'s own 75% root gate so the result is not
-    // then discarded as too broad to be worth narrowing). The real corpus value is 66%, in the same band.
-    // The first 40 also carry "Showcase" (2% -> postings, since 40 * 32 = 1,280 < 2,000).
+    // 2,000 printings: all carry "2015" (dominant, must be dropped: >1,000 and
+    // >25%), the first 40 also carry "Showcase" (selective, must be kept).
     let mut printings: Vec<Printing> = (1..=2000u128).map(|i| stub_printing(i, i, None)).collect();
     for (i, p) in printings.iter_mut().enumerate() {
-        if i < 1200 {
-            p.card_frame_data = modern.clone();
-        }
+        p.card_frame_data = modern.clone();
         if i < 40 {
             p.card_frame_data = [modern.clone(), showcase.clone()].concat();
             p.card_frame_data.sort_unstable();
         }
     }
-    let idx = build_hybrid_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
-    assert!(idx.dense.contains_key("2015"), "a dominant value belongs in `dense`, not dropped");
-    assert!(!idx.sparse.contains_key("2015"), "and not duplicated into `sparse`");
-    assert_eq!(idx.sparse.get("Showcase").map(|v| v.len()), Some(40), "a sparse value stays postings");
-    assert!(!idx.dense.contains_key("Showcase"));
-    // The crossover is a size comparison, so check it directly rather than trusting the two cases above.
-    assert!(super::bitmap_beats_postings(1200, 2000) && !super::bitmap_beats_postings(40, 2000));
-    assert!(super::bitmap_beats_postings(63, 2000) && !super::bitmap_beats_postings(62, 2000), "crossover is 1/32");
+    let idx = build_thresholded_tag_index(&printings, &vocab.strings, |p| &p.card_frame_data);
+    assert!(!idx.contains_key("2015"), "dominant value must be dropped by the threshold");
+    assert_eq!(idx.get("Showcase").map(|v| v.len()), Some(40));
 
+    // Wired into narrowing: selective value narrows in printing space, the
+    // dropped value declines (None, not empty — the scan still answers it).
     let indexes = CardIndexes { frame_data: idx, ..Default::default() };
     let bytes = rkyv::to_bytes::<Error>(&indexes).expect("serialize");
     let archived = rkyv::access::<Archived<CardIndexes>, Error>(&bytes).expect("access");
@@ -6526,25 +6511,12 @@ fn frame_values_stored_dense_or_sparse_and_nothing_dropped() {
         value: value.to_string(),
         value_id: None,
     };
-    // Sparse: postings, in printing space, exactly as before.
     match narrow_candidates(&coll("Showcase"), archived, offsets, &[]) {
         Some(Candidates::Printings(v)) => assert_eq!(v.len(), 40),
-        other => panic!("selective frame value must narrow in printing space, got {other:?}"),
+        _ => panic!("selective frame value must narrow in printing space"),
     }
-    // Dense: a printing BITMAP, and it arrives despite `narrow_candidates` passing `broad_ok = false` --
-    // that gate refuses to PAY for a scatter, and a stored bitmap has none to pay. This is the case that
-    // used to be a full scan.
-    match narrow_candidates(&coll("2015"), archived, offsets, &[]) {
-        Some(Candidates::PrintingBits(b)) => {
-            assert_eq!(b.iter().map(|w| w.count_ones() as usize).sum::<usize>(), 1200);
-        }
-        other => panic!("a dense frame value must narrow to a printing bitmap, got {other:?}"),
-    }
-    // Absent: now a PROOF of emptiness rather than a shrug, because nothing is dropped.
-    match narrow_candidates(&coll("Zzz"), archived, offsets, &[]) {
-        Some(Candidates::Printings(v)) => assert!(v.is_empty(), "unknown value must narrow to empty"),
-        other => panic!("an unknown frame value must be provably empty, got {other:?}"),
-    }
+    assert!(narrow_candidates(&coll("2015"), archived, offsets, &[]).is_none());
+    assert!(narrow_candidates(&coll("Zzz"), archived, offsets, &[]).is_none());
 }
 
 // Streamed selection must agree with the gathered path. Two stores identical
@@ -7200,11 +7172,9 @@ fn collection_compose_leaves() {
         assert!(!super::is_printing_composable(&f, &archived.indexes), "type:goblin op={op:?} (loose) must stay off the compose path");
         assert!(!super::is_printing_composable(&not(f), &archived.indexes), "-(loose collection) must stay off the compose path");
     }
-    // frame_data is complete now, so it composes like every other containment leaf -- the whole point of
-    // storing its dense values rather than dropping them. It was the sole exclusion here.
     let frame = coll(CollField::FrameData, CmpOp::Ge, "showcase");
-    assert!(super::is_printing_composable(&frame.clone(), &archived.indexes), "frame: is complete and must compose");
-    assert!(super::is_printing_composable(&not(frame), &archived.indexes), "-frame: composes via the Not arm");
+    assert!(!super::is_printing_composable(&frame, &archived.indexes), "frame: (non-complete) must stay off the compose path");
+    assert!(!super::is_printing_composable(&not(frame), &archived.indexes), "-frame: must stay off the compose path");
     // A loose Eq inside an And keeps the whole And off the compose path.
     let mixed = FilterExpr::And(vec![ge(CollField::Subtypes, "goblin"), coll(CollField::Keywords, CmpOp::Eq, "Flying")]);
     assert!(!super::is_printing_composable(&mixed, &archived.indexes), "a loose Eq collection inside an And keeps the whole And off the compose path");

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -1,0 +1,129 @@
+# `is:` and `frame:` are 24% of dispatch time and four unrelated bugs
+
+After the value-major layout, the eur/tix indexes and the grouped orderby walk, `is:`/`frame:` queries
+are **24.0% of all remaining dispatch time** in uniform sampled traffic and none of them moved (0.97–1.03
+across every value). They are the largest remaining target, and the prefix hides at least four separate
+problems.
+
+Measured on the production corpus, `unique=card orderby=edhrec limit=60`, plan-own dispatch:
+
+| predicate | resolves to | count source | true | `eval_domain` | µs |
+| --- | --- | --- | --: | --: | --: |
+| `frame:2015` | `card_frame_data` | candidates | 22,562 | **31,508** | **603** |
+| `is:new` | `card_frame_data` | candidates | 22,562 | **31,508** | **558** |
+| `is:permanent` | `Or` over 6 `card_types` | candidates | 24,387 | **31,508** | **641** |
+| `is:old` | `Or` over `card_frame_data` | candidates | 7,191 | 7,191 | 399 |
+| `frame:2003` | `card_frame_data` | candidates | 8,905 | 8,905 | 322 |
+| `frame:1997` | `card_frame_data` | candidates | 6,302 | 6,302 | 251 |
+| `is:historic` | `card_frame_data` | candidates | 7,261 | 7,261 | **59** |
+| `is:dfc` … `is:flip` | `card_layout` | candidates | 20–388 | **31,508** | 70–209 |
+
+`eval_domain == 31,508` means nothing narrowed at all — a full corpus scan.
+
+## 1. The `frame_data` threshold drops its dense values, on a justification that expired
+
+`build_thresholded_tag_index` deliberately discards any value whose postings trip
+`range_too_broad_to_narrow`, and its own doc names the casualty:
+
+> values whose posting would be declined by the range guard anyway (frame:2015 covers 66% of
+> printings) are simply not stored — the absent-key convention already means "no narrowing", so
+> dropped and unknown values both fall back to the scan.
+
+**That reasoning is stale.** The range guard stopped declining broad sets in #636, and the consumer
+followed: `narrow_rec`'s `CollectionCmp` arm now scatters a broad printing-space posting list into a
+bitmap rather than giving up —
+
+```rust
+if !card_space && range_too_broad_to_narrow(v.len(), n_printings) {
+    if !broad_ok { return None; }
+    let bits = scatter_bits(v.iter().map(|x| u32::from(*x)), n_printings);
+    return mk(Candidates::PrintingBits(bits));
+}
+```
+
+So the build throws away postings the consumer is now equipped to use. `frame:2015` and `is:new` are the
+same underlying predicate and together are ~1.16 ms of mean dispatch over 293 sampled queries.
+
+**Fix:** stop thresholding, or raise the threshold to the point where a bitmap scatter stops paying.
+Cost is one posting list for the dropped values — `frame:2015` is 64,139 printings ≈ 257 KB, and it is
+the only value in the corpus above the guard.
+
+Verify with `eval_domain`, not with timing: it should stop reading 31,508.
+
+## 2. An `Or` containing `t:battle` loses the plane path entirely
+
+`is:permanent` desugars to `t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or
+t:battle`, and that last disjunct costs **11.5x**:
+
+| query | count source | plan | µs |
+| --- | --- | --- | --: |
+| 5 disjuncts (through `t:planeswalker`) | plane | PlanePopcountOrder | **55** |
+| … `or t:snow` (6 disjuncts) | plane | PlanePopcountOrder | 57 |
+| `t:instant or t:sorcery or t:snow or t:world or t:basic or t:kindred` (6) | plane | PlanePopcountOrder | 47 |
+| … `or t:battle` (6 disjuncts) | **candidates** | StreamedSelect | **497** |
+| `t:battle or t:creature` (2 disjuncts) | **candidates** | StreamedSelect | 90 |
+| `is:permanent` | **candidates** | StreamedSelect | **641** |
+
+Two candidate explanations are **ruled out** by that table: it is not the disjunct count (six other-type
+disjuncts stay on the plane path), and it is not a missing type plane (`TYPE_PLANES = 14` covers every
+bit including `TYPE_BATTLE = 1 << 2`, and `PERMANENT_TYPES` includes it).
+
+**The actual reason is not yet identified.** `t:battle` alone acquires as `printing_compose` returning 0
+rows in 3.5 µs, which is already odd for a `TypeCmp` — that is the thread to pull. Do not guess: two
+plausible mechanisms were already eliminated above.
+
+Whatever it is, the shape of the fix is likely the algebraic one: an empty or non-compilable disjunct
+should be *dropped* from an `Or` (`Or(x, ∅) = x`), not poison the whole expression.
+
+## 3. `card_types` has no `Battle`, which may be a correctness bug
+
+Counting `card_types` across the corpus gives 12 distinct names and **`Battle` is not among them**:
+
+    Creature 45,976   Legendary 13,537   Land 11,552   Artifact 10,949   Instant 10,725
+    Sorcery 10,626    Enchantment 9,914  Basic 4,196   Planeswalker 1,379  Snow 262
+    Kindred 183       World 42
+
+The corpus carries release dates through 2025-02-14, so battles (March of the Machine, 2023) should be
+present. If the live store is the same, then `t:battle` silently returns nothing and **`is:permanent`
+misses every battle** — a wrong answer, not just a slow one.
+
+Check the importer's type extraction before treating this as a corpus artifact. This is independent of
+(2): fixing the plane path would still return zero battles.
+
+## 4. `card_layout` is unindexed
+
+Already scoped and deprioritized in
+[local-engine-layout-postings.md](./local-engine-layout-postings.md) — `is:dfc`/`is:transform`/
+`is:mdfc`/`is:split`/`is:meld`/`is:leveler`/`is:flip` all resolve to `card_layout`, which has no index
+and no `narrow_rec` arm, so each is a full 31,508-card scan for as few as 20 matches.
+
+## The unexplained one
+
+`is:old` narrows to **7,191** cards and takes **399 µs**. `is:historic` narrows to **7,261** cards —
+0.4% more — and takes **59 µs**. Same field, same count source, near-identical evaluation domain,
+**6.8x** apart. Both are `Or`s over `card_frame_data`.
+
+That gap is not explained by anything above, and it is worth understanding before optimising either:
+whatever makes `is:historic` fast is presumably available to `is:old`.
+
+## Order
+
+1. **The `frame_data` threshold** (1) — largest, most certain, and the fix is deleting a stale guard.
+2. **The `Battle` data question** (3) — cheap to check and it is a correctness issue, so it outranks
+   the remaining performance items even though it is worth less time.
+3. **The `is:old` / `is:historic` gap** — diagnosis only, and it may explain more than those two.
+4. **The `t:battle` plane poisoning** (2) — worth 11.5x on a common idiom, but needs the mechanism found
+   first.
+5. `card_layout` (4) — deprioritized as rare.
+
+## Status
+
+Every number above is measured on the production corpus, minimum of 15 runs after warmup. The traffic
+share (24.0%) is one 150 s uniform sample of 53,071 priced queries. Nothing is implemented, and two
+mechanisms are explicitly open — (2)'s cause and the `is:old`/`is:historic` gap.
+
+`is:` and `frame:` are absent from `REALISTIC_FAMILY_WEIGHTS`, so the same caveat as
+[layout](./local-engine-layout-postings.md) applies: the 24% is a uniform-mode figure and the realistic
+share is unmodelled. Unlike layout, though, `frame:` IS in the realistic weights (0.5), and the
+`is:permanent`/`is:vanilla` shapes reach `card_types` and `oracle_text`, which are heavily weighted — so
+parts of this reach realistic traffic through other spellings.

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -20,7 +20,7 @@ Measured on the production corpus, `unique=card orderby=edhrec limit=60`, plan-o
 
 `eval_domain == 31,508` means nothing narrowed at all — a full corpus scan.
 
-## 1. The `frame_data` threshold drops its dense values — IMPLEMENTED, net latency still negative
+## 1. The `frame_data` threshold drops its dense values — IMPLEMENTED AND REVERTED
 
 `HybridTagIndex` shipped in `fb7f0a9`: every value stored, dense as a printing bitmap and the sparse
 tail as postings. The per-query wins are large and the memory prediction was exact (**130 KB smaller**,
@@ -49,11 +49,47 @@ frame:inverted` 40 → 72 µs, `name:of c:g frame:2003` 107 → 164, `pow<2 fram
 `t:warrior frame:2015` 161 → 211. Compose applicability is a property of the whole EXPRESSION, so one
 composable leaf makes an entire `And` composable however selective its siblings are.
 
-The obvious explanation was tested and is WRONG: the `Perm` branch learns its total from
-`compose_printing_bits` and declines a small one only after paying for the build, so hoisting that
-decline to a pre-build estimate check should have fixed it. It changed nothing (1.81× → 1.85×), and the
-guard was reverted. **Three mechanisms have now been eliminated by measurement in this area** — find the
-cause before judging this again.
+### The mechanism, found — and it is not compose
+
+Two hypotheses were tested and both were wrong. A pre-build sparsity guard (the `Perm` branch learns its
+total from `compose_printing_bits` and declines a small one only after paying) changed nothing:
+1.81× → 1.85×. The cause is not compose at all, which the counters show directly:
+
+| query | count_source | narrowed_repr | eval_domain | µs |
+| --- | --- | --- | --: | --: |
+| `pow<2` | candidates | none | 4,043 | **48.0** |
+| `pow<2 frame:2003` | candidates | **printing_bits** | **1,302** | **155.7** |
+
+Adding the frame leaf makes the narrowing *more* selective — 4,043 candidates down to 1,302 — and 3.2×
+slower, without ever reaching compose. The cost is `narrow_rec`'s `And` arm materialising an 11.9 KB
+dense bitmap and converting id spaces to intersect it, for a query whose sibling had already narrowed
+enough. That is exactly "the 10× And regressions of the first benchmark round" that `broad_ok` exists to
+prevent — and the implementation had bypassed `broad_ok` for dense values, reasoning that a *stored*
+bitmap has no scatter to pay.
+
+**That misread the gate.** `broad_ok` means "nothing downstream would consume this usefully", not merely
+"the scatter would be wasted". Inside an `And` with a selective sibling the bitmap IS consumed and still
+loses.
+
+### Why restoring the gate did not fix it either
+
+Honouring `broad_ok` for dense values moved the whole mix 1.084 → 1.059 and p99 to 549 µs (better than
+base), and turned `keyword:extort frame:inverted` from 1.81× into **0.51×**. But it broke others:
+
+| query | base | bypassing `broad_ok` | honouring it |
+| --- | --: | --: | --: |
+| `keyword:extort frame:inverted` | 39.7 µs | 71.8 (1.81×) | **20.2 (0.51×)** |
+| `pow<2 frame:2003` | 173.1 µs | 261.5 (1.51×) | 299.5 (**1.73×**) |
+| `set:ps11 frame:2015` | 56.9 µs | **11.7 (0.21×)** | 67.2 (1.18×) |
+| `set:hou frame:legendary` | 27.3 µs | **11.0 (0.40×)** | 58.7 (**2.15×**) |
+
+Different sub-populations want opposite settings. **`broad_ok` is a boolean standing in for a cost
+decision**, and that is the real blocker: whether materialising a broad child pays depends on the
+sibling's selectivity and on the id-space conversion it forces, which is a comparison the cost model
+should make and a boolean cannot express.
+
+So this was reverted (the engine change; this analysis stands). Retrying it means giving the `And` arm a
+cost-based choice about materialising a broad child — not a better boolean.
 
 Also note the control column sits on the ~9% run-to-run noise floor, and its worst row (`name:s`
 624 → 1188 µs) has no frame predicate, so part of it is not attributable. Restructuring `frame_data`

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -20,7 +20,26 @@ Measured on the production corpus, `unique=card orderby=edhrec limit=60`, plan-o
 
 `eval_domain == 31,508` means nothing narrowed at all — a full corpus scan.
 
-## 1. The `frame_data` threshold drops its dense values — IMPLEMENTED AND REVERTED
+## 0. FIRST: the revert below rests on a bad measurement — re-measure before trusting it
+
+Every wall-time figure in this doc's section 1 was taken against a baseline captured hours earlier. The
+same build re-measured back-to-back read **180.7 ms then against 220.6 ms later — 22% machine drift** —
+while the canary queries stayed flat at 31-32 µs, because three queries cannot see a broad thermal shift.
+
+Interpolating that drift, the hybrid index's "1.084 worse" was plausibly ~0.98, i.e. neutral or better.
+**The revert of `fb7f0a9` may therefore be wrong.** Before anything else here:
+
+1. On a quiet machine, capture base and hybrid **back-to-back**, two runs each side, per-query minimum.
+2. Include a control subset the change cannot touch (queries with no `frame:`/`is:` leaf) and require it
+   to read ~1.00. That is the check that actually caught this: `name:s` reading 2.21x on a query with no
+   frame predicate was the tell, not the canaries.
+3. Only then judge the aggregate.
+
+`fb7f0a9` is the commit to restore; `9cb7c15` reverted it. The per-query wins in it were measured with 20
+reps each and are not in doubt (`frame:2015` 603 -> 185 µs, `is:new` 558 -> 141, `is:old` 399 -> 62,
+`frame:2015` under `unique=printing` 834 -> 0.4) and neither is the 130 KB saving, which is deterministic.
+
+## 1. The `frame_data` threshold drops its dense values — IMPLEMENTED AND REVERTED (see 0)
 
 `HybridTagIndex` shipped in `fb7f0a9`: every value stored, dense as a printing bitmap and the sparse
 tail as postings. The per-query wins are large and the memory prediction was exact (**130 KB smaller**,
@@ -238,3 +257,24 @@ mechanisms are explicitly open — (2)'s cause and the `is:old`/`is:historic` ga
 share is unmodelled. Unlike layout, though, `frame:` IS in the realistic weights (0.5), and the
 `is:permanent`/`is:vanilla` shapes reach `card_types` and `oracle_text`, which are heavily weighted — so
 parts of this reach realistic traffic through other spellings.
+
+## 5. The `And` arm's cost-based skip — SHIPPED (`3cfd441`)
+
+The general fix the frame_data work turned out to need, and it stands on its own. `narrow_rec`'s `And`
+arm already had the rule — `AND_PROBE_FLOOR`'s doc: *"a child with `k < best` becomes the new,
+strictly-smaller driver (fewer residual verifications, never a regression)"* — but gated it on
+`rank > 0`, and only rank-1 range children had a probe. Rank 0 was assumed cheap to materialise and
+never checked, which is false for containment collections (`is:spell` is ~60k printing ids).
+
+`probe_collection_k` gives collections the same cheap size probe, and the skip drops `rank > 0` in
+favour of "we know what this child costs". Unprobed rank-0 children keep their benefit of the doubt.
+
+Measured against a **back-to-back** baseline: total 0.969, p50 0.971, p90 0.964, p99 0.967, with
+`keyword:extort frame:inverted` at **0.48x** and untouchable queries at 0.98-0.99.
+
+**Open:** `o:owner keyword:flying` at 1.56x. `keyword:flying` is a large *card-space* posting list, and
+card-space children were explicitly exempted from the broad guard ("card-space lists need no guard —
+same argument as `numeric_candidates`") because materialising card ids is cheap. Skipping one under an
+oracle-text driver may be the wrong call, in which case the probe should apply to printing-space
+children only. Not diagnosed — and worth re-measuring on a quiet machine before acting, for the reason
+in section 0.

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -44,9 +44,44 @@ if !card_space && range_too_broad_to_narrow(v.len(), n_printings) {
 So the build throws away postings the consumer is now equipped to use. `frame:2015` and `is:new` are the
 same underlying predicate and together are ~1.16 ms of mean dispatch over 293 sampled queries.
 
-**Fix:** stop thresholding, or raise the threshold to the point where a bitmap scatter stops paying.
-Cost is one posting list for the dropped values — `frame:2015` is 64,139 printings ≈ 257 KB, and it is
-the only value in the corpus above the guard.
+**And the threshold is inverted, not merely stale.** A posting list costs 4 bytes per member; a
+printing-space bitmap costs 1 bit per row of the domain. So a bitmap is smaller above `1/32 = 3.1%`
+density — and it also removes the query-time scatter entirely, rather than paying it per member. Across
+the 29 `frame_data` values in the corpus, 7 are above that crossover and 22 below:
+
+| frame value | printings | density | as postings | as p-bitmap | cheaper | stored today |
+| --- | --: | --: | --: | --: | --- | --- |
+| `2015` | 64,139 | **66.0%** | 250.5 KB | **11.9 KB** | bitmap | **NOT STORED** |
+| `2003` | 16,490 | 17.0% | 64.4 KB | **11.9 KB** | bitmap | postings |
+| `1997` | 10,769 | 11.1% | 42.1 KB | **11.9 KB** | bitmap | postings |
+| `Legendary` | 10,333 | 10.6% | 40.4 KB | **11.9 KB** | bitmap | postings |
+| `Inverted` | 7,244 | 7.5% | 28.3 KB | **11.9 KB** | bitmap | postings |
+| `1993` | 5,569 | 5.7% | 21.8 KB | **11.9 KB** | bitmap | postings |
+| `Extendedart` | 4,157 | 4.3% | 16.2 KB | **11.9 KB** | bitmap | postings |
+| `Showcase` … `Upsidedowndfc` (22 values) | ≤3,006 | ≤3.1% | ≤11.7 KB | 11.9 KB | postings | postings |
+
+The guard drops exactly ONE value, and it is the one where a bitmap wins by the largest margin (21x).
+Everything it keeps as postings includes six more values that would also be smaller as bitmaps.
+
+**Fix: per-value cheaper-of-the-two, which is what `BorderPrintingPlanes` and `RarityPrintingPlanes`
+already do** — a one-hot plane per dense value plus postings for the sparse tail. `frame_data` is the one
+collection index that got neither.
+
+| scheme | total |
+| --- | --: |
+| all 29 as postings | 491 KB |
+| all 29 as printing bitmaps | 344 KB |
+| **per-value cheaper-of-the-two** | **111 KB** |
+| stored today (all but `2015`, as postings) | 240 KB |
+
+So it is **130 KB smaller than today AND removes the full scan** — not a size-for-speed trade.
+
+**A card-space existential bitmap is a different job, not a substitute.** 3.8 KB per value (112 KB for
+all 29), exact for card-mode TOTALS — which is the 132 µs `printing_bits_to_card_bits` projection
+discussed in [the walk-modes doc](./local-engine-orderby-walk-modes.md) — but LOOSE for row selection,
+since "this card has ≥1 printing with frame 2015" does not say which printing. Printing and artwork mode
+still need the printing bitmap. Border already carries both (`PLANE_BORDER` card-space +
+`BorderPrintingPlanes` printing-space), and that pairing is the shape to copy.
 
 Verify with `eval_domain`, not with timing: it should stop reading 31,508.
 

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -20,7 +20,47 @@ Measured on the production corpus, `unique=card orderby=edhrec limit=60`, plan-o
 
 `eval_domain == 31,508` means nothing narrowed at all — a full corpus scan.
 
-## 1. The `frame_data` threshold drops its dense values, on a justification that expired
+## 1. The `frame_data` threshold drops its dense values — IMPLEMENTED, net latency still negative
+
+`HybridTagIndex` shipped in `fb7f0a9`: every value stored, dense as a printing bitmap and the sparse
+tail as postings. The per-query wins are large and the memory prediction was exact (**130 KB smaller**,
+72,158,208 → 72,025,104 bytes):
+
+| query | before | after |
+| --- | --: | --: |
+| `frame:2015` (card) | 603.1 µs | **185.5 µs** |
+| `is:new` (card) | 557.6 µs | **141.1 µs** |
+| `is:old` (card) | 399.1 µs | **62.1 µs** |
+| `frame:2003` (card) | 322.3 µs | **68.6 µs** |
+| `frame:1997` (card) | 250.9 µs | **54.2 µs** |
+| `frame:inverted` (card) | 249.5 µs | **50.9 µs** |
+| `frame:2015` (printing) | 834 µs | **0.4 µs** |
+
+**But the net is not a win yet.** Paired routed-path wall time, 2,000 realistic queries:
+
+| subset | n | before | after | ratio |
+| --- | --: | --: | --: | --: |
+| `is:`/`frame:` touched | 56 | 9.1 ms | 8.4 ms | 0.920 |
+| everything else | 1,944 | 171.6 ms | 187.5 ms | 1.093 |
+| whole mix | 2,000 | 180.7 ms | **195.9 ms** | **1.084** |
+
+A real regression class came with it: **a sparse `And` containing a frame leaf.** `keyword:extort
+frame:inverted` 40 → 72 µs, `name:of c:g frame:2003` 107 → 164, `pow<2 frame:2003` 173 → 262,
+`t:warrior frame:2015` 161 → 211. Compose applicability is a property of the whole EXPRESSION, so one
+composable leaf makes an entire `And` composable however selective its siblings are.
+
+The obvious explanation was tested and is WRONG: the `Perm` branch learns its total from
+`compose_printing_bits` and declines a small one only after paying for the build, so hoisting that
+decline to a pre-build estimate check should have fixed it. It changed nothing (1.81× → 1.85×), and the
+guard was reverted. **Three mechanisms have now been eliminated by measurement in this area** — find the
+cause before judging this again.
+
+Also note the control column sits on the ~9% run-to-run noise floor, and its worst row (`name:s`
+624 → 1188 µs) has no frame predicate, so part of it is not attributable. Restructuring `frame_data`
+shifts every later field's archive offset, which is a plausible global cache effect and a hazard of any
+layout change.
+
+### The original diagnosis, kept for the reasoning
 
 `build_thresholded_tag_index` deliberately discards any value whose postings trip
 `range_too_broad_to_narrow`, and its own doc names the casualty:

--- a/docs/issues/local-engine-layout-postings.md
+++ b/docs/issues/local-engine-layout-postings.md
@@ -3,8 +3,9 @@
 **Deprioritized 2026-08-05** — layout predicates are judged rare in real use, which the traffic caveat
 below already flagged as the deciding unknown. Kept as a scoped, measured, ~4.5 KB fix if that judgement
 ever changes; do not pick it up ahead of
-[the artwork-mode walk gap](./local-engine-orderby-walk-modes.md), which is 136 of the 200 slowest
-queries against this one's 7.
+[the artwork-mode walk gap](./local-engine-orderby-walk-modes.md) (now shipped) or the rest of the
+`is:`/`frame:` family ([local-engine-is-frame-predicates.md](./local-engine-is-frame-predicates.md)),
+which is 24% of remaining dispatch time against this one's share of it.
 
 `is:flip` matches **20 oracle cards**. It takes **187 µs** and scans the whole corpus to get there,
 because `card_layout_id` — an interned string on `OracleCard`, 14 distinct values — has no index and no

--- a/docs/issues/local-engine-orderby-walk-modes.md
+++ b/docs/issues/local-engine-orderby-walk-modes.md
@@ -1,9 +1,9 @@
 # The orderby walk is printing-mode only, and card mode pays 18x for it
 
-**Shipped** (`b0618f0`) — one walk for all three distinct-ons, via the group representative. What the
-work actually turned on was not the walk but an EXACTNESS fix in the router's card estimate; see
-[Outcome](#outcome). Two routing attempts failed first and both are recorded, because each failed in a
-way worth not repeating.
+**Shipped** (`b0618f0`, `38423f5`) — one walk for all three distinct-ons, via the group representative.
+The walk was the easy half; routing it took four attempts, and the thing that finally worked was
+realising that **breadth does not decide it — whether the compose build broadcasts does.** See
+[Outcome](#outcome). Target subset 6.9% faster, whole mix 2.9%, p99 down 8.1%.
 
 `border:black` ordered by rarity takes **25 µs** under `unique=printing`, **451 µs** under
 `unique=card`, and **836 µs** under `unique=artwork`. Same filter, same orderby, same corpus. The walk
@@ -244,28 +244,81 @@ because the formula saturates against the domain while the truth approaches it. 
 bias constant fixed it, and why the 0.85 gate — sitting exactly where the error changes sign — behaved
 so badly.
 
+### Attempt 3 was a fitted threshold, and the sweep that killed it
+
+Comparing result-space totals at a fitted 0.75 got the regressions to 1.00x and kept four wins, but the
+aggregate stayed inside the noise floor — and it excluded `cn>=74 cn<=413` by **0.4 percentage points**
+on a query where the walk is 5x faster. That near-miss was the clue to sweep the axis properly. Forcing
+the branch each way over 14 card-mode filters x {usd, rarity}:
+
+| breadth | query | walk/gather | |
+| --: | --- | --: | --- |
+| 100% | `r<=mythic` | **0.28×** | walk |
+| 100% | `f:duel` | 1.25× | gather |
+| 99% | `border:black` | **0.41×** | walk |
+| 75% | `cn>=74 cn<=413` | **0.20×** | walk |
+| 71% | `f:modern` | 1.08× | gather |
+| 48% | `f:penny` | 1.85× | gather |
+| 45% | `cn>200` | **0.53×** | walk |
+| 35% | `r:rare` | **0.57×** | walk |
+| 34% | `f:pauper` | 1.75× | gather |
+| 15% | `f:future` | 1.37× | gather |
+| 9% | `r>=mythic` | **0.54×** | walk |
+
+**Breadth does not predict the winner. The filter family does** — every legality filter loses, every
+range/plane filter wins, at every breadth from 9% to 100%, 28 of 28 cells separated by one bit.
+
+A legality leaf's compose build BROADCASTS a card-space plane across every printing of every matching
+card, which dominates the query — `f:duel` measures ~180 µs on *both* branches, so paging is noise — and
+legality is card-invariant, so the gather's early break lands at its best possible case, 1.01 printings
+per card. A range or plane leaf composes with a cheap slice or scatter, leaving paging to dominate, and
+that is where an O(page) walk beats an O(matches) gather.
+
+### What shipped: a structural gate
+
+`compose_needs_broadcast(filter)` — does this tree contain a legality leaf — plus the existing sparse
+floor. Structural matters twice: it removes the fitted constant, and it removes the estimate-vs-exact
+disagreement between router and executor that caused attempts 1 and 2, because both sides read the same
+tree. `compose_paging_with_total` takes the filter now, and the acquire passes `compose_source`'s output
+rather than the residual, since a plane-consumed residual would hide the leaf that decides the branch.
+
 ### What it is worth
 
 Paired wall time, 2,000 realistic queries, per-query minimum over two runs on each side:
 
-| subset | n | base | final | ratio |
-| --- | --: | --: | --: | --: |
-| card/artwork × (usd\|rarity) TARGET | 279 | 35.3 ms | 35.0 ms | 0.992 |
-| printing × (usd\|rarity) | 76 | 10.0 ms | 10.1 ms | 1.008 |
-| everything else CONTROL | 1,645 | 140.6 ms | 141.8 ms | 1.008 |
-| whole mix | 2,000 | 186.0 ms | 187.0 ms | 1.005 |
+| subset | n | base | attempt 3 (0.75) | **final** | final/base |
+| --- | --: | --: | --: | --: | --: |
+| card/artwork × (usd\|rarity) TARGET | 279 | 35.3 ms | 35.0 ms | **32.9 ms** | **0.931** |
+| printing × (usd\|rarity) | 76 | 10.0 ms | 10.1 ms | 9.8 ms | 0.981 |
+| everything else CONTROL | 1,645 | 140.6 ms | 141.8 ms | 138.0 ms | 0.981 |
+| whole mix | 2,000 | 186.0 ms | 187.0 ms | **180.7 ms** | **0.971** |
 
-**The aggregate is inside the noise floor and the honest claim is "no regression", not "a win"** — the
-target shapes are 279 queries and the wins total ~500 µs. What is reproducible per query is
-`border:black` 449 → 230, `cn<645` 551 → 319, `f:duel` 450 → 345, `f:oathbreaker` 378 → 303 µs, and
-p99 635 → 620 µs.
+p50 59.0 → 58.1, p90 172.3 → 168.4, **p99 635.4 → 583.8 µs**. Control and printing both read 0.981 —
+inside the noise floor — so the aggregate move is the target subset's. And unlike attempt 3, which paid
+off on four queries, the wins are broad:
 
-### Known limitation, named rather than tuned around
+| query | before | after |
+| --- | --: | --: |
+| `cn>=74 cn<=413` | 849 µs | **227 µs** (attempt 3 excluded it entirely) |
+| `r>=mythic` | 151 µs | **58 µs** (9% breadth; attempt 3 declined it) |
+| `year>=1994 year<=2013` | 352 µs | 156 µs |
+| `r<=uncommon` | 422 µs | 195 µs |
+| `border:black` | 449 µs | 228 µs |
+| `cn<645` | 551 µs | 315 µs |
+| `year>2017` | 516 µs | 297 µs |
+| `date<2019-11-07` | 527 µs | 317 µs |
 
-`cn>=74 cn<=413` went 849 → 224 µs under attempt 1 and is back at 827 µs. It is a two-sided INTERIOR
-range, where `distinct_cards` declines because distinct counts do not subtract, so the router is on the
-estimate and disagrees with the executor. Fixing it means an exact interior-range card count — the
-binned start×end triangle table in
-[local-engine-range-cardinality-estimate.md](./local-engine-range-cardinality-estimate.md) — or
-threading the router's decision to the executor instead of re-deriving it, which is the durable fix for
-the whole class and would also retire `GROUPED_WALK_MIN_FRACTION`'s fitted 0.75.
+Regressions are 1.11–1.28× on queries of 12–45 µs, plus one 100 → 114 µs row on `orderby=name` that
+this change cannot reach.
+
+### Two corrections to earlier readings of this data
+
+- **`r>=mythic` and `t:creature year<=2016` were listed as attempt-1 "wins". They were noise.** Verified
+  by BRANCH rather than by timing: `r>=mythic` card/usd is 9% of the domain, compose declined in every
+  build, and `GatheredScan` ran throughout; `t:creature year<=2016` is `orderby=name`, which has a
+  permutation. A table sorted by timing ratio mixes real branch changes with a ±1.58× per-query noise
+  floor, so branch identity is the check, not the ratio. (`r>=mythic` *is* a genuine win now — but only
+  because the structural gate lets it walk, which is a different mechanism.)
+- **The comparison itself was unfair for one round**: best-of-two on the baseline against a single run of
+  the new build hands the baseline a floor the new build never gets, which manufactured
+  "`f:penny` 2.6× slower" on an orderby that has a permutation. Both sides need the same estimator.


### PR DESCRIPTION
**Layer 8 of 13.** Base: #839. Reference: #830. **Archive bump: `2026080508`.**

`frame_data` was the one collection index that got neither of the two representations its siblings use.
It stored every value as postings and dropped the single densest one (`2015`, 66% of printings) at build,
so `frame:2015` full-scanned 31,508 cards to return 64,139 printings.

Per value, cheaper-of-the-two — a printing bitmap for the dense values, postings for the sparse tail,
which is what `BorderPrintingPlanes` and `RarityPrintingPlanes` already do:

| scheme | total |
| --- | --: |
| all 29 as postings | 491 KB |
| all 29 as printing bitmaps | 344 KB |
| **per-value cheaper-of-the-two** | **111 KB** |
| stored before (all but `2015`) | 240 KB |

So **133 KB smaller and the scan is gone** — not a size-for-speed trade. Whole mix **0.815**, p99 **0.648**.

## Three commits, because the first attempt was wrong

`fb7f0a9` shipped it, `9cb7c15` reverted it, `f855135` reshipped. The revert is the interesting one: the
first cut bypassed `broad_ok` for dense values, reasoning that a *stored* bitmap has no scatter to pay.
That misreads the gate — it means "nothing downstream would consume this usefully", not "the scatter
would be wasted" — and cost 1.3–1.8× on sparse `And`s. The reshipped version honours it, and layer 4's
`And` cost probe is what makes a broad frame child get skipped on cost before the gate is reached.

Squash-merging collapses the three, which is fine; the history is in #830 if the reasoning is wanted.

## Measurement note

An earlier attempt to price this read an 18% regression that was a **stale baseline** — the same build
measured 180.7 ms and 220.6 ms hours apart while canary queries stayed flat at 31–32 µs. The number above
is from an interleaved A/B with a control subset, which is what caught it.

## Verification

`cargo test` (149) and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
