### PR TITLE
Import: Cut the Prefer-Score Backfill 3.2x, and Import Art Tags Before It

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,11 @@ applies every time that stack starts; exporting one in the shell overrides the f
 - `ENVIRONMENT` - Environment mode (default: `dev`)
   - Set to `prod` for production mode with restricted CORS
   - Controlled per environment in `envs/dev` / `envs/blue` / `envs/green`
+- `PREFER_SCORE_BACKFILL_TIMEOUT_MS` - Statement timeout for the prefer-score backfill (default: `120000`)
+  - The backfill rescores the whole corpus in one UPDATE, so its runtime tracks disk speed
+  - Raise it if an import dies in `backfill_prefer_scores` on slow storage (a virtualized
+    Docker-for-Mac volume, a small cloud disk); `0` disables the timeout
+  - Must be a non-negative integer — a malformed value fails at startup rather than being ignored
 - `CDN_URL` - CDN URL for static assets (default: `https://d1hot9ps2xugbc.cloudfront.net`)
   - Override to use a different CDN provider
   - Used in Content-Security-Policy headers

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1054,6 +1054,9 @@ class APIResource:
             self._clear_caches()
             self._last_import_time.value = time.time()
             self._setup_complete_cache = None
+            # Every step above logs its own duration; this closes the sequence with the wall
+            # clock the operator actually waited, upsert through engine reload.
+            logger.info("Import complete in %.2f seconds", time.monotonic() - before)
             return
         logger.error("Failed to import data: %s", result["message"])
         return
@@ -1841,6 +1844,7 @@ class APIResource:
         Returns:
             Dict with status and count of cards updated
         """
+        start = time.monotonic()
         logger.info("Starting prefer score backfill")
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
@@ -1856,12 +1860,21 @@ class APIResource:
 
             conn.commit()
 
-        logger.info("Prefer score backfill complete: %d of %d cards updated", updated_count, total_cards)
+        # cards_updated counts only rows whose score actually moved -- the backfill's UPDATE
+        # skips rows already carrying the right value, so a steady-state re-run reports 0 of N
+        # rather than N of N. Both numbers are worth having: the first says how much churned,
+        # the second that the corpus is fully scored.
+        stats = {
+            "duration_seconds": round(time.monotonic() - start, 2),
+            "cards_updated": updated_count,
+            "cards_scored": total_cards,
+        }
+        logger.info("Prefer score backfill complete: %s", stats)
 
         return {
             "status": "success",
-            "cards_updated": updated_count,
             "message": f"Successfully backfilled prefer scores for {updated_count} of {total_cards} cards",
+            **stats,
         }
 
     def _fetch_cubecobra_data(self, db_oracle_ids: set[uuid.UUID]) -> dict[uuid.UUID, dict[str, Any]]:
@@ -1976,6 +1989,7 @@ class APIResource:
             "w_elo": 1,
             "w_pick_count": 1,
         }
+        start = time.monotonic()
         scale_factor = sum(weights.values()) / 100.0
         weights = {k: v / scale_factor for k, v in weights.items()}
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
@@ -1985,13 +1999,27 @@ class APIResource:
             self._set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
+
+            # The percent ranks are computed over cubecobra_elo and friends, which the normal
+            # import never populates -- they arrive via ingest_cubecobra. Reporting how many
+            # cards actually carry that data distinguishes "ranked the whole corpus" from
+            # "ranked a corpus of all-NULLs", which otherwise look identical in the log.
+            cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE cubecobra_elo IS NOT NULL")
+            result = cursor.fetchone()
+            cards_with_data = result["count"] if result else 0
+
             conn.commit()
 
-        logger.info("CubeCobra score backfill complete: %d cards updated", updated_count)
+        stats = {
+            "duration_seconds": round(time.monotonic() - start, 2),
+            "cards_updated": updated_count,
+            "cards_with_cubecobra_data": cards_with_data,
+        }
+        logger.info("CubeCobra score backfill complete: %s", stats)
         return {
             "status": "success",
-            "cards_updated": updated_count,
             "weights": weights,
+            **stats,
         }
 
     @route()

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1042,10 +1042,14 @@ class APIResource:
                 total_time,
                 rate,
             )
+            # Art tags first: the prefer score's art_style component reads card_art_tags, so
+            # running the backfill ahead of the tag import scored every card as on-style on a
+            # first boot, and nothing rescored until the next import. Oracle tags feed search
+            # rather than scoring, so their position relative to the backfill does not matter.
+            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
             self.backfill_prefer_scores()
             self.backfill_cubecobra_scores()
             _import_oracle_tags(self._conn_pool, self._bulk_data_fetcher)
-            _import_art_tags(self._conn_pool, self._bulk_data_fetcher)
             self._reload_engine(force=True)
             self._clear_caches()
             self._last_import_time.value = time.time()
@@ -1841,9 +1845,7 @@ class APIResource:
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
         with self._conn_pool.connection() as conn, conn.cursor() as cursor:
-            statement_timeout = 120_000
-            # Validate and set statement timeout
-            self._set_statement_timeout(cursor, statement_timeout)
+            self._set_statement_timeout(cursor, settings.prefer_score_backfill_timeout_ms)
             cursor.execute(backfill_sql)
             updated_count = cursor.rowcount
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import os
 
+# Statement timeout for the prefer-score backfill, in milliseconds. The backfill rescores the
+# whole corpus in a single UPDATE, so its runtime scales with disk speed: on a virtualized
+# Docker-for-Mac volume it can exceed a limit that real Linux hardware clears comfortably, and
+# the import is then abandoned after the upsert has already succeeded (#876). Raise this in
+# environments with slow storage.
+DEFAULT_PREFER_SCORE_BACKFILL_TIMEOUT_MS = 120_000
+
 
 def _is_truthy(value: str | None) -> bool:
     """Check if a string value is truthy.
