### PR TITLE
Docs: Backfill Ten Changelog Entries for 2026-01 Through 2026-06

### DIFF
--- a/docs/changelog/2026-01-29-search-history-back-forward.md
+++ b/docs/changelog/2026-01-29-search-history-back-forward.md
@@ -1,0 +1,28 @@
+# Search History and Back/Forward Support
+
+**Date:** 2026-01-29  
+**PR:** #414
+
+## Overview
+
+Browser back/forward now navigate between meaningful search states. Previously the app was a
+single-page app that never updated browser history, so back/forward either left the SPA or did
+nothing useful.
+
+## Behavior
+
+- After a successful search, the URL is updated via `history.replaceState` to reflect the current
+  query and dropdown state.
+- A new `history.pushState` entry is created only when the user has been viewing a result set for
+  at least **2.5 seconds** before moving to a different search. This prevents history spam during
+  rapid typing while still bookmarking states the user dwelt on.
+- The arrival time is stored in `history.state` so the dwell check works correctly when navigating
+  between already-pushed entries.
+- `popstate` events restore the search input, dropdowns, and results (via a re-fetch) for the
+  popped state, so back/forward correctly return to prior results.
+
+## Implementation
+
+All changes are in `api/static/app.js`. The dwell timer starts when results are first rendered and
+is cancelled if the user triggers a new search before it fires. The `popstate` handler reads query
+and ordering from `event.state` and calls `performSearch` directly, bypassing the debounce.

--- a/docs/changelog/2026-03-26-simplify-request-lifecycle.md
+++ b/docs/changelog/2026-03-26-simplify-request-lifecycle.md
@@ -1,0 +1,52 @@
+# Simplify and Fix Search Request Lifecycle
+
+**Date:** 2026-03-26  
+**PR:** #446
+
+## Overview
+
+Rewrites the debounce/cancellation/result-rendering logic in `app.js` around a cleaner set of
+invariants, fixing several bugs. Only `app.js` changed.
+
+## Problems Fixed
+
+- **`clearSearch()` didn't abort in-flight requests.** A pending fetch could complete and repopulate
+  results after the user clicked the header to clear the search.
+- **`clearSearch()` didn't clear `lastRequestedUrl`.** Re-typing the same query after clearing
+  would be silently skipped.
+- **Two conflated staleness mechanisms** (`lastRequestedUrl` + `requestId`) made the lifecycle hard
+  to reason about and left a window where stale responses could still render after an abort.
+- **`showLoading()` was immediately followed by `clearMessages()`**, erasing the "Loading…" text.
+- **In-flight requests weren't aborted during the debounce window**, so an older request could
+  complete and flash stale results while the user was still typing.
+
+## New Design
+
+**State reduced from four fields to three:**
+
+| Field | Purpose |
+|-------|---------|
+| `debounceTimeout` | Debounce timer handle |
+| `currentController` + `currentRequestUrl` | In-flight AbortController and its URL |
+| `lastCompletedUrl` | URL whose results are currently displayed; `null` when results are cleared |
+
+`requestId` is removed. `lastRequestedUrl` is replaced by the split between `currentRequestUrl`
+(in-flight) and `lastCompletedUrl` (completed).
+
+**Single staleness mechanism:** stale responses are detected by checking
+`controller.signal.aborted` after every `await` point. Since JS is single-threaded, this closes
+all gaps.
+
+**Unified dedup in `performSearch`:**
+- Skip if same URL is in-flight and not yet aborted.
+- Skip if `lastCompletedUrl` already matches (results already showing).
+
+**All clear paths are consistent:** `clearSearch()`, the empty-query branch of `handleSearch`, and
+the `popstate` empty-query branch all abort the in-flight request, clear `lastCompletedUrl`, and
+clear the UI in the same order.
+
+**`_processQuery` helper** consolidates the autocomplete → balance → normalize pipeline,
+previously duplicated across callers.
+
+**Early abort during debounce:** `handleSearch` now aborts the in-flight request immediately when
+the processed query has changed, rather than waiting for the debounce timer to fire.

