### PR TITLE
Engine: Exact Three-Space Totals (stack 9/13)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6887,12 +6887,7 @@ fn walk_value_orderby_page<'a>(
 /// No new stored table: both counts are already on the query path. A per-format count table would work
 /// too (there are at most 32 formats x 4 statuses, so ~1 KB) but it would store what a popcount of a
 /// plane the query already reads gives for nothing.
-fn exact_result_total(
-    composed: &FilterExpr,
-    indexes: &Archived<CardIndexes>,
-    n_cards: usize,
-    mode: Mode,
-) -> Option<usize> {
+fn exact_result_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, mode: Mode) -> Option<usize> {
     if let Some((idx, lo, hi)) = bare_range_bounds(composed, indexes) {
         // Printings come free from the index's own partition points; the other two spaces come from the
         // prefix/suffix tables, which now carry an artwork column as well as a card one.
@@ -9284,11 +9279,11 @@ fn acquire_plan_features(
         // mode, because `eval_domain`, `scan_all` and the artwork capacity all consume a card count.
         // `exact_total` is the answer in the query's OWN mode, and is what `result_total` wants.
         // Conflating them puts an artwork count where cards are expected in artwork mode.
-        let exact_cards = exact_result_total(composed, indexes, n_cards as usize, Mode::Card);
+        let exact_cards = exact_result_total(composed, indexes, Mode::Card);
         let exact_total = if matches!(mode, Mode::Card) {
             exact_cards
         } else {
-            exact_result_total(composed, indexes, n_cards as usize, mode)
+            exact_result_total(composed, indexes, mode)
         };
         let est_cards =
             exact_cards.unwrap_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize));
@@ -10627,12 +10622,12 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-// Stack layer 08: `frame_data` becomes a `HybridTagIndex` -- a printing bitmap for the dense values,
-// postings for the sparse tail -- which is an archived-layout change, so a store built against the
-// previous layer must fail the header check and be rebuilt rather than be read as garbage.
-// Numbered by stack patch; the header check is EQUALITY, so the invariant is only that a value is
-// never reused for a different layout.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026080508;
+// Stack layer 09: `RangeCardCounts` gains an artwork column, a sixth table is added for rarity, and
+// `ValueTotals` arrives for border/layout/frame/(format,status). All archived-layout changes, so a
+// store built against the previous layer must fail the header check and be rebuilt rather than be
+// read as garbage. Numbered by stack patch; the check is EQUALITY, so the invariant is only that a
+// value is never reused for a different layout.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026080509;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2447,6 +2447,19 @@ struct RangeCardCounts {
     /// Distinct cards among printings with value == `values[i]`. Serves `Eq`, which cannot be had by
     /// subtracting neighbouring `below` entries.
     at: Vec<u32>,
+    /// The same three aggregates over distinct ARTWORKS.
+    ///
+    /// The third space, added because it was the only one estimated for every range: printings come
+    /// free as `k = e - s` and cards from the triple above, while artwork totals went through
+    /// `printing_bits_to_artwork_bits` and were read as 0.80-0.87 of the truth. Filled in the SAME pass
+    /// as the card triple, over a parallel artwork-seen bitmap, so the two cannot drift.
+    ///
+    /// Costs a measured **156.6 KB** of archive across the five range dimensions (12 bytes per distinct
+    /// value, ~13,400 values), or 0.22% — the honest price of the exactness, and more than the 133 KB
+    /// `frame_data`'s hybrid gave back.
+    below_artworks: Vec<u32>,
+    at_or_above_artworks: Vec<u32>,
+    at_artworks: Vec<u32>,
 }
 
 impl ArchivedRangeCardCounts {
@@ -2458,7 +2471,26 @@ impl ArchivedRangeCardCounts {
     /// several values (only `year:Y`, which covers a whole calendar year of release dates) returns
     /// `None`; distinct counts do not subtract, so the neighbouring entries cannot be combined.
     fn distinct_cards(&self, lo: u32, hi: u32) -> Option<u32> {
-        if self.values.is_empty() || hi <= lo {
+        self.lookup(lo, hi, &self.below, &self.at_or_above, &self.at)
+    }
+
+    /// Exact distinct ARTWORKS for `[lo, hi)`, on the same answerable shapes as `distinct_cards`.
+    fn distinct_artworks(&self, lo: u32, hi: u32) -> Option<u32> {
+        self.lookup(lo, hi, &self.below_artworks, &self.at_or_above_artworks, &self.at_artworks)
+    }
+
+    /// The shape both spaces share: which of the three aggregates a `[lo, hi)` reduces to, or `None`
+    /// where distinct counts cannot be combined. Written once so the two spaces cannot answer
+    /// differently-shaped questions.
+    fn lookup(
+        &self,
+        lo: u32,
+        hi: u32,
+        below: &Archived<Vec<u32>>,
+        at_or_above: &Archived<Vec<u32>>,
+        at: &Archived<Vec<u32>>,
+    ) -> Option<u32> {
+        if self.values.is_empty() || hi <= lo || below.is_empty() {
             return None;
         }
         let pos = |v: u32| self.values.partition_point(|x| u32::from(*x) < v);
@@ -2469,11 +2501,11 @@ impl ArchivedRangeCardCounts {
         let first = u32::from(self.values[0]);
         let last_covers_end = j == self.values.len();
         match (lo <= first, last_covers_end) {
-            (true, true) => Some(u32::from(self.at_or_above[0])), // whole index
-            (true, false) => Some(u32::from(self.below[j])),      // `<` / `<=`
-            (false, true) => Some(u32::from(self.at_or_above[i])), // `>` / `>=`
+            (true, true) => Some(u32::from(at_or_above[0])), // whole index
+            (true, false) => Some(u32::from(below[j])),      // `<` / `<=`
+            (false, true) => Some(u32::from(at_or_above[i])), // `>` / `>=`
             // Interior range: exact only when it holds a single distinct value, which is `Eq`.
-            (false, false) if j == i + 1 => Some(u32::from(self.at[i])),
+            (false, false) if j == i + 1 => Some(u32::from(at[i])),
             _ => None,
         }
     }
@@ -2482,59 +2514,93 @@ impl ArchivedRangeCardCounts {
 /// Build the three count vectors for one range index. O(n) over the index plus one card-seen bitmap
 /// per direction, so two passes; the index is value-major, so the value blocks are already delimited
 /// by `starts` and no boundary scan is needed.
-fn build_range_card_counts(idx: &PrintingValueIndex, printing_to_card: &[u32], n_cards: usize) -> RangeCardCounts {
+fn build_range_card_counts(
+    idx: &PrintingValueIndex,
+    printing_to_card: &[u32],
+    n_cards: usize,
+    // pid -> the printing's artwork group within its card, and card -> its first global artwork id.
+    // Together these give a printing's GLOBAL artwork id, the same derivation
+    // `printing_bits_to_artwork_bits` uses.
+    printings: &[Printing],
+    artwork_base: &[u32],
+) -> RangeCardCounts {
     let mut out = RangeCardCounts::default();
     if idx.pids.is_empty() {
         return out;
     }
     let n_values = idx.keys.len();
+    let n_artworks = artwork_base.last().copied().unwrap_or(0) as usize;
     let run = |b: usize| idx.starts[b] as usize..idx.starts[b + 1] as usize;
     out.values = idx.keys.clone();
+    // (card id, global artwork id) for a printing. One closure so the two spaces are derived from the
+    // same pid in the same place.
+    let ids = |pid: u32| {
+        let cid = printing_to_card[pid as usize] as usize;
+        let aid = artwork_base[cid] as usize + printings[pid as usize].artwork_group_id as usize;
+        (cid, aid)
+    };
 
-    let words = n_cards.div_ceil(64);
-    let mut seen = vec![0u64; words];
-    let mut distinct = 0u32;
+    // Two spaces, two domains, one pass over the index. A set-bit test per space per printing is
+    // cheaper than walking the index twice, and it keeps the card and artwork columns in lockstep.
+    let mut seen_c = vec![0u64; n_cards.div_ceil(64)];
+    let mut seen_a = vec![0u64; n_artworks.div_ceil(64)];
+    let (mut nc, mut na) = (0u32, 0u32);
+    let bump = |seen: &mut [u64], n: &mut u32, id: usize| {
+        let (w, bit) = (id >> 6, 1u64 << (id & 63));
+        if seen[w] & bit == 0 {
+            seen[w] |= bit;
+            *n += 1;
+        }
+    };
     // Forward: `below[i]` is the running distinct count before this value's block begins.
     for b in 0..n_values {
-        out.below.push(distinct);
+        out.below.push(nc);
+        out.below_artworks.push(na);
         for &pid in &idx.pids[run(b)] {
-            let cid = printing_to_card[pid as usize] as usize;
-            let (w, bit) = (cid >> 6, 1u64 << (cid & 63));
-            if seen[w] & bit == 0 {
-                seen[w] |= bit;
-                distinct += 1;
-            }
+            let (cid, aid) = ids(pid);
+            bump(&mut seen_c, &mut nc, cid);
+            bump(&mut seen_a, &mut na, aid);
         }
     }
-    // Backward for `at_or_above`, and per-block for `at` — both need their own fresh bitmap, since a
-    // card counted in one block must still count in another.
-    seen.fill(0);
-    distinct = 0;
+    // Backward for `at_or_above`, and per-block for `at` — both need their own fresh bitmap, since an
+    // id counted in one block must still count in another.
+    seen_c.fill(0);
+    seen_a.fill(0);
+    nc = 0;
+    na = 0;
     out.at_or_above = vec![0; n_values];
     out.at = vec![0; n_values];
-    // One scratch bitmap reused across blocks, cleared by walking back over the cards this block
-    // actually touched — a `fill(0)` per block would be O(n_cards) each, and there are as many
-    // blocks as distinct values.
-    let mut block = vec![0u64; words];
-    let mut touched: Vec<usize> = Vec::new();
+    out.at_or_above_artworks = vec![0; n_values];
+    out.at_artworks = vec![0; n_values];
+    // Scratch bitmaps reused across blocks, cleared by walking back over the ids this block actually
+    // touched — a `fill(0)` per block would be O(domain) each, and there are as many blocks as
+    // distinct values.
+    let mut block_c = vec![0u64; n_cards.div_ceil(64)];
+    let mut block_a = vec![0u64; n_artworks.div_ceil(64)];
+    let (mut touched_c, mut touched_a): (Vec<usize>, Vec<usize>) = (Vec::new(), Vec::new());
     for b in (0..n_values).rev() {
-        touched.clear();
+        touched_c.clear();
+        touched_a.clear();
         for &pid in &idx.pids[run(b)] {
-            let cid = printing_to_card[pid as usize] as usize;
-            let (w, bit) = (cid >> 6, 1u64 << (cid & 63));
-            if seen[w] & bit == 0 {
-                seen[w] |= bit;
-                distinct += 1;
-            }
-            if block[w] & bit == 0 {
-                block[w] |= bit;
-                touched.push(cid);
+            let (cid, aid) = ids(pid);
+            bump(&mut seen_c, &mut nc, cid);
+            bump(&mut seen_a, &mut na, aid);
+            for (blk, touched, id) in [(&mut block_c, &mut touched_c, cid), (&mut block_a, &mut touched_a, aid)] {
+                let (w, bit) = (id >> 6, 1u64 << (id & 63));
+                if blk[w] & bit == 0 {
+                    blk[w] |= bit;
+                    touched.push(id);
+                }
             }
         }
-        out.at_or_above[b] = distinct;
-        out.at[b] = touched.len() as u32;
-        for &cid in &touched {
-            block[cid >> 6] &= !(1u64 << (cid & 63));
+        out.at_or_above[b] = nc;
+        out.at[b] = touched_c.len() as u32;
+        out.at_or_above_artworks[b] = na;
+        out.at_artworks[b] = touched_a.len() as u32;
+        for (blk, touched) in [(&mut block_c, &touched_c), (&mut block_a, &touched_a)] {
+            for &id in touched.iter() {
+                blk[id >> 6] &= !(1u64 << (id & 63));
+            }
         }
     }
     out
@@ -6624,9 +6690,26 @@ fn walk_value_orderby_page<'a>(
 /// No new stored table: both counts are already on the query path. A per-format count table would work
 /// too (there are at most 32 formats x 4 statuses, so ~1 KB) but it would store what a popcount of a
 /// plane the query already reads gives for nothing.
-fn exact_card_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: usize) -> Option<usize> {
+fn exact_result_total(
+    composed: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    n_cards: usize,
+    mode: Mode,
+) -> Option<usize> {
     if let Some((idx, lo, hi)) = bare_range_bounds(composed, indexes) {
-        return range_card_counts_for(indexes, idx).and_then(|counts| counts.distinct_cards(lo, hi)).map(|n| n as usize);
+        // Printings come free from the index's own partition points; the other two spaces come from the
+        // prefix/suffix tables, which now carry an artwork column as well as a card one.
+        let (s, e) = idx.range(lo, hi);
+        return match mode {
+            Mode::Printing => Some(e - s),
+            Mode::Card => range_card_counts_for(indexes, idx).and_then(|c| c.distinct_cards(lo, hi)).map(|n| n as usize),
+            Mode::Artwork => range_card_counts_for(indexes, idx).and_then(|c| c.distinct_artworks(lo, hi)).map(|n| n as usize),
+        };
+    }
+    // The remaining shapes below are exact in CARD space only, so any other mode falls back to the
+    // estimator. Extending them is what the per-value 3-space count table is for.
+    if !matches!(mode, Mode::Card) {
+        return None;
     }
     if let FilterExpr::Legality { shift: Some(shift), expected } = composed {
         return legality_candidate_bits(indexes, n_cards, *shift, *expected, false)
@@ -8963,7 +9046,16 @@ fn acquire_plan_features(
         // projection -- and those are the bulk of what reaches here, since `bare_range_bounds`
         // matches one comparison, not an And of two. One-sided ranges DO land here in quantity:
         // every artwork-mode one, plus card-mode ones whose orderby has no permutation.
-        let exact_cards = exact_card_total(composed, indexes, n_cards as usize);
+        // Two quantities, deliberately separate. `exact_cards` is CARD space no matter the query's
+        // mode, because `eval_domain`, `scan_all` and the artwork capacity all consume a card count.
+        // `exact_total` is the answer in the query's OWN mode, and is what `result_total` wants.
+        // Conflating them puts an artwork count where cards are expected in artwork mode.
+        let exact_cards = exact_result_total(composed, indexes, n_cards as usize, Mode::Card);
+        let exact_total = if matches!(mode, Mode::Card) {
+            exact_cards
+        } else {
+            exact_result_total(composed, indexes, n_cards as usize, mode)
+        };
         let est_cards =
             exact_cards.unwrap_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize));
         // What the MATERIALIZING alternatives scan if compose loses. Every mode narrows -- a
@@ -9014,7 +9106,10 @@ fn acquire_plan_features(
                 // over-picked in artwork specifically: that slice carries 21% of ALL routing regret at
                 // p99 205us against 40us for printing and 36us for card.
                 let capacity_cards = exact_cards.unwrap_or_else(|| balls_into_bins(printing_matches, n_cards as usize));
-                let rt = artwork_estimate(printing_matches, capacity_cards, n_cards as usize, n_artworks);
+                // The two-stage estimate is only reached when nothing exact is available. A bare
+                // one-sided range now answers artwork exactly from the range table's artwork column,
+                // which is the one space every such query used to estimate (0.80-0.87 measured).
+                let rt = exact_total.unwrap_or_else(|| artwork_estimate(printing_matches, capacity_cards, n_cards as usize, n_artworks));
                 // The bitmap `printing_bits_to_artwork_bits` popcounts is n_artworks bits wide, not
                 // n_printings -- 46,112 against 97,206 here, so this was 2.1x over as well.
                 (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
@@ -10821,11 +10916,11 @@ impl QueryEngine {
         let price_eur_idx = build_printing_value_index(&printings, &cards, &offsets, |p| p.price_eur);
         let price_tix_idx = build_printing_value_index(&printings, &cards, &offsets, |p| p.price_tix);
         let collector_number_idx = build_printing_value_index(&printings, &cards, &offsets, |p| p.collector_number_int.map(u32::from));
-        let released_at_cards = build_range_card_counts(&released_at_idx, &printing_to_card, cards.len());
-        let price_usd_cards = build_range_card_counts(&price_usd_idx, &printing_to_card, cards.len());
-        let price_eur_cards = build_range_card_counts(&price_eur_idx, &printing_to_card, cards.len());
-        let price_tix_cards = build_range_card_counts(&price_tix_idx, &printing_to_card, cards.len());
-        let collector_number_cards = build_range_card_counts(&collector_number_idx, &printing_to_card, cards.len());
+        let released_at_cards = build_range_card_counts(&released_at_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
+        let price_usd_cards = build_range_card_counts(&price_usd_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
+        let price_eur_cards = build_range_card_counts(&price_eur_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
+        let price_tix_cards = build_range_card_counts(&price_tix_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
+        let collector_number_cards = build_range_card_counts(&collector_number_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -6632,6 +6632,27 @@ fn exact_card_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, n_ca
         return legality_candidate_bits(indexes, n_cards, *shift, *expected, false)
             .map(|b| b.iter().map(|w| w.count_ones() as usize).sum());
     }
+    // A CARD-space containment leaf (`t:`/`keyword:`/`otag:`) posts card ids, so its postings length IS
+    // the exact distinct-card count -- the same "the answer was already computed and then discarded"
+    // shape the legality arm above fixes. The acquire was projecting the leaf's PRINTING count through
+    // balls-into-bins instead, which reads 1.27x on `t:human` (5,411 estimated against 4,249 exact) and
+    // up to 2.24x on `t:angel`.
+    //
+    // `Ge` only. `Eq`/`Gt` share these postings as a loose superset -- they prove containment but not the
+    // collection-length condition -- so their count is an upper bound, not a total.
+    if let FilterExpr::CollectionCmp { field, op: CmpOp::Ge, value, .. } = composed {
+        let card_space_idx = match field {
+            CollField::Subtypes => Some(&indexes.subtypes),
+            CollField::Keywords => Some(&indexes.keywords),
+            CollField::OracleTags => Some(&indexes.oracle_tags),
+            // Printing-space: postings are printing ids, so their length is not a card count. These want
+            // an import-time count table (the artwork side needs one for every family, including the
+            // ranges and formats that are already exact in card space).
+            CollField::ArtTags | CollField::IsTags | CollField::FrameData => None,
+        };
+        // Absent from a complete index is an exact ZERO, not "no answer".
+        return card_space_idx.map(|idx| idx.get(value.as_str()).map_or(0, |v| v.len()));
+    }
     None
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2992,6 +2992,15 @@ struct CardIndexes {
     price_eur_cards:        RangeCardCounts,
     price_tix_cards:        RangeCardCounts,
     collector_number_cards: RangeCardCounts,
+    /// The sixth, over `rarity_printing_ordered`. Rarity is NOT a `bare_range_bounds` member -- that
+    /// would make rarity queries eligible for `PrintingRangeScan`/`CardRangePopcount`, a routing change
+    /// worth its own measurement -- so this serves `exact_result_total`'s dedicated rarity arm only.
+    /// 6 distinct values, so it is ~144 bytes.
+    ///
+    /// Per-value counts would NOT have worked here: a card can be printed at several rarities, so
+    /// distinct cards for `r<=rare` is not the sum of the at-rarity counts. Prefix/suffix/at is the
+    /// shape the question needs, and it is the shape this struct already is.
+    rarity_cards:           RangeCardCounts,
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     // card space, n_cards+1 entries: prefix sum of artwork_groups, so card c's artworks are the
@@ -5400,6 +5409,32 @@ fn range_card_counts_for<'i>(
 /// — `narrow_rec`'s own range narrowing, `is_printing_composable`, `compose_printing_estimate`,
 /// `compose_printing_bits` — gets the negated shape for free; none of them special-case `Not`
 /// themselves (docs/issues/local-engine-negated-range-narrowing.md).
+/// The `[lo, hi)` rarity-int window a bare rarity comparison covers, or `None` when the filter is not
+/// one. Deliberately narrow: `NumericCmp` on `RarityInt` against a constant, optionally negated, which
+/// is every spelling of `r:`/`rarity:` the parser produces.
+///
+/// Separate from `bare_range_bounds` on purpose -- see `exact_result_total`'s rarity arm.
+fn bare_rarity_bounds(filter: &FilterExpr) -> Option<(u32, u32)> {
+    fn leaf(filter: &FilterExpr, map_op: impl Fn(CmpOp) -> CmpOp) -> Option<(u32, u32)> {
+        let (op, value) = match filter {
+            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(v) } => (map_op(*op), *v),
+            FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
+                (flip_op(map_op(*op)), *v)
+            }
+            _ => return None,
+        };
+        // `Some(None)` is an empty window, which is an exact total of zero rather than no answer.
+        match int_range_bounds(op, value)? {
+            None => Some((0, 0)),
+            Some((lo, hi)) => Some((lo, hi)),
+        }
+    }
+    match filter {
+        FilterExpr::Not(inner) => leaf(inner.as_ref(), negate_op),
+        _ => leaf(filter, |op| op),
+    }
+}
+
 fn bare_range_bounds<'i>(
     filter: &FilterExpr,
     indexes: &'i Archived<CardIndexes>,
@@ -6704,6 +6739,22 @@ fn exact_result_total(
             Mode::Printing => Some(e - s),
             Mode::Card => range_card_counts_for(indexes, idx).and_then(|c| c.distinct_cards(lo, hi)).map(|n| n as usize),
             Mode::Artwork => range_card_counts_for(indexes, idx).and_then(|c| c.distinct_artworks(lo, hi)).map(|n| n as usize),
+        };
+    }
+    // Rarity is the same question one index over, and it gets its own arm rather than joining
+    // `bare_range_bounds`: that predicate gates `PrintingRangeScan`/`CardRangePopcount` applicability in
+    // a dozen places, so admitting rarity there is a ROUTING change (plausibly a good one -- `r:rare` is
+    // 55 us today) and belongs in its own measured commit, not in a counting one.
+    if let Some((lo, hi)) = bare_rarity_bounds(composed) {
+        if hi <= lo {
+            return Some(0); // an empty window is an exact zero in every space, not a declined shape
+        }
+        let idx = &indexes.rarity_printing_ordered;
+        let (s, e) = idx.range(lo, hi);
+        return match mode {
+            Mode::Printing => Some(e - s),
+            Mode::Card => indexes.rarity_cards.distinct_cards(lo, hi).map(|n| n as usize),
+            Mode::Artwork => indexes.rarity_cards.distinct_artworks(lo, hi).map(|n| n as usize),
         };
     }
     // The remaining shapes below are exact in CARD space only, so any other mode falls back to the
@@ -10921,6 +10972,8 @@ impl QueryEngine {
         let price_eur_cards = build_range_card_counts(&price_eur_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
         let price_tix_cards = build_range_card_counts(&price_tix_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
         let collector_number_cards = build_range_card_counts(&collector_number_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
+        let rarity_idx = build_printing_value_index(&printings, &cards, &offsets, |p| p.card_rarity_int.map(u32::from));
+        let rarity_cards = build_range_card_counts(&rarity_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
@@ -10980,7 +11033,8 @@ impl QueryEngine {
             planes:         build_bit_planes(&cards, &printings, &offsets, &strings),
             border_printing: build_border_printing_planes(&printings, &strings),
             rarity_printing: build_rarity_printing_planes(&printings),
-            rarity_printing_ordered: build_printing_value_index(&printings, &cards, &offsets, |p| p.card_rarity_int.map(u32::from)),
+            rarity_printing_ordered: rarity_idx,
+            rarity_cards,
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
             arith_tuple:    build_arith_tuple_index(&cards),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2328,6 +2328,156 @@ fn build_printing_to_card(offsets: &[u32]) -> Vec<u32> {
     out
 }
 
+/// Exact result totals in all three `unique=` spaces for one value of a low-cardinality dimension.
+///
+/// 12 bytes. Every space is stored rather than derived because none derives from the others: printings
+/// is not cards times a reprint rate, and artworks sits between them at a ratio that varies per value
+/// (0.63-0.95 measured across `frame:` values alone, which is exactly why estimating it failed).
+#[derive(Archive, Serialize, Deserialize, Clone, Copy, Default, Debug, PartialEq, Eq)]
+struct SpaceTotals {
+    printings: u32,
+    cards: u32,
+    artworks: u32,
+}
+
+impl ArchivedSpaceTotals {
+    fn get(&self, mode: Mode) -> usize {
+        match mode {
+            Mode::Printing => u32::from(self.printings) as usize,
+            Mode::Card => u32::from(self.cards) as usize,
+            Mode::Artwork => u32::from(self.artworks) as usize,
+        }
+    }
+}
+
+/// Exact 3-space totals per value, for the dimensions whose predicate tests ONE value.
+///
+/// The whole table is ~2 KB on the production corpus, because every dimension here has under 30 values.
+/// At that size there is no threshold to tune and no sparse tail to special-case: store all of them.
+/// This is the counterpart to `RangeCardCounts`, which covers the dimensions whose predicates are
+/// ranges and therefore need prefix/suffix aggregates instead of per-value ones.
+///
+/// What it does NOT replace: where a query already reads a card-space plane, that plane's popcount is
+/// the exact card total for nothing (how legality got exact card counts before this table existed). The
+/// table's value is the two spaces a card-space plane cannot give — a card bit does not say WHICH
+/// printing matched, so it cannot count printings or artworks.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct ValueTotals {
+    /// `border:` — printing-space, 5 values. Keyed by the interned border string, which is what
+    /// `TextExact` compares against byte-for-byte.
+    border: HashMap<String, SpaceTotals>,
+    /// `layout:` and the `is:flip`/`is:split`/… family — card-space, 14 values.
+    layout: HashMap<String, SpaceTotals>,
+    /// `frame:` and `is:new`/`is:old` — printing-space, 29 values. Keyed by the `coll_vocab` string.
+    frame_data: HashMap<String, SpaceTotals>,
+    /// `f:X` / `banned:X` / `restricted:X`, keyed `(shift << 2) | status`.
+    ///
+    /// One entry per (format, status) pair rather than per format, because `FilterExpr::Legality`
+    /// carries a single 2-bit `expected` status and tests `(word >> shift) & 0b11 == expected`. Statuses
+    /// PARTITION each space — a printing has exactly one status per format — so a per-status entry is
+    /// both exact on its own and safely summable if a future predicate ever accepts a set.
+    ///
+    /// Counted per PRINTING, not per card, so `legality_divergent` cards (30A, Collectors' Edition,
+    /// gold border) contribute their printings' own words. Reading the card word for those would
+    /// mis-count exactly the cards the divergence flag exists to flag.
+    legality: HashMap<u16, SpaceTotals>,
+}
+
+/// The key `ValueTotals::legality` uses. `shift` is even and < 64, so this cannot collide.
+fn legality_totals_key(shift: u8, expected: u64) -> u16 {
+    (u16::from(shift) << 2) | (expected as u16 & 0b11)
+}
+
+/// Exact 3-space totals per value, in one pass over printings.
+///
+/// `keys_of` yields every value the printing belongs to — one for a scalar dimension like border,
+/// several for a collection like `frame_data`, one per format for legality. Distinct cards and
+/// artworks are deduped with a per-value stamp rather than a bitmap: a card's printings are contiguous
+/// in pid order, so `last_card` catches card repeats, and a stamp of `cid + 1` per artwork group
+/// catches artwork repeats WITHIN a card (which need not be contiguous). Both are O(values) memory.
+fn build_value_totals<K: Eq + std::hash::Hash>(
+    cards: &[OracleCard],
+    printings: &[Printing],
+    printing_to_card: &[u32],
+    max_artwork_groups: usize,
+    keys_of: impl Fn(&OracleCard, &Printing) -> Vec<K>,
+) -> HashMap<K, SpaceTotals> {
+    struct Acc {
+        totals: SpaceTotals,
+        last_card: u32,
+        /// `stamps[group] == cid + 1` iff this card's artwork group was already counted. `cid + 1`
+        /// rather than `cid` so that 0 means "never seen", and no earlier card can leave a stamp a
+        /// later card reads as its own.
+        stamps: Vec<u32>,
+    }
+    let mut acc: HashMap<K, Acc> = HashMap::new();
+    for (pid, printing) in printings.iter().enumerate() {
+        let cid = printing_to_card[pid];
+        let card = &cards[cid as usize];
+        let group = usize::from(printing.artwork_group_id);
+        for key in keys_of(card, printing) {
+            let e = acc.entry(key).or_insert_with(|| Acc {
+                totals: SpaceTotals::default(),
+                last_card: u32::MAX,
+                stamps: vec![0; max_artwork_groups + 1],
+            });
+            e.totals.printings += 1;
+            if e.last_card != cid {
+                e.last_card = cid;
+                e.totals.cards += 1;
+            }
+            if e.stamps[group] != cid + 1 {
+                e.stamps[group] = cid + 1;
+                e.totals.artworks += 1;
+            }
+        }
+    }
+    acc.into_iter().map(|(k, a)| (k, a.totals)).collect()
+}
+
+/// Build all four `ValueTotals` maps. One call site, so the four cannot be built from different
+/// snapshots of the same printings.
+fn build_all_value_totals(
+    cards: &[OracleCard],
+    printings: &[Printing],
+    printing_to_card: &[u32],
+    strings: &[String],
+    coll_vocab: &[String],
+    max_artwork_groups: usize,
+) -> ValueTotals {
+    // A macro rather than a closure alias: each `keys_of` is a distinct closure type returning a
+    // distinct key type, so one generic-over-both helper binding cannot serve all four.
+    macro_rules! totals {
+        ($keys_of:expr) => {
+            build_value_totals(cards, printings, printing_to_card, max_artwork_groups, $keys_of)
+        };
+    }
+    // ALL 32 format slots, not just the ones this archive assigned. Restricting to the registry
+    // snapshot leaves the table silently under-populated wherever the snapshot is empty (the fuzz store
+    // is), and absence from this table is read as an exact zero — so a missing key is a WRONG total, not
+    // a missing one. Covering every slot costs 32 x 4 statuses x 12 bytes = 1.5 KB and cannot be
+    // under-populated. The entries for unassigned slots are correct rather than merely harmless: an
+    // unassigned format reads as `not_legal` for every card, which is what those entries say.
+    let shifts: Vec<u8> = (0..MAX_FORMATS as u8).map(|i| i * 2).collect();
+    ValueTotals {
+        border: totals!(|_card: &OracleCard, p: &Printing| match p.card_border_id {
+            NONE_STR => Vec::new(),
+            id => vec![strings[id as usize].clone()],
+        }),
+        layout: totals!(|card: &OracleCard, _p: &Printing| match card.card_layout_id {
+            NONE_STR => Vec::new(),
+            id => vec![strings[id as usize].clone()],
+        }),
+        frame_data: totals!(|_card: &OracleCard, p: &Printing| {
+            p.card_frame_data.iter().map(|v| coll_vocab[*v as usize].clone()).collect()
+        }),
+        legality: totals!(|card: &OracleCard, p: &Printing| {
+            let word = if card.legality_divergent { p.card_legalities } else { card.card_legalities };
+            shifts.iter().map(|&shift| legality_totals_key(shift, (word >> shift) & 0b11)).collect()
+        }),
+    }
+}
+
 // ─── Printing-space value-major indexes ──────────────────────────────────────
 // One layout for every printing-space ordering: released_at / price_usd /
 // collector_number (range filters, plus the `usd` orderby walk) and
@@ -3001,6 +3151,9 @@ struct CardIndexes {
     /// distinct cards for `r<=rare` is not the sum of the at-rarity counts. Prefix/suffix/at is the
     /// shape the question needs, and it is the shape this struct already is.
     rarity_cards:           RangeCardCounts,
+    /// Exact 3-space totals for the low-cardinality dimensions whose predicate tests one value:
+    /// border, layout, frame, and (format, status). ~2 KB.
+    value_totals:   ValueTotals,
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     // card space, n_cards+1 entries: prefix sum of artwork_groups, so card c's artworks are the
@@ -5307,6 +5460,15 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// sizes with branch differences under the ~5% noise floor throughout that
 /// band; 1,024 sits at the spread's upper (gather/simple) edge, and past it
 /// streaming's win grows fast (~1.8× by 8k), so the trigger stays put.
+/// Whether `exact_result_total` may answer from the per-value `ValueTotals` table and the rarity range
+/// table, and whether printing mode's `result_total` may take the exact value instead of
+/// `compose_printing_estimate`'s. On by default; 0 falls every one of those back to the estimator.
+///
+/// Kept as a permanent handle, not scaffolding: these arms change ROUTING (a total feeds the argmin),
+/// so the only honest way to price them is an interleaved A/B in which both arms read a byte-identical
+/// archive. The table is archived either way, so flipping this cannot move a field offset.
+static EXACT_VALUE_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_EXACT_VALUE_TOTALS", 1u8) != 0);
+
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));
 
 /// Kill-switch for narrowing the streamed walk to the filter's bound on the sort column
@@ -6745,7 +6907,7 @@ fn exact_result_total(
     // `bare_range_bounds`: that predicate gates `PrintingRangeScan`/`CardRangePopcount` applicability in
     // a dozen places, so admitting rarity there is a ROUTING change (plausibly a good one -- `r:rare` is
     // 55 us today) and belongs in its own measured commit, not in a counting one.
-    if let Some((lo, hi)) = bare_rarity_bounds(composed) {
+    if let Some((lo, hi)) = bare_rarity_bounds(composed).filter(|_| *EXACT_VALUE_TOTALS) {
         if hi <= lo {
             return Some(0); // an empty window is an exact zero in every space, not a declined shape
         }
@@ -6757,14 +6919,35 @@ fn exact_result_total(
             Mode::Artwork => indexes.rarity_cards.distinct_artworks(lo, hi).map(|n| n as usize),
         };
     }
-    // The remaining shapes below are exact in CARD space only, so any other mode falls back to the
-    // estimator. Extending them is what the per-value 3-space count table is for.
+    // The per-value table, which covers the dimensions whose predicate tests ONE value, in all three
+    // spaces. Absence from a COMPLETE table is an exact zero, not a declined shape -- every one of
+    // these maps holds every value present in the corpus, so a miss means nothing matches.
+    let vt = &indexes.value_totals;
+    match composed {
+        // `Eq` only. The ordering ops on an interned string compare lexicographically, which is not a
+        // per-value question and has no entry here.
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
+            return Some(vt.border.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        FilterExpr::TextExact { field: TextField::Layout, op: CmpOp::Eq, value } => {
+            return Some(vt.layout.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        // `Ge` on a collection is containment. `Eq`/`Gt` add a collection-LENGTH condition these
+        // postings do not prove, so their count is an upper bound rather than a total -- the same
+        // distinction the card-space arm below draws.
+        FilterExpr::CollectionCmp { field: CollField::FrameData, op: CmpOp::Ge, value, .. } => {
+            return Some(vt.frame_data.get(value.as_str()).map_or(0, |t| t.get(mode)));
+        }
+        FilterExpr::Legality { shift: Some(shift), expected } => {
+            return Some(vt.legality.get(&legality_totals_key(*shift, *expected).into()).map_or(0, |t| t.get(mode)));
+        }
+        // A format absent from all loaded data matches nothing, in every space.
+        FilterExpr::Legality { shift: None, .. } => return Some(0),
+        _ => {}
+    }
+    // The remaining shapes are exact in CARD space only, so any other mode falls back to the estimator.
     if !matches!(mode, Mode::Card) {
         return None;
-    }
-    if let FilterExpr::Legality { shift: Some(shift), expected } = composed {
-        return legality_candidate_bits(indexes, n_cards, *shift, *expected, false)
-            .map(|b| b.iter().map(|w| w.count_ones() as usize).sum());
     }
     // A CARD-space containment leaf (`t:`/`keyword:`/`otag:`) posts card ids, so its postings length IS
     // the exact distinct-card count -- the same "the answer was already computed and then discarded"
@@ -9130,7 +9313,17 @@ fn acquire_plan_features(
         let scan_all =
             |cards: usize| (((cards as f64) * printings_per_card * COMPOSE_CANDIDATE_SPAN_BIAS) as usize).min(n_printings as usize);
         let (result_total, project, popcount_words, eval_domain, scan_units) = match mode {
-            Mode::Printing => (printing_matches, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards)),
+            Mode::Printing => {
+                // `exact_total` for the RESULT, `printing_matches` for everything else. They are not the
+                // same quantity: `printing_matches` proxies the size of the bitmap compose BUILDS, which
+                // for a legality leaf is every printing of every existentially-legal card -- a superset
+                // that the residual then filters. The cost features are calibrated against that superset
+                // (`printings_examined`, `printing_span`), so substituting the true match count there
+                // would under-charge the scan on exactly the divergent-legality cards the superset exists
+                // for. `f:modern` reads 68,687 against a true 73,783; `banned:modern` 160 against 399.
+                let total = if *EXACT_VALUE_TOTALS { exact_total.unwrap_or(printing_matches) } else { printing_matches };
+                (total, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards))
+            }
             Mode::Card => {
                 // Card mode's result total IS the distinct-card count, which is precisely what
                 // `est_cards` already holds. The estimated fallback used to be the saturating
@@ -10974,6 +11167,16 @@ impl QueryEngine {
         let collector_number_cards = build_range_card_counts(&collector_number_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
         let rarity_idx = build_printing_value_index(&printings, &cards, &offsets, |p| p.card_rarity_int.map(u32::from));
         let rarity_cards = build_range_card_counts(&rarity_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
+        // Out here for the same reason as the count tables: it reads `printing_to_card`, which the
+        // struct literal below moves.
+        let value_totals = build_all_value_totals(
+            &cards,
+            &printings,
+            &printing_to_card,
+            &strings,
+            &coll_vocab,
+            usize::from(artwork_group_counts.iter().copied().max().unwrap_or(0)),
+        );
         let indexes = CardIndexes {
             name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
             oracle_trigram: build_oracle_text_index(&cards, &strings),
@@ -11035,6 +11238,7 @@ impl QueryEngine {
             rarity_printing: build_rarity_printing_planes(&printings),
             rarity_printing_ordered: rarity_idx,
             rarity_cards,
+            value_totals,
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
             arith_tuple:    build_arith_tuple_index(&cards),
@@ -11046,6 +11250,7 @@ impl QueryEngine {
         // Snapshot the registry card_from_pydict just populated so reader
         // processes can adopt the same format→shift assignments.
         let format_shifts_snapshot = format_shifts().read().map(|m| m.clone()).unwrap_or_default();
+
         let card_data = CardData {
             cards,
             printings,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7,7 +7,7 @@ use super::{
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
-    RangeCardCounts, build_range_card_counts,
+    RangeCardCounts, build_range_card_counts, exact_result_total,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -2461,6 +2461,12 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.price_eur = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_eur);
     data.indexes.price_tix = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.price_tix);
     data.indexes.collector_number = build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.collector_number_int.map(u32::from));
+    // Rarity was MISSING from this list until the exact-total arm needed it, so it sat at its empty
+    // default: `idx.len() == 0` with a populated rarity histogram. Nothing failed, because the only
+    // consumer was the `rarity` orderby walk, which declines on an empty index and falls back --
+    // i.e. the walk was silently un-fuzzed, not wrong.
+    data.indexes.rarity_printing_ordered =
+        build_printing_value_index(&data.printings, &data.cards, &data.offsets, |p| p.card_rarity_int.map(u32::from));
     // The exact card-count tables ride on those indexes and must be rebuilt with them — leaving them
     // at their empty defaults would make every range acquire silently fall back to the `k.min(n_cards)`
     // proxy here while production used the table, so the fuzz differential would stop covering the
@@ -2475,6 +2481,8 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.price_eur_cards = build_range_card_counts(&data.indexes.price_eur, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.price_tix_cards = build_range_card_counts(&data.indexes.price_tix, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.collector_number_cards = build_range_card_counts(&data.indexes.collector_number, &p2c, n_cards, &data.printings, &artwork_base);
+    data.indexes.rarity_cards =
+        build_range_card_counts(&data.indexes.rarity_printing_ordered, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.border_printing = build_border_printing_planes(&data.printings, &data.strings);
     data.indexes.rarity_printing = build_rarity_printing_planes(&data.printings);
     data
@@ -3247,6 +3255,56 @@ fn force_plan_differential_agreement() {
     }
 }
 
+/// `exact_result_total`'s rarity arm must be exact in all three spaces, for every op against every
+/// rarity value, against the same brute-force reference the fuzz differential uses.
+///
+/// Rarity is the one dimension where per-value counts would have been WRONG rather than merely
+/// incomplete: a card printed at both common and rare is in the distinct-card count for each, so
+/// `r<=rare` is not a sum. This checks the prefix/suffix shape actually answers the ranges.
+#[test]
+fn exact_result_total_is_exact_for_rarity() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_805);
+    let data = fuzz_store_n(&mut rng, 2_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_cards = archived.cards.len();
+
+    let mut answered = 0usize;
+    for value in 0..=6i32 {
+        for op in [CmpOp::Eq, CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge] {
+            for negate in [false, true] {
+                let leaf = FilterExpr::NumericCmp {
+                    lhs: NumExpr::Field(NumField::RarityInt),
+                    op,
+                    rhs: NumExpr::Const(f64::from(value)),
+                };
+                let f = if negate { FilterExpr::Not(Box::new(leaf)) } else { leaf };
+                for mode in [Mode::Printing, Mode::Card, Mode::Artwork] {
+                    let Some(got) = exact_result_total(&f, &archived.indexes, n_cards, mode) else {
+                        continue;
+                    };
+                    let label = match mode {
+                        Mode::Printing => "printing",
+                        Mode::Card => "card",
+                        Mode::Artwork => "artwork",
+                    };
+                    assert_eq!(
+                        got,
+                        fuzz_reference_total(archived, &f, label),
+                        "rarity {op:?} {value} negate={negate} mode={label}",
+                    );
+                    answered += 1;
+                }
+            }
+        }
+    }
+    // Every cell must be ANSWERED, not merely consistent -- a silently-declining arm would satisfy
+    // every assertion above. The one shape that must decline is a negated `Eq`, i.e. `Ne`, which covers
+    // two disjoint windows and so is not a range at all: 7 values x 3 modes of the 210 cells.
+    assert_eq!(answered, (7 * 5 * 2 - 7) * 3, "the rarity arm should answer every op except `Ne`, in every mode");
+}
+
 /// The per-value count table must be EXACT, not close, in BOTH spaces it carries: every one-sided
 /// cut and every single value, on all three range indexes, checked against a brute-force distinct
 /// count over the store for cards and for artworks alike.
@@ -3566,17 +3624,26 @@ fn compose_paging_prediction_matches_the_branch_taken() {
             FuzzSpec::Leaf(FuzzLeaf::Legality { shift: Some(0), expected: 0b01 }),
             FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
         ]),
-        // Deliberately NARROW, and the only other spec here built from leaves `is_printing_composable`
-        // accepts (`border==`, and `CollectionCmp` at `Ge`). This is what reaches
-        // `GatherWalkDeclined`: the walk declines when the matches carrying an indexed value run out
-        // before `page_offset + limit` while unvalued matches remain, so the missing ingredient was
-        // never nulls -- the store already generates 16% null prices and 15% null rarity -- it was a
-        // match set small enough for the valued ones to fall short of one page. `fateseal` is the
-        // rare tail of `FUZZ_KEYWORDS` (weight 1 of 86), and ANDing a border narrows it ~6x further.
+        // Deliberately NARROW, and one of only three specs here built from leaves
+        // `is_printing_composable` accepts (`border==`, and `CollectionCmp` at `Ge`). `fateseal` is the
+        // rare tail of `FUZZ_KEYWORDS` (weight 1 of 86), and ANDing a border narrows it ~6x further:
+        // 74 matching printings at n=8000. That is BELOW the sparse floor, so this spec declines before
+        // any paging strategy runs and contributes to `declined`, not to the strategy cells.
         FuzzSpec::And(vec![
             FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: "fateseal".to_string() }),
             FuzzSpec::Leaf(FuzzLeaf::Border { value: "black".to_string() }),
         ]),
+        // What actually reaches `GatherWalkDeclined`, which needs three things at once: enough matches
+        // to clear the sparse floor, more matches than `page_offset` (or the page is empty and returns
+        // early), and FEWER matches carrying the sort value than `page_offset + limit` -- that last one
+        // is the decline. At n=8000 `keyword:flying` matches 11,061 printings of which 9,337 are priced,
+        // so at `offset=10_000, limit=60` the walk runs out of priced entries 723 short of the page and
+        // hands over to the gather. Narrowing it further does NOT work: the comment here used to credit
+        // the `fateseal` spec above, but the branch was in fact being reached because
+        // `rarity_printing_ordered` was silently EMPTY in the fuzz store, which made every
+        // rarity-ordered walk decline for want of an index. Populating it (see `fuzz_store_n`) removed
+        // that accident and left this cell at zero, which is how the mis-attribution surfaced.
+        FuzzSpec::Leaf(FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: "flying".to_string() }),
     ];
     // Every orderby, because which one is set is exactly what picks the branch: a card-space
     // permutation gives `Perm`, `usd`/`rarity` in printing mode give `OrderbyWalk` (#744), and
@@ -5968,6 +6035,7 @@ fn bench_checked_vs_unchecked_access() {
         price_eur_cards: RangeCardCounts::default(),
         price_tix_cards: RangeCardCounts::default(),
         collector_number_cards: RangeCardCounts::default(),
+        rarity_cards:   RangeCardCounts::default(),
         sort_perms:     build_sort_permutations(&cards),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2467,11 +2467,14 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     // path it is meant to cover.
     let p2c = build_printing_to_card(&data.offsets);
     let n_cards = data.cards.len();
-    data.indexes.released_at_cards = build_range_card_counts(&data.indexes.released_at, &p2c, n_cards);
-    data.indexes.price_usd_cards = build_range_card_counts(&data.indexes.price_usd, &p2c, n_cards);
-    data.indexes.price_eur_cards = build_range_card_counts(&data.indexes.price_eur, &p2c, n_cards);
-    data.indexes.price_tix_cards = build_range_card_counts(&data.indexes.price_tix, &p2c, n_cards);
-    data.indexes.collector_number_cards = build_range_card_counts(&data.indexes.collector_number, &p2c, n_cards);
+    // The artwork column of the range counts needs each printing's global artwork id, which is
+    // `artwork_base[card] + artwork_group_id`; both are already assigned by `store_of`.
+    let artwork_base = build_artwork_base_from(&data.indexes.artwork_groups.iter().copied().collect::<Vec<u16>>());
+    data.indexes.released_at_cards = build_range_card_counts(&data.indexes.released_at, &p2c, n_cards, &data.printings, &artwork_base);
+    data.indexes.price_usd_cards = build_range_card_counts(&data.indexes.price_usd, &p2c, n_cards, &data.printings, &artwork_base);
+    data.indexes.price_eur_cards = build_range_card_counts(&data.indexes.price_eur, &p2c, n_cards, &data.printings, &artwork_base);
+    data.indexes.price_tix_cards = build_range_card_counts(&data.indexes.price_tix, &p2c, n_cards, &data.printings, &artwork_base);
+    data.indexes.collector_number_cards = build_range_card_counts(&data.indexes.collector_number, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.border_printing = build_border_printing_planes(&data.printings, &data.strings);
     data.indexes.rarity_printing = build_rarity_printing_planes(&data.printings);
     data
@@ -3244,8 +3247,9 @@ fn force_plan_differential_agreement() {
     }
 }
 
-/// The per-value card-count table must be EXACT, not close: every one-sided cut and every single
-/// value, on all three range indexes, checked against a brute-force distinct count over the store.
+/// The per-value count table must be EXACT, not close, in BOTH spaces it carries: every one-sided
+/// cut and every single value, on all three range indexes, checked against a brute-force distinct
+/// count over the store for cards and for artworks alike.
 ///
 /// Exhaustive over the distinct values rather than sampled. There are only a few thousand per
 /// dimension — the same property that makes the table affordable — and this investigation's errors
@@ -3271,30 +3275,44 @@ fn range_card_counts_are_exact() {
         assert_eq!(counts.values.len(), counts.below.len(), "{name}: parallel vectors");
         assert_eq!(counts.values.len(), counts.at_or_above.len(), "{name}: parallel vectors");
         assert_eq!(counts.values.len(), counts.at.len(), "{name}: parallel vectors");
+        assert_eq!(counts.values.len(), counts.below_artworks.len(), "{name}: parallel vectors");
+        assert_eq!(counts.values.len(), counts.at_or_above_artworks.len(), "{name}: parallel vectors");
+        assert_eq!(counts.values.len(), counts.at_artworks.len(), "{name}: parallel vectors");
 
-        // Brute force: distinct cards among printings whose value satisfies the predicate.
-        let distinct = |keep: &dyn Fn(u32) -> bool| -> u32 {
-            let mut seen = std::collections::HashSet::new();
+        // Brute force: distinct cards, and distinct artworks, among printings whose value satisfies
+        // the predicate. The artwork id is global -- `artwork_base[card] + artwork_group_id` -- so a
+        // group id colliding across two cards must not merge them, which is why the base is added.
+        let distinct = |keep: &dyn Fn(u32) -> bool| -> (u32, u32) {
+            let (mut cards, mut arts) = (std::collections::HashSet::new(), std::collections::HashSet::new());
             for (i, key) in idx.keys.iter().enumerate() {
                 if !keep(u32::from(*key)) {
                     continue;
                 }
                 for t in idx.run(i) {
-                    seen.insert(u32::from(p2c[idx.pid_at(t)]));
+                    let pid = idx.pid_at(t);
+                    let cid = u32::from(p2c[pid]);
+                    cards.insert(cid);
+                    arts.insert(u32::from(archived.indexes.artwork_base[cid as usize]) + u32::from(u16::from(archived.printings[pid].artwork_group_id)));
                 }
             }
-            seen.len() as u32
+            (cards.len() as u32, arts.len() as u32)
         };
 
         for (i, value) in counts.values.iter().enumerate() {
             let v = u32::from(*value);
-            assert_eq!(u32::from(counts.below[i]), distinct(&|x| x < v), "{name}: below[{i}] at {v}");
-            assert_eq!(u32::from(counts.at_or_above[i]), distinct(&|x| x >= v), "{name}: at_or_above[{i}] at {v}");
-            assert_eq!(u32::from(counts.at[i]), distinct(&|x| x == v), "{name}: at[{i}] at {v}");
-            // And through the lookup the acquire actually calls, for all three answerable shapes.
-            assert_eq!(counts.distinct_cards(0, v), Some(distinct(&|x| x < v)), "{name}: lookup `< {v}`");
-            assert_eq!(counts.distinct_cards(v, u32::MAX), Some(distinct(&|x| x >= v)), "{name}: lookup `>= {v}`");
-            assert_eq!(counts.distinct_cards(v, v + 1), Some(distinct(&|x| x == v)), "{name}: lookup `== {v}`");
+            let (lt, ge, eq) = (distinct(&|x| x < v), distinct(&|x| x >= v), distinct(&|x| x == v));
+            assert_eq!((u32::from(counts.below[i]), u32::from(counts.below_artworks[i])), lt, "{name}: below[{i}] at {v}");
+            assert_eq!(
+                (u32::from(counts.at_or_above[i]), u32::from(counts.at_or_above_artworks[i])),
+                ge,
+                "{name}: at_or_above[{i}] at {v}",
+            );
+            assert_eq!((u32::from(counts.at[i]), u32::from(counts.at_artworks[i])), eq, "{name}: at[{i}] at {v}");
+            // And through the lookups the acquire actually calls, for all three answerable shapes.
+            for (shape, (lo, hi), want) in [("< {v}", (0, v), lt), (">= {v}", (v, u32::MAX), ge), ("== {v}", (v, v + 1), eq)] {
+                assert_eq!(counts.distinct_cards(lo, hi), Some(want.0), "{name}: cards lookup `{shape}`");
+                assert_eq!(counts.distinct_artworks(lo, hi), Some(want.1), "{name}: artworks lookup `{shape}`");
+            }
         }
 
         // A range spanning several distinct values is the one shape the table declines, rather than
@@ -3304,6 +3322,7 @@ fn range_card_counts_are_exact() {
         if counts.values.len() >= 4 {
             let (lo, hi) = (u32::from(counts.values[1]), u32::from(counts.values[3]));
             assert_eq!(counts.distinct_cards(lo, hi), None, "{name}: multi-value interior must decline");
+            assert_eq!(counts.distinct_artworks(lo, hi), None, "{name}: artworks must decline the same shapes");
             let span = u32::from(counts.values[2]);
             assert!(
                 counts.distinct_cards(0, span).is_some(),

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2485,7 +2485,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     let n_cards = data.cards.len();
     // The artwork column of the range counts needs each printing's global artwork id, which is
     // `artwork_base[card] + artwork_group_id`; both are already assigned by `store_of`.
-    let artwork_base = build_artwork_base_from(&data.indexes.artwork_groups.iter().copied().collect::<Vec<u16>>());
+    let artwork_base = build_artwork_base_from(&data.indexes.artwork_groups.to_vec());
     data.indexes.released_at_cards = build_range_card_counts(&data.indexes.released_at, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.price_usd_cards = build_range_card_counts(&data.indexes.price_usd, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.price_eur_cards = build_range_card_counts(&data.indexes.price_eur, &p2c, n_cards, &data.printings, &artwork_base);
@@ -3297,7 +3297,6 @@ fn value_totals_are_exact_in_all_three_spaces() {
     let data = fuzz_store_n(&mut rng, 2_000);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let n_cards = archived.cards.len();
 
     let mut leaves: Vec<(String, FilterExpr)> = Vec::new();
     // "chartreuse" and "leveler" are absent from the store on purpose: the zero case.
@@ -3343,7 +3342,7 @@ fn value_totals_are_exact_in_all_three_spaces() {
             &archived.mana_vocab, &archived.indexes.flavor, &archived.strings,
         );
         for (mode_label, mode) in [("printing", Mode::Printing), ("card", Mode::Card), ("artwork", Mode::Artwork)] {
-            let got = exact_result_total(&f, &archived.indexes, n_cards, mode)
+            let got = exact_result_total(&f, &archived.indexes, mode)
                 .unwrap_or_else(|| panic!("{label} / {mode_label}: the table must answer, not decline"));
             assert_eq!(got, fuzz_reference_total(archived, &f, mode_label), "{label} / {mode_label}");
             nonzero += usize::from(got > 0);
@@ -3373,7 +3372,6 @@ fn exact_result_total_is_exact_for_rarity() {
     let data = fuzz_store_n(&mut rng, 2_000);
     let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-    let n_cards = archived.cards.len();
 
     let mut answered = 0usize;
     for value in 0..=6i32 {
@@ -3386,7 +3384,7 @@ fn exact_result_total_is_exact_for_rarity() {
                 };
                 let f = if negate { FilterExpr::Not(Box::new(leaf)) } else { leaf };
                 for mode in [Mode::Printing, Mode::Card, Mode::Artwork] {
-                    let Some(got) = exact_result_total(&f, &archived.indexes, n_cards, mode) else {
+                    let Some(got) = exact_result_total(&f, &archived.indexes, mode) else {
                         continue;
                     };
                     let label = match mode {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7,7 +7,7 @@ use super::{
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
-    RangeCardCounts, build_range_card_counts, exact_result_total,
+    EXACT_VALUE_TOTALS, RangeCardCounts, ValueTotals, build_all_value_totals, build_range_card_counts, exact_result_total,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -1650,6 +1650,10 @@ const FUZZ_OPS: [CmpOp; 6] = [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp:
 // `legal_plane_fixture`. Expected status is one of legal(0b01)/restricted(0b10)/
 // banned(0b11); NOT_LEGAL(0b00) is never a query leaf (the parser negates instead).
 const FUZZ_SHIFTS: [u8; 3] = [0, 2, 4];
+
+/// Card layouts the fuzz store assigns, cycled by card index. Weighted toward `normal` the way the
+/// corpus is (96% there), so the tail values stay small enough to exercise the sparse end.
+const FUZZ_LAYOUTS: [&str; 8] = ["normal", "normal", "normal", "normal", "transform", "split", "saga", "flip"];
 const FUZZ_STATUSES: [u64; 3] = [0b01, 0b10, 0b11];
 // Shifts a divergent card is allowed to disagree at. Deliberately NOT all of `FUZZ_SHIFTS`: production
 // has exactly one divergent format (`oldschool`, all 556 of the corpus's divergent cards) and the rest
@@ -2236,6 +2240,12 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     for i in 0..ncards {
         let mut card = stub_card(i as u128 + 1, fuzz_type_bits(rng), &[], &mut vocab);
         card.card_colors = rng.random_range(0..32u8);
+        // Layout, assigned DETERMINISTICALLY from the card index rather than by an rng draw: a draw here
+        // would shift the rng stream and so change every fuzz store in the suite. The skew mirrors the
+        // corpus, where `normal` is 96% of cards and the tail is what the `is:flip`-family predicates
+        // reach. Present at all because `exact_result_total`'s layout arm is otherwise untestable --
+        // this field sat at NONE_STR for every fuzz card.
+        card.card_layout_id = interner.intern(FUZZ_LAYOUTS[i % FUZZ_LAYOUTS.len()].to_string());
         // cmc on the corpus distribution (peaks at 2-3). Power/toughness/loyalty are *derived* from
         // it so bigger stats cost more and P~T track each other, and are present only on the
         // matching card kind: creatures have power/toughness, planeswalkers have loyalty.
@@ -2483,6 +2493,18 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     data.indexes.collector_number_cards = build_range_card_counts(&data.indexes.collector_number, &p2c, n_cards, &data.printings, &artwork_base);
     data.indexes.rarity_cards =
         build_range_card_counts(&data.indexes.rarity_printing_ordered, &p2c, n_cards, &data.printings, &artwork_base);
+    // Same load-bearing property as the count tables: left at its default, every per-value acquire would
+    // read an exact ZERO from an empty-but-"complete" table, which is a wrong total rather than a missing
+    // one. `format_shifts` comes from the data, not the global registry, so the keys match what `bind`
+    // resolved against.
+    data.indexes.value_totals = build_all_value_totals(
+        &data.cards,
+        &data.printings,
+        &p2c,
+        &data.strings,
+        &data.coll_vocab,
+        usize::from(data.indexes.max_artwork_groups),
+    );
     data.indexes.border_printing = build_border_printing_planes(&data.printings, &data.strings);
     data.indexes.rarity_printing = build_rarity_printing_planes(&data.printings);
     data
@@ -3255,6 +3277,82 @@ fn force_plan_differential_agreement() {
     }
 }
 
+/// The per-value `ValueTotals` table must be exact in all three spaces, for every value of every
+/// dimension it covers, against the same brute-force reference the fuzz differential uses.
+///
+/// Includes values the corpus does NOT contain, because absence from this table is claimed to be an
+/// exact ZERO rather than a declined shape — a claim that is only safe while the table is complete, and
+/// this is what checks it.
+#[test]
+fn value_totals_are_exact_in_all_three_spaces() {
+    // Asserts the arm ANSWERS, so it is meaningless with the arm switched off. Skipping rather than
+    // adapting: `CARD_ENGINE_EXACT_VALUE_TOTALS=0` exists to measure the estimator's behaviour, and a
+    // test that quietly passed either way would stop guarding the default.
+    if !*EXACT_VALUE_TOTALS {
+        return;
+    }
+
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_805);
+    let data = fuzz_store_n(&mut rng, 2_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let n_cards = archived.cards.len();
+
+    let mut leaves: Vec<(String, FilterExpr)> = Vec::new();
+    // "chartreuse" and "leveler" are absent from the store on purpose: the zero case.
+    for value in ["black", "white", "borderless", "gold", "yellow", "chartreuse"] {
+        leaves.push((format!("border:{value}"), FilterExpr::TextExact {
+            field: TextField::Border,
+            op: CmpOp::Eq,
+            value: value.to_string(),
+        }));
+    }
+    for value in ["normal", "transform", "split", "saga", "flip", "leveler"] {
+        leaves.push((format!("layout:{value}"), FilterExpr::TextExact {
+            field: TextField::Layout,
+            op: CmpOp::Eq,
+            value: value.to_string(),
+        }));
+    }
+    for (value, _) in FUZZ_FRAME_DATA {
+        leaves.push((format!("frame:{value}"), FilterExpr::CollectionCmp {
+            field: CollField::FrameData,
+            op: CmpOp::Ge,
+            value: value.to_string(),
+            value_id: None,
+        }));
+    }
+    for shift in FUZZ_SHIFTS {
+        for expected in 0..4u64 {
+            leaves.push((format!("legality shift={shift} status={expected}"), FilterExpr::Legality {
+                shift: Some(shift),
+                expected,
+            }));
+        }
+    }
+    // An unregistered format matches nothing in every space.
+    leaves.push(("legality shift=None".to_string(), FilterExpr::Legality { shift: None, expected: 1 }));
+
+    // Bound leaves, because `CollectionCmp` needs its `value_id` resolved before it can be counted.
+    let mut nonzero = 0usize;
+    for (label, leaf) in &leaves {
+        let mut f = leaf.clone();
+        f.bind(
+            &archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab,
+            &archived.mana_vocab, &archived.indexes.flavor, &archived.strings,
+        );
+        for (mode_label, mode) in [("printing", Mode::Printing), ("card", Mode::Card), ("artwork", Mode::Artwork)] {
+            let got = exact_result_total(&f, &archived.indexes, n_cards, mode)
+                .unwrap_or_else(|| panic!("{label} / {mode_label}: the table must answer, not decline"));
+            assert_eq!(got, fuzz_reference_total(archived, &f, mode_label), "{label} / {mode_label}");
+            nonzero += usize::from(got > 0);
+        }
+    }
+    // Otherwise a table that answered 0 to everything would pass every assertion above.
+    assert!(nonzero >= leaves.len(), "too many zero totals ({nonzero}); the sweep is not exercising the table");
+}
+
 /// `exact_result_total`'s rarity arm must be exact in all three spaces, for every op against every
 /// rarity value, against the same brute-force reference the fuzz differential uses.
 ///
@@ -3263,6 +3361,13 @@ fn force_plan_differential_agreement() {
 /// `r<=rare` is not a sum. This checks the prefix/suffix shape actually answers the ranges.
 #[test]
 fn exact_result_total_is_exact_for_rarity() {
+    // Asserts the arm ANSWERS, so it is meaningless with the arm switched off. Skipping rather than
+    // adapting: `CARD_ENGINE_EXACT_VALUE_TOTALS=0` exists to measure the estimator's behaviour, and a
+    // test that quietly passed either way would stop guarding the default.
+    if !*EXACT_VALUE_TOTALS {
+        return;
+    }
+
     use rand::SeedableRng;
     let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_805);
     let data = fuzz_store_n(&mut rng, 2_000);
@@ -6036,6 +6141,7 @@ fn bench_checked_vs_unchecked_access() {
         price_tix_cards: RangeCardCounts::default(),
         collector_number_cards: RangeCardCounts::default(),
         rarity_cards:   RangeCardCounts::default(),
+        value_totals:   ValueTotals::default(),
         sort_perms:     build_sort_permutations(&cards),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,

--- a/docs/issues/local-engine-exact-totals-three-spaces.md
+++ b/docs/issues/local-engine-exact-totals-three-spaces.md
@@ -5,7 +5,9 @@ the store can already answer. `unique=` has three result spaces — printings, c
 predicate backed by a plane or a value index, the exact count in each is a build-time aggregate that
 fits in kilobytes.
 
-Two halves. The first is done.
+Two halves, both now done — and the honest headline is that the second one made 27 of 27 estimate cells
+exact and changed **no plan and no wall time**. Section 2's A/B is the number to read before extending
+this line of work.
 
 ## 1. The artwork column on the range tables — SHIPPED
 
@@ -47,44 +49,79 @@ indexes, against a brute-force distinct count, plus the shapes the table must DE
 interior multi-value range). Exhaustive rather than sampled because the errors in this area clustered at
 range ends.
 
-## 2. The core 3-space count table — NOT YET DONE
+## 2. Rarity, and the per-value core table — SHIPPED, and it bought no latency
 
-Same idea for the predicates that are a plane rather than a range. Five low-cardinality dimensions, 77
-values between them:
+**Rarity** got a sixth `RangeCardCounts` over the `rarity_printing_ordered` index that already existed
+for the rarity orderby walk. Per-value counts would have been *wrong* here, not merely incomplete: a
+card printed at both common and rare is in the distinct-card count for each, so `r<=rare` is not a sum.
+Prefix/suffix/at is the shape the question needs. 184 bytes; artwork went from 1.07-1.35 (error changing
+sign, so no bias constant could have fixed it) to 1.000 on all six values and every op.
 
-| dimension | values |
-| --- | --: |
-| border | 5 |
-| rarity | 6 |
-| layout | 14 |
-| frame | 29 |
-| format | 23 |
+**Border, layout, frame, and (format, status)** got `ValueTotals` — a per-value `SpaceTotals`
+(printings, cards, artworks), built in one pass with per-value stamps for the two dedup questions.
+Measured before/after, `est / true` on the production corpus:
 
-77 values × 3 spaces × 4 bytes = **0.9 KB**. At that size there is no threshold to tune and no sparse
-tail to special-case: store all of them.
+| predicate | mode | before | after |
+| --- | --- | --: | --: |
+| `border:black` / `border:borderless` | artwork | 0.905 / 0.835 | **1.000** |
+| `frame:2015` / `2003` / `1997` | card | 0.952 / 0.901 / 0.874 | **1.000** |
+| `frame:2015` / `2003` / `1997` | artwork | 0.948 / 1.080 / 0.973 | **1.000** |
+| `f:modern` / `f:vintage` / `f:pauper` | printing | 0.931 / 1.005 / 1.039 | **1.000** |
+| `f:modern` / `f:vintage` / `f:pauper` | artwork | 0.835 / 0.882 / 0.873 | **1.000** |
+| `banned:modern` | printing / artwork | 0.401 / 0.411 | **1.000** |
 
-What it fixes, from the accuracy audit:
+All 27 cells exact. Three implementation points:
 
-| predicate | mode | est/true today |
-| --- | --- | --: |
-| `frame:*` | card | 0.63–0.95 |
-| `format:*` | printing | 0.87–0.93 |
-| border / rarity / frame / format | artwork | estimated |
+- **All 32 format slots are stored, not just the assigned ones.** Absence from this table is read as an
+  exact zero, so an under-populated table is a *wrong* total rather than a missing one — and restricting
+  to the registry snapshot left it empty wherever the snapshot was (the fuzz store). The entries for
+  unassigned slots are correct rather than merely harmless: an unassigned format reads `not_legal` for
+  every card, which is what those entries say.
+- **Legality is counted per printing, not per card**, so `legality_divergent` cards contribute their
+  printings' own words. Reading the card word for those would mis-count exactly the cards the flag exists
+  to flag.
+- **Printing mode takes the exact value for `result_total` only.** `printing_matches` also feeds
+  `scan_units` and `project`, and it proxies the size of the bitmap compose BUILDS — for a legality leaf,
+  every printing of every existentially-legal card, a superset the residual then filters. The cost
+  features are calibrated against that superset, so substituting the true match count there would
+  under-charge the scan on precisely the divergent cards.
 
-Wire it into `exact_result_total`, which already has the mode parameter and already returns `None` for
-non-card modes on the shapes it cannot answer — the table is exactly what turns those `None`s into
-answers. Consumers are `compose_total_for_mode` and the acquire's `exact_cards`.
+### It changed no plan, and no wall time
 
-Rare statuses (`banned`, `restricted`) need not be covered: they are a small share of traffic and the
-estimator's error on them is not what is costing time.
+Interleaved A/B, 8 rounds, 1,398 queries (realistic sample plus enrichment across every dimension
+covered), `CARD_ENGINE_EXACT_VALUE_TOTALS` selecting the arm so both read a byte-identical archive:
 
-**Not the same as a popcount of a plane.** Where the query already reads a card-space `_EXISTS` plane,
-its popcount IS the exact card total and no table is needed — that is how legality got exact card counts
-for free, recorded in [the walk-modes doc](./local-engine-orderby-walk-modes.md). The table is for the
-two spaces that popcount cannot give: a card-space plane does not say WHICH printing matched, so it
-cannot count printings or artworks.
+| subset | n | off | on | on/off |
+| --- | --: | --: | --: | --: |
+| exact-total touched TARGET | 482 | 70.5 ms | 70.4 ms | **0.998** |
+| everything else CONTROL | 916 | 81.6 ms | 81.8 ms | 1.003 |
+| whole mix | 1,398 | 152.1 ms | 152.2 ms | **1.001** |
 
-## Why exactness here is worth anything at all
+p50 1.002, p90 1.008, p99 1.001; median cell 1.000 in both subsets. The ±6-8% outliers are on queries
+the change cannot reach (`name:the`, `a:easley`, `o:more`) and appear in both directions — the noise floor.
+
+The reason is not that the wins cancelled. **The router picked the identical plan for all 1,347 query
+configs**, off and on. Estimates wrong by 0.63-1.35x were still on the correct side of every argmin on
+this mix. So the honest accounting is: exactness achieved, latency unchanged, ~3.2 KB spent.
+
+That is consistent with the 2.5%-of-dispatch-time ceiling on all cost-model work
+([measured](./local-engine-layout-postings.md#why-this-was-invisible-before)) — it just lands at the
+bottom of that range rather than the top. It does NOT vindicate the earlier reading that the artwork
+slice's 21% share of routing regret came from its missing exact totals: those totals are now exact and
+the regret did not move.
+
+### What is still not exact, and why the table cannot fix it
+
+`is:flip` reads **1,080x** over and `is:split` 135x, unchanged. Their acquire is `count_source:
+candidates`, not compose, so `exact_result_total` is never consulted — `card_layout` has no narrowing arm
+at all ([layout postings](./local-engine-layout-postings.md)). The `layout` map in `ValueTotals` is
+therefore correct but **unreachable today**; it is kept (14 entries, ~200 bytes) because it is what that
+work will need, not because anything reads it now.
+
+`-r:common` also stays off (0.45 printing, 0.67 artwork): a negated rarity leaf acquires as `candidates`
+rather than compose, so it too never reaches these arms.
+
+## What exactness here was supposed to be worth
 
 Estimation error does not cost time directly; it costs time by mis-routing. The bound on all
 cost-model work is small — 2.5% of dispatch time is the total recoverable regret over uniform traffic
@@ -92,11 +129,22 @@ cost-model work is small — 2.5% of dispatch time is the total recoverable regr
 concentrated: the artwork slice alone carried 21% of it at p99 205 µs against 36–40 µs for the other two
 modes, and the reason is that artwork was the only space with no exact path at all.
 
-So the case for this work is not "the estimate is ugly". It is that a wrong total on one side of an
+So the case for this work was not "the estimate is ugly" — it was that a wrong total on one side of an
 argmin picks the wrong plan, and the two spaces without exact counts were the two where the router was
 most often wrong.
 
+**That reasoning did not survive measurement.** The premise is sound and the conclusion was false here,
+because it assumed the argmin was *close*. It is not: on these dimensions the gap between the best plan
+and the next one is wide enough to absorb a 35% error in the total. The lesson for the next accuracy
+item is to check the argmin's MARGIN before fixing an estimate — a large error on a wide margin is free
+to leave alone, and cheap to prove harmless with the plan-diff probe rather than a full A/B.
+
 ## Status
 
-(1) is implemented and measured on the production corpus; (2) is scoped and not started. Every ratio
-above is measured, minimum of 3 runs after warmup, against the executor's realized `result_total`.
+Both halves are implemented and measured on the production corpus. Every accuracy ratio is a minimum of
+3 runs after warmup against the executor's realized total; the wall-clock table is 8 interleaved rounds
+with a control subset, on a machine with Docker shut down.
+
+Total archive cost: **156.6 KB** for the artwork column plus **3.2 KB** for the per-value table and
+rarity — 0.22% of the store, for exactness that bought no measured latency. Whether that trade is worth
+keeping is a judgement call, and the flat A/B is the number to make it on.

--- a/docs/issues/local-engine-exact-totals-three-spaces.md
+++ b/docs/issues/local-engine-exact-totals-three-spaces.md
@@ -1,0 +1,102 @@
+# Exact result totals in all three spaces, for the predicates that have a plane
+
+The router's biggest remaining estimation error is not a bad formula, it is asking a formula a question
+the store can already answer. `unique=` has three result spaces — printings, cards, artworks — and for a
+predicate backed by a plane or a value index, the exact count in each is a build-time aggregate that
+fits in kilobytes.
+
+Two halves. The first is done.
+
+## 1. The artwork column on the range tables — SHIPPED
+
+`RangeCardCounts` carried prefix / suffix / at triples for **cards** only. Printings were already exact
+(`k = e - s` from the value index's own partition points), so artworks were the one space every
+one-sided range query estimated, through `printing_bits_to_artwork_bits` plus a two-stage
+balls-into-bins.
+
+Measured before and after, `est / true` on the production corpus (`unique=artwork`, sole predicate):
+
+| query | before | after |
+| --- | --: | --: |
+| `usd<50` | 0.87 | **1.000** |
+| `year>=2015` | 0.84 | **1.000** |
+| `cn>200` | 0.80 | **1.000** |
+| `usd>=200`, `year<2000`, `cn<=10`, `eur<5`, `tix>=1` | — | **1.000** |
+
+Card mode stayed 1.000 and printing mode stayed exact by construction; all five range dimensions
+(`released_at`, `price_usd`, `price_eur`, `price_tix`, `collector_number`) are covered.
+
+Three implementation points worth keeping:
+
+- **One pass, two spaces.** The artwork triple is filled in the same sweep as the card triple over a
+  parallel seen-bitmap. Two passes would have been simpler and would have been able to drift.
+- **The artwork id must be global** — `artwork_base[card] + artwork_group_id`. Group ids repeat across
+  cards, so omitting the base merges unrelated artworks. The exactness test brute-forces it the same way.
+- **`exact_cards` and `exact_total` are different quantities.** `eval_domain`, `scan_all` and the
+  artwork capacity all consume a CARD count regardless of the query's mode; only `result_total` wants the
+  mode's own space. `exact_card_total` became `exact_result_total(filter, indexes, n_cards, mode)` and the
+  acquire calls it twice — once pinned to `Mode::Card`, once in the query's mode. Collapsing them into one
+  mode-aware call puts an artwork count where cards are expected.
+
+Cost: **156.6 KB** of archive (12 bytes × ~13,400 distinct values), 0.22% of the store. That is more
+than the 133 KB `frame_data`'s hybrid handed back, so this is a real size-for-accuracy trade and not a
+free win — see [the `is:`/`frame:` doc](./local-engine-is-frame-predicates.md) for that one.
+
+`range_card_counts_are_exact` checks both spaces exhaustively over every distinct value on three
+indexes, against a brute-force distinct count, plus the shapes the table must DECLINE (a genuinely
+interior multi-value range). Exhaustive rather than sampled because the errors in this area clustered at
+range ends.
+
+## 2. The core 3-space count table — NOT YET DONE
+
+Same idea for the predicates that are a plane rather than a range. Five low-cardinality dimensions, 77
+values between them:
+
+| dimension | values |
+| --- | --: |
+| border | 5 |
+| rarity | 6 |
+| layout | 14 |
+| frame | 29 |
+| format | 23 |
+
+77 values × 3 spaces × 4 bytes = **0.9 KB**. At that size there is no threshold to tune and no sparse
+tail to special-case: store all of them.
+
+What it fixes, from the accuracy audit:
+
+| predicate | mode | est/true today |
+| --- | --- | --: |
+| `frame:*` | card | 0.63–0.95 |
+| `format:*` | printing | 0.87–0.93 |
+| border / rarity / frame / format | artwork | estimated |
+
+Wire it into `exact_result_total`, which already has the mode parameter and already returns `None` for
+non-card modes on the shapes it cannot answer — the table is exactly what turns those `None`s into
+answers. Consumers are `compose_total_for_mode` and the acquire's `exact_cards`.
+
+Rare statuses (`banned`, `restricted`) need not be covered: they are a small share of traffic and the
+estimator's error on them is not what is costing time.
+
+**Not the same as a popcount of a plane.** Where the query already reads a card-space `_EXISTS` plane,
+its popcount IS the exact card total and no table is needed — that is how legality got exact card counts
+for free, recorded in [the walk-modes doc](./local-engine-orderby-walk-modes.md). The table is for the
+two spaces that popcount cannot give: a card-space plane does not say WHICH printing matched, so it
+cannot count printings or artworks.
+
+## Why exactness here is worth anything at all
+
+Estimation error does not cost time directly; it costs time by mis-routing. The bound on all
+cost-model work is small — 2.5% of dispatch time is the total recoverable regret over uniform traffic
+([measured](./local-engine-layout-postings.md#why-this-was-invisible-before)). But routing regret is
+concentrated: the artwork slice alone carried 21% of it at p99 205 µs against 36–40 µs for the other two
+modes, and the reason is that artwork was the only space with no exact path at all.
+
+So the case for this work is not "the estimate is ugly". It is that a wrong total on one side of an
+argmin picks the wrong plan, and the two spaces without exact counts were the two where the router was
+most often wrong.
+
+## Status
+
+(1) is implemented and measured on the production corpus; (2) is scoped and not started. Every ratio
+above is measured, minimum of 3 runs after warmup, against the executor's realized `result_total`.

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -20,26 +20,28 @@ Measured on the production corpus, `unique=card orderby=edhrec limit=60`, plan-o
 
 `eval_domain == 31,508` means nothing narrowed at all — a full corpus scan.
 
-## 0. FIRST: the revert below rests on a bad measurement — re-measure before trusting it
+## 0. RESOLVED: shipped in `f855135`, and the earlier revert was a measurement artifact
 
-Every wall-time figure in this doc's section 1 was taken against a baseline captured hours earlier. The
-same build re-measured back-to-back read **180.7 ms then against 220.6 ms later — 22% machine drift** —
-while the canary queries stayed flat at 31-32 µs, because three queries cannot see a broad thermal shift.
+`9cb7c15` reverted this on evidence taken against a baseline captured hours earlier, during which the
+machine drifted **22%** — while the canary queries stayed flat at 31–32 µs, because three queries cannot
+see a distribution-wide move. Re-measured with **15 interleaved A/B rounds** (one binary, one store,
+`CARD_ENGINE_FRAME_HYBRID` selecting the read path so both arms saw a byte-identical archive):
 
-Interpolating that drift, the hybrid index's "1.084 worse" was plausibly ~0.98, i.e. neutral or better.
-**The revert of `fb7f0a9` may therefore be wrong.** Before anything else here:
+| subset | n | A (thresholded) | B (hybrid) | B/A | median cell |
+| --- | --: | --: | --: | --: | --: |
+| `frame:`/`is:` touched **TARGET** | 166 | 58.2 ms | **26.8 ms** | **0.460** | 0.608 |
+| everything else **CONTROL** | 1,190 | 118.8 ms | 117.4 ms | **0.988** | 0.995 |
+| **whole mix** | 1,356 | 177.0 ms | **144.2 ms** | **0.815** | |
 
-1. On a quiet machine, capture base and hybrid **back-to-back**, two runs each side, per-query minimum.
-2. Include a control subset the change cannot touch (queries with no `frame:`/`is:` leaf) and require it
-   to read ~1.00. That is the check that actually caught this: `name:s` reading 2.21x on a query with no
-   frame predicate was the tell, not the canaries.
-3. Only then judge the aggregate.
+p50 0.894, p90 0.837, **p99 0.648**. `is:new` 1354 → 39 µs, `frame:2015` 1375 → 41 µs, `is:old`
+686 → 39 µs. Store 133 KB **smaller** as well.
 
-`fb7f0a9` is the commit to restore; `9cb7c15` reverted it. The per-query wins in it were measured with 20
-reps each and are not in doubt (`frame:2015` 603 -> 185 µs, `is:new` 558 -> 141, `is:old` 399 -> 62,
-`frame:2015` under `unique=printing` 834 -> 0.4) and neither is the 130 KB saving, which is deterministic.
+**Interleaving, not more samples** — the error was systematic, so more samples of each arm measured
+separately would only give two precise numbers describing two different machine states. Drift check,
+same arm first round vs last: A 0.983, B 0.989. And the CONTROL subset is the validity gate: it is what
+exposed the original artifact, when a query the change cannot touch read 2.21×.
 
-## 1. The `frame_data` threshold drops its dense values — IMPLEMENTED AND REVERTED (see 0)
+## 1. The `frame_data` threshold drops its dense values — SHIPPED (see 0)
 
 `HybridTagIndex` shipped in `fb7f0a9`: every value stored, dense as a printing bitmap and the sparse
 tail as postings. The per-query wins are large and the memory prediction was exact (**130 KB smaller**,
@@ -278,3 +280,25 @@ same argument as `numeric_candidates`") because materialising card ids is cheap.
 oracle-text driver may be the wrong call, in which case the probe should apply to printing-space
 children only. Not diagnosed — and worth re-measuring on a quiet machine before acting, for the reason
 in section 0.
+
+## 6. Open: the mid-density regressions
+
+Shipped with three known regressions, all on the **mid-density** frame values — `2003` at 17.0% and
+`1997` at 11.1%, the ones already stored as postings before, so the population where the representation
+changed but the completeness win does not apply:
+
+| query | ratio |
+| --- | --: |
+| `o:this frame:2003` | 2.54× |
+| `t:human frame:1997` | 2.07× |
+| `frame:2003 c:g` (4 configs) | ~1.6× |
+
+The lead is concrete and it does **not** point at the storage. `frame:2003` alone reads
+`eval_domain: 8,026`; `o:this frame:2003` reads **19,968** — adding a partner made the candidate set
+*bigger*, which can only happen if the `And` arm stopped including the frame child. That is the arm
+`3cfd441` gave a cost probe to, so the first thing to check is whether `probe_collection_k` is now
+sizing a dense frame value in printings against a driver counted in cards (the space mismatch its own
+doc admits inheriting from `probe_range_k`) and skipping on a comparison that is off by ~3×.
+
+The A/B harness makes this a 36-second question — it lives in the session scratchpad; the reusable part
+is the protocol, recorded in the benchmark-artifacts memory.


### PR DESCRIPTION
**Layer 9 of 13.** Base: #840. Reference: #830. **Archive bump: `2026080509`.**

`unique=` has three result spaces — printings, cards, artworks — and the estimator was guessing in at
least one of them for nearly every predicate. This makes them exact where the store can already answer.

- **An artwork column on the range count tables.** Printings were already exact from the index's own
  partition points and cards from the existing triple, so artworks were the one space every one-sided
  range estimated: 0.80–0.87 of the truth. Now 1.000 across all five range dimensions. Filled in the
  *same* build pass as the card triple so the two cannot drift.
- **A sixth count table for rarity.** Per-value counts would have been *wrong* here, not merely
  incomplete: a card printed at both common and rare is in the distinct-card count for each, so
  `r<=rare` is not a sum. 184 bytes; artwork 1.07–1.35 → 1.000.
- **`ValueTotals`** for border / layout / frame / (format, status): 27 of 27 measured cells exact where
  card mode had read 2.8–10.1× over.

## Honest accounting

**Zero plans changed.** An A/B over 1,347 query configs picked the identical plan every time, and the
whole mix read 1.001. The estimates were wrong by up to 10× and still on the correct side of every
argmin, because the margin between best and next-best is wider than the error. Kept because exact
information is a foundation later layers do depend on — layer 12's pair table is what finally makes
layer 11's scan-scope fix safe.

Cost: ~157 KB of archive.

## Verification

`cargo test` (151) and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
