### PR TITLE
Import: Sync is:reserved and is:gamechanger From the Bulk Cards' Own Booleans

### DIFF
--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -300,15 +300,42 @@ DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
     "type_line",
 )
 
-# is: values Scryfall ships as BOOLEANS on every bulk card object, so their
-# membership rides the ordinary import stream -- no per-tag API sweep, unlike
-# CUSTOM_IS_TAGS below. Maps the bulk-data field name to the is: tag key.
-# Synced both ways by _sync_boolean_is_tags: a card leaving the list (the
-# game_changer roster moves with WotC's Commander brackets) loses the tag.
+# is: values Scryfall ships as BOOLEANS on every bulk card object, synced
+# in one set-based statement from raw_card_blob after each import (see
+# _sync_boolean_is_tags) -- no per-tag API sweep, unlike CUSTOM_IS_TAGS
+# below, and no accumulation in the import loop. card_is_tags key -> raw
+# blob key; adding a field here is the whole change. foil/promo/reprint are
+# deliberately NOT here yet (higher cardinality, memory check first).
 BOOLEAN_IS_TAGS: dict[str, str] = {
     "reserved": "reserved",
-    "game_changer": "gamechanger",
+    "gamechanger": "game_changer",
 }
+
+_SYNC_BOOLEAN_IS_TAGS_SQL = """
+WITH tag_map(tag, blob_key) AS (
+    SELECT key, value FROM jsonb_each_text(%(tag_map)s::jsonb)
+),
+proposed AS (
+    SELECT
+        cards.scryfall_id,
+        (cards.card_is_tags - (SELECT array_agg(tag_map.tag) FROM tag_map))
+            || COALESCE(
+                   (
+                       SELECT jsonb_object_agg(tag_map.tag, true)
+                       FROM tag_map
+                       WHERE cards.raw_card_blob -> tag_map.blob_key = 'true'::jsonb
+                   ),
+                   '{}'::jsonb
+               ) AS proposed_is_tags
+    FROM magic.cards
+)
+UPDATE magic.cards
+SET card_is_tags = proposed.proposed_is_tags
+FROM proposed
+WHERE
+    cards.scryfall_id = proposed.scryfall_id AND
+    cards.card_is_tags IS DISTINCT FROM proposed.proposed_is_tags
+"""
 
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
@@ -2191,59 +2218,30 @@ class APIResource:
             "message": f"Successfully updated {updated_count} cards with is:{is_tag}",
         }
 
-    def _sync_boolean_is_tags(self, ids_by_tag: dict[str, set[str]], conn: Connection) -> dict[str, int]:
-        """Sync the boolean-backed is: tags (BOOLEAN_IS_TAGS) from the import stream.
+    def _sync_boolean_is_tags(self, conn: Connection) -> int:
+        """Sync the boolean-backed is: tags (BOOLEAN_IS_TAGS) from raw_card_blob, one-shot.
 
-        Adds each tag to the printings whose bulk object carried the boolean and strips
-        it from printings no longer carrying it, so list churn (a card entering or
-        leaving the game-changer roster) converges on every import.
+        Rebuilds each card's managed keys as (existing minus managed) plus the keys whose
+        blob boolean is true, touching only rows whose result actually differs -- so list
+        churn (a card entering or leaving the game-changer roster) converges on every
+        import, and unrelated card_is_tags entries are never disturbed.
 
         Args:
         ----
-            ids_by_tag (dict): tag key -> scryfall ids seen with the boolean set.
-            conn (Connection): open connection; committed per tag.
+            conn (Connection): open connection; committed here.
 
         Returns:
         -------
