### PR TITLE
Engine: Pair Totals, Scan Scope, and the Result/Candidate Split (stack 12/13)

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2533,7 +2533,7 @@ fn build_pair_totals(
     // Assign compact ids to the survivors, one id space across all four dimensions.
     let mut out = PairTotals::default();
     let mut next = 0u16;
-    let mut assign = |n: usize, next: &mut u16| -> Option<u16> {
+    let assign = |n: usize, next: &mut u16| -> Option<u16> {
         (n >= PAIR_MIN_PRINTINGS).then(|| {
             let id = *next;
             *next += 1;
@@ -7328,12 +7328,7 @@ fn leaves_are_disjoint(a: &FilterExpr, b: &FilterExpr) -> bool {
     }
 }
 
-fn exact_result_total(
-    composed: &FilterExpr,
-    indexes: &Archived<CardIndexes>,
-    n_cards: usize,
-    mode: Mode,
-) -> Option<usize> {
+fn exact_result_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, mode: Mode) -> Option<usize> {
     if let Some((idx, lo, hi)) = bare_range_bounds(composed, indexes) {
         // Printings come free from the index's own partition points; the other two spaces come from the
         // prefix/suffix tables, which now carry an artwork column as well as a card one.
@@ -11139,12 +11134,11 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-// Stack layer 09: `RangeCardCounts` gains an artwork column, a sixth table is added for rarity, and
-// `ValueTotals` arrives for border/layout/frame/(format,status). All archived-layout changes, so a
-// store built against the previous layer must fail the header check and be rebuilt rather than be
-// read as garbage. Numbered by stack patch; the check is EQUALITY, so the invariant is only that a
-// value is never reused for a different layout.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026080509;
+// Stack layer 12: `PairTotals` -- exact totals for PAIRS of low-cardinality values -- is a new
+// archived type, so a store built against the previous layer must fail the header check and be
+// rebuilt rather than be read as garbage. Numbered by stack patch; the check is EQUALITY, so the
+// invariant is only that a value is never reused for a different layout.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026080512;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2388,6 +2388,60 @@ fn legality_totals_key(shift: u8, expected: u64) -> u16 {
     (u16::from(shift) << 2) | (expected as u16 & 0b11)
 }
 
+/// A value is worth PAIRING only if it is broad enough that an estimate about it can change a routing
+/// decision. `STREAM_MIN_MATCHES` is that line: below it the sparse floor decides the plan, not the
+/// estimate's precision, and min-over-singles is already within a small factor of the truth.
+///
+/// Measured on the production corpus, this prunes the table 4.2x — 3,705 pairs to 879 — and it removes
+/// `layout` entirely, because only `normal` clears the floor and every other layout query is already
+/// selective. Counted in PRINTINGS, which is the conservative side: cards <= printings always, so a value
+/// with 1,500 printings but 400 cards is kept, and that is exactly the one card-mode routing needs.
+const PAIR_MIN_PRINTINGS: usize = 1_024;
+
+/// Exact 3-space totals for PAIRS of low-cardinality values, so an `And` of two of them is answered
+/// rather than bounded.
+///
+/// `compose_printing_estimate`'s `And` folds with `min`, an intersection upper bound, so the most
+/// selective leaf wins and every other conjunct contributes nothing: every `f:X border:white` estimates
+/// identically at 5,131 against true totals of 658-5,072. For a two-leaf query a stored pair is not a
+/// tighter bound, it is the exact answer; for three leaves, min-over-pairs measured 2.02x against
+/// min-over-singles' 7.80x on `f:modern r:rare border:white`.
+///
+/// **Unlike `ValueTotals`, this table may be incomplete.** Absence there is read as an exact zero and so
+/// the singleton table must cover every value; absence HERE just means "no answer", and the caller falls
+/// back to the min bound it already had. That is what lets the selectivity floor above prune it at all.
+///
+/// Same-dimension pairs are stored only for `frame_data`, the one multi-valued dimension here (1-5 values
+/// per printing; `frame:2015 frame:legendary` really does match 10,321). Border, rarity and legality are
+/// PARTITIONS — one value per printing — so two distinct values of one of them never co-occur, which is a
+/// rule rather than data and needs no bytes.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct PairTotals {
+    /// Each dimension's dense values → a compact id, shared across dimensions so a pair is one `u32`.
+    border: HashMap<String, u16>,
+    rarity: HashMap<u8, u16>,
+    frame: HashMap<String, u16>,
+    /// Keyed as `ValueTotals::legality` is, `(shift << 2) | status`.
+    legality: HashMap<u16, u16>,
+    /// `min(a,b) * n_ids + max(a,b)` → the pair's exact totals. Complete over the stored ids: a present
+    /// key is exact (possibly zero), a missing one means at least one value was pruned by the floor.
+    pairs: HashMap<u32, SpaceTotals>,
+    n_ids: u16,
+}
+
+impl ArchivedPairTotals {
+    fn key(&self, a: u16, b: u16) -> u32 {
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        u32::from(lo) * u32::from(u16::from(self.n_ids)) + u32::from(hi)
+    }
+
+    /// Exact total for the two values together, or `None` when the pair was pruned or the dimension is
+    /// not covered.
+    fn get(&self, a: u16, b: u16, mode: Mode) -> Option<usize> {
+        self.pairs.get(&self.key(a, b).into()).map(|t| t.get(mode))
+    }
+}
+
 /// Exact 3-space totals per value, in one pass over printings.
 ///
 /// `keys_of` yields every value the printing belongs to — one for a scalar dimension like border,
@@ -2433,6 +2487,161 @@ fn build_value_totals<K: Eq + std::hash::Hash>(
         }
     }
     acc.into_iter().map(|(k, a)| (k, a.totals)).collect()
+}
+
+/// Build the pair table: one counting pass to find the dense values, one accumulating pass over their
+/// co-occurrences.
+///
+/// The accumulator is a DENSE `n_ids x n_ids` array rather than the sparse map it is archived as,
+/// because the inner loop runs once per unordered pair of ids on a printing — about 325 with legality's
+/// 23 statuses in play, or ~32M over the corpus — and a hash lookup per increment would dominate the
+/// store build. Only the non-zero cells are archived.
+fn build_pair_totals(
+    cards: &[OracleCard],
+    printings: &[Printing],
+    printing_to_card: &[u32],
+    strings: &[String],
+    coll_vocab: &[String],
+    max_artwork_groups: usize,
+) -> PairTotals {
+    // Pass 1: per-value printing counts, to apply the selectivity floor.
+    let (mut border_n, mut rarity_n, mut frame_n, mut legality_n) =
+        (HashMap::new(), HashMap::new(), HashMap::new(), HashMap::new());
+    let shifts: Vec<u8> = (0..MAX_FORMATS as u8).map(|i| i * 2).collect();
+    for (pid, p) in printings.iter().enumerate() {
+        let card = &cards[printing_to_card[pid] as usize];
+        if p.card_border_id != NONE_STR {
+            *border_n.entry(strings[p.card_border_id as usize].clone()).or_insert(0usize) += 1;
+        }
+        if let Some(r) = p.card_rarity_int {
+            *rarity_n.entry(r).or_insert(0usize) += 1;
+        }
+        for v in &p.card_frame_data {
+            *frame_n.entry(coll_vocab[*v as usize].clone()).or_insert(0usize) += 1;
+        }
+        let word = if card.legality_divergent { p.card_legalities } else { card.card_legalities };
+        for &shift in &shifts {
+            let status = (word >> shift) & 0b11;
+            // `banned`/`restricted` total ~7,000 printing-rows across every format, so those queries are
+            // already tiny and an estimate for them cannot cost routing time. Only legal/not_legal pair.
+            if status == LEGALITY_LEGAL || status == 0 {
+                *legality_n.entry(legality_totals_key(shift, status)).or_insert(0usize) += 1;
+            }
+        }
+    }
+
+    // Assign compact ids to the survivors, one id space across all four dimensions.
+    let mut out = PairTotals::default();
+    let mut next = 0u16;
+    let mut assign = |n: usize, next: &mut u16| -> Option<u16> {
+        (n >= PAIR_MIN_PRINTINGS).then(|| {
+            let id = *next;
+            *next += 1;
+            id
+        })
+    };
+    let mut border_sorted: Vec<_> = border_n.into_iter().collect();
+    border_sorted.sort_unstable();
+    for (v, n) in border_sorted {
+        if let Some(id) = assign(n, &mut next) {
+            out.border.insert(v, id);
+        }
+    }
+    let mut rarity_sorted: Vec<_> = rarity_n.into_iter().collect();
+    rarity_sorted.sort_unstable();
+    for (v, n) in rarity_sorted {
+        if let Some(id) = assign(n, &mut next) {
+            out.rarity.insert(v, id);
+        }
+    }
+    let mut frame_sorted: Vec<_> = frame_n.into_iter().collect();
+    frame_sorted.sort_unstable();
+    for (v, n) in frame_sorted {
+        if let Some(id) = assign(n, &mut next) {
+            out.frame.insert(v, id);
+        }
+    }
+    let mut legality_sorted: Vec<_> = legality_n.into_iter().collect();
+    legality_sorted.sort_unstable();
+    for (v, n) in legality_sorted {
+        if let Some(id) = assign(n, &mut next) {
+            out.legality.insert(v, id);
+        }
+    }
+    out.n_ids = next;
+    let n = usize::from(next);
+    if n == 0 {
+        return out;
+    }
+
+    // Pass 2: co-occurrence. Same dedup shape as `build_value_totals` -- `last_card` catches card
+    // repeats (a card's printings are contiguous), a `cid + 1` stamp per artwork group catches artwork
+    // repeats within a card -- just held per PAIR instead of per value.
+    let groups = max_artwork_groups + 1;
+    let mut totals = vec![SpaceTotals::default(); n * n];
+    let mut last_card = vec![u32::MAX; n * n];
+    let mut stamps = vec![0u32; n * n * groups];
+    let mut ids: Vec<u16> = Vec::with_capacity(32);
+    for (pid, p) in printings.iter().enumerate() {
+        let cid = printing_to_card[pid];
+        let card = &cards[cid as usize];
+        let group = usize::from(p.artwork_group_id);
+        ids.clear();
+        if p.card_border_id != NONE_STR
+            && let Some(&id) = out.border.get(strings[p.card_border_id as usize].as_str())
+        {
+            ids.push(id);
+        }
+        if let Some(r) = p.card_rarity_int
+            && let Some(&id) = out.rarity.get(&r)
+        {
+            ids.push(id);
+        }
+        for v in &p.card_frame_data {
+            if let Some(&id) = out.frame.get(coll_vocab[*v as usize].as_str()) {
+                ids.push(id);
+            }
+        }
+        let word = if card.legality_divergent { p.card_legalities } else { card.card_legalities };
+        for &shift in &shifts {
+            let status = (word >> shift) & 0b11;
+            if (status == LEGALITY_LEGAL || status == 0)
+                && let Some(&id) = out.legality.get(&legality_totals_key(shift, status))
+            {
+                ids.push(id);
+            }
+        }
+        for (i, &a) in ids.iter().enumerate() {
+            for &b in &ids[i + 1..] {
+                let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                let slot = usize::from(lo) * n + usize::from(hi);
+                let e = &mut totals[slot];
+                e.printings += 1;
+                if last_card[slot] != cid {
+                    last_card[slot] = cid;
+                    e.cards += 1;
+                }
+                let stamp = &mut stamps[slot * groups + group];
+                if *stamp != cid + 1 {
+                    *stamp = cid + 1;
+                    e.artworks += 1;
+                }
+            }
+        }
+    }
+    // EVERY pair of stored ids is archived, including the zero ones, so that "both ids present" means
+    // the answer is exact -- possibly exactly zero. Storing only non-zero cells made a provably-empty
+    // pair indistinguishable from a pruned one, and `frame:2003 frame:1997` (no printing carries both era
+    // frames, though the field is multi-valued so nothing rules it out a priori) fell back to
+    // min-over-singles and read 10,769 against a true 0.
+    //
+    // Nearly free: the zero cells are the minority, and the floor already bounded `n_ids`.
+    for lo in 0..n {
+        for hi in lo + 1..n {
+            out.pairs.insert((lo * n + hi) as u32, totals[lo * n + hi]);
+        }
+    }
+    out
 }
 
 /// Build all four `ValueTotals` maps. One call site, so the four cannot be built from different
@@ -3154,6 +3363,9 @@ struct CardIndexes {
     /// Exact 3-space totals for the low-cardinality dimensions whose predicate tests one value:
     /// border, layout, frame, and (format, status). ~2 KB.
     value_totals:   ValueTotals,
+    /// Exact 3-space totals for PAIRS of dense low-cardinality values (~14 KB), so a two-leaf `And` over
+    /// them is answered rather than bounded by `min`.
+    pair_totals:    PairTotals,
     sort_perms:     SortPermutations,          // card space (streamed selection)
     artwork_groups: Vec<u16>,                  // card space: distinct illustration groups
     // card space, n_cards+1 entries: prefix sum of artwork_groups, so card c's artworks are the
@@ -5542,6 +5754,18 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// (1/32). 0 restores the conflated gate, for the A/B that priced the distinction.
 static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_DENSE_FRAME_BROAD_GATE", 1u8) != 0);
 
+/// Whether the PAIR table answers a two-leaf `And` exactly and tightens the `And` fold's bound. 0 falls
+/// both back to `min` over single leaves.
+///
+/// **Default OFF.** The table itself is right -- 21 of 21 measured cells exact where `min` read 2.8-10.1x
+/// over, and the three-leaf bound goes 7.80x to 2.02x -- but feeding it into the estimate regresses the
+/// disjoint cases 24x. `border:white border:black` estimates an exact 0, which collapses `eval_domain`
+/// and `scan_units` for the MATERIALIZING alternatives, so `GatheredScan` prices at 0.2 us and measures
+/// 199.3 us: it still has to scan to discover the set is empty. A result total is not a scan domain.
+/// Turning this on wants those two features derived from a candidate bound rather than from the match
+/// estimate -- docs/issues/local-engine-pair-totals.md.
+static PAIR_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_PAIR_TOTALS", 0u8) != 0);
+
 /// Whether the legality divergent-share correction to `stream_scan_units` is scoped to filters whose
 /// residual can actually settle at card level.
 ///
@@ -6542,13 +6766,24 @@ fn compose_printing_estimate(
         // scatter to 82,421 for an 879-row answer. Fusing same-index children first replaces both with
         // the interval's exact `k` — the same two `partition_point` calls the one-sided arm below
         // already makes, which is why a one-sided range estimates at 1.0x and this did not.
-        FilterExpr::And(v) => fuse_and_range_children(v, indexes, false)
-            .into_iter()
-            .map(|src| match src {
-                AndSource::Child(c) => compose_printing_estimate(c, indexes, offsets, n_printings),
-                AndSource::FusedRange { k, .. } => (k, 0, k),
-            })
-            .fold((n_printings, 0, 0), |(m, bc, sc), (cm, cbc, csc)| (m.min(cm), bc + cbc, sc + csc)),
+        FilterExpr::And(v) => {
+            let (m, bc, sc) = fuse_and_range_children(v, indexes, false)
+                .into_iter()
+                .map(|src| match src {
+                    AndSource::Child(c) => compose_printing_estimate(c, indexes, offsets, n_printings),
+                    AndSource::FusedRange { k, .. } => (k, 0, k),
+                })
+                .fold((n_printings, 0, 0), |(m, bc, sc), (cm, cbc, csc)| (m.min(cm), bc + cbc, sc + csc));
+            // Tighten the `min` bound with every PAIR of children the table stores. `min` over singles
+            // lets the most selective leaf decide alone, which is why `f:modern r:rare border:white`
+            // estimated 5,131 -- `border:white`'s own count -- against a true 658. The pair
+            // `r:rare border:white` is stored exactly at 1,330, taking the bound from 7.80x to 2.02x.
+            //
+            // `n choose 2` over an `And`'s children, bounded in practice by how many predicates a person
+            // types; the two-leaf case is answered exactly one level up in `exact_result_total` and never
+            // needs this.
+            (pair_bounded_min(v, indexes, m), bc, sc)
+        }
         FilterExpr::Or(v) => {
             let (m, bc, sc) = v
                 .iter()
@@ -6976,7 +7211,87 @@ fn walk_value_orderby_page<'a>(
 /// No new stored table: both counts are already on the query path. A per-format count table would work
 /// too (there are at most 32 formats x 4 statuses, so ~1 KB) but it would store what a popcount of a
 /// plane the query already reads gives for nothing.
-fn exact_result_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, mode: Mode) -> Option<usize> {
+/// `min` over every stored pair of an `And`'s children, floored into the caller's existing single-leaf
+/// bound. Returns the tighter of the two, and 0 when any two children are provably disjoint.
+///
+/// Both are still UPPER BOUNDS for three or more children -- the intersection of three sets is at most
+/// the smallest pairwise intersection -- but a pairwise bound is much tighter than a single-leaf one
+/// whenever the leaves are individually broad, which is exactly when the estimate matters.
+fn pair_bounded_min(children: &[FilterExpr], indexes: &Archived<CardIndexes>, single_min: usize) -> usize {
+    if children.len() < 2 || !*PAIR_TOTALS {
+        return single_min;
+    }
+    let pt = &indexes.pair_totals;
+    let ids: Vec<Option<u16>> = children.iter().map(|c| pair_leaf_id(c, pt)).collect();
+    let mut best = single_min;
+    for (i, a) in children.iter().enumerate() {
+        for (j, b) in children.iter().enumerate().skip(i + 1) {
+            if leaves_are_disjoint(a, b) {
+                return 0;
+            }
+            if let (Some(x), Some(y)) = (ids[i], ids[j])
+                && let Some(k) = pt.get(x, y, Mode::Printing)
+            {
+                best = best.min(k);
+            }
+        }
+    }
+    best
+}
+
+/// The pair-table id for a leaf, or `None` when the leaf's dimension is not covered or its value was
+/// pruned by the selectivity floor.
+///
+/// Deliberately the same four shapes `exact_result_total`'s singleton arms accept, and for the same
+/// reasons: `Eq` only on the interned strings (the ordering ops are not a per-value question), `Ge` only
+/// on the collection (`Eq`/`Gt` add a length condition containment does not prove), and rarity only at
+/// `Eq` (any other op is a range over several values, which no per-value entry answers).
+fn pair_leaf_id(filter: &FilterExpr, pt: &ArchivedPairTotals) -> Option<u16> {
+    let id = match filter {
+        FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => pt.border.get(value.as_str()),
+        FilterExpr::CollectionCmp { field: CollField::FrameData, op: CmpOp::Ge, value, .. } => pt.frame.get(value.as_str()),
+        FilterExpr::Legality { shift: Some(shift), expected } => pt.legality.get(&legality_totals_key(*shift, *expected).into()),
+        FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(v) }
+        | FilterExpr::NumericCmp { lhs: NumExpr::Const(v), op: CmpOp::Eq, rhs: NumExpr::Field(NumField::RarityInt) } => {
+            if v.fract() != 0.0 || *v < 0.0 || *v > f64::from(u8::MAX) {
+                return None;
+            }
+            pt.rarity.get(&(*v as u8))
+        }
+        _ => None,
+    }?;
+    Some(u16::from(*id))
+}
+
+/// Whether two leaves are provably disjoint: distinct values of a dimension that holds exactly ONE value
+/// per printing, so no printing can satisfy both.
+///
+/// `frame_data` is excluded because it is multi-valued -- `frame:2015 frame:legendary` matches 10,321
+/// printings. A rule rather than stored data, which is why the pair table need not carry same-dimension
+/// entries for the partitions.
+fn leaves_are_disjoint(a: &FilterExpr, b: &FilterExpr) -> bool {
+    match (a, b) {
+        (
+            FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: x },
+            FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value: y },
+        ) => x != y,
+        (FilterExpr::Legality { shift: Some(sa), expected: ea }, FilterExpr::Legality { shift: Some(sb), expected: eb }) => {
+            sa == sb && ea != eb
+        }
+        (
+            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(x) },
+            FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(y) },
+        ) => x != y,
+        _ => false,
+    }
+}
+
+fn exact_result_total(
+    composed: &FilterExpr,
+    indexes: &Archived<CardIndexes>,
+    n_cards: usize,
+    mode: Mode,
+) -> Option<usize> {
     if let Some((idx, lo, hi)) = bare_range_bounds(composed, indexes) {
         // Printings come free from the index's own partition points; the other two spaces come from the
         // prefix/suffix tables, which now carry an artwork column as well as a card one.
@@ -7002,6 +7317,23 @@ fn exact_result_total(composed: &FilterExpr, indexes: &Archived<CardIndexes>, mo
             Mode::Card => indexes.rarity_cards.distinct_cards(lo, hi).map(|n| n as usize),
             Mode::Artwork => indexes.rarity_cards.distinct_artworks(lo, hi).map(|n| n as usize),
         };
+    }
+    // Two dense low-cardinality leaves: the PAIR table answers them exactly, where the singleton arms
+    // below could only answer one of them and the `And` fold would take the `min` bound. This is what
+    // makes `f:modern border:white` read 978 cards instead of 2,755 -- the difference between predicting
+    // a plan that runs and one that declines against the 1,024 sparse floor.
+    if let FilterExpr::And(children) = composed
+        && children.len() == 2
+        && *PAIR_TOTALS
+    {
+        if leaves_are_disjoint(&children[0], &children[1]) {
+            return Some(0);
+        }
+        if let (Some(a), Some(b)) = (pair_leaf_id(&children[0], &indexes.pair_totals), pair_leaf_id(&children[1], &indexes.pair_totals))
+            && let Some(total) = indexes.pair_totals.get(a, b, mode)
+        {
+            return Some(total);
+        }
     }
     // The per-value table, which covers the dimensions whose predicate tests ONE value, in all three
     // spaces. Absence from a COMPLETE table is an exact zero, not a declined shape -- every one of
@@ -11291,6 +11623,14 @@ impl QueryEngine {
         let rarity_cards = build_range_card_counts(&rarity_idx, &printing_to_card, cards.len(), &printings, &artwork_base);
         // Out here for the same reason as the count tables: it reads `printing_to_card`, which the
         // struct literal below moves.
+        let pair_totals = build_pair_totals(
+            &cards,
+            &printings,
+            &printing_to_card,
+            &strings,
+            &coll_vocab,
+            usize::from(artwork_group_counts.iter().copied().max().unwrap_or(0)),
+        );
         let value_totals = build_all_value_totals(
             &cards,
             &printings,
@@ -11361,6 +11701,7 @@ impl QueryEngine {
             rarity_printing_ordered: rarity_idx,
             rarity_cards,
             value_totals,
+            pair_totals,
             name_bigrams:   build_name_bigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
             arith_tuple:    build_arith_tuple_index(&cards),

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5542,6 +5542,16 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// (1/32). 0 restores the conflated gate, for the A/B that priced the distinction.
 static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_DENSE_FRAME_BROAD_GATE", 1u8) != 0);
 
+/// Whether the legality divergent-share correction to `stream_scan_units` is scoped to filters whose
+/// residual can actually settle at card level.
+///
+/// **Default OFF, deliberately.** The correction is more accurate scoped (see the call site) and it wins
+/// 2x in printing and artwork mode, but on its own it nets a wash: it also moves CARD mode onto
+/// `PrintingCompose`, which then declines at dispatch (`DeclineSparseExact`) and falls back having
+/// already paid the build. Turning this on wants the decline hazard fixed first —
+/// docs/issues/local-engine-legality-scan-scope.md has the chain and the measurements.
+static LEGALITY_SCAN_SCOPE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_LEGALITY_SCAN_SCOPE", 0u8) != 0);
+
 /// Whether a conjunct the candidate set already proves is skipped by `card_pass` instead of
 /// re-verified. 0 restores the re-verification, for the A/B that priced it.
 static PROVEN_CONJUNCTS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_PROVEN_CONJUNCTS", 1u8) != 0);
@@ -9525,7 +9535,18 @@ fn acquire_plan_features(
             // arm multiplies the term by zero on the same signal, so this changes no cost — only whether
             // the feature can be graded honestly.
             0
-        } else if filter_touches_legality(composed) {
+        } else if filter_touches_legality(composed) && !(*LEGALITY_SCAN_SCOPE && touches_printing_field(composed)) {
+            // `&& !touches_printing_field` because the argument below is about what `card_pass` can
+            // SETTLE, and legality being card-level is only decisive when it is the only thing left to
+            // verify. One printing-varying partner -- `border:white`, a range, a frame value -- makes
+            // `card_pass` return `PrintingDep` for every card, and P3 then walks the whole span like P4.
+            //
+            // Scoped on legality alone, the correction charged 2,755 for the entire `f:X border:white`
+            // family against a realized 5,353-19,737, up to 7.2x under, and handed every one of them to
+            // StreamedSelect: `f:modern border:white` measured 100.9 us on the plan the router picked
+            // against 44.3 us for the PrintingCompose it passed over. `Legality` reads false from
+            // `touches_printing_field` (it ranks by the common card-level case), so this composes
+            // cleanly -- a bare legality filter still takes the divergent-share arm.
             let divergent = indexes.legal_divergent.len() as f64;
             let share = (divergent / f64::from(n_cards)).min(1.0);
             // Floored at one printing per candidate: with a divergent format in play the kernel does

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -5757,24 +5757,24 @@ static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD
 /// Whether the PAIR table answers a two-leaf `And` exactly and tightens the `And` fold's bound. 0 falls
 /// both back to `min` over single leaves.
 ///
-/// **Default OFF.** The table itself is right -- 21 of 21 measured cells exact where `min` read 2.8-10.1x
-/// over, and the three-leaf bound goes 7.80x to 2.02x -- but feeding it into the estimate regresses the
-/// disjoint cases 24x. `border:white border:black` estimates an exact 0, which collapses `eval_domain`
-/// and `scan_units` for the MATERIALIZING alternatives, so `GatheredScan` prices at 0.2 us and measures
-/// 199.3 us: it still has to scan to discover the set is empty. A result total is not a scan domain.
-/// Turning this on wants those two features derived from a candidate bound rather than from the match
-/// estimate -- docs/issues/local-engine-pair-totals.md.
-static PAIR_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_PAIR_TOTALS", 0u8) != 0);
+/// 21 of 21 measured cells exact where `min` read 2.8-10.1x over, and the three-leaf bound goes 7.80x to
+/// 2.02x. Wiring it in regressed the disjoint cases 24x until `ComposeEstimate` split the result from the
+/// candidate bound: an exact 0 was collapsing `eval_domain`/`scan_units` for the MATERIALIZING
+/// alternatives, pricing `GatheredScan` at 0.2 us against a measured 199.3 us, because a plan still has
+/// to scan to discover a set is empty. With the split it is neutral in aggregate and it is what lets
+/// `LEGALITY_SCAN_SCOPE` be on -- docs/issues/local-engine-pair-totals.md.
+static PAIR_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_PAIR_TOTALS", 1u8) != 0);
 
 /// Whether the legality divergent-share correction to `stream_scan_units` is scoped to filters whose
 /// residual can actually settle at card level.
 ///
-/// **Default OFF, deliberately.** The correction is more accurate scoped (see the call site) and it wins
-/// 2x in printing and artwork mode, but on its own it nets a wash: it also moves CARD mode onto
-/// `PrintingCompose`, which then declines at dispatch (`DeclineSparseExact`) and falls back having
-/// already paid the build. Turning this on wants the decline hazard fixed first —
-/// docs/issues/local-engine-legality-scan-scope.md has the chain and the measurements.
-static LEGALITY_SCAN_SCOPE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_LEGALITY_SCAN_SCOPE", 0u8) != 0);
+/// On since the pair table made it safe. Scoped, the correction is 5-7x more accurate on this
+/// population and wins 2.0x in printing mode and 1.6x in artwork; unscoped it also moved CARD mode onto
+/// `PrintingCompose`, which then declined at dispatch (`DeclineSparseExact`) and fell back having already
+/// paid the build. `PairTotals` gives card mode the exact total, so `compose_paging` now predicts that
+/// decline instead of walking into it. Aggregate is neutral (0.995 target / 0.997 whole mix over 12
+/// interleaved rounds); the win is per query and the point is a feature that is no longer wrong.
+static LEGALITY_SCAN_SCOPE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_LEGALITY_SCAN_SCOPE", 1u8) != 0);
 
 /// Whether a conjunct the candidate set already proves is skipped by `card_pass` instead of
 /// re-verified. 0 restores the re-verification, for the A/B that priced it.
@@ -6752,28 +6752,59 @@ fn compose_printing_bits(
 /// **only if this plan wins** (why acquire estimates rather than composing — it avoids a throwaway pass).
 /// `AND` takes the min matches (intersection upper bound) and sums each build kind; `OR` the capped sum.
 /// Used only for plan choice — the fast path recomputes the exact total.
+/// What `compose_printing_estimate` returns: the composed set's size, twice.
+///
+/// `result` is the best available estimate — exact where the pair table or a single-leaf table answers.
+/// `candidate` is the plain `min`-over-single-leaves bound, which is what the MATERIALIZING alternatives
+/// actually walk: `narrow_rec` declines broad children (`border:black` at 87% under `broad_ok: false`),
+/// so their candidate set is the surviving leaf's, not the intersection.
+///
+/// Keeping them apart is the whole point. Feeding an exact intersection into `eval_domain`/`scan_units`
+/// prices `GatheredScan` on `border:white border:black` at 0.2 us against a measured 199.3 us, because a
+/// plan still has to scan to DISCOVER a set is empty. A result total is not a scan domain — the same
+/// distinction `exact_cards` vs `exact_total` draws one level down.
+#[derive(Clone, Copy)]
+struct ComposeEstimate {
+    result: usize,
+    candidate: usize,
+    broadcast: usize,
+    scatter: usize,
+}
+
+impl ComposeEstimate {
+    /// A leaf: nothing to tighten, so both figures are the same count.
+    fn leaf(k: usize, broadcast: usize, scatter: usize) -> Self {
+        Self { result: k, candidate: k, broadcast, scatter }
+    }
+}
+
 fn compose_printing_estimate(
     filter: &FilterExpr,
     indexes: &Archived<CardIndexes>,
     offsets: &AOffsets,
     n_printings: usize,
-) -> (usize, usize, usize) {
+) -> ComposeEstimate {
     let popcount = |bits: &[u64]| bits.iter().map(|w| w.count_ones() as usize).sum::<usize>();
     match filter {
-        FilterExpr::True => (n_printings, 0, 0),
+        FilterExpr::True => ComposeEstimate::leaf(n_printings, 0, 0),
         // The min-of-children fold is an intersection UPPER BOUND, and on a two-sided range it is a bad
         // one: `usd>=0.42 usd<=0.43` folded to min(33,862, 48,559) against a true 879, and the summed
         // scatter to 82,421 for an 879-row answer. Fusing same-index children first replaces both with
         // the interval's exact `k` — the same two `partition_point` calls the one-sided arm below
         // already makes, which is why a one-sided range estimates at 1.0x and this did not.
         FilterExpr::And(v) => {
-            let (m, bc, sc) = fuse_and_range_children(v, indexes, false)
+            let folded = fuse_and_range_children(v, indexes, false)
                 .into_iter()
                 .map(|src| match src {
                     AndSource::Child(c) => compose_printing_estimate(c, indexes, offsets, n_printings),
-                    AndSource::FusedRange { k, .. } => (k, 0, k),
+                    AndSource::FusedRange { k, .. } => ComposeEstimate::leaf(k, 0, k),
                 })
-                .fold((n_printings, 0, 0), |(m, bc, sc), (cm, cbc, csc)| (m.min(cm), bc + cbc, sc + csc));
+                .fold(ComposeEstimate::leaf(n_printings, 0, 0), |a, c| ComposeEstimate {
+                    result: a.result.min(c.result),
+                    candidate: a.candidate.min(c.candidate),
+                    broadcast: a.broadcast + c.broadcast,
+                    scatter: a.scatter + c.scatter,
+                });
             // Tighten the `min` bound with every PAIR of children the table stores. `min` over singles
             // lets the most selective leaf decide alone, which is why `f:modern r:rare border:white`
             // estimated 5,131 -- `border:white`'s own count -- against a true 658. The pair
@@ -6782,29 +6813,40 @@ fn compose_printing_estimate(
             // `n choose 2` over an `And`'s children, bounded in practice by how many predicates a person
             // types; the two-leaf case is answered exactly one level up in `exact_result_total` and never
             // needs this.
-            (pair_bounded_min(v, indexes, m), bc, sc)
+            // Only `result` is tightened. `candidate` keeps the untightened `min`, because that is what
+            // narrowing leaves the alternatives to walk once its broad children decline.
+            ComposeEstimate { result: pair_bounded_min(v, indexes, folded.result), ..folded }
         }
         FilterExpr::Or(v) => {
-            let (m, bc, sc) = v
+            let summed = v
                 .iter()
                 .map(|c| compose_printing_estimate(c, indexes, offsets, n_printings))
-                .fold((0usize, 0usize, 0usize), |(m, bc, sc), (cm, cbc, csc)| (m + cm, bc + cbc, sc + csc));
-            (m.min(n_printings), bc, sc)
+                .fold(ComposeEstimate::leaf(0, 0, 0), |a, c| ComposeEstimate {
+                    result: a.result + c.result,
+                    candidate: a.candidate + c.candidate,
+                    broadcast: a.broadcast + c.broadcast,
+                    scatter: a.scatter + c.scatter,
+                });
+            ComposeEstimate {
+                result: summed.result.min(n_printings),
+                candidate: summed.candidate.min(n_printings),
+                ..summed
+            }
         }
         // Precomputed planes: exact cheap popcount, nothing synthesized.
         FilterExpr::TextExact { field: TextField::Border, op: CmpOp::Eq, value } => {
-            (popcount(&border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)), 0, 0)
+            ComposeEstimate::leaf(popcount(&border_leaf_bits(value.as_str(), &indexes.border_printing, n_printings)), 0, 0)
         }
         // #746: `set:`/`watermark:` postings — matches = the value's postings length `k` (each
         // posting is one distinct printing), synthesized by scattering `k` ids → rides `scatter`
         // (the same cheap range-slice scatter rate). O(1) here: the length, no bitmap built.
         FilterExpr::TextExact { field: TextField::SetCode, op: CmpOp::Eq, value } => {
             let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
-            (k, 0, k)
+            ComposeEstimate::leaf(k, 0, k)
         }
         FilterExpr::TextExact { field: TextField::Watermark, op: CmpOp::Eq, value } => {
             let k = indexes.watermarks.get(value.as_str()).map_or(0, |v| v.len());
-            (k, 0, k)
+            ComposeEstimate::leaf(k, 0, k)
         }
         // #746: `-set:VALUE` — matches = all printings minus the value's postings; the scatter cost
         // rides the (small) positive postings size cleared, not the (large) complement it produces.
@@ -6815,7 +6857,7 @@ fn compose_printing_estimate(
                 unreachable!("guarded by the matches! above")
             };
             let k = indexes.set_codes.get(value.as_str()).map_or(0, |v| v.len());
-            (n_printings.saturating_sub(k), 0, k)
+            ComposeEstimate::leaf(n_printings.saturating_sub(k), 0, k)
         }
         // Collection containment leaf (`type:`/`kw:`/`otag:`/`art:`/`is:`, `Ge`): `k` = the exact
         // printing count the leaf matches (card-space sums the matching cards' printing ranges,
@@ -6826,7 +6868,7 @@ fn compose_printing_estimate(
         {
             let src = collection_compose_index(indexes, *field).expect("guarded by the if");
             let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
-            (k, 0, k)
+            ComposeEstimate::leaf(k, 0, k)
         }
         // Negated collection leaf: all printings minus the positive `k`; the scatter cost rides the
         // (small) positive `k` cleared, not the (large) complement it produces — same shape as `-set:`.
@@ -6838,13 +6880,13 @@ fn compose_printing_estimate(
             };
             let src = collection_compose_index(indexes, *field).expect("guarded by the matches!");
             let k = collection_leaf_printing_count(&src, value.as_str(), offsets);
-            (n_printings.saturating_sub(k), 0, k)
+            ComposeEstimate::leaf(n_printings.saturating_sub(k), 0, k)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op, rhs: NumExpr::Const(c) } => {
-            (popcount(&rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)), 0, 0)
+            ComposeEstimate::leaf(popcount(&rarity_cmp_leaf_bits(*op, *c, &indexes.rarity_printing, n_printings)), 0, 0)
         }
         FilterExpr::NumericCmp { lhs: NumExpr::Const(c), op, rhs: NumExpr::Field(NumField::RarityInt) } => {
-            (popcount(&rarity_cmp_leaf_bits(flip_op(*op), *c, &indexes.rarity_printing, n_printings)), 0, 0)
+            ComposeEstimate::leaf(popcount(&rarity_cmp_leaf_bits(flip_op(*op), *c, &indexes.rarity_printing, n_printings)), 0, 0)
         }
         // Legality: matches ≈ the legal-∃ cards' printings (existence-scaled from the cheap card
         // ∃-plane popcount). The build cost rides the *sparser* side (#744): a majority-legal format
@@ -6856,7 +6898,7 @@ fn compose_printing_estimate(
             let legal = legality_candidate_bits(indexes, n_cards, *shift, *expected, false).map_or(0, |b| popcount(&b));
             let illegal = legality_candidate_bits(indexes, n_cards, *shift, *expected, true).map_or(0, |b| popcount(&b));
             let scale = |c: usize| (c * n_printings).checked_div(n_cards).unwrap_or(0);
-            (scale(legal), scale(legal.min(illegal)), 0)
+            ComposeEstimate::leaf(scale(legal), scale(legal.min(illegal)), 0)
         }
         // Range (bare or negated — `-usd<50` etc., see `bare_range_bounds`'s doc): `k` in-range
         // printings from the index partition points (O(log n), no scatter here); matches ≈ k, and k
@@ -6866,7 +6908,7 @@ fn compose_printing_estimate(
         {
             let (idx, lo, hi) = bare_range_bounds(filter, indexes).expect("guarded by bare_range_bounds");
             let (s, e) = idx.range(lo, hi);
-            (e - s, 0, e - s)
+            ComposeEstimate::leaf(e - s, 0, e - s)
         }
         _ => unreachable!("compose_printing_estimate on a non-composable filter — gated by is_printing_composable"),
     }
@@ -9305,7 +9347,8 @@ fn compose_gather_declines(
     cards: &[AOracleCard],
     mode: Mode,
 ) -> Option<PagingTaken> {
-    let (printing_matches, _, _) = compose_printing_estimate(filter, indexes, offsets, printings.len());
+    // The gather's own decline is about the composed set it would page over, so it reads `result`.
+    let printing_matches = compose_printing_estimate(filter, indexes, offsets, printings.len()).result;
     // Artwork's domain is n_artworks, not n_cards. That used to be approximated by `cards.len()`
     // because the exact figure meant prefix-summing `artwork_groups` here -- real O(n_cards) work
     // paid just to maybe decline. It is a stored index now, so read the truth: the stand-in is
@@ -9701,7 +9744,8 @@ fn acquire_plan_features(
         // and compose was costed as if it returned everything for nothing. Applicability, estimate and
         // execution have to agree on which representation this plan is being judged on.
         let composed = compose_source(filter, unsplit, plane);
-        let (printing_matches, broadcast, scatter) = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
+        let est = compose_printing_estimate(composed, indexes, offsets, n_printings as usize);
+        let (printing_matches, broadcast, scatter) = (est.result, est.broadcast, est.scatter);
         // Two build kinds, charged at different rates: `broadcast` = legality broadcast-down (linear
         // pass), `scatter` = range-slice scatter (cheap). `project` = the second pass (printing→
         // card/artwork), 0 for printing mode. Keeping all three separate is what lets a bare range's
@@ -9728,6 +9772,20 @@ fn acquire_plan_features(
         };
         let est_cards =
             exact_cards.unwrap_or_else(|| calibrated_balls_into_bins(printing_matches, n_cards as usize));
+        // The card count the MATERIALIZING alternatives walk, which stops being `est_cards` once the
+        // estimate has been tightened. `est.candidate` is the untightened `min` over single leaves, and
+        // that is what narrowing actually leaves them: it declines broad children (`border:black` at 87%
+        // under `broad_ok: false`), so `border:white border:black` hands them `border:white`'s 5,131
+        // printings, not the empty intersection. Charging the intersection priced `GatheredScan` at
+        // 0.2 us against a measured 199.3 us -- a plan still has to scan to DISCOVER a set is empty.
+        //
+        // Identical to `est_cards` whenever nothing was tightened, which is every query that reached here
+        // before the pair table existed, so no already-calibrated cell moves.
+        let domain_cards = if est.candidate == est.result {
+            est_cards
+        } else {
+            calibrated_balls_into_bins(est.candidate, n_cards as usize)
+        };
         // What the MATERIALIZING alternatives scan if compose loses. Every mode narrows -- a
         // composable filter has an index for every leaf -- so all three are the NARROWED counts.
         // Printing mode took the unnarrowed universe while card/artwork took a narrowed count; only
@@ -9758,7 +9816,7 @@ fn acquire_plan_features(
                 // would under-charge the scan on exactly the divergent-legality cards the superset exists
                 // for. `f:modern` reads 68,687 against a true 73,783; `banned:modern` 160 against 399.
                 let total = if *EXACT_VALUE_TOTALS { exact_total.unwrap_or(printing_matches) } else { printing_matches };
-                (total, 0, (n_printings as usize).div_ceil(64), est_cards, scan_all(est_cards))
+                (total, 0, (n_printings as usize).div_ceil(64), domain_cards, scan_all(domain_cards))
             }
             Mode::Card => {
                 // Card mode's result total IS the distinct-card count, which is precisely what
@@ -9766,7 +9824,7 @@ fn acquire_plan_features(
                 // `printing_matches.min(n_cards)`, which reads a median 1.99x the deduped
                 // `matches_pushed` counter -- p10 1.01, so it is over on nearly every query. Two
                 // names for one quantity, one of them wrong.
-                (est_cards, printing_matches, (n_cards as usize).div_ceil(64), est_cards, scan_all(est_cards))
+                (est_cards, printing_matches, (n_cards as usize).div_ceil(64), domain_cards, scan_all(domain_cards))
             }
             Mode::Artwork => {
                 // `result_total` is consumed as a per-RESULT count (GatheredScan's push term,
@@ -9792,7 +9850,7 @@ fn acquire_plan_features(
                 let rt = exact_total.unwrap_or_else(|| artwork_estimate(printing_matches, capacity_cards, n_cards as usize, n_artworks));
                 // The bitmap `printing_bits_to_artwork_bits` popcounts is n_artworks bits wide, not
                 // n_printings -- 46,112 against 97,206 here, so this was 2.1x over as well.
-                (rt, printing_matches, n_artworks.div_ceil(64), est_cards, scan_all(est_cards))
+                (rt, printing_matches, n_artworks.div_ceil(64), domain_cards, scan_all(domain_cards))
             }
         };
         // `eval_domain` and `scan_units` describe what the MATERIALIZING alternatives walk, and when the

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7,7 +7,7 @@ use super::{
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
     acquire_plan_features, take_phase_stats, PagingTaken, CountSource, NarrowedRepr,
-    EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, build_all_value_totals, build_range_card_counts, exact_result_total,
+    EXACT_VALUE_TOTALS, RangeCardCounts, narrow_rec, ValueTotals, PairTotals, build_all_value_totals, build_pair_totals, build_range_card_counts, exact_result_total,
     PhysicalPlan, ComposePaging, trigram_candidates, finalize_trigram_index, PrintingValueIndex, NARROW_FLOOR,
     gathered_scan_applicable, streamed_select_applicable, plane_popcount_order_applicable, printing_range_scan_applicable,
     walk_printing_page, aligned_page, bare_range_bounds, probe_range_k, printing_range_fastpath, sort_key_bits, orderby_to_col, SortCol, STREAM_MIN_MATCHES,
@@ -2497,6 +2497,14 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     // read an exact ZERO from an empty-but-"complete" table, which is a wrong total rather than a missing
     // one. `format_shifts` comes from the data, not the global registry, so the keys match what `bind`
     // resolved against.
+    data.indexes.pair_totals = build_pair_totals(
+        &data.cards,
+        &data.printings,
+        &p2c,
+        &data.strings,
+        &data.coll_vocab,
+        usize::from(data.indexes.max_artwork_groups),
+    );
     data.indexes.value_totals = build_all_value_totals(
         &data.cards,
         &data.printings,
@@ -6260,6 +6268,7 @@ fn bench_checked_vs_unchecked_access() {
         collector_number_cards: RangeCardCounts::default(),
         rarity_cards:   RangeCardCounts::default(),
         value_totals:   ValueTotals::default(),
+        pair_totals:    PairTotals::default(),
         sort_perms:     build_sort_permutations(&cards),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
         artwork_groups,

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -7347,7 +7347,7 @@ fn set_watermark_compose_leaves() {
         // The estimate feeds plan choice and must be a valid upper bound on the true match count
         // (AND takes the min-of-children intersection bound, OR the capped sum — never an
         // undercount, which would misprice the plan). For a bare leaf it's exact (postings length).
-        let (est_matches, _, _) = super::compose_printing_estimate(f, &archived.indexes, &archived.offsets, n_printings);
+        let est_matches = super::compose_printing_estimate(f, &archived.indexes, &archived.offsets, n_printings).result;
         assert!(est_matches >= want.len(), "compose_printing_estimate undercounts for {label}: {est_matches} < {}", want.len());
         if matches!(f, FilterExpr::TextExact { .. } | FilterExpr::Not(_)) {
             assert_eq!(est_matches, want.len(), "bare-leaf estimate must be exact for {label}");
@@ -7487,7 +7487,7 @@ fn collection_compose_leaves() {
         want.sort_unstable();
         assert_eq!(got, want, "compose_printing_bits disagrees with the residual path for {label}");
         // The estimate feeds plan choice: a valid upper bound at minimum, and exact for a bare leaf.
-        let (est_matches, _, _) = super::compose_printing_estimate(f, &archived.indexes, &archived.offsets, n_printings);
+        let est_matches = super::compose_printing_estimate(f, &archived.indexes, &archived.offsets, n_printings).result;
         assert!(est_matches >= want.len(), "compose_printing_estimate undercounts for {label}: {est_matches} < {}", want.len());
         if matches!(f, FilterExpr::CollectionCmp { .. } | FilterExpr::Not(_)) {
             assert_eq!(est_matches, want.len(), "bare collection-leaf estimate must be exact for {label}");

--- a/docs/issues/local-engine-legality-scan-scope.md
+++ b/docs/issues/local-engine-legality-scan-scope.md
@@ -1,0 +1,111 @@
+# `f:modern border:white` picks a 100 µs plan over a 44 µs one, and the whole family estimates identically
+
+`f:modern border:white` measures **100.5 µs** on the `StreamedSelect` the router picks and **43.8 µs** on
+the `PrintingCompose` it passes over. The same holds across the family, and the reason is that the cost
+model cannot tell its members apart.
+
+## Every `f:X border:white` gets identical features
+
+| query | eval_domain | matches | scan_units | stream_scan_units | broadcast |
+| --- | --: | --: | --: | --: | --: |
+| `f:modern border:white` | 2,755 | 5,131 | 17,848 | 2,755 | 28,518 |
+| `f:pauper border:white` | 2,755 | 5,131 | 17,848 | 2,755 | 33,020 |
+| `f:vintage border:white` | 2,755 | 5,131 | 17,848 | 2,755 | 212 |
+| `f:future border:white` | 2,755 | 5,131 | 17,848 | 2,755 | 14,413 |
+| `f:modern r:rare border:white` | 2,755 | 5,131 | 17,848 | 2,755 | 28,518 |
+
+Only `broadcast_printings` differs, and it feeds `PrintingCompose`'s arm alone — so `StreamedSelect` is
+predicted at 50.3 µs and `GatheredScan` at 120.2 µs for all five, against measured `StreamedSelect` of
+82–181 µs. Note the last row: adding `r:rare` changes nothing either.
+
+`5,131` is `border:white`'s own printing count. `compose_printing_estimate`'s `And` arm folds with
+`m.min(cm)` — an intersection **upper bound** — so the most selective leaf wins and every other conjunct
+contributes nothing. Against the true printing totals that reads 1.01x on `f:vintage`, 1.65x `f:modern`,
+1.91x `f:pauper`, and **6.50x** `f:future`: the error scales with how selective the ignored conjuncts are.
+
+## Defect 1: the `stream_scan_units` correction is scoped on the wrong question
+
+`stream_scan_units` carries a correction for legality: `card_match_count` answers from span arithmetic
+for every card `card_pass` resolves at card level, so P3 examines only the divergent remainder. Measured
+at 0.10–0.26x of P4's count on bare legality filters, and correct there.
+
+It is gated on `filter_touches_legality(composed)`. But the argument is about what `card_pass` can
+**settle**, and legality being card-level is only decisive when it is the *only* thing left to verify.
+One printing-varying partner makes `card_pass` return `PrintingDep` for every card, and P3 then walks the
+whole span like P4:
+
+| query | charged | P3 realized | |
+| --- | --: | --: | --: |
+| `f:vintage border:white` | 2,755 | 19,737 | 7.2x under |
+| `f:modern border:white` | 2,755 | 13,786 | 5.0x under |
+| `f:pauper border:white` | 2,755 | 10,965 | 4.0x under |
+| `f:future border:white` | 2,755 | 5,353 | 1.9x under |
+
+`touches_printing_field` already treats `Legality` as card-level (it ranks by the common case), so
+`filter_touches_legality(composed) && !touches_printing_field(composed)` is the right condition and a
+bare legality filter still takes the divergent-share arm. Implemented behind
+`CARD_ENGINE_LEGALITY_SCAN_SCOPE`, **default off** — see below for why.
+
+Per query, with the scope fixed, all four flip to the correct plan:
+
+| query | before | after |
+| --- | --: | --: |
+| `f:modern border:white` | 100.5 µs (StreamedSelect) | **43.8 µs** (PrintingCompose) |
+| `f:vintage border:white` | 185.0 µs | **3.0 µs** |
+| `f:pauper border:white` | 83.0 µs | **65.8 µs** |
+| `f:future border:white` | 97.0 µs | **37.6 µs** (GatheredScan) |
+
+## Defect 2: card mode is picked into a plan that refuses to run
+
+Fixing defect 1 alone nets a **wash** — interleaved A/B, 8 rounds, 1,374 queries: target 1.008, control
+0.988, whole mix 0.990. The same queries appear in both the improvement and the regression lists, split
+by mode:
+
+| mode | scope off | scope on | |
+| --- | --: | --: | --- |
+| printing | 153.9 µs | **77.0 µs** | 2.0x faster |
+| card | **103.0 µs** | 163.4 µs | 1.6x SLOWER |
+| artwork | 134.4 µs | **84.5 µs** | 1.6x faster |
+
+Card mode is not "compose is slower there". Compose is **picked and produces no trial**:
+
+    card:  PrintingCompose  pred=67.5u  trials=0  declined=9  picked=True  paging_taken='DeclineSparseExact'
+
+Compose builds the bits, computes the exact total, finds it under `STREAM_MIN_MATCHES` (1,024), and
+bails — after paying the build. The fallback then runs a second plan on top of that.
+
+And the trigger is defect 1's own root cause, the `min` fold:
+
+| query (card mode) | est cards | TRUE total | est/true | |
+| --- | --: | --: | --: | --- |
+| `f:modern border:white` | 2,755 | 978 | 2.82 | declines |
+| `f:pauper border:white` | 2,755 | 858 | 3.21 | declines |
+| `f:vintage border:white` | 2,755 | 2,025 | 1.36 | runs |
+| `f:modern r:rare border:white` | 2,755 | 273 | **10.09** | declines |
+
+The estimate says 2,755 for every one, comfortably above the floor, so the router predicts compose will
+run. Three of the four are actually below it.
+
+## What to do, in order
+
+1. **Make `DeclineSparseExact` not throw away paid work.** The sparse floor exists because compose is not
+   worth building for a tiny result — but at the point this fires the bits are *already built*, and
+   finishing the page from them is a page-sized walk. Declining after the exact total is known is
+   strictly worse than completing. The decline belongs before the build, on the estimated total, where
+   `ComposePaging::Decline` already lives.
+2. **Then turn on `CARD_ENGINE_LEGALITY_SCAN_SCOPE`** and re-run the A/B. Printing and artwork already
+   measure 2x and 1.6x; card should stop regressing once the decline is not a cliff.
+3. **Improve the `And` fold** — independence capped by the existing `min` bound. On this family that
+   reads 1.00 / 1.25 / 0.63 / 1.16 against `min`'s 1.01 / 1.65 / 1.91 / 6.50. It does NOT fix the card
+   estimate on its own (independence over exact per-leaf CARD counts still gives 1,455 against a true 978
+   for `f:modern border:white`), which is the second reason (1) has to come first: an estimate near a hard
+   threshold will always sometimes fall the wrong side, so the threshold must not be a cliff.
+
+## Status
+
+Defect 1 is implemented behind a **default-off** toggle, because on its own it is a wash and it moves card
+mode into defect 2's trap. Every number above is measured on the production corpus: per-query figures are
+a minimum of 9–15 trials after warmup, and the A/B is 8 interleaved rounds with a control subset.
+
+Related: [#731](./00731-engine-compose-universal-evaluator.md) — this is the arm that would gain
+`color`/`cmc` as broadcast sources, which is why it is worth fixing the router on it first.

--- a/docs/issues/local-engine-legality-scan-scope.md
+++ b/docs/issues/local-engine-legality-scan-scope.md
@@ -44,7 +44,8 @@ whole span like P4:
 `touches_printing_field` already treats `Legality` as card-level (it ranks by the common case), so
 `filter_touches_legality(composed) && !touches_printing_field(composed)` is the right condition and a
 bare legality filter still takes the divergent-share arm. Implemented behind
-`CARD_ENGINE_LEGALITY_SCAN_SCOPE`, **default off** — see below for why.
+`CARD_ENGINE_LEGALITY_SCAN_SCOPE`, **now default on** — it shipped off until the pair table fixed defect 2
+below.
 
 Per query, with the scope fixed, all four flip to the correct plan:
 
@@ -101,10 +102,20 @@ run. Three of the four are actually below it.
    for `f:modern border:white`), which is the second reason (1) has to come first: an estimate near a hard
    threshold will always sometimes fall the wrong side, so the threshold must not be a cliff.
 
+## Resolved
+
+Defect 2's trigger was the `min` fold, and [the pair table](./local-engine-pair-totals.md) makes the
+two-leaf card total exact (978, not 2,755), so `compose_paging` predicts the decline rather than walking
+into it. Card mode now routes to `GatheredScan` at 102.1 µs instead of picking a compose that bails at
+163.1 µs, while printing keeps 2.0x and artwork 1.6x. Both toggles are on; aggregate is neutral (0.995
+target / 0.997 whole mix over 12 interleaved rounds).
+
+Item (1) of the order below — `DeclineSparseExact` discarding paid work — is still open and still worth
+doing: the pair table removed the case that was biting, not the cliff.
+
 ## Status
 
-Defect 1 is implemented behind a **default-off** toggle, because on its own it is a wash and it moves card
-mode into defect 2's trap. Every number above is measured on the production corpus: per-query figures are
+Defect 1 is on by default. Every number above is measured on the production corpus: per-query figures are
 a minimum of 9–15 trials after warmup, and the A/B is 8 interleaved rounds with a control subset.
 
 Related: [#731](./00731-engine-compose-universal-evaluator.md) — this is the arm that would gain

--- a/docs/issues/local-engine-pair-totals.md
+++ b/docs/issues/local-engine-pair-totals.md
@@ -72,46 +72,65 @@ Three or more leaves get a tighter bound rather than exactness — `min` over st
 | `f:modern frame:2015 border:black` | 64,139 (1.36×) | **51,925 (1.10×)** | 47,332 |
 | `f:pauper r:common border:black` | — | **1.01×** | 24,521 |
 
-## And wiring it into the estimate makes routing worse
+## Wiring it in first made routing 24x worse, and why
 
-Interleaved A/B, 8 rounds, 1,368 queries: whole mix **1.010**, and the regression list is one shape:
-
-| query | off | on | |
-| --- | --: | --: | --: |
-| `border:white border:black` | 9.0 µs | 220.5 µs | **24.5×** |
-| `border:white border:black` (other configs) | 8.8–16.1 µs | 210–242 µs | 15–24× |
-| `r:common r:rare` | 10.2 µs | 88.1 µs | 8.6× |
-
-With `matches = 0`:
+Interleaved A/B, before the fix below: whole mix 1.010, carried by one shape —
+`border:white border:black` 9.0 µs → 220.5 µs. With `matches = 0`:
 
     GatheredScan     pred=  0.2u   meas= 199.3u   <- picked
     StreamedSelect   pred=  0.8u   meas= 192.0u
     PrintingCompose  pred=  1.9u   meas=   1.0u   <- actually best
 
 **A result total is not a scan domain.** `eval_domain` and `scan_units` for the *materializing
-alternatives* are derived from the match estimate, so an exact zero makes them free — but they still walk
+alternatives* were derived from the match estimate, so an exact zero made them free — but they still walk
 their candidate set to discover the set is empty. Compose really is ~1 µs (AND two bitmaps, popcount) and
-loses on predicted cost.
+lost on predicted cost.
 
-This is the same distinction that `exact_cards` vs `exact_total` draws in the compose acquire, and that
-the printing-mode `result_total` change was careful about ("substituting the true match count there would
-under-charge the scan"). It was violated one level up: the pair answer flows into `exact_cards` →
-`est_cards` → `eval_domain`/`scan_all`.
+## The fix: `ComposeEstimate` returns both numbers
 
-## What it needs
+`compose_printing_estimate` now returns `{ result, candidate, broadcast, scatter }`:
 
-`compose_printing_estimate` should return **two** numbers: the best available *result* estimate (exact
-where the pair table answers) and a *candidate* bound (min over singles, which is what the alternatives
-actually walk). `result_total` takes the first; `eval_domain` and `scan_units` take the second. Then the
-disjoint cases price compose at 1.9 µs against alternatives charged for a real scan, and get the plan
-right instead of 24× wrong.
+- **`result`** — the best available estimate, exact where the pair table or a single-leaf table answers.
+  Feeds `result_total` and compose's own cost (`project`, `compose_scan_printings`), which are about the
+  set compose really builds.
+- **`candidate`** — the plain `min`-over-single-leaves bound, which is what the alternatives actually
+  walk. `narrow_rec` declines broad children (`border:black` at 87% under `broad_ok: false`), so
+  `border:white border:black` hands them `border:white`'s 5,131 printings, not the empty intersection.
+  Feeds `eval_domain` and `scan_units`.
 
-Worth doing alongside: an exact total of **0 should short-circuit to an empty result** before routing at
-all. `border:white border:black t:creature` scans 6,402 printings over 79 µs to return nothing, because
-its acquire is `candidates` and never consults these tables — a filter containing two disjoint conjuncts
-is empty regardless of what else it says.
+`domain_cards` falls back to `est_cards` whenever `candidate == result`, i.e. whenever nothing was
+tightened — which is every query that reached here before the pair table existed, so no already-calibrated
+cell moves.
+
+With the split, `GatheredScan` on `border:white border:black` prices at 107.9 µs instead of 0.2 and
+compose wins at 1.0 µs. A/B: target 0.987, control 1.001, whole mix **1.000** — neutral, with the 24x
+regression gone.
+
+## It also unblocked the legality scan-scope fix
+
+[That fix](./local-engine-legality-scan-scope.md) was a wash on its own because it moved CARD mode onto
+`PrintingCompose`, which then declined at dispatch and fell back having paid the build. The trigger was
+the `min` fold estimating 2,755 cards against a true 978 on a 1,024 floor. The pair table makes that
+total exact, so `compose_paging` predicts the decline instead of walking into it:
+
+| | printing | card | artwork |
+| --- | --: | --: | --: |
+| before both | 149.0 µs | 99.5 µs | 134.1 µs |
+| scan-scope alone | 75.5 µs | **163.1 µs** | 83.2 µs |
+| **both** | **76.4 µs** | **102.1 µs** | **83.2 µs** |
+
+Both are now on by default. Aggregate over 12 interleaved rounds is neutral (0.995 target, 0.997 whole
+mix, drift 0.991/1.000); the wins are per query and what actually shipped is two cost features that are
+no longer wrong.
+
+## Still open
+
+An exact total of **0 should short-circuit to an empty result** before routing at all.
+`border:white border:black t:creature` scans 6,402 printings over 79 µs to return nothing, because its
+acquire is `candidates` and never consults these tables — a filter containing two disjoint conjuncts is
+empty regardless of what else it says. `leaves_are_disjoint` already knows; nothing calls it early enough.
 
 ## Status
 
-Built, archived and measured; wiring switched off at `CARD_ENGINE_PAIR_TOTALS` (default 0) pending the
-result-vs-candidate split above. The table's own numbers are all measured on the production corpus.
+Built, archived, wired and measured on the production corpus. `CARD_ENGINE_PAIR_TOTALS` and
+`CARD_ENGINE_LEGALITY_SCAN_SCOPE` both default on; the toggles remain as the handles that priced them.

--- a/docs/issues/local-engine-pair-totals.md
+++ b/docs/issues/local-engine-pair-totals.md
@@ -1,0 +1,117 @@
+# Exact totals for PAIRS of low-cardinality values
+
+`compose_printing_estimate`'s `And` folds with `m.min(cm)` — an intersection upper bound — so the most
+selective leaf decides alone and every other conjunct contributes nothing. Every `f:X border:white`
+estimates identically at 5,131 (`border:white`'s own count) against true totals of 658–5,072.
+
+For two leaves from a low-cardinality dimension, a stored pair count is not a tighter bound: it is the
+exact answer. The dimensions are small enough that the table is tens of kilobytes.
+
+## Sizing it, and what pruning does
+
+Four rounds of correction, each of which shrank it:
+
+| basis | pairs | size |
+| --- | --: | --: |
+| all five dimensions, 32×4 format slots | 7,821 | 92 KB |
+| real format cardinality (23 formats; only `legal`/`not_legal` worth pairing) | 3,705 | 58 KB |
+| drop the frame tail | — | 23 KB |
+| **selectivity floor: both values ≥ `STREAM_MIN_MATCHES`** | **879** | **13.7 KB raw** |
+
+The floor is the useful rule. A pair is only worth storing if *both* values are broad enough that an
+estimate about them can change a routing decision — below `STREAM_MIN_MATCHES` the sparse floor decides
+the plan and min-over-singles is already within a small factor. Measured, that prunes 4.2× and removes
+`layout` entirely, because only `normal` clears the floor:
+
+| dimension | values | survive `≥ 1,024` |
+| --- | --: | --: |
+| border | 5 | 4 |
+| rarity | 5 | 4 |
+| layout | 14 | **1** |
+| frame | 29 | 9 |
+| legality (`legal` + `not_legal`) | 46 | 41 |
+
+Counted in printings, which is the conservative side: cards ≤ printings, so a value with 1,500 printings
+but 400 cards is kept — and that is exactly the one card-mode routing needs.
+
+Realized archive cost is **42.6 KB**, above the 13.7 KB raw figure because rkyv's `HashMap` carries ~26
+bytes per entry. Build cost +0.2 s.
+
+## Two structural points
+
+**Completeness over stored ids, not over all values.** Absence from `ValueTotals` is read as an exact
+zero, so that table must cover everything. This one may prune — a miss just falls back to the `min`
+bound. But every pair of *stored* ids is archived **including the zero ones**, so "both ids present"
+means the answer is exact, possibly exactly zero. Storing only non-zero cells made a provably-empty pair
+indistinguishable from a pruned one: `frame:2003 frame:1997` read 10,769 against a true 0.
+
+**Partitions get disjointness for free.** Border, rarity and legality hold exactly one value per
+printing, so two distinct values never co-occur — a rule (`leaves_are_disjoint`), not stored data.
+`frame_data` is the exception: it is multi-valued (1–5 per printing) and `frame:2015 frame:legendary`
+genuinely matches 10,321, so frame needs real same-dimension entries.
+
+## The table is right
+
+21 of 21 measured cells exact, in all three spaces, where card mode had been 2.8–10.1× over:
+
+| query | printings | cards | artworks |
+| --- | --: | --: | --: |
+| `f:modern border:white` | 3,117 | 978 | 1,501 |
+| `f:pauper border:white` | 2,683 | 858 | 1,274 |
+| `f:vintage border:white` | 5,072 | 2,025 | 2,698 |
+| `f:modern r:rare` | 25,708 | 6,518 | 10,950 |
+| `r:rare border:white` | 1,330 | 625 | 772 |
+| `frame:2015 border:black` | 58,156 | 22,169 | 28,930 |
+| `f:modern frame:2015` | 51,925 | 17,750 | 27,322 |
+
+Three or more leaves get a tighter bound rather than exactness — `min` over stored pairs:
+
+| query | min over singles | min over pairs | truth |
+| --- | --: | --: | --: |
+| `f:modern r:rare border:white` | 5,131 (7.80×) | **1,330 (2.02×)** | 658 |
+| `f:modern frame:2015 border:black` | 64,139 (1.36×) | **51,925 (1.10×)** | 47,332 |
+| `f:pauper r:common border:black` | — | **1.01×** | 24,521 |
+
+## And wiring it into the estimate makes routing worse
+
+Interleaved A/B, 8 rounds, 1,368 queries: whole mix **1.010**, and the regression list is one shape:
+
+| query | off | on | |
+| --- | --: | --: | --: |
+| `border:white border:black` | 9.0 µs | 220.5 µs | **24.5×** |
+| `border:white border:black` (other configs) | 8.8–16.1 µs | 210–242 µs | 15–24× |
+| `r:common r:rare` | 10.2 µs | 88.1 µs | 8.6× |
+
+With `matches = 0`:
+
+    GatheredScan     pred=  0.2u   meas= 199.3u   <- picked
+    StreamedSelect   pred=  0.8u   meas= 192.0u
+    PrintingCompose  pred=  1.9u   meas=   1.0u   <- actually best
+
+**A result total is not a scan domain.** `eval_domain` and `scan_units` for the *materializing
+alternatives* are derived from the match estimate, so an exact zero makes them free — but they still walk
+their candidate set to discover the set is empty. Compose really is ~1 µs (AND two bitmaps, popcount) and
+loses on predicted cost.
+
+This is the same distinction that `exact_cards` vs `exact_total` draws in the compose acquire, and that
+the printing-mode `result_total` change was careful about ("substituting the true match count there would
+under-charge the scan"). It was violated one level up: the pair answer flows into `exact_cards` →
+`est_cards` → `eval_domain`/`scan_all`.
+
+## What it needs
+
+`compose_printing_estimate` should return **two** numbers: the best available *result* estimate (exact
+where the pair table answers) and a *candidate* bound (min over singles, which is what the alternatives
+actually walk). `result_total` takes the first; `eval_domain` and `scan_units` take the second. Then the
+disjoint cases price compose at 1.9 µs against alternatives charged for a real scan, and get the plan
+right instead of 24× wrong.
+
+Worth doing alongside: an exact total of **0 should short-circuit to an empty result** before routing at
+all. `border:white border:black t:creature` scans 6,402 printings over 79 µs to return nothing, because
+its acquire is `candidates` and never consults these tables — a filter containing two disjoint conjuncts
+is empty regardless of what else it says.
+
+## Status
+
+Built, archived and measured; wiring switched off at `CARD_ENGINE_PAIR_TOTALS` (default 0) pending the
+result-vs-candidate split above. The table's own numbers are all measured on the production corpus.

--- a/docs/issues/local-engine-proven-conjuncts.md
+++ b/docs/issues/local-engine-proven-conjuncts.md
@@ -101,11 +101,26 @@ to 0.74–1.34.
 
 ## What this did NOT fix
 
-- **`name:s border:black` is unchanged at ~1,160 µs.** `name:s` does not narrow at all (`eval_domain`
-  31,508 — the whole corpus), so there is no candidate set and nothing to prove. Its residual is genuinely
-  evaluated 60,705 times. A card-invariant conjunct under *no* narrowing wants the other half of this
-  idea: evaluate it once per card and reuse the verdict across the card's printings. `card_pass` already
-  computes exactly that verdict; the streamed/gather loops just have no candidate set to hang it on.
+- **`name:s border:black` is unchanged at ~1,160 µs**, and *not* for the reason first written here. This
+  doc previously claimed its residual is "genuinely evaluated 60,705 times" and that the loops need the
+  card verdict hung on a candidate set. Both are wrong: `card_pass` returns the card-level children as
+  settled and only the `PrintingDep` ones in `residual`, and `push_card_matches` verifies **only that
+  residual** per printing. The card/printing partition has always been there.
+
+  What the 1,160 µs actually is, measured against `name:s` alone (472 µs, 31,508 cards, zero printings
+  examined — 15.0 ns/card for the name residual):
+
+  | query | total | minus card part | per printing |
+  | --- | --: | --: | --: |
+  | `name:s usd>1` | 1,068 µs | 596 µs | 9.8 ns |
+  | `name:s cn>200` | 1,074 µs | 602 µs | 9.9 ns |
+  | `name:s border:black` | 1,158 µs | 686 µs | 11.3 ns |
+  | `name:s frame:2015` | 1,160 µs | 688 µs | 11.3 ns |
+
+  The leaf's own test is 0–1.5 ns of that; the other ~10 ns is the cost of *examining a printing at all*.
+  So the remaining cost is the per-printing WALK, not any redundant evaluation — and it is unavoidable for
+  a plan that verifies row by row, because a printing-varying conjunct means the exact total requires
+  testing every printing under every matching card.
 - **`name:s border:black` also still routes wrong** — GatheredScan at 1,170 µs measured against
   StreamedSelect's 975 (predicted 1,470, p/m 1.51).
 - The earlier diagnosis in


### PR DESCRIPTION
**Layer 12 of 13.** Base: #843. Reference: #830. **Archive bump: `2026080512`.**

Three related changes; the third is what makes the other two safe.

**`PairTotals`** — exact three-space totals for *pairs* of low-cardinality values. The `And` fold uses
`min`, an intersection upper bound, so the most selective leaf decides alone and every `f:X border:white`
estimated identically at 5,131 against true totals of 658–5,072. A stored pair is not a tighter bound for
two leaves, it is the exact answer; for three, min-over-pairs reads 2.02× against min-over-singles' 7.80×.

Pruned by **selectivity**, not frequency: a pair is only stored if *both* values clear
`STREAM_MIN_MATCHES`, because below that the sparse floor decides the plan anyway. That prunes 4.2×
(3,705 pairs → 879) and removes `layout` entirely — only `normal` clears the floor. 42.6 KB, +0.2 s build.

**The legality scan-scope fix** — `stream_scan_units`' divergent-share correction was gated on "does this
touch legality" when the question is "can `card_pass` settle this at card level". One printing-varying
partner makes it settle nothing, and the correction charged 2,755 against a realized 5,353–19,737.

**`ComposeEstimate` splits result from candidate**, and without it the other two regress 24×. An exact
total of 0 for `border:white border:black` collapsed `eval_domain`/`scan_units` for the *materializing*
alternatives, pricing `GatheredScan` at 0.2 µs against a measured 199.3 — a plan still has to scan to
*discover* a set is empty. A result total is not a scan domain.

With all three: `f:modern border:white` goes 149.0/99.5/134.1 µs (printing/card/artwork) to
76.4/102.1/83.2. Aggregate is neutral (0.997 whole mix over 12 interleaved rounds); what ships is two
cost features that are no longer wrong, and the removal of a 24× and a 1.6× regression that the accurate
estimates had exposed.

## Verification

`cargo test` (153) and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
