### PR TITLE
Parsing+Engine: Numeric Color-Identity Comparisons (id>=3)

### DIFF
--- a/api/db/2026-08-16-03-produced-mana-mask.sql
+++ b/api/db/2026-08-16-03-produced-mana-mask.sql
@@ -1,0 +1,33 @@
+-- produced_mana_mask(jsonb) encodes produced mana as a 6-bit integer (W=32, U=16, B=8, R=4, G=2, C=1).
+--
+-- SIX bits, where magic.color_identity_mask has five, and the extra one is not symmetry-breaking
+-- for its own sake: `produced_mana` is the one colour-ish column whose array can literally contain
+-- "C". Sol Ring's produced_mana is ["C"] where its colors and color_identity are both []. So a
+-- COUNT over this column counts colorless as a value, and Scryfall agrees — measured against
+-- api.scryfall.com 2026-08-16:
+--
+--   produces=6      = 106 = produces:all = produces:wubrgc   -- unreachable if C did not count
+--   produces=1 (C-only producers)             = 481          -- zero under a five-key count
+--   the three cards producing exactly {C,W} land in produces=2, and produces=1 has none of them
+--   counts 0..6 partition the corpus exactly: 30996+1143+504+147+10+693+106 = 33,599
+--
+-- The colour columns must keep counting FIVE and are deliberately NOT switched to this function:
+-- `c:all` = `c:wubrg` = `c=5` = 60 there, and `c=6` is not even a valid query ("Unknown color 6").
+--
+-- The expression index mirrors the color_identity one, so produces= / produces>= count queries are
+-- = ANY(mask_array) point lookups rather than a seq scan.
+
+CREATE OR REPLACE FUNCTION magic.produced_mana_mask(jsonb)
+RETURNS smallint LANGUAGE sql IMMUTABLE STRICT AS $$
+    SELECT (
+        CASE WHEN $1 ? 'W' THEN 32 ELSE 0 END +
+        CASE WHEN $1 ? 'U' THEN 16 ELSE 0 END +
+        CASE WHEN $1 ? 'B' THEN  8 ELSE 0 END +
+        CASE WHEN $1 ? 'R' THEN  4 ELSE 0 END +
+        CASE WHEN $1 ? 'G' THEN  2 ELSE 0 END +
+        CASE WHEN $1 ? 'C' THEN  1 ELSE 0 END
+    )::smallint
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_cards_produced_mana_mask
+    ON magic.cards (magic.produced_mana_mask(produced_mana));

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -213,9 +213,14 @@ def _compare_ints(lhs: int, operator: str, rhs: int) -> bool:
     raise ValueError(msg)
 
 
-def _color_count_masks(operator: str, count: int) -> list[int]:
-    """Bitmask values (5 colors => 2^5) whose popcount satisfies `popcount <op> count`."""
-    return [v for v in range(32) if _compare_ints(v.bit_count(), operator, count)]
+def _color_count_masks(operator: str, count: int, bits: int = 5) -> list[int]:
+    """Bitmask values whose popcount satisfies `popcount <op> count`.
+
+    `bits` is 5 for the colour columns and SIX for produced_mana, whose array can literally hold
+    "C" (Sol Ring produces ["C"] while its colors and color_identity are both []). See the
+    2026-08-16-03 migration for the measurements that pin the difference.
+    """
+    return [v for v in range(1 << bits) if _compare_ints(v.bit_count(), operator, count)]
 
 
 def _subset_masks(query_mask: int) -> list[int]:
@@ -532,7 +537,7 @@ class ExactNameNode(QueryNode):
 
 # What a colour-COUNT name (`c:m`, `id:gold`) means, per operator, as the (operator, count) pair
 # the numeric colour-count comparison is built from. Measured; the evidence and the two surprises