--- a/docs/changelog/2026-03-27-cubecobra-sort.md
+++ b/docs/changelog/2026-03-27-cubecobra-sort.md
@@ -1,0 +1,57 @@
+# CubeCobra Sort Ordering
+
+**Date:** 2026-03-27  
+**PR:** #448
+
+## Overview
+
+Adds `orderby=cubecobra` (also `orderby=community` in the UI) which ranks cards by a combined
+score across four community popularity dimensions: EDHREC rank, CubeCobra ELO, cube count, and
+pick count.
+
+## Database
+
+New columns on `magic.cards` (`api/db/2026-03-26-01-cubecobra-columns.sql`):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `cubecobra_elo` | real | Draft power rating from CubeCobra |
+| `cubecobra_cube_count` | integer | Number of cubes the card appears in |
+| `cubecobra_pick_count` | integer | Total times picked across CubeCobra drafts |
+| `cubecobra_score` | real | Pre-computed combined score; lower is better (0–100) |
+
+Data is keyed by `oracle_id` from CubeCobra and stored per-printing (same approach as
+`edhrec_rank`).
+
+## Endpoints
+
+- **`POST /ingest_cubecobra`** — paginates the CubeCobra top-cards API, filters to `oracle_id`s
+  already in the DB, bulk-updates the three raw columns via a single
+  `UPDATE ... FROM jsonb_to_recordset(...)` CTE, then calls `backfill_cubecobra_scores`.
+- **`POST /backfill_cubecobra_scores`** — recomputes `cubecobra_score` for all cards using the
+  formula below. Also called automatically after each Scryfall bulk import.
+
+## Score Formula (`api/sql/backfill_cubecobra_scores.sql`)
+
+```sql
+w_edhrec     * PERCENT_RANK() OVER (ORDER BY edhrec_rank          ASC  NULLS LAST)
++ w_elo        * PERCENT_RANK() OVER (ORDER BY cubecobra_elo        DESC NULLS LAST)
++ w_cube_count * PERCENT_RANK() OVER (ORDER BY cubecobra_cube_count DESC NULLS LAST)
++ w_pick_count * PERCENT_RANK() OVER (ORDER BY cubecobra_pick_count DESC NULLS LAST)
+```
+
+Equal weights (25 each) by default, passed as named SQL parameters and auto-normalised to 0–100.
+One score per distinct `card_name` is propagated to all printings. Cards missing CubeCobra data
+score worst (100) on those dimensions via `NULLS LAST`.
+
+## API / Frontend
+
+- `CardOrdering.CUBECOBRA` added to `enums.py`, mapped to `cubecobra_score ASC NULLS LAST` in
+  `_search()`
+- "CubeCobra" option added to the sort dropdown in `index.html`
+
+## Notes
+
+- `cubecobra_score` follows the lower-is-better convention of `edhrec_rank`, so no special-casing
+  is needed in the sort direction logic.
+- CubeCobra data must be refreshed separately from Scryfall data via `POST /ingest_cubecobra`.

--- a/docs/changelog/2026-05-15-query-explanation.md
+++ b/docs/changelog/2026-05-15-query-explanation.md
@@ -1,0 +1,30 @@
+# Query Explanations (Scryfall-style)
+
+**Date:** 2026-05-15  
+**PR:** #419
+
+## Overview
+
+Search results now include a plain-language explanation of the query, displayed below the search
+box. For example, `(power>3 or toughness>3) and id=g f=m` shows:
+_"(the power is greater than 3 or the toughness is greater than 3) and the color identity is G and
+it's legal in Modern"_
+
+## Implementation
+
+Each AST node type gained a `to_human_explanation()` method that recursively builds a readable
+string. The approach is OO — no `isinstance` dispatch. Key behaviors:
+
+- Attribute shorthands expand to readable names (e.g. `id` → "color identity", `f` → "legal in")
+- Color codes and format codes expand using the existing `COLOR_CODE_TO_NAME` and
+  `FORMAT_CODE_TO_NAME` maps in `db_info.py`
+- OR groups nested inside AND expressions are wrapped in parentheses to reflect actual precedence
+- Operators are mapped to prose (e.g. `>` → "is greater than", `:` → "is")
+
+The explanation is returned in the existing search API response as a `query_explanation` field.
+The frontend renders it in a `<div>` below the search box when the field is non-empty.
+
+## Tests
+
+34 new unit tests covering representative queries, operator prose, color/format expansion, and
+nested grouping. Parse-error responses omit the field.