@@ -19,6 +26,37 @@ def _is_truthy(value: str | None) -> bool:
     return value.lower() in ("true", "1", "yes")
 
 
+def _non_negative_int(name: str, default: int) -> int:
+    """Read a non-negative integer from the environment, falling back to a default.
+
+    Raises rather than silently substituting the default on a malformed value: these tune
+    timeouts, and quietly ignoring a typo means the operator only finds out when the import
+    dies at the limit they thought they had raised.
+
+    Args:
+        name: Environment variable to read.
+        default: Value to use when the variable is unset or empty.
+
+    Returns:
+        The parsed value, or default if the variable is unset or empty.
+
+    Raises:
+        ValueError: If the variable is set to something that is not a non-negative integer.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        msg = f"{name} must be a non-negative integer, got: {raw!r}"
+        raise ValueError(msg) from None
+    if value < 0:
+        msg = f"{name} must be a non-negative integer, got: {raw!r}"
+        raise ValueError(msg)
+    return value
+
+
 class Settings:
     """Simple settings class for runtime configuration."""
 
@@ -27,6 +65,10 @@ class Settings:
         self._enable_cache = _is_truthy(os.environ.get("ENABLE_CACHE", "false"))
         self._enable_engine = _is_truthy(os.environ.get("ENABLE_ENGINE", "true"))
         self._shared_cache_path: str = os.environ.get("SHARED_CACHE_PATH", "/tmp/sylvan.cache")  # noqa: S108
+        self._prefer_score_backfill_timeout_ms = _non_negative_int(
+            "PREFER_SCORE_BACKFILL_TIMEOUT_MS",
+            DEFAULT_PREFER_SCORE_BACKFILL_TIMEOUT_MS,
+        )
 
     @property
     def enable_cache(self) -> bool:
@@ -58,6 +100,14 @@ class Settings:
     def shared_cache_path(self) -> str:
         """Filesystem path for the shared mmap cache file."""
         return self._shared_cache_path
+
+    @property
+    def prefer_score_backfill_timeout_ms(self) -> int:
+        """Statement timeout for the prefer-score backfill, in milliseconds.
+
+        Override with PREFER_SCORE_BACKFILL_TIMEOUT_MS. 0 disables the timeout entirely.
+        """
+        return self._prefer_score_backfill_timeout_ms
 
 
 # Global settings instance

--- a/api/sql/backfill_prefer_scores.sql
+++ b/api/sql/backfill_prefer_scores.sql
@@ -1,48 +1,60 @@
 -- Backfill prefer_score and prefer_score_components for all cards
 -- This script recalculates the prefer score for all existing cards based on multiple attributes
 
-WITH computed_components AS (
+-- How heavily each ARTWORK has been reprinted, as a proxy for how canonical it is. Counts
+-- only real printing events -- three kinds of row are not:
+--
+--   non-English  the same printing already counted in its English row. Mark Poole's Birds
+--                of Paradise art picked up 4bb (Spanish) and fbb (French) on top of the
+--                English 4th Edition printing.
+--   memorabilia  World Championship decks, Collectors' Edition and 30th Anniversary: not
+--                tournament-legal, not real sets. Four of the eight on that same artwork
+--                are BLACK-bordered (30a x2, ced, cei), so a border test alone misses half
+--                of them.
+--   gold/yellow  any remaining non-standard product Scryfall types as something other than
+--                memorabilia.
+--
+-- Together these took Poole's art from 21 counted printings to 11, against Marcelo
+-- Vignali's 12 -- reversing which artwork the site shows for that card.
+--
+-- White borders are deliberately NOT filtered: 2ed-6ed are white-bordered and perfectly
+-- real, and dropping them would penalise exactly the core-set reprints this component
+-- should reward.
+--
+-- Evidence (docs/issues/done/00720-prefer-score-artwork-tuning.md): a 47-card blind swap
+-- review returned 11 better, 36 same, 0 worse, and a later 378-card review against
+-- production added 2 more with no regressions. This changes only the numerator -- it does
+-- not stop such printings being displayed.
+--
+-- Aggregated once for the whole corpus rather than re-counted per card. As a correlated
+-- subquery this was one index lookup per row, and because the planner inlines the CTEs
+-- below it ran FOUR times per row -- once each for the target list and the IS DISTINCT
+-- FROM guard, in both the component object and the score sum.
+WITH artwork_printings AS MATERIALIZED (
     SELECT
-        scryfall_id,
+        illustration_id,
+        card_name,
+        COUNT(*) AS printings
+    FROM magic.cards
+    CROSS JOIN LATERAL JSONB_TO_RECORD(raw_card_blob) AS blob(lang text, set_type text)
+    WHERE (
+        illustration_id IS NOT NULL AND
+        blob.lang = 'en' AND
+        COALESCE(blob.set_type, '') <> 'memorabilia' AND
+        COALESCE(card_border, '') NOT IN ('gold', 'yellow')
+    )
+    GROUP BY illustration_id, card_name
+),
+-- MATERIALIZED on both CTEs is load-bearing, not decoration. Inlined, the whole
+-- JSONB_BUILD_OBJECT expression is substituted into the UPDATE's target list AND its
+-- IS DISTINCT FROM guard, so every component is computed twice over -- and any subquery
+-- inside it twice again.
+computed_components AS MATERIALIZED (
+    SELECT
+        source.scryfall_id,
         JSONB_BUILD_OBJECT(
-            -- How heavily this ARTWORK has been reprinted, as a proxy for how canonical it
-            -- is. The numerator counts rows sharing the illustration, so it must count only
-            -- real printing events -- three kinds of row are not:
-            --
-            --   non-English  the same printing already counted in its English row. Mark
-            --                Poole's Birds of Paradise art picked up 4bb (Spanish) and fbb
-            --                (French) on top of the English 4th Edition printing.
-            --   memorabilia  World Championship decks, Collectors' Edition and 30th
-            --                Anniversary: not tournament-legal, not real sets. Four of the
-            --                eight on that same artwork are BLACK-bordered (30a x2, ced,
-            --                cei), so a border test alone misses half of them.
-            --   gold/yellow  any remaining non-standard product Scryfall types as something
-            --                other than memorabilia.
-            --
-            -- Together these took Poole's art from 21 counted printings to 11, against
-            -- Marcelo Vignali's 12 -- reversing which artwork the site shows for that card.
-            --
-            -- White borders are deliberately NOT filtered: 2ed-6ed are white-bordered and
-            -- perfectly real, and dropping them would penalise exactly the core-set reprints
-            -- this component should reward.
-            --
-            -- Evidence (docs/issues/done/00720-prefer-score-artwork-tuning.md): a 47-card blind
-            -- swap review returned 11 better, 36 same, 0 worse, and a later 378-card review
-            -- against production added 2 more with no regressions. This changes only the
-            -- numerator -- it does not stop such printings being displayed.
-            'illustration_count', (
-                SELECT
-                    ROUND((23 * LN(1 + COUNT(*)) / LN(40))::numeric, 4)
-                FROM magic.cards query_target_cards
-                WHERE (
-                    query_target_cards.illustration_id = source.illustration_id AND
-                    query_target_cards.illustration_id IS NOT NULL AND
-                    query_target_cards.card_name = source.card_name AND
-                    query_target_cards.raw_card_blob ->> 'lang' = 'en' AND
-                    COALESCE(query_target_cards.raw_card_blob ->> 'set_type', '') <> 'memorabilia' AND
-                    COALESCE(query_target_cards.card_border, '') NOT IN ('gold', 'yellow')
-                )
-            ),
+            -- See the artwork_printings CTE above for what counts as a printing.
+            'illustration_count', ROUND((23 * LN(1 + COALESCE(artwork_printings.printings, 0)) / LN(40))::numeric, 4),
             'rarity', (
                 CASE
                     WHEN card_rarity_int = 0 THEN 16  -- common
@@ -77,39 +89,39 @@ WITH computed_components AS (
             ),
             'highres_scan', (
                 CASE
-                    WHEN raw_card_blob ->> 'image_status' = 'highres_scan' THEN 16
+                    WHEN blob.image_status = 'highres_scan' THEN 16
                     ELSE 0
                 END
             ),
             'has_paper', (
                 CASE
-                    WHEN raw_card_blob -> 'games' ? 'paper' THEN 6
+                    WHEN blob.games ? 'paper' THEN 6
                     ELSE 0
                 END
             ),
             'language', (
                 CASE
-                    WHEN raw_card_blob ->> 'lang' = 'en' THEN 40
+                    WHEN blob.lang = 'en' THEN 40
                     ELSE 0
                 END
             ),
             'legendary_frame', (
                 CASE
-                    WHEN raw_card_blob -> 'frame_effects' ? 'legendary' THEN 5
+                    WHEN blob.frame_effects ? 'legendary' THEN 5
                     ELSE 0
                 END
             ),
             'non_showcase', (
                 CASE
-                    WHEN NOT (COALESCE(raw_card_blob -> 'frame_effects', '[]'::jsonb) ? 'showcase') THEN 10
+                    WHEN NOT (COALESCE(blob.frame_effects, '[]'::jsonb) ? 'showcase') THEN 10
                     ELSE 0
                 END
             ),
             'finish', (
                 CASE
-                    WHEN raw_card_blob -> 'finishes' ? 'nonfoil' THEN 10
-                    WHEN raw_card_blob -> 'finishes' ? 'foil' THEN 5
-                    WHEN raw_card_blob -> 'finishes' ? 'etched' THEN 0
+                    WHEN blob.finishes ? 'nonfoil' THEN 10
+                    WHEN blob.finishes ? 'foil' THEN 5
+                    WHEN blob.finishes ? 'etched' THEN 0
                     ELSE 0
                 END
             ),
@@ -158,8 +170,18 @@ WITH computed_components AS (
             )
         ) AS new_components
     FROM magic.cards source
+    -- Pull every raw_card_blob field in one pass. Written as separate `->>` extractions,
+    -- each one detoasts the blob again -- seven times per row, and raw_card_blob is large
+    -- enough to be stored out of line.
+    CROSS JOIN LATERAL JSONB_TO_RECORD(source.raw_card_blob) AS blob(
+        image_status text, lang text, games jsonb, frame_effects jsonb, finishes jsonb
+    )
+    LEFT JOIN artwork_printings ON (
+        artwork_printings.illustration_id = source.illustration_id AND
+        artwork_printings.card_name = source.card_name
+    )
 ),
-computed_scores AS (
+computed_scores AS MATERIALIZED (
     SELECT
         scryfall_id,
         new_components,

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -176,3 +176,48 @@ class TestBackfillPreferScores:
         result = api_resource.backfill_prefer_scores()
 
         assert result["cards_updated"] == 0
+
+    def test_reports_duration_and_scored_count(self, api_resource: APIResource) -> None:
+        """cards_scored counts the whole scored corpus, not just the rows this run moved."""
+        _insert_card(api_resource, make_raw_card(name=f"Stats Card {uuid.uuid4()}"))
+        api_resource.backfill_prefer_scores()
+
+        result = api_resource.backfill_prefer_scores()
+
+        assert result["duration_seconds"] >= 0
+        # Nothing moved on the second run, but the corpus is still fully scored.
+        assert result["cards_updated"] == 0
+        assert result["cards_scored"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# backfill_cubecobra_scores
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillCubecobraScores:
+    def test_returns_success_status(self, api_resource: APIResource) -> None:
+        result = api_resource.backfill_cubecobra_scores()
+        assert result["status"] == "success"
+
+    def test_reports_duration_and_counts(self, api_resource: APIResource) -> None:
+        _insert_card(api_resource, make_raw_card(name=f"Cubecobra Stats Card {uuid.uuid4()}"))
+
+        result = api_resource.backfill_cubecobra_scores()
+
+        assert result["duration_seconds"] >= 0
+        assert result["cards_updated"] >= 0
+        assert result["cards_with_cubecobra_data"] >= 0
+
+    def test_counts_cards_carrying_cubecobra_data(self, api_resource: APIResource) -> None:
+        """Count the cards actually carrying CubeCobra data.
+
+        The normal import never populates cubecobra_elo, so this distinguishes a real ranking
+        from one computed over an all-NULL corpus.
+        """
+        oracle_id = _insert_card(api_resource, make_raw_card(name=f"Cubecobra Data Card {uuid.uuid4()}"))
+        before = api_resource.backfill_cubecobra_scores()["cards_with_cubecobra_data"]
+
+        api_resource._insert_cubecobra_data({oracle_id: {"elo": 1500.0, "cube_count": 7, "pick_count": 9}})
+
+        assert api_resource.backfill_cubecobra_scores()["cards_with_cubecobra_data"] == before + 1


### PR DESCRIPTION
Closes #876.

The backfill's cost was its shape, not a missing index.

## What the plan showed

Three problems, all visible in `EXPLAIN (ANALYZE, BUFFERS)` against the 97,468-row corpus:

1. **The `illustration_count` correlated subquery ran four times per row.** Postgres inlines both CTEs, so the whole `JSONB_BUILD_OBJECT` expression is substituted into the UPDATE's target list *and* into its `IS DISTINCT FROM` guard, and the subquery inside it twice again — SubPlan 1, 3, 4 and 6, all identical. It is now a single grouped aggregate over `(illustration_id, card_name)`, joined once.
2. **`raw_card_blob` was detoasted seven times per row**, once per `->>` extraction, and it is large enough to be stored out of line. One `JSONB_TO_RECORD` lateral now pulls every field in a single pass.
3. **`MATERIALIZED` on both CTEs** pins the first fix in place; without it the planner re-inlines and the duplication returns.

Together: **18.9M buffer accesses → 9.8M**, and **12.7 s → 3.9 s** (three runs each, warm cache, real corpus).

Output is unchanged: **0 of 97,468 rows** differ in `prefer_score_components` or `prefer_score`.

## Two alternatives, measured rather than assumed

**An index.** A partial index on `(illustration_id, card_name)` over the printing filter *is* used by the planner — index-only scan, sort eliminated — but it is worth only ~3%, inside the noise, and it cannot serve the `JSONB_TO_RECORD` form at all. Not added.

**ANALYZE before the backfill.** Measured on an exact fresh-import replica (same rows, `reltuples=-1`, empty `pg_statistic`):

| | no stats | after ANALYZE |
|---|---|---|
| before | 14.0 s | 13.0 s |
| after | 5.6 s | 5.7 s |

Missing stats cost ~10%, not the 5× the report implies, and `ANALYZE magic.cards` itself costs 4.5 s because it detoasts the sample. As a pre-backfill step it does not pay for itself, so it is not added here. (Whether the *whole import* should end with an ANALYZE, for the benefit of serving-query plans on a fresh boot, is a separate question this PR does not answer — nothing in `api/` runs ANALYZE today.)

## Two related fixes to the same import step

**Art tags now import before the backfill.** The `art_style` component reads `card_art_tags`, so on a first boot every card scored 14 (on-style) against an empty tag table, and nothing rescored until the next import. Oracle tags feed search rather than scoring, so they stay where they were.

**The 120 s statement timeout is configurable** via `PREFER_SCORE_BACKFILL_TIMEOUT_MS`, defaulting to the current value, documented in the README. A malformed value raises at startup rather than silently falling back — quietly ignoring a typo means the operator finds out when the import dies at the limit they thought they had raised. `0` disables the timeout.

Note that the rewrite buys headroom on slow disks but does not by itself guarantee the 120 s default is enough there, which is why the timeout is configurable too.

## Testing

Full suite: 2391 passed. `make lint` clean. Equivalence and timings measured against a real 97,468-card database, not a fixture.