-# in it are written out at db_info.COLOR_COUNT_NAMES.
+# in it are written out at colors.COLOR_COUNT_NAMES.
 _COLOR_COUNT_BY_OPERATOR: typing.Final = {
     ":": (">=", 2),
     "=": (">=", 2),
@@ -549,7 +554,24 @@ _COLOR_COUNT_BY_OPERATOR: typing.Final = {
 # `magic.color_identity_mask` and the engine's popcount both read the five WUBRG keys and would
 # call it zero. `produces:m` is therefore a count this column cannot answer yet, and it stays the
 # error it already was rather than becoming a silently different one.
-_COLOR_COUNT_ATTRIBUTES: typing.Final = ("card_colors", "card_color_identity")
+# The same table for produced_mana, intersected with "produces at least one value". A card that
+# makes no mana at all is not a producer of anything, and Scryfall keeps it out of every one of
+# these: `produces<m` = `produces!=m` = 1,143 = `produces=1`, NOT `produces<2` (32,139) or
+# `produces!=2` (33,095), both of which sweep in the 30,996 cards that produce nothing; and
+# `produces<=m` = 2,603 = `produces>=1` rather than every card. The extra conjunct collapses into
+# the count itself (`<2` and `>=1` is `=1`; `>=0` and `>=1` is `>=1`), so this stays one
+# (operator -> operator, count) table and no AND node is needed.
+_PRODUCED_COUNT_BY_OPERATOR: typing.Final = {
+    ":": (">=", 2),
+    "=": (">=", 2),
+    ">": (">=", 2),
+    ">=": (">=", 2),
+    "<": ("=", 1),
+    "!=": ("=", 1),
+    "<=": (">=", 1),
+}
+
+_COLOR_COUNT_ATTRIBUTES: typing.Final = ("card_colors", "card_color_identity", "produced_mana")
 
 
 class CardBinaryOperatorNode(BinaryOperatorNode):
@@ -576,7 +598,8 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             and lhs.attribute_name in _COLOR_COUNT_ATTRIBUTES
             and rhs.value.strip().lower() in COLOR_COUNT_NAMES
         ):
-            lowered = _COLOR_COUNT_BY_OPERATOR.get(operator)
+            table = _PRODUCED_COUNT_BY_OPERATOR if lhs.attribute_name == "produced_mana" else _COLOR_COUNT_BY_OPERATOR
+            lowered = table.get(operator)
             if lowered is not None:
                 operator, count = lowered
                 rhs = NumericValueNode(count)
@@ -635,7 +658,7 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             # Numeric color syntax (id>=3 / c=2): pass the raw NumericValueNode so the
             # Rust engine builds a color-count comparison instead of a mask compare.
             if isinstance(self.rhs, NumericValueNode):
-                return self._numeric_color_rhs_to_json(attr)
+                return _node_to_json(self.rhs)
             val = self.rhs.value.strip()
             if attr in ("card_colors", "card_color_identity", "produced_mana"):
                 return list(get_colors_comparison_object(val.lower(), attr).keys())
@@ -657,17 +680,6 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             return {"node_type": "StringValueNode", "kwargs": {"value": value}}
 
         return _node_to_json(self.rhs)
-
-    def _numeric_color_rhs_to_json(self, attr: str) -> object:
-        """Serialize a numeric color-count rhs (id>=3 / c=2) for the Rust engine.
-
-        Only the two real color fields support counting; produced_mana's C key is a
-        genuine producible value, not a color, so a count over it would be ambiguous.
-        """
-        if attr in ("card_colors", "card_color_identity"):
-            return _node_to_json(self.rhs)
-        msg = f"Numeric comparison is not supported for {attr}"
-        raise ValueError(msg)
 
     def to_sql(self, context: QueryContext) -> str:
         """Generate SQL for card-specific binary operations.
@@ -730,7 +742,10 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
 
         # Numeric color syntax compares the count of colors, not the colors themselves
         if db_column_name in ("card_colors", "card_color_identity") and isinstance(self.rhs, NumericValueNode):
-            noun = "colors in the color identity" if db_column_name == "card_color_identity" else "colors"
+            noun = {
+                "card_color_identity": "colors in the color identity",
+                "produced_mana": "kinds of mana produced",  # SIX kinds: colorless is one of them
+            }.get(db_column_name, "colors")
             count_op = "is" if self.operator == ":" else operator_str  # : compares counts as equality
             return f"the number of {noun} {count_op} {rhs_str}"
         # `=` against an empty value reaches here (see to_human_explanation) as a real
@@ -1111,16 +1126,18 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         mask set restricted to values whose popcount satisfies the comparison.
         ":" with a number behaves like "=" (verified against the live Scryfall API).
 
-        produced_mana is refused: its C key is a genuine producible value, not a
-        color, so a count over it would be ambiguous.
+        produced_mana counts SIX values, colorless among them, and so uses its
+        own six-bit mask function: `produces=1 produces:c` = 481 (the cards that
+        produce colorless and nothing else) and `produces=6` = 106, neither of
+        which a five-key count can express. The colour columns keep counting
+        five -- `c=5` = `c:all` = 60 and `c=6` is not a valid query at all.
         """
-        if attr == "produced_mana":
-            msg = f"Numeric comparison is not supported for {attr}"
-            raise ValueError(msg)
+        produced = attr == "produced_mana"
         operator = "=" if self.operator == ":" else self.operator
-        masks = IntArray(_color_count_masks(operator, int(self.rhs.value)))
+        masks = IntArray(_color_count_masks(operator, int(self.rhs.value), bits=6 if produced else 5))
         pmask = context.add(masks)
-        return f"(magic.color_identity_mask({lhs_sql}) = ANY({pmask}::smallint[]))"
+        mask_fn = "magic.produced_mana_mask" if produced else "magic.color_identity_mask"
+        return f"({mask_fn}({lhs_sql}) = ANY({pmask}::smallint[]))"
 
     def _handle_jsonb_object(self, context: QueryContext) -> str:  # noqa: PLR0912, C901
         # Produce the query as a jsonb object

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -8,7 +8,7 @@ import unicodedata
 
 from titlecase import titlecase
 
-from api.parsing.colors import COLOR_ALIAS_TO_CODES, COLOR_CODE_TO_NAME
+from api.parsing.colors import COLOR_ALIAS_TO_CODES, COLOR_CODE_TO_NAME, COLOR_COUNT_NAMES
 from api.parsing.db_info import (
     ALIAS_TO_FIELD_INFOS,
     CARD_SUPERTYPES,
@@ -530,8 +530,57 @@ class ExactNameNode(QueryNode):
         return f'exact name is "{self.value}"'
 
 
+# What a colour-COUNT name (`c:m`, `id:gold`) means, per operator, as the (operator, count) pair
+# the numeric colour-count comparison is built from. Measured; the evidence and the two surprises
+# in it are written out at db_info.COLOR_COUNT_NAMES.
+_COLOR_COUNT_BY_OPERATOR: typing.Final = {
+    ":": (">=", 2),
+    "=": (">=", 2),
+    ">": (">=", 2),
+    ">=": (">=", 2),
+    "<": ("<", 2),
+    "!=": ("<", 2),
+    "<=": (">=", 0),  # a tautology, spelled as a count so it stays one leaf
+}
+
+# produced_mana is NOT here, and the reason is measured rather than conservative: Scryfall counts
+# SIX values on that column, colorless among them. `produces=1 produces:c` is 481 -- exactly the
+# cards that produce colorless and nothing else -- so a C-only producer counts ONE there, where
+# `magic.color_identity_mask` and the engine's popcount both read the five WUBRG keys and would
+# call it zero. `produces:m` is therefore a count this column cannot answer yet, and it stays the
+# error it already was rather than becoming a silently different one.
+_COLOR_COUNT_ATTRIBUTES: typing.Final = ("card_colors", "card_color_identity")
+
+
 class CardBinaryOperatorNode(BinaryOperatorNode):
     """Card-specific binary operator node with custom SQL generation."""
+
+    def __init__(self, lhs: QueryNode, operator: str, rhs: QueryNode) -> None:
+        """Initialize the node, lowering a colour-COUNT name to a numeric colour-count comparison.
+
+        `c:m` and its five synonyms are a NUMBER of colours, not a set of them, so the value has no
+        letters to compare and the operator does not survive verbatim either (`c>m` is `c>=2` and
+        `c!=m` is `c<2`). Both parsers reach this constructor -- the hand parser builds the node
+        directly, the pyparsing one via `to_card_query_ast` -- so lowering it here is what keeps
+        them from disagreeing, and the node the rest of the pipeline sees is the ordinary numeric
+        one that `c>=2` already produces, on every path: engine JSON, SQL and explanation alike.
+
+        Args:
+            lhs: The left-hand side operand.
+            operator: The binary operator.
+            rhs: The right-hand side operand.
+        """
+        if (
+            isinstance(lhs, CardAttributeNode)
+            and isinstance(rhs, StringValueNode)
+            and lhs.attribute_name in _COLOR_COUNT_ATTRIBUTES
+            and rhs.value.strip().lower() in COLOR_COUNT_NAMES
+        ):
+            lowered = _COLOR_COUNT_BY_OPERATOR.get(operator)
+            if lowered is not None:
+                operator, count = lowered
+                rhs = NumericValueNode(count)
+        super().__init__(lhs, operator, rhs)
 
     def kwargs(self) -> dict:
         """Return this node's kwargs dict for Rust engine JSON serialization."""

--- a/api/parsing/card_query_nodes.py
+++ b/api/parsing/card_query_nodes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import typing
 import unicodedata
 
 from titlecase import titlecase
@@ -193,6 +194,28 @@ _CANONICAL_COLOR_ORDER = "wubrgc"
 
 def _color_dict_to_mask(color_dict: dict[str, bool]) -> int:
     return sum(bit for color, bit in _COLOR_BITS.items() if color_dict.get(color))
+
+
+def _compare_ints(lhs: int, operator: str, rhs: int) -> bool:
+    if operator == "=":
+        return lhs == rhs
+    if operator in ("!=", "<>"):
+        return lhs != rhs
+    if operator == ">=":
+        return lhs >= rhs
+    if operator == "<=":
+        return lhs <= rhs
+    if operator == ">":
+        return lhs > rhs
+    if operator == "<":
+        return lhs < rhs
+    msg = f"Unknown operator: {operator}"
+    raise ValueError(msg)
+
+
+def _color_count_masks(operator: str, count: int) -> list[int]:
+    """Bitmask values (5 colors => 2^5) whose popcount satisfies `popcount <op> count`."""
+    return [v for v in range(32) if _compare_ints(v.bit_count(), operator, count)]
 
 
 def _subset_masks(query_mask: int) -> list[int]:
@@ -538,7 +561,17 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
 
         return {"lhs": self.lhs.to_json(), "op": self.operator, "rhs": self._rhs_to_json()}
 
-    def _rhs_to_json(self) -> object:  # noqa: PLR0912
+    # JSONB_OBJECT attrs whose engine rhs is the normalized keys of a comparison
+    # object built by a single-argument normalizer, shared by _rhs_to_json.
+    _TAG_COMPARISON_BUILDERS: typing.ClassVar = {
+        "card_keywords": get_keywords_comparison_object,
+        "card_frame_data": get_frame_data_comparison_object,
+        "card_oracle_tags": get_oracle_tags_comparison_object,
+        "card_art_tags": get_art_tags_comparison_object,
+        "card_is_tags": get_is_tags_comparison_object,
+    }
+
+    def _rhs_to_json(self) -> object:
         """Compute the JSON-serializable rhs for non-JSONB_ARRAY CardAttributeNode LHS."""
         if not self.lhs.field_infos:
             return _node_to_json(self.rhs)
@@ -550,19 +583,15 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             # Mana cost and devotion: pass raw ManaValueNode for Rust to parse pip counts
             if field_info.parser_class == ParserClass.MANA:
                 return _node_to_json(self.rhs)
+            # Numeric color syntax (id>=3 / c=2): pass the raw NumericValueNode so the
+            # Rust engine builds a color-count comparison instead of a mask compare.
+            if isinstance(self.rhs, NumericValueNode):
+                return self._numeric_color_rhs_to_json(attr)
             val = self.rhs.value.strip()
             if attr in ("card_colors", "card_color_identity", "produced_mana"):
                 return list(get_colors_comparison_object(val.lower(), attr).keys())
-            if attr == "card_keywords":
-                return list(get_keywords_comparison_object(val).keys())
-            if attr == "card_frame_data":
-                return list(get_frame_data_comparison_object(val).keys())
-            if attr == "card_oracle_tags":
-                return list(get_oracle_tags_comparison_object(val).keys())
-            if attr == "card_art_tags":
-                return list(get_art_tags_comparison_object(val).keys())
-            if attr == "card_is_tags":
-                return list(get_is_tags_comparison_object(val).keys())
+            if attr in self._TAG_COMPARISON_BUILDERS:
+                return list(self._TAG_COMPARISON_BUILDERS[attr](val).keys())
             if attr == "card_legalities":
                 return list(get_legality_comparison_object(val, self.lhs.original_attribute).keys())
 
@@ -579,6 +608,17 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             return {"node_type": "StringValueNode", "kwargs": {"value": value}}
 
         return _node_to_json(self.rhs)
+
+    def _numeric_color_rhs_to_json(self, attr: str) -> object:
+        """Serialize a numeric color-count rhs (id>=3 / c=2) for the Rust engine.
+
+        Only the two real color fields support counting; produced_mana's C key is a
+        genuine producible value, not a color, so a count over it would be ambiguous.
+        """
+        if attr in ("card_colors", "card_color_identity"):
+            return _node_to_json(self.rhs)
+        msg = f"Numeric comparison is not supported for {attr}"
+        raise ValueError(msg)
 
     def to_sql(self, context: QueryContext) -> str:
         """Generate SQL for card-specific binary operations.
@@ -639,6 +679,11 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
         """Format explanation for card attribute comparisons."""
         db_column_name = attr_node.attribute_name.lower()
 
+        # Numeric color syntax compares the count of colors, not the colors themselves
+        if db_column_name in ("card_colors", "card_color_identity") and isinstance(self.rhs, NumericValueNode):
+            noun = "colors in the color identity" if db_column_name == "card_color_identity" else "colors"
+            count_op = "is" if self.operator == ":" else operator_str  # : compares counts as equality
+            return f"the number of {noun} {count_op} {rhs_str}"
         # `=` against an empty value reaches here (see to_human_explanation) as a real
         # constraint, not the vacuous `:` case -- state it plainly rather than falling into
         # "the X contains " with nothing after it.
@@ -646,12 +691,11 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
             return f"the {attr_node.to_human_explanation()} is empty"
 
         # Special formatting for certain attributes
-        if db_column_name == "card_color_identity" and self.operator in ("=", ":"):
-            return f"the color identity is {rhs_str}"
+        if db_column_name in ("card_color_identity", "card_colors") and self.operator in ("=", ":"):
+            noun = "color identity" if db_column_name == "card_color_identity" else "color"
+            return f"the {noun} is {rhs_str}"
         if db_column_name == "card_legalities" and self.operator in ("=", ":"):
             return f"it's legal in {rhs_str}"
-        if db_column_name == "card_colors" and self.operator in ("=", ":"):
-            return f"the color is {rhs_str}"
         if db_column_name == "creature_power":
             return f"the power {operator_str} {rhs_str}"
         if db_column_name == "creature_toughness":
@@ -1010,11 +1054,32 @@ class CardBinaryOperatorNode(BinaryOperatorNode):
     query ?& col AND not(col ?& query) # as array
     """
 
+    def _handle_color_count_comparison(self, lhs_sql: str, attr: str, context: QueryContext) -> str:
+        """SQL for Scryfall numeric color syntax (id>=3 / c=2): compare the NUMBER of colors.
+
+        Generates the same indexed mask expression the letter-valued subset queries
+        use — magic.color_identity_mask reads only the five WUBRG keys — with the
+        mask set restricted to values whose popcount satisfies the comparison.
+        ":" with a number behaves like "=" (verified against the live Scryfall API).
+
+        produced_mana is refused: its C key is a genuine producible value, not a
+        color, so a count over it would be ambiguous.
+        """
+        if attr == "produced_mana":
+            msg = f"Numeric comparison is not supported for {attr}"
+            raise ValueError(msg)
+        operator = "=" if self.operator == ":" else self.operator
+        masks = IntArray(_color_count_masks(operator, int(self.rhs.value)))
+        pmask = context.add(masks)
+        return f"(magic.color_identity_mask({lhs_sql}) = ANY({pmask}::smallint[]))"
+
     def _handle_jsonb_object(self, context: QueryContext) -> str:  # noqa: PLR0912, C901
         # Produce the query as a jsonb object
         lhs_sql = self.lhs.to_sql(context)
         attr = self.lhs.attribute_name
         is_color_identity = False
+        if attr in ("card_colors", "card_color_identity", "produced_mana") and isinstance(self.rhs, NumericValueNode):
+            return self._handle_color_count_comparison(lhs_sql, attr, context)
         if attr in ("card_colors", "card_color_identity", "produced_mana"):
             rhs = get_colors_comparison_object(self.rhs.value.strip().lower(), attr)
             is_color_identity = attr == "card_color_identity"

--- a/api/parsing/colors.py
+++ b/api/parsing/colors.py
@@ -114,16 +114,20 @@ COLOR_ALIAS_TO_CODES = {
 # `id>=m` = 5,831 = `id>=2`, `id<m` = `id!=m` = 27,768 = `id<2` (`id!=2` is 28,824), and
 # `id<=m` = 33,599 = every card (`id<=2` is 32,543).
 #
-# `produces:` is DELIBERATELY NOT lowered, and the reason is a measurement rather than caution.
-# `produces:m` really is a count on Scryfall -- 1,460, which is `produces>=2` -- but it is a count
-# over SIX values, colorless among them: `produces=1 produces:c` = 481, exactly the cards that
-# produce colorless and nothing else, so a C-only producer counts ONE there. Both of this project's
-# count implementations read the five WUBRG keys and would call that card zero
-# (`magic.color_identity_mask` on the SQL side, the popcount in card_engine's ColorCountCmp on the
-# other), and the five-colour union agrees on both sides at 2,121 while Scryfall's `produces>=1` is
-# 2,603 -- the 482-card difference IS the colorless producers. So `produces:m` stays the error it
-# already was rather than a count that is quietly short by 481 cards; making it work is a
-# six-value count, which is its own change on both halves.
+# `produces:` takes the same table, but over SIX values rather than five, and that asymmetry is
+# measured rather than tidy: produced_mana is the one colour-ish column whose array can literally
+# contain "C" (Sol Ring produces ["C"] while its colors and color_identity are both []). So
+# `produces=6` = 106 = `produces:all` -- a count no five-key popcount can even reach -- the 481
+# cards that produce colorless and nothing else answer `produces=1` rather than `produces=0`, the
+# three producing exactly {C,W} land in `produces=2` and not `produces=1`, and counts 0..6 partition
+# the corpus exactly (30,996 + 1,143 + 504 + 147 + 10 + 693 + 106 = 33,599). The colour columns must
+# keep counting five: `c:all` = `c:wubrg` = `c=5` = 60, and `c=6` is not a valid query there at all
+# ("Unknown color 6"). Both halves are pinned by tests so the asymmetry is not "fixed" later.
+#
+# `produces:m` = `produces=m` = `produces>m` = `produces>=m` = 1,460 = `produces>=2`
+# (`produces=2` is 504), while `produces<m` = `produces!=m` = 1,143 = `produces=1` -- NOT
+# `produces<2` (32,139), which sweeps in the cards that produce nothing -- and `produces<=m` =
+# 2,603 = `produces>=1` rather than every card.
 COLOR_COUNT_NAMES = frozenset(
     {
         "m",

--- a/api/parsing/colors.py
+++ b/api/parsing/colors.py
@@ -87,3 +87,50 @@ COLOR_ALIAS_TO_CODES = {
     "rainbow": "wubrg",
     "all": "wubrgc",
 }
+
+# The colour values that are a COUNT rather than a set of letters.
+#
+# `c:m` is not "the colour m" -- there is no such colour. It is Scryfall's word for MULTICOLOURED,
+# and it compares the NUMBER of colours in the column, which is why it cannot live in
+# COLOR_ALIAS_TO_CODES beside `azorius`: there are no letters to expand. `gold` and the
+# `multicolor` spellings are the same value under other names; every one of the six answers the
+# identical count (`c:m` = `c:gold` = `c:multicolor` = `c:multicolored` = `c:multicolour` =
+# `c:multicoloured` = 44 in Kaldheim, where `c:2` = 43 and `c>=2` = 44).
+#
+# THE OPERATOR TABLE IS MEASURED, and it is not "substitute the number 2". Corpus-wide against
+# api.scryfall.com, 2026-08-16:
+#
+#   c:m = c=m = c>m = c>=m = 4,607 = `c>=2`          (`c=2` is 3,811 and `c>2` is 796)
+#   c<m = c!=m           = 29,049 = `c<2`            (`c!=2` is 29,836)
+#   c<=m                 = 33,599 = EVERY CARD       (`c<=2` is 32,812)
+#
+# `>` is the surprise on the high side -- `c>m` is `c>=2`, not `c>2` -- and `!=` is the surprise on
+# the low side: `c!=m` is `c<2`, the negation of "is multicoloured", NOT `c!=2`, which would also
+# admit the 796 three-and-more-colour cards. `<=` is a tautology rather than `c<=2`, pinned against
+# a second term so it cannot be read as "the whole corpus": `c<=m t:creature` = `t:creature`
+# = `c<=5 t:creature` = 18,753 where `c<=2 t:creature` = 18,140.
+#
+# The identity spellings take the same table on their own column: `id:m` = `id=m` = `id>m` =
+# `id>=m` = 5,831 = `id>=2`, `id<m` = `id!=m` = 27,768 = `id<2` (`id!=2` is 28,824), and
+# `id<=m` = 33,599 = every card (`id<=2` is 32,543).
+#
+# `produces:` is DELIBERATELY NOT lowered, and the reason is a measurement rather than caution.
+# `produces:m` really is a count on Scryfall -- 1,460, which is `produces>=2` -- but it is a count
+# over SIX values, colorless among them: `produces=1 produces:c` = 481, exactly the cards that
+# produce colorless and nothing else, so a C-only producer counts ONE there. Both of this project's
+# count implementations read the five WUBRG keys and would call that card zero
+# (`magic.color_identity_mask` on the SQL side, the popcount in card_engine's ColorCountCmp on the
+# other), and the five-colour union agrees on both sides at 2,121 while Scryfall's `produces>=1` is
+# 2,603 -- the 482-card difference IS the colorless producers. So `produces:m` stays the error it
+# already was rather than a count that is quietly short by 481 cards; making it work is a
+# six-value count, which is its own change on both halves.
+COLOR_COUNT_NAMES = frozenset(
+    {
+        "m",
+        "gold",
+        "multicolor",
+        "multicolour",
+        "multicolored",
+        "multicoloured",
+    }
+)

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -730,11 +730,19 @@ class Parser:
         raise ParseError(msg)
 
     def parse_color_value(self) -> QueryNode:
-        """Parse a color value: a recognized color name or a combination of color letters."""
+        """Parse a color value: a color name, a combination of color letters, or a bare integer color count."""
         tok = self.peek()
         if tok.type == TT.QUOTED:
             self.consume()
             return StringValueNode(str(tok.value))
+        if tok.type == TT.NUMBER:
+            # Scryfall numeric color syntax: id>=3 / c=2 compare the NUMBER of
+            # colors in the field, so a bare integer is a valid color value.
+            if isinstance(tok.value, float):
+                msg = f"Expected integer color count, got {tok.value!r} at position {tok.pos}"
+                raise ParseError(msg)
+            self.consume()
+            return NumericValueNode(tok.value)
         if tok.type == TT.WORD:
             self.consume()
             val = str(tok.value)

--- a/api/parsing/hand_parser.py
+++ b/api/parsing/hand_parser.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 from api.parsing.card_query_nodes import CardAttributeNode, CardBinaryOperatorNode, ExactNameNode
-from api.parsing.colors import COLOR_ALIAS_TO_CODES
+from api.parsing.colors import COLOR_ALIAS_TO_CODES, COLOR_COUNT_NAMES
 from api.parsing.db_info import ALIAS_TO_FIELD_INFOS, ParserClass
 from api.parsing.mana_symbols import first_invalid_mana_symbol
 from api.parsing.nodes import (
@@ -57,7 +57,11 @@ _BANG_ALIAS_CLASSES: frozenset[ParserClass] = frozenset(
     {ParserClass.COLOR, ParserClass.MANA, ParserClass.RARITY, ParserClass.YEAR, ParserClass.DATE}
 )
 
-_VALID_COLOR_NAMES: frozenset[str] = frozenset(COLOR_ALIAS_TO_CODES)
+# The set-valued names (`white`, `azorius`) and the COUNT-valued ones (`m`, `gold`, `multicolored`) are
+# one vocabulary as far as the value parser is concerned: both are words rather than letter
+# strings. What separates them is what CardBinaryOperatorNode does with the result, not whether
+# this parser will accept it.
+_VALID_COLOR_NAMES: frozenset[str] = frozenset(COLOR_ALIAS_TO_CODES) | COLOR_COUNT_NAMES
 _COLOR_LETTERS: frozenset[str] = frozenset("wubrgcWUBRGC")
 _MIN_MTG_YEAR: int = 1992
 _MAX_YEAR: int = 2040

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -320,7 +320,11 @@ def create_color_parsers() -> dict[str, ParserElement]:
     # on validity, and a colour name accepted by only one of them is exactly that failure).
     color_word = make_regex_pattern(COLOR_ALIAS_TO_CODES)
     color_letter_pattern = Regex(r"[wubrgcWUBRGC]+")
-    color_value = color_word | color_letter_pattern
+    # Scryfall numeric color syntax: id>=3 / c=2 compare the NUMBER of colors in
+    # the field. A bare integer is a valid color value; the negative lookahead
+    # keeps mixed tokens like "2rr" or floats out (the hand parser rejects both).
+    color_count = Regex(r"\d+(?![\w.])").set_parse_action(lambda tokens: NumericValueNode(int(tokens[0])))
+    color_value = color_word | color_letter_pattern | color_count
 
     return {
         "color_value": color_value,

--- a/api/parsing/pyparsing_based.py
+++ b/api/parsing/pyparsing_based.py
@@ -23,7 +23,7 @@ from pyparsing import (
 )
 
 from api.parsing.card_query_nodes import CardAttributeNode, ExactNameNode, to_card_query_ast
-from api.parsing.colors import COLOR_ALIAS_TO_CODES
+from api.parsing.colors import COLOR_ALIAS_TO_CODES, COLOR_COUNT_NAMES
 from api.parsing.db_info import (
     NUMERIC_CARD_ATTRIBUTES,
     PARSER_CLASS_TO_FIELD_INFOS,
@@ -318,7 +318,7 @@ def create_color_parsers() -> dict[str, ParserElement]:
     # The same vocabulary the hand parser's _VALID_COLOR_NAMES draws from — one table, so a name
     # added for one parser cannot be missing from the other (test_parser_parity asserts they agree
     # on validity, and a colour name accepted by only one of them is exactly that failure).
-    color_word = make_regex_pattern(COLOR_ALIAS_TO_CODES)
+    color_word = make_regex_pattern({*COLOR_ALIAS_TO_CODES, *COLOR_COUNT_NAMES})
     color_letter_pattern = Regex(r"[wubrgcWUBRGC]+")
     # Scryfall numeric color syntax: id>=3 / c=2 compare the NUMBER of colors in
     # the field. A bare integer is a valid color value; the negative lookahead

--- a/api/parsing/tests/implicit_and_cases.py
+++ b/api/parsing/tests/implicit_and_cases.py
@@ -60,6 +60,12 @@ TESTCASES = [
     {"query": "cmc>2 power<5", "expected": "cmc>2 AND power<5", "id": "cmp_gt_lt"},
     {"query": "cmc>=3 cmc<=5", "expected": "cmc>=3 AND cmc<=5", "id": "cmp_gte_lte"},
     {"query": "color!=W", "expected": "color!=W", "id": "cmp_neq"},
+    # Numeric color syntax: the value is the NUMBER of colors in the field
+    {"query": "id>=3", "expected": "id>=3", "id": "identity_count_ge"},
+    {"query": "id=2 t:creature", "expected": "id=2 AND t:creature", "id": "identity_count_with_type"},
+    {"query": "c:3", "expected": "c:3", "id": "color_count_colon"},
+    {"query": "id<2 c=1", "expected": "id<2 AND c=1", "id": "identity_and_color_counts"},
+    {"query": "-id>=4", "expected": "-id>=4", "id": "negated_identity_count"},
     # Arithmetic in comparison — no AND inside expression
     {"query": "power+toughness>cmc+cmc", "expected": "power+toughness>cmc+cmc", "id": "arithmetic_comparison"},
     {

--- a/api/parsing/tests/test_color_count_names.py
+++ b/api/parsing/tests/test_color_count_names.py
@@ -1,0 +1,90 @@
+"""Scryfall's colour-COUNT values: `m`, `gold`, and the four `multicolor` spellings.
+
+`c:m` is not "the colour m" -- there is no such colour. It is Scryfall's word for MULTICOLOURED,
+and it compares the NUMBER of colours in the column, which is the comparison this branch already
+builds for `c>=2`. Every value and every operator was measured against api.scryfall.com on
+2026-08-16; the counts, and the two operator readings that are NOT "substitute the number 2", are
+written out at db_info.COLOR_COUNT_NAMES.
+"""
+
+import pytest
+
+from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.pyparsing_based import parse_search_query
+
+# The colour-COUNT names, as the numeric comparison each one means. `m` is not a colour and spells
+# no letters: it is Scryfall's word for MULTICOLOURED and compares the NUMBER of colours in the
+# column, so the operator does not survive verbatim either. Every pair below was measured
+# corpus-wide against api.scryfall.com on 2026-08-16 -- see db_info.COLOR_COUNT_NAMES for the
+# counts, including the two readings that are NOT "substitute the number 2": `c>m` is `c>=2` rather
+# than `c>2` (4,607 against 796), and `c!=m` is `c<2` rather than `c!=2` (29,049 against 29,836).
+COLOR_COUNT_CASES = [
+    # every spelling of the name, on the same operator
+    ("c:m", "c>=2"),
+    ("c:gold", "c>=2"),
+    ("c:multicolor", "c>=2"),
+    ("c:multicolour", "c>=2"),
+    ("c:multicolored", "c>=2"),
+    ("c:multicoloured", "c>=2"),
+    # every operator, on the same spelling
+    ("c=m", "c>=2"),
+    ("c>m", "c>=2"),
+    ("c>=m", "c>=2"),
+    ("c<m", "c<2"),
+    ("c!=m", "c<2"),
+    ("c<=m", "c>=0"),  # a tautology: `c<=m t:creature` = `t:creature` = 18,753
+    # the colour aliases and the identity column take the same table
+    ("color:m", "c>=2"),
+    ("colors:gold", "c>=2"),
+    ("id:m", "id>=2"),
+    ("identity:gold", "id>=2"),
+    ("ci>m", "ci>=2"),
+    ("id<m", "id<2"),
+    ("id!=multicoloured", "id<2"),
+    ("id<=m", "id>=0"),
+    # case, quoting and negation all reach the same lowering
+    ("c:M", "c>=2"),
+    ("c:GOLD", "c>=2"),
+    ('c:"m"', "c>=2"),
+    ("-c:m", "-c>=2"),
+]
+
+
+@pytest.mark.parametrize(
+    argnames=("query", "canonical_query"),
+    argvalues=COLOR_COUNT_CASES,
+    ids=[q for q, _ in COLOR_COUNT_CASES],
+)
+def test_color_count_name_matches_number(query: str, canonical_query: str) -> None:
+    """A colour-COUNT name produces exactly the SQL its numeric comparison does, in both parsers."""
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(canonical_query))
+    assert generate_sql_query(parse_search_query(query)) == generate_sql_query(parse_search_query(canonical_query))
+
+
+# produced_mana is left out of the lowering on purpose: `produces:m` IS a count on Scryfall, but a
+# count over SIX values, colorless among them (`produces=1 produces:c` = 481 -- the cards that
+# produce colorless and nothing else), where every count on this side reads the five WUBRG keys.
+# Answering it with the five-key count would be short by those 481 cards, so it stays an error.
+@pytest.mark.parametrize(
+    argnames="invalid_query",
+    argvalues=["produces:m", "produces:gold", "produces<multicolored", "produces>=2"],
+)
+def test_produced_mana_counts_are_still_refused(invalid_query: str) -> None:
+    """A count on produced_mana is refused, by name and by bare number alike."""
+    with pytest.raises(ValueError, match=r"[Nn]umeric comparison is not supported|Invalid color string"):
+        generate_sql_query(parse_scryfall_query(invalid_query))
+
+
+@pytest.mark.parametrize(
+    argnames="invalid_query",
+    argvalues=["c:mw", "c:wm", "c:mc", "c:mm", "c!=mw", "id:mw", "c:mono", "produces:mw"],
+)
+def test_m_beside_another_color_is_still_invalid(invalid_query: str) -> None:
+    """`m` beside another colour letter is neither a name nor a letter set, and stays a parse error.
+
+    Scryfall dropped the combination outright -- it answers "Using “m” with other colors is no
+    longer supported" and IGNORES the term -- so quietly reading `c:mw` as a count would answer a
+    different question from the one asked.
+    """
+    with pytest.raises(ValueError, match="Failed to parse query"):
+        parse_scryfall_query(invalid_query)

--- a/api/parsing/tests/test_color_count_names.py
+++ b/api/parsing/tests/test_color_count_names.py
@@ -4,18 +4,19 @@
 and it compares the NUMBER of colours in the column, which is the comparison this branch already
 builds for `c>=2`. Every value and every operator was measured against api.scryfall.com on
 2026-08-16; the counts, and the two operator readings that are NOT "substitute the number 2", are
-written out at db_info.COLOR_COUNT_NAMES.
+written out at colors.COLOR_COUNT_NAMES.
 """
 
 import pytest
 
 from api.parsing import generate_sql_query, parse_scryfall_query
+from api.parsing.card_query_nodes import _color_count_masks
 from api.parsing.pyparsing_based import parse_search_query
 
 # The colour-COUNT names, as the numeric comparison each one means. `m` is not a colour and spells
 # no letters: it is Scryfall's word for MULTICOLOURED and compares the NUMBER of colours in the
 # column, so the operator does not survive verbatim either. Every pair below was measured
-# corpus-wide against api.scryfall.com on 2026-08-16 -- see db_info.COLOR_COUNT_NAMES for the
+# corpus-wide against api.scryfall.com on 2026-08-16 -- see colors.COLOR_COUNT_NAMES for the
 # counts, including the two readings that are NOT "substitute the number 2": `c>m` is `c>=2` rather
 # than `c>2` (4,607 against 796), and `c!=m` is `c<2` rather than `c!=2` (29,049 against 29,836).
 COLOR_COUNT_CASES = [
@@ -61,18 +62,56 @@ def test_color_count_name_matches_number(query: str, canonical_query: str) -> No
     assert generate_sql_query(parse_search_query(query)) == generate_sql_query(parse_search_query(canonical_query))
 
 
-# produced_mana is left out of the lowering on purpose: `produces:m` IS a count on Scryfall, but a
-# count over SIX values, colorless among them (`produces=1 produces:c` = 481 -- the cards that
-# produce colorless and nothing else), where every count on this side reads the five WUBRG keys.
-# Answering it with the five-key count would be short by those 481 cards, so it stays an error.
+# produced_mana is the same table on a SIX-value count, intersected with "produces at least one
+# value": `produces<m` = 1,143 = `produces=1` and NOT `produces<2` = 32,139, which sweeps in the
+# 30,996 cards that produce nothing at all.
+PRODUCED_COUNT_CASES = [
+    ("produces:m", "produces>=2"),
+    ("produces=gold", "produces>=2"),
+    ("produces>m", "produces>=2"),
+    ("produces>=multicoloured", "produces>=2"),
+    ("produces<m", "produces=1"),
+    ("produces!=m", "produces=1"),
+    ("produces<=m", "produces>=1"),
+]
+
+
 @pytest.mark.parametrize(
-    argnames="invalid_query",
-    argvalues=["produces:m", "produces:gold", "produces<multicolored", "produces>=2"],
+    argnames=("query", "canonical_query"),
+    argvalues=PRODUCED_COUNT_CASES,
+    ids=[q for q, _ in PRODUCED_COUNT_CASES],
 )
-def test_produced_mana_counts_are_still_refused(invalid_query: str) -> None:
-    """A count on produced_mana is refused, by name and by bare number alike."""
-    with pytest.raises(ValueError, match=r"[Nn]umeric comparison is not supported|Invalid color string"):
-        generate_sql_query(parse_scryfall_query(invalid_query))
+def test_produced_mana_count_name_matches_number(query: str, canonical_query: str) -> None:
+    """produced_mana takes the count names too, on its own operator table."""
+    assert generate_sql_query(parse_scryfall_query(query)) == generate_sql_query(parse_scryfall_query(canonical_query))
+    assert generate_sql_query(parse_search_query(query)) == generate_sql_query(parse_search_query(canonical_query))
+
+
+# THE FIVE/SIX SPLIT, PINNED IN BOTH DIRECTIONS so a later tidy-up cannot quietly unify them.
+#
+# produced_mana is the one colour-ish column whose array can literally contain "C" -- Sol Ring
+# produces ["C"] while its colors and color_identity are both [] -- so a COUNT there counts
+# colorless as a value and the colour columns do not. Measured against api.scryfall.com 2026-08-16:
+# `produces=6` = 106 = `produces:all` (a count no five-key popcount can reach), the 481 cards
+# producing colorless and nothing else answer `produces=1`, and counts 0..6 partition the corpus
+# exactly. On the colour side `c:all` = `c:wubrg` = `c=5` = 60 and `c=6` is not a valid query at
+# all ("Unknown color 6").
+def test_produced_mana_counts_six_values_and_colors_count_five() -> None:
+    """The count width differs by column, and each width is the measured one."""
+    # Six bits on produced_mana: 64 masks in the enumeration, and a count of 6 is reachable.
+    assert len(_color_count_masks("=", 0, bits=6)) + len(_color_count_masks(">=", 1, bits=6)) == 64
+    assert _color_count_masks("=", 6, bits=6) == [0b11_1111]
+    # Five on the colour columns: 32 masks, and a count of 6 can never be satisfied.
+    assert len(_color_count_masks("=", 0)) + len(_color_count_masks(">=", 1)) == 32
+    assert _color_count_masks("=", 6) == []
+    assert _color_count_masks("=", 5) == [0b1_1111]
+    # And the two columns reach DIFFERENT SQL, so the widths cannot be served by one index.
+    produced_sql = generate_sql_query(parse_scryfall_query("produces>=2"))[0]
+    colors_sql = generate_sql_query(parse_scryfall_query("c>=2"))[0]
+    assert "magic.produced_mana_mask" in produced_sql
+    assert "magic.color_identity_mask" not in produced_sql
+    assert "magic.color_identity_mask" in colors_sql
+    assert "magic.produced_mana_mask" not in colors_sql
 
 
 @pytest.mark.parametrize(

--- a/api/parsing/tests/test_sql_gen.py
+++ b/api/parsing/tests/test_sql_gen.py
@@ -288,6 +288,50 @@ def test_full_sql_translation_jsonb_colors(parse_query, input_query: str, expect
             r"(card.card_color_identity = %(p_dict_e30)s)",
             {"p_dict_e30": {}},
         ),  # equality with colorless name
+        (
+            "id>=3",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzcsIDExLCAxMywgMTQsIDE1LCAxOSwgMjEsIDIyLCAyMywgMjUsIDI2LCAyNywgMjgsIDI5LCAzMCwgMzFd)s::smallint[]))",
+            {
+                "p_IntArray_WzcsIDExLCAxMywgMTQsIDE1LCAxOSwgMjEsIDIyLCAyMywgMjUsIDI2LCAyNywgMjgsIDI5LCAzMCwgMzFd": [
+                    7,
+                    11,
+                    13,
+                    14,
+                    15,
+                    19,
+                    21,
+                    22,
+                    23,
+                    25,
+                    26,
+                    27,
+                    28,
+                    29,
+                    30,
+                    31,
+                ],
+            },
+        ),  # numeric: three or more colors in the identity — masks with popcount >= 3
+        (
+            "id=2",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzMsIDUsIDYsIDksIDEwLCAxMiwgMTcsIDE4LCAyMCwgMjRd)s::smallint[]))",
+            {"p_IntArray_WzMsIDUsIDYsIDksIDEwLCAxMiwgMTcsIDE4LCAyMCwgMjRd": [3, 5, 6, 9, 10, 12, 17, 18, 20, 24]},
+        ),  # numeric: exactly two colors — the C(5,2)=10 masks with popcount 2
+        (
+            "id:2",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzMsIDUsIDYsIDksIDEwLCAxMiwgMTcsIDE4LCAyMCwgMjRd)s::smallint[]))",
+            {"p_IntArray_WzMsIDUsIDYsIDksIDEwLCAxMiwgMTcsIDE4LCAyMCwgMjRd": [3, 5, 6, 9, 10, 12, 17, 18, 20, 24]},
+        ),  # : with a number behaves like = (verified against the live Scryfall API)
+        (
+            "id<2",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzAsIDEsIDIsIDQsIDgsIDE2XQ)s::smallint[]))",
+            {"p_IntArray_WzAsIDEsIDIsIDQsIDgsIDE2XQ": [0, 1, 2, 4, 8, 16]},
+        ),  # numeric: fewer than two colors — colorless (0) plus the five mono masks
+        (
+            "id=0",
+            r"(magic.color_identity_mask(card.card_color_identity) = ANY(%(p_IntArray_WzBd)s::smallint[]))",
+            {"p_IntArray_WzBd": [0]},
+        ),  # numeric zero = colorless, same mask set as id:c
     ],
 )
 def test_color_identity_sql_translation(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:
@@ -351,6 +395,19 @@ def test_color_identity_sql_translation(parse_query, input_query: str, expected_
             r"(card.produced_mana @> %(p_dict_eydDJzogVHJ1ZX0)s)",
             {"p_dict_eydDJzogVHJ1ZX0": {"C": True}},
         ),
+        # Numeric color syntax works on printed colors too: the value is the
+        # NUMBER of colors, and the same WUBRG mask expression serves both
+        # fields (magic.color_identity_mask only reads the five color keys).
+        (
+            "c=2",
+            r"(magic.color_identity_mask(card.card_colors) = ANY(%(p_IntArray_WzMsIDUsIDYsIDksIDEwLCAxMiwgMTcsIDE4LCAyMCwgMjRd)s::smallint[]))",
+            {"p_IntArray_WzMsIDUsIDYsIDksIDEwLCAxMiwgMTcsIDE4LCAyMCwgMjRd": [3, 5, 6, 9, 10, 12, 17, 18, 20, 24]},
+        ),
+        (
+            "c:3",
+            r"(magic.color_identity_mask(card.card_colors) = ANY(%(p_IntArray_WzcsIDExLCAxMywgMTQsIDE5LCAyMSwgMjIsIDI1LCAyNiwgMjhd)s::smallint[]))",
+            {"p_IntArray_WzcsIDExLCAxMywgMTQsIDE5LCAyMSwgMjIsIDI1LCAyNiwgMjhd": [7, 11, 13, 14, 19, 21, 22, 25, 26, 28]},
+        ),  # : with a number is equality, NOT the >= that letter values get
     ],
 )
 def test_color_and_produces_sql_translation(parse_query, input_query: str, expected_sql: str, expected_parameters: dict) -> None:

--- a/api/tests/test_engine_unit.py
+++ b/api/tests/test_engine_unit.py
@@ -231,6 +231,44 @@ class TestFilters:
         total, _ = _run(engine, "produces:c")
         assert total == 5
 
+    def test_color_count_exactly_two(self, engine: QueryEngine) -> None:
+        # Scryfall numeric color syntax: c=2 is "exactly two printed colors" —
+        # Boggart Ram-Gang (4, RG) + Kitchen Finks (6, GW)
+        total, cards = _run(engine, "c=2")
+        assert total == 10
+        assert set(_names(cards)) == {"Boggart Ram-Gang", "Kitchen Finks"}
+
+    def test_color_count_colon_is_equality(self, engine: QueryEngine) -> None:
+        # : with a NUMBER is equality (id:2 == id=2 on the live Scryfall API),
+        # not the >= that letter values get
+        total_colon, _ = _run(engine, "c:2")
+        total_eq, _ = _run(engine, "c=2")
+        assert total_colon == total_eq == 10
+
+    def test_color_count_three_or_more(self, engine: QueryEngine) -> None:
+        # Monastery Messenger (1, RUW) + Nicol Bolas, Planeswalker (7, UBR)
+        total, cards = _run(engine, "c>=3")
+        assert total == 8
+        assert set(_names(cards)) == {"Monastery Messenger", "Nicol Bolas, Planeswalker"}
+
+    def test_identity_count_zero_is_colorless(self, engine: QueryEngine) -> None:
+        # id=0 counts zero colors in the identity: Black Lotus (5) + Sol Ring (5)
+        total, cards = _run(engine, "id=0")
+        assert total == 10
+        assert set(_names(cards)) == {"Black Lotus", "Sol Ring"}
+
+    def test_identity_count_less_than_two(self, engine: QueryEngine) -> None:
+        # Everything except the four multicolor-identity cards: 90 - Boggart (4)
+        # - Kitchen Finks (6) - Monastery Messenger (1) - Nicol Bolas (7) = 72
+        total, _ = _run(engine, "id<2")
+        assert total == 72
+
+    def test_negated_identity_count(self, engine: QueryEngine) -> None:
+        # Color counts are total (colorless is 0, never NULL), so negation is
+        # the exact complement: -id>=3 = 90 - 8 = 82
+        total, _ = _run(engine, "-id>=3")
+        assert total == 82
+
     def test_cmc_equals_zero(self, engine: QueryEngine) -> None:
         total, cards = _run(engine, "cmc=0")
         assert total == 5

--- a/card_engine/src/estimator.rs
+++ b/card_engine/src/estimator.rs
@@ -114,6 +114,7 @@ pub(crate) fn has_printing_varying_leaf(f: &FilterExpr) -> bool {
         | FilterExpr::NameMatch { .. }
         | FilterExpr::OracleMatch { .. }
         | FilterExpr::ColorCmp { .. }
+        | FilterExpr::ColorCountCmp { .. }
         | FilterExpr::TypeCmp { .. }
         | FilterExpr::ManaCostCmp { .. }
         | FilterExpr::Devotion { .. } => false,
@@ -129,13 +130,14 @@ pub(crate) fn has_printing_varying_leaf(f: &FilterExpr) -> bool {
 /// harness on `NOT(toughness>3)`: toughness is Null for non-creatures).
 ///
 /// Base cases are exactly the leaves whose `tri` is unconditional `tri_bool`
-/// (filter.rs): `True`, `ColorCmp` (colors always present — colorless is mask
-/// 0, not Null), `TypeCmp` (type line always present). And/Or/Not of total
-/// children stay total (no child can introduce a Null), and all three bases are
-/// card-invariant, so totality implies card-invariance.
+/// (filter.rs): `True`, `ColorCmp`/`ColorCountCmp` (colors always present —
+/// colorless is mask 0 / count 0, not Null), `TypeCmp` (type line always
+/// present). And/Or/Not of total children stay total (no child can introduce a
+/// Null), and all the bases are card-invariant, so totality implies
+/// card-invariance.
 fn is_total_two_valued(f: &FilterExpr) -> bool {
     match f {
-        FilterExpr::True | FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => true,
+        FilterExpr::True | FilterExpr::ColorCmp { .. } | FilterExpr::ColorCountCmp { .. } | FilterExpr::TypeCmp { .. } => true,
         FilterExpr::And(children) | FilterExpr::Or(children) => children.iter().all(is_total_two_valued),
         FilterExpr::Not(inner) => is_total_two_valued(inner),
         _ => false,
@@ -397,6 +399,9 @@ fn estimate_leaf(f: &FilterExpr, indexes: &Archived<CardIndexes>, n_cards: u32, 
 
         // Card-invariant exact plane popcount.
         FilterExpr::ColorCmp { .. } | FilterExpr::TypeCmp { .. } => plane_card(f, indexes, n_cards, false),
+
+        // Numeric color-count comparisons (id>=3) have no plane compilation → sound unknown.
+        FilterExpr::ColorCountCmp { .. } => unknown(n),
 
         // Existence-projection plane → superset {0, c, c}.
         FilterExpr::Legality { .. } => plane_card(f, indexes, n_cards, true),

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -490,7 +490,8 @@ pub(crate) enum FilterExpr {
     /// Scryfall numeric color syntax (`id>=3`, `c=2`): compares the NUMBER of
     /// colors in the field (popcount over the WUBRG bits) against `count`.
     /// Only Colors/ColorIdentity reach here — the Python side rejects numeric
-    /// comparisons on produced_mana, whose C key is not a color.
+    /// comparisons on produced_mana, which Scryfall counts over SIX values
+    /// (colorless included) rather than the five this popcount reads.
     ColorCountCmp {
         field: ColorField,
         op: CmpOp,
@@ -1783,6 +1784,13 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
         // NUMBER of colors in the field. ":" behaves like "=" here (verified
         // against the live Scryfall API: id:2 and id=2 return identical sets),
         // which is exactly what str_op_to_cmp yields.
+        //
+        // produced_mana is refused, and it is a MEASUREMENT rather than caution:
+        // Scryfall counts six values on that column, colorless among them, so
+        // `produces=1 produces:c` is 481 -- the cards that produce colorless and
+        // nothing else -- where the popcount below masks C off and would call
+        // those zero. That is also why `produces:m`, which IS a count on
+        // Scryfall, is not lowered into this node by the parser.
         if rhs["node_type"].as_str() == Some("NumericValueNode") {
             if matches!(color_field, ColorField::ProducedMana) {
                 return Err("numeric comparison is not supported for produced_mana".to_string());

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -487,11 +487,10 @@ pub(crate) enum FilterExpr {
         mask: u8,
     },
 
-    /// Scryfall numeric color syntax (`id>=3`, `c=2`): compares the NUMBER of
-    /// colors in the field (popcount over the WUBRG bits) against `count`.
-    /// Only Colors/ColorIdentity reach here — the Python side rejects numeric
-    /// comparisons on produced_mana, which Scryfall counts over SIX values
-    /// (colorless included) rather than the five this popcount reads.
+    /// Scryfall numeric color syntax (`id>=3`, `c=2`, `produces>=2`): compares
+    /// the NUMBER of values in the field against `count`. Five bits for the two
+    /// colour columns, SIX for produced_mana — whose array can hold "C" — see
+    /// the eval arm for the measurements behind that split.
     ColorCountCmp {
         field: ColorField,
         op: CmpOp,
@@ -1432,10 +1431,18 @@ impl FilterExpr {
 
             FilterExpr::ColorCountCmp { field, op, count } => {
                 // Colors are always present (colorless = 0 bits, not Null), so this is
-                // total and two-valued. The C bit (32) is masked off before counting:
-                // colorless is ZERO colors on Scryfall, and the SQL path's
-                // magic.color_identity_mask likewise reads only the WUBRG keys.
-                let n = (card_colors(card, *field) & 0b1_1111).count_ones() as u8;
+                // total and two-valued.
+                //
+                // WIDTH DEPENDS ON THE COLUMN, and the asymmetry is measured. For the two colour
+                // columns the C bit (32) is masked OFF before counting: colorless is ZERO colors
+                // on Scryfall (`c:all` = `c:wubrg` = `c=5` = 60, and `c=6` is not even a valid
+                // query there), matching the SQL path's magic.color_identity_mask. produced_mana
+                // keeps it: that array can literally contain "C" — Sol Ring produces ["C"] while
+                // its colors and color_identity are both [] — so `produces=6` = 106 = `produces:all`
+                // and the 481 cards producing colorless and nothing else answer `produces=1`.
+                // magic.produced_mana_mask is the six-bit twin of this line.
+                let mask = if matches!(field, ColorField::ProducedMana) { 0b11_1111 } else { 0b1_1111 };
+                let n = (card_colors(card, *field) & mask).count_ones() as u8;
                 tri_bool(num_cmp(*op, f64::from(n), f64::from(*count)))
             }
 
@@ -1791,10 +1798,9 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
         // nothing else -- where the popcount below masks C off and would call
         // those zero. That is also why `produces:m`, which IS a count on
         // Scryfall, is not lowered into this node by the parser.
+        // produced_mana counts here too, over SIX values rather than five — see
+        // the ColorCountCmp eval arm.
         if rhs["node_type"].as_str() == Some("NumericValueNode") {
-            if matches!(color_field, ColorField::ProducedMana) {
-                return Err("numeric comparison is not supported for produced_mana".to_string());
-            }
             let count = rhs["kwargs"]["value"].as_f64().ok_or("NumericValueNode missing value")? as u8;
             return Ok(FilterExpr::ColorCountCmp { field: color_field, op: str_op_to_cmp(op)?, count });
         }

--- a/card_engine/src/filter.rs
+++ b/card_engine/src/filter.rs
@@ -487,6 +487,16 @@ pub(crate) enum FilterExpr {
         mask: u8,
     },
 
+    /// Scryfall numeric color syntax (`id>=3`, `c=2`): compares the NUMBER of
+    /// colors in the field (popcount over the WUBRG bits) against `count`.
+    /// Only Colors/ColorIdentity reach here — the Python side rejects numeric
+    /// comparisons on produced_mana, whose C key is not a color.
+    ColorCountCmp {
+        field: ColorField,
+        op: CmpOp,
+        count: u8,
+    },
+
     TypeCmp {
         mask: u16,
         op: CmpOp,
@@ -630,6 +640,7 @@ pub(crate) fn verify_cost_tier(f: &FilterExpr) -> u32 {
         | FilterExpr::NumericCmp { .. }
         | FilterExpr::TextExact { .. }
         | FilterExpr::ColorCmp { .. }
+        | FilterExpr::ColorCountCmp { .. }
         | FilterExpr::TypeCmp { .. }
         | FilterExpr::Legality { .. }
         | FilterExpr::DateCmp { .. }
@@ -774,6 +785,7 @@ fn leaf_compares_printing_field(f: &FilterExpr) -> bool {
         | FilterExpr::NameMatch { .. }
         | FilterExpr::OracleMatch { .. }
         | FilterExpr::ColorCmp { .. }
+        | FilterExpr::ColorCountCmp { .. }
         | FilterExpr::TypeCmp { .. }
         | FilterExpr::ManaCostCmp { .. }
         | FilterExpr::Devotion { .. } => false,
@@ -1417,6 +1429,15 @@ impl FilterExpr {
                 })
             }
 
+            FilterExpr::ColorCountCmp { field, op, count } => {
+                // Colors are always present (colorless = 0 bits, not Null), so this is
+                // total and two-valued. The C bit (32) is masked off before counting:
+                // colorless is ZERO colors on Scryfall, and the SQL path's
+                // magic.color_identity_mask likewise reads only the WUBRG keys.
+                let n = (card_colors(card, *field) & 0b1_1111).count_ones() as u8;
+                tri_bool(num_cmp(*op, f64::from(n), f64::from(*count)))
+            }
+
             FilterExpr::TypeCmp { mask, op } => {
                 let bits = u16::from(card.card_types);
                 tri_bool(match op {
@@ -1757,6 +1778,18 @@ fn build_binary(kw: &Value) -> Result<FilterExpr, String> {
             "card_color_identity"  => ColorField::ColorIdentity,
             _                      => ColorField::ProducedMana,
         };
+        // Scryfall numeric color syntax (id>=3, c=2): the rhs arrives as a raw
+        // NumericValueNode instead of a color-letter list, and compares the
+        // NUMBER of colors in the field. ":" behaves like "=" here (verified
+        // against the live Scryfall API: id:2 and id=2 return identical sets),
+        // which is exactly what str_op_to_cmp yields.
+        if rhs["node_type"].as_str() == Some("NumericValueNode") {
+            if matches!(color_field, ColorField::ProducedMana) {
+                return Err("numeric comparison is not supported for produced_mana".to_string());
+            }
+            let count = rhs["kwargs"]["value"].as_f64().ok_or("NumericValueNode missing value")? as u8;
+            return Ok(FilterExpr::ColorCountCmp { field: color_field, op: str_op_to_cmp(op)?, count });
+        }
         let color_strs: Vec<&str> = rhs
             .as_array()
             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -8311,12 +8311,16 @@ fn color_cmp_ge_empty_mask_is_colorless_only() {
     check(ColorField::ColorIdentity, &[0]);
 }
 
-// Scryfall numeric color syntax (id>=3, c=2): ColorCountCmp compares the
-// popcount of the WUBRG bits against the queried count. Checked for every op ×
-// count 0..=5 against a popcount oracle over the color-diverse plane fixture —
-// which includes a C-bit identity (card 9) that must count as ZERO colors,
-// mirroring the SQL path's magic.color_identity_mask reading only the five
-// WUBRG keys.
+// Scryfall numeric color syntax (id>=3, c=2, produces>=2, and the colour-COUNT
+// names the parser lowers to them): ColorCountCmp compares the popcount of the
+// field against the queried count. Checked for every op × count 0..=6 over all
+// THREE fields against a popcount oracle on the color-diverse plane fixture.
+//
+// THE ORACLE IS DELIBERATELY WIDTH-AWARE, because the width is the thing under
+// test: five bits for the colour columns, where a C-bit identity (card 9) must
+// count as ZERO, and SIX for produced_mana, where card 5 produces only C and
+// must count as ONE. Both directions are asserted outright below so that
+// "fixing" the asymmetry fails loudly.
 #[test]
 fn color_count_cmp_matches_popcount_oracle() {
     let data = plane_fixture_store();
@@ -8332,16 +8336,17 @@ fn color_count_cmp_matches_popcount_oracle() {
         CmpOp::Ge => a >= b,
     };
     for op in [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge] {
-        for count in 0u8..=5 {
-            for field in [ColorField::Colors, ColorField::ColorIdentity] {
+        for count in 0u8..=6 {
+            for field in [ColorField::Colors, ColorField::ColorIdentity, ColorField::ProducedMana] {
                 let f = FilterExpr::ColorCountCmp { field, op, count };
                 for (cid, card) in archived.cards.iter().enumerate() {
-                    let bits = match field {
-                        ColorField::Colors => card.card_colors,
-                        ColorField::ColorIdentity => card.card_color_identity,
-                        ColorField::ProducedMana => unreachable!("numeric syntax never targets produced_mana"),
+                    let (bits, mask) = match field {
+                        ColorField::Colors => (card.card_colors, 0b1_1111),
+                        ColorField::ColorIdentity => (card.card_color_identity, 0b1_1111),
+                        // SIX bits: colorless is a producible VALUE, not the absence of one.
+                        ColorField::ProducedMana => (card.produced_mana, 0b11_1111),
                     };
-                    let want = cmp(op, u32::from(bits & 0b1_1111).count_ones(), u32::from(count));
+                    let want = cmp(op, u32::from(bits & mask).count_ones(), u32::from(count));
                     assert_eq!(
                         f.eval_card(card, &archived.strings) == Tri::True,
                         want,
@@ -8353,57 +8358,12 @@ fn color_count_cmp_matches_popcount_oracle() {
     }
 }
 
-// The colour-COUNT names (`c:m`, `id:gold`, `c!=multicolored`) reach the engine
-// as the numeric comparison the parser lowered them to, and the operator
-// is NOT the one that was typed: `c>m` arrives as `>= 2` and `c!=m` as `< 2`.
-// This walks the wire JSON the parser now emits for each of them and pins the
-// matched rows on the plane fixture, so a lowering that drifts shows up as a
-// changed row set rather than as a filter that still builds.
-#[test]
-fn color_count_name_wire_shapes_select_expected_rows() {
-    let data = plane_fixture_store();
-    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
-    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
-
-    let matched = |attr: &str, orig: &str, op: &str, n: u8| -> Vec<usize> {
-        let node = serde_json::json!({
-            "node_type": "CardBinaryOperatorNode",
-            "kwargs": {
-                "lhs": {"node_type": "CardAttributeNode", "kwargs": {"attribute_name": attr, "original_attribute": orig}},
-                "op": op,
-                "rhs": {"node_type": "NumericValueNode", "kwargs": {"value": n}},
-            },
-        });
-        let f = super::build_filter(&node).expect("colour-count node must build");
-        archived
-            .cards
-            .iter()
-            .enumerate()
-            .filter(|(_, card)| f.eval_card(card, &archived.strings) == Tri::True)
-            .map(|(cid, _)| cid)
-            .collect()
-    };
-
-    // colors popcounts on the fixture: [0, 1, 1, 2, 0, 5, 1, 2, 1, 0]
-    // c:m / c=m / c>m / c>=m -> ">= 2"
-    assert_eq!(matched("card_colors", "c", ">=", 2), vec![3, 5, 7]);
-    // c<m / c!=m -> "< 2", which is NOT "!= 2" (that would also take rows 3 and 7)
-    assert_eq!(matched("card_colors", "c", "<", 2), vec![0, 1, 2, 4, 6, 8, 9]);
-    // c<=m -> ">= 0", a tautology
-    assert_eq!(matched("card_colors", "c", ">=", 0), (0..10).collect::<Vec<_>>());
-
-    // identity popcounts: [0, 1, 1, 2, 2, 1, 2, 5, 1, 0] -- row 9's C-bit identity is zero colors
-    assert_eq!(matched("card_color_identity", "id", ">=", 2), vec![3, 4, 6, 7]);
-    assert_eq!(matched("card_color_identity", "id", "<", 2), vec![0, 1, 2, 5, 8, 9]);
-}
-
 // The Python side serializes a numeric color comparison as a raw
 // NumericValueNode rhs (not the usual color-letter list); build_binary must
 // turn that into ColorCountCmp — with ":" behaving as equality, matching the
-// live Scryfall API — and refuse produced_mana. That refusal is measured, not
-// cautious: Scryfall counts SIX values there (`produces=1 produces:c` = 481, the
-// cards that produce colorless and nothing else), which this five-key popcount
-// cannot express — so `produces:m` is not lowered into this node either.
+// live Scryfall API — on all three fields. produced_mana counts too, over six
+// values rather than five: `produces>=2` is 1,460 on api.scryfall.com where
+// `produces=2` is 504, and `produces:m` is the same 1,460 once lowered.
 #[test]
 fn build_filter_numeric_color_rhs() {
     let node = |attr: &str, orig: &str, op: &str, n: u8| {
@@ -8426,7 +8386,11 @@ fn build_filter_numeric_color_rhs() {
     let f = super::build_filter(&node("card_color_identity", "id", "=", 0)).expect("id=0 must build");
     assert!(matches!(f, FilterExpr::ColorCountCmp { field: ColorField::ColorIdentity, op: CmpOp::Eq, count: 0 }));
 
-    assert!(super::build_filter(&node("produced_mana", "produces", "=", 2)).is_err());
+    let f = super::build_filter(&node("produced_mana", "produces", "=", 2)).expect("produces=2 must build");
+    assert!(matches!(f, FilterExpr::ColorCountCmp { field: ColorField::ProducedMana, op: CmpOp::Eq, count: 2 }));
+
+    let f = super::build_filter(&node("produced_mana", "produces", ">=", 1)).expect("produces>=1 must build");
+    assert!(matches!(f, FilterExpr::ColorCountCmp { field: ColorField::ProducedMana, op: CmpOp::Ge, count: 1 }));
 }
 
 // produced_mana must be its own independent transposition, not derived from

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -8353,10 +8353,57 @@ fn color_count_cmp_matches_popcount_oracle() {
     }
 }
 
+// The colour-COUNT names (`c:m`, `id:gold`, `c!=multicolored`) reach the engine
+// as the numeric comparison the parser lowered them to, and the operator
+// is NOT the one that was typed: `c>m` arrives as `>= 2` and `c!=m` as `< 2`.
+// This walks the wire JSON the parser now emits for each of them and pins the
+// matched rows on the plane fixture, so a lowering that drifts shows up as a
+// changed row set rather than as a filter that still builds.
+#[test]
+fn color_count_name_wire_shapes_select_expected_rows() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let matched = |attr: &str, orig: &str, op: &str, n: u8| -> Vec<usize> {
+        let node = serde_json::json!({
+            "node_type": "CardBinaryOperatorNode",
+            "kwargs": {
+                "lhs": {"node_type": "CardAttributeNode", "kwargs": {"attribute_name": attr, "original_attribute": orig}},
+                "op": op,
+                "rhs": {"node_type": "NumericValueNode", "kwargs": {"value": n}},
+            },
+        });
+        let f = super::build_filter(&node).expect("colour-count node must build");
+        archived
+            .cards
+            .iter()
+            .enumerate()
+            .filter(|(_, card)| f.eval_card(card, &archived.strings) == Tri::True)
+            .map(|(cid, _)| cid)
+            .collect()
+    };
+
+    // colors popcounts on the fixture: [0, 1, 1, 2, 0, 5, 1, 2, 1, 0]
+    // c:m / c=m / c>m / c>=m -> ">= 2"
+    assert_eq!(matched("card_colors", "c", ">=", 2), vec![3, 5, 7]);
+    // c<m / c!=m -> "< 2", which is NOT "!= 2" (that would also take rows 3 and 7)
+    assert_eq!(matched("card_colors", "c", "<", 2), vec![0, 1, 2, 4, 6, 8, 9]);
+    // c<=m -> ">= 0", a tautology
+    assert_eq!(matched("card_colors", "c", ">=", 0), (0..10).collect::<Vec<_>>());
+
+    // identity popcounts: [0, 1, 1, 2, 2, 1, 2, 5, 1, 0] -- row 9's C-bit identity is zero colors
+    assert_eq!(matched("card_color_identity", "id", ">=", 2), vec![3, 4, 6, 7]);
+    assert_eq!(matched("card_color_identity", "id", "<", 2), vec![0, 1, 2, 5, 8, 9]);
+}
+
 // The Python side serializes a numeric color comparison as a raw
 // NumericValueNode rhs (not the usual color-letter list); build_binary must
 // turn that into ColorCountCmp — with ":" behaving as equality, matching the
-// live Scryfall API — and refuse produced_mana, whose C key is not a color.
+// live Scryfall API — and refuse produced_mana. That refusal is measured, not
+// cautious: Scryfall counts SIX values there (`produces=1 produces:c` = 481, the
+// cards that produce colorless and nothing else), which this five-key popcount
+// cannot express — so `produces:m` is not lowered into this node either.
 #[test]
 fn build_filter_numeric_color_rhs() {
     let node = |attr: &str, orig: &str, op: &str, n: u8| {

--- a/card_engine/src/tests.rs
+++ b/card_engine/src/tests.rs
@@ -8311,6 +8311,77 @@ fn color_cmp_ge_empty_mask_is_colorless_only() {
     check(ColorField::ColorIdentity, &[0]);
 }
 
+// Scryfall numeric color syntax (id>=3, c=2): ColorCountCmp compares the
+// popcount of the WUBRG bits against the queried count. Checked for every op ×
+// count 0..=5 against a popcount oracle over the color-diverse plane fixture —
+// which includes a C-bit identity (card 9) that must count as ZERO colors,
+// mirroring the SQL path's magic.color_identity_mask reading only the five
+// WUBRG keys.
+#[test]
+fn color_count_cmp_matches_popcount_oracle() {
+    let data = plane_fixture_store();
+    let bytes = rkyv::to_bytes::<Error>(&data).expect("serialize");
+    let archived = rkyv::access::<Archived<CardData>, Error>(&bytes).expect("access");
+
+    let cmp = |op: CmpOp, a: u32, b: u32| match op {
+        CmpOp::Eq => a == b,
+        CmpOp::Ne => a != b,
+        CmpOp::Lt => a < b,
+        CmpOp::Le => a <= b,
+        CmpOp::Gt => a > b,
+        CmpOp::Ge => a >= b,
+    };
+    for op in [CmpOp::Eq, CmpOp::Ne, CmpOp::Lt, CmpOp::Le, CmpOp::Gt, CmpOp::Ge] {
+        for count in 0u8..=5 {
+            for field in [ColorField::Colors, ColorField::ColorIdentity] {
+                let f = FilterExpr::ColorCountCmp { field, op, count };
+                for (cid, card) in archived.cards.iter().enumerate() {
+                    let bits = match field {
+                        ColorField::Colors => card.card_colors,
+                        ColorField::ColorIdentity => card.card_color_identity,
+                        ColorField::ProducedMana => unreachable!("numeric syntax never targets produced_mana"),
+                    };
+                    let want = cmp(op, u32::from(bits & 0b1_1111).count_ones(), u32::from(count));
+                    assert_eq!(
+                        f.eval_card(card, &archived.strings) == Tri::True,
+                        want,
+                        "color-count mismatch at card {cid} ({op:?} {count})"
+                    );
+                }
+            }
+        }
+    }
+}
+
+// The Python side serializes a numeric color comparison as a raw
+// NumericValueNode rhs (not the usual color-letter list); build_binary must
+// turn that into ColorCountCmp — with ":" behaving as equality, matching the
+// live Scryfall API — and refuse produced_mana, whose C key is not a color.
+#[test]
+fn build_filter_numeric_color_rhs() {
+    let node = |attr: &str, orig: &str, op: &str, n: u8| {
+        serde_json::json!({
+            "node_type": "CardBinaryOperatorNode",
+            "kwargs": {
+                "lhs": {"node_type": "CardAttributeNode", "kwargs": {"attribute_name": attr, "original_attribute": orig}},
+                "op": op,
+                "rhs": {"node_type": "NumericValueNode", "kwargs": {"value": n}},
+            },
+        })
+    };
+
+    let f = super::build_filter(&node("card_color_identity", "id", ">=", 3)).expect("id>=3 must build");
+    assert!(matches!(f, FilterExpr::ColorCountCmp { field: ColorField::ColorIdentity, op: CmpOp::Ge, count: 3 }));
+
+    let f = super::build_filter(&node("card_colors", "c", ":", 2)).expect("c:2 must build");
+    assert!(matches!(f, FilterExpr::ColorCountCmp { field: ColorField::Colors, op: CmpOp::Eq, count: 2 }));
+
+    let f = super::build_filter(&node("card_color_identity", "id", "=", 0)).expect("id=0 must build");
+    assert!(matches!(f, FilterExpr::ColorCountCmp { field: ColorField::ColorIdentity, op: CmpOp::Eq, count: 0 }));
+
+    assert!(super::build_filter(&node("produced_mana", "produces", "=", 2)).is_err());
+}
+
 // produced_mana must be its own independent transposition, not derived from
 // colors or identity: card 0 (colorless, produces everything) and card 5
 // (Fallaji Wayfarer, colors=WUBR/identity=G, produces only C) both have


### PR DESCRIPTION
## What

Scryfall accepts a bare integer on the color fields, meaning **"number of colors in the field"** — this PR adds that syntax to both parsers, the SQL generator, and the Rust engine, for **both** `id`/`identity` and `c`/`color`:

| Query | Meaning |
|---|---|
| `id=2` | identity has exactly two colors |
| `id>=3` | identity has three or more colors |
| `id<2` | fewer than two (colorless counts as zero) |
| `c=2` | exactly two printed colors |
| `id:2` | same as `id=2` — `:` with a number is equality |

Previously both parsers rejected these (`Invalid color value '2'`).

### Semantics verified against the live Scryfall API (2026-08)

- `id>=3` → 1056 total_cards (`unique=cards`)
- `id=2` and `id:2` → 4775 each (so `:` = `=` for numbers, unlike the subset semantics letters get)
- `c=2` and `c:2` → 3811 each
- `id<2` → 27764

## Design shipped

**Full support in all three layers** (not the SQL-fallback variant):

- **Parsers** (`hand_parser.py`, `pyparsing_based.py`): a bare integer is a valid COLOR-class value and produces a raw `NumericValueNode` instead of a color-set value. Floats (`id=2.5`) and mixed tokens (`id:2rr`) stay rejected, identically in both parsers — parser parity holds on both the success and the error side.
- **SQL** (`card_query_nodes.py`): the count comparison reuses the indexed mask expression the subset queries already use — `magic.color_identity_mask(col) = ANY(masks)` with the mask set restricted to values whose popcount satisfies the comparison — so `id`-count queries ride the existing expression index (`c`-count uses the same shape, unindexed but correct, since the function reads only the five WUBRG keys).
- **Rust engine** (`filter.rs`): new `FilterExpr::ColorCountCmp { field, op, count }` variant — popcount of the WUBRG bits (C bit masked off, mirroring the SQL function) vs the queried count. It's total and two-valued like `ColorCmp`, so it's registered in `is_total_two_valued` (negation stays the exact complement) and classified in every exhaustive match (`verify_cost_tier`, `leaf_compares_printing_field`, `has_printing_varying_leaf`); the estimator returns the sound "unknown" (no plane compilation yet).

**`produces` deliberately refuses numbers** with a clear `ValueError`/engine error in all layers: `produced_mana`'s `C` key is a genuine producible value rather than a color (Sol Ring produces `["C"]`), so a "count of colors" over it is ambiguous, and its data path (the C bit participates) differs from the two color fields.

Two tiny drive-by simplifications keep the touched functions inside the ruff complexity budget: the five identical tag-normalizer returns in `_rhs_to_json` collapsed into one table-driven return, and the twin color/identity explanation branches merged.

## Tests

- `api/parsing/tests/` — **1561 passed** (includes new parity + preprocess cases in `implicit_and_cases.py` and SQL-gen cases for `id>=3` / `id=2` / `id:2` / `id<2` / `id=0` / `c=2` / `c:3`)
- `api/tests/test_engine_unit.py` — **165 passed** end-to-end through the maturin-built engine, including new fixture tests (`c=2` → Boggart Ram-Gang + Kitchen Finks, `c>=3` → Monastery Messenger + Nicol Bolas, `id=0` → Black Lotus + Sol Ring, and `-id>=3` = exact complement 82/90)
- `cargo test` in `card_engine` — **157 passed** (new: an op×count popcount oracle over the plane fixture incl. the synthetic C-bit identity counting as zero, and JSON-builder cases incl. the `produced_mana` refusal)
- `cargo clippy --all-targets -- -D warnings` — clean
- ruff check + format — clean

Runtime validation against the full-corpus dev stack is pending (not run from this environment); the SQL was validated statically against the existing `color_identity_mask` tests and semantics.