### PR TITLE
Import: Report Duration and Counts From Each Backfill Step

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -1054,6 +1054,9 @@ class APIResource:
             self._clear_caches()
             self._last_import_time.value = time.time()
             self._setup_complete_cache = None
+            # Every step above logs its own duration; this closes the sequence with the wall
+            # clock the operator actually waited, upsert through engine reload.
+            logger.info("Import complete in %.2f seconds", time.monotonic() - before)
             return
         logger.error("Failed to import data: %s", result["message"])
         return
@@ -1841,6 +1844,7 @@ class APIResource:
         Returns:
             Dict with status and count of cards updated
         """
+        start = time.monotonic()
         logger.info("Starting prefer score backfill")
 
         backfill_sql = db_utils.read_sql("backfill_prefer_scores")
@@ -1856,12 +1860,21 @@ class APIResource:
 
             conn.commit()
 
-        logger.info("Prefer score backfill complete: %d of %d cards updated", updated_count, total_cards)
+        # cards_updated counts only rows whose score actually moved -- the backfill's UPDATE
+        # skips rows already carrying the right value, so a steady-state re-run reports 0 of N
+        # rather than N of N. Both numbers are worth having: the first says how much churned,
+        # the second that the corpus is fully scored.
+        stats = {
+            "duration_seconds": round(time.monotonic() - start, 2),
+            "cards_updated": updated_count,
+            "cards_scored": total_cards,
+        }
+        logger.info("Prefer score backfill complete: %s", stats)
 
         return {
             "status": "success",
-            "cards_updated": updated_count,
             "message": f"Successfully backfilled prefer scores for {updated_count} of {total_cards} cards",
+            **stats,
         }
 
     def _fetch_cubecobra_data(self, db_oracle_ids: set[uuid.UUID]) -> dict[uuid.UUID, dict[str, Any]]:
@@ -1976,6 +1989,7 @@ class APIResource:
             "w_elo": 1,
             "w_pick_count": 1,
         }
+        start = time.monotonic()
         scale_factor = sum(weights.values()) / 100.0
         weights = {k: v / scale_factor for k, v in weights.items()}
         logger.info("Starting CubeCobra score backfill with weights: %s", weights)
@@ -1985,13 +1999,27 @@ class APIResource:
             self._set_statement_timeout(cursor, 600_000)
             cursor.execute(backfill_sql, weights)
             updated_count = cursor.rowcount
+
+            # The percent ranks are computed over cubecobra_elo and friends, which the normal
+            # import never populates -- they arrive via ingest_cubecobra. Reporting how many
+            # cards actually carry that data distinguishes "ranked the whole corpus" from
+            # "ranked a corpus of all-NULLs", which otherwise look identical in the log.
+            cursor.execute("SELECT COUNT(*) as count FROM magic.cards WHERE cubecobra_elo IS NOT NULL")
+            result = cursor.fetchone()
+            cards_with_data = result["count"] if result else 0
+
             conn.commit()
 
-        logger.info("CubeCobra score backfill complete: %d cards updated", updated_count)
+        stats = {
+            "duration_seconds": round(time.monotonic() - start, 2),
+            "cards_updated": updated_count,
+            "cards_with_cubecobra_data": cards_with_data,
+        }
+        logger.info("CubeCobra score backfill complete: %s", stats)
         return {
             "status": "success",
-            "cards_updated": updated_count,
             "weights": weights,
+            **stats,
         }
 
     @route()

--- a/api/tests/test_cubecobra_and_prefer_scores.py
+++ b/api/tests/test_cubecobra_and_prefer_scores.py
@@ -176,3 +176,48 @@ class TestBackfillPreferScores:
         result = api_resource.backfill_prefer_scores()
 
         assert result["cards_updated"] == 0
+
+    def test_reports_duration_and_scored_count(self, api_resource: APIResource) -> None:
+        """cards_scored counts the whole scored corpus, not just the rows this run moved."""
+        _insert_card(api_resource, make_raw_card(name=f"Stats Card {uuid.uuid4()}"))
+        api_resource.backfill_prefer_scores()
+
+        result = api_resource.backfill_prefer_scores()
+
+        assert result["duration_seconds"] >= 0
+        # Nothing moved on the second run, but the corpus is still fully scored.
+        assert result["cards_updated"] == 0
+        assert result["cards_scored"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# backfill_cubecobra_scores
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillCubecobraScores:
+    def test_returns_success_status(self, api_resource: APIResource) -> None:
+        result = api_resource.backfill_cubecobra_scores()
+        assert result["status"] == "success"
+
+    def test_reports_duration_and_counts(self, api_resource: APIResource) -> None:
+        _insert_card(api_resource, make_raw_card(name=f"Cubecobra Stats Card {uuid.uuid4()}"))
+
+        result = api_resource.backfill_cubecobra_scores()
+
+        assert result["duration_seconds"] >= 0
+        assert result["cards_updated"] >= 0
+        assert result["cards_with_cubecobra_data"] >= 0
+
+    def test_counts_cards_carrying_cubecobra_data(self, api_resource: APIResource) -> None:
+        """Count the cards actually carrying CubeCobra data.
+
+        The normal import never populates cubecobra_elo, so this distinguishes a real ranking
+        from one computed over an all-NULL corpus.
+        """
+        oracle_id = _insert_card(api_resource, make_raw_card(name=f"Cubecobra Data Card {uuid.uuid4()}"))
+        before = api_resource.backfill_cubecobra_scores()["cards_with_cubecobra_data"]
+
+        api_resource._insert_cubecobra_data({oracle_id: {"elo": 1500.0, "cube_count": 7, "pick_count": 9}})
+
+        assert api_resource.backfill_cubecobra_scores()["cards_with_cubecobra_data"] == before + 1


### PR DESCRIPTION
Stacked on #882 — review that one first; this branch targets it, and GitHub will retarget to `main` once #882 merges.

The tag imports already close with a one-line summary of what they did and how long it took. The score backfills logged neither a duration nor enough counts to tell a real run from a no-op. Both now report in the same shape:

```
INFO:api.tag_import:Art tag import complete: {'duration_seconds': 23.81, 'tags_imported': 11509, 'cards_with_tags': 52297, 'cards_updated': 97413, 'cards_cleared': 0}
INFO:api.api_resource:Prefer score backfill complete: {'duration_seconds': 3.91, 'cards_updated': 0, 'cards_scored': 97468}
INFO:api.api_resource:CubeCobra score backfill complete: {'duration_seconds': 1.02, 'cards_updated': 97468, 'cards_with_cubecobra_data': 0}
INFO:api.api_resource:Import complete in 118.44 seconds
```

## Why two counts each

`cards_updated` counts only rows whose score actually *moved* — both backfills skip rows already carrying the right value, so a steady-state re-run reports 0 and is indistinguishable from a broken one. The second count says how much of the corpus is scored.

For CubeCobra that second count earns its place immediately. The percent ranks read `cubecobra_elo` / `cube_count` / `pick_count`, which **the normal import never populates** — they arrive only via `ingest_cubecobra`. On the blue corpus:

```
magic=# SELECT COUNT(*) FROM magic.cards WHERE cubecobra_elo IS NOT NULL;
 0
```

So the backfill has been ranking an all-NULL corpus, and the old log reported that as a successful 97,468-row update. This PR doesn't change that behaviour, only makes it visible.

## Test gap closed

`backfill_cubecobra_scores` had no test touching a database, so the new count query would have shipped unexercised. Adds four tests over the reported counts, including one that inserts CubeCobra data and asserts the count moves.

## Testing

2395 passed (up from 2391). `ruff check` and `ruff format --check` clean. Log output above is real, captured from the test run and from the blue database — not illustrative.
