### PR TITLE
Docs: Design Notes for a Live Scryfall Latency Comparison

### DIFF
--- a/docs/issues/local-cache-bypass-header.md
+++ b/docs/issues/local-cache-bypass-header.md
@@ -1,0 +1,86 @@
+# Token-Gated Cache Bypass Header
+
+Add a request header that makes `CachingMiddleware` skip the response cache, gated by a shared
+secret, so a benchmark can force a real miss deterministically and *prove* it happened.
+
+Prerequisite for [local-scryfall-latency-comparison.md](./local-scryfall-latency-comparison.md).
+
+## Why
+
+A latency benchmark that compares us against another service has to know which arm of the
+comparison it is measuring. Right now a caller has no supported way to say "do the work" — the
+middleware decides, and the only signal back is `X-Cache: hit|miss` after the fact.
+
+That matters less today than it will later. Measured against the live site (from a laptop, not a CI
+runner):
+
+| | value |
+|---|---|
+| wall clock, cold connection | 28 ms |
+| wall clock, warm connection | ~7 ms |
+| `Server-Timing: total` | 0.6–2.8 ms |
+
+Compute is a small share of the response, so bypassing the cache moves the total by a millisecond or
+two. The reason to build this anyway is methodological, not numerical: a measurement you only trust
+while the numbers are flattering is not a measurement. If a regression ever made a query cost 500 ms,
+cached-vs-uncached would become the dominant term, and that is precisely the moment the benchmark
+needs to have been correct all along.
+
+## Design
+
+`X-Bypass-Cache: <token>` on the request.
+
+**Gate it on a secret.** An open bypass is a cheap amplifier against a public deployment: any caller
+could make every request skip the cache and do full engine and database work. The token lives in
+settings (env-provided), and the comparison is `hmac.compare_digest` — not `==` — so the check does
+not leak the token through timing. Absent or wrong token means the header is ignored entirely, and
+the request is served normally. No error, no signal that the feature exists.
+
+**Skip the read *and* the write.** The obvious implementation only skips the lookup, which leaves the
+benchmark inserting an entry per sample. With `LRUCache(maxsize=10_000)` a handful of daily queries
+would not meaningfully evict real traffic, but the benchmark should not perturb the thing it
+measures, and a bypassed response is by definition not the response a normal caller would have
+stored.
+
+**Make it assertable.** Set `X-Cache: bypass` rather than reusing `miss`. The benchmark then checks
+the header on every sample and fails loudly if the bypass did not take effect. Without this, a
+misconfigured token degrades silently into "our cached responses vs their uncached ones" — a
+comparison that looks spectacular and means nothing. That failure is invisible in the output, which
+is what makes it worth designing against rather than trusting.
+
+## Implementation sketch
+
+Both hooks are in [api/middlewares/caching_middleware.py](../../api/middlewares/caching_middleware.py):
+
+- `process_request` — after the `settings.enable_cache` and `CACHEABLE_METHODS` guards, check the
+  header. On a valid token, set `req.context["cache_bypass"] = True`, set `X-Cache: bypass`, and
+  return without probing the cache.
+- `process_response` — return early when `req.context.get("cache_bypass")` is set, alongside the
+  existing `cache_hit` check.
+
+`_cache_key` needs no change: the bypass never reaches a lookup, and the header must **not** join the
+key, or every distinct token value would carve out its own cache namespace.
+
+Note that `X-Cache` is already in `_UNCACHEABLE_HEADER_PREFIXES`, so a stored entry can never replay
+a `bypass` value to a later caller. That invariant is what makes the header trustworthy as an
+assertion target, and it is already in place.
+
+## Tests
+
+`api/middlewares/tests/` covers the middleware directly. Worth asserting:
+
+- valid token → cache is neither read nor written, response carries `X-Cache: bypass`
+- absent / wrong token → behaves exactly as today, no `bypass` value ever emitted
+- bypass on a request whose key is already cached → the stored entry survives untouched
+- the token is not part of the cache key — two different valid tokens hit the same entry
+
+## Open questions
+
+- **Should the bypass be rate-limited independently of the token?** A leaked token otherwise
+  re-creates the amplifier it was meant to prevent. Cheapest answer may be a per-token request
+  budget, but there is no rate-limiting layer in the middleware stack today.
+- **Is a single shared token enough**, or should this be per-caller so one can be revoked without
+  rotating for everyone? One caller is the near-term reality; more than one is speculative.
+- **Should `Cache-Control: no-cache` on the request do the same thing for authenticated callers?**
+  It is the standards-blessed spelling, but overloading it risks a browser or proxy sending it
+  unintentionally, so a custom header is the safer default.

