### PR TITLE
Parsing: Accept Result-Shape Directives and the ci Identity Alias

### DIFF
--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -76,7 +76,7 @@ DB_COLUMNS = [
     FieldInfo(
         db_column_name="card_color_identity",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["color_identity", "coloridentity", "id", "identity"],
+        search_aliases=["color_identity", "coloridentity", "id", "identity", "ci"],
         parser_class=ParserClass.COLOR,
     ),
     FieldInfo(

--- a/api/parsing/db_info.py
+++ b/api/parsing/db_info.py
@@ -196,13 +196,13 @@ DB_COLUMNS = [
     FieldInfo(
         db_column_name="card_oracle_tags",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["oracle_tags", "otag"],
+        search_aliases=["oracle_tags", "otag", "oracletag", "function"],
         parser_class=ParserClass.TEXT,
     ),
     FieldInfo(
         db_column_name="card_art_tags",
         field_type=FieldType.JSONB_OBJECT,
-        search_aliases=["art_tags", "art"],
+        search_aliases=["art_tags", "art", "atag", "arttag"],
         parser_class=ParserClass.TEXT,
     ),
     FieldInfo(

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -435,6 +435,23 @@ class Parser:
 
     # ── word dispatch ─────────────────────────────────────────────────────────
 
+    def parse_directive_primary(self, word: str, wl: str, next_tok: Token) -> QueryNode | None:
+        """Consume a result-shape directive (sort:/order:/direction:/prefer:), or return None.
+
+        Scryfall accepts these inside the query string itself; they constrain presentation,
+        not membership, so a directive parses to the always-true node and the prune pass in
+        rewrite.py removes it from the filter tree entirely.
+        """
+        if wl not in ("sort", "order", "direction", "prefer") or next_tok.type != TT.OP or next_tok.value != ":":
+            return None
+        self.consume()  # ':'
+        val_tok = self.peek()
+        if val_tok.type in (TT.WORD, TT.QUOTED, TT.NUMBER):
+            self.consume()
+            return TrueNode()
+        msg = f"Expected value after '{word}:' at position {val_tok.pos}"
+        raise ParseError(msg)
+
     def parse_word_primary(self, word: str) -> QueryNode:
         """Dispatch on whether word is a known attribute alias, keyword, or implicit name."""
         wl = word.lower()
@@ -444,6 +461,10 @@ class Parser:
 
         pc = _ALIAS_TO_PC.get(wl)
         next_tok = self.peek()
+
+        directive = self.parse_directive_primary(word, wl, next_tok)
+        if directive is not None:
+            return directive
 
         # ── dual-class alias (cn / number): dispatch on value shape ──
         if wl in _DUAL_NUM_TEXT and next_tok.type == TT.OP:

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -356,8 +356,16 @@ def create_all_condition_parsers(basic_parsers: dict, mana_parsers: dict, color_
     )
     attr_attr_condition.set_parse_action(make_binary_operator_node)
 
+    # Result-shape directives Scryfall accepts inside the query string
+    # (sort:edhrec, order:name, direction:asc, prefer:oldest). They constrain
+    # presentation, not membership, so they parse to the always-true node and
+    # contribute nothing to the filter tree.
+    directive_condition = Regex(r"(?i)(?:sort|order|direction|prefer)(?=:)") + Literal(":") + (quoted_string | string_value_word)
+    directive_condition.set_parse_action(TrueNode)
+
     condition = (
-        mana_condition
+        directive_condition
+        | mana_condition
         | rarity_condition
         | legality_condition
         | color_condition

--- a/api/parsing/rewrite.py
+++ b/api/parsing/rewrite.py
@@ -25,6 +25,7 @@ from api.parsing.nodes import (
     Query,
     RegexValueNode,
     StringValueNode,
+    TrueNode,
     flatten_nested_operations,
 )
 
@@ -200,10 +201,46 @@ def expand_derived_predicates(query: Query) -> Query:
     return flatten_nested_operations(Query(root))
 
 
+def _prune_true(node: QueryNode) -> QueryNode:
+    """Return `node` with always-true leaves pruned; the original object when nothing changed."""
+    cls = node.__class__
+    if cls is AndNode:
+        ops = [_prune_true(op) for op in node.operands]
+        kept = [op for op in ops if not isinstance(op, TrueNode)]
+        if not kept:
+            return TrueNode()
+        if len(kept) == 1:
+            return kept[0]
+        return AndNode(kept) if kept != list(node.operands) else node
+    if cls is OrNode:
+        ops = [_prune_true(op) for op in node.operands]
+        if any(isinstance(op, TrueNode) for op in ops):
+            return TrueNode()
+        return OrNode(ops) if ops != list(node.operands) else node
+    if cls is NotNode:
+        inner = _prune_true(node.operand)
+        return NotNode(inner) if inner is not node.operand else node
+    return node
+
+
+def prune_true_operands(query: Query) -> Query:
+    """Drop always-true leaves from compounds, so a result-shape directive leaves no residue.
+
+    A directive like `sort:edhrec` parses to the always-true node; without this pass a query
+    carrying one would serialize with a vestigial `AND TRUE`, making `t:goblin sort:edhrec`
+    compare unequal to `t:goblin` despite filtering identically. An Or containing an
+    always-true operand is itself always true.
+    """
+    root = _prune_true(query.root)
+    if root is query.root:
+        return query
+    return Query(root)
+
+
 # The post-parse rewrite pipeline, applied in order at the shared parse seam. Add future AST
 # rewrites to this tuple — both parsers call `rewrite_query`, so a new pass lands in exactly one
 # place and is guaranteed identical treatment across parsers (enforced by test_parser_parity).
-_REWRITE_PASSES = (expand_derived_predicates, lower_literal_regexes)
+_REWRITE_PASSES = (expand_derived_predicates, lower_literal_regexes, prune_true_operands)
 
 
 def rewrite_query(query: Query) -> Query:

--- a/api/parsing/tests/test_result_directives.py
+++ b/api/parsing/tests/test_result_directives.py
@@ -61,6 +61,27 @@ def test_directive_prefix_of_longer_word_is_a_name() -> None:
     assert generate_sql_query(parse_scryfall_query("sorting")) == generate_sql_query(parse_search_query("sorting"))
 
 
+# Scryfall's tag-alias spellings (each verified live: art/atag/arttag and
+# otag/oracletag/function return identical counts on api.scryfall.com).
+TAG_ALIAS_CASES = [
+    ("atag:squirrel", "art:squirrel"),
+    ("arttag:squirrel", "art:squirrel"),
+    ("oracletag:removal", "otag:removal"),
+    ("function:removal", "otag:removal"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["alias_query", "canonical_query"],
+    argvalues=TAG_ALIAS_CASES,
+    ids=[q for q, _ in TAG_ALIAS_CASES],
+)
+def test_tag_aliases_match_canonical(alias_query: str, canonical_query: str) -> None:
+    """Each Scryfall tag-alias spelling produces identical SQL to its canonical form, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(alias_query)) == generate_sql_query(parse_scryfall_query(canonical_query))
+    assert generate_sql_query(parse_search_query(alias_query)) == generate_sql_query(parse_search_query(canonical_query))
+
+
 CI_CASES = [
     ("ci<=bg", "id<=bg"),
     ("ci:wu", "id:wu"),

--- a/api/parsing/tests/test_result_directives.py
+++ b/api/parsing/tests/test_result_directives.py
@@ -1,0 +1,80 @@
+"""Result-shape directives (sort:/order:/direction:/prefer:) and the `ci` identity alias.
+
+Scryfall accepts presentation directives inside the query string itself — a query
+like `t:goblin sort:edhrec` is valid there and filters exactly as `t:goblin`.
+Rejecting them breaks any client that forwards Scryfall-shaped query strings
+verbatim. Both parsers must consume a directive and contribute nothing to the
+filter tree (the always-true node), keeping SQL identical to the directive-free
+query.
+
+`ci` mirrors Scryfall's alias for color identity (`ci<=bg` == `id<=bg`).
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.pyparsing_based import parse_search_query
+
+# (query with directive, equivalent query without it)
+DIRECTIVE_CASES = [
+    ("t:goblin sort:edhrec", "t:goblin"),
+    ("t:goblin order:name", "t:goblin"),
+    ("t:goblin direction:asc", "t:goblin"),
+    ("t:goblin prefer:oldest", "t:goblin"),
+    ("sort:edhrec t:goblin", "t:goblin"),
+    ('t:goblin sort:"edhrec"', "t:goblin"),
+    ("t:planeswalker f:commander sort:edhrec", "t:planeswalker f:commander"),
+    ("(t:goblin or t:elf) sort:edhrec", "t:goblin or t:elf"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["query", "equivalent"],
+    argvalues=DIRECTIVE_CASES,
+    ids=[q for q, _ in DIRECTIVE_CASES],
+)
+def test_directive_filters_like_equivalent(query: str, equivalent: str) -> None:
+    """A directive-bearing query produces the same SQL as the query without it (hand parser)."""
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(equivalent))
+
+
+@pytest.mark.parametrize(
+    argnames=["query", "equivalent"],
+    argvalues=DIRECTIVE_CASES,
+    ids=[q for q, _ in DIRECTIVE_CASES],
+)
+def test_directive_parser_parity(query: str, equivalent: str) -> None:
+    """Both parsers agree on every directive-bearing query."""
+    del equivalent
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_search_query(query))
+
+
+def test_directive_needs_a_value() -> None:
+    """A dangling directive prefix is still an error, not a silent no-op."""
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_scryfall_query("t:goblin sort:")
+
+
+def test_directive_prefix_of_longer_word_is_a_name() -> None:
+    """Words that merely START with a directive keep their name reading."""
+    # "sorting" must not be consumed as "sort" + garbage.
+    assert generate_sql_query(parse_scryfall_query("sorting")) == generate_sql_query(parse_search_query("sorting"))
+
+
+CI_CASES = [
+    ("ci<=bg", "id<=bg"),
+    ("ci:wu", "id:wu"),
+    ("ci>=rg", "identity>=rg"),
+    ("t:land ci<=bg", "t:land id<=bg"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=["ci_query", "id_query"],
+    argvalues=CI_CASES,
+    ids=[q for q, _ in CI_CASES],
+)
+def test_ci_is_an_identity_alias(ci_query: str, id_query: str) -> None:
+    """`ci` produces identical SQL to the established identity aliases, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(ci_query)) == generate_sql_query(parse_scryfall_query(id_query))
+    assert generate_sql_query(parse_search_query(ci_query)) == generate_sql_query(parse_search_query(id_query))


### PR DESCRIPTION
## What

*(Slimmed to the parser half per review — the rewrite-vocabulary entries now live in their own PR for the quick-merge path you suggested.)*

Two Scryfall-compatibility gaps hit by a client that forwards Scryfall-shaped query strings verbatim:

1. **Result-shape directives** — Scryfall accepts `sort:edhrec`, `order:name`, `direction:asc`, `prefer:oldest` *inside* the query string; they affect presentation, never membership ([example](https://scryfall.com/search?q=t%3Aplaneswalker+sort%3Aedhrec)). Previously these were parse errors here. Both parsers now consume a directive to `TrueNode`, and a new `prune_true_operands` pass in the rewrite pipeline removes true operands from compounds, so `t:goblin sort:edhrec` parses to a tree **equal** to `t:goblin` (no vestigial `AND TRUE` in SQL; the engine already had `FilterExpr::True`). A dangling `sort:` stays a parse error, and words merely *starting* with a directive ("sorting") keep their name reading.

2. **`ci` alias** — Scryfall treats `ci` as a color-identity alias (`ci<=bg` == `id<=bg`). One-word addition to the identity alias list.

## Validation

- `api/parsing/tests/`: full suite green including new `test_result_directives.py` (both parsers, directive/equivalent SQL equality, parity, the dangling-directive error, the prefix-word case, `ci` ≡ `id` in both parsers)
- `ruff check` and `ruff format --check` clean