--- a/docs/changelog/2026-05-19-color-identity-query-performance.md
+++ b/docs/changelog/2026-05-19-color-identity-query-performance.md
@@ -1,0 +1,60 @@
+# Color Identity Query Performance
+
+**Date:** 2026-05-19  
+**PR:** #469
+
+## Overview
+
+Color identity subset queries (`id:wub`, `id<=rg`, etc.) were doing sequential scans. Speed
+improved from ~160 ms to ~22 ms by switching from a JSONB `<@` containment check to a bitmask
+`= ANY(array)` lookup backed by a B-tree expression index.
+
+## Root Cause
+
+The old code emitted `card_color_identity <@ %(param)s`. PostgreSQL's `jsonb_ops` GIN index
+supports `@>` but not `<@`, so the `:` / `<=` / `<` color identity paths fell back to a full scan.
+The `idx_cards_color_identity_gin` index had zero scans in `pg_stat_user_indexes`.
+
+## Fix
+
+### Database (`api/db/2026-05-19-01-color-identity-mask.sql`)
+
+An immutable SQL function computes a 5-bit bitmask from a color identity JSONB value, and a
+B-tree expression index is built on it:
+
+```sql
+CREATE FUNCTION magic.color_identity_mask(jsonb) RETURNS smallint ...
+    -- W=16, U=8, B=4, R=2, G=1
+CREATE INDEX idx_cards_color_identity_mask
+    ON magic.cards (magic.color_identity_mask(card_color_identity));
+```
+
+### `card_query_nodes.py`
+
+Three helpers compute the bitmask and enumerate all valid subset (or proper-subset) masks for a
+query value. The emitted SQL calls the function explicitly so the planner matches the expression
+index:
+
+```python
+return f"(magic.color_identity_mask(card.card_color_identity) = ANY(%({pmask})s))"
+```
+
+`=`, `>=`, and `>` operators are unchanged — they use `@>` against the JSONB column and the
+existing GIN index serves them.
+
+### `db_utils.py` — `IntArray`
+
+psycopg serializes plain Python lists as JSONB. `IntArray` (a `list` subclass) bypasses this so
+the integer subset arrays reach PostgreSQL as native integer arrays, which `= ANY(...)` requires.
+
+## Results
+
+| Query    | Before  | After  |
+|----------|---------|--------|
+| `id:w`   | ~39 ms  | ~13 ms |
+| `id:wub` | ~160 ms | ~22 ms |
+
+## Edge Cases
+
+- `id:c` / `id:colorless` — colorless mask=0, subsets=[0]; correctly returns only colorless cards.
+- `id<rg` — proper subsets of RG (mask=3) are [0, 1, 2]; does not include `id=rg` itself.

