### PR TITLE
Engine: Stop Re-Verifying Conjuncts the Candidate Set Proves (stack 11/13)

### DIFF
--- a/card_engine/src/bench_and_best.rs
+++ b/card_engine/src/bench_and_best.rs
@@ -140,7 +140,7 @@ fn build(rng: &mut rand::rngs::SmallRng, shape: Shape, k: usize) -> Vec<Narrowed
                     Candidates::Cards(random_sorted_list(rng, N_CARDS, (N_CARDS as f64 * fill) as usize))
                 }
             };
-            Narrowed { set, tight: true }
+            Narrowed { set, tight: true, proven: 0 }
         })
         .collect()
 }

--- a/card_engine/src/bench_gather_loop.rs
+++ b/card_engine/src/bench_gather_loop.rs
@@ -436,6 +436,8 @@ fn bench_gather_loop() {
             PreparedCandidates {
                 candidate_cards: Some(self.group[start..end].to_vec()),
                 all_match_known: self.all_match_known,
+                // The loop is driven directly here; no narrowing ran, so nothing is proven.
+                proven_conjuncts: 0,
                 narrowed_repr: NarrowedRepr::Cards,
             }
         }
@@ -602,7 +604,9 @@ fn bench_gather_loop() {
                 let prep = PreparedCandidates {
                     candidate_cards: Some(singleton[start..end].to_vec()),
                     all_match_known: true,
-                    narrowed_repr: NarrowedRepr::Cards,
+                    // The loop is driven directly here; no narrowing ran, so nothing is proven.
+                proven_conjuncts: 0,
+                narrowed_repr: NarrowedRepr::Cards,
                 };
                 black_box(exec_gathered_scan(&ctx, &params, &filter, &prep, None));
                 let st = take_phase_stats();

--- a/card_engine/src/bench_iter_dispatch.rs
+++ b/card_engine/src/bench_iter_dispatch.rs
@@ -99,7 +99,7 @@ fn bench_iter_dispatch_cost() {
         let mut n_match = 0u32;
         for cid in it {
             let card = &data.cards[black_box(cid) as usize];
-            if matches!(filter.card_pass(card, strings, &mut residual, &mut residual_is_or), Tri::True) {
+            if matches!(filter.card_pass(card, strings, &mut residual, &mut residual_is_or, 0), Tri::True) {
                 n_match += 1;
             }
         }
@@ -112,7 +112,7 @@ fn bench_iter_dispatch_cost() {
         let mut n_match = 0u32;
         for cid in it {
             let card = &data.cards[black_box(cid) as usize];
-            if matches!(filter.card_pass(card, strings, &mut residual, &mut residual_is_or), Tri::True) {
+            if matches!(filter.card_pass(card, strings, &mut residual, &mut residual_is_or, 0), Tri::True) {
                 n_match += 1;
             }
         }

--- a/card_engine/src/bench_streamed_loop.rs
+++ b/card_engine/src/bench_streamed_loop.rs
@@ -317,6 +317,8 @@ fn bench_streamed_loop() {
             let prep = PreparedCandidates {
                 candidate_cards: Some(cfg.group[start..end].to_vec()),
                 all_match_known: !cfg.residual,
+                // The loop is driven directly here; no narrowing ran, so nothing is proven.
+                proven_conjuncts: 0,
                 narrowed_repr: NarrowedRepr::Cards,
             };
             black_box(exec_streamed_select(&ctx, &cfg.params, filter, &prep, None));

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -590,6 +590,25 @@ pub(crate) const REGEX_MACHINERY_NS100: u32 = 5_000;
 /// Per-candidate verification cost of a node in the tri walk. Composites take
 /// the max of their children: their short-circuit may have to evaluate every
 /// child, so the most expensive child bounds the cost.
+/// `verify_cost_tier` over an `And` whose `proven` children are skipped, matching what `card_pass` will
+/// actually evaluate (see `Narrowed::proven`).
+///
+/// Without this the model keeps charging the tier of a conjunct nobody verifies: `o:this border:black`
+/// read `TEXT_SCAN` (23 ns/card) when the surviving residual is a `TextExact` at `MASK_COMPARE` (4 ns),
+/// and both plans under-predicted by 2.0-2.6x. A cost model that does not see a change cannot route on it.
+pub(crate) fn verify_cost_tier_unproven(f: &FilterExpr, proven: u64) -> u32 {
+    match f {
+        FilterExpr::And(children) if proven != 0 => children
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i >= 64 || proven & (1 << i) == 0)
+            .map(|(_, c)| verify_cost_tier(c))
+            .max()
+            .unwrap_or(0),
+        _ => verify_cost_tier(f),
+    }
+}
+
 pub(crate) fn verify_cost_tier(f: &FilterExpr) -> u32 {
     match f {
         FilterExpr::TextRegex { regex, .. } => regex_tier(regex.as_str()),
@@ -1108,21 +1127,43 @@ impl FilterExpr {
     /// memoization flips TextContains nodes from the scan tier to the set
     /// tier. The per-printing residual pass inherits the order too, since
     /// card_pass() pushes residual children in child order.
-    pub(crate) fn order_children_by_verify_cost(&mut self) {
+    /// `proven` is a bitmask over THIS node's `And` children (see `Narrowed::proven`) and is permuted in
+    /// step with them. Carrying it through rather than invalidating it matters: this reorder runs on every
+    /// query with a residual, so a mask dropped here would never survive to its consumer. Nested nodes get
+    /// no mask — only the outermost `And`'s is ever read.
+    pub(crate) fn order_children_by_verify_cost(&mut self, proven: &mut u64) {
         match self {
             FilterExpr::And(children) => {
                 for c in children.iter_mut() {
-                    c.order_children_by_verify_cost();
+                    c.order_children_by_verify_cost(&mut 0);
                 }
-                children.sort_by_key(|c| (printing_dependent(c), verify_cost_tier(c), and_child_set_len(c)));
+                let key = |c: &FilterExpr| (printing_dependent(c), verify_cost_tier(c), and_child_set_len(c));
+                if *proven == 0 {
+                    children.sort_by_key(key);
+                    return;
+                }
+                // Sort an index permutation instead of the children, so the mask can be rebuilt against
+                // the new positions. `sort_by_key` is stable, so this produces the same order as the
+                // unmasked path above.
+                let mut order: Vec<usize> = (0..children.len()).collect();
+                order.sort_by_key(|&i| key(&children[i]));
+                let mut moved: Vec<Option<FilterExpr>> = std::mem::take(children).into_iter().map(Some).collect();
+                let mut remapped = 0u64;
+                for (new_i, &old_i) in order.iter().enumerate() {
+                    if new_i < 64 && old_i < 64 && *proven & (1 << old_i) != 0 {
+                        remapped |= 1 << new_i;
+                    }
+                    children.push(moved[old_i].take().expect("each index appears once in a permutation"));
+                }
+                *proven = remapped;
             }
             FilterExpr::Or(children) => {
                 for c in children.iter_mut() {
-                    c.order_children_by_verify_cost();
+                    c.order_children_by_verify_cost(&mut 0);
                 }
                 children.sort_by_key(or_child_key);
             }
-            FilterExpr::Not(inner) => inner.order_children_by_verify_cost(),
+            FilterExpr::Not(inner) => inner.order_children_by_verify_cost(&mut 0),
             _ => {}
         }
     }
@@ -1165,12 +1206,21 @@ impl FilterExpr {
         strings: &AStrings,
         residual: &mut Vec<&'f FilterExpr>,
         residual_is_or: &mut bool,
+        proven: u64,
     ) -> Tri {
         residual.clear();
         *residual_is_or = false;
         match self {
             FilterExpr::And(children) => {
-                for c in children {
+                for (i, c) in children.iter().enumerate() {
+                    // Membership in the candidate set already settles this conjunct for this card, so
+                    // evaluating it can only return `True` — see `Narrowed::proven` for why that is sound
+                    // and for what it costs when it is not done. Skipping it is exactly the `all_match`
+                    // shortcut at conjunct granularity: not in the residual either, since the printings
+                    // of a card cannot disagree about a card-space fact.
+                    if i < 64 && proven & (1 << i) != 0 {
+                        continue;
+                    }
                     match c.tri(card, None, strings) {
                         // And(Null, x) is Null or False for every printing —
                         // never True — so the card cannot match.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2962,14 +2962,14 @@ fn range_narrowed(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32, n_printi
         // is contractually pid-ascending. Cheaper than before if anything — no stride over a tuple.
         let mut result: Vec<u32> = idx.range_pids(lo, hi).collect();
         result.sort_unstable();
-        return Some(Narrowed { set: Candidates::Printings(result), tight: exact });
+        return Some(Narrowed { set: Candidates::Printings(result), tight: exact, proven: 0 });
     }
     if !broad_ok {
         return None; // nothing downstream would consume the bitmap — pre-#636 behavior
     }
     if k <= idx.len() - k {
         let bits = scatter_bits(idx.range_pids(lo, hi), n_printings);
-        return Some(Narrowed { set: Candidates::PrintingBits(bits), tight: exact });
+        return Some(Narrowed { set: Candidates::PrintingBits(bits), tight: exact, proven: 0 });
     }
     let mut bits = scatter_bits(
         idx.pids[..s].iter().chain(idx.pids[e..].iter()).map(|p| u32::from(*p)),
@@ -3242,6 +3242,23 @@ enum Candidates {
 struct Narrowed {
     set: Candidates,
     tight: bool,
+    /// Which of a top-level `And`'s children this candidate set already PROVES, as a bitmask over the
+    /// children in written order. Set only by the `And` arm, and only for children whose own narrowing
+    /// was tight AND card-space; 0 everywhere else, including for a nested `And` (only the outermost
+    /// mask is ever read).
+    ///
+    /// Tightness has always been one bit for the whole expression, so a single un-narrowed conjunct
+    /// makes the whole set loose and the residual re-verifies EVERY conjunct — including ones membership
+    /// in the set already settles. `o:this` alone narrows tightly and runs in 67 us examining zero
+    /// printings; `o:this border:black` re-evaluates the oracle contains on all 19,968 candidates and
+    /// costs 1,993 us. The leaf identity does not matter (`cn>200`, `frame:2015`, three leaves at once
+    /// all land within 8%), because the cost is one card-level text evaluation per candidate CARD.
+    ///
+    /// Card-space only, for the reason `narrow_candidates_exact` spells out: a tight PRINTING-space set
+    /// says "this printing matches", not "every printing of this card does", so it cannot excuse a
+    /// per-printing check. Card-space tight is exactly the `all_match` promotion argument applied to one
+    /// conjunct instead of the whole tree.
+    proven: u64,
 }
 
 /// Ids-to-bits promotion threshold for And/Or composition. Below it the
@@ -3416,11 +3433,11 @@ impl Candidates {
 
 impl Narrowed {
     fn tight(set: Candidates) -> Option<Narrowed> {
-        Some(Narrowed { set, tight: true })
+        Some(Narrowed { set, tight: true, proven: 0 })
     }
 
     fn loose(set: Candidates) -> Option<Narrowed> {
-        Some(Narrowed { set, tight: false })
+        Some(Narrowed { set, tight: false, proven: 0 })
     }
 
     /// Project into card space. Printing→card projection is an existence
@@ -3430,10 +3447,10 @@ impl Narrowed {
         match self.set {
             Candidates::Cards(_) | Candidates::CardBits(_) => self,
             Candidates::Printings(v) => {
-                Narrowed { set: Candidates::Cards(cards_of_printings(offsets, printing_to_card, &v)), tight: false }
+                Narrowed { set: Candidates::Cards(cards_of_printings(offsets, printing_to_card, &v)), tight: false, proven: 0 }
             }
             Candidates::PrintingBits(b) => {
-                Narrowed { set: Candidates::CardBits(printing_bits_to_card_bits(&b, offsets, n_cards)), tight: false }
+                Narrowed { set: Candidates::CardBits(printing_bits_to_card_bits(&b, offsets, n_cards)), tight: false, proven: 0 }
             }
         }
     }
@@ -3498,7 +3515,7 @@ fn and_all(mut sets: Vec<Narrowed>) -> Option<Narrowed> {
         }
         (None, None) => unreachable!("sets was non-empty"),
     };
-    Some(Narrowed { set, tight })
+    Some(Narrowed { set, tight, proven: 0 })
 }
 
 /// Union same-space sets. Small all-vec inputs keep today's merge; anything
@@ -3534,7 +3551,7 @@ fn or_all(mut sets: Vec<Narrowed>, n: usize) -> Option<Narrowed> {
         }
         if card_space { Candidates::CardBits(acc) } else { Candidates::PrintingBits(acc) }
     };
-    Some(Narrowed { set, tight })
+    Some(Narrowed { set, tight, proven: 0 })
 }
 
 /// Static answer to "could narrow_rec(f) produce a tight set, and in which
@@ -3635,18 +3652,20 @@ fn narrow_candidates_exact(
     indexes: &Archived<CardIndexes>,
     offsets: &AOffsets,
     cards: &[AOracleCard],
-) -> (Option<Candidates>, bool) {
+) -> (Option<Candidates>, bool, u64) {
     let n_cards = offsets.len().saturating_sub(1);
     let n_printings = if n_cards == 0 { 0 } else { u32::from(offsets[n_cards]) as usize };
     match narrow_rec(filter, indexes, offsets, cards, false) {
-        None => (None, false),
+        None => (None, false, 0),
         Some(n) => {
             let printing_space = n.set.is_printing_space();
             let domain = if printing_space { n_printings } else { n_cards };
             if n.set.len() <= domain - domain / 4 {
-                (Some(n.set), n.tight && !printing_space)
+                // The mask is only meaningful alongside the set it was derived from: discarding the set
+                // for broadness discards the proof with it.
+                (Some(n.set), n.tight && !printing_space, n.proven)
             } else {
-                (None, false)
+                (None, false, 0)
             }
         }
     }
@@ -4575,7 +4594,23 @@ fn narrow_rec(
             // per child meant popcounting every accumulated bitmap again on every
             // iteration — O(children² × words) for a value that only ever shrinks.
             let mut best: Option<usize> = None;
+            // Which children the returned set will PROVE, by their index in `children` as written. A
+            // child qualifies when its own narrowing came back tight AND card-space, and it actually got
+            // pushed: `and_all` intersects, and an intersection is a subset of each of its inputs, so
+            // every card in the result satisfies each such child. See `Narrowed::proven`.
+            //
+            // Indices are recovered by pointer identity rather than by tracking position through
+            // `fuse_and_range_children`'s regrouping and the sort below — those reorder freely, and a
+            // positional guess that silently slipped would drop a real predicate from the residual.
+            // Children past 64 are simply never marked, which costs a re-verification and cannot be wrong.
+            let mut proven: u64 = 0;
             for (rank, _sort_k, size_k, src) in ranked {
+                let child_index = match &src {
+                    AndSource::Child(c) => children.iter().position(|w| std::ptr::eq(w, *c)),
+                    // A fused interval stands for two or more children at once, and is printing-space
+                    // besides, so it can never be proven.
+                    AndSource::FusedRange { .. } => None,
+                };
                 // A driver this selective already bounds the candidate set the
                 // residual re-verifies, so a costlier (rank>0) child usually
                 // narrows nothing the driver's verification doesn't already do
@@ -4629,6 +4664,12 @@ fn narrow_rec(
                         continue;
                     }
                     best = Some(best.map_or(len, |b| b.min(len)));
+                    if let Some(i) = child_index.filter(|&i| i < 64)
+                        && n.tight
+                        && !n.set.is_printing_space()
+                    {
+                        proven |= 1 << i;
+                    }
                     if n.set.is_printing_space() { printing_sets.push(n) } else { card_sets.push(n) }
                 } else {
                     every_child_included = false;
@@ -4636,8 +4677,12 @@ fn narrow_rec(
             }
             let cards = and_all(card_sets);
             let printings = and_all(printing_sets);
+            // `proven` rides only on results that CONTAIN the card side. Every branch below that returns
+            // the card intersection (alone, or intersected with a projected printing side) is a subset of
+            // each proven child's set; the lone-printing branch is not, and gets 0.
             let seal = |mut n: Narrowed| {
                 n.tight &= every_child_included;
+                n.proven = proven;
                 n
             };
             match (cards, printings) {
@@ -4652,7 +4697,10 @@ fn narrow_rec(
                     // space) project as before.
                     match &p.set {
                         Candidates::PrintingBits(_) if p.set.len() > n_printings / 4 => None,
-                        _ => Some(seal(p)),
+                        // No card side, so nothing here proves a card-space child -- and there cannot be
+                        // one, since a pushed card set would have produced `cards`. `proven` is 0 either
+                        // way; sealed through the same closure so the two branches cannot drift.
+                        _ => Some(Narrowed { proven: 0, ..seal(p) }),
                     }
                 }
                 (Some(c), Some(p)) => {
@@ -5493,6 +5541,10 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// Whether a dense `frame_data` value is gated on being genuinely BROAD (1/4) rather than merely dense
 /// (1/32). 0 restores the conflated gate, for the A/B that priced the distinction.
 static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_DENSE_FRAME_BROAD_GATE", 1u8) != 0);
+
+/// Whether a conjunct the candidate set already proves is skipped by `card_pass` instead of
+/// re-verified. 0 restores the re-verification, for the A/B that priced it.
+static PROVEN_CONJUNCTS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_PROVEN_CONJUNCTS", 1u8) != 0);
 
 static EXACT_VALUE_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_EXACT_VALUE_TOTALS", 1u8) != 0);
 
@@ -7373,6 +7425,10 @@ struct PreparedCandidates {
     /// and it exists because a candidate *count* in some band does not imply the query paid
     /// a sort to get there: a plane AND'd with a range reaches the same count word-wise.
     narrowed_repr: NarrowedRepr,
+    /// Top-level `And` children `card_pass` may skip because the candidate set proves them — see
+    /// `Narrowed::proven`. Already validated against `candidate_cards` and permuted to match the
+    /// post-reorder child positions, so consumers can use it directly.
+    proven_conjuncts: u64,
 }
 
 impl PreparedCandidates {
@@ -7620,7 +7676,7 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // queries exactly as before. Left un-materialized (Candidates, not
     // Vec<u32>) here so the plane branch below can AND two card-space bitmaps
     // directly instead of paying to materialize one of them first.
-    let (raw_candidates, residual_exact): (Option<Candidates>, bool) =
+    let (raw_candidates, residual_exact, proven_conjuncts): (Option<Candidates>, bool, u64) =
         narrow_candidates_exact(filter, indexes, offsets, cards);
     // Captured before the flattening below consumes it — see PreparedCandidates::narrowed_repr.
     let narrowed_repr = raw_candidates.as_ref().map_or(NarrowedRepr::None, Candidates::repr);
@@ -7685,6 +7741,15 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // candidate set with a selective needle memoizes while a narrow one
     // leaves the scan alone. Skipped entirely when all_match_known: card_pass
     // never runs, so there is nothing left for the rewrite to speed up.
+    // The mask indexes `filter`'s top-level children, so it is only valid while BOTH still describe the
+    // same query. Two things here can break that, and each clears it:
+    //
+    //   * `candidate_cards` being None. The narrowing was discarded (too broad, or absent), so the walk
+    //     visits cards the proof never covered. Keeping the mask would skip a real predicate.
+    //   * `order_children_by_verify_cost` permuting the children. The mask is carried THROUGH that
+    //     permutation rather than cleared, because the reorder is exactly what makes the residual cheap
+    //     and dropping the mask here would forfeit the win on every query that reaches it.
+    let mut proven_conjuncts = if candidate_cards.is_some() && *PROVEN_CONJUNCTS { proven_conjuncts } else { 0 };
     if !all_match_known {
         let eval_domain = candidate_cards.as_ref().map_or(cards.len(), Vec::len);
         filter.memoize_text_predicates(cards, strings, &indexes.name_trigram, &indexes.name_bigrams, &indexes.oracle_trigram, eval_domain);
@@ -7693,11 +7758,14 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
         // see order_children_by_verify_cost). After memoization, which flips
         // TextContains nodes from the scan tier to the set tier.
         if *VERIFY_ORDER != 0 {
-            filter.order_children_by_verify_cost();
+            filter.order_children_by_verify_cost(&mut proven_conjuncts);
         }
+    } else {
+        // `card_pass` never runs, so there is nothing to skip and the mask has no consumer.
+        proven_conjuncts = 0;
     }
 
-    PreparedCandidates { candidate_cards, all_match_known, narrowed_repr }
+    PreparedCandidates { candidate_cards, all_match_known, narrowed_repr, proven_conjuncts }
 }
 
 // ─── Plan executors ─────────────────────────────────────────────────────────
@@ -8067,7 +8135,7 @@ fn exec_streamed_select<'a>(
     // when the filter constrains the sort column, the whole permutation otherwise.
     let walk = walk_bounds(perm, ctx.cards, params.sort_col, params.descending, params.sort_bound);
     let existential_plane = existential_plane_for(params.mode, plane, indexes);
-    run_query_streamed(ctx, params, filter, prep.all_match_known, walk, prep.card_ids(ctx), existential_plane)
+    run_query_streamed(ctx, params, filter, prep.all_match_known, prep.proven_conjuncts, walk, prep.card_ids(ctx), existential_plane)
 }
 
 /// Per-query execution counters and coarse phase timings, for checking the cost model against what
@@ -8545,7 +8613,7 @@ fn exec_gathered_scan<'a>(
         // every candidate matches — card_pass would just re-derive Tri::True
         // at real per-node evaluation cost for nothing.
         let all_match = all_match_known
-            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or, prep.proven_conjuncts) {
                 Tri::False | Tri::Null => continue,
                 Tri::True => true,          // every printing matches: skip per-printing checks
                 Tri::PrintingDep => false,  // verify each printing against the residual below
@@ -9091,7 +9159,11 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
         }
     };
     let mut feats =
-        mk_plan_feats(ctx, params, matches, count, scan, if prep.all_match_known { 0 } else { verify_cost_tier(filter) });
+        mk_plan_feats(ctx, params, matches, count, scan, if prep.all_match_known {
+            0
+        } else {
+            verify_cost_tier_unproven(filter, prep.proven_conjuncts)
+        });
     // Diagnostic only (`explain`), so the residual-pass-rate population can be split by traffic before any
     // rate moves. A card-invariant residual answers `True`/`False` per card and never `PrintingDep`, so a
     // matching candidate contributes its WHOLE printing span and a non-matching one none of it — the
@@ -9574,7 +9646,7 @@ fn run_query_routed<'a>(
             // means "what the residual NARROWING produced", and no narrowing ran here — the list
             // came from the plane bitmap. Diagnostic-only and unread on this path, but `CardBits`
             // here would be the one value that contradicts `explain`'s contract if it ever were.
-            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, narrowed_repr: NarrowedRepr::None },
+            &PreparedCandidates { candidate_cards: Some(bitmap_card_ids(&plane_bits)), all_match_known: true, proven_conjuncts: 0, narrowed_repr: NarrowedRepr::None },
             plane,
         ),
         (p, Prep::Candidates(prep)) => exec_from_candidates(p, ctx, params, filter, prep, plane),
@@ -10309,6 +10381,10 @@ fn run_query_streamed<'a>(
     params: &QueryParams,
     filter: &FilterExpr,
     all_match_known: bool,
+    // Conjuncts the candidate set proves, passed straight to `card_pass` (see `Narrowed::proven`).
+    // Alongside `all_match_known` because they are the same idea at two granularities: that flag says the
+    // whole residual is settled, this says which parts of it are.
+    proven_conjuncts: u64,
     walk: &[Archived<u32>],
     card_ids: Box<dyn ExactSizeIterator<Item = u32> + '_>,
     existential_plane: Option<(&PlaneExpr, &Archived<BitPlanes>)>,
@@ -10389,7 +10465,7 @@ fn run_query_streamed<'a>(
         // `plane_leaves_nothing_to_verify`, and only trusts `residual_exact` when the narrowing was not
         // printing-space.
         let all_match = all_match_known
-            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or, proven_conjuncts) {
                 Tri::False | Tri::Null => continue,
                 Tri::True => true,
                 Tri::PrintingDep => false,
@@ -10464,7 +10540,7 @@ fn run_query_streamed<'a>(
             }
             let card = &cards[cid as usize];
             let all_match = all_match_known
-                || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+                || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or, proven_conjuncts) {
                     Tri::True => true,
                     Tri::PrintingDep => false,
                     _ => continue,
@@ -10514,7 +10590,7 @@ fn run_query_streamed<'a>(
         }
         let card = &cards[cid as usize];
         let all_match = all_match_known
-            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or) {
+            || match filter.card_pass(card, strings, &mut residual, &mut residual_is_or, proven_conjuncts) {
                 Tri::True => true,
                 Tri::PrintingDep => false,
                 _ => continue,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -10376,6 +10376,9 @@ fn publish_popcount_phases(ns_setup: u64, ns_loop: u64, ns_finish: u64) {
 /// Streamed selection: match phase records per-card match counts (total is
 /// their sum), then either gathers (small totals — byte-identical to the
 /// gathered path) or walks the orderby permutation emitting only page cards.
+// Eight since `proven_conjuncts` joined `all_match_known`: the two are the same idea at two
+// granularities (see `Narrowed::proven`), and both have to reach `card_pass` at the bottom of the loop.
+#[allow(clippy::too_many_arguments, reason = "all_match_known and proven_conjuncts are one signal at two granularities, both needed by card_pass")]
 fn run_query_streamed<'a>(
     ctx: &QueryCtx<'a>,
     params: &QueryParams,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -406,7 +406,7 @@ fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
 
     for op in [CmpOp::Eq, CmpOp::Gt] {
         match narrow_candidates_exact(&coll(op, "Flying"), archived, offsets, &[]) {
-            (Some(Candidates::Cards(v)), tight) => {
+            (Some(Candidates::Cards(v)), tight, _) => {
                 assert_eq!(v, vec![1], "{op:?} must reuse Ge's exact postings as a candidate superset");
                 assert!(!tight, "{op:?} postings only prove containment, not the length condition — must narrow loose");
             }
@@ -415,7 +415,7 @@ fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
     }
     // Ge itself stays tight over the same postings.
     match narrow_candidates_exact(&coll(CmpOp::Ge, "Flying"), archived, offsets, &[]) {
-        (Some(Candidates::Cards(v)), tight) => {
+        (Some(Candidates::Cards(v)), tight, _) => {
             assert_eq!(v, vec![1]);
             assert!(tight, "Ge's postings are exact containment, must stay tight");
         }
@@ -425,7 +425,7 @@ fn narrow_candidates_eq_gt_reuse_ge_postings_loosely() {
     // too — no row can satisfy either without first satisfying containment.
     for op in [CmpOp::Eq, CmpOp::Gt, CmpOp::Ge] {
         match narrow_candidates_exact(&coll(op, "Trample"), archived, offsets, &[]) {
-            (Some(Candidates::Cards(v)), tight) => {
+            (Some(Candidates::Cards(v)), tight, _) => {
                 assert!(v.is_empty(), "{op:?} over an absent value narrows to the exact empty set");
                 assert!(tight, "{op:?} empty-postings narrowing is exact, not just advisory");
             }
@@ -2821,12 +2821,12 @@ fn arith_tuple_narrowing_matches_reference() {
                     let ref_set = reference(archived, &filter);
                     let ctx = format!("seed={seed} {label} {op:?} negated={negated}");
                     match narrow_candidates_exact(&filter, indexes, offsets, cards) {
-                        (Some(Candidates::Cards(v)), tight) => {
+                        (Some(Candidates::Cards(v)), tight, _) => {
                             assert!(tight, "{ctx}: card-level in-scope narrowing must be tight (exact)");
                             assert_eq!(v, ref_set, "{ctx}: tuple narrowing must equal the per-card reference");
                         }
-                        (Some(other), _) => panic!("{ctx}: expected card-space candidates, got {other:?}"),
-                        (None, _) => assert!(
+                        (Some(other), ..) => panic!("{ctx}: expected card-space candidates, got {other:?}"),
+                        (None, ..) => assert!(
                             ref_set.len() > broad_cap,
                             "{ctx}: declined but the reference isn't broad ({} of {n_cards}) — a narrowing failure, not the breadth cap",
                             ref_set.len()
@@ -3275,6 +3275,75 @@ fn force_plan_differential_agreement() {
              cmc/power/toughness under a matching orderby.",
         );
     }
+}
+
+/// The soundness condition for skipping a proven conjunct: for EVERY candidate the narrowing returns,
+/// every child in the `proven` mask must evaluate to `Tri::True` at card level.
+///
+/// Checked over all candidates rather than over a returned page, because that is the property
+/// `card_pass` relies on — a page-level comparison would pass while a rare candidate silently returned
+/// `False` and got emitted as a false positive.
+///
+/// Also asserts the mask is EMPTY for a printing-space result. A tight printing-space set says "this
+/// printing matches", not "every printing of this card does", so it cannot excuse a per-printing check.
+#[test]
+fn a_proven_conjunct_holds_for_every_candidate() {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(20_260_805);
+    let data = fuzz_store_n(&mut rng, 3_000);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let (indexes, offsets, cards, strings) = (&archived.indexes, &archived.offsets, &*archived.cards, &archived.strings);
+
+    // Mixed `And`s: a card-space child that narrows tightly, plus a printing-space one that does not.
+    // The keyword/subtype postings are the tight card-space case; border and the ranges are the partners.
+    let card_side = [
+        FuzzLeaf::Collection { field: CollField::Keywords, op: CmpOp::Ge, value: "flying".to_string() },
+        FuzzLeaf::Collection { field: CollField::Subtypes, op: CmpOp::Ge, value: "human".to_string() },
+        FuzzLeaf::Collection { field: CollField::OracleTags, op: CmpOp::Ge, value: "removal".to_string() },
+    ];
+    let printing_side = [
+        FuzzLeaf::Border { value: "black".to_string() },
+        FuzzLeaf::Collection { field: CollField::FrameData, op: CmpOp::Ge, value: "2003".to_string() },
+        FuzzLeaf::Collection { field: CollField::ArtTags, op: CmpOp::Ge, value: "dragon".to_string() },
+    ];
+
+    let mut fired = 0usize;
+    for c in &card_side {
+        for p in &printing_side {
+            for order in [[c.clone(), p.clone()], [p.clone(), c.clone()]] {
+                let spec = FuzzSpec::And(order.into_iter().map(FuzzSpec::Leaf).collect());
+                let filter = fuzz_bound_filter(&spec, archived);
+                let (Some(set), _, proven) = narrow_candidates_exact(&filter, indexes, offsets, cards) else {
+                    continue;
+                };
+                if set.is_printing_space() {
+                    assert_eq!(proven, 0, "{}: a printing-space result must prove nothing", fuzz_describe(&spec));
+                    continue;
+                }
+                if proven == 0 {
+                    continue;
+                }
+                fired += 1;
+                let FilterExpr::And(children) = &filter else { panic!("built an And") };
+                let candidate_cards = set.into_cards(offsets, &indexes.printing_to_card);
+                for &cid in &candidate_cards {
+                    for (i, child) in children.iter().enumerate() {
+                        if proven & (1 << i) == 0 {
+                            continue;
+                        }
+                        assert!(
+                            matches!(child.eval_card(&cards[cid as usize], strings), Tri::True),
+                            "{}: proven child {i} is not True for candidate card {cid}",
+                            fuzz_describe(&spec),
+                        );
+                    }
+                }
+            }
+        }
+    }
+    // Otherwise the sweep proves nothing about a mask that is never set.
+    assert!(fired >= 6, "the proven mask fired on only {fired} of 18 mixed Ands; the property is undertested");
 }
 
 /// A dense `frame_data` value must still narrow under `broad_ok: false` unless it is genuinely BROAD.
@@ -6268,14 +6337,14 @@ fn card_pass_extracts_residual_and_matches() {
     let mut is_or = false;
 
     // Creature card: PrintingDep with a one-element residual (the art term).
-    let t = and.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or);
+    let t = and.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or, 0);
     assert!(t == Tri::PrintingDep && residual.len() == 1 && !is_or);
     assert!(!FilterExpr::residual_matches(&archived.cards[0], &archived.printings[0], &archived.strings, &residual, is_or));
     assert!(FilterExpr::residual_matches(&archived.cards[0], &archived.printings[1], &archived.strings, &residual, is_or));
 
     // Instant card: the type child is False at card level — whole And settles
     // to False without touching printings.
-    let t = and.card_pass(&archived.cards[1], &archived.strings, &mut residual, &mut is_or);
+    let t = and.card_pass(&archived.cards[1], &archived.strings, &mut residual, &mut is_or, 0);
     assert!(t == Tri::False);
 
     // Or[t:creature, art:wolf]: True for the creature card at card level (no
@@ -6288,9 +6357,9 @@ fn card_pass_extracts_residual_and_matches() {
     };
     wolf2.bind(&archived.coll_vocab, &archived.coll_vocab_sorted, &archived.artist_vocab, &archived.mana_vocab, &archived.indexes.flavor, &archived.strings);
     let or = FilterExpr::Or(vec![creature(), wolf2]);
-    let t = or.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or);
+    let t = or.card_pass(&archived.cards[0], &archived.strings, &mut residual, &mut is_or, 0);
     assert!(t == Tri::True && residual.is_empty());
-    let t = or.card_pass(&archived.cards[1], &archived.strings, &mut residual, &mut is_or);
+    let t = or.card_pass(&archived.cards[1], &archived.strings, &mut residual, &mut is_or, 0);
     assert!(t == Tri::PrintingDep && residual.len() == 1 && is_or);
     assert!(!FilterExpr::residual_matches(&archived.cards[1], &archived.printings[2], &archived.strings, &residual, is_or));
 }
@@ -7221,7 +7290,7 @@ fn set_watermark_compose_leaves() {
         let mut is_or = false;
         for c in 0..archived.cards.len() {
             let card = &archived.cards[c];
-            let tri = f.card_pass(card, &archived.strings, &mut residual, &mut is_or);
+            let tri = f.card_pass(card, &archived.strings, &mut residual, &mut is_or, 0);
             let (lo, hi) = (u32::from(archived.offsets[c]), u32::from(archived.offsets[c + 1]));
             for pid in lo..hi {
                 let matched = match tri {
@@ -7359,7 +7428,7 @@ fn collection_compose_leaves() {
         let mut is_or = false;
         for c in 0..archived.cards.len() {
             let card = &archived.cards[c];
-            let tri = f.card_pass(card, &archived.strings, &mut residual, &mut is_or);
+            let tri = f.card_pass(card, &archived.strings, &mut residual, &mut is_or, 0);
             let (lo, hi) = (u32::from(archived.offsets[c]), u32::from(archived.offsets[c + 1]));
             for pid in lo..hi {
                 let matched = match tri {
@@ -9916,7 +9985,7 @@ fn verify_order_sorts_and_children_cheap_first() {
         rhs: NumExpr::Const(v),
     };
     let mut f = FilterExpr::And(vec![machinery_regex(), cmc_lt(3.0), contains_scan(), cmc_lt(5.0), type_mask()]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::And(children) = &f else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } if v == 3.0));
     assert!(matches!(children[1], FilterExpr::NumericCmp { rhs: NumExpr::Const(v), .. } if v == 5.0));
@@ -9936,7 +10005,7 @@ fn verify_order_and_refines_by_set_size() {
         FilterExpr::NameMatch { ids: vec![1, 2, 3, 4, 5] },
         FilterExpr::OracleMatch { gids: vec![7, 9] },
     ]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::And(children) = &f else { panic!("still an And") };
     assert!(matches!(&children[0], FilterExpr::OracleMatch { gids } if gids.len() == 2));
     assert!(matches!(&children[1], FilterExpr::NameMatch { ids } if ids.len() == 5));
@@ -9954,7 +10023,7 @@ fn verify_order_or_sorts_by_bucket_only() {
         FilterExpr::OracleMatch { gids: vec![7, 9] },
         type_mask(),
     ]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));
     assert!(matches!(&children[1], FilterExpr::NameMatch { ids } if ids.len() == 5), "written order kept within tier");
@@ -9970,7 +10039,7 @@ fn verify_order_or_sorts_by_bucket_only() {
 fn verify_order_or_keeps_scan_cost_band_in_written_order() {
     let devotion = || FilterExpr::Devotion { op: CmpOp::Ge, pips: packed_pips(&[("B", 3)]) };
     let mut f = FilterExpr::Or(vec![contains_scan(), devotion()]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TextContains { .. }), "contains keeps its written lead");
     assert!(matches!(children[1], FilterExpr::Devotion { .. }));
@@ -9978,7 +10047,7 @@ fn verify_order_or_keeps_scan_cost_band_in_written_order() {
     // In an And the same pair DOES reorder: rejection is what And children
     // short-circuit on, and the pip walk measures ~3× under the text scan.
     let mut g = FilterExpr::And(vec![contains_scan(), devotion()]);
-    g.order_children_by_verify_cost();
+    g.order_children_by_verify_cost(&mut 0);
     let FilterExpr::And(children) = &g else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::Devotion { .. }), "And sorts the cheaper pip walk first");
     assert!(matches!(children[1], FilterExpr::TextContains { .. }));
@@ -9991,7 +10060,7 @@ fn verify_order_or_keeps_scan_cost_band_in_written_order() {
 #[test]
 fn verify_order_or_keeps_sets_and_scans_in_written_order() {
     let mut f = FilterExpr::Or(vec![contains_scan(), FilterExpr::NameMatch { ids: vec![1, 2] }]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TextContains { .. }));
     assert!(matches!(children[1], FilterExpr::NameMatch { .. }));
@@ -10006,7 +10075,7 @@ fn verify_order_and_defers_printing_dependent_children() {
     let usd = || usd_cmp(CmpOp::Gt, 20.0);
     let dragon = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "dragon".to_string(), value_id: None };
     let mut f = FilterExpr::And(vec![usd(), dragon()]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::And(children) = &f else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::CollectionCmp { .. }), "card-level rejector first");
     assert!(matches!(children[1], FilterExpr::NumericCmp { .. }));
@@ -10014,7 +10083,7 @@ fn verify_order_and_defers_printing_dependent_children() {
     // Or(usd, type) can settle at card level through its type member (a True
     // settles an Or), so it is not printing-dependent and leads the contains.
     let mut g = FilterExpr::And(vec![contains_scan(), FilterExpr::Or(vec![usd(), type_mask()])]);
-    g.order_children_by_verify_cost();
+    g.order_children_by_verify_cost(&mut 0);
     let FilterExpr::And(children) = &g else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::Or(_)), "mixed composite can settle: stays card-level");
     assert!(matches!(children[1], FilterExpr::TextContains { .. }));
@@ -10027,14 +10096,14 @@ fn verify_order_and_defers_printing_dependent_children() {
 fn verify_order_or_defers_printing_dependent_children() {
     let usd = || usd_cmp(CmpOp::Gt, 20.0);
     let mut f = FilterExpr::Or(vec![contains_scan(), usd()]);
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::Or(children) = &f else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TextContains { .. }), "card-level scan stays ahead of pdep numeric");
     assert!(matches!(children[1], FilterExpr::NumericCmp { .. }));
 
     // A card-level mask still moves ahead of a printing-dependent set lookup.
     let mut g = FilterExpr::Or(vec![FilterExpr::FlavorMatch { gids: vec![3], dense_ids: vec![] }, type_mask()]);
-    g.order_children_by_verify_cost();
+    g.order_children_by_verify_cost(&mut 0);
     let FilterExpr::Or(children) = &g else { panic!("still an Or") };
     assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));
     assert!(matches!(children[1], FilterExpr::FlavorMatch { .. }));
@@ -10046,7 +10115,7 @@ fn verify_order_or_defers_printing_dependent_children() {
 fn verify_order_recurses_and_ranks_composites() {
     let inner_or = FilterExpr::Or(vec![machinery_regex(), type_mask()]);
     let mut f = FilterExpr::Not(Box::new(FilterExpr::And(vec![inner_or, contains_scan(), type_mask()])));
-    f.order_children_by_verify_cost();
+    f.order_children_by_verify_cost(&mut 0);
     let FilterExpr::Not(inner) = &f else { panic!("still a Not") };
     let FilterExpr::And(children) = inner.as_ref() else { panic!("still an And") };
     assert!(matches!(children[0], FilterExpr::TypeCmp { .. }));

--- a/docs/issues/local-engine-is-frame-predicates.md
+++ b/docs/issues/local-engine-is-frame-predicates.md
@@ -355,11 +355,11 @@ this. Whether it costs anything is now an open question rather than an assumed c
 
 - **`o:this frame:2003` is 418 µs against 52 µs for `o:this` alone.** Much better, not good. It picks
   `GatheredScan` over 19,851 scan units where `o:this` alone streams a page and stops.
-- **Genuinely broad printing-space partners under a card-space driver** still decline entirely:
-  `o:this border:black` 1,989 µs, `o:this cn>200` 1,839 µs, `o:this frame:2015` 1,843 µs, all against 52
-  µs for the driver alone. For a STORED bitmap (a plane, or a dense hybrid value) the AND is nearly free
-  and the projection is one pass, so declining may be wrong even at 66% — but the previous attempt to
-  bypass `broad_ok` for stored bitmaps cost 1.3-1.8x on sparse `And`s, so the rule wants to be
-  contextual (is there a printing-space partner? is the driver large enough for the cut to pay?) rather
-  than removed. That is the next item in this family and it is worth more than what section 6 just fixed.
+- ~~**Genuinely broad printing-space partners under a card-space driver** still decline entirely, and for
+  a stored bitmap the AND would be nearly free~~ — **WITHDRAWN.** The decline was not the cost. Those
+  queries were slow because the candidate set's own card-space conjunct was being re-verified once per
+  printing; narrowing with the border bitmap would not have helped, because the pass over printings was
+  never where the time went. Fixed in
+  [local-engine-proven-conjuncts.md](./local-engine-proven-conjuncts.md), which took
+  `o:this border:black` from 1,993 µs to 542 µs without changing the narrowing at all.
 - (2)'s `t:battle` plane poisoning and (3)'s missing `Battle` in `card_types`, both untouched.

--- a/docs/issues/local-engine-proven-conjuncts.md
+++ b/docs/issues/local-engine-proven-conjuncts.md
@@ -1,0 +1,123 @@
+# A conjunct the candidate set proves was still re-verified per printing
+
+`o:this` runs in **52 µs** and examines **zero** printings. `o:this border:black` runs in **1,993 µs**.
+Adding a predicate that cuts the result set from 55,004 to 49,278 made the query 38× slower.
+
+## The cost is per candidate CARD, and has nothing to do with the added leaf
+
+| query | cards | printings examined | µs | ns/card |
+| --- | --: | --: | --: | --: |
+| `o:this` alone | 19,968 | **0** | 67 | 3.4 |
+| `o:this border:black` | 19,968 | 55,004 | 1,993 | 99.8 |
+| `o:this cn>200` | 19,968 | 55,004 | 1,816 | 90.9 |
+| `o:this frame:2015` | 19,968 | 55,004 | 1,972 | 98.8 |
+| `o:this border:black cn>200 usd>1` | 19,968 | 55,004 | 1,923 | 96.3 |
+
+Every pairing costs ~1.9 ms whatever the partner is, and adding two more printing-level leaves changes
+nothing (36.2 → 37.0 → 35.0 ns/printing). The printing-level predicates are ~1–7 ns each. **The whole
+cost is one card-level oracle-text evaluation per candidate, repeated once per printing of that card.**
+
+## Tightness was one bit for the whole expression
+
+`o:this` narrows tightly in card space — that is exactly why it examines no printings: `all_match_known`
+fires and the residual never runs. Inside an `And`, `narrow_rec`'s `seal` does
+`n.tight &= every_child_included`, so dropping `border:black` (broad, printing-space) makes the whole
+result loose. `card_pass` then re-evaluates **every** conjunct per card, including the oracle contains
+that membership in the candidate set already settles.
+
+`card_pass` was already doing the right thing structurally: it evaluates each child with `printing: None`,
+keeps only `PrintingDep` children in the per-printing residual, and drops settled ones. Card-invariant
+hoisting was never missing. What was missing is that the *proof* — child *k* was fully represented in the
+candidate set — was computed and then thrown away.
+
+## The fix
+
+`Narrowed` gains `proven: u64`, a bitmask over a top-level `And`'s children. A child is marked when its
+own narrowing came back **tight AND card-space** and it actually got pushed: `and_all` intersects, and an
+intersection is a subset of each input, so every card in the result satisfies each marked child.
+`card_pass` skips those children — not into the residual either, since printings of one card cannot
+disagree about a card-space fact. It is the `all_match` promotion argument at conjunct granularity.
+
+Four things that have to be right, each of which would be a wrong answer rather than a slow one:
+
+- **Card-space only.** A tight printing-space set says "this printing matches", not "every printing of
+  this card does". The lone-printing branch returns 0.
+- **The mask dies with the set.** `narrow_candidates_exact` discarding a too-broad set, or
+  `prepare_candidates` dropping `candidate_cards`, clears it — the walk then visits cards the proof never
+  covered.
+- **Indices survive reordering.** `order_children_by_verify_cost` permutes children on every query with a
+  residual, so it now permutes the mask with them (sorting an index permutation, stable, same resulting
+  order as before). Clearing the mask there instead would forfeit the win on every query that reaches it.
+- **Children are located by pointer identity**, not by tracking position through
+  `fuse_and_range_children`'s regrouping and the ranking sort. A positional guess that slipped would drop
+  a real predicate. Children past 64 are never marked: a re-verification, never a wrong answer.
+
+The mask is *not* applied by blanking proven children out of the filter, which was the first idea and is
+unsound: `PrintingCompose`, `PlanePopcountOrder`, `PrintingRangeScan` and `CardRangePopcount` all read
+the same `filter` and never see the candidate set, so a filter with conjuncts removed would hand them a
+weaker predicate.
+
+`verify_cost_tier_unproven` charges the tier of what `card_pass` will actually evaluate. Without it the
+model keeps pricing a conjunct nobody verifies, and a cost model that cannot see a change cannot route on
+it.
+
+## Measured
+
+| query | before | after |
+| --- | --: | --: |
+| `o:this border:black` | 1,993 µs | **542 µs** |
+| `o:this cn>200` | 1,816 µs | **498 µs** |
+| `o:this border:black cn>200 usd>1` | 1,923 µs | **748 µs** |
+| `o:this frame:2003` | 490 µs | **209 µs** |
+
+Per printing: 36.2 ns → 9.9 ns.
+
+Interleaved A/B behind `CARD_ENGINE_PROVEN_CONJUNCTS`, 8 rounds, 1,368 queries:
+
+| subset | n | off | on | on/off |
+| --- | --: | --: | --: | --: |
+| mixed card+printing `And` TARGET | 218 | 128.1 ms | 63.7 ms | **0.497** |
+| everything else CONTROL | 1,150 | 118.6 ms | 113.4 ms | 0.957 |
+| whole mix | 1,368 | 246.6 ms | 177.1 ms | **0.718** |
+
+p90 0.929, **p99 0.428** (2,227 µs → 952 µs). Biggest cells: `o:creature r>=common` 2,241 → 417 µs,
+`o:target cn>200` 1,650 → 369 µs, `year>=2006 o:turn` 1,367 → 309 µs.
+
+The one apparent regression, `name:s t:creature` at 1.68×, is within-query variance: its spread *inside
+arm A* is 2.25×, and the other two sampled configs of the same query read 0.99.
+
+### The estimates were wrong in the same place
+
+| | predicted | measured | p/m |
+| --- | --: | --: | --: |
+| GatheredScan, before | 760 µs | 2,011 µs | 0.38 |
+| StreamedSelect, before | 892 µs | 1,689 µs | 0.53 |
+| StreamedSelect, after | 564 µs | 518 µs | **1.09** |
+| GatheredScan, after | 678 µs | 719 µs | **0.94** |
+
+The router had been picking the *slower* plan (GatheredScan at 2,011 against StreamedSelect's 1,689,
+~320 µs of regret); it now picks StreamedSelect. Across the sampled shapes the pairs moved from 0.38–0.53
+to 0.74–1.34.
+
+## What this did NOT fix
+
+- **`name:s border:black` is unchanged at ~1,160 µs.** `name:s` does not narrow at all (`eval_domain`
+  31,508 — the whole corpus), so there is no candidate set and nothing to prove. Its residual is genuinely
+  evaluated 60,705 times. A card-invariant conjunct under *no* narrowing wants the other half of this
+  idea: evaluate it once per card and reuse the verdict across the card's printings. `card_pass` already
+  computes exactly that verdict; the streamed/gather loops just have no candidate set to hang it on.
+- **`name:s border:black` also still routes wrong** — GatheredScan at 1,170 µs measured against
+  StreamedSelect's 975 (predicted 1,470, p/m 1.51).
+- The earlier diagnosis in
+  [the `is:`/`frame:` doc](./local-engine-is-frame-predicates.md) — that broad printing-space partners
+  under a card-space driver are wrongly declined, and that a stored bitmap's AND would be nearly free —
+  **was measuring the wrong thing.** Narrowing with the border bitmap would not have helped: the pass over
+  printings was never the cost. That item is withdrawn.
+
+## Status
+
+Implemented and measured on the production corpus. Soundness is checked two ways:
+`a_proven_conjunct_holds_for_every_candidate` asserts every marked child evaluates `Tri::True` for
+*every* candidate (not just a returned page, where a rare false positive would hide), and the mask was
+confirmed to fire inside `fuzz_row_identity_matches_reference` and six other differential tests by
+temporarily asserting it never did — so the end-to-end row-identity comparison covers it.


### PR DESCRIPTION
**Layer 11 of 13.** Base: #842. Reference: #830. No archive change.

`o:this` runs in **52 µs** examining **zero** printings. `o:this border:black` ran in **1,993 µs**.
Adding a predicate that cuts the result set 6× made it 38× slower — and the cost is a function of the
candidate *card* count only, not of the added leaf: `cn>200`, `frame:2015` and three leaves at once all
land within 8%.

**Tightness was one bit for the whole expression.** `o:this` narrows tightly in card space, which is why
it examines no printings. Inside an `And`, `seal` does `tight &= every_child_included`, so dropping the
broad printing-space child makes the whole result loose and `card_pass` re-verifies *every* conjunct —
including the oracle contains that membership in the candidate set already proves.

`Narrowed` gains `proven: u64`, a mask over a top-level `And`'s children, set when a child's own
narrowing was tight AND card-space and it was actually pushed. `card_pass` skips those.

Four things that would be wrong answers rather than slow ones if missed, and each is commented at the
site: card-space only; the mask dies with the set it came from; it is *permuted* through
`order_children_by_verify_cost` rather than cleared; and children are located by pointer identity rather
than by position through the fusing and ranking that reorder them.

Blanking proven children out of the filter — the first idea — is unsound: the compose, plane and range
plans read the same filter and never see the candidate set.

Target **0.497**, control 0.957, whole mix 0.718, **p99 0.428**.

## Soundness checking

A new test asserts every marked child evaluates `True` for *every* candidate, not just a returned page
where a rare false positive would hide. And the mask was confirmed to fire inside
`fuzz_row_identity_matches_reference` and six other differential tests by temporarily asserting it never
did — so the existing row-identity comparison covers this path.

## Verification

`cargo test` (152) and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