-            Dict[str, int]: rows changed per tag (adds plus removals).
+            int: rows whose card_is_tags changed.
 
         """
-        changed: dict[str, int] = {}
         with conn.cursor() as cursor:
-            for tag, ids in ids_by_tag.items():
-                new_tag = orjson.dumps({tag: True}).decode("utf-8")
-                id_list = sorted(ids)
-                cursor.execute(
-                    """
-                    UPDATE
-                        magic.cards
-                    SET
-                        card_is_tags = card_is_tags || %(new_tag)s::jsonb
-                    WHERE
-                        scryfall_id = ANY(%(scryfall_ids)s) AND
-                        not(card_is_tags @> %(new_tag)s::jsonb)
-                    """,
-                    {"scryfall_ids": id_list, "new_tag": new_tag},
-                )
-                rows = cursor.rowcount
-                cursor.execute(
-                    """
-                    UPDATE
-                        magic.cards
-                    SET
-                        card_is_tags = card_is_tags - %(tag)s
-                    WHERE
-                        card_is_tags ? %(tag)s AND
-                        NOT (scryfall_id = ANY(%(scryfall_ids)s))
-                    """,
-                    {"scryfall_ids": id_list, "tag": tag},
-                )
-                rows += cursor.rowcount
-                conn.commit()
-                changed[tag] = rows
-                if rows:
-                    logger.info("Synced boolean is:%s on %d printings", tag, rows)
-        return changed
+            cursor.execute(_SYNC_BOOLEAN_IS_TAGS_SQL, {"tag_map": orjson.dumps(BOOLEAN_IS_TAGS).decode("utf-8")})
+            updated_count = cursor.rowcount
+        conn.commit()
+        if updated_count:
+            logger.info("Synced boolean is: tags on %d printings", updated_count)
+        return updated_count
 
     def _add_is_tag_to_printings(self, *, is_tag: str) -> dict[str, Any]:
         """Add a specific is: tag to all printings matching that tag using Scryfall search.
@@ -2627,19 +2625,15 @@ class APIResource:
                     self._set_statement_timeout(cursor, 30_000)
 
                 class _CardStream:
-                    """Preprocesses raw cards lazily, tracking stage counts and boolean is: tags."""
+                    """Preprocesses raw cards lazily, tracking stage counts."""
 
                     def __init__(self) -> None:
                         self.raw = 0
                         self.preprocessed = 0
-                        self.boolean_tag_ids: dict[str, set[str]] = {tag: set() for tag in BOOLEAN_IS_TAGS.values()}
 
                     def __iter__(self) -> Iterator[dict[str, Any]]:
                         for card in cards:
                             self.raw += 1
-                            for field, tag in BOOLEAN_IS_TAGS.items():
-                                if card.get(field) and card.get("id"):
-                                    self.boolean_tag_ids[tag].add(card["id"])
                             for processed in preprocess_card(card):
                                 self.preprocessed += 1
                                 yield processed
@@ -2669,7 +2663,7 @@ class APIResource:
                 conn.commit()
 
                 if cards_sent:
-                    self._sync_boolean_is_tags(stream.boolean_tag_ids, conn)
+                    self._sync_boolean_is_tags(conn)
 
                 if cards_sent == 0:
                     if stream.raw == 0:

--- a/api/api_resource.py
+++ b/api/api_resource.py
@@ -300,6 +300,16 @@ DEFAULT_RESULT_FIELDS: tuple[str, ...] = (
     "type_line",
 )
 
+# is: values Scryfall ships as BOOLEANS on every bulk card object, so their
+# membership rides the ordinary import stream -- no per-tag API sweep, unlike
+# CUSTOM_IS_TAGS below. Maps the bulk-data field name to the is: tag key.
+# Synced both ways by _sync_boolean_is_tags: a card leaving the list (the
+# game_changer roster moves with WotC's Commander brackets) loses the tag.
+BOOLEAN_IS_TAGS: dict[str, str] = {
+    "reserved": "reserved",
+    "game_changer": "gamechanger",
+}
+
 CUSTOM_IS_TAGS = [
     "historic",  # artifact, legendary, saga
     "pathway",  # land and name contains pathway
@@ -2181,6 +2191,60 @@ class APIResource:
             "message": f"Successfully updated {updated_count} cards with is:{is_tag}",
         }
 
