### PR TITLE
Docs: Reconcile the Issue Tracker After the Cost-Model Stack, and File What Measuring It Surfaced

### DIFF
--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -26,7 +26,7 @@ WITH computed_components AS (
             -- perfectly real, and dropping them would penalise exactly the core-set reprints
             -- this component should reward.
             --
-            -- Evidence (docs/issues/00720-prefer-score-artwork-tuning.md): a 47-card blind
+            -- Evidence (docs/issues/done/00720-prefer-score-artwork-tuning.md): a 47-card blind
             -- swap review returned 11 better, 36 same, 0 worse, and a later 378-card review
             -- against production added 2 more with no regressions. This changes only the
             -- numerator -- it does not stop such printings being displayed.
@@ -138,7 +138,7 @@ WITH computed_components AS (
             -- line-art, and is demoted, because a line-art rendering is a departure from the
             -- painted core style whoever owns the IP. Confirmed against the artwork.
             --
-            -- Evidence (docs/issues/00720-prefer-score-artwork-tuning.md): in 177 labelled
+            -- Evidence (docs/issues/done/00720-prefer-score-artwork-tuning.md): in 177 labelled
             -- artwork comparisons where exactly one side was off-style, the on-style side
             -- was chosen 177 times. Blind swap review across weights 6, 9 and 14 gave 78
             -- "better" and 0 "worse" over 114 changed cards. Fixes both cards that opened

--- a/card_engine/src/bench_membership_bittest.rs
+++ b/card_engine/src/bench_membership_bittest.rs
@@ -1,0 +1,183 @@
+//! What an O(1) printing-membership bit test actually costs, for
+//! docs/issues/00856-engine-compose-membership-bittest.md.
+//!
+//! #856 replaces a per-printing residual evaluation with `bitmap_contains(pbits, pid)`. The residual
+//! side is measured end to end at 5.8 ns/printing (`scripts/bench_membership_waste.py`); the bit-test
+//! side was an ASSUMPTION of ~1 ns, and the whole 3.5x estimate rests on it, because the saving is
+//! `residual_ns - bit_test_ns`. This measures it.
+//!
+//! Reproduces the real access pattern rather than a flat scan, because the pattern is what decides the
+//! answer. `push_card_matches` / `card_match_count` walk CANDIDATE CARDS and bit-test each one's
+//! contiguous printing span (`offsets[cid]..offsets[cid+1]`), so the bitmap is read in ascending runs
+//! with gaps where non-candidate cards are skipped. Two axes matter and both are swept:
+//!
+//! - **candidate density** — what fraction of cards are candidates. Dense reads the bitmap
+//!   sequentially; sparse strides it, touching more cache lines per useful test.
+//! - **bitmap density** — what fraction of bits are set. This is a BRANCH-PREDICTION axis, not a
+//!   memory one: at ~50% the `if` is unpredictable and a mispredict costs far more than the load.
+//!   A number measured only at 0% or 100% density would be optimistic by exactly that amount.
+//!
+//! Corpus scale is swept 1x and 5x because the bitmap is 12 KB at production scale (97,206 printings,
+//! 1,519 words) — comfortably L1-resident — and that stops being true as the corpus grows. A result
+//! that only holds while the whole bitmap fits in L1 needs to say so.
+//!
+//! `walk_only` is the floor: identical loops, no bitmap access, so the difference isolates the test
+//! from loop overhead. The inclusive `bit_test` column is the honest figure to compare against 5.8 ns,
+//! since the residual figure also includes its loop.
+//!
+//!     cargo test --release bench_membership_bittest -- --ignored --nocapture
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use rand::RngExt;
+use rand::SeedableRng as _;
+
+use crate::planes::bitmap_contains;
+
+/// Production corpus, from `benchmarks/bitplanes/corpus.jsonl`.
+const N_CARDS_1X: usize = 31_508;
+const N_PRINTINGS_1X: usize = 97_206;
+/// Rounds per cell; min-of-N, matching every other bench here.
+const ITERS: usize = 200;
+/// Reciprocal of the candidate share. 1 = every card (sequential); 135 is the MEASURED production
+/// value (234 candidate cards of 31,508 per query, realistic mode), which is the row to read.
+const CANDIDATE_STRIDES: [usize; 6] = [1, 2, 4, 8, 32, 135];
+/// Fraction of bits set, in percent. 9 is the MEASURED production density (matches/examined on the
+/// #856 population, `scripts/bench_membership_waste.py`); 50 is the branch-prediction worst case.
+const BITMAP_DENSITIES: [u32; 6] = [1, 9, 10, 50, 90, 99];
+
+/// Card printing-span boundaries, `n_cards + 1` long, mirroring the store's `offsets`.
+fn build_offsets(n_cards: usize, n_printings: usize) -> Vec<u32> {
+    let mut offsets = Vec::with_capacity(n_cards + 1);
+    // Spread printings across cards as evenly as the real ratio allows (~3.09/card). Exact per-card
+    // counts do not matter here; span CONTIGUITY does, and that is structural.
+    for i in 0..=n_cards {
+        offsets.push((i * n_printings / n_cards) as u32);
+    }
+    offsets
+}
+
+fn build_bitmap(rng: &mut rand::rngs::SmallRng, n_printings: usize, density_pct: u32) -> Vec<u64> {
+    let mut bits = vec![0u64; n_printings.div_ceil(64)];
+    for pid in 0..n_printings {
+        if rng.random::<u64>() % 100 < u64::from(density_pct) {
+            bits[pid >> 6] |= 1u64 << (pid & 63);
+        }
+    }
+    bits
+}
+
+/// Counting form: `if contains { hits += 1 }`.
+///
+/// **Do not read this as the answer.** The compiler predicates it into `hits += contains as u32` and
+/// vectorizes, so it is branch-free and completely insensitive to bitmap density — which is how the
+/// first version of this bench produced a flat 0.4 ns at every density and would have been believed.
+/// Kept as the lower bound a *predicable* body could reach, and as the control that proves the branchy
+/// number below is really measuring a branch.
+fn bit_test_counting(bits: &[u64], offsets: &[u32], stride: usize) -> u32 {
+    let mut hits = 0u32;
+    let mut cid = 0;
+    while cid + 1 < offsets.len() {
+        let (start, end) = (offsets[cid] as usize, offsets[cid + 1] as usize);
+        for pid in start..end {
+            if bitmap_contains(bits, pid as u32) {
+                hits += 1;
+            }
+        }
+        cid += stride;
+    }
+    hits
+}
+
+/// The form the real loop takes: on a hit, append a row. `push_card_matches` does
+/// `scratch.push((sort_key_bits(...), cid, pid))`, which is a conditional store the compiler cannot
+/// predicate away — so this pays the branch, and the mispredict at ~50% density is a real cost the
+/// counting form hides. `out` is pre-allocated and reused, so no allocation is timed.
+fn bit_test_branchy(bits: &[u64], offsets: &[u32], stride: usize, out: &mut Vec<u32>) -> u32 {
+    out.clear();
+    let mut cid = 0;
+    while cid + 1 < offsets.len() {
+        let (start, end) = (offsets[cid] as usize, offsets[cid + 1] as usize);
+        for pid in start..end {
+            if bitmap_contains(bits, pid as u32) {
+                out.push(pid as u32);
+            }
+        }
+        cid += stride;
+    }
+    out.len() as u32
+}
+
+/// The same traversal with no bitmap access — loop overhead alone, so the difference is the test.
+fn walk_only(offsets: &[u32], stride: usize) -> u32 {
+    let mut acc = 0u32;
+    let mut cid = 0;
+    while cid + 1 < offsets.len() {
+        let (start, end) = (offsets[cid] as usize, offsets[cid + 1] as usize);
+        for pid in start..end {
+            acc = acc.wrapping_add(pid as u32);
+        }
+        cid += stride;
+    }
+    acc
+}
+
+fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
+    let mut best = u128::MAX;
+    let mut out = 0;
+    for _ in 0..ITERS {
+        let t0 = Instant::now();
+        out = black_box(kernel());
+        best = best.min(t0.elapsed().as_nanos());
+    }
+    black_box(out);
+    best as f64
+}
+
+/// Printings actually visited at this stride — the denominator for a per-printing rate.
+fn visited(offsets: &[u32], stride: usize) -> usize {
+    let mut n = 0;
+    let mut cid = 0;
+    while cid + 1 < offsets.len() {
+        n += (offsets[cid + 1] - offsets[cid]) as usize;
+        cid += stride;
+    }
+    n
+}
+
+#[test]
+#[ignore = "micro-benchmark; synthetic data, no external deps"]
+fn bench_membership_bittest_cost() {
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(8_560_001);
+
+    for scale in [1usize, 5] {
+        let (n_cards, n_printings) = (N_CARDS_1X * scale, N_PRINTINGS_1X * scale);
+        let offsets = build_offsets(n_cards, n_printings);
+        let kb = n_printings.div_ceil(64) * 8 / 1024;
+        println!("\n=== corpus {scale}x — {n_printings} printings, bitmap {kb} KB ===");
+        println!(
+            "{:>7}  {:>10}  {:>8}  {:>9}  {:>9}  {:>7}",
+            "stride", "visited", "density", "BRANCHY", "counting", "walk"
+        );
+
+        let mut out: Vec<u32> = Vec::with_capacity(n_printings);
+        for stride in CANDIDATE_STRIDES {
+            let n = visited(&offsets, stride);
+            let t_walk = time_ns(|| walk_only(&offsets, stride)) / n as f64;
+            for density in BITMAP_DENSITIES {
+                let bits = build_bitmap(&mut rng, n_printings, density);
+                let t_branchy = time_ns(|| bit_test_branchy(&bits, &offsets, stride, &mut out)) / n as f64;
+                let t_count = time_ns(|| bit_test_counting(&bits, &offsets, stride)) / n as f64;
+                println!(
+                    "{:>7}  {:>10}  {:>7}%  {:>9.2}  {:>9.2}  {:>7.2}",
+                    stride, n, density, t_branchy, t_count, t_walk
+                );
+            }
+        }
+    }
+    println!("\nns per printing tested, min of {ITERS} rounds.");
+    println!("BRANCHY is the answer: it conditionally appends, as `push_card_matches` does, so it pays the");
+    println!("branch. `counting` is predicated by the compiler and density-flat — the trap, not the result.");
+    println!("Compare BRANCHY against the 5.8 ns/printing residual evaluation it would replace.");
+}

--- a/card_engine/src/bench_membership_bittest.rs
+++ b/card_engine/src/bench_membership_bittest.rs
@@ -1,29 +1,43 @@
-//! What an O(1) printing-membership bit test actually costs, for
+//! What per-printing membership costs the two ways it could be done, for
 //! docs/issues/00856-engine-compose-membership-bittest.md.
 //!
-//! #856 replaces a per-printing residual evaluation with `bitmap_contains(pbits, pid)`. The residual
-//! side is measured end to end at 5.8 ns/printing (`scripts/bench_membership_waste.py`); the bit-test
-//! side was an ASSUMPTION of ~1 ns, and the whole 3.5x estimate rests on it, because the saving is
-//! `residual_ns - bit_test_ns`. This measures it.
+//! #856 replaces a per-printing residual evaluation (measured at 5.9 ns/printing by
+//! `scripts/bench_membership_waste.py`) with an O(1) membership check. That check was an ASSUMPTION of
+//! ~1 ns and the whole estimate rests on it, because the saving is `residual_ns - check_ns`. This
+//! measures it, and measures the alternative that needs no bitmap at all.
 //!
-//! Reproduces the real access pattern rather than a flat scan, because the pattern is what decides the
-//! answer. `push_card_matches` / `card_match_count` walk CANDIDATE CARDS and bit-test each one's
-//! contiguous printing span (`offsets[cid]..offsets[cid+1]`), so the bitmap is read in ascending runs
-//! with gaps where non-candidate cards are skipped. Two axes matter and both are swept:
+//! ## The model comes from the measurement, not from round numbers
 //!
-//! - **candidate density** — what fraction of cards are candidates. Dense reads the bitmap
-//!   sequentially; sparse strides it, touching more cache lines per useful test.
-//! - **bitmap density** — what fraction of bits are set. This is a BRANCH-PREDICTION axis, not a
-//!   memory one: at ~50% the `if` is unpredictable and a mispredict costs far more than the load.
-//!   A number measured only at 0% or 100% density would be optimistic by exactly that amount.
+//! `scripts/bench_membership_waste.py --mode realistic` reports, per query on the population #856
+//! touches: **234 candidate cards, 3,183 printings in their spans (13.6 per card — these are
+//! heavily-reprinted cards, as `set:` queries produce), 366 of them matching (11.5%, so 1.56 per card).**
 //!
-//! Corpus scale is swept 1x and 5x because the bitmap is 12 KB at production scale (97,206 printings,
-//! 1,519 words) — comfortably L1-resident — and that stops being true as the corpus grows. A result
-//! that only holds while the whole bitmap fits in L1 needs to say so.
+//! Two structural facts follow, and an earlier version of this bench got both wrong:
 //!
-//! `walk_only` is the floor: identical loops, no bitmap access, so the difference isolates the test
-//! from loop overhead. The inclusive `bit_test` column is the honest figure to compare against 5.8 ns,
-//! since the residual figure also includes its loop.
+//! 1. **Visited cards are exactly the cards holding a candidate printing**, because `card_ids` is
+//!    derived FROM the candidate printing list via `cards_of_printings`. So every visited card has at
+//!    least one match, and the candidate list contains no pid outside a visited span. A model that
+//!    strides over all cards makes the merge below pay to skip pids that cannot exist.
+//! 2. **Visited cards hold 13.6 printings, not the corpus-average 3.09.** Using the average understates
+//!    the span work per card by 4x.
+//!
+//! ## The two candidates
+//!
+//! - `bit_test` — scatter the candidate list into a printing bitmap, then `bitmap_contains` per printing
+//!   in each span. O(span). Works for any visit order.
+//! - `merge` — two-pointer over the sorted candidate list the narrowing ALREADY produced
+//!   (`Candidates::Printings`, still live as `raw_candidates` before it is flattened to card ids). No
+//!   bitmap, no allocation, no scatter pass, and O(matches) rather than O(span).
+//!
+//! `merge` is sound only because the gather loop visits pids in globally ascending order —
+//! `cards_of_printings` yields ascending cids and each card's span is contiguous. **`StreamedSelect`
+//! walks a permutation in SORT order, so a forward pointer would be wrong there and the bitmap is the
+//! only option.** Every query measured on this population picked `GatheredScan`.
+//!
+//! `walk_only` is the floor: the same traversal touching neither structure.
+//!
+//! Corpus scale is swept because the bitmap is 12 KB at production scale (97,206 printings, 1,519
+//! words) — L1-resident — and that stops being true as the corpus grows.
 //!
 //!     cargo test --release bench_membership_bittest -- --ignored --nocapture
 
@@ -36,89 +50,97 @@ use rand::SeedableRng as _;
 use crate::planes::bitmap_contains;
 
 /// Production corpus, from `benchmarks/bitplanes/corpus.jsonl`.
-const N_CARDS_1X: usize = 31_508;
 const N_PRINTINGS_1X: usize = 97_206;
 /// Rounds per cell; min-of-N, matching every other bench here.
-const ITERS: usize = 200;
-/// Reciprocal of the candidate share. 1 = every card (sequential); 135 is the MEASURED production
-/// value (234 candidate cards of 31,508 per query, realistic mode), which is the row to read.
-const CANDIDATE_STRIDES: [usize; 6] = [1, 2, 4, 8, 32, 135];
-/// Fraction of bits set, in percent. 9 is the MEASURED production density (matches/examined on the
-/// #856 population, `scripts/bench_membership_waste.py`); 50 is the branch-prediction worst case.
-const BITMAP_DENSITIES: [u32; 6] = [1, 9, 10, 50, 90, 99];
+const ITERS: usize = 400;
+/// Candidate cards per query, measured.
+const VISITED_CARDS: usize = 234;
+/// Printings per VISITED card, measured (13.6). Not the corpus average of 3.09.
+const SPAN_LEN: usize = 14;
+/// Matches per visited card. 1 is the floor the construction guarantees; 1.56 is measured, so 2 is the
+/// nearest integer above it; the rest sweep toward "every printing matches" to show the shape.
+const MATCHES_PER_CARD: [usize; 5] = [1, 2, 4, 7, 14];
 
-/// Card printing-span boundaries, `n_cards + 1` long, mirroring the store's `offsets`.
-fn build_offsets(n_cards: usize, n_printings: usize) -> Vec<u32> {
-    let mut offsets = Vec::with_capacity(n_cards + 1);
-    // Spread printings across cards as evenly as the real ratio allows (~3.09/card). Exact per-card
-    // counts do not matter here; span CONTIGUITY does, and that is structural.
-    for i in 0..=n_cards {
-        offsets.push((i * n_printings / n_cards) as u32);
-    }
-    offsets
+/// One query's candidate cards: `VISITED_CARDS` spans of `SPAN_LEN`, spread evenly through the corpus so
+/// the bitmap reads are strided across cache lines the way scattered candidate cards really are.
+fn build_spans(n_printings: usize, n_cards: usize) -> Vec<(usize, usize)> {
+    let gap = n_printings / n_cards;
+    (0..n_cards).map(|i| (i * gap, i * gap + SPAN_LEN)).collect()
 }
 
-fn build_bitmap(rng: &mut rand::rngs::SmallRng, n_printings: usize, density_pct: u32) -> Vec<u64> {
-    let mut bits = vec![0u64; n_printings.div_ceil(64)];
-    for pid in 0..n_printings {
-        if rng.random::<u64>() % 100 < u64::from(density_pct) {
-            bits[pid >> 6] |= 1u64 << (pid & 63);
+/// Sorted candidate pids, `matches_per_card` drawn from each span — so every visited card has at least
+/// one, and no pid falls outside a visited span. Both are true of the real narrowing.
+fn build_candidates(rng: &mut rand::rngs::SmallRng, spans: &[(usize, usize)], matches_per_card: usize) -> Vec<u32> {
+    let mut out = Vec::with_capacity(spans.len() * matches_per_card);
+    for &(start, end) in spans {
+        let mut chosen: Vec<usize> = (start..end).collect();
+        // Take a random subset of the span, then keep it ascending: the list the narrowing hands over
+        // is globally sorted, which is what makes the merge valid.
+        for i in 0..chosen.len() {
+            let j = (rng.random::<u64>() % (chosen.len() as u64)) as usize;
+            chosen.swap(i, j);
         }
+        chosen.truncate(matches_per_card.min(end - start));
+        chosen.sort_unstable();
+        out.extend(chosen.iter().map(|&p| p as u32));
+    }
+    out
+}
+
+fn to_bitmap(pids: &[u32], n_printings: usize) -> Vec<u64> {
+    let mut bits = vec![0u64; n_printings.div_ceil(64)];
+    for &p in pids {
+        bits[(p >> 6) as usize] |= 1u64 << (p & 63);
     }
     bits
 }
 
-/// Counting form: `if contains { hits += 1 }`.
-///
-/// **Do not read this as the answer.** The compiler predicates it into `hits += contains as u32` and
-/// vectorizes, so it is branch-free and completely insensitive to bitmap density — which is how the
-/// first version of this bench produced a flat 0.4 ns at every density and would have been believed.
-/// Kept as the lower bound a *predicable* body could reach, and as the control that proves the branchy
-/// number below is really measuring a branch.
-fn bit_test_counting(bits: &[u64], offsets: &[u32], stride: usize) -> u32 {
-    let mut hits = 0u32;
-    let mut cid = 0;
-    while cid + 1 < offsets.len() {
-        let (start, end) = (offsets[cid] as usize, offsets[cid + 1] as usize);
-        for pid in start..end {
-            if bitmap_contains(bits, pid as u32) {
-                hits += 1;
-            }
-        }
-        cid += stride;
-    }
-    hits
-}
-
-/// The form the real loop takes: on a hit, append a row. `push_card_matches` does
-/// `scratch.push((sort_key_bits(...), cid, pid))`, which is a conditional store the compiler cannot
-/// predicate away — so this pays the branch, and the mispredict at ~50% density is a real cost the
-/// counting form hides. `out` is pre-allocated and reused, so no allocation is timed.
-fn bit_test_branchy(bits: &[u64], offsets: &[u32], stride: usize, out: &mut Vec<u32>) -> u32 {
+/// Scatter + probe: the bitmap route. Conditionally appends, as `push_card_matches` does, so it pays a
+/// real branch — a counting form (`hits += 1`) is predicated by the compiler into branch-free code and
+/// reads density-flat, which is how an earlier version of this bench produced a misleadingly good number.
+fn bit_test(bits: &[u64], spans: &[(usize, usize)], out: &mut Vec<u32>) -> u32 {
     out.clear();
-    let mut cid = 0;
-    while cid + 1 < offsets.len() {
-        let (start, end) = (offsets[cid] as usize, offsets[cid + 1] as usize);
+    for &(start, end) in spans {
         for pid in start..end {
             if bitmap_contains(bits, pid as u32) {
                 out.push(pid as u32);
             }
         }
-        cid += stride;
     }
     out.len() as u32
 }
 
-/// The same traversal with no bitmap access — loop overhead alone, so the difference is the test.
-fn walk_only(offsets: &[u32], stride: usize) -> u32 {
+/// Two-pointer merge against the sorted candidate list. Never touches a non-matching printing.
+fn merge(sorted_pids: &[u32], spans: &[(usize, usize)], out: &mut Vec<u32>) -> u32 {
+    out.clear();
+    let mut j = 0usize;
+    for &(start, end) in spans {
+        while j < sorted_pids.len() && (sorted_pids[j] as usize) < start {
+            j += 1;
+        }
+        while j < sorted_pids.len() && (sorted_pids[j] as usize) < end {
+            out.push(sorted_pids[j]);
+            j += 1;
+        }
+    }
+    out.len() as u32
+}
+
+/// The cost the bitmap route pays before it can probe: allocate and zero `n_printings / 64` words, then
+/// scatter the candidate list. Charged separately because it is per QUERY, not per printing, and it is
+/// exactly what the merge avoids.
+fn scatter_cost(pids: &[u32], n_printings: usize) -> u32 {
+    let bits = to_bitmap(pids, n_printings);
+    bits.len() as u32
+}
+
+/// The traversal touching neither structure — loop overhead alone.
+fn walk_only(spans: &[(usize, usize)]) -> u32 {
     let mut acc = 0u32;
-    let mut cid = 0;
-    while cid + 1 < offsets.len() {
-        let (start, end) = (offsets[cid] as usize, offsets[cid + 1] as usize);
+    for &(start, end) in spans {
         for pid in start..end {
             acc = acc.wrapping_add(pid as u32);
         }
-        cid += stride;
     }
     acc
 }
@@ -135,49 +157,48 @@ fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
     best as f64
 }
 
-/// Printings actually visited at this stride — the denominator for a per-printing rate.
-fn visited(offsets: &[u32], stride: usize) -> usize {
-    let mut n = 0;
-    let mut cid = 0;
-    while cid + 1 < offsets.len() {
-        n += (offsets[cid + 1] - offsets[cid]) as usize;
-        cid += stride;
-    }
-    n
-}
-
 #[test]
 #[ignore = "micro-benchmark; synthetic data, no external deps"]
 fn bench_membership_bittest_cost() {
     let mut rng = rand::rngs::SmallRng::seed_from_u64(8_560_001);
 
     for scale in [1usize, 5] {
-        let (n_cards, n_printings) = (N_CARDS_1X * scale, N_PRINTINGS_1X * scale);
-        let offsets = build_offsets(n_cards, n_printings);
+        let n_printings = N_PRINTINGS_1X * scale;
+        let spans = build_spans(n_printings, VISITED_CARDS);
+        let examined: usize = spans.iter().map(|(s, e)| e - s).sum();
         let kb = n_printings.div_ceil(64) * 8 / 1024;
-        println!("\n=== corpus {scale}x — {n_printings} printings, bitmap {kb} KB ===");
         println!(
-            "{:>7}  {:>10}  {:>8}  {:>9}  {:>9}  {:>7}",
-            "stride", "visited", "density", "BRANCHY", "counting", "walk"
+            "\n=== corpus {scale}x — {n_printings} printings, bitmap {kb} KB, {VISITED_CARDS} cards x {SPAN_LEN} = {examined} examined ==="
+        );
+        println!(
+            "{:>9}  {:>8}  {:>9}  {:>7}  {:>7}  {:>10}  {:>9}",
+            "match/card", "density", "bit_test", "merge", "walk", "scatter/q", "winner"
         );
 
-        let mut out: Vec<u32> = Vec::with_capacity(n_printings);
-        for stride in CANDIDATE_STRIDES {
-            let n = visited(&offsets, stride);
-            let t_walk = time_ns(|| walk_only(&offsets, stride)) / n as f64;
-            for density in BITMAP_DENSITIES {
-                let bits = build_bitmap(&mut rng, n_printings, density);
-                let t_branchy = time_ns(|| bit_test_branchy(&bits, &offsets, stride, &mut out)) / n as f64;
-                let t_count = time_ns(|| bit_test_counting(&bits, &offsets, stride)) / n as f64;
-                println!(
-                    "{:>7}  {:>10}  {:>7}%  {:>9.2}  {:>9.2}  {:>7.2}",
-                    stride, n, density, t_branchy, t_count, t_walk
-                );
-            }
+        let mut out: Vec<u32> = Vec::with_capacity(examined);
+        for m in MATCHES_PER_CARD {
+            let pids = build_candidates(&mut rng, &spans, m);
+            let bits = to_bitmap(&pids, n_printings);
+            let t_bit = time_ns(|| bit_test(&bits, &spans, &mut out)) / examined as f64;
+            let t_merge = time_ns(|| merge(&pids, &spans, &mut out)) / examined as f64;
+            let t_walk = time_ns(|| walk_only(&spans)) / examined as f64;
+            // Per query, not per printing: this is the one-off the bitmap route pays and merge does not.
+            let t_scatter = time_ns(|| scatter_cost(&pids, n_printings)) / 1000.0;
+            let winner = if t_merge < t_bit { "merge" } else { "bit_test" };
+            println!(
+                "{:>10}  {:>7.0}%  {:>9.2}  {:>7.2}  {:>7.2}  {:>8.1}us  {:>9}",
+                m,
+                100.0 * pids.len() as f64 / examined as f64,
+                t_bit,
+                t_merge,
+                t_walk,
+                t_scatter,
+                winner
+            );
         }
     }
-    println!("\nns per printing tested, min of {ITERS} rounds.");
-    println!("BRANCHY is the answer: it conditionally appends, as `push_card_matches` does, so it pays the");
-    println!("branch. `counting` is predicated by the compiler and density-flat — the trap, not the result.");
-    println!("Compare BRANCHY against the 5.8 ns/printing residual evaluation it would replace.");
+    println!("\nns per printing in a visited span, min of {ITERS} rounds; `scatter/q` is microseconds PER QUERY.");
+    println!("Measured production point is 2 matches/card (1.56) at ~11% density — read that row.");
+    println!("Compare against the 5.9 ns/printing residual evaluation both would replace.");
+    println!("merge is GatheredScan-only (ascending pid order); StreamedSelect needs the bitmap.");
 }

--- a/card_engine/src/bench_membership_check.rs
+++ b/card_engine/src/bench_membership_check.rs
@@ -1,5 +1,6 @@
 //! What per-printing membership costs the two ways it could be done, for
-//! docs/issues/00856-engine-compose-membership-bittest.md.
+//! docs/issues/00856-engine-compose-membership-bittest.md (the bitmap route, general) and
+//! docs/issues/00857-engine-membership-merge-sorted-list.md (the merge, GatheredScan only).
 //!
 //! #856 replaces a per-printing residual evaluation (measured at 5.9 ns/printing by
 //! `scripts/bench_membership_waste.py`) with an O(1) membership check. That check was an ASSUMPTION of
@@ -39,7 +40,7 @@
 //! Corpus scale is swept because the bitmap is 12 KB at production scale (97,206 printings, 1,519
 //! words) — L1-resident — and that stops being true as the corpus grows.
 //!
-//!     cargo test --release bench_membership_bittest -- --ignored --nocapture
+//!     cargo test --release bench_membership_check -- --ignored --nocapture
 
 use std::hint::black_box;
 use std::time::Instant;
@@ -134,6 +135,21 @@ fn scatter_cost(pids: &[u32], n_printings: usize) -> u32 {
     bits.len() as u32
 }
 
+/// Per-query setup for the permutation-order route: key each candidate pid by its card's position in the
+/// sort permutation, then sort. That is what would let a forward pointer work during a `StreamedSelect`
+/// walk, which visits cards in permutation order rather than ascending cid.
+///
+/// Charged against `scatter_cost`, since the two are alternatives: both are one-off per-query work that
+/// buys an ordered structure to walk against.
+fn permuted_sort_cost(pids: &[u32], printing_to_card: &[u32], inv_perm: &[u32]) -> u32 {
+    let mut keyed: Vec<(u32, u32)> = pids
+        .iter()
+        .map(|&p| (inv_perm[printing_to_card[p as usize] as usize], p))
+        .collect();
+    keyed.sort_unstable();
+    keyed.len() as u32
+}
+
 /// The traversal touching neither structure — loop overhead alone.
 fn walk_only(spans: &[(usize, usize)]) -> u32 {
     let mut acc = 0u32;
@@ -159,7 +175,7 @@ fn time_ns(mut kernel: impl FnMut() -> u32) -> f64 {
 
 #[test]
 #[ignore = "micro-benchmark; synthetic data, no external deps"]
-fn bench_membership_bittest_cost() {
+fn bench_membership_check_cost() {
     let mut rng = rand::rngs::SmallRng::seed_from_u64(8_560_001);
 
     for scale in [1usize, 5] {
@@ -171,9 +187,28 @@ fn bench_membership_bittest_cost() {
             "\n=== corpus {scale}x — {n_printings} printings, bitmap {kb} KB, {VISITED_CARDS} cards x {SPAN_LEN} = {examined} examined ==="
         );
         println!(
-            "{:>9}  {:>8}  {:>9}  {:>7}  {:>7}  {:>10}  {:>9}",
-            "match/card", "density", "bit_test", "merge", "walk", "scatter/q", "winner"
+            "{:>9}  {:>8}  {:>9}  {:>7}  {:>7}  {:>10}  {:>10}  {:>9}",
+            "match/card", "density", "bit_test", "merge", "walk", "scatter/q", "permsort/q", "winner"
         );
+
+        // Permutation-order inputs for the StreamedSelect route: a card's position in the sort order is
+        // uncorrelated with its cid, so a shuffled permutation is the honest model.
+        let n_cards = n_printings / SPAN_LEN + 1;
+        let mut printing_to_card: Vec<u32> = vec![0; n_printings];
+        for (ci, &(s, e)) in spans.iter().enumerate() {
+            for slot in printing_to_card.iter_mut().take(e.min(n_printings)).skip(s) {
+                *slot = ci as u32;
+            }
+        }
+        let mut perm: Vec<u32> = (0..n_cards as u32).collect();
+        for i in 0..perm.len() {
+            let j = (rng.random::<u64>() % (perm.len() as u64)) as usize;
+            perm.swap(i, j);
+        }
+        let mut inv_perm: Vec<u32> = vec![0; n_cards];
+        for (pos, &cid) in perm.iter().enumerate() {
+            inv_perm[cid as usize] = pos as u32;
+        }
 
         let mut out: Vec<u32> = Vec::with_capacity(examined);
         for m in MATCHES_PER_CARD {
@@ -184,15 +219,17 @@ fn bench_membership_bittest_cost() {
             let t_walk = time_ns(|| walk_only(&spans)) / examined as f64;
             // Per query, not per printing: this is the one-off the bitmap route pays and merge does not.
             let t_scatter = time_ns(|| scatter_cost(&pids, n_printings)) / 1000.0;
+            let t_psort = time_ns(|| permuted_sort_cost(&pids, &printing_to_card, &inv_perm)) / 1000.0;
             let winner = if t_merge < t_bit { "merge" } else { "bit_test" };
             println!(
-                "{:>10}  {:>7.0}%  {:>9.2}  {:>7.2}  {:>7.2}  {:>8.1}us  {:>9}",
+                "{:>10}  {:>7.0}%  {:>9.2}  {:>7.2}  {:>7.2}  {:>8.1}us  {:>8.1}us  {:>9}",
                 m,
                 100.0 * pids.len() as f64 / examined as f64,
                 t_bit,
                 t_merge,
                 t_walk,
                 t_scatter,
+                t_psort,
                 winner
             );
         }
@@ -200,5 +237,7 @@ fn bench_membership_bittest_cost() {
     println!("\nns per printing in a visited span, min of {ITERS} rounds; `scatter/q` is microseconds PER QUERY.");
     println!("Measured production point is 2 matches/card (1.56) at ~11% density — read that row.");
     println!("Compare against the 5.9 ns/printing residual evaluation both would replace.");
-    println!("merge is GatheredScan-only (ascending pid order); StreamedSelect needs the bitmap.");
+    println!("merge is GatheredScan-only (ascending pid order). For StreamedSelect's permutation walk the");
+    println!("options are the bitmap (scatter/q) or keying candidates by perm position and sorting");
+    println!("(permsort/q) so a forward pointer works -- the two per-query setups compared side by side.");
 }

--- a/card_engine/src/cost.rs
+++ b/card_engine/src/cost.rs
@@ -275,7 +275,7 @@ pub(crate) const CARD_RANGE_BUILD_PER_PRINTING_NS: f64 = 0.93;
 // too small to help; it is identical for the plans that actually compete (`StreamedSelect` and
 // `GatheredScan` call the same `prepare_candidates`), so it cannot change an argmin; and its real
 // purpose is to price the bitmap-versus-sort question in
-// docs/issues/local-engine-candidate-materialize.md, which is what it does measure exactly.
+// docs/issues/done/local-engine-candidate-materialize.md, which is what it does measure exactly.
 
 /// `Vec::with_capacity` plus the run walk, before any comparison work
 /// (`bench_candidate_materialize`, axis A).

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1647,7 +1647,7 @@ fn arith_tuple_narrow(filter: &FilterExpr, idx: &Archived<ArithTupleIndex>, n_ca
     if count > *BITS_PROMOTE {
         return Narrowed::tight(Candidates::CardBits(scatter_bits(post_ids(), n_cards)));
     }
-    // The case that prompted docs/issues/local-engine-candidate-materialize.md: up to 564 posting rows
+    // The case that prompted docs/issues/done/local-engine-candidate-materialize.md: up to 564 posting rows
     // concatenated, each sorted, the whole never so. Only reachable below `BITS_PROMOTE`, since the arm
     // above already hands back a bitmap past it.
     Narrowed::tight(Candidates::Cards(sorted_ids(post_ids(), count, n_cards)))
@@ -3201,7 +3201,7 @@ const MATERIALIZE_BITMAP_RATIO: usize = 490;
 /// Ids must also be `< domain`; `scatter_bits` would panic otherwise, which is the loud failure.
 ///
 /// Same output either way given that, so this is a pure cost choice with no consumer effect. See
-/// `MATERIALIZE_BITMAP_RATIO`, and docs/issues/local-engine-candidate-materialize.md for the k-way merge
+/// `MATERIALIZE_BITMAP_RATIO`, and docs/issues/done/local-engine-candidate-materialize.md for the k-way merge
 /// that lost to both by 3-30x.
 fn sorted_ids(ids: impl Iterator<Item = u32>, k: usize, domain: usize) -> Vec<u32> {
     let bitmap = *RANGE_MATERIALIZE_BITMAP && k.saturating_mul(MATERIALIZE_BITMAP_RATIO) > domain;
@@ -3710,7 +3710,7 @@ impl Candidates {
     /// events: `or_all` can scatter a vec-shaped arm into bits, hiding a sort that did
     /// happen, and a bits-shaped arm can be extracted into a vec by `and_all`. Exact
     /// per-site accounting needs the shared materialization helper that
-    /// docs/issues/local-engine-candidate-materialize.md proposes.
+    /// docs/issues/done/local-engine-candidate-materialize.md proposes.
     fn repr(&self) -> NarrowedRepr {
         match self {
             Candidates::Cards(_) => NarrowedRepr::Cards,
@@ -5869,7 +5869,7 @@ static RANGE_BREADTH_VS_CORPUS: LazyLock<bool> = LazyLock::new(|| guard_env("CAR
 /// candidate bound: an exact 0 was collapsing `eval_domain`/`scan_units` for the MATERIALIZING
 /// alternatives, pricing `GatheredScan` at 0.2 us against a measured 199.3 us, because a plan still has
 /// to scan to discover a set is empty. With the split it is neutral in aggregate and it is what lets
-/// `LEGALITY_SCAN_SCOPE` be on -- docs/issues/local-engine-pair-totals.md.
+/// `LEGALITY_SCAN_SCOPE` be on -- docs/issues/done/local-engine-pair-totals.md.
 static PAIR_TOTALS: LazyLock<bool> = LazyLock::new(|| guard_env("CARD_ENGINE_PAIR_TOTALS", 1u8) != 0);
 
 /// Whether the legality divergent-share correction to `stream_scan_units` is scoped to filters whose
@@ -9623,7 +9623,7 @@ fn candidate_feats(ctx: &QueryCtx, params: &QueryParams, prep: &PreparedCandidat
     // The exact answer needs the residual evaluated over the candidates, which is the work being costed. A
     // bitmap AND of the candidate set with an indexed leaf's set would give it for that same 9%; nothing
     // cheap covers the rest. See the candidates-acquire section of
-    // docs/issues/local-engine-loop-phase-measurement.md.
+    // docs/issues/done/local-engine-loop-phase-measurement.md.
     let matches = match params.mode {
         Mode::Card => count,
         Mode::Printing | Mode::Artwork => {

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -2777,7 +2777,7 @@ impl ArchivedPrintingValueIndex {
 /// and the two differ by the local printing:card ratio — measured 1.0 to 4.3 across the corpus, worst
 /// where reprint density is highest. `CardRangePopcount`'s acquire has stood in `k.min(n_cards)` (the
 /// in-range printing count clamped), which over-estimates a median 1.49x and up to 4.33x. See
-/// docs/issues/local-engine-range-cardinality-estimate.md for the estimators that were tried and why
+/// docs/issues/done/local-engine-range-cardinality-estimate.md for the estimators that were tried and why
 /// none of them work: distinct-card counts do not compose by arithmetic, because one card spans many
 /// values, so nothing derived from a coarser summary is exact.
 ///
@@ -9781,7 +9781,12 @@ fn acquire_plan_features(
         // Exact distinct cards from the per-value table when it can answer this shape — every op but
         // `Eq` is one-sided, and `Eq` is a single value, so the only fallback is `year:Y`, which spans
         // a whole year of release dates. The `k.min(n_cards)` proxy it falls back to over-estimates a
-        // median 1.49x (docs/issues/local-engine-range-cardinality-estimate.md).
+        // median 1.49x (docs/issues/done/local-engine-range-cardinality-estimate.md).
+        //
+        // A FUSED two-sided range never arrives here at all: `bare_range_bounds` gates this branch and does
+        // not match `And`, so `usd>=a usd<=b` is declined upstream by `exact_result_total` in every mode and
+        // its card/artwork totals come from compose's projection instead. Both interior-interval shapes are
+        // docs/issues/00853-engine-interior-range-distinct-counts.md.
         let card_est = range_card_counts_for(indexes, idx)
             .and_then(|counts| counts.distinct_cards(lo, hi))
             .unwrap_or_else(|| k.min(n_cards));

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -9287,7 +9287,7 @@ fn declined_sibling_fastpath<'a>(
 /// `eval_domain` to the unnarrowed universe charges a walk-shaped compose for a full-corpus gather
 /// — measured at 33x over-costed from the `PrintingRangeScan` acquire (~125 µs predicted against
 /// ~2.4 µs measured on `usd>20`/printing), which is enough to rank compose last and leave a 46x
-/// faster plan unused. See docs/issues/local-engine-plan-misselection.md.
+/// faster plan unused. See docs/issues/done/local-engine-plan-misselection.md.
 /// The permutation-free gather branch's two decline gates: `Some(reason)` if `printing_compose_fastpath`
 /// will refuse this query, `None` if it will run it.
 ///
@@ -10466,7 +10466,7 @@ pub(crate) struct PlanTrial {
     pub(crate) predicted_ns: f64,
     /// Both carried through from `PlanEstimate` unchanged — see its fields. `picked` in particular
     /// is the router's choice, which is NOT necessarily the fastest `trials_ns`: that difference is
-    /// the whole point of docs/issues/local-engine-plan-misselection.md.
+    /// the whole point of docs/issues/done/local-engine-plan-misselection.md.
     pub(crate) materialize_ns: f64,
     pub(crate) picked: bool,
     pub(crate) trials_ns: Vec<u64>,

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -12286,3 +12286,5 @@ mod bench_loop_design;
 mod bench_gather_loop;
 #[cfg(test)]
 mod bench_streamed_loop;
+#[cfg(test)]
+mod bench_membership_bittest;

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -12287,4 +12287,4 @@ mod bench_gather_loop;
 #[cfg(test)]
 mod bench_streamed_loop;
 #[cfg(test)]
-mod bench_membership_bittest;
+mod bench_membership_check;

--- a/docs/issues/00623-engine-flavor-absent-gram-bitmap.md
+++ b/docs/issues/00623-engine-flavor-absent-gram-bitmap.md
@@ -1,6 +1,6 @@
 # Engine: reject impossible flavor needles via absent-gram presence bitmap
 
-Status: filed 2026-07-07, follow-up to PR #622 / [00620-engine-flavor-text-narrowing.md](00620-engine-flavor-text-narrowing.md).
+Status: filed 2026-07-07, follow-up to PR #622 / [00620-engine-flavor-text-narrowing.md](done/00620-engine-flavor-text-narrowing.md).
 GitHub: #623.
 
 ## Idea

--- a/docs/issues/00718-accent-sensitive-literal-recheck.md
+++ b/docs/issues/00718-accent-sensitive-literal-recheck.md
@@ -2,7 +2,7 @@
 
 [#718](https://github.com/jbylund/sylvan_librarian/issues/718)
 
-Follow-up to [00649-accent-insensitive-name-search.md](00649-accent-insensitive-name-search.md)
+Follow-up to [00649-accent-insensitive-name-search.md](done/00649-accent-insensitive-name-search.md)
 (#649, shipped in #716). That change made fuzzy `name:` folding **symmetric**: both the stored
 name and the query word are diacritic-folded, so `name:eowyn` and `name:Éowyn` produce the
 identical folded search term and match identically.

--- a/docs/issues/00720-prefer-score-artwork-tuning.md
+++ b/docs/issues/00720-prefer-score-artwork-tuning.md
@@ -273,7 +273,7 @@ special foil or a different promo product.
 ## Related
 
 - [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — labelling instrument.
-- [00707-engine-3key-ordering-parity.md](00707-engine-3key-ordering-parity.md) — `prefer_score` is the
+- [00707-engine-3key-ordering-parity.md](done/00707-engine-3key-ordering-parity.md) — `prefer_score` is the
   third sort key and where plans may diverge.
 - [`api/sql/backfill_prefer_scores.sql`](../../api/sql/backfill_prefer_scores.sql) — the scoring
   definition.

--- a/docs/issues/00730-engine-popcount-skip-walk.md
+++ b/docs/issues/00730-engine-popcount-skip-walk.md
@@ -43,11 +43,40 @@ card-search UIs (page 0 dominates), but it is a regression at the tail worth rec
 
    So this is a walk-side addition, not a new index — the projection substrate is in place.
 
+## A second consumer, which changes the deferral calculus
+
+Everything above is about **deep pagination** — skipping past `offset` rows without visiting them. The same
+machinery is wanted for a different purpose, and that is new since this doc was written.
+
+[#856](00856-engine-compose-membership-bittest.md) / [#857](00857-engine-membership-merge-sorted-list.md): the
+narrowing computes exact printing membership and discards it, so the materializing plans re-derive it per
+printing at 5.9 ns each. #857 fixes that for `GatheredScan` with a merge over the sorted candidate list, but a
+merge needs ascending pid order and **`StreamedSelect` walks a permutation in sort order**, so it needs
+membership as a bitmap *in permutation space* — which is exactly `run_query_streamed_popcount`'s
+scatter-through-`inv_perm`.
+
+**The blocking limitation is the same one item 1 below implies:** that walk only runs for `unique=card` with a
+`FilterExpr::True` residual, i.e. where the plane bitmap already *is* the match set. Extending it past `True`
+— carrying a real match set through `inv_perm` — is the prerequisite for both purposes. It needs per-card
+counts for the skip, since a popcount counts cards and not matches.
+[#852](00852-engine-compose-acquire-p3-p4-ranking.md) carries the same item in its carried-forward list.
+
+**An alternative was measured and rejected**, so it does not need re-deriving: keying each candidate pid by its
+card's permutation position (`inv_perm[printing_to_card[pid]]`) and *sorting*, so a forward pointer works
+without a bitmap. **2.4–2.9 µs per query against 0.2–0.3 µs to scatter into a bitmap**, widening to 23 µs
+against 5.5 µs when every printing matches — O(k log k) with two dependent random loads per element, against an
+O(k) scatter. Numbers in `card_engine/src/bench_membership_check.rs`. The scatter is the right shape.
+
 ## Why deferred
 
 Deep pagination is rare, and unifying the three modes onto one walk was the larger win. This is a
 targeted optimization to build once/if deep-offset compose queries prove hot — measure the offset
 distribution of real traffic before spending the complexity.
+
+**That reasoning covers the pagination case only.** With a second consumer above, the question is no longer
+"are deep-offset compose queries hot" alone — it is also whether the `StreamedSelect`-on-compose population is
+worth serving. Which is currently **unmeasured**: it never appeared in #856's sample (0 of 377 picked
+`StreamedSelect`), so sizing it is the cheap first step, not building the walk.
 
 ## Related
 
@@ -55,3 +84,8 @@ distribution of real traffic before spending the complexity.
   unification this splits off from.
 - `run_query_streamed_popcount` (`card_engine/src/lib.rs`) — the existing card-space popcount-skip walk
   to generalize.
+- [#856](00856-engine-compose-membership-bittest.md) / [#857](00857-engine-membership-merge-sorted-list.md) —
+  the second consumer, and where the sort-vs-scatter measurement lives.
+- [local-engine-instrument-fast-paths.md](local-engine-instrument-fast-paths.md) — `run_query_streamed_popcount`
+  is also the one site whose counter would instrument two of the four uninstrumented fast paths, so anyone
+  opening this file should land that first.

--- a/docs/issues/00802-engine-stream-emit-branch.md
+++ b/docs/issues/00802-engine-stream-emit-branch.md
@@ -49,11 +49,14 @@ real total lands at or below it takes the gather with no floor charged.
 ## Evidence it is live
 
 The calibration sweep in
-[`local-engine-plan-misselection.md`](./local-engine-plan-misselection.md) (not yet landed; branch
-`engine-plane-popcount-cost`) puts `StreamedSelect`'s acquire-netted measured/predicted at **0.58
+[`local-engine-plan-misselection.md`](done/local-engine-plan-misselection.md) (**since landed as #805**;
+was branch `engine-plane-popcount-cost`) puts `StreamedSelect`'s acquire-netted measured/predicted at **0.58
 median, 0.18 p25** — systematically over-costed, which is the direction a spurious 52 µs floor
-produces. That doc's item 3 currently defers it as a "13–33 µs `StreamedSelect`/`GatheredScan`
-cluster ... until something shows it matters". This is a mechanism for it, and the branch report
+produces. That doc's item 2 deferred it as a "13–33 µs `StreamedSelect`/`GatheredScan`
+cluster ... until something shows it matters" — **and that deferral is now withdrawn**: the pair is the
+engine's largest single routing error, tracked as
+[#852](00852-engine-compose-acquire-p3-p4-ranking.md). This is a candidate mechanism for part of it, and the
+branch report
 below is what would show whether it does.
 
 ## Why it stayed hidden

--- a/docs/issues/00846-engine-card-numeric-contradictions.md
+++ b/docs/issues/00846-engine-card-numeric-contradictions.md
@@ -1,0 +1,52 @@
+# Card-Level Numeric Contradictions Are Not Detected
+
+Status: proposed, not started. Filed as
+[#846](https://github.com/jbylund/sylvan_librarian/issues/846). Split out of
+[the two-sided range fusion](done/local-engine-two-sided-range-fusion.md) that shipped in #837, which
+closed the printing-space half of this and left the card-space half untouched.
+
+## The asymmetry
+
+`usd>=1 usd<=0.5` is detected for free. `fuse_and_range_children` folds the two comparisons into one
+half-open interval, gets `hi < lo`, clamps to `[lo, lo)`, and every consumer computes
+`k = partition_point(hi) - partition_point(lo)` as `0`. That clamp is load-bearing rather than
+decorative — without it the subtraction underflows and panics.
+
+`power=3 power=5` is the same contradiction and reaches none of that code:
+
+- `resolve_numeric_range_leaf` returns `None` for `Power`, so there is no index and no interval to fold.
+- `printing_dependent` classifies `Power` / `Cmc` / `Toughness` / `Loyalty` as **card-level**, evaluated
+  through `numeric_candidates` rather than through a `PrintingValueIndex`.
+
+So the fields with a printing-space index get contradiction detection as a side effect of fusion, and the
+card-level numerics get nothing. There is no measurement here yet — the query is rare, and the case for
+doing it is that it is a small bind-time pass with an exact answer, not that it is costing measured time.
+
+## Why it is a bind-time pass, not a narrowing arm
+
+#837's mechanism is interval arithmetic over a stored index. These fields have no such index, so there is
+nothing to intersect; what is available is the expression itself. A bind-time pass over an `And`'s
+children, grouping by field and folding comparisons into an interval, would reach the same conclusion
+without needing the store at all — and would also catch it under `Or` and `Not`, where the narrowing arm
+never runs.
+
+## Two semantics decisions first
+
+These are the reason this is not a mechanical port of #837.
+
+**`Ne`.** `power!=3 power=5` is satisfiable and must not fold to empty. An interval representation has no
+natural slot for "everything except one point", so either `Ne` is excluded from the fold or the
+representation grows a hole set.
+
+**Null.** A card with no power satisfies neither `power=3` nor `power=5`. For a *contradiction* that
+distinction does not change the answer — the result is empty either way — but the same pass is the natural
+place to fold non-contradictory bounds, and there `power>=0` and "has a power" are different predicates.
+Settle which one the fold means before it emits anything other than empty.
+
+## Related
+
+- [done/local-engine-two-sided-range-fusion.md](done/local-engine-two-sided-range-fusion.md) — the
+  printing-space half, its measurement, and the unsatisfiable-interval clamp.
+- [#847](00847-engine-empty-conjunction-short-circuit.md) — the other "this filter is provably empty"
+  case, from disjoint plane values rather than from numeric bounds. Both want the same thing: a place
+  early enough to answer empty without routing.

--- a/docs/issues/00847-engine-empty-conjunction-short-circuit.md
+++ b/docs/issues/00847-engine-empty-conjunction-short-circuit.md
@@ -1,0 +1,60 @@
+# An Exact Total of Zero Should Short-Circuit Before Routing
+
+Status: proposed, not started. Filed as
+[#847](https://github.com/jbylund/sylvan_librarian/issues/847). Split out of
+[the pair-totals work](done/local-engine-pair-totals.md) that shipped in #844.
+
+## The gap
+
+`PairTotals` makes the three-space total for two low-cardinality leaves exact, and that includes exactly
+zero — the table deliberately archives the zero cells, because storing only non-zero ones made a
+provably-empty pair indistinguishable from a pruned one (`frame:2003 frame:1997` read 10,769 against a
+true 0).
+
+Nothing consults it early enough to act on the zero.
+
+`border:white border:black t:creature` scans **6,402 printings over 79 µs to return nothing.** Its acquire
+is `candidates`, which never reads the totals tables at all, so the query runs a full match loop to
+discover what a lookup already knows. A filter containing two disjoint conjuncts is empty regardless of
+what else it says.
+
+`leaves_are_disjoint` already encodes the rule that makes this decidable without stored data: border,
+rarity and legality hold exactly one value per printing, so two distinct values never co-occur. It is
+called too late to matter.
+
+## Worth doing for the shape, not the aggregate
+
+These queries are rare in traffic and the aggregate win is near zero. What the change buys is the removal
+of a class where **adding selectivity makes a query slower** — the same complaint that motivated
+[proven conjuncts](done/local-engine-proven-conjuncts.md), where `o:this border:black` was 38× slower than
+`o:this` for a 6× smaller result. Here the result is empty and the query still scans.
+
+## The one thing that will go wrong
+
+Carried from #844, where it cost 24× on the first attempt: **a result total is not a scan domain.**
+
+Letting an exact zero reach the feature vector collapsed `eval_domain` and `scan_units` for the
+*materializing alternatives*, which priced `GatheredScan` at 0.2 µs against a measured 199.3 —
+
+    GatheredScan     pred=  0.2u   meas= 199.3u   <- picked
+    PrintingCompose  pred=  1.9u   meas=   1.0u   <- actually best
+
+A plan still has to scan to *discover* that a set is empty. #844's fix was to split `ComposeEstimate` into
+`result` and `candidate` so the alternatives are priced on what they actually walk.
+
+So the short-circuit must **bypass routing entirely** and return the empty result, not feed routing a
+zero. Those are different changes and only the first is safe.
+
+## Where it goes
+
+Before plan selection, on the bound filter. The check is cheap — group an `And`'s children by dimension,
+ask `leaves_are_disjoint` — and it is exact rather than an estimate, so there is no threshold to tune and
+no A/B to justify it. The verification that matters is row identity: an empty answer must be empty for the
+right reason, in all three result spaces, and under `Or` / `Not` the rule must not fire at all.
+
+## Related
+
+- [done/local-engine-pair-totals.md](done/local-engine-pair-totals.md) — the table, its selectivity
+  pruning, and the 24× regression the result/candidate split fixed.
+- [#846](00846-engine-card-numeric-contradictions.md) — the same "provably empty" question arriving from
+  numeric bounds instead of disjoint values. If both land, they want one pass.

--- a/docs/issues/00848-engine-decline-sparse-exact-wasted-build.md
+++ b/docs/issues/00848-engine-decline-sparse-exact-wasted-build.md
@@ -1,0 +1,79 @@
+# `DeclineSparseExact` Throws Away a Compose Build It Already Paid For
+
+Status: proposed, not started. Filed as
+[#848](https://github.com/jbylund/sylvan_librarian/issues/848). Item (1) of
+[the legality scan-scope work](done/local-engine-legality-scan-scope.md), which otherwise shipped in #844.
+
+## The cliff
+
+`PrintingCompose` can be picked, build its printing bits, compute the exact total, find it under
+`STREAM_MIN_MATCHES` (1,024), and **decline** — having paid the whole build. Dispatch then runs a second
+plan on top of that:
+
+    card:  PrintingCompose  pred=67.5u  trials=0  declined=9  picked=True  paging_taken='DeclineSparseExact'
+
+The sparse floor is a sound rule about whether compose is worth *building* for a tiny result. By the time
+`DeclineSparseExact` fires the bits already exist, and finishing the page from them is a page-sized walk.
+Declining after the exact total is known is strictly worse than completing.
+
+The decline belongs **before** the build, on the estimated total, where `ComposePaging::Decline` already
+lives.
+
+## The trigger was removed; the cliff was not
+
+This is the part worth being precise about, because #844 could be read as having fixed it.
+
+The estimate that walked queries into the cliff was the `min` fold: `f:modern border:white` estimated 2,755
+cards against a true 978, comfortably above the floor, so the router predicted compose would run when it
+would bail. Three of four queries in that family were affected:
+
+| query (card mode) | est cards | true total | est/true | |
+| --- | --: | --: | --: | --- |
+| `f:modern border:white` | 2,755 | 978 | 2.82 | declined |
+| `f:pauper border:white` | 2,755 | 858 | 3.21 | declined |
+| `f:vintage border:white` | 2,755 | 2,025 | 1.36 | ran |
+| `f:modern r:rare border:white` | 2,755 | 273 | **10.09** | declined |
+
+[The pair table](done/local-engine-pair-totals.md) makes those two-leaf card totals exact, so
+`compose_paging` now predicts the decline instead of walking into it, and card mode went **163.1 µs →
+102.1 µs**.
+
+That removed the population that was hitting the cliff. It did not remove the cliff. **An estimate near a
+hard threshold will always sometimes fall the wrong side**, and the cost of being wrong is a full compose
+build discarded. The exact tables cover pairs of low-cardinality values; three or more leaves get a bound
+rather than an exact answer (min-over-pairs reads 2.02× on `f:modern r:rare border:white`), and any leaf
+outside those dimensions is estimated as before.
+
+## What to change
+
+Complete the page from the bits rather than discarding them. The decline exists to avoid *starting* a build
+that will not pay; once started, the marginal cost of finishing is a page walk over a set already known to
+be small. Concretely: `DeclineSparseExact` becomes a completion path, and `ComposePaging::Decline` — the
+pre-build, estimate-based decline — stays as the only place a compose is refused.
+
+Two things to check rather than assume:
+
+- **The prediction must keep matching the branch taken.**
+  `compose_paging_prediction_matches_the_branch_taken` exists for this and caught an earlier attempt at a
+  different paging change immediately. If `DeclineSparseExact` stops being a reachable outcome, that test's
+  coverage guard has to be updated deliberately, not silently.
+- **Row identity.** A completion path is new code producing user-visible rows on a population that
+  previously fell through to a different plan. Compare returned `scryfall_id` sequences across all three
+  result spaces and both prefer settings, not just totals — the trap recorded in
+  [the existential-plane repair pattern](reference-engine-printing-varying-plane-repair-pattern.md).
+
+## Measurement note
+
+A declining plan accumulates no trials, so these queries are **absent from every regret and cost matrix
+taken so far**. Enabling a completion path introduces a population nothing has measured — the same trap
+that made [sparse compose gather](local-engine-sparse-compose-gather.md) look neutral when it was not. Take
+a paired wall-clock A/B on the compose slice, not a regret delta.
+
+## Related
+
+- [done/local-engine-legality-scan-scope.md](done/local-engine-legality-scan-scope.md) — where this was
+  found, and defect 1's scan-scope fix that shipped alongside it.
+- [done/local-engine-pair-totals.md](done/local-engine-pair-totals.md) — the exact totals that removed the
+  trigger.
+- [local-engine-sparse-compose-gather.md](local-engine-sparse-compose-gather.md) — the other end of the
+  same question: what compose should do instead of declining when the result is sparse.

--- a/docs/issues/00849-engine-bitmap-materialize-remaining-sites.md
+++ b/docs/issues/00849-engine-bitmap-materialize-remaining-sites.md
@@ -1,0 +1,60 @@
+# Adopt Bitmap Materialization at the Remaining Narrowing Call Sites
+
+Status: proposed, not started. Filed as
+[#849](https://github.com/jbylund/sylvan_librarian/issues/849). The measurement and the range-arm adoption
+are in [the candidate-materialize record](done/local-engine-candidate-materialize.md); this is the
+remainder.
+
+## The measurement, already done
+
+Any narrowing arm that unions several posting rows has sorted runs and no globally sorted output, because
+posting-row order is not card order. `Candidates::Printings` is contractually ascending, so something has
+to produce that order. Three ways, all asserted to produce the identical `Vec<u32>` first
+(`card_engine/src/bench_candidate_materialize.rs`, domain 31,508, 564 runs):
+
+| candidates | concat+sort µs | merge µs | bitmap+extract µs | best |
+| ---------- | -------------: | -------: | ----------------: | ---- |
+| 16 | **0.25** | 0.33 | 0.42 | sort |
+| 64 | **0.46** | 1.00 | 0.46 | tie |
+| 256 | 1.50 | 3.58 | **0.79** | bitmap 1.9× |
+| 1,024 | 5.25 | 16.08 | **1.42** | bitmap 3.7× |
+| 4,096 | 21.12 | 79.58 | **3.50** | bitmap 6.0× |
+
+The k-way merge loses everywhere despite every run already being sorted.
+
+## What shipped, and the correction it forced
+
+#845 adopted the bitmap for `range_narrowed` (the range arms), where the sort was the dominant cost —
+134–186 µs on a mid-band price range, and 95% of `usd<0.18 t:land`. Whole mix 0.949, target 0.867.
+
+It also corrected this document's own crossover claim: **the crossover is a domain:count ratio (~490:1),
+not an absolute count.** "Below ~64 candidates" was derived on the card-space axis, and printing space has
+3× the domain, so a count threshold ported between the two is wrong by that factor.
+
+## The remaining sites
+
+- **`arith_tuple_narrow`** — the case that prompted the benchmark in the first place. It concatenates the
+  selected rows and calls `sort_unstable`, with a comment naming exactly why the sort is needed.
+- **The other posting-union narrowing arms**, which have the same shape.
+
+Both are **card-space**, so the 490:1 figure cannot be reused — it has to be re-derived on that axis. That
+is the whole reason these were not swept along with #845: the shipped predicate is a ratio against the
+printing domain, and applying it unchanged to a card-space arm would pick the wrong representation on
+exactly the small sets where the sort is still faster.
+
+## Acceptance
+
+- Identical `Vec<u32>` before and after at every site, asserted rather than sampled — this is a
+  representation change under a contract (`Candidates::Printings` ascending) that downstream consumers
+  rely on for correctness, not just for speed.
+- The ratio threshold is a named constant with its measured band in the comment, per the project's
+  measured-constant convention.
+- A kernel micro-benchmark, not end-to-end query timing: at 0.25–3.5 µs these effects are below what
+  routed dispatch can resolve.
+
+## Related
+
+- [done/local-engine-candidate-materialize.md](done/local-engine-candidate-materialize.md) — the full
+  three-way measurement and the range-arm adoption.
+- [done/local-engine-range-breadth-denominator.md](done/local-engine-range-breadth-denominator.md) — the
+  change that admitted 16–20k-element sets into the vec path and made the sort worth retiring.

--- a/docs/issues/00850-engine-battle-type-plane-path.md
+++ b/docs/issues/00850-engine-battle-type-plane-path.md
@@ -1,0 +1,75 @@
+# `card_types` Has No `Battle`, and `t:battle` Poisons an `Or`'s Plane Path
+
+Status: proposed, not started — **and (1) below may be a wrong-answer bug, which is why it outranks
+everything else carried out of that audit.** Filed as
+[#850](https://github.com/jbylund/sylvan_librarian/issues/850). Items 2 and 3 of
+[the `is:` / `frame:` audit](done/local-engine-is-frame-predicates.md), whose other findings shipped in
+#840 and #842.
+
+## 1. The data question — check this first
+
+Counting `card_types` across the corpus gives 12 distinct names and **`Battle` is not among them**:
+
+    Creature 45,976   Legendary 13,537   Land 11,552   Artifact 10,949   Instant 10,725
+    Sorcery 10,626    Enchantment 9,914  Basic 4,196   Planeswalker 1,379  Snow 262
+    Kindred 183       World 42
+
+The corpus carries release dates through 2025-02-14 and battles arrived with March of the Machine in 2023,
+so they should be present. If the live store looks the same, `t:battle` silently returns nothing and
+**`is:permanent` misses every battle** — a wrong answer, not a slow one.
+
+Check the importer's type extraction before treating this as a corpus artifact. It is cheap to check, and
+it decides whether (2) is even the right framing: fixing the plane path would still return zero battles.
+
+## 2. The plane path
+
+`is:permanent` desugars to `t:creature or t:artifact or t:enchantment or t:land or t:planeswalker or
+t:battle`, and that last disjunct costs **11.5×**:
+
+| query | count source | plan | µs |
+| --- | --- | --- | --: |
+| 5 disjuncts (through `t:planeswalker`) | plane | PlanePopcountOrder | **55** |
+| … `or t:snow` (6 disjuncts) | plane | PlanePopcountOrder | 57 |
+| `t:instant or t:sorcery or t:snow or t:world or t:basic or t:kindred` (6) | plane | PlanePopcountOrder | 47 |
+| … `or t:battle` (6 disjuncts) | **candidates** | StreamedSelect | **497** |
+| `t:battle or t:creature` (2 disjuncts) | **candidates** | StreamedSelect | 90 |
+| `is:permanent` | **candidates** | StreamedSelect | **641** |
+
+**Two explanations are ruled out by that table.** It is not the disjunct count — six other-type disjuncts
+stay on the plane path. And it is not a missing type plane: `TYPE_PLANES = 14` covers every bit including
+`TYPE_BATTLE = 1 << 2`, and `PERMANENT_TYPES` includes it.
+
+**The mechanism is not identified.** `t:battle` alone acquires as `printing_compose` returning 0 rows in
+3.5 µs, which is already odd for a `TypeCmp` — that is the thread to pull. Do not guess; two plausible
+mechanisms are already eliminated above.
+
+Whatever it turns out to be, the fix is probably algebraic rather than local: an empty or non-compilable
+disjunct should be **dropped** from an `Or` (`Or(x, ∅) = x`) rather than poisoning the whole expression.
+That generalizes past `Battle` and is the version worth shipping.
+
+## Also carried over: the `is:old` / `is:historic` gap
+
+Recorded here so it is not lost with its parent doc, and it may explain more than it looks like.
+
+`is:old` narrows to **7,191** cards and takes **399 µs**. `is:historic` narrows to **7,261** cards — 0.4%
+more — and takes **59 µs**. Same field, same count source, near-identical evaluation domain, **6.8×** apart.
+Both are `Or`s over `card_frame_data`.
+
+Nothing in the audit explains it, and whatever makes `is:historic` fast is presumably available to `is:old`.
+Diagnosis only; it may share a cause with (2), since both are `Or`s that route differently than their
+siblings.
+
+## Traffic caveat
+
+`is:` is absent from `REALISTIC_FAMILY_WEIGHTS`, so the 24%-of-dispatch figure that motivated the parent
+audit is a **uniform-mode** number and the realistic share is unmodelled. That caveat sizes (2); it does not
+apply to (1), which is a correctness question regardless of how often the query is typed.
+
+## Related
+
+- [done/local-engine-is-frame-predicates.md](done/local-engine-is-frame-predicates.md) — the parent audit,
+  the `frame_data` hybrid that shipped, and the threshold-conflation fix.
+- [local-engine-layout-postings.md](local-engine-layout-postings.md) — item 4 of the same audit,
+  deprioritized separately.
+- [local-engine-empty-text-narrowing.md](local-engine-empty-text-narrowing.md) — `is:vanilla` /
+  `is:permanent` from the other direction: a plane-composable `Or` falling back to the general path.

--- a/docs/issues/00851-engine-card-space-probe-skip.md
+++ b/docs/issues/00851-engine-card-space-probe-skip.md
@@ -1,0 +1,53 @@
+# The `And` Arm's Cost-Based Skip Regresses a Card-Space Posting Child 1.56×
+
+Status: proposed, not diagnosed. Filed as
+[#851](https://github.com/jbylund/sylvan_librarian/issues/851). The one open cell from the cost-based skip
+that shipped in #836 (`3cfd441`), recorded in
+[the `is:` / `frame:` audit](done/local-engine-is-frame-predicates.md).
+
+## What shipped, and what it is worth
+
+`narrow_rec`'s `And` arm already had the rule — `AND_PROBE_FLOOR`'s doc: *"a child with `k < best` becomes
+the new, strictly-smaller driver (fewer residual verifications, never a regression)"* — but gated it on
+`rank > 0`, and only rank-1 range children had a probe. Rank 0 was assumed cheap to materialise and never
+checked, which is false for containment collections (`is:spell` is ~60k printing ids).
+
+`probe_collection_k` gives collections the same cheap size probe, and the skip drops `rank > 0` in favour of
+"we know what this child costs". Unprobed rank-0 children keep their benefit of the doubt.
+
+Measured against a **back-to-back** baseline: total 0.969, p50 0.971, p90 0.964, p99 0.967, with
+`keyword:extort frame:inverted` at **0.48×** and untouchable queries at 0.98–0.99. So the skip earns its
+keep. This is the one cell it does not.
+
+## The regression
+
+`o:owner keyword:flying` reads **1.56×** baseline.
+
+`keyword:flying` is a large **card-space** posting list. Card-space children were explicitly exempted from
+the broad guard, with the reasoning recorded at the site: *"card-space lists need no guard — same argument
+as `numeric_candidates`"*, because materialising card ids is cheap.
+
+That argument covers the **cost of materialising** the child. It does not cover **skipping** one when the
+alternative driver is an oracle-text scan — which is not cheap, and is what `o:owner` makes the driver here.
+If that is the mechanism, the probe should apply to printing-space children only, and card-space lists
+should keep narrowing regardless of their size.
+
+## Two cautions before acting
+
+**Re-measure on a quiet machine.** This cell sits close to the band where the audit's own untouchable
+control queries read 0.98–0.99, and 1.56× is a single cell rather than a population. Machine drift has
+misled this line of work before — canaries missed 22% drift once, which is why baselines here are taken
+back-to-back with a control subset rather than against a stored number.
+
+**The fix is a one-line gate either way.** The work is not the change; it is deciding which side of the gate
+card-space lists belong on, and that needs the paired measurement rather than the argument above. Force the
+skip off for card-space children and measure `o:owner keyword:flying` alongside the cells the skip currently
+wins (`keyword:extort frame:inverted` at 0.48×) — a gate that fixes one and loses the other is not a fix.
+
+## Related
+
+- [done/local-engine-is-frame-predicates.md](done/local-engine-is-frame-predicates.md) — section 5, where
+  the skip shipped and this cell was flagged.
+- [done/local-engine-proven-conjuncts.md](done/local-engine-proven-conjuncts.md) — the other half of what
+  made oracle-text drivers fast, and the reason a broad printing-space partner is no longer the suspect it
+  used to be.

--- a/docs/issues/00852-engine-compose-acquire-p3-p4-ranking.md
+++ b/docs/issues/00852-engine-compose-acquire-p3-p4-ranking.md
@@ -162,7 +162,7 @@ Which tool answers which question, and the measurement traps this line of work p
   measurement record, including the retractions.
 - [done/local-engine-cost-model-agreement.md](done/local-engine-cost-model-agreement.md) — the agreement
   matrix and the four feature fixes.
-- [local-engine-compose-membership-bittest.md](local-engine-compose-membership-bittest.md) — the larger prize
+- [#856](00856-engine-compose-membership-bittest.md) — the larger prize
   on this same population: P3 should not re-derive membership compose already computed exactly.
 - [local-engine-compose-build-rates.md](local-engine-compose-build-rates.md) — the rate measurements, and the
   `Perm` arm's missing `cards_visited` term.

--- a/docs/issues/00852-engine-compose-acquire-p3-p4-ranking.md
+++ b/docs/issues/00852-engine-compose-acquire-p3-p4-ranking.md
@@ -1,0 +1,170 @@
+# Rank `GatheredScan` vs `StreamedSelect` on the Compose Acquire
+
+Status: open — the largest single routing error left in the engine. Filed as
+[#852](https://github.com/jbylund/sylvan_librarian/issues/852). Successor to
+[the loop-phase measurement record](done/local-engine-loop-phase-measurement.md), whose calibration work
+shipped in #833 / #834 / #836.
+
+## Where it stands
+
+The pair went **69% → 87% ordered right** and mean regret **35.96 µs → 4.29 µs** across that stack. What
+moved it last was `eval_domain`, and the mechanism is worth stating because it was misdiagnosed twice:
+
+`eval_domain` was `est_cards` — a count of **matching** cards — graded against `cards_visited`, which counts
+**candidates**, a superset whenever the narrowing is inexact. The distribution is bimodal: **34% of compose
+rows visit every card in the corpus**, and on those the right value is not a better estimate but `n_cards`.
+
+| on the 986 full-scan rows | p10 | p50 | p90 | mean \|log\| |
+| --- | --: | --: | --: | --: |
+| `est_cards` (was) | 0.43 | 0.65 | 0.83 | 0.454 |
+| `n_cards` (now) | 1.00 | 1.00 | 1.00 | **0.000** |
+
+Predicted with the predicate and constant the sibling `PrintingRangeScan` branch already uses for the same
+decision (`range_too_broad_to_narrow`, `MAX_NARROW_FRACTION` 0.25), so no new constant. It catches **98%** of
+full-scan rows at 87% accuracy. Its 26% false positives over-cost both materializing plans by the same
+factor, which an argmin absorbs; the false negatives were the ones losing the pair, so **recall is the side
+to favour** here.
+
+| | before | after |
+| --- | --: | --: |
+| `eval_domain [printing_compose]` p50 / p10 | 0.91 / 0.45 | **1.00 / 0.68** |
+| pair ordered right | 75% | **87%** |
+| pair mean regret | 23.00 µs | **4.29 µs** |
+| pair gap meas/pred | 0.96 | **0.98** |
+
+That is within reach of the well-behaved `candidates` acquire (92%, 2.42 µs). **Total regret is flat** (1.52
+against 1.54 µs) and `StreamedSelect -> GatheredScan` is still 967 queries, because `bench_pairwise_ordering`
+scores every pair including queries where compose wins anyway, so the P3/P4 ordering never reaches the
+routing outcome there. Pairwise accuracy is a leading indicator, not the result.
+
+## The ceiling, and what it says about sequencing
+
+An **oracle** run settles the features-vs-rates question directly: recompute both arms substituting each
+plan's *realized counters* for its estimated features, keeping every shipped rate untouched, then re-run the
+argmin. Over 2,778 non-tie pairs with ≥100 realized cards on both plans:
+
+| features | ordered right | lost time (sum) |
+| --- | --: | --: |
+| shipped estimates | 58% | 116.2 ms |
+| **oracle (realized counters)** | **83%** | **12.8 ms** |
+
+| mode | shipped | oracle |
+| --- | --: | --: |
+| card | 58% | **96%** |
+| printing | 62% | 80% |
+| artwork | 56% | 81% |
+
+Perfect features against *today's* rates reach 83% and cut lost time **9×**. **The rates are adequate to
+83%**; the remaining 17% is what is genuinely attributable to them. Features first — do not open the rate
+question until the estimates stop moving.
+
+(58% here is not the 87% above: this run requires ≥100 realized cards on both plans, which selects the larger
+queries where estimator error dominates. The valid comparison is the internal one, 58 → 83 on identical rows
+with identical rates.)
+
+## Two results that shape the work, both counter-intuitive
+
+**Per-plan features are worth exactly zero.** Leave-one-out from the full oracle, shipped rates throughout,
+2,768 pairs:
+
+| variant | ordered right | lost time |
+| --- | --: | --: |
+| shipped | 59% | 116.7 ms |
+| full oracle (per-plan) | **83%** | **12.4 ms** |
+| oracle, `eval_domain` back to its estimate | 68% | **91.2 ms** |
+| oracle, `scan` back | 79% | 22.4 ms |
+| oracle, `matches` back | 83% | 13.2 ms |
+| oracle, `scan` forced **SHARED** (both read P4's) | 83% | 12.4 ms |
+| oracle, `eval_domain` forced **SHARED** | 83% | 12.4 ms |
+
+`eval_domain` is ~75% of the recoverable loss (78 of 104 ms), `scan` ~10%, `matches` nothing. And forcing
+either feature to be *shared* while keeping it exact costs nothing at all — so the answer is **not** to split
+features per plan, it is to make the one shared number accurate. The mechanism agrees: on the broad-residual
+class both plans examine the same 97,206 printings, and on the card-invariant class the verify-tier gate
+already zeroes P3's scan term.
+
+**A corollary worth checking:** `stream_scan_units` may now be redundant with that gate, since the divergence
+it was built for is the population the gate already handles.
+
+**A feature fix only pays when the two plans weight the feature differently.** Three of four corrections moved
+the pair 0%, because `eval_domain` and `scan_units` feed *both* arms — a correction to either moves both
+predictions the same direction and the difference barely changes. The `scan_units` clamp moved it because it
+lands asymmetrically: 76% of P3's arm on this class against 28% of P4's. Same principle as `cost.rs`'s "a
+term wrong for every plan cancels", applied to features rather than rates.
+
+## Remaining, in order
+
+1. **The residual `eval_domain` error in the *narrowed* regime** (p10 0.68). Two things bound it: the exact
+   path is itself only p50 0.92 / p10 0.50 against the counter, so 1.00 is not the ceiling; and combining two
+   exact range counts is not free — the boundary table answers each range independently, and an `And`'s
+   distinct-card count is not derivable from the two without composing.
+2. **`scan_units` on selective compose queries** — mean |log| **1.22**, p10 0.08, p90 3.62, a ~45× spread that
+   no bias variant improves. Second-order for this pair (~10% of recoverable loss), so it ranks below (1).
+3. **The pair-level loop harness, once the features stop moving.** `bench_streamed_loop` and `bench_gather_loop`
+   share `bench_loop_design` so their cells match, but neither computes the cross-plan quantity — and
+   `explain_analyze` compares predicted against measured *per plan* on sampled traffic and cannot isolate a
+   per-unit rate. So the one number routing depends on, P3's per-printing rate against P4's on identical
+   cells, is produced by nothing.
+
+   **Extend, do not fork.** `bench_loop_design` exists precisely because that comparison is only valid when
+   the cells match, and they had already drifted once (`CARD_COUNTS` sharing two of five sizes). Move cell
+   construction into `bench_loop_design`, then add one reporting test that runs both arms over those cells and
+   prints each rate, the measured ratio, and the shipped ratio beside it.
+
+   Two prerequisites, both already flagged in `bench_streamed_loop`'s own header: the rates there are `ns_loop`
+   only, and *"P3's arm may be absorbing setup or finish cost that its loop never pays — that has to be ruled
+   out before the gap is called an error"* (`Cell` already carries `ns_setup` and `ns_finish`, unused). And the
+   broad-residual population is already the `residual: true` group, so no new cell class is needed.
+
+## Two traps for whoever opens the rate question
+
+**A pooled traffic fit endorses both current rates** (StreamedSelect `SCAN_PER_ROW` 6.04, ratio 1.01;
+GatheredScan 2.53, 1.23), so `fit_cost_model` cannot find this and a pooled refit will confirm the status quo.
+
+**A built design reads warm-cache**, so it yields the *shape* — which of the two rates is misattributed — and
+not the level. For when it opens: the existing harnesses report P3 at 3.30 ns/printing against P4's 2.27, a
+ratio of **1.45**, where the shipped constants are 5.97 and 2.06, a ratio of **2.90**. Both were measured warm
+but *together*, and a ratio between two equally-warm arms survives the cache caveat that voids their levels.
+Wrong-rate concentrates by mode at artwork 29%, printing 24%, card 18%.
+
+## Carried forward, not part of this issue
+
+Recorded so they are not lost with the parent doc. Each is a separate idea and none blocks the above.
+
+- **Extend the popcount-skip walk past `FilterExpr::True`.** `run_query_streamed_popcount` scatters through
+  `inv_perm` and walks words at 64 cards a load, but only for `unique=card` + `True`. Printing mode — where
+  P3 is actually routed — is the case it does not cover. Needs per-card counts for the skip, since a popcount
+  counts cards and not matches. Tracked at [#730](00730-engine-popcount-skip-walk.md).
+- **Compose `format:A AND format:B`,** now that both are usually card-invariant: the shared-witness objection
+  dissolves when neither format diverges, since `∃p: A(p) ∧ B` is `(∃p: A(p)) ∧ B`. `compile_plane` still
+  declines it with `u64::MAX`, and `legality_and_of_two_formats_declines_but_or_compiles` names the assertion
+  to revisit. #835's divergence mask is what makes this newly answerable.
+- **A curvature term for the loop rates** — cause of both the `FIXED` disagreement and corpus drift, though
+  the five-size sweep demoted it: the drift saturates and production sits at the bottom of the curve.
+- **Gate P4's artwork arm on its own.** Every surviving mispick is in artwork mode.
+- **Make the fit loss the actual multi-way routing outcome** rather than a pairwise proxy — see the leading-
+  indicator caveat above, which is the same complaint.
+
+## Reproducing
+
+```bash
+.venv/bin/python scripts/bench_cost_model_agreement.py --seconds 300   # the bar
+.venv/bin/python scripts/bench_plan_misselection.py --source distribution --out A.jsonl
+.venv/bin/python scripts/bench_plan_misselection.py --compare A.jsonl B.jsonl   # the only real verdict
+```
+
+Which tool answers which question, and the measurement traps this line of work paid for one at a time:
+[reference-cost-model-measurement.md](reference-cost-model-measurement.md).
+
+## Related
+
+- [done/local-engine-loop-phase-measurement.md](done/local-engine-loop-phase-measurement.md) — the full
+  measurement record, including the retractions.
+- [done/local-engine-cost-model-agreement.md](done/local-engine-cost-model-agreement.md) — the agreement
+  matrix and the four feature fixes.
+- [local-engine-compose-membership-bittest.md](local-engine-compose-membership-bittest.md) — the larger prize
+  on this same population: P3 should not re-derive membership compose already computed exactly.
+- [local-engine-compose-build-rates.md](local-engine-compose-build-rates.md) — the rate measurements, and the
+  `Perm` arm's missing `cards_visited` term.
+- [local-engine-plan-misselection.md](local-engine-plan-misselection.md) — the other open calibration gap,
+  `PlanePopcountOrder` under-costed a median 1.61×.

--- a/docs/issues/00852-engine-compose-acquire-p3-p4-ranking.md
+++ b/docs/issues/00852-engine-compose-acquire-p3-p4-ranking.md
@@ -166,5 +166,5 @@ Which tool answers which question, and the measurement traps this line of work p
   on this same population: P3 should not re-derive membership compose already computed exactly.
 - [local-engine-compose-build-rates.md](local-engine-compose-build-rates.md) — the rate measurements, and the
   `Perm` arm's missing `cards_visited` term.
-- [local-engine-plan-misselection.md](local-engine-plan-misselection.md) — the other open calibration gap,
+- [local-engine-plan-misselection.md](done/local-engine-plan-misselection.md) — the other open calibration gap,
   `PlanePopcountOrder` under-costed a median 1.61×.

--- a/docs/issues/00853-engine-interior-range-distinct-counts.md
+++ b/docs/issues/00853-engine-interior-range-distinct-counts.md
@@ -224,4 +224,4 @@ All four exist and are tracked. The offline studies read `benchmarks/bitplanes/c
 - [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — the arm half of "nothing ships alone".
 - [#848](00848-engine-decline-sparse-exact-wasted-build.md) — why an exact `result_total` near
   `STREAM_MIN_MATCHES` matters.
-- [local-engine-plan-misselection.md](local-engine-plan-misselection.md) — where the proxy was found.
+- [local-engine-plan-misselection.md](done/local-engine-plan-misselection.md) — where the proxy was found.

--- a/docs/issues/00853-engine-interior-range-distinct-counts.md
+++ b/docs/issues/00853-engine-interior-range-distinct-counts.md
@@ -1,0 +1,154 @@
+# Interior-Interval Distinct Counts, for `year:Y` and Fused Two-Sided Ranges
+
+Status: open, nothing implemented. Filed as
+[#853](https://github.com/jbylund/sylvan_librarian/issues/853). The **two-sided / interior** half of
+[the range-cardinality work](done/local-engine-range-cardinality-estimate.md), whose one-sided half shipped
+as `RangeCardCounts`. That doc holds the nine rejected estimators, the four measurement traps, and the
+sizing for every candidate; this one holds the problem it deferred and the reason it is no longer deferrable.
+
+## The structural limit, which is proven rather than assumed
+
+`RangeCardCounts` stores, per distinct value: `below[i]` (distinct cards among printings with value <
+`values[i]`), `at_or_above[i]`, and `at[i]`. Those answer an interval that runs to an **edge** of the index.
+
+They cannot answer an interior interval, and the parent doc measured why rather than assuming it:
+
+- `suf[i] != total - pre[i]` — a card with printings on both sides of the cut is in both.
+- `val[i] != pre[i+1] - pre[i]` — that counts cards whose *first* printing is at this value, not cards
+  present at it (10 against a true 54 at `usd:2.99`).
+
+**Distinct counts do not subtract.** So an interior interval is not a lookup away; it is a different data
+structure. `ArchivedRangeCardCounts::lookup` (`card_engine/src/lib.rs`) encodes exactly the boundary:
+
+```rust
+match (lo <= first, last_covers_end) {
+    (true, true)  => Some(at_or_above[0]),          // whole index
+    (true, false) => Some(below[j]),                // `<` / `<=`
+    (false, true) => Some(at_or_above[i]),          // `>` / `>=`
+    (false, false) if j == i + 1 => Some(at[i]),    // `Eq` — exactly one distinct value
+    _ => None,                                       // interior, several values
+}
+```
+
+## Two shapes land in that `None` arm, by different routes
+
+### 1. `year:Y` — one leaf, interior interval
+
+`year_range_bounds` turns `year:2015` into `[2015_0000, 2016_0000)`, a whole calendar year of release dates.
+`bare_range_bounds` accepts it (a single `YearCmp`), so it *does* reach `distinct_cards` — and hits
+`(false, false)` with `j > i + 1`, returning `None`. The `CardRangePopcount` acquire then falls back:
+
+```rust
+let card_est = range_card_counts_for(indexes, idx)
+    .and_then(|counts| counts.distinct_cards(lo, hi))
+    .unwrap_or_else(|| k.min(n_cards));
+```
+
+`k.min(n_cards)` is the proxy the parent doc measured at **median 1.49×, p10 1.14, p90 1.82, p99 4.33** —
+over-estimating nearly everywhere, because printings outnumber cards.
+
+The code comment already names this as the sole remaining fallback. It is correct about `year:Y` being the
+only *single-leaf* case; it predates the fusion below.
+
+### 2. Two-sided fused ranges — the part that changed
+
+`bare_range_bounds` matches `NumericCmp` / `DateCmp` / `YearCmp` and `Not` of those — **not `And`**. So
+`usd>=0.42 usd<=0.43`, still an `And` of two leaves, is declined by `exact_result_total` in *every* mode,
+including printing. It does not reach `distinct_cards` at all.
+
+Meanwhile `compose_printing_estimate`'s `And` arm fuses the children and takes
+`AndSource::FusedRange { k } => ComposeEstimate::leaf(k, 0, k)` — **exact in printing space** — then the
+card and artwork totals come from projecting that through balls-into-bins.
+
+So the two shapes share a root cause (no interior-interval distinct count) but fail at different layers:
+`year:Y` asks the table and is refused; two-sided never asks.
+
+### Where each shape actually stands
+
+| shape | printing | card | artwork | path |
+| --- | --- | --- | --- | --- |
+| `usd>=200`, `cn<200`, `date>X` (one-sided) | exact `e - s` | **exact** | **exact** | `exact_result_total` → `distinct_cards`, edge arms |
+| `usd:5`, `date:2023-01-01` (`Eq`) | exact | **exact** | **exact** | same, `j == i + 1` arm |
+| `year:Y` | exact | **1.49× median proxy** | proxy | `distinct_cards` → `None` |
+| `usd>=a usd<=b` (fused two-sided) | **declined, though `k` is free** | estimated | estimated | `exact_result_total` → `None`; compose fuses then projects |
+
+## Why this is newly in scope
+
+The parent doc parked candidate 3 — a wavelet tree over a `prev` array, exact for arbitrary ranges — under
+an explicit condition:
+
+> parked unless two-sided conjunctions are ever routed to the range index
+
+and its "Which shapes actually reach this acquire" section argued:
+
+> So a two-sided conjunction like `cn>=441 cn<=447` never reaches this acquire; it goes through the general
+> candidates route, where the estimate is not `card_est` at all. **It was treated as the motivating bounded
+> case for several turns and is not one.**
+
+That scoping is what justified the conclusion *"candidate (2) plus two small arrays is exact for every shape
+that reaches this acquire, with no wavelet, no banded table, no MCV and no dependency."*
+
+**[#837](https://github.com/jbylund/sylvan_librarian/pull/837) fused same-index `And` children into one
+range-index interval**, in `narrow_rec` and in the compose builders. The premise no longer holds, so the
+conclusion it supported has to be re-decided rather than inherited. The parking condition fired.
+
+## A contradiction to resolve before trusting either figure
+
+[#837's write-up](done/local-engine-two-sided-range-fusion.md) says two things that cannot both be right:
+
+- *"`range_card_counts_for` pairs each range index with an exact `RangeCardCounts` table over the same
+  interval, which is why `usd>=0.42`/card reads 12,408 against a true 12,408."* — one-sided card is exact.
+- *"card and artwork 0.6–0.9× — the same ratios their one-sided forms already carry."*
+
+Both describe different paths: `exact_result_total` answers one-sided card exactly, while compose's internal
+projection reads 0.6–0.9× for one-sided and two-sided alike. The misleading clause is **"the same ratios"**,
+which implies two-sided loses nothing one-sided does not — when one-sided has an exact path above the
+estimator and two-sided has none. Re-measure both before quoting either.
+
+## Three pieces, cheapest first
+
+1. **Give `exact_result_total` a fused-range arm for printing space.** `k` is two `partition_point` calls
+   away and `compose_printing_estimate` already computes exactly it. Today a two-sided range has no exact
+   result total in the one space where it costs nothing, and `result_total` feeds paging decisions —
+   including the `STREAM_MIN_MATCHES` sparse floor, where being on the wrong side is what
+   [#848](00848-engine-decline-sparse-exact-wasted-build.md) is about. Reuse `fuse_and_range_children`; do
+   not re-derive the interval.
+2. **The ~34 per-year counts on `date`.** Named in the parent doc's Plan and never shipped. Closes `year:Y`
+   and nothing else: one array, no dependency, no tuning parameter. After it, the `k.min(n_cards)` proxy has
+   no reachable caller and should be removed rather than left as a dead fallback.
+3. **Decide the general interior-interval question.** Candidate 3 is the only exact option — 1.06 MB
+   (134–252 KB per dimension), verified exact on 2,583 windows across all five dimensions, and needing ~200
+   vendored lines because no maintained Rust crate exposes `count_lt(pos_range, value)`
+   (`qwt` has rank/select only; `sucds` and `vers` expose the inverse `quantile`, ~17× the work).
+
+   The alternative is to accept the projection error on two-sided card/artwork. **Measure the routing
+   consequence before choosing**, because the parent doc's governing lesson applies unchanged: the proxy
+   over-costs and the plan arms under-cost, the two partially cancel, and *nothing here ships alone*.
+   Correcting an estimate without re-fitting the arms pushed arm error from 1.6× to ~2.4× last time.
+
+## Reproducing
+
+```bash
+.venv/bin/python scripts/bench_range_estimate_scan.py   # the acceptance test: per-cell, both directions
+.venv/bin/python scripts/bench_card_range_estimate.py --seconds 60   # engine-side, live store
+.venv/bin/python scripts/study_range_slice_cardinality.py            # offline: closed forms
+.venv/bin/python scripts/study_range_slice_layouts.py                # offline: table shapes
+```
+
+All four exist and are tracked. The offline studies read `benchmarks/bitplanes/corpus.jsonl` directly (239 MB,
+untracked) and cache the extraction. Verified running 2026-08-06.
+
+Report **per cell, not pooled** — every pooled figure in this investigation hid structure that only showed up
+per cell, which is the first of the parent doc's four measurement traps.
+
+## Related
+
+- [done/local-engine-range-cardinality-estimate.md](done/local-engine-range-cardinality-estimate.md) — the
+  one-sided half that shipped, the nine rejected estimators, and the sizing for all three candidates.
+- [done/local-engine-two-sided-range-fusion.md](done/local-engine-two-sided-range-fusion.md) — #837, which
+  created this shape.
+- [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — the arm half of "nothing ships alone". Its oracle
+  result says `eval_domain` carries ~75% of recoverable routing loss, so an estimate this feeds is not
+  cosmetic.
+- [local-engine-plan-misselection.md](local-engine-plan-misselection.md) — where the proxy was found, and the
+  `StreamedSelect`/`GatheredScan`-off-`card_range_popcount` under-costing that shares this operating point.

--- a/docs/issues/00853-engine-interior-range-distinct-counts.md
+++ b/docs/issues/00853-engine-interior-range-distinct-counts.md
@@ -1,24 +1,26 @@
 # Interior-Interval Distinct Counts, for `year:Y` and Fused Two-Sided Ranges
 
 Status: open, nothing implemented. Filed as
-[#853](https://github.com/jbylund/sylvan_librarian/issues/853). The **two-sided / interior** half of
-[the range-cardinality work](done/local-engine-range-cardinality-estimate.md), whose one-sided half shipped
-as `RangeCardCounts`. That doc holds the nine rejected estimators, the four measurement traps, and the
-sizing for every candidate; this one holds the problem it deferred and the reason it is no longer deferrable.
+[#853](https://github.com/jbylund/sylvan_librarian/issues/853).
+
+The **interior-interval** half of the range-cardinality work. The one-sided half shipped as
+`RangeCardCounts`; [that record](done/local-engine-range-cardinality-estimate.md) holds candidate 2 as built,
+the nine rejected estimators, the four measurement traps, and the superseded scoping argument. This doc holds
+the live options and the constraint they ship under.
 
 ## The structural limit, which is proven rather than assumed
 
 `RangeCardCounts` stores, per distinct value: `below[i]` (distinct cards among printings with value <
 `values[i]`), `at_or_above[i]`, and `at[i]`. Those answer an interval that runs to an **edge** of the index.
 
-They cannot answer an interior interval, and the parent doc measured why rather than assuming it:
+They cannot answer an interior interval, and it was measured rather than assumed:
 
 - `suf[i] != total - pre[i]` — a card with printings on both sides of the cut is in both.
 - `val[i] != pre[i+1] - pre[i]` — that counts cards whose *first* printing is at this value, not cards
   present at it (10 against a true 54 at `usd:2.99`).
 
-**Distinct counts do not subtract.** So an interior interval is not a lookup away; it is a different data
-structure. `ArchivedRangeCardCounts::lookup` (`card_engine/src/lib.rs`) encodes exactly the boundary:
+**Distinct counts do not subtract.** An interior interval is not a lookup away; it is a different data
+structure. `ArchivedRangeCardCounts::lookup` (`card_engine/src/lib.rs`) encodes exactly that boundary:
 
 ```rust
 match (lo <= first, last_covers_end) {
@@ -44,111 +46,182 @@ let card_est = range_card_counts_for(indexes, idx)
     .unwrap_or_else(|| k.min(n_cards));
 ```
 
-`k.min(n_cards)` is the proxy the parent doc measured at **median 1.49×, p10 1.14, p90 1.82, p99 4.33** —
-over-estimating nearly everywhere, because printings outnumber cards.
+`k.min(n_cards)` is the proxy measured at **median 1.49×, p10 1.14, p90 1.82, p99 4.33** — over-estimating
+nearly everywhere, because printings outnumber cards.
 
-The code comment already names this as the sole remaining fallback. It is correct about `year:Y` being the
-only *single-leaf* case; it predates the fusion below.
-
-### 2. Two-sided fused ranges — the part that changed
+### 2. Fused two-sided ranges — the part that changed
 
 `bare_range_bounds` matches `NumericCmp` / `DateCmp` / `YearCmp` and `Not` of those — **not `And`**. So
-`usd>=0.42 usd<=0.43`, still an `And` of two leaves, is declined by `exact_result_total` in *every* mode,
-including printing. It does not reach `distinct_cards` at all.
+`usd>=0.42 usd<=0.43` is declined by `exact_result_total` in *every* mode, including printing. It never
+reaches `distinct_cards`.
 
-Meanwhile `compose_printing_estimate`'s `And` arm fuses the children and takes
-`AndSource::FusedRange { k } => ComposeEstimate::leaf(k, 0, k)` — **exact in printing space** — then the
-card and artwork totals come from projecting that through balls-into-bins.
+`compose_printing_estimate`'s `And` arm meanwhile fuses the children and takes
+`AndSource::FusedRange { k } => ComposeEstimate::leaf(k, 0, k)` — **exact in printing space** — and the card
+and artwork totals then come from projecting that through balls-into-bins.
 
-So the two shapes share a root cause (no interior-interval distinct count) but fail at different layers:
-`year:Y` asks the table and is refused; two-sided never asks.
+### Where each shape stands
 
-### Where each shape actually stands
+| shape | printing | card/artwork | path |
+| --- | --- | --- | --- |
+| `usd>=200`, `cn<200`, `date>X` (one-sided) | exact `e - s` | **exact** | `exact_result_total` → `distinct_cards`, edge arms |
+| `usd:5`, `date:2023-01-01` (`Eq`) | exact | **exact** | same, `j == i + 1` arm |
+| `year:Y` | exact | **1.49× median proxy** | reaches `distinct_cards`, gets `None` |
+| `usd>=a usd<=b` (fused two-sided) | **declined, though `k` is free** | estimated | never asks |
 
-| shape | printing | card | artwork | path |
-| --- | --- | --- | --- | --- |
-| `usd>=200`, `cn<200`, `date>X` (one-sided) | exact `e - s` | **exact** | **exact** | `exact_result_total` → `distinct_cards`, edge arms |
-| `usd:5`, `date:2023-01-01` (`Eq`) | exact | **exact** | **exact** | same, `j == i + 1` arm |
-| `year:Y` | exact | **1.49× median proxy** | proxy | `distinct_cards` → `None` |
-| `usd>=a usd<=b` (fused two-sided) | **declined, though `k` is free** | estimated | estimated | `exact_result_total` → `None`; compose fuses then projects |
+## Why candidate 3 is no longer parked
 
-## Why this is newly in scope
+The parent doc parked it under an explicit condition — *"unless two-sided conjunctions are ever routed to the
+range index"* — on the strength of its scoping argument that *"a two-sided conjunction like `cn>=441 cn<=447`
+never reaches this acquire… It was treated as the motivating bounded case for several turns and is not one."*
 
-The parent doc parked candidate 3 — a wavelet tree over a `prev` array, exact for arbitrary ranges — under
-an explicit condition:
+**[#837](done/local-engine-two-sided-range-fusion.md) fused same-index `And` children into one range-index
+interval**, in `narrow_rec` and in the compose builders. The premise is false and the parking condition has
+fired. The claim about `bare_range_bounds` not matching `And` is still literally true — which is why
+`exact_result_total` now *declines* two-sided ranges rather than estimating them — but "out of scope" no
+longer follows.
 
-> parked unless two-sided conjunctions are ever routed to the range index
+## Nothing here ships alone
 
-and its "Which shapes actually reach this acquire" section argued:
+Carried from the parent doc unchanged, because it governs every option below.
 
-> So a two-sided conjunction like `cn>=441 cn<=447` never reaches this acquire; it goes through the general
-> candidates route, where the estimate is not `card_est` at all. **It was treated as the motivating bounded
-> case for several turns and is not one.**
+The proxy over-costs ~1.48×; the plan arms under-cost ~1.5× at this operating point. The two errors point in
+opposite directions and **partially cancel**, which is why routing mostly survives them. Correcting the
+estimate without re-fitting the arms pushes the arm error from 1.6× to ~2.4×.
 
-That scoping is what justified the conclusion *"candidate (2) plus two small arrays is exact for every shape
-that reaches this acquire, with no wavelet, no banded table, no MCV and no dependency."*
+The arm half cannot be fixed by re-fitting rates globally: the same two plans are over-costed (0.57) off
+`candidates` acquires and under-costed (2.56) off this one, and `STREAM_*` / `GATHER_*` are shared constants.
+That half is [#852](00852-engine-compose-acquire-p3-p4-ranking.md), whose oracle result puts `eval_domain` at
+~75% of recoverable routing loss — so this estimate is not cosmetic, and the two want sequencing.
 
-**[#837](https://github.com/jbylund/sylvan_librarian/pull/837) fused same-index `And` children into one
-range-index interval**, in `narrow_rec` and in the compose builders. The premise no longer holds, so the
-conclusion it supported has to be re-decided rather than inherited. The parking condition fired.
+## The live options
 
-## A contradiction to resolve before trusting either figure
+### 0. Give `exact_result_total` a fused-range arm for printing space — free
 
-[#837's write-up](done/local-engine-two-sided-range-fusion.md) says two things that cannot both be right:
+`k` is two `partition_point` calls away and `compose_printing_estimate` already computes exactly it. Today a
+two-sided range has no exact result total in the one space where it costs nothing. `result_total` feeds the
+paging decisions, including the `STREAM_MIN_MATCHES` sparse floor where landing on the wrong side is what
+[#848](00848-engine-decline-sparse-exact-wasted-build.md) is about.
 
-- *"`range_card_counts_for` pairs each range index with an exact `RangeCardCounts` table over the same
-  interval, which is why `usd>=0.42`/card reads 12,408 against a true 12,408."* — one-sided card is exact.
-- *"card and artwork 0.6–0.9× — the same ratios their one-sided forms already carry."*
+Reuse `fuse_and_range_children`; do not re-derive the interval. This closes nothing in card or artwork space —
+it is listed first because it is free, not because it is the fix.
 
-Both describe different paths: `exact_result_total` answers one-sided card exactly, while compose's internal
-projection reads 0.6–0.9× for one-sided and two-sided alike. The misleading clause is **"the same ratios"**,
-which implies two-sided loses nothing one-sided does not — when one-sided has an exact path above the
-estimator and two-sided has none. Re-measure both before quoting either.
+### 1. The ~34 per-year counts on `date` — closes `year:Y`, nothing else
 
-## Three pieces, cheapest first
+Named in the parent doc's Plan and never shipped. One array, no dependency, no tuning parameter. After it the
+`k.min(n_cards)` proxy has no reachable caller and should be **deleted** rather than left as a dead fallback.
 
-1. **Give `exact_result_total` a fused-range arm for printing space.** `k` is two `partition_point` calls
-   away and `compose_printing_estimate` already computes exactly it. Today a two-sided range has no exact
-   result total in the one space where it costs nothing, and `result_total` feeds paging decisions —
-   including the `STREAM_MIN_MATCHES` sparse floor, where being on the wrong side is what
-   [#848](00848-engine-decline-sparse-exact-wasted-build.md) is about. Reuse `fuse_and_range_children`; do
-   not re-derive the interval.
-2. **The ~34 per-year counts on `date`.** Named in the parent doc's Plan and never shipped. Closes `year:Y`
-   and nothing else: one array, no dependency, no tuning parameter. After it, the `k.min(n_cards)` proxy has
-   no reachable caller and should be removed rather than left as a dead fallback.
-3. **Decide the general interior-interval question.** Candidate 3 is the only exact option — 1.06 MB
-   (134–252 KB per dimension), verified exact on 2,583 windows across all five dimensions, and needing ~200
-   vendored lines because no maintained Rust crate exposes `count_lt(pos_range, value)`
-   (`qwt` has rank/select only; `sucds` and `vers` expose the inverse `quantile`, ~17× the work).
+### 2. Build the card bitmap in acquire — exact, no storage
 
-   The alternative is to accept the projection error on two-sided card/artwork. **Measure the routing
-   consequence before choosing**, because the parent doc's governing lesson applies unchanged: the proxy
-   over-costs and the plan arms under-cost, the two partially cancel, and *nothing here ships alone*.
-   Correcting an estimate without re-fitting the arms pushed arm error from 1.6× to ~2.4× last time.
+Carried from the parent doc; it was always "complementary and independent" and is still unshipped.
+
+`CardRangePopcount` already calls `build_card_range_bits` at dispatch, re-deriving the bounds to do so, and it
+wins **138 of 142** sampled range queries. `StreamedSelect` / `GatheredScan` would take `bitmap_card_ids` over
+their own `range_narrowed` → `into_cards`. Only `PrintingCompose` has no use for a card bitmap, and it wins
+**zero**.
+
+So promoting the build into the acquire branch and carrying it in `Prep` — the pattern `Prep::Plane` already
+uses for the plane bitmap — is a reordering of work already done. Its popcount is the exact
+`matches` / `eval_domain`, and it deletes a duplicate bounds derivation.
+
+| | |
+| --- | --- |
+| accuracy | **exact** |
+| memory | **none** — no archive data |
+| query time | 0 in the 97% case (the winner builds it anyway); 47 µs median, 106 µs p90 when a plan wins that does not want it |
+| risk | moves an O(k) build across the acquire/dispatch boundary; the both-fast-paths-decline case (`usd>50`) needs a test |
+
+That 47 µs is why the storage option below still matters — it is the cost when the artifact goes unused.
+Measured from `acquire.range_k`: median slice 38,245 printings at `CARD_RANGE_BUILD_PER_PRINTING_NS` = 1.22.
+
+**This option is exact for interior intervals too**, since a bitmap popcount does not care about interval
+shape — which makes it the cheapest general answer if the unused-artifact cost is acceptable.
+
+### 3. prev-array + wavelet tree — exact for arbitrary ranges, 1.06 MB
+
+Carried from the parent doc, where it was kept "for completeness; **probably not needed**". That judgement
+rested on the scoping argument above and should be re-read as live.
+
+The general problem is **range distinct count** (colored range counting). Let `prev[i]` be the index of the
+previous printing of the same card, or −1. Then
+
+    distinct cards in [a, b)  ==  #{ i in [a, b) : prev[i] < a }
+
+because each card in the window has exactly one occurrence that is its first there, and only that one points
+back outside it. A wavelet tree over `prev` answers that dominance count in O(log n), and the tree encodes
+`prev`, so the array need not be stored. Verified exact on 2,583 windows across all five dimensions —
+bounded, one-sided and random. Space is 1.06 MB, 134–252 KB per dimension.
+
+No maintained Rust crate exposes the operation. [`qwt`](https://docs.rs/qwt/) has rank/select/access only.
+[`sucds`](https://github.com/kampersanda/sucds) and [`vers`](https://github.com/Cydhra/vers) — both
+Apache-2.0, both actively maintained — expose `quantile(range, k)`, the inverse, which would have to be
+binary-searched at roughly 17× the work. [`wavelet-matrix`](https://github.com/sekineh/wavelet-matrix-rs) has
+exactly `count_lt(pos_range, value)` and is MIT (declared in `Cargo.toml`; there is no LICENSE file, which is
+why GitHub's API reports none) but was last touched in 2022. Vendoring the ~200 lines that path needs —
+`prefix_rank_op`, the struct, and a rank-capable bitvector the engine can supply itself — is viable under an
+MIT attribution header if it is ever wanted.
+
+### Fallback if the storage is unaffordable
+
+A trapezoid histogram — bucket widths doubling in from each edge, capped, uniform between — over
+prefix/suffix arrays reaches 1.19× worst case at 3.4 KB, or 1.06× at 42 KB. Dominated by candidate 2 on every
+axis except size, and for `date` not even that, since 1,048 cuts exceeds the 915 possible answers.
+
+## Order
+
+1. **Option 0**, because it is free and independent of the rest.
+2. **Option 1**, because it closes a named shape with one array and lets the proxy be deleted.
+3. **Then decide between options 2 and 3 on measurement**, not on elegance. Option 2 is exact with no archive
+   cost but pays 47 µs when its artifact goes unused; option 3 is exact with no query cost but 1.06 MB and a
+   vendored dependency. The deciding number is how often a plan wins that does not want the bitmap.
+4. **Re-ask the arm question afterwards.** With exact features, part of the arms' ~1.5× under-costing may
+   disappear — it may be the model charging `card_est`-shaped terms for true-card-shaped work. Re-fit only
+   afterwards, and only against prep-netted measurements. That is [#852](00852-engine-compose-acquire-p3-p4-ranking.md)'s
+   territory, and its oracle run says features come before rates.
+
+## Acceptance
+
+`scripts/bench_range_estimate_scan.py` is the test. It sweeps thresholds across each dimension in both
+directions and reports `acquire.matches / true total` **per point** — scans rather than a pooled median,
+because every pooled figure in this investigation hid structure that only showed up per cell. That is the
+first of [the four measurement traps](done/local-engine-range-cardinality-estimate.md#measurement-traps-worth-keeping),
+all of which still apply.
+
+**Target:** every `unique=card` cell within 1% of true, and the interior shapes are the cells that are not
+there yet. The one-sided baseline is in the parent doc as a historical record; those cells now answer exactly.
+
+**`eur` and `tix` are now IN scope.** The parent doc's Acceptance section excludes them as having "no range
+index and never reach this acquire" — [#838](https://github.com/jbylund/sylvan_librarian/pull/838) gave both a
+`PrintingValueIndex` and both now carry a `RangeCardCounts` (`price_eur_cards`, `price_tix_cards`). The scan
+should cover them, and `tix` is the interesting one: it is only 56.5% present, the highest null rate of any
+range index.
+
+**Control:** all eight cells at `unique=printing` read 1.000 across 26 scan points, because that branch sets
+`matches = k` and in printing mode that *is* the result cardinality. Those rows must stay at 1.000 — and
+option 0 should extend that guarantee to fused two-sided ranges, which currently have no exact total at all.
+
+**Routing is deliberately not an acceptance criterion for the estimate alone**, per "nothing here ships
+alone" above.
 
 ## Reproducing
 
 ```bash
-.venv/bin/python scripts/bench_range_estimate_scan.py   # the acceptance test: per-cell, both directions
+.venv/bin/python scripts/bench_range_estimate_scan.py               # the acceptance test, per cell
 .venv/bin/python scripts/bench_card_range_estimate.py --seconds 60   # engine-side, live store
 .venv/bin/python scripts/study_range_slice_cardinality.py            # offline: closed forms
 .venv/bin/python scripts/study_range_slice_layouts.py                # offline: table shapes
 ```
 
-All four exist and are tracked. The offline studies read `benchmarks/bitplanes/corpus.jsonl` directly (239 MB,
-untracked) and cache the extraction. Verified running 2026-08-06.
-
-Report **per cell, not pooled** — every pooled figure in this investigation hid structure that only showed up
-per cell, which is the first of the parent doc's four measurement traps.
+All four exist and are tracked. The offline studies read `benchmarks/bitplanes/corpus.jsonl` directly
+(239 MB, untracked) and cache the extraction. `study_range_slice_cardinality.py` verified running 2026-08-06.
 
 ## Related
 
 - [done/local-engine-range-cardinality-estimate.md](done/local-engine-range-cardinality-estimate.md) — the
-  one-sided half that shipped, the nine rejected estimators, and the sizing for all three candidates.
+  one-sided half as shipped, the nine rejected estimators (all measured, so the next attempt does not repeat
+  them), and the measurement traps.
 - [done/local-engine-two-sided-range-fusion.md](done/local-engine-two-sided-range-fusion.md) — #837, which
-  created this shape.
-- [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — the arm half of "nothing ships alone". Its oracle
-  result says `eval_domain` carries ~75% of recoverable routing loss, so an estimate this feeds is not
-  cosmetic.
-- [local-engine-plan-misselection.md](local-engine-plan-misselection.md) — where the proxy was found, and the
-  `StreamedSelect`/`GatheredScan`-off-`card_range_popcount` under-costing that shares this operating point.
+  created this shape and whose write-up contains a correction on exactly this point.
+- [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — the arm half of "nothing ships alone".
+- [#848](00848-engine-decline-sparse-exact-wasted-build.md) — why an exact `result_total` near
+  `STREAM_MIN_MATCHES` matters.
+- [local-engine-plan-misselection.md](local-engine-plan-misselection.md) — where the proxy was found.

--- a/docs/issues/00854-engine-plane-popcount-arm-remeasure.md
+++ b/docs/issues/00854-engine-plane-popcount-arm-remeasure.md
@@ -1,0 +1,124 @@
+# `PlanePopcountOrder`'s Under-Costing: Re-Measure, and Instrument `popcount_words` First
+
+Status: open, not started. Filed as
+[#854](https://github.com/jbylund/sylvan_librarian/issues/854). The one calibration finding left over from
+[the decline-fallback work](done/local-engine-plan-misselection.md), which otherwise shipped in #805. That doc
+called this *"real and unexplained"*, and it is the last of its items without a home — the other three route to
+[#852](00852-engine-compose-acquire-p3-p4-ranking.md),
+[#853](00853-engine-interior-range-distinct-counts.md), or are deliberately parked.
+
+## What was measured
+
+Both figures are `measured / predicted`, the convention `bench_plan_misselection.py` prints, so **> 1 means
+under-costed** — the model thinks the plan is cheaper than it is and over-picks it.
+
+| scan | n | median | tail |
+| --- | --: | --: | --: |
+| 200 generated queries | 36 | **2.44** | worst 8.69 |
+| 2,500-query scan | 157 | **1.61** | p90 6.16 |
+
+It materializes nothing, so netting the acquire is a no-op and raw and net agree. That is what made it worth
+keeping: every other apparent defect in that scan dissolved under netting — `GatheredScan` went 6.47 raw to
+0.84 net, and *"anyone reading the raw column alone would go and 'fix' a calibrated arm"* — and this one did
+not.
+
+## It has probably narrowed, and that needs confirming rather than assuming
+
+`CARD_RANGE_BUILD_PER_PRINTING_NS`'s doc comment (`card_engine/src/cost.rs`), written in #813, records
+PlanePopcountOrder as *"slightly UNDER-costed at 0.92"*.
+
+**Mind the convention — the tree uses both directions.** That comment's ratios are `predicted / measured`: it
+calls the arm *"over-costed by a near-uniform 1.20"* and fixes it by **lowering** the rate 1.22 → 0.93, and one
+only lowers a rate that over-predicts. Converted, its 0.92 is `measured / predicted` ≈ **1.09**, against the
+1.61 above.
+
+So #813's refit closed most of the gap. Two reasons not to call it done:
+
+1. **It is a passing remark, not a re-measure.** The 0.92 appears in *another constant's* doc, as the argument
+   for why shared constants cannot absorb `CardRangePopcount`'s error. It is not an n=157 sweep, and the
+   population behind it is plausibly narrower — bare ranges at `unique=card`, which is where
+   `CardRangePopcount` lives.
+2. **The measurement basis moved, not just the constants.** [#833](https://github.com/jbylund/sylvan_librarian/pull/833)
+   re-based regret on dispatch and made plane rows dispatch-comparable *specifically because plane rows were
+   getting negative regret* — the routed path reuses an artifact a forced trial rebuilds. Every plane-row
+   number taken before that is suspect in a way a rate refit does not address.
+
+## There is a feature question underneath, and it should be settled first
+
+[#852](00852-engine-compose-acquire-p3-p4-ranking.md)'s oracle result is that features come before rates. This
+arm has a feature that has never been checked against anything.
+
+Its cost is four terms (`card_engine/src/cost.rs`):
+
+```rust
+PhysicalPlan::PlanePopcountOrder => {
+    matches * PLANE_POPCOUNT_SCATTER_PER_MATCH_NS
+        + (n_cards / 64.0) * PLANE_POPCOUNT_PER_WORD_NS
+        + limit * PLANE_POPCOUNT_EMIT_PER_CARD_NS
+        + PLANE_POPCOUNT_FIXED_COST_NS
+}
+```
+
+`(n_cards / 64.0)` charges the **whole corpus in words, every time**. The executor's skip-scan stops once it
+reaches the page offset, so the words actually scanned depend on page depth: a shallow page should scan far
+fewer, a deep one more.
+
+**Hypothesis, not a measurement.** If that is the mechanism, this is a feature error rather than a rate error,
+and it would produce exactly the observed shape — a median near 1 with a fat tail (p90 6.16), the tail being
+deep pages. Worth stating because it is falsifiable in one breakdown, and because a rate refit would paper over
+it while leaving the tail.
+
+## The prerequisite is one counter at one site
+
+[local-engine-instrument-fast-paths.md](local-engine-instrument-fast-paths.md) item 1 specifies it already, and
+it is the cheapest step in that doc: counter the word passes in `run_query_streamed_popcount` — the single
+function both `PlanePopcountOrder` and `CardRangePopcount` delegate to — reported against `popcount_words`, **a
+cost feature that already exists**. One site closes two of the four uninstrumented fast paths, against a
+feature needing no new plumbing. [#798](https://github.com/jbylund/sylvan_librarian/issues/798) tracks the
+wider instrumentation gap; item 3 there is the compose half.
+
+`plan_stats_never_leak_between_participants` currently asserts the **opposite** contract — that these four
+plans report zeros — and does so deliberately, to pin today's behaviour so that instrumenting one is a decision
+someone makes on purpose rather than a silent change in what a zero means. Expect to update it, one plan at a
+time.
+
+## The coupling that makes a blind refit expensive
+
+Three of the four constants above are **shared with `CardRangePopcount`**. That is precisely why its own retune
+had to move `CARD_RANGE_BUILD_PER_PRINTING_NS` — 80% of its error, and unshared — rather than touch the shared
+terms: *"Its four other constants are shared with PlanePopcountOrder… so they cannot absorb it."*
+
+So re-fitting this arm's rates moves `CardRangePopcount` too, and that arm is currently calibrated. A feature
+fix does not have that problem, which is a second reason to instrument before fitting.
+
+## Order
+
+1. **Land the `popcount_words` counter** (instrument-fast-paths item 1).
+2. **Re-measure on a larger sample**, on post-#833 regret basing. **Expect this to come back near 1.0** — if it
+   does, close it and record the figure, because the open item then costs more to carry than to settle.
+3. **Only if a real gap survives:** decide feature vs rate from the page-depth breakdown, not a pooled median.
+   Every pooled figure in this line of work hid structure that only showed up per cell — the parent doc lists
+   three methodology traps that each produced a confidently wrong answer.
+
+## Reproducing
+
+```bash
+.venv/bin/python scripts/bench_plan_misselection.py --source distribution --out A.jsonl
+.venv/bin/python scripts/bench_plan_misselection.py --compare A.jsonl B.jsonl   # the only real verdict
+.venv/bin/python scripts/bench_cost_model_agreement.py --seconds 300            # the per-cell bar
+```
+
+The parent doc's method notes still apply and are the reason its figures are quotable: min of 15 trials after 3
+warmups, plans rotated each round, every plan from a fresh `filter.clone()` so each pays `memoize_text_predicates`
+identically, and queries where the best measured plan *is* the picked plan excluded. Misses under ~5 µs flip
+run to run; quote only the larger ones.
+
+## Related
+
+- [done/local-engine-plan-misselection.md](done/local-engine-plan-misselection.md) — the shipped fix, the
+  mis-costing scan this came from, and the three methodology traps.
+- [local-engine-instrument-fast-paths.md](local-engine-instrument-fast-paths.md) — the counter, and why the
+  four fast paths' zeros are zero-by-definition rather than zero-by-omission.
+- [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — features before rates, established by oracle run.
+- [#853](00853-engine-interior-range-distinct-counts.md) — shares the `card_range_popcount` acquire, where the
+  parent doc's thin-sample `StreamedSelect`/`GatheredScan` finding (~2.4×, n=13) also lives.

--- a/docs/issues/00855-prefer-score-remaining-tuning.md
+++ b/docs/issues/00855-prefer-score-remaining-tuning.md
@@ -1,0 +1,101 @@
+# Prefer-Score Artwork Selection: The Tuning Work Left After `art_style`
+
+Status: open, nothing started. Filed as
+[#855](https://github.com/jbylund/sylvan_librarian/issues/855). Split out of
+[#720](done/00720-prefer-score-artwork-tuning.md), which closed as completed when `art_style` shipped.
+
+**Read the parent record before touching any of this.** Three hypotheses here were built, reviewed and
+rejected, and a fourth was deferred for one specific missing table. Each re-derivation costs a blind review
+round, and the parent doc has the review counts.
+
+## Already rejected — do not simply retry
+
+**One printing credit per set.** [#720's own last comment](https://github.com/jbylund/sylvan_librarian/issues/720)
+asks for exactly this, so it is the first thing anyone will reach for. It was built and reviewed at **28 better
+/ 22 worse**, and the losses concentrate **17–1 on 7th–10th Edition `★` foils**, where collapsing the foil twin
+removes the only thing separating a core-set artwork from an older alternative. It never independently earned
+its place.
+
+A future attempt has to handle that population specifically rather than re-run the same rule. The principle is
+sound — a set including an artwork twice is one editorial decision — which is what makes it tempting twice.
+
+**Excluding `promo` sets.** Zeroes the count for 1,018 artworks that exist only as promos, telling the score
+they were never printed. Rejected on that alone.
+
+## Live work
+
+### 1. Collapse child sets into parents — deferred, not rejected, and the largest effect measured
+
+`blc`→`blb` and similar. **16,357 duplicate credits across 10,502 artworks** — a larger effect than anything
+that shipped in #720.
+
+Blocked on data rather than judgement: `parent_set_code` is absent from our data and would need a
+`magic.set_parents` table.
+
+Release date is a usable proxy — 87 of 91 changes correct — but **systematically fails on late-released
+promos**: `pltc` lands 16 months after `ltr`. So the proxy is not a substitute for the table; it is a way to
+prototype the win and size it before paying for one.
+
+This item is independent of everything below and can go first.
+
+### 2. Expand the `art_style` tag set — needs statistical power first
+
+The shipped tag set is **partly a hypothesis**. 533 further candidates exist, found by a measurable proxy: art
+tags whose artworks concentrate in few sets separate style/setting tags from content tags. Content tags span
+**450–520 sets**; style tags span **2–53**.
+
+Two real obstacles:
+
+- Scanning 533 candidates needs more than the **517 observations** the shipped component rests on, without
+  multiple-comparison inflation.
+- The proxy has **known false positives** — `ghirapur-grand-prix`, `cho-arrim` — set-specific Magic *content*,
+  not style. So the proxy nominates candidates; it does not decide them.
+
+### 3. Weight 14 is evidenced, not optimal
+
+Every step up has been free, and the stopping signal is the first "worse" verdict. Finding the actual optimum
+is a coefficient search, not another hand-reviewed step — and see the frame-ladder trap below for why it has to
+be a *joint* search.
+
+### 4. Lift weights out of SQL — the enabler for (2) and (3)
+
+Feature/weight separation currently lives only in the Python tooling.
+[`api/sql/backfill_prefer_scores.sql`](../../api/sql/backfill_prefer_scores.sql) still fuses extraction and
+weights, so any coefficient search has to run through the scripts. Lifting weights into config is the remaining
+refactor, and it is what makes (2) and (3) tractable rather than artisanal.
+
+## Sequencing
+
+**(1) first** — independent data work with a known payoff and no tooling dependency.
+
+**(2) and (3) are blocked on tooling, not on this issue.** The labelling instrument and the closed loop are the
+prerequisite: [label harness](local-prefer-score-label-harness.md) and
+[the closed tuning loop](local-prefer-score-tuning-loop.md). The latter exists precisely because #720's
+analysis was **wrong three separate times** without one. Do **(4)** alongside whichever of those lands, since
+it is what a coefficient search needs.
+
+## Two traps from the parent, both load-bearing here
+
+**Weights cannot be moved one at a time.** The frame ladder is 1993=10, 1997=25, 2003=30, 2015=42, and every
+single-weight change perturbs *two* gaps. Raising `frame_2003` to widen 1997↔2003 also narrowed 2003↔2015 and
+reviewed at 8 better / 22 worse; lowering `frame_1997` instead narrowed 1993↔1997 and sent **161 of 179 swaps
+to the oldest frame**. Only moving both old frames together isolates a gap. This is a direct argument for (3)
+being a joint search rather than a ladder of single steps.
+
+**Confounded batches lie, and they lied in the reassuring direction.** Six accidental foil-vs-nonfoil pairs came
+back 6/6 "no difference", suggesting the `finish` component could be deleted outright. A deliberately
+controlled batch — same card, set, artwork, frame, border, rarity, scan quality, promo types and stamp,
+differing *only* in finish — returned **24 nonfoil, 0 foil, 26 same**. Only 162 such controlled pairs exist
+corpus-wide, so any component this small needs a built batch rather than found pairs.
+
+## Related
+
+- [done/00720-prefer-score-artwork-tuning.md](done/00720-prefer-score-artwork-tuning.md) — what shipped, the
+  rejected hypotheses with their review counts, and the corpus analysis.
+- [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the labelling instrument and
+  weight fitting.
+- [local-prefer-score-tuning-loop.md](local-prefer-score-tuning-loop.md) — the closed loop: propose, grade ~20
+  cards, accept or reject, with one number going up.
+- [done/00707-engine-3key-ordering-parity.md](done/00707-engine-3key-ordering-parity.md) — `prefer_score` was
+  the third sort key; the engine has since dropped key 3 from cross-card comparison, though SQL still carries
+  it.

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -1,8 +1,11 @@
 # The materializing plans re-derive membership compose already computed exactly
 
 Status: **designed and measured, not implemented.** Filed as
-[#856](https://github.com/jbylund/sylvan_librarian/issues/856). Worth ~**8×** on the highest-regret query
-class in the engine — see the re-measurement caveat at the bottom before quoting that figure.
+[#856](https://github.com/jbylund/sylvan_librarian/issues/856).
+
+**Worth 3.5× end to end on the population that pays it, where the match loop is 86% of query time.**
+Re-measured on `main` 2026-08-06, post-#833–#845 — figures and method under "What it is worth". The
+earlier ~8× headline is withdrawn: it was a *forced-trial loop-time* ratio, not an end-to-end one.
 
 **Mechanism re-verified against `main` after the #833–#845 stack.** The anchor line below is unchanged; #843
 added `n.proven` as a third element and nothing else.
@@ -36,10 +39,13 @@ So `all_match_known` is false, and the materializing plans re-derive per printin
 already proved: `push_card_matches` and `card_match_count` evaluate the full residual for every printing
 they touch.
 
-Measured over 3,054 compose-acquired printing queries: **1,213 ms of match-loop time over 145 million
-printings scanned, 6.98 ns each**. An O(1) bit test is ~1 ns, so ~145 ms — **roughly 8x less**. This is
-the cell both the cost and regret matrices name as the top target
+This is the cell both the cost and regret matrices independently named as the top target
 ([local-engine-cost-model-agreement.md](done/local-engine-cost-model-agreement.md)).
+
+The original measurement here read *"3,054 compose-acquired printing queries: 1,213 ms of match-loop time
+over 145 million printings scanned, 6.98 ns each… roughly 8× less"*. That has been re-measured and the
+population re-identified — see [What it is worth](#what-it-is-worth). Current figures: **86% of routed time
+on 896 queries at 5.8 ns per printing, ~3.5× end to end.**
 
 There is in-tree precedent: `exec_card_range_popcount` threads `range_pbits` beside its card bitmap and
 membership-tests in O(1), for exactly this reason — "the shown printing must actually be in range, not
@@ -81,19 +87,78 @@ so:
 Gate the fast path on that distinction, exactly as `prepare_candidates` already does for
 `all_match_known`.
 
-## Re-measure the magnitude before quoting it
+## What it is worth
 
-The defect is verified present; the **numbers are not current**. The 1,213 ms / 145 M printings / 6.98 ns
-figures predate the #833–#845 stack, and two of its layers moved the inputs:
+Re-measured on `main` at `1e5035e` (2026-08-06), after the whole #833–#845 stack, with
+`scripts/bench_membership_waste.py`. 30,000 uniform-sampled queries, Docker shut down, two seeds.
 
-- [#843](done/local-engine-proven-conjuncts.md) cut re-verification for card-space conjuncts, which changes
-  how much of that 1,213 ms was this defect versus the one it fixed. `o:this border:black` went 1,993 → 542 µs
-  on that change alone.
-- [#840](done/local-engine-is-frame-predicates.md) / #842 changed what narrows at all, so the 3,054-query
-  population is not the same population.
+**The population.** 2,495 of 30,000 sampled queries are printing-mode on a compose acquire; **896 of those
+(36%) route to a materializing plan**, which is the population this change can touch — 3.0% of the uniform
+sample. Every one of the 896 picked `GatheredScan`; `StreamedSelect` was never chosen here, so in practice
+this is `push_card_matches`, not `card_match_count`.
 
-Expect the direction to hold — a discarded exact bitmap is still discarded — and the factor to change. Take
-the measurement before writing the PR description, not after.
+**The rate, and how much of the query it is.**
+
+| | seed 20260806 | seed 777 |
+| --- | --: | --: |
+| queries (picked, materializing) | 896 | 874 |
+| routed time | 18.5 ms | 18.5 ms |
+| of which match loop | 16.0 ms — **86.2%** | 16.0 ms — **86.6%** |
+| printings examined | 2.8 M | 2.6 M |
+| **ns per printing** | **5.80** | **6.11** |
+| per-query median ns/printing | 5.81 | 6.01 |
+
+Pooled and median agree to within 2%, so no single large query is carrying the rate.
+
+**The counterfactual**, at three bit-test costs, because the saving is `rate − bit_test_ns` and the answer
+depends on that more than on anything else measured here:
+
+| bit test | saves | of routed time | speedup on the population |
+| --- | --: | --: | --: |
+| 0.5 ns | 14.6 ms | 78.7% | **4.70×** |
+| **1.0 ns** | **13.2 ms** | **71.3%** | **3.48×** |
+| 2.0 ns | 10.5 ms | 56.5% | 2.30× |
+
+So **~3.5×** end to end at a 1 ns bit test, and still 2.3× if the bit test costs twice that. The match loop
+itself goes ~5.8× faster; the end-to-end figure is smaller because 14% of the query is not the loop.
+
+### Where the old 8× came from, and why it is withdrawn
+
+The all-trials view reproduces the original almost exactly — **1,070 ms over 101.9 M printings** here against
+the doc's **1,213 ms over 145 M** — which identifies the original figure as counting **forced trials of plans
+the router did not choose**. Those runs are real work, but production never pays them, and they examine 36×
+more printings than the picked path (101.9 M against 2.8 M) because a forced plan often scans the whole
+corpus.
+
+Two things follow. The 8× was a **loop-time** ratio on a **non-production** population, so it overstated the
+end-to-end win by ~2.3×. And the per-printing rate on that view is 10.50 ns against the picked path's 5.80 —
+forced runs are slower per printing too, which is why the two views cannot be mixed.
+
+The defect itself is unchanged, and the direction held.
+
+### What this does not establish
+
+- **`n.tight` is not observable from outside Rust**, and neither is the printing-space half:
+  `narrowed_repr` is `None` *by construction* for a compose acquire, because `Prep::Range` and `Prep::Plane`
+  "materialize no candidate list at all" — the narrowing happens at dispatch, after the router's acquire.
+  So 896 is an **upper bound** on the addressable population; the gate may fire on fewer.
+- **Uniform sampling.** 3.0% is a uniform-mode share, which over-samples rare shapes by construction. The
+  realistic-traffic weight is unmodelled, the same caveat every `is:`/`frame:` figure carries.
+- **The 1 ns bit test is an assumption**, not a measurement — hence the sensitivity table rather than one
+  number. A kernel micro-benchmark of `bitmap_contains` over a 12 KB bitmap would settle it, and is the
+  cheapest thing that would tighten this estimate.
+
+### Reproducing
+
+```bash
+.venv/bin/python scripts/bench_membership_waste.py \
+    --corpus benchmarks/bitplanes/corpus.jsonl --shm /tmp/membership.store --sample 30000
+```
+
+Observational, not an A/B — both inputs are counters `explain_analyze` has published since #833, so there is
+no second build and no drift to control for. `ns_loop` is the fastest round's phase split, matching every
+consumer's `min(trials_ns)`, so the rate is a floor. Delete the harness when this ships;
+[the toolkit audit](local-benchmark-toolkit-audit.md) is a standing argument against keeping one-off benches.
 
 ## Verifying it
 

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -53,8 +53,8 @@ This is the cell both the cost and regret matrices independently named as the to
 
 The original measurement here read *"3,054 compose-acquired printing queries: 1,213 ms of match-loop time
 over 145 million printings scanned, 6.98 ns each… roughly 8× less"*. That has been re-measured and the
-population re-identified — see [What it is worth](#what-it-is-worth). Current figures: **87% of routed time
-at 5.9 ns per printing against a 0.17 ns merge, ~6.5× end to end.**
+population re-identified — see [What it is worth](#what-it-is-worth). Current figures: **87% of routed time at
+5.9 ns per printing, against 0.88 ns for this route's bitmap probe — 3.84× end to end.**
 
 There is in-tree precedent: `exec_card_range_popcount` threads `range_pbits` beside its card bitmap and
 membership-tests in O(1), for exactly this reason — "the shown printing must actually be in range, not
@@ -82,11 +82,10 @@ B is the better shape; A is the smaller change. Either way the plumbing is the s
 membership structure in `narrow_candidates_exact` when `n.tight && printing_space`, carry it on
 `PreparedCandidates`, and use it in the walk.
 
-**Superseded in one respect: carry the sorted list, not a bitmap.** Both designs above assumed a bitmap and
-`bitmap_contains`. The measurement below says to carry `Candidates::Printings` as it already is and merge
-against it — 0.17 against 0.88 ns/printing, no allocation, and it is the structure `narrow_candidates_exact`
-already produced. Keep the bitmap only as the `StreamedSelect` fallback, since a permutation walk cannot use
-a forward pointer. That makes design **A** the smaller change *and* the faster one, which it was not before.
+**Where the sorted list beats both:** for `GatheredScan` the candidate list can be merged against directly,
+with no bitmap — cheaper and simpler, and split out as
+[#857](00857-engine-membership-merge-sorted-list.md). The designs above remain the right shape for this route,
+whose job is the visit orders #857 cannot serve.
 
 ## The correctness constraint that decides the gate
 
@@ -129,60 +128,61 @@ route to a materializing plan** — 3.0% of the uniform sample. Every one picked
 
 Pooled and median agree to within 2%, so no single large query is carrying the rate.
 
-### Which structure to test against
+### What the bitmap probe costs
 
-**`set:` already has the index this needs.** `indexes.set_codes` is a `TagIndex` in printing space — set
-code → sorted printing ids — and `narrow_candidates_exact` turns `set:X` straight into
-`Narrowed::tight(Candidates::Printings(...))`. So on the dominant family the exact answer is *already a
-sorted `Vec<u32>`*, and `raw_candidates` still holds it at the point this change wants to capture something
-(it is consumed by the flattening to card ids immediately after).
+`card_engine/src/bench_membership_check.rs`, modelled on the measured production shape — 234 candidate cards,
+13.6 printings each, 1.56 matching. ns per printing in a visited span, plus the per-query cost of building the
+bitmap before anything can be probed:
 
-That makes a bitmap optional rather than necessary, and measuring both says skip it.
-`card_engine/src/bench_membership_bittest.rs`, modelled on the measured production shape — 234 candidate
-cards, 13.6 printings each, 1.56 matching — ns per printing in a visited span:
-
-| matches/card | density | bitmap probe | **merge** | walk floor | bitmap build |
-| --- | --: | --: | --: | --: | --: |
-| 1 | 7% | 0.80 | **0.14** | 0.10 | 0.3 µs/query |
-| **2 (measured 1.56)** | **14%** | **0.88** | **0.17** | 0.09 | **0.5 µs/query** |
-| 4 | 29% | 0.97 | **0.22** | 0.09 | 1.7 µs |
-| 7 | 50% | 0.64 | **0.31** | 0.09 | 4.4 µs |
-| 14 | 100% | 0.98 | **0.64** | 0.08 | 8.5 µs |
-
-The merge wins at every density, and for a structural reason rather than a constant-factor one: it is
-**O(matches)** where the probe is **O(span)**, so it never touches the 86% of printings that do not match.
-It also avoids allocating and zeroing the bitmap — 0.5 µs per query at production scale, which is ~2% of a
-22 µs query.
-
-**Soundness, and the one place it does not hold.** The merge needs the walk to visit pids in globally
-ascending order. It does for `GatheredScan`: `cards_of_printings` yields
-ascending cids, and each card's printing span is contiguous, so one forward pointer suffices.
-**`StreamedSelect` walks a permutation in sort order, so the pointer would be wrong there and the bitmap is
-the only option.** Every query measured on this population picked `GatheredScan`, so the merge covers the
-measured case and the bitmap is the fallback for the plan that was never chosen.
-
-**Two corrections this measurement forced**, recorded because both produced believable wrong answers:
-
-- A counting kernel (`if contains { hits += 1 }`) reads a flat 0.4 ns at *every* density, because the
-  compiler predicates it into `hits += contains as u32` and vectorizes. Density-flatness was the tell — an
-  unpredictable branch has to cost something. The real loop conditionally *appends*, which cannot be
-  predicated.
-- An earlier model strided over *all* cards, which made the merge advance its pointer through pids belonging
-  to skipped cards and read 3.75 ns instead of 0.17. That cannot happen: `card_ids` is derived **from** the
-  candidate list, so every visited card holds at least one match and the list has no pid outside a visited
-  span. The same model also used the corpus-average 3.09 printings per card where visited cards really hold
-  13.6, understating span work 4×.
-
-**So the counterfactual, anchored on both measurements** — realistic mode, 377 queries, 8.2 ms routed of
-which 7.1 ms (87.1%) is the match loop:
-
-| membership check | saves | of routed time | speedup on the population |
+| matches/card | density | **bitmap probe** | bitmap build |
 | --- | --: | --: | --: |
-| **0.17 ns — merge (recommended)** | **6.9 ms** | **84.5%** | **6.47×** |
-| 0.88 ns — bitmap probe | 6.1 ms | 73.9% | 3.84× |
-| 2.0 ns — control, 2× worse than the bitmap | 4.7 ms | 57.2% | 2.34× |
+| 1 | 7% | 0.33–0.80 | 0.3 µs/query |
+| **2 (measured 1.56)** | **14%** | **0.38–0.88** | **0.3–0.5 µs/query** |
+| 4 | 29% | 0.52–0.97 | 0.9–1.7 µs |
+| 7 | 50% | 0.64–1.09 | 3.5–4.4 µs |
+| 14 | 100% | 0.42–0.98 | 5.5–8.5 µs |
 
-**~6.5×** with the merge, ~3.8× with a bitmap, and a 2.3× floor even at a check cost nobody measured.
+**Ranges, not points, and deliberately so.** These kernels run at 0.1–1 ns per operation, where run-to-run and
+build-to-build variation is a large fraction of the value: the production row moved 0.88 → 0.38 between two
+versions of the bench that did not touch the kernel, then held at 0.37–0.43 across three consecutive runs. So
+the absolute level is soft. What is robust is the **ratio** against the merge, which reads 5.0× in the first
+run and 5.4× in the second — and the fact that both routes are an order of magnitude under the 5.9 ns residual
+they replace. Every figure quoted elsewhere in this doc uses the **pessimistic end (0.88)**, so the speedups
+are conservative.
+
+The same bench measures the [#857](00857-engine-membership-merge-sorted-list.md) merge alongside it and finds
+it 5× cheaper (0.17 ns) with no build cost, for the structural reason that it is O(matches) where this is
+O(span). This route earns its place on **reach**, not cost: it needs nothing of the visit order, so it serves
+`StreamedSelect`'s permutation walk, which the merge cannot.
+
+### For permutation order, scatter — do not sort
+
+A natural idea for the `StreamedSelect` case is to make a forward pointer work anyway: key each candidate pid
+by its card's position in the sort permutation (`inv_perm[printing_to_card[pid]]`), sort, then merge during the
+walk. Measured, it does not pay — the two per-query setups, at the production point:
+
+| setup | cost/query |
+| --- | --: |
+| scatter candidates into a printing bitmap | **0.2–0.3 µs** |
+| key by permutation position and sort | **2.4–2.9 µs** |
+
+An order of magnitude apart, and it widens with density (5.5 µs against 23.2 µs when every printing matches).
+The reason is structural: the scatter is O(k) with one store each, while the sort is O(k log k) with **two
+dependent random loads per element** to compute the key. On a ~22 µs query, 2.9 µs of setup would eat most of
+what the change wins.
+
+**The right shape for permutation order is a scatter too, just into permutation space** — and the engine
+already does it. `run_query_streamed_popcount` scatters the match set through `inv_perm` and walks words at 64
+cards a load, for `unique=card` + `True`. Extending that to printing mode is
+[#730](00730-engine-popcount-skip-walk.md), which is the better home for the permutation-order half of this
+than a sort would be.
+
+**One trap, recorded because it produced a believable wrong answer.** A counting kernel
+(`if contains { hits += 1 }`) reads a flat 0.4 ns at *every* match density, because the compiler predicates it
+into `hits += contains as u32` and vectorizes. Density-flatness was the tell — an unpredictable branch has to
+cost something. The real loop conditionally *appends* a match, which cannot be predicated, and once the kernel
+does that the expected inverted-U appears. Both kernels are kept in the bench, the counting one labelled as the
+trap.
 
 ### Which queries this touches
 

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -3,9 +3,13 @@
 Status: **designed and measured, not implemented.** Filed as
 [#856](https://github.com/jbylund/sylvan_librarian/issues/856).
 
-**Worth 3.5× end to end on the population that pays it, where the match loop is 86% of query time.**
-Re-measured on `main` 2026-08-06, post-#833–#845 — figures and method under "What it is worth". The
-earlier ~8× headline is withdrawn: it was a *forced-trial loop-time* ratio, not an end-to-end one.
+**Worth ~5× on the population that pays it, which is 1.3% of realistic queries and `set:`-dominated.**
+Both sides now measured on `main` 2026-08-06, post-#833–#845: the residual costs **5.9 ns/printing** and the
+bit test replacing it costs **0.46 ns** at the production access pattern. The match loop is **87% of routed
+time** on that population. Figures and method under "What it is worth".
+
+The earlier ~8× headline is withdrawn — it was a *forced-trial loop-time* ratio, not an end-to-end one — and
+the ~1 ns bit-test assumption it rested on turned out **conservative**.
 
 **Mechanism re-verified against `main` after the #833–#845 stack.** The anchor line below is unchanged; #843
 added `n.proven` as a third element and nothing else.
@@ -44,8 +48,8 @@ This is the cell both the cost and regret matrices independently named as the to
 
 The original measurement here read *"3,054 compose-acquired printing queries: 1,213 ms of match-loop time
 over 145 million printings scanned, 6.98 ns each… roughly 8× less"*. That has been re-measured and the
-population re-identified — see [What it is worth](#what-it-is-worth). Current figures: **86% of routed time
-on 896 queries at 5.8 ns per printing, ~3.5× end to end.**
+population re-identified — see [What it is worth](#what-it-is-worth). Current figures: **87% of routed time
+at 5.9 ns per printing against a 0.46 ns bit test, ~5× end to end.**
 
 There is in-tree precedent: `exec_card_range_popcount` threads `range_pbits` beside its card bitmap and
 membership-tests in O(1), for exactly this reason — "the shown printing must actually be in range, not
@@ -90,14 +94,18 @@ Gate the fast path on that distinction, exactly as `prepare_candidates` already 
 ## What it is worth
 
 Re-measured on `main` at `1e5035e` (2026-08-06), after the whole #833–#845 stack, with
-`scripts/bench_membership_waste.py`. 30,000 uniform-sampled queries, Docker shut down, two seeds.
+`scripts/bench_membership_waste.py` and `card_engine/src/bench_membership_bittest.rs`. 30,000 sampled
+queries per run, Docker shut down.
 
-**The population.** 2,495 of 30,000 sampled queries are printing-mode on a compose acquire; **896 of those
-(36%) route to a materializing plan**, which is the population this change can touch — 3.0% of the uniform
-sample. Every one of the 896 picked `GatheredScan`; `StreamedSelect` was never chosen here, so in practice
-this is `push_card_matches`, not `card_match_count`.
+**Read uniform for the rate and realistic for the share**, and do not mix them: uniform resolves the
+per-printing rate better because it reaches rare shapes at all, while only realistic weights say how much
+traffic this is. Both are labelled below.
 
-**The rate, and how much of the query it is.**
+**The population** (uniform). 2,495 of 30,000 are printing-mode on a compose acquire; **896 of those (36%)
+route to a materializing plan** — 3.0% of the uniform sample. Every one picked `GatheredScan`;
+`StreamedSelect` was never chosen here, so in practice this is `push_card_matches`, not `card_match_count`.
+
+**The rate, and how much of the query it is** — uniform, two seeds.
 
 | | seed 20260806 | seed 777 |
 | --- | --: | --: |
@@ -110,17 +118,72 @@ this is `push_card_matches`, not `card_match_count`.
 
 Pooled and median agree to within 2%, so no single large query is carrying the rate.
 
-**The counterfactual**, at three bit-test costs, because the saving is `rate − bit_test_ns` and the answer
-depends on that more than on anything else measured here:
+**What the bit test costs — measured, not assumed.** `card_engine/src/bench_membership_bittest.rs`
+reproduces the real access pattern (walk candidate cards, test each one's contiguous printing span) and
+sweeps the two axes that decide it. ns per printing tested, 1× corpus:
+
+| candidate stride | 1% dense | 9% dense | 50% dense | 99% dense |
+| --- | --: | --: | --: | --: |
+| 1 (every card) | 0.52 | 0.83 | **2.25** | 0.61 |
+| 32 | 0.47 | 0.45 | 0.81 | 0.62 |
+| **135 (measured production)** | 0.46 | **0.46** | 0.69 | 0.58 |
+
+Two things fall out. The cost is **non-monotonic in density** — it peaks in the middle, where the branch is
+unpredictable, and is cheap at both ends. And the mispredict penalty **largely disappears as the candidate
+set gets sparse**: real queries visit 234 candidate cards of 31,508 (stride ~135) and only 722 printings, few
+enough decisions that even 50% density costs 0.69 ns.
+
+At the production point — stride 135, 9% density — the bit test is **0.46 ns**.
+
+**So the counterfactual, now anchored** — realistic mode, 377 queries, 8.4 ms routed of which 7.3 ms
+(87.3%) is the match loop:
 
 | bit test | saves | of routed time | speedup on the population |
 | --- | --: | --: | --: |
-| 0.5 ns | 14.6 ms | 78.7% | **4.70×** |
-| **1.0 ns** | **13.2 ms** | **71.3%** | **3.48×** |
-| 2.0 ns | 10.5 ms | 56.5% | 2.30× |
+| **0.5 ns (measured)** | **6.7 ms** | **80.0%** | **5.01×** |
+| 1.0 ns (the old assumption) | 6.1 ms | 72.8% | 3.67× |
+| 2.0 ns | 4.9 ms | 58.2% | 2.39× |
 
-So **~3.5×** end to end at a 1 ns bit test, and still 2.3× if the bit test costs twice that. The match loop
-itself goes ~5.8× faster; the end-to-end figure is smaller because 14% of the query is not the loop.
+**~5×** end to end on this population, and the floor is 2.4× even if the bit test came in 4× worse than
+measured. The match loop itself goes ~12× faster; the end-to-end figure is smaller because 13% of the query
+is not the loop.
+
+### Which queries this touches
+
+The question the population share has to answer, since a rate alone does not justify the work. Under
+**realistic** family weights, by share of printings examined:
+
+| family | share | n | median density |
+| --- | --: | --: | --: |
+| `set:` | **63.2%** | 153 | 7.9% |
+| `f:` + `set:` | 6.2% | 16 | 7.3% |
+| `r:` | 4.3% | 14 | 10.5% |
+| `set:` + `usd:` | 3.0% | 7 | 4.9% |
+| `keyword:` | 2.8% | 77 | 100.0% |
+| `date:`/`tix:`/`cn:`/`eur:`/`year:` + `set:` | ~8% | 18 | 0–15% |
+
+**This is a `set:`-dominated change.** That is not a coincidence: `set:` and `watermark:` are the
+*exact-postings* compose leaves added by #748 (index #739), and exact postings are what make the narrowing
+tight — which is precisely #856's gate. The families that reach it are the ones whose narrowing can be
+tight.
+
+Note `watermark:` is 17.3% under **uniform** sampling and falls out of the top ten under realistic weights,
+where it carries 0.5 against `set:`'s 5. Read the uniform run for the rate and the realistic one for the
+share.
+
+Two consequences worth stating plainly:
+
+- **`f:` queries benefit only partly.** Legality is an existential plane, and the gate below excludes those
+  from the complete-bit-test case — the per-printing plane check still runs.
+- **Text predicates are not in this population at all.** `name:`/`oracle:`/`flavor:` are not
+  compose-composable ([#731](00731-engine-compose-universal-evaluator.md) step 3, not started), so a query
+  like `name:s` never reaches this path; and where a text leaf rides *alongside* a composable one it is the
+  residual, which makes the narrowing not-tight, so the gate does not fire either. #856's design B cites
+  `memoize_text_predicates` as a mechanism precedent, which is a different thing from sharing its target.
+
+**Scale:** 1,116 of 30,000 realistic-sampled queries are printing-mode on a compose acquire, and 377 of
+those (34%) route to a materializing plan — **1.3% of queries**. A 5× win on 1.3% of traffic is roughly a
+4% aggregate effect, and the honest case for doing it is the per-query tail rather than the mean.
 
 ### Where the old 8× came from, and why it is withdrawn
 
@@ -144,15 +207,25 @@ The defect itself is unchanged, and the direction held.
   So 896 is an **upper bound** on the addressable population; the gate may fire on fewer.
 - **Uniform sampling.** 3.0% is a uniform-mode share, which over-samples rare shapes by construction. The
   realistic-traffic weight is unmodelled, the same caveat every `is:`/`frame:` figure carries.
-- **The 1 ns bit test is an assumption**, not a measurement — hence the sensitivity table rather than one
-  number. A kernel micro-benchmark of `bitmap_contains` over a 12 KB bitmap would settle it, and is the
-  cheapest thing that would tighten this estimate.
+- **The bit test is now measured (0.46 ns), but on a synthetic bitmap.** `bench_membership_bittest.rs`
+  builds spans and bits synthetically, so it captures the access pattern and the branch behaviour but not
+  cache competition: in the real loop the bitmap shares L1 with `APrinting` rows being streamed. That makes
+  0.46 ns a floor. The sensitivity table is kept for exactly that reason — at 4× the measured cost the change
+  still returns 2.4×.
+- **The density figure was a pooled mean and is now a distribution.** 8.7% pooled (uniform) hid a bimodal
+  spread: under realistic weights p10/p50/p90 is 4% / 10% / 100%, with 96 of 377 queries above 80% density
+  and only 32 in the expensive 20–80% band. A mean is the wrong summary for a non-monotonic cost curve — two
+  queries at 1% and 99% average to the worst case while both are cheap.
 
 ### Reproducing
 
 ```bash
+# The residual side, the population, and which families reach it. --mode realistic for the share.
 .venv/bin/python scripts/bench_membership_waste.py \
-    --corpus benchmarks/bitplanes/corpus.jsonl --shm /tmp/membership.store --sample 30000
+    --corpus benchmarks/bitplanes/corpus.jsonl --shm /tmp/membership.store --sample 30000 --mode realistic
+
+# The bit-test side, swept over candidate sparsity and match density.
+cargo test --release bench_membership_bittest -- --ignored --nocapture
 ```
 
 Observational, not an A/B — both inputs are counters `explain_analyze` has published since #833, so there is

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -3,7 +3,9 @@
 Status: **designed and measured, not implemented.** Filed as
 [#856](https://github.com/jbylund/sylvan_librarian/issues/856).
 
-**Worth ~6.5× on the population that pays it, which is 1.3% of realistic queries and `set:`-dominated.**
+**Worth ~6.5× on the population that pays it — but that is 1.22% of routed time and contains no slow
+queries, so this is a ~1% aggregate rather than a latency fix.** `set:`-dominated. See
+[It touches no slow queries](#it-touches-no-slow-queries-and-that-is-structural) before citing the ratio.
 Both sides measured on `main` 2026-08-06, post-#833–#845: the residual costs **5.9 ns/printing**, the match
 loop is **87% of routed time**, and the replacement costs **0.17 ns**.
 
@@ -216,8 +218,36 @@ Two consequences worth stating plainly:
   `memoize_text_predicates` as a mechanism precedent, which is a different thing from sharing its target.
 
 **Scale:** 1,116 of 30,000 realistic-sampled queries are printing-mode on a compose acquire, and 377 of
-those (34%) route to a materializing plan — **1.3% of queries**. A 5× win on 1.3% of traffic is roughly a
-4% aggregate effect, and the honest case for doing it is the per-query tail rather than the mean.
+those (34%) route to a materializing plan — **1.3% of queries**, and **1.22% of all routed time**. The
+change saves **1.03% of total routed time**.
+
+### It touches no slow queries, and that is structural
+
+An earlier draft of this doc claimed "the honest case for doing it is the per-query tail rather than the
+mean." **That was asserted rather than measured, and it is false.** Measured routed time, realistic mode:
+
+| | p50 | p90 | p99 | max |
+| --- | --: | --: | --: | --: |
+| all sampled | 10.6 µs | 49.4 µs | **215.8 µs** | **1,132.6 µs** |
+| **this population** | 28.3 µs | 36.4 µs | 64.5 µs | **78.5 µs** |
+
+The population's *maximum* is about the overall *p90*. The engine's actual slow tail — 216 µs at p99, 1.1 ms
+worst — lies entirely outside it. These queries are consistently ~3× the median and never in the tail. The
+largest per-query win available is 78.5 µs → 9.2 µs, which no user can perceive.
+
+**And that is not luck.** This population is compose-acquired queries whose narrowing came back *tight*, and
+a tight narrowing is precisely what makes a query fast. The defect makes already-fast queries slower than they
+should be; it cannot produce a slow one. So the case is a ~1% aggregate, not a latency fix, and anything
+claiming otherwise should be checked against the table above — `scripts/bench_membership_waste.py` prints it.
+
+The slowest rows, for reference:
+
+```
+   78.5us ->    9.2us  (8.5x)  border:white f:historic cn<217
+   77.0us ->   12.7us  (6.1x)  usd>=0.15 usd<=0.15 f:pioneer
+   71.2us ->   14.6us  (4.9x)  eur:0.09 f:pauper
+   46.1us ->    2.2us  (20.5x) tix>=0.03 tix<=416.84 set:neo
+```
 
 ### Where the old 8× came from, and why it is withdrawn
 

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -1,13 +1,30 @@
 # The materializing plans re-derive membership compose already computed exactly
 
-Worth ~**8x** on the highest-regret query class in the engine. Designed and measured, not implemented.
+Status: **designed and measured, not implemented.** Filed as
+[#856](https://github.com/jbylund/sylvan_librarian/issues/856). Worth ~**8×** on the highest-regret query
+class in the engine — see the re-measurement caveat at the bottom before quoting that figure.
+
+**Mechanism re-verified against `main` after the #833–#845 stack.** The anchor line below is unchanged; #843
+added `n.proven` as a third element and nothing else.
+
+## No, #843 did not already do this
+
+The first question a reviewer will ask, and the answer is in the code rather than in judgement.
+[#843](done/local-engine-proven-conjuncts.md)'s `Narrowed::proven` mask is **card-space only by
+construction** — a child qualifies only when its own narrowing came back *"tight AND card-space"*, and a
+fused range interval *"is printing-space besides, so it can never be proven"* (`card_engine/src/lib.rs`,
+at the mask construction).
+
+So #843 stops `card_pass` from re-verifying **card-space** conjuncts the candidate set proves; this stops the
+per-printing walk from re-deriving **printing-space** membership. The two are complementary, and the second
+was deliberately out of #843's scope.
 
 ## The waste
 
 `narrow_candidates_exact` ends with:
 
 ```rust
-(Some(n.set), n.tight && !printing_space)
+(Some(n.set), n.tight && !printing_space, n.proven)
 ```
 
 A printing-space narrowing is never reported as `residual_exact`, even when `n.tight`. That is correct
@@ -64,9 +81,27 @@ so:
 Gate the fast path on that distinction, exactly as `prepare_candidates` already does for
 `all_match_known`.
 
+## Re-measure the magnitude before quoting it
+
+The defect is verified present; the **numbers are not current**. The 1,213 ms / 145 M printings / 6.98 ns
+figures predate the #833–#845 stack, and two of its layers moved the inputs:
+
+- [#843](done/local-engine-proven-conjuncts.md) cut re-verification for card-space conjuncts, which changes
+  how much of that 1,213 ms was this defect versus the one it fixed. `o:this border:black` went 1,993 → 542 µs
+  on that change alone.
+- [#840](done/local-engine-is-frame-predicates.md) / #842 changed what narrows at all, so the 3,054-query
+  population is not the same population.
+
+Expect the direction to hold — a discarded exact bitmap is still discarded — and the factor to change. Take
+the measurement before writing the PR description, not after.
+
 ## Verifying it
 
 This changes what rows come back if it is wrong, so measure rows, not timings. The row-diff harness used
 for the sparse-gather experiment captured totals and page rows over **127,640 compose-acquire queries**
 and compared them before/after; it found 0 differences there and would find these. Timings second:
 paired `bench_query_latency_ab.py`, interleaved.
+
+The existential-plane gate above is the part most likely to produce wrong rows rather than slow ones, and it
+is per-printing-varying — so verify returned row *identity* against real data across all three distinct-ons,
+not just totals ([the repair pattern](reference-engine-printing-varying-plane-repair-pattern.md) is why).

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -173,9 +173,15 @@ what the change wins.
 
 **The right shape for permutation order is a scatter too, just into permutation space** — and the engine
 already does it. `run_query_streamed_popcount` scatters the match set through `inv_perm` and walks words at 64
-cards a load, for `unique=card` + `True`. Extending that to printing mode is
-[#730](00730-engine-popcount-skip-walk.md), which is the better home for the permutation-order half of this
-than a sort would be.
+cards a load.
+
+Its limitation is the thing to extend: it runs only for `unique=card` with a `FilterExpr::True` residual, i.e.
+where the plane bitmap already *is* the match set. Carrying a real match set through `inv_perm` is what this
+route needs, and it needs per-card counts for the skip since a popcount counts cards and not matches. That
+extension is tracked at [#730](00730-engine-popcount-skip-walk.md) — whose own subject is deep pagination,
+with this as a **second consumer** of the same machinery — and it is also item 3 of
+[#852](00852-engine-compose-acquire-p3-p4-ranking.md)'s carried-forward list. #730 has the sort-vs-scatter
+numbers recorded so they are not re-derived there.
 
 **One trap, recorded because it produced a believable wrong answer.** A counting kernel
 (`if contains { hits += 1 }`) reads a flat 0.4 ns at *every* match density, because the compiler predicates it

--- a/docs/issues/00856-engine-compose-membership-bittest.md
+++ b/docs/issues/00856-engine-compose-membership-bittest.md
@@ -3,13 +3,16 @@
 Status: **designed and measured, not implemented.** Filed as
 [#856](https://github.com/jbylund/sylvan_librarian/issues/856).
 
-**Worth ~5× on the population that pays it, which is 1.3% of realistic queries and `set:`-dominated.**
-Both sides now measured on `main` 2026-08-06, post-#833–#845: the residual costs **5.9 ns/printing** and the
-bit test replacing it costs **0.46 ns** at the production access pattern. The match loop is **87% of routed
-time** on that population. Figures and method under "What it is worth".
+**Worth ~6.5× on the population that pays it, which is 1.3% of realistic queries and `set:`-dominated.**
+Both sides measured on `main` 2026-08-06, post-#833–#845: the residual costs **5.9 ns/printing**, the match
+loop is **87% of routed time**, and the replacement costs **0.17 ns**.
 
-The earlier ~8× headline is withdrawn — it was a *forced-trial loop-time* ratio, not an end-to-end one — and
-the ~1 ns bit-test assumption it rested on turned out **conservative**.
+**The recommended design changed as a result: use a two-pointer merge, not a bitmap.** The narrowing already
+hands over a *sorted* candidate printing list, and the gather loop visits pids in ascending order, so no
+bitmap is needed — and the merge is 5× cheaper than one (0.17 against 0.88 ns/printing) while skipping a
+~0.5 µs/query scatter. See "Which structure to test against".
+
+The earlier ~8× headline is withdrawn — it was a *forced-trial loop-time* ratio, not an end-to-end one.
 
 **Mechanism re-verified against `main` after the #833–#845 stack.** The anchor line below is unchanged; #843
 added `n.proven` as a third element and nothing else.
@@ -49,7 +52,7 @@ This is the cell both the cost and regret matrices independently named as the to
 The original measurement here read *"3,054 compose-acquired printing queries: 1,213 ms of match-loop time
 over 145 million printings scanned, 6.98 ns each… roughly 8× less"*. That has been re-measured and the
 population re-identified — see [What it is worth](#what-it-is-worth). Current figures: **87% of routed time
-at 5.9 ns per printing against a 0.46 ns bit test, ~5× end to end.**
+at 5.9 ns per printing against a 0.17 ns merge, ~6.5× end to end.**
 
 There is in-tree precedent: `exec_card_range_popcount` threads `range_pbits` beside its card bitmap and
 membership-tests in O(1), for exactly this reason — "the shown printing must actually be in range, not
@@ -74,8 +77,14 @@ a considered cost here"), so it touches ~20 matches across filter.rs, estimator.
 lib.rs, plus 39 in tests.rs.
 
 B is the better shape; A is the smaller change. Either way the plumbing is the same: capture the
-bitmap in `narrow_candidates_exact` when `n.tight && printing_space`, carry it on
+membership structure in `narrow_candidates_exact` when `n.tight && printing_space`, carry it on
 `PreparedCandidates`, and use it in the walk.
+
+**Superseded in one respect: carry the sorted list, not a bitmap.** Both designs above assumed a bitmap and
+`bitmap_contains`. The measurement below says to carry `Candidates::Printings` as it already is and merge
+against it — 0.17 against 0.88 ns/printing, no allocation, and it is the structure `narrow_candidates_exact`
+already produced. Keep the bitmap only as the `StreamedSelect` fallback, since a permutation walk cannot use
+a forward pointer. That makes design **A** the smaller change *and* the faster one, which it was not before.
 
 ## The correctness constraint that decides the gate
 
@@ -118,35 +127,60 @@ route to a materializing plan** — 3.0% of the uniform sample. Every one picked
 
 Pooled and median agree to within 2%, so no single large query is carrying the rate.
 
-**What the bit test costs — measured, not assumed.** `card_engine/src/bench_membership_bittest.rs`
-reproduces the real access pattern (walk candidate cards, test each one's contiguous printing span) and
-sweeps the two axes that decide it. ns per printing tested, 1× corpus:
+### Which structure to test against
 
-| candidate stride | 1% dense | 9% dense | 50% dense | 99% dense |
-| --- | --: | --: | --: | --: |
-| 1 (every card) | 0.52 | 0.83 | **2.25** | 0.61 |
-| 32 | 0.47 | 0.45 | 0.81 | 0.62 |
-| **135 (measured production)** | 0.46 | **0.46** | 0.69 | 0.58 |
+**`set:` already has the index this needs.** `indexes.set_codes` is a `TagIndex` in printing space — set
+code → sorted printing ids — and `narrow_candidates_exact` turns `set:X` straight into
+`Narrowed::tight(Candidates::Printings(...))`. So on the dominant family the exact answer is *already a
+sorted `Vec<u32>`*, and `raw_candidates` still holds it at the point this change wants to capture something
+(it is consumed by the flattening to card ids immediately after).
 
-Two things fall out. The cost is **non-monotonic in density** — it peaks in the middle, where the branch is
-unpredictable, and is cheap at both ends. And the mispredict penalty **largely disappears as the candidate
-set gets sparse**: real queries visit 234 candidate cards of 31,508 (stride ~135) and only 722 printings, few
-enough decisions that even 50% density costs 0.69 ns.
+That makes a bitmap optional rather than necessary, and measuring both says skip it.
+`card_engine/src/bench_membership_bittest.rs`, modelled on the measured production shape — 234 candidate
+cards, 13.6 printings each, 1.56 matching — ns per printing in a visited span:
 
-At the production point — stride 135, 9% density — the bit test is **0.46 ns**.
+| matches/card | density | bitmap probe | **merge** | walk floor | bitmap build |
+| --- | --: | --: | --: | --: | --: |
+| 1 | 7% | 0.80 | **0.14** | 0.10 | 0.3 µs/query |
+| **2 (measured 1.56)** | **14%** | **0.88** | **0.17** | 0.09 | **0.5 µs/query** |
+| 4 | 29% | 0.97 | **0.22** | 0.09 | 1.7 µs |
+| 7 | 50% | 0.64 | **0.31** | 0.09 | 4.4 µs |
+| 14 | 100% | 0.98 | **0.64** | 0.08 | 8.5 µs |
 
-**So the counterfactual, now anchored** — realistic mode, 377 queries, 8.4 ms routed of which 7.3 ms
-(87.3%) is the match loop:
+The merge wins at every density, and for a structural reason rather than a constant-factor one: it is
+**O(matches)** where the probe is **O(span)**, so it never touches the 86% of printings that do not match.
+It also avoids allocating and zeroing the bitmap — 0.5 µs per query at production scale, which is ~2% of a
+22 µs query.
 
-| bit test | saves | of routed time | speedup on the population |
+**Soundness, and the one place it does not hold.** The merge needs the walk to visit pids in globally
+ascending order. It does for `GatheredScan`: `cards_of_printings` yields
+ascending cids, and each card's printing span is contiguous, so one forward pointer suffices.
+**`StreamedSelect` walks a permutation in sort order, so the pointer would be wrong there and the bitmap is
+the only option.** Every query measured on this population picked `GatheredScan`, so the merge covers the
+measured case and the bitmap is the fallback for the plan that was never chosen.
+
+**Two corrections this measurement forced**, recorded because both produced believable wrong answers:
+
+- A counting kernel (`if contains { hits += 1 }`) reads a flat 0.4 ns at *every* density, because the
+  compiler predicates it into `hits += contains as u32` and vectorizes. Density-flatness was the tell — an
+  unpredictable branch has to cost something. The real loop conditionally *appends*, which cannot be
+  predicated.
+- An earlier model strided over *all* cards, which made the merge advance its pointer through pids belonging
+  to skipped cards and read 3.75 ns instead of 0.17. That cannot happen: `card_ids` is derived **from** the
+  candidate list, so every visited card holds at least one match and the list has no pid outside a visited
+  span. The same model also used the corpus-average 3.09 printings per card where visited cards really hold
+  13.6, understating span work 4×.
+
+**So the counterfactual, anchored on both measurements** — realistic mode, 377 queries, 8.2 ms routed of
+which 7.1 ms (87.1%) is the match loop:
+
+| membership check | saves | of routed time | speedup on the population |
 | --- | --: | --: | --: |
-| **0.5 ns (measured)** | **6.7 ms** | **80.0%** | **5.01×** |
-| 1.0 ns (the old assumption) | 6.1 ms | 72.8% | 3.67× |
-| 2.0 ns | 4.9 ms | 58.2% | 2.39× |
+| **0.17 ns — merge (recommended)** | **6.9 ms** | **84.5%** | **6.47×** |
+| 0.88 ns — bitmap probe | 6.1 ms | 73.9% | 3.84× |
+| 2.0 ns — control, 2× worse than the bitmap | 4.7 ms | 57.2% | 2.34× |
 
-**~5×** end to end on this population, and the floor is 2.4× even if the bit test came in 4× worse than
-measured. The match loop itself goes ~12× faster; the end-to-end figure is smaller because 13% of the query
-is not the loop.
+**~6.5×** with the merge, ~3.8× with a bitmap, and a 2.3× floor even at a check cost nobody measured.
 
 ### Which queries this touches
 
@@ -207,11 +241,14 @@ The defect itself is unchanged, and the direction held.
   So 896 is an **upper bound** on the addressable population; the gate may fire on fewer.
 - **Uniform sampling.** 3.0% is a uniform-mode share, which over-samples rare shapes by construction. The
   realistic-traffic weight is unmodelled, the same caveat every `is:`/`frame:` figure carries.
-- **The bit test is now measured (0.46 ns), but on a synthetic bitmap.** `bench_membership_bittest.rs`
-  builds spans and bits synthetically, so it captures the access pattern and the branch behaviour but not
-  cache competition: in the real loop the bitmap shares L1 with `APrinting` rows being streamed. That makes
-  0.46 ns a floor. The sensitivity table is kept for exactly that reason — at 4× the measured cost the change
-  still returns 2.4×.
+- **Both checks are measured (0.17 / 0.88 ns), but on synthetic spans.** `bench_membership_bittest.rs`
+  builds spans and candidate lists synthetically, so it captures the access pattern, the branch behaviour and
+  the O(matches)-vs-O(span) difference, but not cache competition: in the real loop these structures share L1
+  with `APrinting` rows being streamed. Both figures are therefore floors, which is why the control row at
+  2.0 ns is kept — the change still returns 2.3× at a cost an order of magnitude above the merge's.
+- **Span placement is idealised.** Visited cards are spread evenly through the corpus; real candidate cards
+  cluster (a `set:` is a release, and printings of one release sit near each other in pid order). Clustering
+  helps both routes and helps the merge more, so this biases against the recommendation rather than for it.
 - **The density figure was a pooled mean and is now a distribution.** 8.7% pooled (uniform) hid a bimodal
   spread: under realistic weights p10/p50/p90 is 4% / 10% / 100%, with 96 of 377 queries above 80% density
   and only 32 in the expensive 20–80% band. A mean is the wrong summary for a non-monotonic cost curve — two

--- a/docs/issues/00857-engine-membership-merge-sorted-list.md
+++ b/docs/issues/00857-engine-membership-merge-sorted-list.md
@@ -117,8 +117,7 @@ cargo test --release bench_membership_check -- --ignored --nocapture
 - [#856](00856-engine-compose-membership-bittest.md) — the defect, the gate, and the general bitmap route.
 - [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — the routing error on this same acquire, and where
   the engine's actual slow tail is.
-- [#730](00730-engine-popcount-skip-walk.md) — the permutation-order analogue. Keying candidates by
-  permutation position and *sorting* to make a forward pointer work there was measured and rejected (2.4–2.9 µs
-  per query against 0.2–0.3 for a scatter); the shape that works is a scatter through `inv_perm` into
-  permutation space, which `run_query_streamed_popcount` already does for `unique=card` + `True`. Recorded in
-  [#856](00856-engine-compose-membership-bittest.md#for-permutation-order-scatter--do-not-sort).
+- [#730](00730-engine-popcount-skip-walk.md) — the machinery the permutation-order route would use. Its own
+  subject is deep pagination; membership under a residual is a **second consumer**, recorded there along with
+  the measured rejection of sorting (2.4–2.9 µs/query against 0.2–0.3 for a scatter) and the note that its
+  "why deferred" reasoning covered only the pagination case.

--- a/docs/issues/00857-engine-membership-merge-sorted-list.md
+++ b/docs/issues/00857-engine-membership-merge-sorted-list.md
@@ -1,0 +1,124 @@
+# Merge against the sorted candidate list instead of re-deriving membership — 0.17 ns where 5.9 is paid
+
+Status: **designed and measured, not implemented.** Filed as
+[#857](https://github.com/jbylund/sylvan_librarian/issues/857). Split out of
+[#856](00856-engine-compose-membership-bittest.md), which owns the defect, the correctness gate and the shared
+population measurement. Read that first; this doc is one alternative route and does not restate it.
+
+**The split is along reach, not preference.** #856 restores the discarded membership as a **printing bitmap**,
+probed per printing — general, works for any visit order. This is the cheaper special case that covers the
+whole *measured* population but cannot serve every visit order. Both are worth having.
+
+## The narrowing already hands over a sorted list
+
+`indexes.set_codes` is a printing-space `TagIndex` — set code → sorted printing ids — and
+`narrow_candidates_exact` turns `set:X` straight into `Narrowed::tight(Candidates::Printings(...))`
+(`card_engine/src/lib.rs`). On the dominant family — `set:` is **63%** of the population by printings
+examined — the exact answer is **already a sorted `Vec<u32>`**, and it is still live as `raw_candidates` at
+exactly the point #856 would scatter it into a bitmap:
+
+```rust
+let (raw_candidates, residual_exact, proven_conjuncts): (Option<Candidates>, bool, u64) =
+    narrow_candidates_exact(filter, indexes, offsets, cards);
+// Captured before the flattening below consumes it — see PreparedCandidates::narrowed_repr.
+```
+
+So carry the list itself and walk it with a **two-pointer merge** against the card spans. No bitmap, no
+allocation, no scatter pass.
+
+## Cheaper at every density, and structurally so
+
+`card_engine/src/bench_membership_check.rs`, modelled on the measured production shape — 234 candidate cards,
+13.6 printings each, 1.56 matching. ns per printing in a visited span:
+
+| matches/card | density | bitmap probe (#856) | **merge (this)** | bitmap build |
+| --- | --: | --: | --: | --: |
+| 1 | 7% | 0.33–0.80 | **0.06–0.14** | 0.3 µs/query |
+| **2 (measured 1.56)** | **14%** | **0.38–0.88** | **0.06–0.17** | **0.3–0.5 µs/query** |
+| 4 | 29% | 0.52–0.97 | **0.13–0.22** | 0.9–1.7 µs |
+| 7 | 50% | 0.64–1.09 | **0.28–0.31** | 3.5–4.4 µs |
+| 14 | 100% | 0.42–0.98 | **0.39–0.64** | 5.5–8.5 µs |
+
+**Read the ratio, not the absolutes.** These kernels run at 0.1–1 ns per operation, where variation is a large
+fraction of the value: the production row read 0.17 in one version of the bench and 0.06–0.08 across three runs
+of the next, with the probe moving 0.88 → 0.37–0.43 alongside it. The **merge:probe ratio held at 5.0× and
+5.4×**, and both routes stay an order of magnitude under the 5.9 ns residual. The figures quoted here are the
+**pessimistic end**, so the 6.47× is conservative.
+
+Not a constant-factor win: the merge is **O(matches)** where a probe is **O(span)**, so it never touches the
+86% of printings that do not match. It also avoids allocating and zeroing the bitmap — 0.5 µs per query at
+production scale, ~2% of a 22 µs query, which the probe route pays before it can probe anything.
+
+End to end on the shared population, against the 5.9 ns/printing residual both would replace:
+
+| route | saves | of routed time | speedup on the population |
+| --- | --: | --: | --: |
+| **merge, 0.17 ns (this)** | **6.9 ms** | **84.5%** | **6.47×** |
+| bitmap probe, 0.88 ns (#856) | 6.1 ms | 73.9% | 3.84× |
+
+## Why this cannot replace #856
+
+The merge needs the walk to visit pids in **globally ascending order**, because it carries a single forward
+pointer.
+
+- **`GatheredScan` — holds.** `cards_of_printings` yields ascending cids (both its paths: the small one dedups
+  consecutive cards from a sorted printing list, the large one goes through `bitmap_card_ids`, which is
+  ascending by construction), and each card's printing span is contiguous. So the walk visits pids ascending.
+- **`StreamedSelect` — does not hold.** It walks a permutation in *sort* order, so a forward pointer would
+  skip past matches and silently drop rows. Only a bitmap works there.
+
+Every query in the measured population picked `GatheredScan` — **377 of 377** — so this covers the measured
+case, and #856 stays as the general route for the plan that was never chosen there. That also means #856's own
+value is currently **unmeasured**: its population is the one where `StreamedSelect` is picked on a compose
+acquire, which this sample never produced.
+
+## Scope — do not read the 6.5× as a latency win
+
+Owned by [#856](00856-engine-compose-membership-bittest.md#it-touches-no-slow-queries-and-that-is-structural)
+and summarised here only so this doc cannot be read in isolation as a bigger win than it is: the population is
+1.3% of realistic queries and **1.22% of all routed time**, and it contains **no slow queries** — its maximum
+is 78.5 µs against the overall p99 of 216 µs and max of 1.1 ms. That is structural, because a tight narrowing
+is what makes a query fast in the first place.
+
+## The correctness gate is #856's, unchanged
+
+The bitmap-or-list covers the **narrowed subexpression only**, so an ANDed existential plane (legality) still
+needs its per-printing check. That reasoning is identical for both routes and lives in
+[#856](00856-engine-compose-membership-bittest.md#the-correctness-constraint-that-decides-the-gate).
+
+One addition specific to this route: **the merge is order-dependent, so getting the plan gate wrong is a
+wrong-answer bug, not a slow one.** Assert the ascending-order precondition in debug rather than relying on
+the `GatheredScan`-only gate holding through future refactors — the same discipline `sorted_ids` got in #844.
+
+## One measurement trap, recorded
+
+An early model strided over *all* cards, which made the merge advance its pointer through pids belonging to
+skipped cards and read **3.75 ns** instead of 0.17 — a 22× error, in the direction that would have killed the
+idea. That cannot happen: `card_ids` is derived **from** the candidate list, so every visited card holds at
+least one match and the list contains no pid outside a visited span. The same model used the corpus-average
+3.09 printings per card where visited cards really hold 13.6, understating span work 4×.
+
+## Verifying it
+
+Rows first, timings second — this changes what comes back if the order precondition is ever violated. The
+row-diff harness from the sparse-gather experiment captured totals and page rows over **127,640
+compose-acquire queries**; compare before/after across all three distinct-ons and both prefer settings, since
+the gate interacts with per-printing-varying fields
+([the repair pattern](reference-engine-printing-varying-plane-repair-pattern.md)).
+
+```bash
+cargo test --release bench_membership_check -- --ignored --nocapture
+.venv/bin/python scripts/bench_membership_waste.py \
+    --corpus benchmarks/bitplanes/corpus.jsonl --shm /tmp/membership.store --sample 30000 --mode realistic
+```
+
+## Related
+
+- [#856](00856-engine-compose-membership-bittest.md) — the defect, the gate, and the general bitmap route.
+- [#852](00852-engine-compose-acquire-p3-p4-ranking.md) — the routing error on this same acquire, and where
+  the engine's actual slow tail is.
+- [#730](00730-engine-popcount-skip-walk.md) — the permutation-order analogue. Keying candidates by
+  permutation position and *sorting* to make a forward pointer work there was measured and rejected (2.4–2.9 µs
+  per query against 0.2–0.3 for a scatter); the shape that works is a scatter through `inv_perm` into
+  permutation space, which `run_query_streamed_popcount` already does for `unique=card` + `True`. Recorded in
+  [#856](00856-engine-compose-membership-bittest.md#for-permutation-order-scatter--do-not-sort).

--- a/docs/issues/00858-engine-short-needle-text-scan.md
+++ b/docs/issues/00858-engine-short-needle-text-scan.md
@@ -1,0 +1,124 @@
+# Single-character text needles have no index and scan every card — 1.16 ms for `o:s`
+
+Status: **problem measured, neither fix measured.** Filed as
+[#858](https://github.com/jbylund/sylvan_librarian/issues/858).
+
+This is the engine's actual slow tail. It is worse than anything in
+[#852](00852-engine-compose-acquire-p3-p4-ranking.md)'s or
+[#856](00856-engine-compose-membership-bittest.md)'s populations — #856's whole population tops out at 78.5 µs,
+and `o:s` is **fifteen times** that on its own.
+
+## Measured
+
+`unique=card`, `orderby=name`, limit 60, min of 15 trials after 3 warmups, on the production corpus:
+
+| query | routed | `narrowed_repr` | results |
+| --- | --: | --- | --: |
+| **`o:s`** | **1,164.8 µs** | none | 30,247 |
+| **`ft:s`** | **1,019.8 µs** | none | 19,620 |
+| **`name:s`** | **446.6 µs** | none | 19,776 |
+| `name:so` | **8.2 µs** | cards | 972 |
+| `name:sol` | 4.4 µs | cards | 178 |
+| `name:solr` | 0.7 µs | cards | 0 |
+| `o:the` | 732.1 µs | cards | 16,240 |
+
+A **54× cliff** between one character and two. And `o:s` at 1.16 ms lines up with the overall max (~1,133 µs)
+in [#856's latency profile](00856-engine-compose-membership-bittest.md#it-touches-no-slow-queries-and-that-is-structural),
+which is how we know this shape is the tail rather than merely slow in isolation.
+
+## Why: three tiers, and the bottom one is missing
+
+| needle length | mechanism | result |
+| --- | --- | --- |
+| ≥ 3 bytes | `trigram_candidates` | narrows |
+| == 2 bytes | `NameBigramIndex` | **exact** — no `contains()` verification runs at all |
+| == 1 byte | *nothing* | full per-card residual scan |
+
+`trigram_candidates` returns `None` at `bytes.len() < 3` (`card_engine/src/lib.rs`). The consequence that makes
+it expensive rather than merely unnarrowed: **`memoize_text_predicates` is gated on that returning `Some`** —
+
+```rust
+let Some(cand) = trigram_candidates(name_trigram, word) else { return };
+let finder = memmem::Finder::new(word.as_bytes()); // built once, reused across the verify scan
+```
+
+— so for a 1-byte needle memoization returns early, the filter stays a `TextContains`, and it is evaluated
+**per card inside the match loop**. The `Finder`-reuse optimisation on the line below never applies.
+
+`o:s` misses the word index for the same class of reason: `oracle_word_eligible` requires `word.len() > 3`.
+
+## Where the 446 µs goes, and it is not the search
+
+446.6 µs / 31,508 cards = **14.2 ns per card**, ~43 cycles at 3 GHz. `str::contains` on a single-byte needle
+lowers to `memchr`, which over a ~20-byte name is a few cycles. So the search is not the cost. Two things are:
+
+- **The row stride.** `AOracleCard` is **288 bytes** (measured with `size_of`), and `card_name_folded` is an
+  `InlineStr<61>` (62 bytes) inline in it. Reading every name therefore walks **9.07 MB** of card rows to touch
+  **1.95 MB** of name field, of which the actual name content is ~630 KB. Same shape as
+  [the `APrinting` width problem](local-engine-aprinting-layout.md), one struct over.
+- **Per-card dispatch** through `FilterExpr` 31,508 times.
+
+## Fix A: a unigram index, extending the tier that already works
+
+`NameBigramIndex` already makes 2-byte needles exact, and the 1-byte case is the same structure one size down.
+Only ~40 byte values actually occur in lowercased names, most of them dense enough to want a plane, and a plane
+is `n_cards / 8` = **3,939 bytes** — so roughly **150 KB per text field**.
+
+`name:s` then becomes an O(1) bitmap read: the 8.2 µs shape `name:so` already gets, which would be **~50×**.
+
+Cheapest change, and it follows a precedent in the same file rather than inventing one.
+
+## Fix B: a name/oracle blob and one `memmem` pass — which already exists here
+
+**This design is already in the tree**, as `OracleWordIndex::sparse_blob`:
+
+- dictionary words concatenated, each preceded by a `\0` — `WORD_BLOB_DELIM`, chosen because no eligible needle
+  can contain it, so *a match can never straddle two entries*
+- `sparse_word_starts` maps a match's byte offset back to an entry index by binary search
+- one `memmem` pass replacing ~6,300 separate `.contains()` calls, **measured 5–6× faster** than the per-item
+  loop (`bench_word_dict_scan.rs`)
+
+The load-bearing supporting result is the one next to it: `bench_text_search.rs` found memmem **loses** on many
+short separate haystacks, where its setup dominates, and **wins** on one long contiguous scan. Per-card name
+scanning today is exactly the losing configuration by construction; blobbing converts it into the winning one,
+and cuts traffic from 9.07 MB to ~630 KB.
+
+Two notes for whoever builds it:
+
+- memmem yields **ascending** positions, so a forward pointer over the offsets beats a binary search per match —
+  the same trick [#857](00857-engine-membership-merge-sorted-list.md) uses, and it matters here because
+  `name:s` matches 63% of cards.
+- Once a card matches, restart past the end of that name. That makes the work one short find per card rather
+  than one per occurrence.
+
+## Which to do
+
+**A is probably the bigger and cheaper win for the measured symptom**, and should be costed first.
+
+**B is the more general mechanism**, and its case does not rest on 1-char needles: it also attacks the
+*verification* pass where narrowing happens but is broad. `o:the` narrows to 16,240 cards and still takes
+**732 µs** — A does nothing for that, and B would. They are not exclusive, and B is the deferred
+"memmem for `TextContains`" item from the #694/#731 text-search follow-ups.
+
+## Not yet measured — read the estimates as estimates
+
+The problem is measured; **neither fix is**. The ~50× for A is arithmetic from `name:so`'s realized 8.2 µs, and
+the 5–6× for B is the word index's result on a *different* blob with a longer needle. Build the kernel
+comparison before committing.
+
+One thing that comparison must model, because this session already produced a wrong answer by missing it: a
+1-char needle matching 63% of cards is a **branch-unpredictable** workload, where a scan stops being purely
+bandwidth-bound. [#856's density curve](00856-engine-compose-membership-bittest.md#what-the-bitmap-probe-costs)
+shows the same effect costing 2–6× on a kernel that looked flat when measured only at the extremes.
+
+## Related
+
+- [local-engine-aprinting-layout.md](local-engine-aprinting-layout.md) — the same row-width-versus-scan problem
+  for `APrinting`. Note its "don't implement" verdict was about a *misattributed* 55%; the mechanism it
+  describes is real and this is another instance of it.
+- [done/00663-engine-oracle-word-index.md](done/00663-engine-oracle-word-index.md) — where the blob-plus-memmem
+  pattern and its 5–6× came from.
+- [done/00649-accent-insensitive-name-search.md](done/00649-accent-insensitive-name-search.md) — why the scanned
+  field is `card_name_folded` rather than `card_name_lower`.
+- [#856](00856-engine-compose-membership-bittest.md) — the latency profile this is measured against, and the
+  density-curve caution above.

--- a/docs/issues/00858-engine-short-needle-text-scan.md
+++ b/docs/issues/00858-engine-short-needle-text-scan.md
@@ -97,7 +97,12 @@ Two notes for whoever builds it:
 
 **B is the more general mechanism**, and its case does not rest on 1-char needles: it also attacks the
 *verification* pass where narrowing happens but is broad. `o:the` narrows to 16,240 cards and still takes
-**732 µs** — A does nothing for that, and B would. They are not exclusive, and B is the deferred
+**732 µs** — A does nothing for that, and B would.
+
+**But check [#859](00859-engine-exact-trigram-no-verify.md) before costing B against `o:the`.** A 3-byte needle
+is exactly one trigram, so its verification is *provably redundant* and should be deleted rather than made
+faster. That removes `o:the` from B's case, and leaves B justified on needles of 4+ bytes, where the trigram
+intersection really is a superset and verification really is needed. They are not exclusive, and B is the deferred
 "memmem for `TextContains`" item from the #694/#731 text-search follow-ups.
 
 ## Not yet measured — read the estimates as estimates
@@ -120,5 +125,8 @@ shows the same effect costing 2–6× on a kernel that looked flat when measured
   pattern and its 5–6× came from.
 - [done/00649-accent-insensitive-name-search.md](done/00649-accent-insensitive-name-search.md) — why the scanned
   field is `card_name_folded` rather than `card_name_lower`.
+- [#859](00859-engine-exact-trigram-no-verify.md) — the tier above: 3-byte needles have an exact index and
+  verify anyway, *and* get declined by the same memoize gate that skips 1-byte needles. Independent fix, same
+  family.
 - [#856](00856-engine-compose-membership-bittest.md) — the latency profile this is measured against, and the
   density-curve caution above.

--- a/docs/issues/00859-engine-exact-trigram-no-verify.md
+++ b/docs/issues/00859-engine-exact-trigram-no-verify.md
@@ -1,7 +1,14 @@
-# A 3-byte needle is one trigram and needs no verification — but gets verified, and declined
+# A 3-byte needle's trigram set is exact, but `narrow_rec` marks it loose — so every candidate is re-verified
 
-Status: **defect confirmed by reading the index; the size of the win is not measured.** Filed as
+Status: **defect confirmed by reading the code; the size of the win is not measured.** Filed as
 [#859](https://github.com/jbylund/sylvan_librarian/issues/859).
+
+**The fix is one guard, and it is not in `memoize_text_predicates`.** `narrow_rec`'s text arm returns
+`Narrowed::loose` for every needle of 3 bytes or more; at exactly 3 bytes the set is exact, so it should return
+`Narrowed::tight`. Tight propagates to `residual_exact` → `all_match_known`, and the match loop's #634 Step 1
+short-circuit then skips `card_pass` **entirely** — no verification anywhere, memoized or not. An earlier draft
+of this doc proposed changing memoize instead; that would have been the wrong lever, and is recorded below as
+the secondary effect it actually is.
 
 ## The trigram is already exact at 3 bytes
 
@@ -23,39 +30,73 @@ A needle of exactly 3 bytes is exactly **one** trigram, so the posting list *is*
 `intersect_operands` even names the case in its own comment — *"a 3-byte needle (a single window…)"* — so the
 shape is recognised; the consequence just was not drawn.
 
-## It gets verified anyway
+## Where it goes wrong: one guard, one word
 
-Both memoize arms do this (`card_engine/src/filter.rs`):
+`narrow_rec` (`card_engine/src/lib.rs`):
 
 ```rust
-let Some(dense) = trigram_candidates(&oracle.trigrams, word) else { return };
-let finder = memmem::Finder::new(word.as_bytes()); // built once, reused across the verify scan
-// ... finder.find(...) once per candidate
+FilterExpr::TextContains { field, word }
+    if word.len() >= 3
+        && matches!(field, TextSearchField::NameLower | TextSearchField::OracleTextLower) =>
+{
+    // Trigram candidates are supersets (false positives until the walk
+    // verifies), so these sets are loose.
+    match field {
+        TextSearchField::NameLower => trigram_candidates(&indexes.name_trigram, word)
+            .and_then(|v| Narrowed::loose(Candidates::Cards(v))),
+        ...
 ```
 
-The **bigram** arm one size down already gets this right, and its comment states the argument:
+**That comment is true at ≥ 4 bytes and false at exactly 3.** At 4+ the intersection of several trigrams really
+is a superset — a text can contain `the` and `her` without containing `ther`. At exactly 3 there is one window
+and no intersection, so there are no false positives to verify away.
+
+Split the guard: `word.len() == 3` → `Narrowed::tight(...)`, `>= 4` stays loose.
+
+### Why that is the whole fix
+
+`Narrowed::tight` is what `narrow_candidates_exact` turns into `residual_exact`, which becomes
+`all_match_known`, which the match loop reads first:
+
+```rust
+let all_match = all_match_known
+    || match filter.card_pass(card, strings, &mut residual, ...) { ... };
+```
+
+So a tight narrowing makes `card_pass` never run — the #634 Step 1 short-circuit, already built and already
+load-bearing elsewhere. **Nothing needs to memoize, and nothing needs a faster verify: the verification simply
+does not happen.**
+
+### The walk verifies the same field the index is built over, which is what makes tight sound
+
+The one thing that could break exactness is the index and the walk disagreeing about *which* string they mean,
+and #649's accent folding makes that a live question. They agree:
+
+| field | index built over | walk evaluates |
+| --- | --- | --- |
+| `NameLower` | `card_name_folded` | `card_name_folded` (`filter.rs`, with #649's note that "the query word is folded the same way in Python before it reaches TextContains") |
+| `OracleTextLower` | `strings[global]` | `str_at(strings, card.oracle_text_lower_id)` |
+
+For oracle the candidates also pass through `expand_text_ids`, a CSR from text id to the cards carrying that
+text — exact, so exactness survives the expansion.
+
+## Secondary: the memoize arms become moot, and their gate was already unjustified at 3 bytes
+
+Worth recording, but *not* the fix.
+
+Both memoize arms run a verify scan (`finder.find(...)` per candidate) that is redundant at 3 bytes for the same
+reason. The **bigram** arm one size down already gets this right, and states the argument in its comment:
 
 > 2-byte needles resolve exactly through the bigram index: the member cards are the complete match set
 > (containment IS bigram membership), so no `contains()` verification runs at all.
 
-Identical reasoning applies at 3 bytes. Nothing propagated it upward.
-
-## The larger consequence: the decline gate's premise fails too
-
-Memoization is gated on the needle not being too common:
-
-```rust
-Some(min) if min <= oracle.gids.len() / 2 && Self::memoize_pays(min, eval_domain, cards.len()) => {}
-_ => return,
-```
-
-**That gate exists because the verify scan has to pay for itself.** At 3 bytes there is no verify scan, so the
-premise does not hold: materializing the posting list is O(k) with no per-text work. A 3-byte needle should
-therefore **always** memoize — and today the engine declines exactly the common needles that cost the most,
-sending them to per-card evaluation over full oracle texts.
-
-This is probably the bigger half of the fix, and it is the same shape of error as
+And memoization is gated on the needle not being too common (`min <= oracle.gids.len() / 2 && memoize_pays(...)`)
+— a gate whose entire premise is that the verify scan must pay for itself. At 3 bytes there is no verify scan,
+so the premise does not hold, which is the same shape of error as
 [#856](00856-engine-compose-membership-bittest.md): a gate whose justification stopped applying, left in place.
+
+But once the narrowing is tight, none of this matters for correctness or cost — whether memoize fires becomes an
+optimisation of a path that no longer runs. Fix the narrowing; leave memoize alone unless it measures.
 
 ## Measured
 
@@ -78,24 +119,29 @@ oracle texts looks like next to ~20-byte names.
 
 ## What is not established
 
-**How much of `o:the`'s 776 µs is the redundant verify** against legitimate work to produce 16,240 rows. That
-cannot be separated from outside Rust — `explain_analyze` does not report whether memoization fired — and the
-experiment that answers it *is* the fix. So settle it by building it rather than by modelling it.
+**How much of `o:the`'s 776 µs is verification** against the floor of emitting 16,240 rows. The arithmetic bounds
+it: 776 µs / 16,240 candidates = **47.8 ns per candidate**, which is what a `memmem` over a few hundred bytes of
+oracle text costs, so most of it is plausibly the verify. But `name:the` runs at 15.9 ns/result *including its
+own loose verify over ~20-byte names*, so the pure emit floor is below that — putting `o:the`'s floor under
+~258 µs and the likely win at **3–4×**, not 776 µs → nothing.
 
-Do not assume the whole 776 µs is recoverable: emitting 16,240 rows through `StreamedSelect` has a real floor,
-and `name:the`'s 16 ns/result suggests the floor is a substantial fraction.
+That is an estimate from two measurements, not a measurement. The experiment that settles it *is* the fix, so
+build it rather than model it further.
 
-## Two changes, independent
+## The change
 
-1. **Skip the verify at `len == 3`** — the candidates are the answer.
-2. **Bypass the decline gate at `len == 3`** — always memoize, since there is no scan to amortise. Likely the
-   bigger win, and the one that currently sends `o:the` and `o:you` down the per-card path.
+Split `narrow_rec`'s text arm at `word.len() == 3` and return `Narrowed::tight`. That is it — the tightness
+plumbing, `all_match_known`, and the loop short-circuit all exist already.
 
 ## Verifying it
 
-Exactness is a claim about the index, so **assert it rather than trusting the argument above**: over a sample
-of 3-byte needles, the memoized id set must be byte-identical with and without the verify scan. If a candidate
-is ever rejected, the index is not what its doc says, and *that* is the finding instead.
+Exactness is a claim about the index, so **assert it rather than trusting the argument above**: over a sample of
+3-byte needles, run `card_pass` on every candidate the narrowing returns and require that **none is rejected**.
+If any is, the index is not what its doc says and *that* is the finding — a debug assertion is the right home,
+since it is cheap to state and this is the invariant the whole change rests on.
+
+The same shape as the guard [#857](00857-engine-membership-merge-sorted-list.md) wants for its ordering
+precondition, and for the same reason: marking something tight that is not tight drops rows silently.
 
 Then rows before timings, as ever — this changes which cards a text predicate matches if the exactness claim is
 wrong, which is a wrong-answer bug rather than a slow one.

--- a/docs/issues/00859-engine-exact-trigram-no-verify.md
+++ b/docs/issues/00859-engine-exact-trigram-no-verify.md
@@ -1,0 +1,115 @@
+# A 3-byte needle is one trigram and needs no verification — but gets verified, and declined
+
+Status: **defect confirmed by reading the index; the size of the win is not measured.** Filed as
+[#859](https://github.com/jbylund/sylvan_librarian/issues/859).
+
+## The trigram is already exact at 3 bytes
+
+A needle of exactly 3 bytes is exactly **one** trigram, so the posting list *is* the complete containment set.
+`SortedTrigramIndex`'s own doc says as much — *"trigram → ascending list of dense text ids whose text
+**contains** it"* — and three properties make that hold rather than merely sound plausible:
+
+- **The index is lossless.** `build_trigram_index` / `build_oracle_text_index` walk *every* 3-byte window of
+  every text (`bytes.windows(3)`), and `finalize_trigram_index` stores each posting in full — sparse as `u16`
+  postings, dense as a bitmap. No thresholding, no dropped entries.
+- **Index and verify read the same field.** `name_trigram` is built over `card_name_folded`
+  (`build_trigram_index(&cards, |c| c.card_name_folded.as_str())`) and the verify reads
+  `card_name_folded`; the oracle index is built over `strings[global]` and the verify reads
+  `str_at(strings, gid)`. So #649's accent folding cannot desynchronise them, which was the one plausible
+  reason a verify might be needed.
+- **Both sides match bytewise.** Windows are over bytes and `memmem::find` is bytewise, so a multi-byte UTF-8
+  needle behaves identically on both.
+
+`intersect_operands` even names the case in its own comment — *"a 3-byte needle (a single window…)"* — so the
+shape is recognised; the consequence just was not drawn.
+
+## It gets verified anyway
+
+Both memoize arms do this (`card_engine/src/filter.rs`):
+
+```rust
+let Some(dense) = trigram_candidates(&oracle.trigrams, word) else { return };
+let finder = memmem::Finder::new(word.as_bytes()); // built once, reused across the verify scan
+// ... finder.find(...) once per candidate
+```
+
+The **bigram** arm one size down already gets this right, and its comment states the argument:
+
+> 2-byte needles resolve exactly through the bigram index: the member cards are the complete match set
+> (containment IS bigram membership), so no `contains()` verification runs at all.
+
+Identical reasoning applies at 3 bytes. Nothing propagated it upward.
+
+## The larger consequence: the decline gate's premise fails too
+
+Memoization is gated on the needle not being too common:
+
+```rust
+Some(min) if min <= oracle.gids.len() / 2 && Self::memoize_pays(min, eval_domain, cards.len()) => {}
+_ => return,
+```
+
+**That gate exists because the verify scan has to pay for itself.** At 3 bytes there is no verify scan, so the
+premise does not hold: materializing the posting list is O(k) with no per-text work. A 3-byte needle should
+therefore **always** memoize — and today the engine declines exactly the common needles that cost the most,
+sending them to per-card evaluation over full oracle texts.
+
+This is probably the bigger half of the fix, and it is the same shape of error as
+[#856](00856-engine-compose-membership-bittest.md): a gate whose justification stopped applying, left in place.
+
+## Measured
+
+`unique=card`, `orderby=name`, limit 60, min of 15 trials after 3 warmups, production corpus:
+
+| query | routed | results | ns/result |
+| --- | --: | --: | --: |
+| `o:you` | **975.5 µs** | 20,247 | 48 |
+| `o:the` | **775.9 µs** | 16,240 | 48 |
+| `o:and` | 739.2 µs | 13,691 | 54 |
+| `o:tar` | 732.5 µs | 12,605 | 58 |
+| `o:qua` | 41.5 µs | 1,708 | 24 |
+| `o:zap` | 0.3 µs | 1 | — |
+| `name:the` | 47.7 µs | 3,002 | **16** |
+| `name:sol` | 4.2 µs | 178 | — |
+
+Two readings. Cost **tracks result count** rather than cliffing, so this is not a single threshold flipping.
+And **oracle costs ~3.6× more per result than name** (58 against 16 ns/result), which is what scanning full
+oracle texts looks like next to ~20-byte names.
+
+## What is not established
+
+**How much of `o:the`'s 776 µs is the redundant verify** against legitimate work to produce 16,240 rows. That
+cannot be separated from outside Rust — `explain_analyze` does not report whether memoization fired — and the
+experiment that answers it *is* the fix. So settle it by building it rather than by modelling it.
+
+Do not assume the whole 776 µs is recoverable: emitting 16,240 rows through `StreamedSelect` has a real floor,
+and `name:the`'s 16 ns/result suggests the floor is a substantial fraction.
+
+## Two changes, independent
+
+1. **Skip the verify at `len == 3`** — the candidates are the answer.
+2. **Bypass the decline gate at `len == 3`** — always memoize, since there is no scan to amortise. Likely the
+   bigger win, and the one that currently sends `o:the` and `o:you` down the per-card path.
+
+## Verifying it
+
+Exactness is a claim about the index, so **assert it rather than trusting the argument above**: over a sample
+of 3-byte needles, the memoized id set must be byte-identical with and without the verify scan. If a candidate
+is ever rejected, the index is not what its doc says, and *that* is the finding instead.
+
+Then rows before timings, as ever — this changes which cards a text predicate matches if the exactness claim is
+wrong, which is a wrong-answer bug rather than a slow one.
+
+```bash
+.venv/bin/python scripts/bench_short_needle_cliff.py --shm /tmp/needle.store
+```
+
+## Related
+
+- [#858](00858-engine-short-needle-text-scan.md) — the tier below: 1-byte needles have no index at all, and
+  lose memoization for the same gating reason. Same family, different mechanism, and the two fixes are
+  independent.
+- [done/00663-engine-oracle-word-index.md](done/00663-engine-oracle-word-index.md) — the word index, which
+  covers needles `> 3` bytes and so does not reach this case.
+- [done/00649-accent-insensitive-name-search.md](done/00649-accent-insensitive-name-search.md) — why the name
+  index and verify both use `card_name_folded`, which is what makes exactness hold here.

--- a/docs/issues/00859-engine-exact-trigram-no-verify.md
+++ b/docs/issues/00859-engine-exact-trigram-no-verify.md
@@ -1,7 +1,10 @@
 # A 3-byte needle's trigram set is exact, but `narrow_rec` marks it loose — so every candidate is re-verified
 
-Status: **defect confirmed by reading the code; the size of the win is not measured.** Filed as
+Status: **prototyped and measured 2026-08-06; change reverted, not committed.** Filed as
 [#859](https://github.com/jbylund/sylvan_librarian/issues/859).
+
+**Measured: `o:the` 783.9 µs → 168.5 µs (4.7×), `o:tar` 9.3×, and 0 of 104 result cells changed.** The full
+engine test suite passes. Details under [Prototyped](#prototyped-and-measured).
 
 **The fix is one guard, and it is not in `memoize_text_predicates`.** `narrow_rec`'s text arm returns
 `Narrowed::loose` for every needle of 3 bytes or more; at exactly 3 bytes the set is exact, so it should return
@@ -117,16 +120,50 @@ Two readings. Cost **tracks result count** rather than cliffing, so this is not 
 And **oracle costs ~3.6× more per result than name** (58 against 16 ns/result), which is what scanning full
 oracle texts looks like next to ~20-byte names.
 
-## What is not established
+## Prototyped and measured
 
-**How much of `o:the`'s 776 µs is verification** against the floor of emitting 16,240 rows. The arithmetic bounds
-it: 776 µs / 16,240 candidates = **47.8 ns per candidate**, which is what a `memmem` over a few hundred bytes of
-oracle text costs, so most of it is plausibly the verify. But `name:the` runs at 15.9 ns/result *including its
-own loose verify over ~20-byte names*, so the pure emit floor is below that — putting `o:the`'s floor under
-~258 µs and the likely win at **3–4×**, not 776 µs → nothing.
+Built as described — `let mk = if word.len() == 3 { Narrowed::tight } else { Narrowed::loose };` — measured, then
+**reverted**. Nothing is committed. Release build, Docker down, min of 9 trials, same store both sides.
 
-That is an estimate from two measurements, not a measurement. The experiment that settles it *is* the fix, so
-build it rather than model it further.
+**Correctness first: 0 of 104 cells changed.** 26 queries × 4 shapes, comparing total, row count, and a SHA over
+the returned row-identity sequence in order. The set deliberately includes the shapes where tightness propagates
+and could go wrong: negations (`-o:the`, `-name:the`), conjunctions (`o:the t:creature`, `o:the -t:land`,
+`name:the o:the`, `o:the c:g cmc<=3`), a disjunction (`o:the or o:you`), 2- and 4-byte controls (`o:th`,
+`o:they`, `o:ther`), and all three distinct-ons at two offsets each. The full engine suite also passes in debug —
+153 tests, including `fuzz_row_identity_matches_reference` and `force_plan_differential_agreement`.
+
+**Engine-side (`explain_analyze` routed_ns):**
+
+| query | before | after | |
+| --- | --: | --: | --: |
+| `o:the` | 783.9 µs | **168.5 µs** | **4.7×** |
+
+**End-to-end through `engine.query`** (includes Python marshalling, so these ratios are *conservative* — fixed
+overhead sits on both sides and pulls the ratio toward 1):
+
+| query / shape | before | after | |
+| --- | --: | --: | --: |
+| `o:tar` card/name | 1,559.4 µs | **167.0 µs** | **9.3×** |
+| `o:and` card/name | 1,255.1 | **178.3** | 7.0× |
+| `o:the` card/name offset 600 | 1,257.0 | **220.8** | 5.7× |
+| `o:you` card/name | 1,089.8 | **263.2** | 4.1× |
+| `o:the` card/name | 823.0 | **212.7** | 3.9× |
+| `o:the -t:land` | 929.5 | **220.8** | 4.2× |
+| `o:the t:creature` | 511.3 | **227.1** | 2.3× |
+| `name:the` | 88.8 | **46.5** | 1.9× |
+| `ft:the o:the` | 2,465.7 | **1,464.5** | 1.7× |
+| `o:qua` | 85.2 | **51.6** | 1.6× |
+
+1-byte needles are unchanged, as expected — that is [#858](00858-engine-short-needle-text-scan.md), a different
+mechanism.
+
+**The earlier 3–4× estimate was low, and here is why.** It put the emit floor at `name:the`'s 15.9 ns/result —
+but `name:the` was itself paying a loose verify, and improved 1.9×. So the floor was inflated by the very defect
+being measured. The lesson generalises: do not derive a floor from another query that has the same bug.
+
+**Compositions benefit more than the bare predicate**, which was not predicted. `o:the -t:land` gains 4.2×
+against the bare `o:the`'s 3.9×, because a tight text child lets the `And` skip `card_pass` for the whole
+conjunction rather than just the text leaf.
 
 ## The change
 

--- a/docs/issues/00859-engine-exact-trigram-no-verify.md
+++ b/docs/issues/00859-engine-exact-trigram-no-verify.md
@@ -165,6 +165,13 @@ being measured. The lesson generalises: do not derive a floor from another query
 against the bare `o:the`'s 3.9×, because a tight text child lets the `And` skip `card_pass` for the whole
 conjunction rather than just the text leaf.
 
+**One shape gets nothing, and it opened a separate finding.** `o:the or o:you` stays slow: the union of the two
+exact sets is 23,675 cards against a breadth guard that discards anything over 23,631, so the whole narrowing is
+thrown away 44 cards short. Relaxing that guard for tight sets is worth a further 4.4× — but attempting it
+**fails `fuzz_row_identity_matches_reference`** on a filter with no text in it, which means some narrowing
+already over-claims tightness and the guard has been masking it. That is
+[#860](00860-engine-broad-tight-narrowing-discarded.md), and it does not block this change.
+
 ## The change
 
 Split `narrow_rec`'s text arm at `word.len() == 3` and return `Narrowed::tight`. That is it — the tightness

--- a/docs/issues/00860-engine-broad-tight-narrowing-discarded.md
+++ b/docs/issues/00860-engine-broad-tight-narrowing-discarded.md
@@ -1,0 +1,104 @@
+# The breadth guard discards exact narrowings — and is masking a tightness over-claim
+
+Status: **prototyped and measured 2026-08-06; NOT safe as written — it fails the fuzz suite.** Filed as
+[#860](https://github.com/jbylund/sylvan_librarian/issues/860). Depends on
+[#859](00859-engine-exact-trigram-no-verify.md).
+
+The performance idea is worth 4.4×. The reason to read this doc is the second finding: attempting it exposes a
+narrowing that **already** claims tightness it does not have, which the breadth guard has been hiding.
+
+`o:the or o:you` takes **1,819 µs** and reports `narrowed_repr: none` — it does no narrowing at all, even though
+both children narrow individually and (after #859) both are *exact*. The union of two exact sets is exact, so
+this query should be answerable with no verification whatever.
+
+## Why it declines, and the margin is 44 cards
+
+`narrow_candidates_exact` discards the whole narrowing when the set is too broad:
+
+```rust
+let domain = if printing_space { n_printings } else { n_cards };
+if n.set.len() <= domain - domain / 4 {
+    (Some(n.set), n.tight && !printing_space, n.proven)
+} else {
+    (None, false, 0)
+}
+```
+
+- threshold: `31,508 - 31,508/4` = **23,631**
+- `o:the or o:you` union: **23,675**
+
+**Over by 44 cards, 0.19%** — and the consequence is not a slightly worse plan, it is scanning all 31,508 cards
+and running a full oracle-text `memmem` on each.
+
+## The guard's reasoning inverts under tightness
+
+The guard is right for a **loose** set: you pay union, projection and materialization, and then still verify
+every candidate, so a near-total loose set is worse than no narrowing. It is wrong for a **tight** set, where
+keeping it eliminates verification entirely. 23,675 candidates with no `card_pass` beats 31,508 with one full
+oracle-text scan each, and it is not close.
+
+## Measured — the win is real
+
+Prototyped (#859's tightness plus `|| (n.tight && !printing_space)` on the guard), measured, reverted:
+
+| query | before | after | |
+| --- | --: | --: | --: |
+| `o:the or o:you` routed | 1,819.3 µs | **415.2 µs** | **4.4×** |
+| `o:the or o:you` end-to-end | 2,198.4 | **473.6** | 4.6× |
+| `o:the or o:zap` | 732.2 | **201.5** | 3.6× |
+| `o:tar or o:qua` | 850.3 | **172.7** | 4.9× |
+
+`narrowed_repr` goes `none` → `card_bits`, and all 104 row-identity cells stayed identical.
+
+## But it is NOT safe as written, and that is the actual finding
+
+**`fuzz_row_identity_matches_reference` fails**, on a filter with no text predicate in it at all:
+
+```
+unplaned total mismatch (mode=card, orderby=rarity, dir=asc, seed=19,
+                         filter=AND(cmc<8, colors!=0b00011))
+  left: 15   right: 14
+```
+
+An **extra row**. #859 alone passes the full suite (153 tests); adding the guard change is what breaks it, and
+the filter contains no text, so #859 is not implicated.
+
+**So some narrowing already claims `tight: true` without being exact, and the breadth guard has been masking
+it** — the over-claimed set was being discarded for breadth before anything trusted it. `colors != …` is the
+obvious suspect (`tight_narrow_space` classifies `ColorCmp` as tight-in-card-space unconditionally, and a `Ne`
+over a colour bitmask has to get colourless/null exactly right to be exact), but that is a hypothesis, not a
+diagnosis.
+
+## What to do, in order
+
+1. **Find the over-claiming narrowing.** It is a latent correctness bug today, not merely an obstacle: any other
+   change that causes a tight set to be trusted where it currently is not would expose it the same way. The
+   fuzz case above is a reproducer.
+2. **Then relax the guard on tightness**, and re-run the fuzz suite rather than a hand-picked query set — mine
+   was 104 cells across negations, conjunctions, disjunctions and all three distinct-ons, and it missed this
+   entirely.
+3. Consider asserting the invariant directly: a set marked tight should have every member pass `card_pass`.
+   That turns "the guard happens to hide it" into a named failure, and it is the same debug assertion
+   [#859](https://github.com/jbylund/sylvan_librarian/issues/859) and #857 both want.
+
+Depends on [#859](https://github.com/jbylund/sylvan_librarian/issues/859) for the tightness that makes the union
+exact in the first place.
+
+## Reproducing
+
+```bash
+.venv/bin/python scripts/bench_short_needle_cliff.py --shm /tmp/needle.store   # shows narrowed_repr: none
+rtk proxy cargo test --manifest-path card_engine/Cargo.toml fuzz_row_identity_matches_reference
+```
+
+The prototype was: #859's `mk = if word.len() == 3 { Narrowed::tight } else { Narrowed::loose }`, plus
+`let worth_keeping = n.set.len() <= domain - domain / 4 || (n.tight && !printing_space);` in
+`narrow_candidates_exact`. Both reverted; nothing is committed.
+
+## Related
+
+- [#859](00859-engine-exact-trigram-no-verify.md) — supplies the tightness. Safe on its own: full suite green,
+  4.7× on `o:the`.
+- [#858](00858-engine-short-needle-text-scan.md) — the 1-byte tier, unaffected by either.
+- [#857](00857-engine-membership-merge-sorted-list.md) — wants the same class of debug assertion for its own
+  ordering precondition.

--- a/docs/issues/00860-engine-broad-tight-narrowing-discarded.md
+++ b/docs/issues/00860-engine-broad-tight-narrowing-discarded.md
@@ -63,6 +63,11 @@ unplaned total mismatch (mode=card, orderby=rarity, dir=asc, seed=19,
 An **extra row**. #859 alone passes the full suite (153 tests); adding the guard change is what breaks it, and
 the filter contains no text, so #859 is not implicated.
 
+**#859 is not needed to reproduce it.** Verified separately: the guard relaxation *alone*, with #859's
+tightness change absent from the tree, fails the same assertion on the same filter and seed. That follows from
+the filter containing no text predicate, but it was measured rather than inferred — so this issue can be worked
+on `main` as it stands, with no dependency on #859 for the reproducer.
+
 **So some narrowing already claims `tight: true` without being exact, and the breadth guard has been masking
 it** — the over-claimed set was being discarded for breadth before anything trusted it. `colors != …` is the
 obvious suspect (`tight_narrow_space` classifies `ColorCmp` as tight-in-card-space unconditionally, and a `Ne`
@@ -81,8 +86,9 @@ diagnosis.
    That turns "the guard happens to hide it" into a named failure, and it is the same debug assertion
    [#859](https://github.com/jbylund/sylvan_librarian/issues/859) and #857 both want.
 
-Depends on [#859](https://github.com/jbylund/sylvan_librarian/issues/859) for the tightness that makes the union
-exact in the first place.
+Relationship to [#859](00859-engine-exact-trigram-no-verify.md): #859 supplies the tightness that makes the
+`o:the or o:you` *union* exact, so the 4.4× **performance** win needs it. The **bug** does not — see above. Step
+1 below is workable on `main` today.
 
 ## Reproducing
 

--- a/docs/issues/done/00480-hashagg-distinct-on-replacement.md
+++ b/docs/issues/done/00480-hashagg-distinct-on-replacement.md
@@ -8,7 +8,7 @@ essentially identical to `DISTINCT ON` — the avoid-the-sort hypothesis did not
 data scale. What shipped instead: `DISTINCT ON` keyed on `oracle_id` (~23% faster than the
 `card_name` key) and dropping the no-op `DISTINCT ON` for `unique=printing` (~9% faster).
 Not pursuing further: SQL-path query-shape work is deprioritized in favor of the Rust engine
-path ([done/00490-rust-filter-extension.md](00490-rust-filter-extension.md)).
+path ([00490-rust-filter-extension.md](00490-rust-filter-extension.md)).
 
 ## Problem
 

--- a/docs/issues/done/00504-engine-store-size-reduction.md
+++ b/docs/issues/done/00504-engine-store-size-reduction.md
@@ -140,7 +140,7 @@ it.
    48 B/card (~4.6 MB) and keeps the ids queryable — wanted for future lookup by scryfall /
    oracle / illustration id (Scryfall supports this undocumented). That makes
    `oracle_group`/`artwork_group` (introduced by
-   [done/local-engine-broad-query-selection.md](local-engine-broad-query-selection.md)) redundant: the
+   [local-engine-broad-query-selection.md](local-engine-broad-query-selection.md)) redundant: the
    linear dedup paths only need "did the key change between adjacent cards" (u128 equality —
    same cost as the u32 compares, so no perf regression), the HashMap path can key on u128, and
    the dense ids that items 2–3 need as array indices come from the interner (it assigns

--- a/docs/issues/done/00605-engine-unindexed-predicates.md
+++ b/docs/issues/done/00605-engine-unindexed-predicates.md
@@ -6,7 +6,7 @@ released-at index) plus the survey's price index shipped in PR #605
 (2026-07-03): targeted-suite geomean 4.2× (artist ~10×, set 4–8×, year ~4×;
 the compound-Or worst case 4.7×), parity exact, archive +1.6 MB. Approach 3
 (legality postings) split out to
-[local-engine-legality-postings.md](../local-engine-legality-postings.md), along with the
+[local-engine-legality-postings.md](local-engine-legality-postings.md), along with the
 survey's rarity-postings suggestion.
 
 ## Problem
@@ -83,7 +83,7 @@ the existing card-space indexes via the Candidates space rules.
 - [x] Artist vocab + query-time id-set resolution + CSR artist index (PR #605)
 - [x] Set-code TagIndex in printing space + narrow_candidates arm (PR #605)
 - [x] Legality (format, status) postings — split out to
-      [local-engine-legality-postings.md](../local-engine-legality-postings.md)
+      [local-engine-legality-postings.md](local-engine-legality-postings.md)
 - [x] Released-at index in printing space for date/year filters (PR #605)
 - [x] Re-run the #604 benchmark suites; the compound Or config (4.7×) and
       `a:rebecca` (9.2×) were the acceptance cases (PR #605)
@@ -105,11 +105,11 @@ Implications, in value order:
   eur/tix are three more lines each if ever wanted.
 - **Rarity postings with the selectivity threshold**: six values; mythic/rare
   selective, common/uncommon dropped by the threshold. Folded into
-  [local-engine-legality-postings.md](../local-engine-legality-postings.md) (same mechanism).
+  [local-engine-legality-postings.md](local-engine-legality-postings.md) (same mechanism).
 - **Legality postings** (already task 3): 8 of the slowest 60. Split out to
-  [local-engine-legality-postings.md](../local-engine-legality-postings.md).
+  [local-engine-legality-postings.md](local-engine-legality-postings.md).
 - **Flavor text**: split out to
-  [00620-engine-flavor-text-narrowing.md](../00620-engine-flavor-text-narrowing.md) — a
+  [00620-engine-flavor-text-narrowing.md](00620-engine-flavor-text-narrowing.md) — a
   measured 9 MB trigram index was rejected in favor of a ~0.4 MB
   distinct-text-scan + CSR design.
 - Bounded non-items: 2-char name contains (0.89 ms worst case, inherent trigram
@@ -123,7 +123,7 @@ Implications, in value order:
   restructure whose benchmarks surfaced this list; candidate-space rules live there
 - [00598-engine-collection-vocab-interning.md](00598-engine-collection-vocab-interning.md) —
   the VocabInterner pattern approach 1 reuses
-- [local-engine-legality-postings.md](../local-engine-legality-postings.md) — the remaining
+- [local-engine-legality-postings.md](local-engine-legality-postings.md) — the remaining
   approach 3 + rarity postings, split out when this doc moved to done/
 - Selective-index thresholding (PR #600 discussion) — approach 3 is its first
   concrete application; frame_data indexing composes with it

--- a/docs/issues/done/00619-engine-bitmap-streaming-select.md
+++ b/docs/issues/done/00619-engine-bitmap-streaming-select.md
@@ -97,7 +97,7 @@ this is not an approximate-counts design.
 - [00620-engine-flavor-text-narrowing.md](00620-engine-flavor-text-narrowing.md) — the
   other big tail item; independent, composes (its narrowing feeds this match
   phase)
-- [done/00603-engine-card-printing-split.md](done/00603-engine-card-printing-split.md) —
+- [00603-engine-card-printing-split.md](00603-engine-card-printing-split.md) —
   candidate spaces, contiguous printing ranges, prefer walk this reuses
 - PR #609 / #618 — measured-constant-instead-of-cost-model precedent for the
   popcount planner threshold; the ~2× random-access penalty measured there is

--- a/docs/issues/done/00619-engine-bitmap-streaming-select.md
+++ b/docs/issues/done/00619-engine-bitmap-streaming-select.md
@@ -1,6 +1,9 @@
 # Engine: bitmap match phase + per-orderby permutation streaming
 
-Status: written up 2026-07-07 (design discussion following PR #618), not started. GitHub: #619.
+**DONE — shipped; #619 is closed.** `PhysicalPlan::StreamedSelect` and `build_sort_permutations` are in
+`card_engine/src/lib.rs`. The unchecked boxes below are the original plan, not outstanding work.
+
+*Original status, kept for dating* — written up 2026-07-07, design discussion following PR #618.
 
 ## Problem
 

--- a/docs/issues/done/00620-engine-flavor-text-narrowing.md
+++ b/docs/issues/done/00620-engine-flavor-text-narrowing.md
@@ -1,6 +1,6 @@
 # Engine: flavor-text narrowing via distinct-text scan + CSR
 
-Follow-on to [00605-engine-unindexed-predicates.md](done/00605-engine-unindexed-predicates.md)
+Follow-on to [00605-engine-unindexed-predicates.md](00605-engine-unindexed-predicates.md)
 (PR #605). Status: written up 2026-07-03, not started. GitHub: #620.
 
 ## Problem
@@ -21,7 +21,7 @@ the same arithmetic reproduces the oracle trigram index's known ~15 MB.)
 
 ## Proposed: distinct-text scan at bind + CSR (~0.4 MB)
 
-The artist-vocab trick ([PR #605](done/00605-engine-unindexed-predicates.md)) scaled up.
+The artist-vocab trick ([PR #605](00605-engine-unindexed-predicates.md)) scaled up.
 Flavor has only 26.3k distinct texts (2.3 MB payload, already interned as
 `flavor_text_lower_id` in the strings table):
 
@@ -67,7 +67,7 @@ Expected: `ft:` ~1.4 → ~0.3–0.5 ms (bind-dominated), worst-case Or-combos
 
 ## Related
 
-- [00605-engine-unindexed-predicates.md](done/00605-engine-unindexed-predicates.md) — parent
+- [00605-engine-unindexed-predicates.md](00605-engine-unindexed-predicates.md) — parent
   ticket; artist vocab is the small-cardinality version of this pattern
-- [00603-engine-card-printing-split.md](done/00603-engine-card-printing-split.md) — candidate
+- [00603-engine-card-printing-split.md](00603-engine-card-printing-split.md) — candidate
   space rules the narrowing arm plugs into

--- a/docs/issues/done/00620-engine-flavor-text-narrowing.md
+++ b/docs/issues/done/00620-engine-flavor-text-narrowing.md
@@ -1,7 +1,15 @@
 # Engine: flavor-text narrowing via distinct-text scan + CSR
 
 Follow-on to [00605-engine-unindexed-predicates.md](00605-engine-unindexed-predicates.md)
-(PR #605). Status: written up 2026-07-03, not started. GitHub: #620.
+(PR #605).
+
+**DONE — shipped; #620 is closed.** It landed as `FlavorIndex`: `build_flavor_index`,
+`expand_flavor_ids` ("expand matched dense flavor text ids to sorted printing ids via the CSR"), and the
+`flavor` field on `CardIndexes` described as "printing space (CSR by dense flavor text id)" — which is all
+three unchecked boxes below. The names differ from what this doc predicted, which is why it reads as
+unstarted.
+
+*Original status, kept for dating* — written up 2026-07-03.
 
 ## Problem
 

--- a/docs/issues/done/00649-accent-insensitive-name-search.md
+++ b/docs/issues/done/00649-accent-insensitive-name-search.md
@@ -18,23 +18,23 @@ Two independent matching engines exist here — a Postgres SQL path and a Rust `
 same name" or the two would silently diverge on which cards a query returns.
 
 **Single source of truth in Python:** `fold_accents()` in
-[card_query_nodes.py](../../api/parsing/card_query_nodes.py) NFKD-decomposes each character and
+[card_query_nodes.py](../../../api/parsing/card_query_nodes.py) NFKD-decomposes each character and
 drops combining marks (stdlib `unicodedata`, no new dependency). Both engines consume its output
 rather than each re-implementing folding:
 
 - **Ingest:** `preprocess_card()` computes `card_name_folded = fold_accents(card_name.lower())`
   once per card and stores it as a real column
-  ([migration](../../api/db/2026-07-20-01-accent-folded-name.sql)) with its own trigram GIN index.
+  ([migration](../../../api/db/2026-07-20-01-accent-folded-name.sql)) with its own trigram GIN index.
   The Rust engine reads the same column at reload time (`ENGINE_COLUMNS`) into a new
   `card_name_folded: InlineStr<61>` field, so it needs zero folding logic of its own — it's plumbing,
   not computation. This is why `ARCHIVE_FORMAT_VERSION` bumped
-  ([lib.rs:5210](../../card_engine/src/lib.rs#L5210)).
+  ([lib.rs:5210](../../../card_engine/src/lib.rs#L5210)).
 - **Query side:** the fuzzy-match code path folds the search word the same way before it reaches
   either engine — `_handle_text_field_pattern_matching` for SQL, `_rhs_to_json` for the JSON that
   crosses into Rust's `build_text_filter`. Whether the user types "eowyn" or "Éowyn", both fold to
   the same word by the time either engine sees it.
 - **Rust internals:** `name_trigram`, `name_bigrams`, and the `TextSearchField::NameLower`
-  eval/verification path ([filter.rs](../../card_engine/src/filter.rs)) were repointed from
+  eval/verification path ([filter.rs](../../../card_engine/src/filter.rs)) were repointed from
   `card_name_lower` to `card_name_folded`. Both indexes exist *only* to serve this fuzzy path
   (confirmed via grep — `TextField::NameLower`/`TextExact`/`ExactName` are separate enums reading the
   unfolded field), so the swap is contained.
@@ -82,7 +82,7 @@ Both parsers were verified to agree via the shared `TESTCASES` parity fixture
 
 Folding is currently symmetric: an accented query (`name:Éowyn`) folds to the same term as its
 unaccented spelling and would match an unaccented card too, if one existed with the same base
-name. See [00718-accent-sensitive-literal-recheck.md](00718-accent-sensitive-literal-recheck.md)
+name. See [00718-accent-sensitive-literal-recheck.md](../00718-accent-sensitive-literal-recheck.md)
 (#718) for the planned fix — deliberately a separate follow-up PR rather than amending this one.
 
 ## Validation
@@ -104,4 +104,4 @@ name. See [00718-accent-sensitive-literal-recheck.md](00718-accent-sensitive-lit
 
 **Resolved — [PR #716](https://github.com/jbylund/sylvan_librarian/pull/716).**
 
-See [PR description](../prs/accent-insensitive-name-search.md) for full details of what shipped.
+See [PR description](../../prs/accent-insensitive-name-search.md) for full details of what shipped.

--- a/docs/issues/done/00663-engine-oracle-word-index.md
+++ b/docs/issues/done/00663-engine-oracle-word-index.md
@@ -1,6 +1,10 @@
 # Engine: word-level inverted index for oracle text search
 
-Status: proposed design, not started. Surfaced 2026-07-10 while investigating
+**DONE — shipped as PR #663 (merged).** `OracleWordIndex` and `scan_oracle_words` are in
+`card_engine/src/lib.rs`, with `bench_word_dict_scan.rs` as the harness. The "No GitHub issue filed yet"
+note below is also stale.
+
+*Original status, kept for dating* — proposed design, surfaced 2026-07-10 while investigating
 `oracle:token`'s cost (see
 [00624-engine-bind-memoized-text-predicates.md](00624-engine-bind-memoized-text-predicates.md)).
 No GitHub issue filed yet.

--- a/docs/issues/done/00664-engine-border-planes.md
+++ b/docs/issues/done/00664-engine-border-planes.md
@@ -1,7 +1,7 @@
 # Engine: card-level narrowing planes for border:
 
 Status: proposed, not started. GitHub: #664. Follows
-[docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+[docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 
 ## Measured problem
 

--- a/docs/issues/done/00664-engine-border-planes.md
+++ b/docs/issues/done/00664-engine-border-planes.md
@@ -1,6 +1,9 @@
 # Engine: card-level narrowing planes for border:
 
-Status: proposed, not started. GitHub: #664. Follows
+**DONE — shipped; #664 is closed.** `BorderPrintingPlanes` is in `card_engine/src/planes.rs`, and the
+per-value cheaper-of-the-two scheme it established is what #840 later reused for `frame_data`.
+
+*Original status, kept for dating* — proposed. Follows
 [docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 
 ## Measured problem

--- a/docs/issues/done/00667-engine-legality-divergent-carveout.md
+++ b/docs/issues/done/00667-engine-legality-divergent-carveout.md
@@ -2,7 +2,7 @@
 
 Status: implemented, including the row-selection fix (see "Row selection for `unique=card`" below),
 benchmarked, pending PR merge. GitHub: #667.
-Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+Follows [docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 Follow-on to #634 (Steps 1/2, shipped in #658), flagged in that issue's own comment thread.
 
 ## Measured problem

--- a/docs/issues/done/00669-engine-produces-planes.md
+++ b/docs/issues/done/00669-engine-produces-planes.md
@@ -1,7 +1,7 @@
 # Engine: bitplanes for produces: (produced mana)
 
 Status: proposed, not started until now. Follows
-[docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+[docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 No GitHub issue filed yet — surfaced while investigating the broad-survey slow tail after #666.
 
 ## Measured problem

--- a/docs/issues/done/00669-engine-produces-planes.md
+++ b/docs/issues/done/00669-engine-produces-planes.md
@@ -1,6 +1,9 @@
 # Engine: bitplanes for produces: (produced mana)
 
-Status: proposed, not started until now. Follows
+**DONE — shipped as PR #669 (merged).** `card_engine/src/planes.rs` cites this doc by path at the
+produced-mana plane definition.
+
+*Original status, kept for dating* — proposed. Follows
 [docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 No GitHub issue filed yet — surfaced while investigating the broad-survey slow tail after #666.
 

--- a/docs/issues/done/00670-engine-rarity-planes.md
+++ b/docs/issues/done/00670-engine-rarity-planes.md
@@ -1,7 +1,7 @@
 # Engine: card-level rarity bitplanes (common/uncommon/rare/mythic)
 
 Status: implemented, PR pending. GitHub: #670. Follows
-[docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+[docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 Split out of #630 (bitplanes phase 3) after that issue closed with phases 1/2 shipped.
 Verification-side follow-on tracked separately: #674.
 

--- a/docs/issues/done/00678-engine-legality-banned-restricted-planes.md
+++ b/docs/issues/done/00678-engine-legality-banned-restricted-planes.md
@@ -1,6 +1,6 @@
 # Engine: banned:/restricted: legality planes (#678)
 
-Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+Follows [docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 GitHub: #678. Extends the two-exact-plane design already shipped for `LEGAL`
 ([00667-engine-legality-divergent-carveout.md](00667-engine-legality-divergent-carveout.md), #667/#676) to the
 two `expected` values it deliberately left out of scope.

--- a/docs/issues/done/00680-engine-existential-plane-generalization.md
+++ b/docs/issues/done/00680-engine-existential-plane-generalization.md
@@ -1,6 +1,6 @@
 # Engine: generalize existential planes beyond legality (Y-predicate framework)
 
-Follows [docs/workflows/performance-pr-workflow.md](../workflows/performance-pr-workflow.md).
+Follows [docs/workflows/performance-pr-workflow.md](../../workflows/performance-pr-workflow.md).
 GitHub: #680. Status: done — merged and shipped (rarity + border). Remaining Y≥2/unique=printing
 scope split out to #681. Grew out of
 investigating #678's rarity follow-on

--- a/docs/issues/done/00702-engine-plan-selection-layer.md
+++ b/docs/issues/done/00702-engine-plan-selection-layer.md
@@ -344,7 +344,7 @@ corner (though #656 flags it as a known ~1.07ms gap). **Decision pending:** buil
 deferred. This is a prioritization call, not a technical unknown.
 
 → Extracted to an active plan (parts, ship order, target queries):
-[local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md).
+[local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md).
 
 ## Keeping costs/plans current as the engine changes
 

--- a/docs/issues/done/00707-engine-3key-ordering-parity.md
+++ b/docs/issues/done/00707-engine-3key-ordering-parity.md
@@ -1,8 +1,30 @@
 # 3-Key Ordering Parity Across Plans
 
+**DONE — resolved, and by neither of the options this doc proposed.** Key 3 was **dropped from cross-card
+comparison entirely** rather than made consistent: `page_cmp` no longer reads `prefer_score`, so within a
+key the order is `(edhrec_rank, cid, pid)` ascending for every plan (`card_engine/src/lib.rs`, and the
+comment at the permutation build site says as much). With no key 3, the perm-vs-gathered divergence
+described below cannot occur — option (A)'s cost to the fast paths was avoided and option (F)'s
+product-semantics decision never had to be made.
+
+**One thing this does not cover, and it is a different question.** The SQL path still carries
+`prefer_score DESC NULLS LAST` as its third `ORDER BY` term
+([api/api_resource.py](../../../api/api_resource.py)). So engine and SQL can now order a
+`(primary, edhrec_rank)` tie differently — the *engine* is internally consistent, which is what #707 asked
+for, but engine-vs-SQL tie order is not asserted anywhere. Not filed: the same "SQL's `ORDER BY` is only
+three terms then arbitrary" argument below applies, and the engine is the serving path.
+
+Two related findings, both separate:
+
+- [`PrintingRangeScan` orders tied rows differently from every other plan](../local-engine-range-scan-row-order.md)
+  — still open. Probed directly and it is **not** this bug: with the `cid` tiebreak removed from `page_cmp`
+  it fails identically.
+- The 2-key ordering contract that used to hide both is now a full row-order assertion, which is how the
+  range-scan divergence became visible at all.
+
 [#707](https://github.com/jbylund/sylvan_librarian/issues/707) — deferred from
 [#706](https://github.com/jbylund/sylvan_librarian/pull/706) /
-[00702](./00702-engine-plan-selection-layer.md).
+[00702](00702-engine-plan-selection-layer.md).
 
 The plan-selection layer enforces **2-key** ordering parity (primary sort
 column → `edhrec_rank`). Key 3 (`prefer_score`) is deliberately not enforced

--- a/docs/issues/done/00713-is-tag-recovery.md
+++ b/docs/issues/done/00713-is-tag-recovery.md
@@ -160,7 +160,7 @@ aliases especially) trips a tripwire.
 
 - Frame synonyms + query-tree rewriting (this doc's parent thread) — the rewrite seam is
   `get_frame_data_comparison_object` / node-construction, feeding both SQL and engine.
-- [00667-engine-legality-divergent-carveout.md](done/00667-engine-legality-divergent-carveout.md) —
+- [00667-engine-legality-divergent-carveout.md](00667-engine-legality-divergent-carveout.md) —
   legality is the analogous per-printing existence-projection problem.
 - [00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md) — the "observed
   values" dictionary (leaf cardinality 0 for absent values) is the same build-time artifact this

--- a/docs/issues/done/00720-prefer-score-artwork-tuning.md
+++ b/docs/issues/done/00720-prefer-score-artwork-tuning.md
@@ -1,12 +1,24 @@
 # Prefer-Score Artwork Selection: Tuneable Weights and a Measured Objective
 
-Status: **in progress.** Tracked as [#720](https://github.com/jbylund/sylvan_librarian/issues/720),
-which carries the standalone problem statement. One component (`art_style`) is evidenced and ready to
-land; the labelling and swap-review tooling that produced it is built and working. This doc is the
-depth: what was measured, what was wrong, and why the shipped answer is not the one it looked like for
-most of the investigation.
+**DONE — [#720](https://github.com/jbylund/sylvan_librarian/issues/720) closed as completed 2026-07-26.**
+Two changes shipped: the `art_style` component at weight 14 (visible in
+[`api/sql/backfill_prefer_scores.sql`](../../../api/sql/backfill_prefer_scores.sql)) and the filtered
+`illustration_count` numerator that excludes memorabilia and foreign-language rows.
 
-Companion: [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the labelling
+**The remaining tuning work is [#855](../00855-prefer-score-remaining-tuning.md)** — child-set collapsing
+(deferred for a missing `magic.set_parents` table, and the largest effect measured at 16,357 duplicate credits),
+the 533-candidate `art_style` tag-set expansion, weight optimization, and lifting weights out of SQL.
+
+**If you are here because of #720's last comment ("Should only get 1 printing credit per set"): that was built
+and rejected**, at 28 better / 22 worse, with losses concentrated 17–1 on 7th–10th Edition `★` foils. See
+"Counting rules that were built and rejected" below before retrying it.
+
+This doc is the depth: what was measured, what was wrong, and why the shipped answer is not the one it looked
+like for most of the investigation.
+
+*Original status, kept for dating* — in progress; one component evidenced and ready to land.
+
+Companion: [local-prefer-score-label-harness.md](../local-prefer-score-label-harness.md) — the labelling
 instrument, its schema, sampling strategy, and fitting method.
 
 ## Why this cannot be hand-written
@@ -207,7 +219,10 @@ One new component, nothing else changed. `extended_art` stays at 12.
 Expressed as a bonus for being on-style rather than a penalty on being off-style, so every component
 stays non-negative, matching the rest of the table.
 
-## Open
+## Open — all four items now tracked as [#855](../00855-prefer-score-remaining-tuning.md)
+
+Kept here because the evidence behind each one is in this doc; #855 carries the sequencing and the reason (2)
+and (3) are blocked on the labelling tooling rather than on scoring judgement.
 
 - **The tag set is partly a hypothesis.** 533 further candidates exist — art tags whose artworks
   concentrate in few sets, a measurable proxy separating style/setting tags from content tags like
@@ -272,8 +287,8 @@ special foil or a different promo product.
 
 ## Related
 
-- [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — labelling instrument.
-- [00707-engine-3key-ordering-parity.md](done/00707-engine-3key-ordering-parity.md) — `prefer_score` is the
+- [local-prefer-score-label-harness.md](../local-prefer-score-label-harness.md) — labelling instrument.
+- [00707-engine-3key-ordering-parity.md](00707-engine-3key-ordering-parity.md) — `prefer_score` is the
   third sort key and where plans may diverge.
-- [`api/sql/backfill_prefer_scores.sql`](../../api/sql/backfill_prefer_scores.sql) — the scoring
+- [`api/sql/backfill_prefer_scores.sql`](../../../api/sql/backfill_prefer_scores.sql) — the scoring
   definition.

--- a/docs/issues/done/00724-engine-printing-existential-planes.md
+++ b/docs/issues/done/00724-engine-printing-existential-planes.md
@@ -6,7 +6,7 @@ across [#728](https://github.com/jbylund/sylvan_librarian/pull/728) (border slic
 projected to card & artwork) — see the "Result" sections below for each phase. It shipped a
 standalone win (bare printing-mode plane queries via `popcount` + a reused page walk, ~3×) *and* is
 the substrate the
-[printing-space popcount-order plan](../local-engine-printing-plane-popcount-order.md) needs for
+[printing-space popcount-order plan](local-engine-printing-plane-popcount-order.md) needs for
 compounds. See "The standalone win" below.
 
 ## What — exact, not existential
@@ -93,7 +93,7 @@ Two honest scope notes:
 - Where #724 is the **only** exact option across all three modes is **compounds** (`border:black
   r:rare`, `usd<50 f:modern`): card-space existence-AND can't compose them, so they must be AND'd in
   printing space and projected once (see the two strategies above) — that's the full printing-space
-  plan ([local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md)),
+  plan ([local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md)),
   built on these planes.
 
 So the split is: **#724 delivers bare printing-mode queries standalone** (popcount + walk, ~3×); the
@@ -317,7 +317,7 @@ total turns out hot before these planes land.
 
 ## Related
 
-- [local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md) —
+- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
   the consumer plan; this is its existential leaf source.
 - [00667 legality](00667-engine-legality-divergent-carveout.md),
   [00664 border planes](00664-engine-border-planes.md) — the card-space versions this extends

--- a/docs/issues/done/00739-engine-watermark-postings.md
+++ b/docs/issues/done/00739-engine-watermark-postings.md
@@ -72,7 +72,7 @@ no residual verification — same as an absent set code today.
 
 ## Related
 
-- Found via [`scripts/survey_queries.py`](../../scripts/survey_queries.py)'s broad realistic-traffic
+- Found via [`scripts/survey_queries.py`](../../../scripts/survey_queries.py)'s broad realistic-traffic
   survey.
 - [00664 border planes](00664-engine-border-planes.md) — the plane-vs-postings crossover this
   reasons from, for a field dense enough to go the other way.

--- a/docs/issues/done/00744-engine-compose-orderby-range-walk.md
+++ b/docs/issues/done/00744-engine-compose-orderby-range-walk.md
@@ -196,12 +196,12 @@ api/tests/test_engine_unit.py`: 158/158. CSVs under `benchmarks/compose-orderby-
 
 ## Related
 
-- [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md) —
+- [00740-engine-compose-permutation-fallback.md](00740-engine-compose-permutation-fallback.md) —
   where `gather_composed_page` and `COMPOSE_GATHER_MAX_CARD_FRACTION` came from; this doc's paging
   fix is the case that guard was never meant to cover.
-- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) —
+- [00741-engine-negated-range-narrowing.md](00741-engine-negated-range-narrowing.md) —
   sibling investigation from the same survey-driven thread; also has the `and_child_rank`/
   `narrow_rec` single-source-of-truth precedent this doc's paging branch should follow when it's
   implemented.
-- [done/00667-engine-legality-divergent-carveout.md](done/00667-engine-legality-divergent-carveout.md)
+- [00667-engine-legality-divergent-carveout.md](00667-engine-legality-divergent-carveout.md)
   — the existing `_EXISTS`/`_ABSENT` plane pair and divergent-repair mechanism this reuses.

--- a/docs/issues/done/00745-engine-explain-analyze.md
+++ b/docs/issues/done/00745-engine-explain-analyze.md
@@ -2,7 +2,7 @@
 
 **Status: proposed**, filed as [#745](https://github.com/jbylund/sylvan_librarian/issues/745). Builds
 directly on
-[00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md)
+[00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md)
 (landed): that issue gave the engine a single cost-based router
 (`run_query_routed`, lib.rs) that argmins `cost::plan_cost` over
 `PhysicalPlan::ALL.filter(applicable)` (6 variants: `PrintingRangeScan`,
@@ -53,7 +53,7 @@ looking at right now" without writing a new `#[bench]`.
   Returning raw timings rather than a summary lets the caller compute a
   median themselves and — as important — see whether a plan's timing is
   bimodal, which this engine has measured happening on identical work
-  before ([00648-engine-verifier-cost-ordering.md](done/00648-engine-verifier-cost-ordering.md)'s
+  before ([00648-engine-verifier-cost-ordering.md](00648-engine-verifier-cost-ordering.md)'s
   measurement-traps section). Given plans here run sub-few-ms, 3 warmups +
   10 trials × 6 plans is a small fraction of a second per call.
 
@@ -104,10 +104,10 @@ which is fine for an on-demand debug call and wrong for every query.
 
 ## Related
 
-- [00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) —
+- [00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md) —
   the cost model, `PhysicalPlan`, `run_query_with_plan`, and the calibration
   harness this builds on.
-- [00648-engine-verifier-cost-ordering.md](done/00648-engine-verifier-cost-ordering.md) —
+- [00648-engine-verifier-cost-ordering.md](00648-engine-verifier-cost-ordering.md) —
   source of the interleaved-measurement discipline and the documented
   bimodal-timing / env-var-size measurement traps.
 - [docs/prs/verifier-cost-ordering.md](../prs/verifier-cost-ordering.md) —

--- a/docs/issues/done/00746-engine-tag-postings-compose.md
+++ b/docs/issues/done/00746-engine-tag-postings-compose.md
@@ -4,10 +4,10 @@
 Filed investigating why `-set:dmu year:2023`
 (0.451ms, printing/edhrec) costs noticeably more than `year:2023` alone (0.268ms) despite excluding
 only 2 of its 9,234 matches. A step 4 for
-[#731](00731-engine-compose-universal-evaluator.md)'s leaf-source table, alongside step 1 (range
+[#731](../00731-engine-compose-universal-evaluator.md)'s leaf-source table, alongside step 1 (range
 leaves, shipped) and the sibling work this session added:
-[done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md)
-and [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md).
+[00740-engine-compose-permutation-fallback.md](00740-engine-compose-permutation-fallback.md)
+and [00741-engine-negated-range-narrowing.md](00741-engine-negated-range-narrowing.md).
 
 ## The finding
 
@@ -15,7 +15,7 @@ and [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-ran
 for the *whole* filter) — a non-materializing binary-search plan, effectively free. `-set:dmu
 year:2023` is an `And`, so `bare_range_bounds` returns `None` for the compound as a whole regardless
 of how cheap one side is; `PrintingRangeScan` is inapplicable and the query falls to a materializing
-plan. There, `narrow_rec`'s `And` arm ([lib.rs:3338](../../card_engine/src/lib.rs#L3338)) narrows via
+plan. There, `narrow_rec`'s `And` arm ([lib.rs:3338](../../../card_engine/src/lib.rs#L3338)) narrows via
 `year:2023` (rank 1) to 9,234 candidates, then correctly skips `-set:dmu`'s narrowing contribution
 (rank 2, "complements only pay as sole source") — `-set:dmu` becomes a per-candidate residual check
 instead. Per the engine's own measured cost model (`MASK_COMPARE_NS100` ≈ 4ns/candidate,
@@ -25,15 +25,15 @@ computation, accumulator bookkeeping), not the predicate itself.
 
 ## The idea
 
-`is_printing_composable`/`compose_printing_bits` ([lib.rs:4393](../../card_engine/src/lib.rs#L4393),
-[lib.rs:4551](../../card_engine/src/lib.rs#L4551)) already turn border, rarity, legality, and
+`is_printing_composable`/`compose_printing_bits` ([lib.rs:4393](../../../card_engine/src/lib.rs#L4393),
+[lib.rs:4551](../../../card_engine/src/lib.rs#L4551)) already turn border, rarity, legality, and
 range leaves into exact printing-space bitmaps, composed with `AND`/`OR` — #731's model. `set:`/
 `watermark:` aren't in that table at all today: they're backed by a plain postings `TagIndex`
 (`indexes.set_codes`/`indexes.watermarks`, a `HashMap<String, Vec<u32>>` of sorted printing ids), no
 plane, no leaf-bits function, positive or negated.
 
 Adding one is cheap and reuses an existing primitive: `scatter_bits`
-([lib.rs:2406](../../card_engine/src/lib.rs#L2406)) already does exactly this for border's
+([lib.rs:2406](../../../card_engine/src/lib.rs#L2406)) already does exactly this for border's
 non-plane postings fallback (`border_leaf_bits`, lib.rs:4443). A `set:dmu` leaf is
 `scatter_bits(indexes.set_codes["dmu"], n_printings)` — the same shape, just keyed off a different
 index.
@@ -127,10 +127,10 @@ known-mask is built. See the correctness caveat below.
 `#731`'s own caveat applies here directly: **`NOT` over a nullable field needs a "known" mask** — a
 null-valued printing satisfies neither the direct predicate nor its negation (the same trivalent trap
 `tight_narrow_space` had for `DateCmp`/`YearCmp`, fixed this session in
-[done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md)). `set_code` has
+[00741-engine-negated-range-narrowing.md](00741-engine-negated-range-narrowing.md)). `set_code` has
 no null case (every printing belongs to exactly one set) — "all-ones minus postings" is exact.
 `watermark` **is** nullable (`card_watermark_id != NONE_STR` gates the postings build in
-`reload_commit`, see [00739-engine-watermark-postings.md](done/00739-engine-watermark-postings.md)) —
+`reload_commit`, see [00739-engine-watermark-postings.md](00739-engine-watermark-postings.md)) —
 "all-ones minus postings" would wrongly count no-watermark printings as matching `-watermark:x`. The
 negated compose leaf should therefore cover `set:` only, or `watermark:` needs an explicit
 known-mask subtraction (a third small postings-derived bitmap of "has any watermark") before its
@@ -156,12 +156,12 @@ known-mask question.
 
 ## Related
 
-- [#731](00731-engine-compose-universal-evaluator.md) — the parent plan; this is a step-4 leaf kind
+- [#731](../00731-engine-compose-universal-evaluator.md) — the parent plan; this is a step-4 leaf kind
   its table doesn't yet enumerate.
-- [done/00740-engine-compose-permutation-fallback.md](done/00740-engine-compose-permutation-fallback.md) —
+- [00740-engine-compose-permutation-fallback.md](00740-engine-compose-permutation-fallback.md) —
   sibling fix from the same broad-survey investigation.
-- [done/00741-engine-negated-range-narrowing.md](done/00741-engine-negated-range-narrowing.md) — where the
+- [00741-engine-negated-range-narrowing.md](00741-engine-negated-range-narrowing.md) — where the
   nullable-field `NOT` trap was found and fixed for dates; the same discipline applies to watermark
   here.
-- [done/00739-engine-watermark-postings.md](done/00739-engine-watermark-postings.md) — the
+- [00739-engine-watermark-postings.md](00739-engine-watermark-postings.md) — the
   `set_codes`/`watermarks` `TagIndex` this reuses.

--- a/docs/issues/done/00757-engine-query-ctx-arg-bundle.md
+++ b/docs/issues/done/00757-engine-query-ctx-arg-bundle.md
@@ -1,7 +1,7 @@
 # Engine: Bundle the Plan-Selection Layer's Repeated Args into Two Borrow Structs
 
-Status: **implemented 2026-07-24** on `engine-query-ctx-arg-bundle`. Tracked as #757. Filed from the
-#752 ([00745-engine-explain-analyze.md](done/00745-engine-explain-analyze.md)) review — the `explain`/
+**DONE.** Status: **implemented 2026-07-24** on `engine-query-ctx-arg-bundle`. Tracked as #757. Filed from the
+#752 ([00745-engine-explain-analyze.md](00745-engine-explain-analyze.md)) review — the `explain`/
 `explain_analyze` primitives pushed the plan-selection layer's argument lists past the point where
 threading them individually reads well. Revised the same day before implementing: scope widened (two
 structs, not one; 13 all-five-slice functions, not 6) and the priority re-argued — see
@@ -35,28 +35,28 @@ meaningful signal, and they are outnumbered better than 2:1 by the boilerplate.
 
 | Function | Args | of which cluster A | cluster B | varying | Location |
 | --- | --- | --- | --- | --- | --- |
-| `walk_printing_page` | 10 | 4 | 4 | 2 | [lib.rs:4442](../../card_engine/src/lib.rs#L4442) |
-| `printing_range_fastpath` | 10 | 5 | 4 | 1 | [lib.rs:4587](../../card_engine/src/lib.rs#L4587) |
-| `printing_compose_fastpath` | 11 | 4 | 6 | 1 | [lib.rs:5404](../../card_engine/src/lib.rs#L5404) |
-| `prepare_candidates` | 7 | 4 | 1 | 2 | [lib.rs:5789](../../card_engine/src/lib.rs#L5789) |
-| `exec_plane_popcount_order` | 11 | 5 | 5 | 1 | [lib.rs:5904](../../card_engine/src/lib.rs#L5904) |
-| `exec_plane_popcount_order_with_bitmap` | 12 | 5 | 5 | 2 | [lib.rs:5936](../../card_engine/src/lib.rs#L5936) |
-| `exec_card_range_popcount` | 12 | 5 | 5 | 2 | [lib.rs:5964](../../card_engine/src/lib.rs#L5964) |
-| `walk_grouped_page` | 12 | 3 | 6 | 3 | [lib.rs:6035](../../card_engine/src/lib.rs#L6035) |
-| `gather_composed_page` | 11 | 3 | 6 | 2 | [lib.rs:6139](../../card_engine/src/lib.rs#L6139) |
-| `exec_streamed_select` | 14 | 5 | 6 | 3 | [lib.rs:6226](../../card_engine/src/lib.rs#L6226) |
-| `exec_gathered_scan` | 14 | 5 | 6 | 3 | [lib.rs:6258](../../card_engine/src/lib.rs#L6258) |
-| `run_query` | 13 | 5 | 3 | 5 | [lib.rs:6324](../../card_engine/src/lib.rs#L6324) |
-| `exec_from_candidates` | 15 | 5 | 6 | 4 | [lib.rs:6376](../../card_engine/src/lib.rs#L6376) |
-| `mk_plan_feats` | 8 | 0 | 2 | 6 | [lib.rs:6407](../../card_engine/src/lib.rs#L6407) |
-| `candidate_feats` | 8 | 1 | 3 | 4 | [lib.rs:6443](../../card_engine/src/lib.rs#L6443) |
-| `acquire_plan_features` | 12 | 5 | 5 | 2 | [lib.rs:6469](../../card_engine/src/lib.rs#L6469) |
-| `run_query_routed` | 13 | 5 | 6 | 2 | [lib.rs:6595](../../card_engine/src/lib.rs#L6595) |
-| `run_query_with_plan` | 14 | 5 | 3 | 6 | [lib.rs:6696](../../card_engine/src/lib.rs#L6696) |
-| `explain` | 12 | 5 | 5 | 2 | [lib.rs:6792](../../card_engine/src/lib.rs#L6792) |
-| `explain_analyze` | 15 | 5 | 3 | 7 | [lib.rs:6859](../../card_engine/src/lib.rs#L6859) |
-| `run_query_streamed_popcount` | 13 | 4 | 3 | 6 | [lib.rs:6923](../../card_engine/src/lib.rs#L6923) |
-| `run_query_streamed` | 18 | 4 | 6 | 8 | [lib.rs:7052](../../card_engine/src/lib.rs#L7052) |
+| `walk_printing_page` | 10 | 4 | 4 | 2 | [lib.rs:4442](../../../card_engine/src/lib.rs#L4442) |
+| `printing_range_fastpath` | 10 | 5 | 4 | 1 | [lib.rs:4587](../../../card_engine/src/lib.rs#L4587) |
+| `printing_compose_fastpath` | 11 | 4 | 6 | 1 | [lib.rs:5404](../../../card_engine/src/lib.rs#L5404) |
+| `prepare_candidates` | 7 | 4 | 1 | 2 | [lib.rs:5789](../../../card_engine/src/lib.rs#L5789) |
+| `exec_plane_popcount_order` | 11 | 5 | 5 | 1 | [lib.rs:5904](../../../card_engine/src/lib.rs#L5904) |
+| `exec_plane_popcount_order_with_bitmap` | 12 | 5 | 5 | 2 | [lib.rs:5936](../../../card_engine/src/lib.rs#L5936) |
+| `exec_card_range_popcount` | 12 | 5 | 5 | 2 | [lib.rs:5964](../../../card_engine/src/lib.rs#L5964) |
+| `walk_grouped_page` | 12 | 3 | 6 | 3 | [lib.rs:6035](../../../card_engine/src/lib.rs#L6035) |
+| `gather_composed_page` | 11 | 3 | 6 | 2 | [lib.rs:6139](../../../card_engine/src/lib.rs#L6139) |
+| `exec_streamed_select` | 14 | 5 | 6 | 3 | [lib.rs:6226](../../../card_engine/src/lib.rs#L6226) |
+| `exec_gathered_scan` | 14 | 5 | 6 | 3 | [lib.rs:6258](../../../card_engine/src/lib.rs#L6258) |
+| `run_query` | 13 | 5 | 3 | 5 | [lib.rs:6324](../../../card_engine/src/lib.rs#L6324) |
+| `exec_from_candidates` | 15 | 5 | 6 | 4 | [lib.rs:6376](../../../card_engine/src/lib.rs#L6376) |
+| `mk_plan_feats` | 8 | 0 | 2 | 6 | [lib.rs:6407](../../../card_engine/src/lib.rs#L6407) |
+| `candidate_feats` | 8 | 1 | 3 | 4 | [lib.rs:6443](../../../card_engine/src/lib.rs#L6443) |
+| `acquire_plan_features` | 12 | 5 | 5 | 2 | [lib.rs:6469](../../../card_engine/src/lib.rs#L6469) |
+| `run_query_routed` | 13 | 5 | 6 | 2 | [lib.rs:6595](../../../card_engine/src/lib.rs#L6595) |
+| `run_query_with_plan` | 14 | 5 | 3 | 6 | [lib.rs:6696](../../../card_engine/src/lib.rs#L6696) |
+| `explain` | 12 | 5 | 5 | 2 | [lib.rs:6792](../../../card_engine/src/lib.rs#L6792) |
+| `explain_analyze` | 15 | 5 | 3 | 7 | [lib.rs:6859](../../../card_engine/src/lib.rs#L6859) |
+| `run_query_streamed_popcount` | 13 | 4 | 3 | 6 | [lib.rs:6923](../../../card_engine/src/lib.rs#L6923) |
+| `run_query_streamed` | 18 | 4 | 6 | 8 | [lib.rs:7052](../../../card_engine/src/lib.rs#L7052) |
 
 Thirteen of these take all five of cluster A. (The original filing listed six functions; it was
 scoped to the plan-selection entry points and missed the executors, the fastpaths, and the streamed
@@ -97,9 +97,9 @@ from 14 args to `(ctx, filter, prep, plane, params)`. Most of the 25 `#[allow]`s
 
 - **`QueryParams::from_strs(unique, prefer, orderby, direction, limit, offset)`.** The
   `orderby_to_col` / `direction == "desc"` / `prefer_from_str` / `mode_from_unique` block is
-  copy-pasted at four sites in `lib.rs` — [6339](../../card_engine/src/lib.rs#L6339),
-  [6712](../../card_engine/src/lib.rs#L6712), [6876](../../card_engine/src/lib.rs#L6876),
-  [7963](../../card_engine/src/lib.rs#L7963) — plus several in `tests.rs`. This is also what lets
+  copy-pasted at four sites in `lib.rs` — [6339](../../../card_engine/src/lib.rs#L6339),
+  [6712](../../../card_engine/src/lib.rs#L6712), [6876](../../../card_engine/src/lib.rs#L6876),
+  [7963](../../../card_engine/src/lib.rs#L7963) — plus several in `tests.rs`. This is also what lets
   `run_query`, `run_query_with_plan`, and `explain_analyze` stop taking four `&str`s each: they take
   `&QueryParams` and the string→enum adapter exists once.
 - **`impl<'a> From<&'a Archived<CardData>> for QueryCtx<'a>`.** Every construction site is
@@ -114,13 +114,13 @@ These are too small to be their own PRs and sit in exactly the signatures being 
 - `PhysicalPlan::applicable(filter, mode, cards, plane, sort_col, descending, indexes)` — 7 args, 6
   call sites in `run_query_routed`/`explain`/`acquire_plan_features` — becomes
   `applicable(&ctx, &params, filter, plane)`.
-- [exec_streamed_select](../../card_engine/src/lib.rs#L6244) and
-  [exec_gathered_scan](../../card_engine/src/lib.rs#L6276) both open with the identical
+- [exec_streamed_select](../../../card_engine/src/lib.rs#L6244) and
+  [exec_gathered_scan](../../../card_engine/src/lib.rs#L6276) both open with the identical
   `existential_plane_for` + `Box<dyn Iterator<Item = u32>>` candidate-ids preamble. One method on
   `PreparedCandidates`.
-- [exec_plane_popcount_order](../../card_engine/src/lib.rs#L5904) is a ten-line thread-local wrapper
+- [exec_plane_popcount_order](../../../card_engine/src/lib.rs#L5904) is a ten-line thread-local wrapper
   around `_with_bitmap`, and both spell out the full 11/12-arg list.
-- [mk_plan_feats](../../card_engine/src/lib.rs#L6407) exists purely to avoid an 8-field struct
+- [mk_plan_feats](../../../card_engine/src/lib.rs#L6407) exists purely to avoid an 8-field struct
   literal, and needs its own `#[allow]` to do it. With the two structs in place it takes those plus
   the four fields that actually vary by count source.
 
@@ -154,8 +154,8 @@ inverse one does:
 - **The layer is quiet.** The only open engine PR is #692, which touches `filter.rs` and nothing
   else. Every other open PR is images / fonts / query-runner / DFC work.
 - **The next four engine issues all land here.** #754 (plane-subtree compose leaf + general `Not`
-  arm), [#731](00731-engine-compose-universal-evaluator.md) (compose as the universal exact
-  evaluator), [#730](00730-engine-popcount-skip-walk.md) (popcount-skip walk generalized to all
+  arm), [#731](../00731-engine-compose-universal-evaluator.md) (compose as the universal exact
+  evaluator), [#730](../00730-engine-popcount-skip-walk.md) (popcount-skip walk generalized to all
   distinct-ons), and #656 each add plans or args to these exact signatures. Landing the bundle first
   means they build on 4-arg signatures instead of each pushing a 15-arg list to 16 — which is the
   "do it while the layer is open" intent, just resolved in the other direction.
@@ -241,17 +241,17 @@ docs rather than folded in here:
   [local-engine-clippy-ci-gate.md](local-engine-clippy-ci-gate.md), stacked directly on this change.
 - **`lib.rs` is 8146 lines** and already carved by 30 `// ───` section banners that map cleanly onto
   modules. The split is close to mechanical: `mod tests` sits at the crate root
-  ([lib.rs:8130](../../card_engine/src/lib.rs#L8130)) importing ~100 names via `use super::{…}`, and
+  ([lib.rs:8130](../../../card_engine/src/lib.rs#L8130)) importing ~100 names via `use super::{…}`, and
   a private `use newmod::*;` at the root keeps all of them resolving through `super::` unchanged.
   Sequence it *after* this change, so the new module boundaries carry 4-arg signatures rather than
   15-arg ones.
 
 ## Related
 
-- [00745-engine-explain-analyze.md](done/00745-engine-explain-analyze.md) — the diagnostic work (#752)
+- [00745-engine-explain-analyze.md](00745-engine-explain-analyze.md) — the diagnostic work (#752)
   that pushed the arg counts up and surfaced this.
-- [done/00702-engine-plan-selection-layer.md](done/00702-engine-plan-selection-layer.md) — the
+- [00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md) — the
   cost-based router (`run_query_routed`, `acquire_plan_features`) whose signatures this cleans up.
-- [local-engine-range-veto-redundancy.md](local-engine-range-veto-redundancy.md) — the other
+- [local-engine-range-veto-redundancy.md](../local-engine-range-veto-redundancy.md) — the other
   standing cleanup in this layer, but a *semantic* one (a hardcoded second copy of a cost decision)
   that needs measurement first, unlike this one.

--- a/docs/issues/done/local-ci-skip-stub-masks-failures.md
+++ b/docs/issues/done/local-ci-skip-stub-masks-failures.md
@@ -1,6 +1,6 @@
 # CI: The Skip-Stub Workflow Pair Can Report a Passing Check While the Real Run Fails
 
-Status: **implemented 2026-07-24** on `ci-single-workflow-change-detection`. Not filed as a GitHub
+**DONE.** Status: **implemented 2026-07-24** on `ci-single-workflow-change-detection`. Not filed as a GitHub
 issue — found while landing [local-engine-clippy-ci-gate.md](local-engine-clippy-ci-gate.md) (#760),
 where it actively hid a red build.
 
@@ -41,7 +41,7 @@ filters are complements.
 One workflow per suite:
 
 - **No `paths:` filter at all**, so the workflow always runs and its check is reported exactly once.
-- A `changes` job that calls [`.github/scripts/changed-paths.sh`](../../.github/scripts/changed-paths.sh)
+- A `changes` job that calls [`.github/scripts/changed-paths.sh`](../../../.github/scripts/changed-paths.sh)
   and outputs a boolean.
 - The real job (`rust-test` / `python-test` / `js-test`) gains `needs: changes` and
   `if: needs.changes.outputs.relevant == 'true'`. The Python job was renamed from the bare `test` to

--- a/docs/issues/done/local-engine-artwork-skip-repped.md
+++ b/docs/issues/done/local-engine-artwork-skip-repped.md
@@ -16,7 +16,7 @@ Cumulative vs `main` (97,206-printing corpus, artwork/usd, byte-identical output
 ## The lever
 
 For `unique=artwork`, the gather picks one best-`prefer_score` representative per artwork group.
-The [APrinting-layout investigation](./local-engine-aprinting-layout.md) established (after a
+The [APrinting-layout investigation](../local-engine-aprinting-layout.md) established (after a
 misattributed profile) that the real gather cost on `border:black -(names)` / artwork / usd is
 **per-printing residual verification of a printing-varying predicate** (`border`) — the loop calls
 `residual_matches(&printings[pid], …)` on every printing to find a black-bordered rep, reading the

--- a/docs/issues/done/local-engine-broad-range-fastpath.md
+++ b/docs/issues/done/local-engine-broad-range-fastpath.md
@@ -344,7 +344,7 @@ fifth (tight/loose) axis to worry about — every field behaves identically ther
 
 ## Related
 
-- [local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md) —
+- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
   the consolidated forward plan for idea 2 (the printing-space popcount plan, #656): parts, ship
   order, target queries, and the #656 assembly. This doc is history; that one is the plan.
 - [00690-engine-direct-projection-arrays.md](00690-engine-direct-projection-arrays.md) —

--- a/docs/issues/done/local-engine-candidate-materialize.md
+++ b/docs/issues/done/local-engine-candidate-materialize.md
@@ -1,5 +1,13 @@
 # Materializing a sorted candidate list: bitmap beats sort, merge loses badly
 
+**DONE for the range arms — merged in [#845](https://github.com/jbylund/sylvan_librarian/pull/845)** (layer
+13 of the cost-model stack). Whole mix 0.949, target 0.867.
+
+**The remaining call sites are [#849](https://github.com/jbylund/sylvan_librarian/issues/849)** —
+`arith_tuple_narrow` (the case that prompted this benchmark) and the other posting-union arms. They are
+card-space, so the ~490:1 domain:count crossover measured here has to be re-derived on that axis rather than
+reused.
+
 **Shipped for `range_narrowed` (the range arms).** See "What shipped" at the bottom; the crossover turned
 out to be a domain:count RATIO, not a count, and the remaining call sites (`arith_tuple_narrow` and the
 other posting-union arms) have not adopted it yet.
@@ -109,7 +117,7 @@ Interleaved A/B, 10 rounds, 1,362 queries, drift 0.978/1.010: range TARGET **0.8
 mix **0.949**, p90 0.902. No regression above 1.07 and all of those are sub-20 µs queries.
 
 This also retired the one regression from
-[the breadth-denominator change](./local-engine-range-breadth-denominator.md): `eur<0.13 t:land` went
+[the breadth-denominator change](local-engine-range-breadth-denominator.md): `eur<0.13 t:land` went
 208 µs before that change, 267 after it, and **71.5 µs** now.
 
 Note `usd<0.18 t:land` was never affected by the denominator at all — it was already narrowing, and

--- a/docs/issues/done/local-engine-clippy-ci-gate.md
+++ b/docs/issues/done/local-engine-clippy-ci-gate.md
@@ -1,6 +1,6 @@
 # Engine: Clean Clippy and Gate It in CI
 
-Status: **implemented 2026-07-24** on `engine-clippy-clean` (stacked on
+**DONE.** Status: **implemented 2026-07-24** on `engine-clippy-clean` (stacked on
 [#757](00757-engine-query-ctx-arg-bundle.md)). Not filed as a GitHub issue — found while scoping #757,
 implemented immediately after it.
 
@@ -8,8 +8,8 @@ implemented immediately after it.
 
 Clippy was not running in CI at all, and was not clean.
 
-- [rust-tests.yml](../../.github/workflows/rust-tests.yml) ran only `cargo test` for the two crates.
-- [lint.yml](../../.github/workflows/lint.yml) is Python-only: its `paths` filter is `**/*.py`,
+- [rust-tests.yml](../../../.github/workflows/rust-tests.yml) ran only `cargo test` for the two crates.
+- [lint.yml](../../../.github/workflows/lint.yml) is Python-only: its `paths` filter is `**/*.py`,
   `requirements/**`, `pyproject.toml`, and itself. No Rust path can trigger it.
 - `cargo clippy --all-targets` emitted **68 warnings** on `card_engine` and 3 on `shared_cache`.
 
@@ -78,7 +78,7 @@ Two `cargo clippy --all-targets -- -D warnings` steps (one per crate) added to t
 `rust-test` job rather than as a new job. Three reasons, in order:
 
 1. A new job means a new required check, which means
-   [rust-tests-skip.yml](../../.github/workflows/rust-tests-skip.yml) needs a matching stub job or
+   [rust-tests-skip.yml](../../../.github/workflows/rust-tests-skip.yml) needs a matching stub job or
    PRs touching no `.rs` file hang forever on a check that never runs. Steps in the existing job need
    no such coordination.
 2. `rust-tests.yml`'s `paths` filter (`**/*.rs`, `**/Cargo.*`) is already exactly the right trigger.
@@ -97,7 +97,7 @@ and CI's `dtolnay/rust-toolchain@stable` resolved to **1.97.0**, which added tha
 `-D warnings` on a floating `@stable` means every Rust release (~6 weeks) turns into a red build on
 whichever PR is open at the time, for code that didn't change — and it can't be reproduced locally
 until the contributor happens to update. So the toolchain is now **pinned to 1.97.1** in
-[rust-tests.yml](../../.github/workflows/rust-tests.yml). Bumping it becomes a deliberate PR where the
+[rust-tests.yml](../../../.github/workflows/rust-tests.yml). Bumping it becomes a deliberate PR where the
 new lints get reviewed on purpose, instead of a surprise on unrelated work.
 
 The three literals were fixed (`*b"abc"`), not suppressed. Verified against 1.97.1 locally after

--- a/docs/issues/done/local-engine-compose-walk-features.md
+++ b/docs/issues/done/local-engine-compose-walk-features.md
@@ -1,11 +1,22 @@
 # Compose's two walk branches, graded separately
 
+**DONE — resolved, and not by any of the three fixes this doc worked up.** All three were about *describing*
+the walk's bucket granularity better; the value-major layout in
+[#838](https://github.com/jbylund/sylvan_librarian/pull/838) deleted the granularity instead, along with
+`orderby_walk_scan` and `collect_orderby_page`. See "Where this stands" at the bottom for the item-by-item
+outcome.
+
+Two live follow-ups, both already their own docs:
+[compose paging on cost](../local-engine-compose-paging-cost-based.md) (item 3, clumping) and
+[compose build rates](../local-engine-compose-build-rates.md) (item 4, `Perm`'s missing `cards_visited`
+term).
+
 Branched off `engine-loop-phase-measurement` at `c11ad25`, which shipped the Gather arm's missing build
 term. That work left `Perm` and `OrderbyWalk` unaddressed and named them one problem. Measured, they
 are three, and only one of them is what it looked like.
 
 Context and the corpus-axis method:
-[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md).
+[local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md).
 
 ## The walk feature was never graded, and a counter for it already existed
 
@@ -177,7 +188,7 @@ explain that cell too.
 
 **Resolved, and not by any of the three fixes this doc worked up.** All three were about *describing*
 the walk's bucket granularity better; the layout change deleted the granularity instead. See
-[done/local-engine-value-major-sort-indexes.md](./done/local-engine-value-major-sort-indexes.md) for
+[local-engine-value-major-sort-indexes.md](local-engine-value-major-sort-indexes.md) for
 what shipped and the measurements.
 
 Item by item, so the reasoning above is readable against the outcome:
@@ -191,10 +202,10 @@ Item by item, so the reasoning above is readable against the outcome:
    the patch never had to be resolved.
 2. **OW/rarity's two errors — both moot.** The rate split priced plane-bucket steps against entry steps;
    the walk reads no planes now. The 124x `special`/`bonus` over-charge was `orderby_walk_scan`, which is
-   deleted. [done/local-engine-rarity-walk-cost.md](./done/local-engine-rarity-walk-cost.md) carries
+   deleted. [local-engine-rarity-walk-cost.md](local-engine-rarity-walk-cost.md) carries
    that analysis with its resolution.
 3. **Clumping is still the ceiling, and still not a rate.**
-   [local-engine-compose-paging-cost-based.md](./local-engine-compose-paging-cost-based.md) is the live
+   [local-engine-compose-paging-cost-based.md](../local-engine-compose-paging-cost-based.md) is the live
    item: `compose_paging_with_total` picks `OrderbyWalk` by SHAPE, so compose has no argmin against
    `Gather` even though `plan_cost` has both arms. A router does not need to know how bad a clumped walk
    is, only that it is bad, and `Gather` is O(matches) — it gets safer exactly as the walk gets worse.
@@ -207,7 +218,7 @@ Item by item, so the reasoning above is readable against the outcome:
    `OrderbyWalk`'s (0.3135 against 0.3057). Which retires the puzzle above about `printings_walked /
    cards_visited` grading 4.53 while `/printings_examined` graded 1.17 — the arm needs BOTH columns, and
    has neither a cards term nor an estimator for one.
-   [local-engine-compose-build-rates.md](./local-engine-compose-build-rates.md) has the numbers.
+   [local-engine-compose-build-rates.md](../local-engine-compose-build-rates.md) has the numbers.
 
 The general lesson this branch keeps re-teaching: a partial accuracy fix on the compose arm loses regret
 (`compose_scan_printings`'s span patch 1.33 -> 1.41 µs, the build term applied build-wide 1.193 -> 1.544

--- a/docs/issues/done/local-engine-cost-model-agreement.md
+++ b/docs/issues/done/local-engine-cost-model-agreement.md
@@ -1,11 +1,28 @@
 # Cost-model: agreement 8/16 cells to 15/16, and why routing did not move
 
+**DONE — the feature and rate work here merged in
+[#834](https://github.com/jbylund/sylvan_librarian/pull/834) and
+[#836](https://github.com/jbylund/sylvan_librarian/pull/836)** (layers 2 and 4 of the cost-model stack),
+on the instrumentation substrate from [#833](https://github.com/jbylund/sylvan_librarian/pull/833).
+
+This doc's residuals were already extracted into their own docs while it was live, and both are still open:
+
+- **P3 should not re-derive membership at all** (the "larger prize" of the top-target section) —
+  [local-engine-compose-membership-bittest.md](../local-engine-compose-membership-bittest.md). Worth ~8× on
+  the highest-regret query class.
+- **Sparse compose should gather, not decline** —
+  [local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md).
+
+The one cell in "What is still wrong" that was called real — `StreamedSelect/printing_compose` at 1.31 — is
+now tracked as part of [#852](https://github.com/jbylund/sylvan_librarian/issues/852), which carries the
+P3-vs-P4 ranking on this acquire and the oracle bound on what estimator work can buy.
+
 `cost::plan_cost` was accurate enough to rank plans correctly most of the time while being badly
 wrong in absolute terms on several arms — a state that holds until something competes closely, and
 then mis-routes. This is the record of measuring that gap and closing most of it.
 
 Bar, set before the work: **every (plan, acquire) cell's measured/predicted median inside
-[0.8, 1.25]**, measured by [`scripts/bench_cost_model_agreement.py`](../../scripts/bench_cost_model_agreement.py).
+[0.8, 1.25]**, measured by [`scripts/bench_cost_model_agreement.py`](../../../scripts/bench_cost_model_agreement.py).
 
 Measured baseline-to-branch on the same sampler (`92ecebf`, before any cost change, vs the branch tip):
 
@@ -36,7 +53,7 @@ the mode-split commit against the commit immediately before it, not against the 
 cost commit zeroed compose's verify tier for all three modes, which *introduced* that regression; the
 mode-split commit fixed it. The pair nets to zero, which is what the baseline comparison above shows.
 
-Use [`scripts/bench_pairwise_ordering.py`](../../scripts/bench_pairwise_ordering.py) to target routing
+Use [`scripts/bench_pairwise_ordering.py`](../../../scripts/bench_pairwise_ordering.py) to target routing
 work: it reports, per plan pair, how often the order is right and what being wrong costs. Its own
 limitation, measured: pairwise regret OVERSTATES routing loss, because argmin is over all plans. On
 the worst pair, compose beat StreamedSelect in 708 mis-ordered cases but beat the best of all plans
@@ -55,7 +72,7 @@ failures are worth keeping:
    noise was signal, and concluded "no detectable difference". That was also wrong, because the
    generator drew thresholds from hardcoded value lists (`year:2019`–`2024` on a 1993–2026 corpus)
    and never produced bounded ranges at all.
-3. **Paired, with corpus-drawn thresholds** ([`client/query_sampler.py`](../../client/query_sampler.py)).
+3. **Paired, with corpus-drawn thresholds** ([`client/query_sampler.py`](../../../client/query_sampler.py)).
    Found a 12x difference the first two could not see.
 
 The harness was validated in both directions before being believed: on a **null** (same engine
@@ -147,7 +164,7 @@ it): adding the term back still makes agreement worse, 0.74 → 0.70.
 
 ## Fitting the rates
 
-[`scripts/fit_cost_model.py`](../../scripts/fit_cost_model.py) regresses measured time on exactly the
+[`scripts/fit_cost_model.py`](../../../scripts/fit_cost_model.py) regresses measured time on exactly the
 vector `plan_cost` consumes. Three choices were forced by measurement, each after the obvious
 alternative failed:
 
@@ -264,7 +281,7 @@ times per query, so it needs a feature gate rather than an unconditional increme
 
 ## Where the remaining error is, and that it is reachable
 
-[`scripts/bench_cost_error_attribution.py`](../../scripts/bench_cost_error_attribution.py) splits each
+[`scripts/bench_cost_error_attribution.py`](../../../scripts/bench_cost_error_attribution.py) splits each
 cell's error three ways by substituting realized executor counters for estimated features (isolates
 cardinality error), refitting coefficients on those (isolates coefficient error), and calling what
 survives both the model's shape. Over 267,938 plan-rows realistic and 178,430 uniform:
@@ -370,7 +387,7 @@ REALIZED features it fits `push` to 0.00 against a shipped 3.30.
 ### Second attempt, after fixing the blocker — still reverted
 
 The blocker was real and is now fixed: `fit_cost_model.py` had drifted and is
-[synced and self-checking](../../scripts/fit_cost_model.py). With a trustworthy fitter, the feature was
+[synced and self-checking](../../../scripts/fit_cost_model.py). With a trustworthy fitter, the feature was
 reapplied and four cost forms tried. None beats the baseline:
 
 | variant | uniform | realistic |
@@ -408,7 +425,7 @@ leaves is ~1.15x on ~5% of queries, so it is genuinely marginal on its own.
 
 ## The percentile view, and the two defects it found
 
-[`scripts/bench_cost_error_percentiles.py`](../../scripts/bench_cost_error_percentiles.py) prints
+[`scripts/bench_cost_error_percentiles.py`](../../../scripts/bench_cost_error_percentiles.py) prints
 estimate/real at p1/p10/p20/p50/p70/p90/p99 per plan. Every other view here reports a median, and a
 median is structurally blind to a tail — which is where two real defects were hiding.
 
@@ -464,7 +481,7 @@ artwork total. `artwork_base.last()` is that total, now free.
 
 ## Sparse compose should gather, not decline — blocked on this arm
 
-Extracted to its own doc: **[local-engine-sparse-compose-gather.md](local-engine-sparse-compose-gather.md)**.
+Extracted to its own doc: **[local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md)**.
 
 One line, verified byte-identical over 127,640 queries, and blocked twice on routing (+0.445 µs, then
 +0.377 µs after compose's artwork arm was corrected — which falsified the theory that mode-specific
@@ -537,7 +554,7 @@ printing-mode compose, and have the materializing executors bit-test instead of 
 
 Which tool answers which question, how to read the two matrices, and the measurement traps this work
 paid for one at a time:
-**[reference-cost-model-measurement.md](reference-cost-model-measurement.md)**.
+**[reference-cost-model-measurement.md](../reference-cost-model-measurement.md)**.
 
-Related: [plan mis-selection](local-engine-plan-misselection.md),
+Related: [plan mis-selection](../local-engine-plan-misselection.md),
 [candidate materialization](local-engine-candidate-materialize.md).

--- a/docs/issues/done/local-engine-cost-model-agreement.md
+++ b/docs/issues/done/local-engine-cost-model-agreement.md
@@ -8,7 +8,7 @@ on the instrumentation substrate from [#833](https://github.com/jbylund/sylvan_l
 This doc's residuals were already extracted into their own docs while it was live, and both are still open:
 
 - **P3 should not re-derive membership at all** (the "larger prize" of the top-target section) —
-  [local-engine-compose-membership-bittest.md](../local-engine-compose-membership-bittest.md). Worth ~8× on
+  [#856](../00856-engine-compose-membership-bittest.md). Worth ~8× on
   the highest-regret query class.
 - **Sparse compose should gather, not decline** —
   [local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md).

--- a/docs/issues/done/local-engine-cost-model-agreement.md
+++ b/docs/issues/done/local-engine-cost-model-agreement.md
@@ -556,5 +556,5 @@ Which tool answers which question, how to read the two matrices, and the measure
 paid for one at a time:
 **[reference-cost-model-measurement.md](../reference-cost-model-measurement.md)**.
 
-Related: [plan mis-selection](../local-engine-plan-misselection.md),
+Related: [plan mis-selection](local-engine-plan-misselection.md),
 [candidate materialization](local-engine-candidate-materialize.md).

--- a/docs/issues/done/local-engine-cost-model-stack-result.md
+++ b/docs/issues/done/local-engine-cost-model-stack-result.md
@@ -1,5 +1,11 @@
 # What the cost-model stack measured, end to end
 
+**DONE — the end-to-end measurement record for the #804–#816 stack, which has merged.** Kept as the results
+record rather than as open work.
+
+The successor stack (#833–#845) reports its own end-to-end numbers on
+[#830](https://github.com/jbylund/sylvan_librarian/pull/830), the reference PR that carried it.
+
 The eight PRs from #804 to #816 against `origin/main`, on the query distribution the work was
 targeted at. Recorded here because the individual PRs each report a component metric — agreement,
 feature-vs-counter ratios, paging-prediction rates — and none of them answers "did queries get
@@ -8,7 +14,7 @@ faster".
 ## The measurement
 
 `bench_query_latency_ab.py`, uniform weighting from
-[`query_sampler.py`](../../client/query_sampler.py), 120,000 sampled queries per side, 1 warmup and
+[`query_sampler.py`](../../../client/query_sampler.py), 120,000 sampled queries per side, 1 warmup and
 3 trials each, **interleaved A/B/A/B** across two reps with a separate store per side. Two reps
 because one number is not a measurement here: at `--sample 400` the same engine and seed has
 produced 0.26 and 0.82 µs on consecutive runs.

--- a/docs/issues/done/local-engine-eur-tix-range-index.md
+++ b/docs/issues/done/local-engine-eur-tix-range-index.md
@@ -8,7 +8,7 @@ criteria at the bottom of this doc pass as written — see [Outcome](#outcome).
 `PrintingRangeIndex`, so `eur` and `tix` predicates never narrow and fall through to a scan.
 
 Found while scoping the acceptance test for
-[local-engine-range-cardinality-estimate.md](../local-engine-range-cardinality-estimate.md): those two
+[local-engine-range-cardinality-estimate.md](local-engine-range-cardinality-estimate.md): those two
 dimensions showed estimate errors up to 106x, which turned out to be a symptom of routing elsewhere
 entirely rather than a bad estimate.
 

--- a/docs/issues/done/local-engine-exact-totals-three-spaces.md
+++ b/docs/issues/done/local-engine-exact-totals-three-spaces.md
@@ -1,5 +1,16 @@
 # Exact result totals in all three spaces, for the predicates that have a plane
 
+**DONE — merged in [#841](https://github.com/jbylund/sylvan_librarian/pull/841)** (layer 9 of the
+cost-model stack), archive `2026080509`. Nothing carried forward.
+
+Kept deliberately despite measuring flat: **zero plans changed** across 1,347 query configs and the whole
+mix read 1.001. The estimates were wrong by up to 10× and still on the correct side of every argmin,
+because the margin between best and next-best is wider than the error. What justified shipping it is that
+a later layer depends on the exactness: [#844](https://github.com/jbylund/sylvan_librarian/pull/844)'s pair
+table is what made the legality scan-scope fix in that same layer safe — see
+[local-engine-legality-scan-scope.md](local-engine-legality-scan-scope.md). (#841's own body credits that
+to "layer 11"; the scan-scope fix is in layer 12, alongside the pair table.)
+
 The router's biggest remaining estimation error is not a bad formula, it is asking a formula a question
 the store can already answer. `unique=` has three result spaces — printings, cards, artworks — and for a
 predicate backed by a plane or a value index, the exact count in each is a build-time aggregate that
@@ -42,7 +53,7 @@ Three implementation points worth keeping:
 
 Cost: **156.6 KB** of archive (12 bytes × ~13,400 distinct values), 0.22% of the store. That is more
 than the 133 KB `frame_data`'s hybrid handed back, so this is a real size-for-accuracy trade and not a
-free win — see [the `is:`/`frame:` doc](./local-engine-is-frame-predicates.md) for that one.
+free win — see [the `is:`/`frame:` doc](local-engine-is-frame-predicates.md) for that one.
 
 `range_card_counts_are_exact` checks both spaces exhaustively over every distinct value on three
 indexes, against a brute-force distinct count, plus the shapes the table must DECLINE (a genuinely
@@ -105,7 +116,7 @@ configs**, off and on. Estimates wrong by 0.63-1.35x were still on the correct s
 this mix. So the honest accounting is: exactness achieved, latency unchanged, ~3.2 KB spent.
 
 That is consistent with the 2.5%-of-dispatch-time ceiling on all cost-model work
-([measured](./local-engine-layout-postings.md#why-this-was-invisible-before)) — it just lands at the
+([measured](../local-engine-layout-postings.md#why-this-was-invisible-before)) — it just lands at the
 bottom of that range rather than the top. It does NOT vindicate the earlier reading that the artwork
 slice's 21% share of routing regret came from its missing exact totals: those totals are now exact and
 the regret did not move.
@@ -114,7 +125,7 @@ the regret did not move.
 
 `is:flip` reads **1,080x** over and `is:split` 135x, unchanged. Their acquire is `count_source:
 candidates`, not compose, so `exact_result_total` is never consulted — `card_layout` has no narrowing arm
-at all ([layout postings](./local-engine-layout-postings.md)). The `layout` map in `ValueTotals` is
+at all ([layout postings](../local-engine-layout-postings.md)). The `layout` map in `ValueTotals` is
 therefore correct but **unreachable today**; it is kept (14 entries, ~200 bytes) because it is what that
 work will need, not because anything reads it now.
 
@@ -125,7 +136,7 @@ rather than compose, so it too never reaches these arms.
 
 Estimation error does not cost time directly; it costs time by mis-routing. The bound on all
 cost-model work is small — 2.5% of dispatch time is the total recoverable regret over uniform traffic
-([measured](./local-engine-layout-postings.md#why-this-was-invisible-before)). But routing regret is
+([measured](../local-engine-layout-postings.md#why-this-was-invisible-before)). But routing regret is
 concentrated: the artwork slice alone carried 21% of it at p99 205 µs against 36–40 µs for the other two
 modes, and the reason is that artwork was the only space with no exact path at all.
 

--- a/docs/issues/done/local-engine-is-frame-predicates.md
+++ b/docs/issues/done/local-engine-is-frame-predicates.md
@@ -1,5 +1,25 @@
 # `is:` and `frame:` are 24% of dispatch time and four unrelated bugs
 
+**MOSTLY DONE.** Of the four bugs plus the two mechanisms found while fixing them:
+
+| item | outcome |
+| --- | --- |
+| 1. `frame_data` drops its dense values | **merged in [#840](https://github.com/jbylund/sylvan_librarian/pull/840)** — hybrid index, 133 KB *smaller* and the scan gone. Whole mix 0.815, p99 0.648 |
+| 6. the mid-density regressions it shipped with | **merged in [#842](https://github.com/jbylund/sylvan_librarian/pull/842)** — `dense` and `broad` are eight times apart and the dense branch conflated them. `o:this frame:1993` 2,102 → 148 µs |
+| 5. the `And` arm's cost-based skip | **merged in [#836](https://github.com/jbylund/sylvan_librarian/pull/836)** (`3cfd441`) — total 0.969, p99 0.967 |
+| 2. `t:battle` poisons an `Or`'s plane path | refiled as [#850](https://github.com/jbylund/sylvan_librarian/issues/850) |
+| 3. `card_types` has no `Battle` | refiled as [#850](https://github.com/jbylund/sylvan_librarian/issues/850) — possibly a wrong answer, so it leads that issue |
+| 4. `card_layout` is unindexed | already its own doc, [layout postings](../local-engine-layout-postings.md), deprioritized |
+| `o:owner keyword:flying` at 1.56× | refiled as [#851](https://github.com/jbylund/sylvan_librarian/issues/851) |
+| the `is:old` / `is:historic` 6.8× gap | carried into [#850](https://github.com/jbylund/sylvan_librarian/issues/850) |
+
+The withdrawn item in section 7 — broad printing-space partners under a card-space driver — was fixed from a
+different direction entirely by [#843](https://github.com/jbylund/sylvan_librarian/pull/843); see
+[proven conjuncts](local-engine-proven-conjuncts.md).
+
+(The `## Status` section below still reads "Nothing is implemented", which was true when the audit was
+written. The per-section SHIPPED / FIXED markers are current.)
+
 After the value-major layout, the eur/tix indexes and the grouped orderby walk, `is:`/`frame:` queries
 are **24.0% of all remaining dispatch time** in uniform sampled traffic and none of them moved (0.97–1.03
 across every value). They are the largest remaining target, and the prefix hides at least four separate
@@ -175,7 +195,7 @@ So it is **130 KB smaller than today AND removes the full scan** — not a size-
 
 **A card-space existential bitmap is a different job, not a substitute.** 3.8 KB per value (112 KB for
 all 29), exact for card-mode TOTALS — which is the 132 µs `printing_bits_to_card_bits` projection
-discussed in [the walk-modes doc](./local-engine-orderby-walk-modes.md) — but LOOSE for row selection,
+discussed in [the walk-modes doc](local-engine-orderby-walk-modes.md) — but LOOSE for row selection,
 since "this card has ≥1 printing with frame 2015" does not say which printing. Printing and artwork mode
 still need the printing bitmap. Border already carries both (`PLANE_BORDER` card-space +
 `BorderPrintingPlanes` printing-space), and that pairing is the shape to copy.
@@ -225,7 +245,7 @@ Check the importer's type extraction before treating this as a corpus artifact. 
 ## 4. `card_layout` is unindexed
 
 Already scoped and deprioritized in
-[local-engine-layout-postings.md](./local-engine-layout-postings.md) — `is:dfc`/`is:transform`/
+[local-engine-layout-postings.md](../local-engine-layout-postings.md) — `is:dfc`/`is:transform`/
 `is:mdfc`/`is:split`/`is:meld`/`is:leveler`/`is:flip` all resolve to `card_layout`, which has no index
 and no `narrow_rec` arm, so each is a full 31,508-card scan for as few as 20 matches.
 
@@ -255,7 +275,7 @@ share (24.0%) is one 150 s uniform sample of 53,071 priced queries. Nothing is i
 mechanisms are explicitly open — (2)'s cause and the `is:old`/`is:historic` gap.
 
 `is:` and `frame:` are absent from `REALISTIC_FAMILY_WEIGHTS`, so the same caveat as
-[layout](./local-engine-layout-postings.md) applies: the 24% is a uniform-mode figure and the realistic
+[layout](../local-engine-layout-postings.md) applies: the 24% is a uniform-mode figure and the realistic
 share is unmodelled. Unlike layout, though, `frame:` IS in the realistic weights (0.5), and the
 `is:permanent`/`is:vanilla` shapes reach `card_types` and `oracle_text`, which are heavily weighted — so
 parts of this reach realistic traffic through other spellings.
@@ -360,6 +380,6 @@ this. Whether it costs anything is now an open question rather than an assumed c
   queries were slow because the candidate set's own card-space conjunct was being re-verified once per
   printing; narrowing with the border bitmap would not have helped, because the pass over printings was
   never where the time went. Fixed in
-  [local-engine-proven-conjuncts.md](./local-engine-proven-conjuncts.md), which took
+  [local-engine-proven-conjuncts.md](local-engine-proven-conjuncts.md), which took
   `o:this border:black` from 1,993 µs to 542 µs without changing the narrowing at all.
 - (2)'s `t:battle` plane poisoning and (3)'s missing `Battle` in `card_types`, both untouched.

--- a/docs/issues/done/local-engine-legality-bitplanes.md
+++ b/docs/issues/done/local-engine-legality-bitplanes.md
@@ -196,7 +196,7 @@ narrowing-fraction argument. Negation shows the same pattern mirrored.
 - #634 — cites `f:modern t:creature power>3` as the motivating composite case
 - [local-engine-legality-postings.md](local-engine-legality-postings.md) — banned/restricted
   postings, still open, unaffected by this
-- [local-format-legality-search.md](local-format-legality-search.md) — separate, unimplemented
+- [local-format-legality-search.md](../local-format-legality-search.md) — separate, unimplemented
   proposal to change `f:x` semantics to "playable" (legal OR restricted); this
   plan keeps today's exact-legal-only semantics unchanged, so that proposal
   would layer on top later, not conflict

--- a/docs/issues/done/local-engine-legality-postings.md
+++ b/docs/issues/done/local-engine-legality-postings.md
@@ -1,6 +1,6 @@
 # Engine: legality postings with a selectivity threshold
 
-Split out of [done/00605-engine-unindexed-predicates.md](done/00605-engine-unindexed-predicates.md)
+Split out of [00605-engine-unindexed-predicates.md](00605-engine-unindexed-predicates.md)
 (approach 3 there — the one approach PR #605 didn't ship). Status: superseded.
 
 **Superseded**: the `legal` dimension shipped as exact planes instead
@@ -34,7 +34,7 @@ Advisory narrowing means the threshold is purely a size/speed dial, not a
 correctness concern — eval verifies every candidate against the exact word.
 
 **Divergent-legality cards** (the 556 with genuinely per-printing legality, see
-[done/00603-engine-card-printing-split.md](done/00603-engine-card-printing-split.md)) must
+[00603-engine-card-printing-split.md](00603-engine-card-printing-split.md)) must
 appear in any posting a minority printing qualifies for, or be excluded from
 postings entirely and left to the scan — decide during implementation.
 
@@ -64,9 +64,9 @@ posting lists (mythic/rare ≈ 20k printing ids ≈ 80 kB).
 
 ## Related
 
-- [done/00605-engine-unindexed-predicates.md](done/00605-engine-unindexed-predicates.md) —
+- [00605-engine-unindexed-predicates.md](00605-engine-unindexed-predicates.md) —
   parent doc; artist/set/date/price indexing shipped there (PR #605)
-- [done/00603-engine-card-printing-split.md](done/00603-engine-card-printing-split.md) —
+- [00603-engine-card-printing-split.md](00603-engine-card-printing-split.md) —
   candidate-space rules and the divergent-legality design
 - Selective-index thresholding (PR #600 discussion) — this is its first concrete
   application; frame_data indexing composes with it

--- a/docs/issues/done/local-engine-legality-scan-scope.md
+++ b/docs/issues/done/local-engine-legality-scan-scope.md
@@ -1,5 +1,15 @@
 # `f:modern border:white` picks a 100 µs plan over a 44 µs one, and the whole family estimates identically
 
+**DONE — merged in [#844](https://github.com/jbylund/sylvan_librarian/pull/844)** (layer 12 of the
+cost-model stack), alongside the pair table that unblocked it. `f:modern border:white` goes
+149.0/99.5/134.1 µs (printing/card/artwork) to 76.4/102.1/83.2.
+
+Defect 1 (the `stream_scan_units` correction scoped on the wrong question) shipped. Defect 2 resolved
+itself once the pair table made the two-leaf card total exact. **Item (1) of "What to do" — the
+`DeclineSparseExact` cliff that discards a compose build already paid for — is refiled as
+[#848](https://github.com/jbylund/sylvan_librarian/issues/848)**: the pair table removed the population
+that was hitting it, not the cliff.
+
 `f:modern border:white` measures **100.5 µs** on the `StreamedSelect` the router picks and **43.8 µs** on
 the `PrintingCompose` it passes over. The same holds across the family, and the reason is that the cost
 model cannot tell its members apart.
@@ -104,7 +114,7 @@ run. Three of the four are actually below it.
 
 ## Resolved
 
-Defect 2's trigger was the `min` fold, and [the pair table](./local-engine-pair-totals.md) makes the
+Defect 2's trigger was the `min` fold, and [the pair table](local-engine-pair-totals.md) makes the
 two-leaf card total exact (978, not 2,755), so `compose_paging` predicts the decline rather than walking
 into it. Card mode now routes to `GatheredScan` at 102.1 µs instead of picking a compose that bails at
 163.1 µs, while printing keeps 2.0x and artwork 1.6x. Both toggles are on; aggregate is neutral (0.995
@@ -118,5 +128,5 @@ doing: the pair table removed the case that was biting, not the cliff.
 Defect 1 is on by default. Every number above is measured on the production corpus: per-query figures are
 a minimum of 9–15 trials after warmup, and the A/B is 8 interleaved rounds with a control subset.
 
-Related: [#731](./00731-engine-compose-universal-evaluator.md) — this is the arm that would gain
+Related: [#731](../00731-engine-compose-universal-evaluator.md) — this is the arm that would gain
 `color`/`cmc` as broadcast sources, which is why it is worth fixing the router on it first.

--- a/docs/issues/done/local-engine-loop-phase-measurement.md
+++ b/docs/issues/done/local-engine-loop-phase-measurement.md
@@ -1,14 +1,30 @@
 # Measuring P3 and P4's loop and finish phases with built designs
 
+**DONE — this is the lab record behind layers 1, 2 and 4 of the cost-model stack:
+[#833](https://github.com/jbylund/sylvan_librarian/pull/833) (instrumentation and phase timing),
+[#834](https://github.com/jbylund/sylvan_librarian/pull/834) (calibration) and
+[#836](https://github.com/jbylund/sylvan_librarian/pull/836) (the compose acquire).** Several of its
+measurements deliberately declined to move a constant, and two findings are retractions of earlier
+conclusions — both preserved below, because the declined measurement is the deliverable either way.
+
+**The remaining work is [#852](https://github.com/jbylund/sylvan_librarian/issues/852)**, which carries
+"What is left" items 1 / 1b / 1c — ranking `GatheredScan` vs `StreamedSelect` on the compose acquire, the
+oracle bound (58% → 83% ordered right, 9× less lost time, rates untouched), the two counter-intuitive
+results (per-plan features are worth zero; a feature fix only pays when the arms weight it differently), and
+the smaller items 3–7 as carried-forward notes.
+
+At ~1,360 lines this is far past the point where a doc should have been split, and #852 is deliberately
+narrower. Read this one for the measurement history; read #852 for what to do next.
+
 Branch `engine-compose-feature-accuracy`. Companion to
-[reference-cost-model-measurement.md](./reference-cost-model-measurement.md), which covers which tool
+[reference-cost-model-measurement.md](../reference-cost-model-measurement.md), which covers which tool
 answers which question; this covers what the tools said about `StreamedSelect` (P3) and
 `GatheredScan` (P4), and what is left.
 
 The method this campaign arrived at, extracted so it can be reused without reading the whole file:
-[diagnosing-a-plan-cost-error.md](../workflows/diagnosing-a-plan-cost-error.md).
+[diagnosing-a-plan-cost-error.md](../../workflows/diagnosing-a-plan-cost-error.md).
 
-The earlier campaign in [local-engine-cost-model-agreement.md](./local-engine-cost-model-agreement.md)
+The earlier campaign in [local-engine-cost-model-agreement.md](local-engine-cost-model-agreement.md)
 fitted rates from sampled traffic. This one built designed experiments instead, because several rates
 are **unidentifiable from traffic at any corpus size** — and that turned out to be the least
 interesting thing it found.
@@ -1316,7 +1332,7 @@ is only the P3-vs-P4 difference among the fallbacks, because **regret compares o
 declining plan accumulates no trials. Second time today that blind spot hid the larger finding, after
 `r>=rare`.
 
-[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md) had already designed the
+[local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md) had already designed the
 fix — `gather_composed_page` in place of the `return None` — and verified it byte-identical over 127,640
 queries. Its stated blocker was that `plan_cost` could not price the path, and this stack added the
 `ComposePaging::Gather` arm, so it looked unblocked.
@@ -1354,7 +1370,7 @@ Both halves have now shipped — `4991759` for the narrowing (15–33× on that 
 compose's builders, where the estimate was 38.5× off a count that was two binary searches away. Together:
 regret 1.42 → 1.30 µs, and the fusible traffic slice to 0.81× of baseline. The evidence, the noise analysis
 behind the sparsity gate, and what is left (the sparse gather, now that its prediction is correct):
-[local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md).
+[local-engine-two-sided-range-fusion.md](local-engine-two-sided-range-fusion.md).
 
 ## A note on the test counts quoted throughout
 

--- a/docs/issues/done/local-engine-orderby-walk-modes.md
+++ b/docs/issues/done/local-engine-orderby-walk-modes.md
@@ -1,5 +1,13 @@
 # The orderby walk is printing-mode only, and card mode pays 18x for it
 
+**DONE — merged in [#839](https://github.com/jbylund/sylvan_librarian/pull/839)** (layer 7 of the
+cost-model stack). Target subset 0.931, p99 −8.1%. Nothing carried forward; the related open item is
+[cost-based OrderbyWalk vs Gather](../local-engine-compose-paging-cost-based.md), which is about choosing
+between two branches that are both available rather than about a branch being unavailable.
+
+(The `## Status` section below still reads "Measured, not implemented" — it describes the state at the time
+the investigation was written, and `## Outcome` immediately after it is what shipped.)
+
 **Shipped** (`b0618f0`, `38423f5`) — one walk for all three distinct-ons, via the group representative.
 The walk was the easy half; routing it took four attempts, and the thing that finally worked was
 realising that **breadth does not decide it — whether the compose build broadcasts does.** See
@@ -175,7 +183,7 @@ Whole-corpus-broad artwork queries on `usd`/`rarity` are 136 of the 200 slowest 
 dispatch time in uniform sampling. `unique=artwork` is 5% of realistic traffic
 (`REALISTIC_UNIQUE_WEIGHTS`: card 75, printing 20, artwork 5) and `usd`/`rarity` together are a
 meaningful slice of `REALISTIC_ORDERBY_WEIGHTS`, so unlike
-[the layout question](./local-engine-layout-postings.md) this shape is genuinely sampled by realistic
+[the layout question](../local-engine-layout-postings.md) this shape is genuinely sampled by realistic
 traffic — it just needs the realistic-mode number measured before the work is priced.
 
 Card mode was described here as "a separate case and mostly NOT this problem". That was wrong: it is
@@ -190,7 +198,7 @@ Measured, not implemented. Timings are the routed path through `engine.query` on
 minimum of 20 after warmup; the 200-slowest breakdown is one 150 s uniform sample of 52,330 priced
 queries.
 
-Related: [cost-based OrderbyWalk vs Gather](./local-engine-compose-paging-cost-based.md) is about
+Related: [cost-based OrderbyWalk vs Gather](../local-engine-compose-paging-cost-based.md) is about
 choosing between the two branches where BOTH are available; this is about the branch not being
 available at all.
 

--- a/docs/issues/done/local-engine-pair-totals.md
+++ b/docs/issues/done/local-engine-pair-totals.md
@@ -1,5 +1,13 @@
 # Exact totals for PAIRS of low-cardinality values
 
+**DONE — merged in [#844](https://github.com/jbylund/sylvan_librarian/pull/844)** (layer 12 of the
+cost-model stack), archive `2026080512`. 42.6 KB, +0.2 s build; aggregate neutral (0.997 whole mix), and
+what shipped is two cost features that are no longer wrong plus the removal of a 24× and a 1.6× regression.
+
+The "Still open" item — an exact total of **0** should short-circuit to an empty result before routing at
+all — is refiled as [#847](https://github.com/jbylund/sylvan_librarian/issues/847), which carries this
+doc's warning that a result total is not a scan domain.
+
 `compose_printing_estimate`'s `And` folds with `m.min(cm)` — an intersection upper bound — so the most
 selective leaf decides alone and every other conjunct contributes nothing. Every `f:X border:white`
 estimates identically at 5,131 (`border:white`'s own count) against true totals of 658–5,072.
@@ -108,7 +116,7 @@ regression gone.
 
 ## It also unblocked the legality scan-scope fix
 
-[That fix](./local-engine-legality-scan-scope.md) was a wash on its own because it moved CARD mode onto
+[That fix](local-engine-legality-scan-scope.md) was a wash on its own because it moved CARD mode onto
 `PrintingCompose`, which then declined at dispatch and fell back having paid the build. The trigger was
 the `min` fold estimating 2,755 cards against a true 978 on a 1,024 floor. The pair table makes that
 total exact, so `compose_paging` predicts the decline instead of walking into it:

--- a/docs/issues/done/local-engine-plan-misselection.md
+++ b/docs/issues/done/local-engine-plan-misselection.md
@@ -1,16 +1,29 @@
 # The decline fallback never reconsidered a non-materializing plan, at up to 260 µs (fixed)
 
-Status: **the headline fix shipped; this stays open for the calibration findings under "What is left".**
-Kept here rather than moved to `done/` because the largest of those — `PlanePopcountOrder` under-costed a
-median 1.61×, p90 6.16 over n=157, unexplained and not attributable to acquire netting — is still the
-engine's largest un-diagnosed calibration gap and has no other home.
+**DONE — the fix merged in [#805](https://github.com/jbylund/sylvan_librarian/pull/805)**
+(`declined_sibling_fastpath`, plus `compose_paging_for` shared by every branch that costs compose). `usd>20`
+at `unique=printing` went **111.0 µs → 2.4 µs**, `usd>5` **267.7 → 4.2**, and the random sweep's max regret
+**265.0 → 61.3 µs**. The 100 µs-class decline-fallback category is gone.
 
-Re-read after the cost-model stack (#833–#845): the numbers below predate it, and its "What to do" item 2
-(the 26–34 µs `StreamedSelect`/`GatheredScan` cluster) is now the subject of
-[#852](https://github.com/jbylund/sylvan_librarian/issues/852), which supersedes the advice to leave it
-alone — that pair turned out to be the engine's largest single routing error. **Re-measure before acting on
-any figure in this doc**; every one of them was taken against a cost model that has since had four feature
-corrections and a rate calibration.
+**Every calibration finding under "What is left" now has a home**, so this is the record rather than a live
+item:
+
+| finding | disposition |
+| --- | --- |
+| `PlanePopcountOrder` under-costed median 1.61×, p90 6.16 (n=157) | [#854](../00854-engine-plane-popcount-arm-remeasure.md) — narrowed to ~1.09× by #813's refit; needs confirming, and the `popcount_words` counter first |
+| the 26–34 µs `StreamedSelect`/`GatheredScan` cluster, "leave alone until something shows it matters" | **superseded** — [#852](../00852-engine-compose-acquire-p3-p4-ranking.md). Something did: that pair is the engine's largest single routing error |
+| `StreamedSelect`/`GatheredScan` off `card_range_popcount`, ~2.4×, n=13 (thin) | [#853](../00853-engine-interior-range-distinct-counts.md) — same acquire, and its `card_est` input is now exact for one-sided shapes, so the measurement has to be retaken anyway |
+| `PrintingCompose` ~1.5× over-costed generally | parked here and still parked: *"harmless at that size, and tightening it risks the ranking that now works."* |
+
+**Re-measure before acting on any figure below.** All of them predate the cost-model stack (#833–#845), which
+brought four feature corrections, a rate calibration, and — for the plane rows specifically — a re-basing of
+regret on dispatch, because plane rows had been getting *negative* regret. Note also that this doc's ratios
+are `measured / predicted` (so > 1 is under-costed), while `cost.rs`'s constant docs use `predicted / measured`;
+the two are easy to compare backwards.
+
+What is worth reading here rather than re-deriving: the mechanism, and the three methodology traps under "Why
+this stayed hidden through three earlier passes" — each produced a confidently wrong answer, and the netting
+lesson (`GatheredScan` at 6.47 raw against 0.84 net) is one anybody re-running this scan needs.
 
 When a `Prep::Range`-acquired query's chosen fast path declines at runtime, dispatch re-chooses
 among **materializing plans only** — so `PrintingCompose`, which is applicable and often 30–70x
@@ -22,7 +35,7 @@ Everything else the router does is fine. Across 249 wild-operator queries the me
 
 ## The mechanism
 
-[`run_query_routed`'s `Prep::Range` dispatch arm](../../card_engine/src/lib.rs) runs the chosen
+[`run_query_routed`'s `Prep::Range` dispatch arm](../../../card_engine/src/lib.rs) runs the chosen
 fast path, and on `None`:
 
 ```rust
@@ -163,13 +176,25 @@ Two calibration findings from the 2,500-query scan remain unaddressed, both pre-
 - `StreamedSelect`/`GatheredScan` costed off the `card_range_popcount` acquire are under-costed
   ~2.4x (n=13). Thin sample; re-measure before acting.
 
-## What to do
+## What to do — where each item went
 
-1. Re-measure `PlanePopcountOrder`'s 1.61x under-costing on a larger sample and find the term it is
-   missing. It is the largest remaining calibration gap and it is not explained by acquire.
-2. Leave the 26–34 µs `StreamedSelect`/`GatheredScan` cluster alone until something shows it matters.
+Kept as written, with its disposition, because two of the three judgements turned out wrong and that is worth
+seeing rather than quietly overwriting. The table at the top of this doc is the summary.
+
+1. ~~Re-measure `PlanePopcountOrder`'s 1.61x under-costing on a larger sample and find the term it is
+   missing. It is the largest remaining calibration gap and it is not explained by acquire.~~
+   → **[#854](../00854-engine-plane-popcount-arm-remeasure.md).** Still the right action. Two things it could
+   not have known: #813's refit has since taken the arm to ~1.09× (`measured / predicted`), and the arm's
+   `(n_cards / 64.0)` word term has no counter behind it — so "find the term it is missing" may be a *feature*
+   question, and the counter that would answer it is one call site.
+2. ~~Leave the 26–34 µs `StreamedSelect`/`GatheredScan` cluster alone until something shows it matters.~~
+   → **Wrong, and [#852](../00852-engine-compose-acquire-p3-p4-ranking.md) is what showed it.** That pair is
+   the engine's largest single routing error; it went 69% → 87% ordered right across the cost-model stack and
+   the oracle bound says perfect features would reach 83% with a 9× cut in lost time. Reading this cluster as
+   small was an artifact of scoring it on the bare-range population this doc was investigating.
 3. `PrintingCompose` is still ~1.5x over-costed generally (0.69 from its own acquire). Harmless at
    that size, and tightening it risks the ranking that now works.
+   → **Still parked, and still for that reason.** #836 calibrated the compose acquire without disturbing it.
 
 ## Method notes
 

--- a/docs/issues/done/local-engine-printing-plane-popcount-order.md
+++ b/docs/issues/done/local-engine-printing-plane-popcount-order.md
@@ -341,7 +341,7 @@ range+range gap proves worth closing.
 
 ## Related
 
-- [done/00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md) — the cost
+- [00702-engine-plan-selection-layer.md](00702-engine-plan-selection-layer.md) — the cost
   router; where this was the deferred "one real win."
 - [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — historical
   idea-1/idea-2 crossover analysis (the range-narrowing bitmap source).

--- a/docs/issues/done/local-engine-proven-conjuncts.md
+++ b/docs/issues/done/local-engine-proven-conjuncts.md
@@ -1,5 +1,8 @@
 # A conjunct the candidate set proves was still re-verified per printing
 
+**DONE — merged in [#843](https://github.com/jbylund/sylvan_librarian/pull/843)** (layer 11 of the
+cost-model stack). Target 0.497, control 0.957, whole mix 0.718, p99 0.428. Nothing carried forward.
+
 `o:this` runs in **52 µs** and examines **zero** printings. `o:this border:black` runs in **1,993 µs**.
 Adding a predicate that cuts the result set from 55,004 to 49,278 made the query 38× slower.
 
@@ -124,7 +127,7 @@ to 0.74–1.34.
 - **`name:s border:black` also still routes wrong** — GatheredScan at 1,170 µs measured against
   StreamedSelect's 975 (predicted 1,470, p/m 1.51).
 - The earlier diagnosis in
-  [the `is:`/`frame:` doc](./local-engine-is-frame-predicates.md) — that broad printing-space partners
+  [the `is:`/`frame:` doc](local-engine-is-frame-predicates.md) — that broad printing-space partners
   under a card-space driver are wrongly declined, and that a stored bitmap's AND would be nearly free —
   **was measuring the wrong thing.** Narrowing with the border bitmap would not have helped: the pass over
   printings was never the cost. That item is withdrawn.

--- a/docs/issues/done/local-engine-range-breadth-denominator.md
+++ b/docs/issues/done/local-engine-range-breadth-denominator.md
@@ -1,5 +1,14 @@
 # Range breadth was measured against the index's own length, so nullable columns looked broader
 
+**DONE — merged in [#845](https://github.com/jbylund/sylvan_librarian/pull/845)** (layer 13, the top of the
+cost-model stack). Whole mix 0.905, p99 0.680.
+
+The follow-up this doc names at the end — splitting "is this worth narrowing" from "vec or bitmap", which
+would retire the `eur<0.13 t:land` regression — **shipped in the same PR** as its second change: materialize
+by bitmap scatter rather than by sorting, whole mix 0.949. So nothing carries forward from here. The
+remaining call sites for that materialization are
+[#849](https://github.com/jbylund/sylvan_librarian/issues/849).
+
 `eur>0.15 tix>=0.03 tix<=0.03 id:bgruw` took **1.5 ms**. The same query without the last leaf takes
 **39 µs**. Adding `id:bgruw` — which matches *every* card, since identity ⊆ {W,U,B,R,G} is universally
 true — took the query from a `PrintingCompose` to a whole-corpus scan with `narrowed_repr: none`: the
@@ -84,7 +93,7 @@ that sort; scattering the same 16,664 into 1,519 words would be ~20–30 µs.
 
 Splitting them — bitmap above some absolute size, vec below — is the follow-up, worth ~90 µs on the
 headline query and it should retire the `eur<0.13` class entirely. Same shape as the `dense` vs `broad`
-conflation in [the frame gate](./local-engine-is-frame-predicates.md).
+conflation in [the frame gate](local-engine-is-frame-predicates.md).
 
 ## Status
 

--- a/docs/issues/done/local-engine-range-cardinality-estimate.md
+++ b/docs/issues/done/local-engine-range-cardinality-estimate.md
@@ -41,37 +41,16 @@ proxy while investigating why every plan costed off that acquire is under-costed
 
 ## Nothing here ships alone
 
-The proxy over-costs ~1.48x; the plan arms under-cost ~1.5x at this operating point. The two errors
-point in opposite directions and **partially cancel**, which is why routing mostly survives them.
-Correcting the estimate without re-fitting the arms pushes the arm error from 1.6x to ~2.4x.
-
-The arm half belongs to the sibling doc, and cannot be fixed by re-fitting rates globally: the same
-two plans are over-costed (0.57) off `candidates` acquires and under-costed (2.56) off this one, and
-`STREAM_*`/`GATHER_*` are shared constants. This doc owns the estimate half only.
+Moved to [#853](../00853-engine-interior-range-distinct-counts.md#nothing-here-ships-alone), because it
+governs the work that is left rather than the work that shipped. In short: this estimate's error and the plan
+arms' error point in opposite directions and partially cancel, so correcting one alone regresses routing.
 
 ## The surviving candidates
 
-### 1. Build the card bitmap in acquire — exact, no storage
-
-`CardRangePopcount` already calls `build_card_range_bits` at dispatch, re-deriving the bounds to do
-so, and it wins **138 of 142** sampled range queries. `StreamedSelect`/`GatheredScan` would take
-`bitmap_card_ids` over their own `range_narrowed` → `into_cards`. Only `PrintingCompose` has no use
-for a card bitmap, and it wins **zero**.
-
-So promoting the build into the acquire branch and carrying it in `Prep` — the pattern `Prep::Plane`
-already uses for the plane bitmap — is a reordering of work already done. Its popcount is the exact
-`matches`/`eval_domain`, and it deletes a duplicate bounds derivation.
-
-| | |
-| --- | --- |
-| accuracy | **exact** |
-| memory | **none** — no archive data |
-| query time | 0 in the 97% case (the winner builds it anyway); 47 µs median, 106 µs p90 when a plan wins that does not want it |
-| risk | moves an O(k) build across the acquire/dispatch boundary; the both-fast-paths-decline case (`usd>50`) needs a test |
-
-That 47 µs is why the storage options below still matter — it is the cost when the artifact goes
-unused. Measured from `acquire.range_k`: median slice 38,245 printings at
-`CARD_RANGE_BUILD_PER_PRINTING_NS` = 1.22.
+Candidate 1 (build the card bitmap in acquire) and candidate 3 (prev-array + wavelet tree) were both
+unshipped and are now
+[the live options in #853](../00853-engine-interior-range-distinct-counts.md#the-live-options), along with the
+trapezoid-histogram fallback. Only candidate 2 shipped, and it is kept below as the record of what was built.
 
 ### 2. One boundary table, three counts — exact for every shape here, 159 KB
 
@@ -116,26 +95,9 @@ reason the arith-tuple index escapes it (each card has exactly one tuple).
 
 ### 3. prev-array + wavelet tree — exact for arbitrary ranges, 1.06 MB
 
-Kept for completeness; **probably not needed** — see the next section.
-
-The general problem is **range distinct count** (colored range counting). Let `prev[i]` be the index
-of the previous printing of the same card, or −1. Then
-
-    distinct cards in [a, b)  ==  #{ i in [a, b) : prev[i] < a }
-
-because each card in the window has exactly one occurrence that is its first there, and only that one
-points back outside it. A wavelet tree over `prev` answers that dominance count in O(log n), and the
-tree encodes `prev`, so the array need not be stored. Verified exact on 2,583 windows across all five
-dimensions — bounded, one-sided and random. Space is 1.06 MB, 134–252 KB per dimension.
-
-No maintained Rust crate exposes the operation. [`qwt`](https://docs.rs/qwt/) has rank/select/access
-only. [`sucds`](https://github.com/kampersanda/sucds) and [`vers`](https://github.com/Cydhra/vers) —
-both Apache-2.0, both actively maintained — expose `quantile(range, k)`, the inverse, which would have
-to be binary-searched at roughly 17x the work. [`wavelet-matrix`](https://github.com/sekineh/wavelet-matrix-rs)
-has exactly `count_lt(pos_range, value)` and is MIT (declared in `Cargo.toml`; there is no LICENSE
-file, which is why GitHub's API reports none) but was last touched in 2022. Vendoring the ~200 lines
-that path needs — `prefix_rank_op`, the struct, and a rank-capable bitvector the engine can supply
-itself — is viable under an MIT attribution header if it is ever wanted.
+**Moved to [#853](../00853-engine-interior-range-distinct-counts.md#3-prev-array--wavelet-tree--exact-for-arbitrary-ranges-106-mb).**
+It was parked here as "probably not needed" on the strength of the scoping argument immediately below, and
+that argument no longer holds.
 
 ## Which shapes actually reach this acquire
 
@@ -175,23 +137,19 @@ The engine's documented negation hazards are a different category and do not app
 away the boundary printings", is about the **tightness of the candidate set** — which cards come back.
 These arrays feed only the cost estimate, so an error there would degrade routing, not results.
 
-## Plan
+## Plan — how it actually went
 
-1. **The boundary table (candidate 2).** ~159 KB, O(1), no dependency, no tuning parameter — three
-   columns built in one pass, exact for every shape that reaches this acquire. Add the ~34 per-year
-   counts on `date` in the same change; after it the proxy is gone.
-2. **Re-ask the arm question.** With exact features, part of the arms' ~1.5x under-costing may
-   disappear — it may be the model charging `card_est`-shaped terms for true-card-shaped work. Re-fit
-   only afterwards, and only against prep-netted measurements.
+1. **The boundary table (candidate 2). SHIPPED**, at a measured 156.6 KB, with the artwork triple added in
+   [#841](https://github.com/jbylund/sylvan_librarian/pull/841). The *"add the ~34 per-year counts on `date`
+   in the same change; after it the proxy is gone"* half **did not ship**, which is why `year:Y` still falls
+   back to `k.min(n_cards)`.
+2. **Re-ask the arm question.** Not done. Now
+   [#852](../00852-engine-compose-acquire-p3-p4-ranking.md), whose oracle run answers the sequencing question
+   this item left open: features before rates, and `eval_domain` carries ~75% of the recoverable loss.
 
-Candidate (1), the prep artifact, is complementary and independent: it removes the proxy for the
-`CardRangePopcount` branch by reordering work already done, at no storage cost. Candidate (3) is parked
-unless two-sided conjunctions are ever routed to the range index.
-
-**Fallback if 107 KB is somehow unaffordable:** a trapezoid histogram — bucket widths doubling in from
-each edge, capped, uniform between — over prefix/suffix arrays reaches 1.19x worst case at 3.4 KB, or
-1.06x at 42 KB. Dominated by (2) on every axis except size, and for `date` not even that, since 1,048
-cuts exceeds the 915 possible answers.
+The per-year counts, candidate 1, candidate 3 and the trapezoid fallback are all
+[live options in #853](../00853-engine-interior-range-distinct-counts.md#the-live-options). Candidate 3's
+parking condition — *"unless two-sided conjunctions are ever routed to the range index"* — has since fired.
 
 ## What was tried and rejected
 
@@ -236,7 +194,12 @@ Four wrong answers here came from the same habit, so the note is itself the find
 directions and reports `acquire.matches / true total` per point — scans rather than a pooled median,
 because every pooled figure in this investigation hid structure that only showed up per cell.
 
-**Target:** every `unique=card` cell within 1% of true. Baseline today, 0 of 8 cells passing:
+**Target:** every `unique=card` cell within 1% of true. The baseline below is a **historical record** — these
+eight one-sided cells now answer exactly from `RangeCardCounts`. The cells that are still short are the
+interior ones, and the current acceptance bar lives in
+[#853](../00853-engine-interior-range-distinct-counts.md#acceptance).
+
+Baseline at the time of writing, 0 of 8 cells passing:
 
 | cell | n | median | worst |
 | ---- | -: | -----: | ----: |
@@ -253,8 +216,11 @@ because every pooled figure in this investigation hid structure that only showed
 already read 1.000 across 26 scan points: that branch sets `matches = k`, the in-range printing count,
 and in printing mode that *is* the result cardinality. Those rows must stay at 1.000.
 
-**Out of scope:** `eur` and `tix`, which have no range index and never reach this acquire — a separate
-and much larger defect, see [local-engine-eur-tix-range-index.md](local-engine-eur-tix-range-index.md).
+~~**Out of scope:** `eur` and `tix`, which have no range index and never reach this acquire — a separate
+and much larger defect, see [local-engine-eur-tix-range-index.md](local-engine-eur-tix-range-index.md).~~
+**No longer true.** [#838](https://github.com/jbylund/sylvan_librarian/pull/838) gave both a
+`PrintingValueIndex`, and both now carry a `RangeCardCounts` (`price_eur_cards`, `price_tix_cards`). They are
+in scope for the scan; see [#853](../00853-engine-interior-range-distinct-counts.md#acceptance).
 
 Routing is deliberately **not** an acceptance criterion for this change alone. Correcting the estimate
 lowers predicted cost for the materializing plans, which are already over-picked, so routing should

--- a/docs/issues/done/local-engine-range-cardinality-estimate.md
+++ b/docs/issues/done/local-engine-range-cardinality-estimate.md
@@ -1,4 +1,29 @@
-# Estimating distinct cards in a range slice
+# Estimating distinct cards in a range slice (one-sided)
+
+**DONE for one-sided ranges and `Eq` — candidate 2 shipped as `RangeCardCounts`**
+(`card_engine/src/lib.rs`), with the artwork triple added in
+[#841](https://github.com/jbylund/sylvan_librarian/pull/841) at a measured **156.6 KB** against this
+doc's 159 KB estimate. Six dimensions carry one: `released_at`, `price_usd`, `price_eur`, `price_tix`,
+`collector_number`, `rarity`. `<` / `<=` / `>` / `>=` / `Eq` are now **exact in all three spaces**;
+`usd>=0.42`/card reads 12,408 against a true 12,408.
+
+**Split: the two-sided and interior-interval half is
+[#853](../00853-engine-interior-range-distinct-counts.md).** The prefix/suffix arrays answer an interval
+that runs to an *edge* of the index; an interior one is not derivable from them, which the "what was tried
+and rejected" table below proves (`suf[i] != total - pre[i]` — distinct counts do not subtract). Two shapes
+are still inexact: `year:Y`, which reaches `distinct_cards` and gets `None`, falling back to the
+`k.min(n_cards)` proxy measured below; and fused two-sided ranges, which `exact_result_total` declines
+outright because `bare_range_bounds` does not match `And`.
+
+**One conclusion in this doc is now void.** The "Which shapes actually reach this acquire" section argues
+that two-sided conjunctions never reach the range index, and on that basis parks candidate 3 and calls
+candidate 2 plus two small arrays complete. [#837](local-engine-two-sided-range-fusion.md) fuses same-index
+`And` children into one range-index interval, so the premise is false and candidate 3's own parking condition
+— *"unless two-sided conjunctions are ever routed to the range index"* — has fired. Read that section as
+history; #853 re-decides it.
+
+Still unshipped from the Plan below: the **~34 per-year counts on `date`**, which is exactly why the
+`year:Y` fallback survives.
 
 `CardRangePopcount`'s acquire feeds `matches`/`eval_domain`/`scan_units` from
 `card_est = k.min(n_cards)`, where `k` counts in-range **printings** and stands in for a card count —
@@ -11,7 +36,7 @@ a proxy the branch's own comment flags. Measured against the true total on reali
 Not a tail problem — the median is 1.49x and p10 is already 1.14, so it over-estimates nearly
 everywhere, because printings outnumber cards.
 
-Split out of [local-engine-plan-misselection.md](local-engine-plan-misselection.md), which found the
+Split out of [local-engine-plan-misselection.md](../local-engine-plan-misselection.md), which found the
 proxy while investigating why every plan costed off that acquire is under-costed 2.0–2.6x.
 
 ## Nothing here ships alone
@@ -113,6 +138,13 @@ that path needs — `prefix_rank_op`, the struct, and a rank-capable bitvector t
 itself — is viable under an MIT attribution header if it is ever wanted.
 
 ## Which shapes actually reach this acquire
+
+> **SUPERSEDED by [#837](local-engine-two-sided-range-fusion.md).** The argument below is what parked
+> candidate 3 and made candidate 2 look complete, and its premise no longer holds: fusion turns a two-sided
+> conjunction into a single range-index interval in `narrow_rec` and the compose builders. The claim about
+> `bare_range_bounds` not matching `And` is still literally true — which is why `exact_result_total` now
+> *declines* two-sided ranges in every mode rather than estimating them — but the conclusion that two-sided
+> shapes are out of scope is void. See [#853](../00853-engine-interior-range-distinct-counts.md).
 
 This narrows the problem sharply, and was established late. `bare_range_bounds` matches only
 `NumericCmp`, `DateCmp`, `YearCmp` and `Not` of those — **not `And`**. So a two-sided conjunction like
@@ -222,7 +254,7 @@ already read 1.000 across 26 scan points: that branch sets `matches = k`, the in
 and in printing mode that *is* the result cardinality. Those rows must stay at 1.000.
 
 **Out of scope:** `eur` and `tix`, which have no range index and never reach this acquire — a separate
-and much larger defect, see [local-engine-eur-tix-range-index.md](done/local-engine-eur-tix-range-index.md).
+and much larger defect, see [local-engine-eur-tix-range-index.md](local-engine-eur-tix-range-index.md).
 
 Routing is deliberately **not** an acceptance criterion for this change alone. Correcting the estimate
 lowers predicted cost for the materializing plans, which are already over-picked, so routing should

--- a/docs/issues/done/local-engine-range-cardinality-estimate.md
+++ b/docs/issues/done/local-engine-range-cardinality-estimate.md
@@ -36,7 +36,7 @@ a proxy the branch's own comment flags. Measured against the true total on reali
 Not a tail problem — the median is 1.49x and p10 is already 1.14, so it over-estimates nearly
 everywhere, because printings outnumber cards.
 
-Split out of [local-engine-plan-misselection.md](../local-engine-plan-misselection.md), which found the
+Split out of [local-engine-plan-misselection.md](local-engine-plan-misselection.md), which found the
 proxy while investigating why every plan costed off that acquire is under-costed 2.0–2.6x.
 
 ## Nothing here ships alone

--- a/docs/issues/done/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/done/local-engine-sorted-range-fastpath.md
@@ -431,7 +431,7 @@ compose source on top of it — reaching the same compound wins without a dedica
 
 ## Related
 
-- [local-engine-printing-plane-popcount-order.md](../local-engine-printing-plane-popcount-order.md) —
+- [local-engine-printing-plane-popcount-order.md](local-engine-printing-plane-popcount-order.md) —
   the consolidated plan for the deferred Idea-2 printing-space popcount plan (#656): parts, ship
   order, target queries, and the #656 assembly.
 - [local-engine-broad-range-fastpath.md](local-engine-broad-range-fastpath.md) — history:

--- a/docs/issues/done/local-engine-sorted-range-fastpath.md
+++ b/docs/issues/done/local-engine-sorted-range-fastpath.md
@@ -446,7 +446,8 @@ compose source on top of it — reaching the same compound wins without a dedica
   card-invariant `cmc`/`power`/`toughness` analogue; does not transfer (no existential dimension).
 - [00647-engine-cost-guard-calibration.md](00647-engine-cost-guard-calibration.md) — the
   guard-from-measurement precedent for Idea 1's crossover.
-- [#638] `tix`/`eur` range index; [#656] printing-space popcount pager; [#693] artwork dedup bitmask.
+- [#638] `tix`/`eur` range index (**shipped in #838, issue closed**); [#656] printing-space popcount pager;
+  [#693] artwork dedup bitmask.
 
 [#638]: https://github.com/jbylund/sylvan_librarian/issues/638
 [#647]: https://github.com/jbylund/sylvan_librarian/pull/647

--- a/docs/issues/done/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/done/local-engine-two-sided-range-fusion.md
@@ -1,6 +1,20 @@
 # Fusing a two-sided range into one index interval
 
-Split out of [local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md),
+**DONE — merged in [#837](https://github.com/jbylund/sylvan_librarian/pull/837)** (layer 5 of the
+cost-model stack). Fusible slice 0.81×; the `sparse_only` gate this doc argues for was later revisited and
+loosened in [#845](https://github.com/jbylund/sylvan_librarian/pull/845), which judged breadth against the
+corpus instead of the index.
+
+Of the three items under "What is left":
+
+- **`eur` and `tix` cannot fuse at all** — fixed. [#838](https://github.com/jbylund/sylvan_librarian/pull/838)
+  gave both a `PrintingValueIndex`, and `tix:2.94` went 1,243 µs → 11.5 µs.
+- **The sparse gather is still declined** — still open, and still its own doc:
+  [local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md).
+- **Card-level numeric contradictions** (`power=3 power=5`) — refiled as
+  [#846](https://github.com/jbylund/sylvan_librarian/issues/846).
+
+Split out of [local-engine-loop-phase-measurement.md](local-engine-loop-phase-measurement.md),
 which found this while auditing plan-cost features and where the routing context lives. Shipped in two
 commits — `4991759` for the narrowing, `7374e19` for the compose builders.
 
@@ -119,7 +133,7 @@ ratios their one-sided forms already carry, since those project printings to dis
 `STREAM_MIN_MATCHES`, so `compose_paging_with_total` now predicts `Decline` where it predicted `Perm` —
 matching what the fastpath actually does — and the pick moves off `PrintingCompose` onto the plan that
 was already answering. That removes the blocker named in
-[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md): its `Decline` →
+[local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md): its `Decline` →
 `Gather` flip regressed routing purely because `compose_paging_for` branches on `result_total`, the
 estimate, and so could not tell a sparse query from a broad one. It can now.
 
@@ -139,7 +153,7 @@ indexes fused inside one compose, unsatisfiable pairs, an `Or` of two fused `And
 ## What is left
 
 **The sparse gather was re-attempted and is still declined** — see
-[local-engine-sparse-compose-gather.md](./local-engine-sparse-compose-gather.md). The accurate estimate
+[local-engine-sparse-compose-gather.md](../local-engine-sparse-compose-gather.md). The accurate estimate
 did remove its stated blocker (the prediction can now tell sparse from broad), and a second stale
 blocker fell with it (the tie-ordering reason the code gives for the decline died with #815). What
 remains is narrower and better quantified: the arm under-prices the gather to 0.27–0.53 of real, the
@@ -153,7 +167,7 @@ rarity widening flagged.
 
 **`eur` and `tix` cannot fuse at all**, because `resolve_numeric_range_leaf` covers only `price_usd` and
 `collector_number` (plus `DateCmp`/`YearCmp` reaching `released_at` directly). That is the same root
-cause as [local-engine-eur-tix-range-index.md](./local-engine-eur-tix-range-index.md), and fusion adds
+cause as [local-engine-eur-tix-range-index.md](local-engine-eur-tix-range-index.md), and fusion adds
 one more reason to fix it: several top-100 regret rows are two-sided `eur:`/`tix:` ranges, which are
 exactly the shape that gains most and currently gains nothing.
 

--- a/docs/issues/done/local-engine-two-sided-range-fusion.md
+++ b/docs/issues/done/local-engine-two-sided-range-fusion.md
@@ -129,6 +129,15 @@ subset cannot lose to two scatters of its supersets plus an AND, and the estimat
 an upper bound at any width. After: printing mode reads **1.0×**, card and artwork 0.6–0.9× — the same
 ratios their one-sided forms already carry, since those project printings to distinct rows.
 
+> **Correction.** "The same ratios their one-sided forms already carry" is misleading, and contradicts the
+> paragraph above it, which reports one-sided `usd>=0.42`/card as **exact** (12,408 against a true 12,408).
+> Both are true of different layers: `exact_result_total` answers a one-sided range's card and artwork
+> totals exactly from `RangeCardCounts`, while *compose's own* projection reads 0.6–0.9× for one-sided and
+> two-sided alike. The difference that matters is that one-sided has an exact path **above** the estimator
+> and two-sided has none — `bare_range_bounds` does not match `And`, so `exact_result_total` declines a fused
+> range in every mode, including the printing space where `k` is free. Tracked as
+> [#853](../00853-engine-interior-range-distinct-counts.md).
+
 **The paging prediction follows for free, which is the part sparse-gather needed.** 879 is under
 `STREAM_MIN_MATCHES`, so `compose_paging_with_total` now predicts `Decline` where it predicted `Perm` —
 matching what the fastpath actually does — and the pick moves off `PrintingCompose` onto the plan that

--- a/docs/issues/done/local-engine-unified-router-target.md
+++ b/docs/issues/done/local-engine-unified-router-target.md
@@ -136,7 +136,7 @@ argmin is already free.
 
 ## Cost model
 
-One formula per plan, constants fit on the real corpus ([cost.rs](../../card_engine/src/cost.rs)).
+One formula per plan, constants fit on the real corpus ([cost.rs](../../../card_engine/src/cost.rs)).
 `argmin` cares about *ratios*, which is what makes P1's bad tail visible: the tree
 took P1 unconditionally; here P1 competes and *loses* when its walk is pathological
 (narrow range under a misaligned sort — the idea-1/idea-2 crossover, the founding

--- a/docs/issues/local-engine-aprinting-layout.md
+++ b/docs/issues/local-engine-aprinting-layout.md
@@ -256,7 +256,7 @@ archive change.
 ## Precedent
 
 The engine already applies struct-of-arrays selectively — this generalizes it:
-[`printing_to_card`](00690-engine-direct-projection-arrays.md) (pid-indexed column), the bit-planes
+[`printing_to_card`](done/00690-engine-direct-projection-arrays.md) (pid-indexed column), the bit-planes
 (per-value bit-columns), and the value-sorted range indexes.
 
 ## Cost, open questions, priority
@@ -274,6 +274,6 @@ The engine already applies struct-of-arrays selectively — this generalizes it:
 
 ## Related
 
-- [#690](00690-engine-direct-projection-arrays.md) — direct-projection array precedent.
+- [#690](done/00690-engine-direct-projection-arrays.md) — direct-projection array precedent.
 - #629 — artwork groups (`artwork_group_id`); #664/#724 — border/rarity printing planes.
 - `exec_gathered_scan` / `push_card_matches` (`card_engine/src/lib.rs`) — the gather path this targets.

--- a/docs/issues/local-engine-compose-build-rates.md
+++ b/docs/issues/local-engine-compose-build-rates.md
@@ -115,7 +115,7 @@ disagreement between the branches was `walk_grouped_page`'s per-card work (1.89 
 to go. `plan_cost`'s `Perm` arm has no cards term at all today.
 
 That also explains an older observation in
-[local-engine-compose-walk-features.md](./local-engine-compose-walk-features.md): `printings_walked /
+[local-engine-compose-walk-features.md](done/local-engine-compose-walk-features.md): `printings_walked /
 cards_visited` graded 4.53 while `/printings_examined` graded 1.17. The model needs both columns, not a
 choice between them.
 

--- a/docs/issues/local-engine-compose-membership-bittest.md
+++ b/docs/issues/local-engine-compose-membership-bittest.md
@@ -22,7 +22,7 @@ they touch.
 Measured over 3,054 compose-acquired printing queries: **1,213 ms of match-loop time over 145 million
 printings scanned, 6.98 ns each**. An O(1) bit test is ~1 ns, so ~145 ms — **roughly 8x less**. This is
 the cell both the cost and regret matrices name as the top target
-([local-engine-cost-model-agreement.md](local-engine-cost-model-agreement.md)).
+([local-engine-cost-model-agreement.md](done/local-engine-cost-model-agreement.md)).
 
 There is in-tree precedent: `exec_card_range_popcount` threads `range_pbits` beside its card bitmap and
 membership-tests in O(1), for exactly this reason — "the shown printing must actually be in range, not

--- a/docs/issues/local-engine-drop-lowercase-copies.md
+++ b/docs/issues/local-engine-drop-lowercase-copies.md
@@ -13,7 +13,7 @@ reload peak 549 → 291 MB) live in
   no fold-at-verify tradeoff — the 2.2k-entry vocab is lowercase-only and the
   fold happens once per query at bind.
 - `flavor_text_lower` (~2.3 MB distinct): expected to fall out of
-  [00620-engine-flavor-text-narrowing.md](00620-engine-flavor-text-narrowing.md) the same
+  [00620-engine-flavor-text-narrowing.md](done/00620-engine-flavor-text-narrowing.md) the same
   way — its bind-time distinct-text scan can fold case itself.
 - `oracle_text_lower` (~4.7 MB distinct): the only remaining field that needs
   this doc's gate benchmark. The card/printing split (PR #604) improved its
@@ -42,7 +42,7 @@ deciding. ~4.7 MB is the prize; a regression on a common query class is the risk
 
 - [done/00598-engine-collection-vocab-interning.md](done/00598-engine-collection-vocab-interning.md) — item 5
   of the same series (done)
-- [00620-engine-flavor-text-narrowing.md](00620-engine-flavor-text-narrowing.md) — would retire
+- [00620-engine-flavor-text-narrowing.md](done/00620-engine-flavor-text-narrowing.md) — would retire
   flavor_text_lower as a side effect
 - [local-engine-reload-publish-transient.md](local-engine-reload-publish-transient.md) — the other open
   engine-memory ticket; staging-structure size (this item) sets its live-heap floor

--- a/docs/issues/local-engine-instrument-fast-paths.md
+++ b/docs/issues/local-engine-instrument-fast-paths.md
@@ -1,5 +1,26 @@
 # The four fast paths report features nobody can check
 
+Status: **still open, and re-verified against `main` after the cost-model stack merged (#833–#845).** None
+of the four counters exist: `popcount_words` appears nowhere in `card_engine/src/`, and `PhaseStats` carries
+`cards_visited` / `printing_span` / `printings_examined` / `matches_pushed` / `perm_steps` only.
+
+Two things moved underneath this doc, in opposite directions:
+
+- **The "what this does not cover" section is closed.** Phase timings shipped in
+  [#833](https://github.com/jbylund/sylvan_librarian/pull/833) — `ns_setup` / `ns_prepare` / `ns_loop` /
+  `ns_finish` per plan, with `plan_self_ns` computed by *adding* phases rather than subtracting a shared
+  prepare, because subtraction gave plane rows negative regret. So the lower-value half of this doc is done
+  and the counters — the half a rate constant cannot repair — are what remain.
+- **The prerequisite is partly settled.** [#844](https://github.com/jbylund/sylvan_librarian/pull/844) split
+  `ComposeEstimate` into `result` and `candidate`, which answers "what does `scan_units` mean under a compose
+  acquire" for that branch specifically: `candidate` is what the materializing alternatives walk, `result` is
+  the set compose builds. That is item 2's definition for one acquire branch. The **range** branch still
+  estimates its materializing alternatives unnarrowed, so a counter compared against `scan_units` there
+  would still be comparing a fast path's real work against a number that was never about it.
+
+The tracked remainder of the wider instrumentation gap is
+[#798](https://github.com/jbylund/sylvan_librarian/issues/798); item 3 there is this doc's item 3.
+
 `explain` reports a cost feature vector for all six plans. `explain_analyze` reports execution
 counters for two of them. The other four — `PrintingRangeScan`, `PrintingCompose`,
 `PlanePopcountOrder`, `CardRangePopcount` — return zeros, so every feature their cost arms key on is

--- a/docs/issues/local-engine-layout-postings.md
+++ b/docs/issues/local-engine-layout-postings.md
@@ -3,8 +3,8 @@
 **Deprioritized 2026-08-05** — layout predicates are judged rare in real use, which the traffic caveat
 below already flagged as the deciding unknown. Kept as a scoped, measured, ~4.5 KB fix if that judgement
 ever changes; do not pick it up ahead of
-[the artwork-mode walk gap](./local-engine-orderby-walk-modes.md) (now shipped) or the rest of the
-`is:`/`frame:` family ([local-engine-is-frame-predicates.md](./local-engine-is-frame-predicates.md)),
+[the artwork-mode walk gap](done/local-engine-orderby-walk-modes.md) (now shipped) or the rest of the
+`is:`/`frame:` family ([local-engine-is-frame-predicates.md](done/local-engine-is-frame-predicates.md)),
 which is 24% of remaining dispatch time against this one's share of it.
 
 `is:flip` matches **20 oracle cards**. It takes **187 µs** and scans the whole corpus to get there,

--- a/docs/issues/local-engine-plan-misselection.md
+++ b/docs/issues/local-engine-plan-misselection.md
@@ -1,5 +1,17 @@
 # The decline fallback never reconsidered a non-materializing plan, at up to 260 µs (fixed)
 
+Status: **the headline fix shipped; this stays open for the calibration findings under "What is left".**
+Kept here rather than moved to `done/` because the largest of those — `PlanePopcountOrder` under-costed a
+median 1.61×, p90 6.16 over n=157, unexplained and not attributable to acquire netting — is still the
+engine's largest un-diagnosed calibration gap and has no other home.
+
+Re-read after the cost-model stack (#833–#845): the numbers below predate it, and its "What to do" item 2
+(the 26–34 µs `StreamedSelect`/`GatheredScan` cluster) is now the subject of
+[#852](https://github.com/jbylund/sylvan_librarian/issues/852), which supersedes the advice to leave it
+alone — that pair turned out to be the engine's largest single routing error. **Re-measure before acting on
+any figure in this doc**; every one of them was taken against a cost model that has since had four feature
+corrections and a rate calibration.
+
 When a `Prep::Range`-acquired query's chosen fast path declines at runtime, dispatch re-chooses
 among **materializing plans only** — so `PrintingCompose`, which is applicable and often 30–70x
 faster, is never reconsidered. Measured worst case: a bare `year:` or `usd:` range at

--- a/docs/issues/local-engine-range-cardinality-estimate.md
+++ b/docs/issues/local-engine-range-cardinality-estimate.md
@@ -222,7 +222,7 @@ already read 1.000 across 26 scan points: that branch sets `matches = k`, the in
 and in printing mode that *is* the result cardinality. Those rows must stay at 1.000.
 
 **Out of scope:** `eur` and `tix`, which have no range index and never reach this acquire — a separate
-and much larger defect, see [local-engine-eur-tix-range-index.md](local-engine-eur-tix-range-index.md).
+and much larger defect, see [local-engine-eur-tix-range-index.md](done/local-engine-eur-tix-range-index.md).
 
 Routing is deliberately **not** an acceptance criterion for this change alone. Correcting the estimate
 lowers predicted cost for the materializing plans, which are already over-picked, so routing should

--- a/docs/issues/local-engine-sparse-compose-gather.md
+++ b/docs/issues/local-engine-sparse-compose-gather.md
@@ -6,7 +6,7 @@ makes the router redo the same work with a full scan. It does not have to. The r
 
 It is nonetheless **blocked**, twice measured, and the blocker is not the change itself — it is that
 `plan_cost` cannot price the path the change routes to. Written up separately from
-[the cost-model work](local-engine-cost-model-agreement.md) because it is one shippable idea with a
+[the cost-model work](done/local-engine-cost-model-agreement.md) because it is one shippable idea with a
 clean acceptance test, waiting on a prerequisite that lives elsewhere.
 
 ## The change
@@ -100,7 +100,7 @@ mispricing was not the blocker, or not the only one.
 
 ## Re-measured 2026-08-04, after the two-sided range fusion
 
-[local-engine-two-sided-range-fusion.md](./local-engine-two-sided-range-fusion.md) made
+[local-engine-two-sided-range-fusion.md](done/local-engine-two-sided-range-fusion.md) made
 `compose_printing_estimate` exact on ranges, which removed the second stated blocker: the prediction
 can now tell a sparse query from a broad one (879 against a true 879, where it read 20,411). Both
 executors were then re-tried behind a runtime toggle on one binary.
@@ -169,7 +169,7 @@ sequencing:
 | all three realized | **0.57×** |
 
 So perfect features close about 40% of the gap and leave 1.75×. That is the **opposite** of the P3/P4
-result in [the loop-phase doc](./local-engine-loop-phase-measurement.md), where the oracle reached 83%
+result in [the loop-phase doc](done/local-engine-loop-phase-measurement.md), where the oracle reached 83%
 and features were the whole story — worth noting before reusing that conclusion on a different arm.
 
 **What is left is a missing term, not a level error.** The oracle column spans 0.32–0.79, so no single
@@ -230,7 +230,7 @@ population, with and without the term applied:
 | 5.0x | 0.855 | 1.061 |
 
 **Both curves SATURATE past ~3.5x** — the same phenomenon [the loop-phase
-doc](./local-engine-loop-phase-measurement.md) already records, and the reason a linear term shifts this
+doc](done/local-engine-loop-phase-measurement.md) already records, and the reason a linear term shifts this
 curve instead of flattening it. With the term the asymptote is ~1.045 (right) against ~0.845 (18% under)
 without, so the term is real here as well. But at the **production** size it makes Perm worse, 1.185 ->
 1.449, which is what happens when an arm's rates were fitted with the cost already absorbed into them.
@@ -391,7 +391,7 @@ more expensive -- the direction that lost argmins compose deserved. It lands wit
 before it. And the 14 intervals are hand-picked; grade it over the regret matrix's traffic first.
 
 Progress on the compose arm generally is tracked in
-[the cost-model doc](local-engine-cost-model-agreement.md).
+[the cost-model doc](done/local-engine-cost-model-agreement.md).
 
 ## Acceptance
 

--- a/docs/issues/local-prefer-score-label-harness.md
+++ b/docs/issues/local-prefer-score-label-harness.md
@@ -3,7 +3,12 @@
 Status: proposed, not started. Split out of
 [00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) once it became clear this
 is an independent deliverable: 00720 is the scoring defect, this is the instrument for fixing it and for
-preventing the next one. Not filed as a GitHub issue of its own — it is the first step of #720.
+preventing the next one. Not filed as a GitHub issue of its own.
+
+**#720 has since closed as completed** — `art_style` shipped — so this is no longer "the first step of
+#720"; it is the instrument that outlives it, and the reason it still matters is
+[the closed tuning loop](local-prefer-score-tuning-loop.md): that analysis was wrong three separate times
+without one.
 
 ## Why an instrument is needed at all
 

--- a/docs/issues/local-prefer-score-label-harness.md
+++ b/docs/issues/local-prefer-score-label-harness.md
@@ -1,7 +1,7 @@
 # Prefer-Score Label Harness: Pairwise Screening and Weight Fitting
 
 Status: proposed, not started. Split out of
-[00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) once it became clear this
+[00720-prefer-score-artwork-tuning.md](done/00720-prefer-score-artwork-tuning.md) once it became clear this
 is an independent deliverable: 00720 is the scoring defect, this is the instrument for fixing it and for
 preventing the next one. Not filed as a GitHub issue of its own.
 

--- a/docs/issues/local-prefer-score-tuning-loop.md
+++ b/docs/issues/local-prefer-score-tuning-loop.md
@@ -1,6 +1,6 @@
 # A closed tuning loop for `prefer_score`
 
-The tuning in [#720](00720-prefer-score-artwork-tuning.md) worked but the *process* did not. Each
+The tuning in [#720](done/00720-prefer-score-artwork-tuning.md) worked but the *process* did not. Each
 change took a bespoke script, a hand-built review page and a hand-written analysis, and the analysis
 was wrong three separate times. This is a design for replacing that with one loop: propose a change,
 grade ~20 cards, accept or reject, repeat — with a single number going up.
@@ -69,7 +69,7 @@ change is hand-copied — the weights should move to config that both the SQL an
 
 ## Related
 
-- [00720-prefer-score-artwork-tuning.md](00720-prefer-score-artwork-tuning.md) — the tuning this
+- [00720-prefer-score-artwork-tuning.md](done/00720-prefer-score-artwork-tuning.md) — the tuning this
   process was derived from, and the record of what it got wrong.
 - [local-prefer-score-label-harness.md](local-prefer-score-label-harness.md) — the labelling
   instrument that produces the objective.

--- a/docs/issues/reference-cost-model-measurement.md
+++ b/docs/issues/reference-cost-model-measurement.md
@@ -1,7 +1,7 @@
 # Measuring the cost model: which tool answers which question
 
 Eight harnesses, built while doing the work in
-[local-engine-cost-model-agreement.md](local-engine-cost-model-agreement.md). They exist because each
+[local-engine-cost-model-agreement.md](done/local-engine-cost-model-agreement.md). They exist because each
 answers a question the others structurally cannot, and reaching for the wrong one wastes days — three
 successive reworkings of one term improved the metric being watched and moved routing by
 `-0.003 µs, CI [-0.206, +0.214]`.
@@ -41,7 +41,7 @@ declining compose, which no `predicted_ns <= 0` guard catches, and any ratio bui
 poisons the percentile cell it lands in.
 
 The end-to-end answer for the whole cost-model stack is recorded in
-[local-engine-cost-model-stack-result.md](local-engine-cost-model-stack-result.md) — including the
+[local-engine-cost-model-stack-result.md](done/local-engine-cost-model-stack-result.md) — including the
 bands, because a mean over this distribution understates the tail and a p99 overstates it.
 
 Most of them draw queries from one universe, [`query_sampler.py`](../../client/query_sampler.py), in
@@ -62,7 +62,7 @@ the question is what users actually lose.
 
 For built designs — kernel harnesses that control the ratios instead of sampling them — and the rule
 that came out of them (**shape from a built design, levels from traffic**), see
-[local-engine-loop-phase-measurement.md](./local-engine-loop-phase-measurement.md). It also records
+[local-engine-loop-phase-measurement.md](done/local-engine-loop-phase-measurement.md). It also records
 why a min-of-N benchmark over one candidate list measures a cache state production never reaches, and
 why a whole-arm fit's intercept cannot be read as a fixed cost.
 

--- a/docs/issues/reference-engine-union-summary-planes.md
+++ b/docs/issues/reference-engine-union-summary-planes.md
@@ -62,8 +62,8 @@ flat (small closed algebras) or plain two-tier (membership-only) wins.
 
 ## Related
 
-- [00630-engine-card-bitplanes.md](00630-engine-card-bitplanes.md) — #630/#633 flat planes
-- [00636-engine-adaptive-candidate-sets.md](00636-engine-adaptive-candidate-sets.md) —
+- [00630-engine-card-bitplanes.md](done/00630-engine-card-bitplanes.md) — #630/#633 flat planes
+- [00636-engine-adaptive-candidate-sets.md](done/00636-engine-adaptive-candidate-sets.md) —
   #636/#637 scatter/complement machinery this leans on
 - [00623-engine-flavor-absent-gram-bitmap.md](00623-engine-flavor-absent-gram-bitmap.md) —
   #623, the same union-summary-as-rejector idea

--- a/docs/workflows/diagnosing-a-plan-cost-error.md
+++ b/docs/workflows/diagnosing-a-plan-cost-error.md
@@ -7,7 +7,7 @@ fix. This is the diagnosis in between.
 
 Every step below exists because skipping it produced a wrong answer at least once. The worked example
 throughout is `StreamedSelect` (P3) against `GatheredScan` (P4) and `PrintingCompose` on legality queries,
-from `local-engine-loop-phase-measurement.md`.
+from `done/local-engine-loop-phase-measurement.md`.
 
 ## Where you are trying to end up
 
@@ -141,7 +141,7 @@ discarded a correct change and left the real defect hidden, which is the trap th
 Two things make the reading trustworthy. **Regret TOTAL is a sum over however many queries the budget
 reached**, so it is not comparable across runs — compare the mean, and measure your own baseline in the same
 session rather than against a number in a doc. The 48.7 ms and 55.0 ms figures still quoted in the earlier
-sections of `local-engine-loop-phase-measurement.md` were taken at unrecorded settings and are **not** on the
+sections of `done/local-engine-loop-phase-measurement.md` were taken at unrecorded settings and are **not** on the
 same scale as the 81.7 → 61.2 ms above; that is why a fresh paired baseline was measured rather than compared
 against them. And a cost-only change
 needs **no new row-identity run**: `force_plan_differential_agreement` already proves every plan returns the

--- a/scripts/bench_membership_waste.py
+++ b/scripts/bench_membership_waste.py
@@ -1,0 +1,168 @@
+"""Size the waste #856 targets: per-printing residual re-evaluation under a compose acquire.
+
+`narrow_candidates_exact` computes exact printing-space membership and discards it, so the materializing
+plans re-derive per printing what the narrowing already proved. What that costs is
+`ns_loop / printings_examined` on printing-mode queries acquired through `printing_compose`.
+
+Both inputs are realized counters `explain_analyze` has published since #833, so this is an
+OBSERVATIONAL measurement rather than an A/B: no second build, and no drift to control for. `ns_loop`
+comes from the fastest recorded round (matching every consumer's `min(trials_ns)`), so the rate is a
+floor rather than an average.
+
+Two views, answering different questions -- conflating them is how the original 8x figure was produced:
+
+- **PICKED** -- only queries where the router actually chose a materializing plan. This is what
+  production pays and the only view a latency claim may cite.
+- **ALL TRIALS** -- every materializing trial that ran, picked or not. Better-resolved RATE, but it
+  includes forced runs of plans the router rejected and double-counts queries where both ran, so its
+  total is not a saving.
+
+Not observable from outside Rust: `n.tight`. #856's gate is `n.tight && printing_space`, and neither half
+is visible here -- `narrowed_repr` is `None` by construction for a compose acquire (`Prep::Range` and
+`Prep::Plane` materialize no candidate list), because the narrowing happens at DISPATCH, after the
+router's acquire. So the population below is an upper bound on what the change can touch; the
+per-printing rate is the solid part.
+
+Delete this harness when #856 ships -- it exists to size one defect, and
+`docs/issues/local-benchmark-toolkit-audit.md` is a standing argument against keeping one-off benches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import pathlib
+import random
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# The two plans that walk printings under a candidate and evaluate the residual per printing --
+# `push_card_matches` (GatheredScan) and `card_match_count` (StreamedSelect), the two call sites #856
+# would replace with a bit test.
+MATERIALIZING = ("StreamedSelect", "GatheredScan")
+
+# The acquire branch whose dispatch-time narrowing produces an exact printing-space bitmap and drops it.
+COMPOSE_ACQUIRE = "printing_compose"
+
+# Cost of an O(1) bitmap membership test, for the counterfactual. Reported across a range rather than at
+# one value because the saving is (measured_rate - bit_test_ns): the original 8x assumed 1 ns, and a
+# reader should see how much the conclusion rests on that.
+BIT_TEST_NS = (0.5, 1.0, 2.0)
+
+
+class Totals:
+    """Running sums for one view (picked-only, or all materializing trials)."""
+
+    def __init__(self) -> None:
+        """Start every accumulator at zero."""
+        self.loop_ns = 0.0
+        self.printings = 0
+        self.rows = 0
+        self.routed_ns = 0.0
+        self.rates: list[float] = []
+
+    def add(self, loop_ns: float, printings: int, routed_ns: float = 0.0) -> None:
+        """Fold one measured plan trial in."""
+        self.loop_ns += loop_ns
+        self.printings += printings
+        self.rows += 1
+        self.routed_ns += routed_ns
+        self.rates.append(loop_ns / printings)
+
+
+def collect(engine: object, sampler: object, rng: random.Random, budget: object) -> tuple:
+    """Sample queries and accumulate the two views, plus the population breakdown."""
+    from scripts import costbench  # noqa: PLC0415 - deferred so this imports without the built extension
+
+    picked, every = Totals(), Totals()
+    pop_n = 0
+    by_repr: collections.Counter[str] = collections.Counter()
+    picked_plans: collections.Counter[str] = collections.Counter()
+
+    for s in costbench.iter_samples(engine, sampler, rng, budget):
+        if s.kw["unique"] != "printing" or s.acquire["count_source"] != COMPOSE_ACQUIRE:
+            continue
+        pop_n += 1
+        by_repr[s.acquire.get("narrowed_repr", "?")] += 1
+        for p in s.plans:
+            if p["plan"] not in MATERIALIZING or not p["trials_ns"]:
+                continue
+            loop, exam = float(p["ns_loop"]), int(p["printings_examined"])
+            if exam <= 0 or loop <= 0:
+                continue
+            every.add(loop, exam)
+            if p["picked"]:
+                # routed_ns is a per-round list; min matches how consumers reduce trials_ns, and pairs
+                # with ns_loop, which is itself the fastest round's phase split.
+                picked.add(loop, exam, float(min(s.res["acquire"]["routed_ns"])))
+                picked_plans[p["plan"]] += 1
+    return picked, every, pop_n, by_repr, picked_plans
+
+
+def report_view(label: str, t: Totals) -> None:
+    """Print one view's volume, rate, and the bit-test counterfactual."""
+    print(f"\n-- {label} --")
+    if not t.printings:
+        print("   no rows")
+        return
+    rate = t.loop_ns / t.printings
+    print(f"   rows                 {t.rows:,}")
+    print(f"   match-loop time      {t.loop_ns / 1e6:,.1f} ms")
+    print(f"   printings examined   {t.printings / 1e6:,.1f} M")
+    print(f"   per printing         {rate:.2f} ns")
+    for bt in BIT_TEST_NS:
+        print(f"   at {bt:>4.1f} ns/bit-test -> {t.printings * bt / 1e6:>7.1f} ms  ({rate / bt:.1f}x less)")
+
+
+def report_worth(t: Totals) -> None:
+    """Print what the change is worth end to end on the population that actually pays it."""
+    if not t.routed_ns:
+        return
+    print("\n-- what it is worth on the PICKED path (end to end) --")
+    print(f"   routed (total) time  {t.routed_ns / 1e6:,.1f} ms over {t.rows:,} queries")
+    print(f"   of which match loop  {t.loop_ns / 1e6:,.1f} ms  ({100 * t.loop_ns / t.routed_ns:.1f}%)")
+    for bt in BIT_TEST_NS:
+        saved = t.loop_ns - t.printings * bt
+        speedup = t.routed_ns / max(t.routed_ns - saved, 1e-9)
+        print(
+            f"   at {bt:>4.1f} ns/bit-test -> saves {saved / 1e6:>6.1f} ms"
+            f" = {100 * saved / t.routed_ns:>4.1f}% of routed, {speedup:.2f}x on the population",
+        )
+
+
+def main() -> None:
+    """Load a store from the corpus, sample, and report both views."""
+    ap = argparse.ArgumentParser(description="Size #856's per-printing residual re-evaluation waste.")
+    ap.add_argument("--corpus", type=pathlib.Path, required=True)
+    ap.add_argument("--shm", type=pathlib.Path, required=True)
+    ap.add_argument("--sample", type=int, default=30000)
+    ap.add_argument("--seed", type=int, default=20260806)
+    args = ap.parse_args()
+
+    from client.query_sampler import QuerySampler  # noqa: PLC0415 - deferred with costbench, same reason
+    from scripts import costbench  # noqa: PLC0415
+
+    engine = costbench.load_engine(args.corpus, args.shm)
+    picked, every, pop_n, by_repr, picked_plans = collect(
+        engine,
+        QuerySampler(mode="uniform"),
+        random.Random(args.seed),
+        costbench.Budget(sample=args.sample),
+    )
+
+    print(f"\n{'=' * 78}\nPopulation: unique=printing, acquire={COMPOSE_ACQUIRE}\n{'=' * 78}")
+    print(f"queries in population: {pop_n:,}  (of {args.sample:,} sampled, uniform mode)")
+    print("narrowed_repr:", ", ".join(f"{k}={v:,}" for k, v in by_repr.most_common()))
+    report_view("PICKED (what production pays)", picked)
+    report_view("ALL materializing trials (rate only, NOT a saving)", every)
+    report_worth(picked)
+    if picked.rates:
+        mid = sorted(picked.rates)[len(picked.rates) // 2]
+        print(f"\n   per-query ns/printing, median {mid:.2f}  (pooled is volume-weighted)")
+    if picked_plans:
+        print("   picked plan:", ", ".join(f"{k}={v:,}" for k, v in picked_plans.most_common()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_membership_waste.py
+++ b/scripts/bench_membership_waste.py
@@ -75,6 +75,7 @@ class Totals:
         self.cards = 0
         self.rates: list[float] = []
         self.rows_detail: list[tuple[float, int, str]] = []
+        self.tail: list[tuple[float, float, int, str]] = []
 
     def add(self, loop_ns: float, printings: int, routed_ns: float = 0.0, matches: int = 0, cards: int = 0) -> None:
         """Fold one measured plan trial in."""
@@ -92,11 +93,16 @@ def collect(engine: object, sampler: object, rng: random.Random, budget: object)
     from scripts import costbench  # noqa: PLC0415 - deferred so this imports without the built extension
 
     picked, every = Totals(), Totals()
+    # Every sampled query's routed time, so the population can be placed in the OVERALL latency
+    # distribution. A speedup on queries that are already fast is not a user-visible win, and only the
+    # comparison against all traffic can say which this is.
+    all_routed_ns: list[float] = []
     pop_n = 0
     by_repr: collections.Counter[str] = collections.Counter()
     picked_plans: collections.Counter[str] = collections.Counter()
 
     for s in costbench.iter_samples(engine, sampler, rng, budget):
+        all_routed_ns.append(float(min(s.res["acquire"]["routed_ns"])))
         if s.kw["unique"] != "printing" or s.acquire["count_source"] != COMPOSE_ACQUIRE:
             continue
         pop_n += 1
@@ -113,8 +119,9 @@ def collect(engine: object, sampler: object, rng: random.Random, budget: object)
                 # with ns_loop, which is itself the fastest round's phase split.
                 picked.add(loop, exam, float(min(s.res["acquire"]["routed_ns"])), int(p["matches_pushed"]), int(p["cards_visited"]))
                 picked.rows_detail.append((100.0 * int(p["matches_pushed"]) / exam, exam, s.q))
+                picked.tail.append((float(min(s.res["acquire"]["routed_ns"])), loop, exam, s.q))
                 picked_plans[p["plan"]] += 1
-    return picked, every, pop_n, by_repr, picked_plans
+    return picked, every, pop_n, by_repr, picked_plans, all_routed_ns
 
 
 def report_view(label: str, t: Totals) -> None:
@@ -216,7 +223,7 @@ def main() -> None:
     from scripts import costbench  # noqa: PLC0415
 
     engine = costbench.load_engine(args.corpus, args.shm)
-    picked, every, pop_n, by_repr, picked_plans = collect(
+    picked, every, pop_n, by_repr, picked_plans, all_routed_ns = collect(
         engine,
         QuerySampler(mode=args.mode),
         random.Random(args.seed),
@@ -234,6 +241,45 @@ def main() -> None:
         print(f"\n   per-query ns/printing, median {mid:.2f}  (pooled is volume-weighted)")
     if picked_plans:
         print("   picked plan:", ", ".join(f"{k}={v:,}" for k, v in picked_plans.most_common()))
+    report_tail(picked, all_routed_ns)
+
+
+def pctl(xs: list[float], q: float) -> float:
+    """The q-quantile of an unsorted list, nearest-rank."""
+    s = sorted(xs)
+    return s[min(int(q * len(s)), len(s) - 1)]
+
+
+def merge_ns_share() -> float:
+    """The recommended route's measured per-printing cost."""
+    return BIT_TEST_NS[0]
+
+
+def report_tail(t: Totals, all_routed_ns: list[float]) -> None:
+    """Place the population in the overall latency distribution, and show its slowest queries.
+
+    The aggregate speedup says nothing about whether any user-visible slow query gets faster. If the
+    population sits entirely inside the fast part of the distribution, the honest answer is that it does
+    not, however large the ratio.
+    """
+    if not t.tail or not all_routed_ns:
+        return
+    print("\n-- is anything SLOW here? --")
+    pop = [r for r, _, _, _ in t.tail]
+    print(f"   {'':<12}{'p50':>10}{'p90':>10}{'p99':>10}{'max':>10}")
+    for label, xs in (("all sampled", all_routed_ns), ("this population", pop)):
+        print(f"   {label:<12}" + "".join(f"{pctl(xs, q) / 1000:>9.1f}u" for q in (0.5, 0.9, 0.99, 1.0)))
+    # The aggregate that matters: this population's share of ALL routed time, and what the change saves
+    # of the whole. A large ratio on a small share is a small change.
+    total_all, total_pop = sum(all_routed_ns), sum(pop)
+    saved = t.loop_ns - t.printings * merge_ns_share()
+    print(f"   population share of all routed time: {100 * total_pop / total_all:.2f}%")
+    print(f"   saving as a share of ALL routed time: {100 * saved / total_all:.2f}%")
+    merge_ns = merge_ns_share()
+    print(f"   slowest in population, and what {merge_ns} ns/printing would make them:")
+    for routed, loop, exam, q in sorted(t.tail, key=lambda r: -r[0])[:8]:
+        after = routed - loop + exam * merge_ns
+        print(f"      {routed / 1000:>7.1f}us -> {after / 1000:>6.1f}us  ({routed / max(after, 1):.1f}x)  {q[:44]}")
 
 
 if __name__ == "__main__":

--- a/scripts/bench_membership_waste.py
+++ b/scripts/bench_membership_waste.py
@@ -33,6 +33,7 @@ import argparse
 import collections
 import pathlib
 import random
+import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
@@ -50,6 +51,13 @@ COMPOSE_ACQUIRE = "printing_compose"
 # reader should see how much the conclusion rests on that.
 BIT_TEST_NS = (0.5, 1.0, 2.0)
 
+# Match-density bands, chosen from bench_membership_bittest.rs's measured cost curve rather than as
+# round numbers: the bit test is ~0.5 ns where the branch is predictable (below ~2% or above ~80%) and
+# peaks at 2.3 ns in the middle, so these are the bands that actually differ in cost.
+DENSITY_PREDICTABLE_LOW = 2.0
+DENSITY_MIDDLE_LOW = 20.0
+DENSITY_MIDDLE_HIGH = 80.0
+
 
 class Totals:
     """Running sums for one view (picked-only, or all materializing trials)."""
@@ -60,10 +68,15 @@ class Totals:
         self.printings = 0
         self.rows = 0
         self.routed_ns = 0.0
+        self.matches = 0
+        self.cards = 0
         self.rates: list[float] = []
+        self.rows_detail: list[tuple[float, int, str]] = []
 
-    def add(self, loop_ns: float, printings: int, routed_ns: float = 0.0) -> None:
+    def add(self, loop_ns: float, printings: int, routed_ns: float = 0.0, matches: int = 0, cards: int = 0) -> None:
         """Fold one measured plan trial in."""
+        self.matches += matches
+        self.cards += cards
         self.loop_ns += loop_ns
         self.printings += printings
         self.rows += 1
@@ -95,7 +108,8 @@ def collect(engine: object, sampler: object, rng: random.Random, budget: object)
             if p["picked"]:
                 # routed_ns is a per-round list; min matches how consumers reduce trials_ns, and pairs
                 # with ns_loop, which is itself the fastest round's phase split.
-                picked.add(loop, exam, float(min(s.res["acquire"]["routed_ns"])))
+                picked.add(loop, exam, float(min(s.res["acquire"]["routed_ns"])), int(p["matches_pushed"]), int(p["cards_visited"]))
+                picked.rows_detail.append((100.0 * int(p["matches_pushed"]) / exam, exam, s.q))
                 picked_plans[p["plan"]] += 1
     return picked, every, pop_n, by_repr, picked_plans
 
@@ -111,8 +125,59 @@ def report_view(label: str, t: Totals) -> None:
     print(f"   match-loop time      {t.loop_ns / 1e6:,.1f} ms")
     print(f"   printings examined   {t.printings / 1e6:,.1f} M")
     print(f"   per printing         {rate:.2f} ns")
+    if t.matches:
+        # Match density decides how predictable the bit-test branch is, and the bit test is 0.5 ns at
+        # 1% density against 2.3 ns at 50% (bench_membership_bittest.rs). Without this the micro-
+        # benchmark cannot be read against this population.
+        print(f"   matches / examined   {100 * t.matches / t.printings:.1f}%  (bit-test branch density)")
+    report_density(t)
+    if t.cards:
+        # Candidate share of the corpus sets how scattered the bitmap reads are -- the other axis
+        # bench_membership_bittest.rs sweeps (as `stride`, = 1 / this share).
+        per_q = t.cards / max(t.rows, 1)
+        print(f"   cards visited/query  {per_q:,.0f} of 31,508 -> stride ~{31508 / max(per_q, 1):.0f}")
     for bt in BIT_TEST_NS:
         print(f"   at {bt:>4.1f} ns/bit-test -> {t.printings * bt / 1e6:>7.1f} ms  ({rate / bt:.1f}x less)")
+
+
+def report_density(t: Totals) -> None:
+    """Print the match-density DISTRIBUTION and which predicate families make up the population.
+
+    A pooled mean is the wrong summary here: the bit test costs ~0.5 ns where the branch is predictable
+    (below ~2% or above ~80% density) and 2.3 ns in the middle, so two queries at 1% and 99% average to
+    the worst case while both are cheap.
+    """
+    if t.rows_detail:
+        ds = sorted(d for d, _, _ in t.rows_detail)
+        pct = [ds[int(q * (len(ds) - 1))] for q in (0.10, 0.25, 0.50, 0.75, 0.90)]
+        print("   density p10/p25/p50/p75/p90  " + " / ".join(f"{v:.0f}%" for v in pct))
+        buckets = {"<2% (cheap)": 0, "2-20%": 0, "20-80% (worst)": 0, ">80% (cheap)": 0}
+        for d in ds:
+            if d < DENSITY_PREDICTABLE_LOW:
+                key = "<2% (cheap)"
+            elif d < DENSITY_MIDDLE_LOW:
+                key = "2-20%"
+            elif d < DENSITY_MIDDLE_HIGH:
+                key = "20-80% (worst)"
+            else:
+                key = ">80% (cheap)"
+            buckets[key] += 1
+        print("   in cost bands: " + ", ".join(f"{k}={v}" for k, v in buckets.items()))
+        print("   heaviest queries (by printings examined):")
+        for d, exam, q in sorted(t.rows_detail, key=lambda r: -r[1])[:4]:
+            print(f"      {exam:>8,} printings  {d:>5.1f}% dense   {q[:52]}")
+        # WHICH QUERIES this touches is the question a traffic-weight caveat has to answer, so group by
+        # the predicate families present rather than listing individual query strings.
+        fam: dict[str, list] = {}
+        for d, exam, q in t.rows_detail:
+            keys = tuple(sorted(set(re.findall(r"([a-z_]+)[:<>=]", q)))) or ("<bare>",)
+            fam.setdefault(" + ".join(keys), []).append((exam, d))
+        print("   predicate families, by share of printings examined:")
+        total = sum(exam for exam, _ in ((e, d) for rows in fam.values() for e, d in rows))
+        for name, rows in sorted(fam.items(), key=lambda kv: -sum(e for e, _ in kv[1]))[:10]:
+            ex = sum(e for e, _ in rows)
+            md = sorted(d for _, d in rows)[len(rows) // 2]
+            print(f"      {100 * ex / total:>5.1f}%  n={len(rows):>4}  median {md:>5.1f}% dense   {name[:46]}")
 
 
 def report_worth(t: Totals) -> None:
@@ -138,6 +203,10 @@ def main() -> None:
     ap.add_argument("--shm", type=pathlib.Path, required=True)
     ap.add_argument("--sample", type=int, default=30000)
     ap.add_argument("--seed", type=int, default=20260806)
+    # Uniform is the default because it resolves the RATE best (it reaches rare shapes at all), but the
+    # population share only means something under realistic weights -- `watermark` carries 0.5 there
+    # against `set`'s 5, and uniform over-samples both.
+    ap.add_argument("--mode", choices=("uniform", "realistic"), default="uniform")
     args = ap.parse_args()
 
     from client.query_sampler import QuerySampler  # noqa: PLC0415 - deferred with costbench, same reason
@@ -146,13 +215,13 @@ def main() -> None:
     engine = costbench.load_engine(args.corpus, args.shm)
     picked, every, pop_n, by_repr, picked_plans = collect(
         engine,
-        QuerySampler(mode="uniform"),
+        QuerySampler(mode=args.mode),
         random.Random(args.seed),
         costbench.Budget(sample=args.sample),
     )
 
     print(f"\n{'=' * 78}\nPopulation: unique=printing, acquire={COMPOSE_ACQUIRE}\n{'=' * 78}")
-    print(f"queries in population: {pop_n:,}  (of {args.sample:,} sampled, uniform mode)")
+    print(f"queries in population: {pop_n:,}  (of {args.sample:,} sampled, {args.mode} mode)")
     print("narrowed_repr:", ", ".join(f"{k}={v:,}" for k, v in by_repr.most_common()))
     report_view("PICKED (what production pays)", picked)
     report_view("ALL materializing trials (rate only, NOT a saving)", every)

--- a/scripts/bench_membership_waste.py
+++ b/scripts/bench_membership_waste.py
@@ -46,10 +46,13 @@ MATERIALIZING = ("StreamedSelect", "GatheredScan")
 # The acquire branch whose dispatch-time narrowing produces an exact printing-space bitmap and drops it.
 COMPOSE_ACQUIRE = "printing_compose"
 
-# Cost of an O(1) bitmap membership test, for the counterfactual. Reported across a range rather than at
-# one value because the saving is (measured_rate - bit_test_ns): the original 8x assumed 1 ns, and a
-# reader should see how much the conclusion rests on that.
-BIT_TEST_NS = (0.5, 1.0, 2.0)
+# Per-printing cost of the membership check that would replace the residual, MEASURED by
+# card_engine/src/bench_membership_bittest.rs at the production point (234 cards x 13.6 printings,
+# 1.56 matches each). Two routes, plus a pessimistic control:
+#   0.17 - two-pointer merge over the sorted candidate list (no bitmap, GatheredScan only)
+#   0.88 - scatter into a printing bitmap then probe (also costs ~0.5 us/query to build)
+#   2.00 - control: 2x worse than the bitmap route, to show the floor
+BIT_TEST_NS = (0.17, 0.88, 2.0)
 
 # Match-density bands, chosen from bench_membership_bittest.rs's measured cost curve rather than as
 # round numbers: the bit test is ~0.5 ns where the branch is predictable (below ~2% or above ~80%) and

--- a/scripts/bench_plan_misselection.py
+++ b/scripts/bench_plan_misselection.py
@@ -109,7 +109,7 @@ def calibration(engine: card_engine.QueryEngine, queries: list[tuple[str, str, s
     < 1 means over-costed and under-picked.
     """
     # Two ratios, because `measured` includes the acquire step and `predicted` does not — that
-    # unpriced term (docs/issues/local-engine-candidate-materialize.md) would otherwise be read as
+    # unpriced term (docs/issues/done/local-engine-candidate-materialize.md) would otherwise be read as
     # the plan arm being wrong. `net` subtracts the measured acquire, isolating the arm itself.
     ratios: collections.defaultdict[str, list[float]] = collections.defaultdict(list)
     nets: collections.defaultdict[str, list[float]] = collections.defaultdict(list)

--- a/scripts/bench_range_estimate_scan.py
+++ b/scripts/bench_range_estimate_scan.py
@@ -1,6 +1,6 @@
 """Acceptance test for the range-cardinality estimate: scan each dimension, compare estimate to truth.
 
-`docs/issues/local-engine-range-cardinality-estimate.md` proposes replacing `card_est = k.min(n_cards)`
+`docs/issues/done/local-engine-range-cardinality-estimate.md` proposes replacing `card_est = k.min(n_cards)`
 with a three-column boundary table (prefix / suffix / per-value distinct-card counts), which should be
 **exact**. This is the test that says whether it worked.
 

--- a/scripts/bench_short_needle_cliff.py
+++ b/scripts/bench_short_needle_cliff.py
@@ -34,6 +34,9 @@ QUERIES = [
     "o:s",
     "o:the",
     "ft:s",
+    "o:the or o:you",
+    "o:the or o:zap",
+    "o:tar or o:qua",
 ]
 
 

--- a/scripts/bench_short_needle_cliff.py
+++ b/scripts/bench_short_needle_cliff.py
@@ -1,0 +1,59 @@
+"""Time the needle-length cliff for text containment -- the measurement behind #858.
+
+Three tiers: trigram narrowing needs 3 bytes (`trigram_candidates` returns None below that), 2-byte needles
+resolve exactly through `NameBigramIndex`, and 1-byte needles have neither. The third case also loses
+memoization, because `memoize_text_predicates` is gated on `trigram_candidates` returning `Some`, so the
+filter stays a `TextContains` evaluated per card inside the match loop.
+
+Reports routed time beside the acquire facts, because `narrowed_repr: none` is what distinguishes the broken
+tier from the working ones.
+
+    .venv/bin/python scripts/bench_short_needle_cliff.py --shm /tmp/needle.store
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from api.parsing import parse_scryfall_query  # noqa: E402
+from scripts import costbench  # noqa: E402
+
+# One char (no index), two chars (bigram, exact), three+ (trigram). Plus a couple of controls.
+QUERIES = [
+    "name:s",
+    "name:e",
+    "name:a",
+    "name:so",
+    "name:sol",
+    "name:solr",
+    "o:s",
+    "o:the",
+    "ft:s",
+]
+
+
+def main() -> None:
+    """Time each needle length against a store built from the corpus."""
+    ap = argparse.ArgumentParser(description="Time the needle-length cliff for text containment (#858).")
+    ap.add_argument("--corpus", type=pathlib.Path, default=REPO / "benchmarks/bitplanes/corpus.jsonl")
+    ap.add_argument("--shm", type=pathlib.Path, required=True)
+    args = ap.parse_args()
+    engine = costbench.load_engine(args.corpus, args.shm)
+    print(f"\n{'query':<12}{'routed':>10}{'results':>10}{'plan':>16}{'count_src':>18}{'narrowed':>12}")
+    for q in QUERIES:
+        kw = {"filters": parse_scryfall_query(q), "unique": "card", "orderby": "name", "direction": "asc", "limit": 60, "offset": 0}
+        acq = engine.explain(**kw)["acquire"]
+        res = engine.explain_analyze(num_warmups=3, num_trials=15, **kw)
+        routed = min(res["acquire"]["routed_ns"]) / 1000.0
+        picked = next((p["plan"] for p in res["plans"] if p["picked"]), "?")
+        total = next((p["result_total"] for p in res["plans"] if p["picked"]), 0)
+        print(f"{q:<12}{routed:>9.1f}u{total:>10,}{picked:>16}{acq['count_source']:>18}{acq['narrowed_repr']:>12}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/census_candidate_materialize.py
+++ b/scripts/census_candidate_materialize.py
@@ -1,6 +1,6 @@
 """Census: which real queries would a change to candidate materialization actually touch?
 
-Step 1 of docs/issues/local-engine-candidate-materialize.md. Six engine sites turn selected
+Step 1 of docs/issues/done/local-engine-candidate-materialize.md. Six engine sites turn selected
 index rows into a sorted candidate list via `collect` + `sort_unstable`; replacing that with
 a bitmap scatter pays off from roughly `n_cards / 460` candidates up. This asks how many
 queries land in that band before any engine code changes.


### PR DESCRIPTION
The #833–#845 cost-model stack landed thirteen layers of engine work whose design docs were all still sitting
in `docs/issues/` as open items. This is the reconciliation pass, plus the new work it surfaced.

No engine code changes. Two experimental patches were built and measured during this work and both are
reverted; what is committed is documentation, two measurement harnesses, and one Rust micro-benchmark.

## Reconciliation

**19 docs move to `done/`**, each gaining a header naming the PR it shipped in and the measured result. Nine
were complete; the rest shipped with a named remainder that is now refiled rather than stranded.

**Five `done/` docs claimed their shipped work was never started** — 00619, 00620, 00663, 00664, 00669 all read
"not started" or "proposed design" for merged features. Anyone trusting the status could have reimplemented
one. 00620 and 00663 are the instructive pair: both shipped under names their docs never predicted
(`FlavorIndex`, `OracleWordIndex`), so grepping the doc's own vocabulary finds nothing.

**#638 and #707 closed.** #638's eur/tix indexes shipped in #838. #707 was resolved a different way than it
proposed — key 3 was dropped from `page_cmp` outright rather than made consistent — and the closure records
what that does *not* cover: the SQL path still carries `prefer_score` as its third ORDER BY term.

**101 broken relative links repaired.** Moving a doc into `done/` shifts every relative path a level, and 23 of
the breaks predated this pass at the same depth. Six remain, pointing at files that genuinely do not exist;
they are left rather than guessed at.

## Fifteen new issues, #846–#860

Most are remainders extracted from docs that shipped. Four came out of measurement done in this pass, and those
are the ones worth reading:

- **#859 — a 3-byte needle is one trigram and needs no verification.** `narrow_rec` marks every text needle of
  3+ bytes loose; at exactly 3 bytes the trigram posting *is* the containment set. **Prototyped: `o:the`
  783.9 µs → 168.5 µs (4.7×), `o:tar` 9.3×, 0 of 104 row-identity cells changed, full suite green.** One guard.
- **#858 — 1-byte needles have no index at all** and lose memoization too, so `o:s` costs **1.16 ms** — the
  engine's actual slow tail, fifteen times #856's whole population. Two candidate fixes, neither measured.
- **#860 — the breadth guard discards exact narrowings, and is masking a real bug.** `o:the or o:you` throws
  away a 23,675-card exact union against a 23,631 threshold, 44 cards short. Relaxing it is worth 4.4× — but it
  **fails `fuzz_row_identity_matches_reference`** on a filter containing no text, which means some narrowing
  already over-claims tightness and the guard has been hiding it. That is a latent correctness bug.
- **#856/#857 — printing membership is computed exactly, discarded, then re-derived per printing.** Split along
  reach: #857 merges the sorted candidate list (`GatheredScan` only, 6.5×), #856 keeps the general bitmap route
  for `StreamedSelect`.

## Measurements, and four claims withdrawn

Every performance figure in the new docs is measured on `main` post-stack, and several corrected claims I had
made earlier in the same pass:

- **#856's "~8×" was withdrawn.** It was a *forced-trial loop-time* ratio; the picked path is 3.8×, and the
  population contains **no slow queries** (max 78.5 µs against an overall p99 of 216 µs), so it is a ~1%
  aggregate rather than a latency fix.
- **"The case rests on the per-query tail"** — asserted, not measured, and false. Replaced with the
  distribution.
- **#856's design changed** from a bitmap to a merge once `set_codes` turned out to already hold the sorted
  list — and #857's own measurement showed the merge is O(matches) where a probe is O(span).
- **#859's estimate was 3–4×; it measured 4.7×**, because I derived the emit floor from `name:the`, which was
  itself paying the same defect.

Two measurement traps are recorded at the kernels that produced them: a counting kernel reads density-flat
because the compiler predicates it branch-free, and a stride model made a merge pay to skip candidates that
cannot exist.

## Committed tooling

- `scripts/bench_membership_waste.py` — sizes #856/#857's population, with the latency-percentile table that
  caught the tail claim.
- `scripts/bench_short_needle_cliff.py` — the needle-length cliff, including the `Or` shapes that surfaced #860.
- `card_engine/src/bench_membership_check.rs` — three candidate membership routes, with the two wrong kernels
  kept and labelled.