--- a/docs/issues/local-scryfall-latency-comparison.md
+++ b/docs/issues/local-scryfall-latency-comparison.md
@@ -1,0 +1,109 @@
+# Near-Live Latency Comparison Against Scryfall
+
+A small suite of queries run daily against both sylvan-librarian.com and api.scryfall.com,
+published as a table through the existing badge pipeline.
+
+Depends on [local-cache-bypass-header.md](./local-cache-bypass-header.md) for a deterministic,
+assertable cache miss on our side.
+
+## The measurement is mostly a methodology problem
+
+A naive "time both, print the ratio" produces a number that is wrong by two orders of magnitude in
+whichever direction flatters the author. Exploratory measurements below are all from one laptop on
+one evening, `n` of 3–4 per cell — enough to establish which confounds matter, not enough to publish.
+
+### Handshake is the largest removable term
+
+`conn` and `tls` go to exactly zero on a reused connection.
+
+| | new connection | reused |
+|---|---|---|
+| sylvan-librarian.com | 28 ms total | ~7 ms |
+| api.scryfall.com | ~100 ms TTFB | ~20 ms |
+
+So: warm the connection, discard the first sample. Both endpoints speak HTTP/2.
+
+### Payload size dominates, and nearly fooled us
+
+The first wide-query comparison looked like a 200× win. It was mostly serialization.
+
+Same query, `t:beast cmc>3 pow>2`:
+
+| | cards returned | fields/card | payload |
+|---|---|---|---|
+| sylvan-librarian.com | 100 | 9 | 41 KB |
+| api.scryfall.com | 175 | 67 | 895 KB |
+
+Re-running with narrow queries that return a handful of cards collapses the gap by an order of
+magnitude on their side:
+
+| query shape | ours (TTFB) | Scryfall origin (TTFB) |
+|---|---|---|
+| wide (100–175 cards) | 5.0–6.8 ms | 1,049–1,677 ms |
+| narrow (1–5 cards) | 5.2–6.6 ms | 78–85 ms |
+
+Our own time barely moves between the two, which is itself the interesting result — but a published
+table built only on wide queries would be claiming credit for returning 9 fields instead of 67.
+
+**Design consequence:** the suite must hold both shapes and report them separately, and the field
+count must be stated. Matching payloads exactly is not possible — Scryfall has no field-selection
+parameter — so the honest move is to disclose rather than normalize.
+
+### Cache state has to be matched, and is second-order
+
+Their edge and our in-process LRU are different mechanisms; there is no configuration in which they
+are equivalent. What is achievable is labelling each arm truthfully:
+
+- **origin vs origin** — our `X-Bypass-Cache` against a `cf-cache-status: MISS`. Forcing their miss
+  means a novel query each run, which drifts the workload; a generator producing
+  equivalent-difficulty-but-unseen queries is the fix.
+- **warm vs warm** — our cache hit against `cf-cache-status: HIT`. This is what users actually
+  experience and is the fairer headline.
+
+Cache-layer differences are a few ms against a query-processing gap of tens to hundreds. Worth
+getting right for correctness of labelling, not because it moves the number.
+
+### Server compute can be differenced out
+
+We publish `Server-Timing` (`handler`, `parse`, `engine_query`, `engine_collect`, `total`); Scryfall
+does not. Compute is recoverable for both by differencing a known-cached against a known-uncached
+request on one warm connection — network cancels, the remainder is server work.
+
+The reason to trust that on their side is that it can be **calibrated on ours, where ground truth
+exists**: our observed hit-vs-miss delta of ~1–2 ms matches the 0.6–2.8 ms `Server-Timing` reports
+independently. Validate the technique where it can be checked, then apply it where it cannot.
+
+### Confounds that cannot be removed, only disclosed
+
+- **Load.** Scryfall serves the Magic community; we serve approximately nobody. This is the single
+  largest uncontrolled variable and no amount of measurement technique touches it.
+- **Geography.** Their Cloudflare edge is global; we are one origin. The result depends on where the
+  runner sits, and a CI runner is not where our users sit either.
+- **Corpus.** `total_cards` differs for identical queries (326 vs 340 on one sample) — different
+  printing and language coverage, so the engines are not answering quite the same question.
+
+## Publishing
+
+Reuse what already exists: `scripts/gen_badges.py` writes JSON and SVG, `.github/workflows/badges.yml`
+publishes to S3 behind CloudFront daily. This wants a sibling script on the same schedule and the
+same upload step, not new infrastructure.
+
+Output as an SVG table rather than shields endpoints — this is a grid of numbers, not a status chip.
+
+**Scryfall's terms constrain the presentation.** Their docs require a `User-Agent` naming the
+application and an `Accept` header, and note hard rate limits; a daily handful of queries is well
+within courteous use, and samples should be spaced. Their guidelines also say their name may not be
+used in a way implying endorsement — so a factual table is fine, their logo in our README is not, and
+the framing should avoid reading as a marketing claim. Given the load confound above, that is also
+just accurate.
+
+## Open questions
+
+- **Where does it run from?** A CI runner is convenient and reproducible; it is also a datacenter,
+  which is nobody's browser. Reporting the vantage point may be enough.
+- **How many samples per query** before the number is worth publishing? The wide-query spread
+  (1,049–1,677 ms) is ~45% of the median, so a single sample per day would be mostly noise.
+- **Does a failure to reach either service publish a gap, or hold the last good value?** The badge
+  pipeline's existing answer is "skip and keep the previous upload", which likely applies here too.
+- **Should the query suite live in the repo as a fixture** so a change to it is reviewable, rather
+  than being generated fresh each run?