+    def _sync_boolean_is_tags(self, ids_by_tag: dict[str, set[str]], conn: Connection) -> dict[str, int]:
+        """Sync the boolean-backed is: tags (BOOLEAN_IS_TAGS) from the import stream.
+
+        Adds each tag to the printings whose bulk object carried the boolean and strips
+        it from printings no longer carrying it, so list churn (a card entering or
+        leaving the game-changer roster) converges on every import.
+
+        Args:
+        ----
+            ids_by_tag (dict): tag key -> scryfall ids seen with the boolean set.
+            conn (Connection): open connection; committed per tag.
+
+        Returns:
+        -------
+            Dict[str, int]: rows changed per tag (adds plus removals).
+
+        """
+        changed: dict[str, int] = {}
+        with conn.cursor() as cursor:
+            for tag, ids in ids_by_tag.items():
+                new_tag = orjson.dumps({tag: True}).decode("utf-8")
+                id_list = sorted(ids)
+                cursor.execute(
+                    """
+                    UPDATE
+                        magic.cards
+                    SET
+                        card_is_tags = card_is_tags || %(new_tag)s::jsonb
+                    WHERE
+                        scryfall_id = ANY(%(scryfall_ids)s) AND
+                        not(card_is_tags @> %(new_tag)s::jsonb)
+                    """,
+                    {"scryfall_ids": id_list, "new_tag": new_tag},
+                )
+                rows = cursor.rowcount
+                cursor.execute(
+                    """
+                    UPDATE
+                        magic.cards
+                    SET
+                        card_is_tags = card_is_tags - %(tag)s
+                    WHERE
+                        card_is_tags ? %(tag)s AND
+                        NOT (scryfall_id = ANY(%(scryfall_ids)s))
+                    """,
+                    {"scryfall_ids": id_list, "tag": tag},
+                )
+                rows += cursor.rowcount
+                conn.commit()
+                changed[tag] = rows
+                if rows:
+                    logger.info("Synced boolean is:%s on %d printings", tag, rows)
+        return changed
+
     def _add_is_tag_to_printings(self, *, is_tag: str) -> dict[str, Any]:
         """Add a specific is: tag to all printings matching that tag using Scryfall search.
 
@@ -2563,15 +2627,19 @@ class APIResource:
                     self._set_statement_timeout(cursor, 30_000)
 
                 class _CardStream:
-                    """Preprocesses raw cards lazily, tracking stage counts."""
+                    """Preprocesses raw cards lazily, tracking stage counts and boolean is: tags."""
 
                     def __init__(self) -> None:
                         self.raw = 0
                         self.preprocessed = 0
+                        self.boolean_tag_ids: dict[str, set[str]] = {tag: set() for tag in BOOLEAN_IS_TAGS.values()}
 
                     def __iter__(self) -> Iterator[dict[str, Any]]:
                         for card in cards:
                             self.raw += 1
+                            for field, tag in BOOLEAN_IS_TAGS.items():
+                                if card.get(field) and card.get("id"):
+                                    self.boolean_tag_ids[tag].add(card["id"])
                             for processed in preprocess_card(card):
                                 self.preprocessed += 1
                                 yield processed
@@ -2599,6 +2667,9 @@ class APIResource:
                     )
 
                 conn.commit()
+
+                if cards_sent:
+                    self._sync_boolean_is_tags(stream.boolean_tag_ids, conn)
 
                 if cards_sent == 0:
                     if stream.raw == 0:

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -61,6 +61,66 @@ class TestUpsertCardsStatus:
 
 
 # ---------------------------------------------------------------------------
+# Boolean-backed is: tags (reserved / game_changer)
+# ---------------------------------------------------------------------------
+
+
+def _is_tags_for(api_resource: APIResource, scryfall_id: str) -> dict:
+    with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+        cursor.execute(
+            "SELECT card_is_tags FROM magic.cards WHERE scryfall_id = %(sid)s",
+            {"sid": scryfall_id},
+        )
+        row = cursor.fetchone()
+    return row["card_is_tags"] if row else {}
+
+
+class TestBooleanIsTags:
+    """reserved/game_changer booleans on bulk cards sync into card_is_tags both ways."""
+
+    def test_reserved_boolean_lands_as_is_tag(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Reserved Import Test")
+        card["reserved"] = True
+        api_resource._upsert_cards([card])
+        assert _is_tags_for(api_resource, card["id"]).get("reserved") is True
+
+    def test_game_changer_boolean_lands_as_gamechanger(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Bracket Import Test")
+        card["game_changer"] = True
+        api_resource._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert tags.get("gamechanger") is True
+        assert "reserved" not in tags
+
+    def test_flag_removal_strips_the_tag(self, api_resource: APIResource) -> None:
+        # A card leaving the game-changer roster must lose the tag on reimport.
+        card = make_raw_card(name="Debracketed Test")
+        card["game_changer"] = True
+        api_resource._upsert_cards([card])
+        del card["game_changer"]
+        card["oracle_text"] = "changed so the reimport writes"
+        api_resource._upsert_cards([card])
+        assert "gamechanger" not in _is_tags_for(api_resource, card["id"])
+
+    def test_sync_preserves_unrelated_is_tags(self, api_resource: APIResource) -> None:
+        card = make_raw_card(name="Historic Bystander Test")
+        card["reserved"] = True
+        api_resource._upsert_cards([card])
+        with api_resource._conn_pool.connection() as conn, conn.cursor() as cursor:
+            cursor.execute(
+                """UPDATE magic.cards SET card_is_tags = card_is_tags || '{"historic": true}'::jsonb
+                   WHERE scryfall_id = %(sid)s""",
+                {"sid": card["id"]},
+            )
+            conn.commit()
+        card["oracle_text"] = "changed so the reimport writes"
+        api_resource._upsert_cards([card])
+        tags = _is_tags_for(api_resource, card["id"])
+        assert tags.get("historic") is True
+        assert tags.get("reserved") is True
+
+
+# ---------------------------------------------------------------------------
 # _CardStream counting tests
 # ---------------------------------------------------------------------------
 

--- a/api/tests/test_upsert_cards.py
+++ b/api/tests/test_upsert_cards.py
@@ -94,12 +94,16 @@ class TestBooleanIsTags:
 
     def test_flag_removal_strips_the_tag(self, api_resource: APIResource) -> None:
         # A card leaving the game-changer roster must lose the tag on reimport.
+        # Each import builds a FRESH dict, as the real bulk stream does --
+        # preprocess_card embeds a raw_card_blob snapshot into the dict it is
+        # given and short-circuits dicts that already carry one, so reusing
+        # the first import's object would re-store the stale blob.
         card = make_raw_card(name="Debracketed Test")
         card["game_changer"] = True
         api_resource._upsert_cards([card])
-        del card["game_changer"]
-        card["oracle_text"] = "changed so the reimport writes"
-        api_resource._upsert_cards([card])
+        reimport = make_raw_card(card_id=card["id"], name="Debracketed Test")
+        reimport["oracle_text"] = "changed so the reimport writes"
+        api_resource._upsert_cards([reimport])
         assert "gamechanger" not in _is_tags_for(api_resource, card["id"])
 
     def test_sync_preserves_unrelated_is_tags(self, api_resource: APIResource) -> None:
@@ -113,8 +117,10 @@ class TestBooleanIsTags:
                 {"sid": card["id"]},
             )
             conn.commit()
-        card["oracle_text"] = "changed so the reimport writes"
-        api_resource._upsert_cards([card])
+        reimport = make_raw_card(card_id=card["id"], name="Historic Bystander Test")
+        reimport["reserved"] = True
+        reimport["oracle_text"] = "changed so the reimport writes"
+        api_resource._upsert_cards([reimport])
         tags = _is_tags_for(api_resource, card["id"])
         assert tags.get("historic") is True
         assert tags.get("reserved") is True


### PR DESCRIPTION
## What

`is:reserved` and `is:gamechanger` currently return silent zeros (empty `card_is_tags`). Both memberships ship as **booleans on every bulk card object** (`reserved`, `game_changer`), so this syncs them with no per-tag API sweep, no parser changes, and no engine changes:

- `BOOLEAN_IS_TAGS` maps each `card_is_tags` key to its raw blob key — `reserved` → `reserved`, `gamechanger` → `game_changer`. Adding a future boolean-backed tag is a one-line addition here.
- `_sync_boolean_is_tags` runs a single set-based UPDATE after each import: for every card, it rebuilds the managed keys as (existing tags minus the managed set) plus whichever managed keys are `true` in `raw_card_blob`, writing only rows whose result actually differs (`IS DISTINCT FROM` guard). No accumulation during the import loop.
- Because the sync only ever touches its own two keys, tags added by other means (e.g. `CUSTOM_IS_TAGS` API sweeps) are left untouched by construction, and list churn — like the game-changer roster moving with WotC's Commander brackets — converges on every import in both directions (adds and removals).
- The unknown-`is:` parse path already falls through to the `card_is_tags` lookup, so both values light up as soon as the data exists.

This is the first data through the `card_is_tags` mechanism from #874, sourced purely from the bulk stream every instance already downloads.

## Validation

- Live reimport on a full-corpus dev stack: `is:gamechanger` → 53, matches Scryfall exactly; `is:reserved` → 566 vs Scryfall's 571, the five absent being the never-legal Reserved List cards (ante cards, Shahrazad) the corpus's legality policy excludes
- `api/tests/test_upsert_cards.py`: 22 passed, including cases for both flags landing, tag removal on reimport, and preservation of unrelated `card_is_tags` entries
- Test fixtures now build a fresh dict per import (matching the real bulk stream) — `preprocess_card` short-circuits on a dict that already carries a `raw_card_blob`, which was masking flag removal when a test reused the same dict across imports

## Notes

- Tag key is `gamechanger` (matching what users type after `is:`), mapped from the JSON field `game_changer`.
- `foil`/`promo`/`reprint` deliberately left out for now — higher cardinality, pending a memory check.
- Open TODO from review: check one row from `is:` tags and add a test asserting `xmin` is unchanged when the sync is a no-op.