### PR TITLE
Docs: Close #850 Into #400 — the Corpus Stores the Back Face of Every DFC

### DIFF
--- a/docs/issues/done/00850-engine-battle-type-plane-path.md
+++ b/docs/issues/done/00850-engine-battle-type-plane-path.md
@@ -1,9 +1,40 @@
 # `card_types` Has No `Battle`, and `t:battle` Poisons an `Or`'s Plane Path
 
-Status: proposed, not started — **and (1) below may be a wrong-answer bug, which is why it outranks
-everything else carried out of that audit.** Filed as
-[#850](https://github.com/jbylund/sylvan_librarian/issues/850). Items 2 and 3 of
-[the `is:` / `frame:` audit](done/local-engine-is-frame-predicates.md), whose other findings shipped in
+**CLOSED — root cause found, and it is not type extraction. Folded into
+[#400](https://github.com/jbylund/sylvan_librarian/issues/400) (DFC support).**
+
+The suspicion in (1) was right — it *is* a wrong-answer bug — but the cause is one layer up, and far wider
+than battles. **The corpus stores the BACK face of every multi-face card.**
+
+Every battle is a Siege and every Siege is double-faced, so the front face is exactly what is dropped:
+`Invasion of Fiora // Marchesa, Resolute Monarch` is stored with `type_line` = `Legendary Creature — Human
+Noble`, its back. All 54 `Invasion of …` cards are present under their back sides, `Battle` appears in **zero**
+type lines corpus-wide, and `card_types` therefore has no `Battle`. So (1) is not a missing type — it is a
+missing *face*.
+
+It is not only the type line. On the same card, `oracle_text`, `creature_power`/`toughness`, `card_colors`
+(`{B}` where the cost is `{3}{W}{B}`) and `mana_cost_text` (empty) all come from the back too.
+
+**Blast radius, measured:** 1,102 printings / 461 distinct cards carry the mechanical signature — an empty
+`mana_cost_text` against a nonzero card-level `cmc`, which only a non-front face produces. `transform` 969 of
+984, `flip` 36 of 36, `meld` 21 of 63, `modal_dfc` 76 of 260. A lower bound, since MDFC backs *do* carry a
+cost; the real figure is nearer all 1,343 multi-face printings.
+
+So (2), the `t:battle` `Or` poisoning, should be **re-tested after the face fix rather than diagnosed now**:
+`TYPE_BATTLE` is currently an all-zero plane, and an empty plane is a plausible cause of the very behaviour
+that section could not explain.
+
+The measured detail and the correction to #400's stated premise — it says DFCs are *filtered out*, and they are
+not, which makes this a silent wrong answer rather than a visible gap — are in
+[that issue's thread](https://github.com/jbylund/sylvan_librarian/issues/400#issuecomment-5210677523).
+
+**One item here is NOT covered by #400 and is now untracked:** the `is:old` / `is:historic` 6.8× gap below
+(7,191 cards in 399 µs against 7,261 in 59 µs, both `Or`s over `card_frame_data`). It rode along on this issue
+and has nothing to do with faces. Still only a diagnostic, never explained; file it if it becomes worth
+chasing.
+
+*Original status, kept for dating* — proposed, items 2 and 3 of
+[the `is:` / `frame:` audit](local-engine-is-frame-predicates.md), whose other findings shipped in
 #840 and #842.
 
 ## 1. The data question — check this first
@@ -67,9 +98,9 @@ apply to (1), which is a correctness question regardless of how often the query 
 
 ## Related
 
-- [done/local-engine-is-frame-predicates.md](done/local-engine-is-frame-predicates.md) — the parent audit,
+- [done/local-engine-is-frame-predicates.md](local-engine-is-frame-predicates.md) — the parent audit,
   the `frame_data` hybrid that shipped, and the threshold-conflation fix.
-- [local-engine-layout-postings.md](local-engine-layout-postings.md) — item 4 of the same audit,
+- [local-engine-layout-postings.md](../local-engine-layout-postings.md) — item 4 of the same audit,
   deprioritized separately.
-- [local-engine-empty-text-narrowing.md](local-engine-empty-text-narrowing.md) — `is:vanilla` /
+- [local-engine-empty-text-narrowing.md](../local-engine-empty-text-narrowing.md) — `is:vanilla` /
   `is:permanent` from the other direction: a plane-composable `Or` falling back to the general path.

--- a/docs/issues/done/local-engine-is-frame-predicates.md
+++ b/docs/issues/done/local-engine-is-frame-predicates.md
@@ -7,11 +7,11 @@
 | 1. `frame_data` drops its dense values | **merged in [#840](https://github.com/jbylund/sylvan_librarian/pull/840)** — hybrid index, 133 KB *smaller* and the scan gone. Whole mix 0.815, p99 0.648 |
 | 6. the mid-density regressions it shipped with | **merged in [#842](https://github.com/jbylund/sylvan_librarian/pull/842)** — `dense` and `broad` are eight times apart and the dense branch conflated them. `o:this frame:1993` 2,102 → 148 µs |
 | 5. the `And` arm's cost-based skip | **merged in [#836](https://github.com/jbylund/sylvan_librarian/pull/836)** (`3cfd441`) — total 0.969, p99 0.967 |
-| 2. `t:battle` poisons an `Or`'s plane path | refiled as [#850](https://github.com/jbylund/sylvan_librarian/issues/850) |
-| 3. `card_types` has no `Battle` | refiled as [#850](https://github.com/jbylund/sylvan_librarian/issues/850) — possibly a wrong answer, so it leads that issue |
+| 2. `t:battle` poisons an `Or`'s plane path | **re-test after the DFC fix** — `TYPE_BATTLE` is an all-zero plane today, which is a plausible cause of the behaviour this could not explain. Via [#850](00850-engine-battle-type-plane-path.md) → [#400](https://github.com/jbylund/sylvan_librarian/issues/400) |
+| 3. `card_types` has no `Battle` | **root cause found, and it is not type extraction** — the corpus stores the BACK face of every multi-face card, and every battle is a double-faced Siege. Folded into [#400](https://github.com/jbylund/sylvan_librarian/issues/400); see [#850](00850-engine-battle-type-plane-path.md) |
 | 4. `card_layout` is unindexed | already its own doc, [layout postings](../local-engine-layout-postings.md), deprioritized |
 | `o:owner keyword:flying` at 1.56× | refiled as [#851](https://github.com/jbylund/sylvan_librarian/issues/851) |
-| the `is:old` / `is:historic` 6.8× gap | carried into [#850](https://github.com/jbylund/sylvan_librarian/issues/850) |
+| the `is:old` / `is:historic` 6.8× gap | **unresolved and currently untracked** — it rode on #850, which closed into #400 for an unrelated cause. Nothing to do with DFCs; still just a diagnostic. Recorded in [#850's doc](00850-engine-battle-type-plane-path.md) |
 
 The withdrawn item in section 7 — broad printing-space partners under a card-space driver — was fixed from a
 different direction entirely by [#843](https://github.com/jbylund/sylvan_librarian/pull/843); see


### PR DESCRIPTION
Closes #850, into #400.

Checking #850 confirmed its wrong-answer suspicion and refuted its diagnosis. Docs-only.

## `card_types` has no `Battle` because the corpus stores the BACK face

Not a type-extraction bug. Every battle is a Siege and every Siege is double-faced, so the front face is
exactly what gets dropped. `Invasion of Fiora // Marchesa, Resolute Monarch` is stored as:

| field | stored | front face |
| --- | --- | --- |
| `type_line` | `Legendary Creature — Human Noble` | `Battle — Siege` |
| `oracle_text` | "Whenever Marchesa attacks…" | the Siege's text |
| `creature_power` / `toughness` | 3 / 6 | none (battles have defense) |
| `card_colors` | `{B}` | `{W, B}` — the cost is `{3}{W}{B}` |
| `mana_cost_text` | `''` | `{3}{W}{B}` |

All 54 `Invasion of …` cards are present under their back sides, and `Battle` appears in **zero** type lines
corpus-wide. The name field keeps both faces (`A // B`), so these look right in a result list while every
searchable attribute belongs to the wrong side.

## Blast radius, measured

A transform back has no mana cost but card-level `cmc` comes from the front, so a stored non-front face shows
an empty cost against a nonzero cmc — mechanically checkable, no Magic knowledge needed:

**1,102 printings / 461 distinct cards.** `transform` 969 of 984, `flip` 36 of 36, `meld` 21 of 63,
`modal_dfc` 76 of 260. A **lower bound** — MDFC backs *do* carry a cost, so the test misses most of them; the
real figure is nearer all 1,343 multi-face printings, ~1.4% of the corpus.

## #400's premise was stale, and the correction raises its priority

It says DFCs are *"filtered out during preprocessing"*. They are not. That matters: filtered-out is a
**visible** gap a user notices, while present-with-the-wrong-face is a **silent wrong answer** —
`t:creature` misses `Nissa, Vastwood Seer` (a creature stored as a planeswalker), `t:planeswalker` wrongly
matches it, and a W/B card is unfindable by `c:w`. Posted to
[#400 with the numbers](https://github.com/jbylund/sylvan_librarian/issues/400#issuecomment-5210677523),
including the warning that the obvious validation query does **not** fire: `card_colors ⊄ card_color_identity`
catches 2 printings, because both fields came from the back face and are consistently wrong together.

## Two things deliberately not done

**Item 2 of #850** — `t:battle` poisoning an `Or`'s plane path — is not diagnosed. `TYPE_BATTLE` is an
all-zero plane today, which is a plausible cause of the behaviour that section could not explain, so it should
be **re-tested after the face fix** rather than chased now. Recorded as such in the parent audit's table.

**The `is:old` / `is:historic` 6.8× gap** rode along on #850 and has nothing to do with faces, so closing #850
would have orphaned it. It is now flagged as *unresolved and untracked* in both #850's doc and the audit's
disposition table rather than vanishing with the close. File it if it becomes worth chasing.

## Caveat

This is the **corpus snapshot** (`benchmarks/bitplanes/corpus.jsonl`), not the live importer. The export path
that produced it may differ from production, so confirm there before writing the fix. I verified the fields in
the table above; `illustration_id`, `flavor_text`, `card_keywords` and `card_frame_data` also look
back-face-sourced on the two cards I dumped, but I did not check those at corpus scale.