### PR DESCRIPTION
Docs only. Two `local-` docs, one shippable idea each, cross-linked.

- **`local-cache-bypass-header.md`** — a token-gated `X-Bypass-Cache` header, prerequisite for the comparison.
- **`local-scryfall-latency-comparison.md`** — the daily comparison table itself.

## Why two docs

The header is independently shippable and useful on its own; the comparison depends on it. Per `docs/issues/README.md`, that is the split signal.

## The measurement nearly produced a bogus headline

Worth surfacing, because it is the reason the second doc is mostly about methodology rather than results. The first wide-query comparison looked like a **200× win**. It was mostly serialization.

Same query, `t:beast cmc>3 pow>2`:

| | cards | fields/card | payload |
|---|---|---|---|
| sylvan-librarian.com | 100 | 9 | 41 KB |
| api.scryfall.com | 175 | 67 | 895 KB |

Re-running with narrow queries collapses their side by an order of magnitude while ours barely moves:

| query shape | ours (TTFB) | Scryfall origin (TTFB) |
|---|---|---|
| wide (100–175 cards) | 5.0–6.8 ms | 1,049–1,677 ms |
| narrow (1–5 cards) | 5.2–6.6 ms | 78–85 ms |

A table built only on wide queries would be claiming credit for returning 9 fields instead of 67.

## Other findings recorded

- **Handshake is the largest removable term** — `conn` and `tls` go to exactly zero on a reused connection, worth ~20 ms to us and ~78 ms to them.
- **Server compute can be differenced out** for Scryfall, who publish no `Server-Timing`, by comparing a known-cached against a known-uncached request on one warm connection. The technique is calibrated against our own `Server-Timing`, where ground truth exists.
- **Cache state is second-order** — a few ms against a query-processing gap of tens to hundreds. It matters for correctness of labelling, not for the number.
- **Confounds that cannot be removed, only disclosed** — their production load against our near-zero traffic is the largest, followed by geography and a corpus that answers slightly different questions (`total_cards` 326 vs 340 for an identical query).

All exploratory numbers are from one laptop on one evening at n=3–4, and the docs say so — enough to establish which confounds matter, not enough to publish.

## Note on scope

Neither doc has a GitHub issue yet, hence the `local-` prefix; rename to numbers if filed.