### PR TITLE
CI: Add Status Badges, and Publish Language and Test-Count Assets Daily

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -86,5 +86,5 @@ npx prettier --write <changed .html/.js files>
 
 ## CI
 
-GitHub Actions run on every push/PR: `unit-tests.yml` (pytest on Python 3.13 with cached Rust
+GitHub Actions run on every push/PR: `python-tests.yml` (pytest on Python 3.13 with cached Rust
 extension wheels) and `lint.yml` (ruff). All tests must pass and ruff must be clean before merge.

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -42,6 +42,12 @@ env:
   # Short TTL: camo caches against the origin's max-age, and a badge that lags a day
   # behind the daily regeneration would defeat the point of regenerating daily.
   BADGE_CACHE_CONTROL: 'public, max-age=300'
+  # Literal rather than repo variables: both already appear in tracked files of this
+  # public repo (docs/technical/s3_image_storage.md names the bucket), so hiding them
+  # buys nothing and only adds a setup step that can be mistyped. The distribution ID
+  # stays a variable — it is not derivable from the public d1hot… domain.
+  AWS_REGION: us-east-1
+  BADGE_BUCKET: biblioplex
 
 jobs:
   # Most days main does not move, and republishing byte-identical badges costs the full
@@ -153,20 +159,32 @@ jobs:
       - name: Generate badge assets
         run: python scripts/gen_badges.py --out-dir dist/badges --tokei ~/.cargo/bin/tokei
 
+      # An unset secret or variable is the empty string, which reaches AWS as a baffling
+      # error ("Not authorized to perform sts:AssumeRoleWithWebIdentity") rather than as
+      # "you forgot a setting". Worth five lines on a job whose first run is a setup step.
+      - name: Check publish settings are configured
+        env:
+          PUBLISH_ROLE: ${{ secrets.AWS_BADGE_PUBLISH_ROLE }}
+          DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          set -euo pipefail
+          [ -n "${PUBLISH_ROLE}" ] || { echo "::error::secret AWS_BADGE_PUBLISH_ROLE is not set"; exit 1; }
+          [ -n "${DISTRIBUTION_ID}" ] || { echo "::error::variable CLOUDFRONT_DISTRIBUTION_ID is not set"; exit 1; }
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_BADGE_PUBLISH_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       # Content types are set explicitly: S3 defaults to application/octet-stream, and
       # camo will not render an image it was not told is an image.
       - name: Upload to S3
         run: |
-          aws s3 cp dist/badges "s3://${{ vars.BADGE_BUCKET }}/${BADGE_PREFIX}/" \
+          aws s3 cp dist/badges "s3://${BADGE_BUCKET}/${BADGE_PREFIX}/" \
             --recursive --exclude '*' --include '*.svg' \
             --content-type image/svg+xml --cache-control "${BADGE_CACHE_CONTROL}"
-          aws s3 cp dist/badges "s3://${{ vars.BADGE_BUCKET }}/${BADGE_PREFIX}/" \
+          aws s3 cp dist/badges "s3://${BADGE_BUCKET}/${BADGE_PREFIX}/" \
             --recursive --exclude '*' --include '*.json' \
             --content-type application/json --cache-control "${BADGE_CACHE_CONTROL}"
 

--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,177 @@
+name: Badges
+
+# Regenerates the README's two dynamic badge assets — the language donut and the
+# per-suite test counts — and publishes them to S3 behind the same CloudFront
+# distribution that already serves card images.
+#
+# Why a scheduled job rather than a committed artifact: the alternative is a bot commit
+# on every merge, or a drift check that fails PRs for a number nobody edited on purpose.
+# Neither is worth it for a decorative asset. Daily is fast enough for a line count.
+#
+# Why not a gist: shields.io reads endpoint JSON server-side and would be fine from a
+# gist, but the donut is an <img> and GitHub proxies those through camo, which refuses
+# gist raw URLs (they are served text/plain with nosniff). One host for both keeps the
+# publishing step single-purpose.
+
+on:
+  schedule:
+    # 07:20 UTC daily — off the hour, since the top of the hour is the busiest slot on
+    # shared runners and this job is in no hurry.
+    - cron: '20 7 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/gen_badges.py'
+      - '.github/workflows/badges.yml'
+
+permissions:
+  contents: read
+  actions: read # the staleness gate reads this workflow's own run history
+  id-token: write # for the OIDC handshake in configure-aws-credentials
+
+# tokei ships no prebuilt binaries (v13 and v14 releases carry no assets), so it is built
+# from source and cached on the version key — the job already needs a Rust toolchain for
+# the cargo test --list count, so this costs a cache hit rather than a toolchain. Pinned
+# because an unpinned counter would silently reclassify languages under the badge one
+# morning.
+env:
+  TOKEI_VERSION: '14.0.0'
+  BADGE_PREFIX: badges
+  # Short TTL: camo caches against the origin's max-age, and a badge that lags a day
+  # behind the daily regeneration would defeat the point of regenerating daily.
+  BADGE_CACHE_CONTROL: 'public, max-age=300'
+
+jobs:
+  # Most days main does not move, and republishing byte-identical badges costs the full
+  # toolchain install for nothing. This gate is ~15s against the ~5min it guards.
+  #
+  # It compares against the head SHA of the last *successful* publish rather than asking
+  # "were there commits in the last 24h". The window version has a hole: if a run fails
+  # or a cron is skipped (GitHub drops scheduled runs on busy repos), a commit older than
+  # the window never triggers a publish and the badges stay stale indefinitely. Comparing
+  # SHAs is self-healing — whatever the reason the last publish did not happen, the SHAs
+  # still differ and the next run picks it up.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      stale: ${{ steps.gate.outputs.stale }}
+    steps:
+      - name: Has main moved since the last successful publish?
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # A manual run is someone asking for a rebuild on purpose, and a push here means
+          # the generator itself changed — the output can differ at an unchanged tree.
+          if [ "${EVENT_NAME}" != "schedule" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "${EVENT_NAME} run — publishing regardless of history"
+            exit 0
+          fi
+
+          # Fails open: this endpoint 404s until the workflow has been registered with at
+          # least one run, and `set -e` would otherwise turn that into a failed gate on
+          # the very first schedule. An extra publish is the cheap error here.
+          published_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/badges.yml/runs?status=success&branch=main&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // ""' 2>/dev/null || echo "")
+
+          if [ -z "${published_sha}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "no successful publish on record — bootstrapping"
+          elif [ "${published_sha}" = "${CURRENT_SHA}" ]; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+            echo "main is still at ${CURRENT_SHA} — badges are current, skipping"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "main moved ${published_sha} -> ${CURRENT_SHA} — republishing"
+          fi
+
+  publish-badges:
+    needs: changes
+    if: needs.changes.outputs.stale == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: 'npm'
+
+      # Pinned to match rust-tests.yml — see the comment there on why this is not @stable.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - name: Cache Cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            card_engine
+            shared_cache
+
+      - name: Install uv dependencies
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv pip install --system --break-system-packages -r requirements/base.txt -r requirements/test.txt
+
+      # pytest --collect-only still imports the test modules, so the Rust extensions have
+      # to be importable or collection fails and the python badge is skipped.
+      - name: Install Rust extensions
+        run: |
+          pip install ./card_engine
+          pip install ./shared_cache
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Cache tokei
+        id: tokei-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/tokei
+          key: tokei-${{ runner.os }}-${{ env.TOKEI_VERSION }}
+
+      - name: Install tokei
+        if: steps.tokei-cache.outputs.cache-hit != 'true'
+        run: cargo install tokei --version "${TOKEI_VERSION}" --locked
+
+      - name: Generate badge assets
+        run: python scripts/gen_badges.py --out-dir dist/badges --tokei ~/.cargo/bin/tokei
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_BADGE_PUBLISH_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      # Content types are set explicitly: S3 defaults to application/octet-stream, and
+      # camo will not render an image it was not told is an image.
+      - name: Upload to S3
+        run: |
+          aws s3 cp dist/badges "s3://${{ vars.BADGE_BUCKET }}/${BADGE_PREFIX}/" \
+            --recursive --exclude '*' --include '*.svg' \
+            --content-type image/svg+xml --cache-control "${BADGE_CACHE_CONTROL}"
+          aws s3 cp dist/badges "s3://${{ vars.BADGE_BUCKET }}/${BADGE_PREFIX}/" \
+            --recursive --exclude '*' --include '*.json' \
+            --content-type application/json --cache-control "${BADGE_CACHE_CONTROL}"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}" \
+            --paths "/${BADGE_PREFIX}/*"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Python Tests
 
 on:
   push:
@@ -28,10 +28,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >-
           .github/scripts/changed-paths.sh
-          '\.py$|\.rs$|(^|/)Cargo\.(toml|lock)$|^requirements/|(^|/)pyproject\.toml$|^api/static/fixtures/|^\.github/(workflows/unit-tests\.yml|scripts/changed-paths\.sh)$'
+          '\.py$|\.rs$|(^|/)Cargo\.(toml|lock)$|^requirements/|(^|/)pyproject\.toml$|^api/static/fixtures/|^\.github/(workflows/python-tests\.yml|scripts/changed-paths\.sh)$'
 
   # Named python-test (not `test`) to match js-test / rust-test — the three check
   # names should read alike in the PR checks list and in the required-checks rule.
+  # The workflow was called "Unit Tests" until the Rust suites arrived and made that
+  # name ambiguous; the job name has always been python-test, so renaming the workflow
+  # did not disturb the required-checks rule, which matches on the check name.
   python-test:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Sylvan Librarian
 
+[![Python Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=python%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml)
+[![Rust Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=rust%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml)
+[![Last commit](https://img.shields.io/github/last-commit/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/commits/main)
+[![Issues](https://img.shields.io/github/issues/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/issues)
+[![Pull requests](https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/pulls)
+[![Stars](https://img.shields.io/github/stars/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/stargazers)
+[![License](https://img.shields.io/github/license/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/blob/main/LICENSE)
+
+[![python tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml)
+[![rust tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml)
+[![js tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml)
+
 ![Web Interface](screenshot.webp)
 
 *Web interface in dark mode: `t:beast` matching 525 cards, returned in 3 ms*
@@ -101,11 +113,16 @@ Based on [comprehensive functionality analysis](docs/technical/scryfall_function
 ### Implementation Status
 
 - **Current API Success Rate**: 100% for supported features (enhanced coverage with flavor text search)
-- **Test Coverage**: 1,821 total tests including 1,302 parser tests with comprehensive validation
+- **Test Coverage**: see the per-suite test-count badges at the top of this file — they are regenerated daily, so they do not go stale the way a number written into prose does
 - **Performance**: In-memory Rust query engine (sub-millisecond for most queries) backed by optimized PostgreSQL with proper indexing including full-text search capabilities
 - **Data Quality**: Regular comparison testing against official Scryfall API
 
 ## Code Organization
+
+![Lines of code by language](https://d1hot9ps2xugbc.cloudfront.net/badges/languages.svg)
+
+*Source lines by language, excluding comments, blank lines, and benchmark harnesses.
+Regenerated daily — see [scripts/gen_badges.py](scripts/gen_badges.py).*
 
 ```
 sylvan_librarian/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Sylvan Librarian
 
-[![Python Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=python%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml)
-[![Rust Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=rust%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml)
+[![Python Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=python%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain)
+[![Rust Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=rust%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain)
 [![Last commit](https://img.shields.io/github/last-commit/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/commits/main)
 [![Issues](https://img.shields.io/github/issues/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/issues)
 [![Pull requests](https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/pulls)
 [![Stars](https://img.shields.io/github/stars/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/stargazers)
 [![License](https://img.shields.io/github/license/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/blob/main/LICENSE)
 
-[![python tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml)
-[![rust tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml)
-[![js tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml)
+[![python tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain)
+[![rust tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain)
+[![js tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain)
 
 ![Web Interface](screenshot.webp)
 

--- a/docs/workflows/readme_ci_monitor.md
+++ b/docs/workflows/readme_ci_monitor.md
@@ -90,7 +90,7 @@ When a CI failure issue is created:
 
 The CI Monitor currently tracks these workflows:
 - **Lint**: Python code style and quality checks
-- **Unit Tests**: Comprehensive test suite execution
+- **Python Tests**: Comprehensive test suite execution
 - **Any other workflows**: Automatically detects and monitors all repository workflows
 
 ## Testing

--- a/scripts/gen_badges.py
+++ b/scripts/gen_badges.py
@@ -1,0 +1,368 @@
+"""Generate the README's dynamic badge assets.
+
+Two kinds of asset land in the output directory:
+
+1. ``languages.svg`` — a donut of source lines per language, counted over tracked files
+   only (``git ls-files``), with comments and blank lines excluded. This deliberately
+   differs from GitHub's own Languages sidebar, which measures *bytes*: Rust averages
+   ~54 bytes/line in this repo against Python's ~42, so the byte view ranks Rust first
+   while the line view ranks Python first. Lines are the number a reader actually means
+   by "how much code".
+
+2. ``tests-<suite>.json`` — one shields.io endpoint document per test suite, so the
+   three badges read alike in the README the way the three checks read alike in the PR
+   checks list.
+
+Both are uploaded to S3 and served through CloudFront by .github/workflows/badges.yml;
+nothing generated here is committed to the repo.
+
+Counting code-vs-comment lines is delegated to ``tokei`` rather than hand-rolled: getting
+it right means knowing that Rust block comments nest and that a ``//`` inside a string
+literal is not a comment. Note that tokei counts a Python docstring as code, not as a
+comment — it is a string expression, not comment syntax — which is worth roughly 600
+lines of the Python total here. Tools disagree on this; scc scores it the other way.
+
+Usage:
+    python scripts/gen_badges.py --out-dir dist/badges
+    python scripts/gen_badges.py --out-dir dist/badges --skip-tests    # chart only
+    python scripts/gen_badges.py --out-dir dist/badges --tokei ./tokei # non-PATH binary
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+LOGGER = logging.getLogger("gen_badges")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Which tracked files count as source at all. Only languages GitHub's linguist treats as
+# code appear here; prose (.md) and data (.json, .toml, .yml) are excluded so the chart
+# answers "how much code" rather than "how many bytes are in the tree".
+COUNTED_SUFFIXES = frozenset({".rs", ".py", ".js", ".html", ".sql", ".css", ".sh"})
+# Compared case-insensitively: this repo's makefile is lowercase, and matching only
+# "Makefile" silently dropped it.
+COUNTED_STEMS = frozenset({"makefile", "gnumakefile", "dockerfile"})
+
+# tokei's language names -> the labels used here. Only entries that actually differ need
+# listing; anything tokei reports that is missing from this map keeps its own name, and
+# anything outside CHARTED_LANGUAGES ends up in "Other" regardless.
+TOKEI_NAME_ALIASES = {
+    "SQL": "PLpgSQL",  # the schema is Postgres-flavoured; linguist agrees
+}
+
+# tokei repeats every count under a synthetic "Total" language; adding it would double
+# every figure in the chart.
+TOKEI_TOTAL_KEY = "Total"
+
+# linguist's own colors, so the chart matches what GitHub renders in the sidebar.
+LANGUAGE_COLORS = {
+    "Rust": "#dea584",
+    "Python": "#3572A5",
+    "JavaScript": "#f1e05a",
+    "HTML": "#e34c26",
+    "PLpgSQL": "#336790",
+    "CSS": "#663399",
+    "Makefile": "#427819",
+    "Dockerfile": "#384d54",
+    "Shell": "#89e051",
+    "Other": "#8b949e",
+}
+
+# Generated or minified files are checked in for deployment but are not authored code;
+# counting them would swamp the chart with one-line minified bundles.
+EXCLUDED_PATH_PARTS = (".min.js", ".min.css")
+
+# Benchmark harnesses are measurement scaffolding, not the shipping engine. They are
+# excluded in BOTH languages on purpose: card_engine carries ~4.3k lines of bench_*.rs
+# and scripts/ carries ~7.1k lines of bench_*.py, so dropping one without the other would
+# tilt the very Python-vs-Rust ratio this chart exists to report.
+EXCLUDED_PATH_GLOBS = (
+    "card_engine/src/bench_*.rs",
+    "shared_cache/src/bench_*.rs",
+    "scripts/bench_*.py",
+)
+
+# Only these get a slice of their own; everything else in COUNTED_SUFFIXES is still
+# counted, but lands in "Other". The remaining languages are all support material — the
+# schema, the stylesheet, the Makefile — and a legend of six 1% wedges says less about
+# what this project is made of than one honest "Other" does.
+CHARTED_LANGUAGES = ("Python", "Rust", "JavaScript")
+
+# --- SVG geometry, in user units (the whole card scales with the viewBox) ---
+CARD_WIDTH = 344
+CARD_PADDING = 16
+DONUT_CENTER_X = 88
+DONUT_RADIUS = 52  # radius of the stroke's centerline, not its outer edge
+DONUT_STROKE_WIDTH = 26
+TITLE_BASELINE_Y = 16
+LEGEND_LEFT_X = 168
+LEGEND_TOP_Y = 34
+LEGEND_ROW_HEIGHT = 22
+LEGEND_SWATCH_RADIUS = 5
+LEGEND_LABEL_DX = 14  # label offset from the swatch center
+SEGMENT_GAP_DEGREES = 1.5  # hairline separator so adjacent slices stay distinguishable
+
+# Line counts are abbreviated past this, so "27855" reads as "27.9k".
+THOUSAND = 1000
+
+# How much of a malformed tokei response to quote back in the error.
+JSON_ERROR_EXCERPT_CHARS = 500
+
+
+@dataclass
+class LanguageCount:
+    """Source-line count for one language, excluding comments and blank lines."""
+
+    name: str
+    lines: int
+
+    @property
+    def color(self) -> str:
+        """The linguist color for this language, falling back to the "Other" grey."""
+        return LANGUAGE_COLORS.get(self.name, LANGUAGE_COLORS["Other"])
+
+
+def run(cmd: list[str], cwd: Path = REPO_ROOT, check: bool = True) -> str:
+    """Run a command and return its combined output."""
+    LOGGER.debug("running %s", " ".join(cmd))
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=False)
+    if check and result.returncode != 0:
+        message = f"{' '.join(cmd)} exited {result.returncode}:\n{result.stdout}\n{result.stderr}"
+        raise RuntimeError(message)
+    return result.stdout + result.stderr
+
+
+def is_counted(path: Path) -> bool:
+    """Whether a tracked path contributes to the language chart."""
+    if any(part in path.name for part in EXCLUDED_PATH_PARTS):
+        return False
+    if any(path.match(pattern) for pattern in EXCLUDED_PATH_GLOBS):
+        return False
+    return path.suffix in COUNTED_SUFFIXES or path.name.lower() in COUNTED_STEMS
+
+
+def tracked_source_files() -> list[str]:
+    """List the tracked files the chart counts.
+
+    Deliberately an explicit file list rather than pointing tokei at the tree: tokei
+    would otherwise walk untracked working-tree directories (benchmarks/, ignored/, draft
+    blog posts) that are not part of the project's source.
+    """
+    tracked = run(["git", "ls-files", "-z"]).split("\0")
+    return [entry for entry in tracked if entry and is_counted(Path(entry)) and (REPO_ROOT / entry).is_file()]
+
+
+def count_lines(tokei_binary: str) -> list[LanguageCount]:
+    """Count source lines per language across tracked files, largest first.
+
+    Uses tokei's ``code`` figure, which is physical lines minus comments and blanks.
+    """
+    paths = tracked_source_files()
+    if not paths:
+        message = "git ls-files matched no countable source files"
+        raise RuntimeError(message)
+    # One exec with every path: xargs-style batching would split the run into several
+    # invocations and emit several JSON documents instead of one.
+    raw = run([tokei_binary, "--output", "json", *paths])
+    try:
+        report = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        message = f"could not parse tokei output as JSON: {exc}\n{raw[:JSON_ERROR_EXCERPT_CHARS]}"
+        raise RuntimeError(message) from exc
+
+    totals: dict[str, int] = {}
+    for name, stats in report.items():
+        if name == TOKEI_TOTAL_KEY:
+            continue
+        label = TOKEI_NAME_ALIASES.get(name, name)
+        totals[label] = totals.get(label, 0) + stats["code"]
+    return sorted((LanguageCount(name, lines) for name, lines in totals.items() if lines), key=lambda lc: -lc.lines)
+
+
+def collapse_tail(counts: list[LanguageCount]) -> list[LanguageCount]:
+    """Fold everything outside CHARTED_LANGUAGES into a single "Other" slice."""
+    kept = [entry for entry in counts if entry.name in CHARTED_LANGUAGES]
+    folded = sum(entry.lines for entry in counts if entry.name not in CHARTED_LANGUAGES)
+    if folded:
+        kept.append(LanguageCount("Other", folded))
+    return kept
+
+
+def human_lines(lines: int) -> str:
+    """Format a line count the way a reader scans it: 42410 -> "42.4k"."""
+    if lines < THOUSAND:
+        return str(lines)
+    return f"{lines / THOUSAND:.1f}k"
+
+
+def render_donut(counts: list[LanguageCount]) -> str:
+    """Render the language breakdown as a self-contained, theme-aware SVG donut.
+
+    Segments are drawn as dash-array arcs on a single circle rather than as path arcs:
+    the arithmetic is a running offset instead of trigonometry per wedge, and there are
+    no seams where wedges meet.
+    """
+    total = sum(lc.lines for lc in counts)
+    if not total:
+        message = "no countable source lines found"
+        raise RuntimeError(message)
+
+    # The legend is a single column that grows with the entry count, and the card grows
+    # with it — a wrapped second column holding one orphaned row reads as a mistake.
+    donut_extent = 2 * (DONUT_RADIUS + DONUT_STROKE_WIDTH / 2)
+    legend_extent = LEGEND_TOP_Y + len(counts) * LEGEND_ROW_HEIGHT
+    card_height = int(max(donut_extent + 2 * CARD_PADDING, legend_extent + CARD_PADDING))
+    donut_center_y = card_height / 2
+
+    circumference = 2 * math.pi * DONUT_RADIUS
+    gap = circumference * (SEGMENT_GAP_DEGREES / 360)
+
+    segments = []
+    offset = 0.0
+    for entry in counts:
+        arc = circumference * entry.lines / total
+        # Never let the gap eat a thin slice entirely.
+        drawn = max(arc - gap, circumference * 0.002)
+        segments.append(
+            f'    <circle cx="{DONUT_CENTER_X}" cy="{donut_center_y}" r="{DONUT_RADIUS}" fill="none"'
+            f' stroke="{entry.color}" stroke-width="{DONUT_STROKE_WIDTH}"'
+            f' stroke-dasharray="{drawn:.2f} {circumference - drawn:.2f}"'
+            f' stroke-dashoffset="{-offset:.2f}"><title>{entry.name}: {entry.lines:,} lines</title></circle>'
+        )
+        offset += arc
+
+    rows = []
+    for index, entry in enumerate(counts):
+        cy = LEGEND_TOP_Y + index * LEGEND_ROW_HEIGHT
+        share = 100 * entry.lines / total
+        rows.append(
+            f'    <circle cx="{LEGEND_LEFT_X}" cy="{cy}" r="{LEGEND_SWATCH_RADIUS}" fill="{entry.color}"/>\n'
+            f'    <text class="legend" x="{LEGEND_LEFT_X + LEGEND_LABEL_DX}" y="{cy + 4}">'
+            f'{entry.name} <tspan class="muted">{human_lines(entry.lines)} · {share:.1f}%</tspan></text>'
+        )
+
+    newline = "\n"
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{CARD_WIDTH}" height="{card_height}" \
+viewBox="0 0 {CARD_WIDTH} {card_height}" role="img" aria-label="Lines of code by language">
+  <style>
+    text {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }}
+    .title {{ font-size: 13px; font-weight: 600; fill: #24292f; }}
+    .legend {{ font-size: 12px; fill: #24292f; }}
+    .muted {{ fill: #57606a; }}
+    .total {{ font-size: 15px; font-weight: 600; fill: #24292f; }}
+    .totall {{ font-size: 9px; fill: #57606a; letter-spacing: 0.06em; }}
+    @media (prefers-color-scheme: dark) {{
+      .title, .legend, .total {{ fill: #e6edf3; }}
+      .muted, .totall {{ fill: #8b949e; }}
+    }}
+  </style>
+  <text class="title" x="{LEGEND_LEFT_X}" y="{TITLE_BASELINE_Y}">Lines of code by language</text>
+{newline.join(segments)}
+  <text class="total" x="{DONUT_CENTER_X}" y="{donut_center_y + 1}" text-anchor="middle">{human_lines(total)}</text>
+  <text class="totall" x="{DONUT_CENTER_X}" y="{donut_center_y + 15}" text-anchor="middle">LINES</text>
+{newline.join(rows)}
+</svg>
+"""
+
+
+def count_python_tests() -> int | None:
+    """Collect (without running) the pytest suite."""
+    output = run([sys.executable, "-m", "pytest", "--collect-only", "-q"], check=False)
+    match = re.search(r"(\d+) tests? collected", output)
+    return int(match.group(1)) if match else None
+
+
+def count_rust_tests() -> int | None:
+    """Sum the test counts every cargo test binary reports under --list."""
+    total = 0
+    found = False
+    for manifest in ("card_engine/Cargo.toml", "shared_cache/Cargo.toml"):
+        output = run(["cargo", "test", "--manifest-path", manifest, "--", "--list"], check=False)
+        for match in re.finditer(r"(\d+) tests?, \d+ benchmarks", output):
+            total += int(match.group(1))
+            found = True
+    return total if found else None
+
+
+def count_js_tests() -> int | None:
+    """Run jest and read the count off its summary line."""
+    output = run(["npx", "jest"], check=False)
+    match = re.search(r"^Tests:.*?(\d+) total", output, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+TEST_SUITES = {
+    "python": count_python_tests,
+    "rust": count_rust_tests,
+    "js": count_js_tests,
+}
+
+# shields.io renders the endpoint document; this is its schema version, not ours.
+SHIELDS_SCHEMA_VERSION = 1
+SHIELDS_COLOR = "#0a7bbb"
+
+
+def write_test_badges(out_dir: Path) -> None:
+    """Write one shields.io endpoint document per suite.
+
+    A suite whose count cannot be collected is skipped rather than written as zero: a
+    missing badge is an obvious problem, whereas "0 tests" looks like a real answer.
+    """
+    for suite, counter in TEST_SUITES.items():
+        try:
+            count = counter()
+        except RuntimeError as exc:
+            LOGGER.warning("could not count %s tests: %s", suite, exc)
+            continue
+        if count is None:
+            LOGGER.warning("could not parse a test count for %s; leaving its badge untouched", suite)
+            continue
+        target = out_dir / f"tests-{suite}.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": SHIELDS_SCHEMA_VERSION,
+                    "label": suite,
+                    "message": f"{count:,} tests",
+                    "color": SHIELDS_COLOR,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        LOGGER.info("wrote %s (%d tests)", target, count)
+
+
+def main() -> int:
+    """Render the badge assets into --out-dir."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, required=True, help="directory to write badge assets into")
+    parser.add_argument("--skip-tests", action="store_true", help="only render the language chart")
+    parser.add_argument("--tokei", default="tokei", help="path to the tokei binary (default: found on PATH)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(levelname)s %(message)s")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    counts = collapse_tail(count_lines(args.tokei))
+    chart = args.out_dir / "languages.svg"
+    chart.write_text(render_donut(counts), encoding="utf-8")
+    LOGGER.info("wrote %s (%s)", chart, ", ".join(f"{c.name} {c.lines:,}" for c in counts))
+
+    if not args.skip_tests:
+        write_test_badges(args.out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #864.

Adds the badge row from #864, plus two badge families that no shields endpoint can serve on its own: a language breakdown and per-suite test counts.

## Blocked on AWS wiring — do not merge yet

The publish job needs credentials that do not exist yet. The assets reuse the existing `biblioplex` bucket and card-image distribution under a new `badges/` prefix, so the README URLs are already correct.

- [x] Add the GitHub OIDC identity provider in IAM (if not already present)
- [x] Create the publish role, scoped to `biblioplex/badges/*` and `CreateInvalidation` on the one distribution
- [x] Add secret `AWS_BADGE_PUBLISH_ROLE`, vars `AWS_REGION` / `BADGE_BUCKET` / `CLOUDFRONT_DISTRIBUTION_ID`
- [x] Confirm the distribution's cache behavior honors the origin `max-age=300` — the image objects it normally serves are `immutable` with a 105-day TTL, so a fixed-TTL cache policy would pin the badges too

`badges.yml` runs on push to `main` when it or `gen_badges.py` changes, so merging before the above lands means a red run.

## Why the generated assets are hosted rather than committed

Both are derivable from the tree, so the obvious options were a committed artifact with a CI drift check, or a gist. Both were rejected:

- A committed artifact means either a bot commit on every merge, or a drift check that fails PRs over a number nobody edited on purpose.
- A gist works for the shields endpoint JSON, which shields fetches server-side, but not for the donut. GitHub proxies README images through camo, and gist raw URLs are served `text/plain` with `nosniff`, so camo refuses them.

The public github-readme-stats instance, which renders this kind of chart dynamically, currently returns `DEPLOYMENT_PAUSED` on every request.

## What the chart measures

Source lines, not bytes. GitHub's Languages sidebar measures bytes, which inverts the ranking here:

| | bytes (GitHub) | source lines |
|---|---|---|
| Python | 46.2% | **54.2%** (27,855) |
| Rust | **48.5%** | 36.6% (18,814) |

Rust averages ~54 bytes/line against Python's ~42.

Comments and blanks are excluded via tokei. Benchmark harnesses are excluded in *both* languages — `card_engine` carries ~4.3k lines of `bench_*.rs` and `scripts/` carries ~7.1k of `bench_*.py`, so dropping one without the other would tilt the very ratio the chart reports.

Note tokei scores a Python docstring as code rather than comment; worth ~600 lines of the Python total. scc scores it the other way.

One SVG covers light and dark — verified in a browser that `prefers-color-scheme` inside an SVG still applies when loaded via `<img>`, so no `<picture>` pair is needed.

## The scheduled job skips quiet days

A ~15s gate guards the ~5min publish. It compares against the head SHA of the last *successful* publish rather than asking whether there were commits in the last 24h — the window version has a hole, in that a failed or dropped run leaves a commit older than the window that never triggers a publish. SHA comparison is self-healing. Manual and push runs bypass the gate, and the gate fails open (the runs endpoint 404s until the workflow is registered).

## Renames unit-tests.yml to python-tests.yml

The name predates the Rust suites. The job inside is already `python-test` and the `checks_on_main` ruleset matches on check name, so the rename does not disturb it.

## Verification

- `gen_badges.py` run end to end locally: 2,360 python / 192 rust / 1,741 js — the python figure matches the CI run in #864's thread exactly.
- `actionlint` clean on both `badges.yml` and `python-tests.yml`.
- `ruff check` clean.
- Gate logic simulated across all five paths (unchanged / moved / 404 / dispatch / push).
