### PR TITLE
Engine: A Dense frame_data Value Is Not a Broad One (stack 10/13)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -4367,7 +4367,30 @@ fn narrow_rec(
             if matches!(field, CollField::FrameData) {
                 let idx = &indexes.frame_data;
                 if idx.is_dense(value.as_str()) {
-                    if !broad_ok {
+                    // DENSE is the storage crossover (1/32 of printings, where a bitmap gets smaller
+                    // than postings). BROAD is the narrowing guard (`MAX_NARROW_FRACTION`, 1/4, where
+                    // intersecting stops paying). They are different questions eight times apart, and
+                    // consulting `broad_ok` for every dense value conflated them: `frame:2003` (17% of
+                    // printings), `frame:1997` (11%) and `frame:legendary` (10.6%) all sit BETWEEN the
+                    // two, so each was declined as if it were broad.
+                    //
+                    // That is the whole of the mid-density regression this index shipped with, and it is
+                    // not the `probe_collection_k` space mismatch it was first blamed on. Those three
+                    // values were POSTINGS before the hybrid, which took the branch below — where
+                    // `range_too_broad_to_narrow` is tested first and `broad_ok` only decides the broad
+                    // case. Moving them to a bitmap silently moved them behind a stricter gate.
+                    //
+                    // It bites hardest with a CARD-space partner, because `narrow_candidates_exact`
+                    // enters with `broad_ok: false` and rank-0 children inherit it: `o:this frame:2003`
+                    // narrowed to `o:this` alone (19,968 cards, identical features to `o:this
+                    // border:black`) and ran 1,809 us against 52 us for `o:this` by itself — adding a
+                    // predicate that CUTS the result set 6x made the query 35x slower, because the
+                    // frame test became a per-printing residual instead of a bitmap AND.
+                    let k = idx.len_of(value.as_str())?;
+                    // `DENSE_FRAME_BROAD_GATE=0` restores the conflated gate this fixed, so the two can
+                    // be measured against each other on a byte-identical archive.
+                    let broad = if *DENSE_FRAME_BROAD_GATE { range_too_broad_to_narrow(k, n_printings) } else { true };
+                    if broad && !broad_ok {
                         return None;
                     }
                     return mk(Candidates::PrintingBits(idx.bits(value.as_str(), n_printings)?));
@@ -5467,6 +5490,10 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// Kept as a permanent handle, not scaffolding: these arms change ROUTING (a total feeds the argmin),
 /// so the only honest way to price them is an interleaved A/B in which both arms read a byte-identical
 /// archive. The table is archived either way, so flipping this cannot move a field offset.
+/// Whether a dense `frame_data` value is gated on being genuinely BROAD (1/4) rather than merely dense
+/// (1/32). 0 restores the conflated gate, for the A/B that priced the distinction.
+static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_DENSE_FRAME_BROAD_GATE", 1u8) != 0);
+
 static EXACT_VALUE_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_EXACT_VALUE_TOTALS", 1u8) != 0);
 
 static STREAM_MIN_MATCHES: LazyLock<usize> = LazyLock::new(|| guard_env("CARD_ENGINE_STREAM_MIN_MATCHES", 1_024));

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7,7 +7,7 @@ use super::{
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
-    EXACT_VALUE_TOTALS, RangeCardCounts, ValueTotals, build_all_value_totals, build_range_card_counts, exact_result_total,
+    EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, build_all_value_totals, build_range_card_counts, exact_result_total,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -3275,6 +3275,57 @@ fn force_plan_differential_agreement() {
              cmc/power/toughness under a matching orderby.",
         );
     }
+}
+
+/// A dense `frame_data` value must still narrow under `broad_ok: false` unless it is genuinely BROAD.
+///
+/// Dense is the storage crossover (1/32 of printings); broad is the narrowing guard
+/// (`MAX_NARROW_FRACTION`, 1/4). Values between the two — the corpus has three, at 10.6%, 11% and 17% —
+/// must produce a bitmap, because `narrow_candidates_exact` enters with `broad_ok: false` and an `And`'s
+/// rank-0 children inherit it. Conflating the two thresholds cost `o:this frame:2003` 1,809 us against
+/// 52 us for `o:this` alone, with results identical either way — so no correctness test could see it and
+/// this asserts the representation decision directly.
+#[test]
+fn a_dense_but_not_broad_frame_value_narrows_without_broad_ok() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_805);
+    let data = fuzz_store_n(&mut rng, 4_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let (offsets, cards) = (&archived.offsets, &archived.cards);
+    let n_printings = archived.printings.len();
+
+    let mut checked = (0usize, 0usize); // (dense-not-broad, broad)
+    for (value, _) in FUZZ_FRAME_DATA {
+        if !archived.indexes.frame_data.is_dense(value) {
+            continue;
+        }
+        let k = archived.indexes.frame_data.len_of(value).expect("a dense value has a count");
+        let mut f = FilterExpr::CollectionCmp {
+            field: CollField::FrameData,
+            op: CmpOp::Ge,
+            value: value.to_string(),
+            value_id: None,
+        };
+        f.bind(
+            &archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab,
+            &archived.mana_vocab, &archived.indexes.flavor, &archived.strings,
+        );
+        let got = narrow_rec(&f, &archived.indexes, offsets, cards, false);
+        if range_too_broad_to_narrow(k, n_printings) {
+            assert!(got.is_none(), "frame:{value} is broad ({k} of {n_printings}) and must decline without broad_ok");
+            checked.1 += 1;
+        } else {
+            let n = got.unwrap_or_else(|| panic!("frame:{value} is dense but NOT broad ({k} of {n_printings}) — must narrow"));
+            assert_eq!(n.set.len(), k, "frame:{value}: the bitmap must hold exactly the indexed printings");
+            assert!(n.tight, "Ge containment postings are exact, so the bitmap is tight");
+            checked.0 += 1;
+        }
+    }
+    // Both sides of the threshold must actually be present, or the test proves nothing about the
+    // distinction it exists to pin down.
+    assert!(checked.0 > 0, "no dense-but-not-broad frame value in the store; the regression case is uncovered");
+    assert!(checked.1 > 0, "no broad frame value in the store; the decline case is uncovered");
 }
 
 /// The per-value `ValueTotals` table must be exact in all three spaces, for every value of every

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -281,24 +281,85 @@ oracle-text driver may be the wrong call, in which case the probe should apply t
 children only. Not diagnosed — and worth re-measuring on a quiet machine before acting, for the reason
 in section 0.
 
-## 6. Open: the mid-density regressions
+## 6. The mid-density regressions — FIXED, and the first hypothesis was wrong
 
-Shipped with three known regressions, all on the **mid-density** frame values — `2003` at 17.0% and
-`1997` at 11.1%, the ones already stored as postings before, so the population where the representation
-changed but the completeness win does not apply:
+The hybrid shipped with three regressions, all on the **mid-density** frame values — the ones stored as
+postings before, where the representation changed but the completeness win does not apply.
 
-| query | ratio |
-| --- | --: |
-| `o:this frame:2003` | 2.54× |
-| `t:human frame:1997` | 2.07× |
-| `frame:2003 c:g` (4 configs) | ~1.6× |
+**Cause: `dense` and `broad` are different thresholds, and the dense branch conflated them.**
 
-The lead is concrete and it does **not** point at the storage. `frame:2003` alone reads
-`eval_domain: 8,026`; `o:this frame:2003` reads **19,968** — adding a partner made the candidate set
-*bigger*, which can only happen if the `And` arm stopped including the frame child. That is the arm
-`3cfd441` gave a cost probe to, so the first thing to check is whether `probe_collection_k` is now
-sizing a dense frame value in printings against a driver counted in cards (the space mismatch its own
-doc admits inheriting from `probe_range_k`) and skipping on a comparison that is off by ~3×.
+| | threshold | meaning |
+| --- | --: | --- |
+| DENSE | 1/32 of printings | a bitmap is smaller than postings (`bitmap_beats_postings`) |
+| BROAD | 1/4 of printings | intersecting stops paying (`MAX_NARROW_FRACTION`) |
 
-The A/B harness makes this a 36-second question — it lives in the session scratchpad; the reusable part
-is the protocol, recorded in the benchmark-artifacts memory.
+Eight times apart, and three frame values sit between them: `legendary` 10.6%, `1997` 11.1%, `2003`
+17.0%. The dense branch consulted `broad_ok` for *every* dense value, so all three were declined as if
+they were broad. As postings they had taken the branch below, where `range_too_broad_to_narrow` is tested
+FIRST and `broad_ok` only decides the genuinely-broad case. Moving them to a bitmap silently moved them
+behind a stricter gate.
+
+It bites hardest with a **card-space partner**, because `narrow_candidates_exact` enters with
+`broad_ok: false` and an `And`'s rank-0 children inherit it. So the frame predicate stopped narrowing at
+all and became a per-printing residual instead of a bitmap AND:
+
+| query | before | after |
+| --- | --: | --: |
+| `o:this frame:1993` | 2,102 µs | **148 µs** |
+| `o:this frame:legendary` | 2,111 µs | **193 µs** |
+| `o:this frame:1997` | 1,829 µs | **288 µs** |
+| `o:this frame:2003` | 1,834 µs | **418 µs** |
+| `frame:2003 c:g` | 184 µs | **66 µs** |
+| `o:this` alone, for scale | 52 µs | 52 µs |
+
+Adding a predicate that CUT the result set 6x made the query 35x slower. `eval_domain` for
+`o:this frame:2003` was 19,968 — identical to `o:this` alone, and byte-identical to
+`o:this border:black`, which is how the mechanism was found: every printing-space partner behaved the
+same regardless of its selectivity.
+
+The fix is three lines — test broadness, then `broad_ok` — mirroring the non-hybrid path exactly.
+
+### What it is worth
+
+Interleaved A/B behind `CARD_ENGINE_DENSE_FRAME_BROAD_GATE`, 8 rounds, 1,374 queries:
+
+| subset | n | conflated | fixed | fixed/conflated |
+| --- | --: | --: | --: | --: |
+| `frame:` touched TARGET | 143 | 116.1 ms | 45.5 ms | **0.392** |
+| everything else CONTROL | 1,231 | 124.3 ms | 125.1 ms | 1.007 |
+| whole mix | 1,374 | 240.3 ms | 170.6 ms | **0.710** |
+
+p90 0.903, **p99 0.385** (2,114 µs → 813 µs), median target cell 0.754.
+
+The apparent control regressions (`name:s` 1.91x, `border:black is:flip` 1.43x, `is:mdfc` 1.39x) are
+within-query variance, not signal: `name:s`'s spread *inside arm A* is 2.40x, wider than the cross-arm
+ratio, and its other sampled config reads 1.00. None of the three contains a `frame:` leaf, so the change
+cannot reach them. Broad values still decline as designed — `o:this frame:2015` (66%) is unchanged.
+
+### Why the first hypothesis was wrong
+
+This was originally blamed on `probe_collection_k` sizing a dense frame value in PRINTINGS against a
+driver counted in CARDS, and the evidence offered was that adding a partner made `eval_domain` bigger.
+That evidence was real and the inference was wrong. The `And` arm's skip never fired: it is guarded on
+`best <= AND_SKIP_THRESHOLD` (2,048) and the oracle driver was 19,968. The child was not skipped by a
+cost comparison, it declined to narrow at all one level down.
+
+The lesson is the same one the walk-modes work learned twice: read the branch that actually ran before
+theorising about the one that looks suspicious. `eval_domain` alone could not distinguish "the parent
+skipped this child" from "the child declined", and those have different fixes.
+
+`probe_collection_k`'s printing-vs-card space mismatch is real and still unaddressed — it just was not
+this. Whether it costs anything is now an open question rather than an assumed cause.
+
+## 7. Still open
+
+- **`o:this frame:2003` is 418 µs against 52 µs for `o:this` alone.** Much better, not good. It picks
+  `GatheredScan` over 19,851 scan units where `o:this` alone streams a page and stops.
+- **Genuinely broad printing-space partners under a card-space driver** still decline entirely:
+  `o:this border:black` 1,989 µs, `o:this cn>200` 1,839 µs, `o:this frame:2015` 1,843 µs, all against 52
+  µs for the driver alone. For a STORED bitmap (a plane, or a dense hybrid value) the AND is nearly free
+  and the projection is one pass, so declining may be wrong even at 66% — but the previous attempt to
+  bypass `broad_ok` for stored bitmaps cost 1.3-1.8x on sparse `And`s, so the rule wants to be
+  contextual (is there a printing-space partner? is the driver large enough for the cut to pay?) rather
+  than removed. That is the next item in this family and it is worth more than what section 6 just fixed.
+- (2)'s `t:battle` plane poisoning and (3)'s missing `Battle` in `card_types`, both untouched.


### PR DESCRIPTION
**Layer 10 of 13.** Base: #841. Reference: #830. One commit, no archive change, clippy-clean as replayed.

Layer 8 shipped the `frame_data` hybrid with three known regressions, all on the **mid-density** values.
This is the cause, and it is a threshold conflation:

| | threshold | means |
| --- | --: | --- |
| DENSE | 1/32 of printings | a bitmap is smaller than postings |
| BROAD | 1/4 of printings | intersecting stops paying |

Eight times apart, and three frame values sit between them — `legendary` 10.6%, `1997` 11.1%, `2003`
17.0%. The dense branch consulted `broad_ok` for *every* dense value, so all three were declined as if
broad. As postings they had taken the branch below, where broadness is tested first and `broad_ok` only
decides the genuinely-broad case; giving them a bitmap silently moved them behind a stricter gate.

It bites hardest with a card-space partner, because `narrow_candidates_exact` enters with
`broad_ok: false` and an `And`'s rank-0 children inherit it — so the frame predicate stopped narrowing at
all and became a per-printing residual:

| query | before | after |
| --- | --: | --: |
| `o:this frame:1993` | 2,102 µs | **148 µs** |
| `o:this frame:legendary` | 2,111 | **193** |
| `o:this frame:1997` | 1,829 | **288** |
| `o:this frame:2003` | 1,834 | **418** |
| `o:this` alone, for scale | 52 | 52 |

Adding a predicate that *cut* the result set 6× had been making the query 35× slower.

A/B: target **0.392**, control 1.007, whole mix 0.710, **p99 0.385**.

## Note on the diagnosis

This was originally blamed on `probe_collection_k` sizing printings against a card-space driver, on the
evidence that adding a partner made `eval_domain` bigger. The evidence was real and the inference wrong —
the `And` skip is guarded on `best <= 2,048` against a driver of 19,968, so it never fired. `eval_domain`
cannot distinguish "the parent skipped this child" from "the child declined to narrow".

## Verification

`cargo test` and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
