### PR TITLE
Chore: Ignore Benchmark Harness Artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,17 @@ docs/issues/security-*
 # slash, so both match at every depth.
 .DS_Store
 ._*
+
+# Benchmark harness output. 22 GB as of 2026-08: engine .store archives (~68 MB each),
+# corpus .jsonl exports (hundreds of MB), and the .lock files beside them. None of it is
+# evidence — the CSVs the harnesses emit are, and posts cite those by path rather than
+# committing them. Nothing under benchmarks/ has ever been tracked.
+benchmarks/
+
+# The same two artifact kinds wherever else a harness drops them, so a run outside
+# benchmarks/ cannot quietly stage 68 MB. Nothing legitimate here carries either
+# extension: Scryfall's JSONL bulk data is fetched at runtime by
+# api/scryfall_bulk_data_fetcher.py and never committed. Neither pattern has a slash,
+# so both match at every depth. (*.store does not match .DS_Store — no dot before Store.)
+*.store
+*.jsonl


### PR DESCRIPTION
`benchmarks/` holds **22 GB** of harness output that is neither tracked nor ignored — one `git add -A` from any session stages all of it.

| Kind | Count | Size |
|---|---|---|
| `.store` engine archives | 276 | ~68 MB each |
| `.lock` | 279 | — |
| `.jsonl` corpus exports | — | hundreds of MB |
| **total** | **283 matching** | **22 GB** |

Ignores `benchmarks/` wholesale, plus `*.store` and `*.jsonl` globally so a harness run *outside* that directory can't quietly stage the same artifacts.

### Why the global patterns are safe

Nothing legitimate in the repo carries either extension. Scryfall's JSONL bulk data is fetched at runtime by `api/scryfall_bulk_data_fetcher.py` and never committed — no `.jsonl` or `.store` file is tracked in main.

### Verified before pushing

- **Nothing currently tracked becomes ignored** — `git ls-files | git check-ignore --stdin` returns empty, so no `git rm --cached` is needed.
- **`.DS_Store` still matches its own rule** (line 23), not `*.store` — the filename has no dot before `Store`.
- Untracked entries in `git status` drop from 24 to 12.

### One thing to know

`.gitignore` only affects *untracked* files. Two unmerged branches — `blog-arith-tuple-postings` (27 files) and `blog-arith-tuple-postings-post` (6) — track benchmark CSVs. If either merges, those arrive as tracked files and stay tracked despite this rule. Worth deciding at merge time whether to keep them or drop them for consistency.