### PR TITLE
API: Add a Fuzzy Card-Name Lookup Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ python -m client.query_runner
 
 - **GET /** - Web interface (serves `index.html`)
 - **GET /search** - Card search with query parameter support
+- **GET /named** - Typo-tolerant single-card lookup by name (`?fuzzy=lighning+bolt`), mirroring Scryfall's `/cards/named` (also served at `/cards/named`)
 - **GET /favicon.ico** - Favicon for web interface
 
 ### Tagging Endpoints

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -45,6 +45,7 @@ from api.enums import CardOrdering, PreferOrder, ResponseShape, SortDirection, U
 from api.middlewares.timing import record_span
 from api.noscript_helpers import generate_results_count_html, generate_results_html
 from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.card_query_nodes import fold_accents
 from api.scryfall_bulk_data_fetcher import BulkDataKey, ScryfallBulkDataFetcher
 from api.settings import settings
 from api.tag_import import import_art_tags as _import_art_tags
@@ -294,6 +295,24 @@ DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
     "set_name",
     "type_line",
 )
+
+# What /named returns for the one card it resolves: the same default 9 fields /search returns,
+# plus scryfall_id so the caller can address the exact printing it was given.
+NAMED_LOOKUP_FIELDS: tuple[str, ...] = (*DEFAULT_RESULT_FIELDS, "scryfall_id")
+
+# Minimum pg_trgm similarity between the (accent-folded, lowercased) query and a card name for the
+# card to count as a plausible fuzzy match at all. 0.4 keeps one-or-two-letter typos ("lighning
+# bolt", "counterspel") comfortably in while rejecting queries that merely share a common word
+# ("bolt of anything" scoring ~0.3 against half the corpus). Deliberately above pg_trgm's default
+# 0.3 similarity_threshold, so the index-assisted % prefilter in the SQL below is always a strict
+# superset of what this floor admits.
+NAMED_LOOKUP_SIMILARITY_FLOOR = 0.4
+
+# How far the best fuzzy candidate must lead the runner-up for the match to count as unambiguous.
+# Two distinct card names within this margin of each other means the query does not clearly
+# identify either ("obelisk of urd" vs. the five Obelisks), which mirrors Scryfall's behavior of
+# returning an error rather than guessing.
+NAMED_LOOKUP_AMBIGUITY_MARGIN = 0.05
 
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
@@ -1490,6 +1509,109 @@ class APIResource:
             "inner_timings": result_bag.pop("timings"),
             "total_cards": total_cards,
         }
+
+    @route(paths=("named", "cards/named"))
+    def named(
+        self,
+        *,
+        falcon_response: falcon.Response | None = None,
+        fuzzy: str | None = None,
+        **_: object,
+    ) -> dict[str, Any]:
+        """Look up a single card by name, tolerating typos — Scryfall's GET /cards/named?fuzzy=.
+
+        Resolution mirrors Scryfall: a case-insensitive exact name match wins immediately;
+        otherwise the best trigram match on the accent-folded name wins, provided it clears
+        NAMED_LOOKUP_SIMILARITY_FLOOR and leads the next-best *distinct* card name by at least
+        NAMED_LOOKUP_AMBIGUITY_MARGIN. An ambiguous or implausible name is a 404, so a client
+        never silently receives a card the query did not clearly identify.
+
+        Card-face names are not matched yet: only the full printed name (for multi-face cards,
+        "Front // Back") participates, because face names live inside raw_card_blob where no
+        trigram index can reach them.
+
+        Args:
+            falcon_response: The Falcon response object (used only to set cache headers).
+            fuzzy: The card name to look up, exactly or approximately. Required.
+
+        Returns:
+            The single best-matching card, carrying the same default 9 fields /search returns
+            plus scryfall_id — one row, for the printing with the highest prefer_score.
+
+        Raises:
+            falcon.HTTPBadRequest: If no name is supplied.
+            falcon.HTTPNotFound: If nothing matches closely enough, or several cards match
+                about equally well.
+        """
+        self._require_setup_complete()
+        name = (fuzzy or "").strip()
+        if not name:
+            raise falcon.HTTPBadRequest(
+                title="Missing Parameter",
+                description="A card name must be supplied via the fuzzy= query parameter.",
+            )
+        set_cache_header(falcon_response, duration=timedelta(seconds=90))
+        result_cols = ",\n                ".join(f"{RESULT_FIELD_COLUMNS[field]} AS {field}" for field in NAMED_LOOKUP_FIELDS)
+
+        exact_sql = f"""
+            SELECT
+                {result_cols}
+            FROM
+                magic.cards AS card
+            WHERE
+                lower(card_name) = %(name_lower)s
+            ORDER BY
+                prefer_score DESC NULLS LAST,
+                edhrec_rank ASC NULLS LAST
+            LIMIT 1"""
+        exact_rows = self._run_query(query=exact_sql, params={"name_lower": name.lower()}, explain=False)["result"]
+        if exact_rows:
+            return exact_rows[0]
+
+        # The OPERATOR(magic.%) prefilter is what lets idx_cards_cardname_folded_lower_trgm serve
+        # this query; a bare ORDER BY similarity() would score every row in the table. It admits
+        # candidates down to pg_trgm's similarity_threshold (default 0.3), below both the floor and
+        # the lowest runner-up the ambiguity margin can care about (floor - margin), so no decision
+        # made in Python below ever depends on a row the prefilter dropped. DISTINCT ON collapses
+        # printings to one row per card name — best prefer_score — *before* the LIMIT 2, so two
+        # printings of the winner can never masquerade as an ambiguous pair.
+        fuzzy_sql = f"""
+            WITH candidates AS (
+                SELECT DISTINCT ON (card_name)
+                    {result_cols},
+                    magic.similarity(lower(card_name_folded), %(name_folded)s) AS name_similarity
+                FROM
+                    magic.cards AS card
+                WHERE
+                    lower(card_name_folded) OPERATOR(magic.%%) %(name_folded)s
+                ORDER BY
+                    card_name,
+                    prefer_score DESC NULLS LAST,
+                    edhrec_rank ASC NULLS LAST
+            )
+            SELECT
+                *
+            FROM
+                candidates
+            ORDER BY
+                name_similarity DESC
+            LIMIT 2"""
+        folded_name = fold_accents(name.lower())
+        rows = self._run_query(query=fuzzy_sql, params={"name_folded": folded_name}, explain=False)["result"]
+
+        if not rows or rows[0]["name_similarity"] < NAMED_LOOKUP_SIMILARITY_FLOOR:
+            raise falcon.HTTPNotFound(
+                title="Not Found",
+                description=f"No cards found matching {name!r}.",
+            )
+        top, *rest = rows
+        if rest and top["name_similarity"] - rest[0]["name_similarity"] < NAMED_LOOKUP_AMBIGUITY_MARGIN:
+            raise falcon.HTTPNotFound(
+                title="Ambiguous Name",
+                description=f"Multiple different cards match {name!r} about equally well. Add more words to disambiguate.",
+            )
+        del top["name_similarity"]
+        return top
 
     @route(paths=("index", "index.html"))
     def _redirect_to_root(self, **_: object) -> None:

--- a/api/tests/test_named_lookup.py
+++ b/api/tests/test_named_lookup.py
@@ -1,0 +1,109 @@
+"""Tests for the /named fuzzy card-name lookup endpoint."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import falcon
+import falcon.testing
+import pytest
+
+from api.api_resource import NAMED_LOOKUP_FIELDS
+from api.tests.helpers import make_raw_card
+
+if TYPE_CHECKING:
+    from api.api_resource import APIResource
+
+
+def _insert_cards(api: APIResource, *names: str) -> None:
+    """Insert one printing per name into the shared test database."""
+    api._upsert_cards([make_raw_card(name=name) for name in names])
+
+
+class TestNamedLookup:
+    def test_exact_match_wins(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Lightning Bolt", "Lightning Strike")
+
+        result = api_resource.named(fuzzy="Lightning Bolt")
+
+        assert result["name"] == "Lightning Bolt"
+
+    def test_exact_match_is_case_insensitive(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Lightning Bolt")
+
+        result = api_resource.named(fuzzy="LIGHTNING bolt")
+
+        assert result["name"] == "Lightning Bolt"
+
+    def test_result_carries_default_fields_plus_scryfall_id(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Lightning Bolt")
+
+        result = api_resource.named(fuzzy="Lightning Bolt")
+
+        assert set(result) == set(NAMED_LOOKUP_FIELDS)
+        assert result["scryfall_id"] is not None
+
+    def test_typo_resolves_to_closest_name(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Lightning Bolt", "Lightning Strike", "Lightning Helix")
+
+        result = api_resource.named(fuzzy="lighning bolt")
+
+        assert result["name"] == "Lightning Bolt"
+
+    def test_accented_name_matches_unaccented_query(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Éowyn of Fuzzmark")
+
+        result = api_resource.named(fuzzy="eowyn of fuzzmark")
+
+        assert result["name"] == "Éowyn of Fuzzmark"
+
+    def test_multiple_printings_of_one_name_are_not_ambiguous(self, api_resource: APIResource) -> None:
+        api_resource._upsert_cards(
+            [
+                make_raw_card(name="Reprinted Fuzz Sentinel"),
+                make_raw_card(name="Reprinted Fuzz Sentinel"),
+            ],
+        )
+
+        result = api_resource.named(fuzzy="reprinted fuz sentinel")
+
+        assert result["name"] == "Reprinted Fuzz Sentinel"
+
+    def test_two_equally_close_names_are_ambiguous(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Obelisk of Fuzz Alara", "Obelisk of Fuzz Bant")
+
+        with pytest.raises(falcon.HTTPNotFound) as exc_info:
+            api_resource.named(fuzzy="obelisk of fuzz")
+
+        assert exc_info.value.title == "Ambiguous Name"
+
+    def test_garbage_finds_nothing(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Lightning Bolt")
+
+        with pytest.raises(falcon.HTTPNotFound) as exc_info:
+            api_resource.named(fuzzy="zzxqjw vvkpqr")
+
+        assert exc_info.value.title == "Not Found"
+
+    def test_missing_fuzzy_parameter_is_rejected(self, api_resource: APIResource) -> None:
+        with pytest.raises(falcon.HTTPBadRequest):
+            api_resource.named()
+
+    def test_blank_fuzzy_parameter_is_rejected(self, api_resource: APIResource) -> None:
+        with pytest.raises(falcon.HTTPBadRequest):
+            api_resource.named(fuzzy="   ")
+
+    def test_registered_under_both_paths(self, api_resource: APIResource) -> None:
+        assert "named" in api_resource.routes
+        assert "cards/named" in api_resource.routes
+        assert api_resource.routes["named"] is api_resource.routes["cards/named"]
+
+    def test_full_dispatch_over_scryfall_path(self, api_resource: APIResource) -> None:
+        _insert_cards(api_resource, "Lightning Bolt")
+
+        req = falcon.Request(falcon.testing.create_environ(path="/cards/named", query_string="fuzzy=lighning+bolt"))
+        resp = falcon.Response()
+        api_resource._handle(req, resp)
+
+        assert resp.status == falcon.HTTP_200
+        assert resp.media["name"] == "Lightning Bolt"


### PR DESCRIPTION
## Motivation

Clients replacing Scryfall's API with a self-hosted Sylvan Librarian can already cover search, but `GET /cards/named?fuzzy=<name>` — typo-tolerant single-card lookup — still has to go to Scryfall. It's the last per-card endpoint such a client would still hit Scryfall for; adding it makes going fully self-hosted possible.

## What this adds

`GET /named?fuzzy=<name>`, also served at `/cards/named` so Scryfall-shaped clients can point their base URL here unchanged. (`/search` already mirrors Scryfall's `/cards/search` without the `/cards` prefix, so `/named` follows the local convention and the alias covers the Scryfall one — happy to drop either spelling if you prefer just one.)

Resolution mirrors Scryfall's contract:

1. **Exact match wins immediately** — case-insensitive on `card_name`, best `prefer_score` printing.
2. **Otherwise fuzzy** — `magic.similarity()` between the accent-folded, lowercased query (same `fold_accents()` the import and `name:` search use) and `card_name_folded`, so `eowyn` still finds `Éowyn`.
3. **One clearly-best match returns that card**; anything else is a 404-style `{"title": ..., "description": ...}` error like the existing handlers raise.

### Ambiguity rule

A fuzzy candidate must clear a **similarity floor of 0.4**, and the best candidate must lead the next-best *distinct card name* by at least **0.05** — closer than that means the query doesn't clearly identify either card (`obelisk of` vs. the many Obelisks), so it's an error rather than a guess. Both constants are module-level and documented in `api_resource.py`; the floor sits deliberately above pg_trgm's default 0.3 `similarity_threshold`, so the index-assisted `%` prefilter is always a strict superset of what the floor admits and no decision depends on a row the prefilter dropped.

### Implementation notes

- Pure SQL via the existing `_run_query` path (statement timeout, per-worker cache); no engine changes.
- The fuzzy stage prefilters with `lower(card_name_folded) OPERATOR(magic.%) <query>`, which the existing `idx_cards_cardname_folded_lower_trgm` GIN index serves — no new migration needed.
- `DISTINCT ON (card_name)` (best `prefer_score` first) collapses printings *before* the `LIMIT 2` ambiguity probe, so two printings of the winner can never masquerade as an ambiguous pair.
- The response is the single card object with the same default 9 fields `/search` returns, plus `scryfall_id` so the caller can address the exact printing it was given.
- **Not covered yet:** card-face names. Only the full printed name ("Front // Back") participates, because face names live inside `raw_card_blob` where no trigram index can reach them; front-face queries usually still resolve through the full name's trigrams, but a dedicated face-name column/index would be the follow-up if face-level parity matters. `exact=` is also not implemented (it's expressible as `/search?q=!"..."` today) but would slot into the same handler trivially.

## Validation

- 12 new tests in `api/tests/test_named_lookup.py` against the testcontainers postgres: exact hit, case-insensitive exact, field shape, typo hit (`lighning bolt` → Lightning Bolt), accent folding, printing dedup, ambiguous pair → 404, garbage → 404, missing/blank `fuzzy` → 400, dual-path registration, and a full Falcon dispatch through `_handle` at `/cards/named`.
- `api/tests/test_api_resource.py` and `api/tests/test_routing.py` (120 tests) still green.
- `ruff check` and `ruff format` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)