### PR TITLE
Docs: Move the Text-Tier Issues to done/, and Record What #858 Did Not Cover

### DIFF
--- a/docs/issues/done/00858-engine-short-needle-text-scan.md
+++ b/docs/issues/done/00858-engine-short-needle-text-scan.md
@@ -1,11 +1,43 @@
 # Single-character text needles have no index and scan every card — 1.16 ms for `o:s`
 
-Status: **problem measured, neither fix measured.** Filed as
-[#858](https://github.com/jbylund/sylvan_librarian/issues/858).
+**DONE for the name tier — shipped in [#863](https://github.com/jbylund/sylvan_librarian/pull/863)**
+(2026-08-07), as Fix A below. `name:s` **446.6 µs → 58.5 µs** on merged `main`, with `name:1` 65× and
+`name:q` 51× end to end. 109 KB, 0.155% of the archive, matching the prediction exactly.
 
-This is the engine's actual slow tail. It is worse than anything in
-[#852](00852-engine-compose-acquire-p3-p4-ranking.md)'s or
-[#856](00856-engine-compose-membership-bittest.md)'s populations — #856's whole population tops out at 78.5 µs,
+`NameUnigramIndex` mirrors `NameBigramIndex` one length down, and the narrowing is **tight** because
+containment *is* byte membership. Negations came along too — `-name:q` 463 → 91 µs — via a `never_null` gate
+(names are the one text field whose `StrVal` is unconditionally `Known`) plus the 7/8 filter's tightness
+exemption that [#860](00860-engine-broad-tight-narrowing-discarded.md) had deferred.
+
+## What was NOT done, and why
+
+**Oracle and flavor 1-byte needles.** Deliberate scope call, not an oversight. A bare query term parses to
+`card_name` contains, so `name:s` is the first query of every search session; `o:s` is only reachable by typing
+`o:` first and is semantically useless besides. Sizing is recorded below if that judgement ever changes:
+**162 KB** for oracle with the cheaper-of-three encoding, and the builder is field-shaped so it is a build-site
+change rather than a rewrite.
+
+**They remain the measured slow tail**, and nothing tracks them now that this doc is closed:
+
+| query | on merged `main` |
+| --- | --: |
+| `o:s` | **1,168.7 µs** |
+| `ft:s` | **993.6 µs** |
+
+`ft:` is the more interesting of the two, and was never argued against — flavor has a CSR over ~29k distinct
+*texts* rather than 31.5k cards, so the index would be smaller and the scan shorter. That is a different shape
+from what shipped here and would want its own issue.
+
+**Fix B, the blob + `memmem`.** Untouched, and its case narrowed while this was open:
+[#859](00859-engine-exact-trigram-no-verify.md) removed `o:the` from it by making 3-byte needles exact, so B is
+now justified only on needles of 4+ bytes, where the trigram intersection really is a superset and verification
+really does run.
+
+---
+
+This was the engine's actual slow tail. It is worse than anything in
+[#852](../00852-engine-compose-acquire-p3-p4-ranking.md)'s or
+[#856](../00856-engine-compose-membership-bittest.md)'s populations — #856's whole population tops out at 78.5 µs,
 and `o:s` is **fifteen times** that on its own.
 
 ## Measured
@@ -23,7 +55,7 @@ and `o:s` is **fifteen times** that on its own.
 | `o:the` | 732.1 µs | cards | 16,240 |
 
 A **54× cliff** between one character and two. And `o:s` at 1.16 ms lines up with the overall max (~1,133 µs)
-in [#856's latency profile](00856-engine-compose-membership-bittest.md#it-touches-no-slow-queries-and-that-is-structural),
+in [#856's latency profile](../00856-engine-compose-membership-bittest.md#it-touches-no-slow-queries-and-that-is-structural),
 which is how we know this shape is the tail rather than merely slow in isolation.
 
 ## Why: three tiers, and the bottom one is missing
@@ -55,7 +87,7 @@ lowers to `memchr`, which over a ~20-byte name is a few cycles. So the search is
 - **The row stride.** `AOracleCard` is **288 bytes** (measured with `size_of`), and `card_name_folded` is an
   `InlineStr<61>` (62 bytes) inline in it. Reading every name therefore walks **9.07 MB** of card rows to touch
   **1.95 MB** of name field, of which the actual name content is ~630 KB. Same shape as
-  [the `APrinting` width problem](local-engine-aprinting-layout.md), one struct over.
+  [the `APrinting` width problem](../local-engine-aprinting-layout.md), one struct over.
 - **Per-card dispatch** through `FilterExpr` 31,508 times.
 
 ## Fix A: a unigram index, extending the tier that already works
@@ -86,7 +118,7 @@ and cuts traffic from 9.07 MB to ~630 KB.
 Two notes for whoever builds it:
 
 - memmem yields **ascending** positions, so a forward pointer over the offsets beats a binary search per match —
-  the same trick [#857](00857-engine-membership-merge-sorted-list.md) uses, and it matters here because
+  the same trick [#857](../00857-engine-membership-merge-sorted-list.md) uses, and it matters here because
   `name:s` matches 63% of cards.
 - Once a card matches, restart past the end of that name. That makes the work one short find per card rather
   than one per occurrence.
@@ -113,20 +145,20 @@ comparison before committing.
 
 One thing that comparison must model, because this session already produced a wrong answer by missing it: a
 1-char needle matching 63% of cards is a **branch-unpredictable** workload, where a scan stops being purely
-bandwidth-bound. [#856's density curve](00856-engine-compose-membership-bittest.md#what-the-bitmap-probe-costs)
+bandwidth-bound. [#856's density curve](../00856-engine-compose-membership-bittest.md#what-the-bitmap-probe-costs)
 shows the same effect costing 2–6× on a kernel that looked flat when measured only at the extremes.
 
 ## Related
 
-- [local-engine-aprinting-layout.md](local-engine-aprinting-layout.md) — the same row-width-versus-scan problem
+- [local-engine-aprinting-layout.md](../local-engine-aprinting-layout.md) — the same row-width-versus-scan problem
   for `APrinting`. Note its "don't implement" verdict was about a *misattributed* 55%; the mechanism it
   describes is real and this is another instance of it.
-- [done/00663-engine-oracle-word-index.md](done/00663-engine-oracle-word-index.md) — where the blob-plus-memmem
+- [done/00663-engine-oracle-word-index.md](00663-engine-oracle-word-index.md) — where the blob-plus-memmem
   pattern and its 5–6× came from.
-- [done/00649-accent-insensitive-name-search.md](done/00649-accent-insensitive-name-search.md) — why the scanned
+- [done/00649-accent-insensitive-name-search.md](00649-accent-insensitive-name-search.md) — why the scanned
   field is `card_name_folded` rather than `card_name_lower`.
 - [#859](00859-engine-exact-trigram-no-verify.md) — the tier above: 3-byte needles have an exact index and
   verify anyway, *and* get declined by the same memoize gate that skips 1-byte needles. Independent fix, same
   family.
-- [#856](00856-engine-compose-membership-bittest.md) — the latency profile this is measured against, and the
+- [#856](../00856-engine-compose-membership-bittest.md) — the latency profile this is measured against, and the
   density-curve caution above.

--- a/docs/issues/done/00859-engine-exact-trigram-no-verify.md
+++ b/docs/issues/done/00859-engine-exact-trigram-no-verify.md
@@ -1,10 +1,17 @@
 # A 3-byte needle's trigram set is exact, but `narrow_rec` marks it loose — so every candidate is re-verified
 
-Status: **prototyped and measured 2026-08-06; change reverted, not committed.** Filed as
-[#859](https://github.com/jbylund/sylvan_librarian/issues/859).
+**DONE — shipped in [#862](https://github.com/jbylund/sylvan_librarian/pull/862)** (2026-08-07), alongside
+[#860](00860-engine-broad-tight-narrowing-discarded.md), which had to land with it.
 
-**Measured: `o:the` 783.9 µs → 168.5 µs (4.7×), `o:tar` 9.3×, and 0 of 104 result cells changed.** The full
-engine test suite passes. Details under [Prototyped](#prototyped-and-measured).
+`o:the` **783.9 µs → 163.6 µs** on merged `main`, `o:tar` 9.1×, with 0 of 144 row-identity cells changed and
+the full suite green. The fix was one guard: `narrow_rec`'s text arm now returns `Narrowed::tight` at exactly
+3 bytes instead of `loose`, and the existing `residual_exact` → `all_match_known` → #634 Step 1 chain does the
+rest — `card_pass` stops running entirely.
+
+Two things the estimate got wrong, kept below because both generalize: it predicted 3–4× by deriving the emit
+floor from `name:the`, which was itself paying the same defect and improved 1.9×; and compositions gain *more*
+than the bare predicate (`o:the -t:land` 4.2× against `o:the`'s 3.9×), because a tight text child lets the whole
+`And` skip `card_pass` rather than just the leaf.
 
 **The fix is one guard, and it is not in `memoize_text_predicates`.** `narrow_rec`'s text arm returns
 `Narrowed::loose` for every needle of 3 bytes or more; at exactly 3 bytes the set is exact, so it should return
@@ -96,7 +103,7 @@ reason. The **bigram** arm one size down already gets this right, and states the
 And memoization is gated on the needle not being too common (`min <= oracle.gids.len() / 2 && memoize_pays(...)`)
 — a gate whose entire premise is that the verify scan must pay for itself. At 3 bytes there is no verify scan,
 so the premise does not hold, which is the same shape of error as
-[#856](00856-engine-compose-membership-bittest.md): a gate whose justification stopped applying, left in place.
+[#856](../00856-engine-compose-membership-bittest.md): a gate whose justification stopped applying, left in place.
 
 But once the narrowing is tight, none of this matters for correctness or cost — whether memoize fires becomes an
 optimisation of a path that no longer runs. Fix the narrowing; leave memoize alone unless it measures.
@@ -184,7 +191,7 @@ Exactness is a claim about the index, so **assert it rather than trusting the ar
 If any is, the index is not what its doc says and *that* is the finding — a debug assertion is the right home,
 since it is cheap to state and this is the invariant the whole change rests on.
 
-The same shape as the guard [#857](00857-engine-membership-merge-sorted-list.md) wants for its ordering
+The same shape as the guard [#857](../00857-engine-membership-merge-sorted-list.md) wants for its ordering
 precondition, and for the same reason: marking something tight that is not tight drops rows silently.
 
 Then rows before timings, as ever — this changes which cards a text predicate matches if the exactness claim is
@@ -199,7 +206,7 @@ wrong, which is a wrong-answer bug rather than a slow one.
 - [#858](00858-engine-short-needle-text-scan.md) — the tier below: 1-byte needles have no index at all, and
   lose memoization for the same gating reason. Same family, different mechanism, and the two fixes are
   independent.
-- [done/00663-engine-oracle-word-index.md](done/00663-engine-oracle-word-index.md) — the word index, which
+- [done/00663-engine-oracle-word-index.md](00663-engine-oracle-word-index.md) — the word index, which
   covers needles `> 3` bytes and so does not reach this case.
-- [done/00649-accent-insensitive-name-search.md](done/00649-accent-insensitive-name-search.md) — why the name
+- [done/00649-accent-insensitive-name-search.md](00649-accent-insensitive-name-search.md) — why the name
   index and verify both use `card_name_folded`, which is what makes exactness hold here.

--- a/docs/issues/done/00860-engine-broad-tight-narrowing-discarded.md
+++ b/docs/issues/done/00860-engine-broad-tight-narrowing-discarded.md
@@ -1,11 +1,23 @@
 # The breadth guard discards exact narrowings — and is masking a tightness over-claim
 
-Status: **prototyped and measured 2026-08-06; NOT safe as written — it fails the fuzz suite.** Filed as
-[#860](https://github.com/jbylund/sylvan_librarian/issues/860). Depends on
-[#859](00859-engine-exact-trigram-no-verify.md).
+**DONE — shipped in [#862](https://github.com/jbylund/sylvan_librarian/pull/862)** (2026-08-07), together with
+[#859](00859-engine-exact-trigram-no-verify.md), which supplies the tightness that makes the union exact.
 
-The performance idea is worth 4.4×. The reason to read this doc is the second finding: attempting it exposes a
-narrowing that **already** claims tightness it does not have, which the breadth guard has been hiding.
+`o:the or o:you` **1,819 µs → 401 µs** on merged `main`, `narrowed_repr` going `none` → `card_bits`.
+
+**The latent bug was real, and it was not where this doc first guessed.** A diagnostic showed the narrowings in
+`AND(cmc<8, colors!=0b00011)` are all exact — len 14 against a brute-forced truth of 14, zero members failing
+`card_pass`. The fault was downstream: `prepare_candidates` carries a *second* breadth filter
+(`v.len() < cards.len() - cards.len() / 8`), and `all_match_known` was computed before it and never cleared when
+it dropped the set to `None`, so the walk fell back to `0..n_cards` with verification skipped and emitted every
+card. `residual_exact` now requires `candidate_cards.is_some()`.
+
+It was unreachable before this change because the 3/4 guard is stricter than the 7/8 filter at every corpus size
+— checked at 15, 16, 24, 40, 100, 1,000 and 31,508 — which made the second filter dead code. Relaxing the first
+is what woke it up.
+
+Sequel: [#863](https://github.com/jbylund/sylvan_librarian/pull/863) gave the 7/8 filter the same tightness
+exemption, which is what this doc listed as left for later.
 
 `o:the or o:you` takes **1,819 µs** and reports `narrowed_repr: none` — it does no narrowing at all, even though
 both children narrow individually and (after #859) both are *exact*. The union of two exact sets is exact, so
@@ -106,5 +118,5 @@ The prototype was: #859's `mk = if word.len() == 3 { Narrowed::tight } else { Na
 - [#859](00859-engine-exact-trigram-no-verify.md) — supplies the tightness. Safe on its own: full suite green,
   4.7× on `o:the`.
 - [#858](00858-engine-short-needle-text-scan.md) — the 1-byte tier, unaffected by either.
-- [#857](00857-engine-membership-merge-sorted-list.md) — wants the same class of debug assertion for its own
+- [#857](../00857-engine-membership-merge-sorted-list.md) — wants the same class of debug assertion for its own
   ordering precondition.

--- a/scripts/bench_short_needle_cliff.py
+++ b/scripts/bench_short_needle_cliff.py
@@ -1,12 +1,18 @@
-"""Time the needle-length cliff for text containment -- the measurement behind #858.
+"""Time the needle-length cliff for text containment, per tier.
 
-Three tiers: trigram narrowing needs 3 bytes (`trigram_candidates` returns None below that), 2-byte needles
-resolve exactly through `NameBigramIndex`, and 1-byte needles have neither. The third case also loses
-memoization, because `memoize_text_predicates` is gated on `trigram_candidates` returning `Some`, so the
-filter stays a `TextContains` evaluated per card inside the match loop.
+Originally the measurement behind #858; now a regression guard for what shipped and the standing
+measurement of what did not.
 
-Reports routed time beside the acquire facts, because `narrowed_repr: none` is what distinguishes the broken
-tier from the working ones.
+NAME needles are fully tiered as of #862 / #863: 1 byte resolves exactly through `NameUnigramIndex`, 2 through
+`NameBigramIndex`, 3 through a single trigram (all three TIGHT, so `card_pass` never runs), and 4+ narrow to a
+trigram superset that the walk verifies. Every row below should read `narrowed_repr` of `cards` or `card_bits`.
+
+ORACLE and FLAVOR are untouched and still show the original cliff -- `o:s` and `ft:s` cost ~1 ms with
+`narrowed_repr: none`, because sub-trigram needles have no index there and lose memoization too
+(`memoize_text_predicates` is gated on `trigram_candidates` returning `Some`). Keeping them here is the point:
+`narrowed_repr` is what distinguishes a served tier from an unserved one at a glance.
+
+The `Or` rows are what surfaced #860 -- `o:the or o:you` reported `none` where both halves narrow.
 
     .venv/bin/python scripts/bench_short_needle_cliff.py --shm /tmp/needle.store
 """


### PR DESCRIPTION
Closes #858. #859 and #860 auto-closed on #862's merge; this moves all three docs to `done/` with what
actually shipped.

No code changes beyond one harness docstring.

## The three

**#859** — one guard in `narrow_rec`, `Narrowed::tight` at exactly 3 bytes. `o:the` **783.9 → 163.6 µs** on
merged `main`. The doc keeps both things its estimate got wrong, because both generalize: it predicted 3–4× by
deriving the emit floor from `name:the`, which was itself paying the same defect and improved 1.9×; and
compositions gain *more* than the bare predicate, since a tight text child lets the whole `And` skip
`card_pass` rather than just the leaf.

**#860** — `o:the or o:you` **1,819 → 401 µs**, `narrowed_repr` `none` → `card_bits`. The header records that
the latent bug was **not** where the doc first guessed: the narrowings were all exact, and the fault was
`prepare_candidates` computing `all_match_known` before a second breadth filter that could drop the set to
`None`. It was unreachable beforehand because the 3/4 guard is stricter than the 7/8 filter at every corpus
size, making that filter dead code.

**#858** — the one that needed care, because only half of it shipped.

## #858 is closed on the half that mattered, and says so about the rest

The **name tier is done**: `name:s` **446.6 → 58.5 µs**, 109 KB (0.155% of the archive, matching the
prediction exactly), and negations too — `-name:q` 463 → 91 µs — via the `never_null` gate plus the 7/8
tightness exemption #860 had deferred.

**Oracle and flavor are not**, and the doc now says so with numbers rather than letting the closure imply
otherwise:

| query | on merged `main` |
| --- | --: |
| `o:s` | **1,168.7 µs** |
| `ft:s` | **993.6 µs** |

Oracle was a deliberate scope call — a bare term parses to `card_name` contains, so `name:s` is the first query
of every search session while `o:s` is only reachable by typing `o:` first, and is semantically useless
besides. Sizing is recorded (162 KB) and the builder is field-shaped, so revisiting is a build-site change.

**Flavor was never argued against**, and is the more interesting of the two: its CSR is over ~29k distinct
*texts* rather than 31.5k cards, so the index would be smaller and the scan shorter. It wants its own issue if
it is worth doing — flagged rather than silently dropped.

**Fix B (the blob + `memmem`)** is untouched, and its case narrowed while the issue was open: #859 removed
`o:the` from it by making 3-byte needles exact, so it is now justified only on 4+ byte needles where the
trigram intersection really is a superset and verification really does run.

## Harness

`bench_short_needle_cliff.py`'s docstring described itself as "the measurement behind #858", which is no longer
what it is. It is now a regression guard for the shipped name tiers — every name row should read `cards` or
`card_bits` — and the standing measurement of the oracle/flavor gap, which is why those rows stay in it.
