### PR TITLE
Docs: Group the Test Badges by Language, and Mirror the Header Logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <table>
   <tr>
-    <td align="center"><img src="https://cdn.simpleicons.org/github/181717/ffffff" alt="GitHub" width="40" height="40"></td>
+    <td align="center"><img src="https://d1hot9ps2xugbc.cloudfront.net/badges/logo-github.svg" alt="GitHub" width="40" height="40"></td>
     <td>
       <a href="https://github.com/jbylund/sylvan_librarian/issues"><img src="https://img.shields.io/github/issues/jbylund/sylvan_librarian" alt="Issues"></a>      <br>
       <a href="https://github.com/jbylund/sylvan_librarian/pulls"><img src="https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian" alt="Pull requests"></a>      <br>
@@ -16,7 +16,7 @@
     </td>
   </tr>
   <tr>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="40" height="40"></td>
+    <td align="center"><img src="https://d1hot9ps2xugbc.cloudfront.net/badges/logo-python.svg" alt="Python" width="40" height="40"></td>
     <td>
       <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=tests" alt="Python tests"></a>
       <br>
@@ -24,7 +24,7 @@
     </td>
   </tr>
   <tr>
-    <td align="center"><img src="https://cdn.simpleicons.org/rust/000000/ffffff" alt="Rust" width="40" height="40"></td>
+    <td align="center"><img src="https://d1hot9ps2xugbc.cloudfront.net/badges/logo-rust.svg" alt="Rust" width="40" height="40"></td>
     <td>
       <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=tests" alt="Rust tests"></a>
       <br>
@@ -32,7 +32,7 @@
     </td>
   </tr>
   <tr>
-    <td align="center"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" width="40" height="40"></td>
+    <td align="center"><img src="https://d1hot9ps2xugbc.cloudfront.net/badges/logo-javascript.svg" alt="JavaScript" width="40" height="40"></td>
     <td>
       <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/js-tests.yml?branch=main&label=tests" alt="JavaScript tests"></a>
       <br>

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
   <tr>
     <td align="center"><img src="https://cdn.simpleicons.org/github/181717/ffffff" alt="GitHub" width="40" height="40"></td>
     <td>
-      <a href="https://github.com/jbylund/sylvan_librarian/issues"><img src="https://img.shields.io/github/issues/jbylund/sylvan_librarian" alt="Issues"></a>
-      <br>
-      <a href="https://github.com/jbylund/sylvan_librarian/pulls"><img src="https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian" alt="Pull requests"></a>
-      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/issues"><img src="https://img.shields.io/github/issues/jbylund/sylvan_librarian" alt="Issues"></a>      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/pulls"><img src="https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian" alt="Pull requests"></a>      <br>
       <a href="https://github.com/jbylund/sylvan_librarian/stargazers"><img src="https://img.shields.io/github/stars/jbylund/sylvan_librarian" alt="Stars"></a>
+    </td>
+    <td rowspan="4" align="center">
+      <img src="https://d1hot9ps2xugbc.cloudfront.net/badges/languages.svg" alt="Lines of code by language">
     </td>
   </tr>
   <tr>
