### PR TITLE
CI: Label Fork PRs, and Bucket PR Size on log10 of Changed Lines

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,32 @@
 name: Label PR
 
+# Runs on pull_request_target, not pull_request, so that PRs from forks get
+# labelled too. Under pull_request the workflow definition comes from the PR's
+# merge ref (the contributor's copy of this file and of .github/labeler.yml),
+# and GITHUB_TOKEN is forced read-only for fork PRs no matter what the
+# permissions block says — so labelling silently fails on exactly the PRs that
+# most need it. pull_request_target runs this file from the base branch with a
+# writable token, and never requires the first-time-contributor "approve and
+# run" click.
+#
+# SAFETY: pull_request_target grants a write token to a job triggered by
+# untrusted code, so this workflow must never check out or execute the head
+# ref. It does not: actions/labeler reads the changed-file list from the pulls
+# API, and with no checkout present it fetches .github/labeler.yml over the API
+# at github.sha, which under this event is the base commit. Nothing from the
+# PR branch is read as code or configuration. Do not add actions/checkout here.
+#
+# There is deliberately no `branches: [main]` filter and no base-ref `if:`.
+# Neither would be a security control: pull_request_target resolves the
+# workflow file from the PR's *base branch*, so a PR based on some branch X
+# runs X's copy of this file, filters and all — a guard written here is never
+# consulted in the case it would be guarding. The control that actually holds
+# is that creating branch X in this repo requires push access. Re-examine this
+# workflow if anyone or any bot is ever granted that. Filtering to main would
+# also skip ~22% of PRs, which sit on a non-main base until they're retargeted.
+
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -16,3 +41,51 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
           sync-labels: false
+
+      # Size label, bucketed on log10(changed lines) so the scale matches how
+      # review effort actually grows: a 900-line PR is not 9x the work of a
+      # 100-line one, but it is a step up, and a linear scale would put almost
+      # every PR in this repo in the top bucket. Runs after the labeler step
+      # because actions/labeler calls setLabels() with the full label set it
+      # read at its own start, and would drop a size label written first.
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+
+            // Generated files: a lockfile refresh is thousands of lines of
+            // nothing to review, and would otherwise dominate the bucket.
+            const GENERATED = /(^|\/)(package-lock\.json|[^/]+\.lock|[^/]+\.min\.js)$/;
+
+            // Half-decade buckets: each step is ~3.16x the previous. Index
+            // floor(2*log10(n)) is offset by 2 and clamped, so XS is anything
+            // under 10^1.5 lines and XXL is 10^3.5 and up.
+            const SIZES = ["size/XS", "size/S", "size/M", "size/L", "size/XL", "size/XXL"];
+            const BUCKET_OFFSET = 2;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: number, per_page: 100,
+            });
+            const lines = files
+              .filter((f) => !GENERATED.test(f.filename))
+              .reduce((sum, f) => sum + f.additions + f.deletions, 0);
+
+            const index = Math.min(
+              SIZES.length - 1,
+              Math.max(0, Math.floor(2 * Math.log10(lines)) - BUCKET_OFFSET),
+            );
+            const want = SIZES[index];
+            core.info(`${lines} reviewable changed lines -> ${want}`);
+
+            // Read labels back rather than trusting the event payload: the
+            // labeler step above rewrote the set after the payload was cut.
+            const current = (await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner, repo, issue_number: number, per_page: 100,
+            })).map((l) => l.name);
+            for (const stale of current.filter((l) => SIZES.includes(l) && l !== want)) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: stale });
+            }
+            if (!current.includes(want)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [want] });
+            }


### PR DESCRIPTION
## Summary

The PR labeller ran on `pull_request`, which forces `GITHUB_TOKEN` read-only for fork PRs no matter what the `permissions:` block says — so `actions/labeler` failed with "Resource not accessible by integration" on exactly the PRs from outside contributors that most need labelling, and first-time contributors also hit the "approve and run" gate. This switches to `pull_request_target`, which runs the workflow from the base branch with a writable token, and adds a size label bucketed on `log10` of the changed lines.

Does not touch query parsing or evaluation.

## Changes

- `pull_request` → `pull_request_target` on [.github/workflows/label-pr.yml](.github/workflows/label-pr.yml), so fork PRs get labelled.
- New size label step (`actions/github-script@v7`) after the labeler step, assigning one of `size/XS`…`size/XXL`.
- Header comment recording the safety argument and the two guards that were considered and rejected.
- The six `size/*` labels already exist in the repo (created out of band, green→red gradient).

## Related issues

none

---

## Reviewer notes

**Why `pull_request_target` is safe here.** It grants a write token to a job triggered by untrusted code, so the rule is that the workflow must never check out or execute the head ref. This one doesn't: [actions/labeler@v5](https://github.com/actions/labeler/blob/v5/src/api/get-content.ts) reads the changed-file list from the pulls API, and with no checkout step present it fetches `labeler.yml` over the API at `github.sha`, which under this event is the base commit. Nothing from the PR branch is read as code or configuration. **Do not add `actions/checkout` to this workflow.**

**Why there's no `branches: [main]` filter or base-ref `if:`.** Both were considered. Neither is a security control, because `pull_request_target` resolves the workflow file from the PR's *base branch* — a PR based on some branch X runs X's copy of this file, `on:` filters and all. A guard written here is never consulted in the case it would be guarding. The control that actually holds is that creating branch X in this repo requires push access, which only the owner has; worth re-examining if that ever changes. Filtering to `main` would also skip ~22% of PRs (27 of the last 120 were retargeted at least once, so they sit on a non-main base for part of their life).

**Step ordering is load-bearing.** `actions/labeler` calls `setLabels()` with the full label set it read at its own start, so a size label written before it would be silently dropped. The size step must stay second.

**Size buckets** are half-decades on `log10(lines)` — each step ~3.16×:

| label | changed lines |
|---|---|
| `size/XS` | < 32 |
| `size/S` | 32–99 |
| `size/M` | 100–316 |
| `size/L` | 317–999 |
| `size/XL` | 1000–3162 |
| `size/XXL` | 3163+ |

Lockfiles and `.min.js` are excluded so a `uv.lock` refresh doesn't read as XXL.

One tradeoff worth flagging: this repo's PRs are large — p50 is 383 changed lines over the last 100 merged, p90 is 1628 — so the *median* PR lands at `size/L` and almost nothing will be XS. Excluding docs barely moves it (p50 344), so it's genuine code volume rather than blog posts. I kept the conventional scale rather than shifting it up a half-decade to re-center the median, on the grounds that `size/S` should mean roughly the same thing here as in any other repo. `BUCKET_OFFSET` is the single knob if you'd rather the labels be relative to this repo.

**Untested against a live PR.** The logic only runs on `pull_request_target`, which reads from the base branch, so it cannot execute until this is on `main`. The first PR opened afterwards is the real test. If the size step misfires there, the labeler step will still have done its job — the two are independent.
