### PR TITLE
Engine: Range Breadth vs the Corpus, and Bitmap Materialization (stack 13/13)

### DIFF
--- a/card_engine/src/bench_candidate_materialize.rs
+++ b/card_engine/src/bench_candidate_materialize.rs
@@ -308,6 +308,9 @@ fn row(domain: usize, count: usize, runs_n: usize, label: &str) {
     );
 }
 
+/// The engine's printing-space domain, the one `range_narrowed` scatters into.
+const N_PRINTINGS_REF: usize = 97_206;
+
 fn header(axis: &str) {
     println!("\n{axis:<26}{:>8}{:>10}{:>10}{:>10}{:>9}{:>8}", "cands", "sort µs", "merge µs", "bitmap µs", "best", "spread");
 }
@@ -337,6 +340,15 @@ fn bench_candidate_materialize_contenders() {
     header("C. runs @ 4,096 cands");
     for k in [8, 64, 564, 2_048] {
         row(REAL_DOMAIN, 4_096, k, &format!("  {k} runs"));
+    }
+
+    // Axis 4: where the crossover actually sits in PRINTING space, which is the domain
+    // `range_narrowed` materializes into. Axis A is card space (31,508); printings are 97,206, and the
+    // bitmap pays `domain/64` words whatever `k` is -- 1,519 against 493 -- so the crossover has to move
+    // up. `MATERIALIZE_BITMAP_MIN` is set from THIS axis, not from axis A.
+    header("D. count @ printing domain");
+    for c in [16, 32, 64, 128, 256, 512, 1_024, 2_048] {
+        row(N_PRINTINGS_REF, c, REAL_RUNS, &format!("  {c} of {N_PRINTINGS_REF}"));
     }
 }
 

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3222,7 +3222,7 @@ fn sorted_ids(ids: impl Iterator<Item = u32>, k: usize, domain: usize) -> Vec<u3
              duplicate, which the bitmap collapses and the sort keeps",
             collected.len(),
         );
