### PR TITLE
Engine: Index 1-Byte Name Needles, and Complement Them Tightly

### DIFF
--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -1260,6 +1260,69 @@ fn build_name_bigram_index(cards: &[OracleCard]) -> NameBigramIndex {
     idx
 }
 
+/// Exact 1-byte name containment — the tier below `NameBigramIndex`, and the reason it exists is
+/// traffic rather than symmetry.
+///
+/// A bare query term parses to `card_name` contains (`parse_scryfall_query("s")`), and the UI searches
+/// on every keystroke behind a 50 ms debounce, so a ONE-CHARACTER name needle is the first query of
+/// every search session a user makes. It was also the only text tier with no index at all: three bytes
+/// narrow through `name_trigram`, two resolve exactly through `name_bigrams`, and one fell through to a
+/// full residual scan over every card — 446 µs against `name:so`'s 8 µs, a 54x cliff at the one length
+/// every search passes through.
+///
+/// Containment IS byte membership for a 1-byte needle, so the tier lookup is the complete answer and
+/// the narrowing is TIGHT — the same argument `name_bigrams` makes one length up.
+///
+/// Two tiers, not three: the corpus has 51 distinct bytes in folded names, and the cheaper-of-two split
+/// lands at 25 planes / 26 posting lists for **109 KB**. A complement tier (store the cards LACKING the
+/// byte) was measured and never wins here — the most common byte is `' '` at 92%, whose 8% complement is
+/// 2,520 ids = 5 KB against a 3,939 B plane. It would win on `oracle_text`, where 19 bytes exceed 75%,
+/// which is one reason this is names-only for now.
+#[derive(Archive, Serialize, Deserialize, Default)]
+struct NameUnigramIndex {
+    /// Sparse tier: byte → ascending card ids, u16 for the same reason as the bigram index.
+    postings: HashMap<u8, Vec<u16>>,
+    /// Dense tier: byte → plane index into `plane_words`.
+    plane_of: HashMap<u8, u32>,
+    /// `plane_of.len()` × `words_per_plane(n_cards)`, flattened plane-major.
+    plane_words: Vec<u64>,
+    n_cards: u32,
+}
+
+fn build_name_unigram_index(cards: &[OracleCard]) -> NameUnigramIndex {
+    let mut lists: HashMap<u8, Vec<u32>> = HashMap::new();
+    for (i, card) in cards.iter().enumerate() {
+        // Folded (#649), matching what `name_trigram` / `name_bigrams` index and what the walk evaluates
+        // — that agreement is what makes the tight narrowing sound.
+        let mut seen = [false; 256];
+        for &b in card.card_name_folded.as_str().as_bytes() {
+            if !seen[b as usize] {
+                seen[b as usize] = true;
+                lists.entry(b).or_default().push(i as u32);
+            }
+        }
+    }
+    let wpp = cards.len().div_ceil(64);
+    let plane_bytes = wpp * 8;
+    let mut idx = NameUnigramIndex { n_cards: cards.len() as u32, ..Default::default() };
+    // u16 ids require the card count to fit; past that every byte promotes to a plane, which is valid at
+    // any count. Same rule as the bigram index.
+    let u16_ok = cards.len() <= u16::MAX as usize + 1;
+    for (b, ids) in lists {
+        if u16_ok && ids.len() * 2 <= plane_bytes {
+            idx.postings.insert(b, ids.into_iter().map(|c| c as u16).collect());
+        } else {
+            let plane = idx.plane_of.len() as u32;
+            idx.plane_of.insert(b, plane);
+            idx.plane_words.resize((plane as usize + 1) * wpp, 0);
+            for c in ids {
+                idx.plane_words[plane as usize * wpp + (c >> 6) as usize] |= 1u64 << (c & 63);
+            }
+        }
+    }
+    idx
+}
+
 // Named lifetime (not elided/HRTB) so get_text may return text borrowed from the
 // string table rather than from the card itself.
 fn build_trigram_index<'a, T>(rows: &'a [T], get_text: impl Fn(&'a T) -> &'a str) -> SortedTrigramIndex {
@@ -3477,6 +3540,7 @@ struct CardIndexes {
     // `PrintingValueIndex` the three range dimensions use, so it costs a builder call and ~389 KB.
     rarity_printing_ordered: PrintingValueIndex,
     name_bigrams:   NameBigramIndex,           // card space: exact 2-byte name containment (#639)
+    name_unigrams:  NameUnigramIndex,          // card space: exact 1-byte name containment (#858)
     legal_divergent: Vec<u16>,                // card space: ids with divergent legality (#630 phase 2), postings not a plane — see build_divergent_ids
     arith_tuple:    ArithTupleIndex,           // card space: joint (cmc,power,toughness,loyalty) postings for arith predicates (#743)
 }
@@ -3863,8 +3927,8 @@ fn tight_narrow_space(f: &FilterExpr) -> Option<bool> {
         FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => Some(false),
         // Exact names resolve exactly through the sorted name permutation.
         FilterExpr::ExactName(_) => Some(false),
-        // 2-byte name needles resolve exactly through the bigram index.
-        FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 2 => Some(false),
+        // 1- and 2-byte name needles resolve exactly through the unigram / bigram indexes.
+        FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() <= 2 => Some(false),
         // Ge-only guard is deliberate (#700): narrow_rec's CollectionCmp arm
         // now also narrows Eq/Gt through the same containment postings, but
         // only loosely — the postings prove `contains(value)`, not the
@@ -4375,6 +4439,28 @@ fn narrow_rec(
             let lo = perm.partition_point(|cid| name_of(cid) < needle.as_str());
             let width = perm[lo..].partition_point(|cid| name_of(cid) == needle.as_str());
             let ids: Vec<u32> = perm[lo..lo + width].iter().map(|x| u32::from(*x)).collect();
+            Narrowed::tight(Candidates::Cards(ids))
+        }
+
+        FilterExpr::TextContains { field: TextSearchField::NameLower, word } if word.len() == 1 => {
+            // A 1-byte needle's containment IS byte membership, so the tier lookup is the complete
+            // answer — tight, exactly as the 2-byte arm below. A byte absent from the index appears in
+            // no name, so the empty narrowing is exact too. (#858)
+            let idx = &indexes.name_unigrams;
+            if u32::from(idx.n_cards) as usize != n_cards {
+                return None; // archive without unigrams for this store
+            }
+            let b = word.as_bytes()[0];
+            if let Some(p) = idx.plane_of.get(&b) {
+                let wpp = n_cards.div_ceil(64);
+                let start = u32::from(*p) as usize * wpp;
+                let bits: Vec<u64> = idx.plane_words[start..start + wpp].iter().map(|w| u64::from(*w)).collect();
+                return Narrowed::tight(Candidates::CardBits(bits));
+            }
+            let ids: Vec<u32> = idx
+                .postings
+                .get(&b)
+                .map_or_else(Vec::new, |v| v.iter().map(|x| u32::from(u16::from(*x))).collect());
             Narrowed::tight(Candidates::Cards(ids))
         }
 
@@ -11273,11 +11359,10 @@ const ARCHIVE_MAGIC: [u8; 8] = *b"ATCARDS\0";
 /// catch (e.g. reordering same-size fields, changing an index type) — and on
 /// any FLAVOR_FP_FEATURES change: archived fingerprints are built with that
 /// table, so a new table reading old fingerprints breaks the superset test.
-// Stack layer 12: `PairTotals` -- exact totals for PAIRS of low-cardinality values -- is a new
-// archived type, so a store built against the previous layer must fail the header check and be
-// rebuilt rather than be read as garbage. Numbered by stack patch; the check is EQUALITY, so the
-// invariant is only that a value is never reused for a different layout.
-const ARCHIVE_FORMAT_VERSION: u32 = 2026080512;
+// `NameUnigramIndex` (#858) is a new archived type, so a store built before it must fail the header
+// check and be rebuilt rather than be read as garbage. Dated 2026-08-06, patch 01; the check is
+// EQUALITY, so the invariant is only that a value is never reused for a different layout.
+const ARCHIVE_FORMAT_VERSION: u32 = 2026080601;
 const ARCHIVE_HEADER_LEN: usize = 16;
 
 fn archive_header() -> [u8; ARCHIVE_HEADER_LEN] {
@@ -11894,6 +11979,7 @@ impl QueryEngine {
             value_totals,
             pair_totals,
             name_bigrams:   build_name_bigram_index(&cards),
+            name_unigrams:  build_name_unigram_index(&cards),
             legal_divergent: build_divergent_ids(&cards),
             arith_tuple:    build_arith_tuple_index(&cards),
         };

--- a/card_engine/src/lib.rs
+++ b/card_engine/src/lib.rs
@@ -3917,6 +3917,23 @@ fn or_all(mut sets: Vec<Narrowed>, n: usize) -> Option<Narrowed> {
     Some(Narrowed { set, tight, proven: 0 })
 }
 
+/// Can `f` never evaluate to `Tri::Null` on any card? Only then is the complement of a tight narrowing
+/// exact, because a Null card satisfies neither `f` nor `Not(f)` yet still lands in the complement.
+///
+/// Deliberately tiny, and conservative by default: a `false` answer only costs the `Not` arm its tight
+/// marking, while a wrong `true` drops or invents rows. The one field that qualifies today is
+/// `NameLower`, and the proof is one line in `str_val_of` -- it returns `StrVal::Known(...)`
+/// UNCONDITIONALLY, where oracle goes through `opt_sv` and flavor through `map_or(StrVal::PDep, ..)`.
+/// An empty name is still `Known("")`, and `"".contains(needle)` is `false` rather than Null, so the
+/// empty case needs no carve-out.
+///
+/// Before extending this: nullable fields are a repeat source of exactly this bug --
+/// `tight_narrow_space` had to drop `released_at` for being nullable, and excludes price for the same
+/// class of reason. Add a field only with the `str_val_of` / accessor line that proves totality.
+fn never_null(f: &FilterExpr) -> bool {
+    matches!(f, FilterExpr::TextContains { field: TextSearchField::NameLower, .. })
+}
+
 /// Static answer to "could narrow_rec(f) produce a tight set, and in which
 /// space?" — Some(true) = printing space, Some(false) = card space, None =
 /// never tight. Conservative: loose-by-construction sources and mixed-space
@@ -5185,6 +5202,21 @@ fn narrow_rec(
             let (printing_space, domain) = (n.set.is_printing_space(), if n.set.is_printing_space() { n_printings } else { n_cards });
             let mut bits = n.set.into_bits(domain);
             complement_bits(&mut bits, domain);
+            // The complement of a tight set is EXACT whenever the inner predicate can never evaluate
+            // `Tri::Null` — the one thing the loose marking was protecting against, since a Null card
+            // satisfies neither the predicate nor its negation but lands in the complement anyway.
+            //
+            // That matters most where the inner set is SPARSE: its complement is then ~the whole corpus,
+            // which the breadth guard discards for a loose set, so `-name:q` fell back to a full scan
+            // with `card_pass` on every card (463 us) while `-name:e` -- complement of a DENSE set, so
+            // only 16% of cards -- stayed under the guard and cost 76 us. Marking the exact case tight
+            // keeps the broad complement (via #860's tight exemption) and skips verification entirely.
+            //
+            // Printing space is excluded: `into_card_space` drops tightness on projection, so a tight
+            // printing-space complement would not survive to the walk as one anyway.
+            if !printing_space && never_null(inner) {
+                return Narrowed::tight(Candidates::CardBits(bits));
+            }
             Narrowed::loose(if printing_space { Candidates::PrintingBits(bits) } else { Candidates::CardBits(bits) })
         }
 
@@ -8280,9 +8312,14 @@ fn prepare_candidates(ctx: &QueryCtx, params: &QueryParams, filter: &mut FilterE
     // reused across queries (thread-local), same as the streamed counts
     // buffer.
     let candidate_cards: Option<Vec<u32>> = match plane {
+        // The 7/8 breadth filter has the same inverted reasoning as `narrow_candidates_exact`'s 3/4 guard
+        // (#860): a near-total LOOSE list costs materialization and still verifies every card, but a
+        // near-total TIGHT one removes verification altogether, which is the larger term. `-name:q` is the
+        // case -- its complement is 30,918 of 31,508 cards, so it was dropped here, `all_match_known` was
+        // then correctly cleared, and the query fell back to a full scan with `card_pass` on every card.
         None => raw_candidates
             .map(|c| c.into_cards(offsets, &indexes.printing_to_card))
-            .filter(|v| v.len() < cards.len() - cards.len() / 8),
+            .filter(|v| residual_exact || v.len() < cards.len() - cards.len() / 8),
         Some(expr) => {
             thread_local! {
                 static PLANE_BITMAP: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     and_child_rank, assign_name_ranks,
     build_numeric_index, build_oracle_text_index, build_tag_index, build_trigram_index,
     build_rarity_index, build_flavor_index, build_hybrid_tag_index, bitmap_beats_postings, HybridTagIndex, build_sort_permutations,
-    assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
+    assign_artwork_groups, build_artwork_base_from, build_bit_planes, build_border_printing_planes, build_rarity_printing_planes, build_divergent_ids, build_name_bigram_index, build_name_unigram_index, build_printing_to_card, flavor_fingerprint, flavor_match_sets,
     cards_of_printings, count_common_keywords, count_common_types,
     build_artist_index, build_printing_value_index, build_arith_tuple_index, is_arith_tuple_route, range_candidates, narrow_candidates, narrow_candidates_exact, rarity_candidates,
     range_too_broad_to_narrow, run_query, run_query_with_plan, explain, explain_analyze, AcquireFacts, PlanEstimate, PlanTrial,
@@ -293,6 +293,7 @@ fn store_of(cards: Vec<OracleCard>, printing_counts: &[usize], vocab: VocabInter
         // safe here -- the border-scatter loop skips every printing regardless.
         planes: build_bit_planes(&cards, &printings, &offsets, &[]),
         name_bigrams: build_name_bigram_index(&cards),
+        name_unigrams: build_name_unigram_index(&cards),
         legal_divergent: build_divergent_ids(&cards),
         sort_perms: build_sort_permutations(&cards),
         max_artwork_groups: artwork_groups.iter().copied().max().unwrap_or(0),
@@ -2454,6 +2455,7 @@ fn fuzz_store_n(rng: &mut rand::rngs::SmallRng, ncards: usize) -> CardData {
     // narrowing and the full-scan memoization; flavor is the printing-space CSR bind() resolves against.
     data.indexes.name_trigram = build_trigram_index(&data.cards, |c| c.card_name_folded.as_str());
     data.indexes.name_bigrams = build_name_bigram_index(&data.cards);
+    data.indexes.name_unigrams = build_name_unigram_index(&data.cards);
     data.indexes.oracle_trigram = build_oracle_text_index(&data.cards, &data.strings);
     data.indexes.flavor = build_flavor_index(&data.printings, &data.strings);
     data.indexes.planes = build_bit_planes(&data.cards, &data.printings, &data.offsets, &data.strings);
@@ -6240,6 +6242,7 @@ fn bench_checked_vs_unchecked_access() {
     let indexes = CardIndexes {
         artwork_base,
         name_trigram:   build_trigram_index(&cards, |c| c.card_name_folded.as_str()),
+        name_unigrams:  build_name_unigram_index(&cards),
         oracle_trigram: build_oracle_text_index(&cards, &strings),
         cmc:            build_numeric_index(&cards, |c| c.cmc.map(|v| v as i16)),
         power:          build_numeric_index(&cards, |c| c.creature_power.map(|v| v as i16)),
@@ -9312,7 +9315,9 @@ fn not_narrows_only_tight_children() {
     let goblin = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".into(), value_id: goblin_id };
     let rarity = || FilterExpr::NumericCmp { lhs: NumExpr::Field(NumField::RarityInt), op: CmpOp::Eq, rhs: NumExpr::Const(0.0) };
     // 1-char: below even the bigram floor, so genuinely unindexable.
-    let name1 = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() };
+    // A sub-trigram ORACLE needle: names have unigram/bigram indexes (#858, #639) so they narrow
+    // tightly, but oracle text has neither and still cannot narrow at all.
+    let name1 = || FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "q".into() };
 
     // Tight leaf → complement narrows, loose, and covers every ¬-match.
     let n = rec(&FilterExpr::Not(Box::new(goblin()))).expect("Not(subtype) must narrow");
@@ -9343,7 +9348,7 @@ fn not_narrows_only_tight_children() {
     }
 
     // Genuinely loose children with no dedicated Not arm still block it.
-    assert!(rec(&FilterExpr::Not(Box::new(name1()))).is_none(), "sub-bigram text cannot narrow at all");
+    assert!(rec(&FilterExpr::Not(Box::new(name1()))).is_none(), "sub-trigram oracle text cannot narrow at all");
     let double_not = FilterExpr::Not(Box::new(FilterExpr::Not(Box::new(goblin()))));
     assert!(rec(&double_not).is_none(), "complements are loose, so double negation stops narrowing");
 
@@ -9372,9 +9377,9 @@ fn or_composes_plane_and_complement_children() {
     let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
     assert_eq!(cand, vec![0, 1, 3], "goblins ∪ green");
 
-    // An unindexable child still vetoes: nothing can represent it (1-char is
-    // below even the bigram floor).
-    let or = FilterExpr::Or(vec![goblin(), FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() }]);
+    // An unindexable child still vetoes: nothing can represent it. Oracle rather than name, since a
+    // 1-byte name needle now resolves exactly through the unigram index (#858).
+    let or = FilterExpr::Or(vec![goblin(), FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "q".into() }]);
     assert!(rec(&or).is_none());
 }
 
@@ -9431,7 +9436,12 @@ fn not_over_partial_and_is_blocked() {
     let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
     let goblin_id = archived.coll_vocab.iter().position(|s| s.as_str() == "goblin").map(|i| i as u16);
     let goblin = || FilterExpr::CollectionCmp { field: CollField::Subtypes, op: CmpOp::Ge, value: "goblin".into(), value_id: goblin_id };
-    let unindexable = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() };
+    // A 4+ byte name needle: unrepresentable for the Not arm (trigram sets are supersets, so
+    // `tight_narrow_space` declines it) while still evaluating cleanly FALSE for every card, which is what
+    // the total below pins. Not a 1-byte needle any more -- those resolve exactly through the unigram
+    // index now (#858) -- and not an oracle needle either, since this fixture leaves oracle text unset,
+    // making it Null rather than False and changing what the negation matches.
+    let unindexable = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "qqqq".into() };
 
     // Static check: And with an unrepresentable child can't be tight → Not
     // must refuse to narrow at all.
@@ -9439,7 +9449,7 @@ fn not_over_partial_and_is_blocked() {
     assert!(super::narrow_rec(&not_partial, &archived.indexes, &archived.offsets, &archived.cards, true).is_none());
 
     // Dynamic check via run_query: totals must equal brute force. Every card
-    // fails `name:q` here, so every card matches the negation — a complement
+    // fails `name:qqqq` here, so every card matches the negation — a complement
     // of the goblins-only set would have dropped cards 0 and 1.
     let brute = archived
         .cards
@@ -9453,7 +9463,7 @@ fn not_over_partial_and_is_blocked() {
     let mut f = FilterExpr::Not(Box::new(FilterExpr::And(vec![goblin(), unindexable()])));
     let (total, _) = run_query(&QueryCtx::from(archived), &mut f, None, "card", "default", "edhrec", "asc", 100, 0);
     assert_eq!(total, brute);
-    assert_eq!(total, 6, "every card matches -(goblin and name:q)");
+    assert_eq!(total, 6, "every card matches -(goblin and name:qqqq)");
 }
 
 
@@ -9525,9 +9535,56 @@ fn name_bigrams_tiers_and_exactness() {
     // Absent bigram: exact empty (no name contains it), not None.
     let n = rec("vw").expect("absent bigram is an exact empty narrowing");
     assert_eq!(n.set.len(), 0);
-    // 1-char stays unindexable.
-    let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: "z".to_string() };
+    // 1-char is indexed too now (#858) -- see name_unigrams_tiers_and_exactness for its tiers. What
+    // stays unindexable is a sub-trigram ORACLE needle, which has no unigram/bigram index.
+    let f = FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "z".to_string() };
     assert!(super::narrow_rec(&f, &archived.indexes, &archived.offsets, &archived.cards, false).is_none());
+}
+
+/// The 1-byte name tier: both storage tiers, exactness against brute-force `contains`, and the empty
+/// case. Mirrors `name_bigrams_tiers_and_exactness` one length down (#858).
+#[test]
+fn name_unigrams_tiers_and_exactness() {
+    // 4,096 cards: every name contains 'z' (dense -> plane tier); every 64th contains 'q' (64 entries
+    // x 2 B <= the 512 B plane cost at this store size -> u16 postings tier). No name contains 'v'.
+    // Digits are unavoidable in the unique suffix, so the probe bytes are letters only.
+    let mut vocab = VocabInterner::new();
+    let cards: Vec<OracleCard> = (0..4096u32).map(|i| {
+        let mut c = stub_card(u128::from(i) + 1, TYPE_CREATURE, &[], &mut vocab);
+        let name = if i % 64 == 0 { format!("az q{i}") } else { format!("az b{i}") };
+        c.card_name_lower = InlineStr::from_str(&name);
+        c.card_name_folded = c.card_name_lower;
+        c
+    }).collect();
+    let data = store_of(cards, &vec![1usize; 4096], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let idx = &archived.indexes.name_unigrams;
+
+    assert!(idx.plane_of.get(&b'z').is_some(), "a byte in 4,096 names must promote to a plane");
+    assert!(idx.postings.get(&b'q').is_some(), "a byte in 64 names stays a posting list");
+
+    let rec = |w: &str| {
+        let f = FilterExpr::TextContains { field: TextSearchField::NameLower, word: w.to_string() };
+        super::narrow_rec(&f, &archived.indexes, &archived.offsets, &archived.cards, false)
+    };
+    // Dense tier: exact bitmap, tight.
+    let n = rec("z").expect("dense byte narrows");
+    assert!(n.tight);
+    assert!(matches!(n.set, Candidates::CardBits(_)));
+    assert_eq!(n.set.len(), 4096);
+    // Sparse tier: exact vec, tight, and byte-for-byte the contains() answer.
+    let n = rec("q").expect("sparse byte narrows");
+    assert!(n.tight);
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
+    let brute: Vec<u32> = archived.cards.iter().enumerate()
+        .filter(|(_, c)| c.card_name_folded.as_str().contains('q'))
+        .map(|(i, _)| i as u32)
+        .collect();
+    assert_eq!(cand, brute, "byte membership IS containment for 1-byte needles");
+    // Absent byte: exact empty, not None -- the same convention the bigram tier uses.
+    let n = rec("v").expect("absent byte is an exact empty narrowing");
+    assert_eq!(n.set.len(), 0);
 }
 
 // The motivating composition: `name:xx or name:yy` previously full-scanned

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -9541,6 +9541,54 @@ fn name_bigrams_tiers_and_exactness() {
     assert!(super::narrow_rec(&f, &archived.indexes, &archived.offsets, &archived.cards, false).is_none());
 }
 
+/// The complement of a 1-byte NAME needle is exact, so the `Not` arm may mark it tight — and the
+/// complement of an ORACLE needle may not, because oracle text can be absent and a Null card satisfies
+/// neither the predicate nor its negation. Pins both sides of `never_null` (#858).
+#[test]
+fn not_over_unigram_is_tight_but_oracle_stays_loose() {
+    let mut vocab = VocabInterner::new();
+    // 'q' in every 8th name; no name contains 'v'. Oracle text left unset, which is what makes the
+    // oracle side Null rather than false.
+    let cards: Vec<OracleCard> = (0..256u32)
+        .map(|i| {
+            let mut c = stub_card(u128::from(i) + 1, TYPE_CREATURE, &[], &mut vocab);
+            let name = if i % 8 == 0 { format!("aq b{i}") } else { format!("ab c{i}") };
+            c.card_name_lower = InlineStr::from_str(&name);
+            c.card_name_folded = c.card_name_lower;
+            c
+        })
+        .collect();
+    let data = store_of(cards, &vec![1usize; 256], vocab);
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+    let rec = |f: &FilterExpr| super::narrow_rec(f, &archived.indexes, &archived.offsets, &archived.cards, true);
+
+    let name_q = || FilterExpr::TextContains { field: TextSearchField::NameLower, word: "q".into() };
+    let n = rec(&FilterExpr::Not(Box::new(name_q()))).expect("-name:q must narrow");
+    assert!(n.tight, "name is never Null, so the complement of a tight 1-byte set is exact");
+    let cand = n.set.into_cards(&archived.offsets, &archived.indexes.printing_to_card);
+    let brute: Vec<u32> = archived
+        .cards
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| !c.card_name_folded.as_str().contains('q'))
+        .map(|(i, _)| i as u32)
+        .collect();
+    assert_eq!(cand, brute, "-name:q must be exactly the cards whose name lacks 'q'");
+
+    // An absent byte complements to every card, and that must stay exact rather than trip a breadth guard.
+    let name_v = FilterExpr::TextContains { field: TextSearchField::NameLower, word: "v".into() };
+    let n = rec(&FilterExpr::Not(Box::new(name_v))).expect("-name:v must narrow");
+    assert!(n.tight);
+    assert_eq!(n.set.len(), archived.cards.len(), "no name contains 'v', so its negation is every card");
+
+    // The other side of the gate: oracle text can be absent, so its complement is NOT exact. It cannot
+    // narrow at all here (no sub-trigram oracle index), which is the conservative outcome either way.
+    let oracle_q = FilterExpr::TextContains { field: TextSearchField::OracleTextLower, word: "q".into() };
+    assert!(!super::never_null(&oracle_q), "oracle text is nullable, so its negation must not be tight");
+    assert!(rec(&FilterExpr::Not(Box::new(oracle_q))).is_none());
+}
+
 /// The 1-byte name tier: both storage tiers, exactness against brute-force `contains`, and the empty
 /// case. Mirrors `name_bigrams_tiers_and_exactness` one length down (#858).
 #[test]


### PR DESCRIPTION
Addresses the 1-byte name tier of #858. Stacked on #862; retarget as its parents merge.

`name:s` cost **446 µs** against `name:so`'s 8 µs — a 54× cliff at exactly one character, because that
was the only text tier with no index at all. Three bytes narrow through `name_trigram`, two resolve
exactly through `name_bigrams`, and one fell through to a full residual scan of every card. It also lost
memoization, because `memoize_text_predicates` is gated on `trigram_candidates` returning `Some`.

**This is not a rare shape.** A bare query term parses to `card_name` contains — verified,
`parse_scryfall_query("s")` — and the UI searches on every keystroke behind a 50 ms debounce
(`app.js` `handleSearch`). So a one-character name needle is the **first query of every search session a
user makes**, and it was the slowest thing the engine did on the name path.

## The index

`NameUnigramIndex` mirrors `NameBigramIndex` one length down: 1-byte key, u16 postings or a plane,
cheaper-of-two per value. Containment **is** byte membership for a 1-byte needle, so the tier lookup is
the complete answer and `narrow_rec` marks it **tight** — the same argument the bigram arm makes — after
which `card_pass` never runs.

**109 KB, 0.155% of the archive**, measured, matching the prediction from counting the corpus: 51 distinct
bytes in folded names, splitting 25 planes / 26 posting lists. A third *complement* tier was measured and
never wins for names — the most common byte is `' '` at 92%, whose 8% complement is 2,520 ids = 5 KB
against a 3,939 B plane. It would win on oracle text, where 19 bytes exceed 75%.

**Oracle and flavor are deliberately excluded.** A single-letter oracle search is semantically useless
*and* only reachable by typing `o:` first, so it carries a fraction of bare-term name traffic. The builder
is field-shaped, so adding them later is a build-site change; the sizing is known at 162 KB for oracle
with the complement tier.

## Negations, which needed two gates

`-name:q` cost 463 µs where `name:q` cost 5. The mechanism already existed — the `Not` arm already
inverts the bitmap — and the only thing making it slow was the `loose` marking.

**Gate 1: `never_null`.** The loose marking exists solely for Null safety, since a card where the inner
predicate is Null satisfies neither it nor its negation yet lands in the complement. So the complement of
a tight set is exact whenever the inner can never be Null. `never_null` admits exactly one thing today,
`TextContains{NameLower}`, and the proof is one line in `str_val_of`: NameLower returns `StrVal::Known`
**unconditionally**, where oracle goes through `opt_sv` and flavor through `map_or(StrVal::PDep, ..)`. An
empty name is still `Known("")` and `"".contains(needle)` is `false` rather than Null, so the empty case
needs no carve-out.

Deliberately tiny: a `false` answer only costs a tight marking, a wrong `true` drops or invents rows, and
nullable fields are a repeat source of this bug — `tight_narrow_space` had to drop `released_at` for being
nullable and excludes price for the same class of reason.

**Gate 2: the 7/8 filter.** Gate 1 fixed *dense* complements and did nothing for sparse ones, which is
what pointed here. `-name:e` (16% complement) went 75.9 → 15.0 µs while `-name:q` (98%) did not move: it
narrowed now, but `prepare_candidates`' 7/8 breadth filter dropped the list and #862's fix then correctly
cleared `all_match_known`, so it fell back to a full scan. So the 7/8 filter takes the same tightness
exemption the 3/4 guard took in #862, for the same reason — a near-total *loose* list costs materialization
and still verifies everything, a near-total *tight* one removes verification altogether. This is the item
#862 listed as left for later.

## Measured

`routed_ns`, production corpus, release build:

| query | before | after | |
| --- | --: | --: | --: |
| `name:s` | 446.6 µs | **64.0 µs** | 7.0× |
| `-name:q` | 463.0 | **91.2** | 5.1× |
| `-name:z` | 464.4 | **95.8** | 4.8× |
| `-name:s` | 202.5 | **35.7** | 5.7× |
| `-name:e` | 75.9 | **15.3** | 5.0× |

End to end through `engine.query`, min of 9: `name:1` **65×**, `name:q` 51×, `name:s name:z` 16×,
`name:z` 12×, `name:s or name:q` 6.4×, `name:s` 5.9×, `name:s t:creature` 5.0×. Needles of 2+ bytes are
flat at 1.0×, so there is no collateral.

## Verification

- **Rows unchanged: 0 of 144 cells differ** against a baseline captured on this branch with the index
  stashed out — total, row count, and a SHA over the returned identity sequence in order, across
  conjunctions, a disjunction, negations, an absent byte, a digit, and all three distinct-ons at two
  offsets each.
- Every negation total additionally checked against a **brute-force pass over the corpus**.
- **155 tests green in debug**, where `fuzz_row_identity_matches_reference` and
  `force_plan_differential_agreement` run. Clippy clean on all targets.
- Two cells read 1.15–1.18× slower (`o:t`, `ft:the o:the`) on paths this does not touch; `o:t` alone
  spanned 907–1,559 µs across runs today, so they are noise.

## Tests

`name_unigrams_tiers_and_exactness` mirrors the bigram tier test: both tiers, exactness against
brute-force `contains()`, and the absent-byte empty case.
`not_over_unigram_is_tight_but_oracle_stays_loose` pins both sides of `never_null` — `-name:q` is tight
and equals brute-force "lacks q", `-name:v` complements to every card, and an oracle needle is asserted
**not** `never_null` so its negation can never take the tight path.

Four existing tests used a 1-char name needle as their canonical "unindexable" example and needed a new
one, which is the change working. Three take a sub-trigram *oracle* needle. `not_over_partial_and_is_blocked`
takes a 4-byte *name* needle instead: it needs a predicate that is unrepresentable for the `Not` arm **and**
evaluates cleanly *false* for every card, and an oracle needle is *Null* there since that fixture leaves
oracle text unset — which changes what the negation matches, and was what the first attempt got wrong.

`ARCHIVE_FORMAT_VERSION` → `2026080601`: `NameUnigramIndex` is a new archived type, so an older store must
fail the header check and be rebuilt rather than read as garbage.