--- a/docs/changelog/2026-05-20-ilike-to-lower-like.md
+++ b/docs/changelog/2026-05-20-ilike-to-lower-like.md
@@ -1,0 +1,92 @@
+# ILIKE planning overhead on trigram-indexed text columns
+
+## Problem
+
+Text search queries (`name:`, `oracle:`, `artist:`, `flavor:`) are slow to plan. Planning time
+scales roughly linearly with the number of ILIKE conditions:
+
+| ILIKE conditions | Planning time | Execution time |
+|-----------------|---------------|----------------|
+| 0               | ~0.3 ms       | ~25 ms         |
+| 1               | ~40 ms        | ~8 ms          |
+| 3               | ~110 ms       | ~3 ms          |
+
+A query like `oracle:counter oracle:flying oracle:sacrifice tou>=5` spends ~110ms planning and ~3ms
+executing — the query itself is essentially free, but the planner is the bottleneck.
+
+## Root cause
+
+PostgreSQL uses different selectivity estimators for `LIKE` and `ILIKE`. The `ILIKE` estimator must
+account for case-folding across the trigram set, which involves significantly more work than the
+`LIKE` estimator. This cost is paid once per `ILIKE` condition at planning time, regardless of
+whether the query result is cached afterward.
+
+The current query generator in `card_query_nodes.py` always emits `ILIKE`:
+
+```python
+return f"({lhs_sql} ILIKE %({_param_name})s)"
+```
+
+The existing GIN trigram indexes (`idx_cards_oracle_text_trgm`, `idx_cards_cardname_trgm`, etc.)
+are effective at *execution* time — the trigram bitmap scans are fast. The cost is entirely in
+planning.
+
+## Fix
+
+Replace `ILIKE` with `LIKE` by:
+
+1. Creating functional indexes on `lower(column)` for each trigram-indexed text field.
+2. Lowercasing the search pattern at query-build time in `card_query_nodes.py`.
+3. Emitting `lower(column) LIKE '%pattern%'` instead of `column ILIKE '%pattern%'`.
+
+### Migration
+
+```sql
+CREATE INDEX idx_cards_oracle_text_lower_trgm
+    ON magic.cards USING gin (lower(oracle_text) gin_trgm_ops);
+
+CREATE INDEX idx_cards_cardname_lower_trgm
+    ON magic.cards USING gin (lower(card_name) gin_trgm_ops);
+
+CREATE INDEX idx_cards_artist_lower_trgm
+    ON magic.cards USING gin (lower(card_artist) gin_trgm_ops)
+    WHERE card_artist IS NOT NULL;
+
+CREATE INDEX idx_cards_flavor_text_lower_trgm
+    ON magic.cards USING gin (lower(flavor_text) gin_trgm_ops)
+    WHERE flavor_text IS NOT NULL;
+```
+
+The existing `ILIKE` indexes can be dropped once the new ones are in place, since any remaining
+`ILIKE` uses would fall back to a sequential scan anyway and the `lower()` indexes won't serve them.
+
+### `card_query_nodes.py`
+
+In `_handle_text_field_pattern_matching`, lowercase the pattern and wrap the column:
+
+```python
+words = ["", *txt_val.lower().split(), ""]
+pattern = "%".join(words)
+_param_name = param_name(pattern)
+context[_param_name] = pattern
+return f"(lower({lhs_sql}) LIKE %({_param_name})s)"
+```
+
+No changes needed to the regex path (`~*`) — PostgreSQL's regex selectivity estimator does not have
+the same planning overhead as `ILIKE`.
+
+## Trade-offs
+
+- Functional indexes are maintained automatically by PostgreSQL and require no changes to the data
+  model.
+- `lower()` substring search is semantically equivalent to `ILIKE` for all ASCII input. Non-ASCII
+  edge cases (locale-dependent case folding) are unlikely to matter for card names and oracle text.
+- The old `ILIKE` indexes become dead weight after this change and should be dropped.
+
+---
+
+## Status
+
+**Resolved — merged to main as [#470](https://github.com/jbylund/sylvan_librarian/pull/470) (2026-05-20).**
+
+See [PR description](../prs/optimize_like.md) for full details of what shipped.

--- a/docs/changelog/2026-05-21-hand-parser-parity-gaps.md
+++ b/docs/changelog/2026-05-21-hand-parser-parity-gaps.md
@@ -1,0 +1,78 @@
+# Hand-rolled parser parity gaps (resolved)
+
+Discovered via `test_parser_parity.py`, which runs every query in
+`implicit_and_cases.py` through both parsers and asserts identical SQL output.
+Started with 22 failing cases; all fixed.
+
+## 1. Pyparsing AND/OR precedence
+
+**Query:** `a OR b AND c`
+
+Pyparsing evaluated left-to-right (`(a OR b) AND c`) instead of respecting
+AND > OR precedence. Fixed by splitting the grammar into two levels:
+`and_expr = factor + ZeroOrMore(AND + factor)` at higher precedence, then
+`expr = and_expr + ZeroOrMore(OR + and_expr)`.
+
+## 2. AND/OR flattening
+
+**Queries:** `(foo bar) baz`, `a (b c)`, `(a AND b) c`
+
+Pyparsing was flattening nested AND chains into `AndNode(a, b, c)` while
+hand-rolled kept them nested as `AndNode(AndNode(a, b), c)`. Fixed by moving
+`flatten_nested_operations` from `pyparsing_based.py` into `nodes.py` and
+calling it in both parsers, producing canonical n-ary AND/OR nodes everywhere.
+
+## 3. Pyparsing crash — paren on arithmetic LHS
+
+**Queries:** `(2*power)-1>3`, `(power+toughness)-cmc>0`, `power-(cmc-1)>2`,
+`(power+1)-(cmc-1)>0`, and spaced variants.
+
+`arithmetic_term` used `Group(lparen + expr + rparen)`, which wrapped the inner
+result in a `ParseResults` sublist. `create_value_node` didn't recognise it as a
+`QueryNode`, leaving a raw `ParseResults` in the AST that raised
+`TypeError: 'str' object is not callable` when `.to_sql()` was called.
+
+Fixed by dropping the `Group` wrapper — since `lparen` and `rparen` are
+suppressed, `(lparen + expr + rparen)` yields exactly one `QueryNode` token
+as intended.
+
+## 4. Hand-rolled parser gaps
+
+### 4a. Arithmetic subtraction with spaces
+
+The hand-rolled parser treated a space before `-` as an AND boundary. Fixed by
+adding `_spaced_sub_tail`, which triggers when both the `-` and the following
+operand have `space_before=True` and the operand is a numeric term. This
+correctly distinguishes `power - cmc` (arithmetic) from `power -cmc` (negation).
+
+### 4b. Comparison followed by spaced negated expression
+
+**Queries:** `Power>2 -1+CMC<2`, `power>2 -cmc>0`, and similar.
+
+`parse_num_expr_value` was treating ` -cmc` (space before MINUS, no space after)
+as arithmetic subtraction, consuming `cmc` into the RHS and leaving `> 0`
+unmatched. Fixed by breaking out of `parse_num_expr_value` when MINUS has
+`space_before=True` and the following token has `space_before=False`.
+
+Also fixed a pyparsing issue where `-(cmc-1)>0` was rejected because
+`negatable_primary` grabbed just `(cmc-1)` instead of the full condition.
+Fixed by adding `paren_expr_term = (lparen + expr + rparen)` as a valid LHS/RHS
+in `unified_numeric_comparison`.
+
+### 4c. Spaced paren-minus-paren
+
+**Query:** `(power + 1) - (cmc - 1) > 0`
+
+`_spaced_sub_tail` only handled `-`, so spaced `+` inside parenthesised groups
+failed. Replaced with `_spaced_arith_tail`, which handles all four operators
+(`+`, `-`, `*`, `/`) with spaces, keeping the `space_before` guard on `-` only
+(to preserve the negation disambiguation).
+
+### 4d. Multi-hyphen bare words
+
+**Query:** `a-b-c`
+
+Known attribute aliases (e.g. `a` → artist) without a following operator were
+returning early via `_name_node` instead of calling `parse_hyphenated_name`.
+Fixed by routing that branch through `parse_hyphenated_name`, which checks for
+no-space hyphen continuations.

--- a/docs/changelog/2026-05-21-hand-rolled-parser.md
+++ b/docs/changelog/2026-05-21-hand-rolled-parser.md
@@ -1,0 +1,30 @@
+# Hand-rolled recursive-descent parser replaces pyparsing (#482)
+
+The query parser is now a hand-rolled recursive-descent implementation
+([api/parsing/hand_parser.py](../../api/parsing/hand_parser.py)), replacing pyparsing as the
+production parse path. On a diverse query set it parses ~49x faster (158k vs 3.2k parses/sec).
+
+## What changed
+
+- `api.parsing.parse_search_query` is the new primary entry point, backed by the hand-rolled
+  parser. It handles the full query DSL: arithmetic expressions, negation, implicit AND,
+  quoted strings, and parenthesised sub-expressions.
+- The pyparsing grammar was extracted from `parsing_f.py` into
+  [pyparsing_based.py](../../api/parsing/pyparsing_based.py) and demoted to a comparison-testing
+  path; `parsing_f.py` is now a thin shim.
+- Shared SQL-generation helpers moved to
+  [sql_generation.py](../../api/parsing/sql_generation.py), and `flatten_nested_operations`
+  moved into `nodes.py` so both parsers produce canonical n-ary AND/OR trees.
+
+## Parity guarantee
+
+A parametrized parity suite
+([test_parser_parity.py](../../api/parsing/tests/test_parser_parity.py)) runs every query in
+the consolidated corpus through both parsers and asserts identical SQL output (or that both
+fail). The shared `parse_query` fixture in `conftest.py` also runs the pre-existing parser
+tests against both implementations automatically.
+
+Parity testing surfaced and fixed several latent pyparsing bugs along the way — AND/OR
+precedence, a crash on parenthesised arithmetic LHS, and rejection of negated parenthesised
+expressions. Details in
+[hand-parser-parity-gaps](2026-05-21-hand-parser-parity-gaps.md).

--- a/docs/changelog/2026-05-27-cross-process-cache-invalidation.md
+++ b/docs/changelog/2026-05-27-cross-process-cache-invalidation.md
@@ -1,0 +1,16 @@
+# Cross-process cache invalidation
+
+Implemented Option B from the [per-worker cache staleness](../issues/per-worker-cache-staleness.md)
+design doc. The server runs 10 independent Bjoern worker processes with `SO_REUSEPORT`; each had
+its own `_query_cache` and `_all_preferred_cards` that were only cleared on the worker that
+handled a mutation, leaving the other nine serving stale data indefinitely.
+
+## What changed
+
+Added a `cache_generation` shared `multiprocessing.Value("i", 0)` passed to every worker at
+startup. `_clear_caches()` increments it under a lock. Each worker checks the current generation
+on every request via `GenerationCache` (in `api/utils/generation_cache.py`) and discards its
+local caches if it has fallen behind. The check is a single integer read in the hot path.
+
+`_all_preferred_cards` and `_search` are now stored as `generation → value` LRU maps (maxsize=1),
+so a stale worker transparently rebuilds on its next request after a mutation on any worker.

--- a/docs/changelog/2026-06-12-rust-query-engine.md
+++ b/docs/changelog/2026-06-12-rust-query-engine.md
@@ -1,0 +1,44 @@
+# Rust in-process query engine replaces PostgreSQL in the search hot path (#490, #502, #505)
+
+Search is now served by a Rust/PyO3 in-memory filter engine instead of PostgreSQL. Queries are
+still parsed in Python; the AST is serialized to JSON, evaluated entirely in Rust against an
+in-memory card store, and the top-N result dicts cross back over the FFI boundary. The SQL
+path is retained in parallel as a transparent fallback — any engine exception logs a warning
+and the request is served from PostgreSQL, and a cold (empty) store serves from SQL while a
+background reload populates the engine.
+
+Across a representative query mix the engine is **~76x faster** than the SQL path (geometric
+mean 0.20 ms vs 14.9 ms against ~96k cards), with individual queries ranging from 20x
+(`power+toughness>8`) to 190x (`t:merfolk and name:tide`). Full benchmark table in
+[docs/prs/00490-rust-filter-extension.md](../prs/00490-rust-filter-extension.md).
+
+## How it landed
+
+**#490 — Rust in-process filter engine.** `QueryEngine` (PyO3, in
+[card_engine/](../../card_engine/)) holds the card corpus on the Rust heap with prebuilt
+indexes: name/oracle trigram maps, B-trees over cmc/power/toughness, and posting lists for
+card types, subtypes, oracle tags, and is-tags. AND queries intersect candidate sets, OR
+queries union them, and colors/types are bitfields so containment checks are single
+instructions. Each AST node gained a `to_json()` method for serialization across the boundary.
+
+**#502 — Shared-memory card store (rkyv + mmap).** The store moved out of per-worker memory
+into a single rkyv archive in tmpfs (`/dev/shm/sylvan_librarian_cards`) that every worker mmaps
+read-only and queries with zero deserialization. This collapsed ~800 MB–1 GB of duplicated
+per-worker RSS into one shared copy, and only one worker (cross-process flock + atomic rename
+publish) pays the reload cost. Details in
+[docs/prs/joe/shared-memory-card-store.md](../prs/joe/shared-memory-card-store.md).
+
+**#505 — Streaming engine reload.** The DB → store reload became a staged streaming pipeline
+(`reload_begin` / `add_batch` / `reload_commit`): a server-side cursor feeds 2,000-row batches
+into Rust, and the archive is serialized directly to file instead of through a heap buffer.
+Building-worker peak memory dropped from ~1.3 GB to ~350 MB, which is what made it safe to
+enable the engine in memory-constrained deployments. Details in
+[docs/prs/joe/00505-engine-incremental-loading.md](../prs/joe/00505-engine-incremental-loading.md).
+
+## Operational notes
+
+- The engine is gated by `ENABLE_ENGINE` (now `true` in all environments).
+- The Rust wheel builds in a dedicated `rust-builder` Docker stage via maturin; locally,
+  `make engine` builds and installs the extension, and the test targets depend on it.
+- Bulk imports trigger an engine reload to keep the store current; queries keep serving the
+  old archive until the atomic rename publishes the new one.


### PR DESCRIPTION
The changelog jumps from **2026-01-30 straight to 2026-07-09** — a five-month hole covering the parser rewrite, the Rust engine, and the ILIKE work.

Ten entries were written as that work shipped but never committed. Five sat on the `joe/update_changelog` branch; five were untracked in the working tree.

| Date | Entry |
|---|---|
| 2026-01-29 | search history back/forward |
| 2026-03-26 | simplify request lifecycle |
| 2026-03-27 | cubecobra sort |
| 2026-05-15 | query explanation |
| 2026-05-19 | color identity query performance |
| 2026-05-20 | ilike → lower(like) |
| 2026-05-21 | hand-rolled parser |
| 2026-05-21 | hand parser parity gaps |
| 2026-05-27 | cross-process cache invalidation |
| 2026-06-12 | rust query engine |

Every entry describes work already in main. Spot-checked against the tree:

- hand-rolled parser → `api/parsing/hand_parser.py`
- rust query engine → `card_engine/`, 33 files
- ilike → lower(like) → `api/db/2026-05-20-02-lower-trgm-indexes.sql`

487 lines, documentation only.