@@ -146,11 +147,6 @@ Based on [comprehensive functionality analysis](docs/technical/scryfall_function
 - **Data Quality**: Regular comparison testing against official Scryfall API
 
 ## Code Organization
-
-![Lines of code by language](https://d1hot9ps2xugbc.cloudfront.net/badges/languages.svg)
-
-*Source lines by language, excluding comments, blank lines, and benchmark harnesses.
-Regenerated daily — see [scripts/gen_badges.py](scripts/gen_badges.py).*
 
 ```
 sylvan_librarian/

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 <table>
   <tr>
-    <td><img src="https://cdn.simpleicons.org/python" alt="Python" width="28" height="28"></td>
+    <td><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="28" height="28"></td>
     <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=tests" alt="Python tests"></a></td>
     <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json" alt="Python test count"></a></td>
   </tr>
   <tr>
-    <td><img src="https://cdn.simpleicons.org/rust" alt="Rust" width="28" height="28"></td>
+    <td><img src="https://cdn.simpleicons.org/rust/000000/ffffff" alt="Rust" width="28" height="28"></td>
     <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=tests" alt="Rust tests"></a></td>
     <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json" alt="Rust test count"></a></td>
   </tr>
   <tr>
-    <td><img src="https://cdn.simpleicons.org/javascript" alt="JavaScript" width="28" height="28"></td>
+    <td><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" width="28" height="28"></td>
     <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/js-tests.yml?branch=main&label=tests" alt="JavaScript tests"></a></td>
     <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json" alt="JavaScript test count"></a></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -8,19 +8,28 @@
 
 <table>
   <tr>
-    <td><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="28" height="28"></td>
-    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=tests" alt="Python tests"></a></td>
-    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json" alt="Python test count"></a></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="40" height="40"></td>
+    <td>
+      <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=tests" alt="Python tests"></a>
+      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json" alt="Python test count"></a>
+    </td>
   </tr>
   <tr>
-    <td><img src="https://cdn.simpleicons.org/rust/000000/ffffff" alt="Rust" width="28" height="28"></td>
-    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=tests" alt="Rust tests"></a></td>
-    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json" alt="Rust test count"></a></td>
+    <td align="center"><img src="https://cdn.simpleicons.org/rust/000000/ffffff" alt="Rust" width="40" height="40"></td>
+    <td>
+      <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=tests" alt="Rust tests"></a>
+      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json" alt="Rust test count"></a>
+    </td>
   </tr>
   <tr>
-    <td><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" width="28" height="28"></td>
-    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/js-tests.yml?branch=main&label=tests" alt="JavaScript tests"></a></td>
-    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json" alt="JavaScript test count"></a></td>
+    <td align="center"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" width="40" height="40"></td>
+    <td>
+      <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/js-tests.yml?branch=main&label=tests" alt="JavaScript tests"></a>
+      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json" alt="JavaScript test count"></a>
+    </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Sylvan Librarian
 
-[![Last commit](https://img.shields.io/github/last-commit/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/commits/main)
-[![License](https://img.shields.io/github/license/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/blob/main/LICENSE)
-
 <table>
   <tr>
     <td align="center"><img src="https://cdn.simpleicons.org/github/181717/ffffff" alt="GitHub" width="40" height="40"></td>
@@ -13,6 +10,9 @@
     </td>
     <td rowspan="4" align="center">
       <img src="https://d1hot9ps2xugbc.cloudfront.net/badges/languages.svg" alt="Lines of code by language">
+      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/commits/main"><img src="https://img.shields.io/github/last-commit/jbylund/sylvan_librarian" alt="Last commit"></a>
+      <a href="https://github.com/jbylund/sylvan_librarian/blob/main/LICENSE"><img src="https://img.shields.io/github/license/jbylund/sylvan_librarian" alt="License"></a>
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
 # Sylvan Librarian
 
-[![Python Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=python%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain)
-[![Rust Tests](https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=rust%20tests)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain)
 [![Last commit](https://img.shields.io/github/last-commit/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/commits/main)
 [![Issues](https://img.shields.io/github/issues/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/issues)
 [![Pull requests](https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/pulls)
 [![Stars](https://img.shields.io/github/stars/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/stargazers)
 [![License](https://img.shields.io/github/license/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/blob/main/LICENSE)
 
-[![python tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain)
-[![rust tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain)
-[![js tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json)](https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain)
+<table>
+  <tr>
+    <td><img src="https://cdn.simpleicons.org/python" alt="Python" width="28" height="28"></td>
+    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/python-tests.yml?branch=main&label=tests" alt="Python tests"></a></td>
+    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/python-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-python.json" alt="Python test count"></a></td>
+  </tr>
+  <tr>
+    <td><img src="https://cdn.simpleicons.org/rust" alt="Rust" width="28" height="28"></td>
+    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/rust-tests.yml?branch=main&label=tests" alt="Rust tests"></a></td>
+    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/rust-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-rust.json" alt="Rust test count"></a></td>
+  </tr>
+  <tr>
+    <td><img src="https://cdn.simpleicons.org/javascript" alt="JavaScript" width="28" height="28"></td>
+    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/jbylund/sylvan_librarian/js-tests.yml?branch=main&label=tests" alt="JavaScript tests"></a></td>
+    <td><a href="https://github.com/jbylund/sylvan_librarian/actions/workflows/js-tests.yml?query=branch%3Amain"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fd1hot9ps2xugbc.cloudfront.net%2Fbadges%2Ftests-js.json" alt="JavaScript test count"></a></td>
+  </tr>
+</table>
 
 ![Web Interface](screenshot.webp)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Sylvan Librarian
 
 [![Last commit](https://img.shields.io/github/last-commit/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/commits/main)
-[![Issues](https://img.shields.io/github/issues/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/issues)
-[![Pull requests](https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/pulls)
-[![Stars](https://img.shields.io/github/stars/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/stargazers)
 [![License](https://img.shields.io/github/license/jbylund/sylvan_librarian)](https://github.com/jbylund/sylvan_librarian/blob/main/LICENSE)
 
 <table>
+  <tr>
+    <td align="center"><img src="https://cdn.simpleicons.org/github/181717/ffffff" alt="GitHub" width="40" height="40"></td>
+    <td>
+      <a href="https://github.com/jbylund/sylvan_librarian/issues"><img src="https://img.shields.io/github/issues/jbylund/sylvan_librarian" alt="Issues"></a>
+      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/pulls"><img src="https://img.shields.io/github/issues-pr/jbylund/sylvan_librarian" alt="Pull requests"></a>
+      <br>
+      <a href="https://github.com/jbylund/sylvan_librarian/stargazers"><img src="https://img.shields.io/github/stars/jbylund/sylvan_librarian" alt="Stars"></a>
+    </td>
+  </tr>
   <tr>
     <td align="center"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" width="40" height="40"></td>
     <td>

--- a/docs/legal/legal.md
+++ b/docs/legal/legal.md
@@ -39,6 +39,18 @@ Card images are processed from Scryfall's PNG images and served via our own infr
 - **Beleren font**: Used for card text display (respecting font licensing)
 - **MPlantin font**: Used for flavor text and card names
 
+### Language Marks in the README
+
+The Python, Rust, JavaScript, and GitHub marks in the README header are redistributed from
+upstream icon sets rather than hotlinked — `scripts/gen_badges.py` mirrors them to this
+project's CDN on a schedule. Both source licenses permit that redistribution:
+
+- **[devicon](https://github.com/devicons/devicon)** (Python, JavaScript) — MIT
+- **[simple-icons](https://github.com/simple-icons/simple-icons)** (GitHub, Rust) — CC0-1.0
+
+The marks themselves remain the trademarks of their respective projects and are used only
+to identify the languages this codebase is written in.
+
 ## Intellectual Property Attribution
 
 ### Wizards of the Coast

--- a/scripts/gen_badges.py
+++ b/scripts/gen_badges.py
@@ -13,6 +13,9 @@ Two kinds of asset land in the output directory:
    three badges read alike in the README the way the three checks read alike in the PR
    checks list.
 
+3. ``logo-<language>.svg`` — the header's language marks, mirrored from upstream so the
+   README depends on our own CDN rather than on two third-party ones staying up.
+
 Both are uploaded to S3 and served through CloudFront by .github/workflows/badges.yml;
 nothing generated here is committed to the repo.
 
@@ -26,6 +29,7 @@ Usage:
     python scripts/gen_badges.py --out-dir dist/badges
     python scripts/gen_badges.py --out-dir dist/badges --skip-tests    # chart only
     python scripts/gen_badges.py --out-dir dist/badges --tokei ./tokei # non-PATH binary
+    python scripts/gen_badges.py --out-dir dist/badges --skip-logos    # no logo mirror
 """
 
 from __future__ import annotations
@@ -37,12 +41,45 @@ import math
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
 LOGGER = logging.getLogger("gen_badges")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Language marks for the README header, mirrored onto our own CDN rather than hotlinked.
+# A hotlinked header depends on two third-party CDNs staying up and keeping their URL
+# schemes; mirroring costs four small files a day and puts the whole header on
+# infrastructure we control.
+#
+# devicon is pinned to a release tag because its `main` is a moving target — an icon
+# redraw would land in the README unannounced. simple-icons has no versioned CDN path,
+# so the daily snapshot is the pin.
+#
+# Licensing: devicon is MIT, simple-icons is CC0-1.0. Both permit redistribution; the
+# attribution is recorded in docs/legal/legal.md.
+DEVICON_VERSION = "v2.17.0"
+DEVICON = f"https://cdn.jsdelivr.net/gh/devicons/devicon@{DEVICON_VERSION}/icons"
+LOGO_SOURCES = {
+    # The GitHub and Rust marks are near-black, so they use the simple-icons dual-color
+    # form, which emits a prefers-color-scheme rule instead of a fixed fill. Without it
+    # they disappear against a dark README.
+    "github": "https://cdn.simpleicons.org/github/181717/ffffff",
+    "rust": "https://cdn.simpleicons.org/rust/000000/ffffff",
+    "python": f"{DEVICON}/python/python-original.svg",
+    "javascript": f"{DEVICON}/javascript/javascript-original.svg",
+}
+LOGO_FETCH_TIMEOUT_SECONDS = 20
+
+# cdn.simpleicons.org answers 403 to clients that send no User-Agent, which is what
+# urllib does by default. The value does not matter; its presence does.
+LOGO_FETCH_USER_AGENT = "sylvan-librarian-badge-generator"
+
+# Enough of the response to tell an SVG from a CDN error page.
+MARKUP_SNIFF_BYTES = 512
 
 # Which tracked files count as source at all. Only languages GitHub's linguist treats as
 # code appear here; prose (.md) and data (.json, .toml, .yml) are excluded so the chart
@@ -342,11 +379,36 @@ def write_test_badges(out_dir: Path) -> None:
         LOGGER.info("wrote %s (%d tests)", target, count)
 
 
+def mirror_logos(out_dir: Path) -> None:
+    """Copy the header's language marks into the output directory.
+
+    A logo that cannot be fetched is skipped rather than written empty: the previous
+    upload stays in place on the CDN, so a transient upstream outage leaves yesterday's
+    mark in the README instead of a broken image.
+    """
+    for name, url in LOGO_SOURCES.items():
+        request = urllib.request.Request(url, headers={"User-Agent": LOGO_FETCH_USER_AGENT})  # noqa: S310
+        try:
+            with urllib.request.urlopen(request, timeout=LOGO_FETCH_TIMEOUT_SECONDS) as response:  # noqa: S310
+                body = response.read()
+        except (urllib.error.URLError, TimeoutError) as exc:
+            LOGGER.warning("could not fetch the %s logo from %s: %s", name, url, exc)
+            continue
+        # Guard against a CDN error page being mirrored as if it were the icon.
+        if b"<svg" not in body[:MARKUP_SNIFF_BYTES]:
+            LOGGER.warning("%s did not return SVG for %s; leaving the published copy alone", url, name)
+            continue
+        target = out_dir / f"logo-{name}.svg"
+        target.write_bytes(body)
+        LOGGER.info("wrote %s (%d bytes)", target, len(body))
+
+
 def main() -> int:
     """Render the badge assets into --out-dir."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out-dir", type=Path, required=True, help="directory to write badge assets into")
-    parser.add_argument("--skip-tests", action="store_true", help="only render the language chart")
+    parser.add_argument("--skip-tests", action="store_true", help="skip the per-suite test counts")
+    parser.add_argument("--skip-logos", action="store_true", help="skip mirroring the header logos")
     parser.add_argument("--tokei", default="tokei", help="path to the tokei binary (default: found on PATH)")
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
@@ -361,6 +423,8 @@ def main() -> int:
 
     if not args.skip_tests:
         write_test_badges(args.out_dir)
+    if not args.skip_logos:
+        mirror_logos(args.out_dir)
     return 0
 
 


### PR DESCRIPTION
Regroups the README header so each language reads as one unit, and puts the whole thing on our own CDN.

## What it looks like

A single table: a mark per row, its badges beside it, and the language chart spanning all four rows.

| row | left | right |
|---|---|---|
| GitHub | issues, pull requests, stars | the language donut, spanning all four rows, with last commit and license filling the slack below it |
| Python | tests passing, 2,360 tests | |
| Rust | tests passing, 192 tests | |
| JavaScript | tests passing, 1,741 tests | |

Nothing floats above the table — the header is one block, 602×287 at desktop width.

Adds a **js-tests status badge**; JavaScript was the one language with a test count but no pass/fail.

## Logos are mirrored, not hotlinked

`gen_badges.py` now copies the four marks to our CDN alongside the badges it already publishes, so the header no longer depends on `cdn.jsdelivr.net` and `cdn.simpleicons.org` staying up and keeping their URL schemes. They ride the existing upload step, which already globs `*.svg`.

- **devicon is pinned to v2.17.0.** Its `main` is a moving target, and an icon redraw would land in the README unannounced. simple-icons has no versioned CDN path, so the daily snapshot is the pin.
- **A logo that cannot be fetched is skipped**, leaving the previously published copy in place rather than breaking the header on a transient outage. That path proved itself during development: `cdn.simpleicons.org` answers 403 to clients sending no User-Agent, which is urllib's default, and the run degraded exactly as intended before the header was added.
- MIT (devicon) and CC0 (simple-icons) attribution recorded in `docs/legal/legal.md`, since these files are now redistributed rather than linked.

## Two choices worth knowing

**JavaScript uses devicon's mark, not simple-icons'.** simple-icons draws the JS letters as a knockout, so they show the page background through and render white-on-yellow in light mode — nearly illegible. devicon keeps them solid black on both themes.

**The GitHub and Rust marks are theme-aware.** Both are near-black and would disappear against a dark README, so they use the dual-color form that emits a `prefers-color-scheme` rule rather than a fixed fill.

## Known tradeoff

The chart is in a spanning cell, so it gets roughly half the article width. At desktop that is its native 344px; on a 390px viewport it scales to 47% and the legend becomes unreadable. Accepted deliberately — it is an ornament, and README traffic is overwhelmingly desktop. The chart's methodology (source lines, excluding comments, blanks, and benchmark harnesses) is documented in the `gen_badges.py` docstring.

The chart no longer appears under Code Organization; the same generated image twice on one page is worse than either placement alone.

## Verification

Rendered and measured in a real browser at 1280px and 390px: 0 broken images, no horizontal overflow, `rowspan` cell spanning the full 287px. `ruff check` and `ruff format --check` clean.