-        return if bitmap { by_bitmap } else { by_sort };
+        if bitmap { by_bitmap } else { by_sort }
     }
     #[cfg(not(debug_assertions))]
     if bitmap {
@@ -9245,9 +9245,10 @@ fn exec_from_candidates<'a>(
 /// fallback it replaces on the model's own terms. Both paths are correct for any query either is
 /// applicable to — `force_plan_differential_agreement` holds every plan to identical results — so
 /// this changes only which correct plan runs.
-// Eight: the declined plan, the three shared query artifacts, the two split-filter pieces a sibling
-// needs to re-derive its own applicability, and the router's `choose`. A wrapper struct would only be
-// unpacked again at the two call sites.
+// Eight parameters: the declined plan, the three shared query artifacts (`ctx`, `params`, `filter`),
+// the two split-filter pieces a sibling needs to re-derive its own applicability (`unsplit`, `plane`),
+// and the router's `choose`. Bundling them would mean a struct whose only purpose is this call, and
+// whose fields the two call sites would immediately destructure again.
 #[allow(clippy::too_many_arguments, reason = "shared query artifacts plus the router's choose; a wrapper struct would only be unpacked again")]
 fn declined_sibling_fastpath<'a>(
     declined: PhysicalPlan,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3166,7 +3166,22 @@ fn range_candidates(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32) -> Opt
 fn range_narrowed(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32, n_printings: usize, broad_ok: bool, exact: bool) -> Option<Narrowed> {
     let (s, e) = idx.range(lo, hi);
     let k = e - s;
-    if !range_too_broad_to_narrow(k, idx.len()) {
+    // Breadth against the WALK's domain, not the index's own length. A printing-value index omits
+    // null-valued printings, so `idx.len()` is the priced subset -- 54,896 of 97,206 for tix -- and
+    // measuring against it overstates breadth by exactly the null rate (1.77x for tix, 1.19x for
+    // usd/eur, 1.00x for the always-present date and collector-number indexes).
+    //
+    // The guard asks "is this set too big a fraction of what we would otherwise scan to be worth
+    // materializing", and what we would otherwise scan is the corpus. `tix>=0.03 tix<=0.03` is 16,664
+    // printings: 30.4% of the tix index and 17.1% of the corpus. Judged the first way it is broad, so it
+    // declines under `broad_ok: false` and narrows NOTHING -- which is why
+    // `eur>0.15 tix>=0.03 tix<=0.03` runs 39 us alone but 1,405 us with any plane-consumed partner, the
+    // plane having taken the only leaf that could have supplied a printing-space set.
+    //
+    // The collection and frame arms already use `n_printings` for the same guard; the range arms were
+    // the inconsistent ones.
+    let domain = if *RANGE_BREADTH_VS_CORPUS { n_printings } else { idx.len() };
+    if !range_too_broad_to_narrow(k, domain) {
         // Still a sort: the run order is the sort-key tiebreak, not pid, and `Candidates::Printings`
         // is contractually pid-ascending. Cheaper than before if anything — no stride over a tuple.
         let mut result: Vec<u32> = idx.range_pids(lo, hi).collect();
@@ -4130,13 +4145,26 @@ fn fuse_and_range_children<'f, 'i>(
     // touch at all is ±170 µs, so the two are indistinguishable. What the gate does buy is a bound —
     // outside the sparse population where the win IS demonstrated (up to 1.3 ms/query), narrowing is a
     // provable no-op. `k` survives for the survivors so the probe isn't recomputed downstream.
+    // Every printing has a card, so this CSR is corpus-length -- unlike the value indexes, which omit nulls.
+    let corpus_printings = indexes.printing_to_card.len();
     let mut fused: Vec<(&Group<'i>, usize)> = Vec::new();
     for g in &groups {
         if g.count < 2 {
             continue;
         }
         let (s, e) = g.idx.range(g.lo, g.hi);
-        if !sparse_only || !range_too_broad_to_narrow(e - s, g.idx.len()) {
+        // Same denominator argument as `range_narrowed`'s: the index omits null-valued printings, so
+        // `g.idx.len()` is the priced subset and judging breadth against it overstates it by the null
+        // rate. `tix>=0.03 tix<=0.03` fuses to 16,664 printings -- 30.4% of the tix index but 17.1% of
+        // the corpus -- so this gate refused to fuse it, the two halves stayed separate and individually
+        // broad, and BOTH declined under `broad_ok: false`. The result was a query that narrowed nothing:
+        // `eur>0.15 tix>=0.03 tix<=0.03 id:bgruw` at 1,405 us against 39 us for the same query without
+        // the plane-consumed partner.
+        //
+        // This gate, not `range_narrowed`'s, is the one that fires first -- changing only the latter
+        // moved nothing, because unfused halves never reach it as an interval.
+        let domain = if *RANGE_BREADTH_VS_CORPUS { corpus_printings } else { g.idx.len() };
+        if !sparse_only || !range_too_broad_to_narrow(e - s, domain) {
             fused.push((g, e - s));
         }
     }
@@ -5753,6 +5781,10 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// Whether a dense `frame_data` value is gated on being genuinely BROAD (1/4) rather than merely dense
 /// (1/32). 0 restores the conflated gate, for the A/B that priced the distinction.
 static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_DENSE_FRAME_BROAD_GATE", 1u8) != 0);
+
+/// Whether range breadth is judged against the corpus (`n_printings`) or the index's own length. The
+/// index omits nulls, so the latter overstates breadth by the null rate. 0 restores it, for the A/B.
+static RANGE_BREADTH_VS_CORPUS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_RANGE_BREADTH_VS_CORPUS", 1u8) != 0);
 
 /// Whether the PAIR table answers a two-leaf `And` exactly and tightens the `And` fold's bound. 0 falls
 /// both back to `min` over single leaves.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3163,6 +3163,43 @@ fn range_candidates(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32) -> Opt
 /// widened one position for f32/f64 rounding (see price_bounds) and therefore
 /// produce supersets that must never be marked tight — a Not would complement
 /// away the boundary printings, which are exactly the negation's matches.
+/// Where a bitmap scatter-then-extract becomes cheaper than `collect` + `sort_unstable` for producing
+/// an ascending id vector, as a DOMAIN:COUNT ratio rather than a count.
+///
+/// A count constant is only right at one domain: the bitmap pays `domain/64` words whatever the answer
+/// size is, so its fixed cost triples between card space (493 words) and printing space (1,519). The
+/// crossover collapses cleanly to a ratio instead -- `bench_candidate_materialize`'s fine sweep, 12%
+/// steps with 2 confirmations:
+///
+///        domain     words   crossover     ratio
+///        31,508       493          90     350:1
+///        97,206     1,519         194     501:1
+///       300,000     4,688         667     450:1
+///     1,000,000    15,625       2,064     484:1
+///     3,000,000    46,875       6,401     469:1
+///
+/// So `k * 490 > domain`, which puts printing space at k > 198. Same shape as
+/// `bitmap_beats_postings`'s `k * 32 > n`, but that one is a STORAGE crossover in bytes and this is a
+/// materialization-time one; the two are unrelated and their constants should not be conflated.
+///
+/// What it is worth where it matters: at 2,048 ids the bitmap is 3.6x, at 16,384 it is 5.8x, at 31,508
+/// 6.3x. A mid-band price range materializes 13,000-24,000.
+const MATERIALIZE_BITMAP_RATIO: usize = 490;
+
+/// An ascending id vector, by whichever route is cheaper at this size and domain. `ids` may arrive in
+/// any order -- `range_pids` yields key-major, which is the tiebreak order, not pid order.
+///
+/// Same output either way, so this is a pure cost choice. See `MATERIALIZE_BITMAP_RATIO`, and
+/// docs/issues/local-engine-candidate-materialize.md for the k-way merge that lost to both by 3-30x.
+fn sorted_ids(ids: impl Iterator<Item = u32>, k: usize, domain: usize) -> Vec<u32> {
+    if !*RANGE_MATERIALIZE_BITMAP || k.saturating_mul(MATERIALIZE_BITMAP_RATIO) <= domain {
+        let mut v: Vec<u32> = ids.collect();
+        v.sort_unstable();
+        return v;
+    }
+    bitmap_card_ids(&scatter_bits(ids, domain))
+}
+
 fn range_narrowed(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32, n_printings: usize, broad_ok: bool, exact: bool) -> Option<Narrowed> {
     let (s, e) = idx.range(lo, hi);
     let k = e - s;
@@ -3182,10 +3219,11 @@ fn range_narrowed(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32, n_printi
     // the inconsistent ones.
     let domain = if *RANGE_BREADTH_VS_CORPUS { n_printings } else { idx.len() };
     if !range_too_broad_to_narrow(k, domain) {
-        // Still a sort: the run order is the sort-key tiebreak, not pid, and `Candidates::Printings`
-        // is contractually pid-ascending. Cheaper than before if anything — no stride over a tuple.
-        let mut result: Vec<u32> = idx.range_pids(lo, hi).collect();
-        result.sort_unstable();
+        // The run order is the sort-key tiebreak, not pid, and `Candidates::Printings` is contractually
+        // pid-ascending -- so the ids have to be ordered somehow. `sorted_ids` picks the cheaper of the
+        // two ways: at this call site `k` reaches 20,000+ on a mid-band price range, where the sort cost
+        // 157 us of a 166 us query while the scatter costs ~25.
+        let result = sorted_ids(idx.range_pids(lo, hi), k, n_printings);
         return Some(Narrowed { set: Candidates::Printings(result), tight: exact, proven: 0 });
     }
     if !broad_ok {
@@ -5781,6 +5819,9 @@ static RESIDUAL_PASS_RATE_ARTWORK: LazyLock<f64> = LazyLock::new(|| guard_env("C
 /// Whether a dense `frame_data` value is gated on being genuinely BROAD (1/4) rather than merely dense
 /// (1/32). 0 restores the conflated gate, for the A/B that priced the distinction.
 static DENSE_FRAME_BROAD_GATE: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_DENSE_FRAME_BROAD_GATE", 1u8) != 0);
+
+/// Whether `sorted_ids` may take the bitmap route. 0 forces `collect` + `sort_unstable`, for the A/B.
+static RANGE_MATERIALIZE_BITMAP: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_RANGE_MATERIALIZE_BITMAP", 1u8) != 0);
 
 /// Whether range breadth is judged against the corpus (`n_printings`) or the index's own length. The
 /// index omits nulls, so the latter overstates breadth by the null rate. 0 restores it, for the A/B.

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1486,7 +1486,9 @@ fn negate_op(op: CmpOp) -> CmpOp {
 /// for the printing-space indexes): candidates are bounded by the ~3× smaller
 /// card count, so even a slice covering the whole index measures at worst
 /// break-even against the per-printing scan it would replace.
-fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Option<Vec<u32>> {
+/// `n_cards` is the id DOMAIN, which is not `idx.len()`: the numeric indexes are nullable (a card with
+/// no power has no entry), so ids run past the index's length and a bitmap sized from it would panic.
+fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64, n_cards: usize) -> Option<Vec<u32>> {
     let (start, end) = match op {
         CmpOp::Ne => return None,
         CmpOp::Eq => {
@@ -1500,9 +1502,9 @@ fn numeric_candidates(idx: &Archived<NumericIndex>, op: CmpOp, val: f64) -> Opti
         CmpOp::Gt => (idx.partition_point(|p| (i16::from(p.0) as f64) <= val), idx.len()),
         CmpOp::Ge => (idx.partition_point(|p| (i16::from(p.0) as f64) < val), idx.len()),
     };
-    let mut result: Vec<u32> = idx[start..end].iter().map(|p| u32::from(p.1)).collect();
-    result.sort_unstable();
-    Some(result)
+    // Card space, so the domain is `n_cards` -- `MATERIALIZE_BITMAP_RATIO` reads the domain rather than
+    // assuming printing space, which is the whole reason it is a ratio.
+    Some(sorted_ids(idx[start..end].iter().map(|p| u32::from(p.1)), end - start, n_cards))
 }
 
 // ─── Arith-expression tuple postings (#743) ──────────────────────────────────
@@ -1645,10 +1647,10 @@ fn arith_tuple_narrow(filter: &FilterExpr, idx: &Archived<ArithTupleIndex>, n_ca
     if count > *BITS_PROMOTE {
         return Narrowed::tight(Candidates::CardBits(scatter_bits(post_ids(), n_cards)));
     }
-    let mut result: Vec<u32> = Vec::with_capacity(count);
-    result.extend(post_ids());
-    result.sort_unstable();
-    Narrowed::tight(Candidates::Cards(result))
+    // The case that prompted docs/issues/local-engine-candidate-materialize.md: up to 564 posting rows
+    // concatenated, each sorted, the whole never so. Only reachable below `BITS_PROMOTE`, since the arm
+    // above already hands back a bitmap past it.
+    Narrowed::tight(Candidates::Cards(sorted_ids(post_ids(), count, n_cards)))
 }
 
 // ─── Tag index ───────────────────────────────────────────────────────────────
@@ -3189,15 +3191,47 @@ const MATERIALIZE_BITMAP_RATIO: usize = 490;
 /// An ascending id vector, by whichever route is cheaper at this size and domain. `ids` may arrive in
 /// any order -- `range_pids` yields key-major, which is the tiebreak order, not pid order.
 ///
-/// Same output either way, so this is a pure cost choice. See `MATERIALIZE_BITMAP_RATIO`, and
-/// docs/issues/local-engine-candidate-materialize.md for the k-way merge that lost to both by 3-30x.
+/// **Precondition: `ids` must be duplicate-free.** This is the one way the two routes differ, and it is
+/// silent: a bitmap DEDUPS and a sort does not, so a caller emitting an id twice gets a shorter vec from
+/// one route than the other. Every current caller satisfies it by construction -- a `PrintingValueIndex`
+/// holds one entry per printing with a value, `build_numeric_index` one per card, and a card lives in
+/// exactly one `arith_tuple` posting row -- and the debug build checks it on every call rather than
+/// trusting that list to stay true.
+///
+/// Ids must also be `< domain`; `scatter_bits` would panic otherwise, which is the loud failure.
+///
+/// Same output either way given that, so this is a pure cost choice with no consumer effect. See
+/// `MATERIALIZE_BITMAP_RATIO`, and docs/issues/local-engine-candidate-materialize.md for the k-way merge
+/// that lost to both by 3-30x.
 fn sorted_ids(ids: impl Iterator<Item = u32>, k: usize, domain: usize) -> Vec<u32> {
-    if !*RANGE_MATERIALIZE_BITMAP || k.saturating_mul(MATERIALIZE_BITMAP_RATIO) <= domain {
+    let bitmap = *RANGE_MATERIALIZE_BITMAP && k.saturating_mul(MATERIALIZE_BITMAP_RATIO) > domain;
+    // Debug builds run BOTH and compare, so every call site the fuzz suite reaches is a live check of
+    // the precondition above -- not a claim in a doc comment that drifts. Release picks one.
+    #[cfg(debug_assertions)]
+    {
+        let collected: Vec<u32> = ids.collect();
+        let by_sort = {
+            let mut v = collected.clone();
+            v.sort_unstable();
+            v
+        };
+        let by_bitmap = bitmap_card_ids(&scatter_bits(collected.iter().copied(), domain));
+        debug_assert_eq!(
+            by_sort, by_bitmap,
+            "sorted_ids routes disagree over {} ids in a domain of {domain} -- the caller emitted a \
+             duplicate, which the bitmap collapses and the sort keeps",
+            collected.len(),
+        );
+        return if bitmap { by_bitmap } else { by_sort };
+    }
+    #[cfg(not(debug_assertions))]
+    if bitmap {
+        bitmap_card_ids(&scatter_bits(ids, domain))
+    } else {
         let mut v: Vec<u32> = ids.collect();
         v.sort_unstable();
-        return v;
+        v
     }
-    bitmap_card_ids(&scatter_bits(ids, domain))
 }
 
 fn range_narrowed(idx: &Archived<PrintingValueIndex>, lo: u32, hi: u32, n_printings: usize, broad_ok: bool, exact: bool) -> Option<Narrowed> {
@@ -4479,7 +4513,7 @@ fn narrow_rec(
             // loose in the sense that matters for Not: a posted card can have
             // other printings that do NOT satisfy the comparison, so the
             // complement would wrongly exclude cards `-rarity:x` matches.
-            let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
+            let numeric = |idx, op, v: &f64| numeric_candidates(idx, op, *v, n_cards).and_then(|c| Narrowed::tight(Candidates::Cards(c)));
             let rarity = |op, v: &f64| narrow_rarity(indexes, n_cards, op, *v);
             // Same shape as `cn` below now that price is integer cents, not lossy f32 dollars --
             // the only price-specific step is snapping the *PRICE_CENTS_PER_DOLLAR conversion

--- a/docs/issues/local-engine-candidate-materialize.md
+++ b/docs/issues/local-engine-candidate-materialize.md
@@ -1,5 +1,9 @@
 # Materializing a sorted candidate list: bitmap beats sort, merge loses badly
 
+**Shipped for `range_narrowed` (the range arms).** See "What shipped" at the bottom; the crossover turned
+out to be a domain:count RATIO, not a count, and the remaining call sites (`arith_tuple_narrow` and the
+other posting-union arms) have not adopted it yet.
+
 Any narrowing arm that unions several postings rows has sorted rows and no globally
 sorted output, because posting-row order is not card order. `arith_tuple_narrow` is
 the case that prompted this — it concatenates the selected rows and calls
@@ -65,7 +69,54 @@ Break-even sits near 600:1. The card corpus is 7.7:1 for a 4,096-card result and
 range for anything but a handful of matches. Printing space (97,206) does not change
 that conclusion.
 
-## What to change
+## The crossover is a ratio, not a count
+
+The original recommendation below said "keep concat+sort below ~64 candidates", from axis A — which is
+measured at the CARD domain (31,508, 493 words). `range_narrowed` materializes into PRINTING space
+(97,206, 1,519 words), where the bitmap's fixed cost triples and the crossover moves to ~194. A count
+constant is only ever right at one domain.
+
+Axis G's fine sweep (12% steps, 2 confirmations) shows it collapses to a ratio:
+
+| domain | words | measured crossover | ratio |
+| --: | --: | --: | --: |
+| 31,508 (cards) | 493 | 90 | 350:1 |
+| 97,206 (printings) | 1,519 | **194** | **501:1** |
+| 300,000 | 4,688 | 667 | 450:1 |
+| 1,000,000 | 15,625 | 2,064 | 484:1 |
+| 3,000,000 | 46,875 | 6,401 | 469:1 |
+
+So `k * 490 > domain`, which is `MATERIALIZE_BITMAP_RATIO`. Same shape as `bitmap_beats_postings`'s
+`k * 32 > n` — but that is a STORAGE crossover in bytes and this is a materialization-time one, so the
+two constants are unrelated and should not be conflated.
+
+## What shipped
+
+`sorted_ids(ids, k, domain)` picks the route by the ratio above, and `range_narrowed` calls it instead of
+`collect` + `sort_unstable`. Byte-identical output, so it is a pure cost choice with no consumer effect.
+
+Per query, on the production corpus — `prep` is `ns_prepare`, which is where the sort lived:
+
+| query | prep before | prep after | total before | total after |
+| --- | --: | --: | --: | --: |
+| `usd<0.18 t:land` | 134.0 µs | **54.5** | 140.3 µs | **60.8** |
+| `usd<0.20 t:land` | 160.3 | **67.4** | 167.8 | **74.5** |
+| `usd<0.20 t:creature` | 171.8 | **80.2** | 287.5 | **195.3** |
+| `usd<0.20 c:g` | 162.6 | **70.7** | 203.3 | **111.8** |
+| `eur<0.13 t:land` | 153.5 | **63.6** | 161.8 | **71.5** |
+
+Interleaved A/B, 10 rounds, 1,362 queries, drift 0.978/1.010: range TARGET **0.867**, control 0.989, whole
+mix **0.949**, p90 0.902. No regression above 1.07 and all of those are sub-20 µs queries.
+
+This also retired the one regression from
+[the breadth-denominator change](./local-engine-range-breadth-denominator.md): `eur<0.13 t:land` went
+208 µs before that change, 267 after it, and **71.5 µs** now.
+
+Note `usd<0.18 t:land` was never affected by the denominator at all — it was already narrowing, and
+already paying 134 µs to sort 13,328 ids. The sort cost was pre-existing across the whole mid band; the
+denominator change only made more queries visit it.
+
+## What to change (original, for the remaining call sites)
 
 The sorted-vec path only runs below `BITS_PROMOTE` (4,096) — above it the engine
 already hands back `CardBits`. So the band this affects is roughly 64 to 4,096

--- a/docs/issues/local-engine-candidate-materialize.md
+++ b/docs/issues/local-engine-candidate-materialize.md
@@ -116,6 +116,38 @@ Note `usd<0.18 t:land` was never affected by the denominator at all — it was a
 already paying 134 µs to sort 13,328 ids. The sort cost was pre-existing across the whole mid band; the
 denominator change only made more queries visit it.
 
+## The remaining call sites: adopted, and measurably neutral
+
+`numeric_candidates` and `arith_tuple_narrow` now call `sorted_ids` too. Both are **within noise on every
+query sampled**, and the reason is worth recording so nobody re-measures it hoping for the range result:
+
+- **`numeric_candidates` is mostly shadowed.** `cmc`/`power`/`toughness` are `BitPlanes`, so `split_planes`
+  consumes them and this function is never reached for the queries that would have large `k`.
+- **`arith_tuple_narrow` is already capped.** Its vec path only runs below `BITS_PROMOTE` (4,096) —
+  past that the arm above already hands back `CardBits`. So the affected band is 65–4,096 ids in card
+  space, worth 0.3 µs at the bottom and 16 µs at the top.
+
+`range_narrowed` was the outlier because its vec path has **no such cap**: a mid-band price range
+materializes up to 24,301 ids through the sort, which is where the 2.4× came from.
+
+Keeping the adoption anyway: it is equivalence-checked (below), it costs nothing, and it removes the trap
+if `BITS_PROMOTE` ever moves — which is this doc's own open question.
+
+## Demonstrating the change respects the API
+
+The two routes differ in exactly one way, and it is silent: **a bitmap dedups, a sort does not.** A caller
+emitting an id twice gets a shorter vec from one route than the other, with no error.
+
+Every current caller is duplicate-free by construction — a `PrintingValueIndex` holds one entry per
+printing with a value, `build_numeric_index` one per card, and a card lives in exactly one `arith_tuple`
+posting row — but that is a list that can go stale. So the debug build **runs both routes on every call
+and compares them**, making the precondition a live check at every call site the test suite reaches
+rather than a claim in a doc comment.
+
+Verified live rather than assumed: sabotaging the bitmap route (dropping one id) fails **12 tests**
+across the suite, including the fuzz row-identity differentials. Release builds pick one route and pay
+nothing.
+
 ## What to change (original, for the remaining call sites)
 
 The sorted-vec path only runs below `BITS_PROMOTE` (4,096) — above it the engine

--- a/docs/issues/local-engine-range-breadth-denominator.md
+++ b/docs/issues/local-engine-range-breadth-denominator.md
@@ -1,0 +1,92 @@
+# Range breadth was measured against the index's own length, so nullable columns looked broader
+
+`eur>0.15 tix>=0.03 tix<=0.03 id:bgruw` took **1.5 ms**. The same query without the last leaf takes
+**39 µs**. Adding `id:bgruw` — which matches *every* card, since identity ⊆ {W,U,B,R,G} is universally
+true — took the query from a `PrintingCompose` to a whole-corpus scan with `narrowed_repr: none`: the
+price ranges contributed nothing at all.
+
+## The denominator
+
+A `PrintingValueIndex` omits null-valued printings — they can never satisfy a comparison. So `idx.len()`
+is the *priced subset*, and judging breadth against it overstates breadth by exactly the null rate:
+
+| index | present | % of corpus | breadth inflation |
+| --- | --: | --: | --: |
+| `released_at` | 97,206 | 100.0% | 1.00× |
+| `collector_number` | 97,206 | 100.0% | 1.00× |
+| `price_usd` | 81,542 | 83.9% | 1.19× |
+| `price_eur` | 81,523 | 83.9% | 1.19× |
+| `price_tix` | **54,896** | **56.5%** | **1.77×** |
+
+`tix>=0.03 tix<=0.03` is 16,664 printings — 30.4% of the tix index, 17.1% of the corpus. Judged the first
+way it is broad; judged the second it is clearly worth narrowing. The guard asks "is this too big a
+fraction of what we would otherwise scan", and what we would otherwise scan is the corpus.
+
+The same guard already used `n_printings` in the collection and frame arms. The range arms were the
+inconsistent ones.
+
+## Which gate actually fired
+
+`range_narrowed` has the visible copy of the test, and changing **only** it moved nothing. The gate that
+fires first is in `fuse_and_range_children`:
+
+```rust
+if !sparse_only || !range_too_broad_to_narrow(e - s, g.idx.len()) {
+```
+
+Under `sparse_only`, fusion exists to discover a sparse intersection hiding behind broad halves. Judged
+against the index, the tix interval was not sparse, so **the two halves were never fused** — and each
+half alone (`tix>=0.03`, `tix<=0.03`) is genuinely broad, so both declined under `broad_ok: false` and
+nothing narrowed. The unfused halves never reach `range_narrowed` as an interval at all.
+
+Both call sites now take the corpus, behind `CARD_ENGINE_RANGE_BREADTH_VS_CORPUS`.
+
+## Measured
+
+Per query:
+
+| query | before | after | |
+| --- | --: | --: | --: |
+| `eur>0.15 tix>=0.03 tix<=0.03 id:bgruw` | 1,415.8 µs | **333.8 µs** | 4.2× |
+| `tix>=0.03 tix<=0.03 t:creature` | 612.7 µs | **337.7 µs** | 1.8× |
+| `tix>=0.03 tix<=0.03 c:g` | 246.1 µs | **206.2 µs** | 1.2× |
+
+`narrowed_repr` goes `none` → `printings` and `eval_domain` 31,508 → 4,701, with `matches` landing at
+4,701 against a true 4,621 (1.017×). Already-sparse ranges (`tix=0.02`, `tix=0.04`, `usd>100`) and
+genuinely broad ones (`eur>0.15` at 57%, `cn>200` at 38%) are untouched, as are the always-present
+`date`/`cn` indexes where the two denominators are identical by construction.
+
+Interleaved A/B, 10 rounds, 1,368 queries, drift 0.996:
+
+| subset | n | index-denominator | corpus-denominator | ratio |
+| --- | --: | --: | --: | --: |
+| nullable-range TARGET | 159 | 61.8 ms | 45.0 ms | **0.729** |
+| everything else CONTROL | 1,209 | 124.5 ms | 123.6 ms | 0.993 |
+| whole mix | 1,368 | 186.3 ms | 168.6 ms | **0.905** |
+
+**p99 0.680** (1,056.9 → 718.5 µs); p50 0.989, p90 1.004.
+
+## The one real regression, and what it points at
+
+`eur<0.13 t:land` went 208.0 → 267.5 µs (1.29×). `eur<0.13` is 20,408 printings: **25.0% of the eur
+index** — right at the old cutoff — and 21.0% of the corpus, so it is newly admitted. It then takes
+`range_narrowed`'s **vec** path: `collect` + `sort_unstable` over 20,408 `u32`s, because `range_pids`
+yields key-major order and `Candidates::Printings` is contractually pid-ascending. That sort costs more
+than narrowing a plane which was already only 11,552 cards.
+
+The other apparent regressions are noise: `name:s` spreads 2.52× inside one arm and its other two configs
+read 1.01 and 0.99; `tix>=0.02 tix<=0.03` and `tix>=0.03 tix<=0.04` read 0.93–1.01 in their other configs.
+
+**The threshold is deciding two different questions with one number** — *is this worth narrowing at all*
+and *vec or bitmap*. Widening the first pushed 16–20k-element sets onto a representation meant for small
+sparse ones. On the headline query, `ns_prepare` is 124 µs of the remaining 334 µs, essentially all of it
+that sort; scattering the same 16,664 into 1,519 words would be ~20–30 µs.
+
+Splitting them — bitmap above some absolute size, vec below — is the follow-up, worth ~90 µs on the
+headline query and it should retire the `eur<0.13` class entirely. Same shape as the `dense` vs `broad`
+conflation in [the frame gate](./local-engine-is-frame-predicates.md).
+
+## Status
+
+Shipped on by default. Every figure measured on the production corpus; per-query numbers are a minimum of
+11 trials after warmup, the A/B is 10 interleaved rounds with a control subset.


### PR DESCRIPTION
**Layer 13 of 13 — the top.** Base: #844. Reference: #830. No archive change.

Two changes to how a range predicate becomes a candidate set, found by re-running the uniform sampler
after the earlier layers landed. Two-sided ranges were 17.1% of dispatch at a mean of 64.9 µs, and the
single slowest query in the whole 49,919-query sample was one.

**1. Judge breadth against the corpus, not the index.** A `PrintingValueIndex` omits null-valued
printings, so `idx.len()` is the priced subset and measuring breadth against it overstates it by the null
rate — 1.77× for tix, 1.19× for usd/eur, 1.00× for the always-present date and collector-number indexes.
`tix>=0.03 tix<=0.03` is 30.4% of the tix index and 17.1% of the corpus; judged the first way it declined
to narrow at all. The collection and frame arms already used the corpus for the same guard.

The gate that fires is *not* the visible one in `range_narrowed` — changing only that moved nothing. It
is `fuse_and_range_children`'s `sparse_only` gate: the two halves were never fused, and each half alone
is genuinely broad, so both declined. Whole mix **0.905**, p99 **0.680**.

**2. Materialize by bitmap scatter, not by sorting.** `range_pids` yields key-major order and
`Candidates::Printings` is contractually pid-ascending, so the vec path sorted — 134–186 µs on a mid-band
price range, which for `usd<0.18 t:land` was 95% of the query. `bench_candidate_materialize` had already
measured the alternative and recommended it; this adopts it, with one correction: **the crossover is a
domain:count ratio (~490:1), not a count.** The doc's "below ~64 candidates" came from the card-space
axis, and printing space is 3× the domain. Whole mix **0.949**, target 0.867.

The two interact: (1) admitted more ranges into a representation meant for small sparse sets, and (2)
retired the one regression that caused — `eur<0.13 t:land` was 208 µs before (1), 267 after it, and 71.5
after (2).

## API equivalence, checked rather than asserted

The two materialization routes differ in one silent way: a bitmap dedups, a sort does not. Every caller
is duplicate-free by construction, but that list can go stale, so **debug builds run both routes on every
call and compare**. Verified live rather than assumed: sabotaging the bitmap route fails 12 tests,
including the fuzz row-identity differentials. Release picks one and pays nothing.

## This layer completes the stack

`stack/13-range-materialize` is tree-identical to #830's reference commit.

## Verification

`cargo test` (153) and `cargo clippy --all-targets -- -D warnings` green on both manifests; ruff clean.
